### PR TITLE
perf(layout): remove 50ms debounce on window resize — live HWND tracking

### DIFF
--- a/.changesets/1782240141-perf-layout-remove-50ms-debounce-on-container-resize-hwnd-st-w68r.md
+++ b/.changesets/1782240141-perf-layout-remove-50ms-debounce-on-container-resize-hwnd-st-w68r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(layout): remove 50ms debounce on container resize — HWND stays in sync during window resize

--- a/frontend/layout/lib/layoutModelHooks.ts
+++ b/frontend/layout/lib/layoutModelHooks.ts
@@ -66,7 +66,7 @@ export function useTileLayout(tabAtom: () => Tab, tileContent: TileLayoutContent
     tabAtom();
     const layoutModel = useLayoutModel(tabAtom);
 
-    useOnResize(layoutModel?.displayContainerRef, layoutModel?.onContainerResize, 50);
+    useOnResize(layoutModel?.displayContainerRef, layoutModel?.onContainerResize);
 
     // Once the TileLayout is mounted, re-run the state update to get all nodes to flow into the layout.
     onMount(() => fireAndForget(() => layoutModel.onTreeStateAtomUpdated(true)));


### PR DESCRIPTION
## Summary

- The 50ms trailing debounce on `useOnResize` for `onContainerResize` caused native browser pane HWNDs to freeze for the entire drag and snap to the final position ~50ms after the user stopped resizing the window. This made the REFLOW_WINDOW_MS reduction in #1699 (32ms → 4ms) invisible on the window-resize path.
- Root cause traced: 50ms debounce → delayed `updateTree()` → delayed placeholder rect update → delayed `browser_pane_resize` IPC. All downstream steps were already instant.
- Fix: drop the debounce (`debounceMs = null`, the default), so `onContainerResize` fires per animation frame via ResizeObserver's own batching — same rate as the splitter-drag path (`onResizeMove` calls `updateTree()` every `mousemove`).

## Test plan

- [ ] Resize the window by dragging the edge — panes should track the window edge at native frame rate with no trailing snap
- [ ] Pane open/close/split still works (different path: `notifyPaneReflow` / `paneReflowActive`, unaffected)
- [ ] Splitter drag still works (`onResizeMove`, unaffected)

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID} -->