### PR TITLE
chore: release v0.49.0

### DIFF
--- a/.changesets/1782078641-fix-sysinfo-robust-cpu-chart-zoh-gap-fill-debounced-resize-n-tua9.md
+++ b/.changesets/1782078641-fix-sysinfo-robust-cpu-chart-zoh-gap-fill-debounced-resize-n-tua9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(sysinfo): robust CPU chart — ZOH gap fill, debounced resize, no blank-on-reload

--- a/.changesets/1782171094-fix-lifecycle-typed-floater-browserkind-floaters-excluded-fr-g6fe.md
+++ b/.changesets/1782171094-fix-lifecycle-typed-floater-browserkind-floaters-excluded-fr-g6fe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lifecycle): typed Floater BrowserKind; floaters excluded from quit gate by type

--- a/.changesets/1782171756-fix-agent-pane-busy-bar-no-longer-freezes-under-reduced-moti-nm9r.md
+++ b/.changesets/1782171756-fix-agent-pane-busy-bar-no-longer-freezes-under-reduced-moti-nm9r.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): busy bar no longer freezes under reduced-motion + opaque bar (no text bleed-through)

--- a/.changesets/1782171773-feat-tool-renderers-webfetch-content-view-fix-websearch-json-zkxy.md
+++ b/.changesets/1782171773-feat-tool-renderers-webfetch-content-view-fix-websearch-json-zkxy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tool-renderers): WebFetch content view + fix WebSearch JSON-string extraction

--- a/.changesets/1782174197-fix-swarm-emit-agent-process-added-on-reactive-register-so-p-hu2y.md
+++ b/.changesets/1782174197-fix-swarm-emit-agent-process-added-on-reactive-register-so-p-hu2y.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): emit agent:process-added on reactive register so panes appear in Swarm view

--- a/.changesets/1782175548-chore-ci-fast-pr-nightly-cef-test-runners-on-standard-runner-5xrr.md
+++ b/.changesets/1782175548-chore-ci-fast-pr-nightly-cef-test-runners-on-standard-runner-5xrr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(ci): fast (PR) + nightly (CEF) test runners on standard runners

--- a/.changesets/1782176393-fix-memory-agent-def-get-global-registry-fallback-automemory-4d5x.md
+++ b/.changesets/1782176393-fix-memory-agent-def-get-global-registry-fallback-automemory-4d5x.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(memory): agent_def_get global-registry fallback, autoMemory guard, brain UI inline input, seed memory discipline

--- a/.changesets/1782176589-fix-agent-pane-keep-the-busy-bar-a-fixed-size-regardless-of--56wl.md
+++ b/.changesets/1782176589-fix-agent-pane-keep-the-busy-bar-a-fixed-size-regardless-of--56wl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): keep the busy bar a fixed size regardless of pane zoom

--- a/.changesets/1782176744-fix-macos-remove-alertnotificationservice-helper-from-bundle-rojg.md
+++ b/.changesets/1782176744-fix-macos-remove-alertnotificationservice-helper-from-bundle-rojg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(macos): remove AlertNotificationService helper from bundle to eliminate duplicate notification prompts

--- a/.changesets/1782178546-fix-test-un-skip-agentlaunchmodal-preset-test-stale-memory-p-x16s.md
+++ b/.changesets/1782178546-fix-test-un-skip-agentlaunchmodal-preset-test-stale-memory-p-x16s.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(test): un-skip AgentLaunchModal preset test (stale Memory->Preset label)

--- a/.changesets/1782178592-fix-agent-pane-keep-marching-ants-under-reduced-motion-slowe-tr48.md
+++ b/.changesets/1782178592-fix-agent-pane-keep-marching-ants-under-reduced-motion-slowe-tr48.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): keep marching ants under reduced-motion (slower) instead of an opacity breathe

--- a/.changesets/1782209542-feat-tool-log-collapse-consecutive-spinner-char-frames-to-in-z5vb.md
+++ b/.changesets/1782209542-feat-tool-log-collapse-consecutive-spinner-char-frames-to-in-z5vb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tool-log): collapse consecutive spinner-char frames to in-place animation

--- a/.changesets/1782209694-chore-ci-run-test-workflows-nightly-not-per-pr-qdtk.md
+++ b/.changesets/1782209694-chore-ci-run-test-workflows-nightly-not-per-pr-qdtk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(ci): run test workflows nightly, not per-PR

--- a/.changesets/1782210050-chore-ci-nightly-cross-platform-compile-build-phase-a-1718-cpuj.md
+++ b/.changesets/1782210050-chore-ci-nightly-cross-platform-compile-build-phase-a-1718-cpuj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(ci): nightly cross-platform compile-build (Phase A, #1718)

--- a/.changesets/1782210673-chore-ci-move-input-handler-guardrails-to-nightly-not-per-pr-rcoq.md
+++ b/.changesets/1782210673-chore-ci-move-input-handler-guardrails-to-nightly-not-per-pr-rcoq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(ci): move input-handler guardrails to nightly (not per-PR)

--- a/.changesets/1782212989-fix-agent-pane-marching-ants-freeze-on-macos-with-reduce-mot-rzgm.md
+++ b/.changesets/1782212989-fix-agent-pane-marching-ants-freeze-on-macos-with-reduce-mot-rzgm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): marching ants freeze on macOS with Reduce Motion — add animation-iteration-count: infinite in reduced-motion block

--- a/.changesets/1782213380-fix-cef-disable-gpu-process-in-macos-dev-mode-to-avoid-sandb-8ury.md
+++ b/.changesets/1782213380-fix-cef-disable-gpu-process-in-macos-dev-mode-to-avoid-sandb-8ury.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): use --no-sandbox in macOS dev mode so unsigned dev binary can init GPU and network service

--- a/.changesets/1782229545-fix-agent-pane-red-input-styling-when-bang-cmd-sh-c-on-windo-bgyc.md
+++ b/.changesets/1782229545-fix-agent-pane-red-input-styling-when-bang-cmd-sh-c-on-windo-bgyc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): red input styling when bang-cmd; sh -c on Windows; MSYS path fix

--- a/.changesets/1782229694-fix-auth-seed-from-global-primary-redact-tokens-in-login-pty-gqip.md
+++ b/.changesets/1782229694-fix-auth-seed-from-global-primary-redact-tokens-in-login-pty-gqip.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): seed-from-global primary; redact tokens in login PTY logs

--- a/.changesets/1782231138-feat-auth-seed-from-global-is-the-primary-pre-launch-cta-for-fvnp.md
+++ b/.changesets/1782231138-feat-auth-seed-from-global-is-the-primary-pre-launch-cta-for-fvnp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(auth): seed-from-global is the primary pre-launch CTA for Claude

--- a/.changesets/1782231177-feat-swarm-agent-pane-visibility-in-swarm-click-to-focus-and-jvs7.md
+++ b/.changesets/1782231177-feat-swarm-agent-pane-visibility-in-swarm-click-to-focus-and-jvs7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): agent pane visibility in Swarm, click-to-focus, and two-way active-row highlight

--- a/.changesets/1782231236-feat-swarm-granular-per-block-agent-status-from-turnphase-wo-js6c.md
+++ b/.changesets/1782231236-feat-swarm-granular-per-block-agent-status-from-turnphase-wo-js6c.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): granular per-block agent status from TurnPhase (working/tools/stopping/error/offline)

--- a/.changesets/1782232002-fix-container-agent-empty-image-fallback-skip-empty-meta-gua-l8c6.md
+++ b/.changesets/1782232002-fix-container-agent-empty-image-fallback-skip-empty-meta-gua-l8c6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(container-agent): empty image fallback, skip empty meta, guard null blockId in swarm

--- a/.changesets/1782234264-feat-layout-fix-floating-pane-redock-ghost-size-mismatch-pha-yyoj.md
+++ b/.changesets/1782234264-feat-layout-fix-floating-pane-redock-ghost-size-mismatch-pha-yyoj.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(layout): fix floating-pane redock ghost-size mismatch (Phase 4b)

--- a/.changesets/1782234851-docs-readme-refresh-tone-accuracy-first-class-agents-multi-p-h32l.md
+++ b/.changesets/1782234851-docs-readme-refresh-tone-accuracy-first-class-agents-multi-p-h32l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(readme): refresh tone + accuracy (first-class agents, multi-provider, one-shot CLIs, local-first)

--- a/.changesets/1782234871-ci-nightly-windows-artifact-build-portable-zip-setup-install-l0xu.md
+++ b/.changesets/1782234871-ci-nightly-windows-artifact-build-portable-zip-setup-install-l0xu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci: nightly Windows artifact build — portable ZIP + setup installer (Phase B of #1718)

--- a/.changesets/1782237814-refactor-reactive-rename-pollerconfig-fields-to-muxbus-arch--4cgx.md
+++ b/.changesets/1782237814-refactor-reactive-rename-pollerconfig-fields-to-muxbus-arch--4cgx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(reactive): rename PollerConfig fields to muxbus_* (ARCH-001; wire key unchanged)

--- a/.changesets/1782237945-fix-auth-use-existing-login-primary-for-claude-in-failure-ba-ze7k.md
+++ b/.changesets/1782237945-fix-auth-use-existing-login-primary-for-claude-in-failure-ba-ze7k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): Use existing login primary for Claude in failure banner; add Login via terminal fallback (CREATE_NEW_CONSOLE)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.48.1"
+version = "0.49.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,37 @@
 # AgentMux Version History
 
+## 0.49.0 — 2026-06-23
+
+- fix(sysinfo): robust CPU chart — ZOH gap fill, debounced resize, no blank-on-reload
+- fix(lifecycle): typed Floater BrowserKind; floaters excluded from quit gate by type
+- fix(agent-pane): busy bar no longer freezes under reduced-motion + opaque bar (no text bleed-through)
+- feat(tool-renderers): WebFetch content view + fix WebSearch JSON-string extraction
+- fix(swarm): emit agent:process-added on reactive register so panes appear in Swarm view
+- chore(ci): fast (PR) + nightly (CEF) test runners on standard runners
+- fix(memory): agent_def_get global-registry fallback, autoMemory guard, brain UI inline input, seed memory discipline
+- fix(agent-pane): keep the busy bar a fixed size regardless of pane zoom
+- fix(macos): remove AlertNotificationService helper from bundle to eliminate duplicate notification prompts
+- fix(test): un-skip AgentLaunchModal preset test (stale Memory->Preset label)
+- fix(agent-pane): keep marching ants under reduced-motion (slower) instead of an opacity breathe
+- feat(tool-log): collapse consecutive spinner-char frames to in-place animation
+- chore(ci): run test workflows nightly, not per-PR
+- chore(ci): nightly cross-platform compile-build (Phase A, #1718)
+- chore(ci): move input-handler guardrails to nightly (not per-PR)
+- fix(agent-pane): marching ants freeze on macOS with Reduce Motion — add animation-iteration-count: infinite in reduced-motion block
+- fix(cef): use --no-sandbox in macOS dev mode so unsigned dev binary can init GPU and network service
+- fix(agent-pane): red input styling when bang-cmd; sh -c on Windows; MSYS path fix
+- fix(auth): seed-from-global primary; redact tokens in login PTY logs
+- feat(auth): seed-from-global is the primary pre-launch CTA for Claude
+- feat(swarm): agent pane visibility in Swarm, click-to-focus, and two-way active-row highlight
+- feat(swarm): granular per-block agent status from TurnPhase (working/tools/stopping/error/offline)
+- fix(container-agent): empty image fallback, skip empty meta, guard null blockId in swarm
+- feat(layout): fix floating-pane redock ghost-size mismatch (Phase 4b)
+- docs(readme): refresh tone + accuracy (first-class agents, multi-provider, one-shot CLIs, local-first)
+- ci: nightly Windows artifact build — portable ZIP + setup installer (Phase B of #1718)
+- refactor(reactive): rename PollerConfig fields to muxbus_* (ARCH-001; wire key unchanged)
+- fix(auth): Use existing login primary for Claude in failure banner; add Login via terminal fallback (CREATE_NEW_CONSOLE)
+
+
 ## 0.48.1 — 2026-06-22
 
 - feat(widgets): per-widget port override and widget.api HTTP proxy RPC

--- a/docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md
+++ b/docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md
@@ -1,0 +1,235 @@
+# AgentMux Context Analysis
+**Date:** 2026-06-19 | **Version:** v0.46.5
+
+---
+
+## 1. CLI Baseline (what `claude -p` uses before AgentMux adds anything)
+
+Measured in an empty directory, no CLAUDE.md, no MCP servers.
+Source: claudecodecamp.com system prompt teardown + GitHub issue #52979.
+
+| Component | Tokens | Controlled by |
+|---|---|---|
+| System prompt text (instructions, output rules, tone) | ~2,300–3,600 | Anthropic |
+| Built-in tool definitions (Bash, Edit, Read, Write, etc.) | ~14,000–17,600 | Anthropic |
+| Memory preamble (hardcoded instructional template for MEMORY.md) | ~11,300 | Anthropic |
+| **Total baseline** | **~27,000–32,000** | **Anthropic** |
+
+AgentMux has no access to and cannot modify any of this.
+
+The system prompt and tool definitions are cache-eligible. For OAuth subscription users
+the cache TTL is **1 hour** — so turns 2+ within a session pay ~10% of the baseline
+cost for these layers, not the full amount.
+
+---
+
+## 2. What AgentMux Adds
+
+| Component | Tokens | When |
+|---|---|---|
+| CLAUDE.md (default, no customization) | ~28 | Fresh session only |
+| CLAUDE.md (with soul + agentmd + memory + skills) | 28 – unbounded | Fresh session only |
+| Startup payload (identity + accounts + peers + checklist) | ~46–548 | Turn 1 of new session only |
+
+**AgentMux's direct addition to the baseline is ~28 tokens by default.**
+
+Both components are injected as **user messages**, not system prompt. They are part
+of the conversation history — sent once, then carried forward by `--resume`.
+
+The startup payload is the one item worth scrutiny: it is ~487 tokens at typical
+configuration, and the STARTUP verification checklist inside it forces a full
+agentic verification turn before the user gets any help (see §4).
+
+---
+
+## 3. How MEMORY.md Actually Works
+
+This section covers only verified facts from official docs and confirmed GitHub issues.
+
+### What it is
+
+Claude Code's native cross-session memory. Claude writes to it autonomously (build
+commands discovered, patterns noticed, mistakes to avoid). Users can also edit it
+directly.
+
+**Path:** `~/.claude/projects/<git-repo-root-hash>/memory/MEMORY.md`
+
+All worktrees of the same git repo share one memory directory.
+
+### When it loads
+
+MEMORY.md is injected **once at fresh session start** as a user message (same
+mechanism as CLAUDE.md — wrapped in `<system-reminder>` XML tags in the first user
+message of the session).
+
+**`--resume` does NOT re-inject MEMORY.md.** Source: official sessions docs —
+resume "reopens it under the same session ID and appends new messages." It is not
+a new session start. The MEMORY.md content from session start is already in
+conversation history and is replayed via `--resume` like any other message.
+
+**After `/compact`:** MEMORY.md is re-read from disk and re-injected. Compaction
+clears conversation history and re-loads all project context files.
+
+### Size limit
+
+The first **200 lines or 25KB** of MEMORY.md (whichever comes first) loads at
+session start. Content beyond this threshold is silently ignored. Topic files
+(`memory/debugging.md`, etc.) do **not** load at startup — only on demand.
+
+### The memory preamble bug
+
+Setting `autoMemoryEnabled: false` in `.claude/settings.json` suppresses Claude's
+write attempts but does **not** suppress the hardcoded memory preamble template.
+The ~11,300-token preamble (on Sonnet) is still injected at session start even
+when memory is disabled.
+
+Source: GitHub issue #63903 (open, 2026-05-30). Previous issue #44829 was closed
+as "not planned."
+
+This means: **there is currently no way to avoid the 11,300-token memory preamble.**
+It is Anthropic-controlled overhead, part of the ~27–32K baseline.
+
+### Disabling auto-memory writes
+
+```json
+// .claude/settings.json (project or user scope)
+{ "autoMemoryEnabled": false }
+```
+
+Or: `export CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`
+
+This stops Claude from writing new memories. It does not suppress the preamble.
+
+---
+
+## 4. The Interaction Between AgentMux and MEMORY.md
+
+### Two separate memory systems are running simultaneously
+
+| System | Writes | Loads | Path |
+|---|---|---|---|
+| CLI auto-memory | Claude decides autonomously | Fresh session + post-compact | `~/.claude/projects/<hash>/memory/MEMORY.md` |
+| AgentMux memory | AgentMux on agent definition save | Every spawn (reads CLAUDE.md from disk) | `<workdir>/CLAUDE.md` (memory section) |
+
+**These are additive.** Both are injected at session start. The same fact (e.g., "user
+prefers patch bumps") could end up in both, paying the token cost twice.
+
+### Does AgentMux's per-spawn model pick up CLAUDE.md changes mid-session?
+
+Unclear from documentation alone. The logical answer is **no**:
+
+- CLAUDE.md is injected as a user message on fresh session start
+- That message is stored in the JSONL transcript
+- `--resume` replays the transcript including the original CLAUDE.md injection
+- The CLI has no reason to re-read CLAUDE.md from disk on every `--resume` spawn
+
+If this is correct, memory written to CLAUDE.md by AgentMux mid-session is **not**
+visible to the agent until the next fresh session or after `/compact`. Needs
+verification by inspecting actual `claude -p --resume` behavior with a modified
+CLAUDE.md between spawns.
+
+### What this means for AgentMux memory strategy
+
+If the agent already "knows" the memory content from session start (it's in
+conversation history), writing it again into CLAUDE.md is redundant for the
+current session. CLAUDE.md memory's value is **cross-session persistence** only —
+so a fresh start or post-compact session picks up what was learned.
+
+---
+
+## 5. Context Window: Where It Actually Goes
+
+For a resumed session (turn N), the full API request contains:
+
+```
+[CACHED — 1hr TTL for OAuth users]
+  system prompt: ~27,000–32,000 tokens   ← Anthropic, not AgentMux
+    ↳ core instructions: ~2,300–3,600
+    ↳ tool definitions: ~14,000–17,600
+    ↳ memory preamble: ~11,300
+
+[IN CONVERSATION HISTORY — grows with session]
+  message 1 (synthetic, session start):
+    CLAUDE.md: ~28 tokens default         ← AgentMux writes, CLI injects
+    MEMORY.md: 0 → 200 lines max          ← CLI writes and injects
+  message 2 (turn 1):
+    AgentMux startup payload: ~487 tokens ← AgentMux, new sessions only
+    [agent's startup verification response if STARTUP checklist is set]
+  messages 3..N: all prior turns
+  message N+1: current user message
+```
+
+The dominant growing cost is **conversation history**, not any injection.
+At ~2,000 tokens per exchange, a 50-turn session adds ~100,000 tokens of history.
+The CLI auto-compacts when the window fills (~200K total), producing a summary at
+~12% of the original size.
+
+---
+
+## 6. Optimizations
+
+### P1 — Default startup to `__SKIP__`
+
+The STARTUP verification checklist (~317 tokens + ACTION REQUIRED directive) forces
+an agentic verification turn on every new session. For OAuth users this wastes a quota
+turn before the user gets any help. The `/startup` slash command already exists as the
+opt-in path.
+
+```js
+// scripts/gen-seed.js
+content: {
+    env: `AGENT_NAME=${d.id}\nAGENTMUX_AGENT_ID=${d.name}`,
+    startup: "__SKIP__",
+},
+```
+
+### P2 — Audit the two-memory situation
+
+Determine whether CLI auto-memory (`MEMORY.md`) and AgentMux memory (in `CLAUDE.md`)
+are accumulating duplicate facts. Options:
+
+- **Option A:** Disable CLI auto-memory via AgentMux's `.claude/settings.json` write
+  (`autoMemoryEnabled: false`) and let AgentMux own all memory. Downside: loses
+  Claude's autonomous memory writes; can't suppress the 11,300-token preamble anyway.
+- **Option B:** Let CLI auto-memory run and remove the `memory` section from AgentMux's
+  CLAUDE.md write. Let Claude write its own cross-session memory natively. Simpler.
+- **Option C:** Keep both, but scope them: CLI auto-memory for technical/task facts
+  (build commands, patterns); AgentMux memory for user-level preferences and
+  identity context.
+
+### P3 — Verify CLAUDE.md re-read behavior on `--resume`
+
+Confirm empirically whether `claude -p --resume <id>` re-reads CLAUDE.md from disk or
+uses the version already in conversation history. The answer determines whether
+mid-session memory writes in AgentMux are visible on the next turn.
+
+Test: write a sentinel string to CLAUDE.md after turn 1, then on turn 2 ask the agent
+what CLAUDE.md says. If it sees the sentinel, --resume re-reads from disk. If not, it
+uses history.
+
+### P4 — Add `--exclude-dynamic-system-prompt-sections`
+
+This CLI flag moves per-machine content (working directory, OS, git info) from the
+system prompt into the first user message. Designed for multi-user scripted workloads.
+Improves cache reuse when multiple machines run the same agent definition.
+
+Add to `agent_handlers.rs:3031` default CLI args.
+
+---
+
+## Sources
+
+All facts verified against primary sources:
+
+- [Claude Code memory docs](https://code.claude.com/docs/en/memory)
+- [Claude Code sessions docs](https://code.claude.com/docs/en/sessions)
+- [Claude Code how-it-works docs](https://code.claude.com/docs/en/how-claude-code-works)
+- [GitHub #63903 — autoMemoryEnabled=false doesn't suppress preamble](https://github.com/anthropics/claude-code/issues/63903)
+- [GitHub #52979 — 27–31K tokens for trivial prompts](https://github.com/anthropics/claude-code/issues/52979)
+- [GitHub #45188 — 70K token growth in 5 days](https://github.com/anthropics/claude-code/issues/45188)
+- [claudecodecamp.com — system prompt teardown](https://www.claudecodecamp.com/p/inside-claude-code-s-system-prompt)
+- [justacuriousengineer.substack.com — API traffic analysis](https://justacuriousengineer.substack.com/p/breaking-down-claude-codes-prompt)
+- `agentmux-srv/src/backend/agent_config.rs`
+- `agentmux-srv/src/backend/blockcontroller/subprocess.rs`
+- `frontend/app/view/agent/startup/buildStartupPayload.ts`
+- `agentmux-srv/agent-seed.json`

--- a/docs/handoff/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md
+++ b/docs/handoff/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md
@@ -1,0 +1,193 @@
+# Handoff — Memory/Identity Modal Redesign
+**Date:** 2026-06-19  
+**Branch:** `agenta/feat-memory-identity-modals`  
+**Head:** `c430bff1`  
+**Author:** AgentA  
+
+---
+
+## What was completed this session
+
+### PR #1584 — Global memory bundles (MERGED `d928b384`)
+Added `is_global` flag to memory bundles in the Trust Center. Bundles with `is_global=true` are injected into every agent's `CLAUDE.md` at launch. This is **Layer 1** of the two-layer memory model: human-defined rules/policies that Claude reads but doesn't write.
+
+### PR #1585 — Re-enable `autoMemoryEnabled` (MERGED `2c0ade87`)
+Reverted a prior `or_insert(json!(false))` in `agentmux-srv/src/backend/agent_config.rs` that was suppressing native memory writes. Research (GitHub issue #63903) confirmed the 11k-token preamble loads regardless — disabling writes had zero benefit. 
+
+**Key fix in `agentmux-srv/src/server/app_api.rs`** (`write_agent_config_files`): instead of disabling globally, we only disable `autoMemoryEnabled` for agents using the *shared* slug-based workdir (`~/.agentmux/agents/<slug>`), because concurrent MEMORY.md writes there risk corruption (GitHub issue #29051). Agents with an explicit `working_directory` (isolated dirs) keep writes enabled.
+
+### PR #1587 — Brain + id-card icons replace cog overlay (OPEN, awaiting bot reviews)
+**This is where you resume.** Phase 1 of `SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md`.
+
+---
+
+## PR #1587 — What changed
+
+### Deleted
+- `frontend/app/view/agent/components/AgentFocusedPanel.tsx`
+- `frontend/app/view/agent/components/AgentCardSettingsPanel.tsx`
+
+Both were the half-pane overlay system (cog → Agent/Identity tabs). Gone entirely.
+
+### Modified — `frontend/app/view/agent/agent-model.ts`
+- Removed `export type OverlayTab = "agent" | "identity"`
+- Removed `_setOverlayTab: ((tab: OverlayTab | null) => void) | null`
+- Removed `_lastOverlayTab: OverlayTab = "agent"`
+- Added `_openIdentityModal: (() => void) | null = null`
+- Added `_openMemoryModal: (() => void) | null = null`
+- `endIconButtons` now returns `["brain", "id-card"]` icons instead of single `"gear"`
+
+### Modified — `frontend/app/view/agent/agent-view.tsx`
+- Removed `import { AgentFocusedPanel }` (line was 69)
+- Added `import { useModalLayer } from "@/element/modal-layer"`
+- Removed `showOverlayTab` signal + `_setOverlayTab` mount/cleanup wiring
+- Added `useModalLayer()` call + wires `_openIdentityModal` and `_openMemoryModal` on mount/cleanup
+- Removed `<AgentFocusedPanel ...>` render block (was ~1011-1020)
+
+### Modified — `frontend/app/element/modal-layer.ts`
+Added to `ModalLayerRequest` union:
+```typescript
+| AgentIdentityRequest  // { kind: "agent-identity"; agent: AgentDefinition; blockId: string }
+| AgentMemoryRequest    // { kind: "agent-memory"; agentId: string; agentName: string; workingDirectory: string }
+```
+
+### Modified — `frontend/app/element/modal-dispatch.tsx`
+Added imports + cases for both new kinds. Dispatch:
+- `"agent-identity"` → `<AgentIdentityModalPanel agent blockId onClose={api.close} />`
+- `"agent-memory"` → `<AgentMemoryModalPanel agentName workingDirectory onClose={api.close} />`
+
+### New — `frontend/app/view/agent/components/AgentIdentityModal.tsx`
+Full implementation. Wraps `AgentIdentityPanel` with a "Done" button. `IdentityViewModel` instantiated with `(blockId, null as any)` — nodeModel is stored but never called in the constructor so null is safe. `handleAccountsUpdate` sends `UpdateAgentDefinitionCommand` with all existing agent fields + new `accounts`.
+
+### New — `frontend/app/view/agent/components/AgentMemoryModal.tsx`
+Phase 1 placeholder. Shows `previewMemoryPath(workingDirectory)` (client-side approximation of the sanitize algorithm: replace non-alphanumeric with `-`, truncate at 48 chars for display). Full browser in Phase 3.
+
+---
+
+## Architecture — Two-Layer Memory Model
+
+| Layer | Content | Written by | Where |
+|---|---|---|---|
+| 1 — Global bundles | Rules, policies, tool configs | Human (via Trust Center) | Injected into agent's `CLAUDE.md` at launch via `is_global` flag |
+| 2 — Native memory | Discovered facts, codebase patterns, session insights | Claude autonomously | `~/.claude/projects/<sanitized-workdir>/memory/` |
+
+**Path computation** (Claude Code `sessionStoragePortable.ts`):
+```
+sanitized = path.replace(/[^a-zA-Z0-9]/g, '-')
+if len <= 200: project_dir = sanitized
+else: project_dir = sanitized[0:200] + "-" + base36(djb2(path))
+```
+Windows example: `C:\Users\area54\agentmux-agents\parko-0617i` → `C--Users-area54--agentmux-agents-parko-0617i`
+
+**MEMORY.md** is the index file (auto-loaded every session, 200-line/25KB hard cap). Topic `.md` files have YAML frontmatter (`name`, `description`, `metadata.type: user|project|feedback|reference`) and are loaded on demand.
+
+---
+
+## What to do when you wake up
+
+### Step 1 — Merge PR #1587
+```bash
+gh api repos/agentmuxai/agentmux/pulls/1587/reviews \
+  --jq '.[] | "\(.user.login) [\(.state)]: \(.body[:120])"'
+```
+Read reagent review. Address any CHANGES_REQUESTED. Codex reviews on PR open — re-trigger with a5af PAT if it hasn't posted. Merge when reagent APPROVED on HEAD.
+
+### Step 2 — Phase 2: Rust backend RPCs
+New file: `agentmux-srv/src/server/native_memory_handlers.rs`
+
+Three handlers:
+```rust
+// NativeMemoryListCommand
+// Request: { agent_id: String }
+// Response: { files: Vec<NativeMemoryFileMeta> }
+// - Compute memory dir: get agent's working_directory, apply sanitize_claude_path(),
+//   append "/.claude/projects/<sanitized>/memory/"
+// - List *.md files; return empty vec (not error) if dir missing
+
+// NativeMemoryReadFileCommand  
+// Request: { agent_id: String, filename: String }
+// Response: { content: String }
+// - Reject filenames with path separators (no traversal)
+
+// NativeMemoryWriteFileCommand
+// Request: { agent_id: String, filename: String, content: String }
+// Response: {}
+// - Validate filename: only [a-zA-Z0-9_-] + ".md" suffix, no separators
+// - Create dir if needed; write atomically (write to .tmp then rename)
+```
+
+Rust sanitize helper (goes in `native_memory_handlers.rs` or a shared util):
+```rust
+fn sanitize_claude_path(path: &str) -> String {
+    let s: String = path.chars().map(|c| {
+        if c.is_ascii_alphanumeric() { c } else { '-' }
+    }).collect();
+    if s.len() <= 200 { return s; }
+    let h = djb2_base36(path);
+    format!("{}-{}", &s[..200], h)
+}
+
+fn djb2_base36(s: &str) -> String {
+    let mut h: i32 = 0;
+    for c in s.chars() {
+        h = h.wrapping_shl(5).wrapping_sub(h).wrapping_add(c as i32);
+    }
+    radix_n((h as i64).unsigned_abs(), 36)
+}
+```
+
+Register in `agentmux-srv/src/server/app_api.rs` alongside other handlers, then run type generation.
+
+### Step 3 — Phase 3: Full memory modal UI
+Replace the placeholder in `AgentMemoryModal.tsx` with a real two-column browser:
+- Left: file list (`MEMORY.md` + topic files, labeled by frontmatter `metadata.type`)
+- Right: read/edit view (textarea with Save/Cancel)
+- "New file" button → prompt filename → `NativeMemoryWriteFileCommand`
+- Empty state: "No memory files yet" + "Create MEMORY.md" button
+
+New class `AgentNativeMemoryModel` (same pattern as `MemoryViewModel`) with reactive atoms for files list, selected file, content, editing state, saving state, error state.
+
+### Step 4 — Phase 4: Polish
+- YAML frontmatter parsing for type labels
+- Resizable split pane in memory modal (~780px wide, per spec §5.4)
+- `[i]` tooltip on MEMORY.md: "Loaded into every new session"
+- Empty-state "Create MEMORY.md" scaffold
+
+---
+
+## Key file paths
+
+| File | Notes |
+|---|---|
+| `docs/specs/SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md` | Full spec; §4 = identity modal, §5 = memory modal, §7 = backend RPCs, §8 = frontend model, §9 = phases |
+| `frontend/app/element/modal-layer.ts` | `ModalLayerRequest` union — add new kinds here |
+| `frontend/app/element/modal-dispatch.tsx` | Add `requestLabel` + `renderRequest` cases here |
+| `frontend/app/view/agent/components/AgentIdentityModal.tsx` | NEW (Phase 1) — identity modal |
+| `frontend/app/view/agent/components/AgentMemoryModal.tsx` | NEW (Phase 1) — memory stub |
+| `frontend/app/view/agent/agent-model.ts` | `_openIdentityModal`, `_openMemoryModal` callbacks |
+| `frontend/app/view/agent/agent-view.tsx` | Wires modal callbacks; `<ModalLayer scope="pane">` at line ~103 |
+| `agentmux-srv/src/server/app_api.rs` | `write_agent_config_files` has the shared-workdir guard (~line 2297) |
+| `agentmux-srv/src/backend/agent_config.rs` | Global settings injected at launch; `autoMemoryEnabled` now NOT suppressed |
+
+---
+
+## PR / merge sequence to complete this feature
+
+| PR | Status | Content |
+|---|---|---|
+| #1584 | MERGED | Global memory bundles (`is_global` flag) |
+| #1585 | MERGED | Re-enable `autoMemoryEnabled` + shared-workdir guard |
+| #1587 | OPEN | Phase 1: brain+id-card icons + identity modal + memory stub |
+| TBD | not started | Phase 2: Rust native memory RPCs |
+| TBD | not started | Phase 3: Full memory modal UI |
+
+---
+
+## PR rules (from memory)
+
+- **Never push to main** — all changes via PR
+- **Read both reagent AND codex** before merging — `gh api repos/agentmuxai/agentmux/pulls/N/reviews` AND `gh api repos/agentmuxai/agentmux/issues/N/comments`
+- codex only auto-reviews on PR open; re-trigger with `@codex review` comment using the a5af PAT (see `reference_a5af_pat_path.md`)
+- reagent re-reviews on every push automatically
+- Merge when reagent APPROVED on HEAD; codex quota-limit is acceptable blocker to skip
+- `bump patch` before each build; use `scripts/bump-wrapper.sh` or sync package-lock.json after

--- a/docs/specs/SPEC_TRUST_CENTER_MODALS_IDENTITY_MEMORY_SEED_2026_06_19.md
+++ b/docs/specs/SPEC_TRUST_CENTER_MODALS_IDENTITY_MEMORY_SEED_2026_06_19.md
@@ -1,0 +1,401 @@
+# SPEC: Trust Center Centered Modals + Identity/Memory Seed
+
+**Date:** 2026-06-19  
+**Author:** AgentA  
+**Status:** Draft
+
+---
+
+## 1. Overview
+
+Three related initiatives shipped together:
+
+1. **Trust Center modal refactor** — detail views inside the Trust Center (BundleManagerModal) currently open as raw `position:fixed` overlays. Replace with proper centered `<Modal>` panels for focus trapping, backdrop, escape-key dismiss, and consistent chrome.
+
+2. **Identity seed** — one-time operation: create GitHub and AWS identity accounts for agent1–5, agentx, agenty and assign them. Credentials live in AWS Secrets Manager (`services/infra`). Idempotent — skips agents whose account slot is already populated.
+
+3. **Memory seed** — one-time operation: write claw template `.md` files into each agent's native memory folder (`~/.claude/projects/<sanitized-cwd>/memory/`). Source is the `a5af/claw` GitHub repo (`templates/` tree). Idempotent — skip files that already exist.
+
+---
+
+## 2. Trust Center Modal Refactor
+
+### 2.1 Current state
+
+`BundleManagerModal` (`frontend/app/modals/bundle-manager-modal.tsx`) is itself a `<Modal scope="window" size="xl">` (960 px). Inside it, three tab panels are always mounted and toggled via `is-hidden { display: none }`:
+- **AccountsManager** — left-nav + account list
+- **IdentityManager** — identity/bundle list
+- **MemoryManager** — memory bundle list
+
+When the user clicks an item, detail views open via:
+- **`accounts-chooser-overlay`** — `position: fixed; inset: 0` div rendered inside AccountsManager. No backdrop, no focus trap, no escape handler.
+- **AccountForm** — conditionally rendered inline inside AccountsManager, pushing content down.
+- **AgentMuxConnectPanel** — same fixed-overlay pattern as accounts-chooser.
+
+### 2.2 Target state
+
+Each detail view opens in a proper `<Modal>` centered on screen:
+
+| Trigger | Current | Target |
+|---|---|---|
+| Click account row | `accounts-chooser-overlay` fixed div | `openModal({ kind: "trust-center-account-detail", accountId })` |
+| "+ New account" | AccountForm inline expansion | `openModal({ kind: "trust-center-account-form", provider?, prefill? })` |
+| Click identity row | (identify exact pattern) | `openModal({ kind: "trust-center-identity-detail", bundleId })` |
+| Click memory row | (identify exact pattern) | `openModal({ kind: "trust-center-memory-detail", bundleId })` |
+| AgentMux connect | fixed overlay | `openModal({ kind: "trust-center-agentmux-connect" })` |
+
+All new kinds use `size="md"` (520 px) or `size="lg"` (720 px) depending on content. All are `scope="window"` so they stack above BundleManagerModal.
+
+### 2.3 Implementation — modal-layer.ts
+
+Add to `ModalLayerRequest` union in `frontend/app/element/modal-layer.ts`:
+
+```typescript
+| { kind: "trust-center-account-detail"; accountId: string }
+| { kind: "trust-center-account-form"; provider?: string; prefill?: Partial<IdentityAccount> }
+| { kind: "trust-center-identity-detail"; bundleId: string }
+| { kind: "trust-center-memory-detail"; bundleId: string }
+| { kind: "trust-center-agentmux-connect" }
+```
+
+### 2.4 Implementation — modal-dispatch.tsx
+
+Add `requestLabel` and `renderRequest` cases. Each case renders the matching panel component (extract from the existing inline JSX in `AccountsManager`, `IdentityManager`, `MemoryManager`). Panel receives `api.close()` as `onClose` prop.
+
+### 2.5 Implementation — AccountsManager refactor
+
+1. Remove the `accounts-chooser-overlay` `<div>` (and its `position: fixed` SCSS).
+2. Remove the inline `AccountForm` conditional render.
+3. Replace both with `openModal()` calls (import from `frontend/app/store/modalmodel.ts`).
+4. Extract `AccountDetailPanel` and `AccountFormPanel` as standalone panel components to `frontend/app/modals/trust-center/`.
+5. Repeat the same extraction for `AgentMuxConnectPanel`.
+
+### 2.6 SCSS
+
+New panel components use the standard modal fragment classes:
+- `.modal-panel-header` / `.modal-panel-title` / `.modal-panel-description`
+- `.modal-panel-body`
+- `.modal-panel-footer` (flex-end, border-top, subtle bg tint)
+- All CSS variables — no raw hex. Hard corners (`border-radius: 0`).
+
+Import new SCSS in `modal-dispatch.tsx` (same pattern as `AgentNewBundleModal.scss`).
+
+---
+
+## 3. Identity Seed
+
+### 3.1 Account model (DB)
+
+Table `db_identity_accounts`:
+
+| Column | Description |
+|---|---|
+| `id` | UUID (empty → server mints one) |
+| `provider` | `"github"` \| `"aws"` \| `"anthropic"` \| … |
+| `kind` | `"pat"` \| `"role"` \| `"api_key"` \| `"env_ref"` \| `"oauth"` |
+| `display_name` | Human label shown in Trust Center |
+| `secret_ref` | JSON — points backend to credential store |
+| `context` | JSON — provider-specific extras (profile name, region, etc.) |
+| `status` | `"unknown"` \| `"valid"` \| `"invalid"` |
+
+Per-agent assignment stored as JSON blob in `db_agent_definitions.accounts`:
+```json
+{ "github": "<acct-uuid>", "aws": "<acct-uuid>" }
+```
+
+### 3.2 Agent → account mapping
+
+| Agent | Display name | GitHub PAT secret | AWS profile | AWS account |
+|---|---|---|---|---|
+| agent1 | Agent1 GitHub | `services/infra → gh-token-agent1` | `Agent1` | `050544946291` |
+| agent2 | Agent2 GitHub | `services/infra → gh-token-agent2` | `Agent2` | `050544946291` |
+| agent3 | Agent3 GitHub | `services/infra → gh-token-agent3` | `Agent3` | `050544946291` |
+| agent4 | Agent4 GitHub | `services/infra → gh-token-agent4` | `Agent4` | `050544946291` |
+| agent5 | Agent5 GitHub | `services/infra → gh-token-agent5` | `Agent5` | `050544946291` |
+| agentx | AgentX GitHub | `services/infra → gh-token-agentx` | `AgentX` | `050544946291` |
+| agenty | AgentY GitHub | `services/infra → gh-token-agenty` | `AgentY` | `050544946291` |
+
+**GitHub account `secret_ref`:**
+```json
+{
+  "backend": "secrets_manager",
+  "sm_path": "services/infra",
+  "sm_json_path": "gh-token-agent1"
+}
+```
+
+**AWS account `secret_ref`** (named profile — credentials already on disk):
+```json
+{
+  "backend": "env_ref",
+  "env_var": "AWS_PROFILE"
+}
+```
+**AWS account `context`** (profile name + region):
+```json
+{
+  "profile": "Agent1",
+  "region": "us-east-1",
+  "account_id": "050544946291"
+}
+```
+
+### 3.3 GitHub App accounts (optional, Phase 2)
+
+Each agent also has a GitHub App identity (`agent1-workflow`, etc.) for Layer 1 access. Credentials stored at `services/infra → agent-configs.<agentname>` (JSON with `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`) and `services/infra → <agentname>-workflow-key` (PEM). These are higher-privilege and can be added as a second `provider="github"` account per agent with `kind="role"` and `context: { "layer": 1, "app_id": "...", "installation_id": "..." }`.
+
+### 3.4 Implementation options
+
+**Option A — Frontend seed script (recommended for one-time)**
+
+A TypeScript script at `scripts/seed-identities.ts` (run via `npx tsx scripts/seed-identities.ts`):
+
+```typescript
+// Pseudocode
+const AGENTS = [
+  { name: "agent1", githubSecretKey: "gh-token-agent1", awsProfile: "Agent1" },
+  // ...agent2-5, agentx, agenty
+];
+
+for (const agent of AGENTS) {
+  // 1. Find agent by name (GET agent definitions, filter by name)
+  const agentDef = await rpc("listagents").then(r => r.find(a => a.name === agent.name));
+  if (!agentDef) { console.warn(`Agent ${agent.name} not found — skipping`); continue; }
+
+  // 2. Skip if already has github + aws assigned
+  const existing = JSON.parse(agentDef.accounts || "{}");
+  if (existing.github && existing.aws) { console.log(`${agent.name} already seeded`); continue; }
+
+  // 3. Create GitHub account
+  const ghAcct = await rpc("upsertidentityaccount", {
+    id: "", provider: "github", kind: "pat",
+    display_name: `${agent.name} GitHub`,
+    secret_ref: JSON.stringify({ backend: "secrets_manager", sm_path: "services/infra", sm_json_path: agent.githubSecretKey }),
+    context: "{}",
+  });
+
+  // 4. Create AWS account
+  const awsAcct = await rpc("upsertidentityaccount", {
+    id: "", provider: "aws", kind: "role",
+    display_name: `${agent.name} AWS`,
+    secret_ref: JSON.stringify({ backend: "env_ref", env_var: "AWS_PROFILE" }),
+    context: JSON.stringify({ profile: agent.awsProfile, region: "us-east-1", account_id: "050544946291" }),
+  });
+
+  // 5. Assign to agent
+  await rpc("updateagent", {
+    ...agentDef,
+    accounts: JSON.stringify({ github: ghAcct.id, aws: awsAcct.id }),
+  });
+
+  console.log(`✓ ${agent.name} seeded`);
+}
+```
+
+**Option B — Rust seed extension**
+
+Extend `agent_seed.rs` `SeedAgent` struct with `seed_accounts: Vec<SeedAccount>`. Called only when `seed_version` < threshold. More integrated but requires Rust rebuild.
+
+**Option C — Trust Center one-shot button**
+
+Add a "Seed from claw" button in the Trust Center (developer/admin-only, gated behind a feature flag or dev-mode check). Calls the same RPC sequence. Visible only when no agents have accounts assigned.
+
+**Recommendation:** Option A for immediate use (run once, no rebuild). Option C for ongoing operational use (re-seedable from UI without CLI access).
+
+### 3.5 RPC wire details
+
+```typescript
+// upsertidentityaccount
+type UpsertIdentityAccountCommand = {
+  id: string;            // empty = create new, uuid = update
+  name: string;
+  provider: string;
+  kind: string;
+  display_name: string;
+  secret_ref: string;    // JSON string
+  context: string;       // JSON string
+};
+
+// updateagent — pass full current agentDef spread + new accounts field
+// accounts: JSON.stringify({ github: "<uuid>", aws: "<uuid>" })
+```
+
+---
+
+## 4. Memory Seed
+
+### 4.1 Architecture note
+
+Native memory lives at:
+```
+~/.claude/projects/<sanitized-working-dir>/memory/<filename>.md
+```
+Path computed by `memory_dir_for_cwd(agent.working_directory)` — same algorithm in Rust and JS. **Agents must have `working_directory` set** for the path to resolve to something agent-specific. If empty, `agent:memory:write_file` returns an error.
+
+### 4.2 Source files (a5af/claw)
+
+Fetch from GitHub API: `gh api repos/a5af/claw/contents/<path>` (content is base64-encoded).
+
+| claw path | Target filename | Applies to |
+|---|---|---|
+| `templates/CLAUDE.md` | `CLAUDE.md` | All agents |
+| `templates/CRITICAL_RULES.md` | `CRITICAL_RULES.md` | All agents |
+| `templates/host/CLAUDE.md` | `CLAUDE-host.md` | agentx, agenty |
+| `templates/container/CLAUDE.md` | `CLAUDE-container.md` | agent1–5 |
+| `templates/host/STARTUP_PROMPT.md` | `STARTUP_PROMPT.md` | agentx, agenty |
+| `templates/container/STARTUP_PROMPT.md` | `STARTUP_PROMPT.md` | agent1–5 |
+| `templates/CLAUDE_CONTAINER.md` | `CLAUDE_CONTAINER.md` | agent1–5 |
+| `templates/skills/aws-setup.md` | `skills-aws-setup.md` | All agents |
+| `templates/skills/github-layers.md` | `skills-github-layers.md` | All agents |
+| `templates/skills/mcp-servers.md` | `skills-mcp-servers.md` | All agents |
+| `templates/skills/git-workflow.md` | `skills-git-workflow.md` | All agents |
+
+### 4.3 Frontmatter strategy
+
+The claw templates have no YAML frontmatter. Prepend minimal frontmatter before writing:
+
+```markdown
+---
+name: claude-identity
+description: Agent identity, rules, and collaboration guidelines
+metadata:
+  type: user
+---
+
+<original file content>
+```
+
+Map claw files to frontmatter `type`:
+- `CLAUDE.md`, `CLAUDE-host.md`, `CLAUDE-container.md`, `CLAUDE_CONTAINER.md` → `type: user`
+- `CRITICAL_RULES.md` → `type: user`
+- `STARTUP_PROMPT.md` → `type: reference`
+- `skills-*.md` → `type: reference`
+
+The `name` slug = filename stem (e.g. `CLAUDE` → `claude`, `CRITICAL_RULES` → `critical-rules`).
+
+### 4.4 Implementation
+
+Script at `scripts/seed-memories.ts` (run once via `npx tsx scripts/seed-memories.ts`):
+
+```typescript
+// Pseudocode
+const CLAW_FILES = [
+  { clawPath: "templates/CLAUDE.md", filename: "CLAUDE.md", agents: ALL, type: "user", name: "claude-identity" },
+  { clawPath: "templates/CRITICAL_RULES.md", filename: "CRITICAL_RULES.md", agents: ALL, type: "user", name: "critical-rules" },
+  { clawPath: "templates/host/CLAUDE.md", filename: "CLAUDE-host.md", agents: HOST, type: "user", name: "claude-host" },
+  // ...
+];
+
+// Fetch all files from GitHub first
+const contents = await Promise.all(
+  CLAW_FILES.map(f => fetchClawFile(f.clawPath))
+);
+
+// Write per agent
+for (const agentDef of agentDefs) {
+  if (!agentDef.working_directory) {
+    console.warn(`${agentDef.name}: no working_directory — skipping memory seed`);
+    continue;
+  }
+
+  // First list existing files to skip already-seeded ones
+  const existing = await rpc("agent:memory:list", { agent_id: agentDef.id });
+  const existingNames = new Set(existing.files.map(f => f.filename));
+
+  for (const [i, f] of CLAW_FILES.entries()) {
+    if (!f.agents.includes(agentDef.name)) continue;
+    if (existingNames.has(f.filename)) { console.log(`skip ${agentDef.name}/${f.filename}`); continue; }
+
+    const body = addFrontmatter(contents[i], f);
+    await rpc("agent:memory:write_file", {
+      agent_id: agentDef.id,
+      filename: f.filename,
+      content: body,
+    });
+    console.log(`✓ ${agentDef.name}/${f.filename}`);
+  }
+}
+
+function addFrontmatter(content: string, f: ClawFile): string {
+  const slug = f.filename.replace(/\.md$/, "").toLowerCase().replace(/_/g, "-");
+  return `---\nname: ${slug}\ndescription: ${f.description}\nmetadata:\n  type: ${f.type}\n---\n\n${content}`;
+}
+```
+
+### 4.5 Working directory prerequisites
+
+Memory seeding is a no-op for agents without `working_directory`. Before running the seed:
+- agentx: set `working_directory` to `C:\Users\<user>\.claw\agentx-workspace` (or confirm it's already set)
+- agenty: `C:\Users\<user>\.claw\agenty-workspace`
+- agent1–5: set to the agent's container workspace root OR the host-side workspace mount (e.g. `C:\Users\<user>\.claw\workspaces\agent1`)
+
+Memory is written to the **host filesystem** in all cases (via `memory_dir_for_cwd`) — it doesn't matter if the agent is a container or host agent from the path-resolution standpoint.
+
+---
+
+## 5. Phase Breakdown
+
+### Phase T1 — Trust Center: Account detail modal (1 PR)
+- Extract `AccountDetailPanel` from inline AccountsManager render
+- Add `trust-center-account-detail` kind to modal-layer
+- Remove `accounts-chooser-overlay` fixed div
+- Wire `openModal()` call on row click
+- SCSS for `AccountDetailPanel`
+
+### Phase T2 — Trust Center: Account form + AgentMux connect (1 PR)
+- Extract `AccountFormPanel` and `AgentMuxConnectPanel`
+- Add `trust-center-account-form` and `trust-center-agentmux-connect` kinds
+- Remove inline AccountForm expansion
+- Wire modals
+
+### Phase T3 — Trust Center: Identity + Memory detail modals (1 PR)
+- Same pattern for IdentityManager and MemoryManager detail views
+- Add `trust-center-identity-detail` and `trust-center-memory-detail` kinds
+
+### Phase S1 — Identity seed script (1 script, no PR needed)
+- `scripts/seed-identities.ts`
+- Idempotent: check existing accounts before creating
+- Confirm with user before write (`--dry-run` flag)
+- Run: `npx tsx scripts/seed-identities.ts`
+
+### Phase S2 — Memory seed script (1 script, no PR needed)
+- `scripts/seed-memories.ts`
+- Fetches from `a5af/claw` via `gh api`
+- Adds frontmatter
+- Idempotent: skips existing files
+- Run: `npx tsx scripts/seed-memories.ts`
+
+### Phase S3 — Trust Center "Seed from claw" button (optional, 1 PR)
+- Surfaced in Trust Center dev panel or admin section
+- Runs identity + memory seed logic inline (same RPCs)
+- Gated: visible only in dev mode or when env `AGENTMUX_SEED_UI=1`
+
+---
+
+## 6. Open Questions
+
+1. **Trust Center tab panels always mounted** — toggling via `is-hidden` means all three managers are mounted simultaneously. Should the modal refactor also switch them to lazy-mount (unmount on hide, remount on show)? Lazy-mount reduces DOM but loses unsaved form state. Recommend: keep always-mounted for now, flag as a follow-up.
+
+2. **GitHub App accounts** (Phase 2 of identity seed) — do we want Layer 1 (App) accounts seeded alongside Layer 2 (PAT) accounts? Adds complexity: need to pull `GITHUB_APP_ID` and `GITHUB_APP_INSTALLATION_ID` from `services/infra → agent-configs.<agentname>`. Defer unless needed.
+
+3. **agenty PAT path** — `gh-token-agenty` doesn't appear in the confirmed Secrets Manager key list (only `gh-token-agent1` through `gh-token-agent5` and `gh-token-agentx` confirmed). Verify before seeding.
+
+4. **Memory working_directory** — agent1–5 may be container agents with a Linux working_directory (e.g. `/workspace`). The memory path computed on the host would be `~/.claude/projects/-workspace/memory/` which may conflict if multiple container agents use `/workspace`. Clarify whether each container agent has a distinct host-side workspace path or a container-internal Linux path.
+
+5. **`--dry-run` flag** — seed scripts should print what they would do without writing. Implement for safety.
+
+---
+
+## 7. File Index
+
+| File | Role |
+|---|---|
+| `frontend/app/modals/bundle-manager-modal.tsx` | Trust Center root — contains AccountsManager, IdentityManager, MemoryManager |
+| `frontend/app/element/modal-layer.ts` | `ModalLayerRequest` union — add new kinds here |
+| `frontend/app/element/modal-dispatch.tsx` | `requestLabel` + `renderRequest` switch — add cases here |
+| `frontend/app/modals/trust-center/` | New dir for extracted panel components |
+| `agentmux-srv/src/backend/storage/identities.rs` | Identity CRUD (Rust) |
+| `agentmux-srv/src/server/native_memory_handlers.rs` | Memory RPCs (Rust, complete) |
+| `scripts/seed-identities.ts` | One-time identity seed (new) |
+| `scripts/seed-memories.ts` | One-time memory seed (new) |
+| `a5af/claw` | Source for memory template `.md` files |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.48.1",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Release v0.49.0

Consumes 28 changesets. Highlights:

**Auth**
- `seedGlobalLogin` is the primary Claude pre-launch CTA (`PreLaunchAuthPanel` shows "🌐 Use my existing login" instead of OAuth connect)
- In-agent failure banner: "Use existing login" is now primary for Claude; "Login via terminal" (`CREATE_NEW_CONSOLE`) replaces the broken PTY "Login Again" and polls for creds after the browser completes
- Token redaction for `sk-ant-*` credentials in PTY log lines

**CI**
- All test/build workflows moved to nightly (no per-PR CI)
- `ci-nightly-artifacts.yml`: produces Windows portable ZIP + setup installer daily and on-demand

**Agent pane**
- Busy bar fixes (size, reduced-motion marching ants, freeze on macOS)
- Tool renderers: WebFetch content view fix, WebSearch JSON fix
- Tool log: collapse consecutive spinner frames

**Swarm**
- Agent pane visibility; click-to-focus; active-row sync
- Granular per-block agent status from TurnPhase

**Layout / floaters**
- Redock ghost-size mismatch fix (Phase 4b)
- Typed floater BrowserKind floaters excluded from lifecycle count

**Other**
- Memory: `agent_def::get_global_registry` fallback for automemory
- macOS: remove AlertNotificationService helper; disable GPU process in dev mode
- Container agent: empty-image fallback / skip empty meta guard

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->