### PR TITLE
refactor(reactive): rename MuxBus poller wire keys agentmux_* -> muxbus_* (ARCH-001)

### DIFF
--- a/.changesets/1782240326-refactor-reactive-rename-muxbus-poller-wire-keys-agentmux-mu-dmfq.md
+++ b/.changesets/1782240326-refactor-reactive-rename-muxbus-poller-wire-keys-agentmux-mu-dmfq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(reactive): rename MuxBus poller wire keys agentmux_* -> muxbus_* (ARCH-001)

--- a/agentmux-srv/src/backend/reactive/mod.rs
+++ b/agentmux-srv/src/backend/reactive/mod.rs
@@ -43,7 +43,7 @@ pub use handler::{get_global_handler, Handler, ReactiveHandler};
 pub use poller::Poller;
 #[allow(unused_imports)]
 pub use sanitize::{
-    format_injected_message, sanitize_message, validate_agent_id, validate_agentmux_url,
+    format_injected_message, sanitize_message, validate_agent_id, validate_muxbus_url,
 };
 #[allow(unused_imports)]
 pub use types::*;

--- a/agentmux-srv/src/backend/reactive/sanitize.rs
+++ b/agentmux-srv/src/backend/reactive/sanitize.rs
@@ -146,7 +146,7 @@ pub fn format_injected_message(msg: &str, source_agent: Option<&str>, include_so
 ///
 /// Only allows https:// or http://localhost/127.0.0.1/::1.
 #[allow(dead_code)]
-pub fn validate_agentmux_url(url_str: &str) -> Result<(), String> {
+pub fn validate_muxbus_url(url_str: &str) -> Result<(), String> {
     if url_str.is_empty() {
         return Err("URL is empty".to_string());
     }

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -98,35 +98,35 @@ fn test_validate_agent_id_max_length() {
 
 #[test]
 fn test_validate_url_https() {
-    assert!(validate_agentmux_url("https://agentmux.example.com/api").is_ok());
+    assert!(validate_muxbus_url("https://agentmux.example.com/api").is_ok());
 }
 
 #[test]
 fn test_validate_url_http_localhost() {
-    assert!(validate_agentmux_url("http://localhost:8080/api").is_ok());
-    assert!(validate_agentmux_url("http://127.0.0.1:8080/api").is_ok());
-    assert!(validate_agentmux_url("http://[::1]:8080/api").is_ok());
+    assert!(validate_muxbus_url("http://localhost:8080/api").is_ok());
+    assert!(validate_muxbus_url("http://127.0.0.1:8080/api").is_ok());
+    assert!(validate_muxbus_url("http://[::1]:8080/api").is_ok());
 }
 
 #[test]
 fn test_validate_url_http_remote_rejected() {
-    assert!(validate_agentmux_url("http://evil.com/api").is_err());
+    assert!(validate_muxbus_url("http://evil.com/api").is_err());
 }
 
 #[test]
 fn test_validate_url_bad_scheme() {
-    assert!(validate_agentmux_url("ftp://example.com").is_err());
-    assert!(validate_agentmux_url("file:///etc/passwd").is_err());
+    assert!(validate_muxbus_url("ftp://example.com").is_err());
+    assert!(validate_muxbus_url("file:///etc/passwd").is_err());
 }
 
 #[test]
 fn test_validate_url_empty() {
-    assert!(validate_agentmux_url("").is_err());
+    assert!(validate_muxbus_url("").is_err());
 }
 
 #[test]
 fn test_validate_url_no_scheme() {
-    assert!(validate_agentmux_url("example.com/api").is_err());
+    assert!(validate_muxbus_url("example.com/api").is_err());
 }
 
 // -- Format injected message tests --

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -70,13 +70,12 @@ pub struct AuditLogEntry {
 /// Poller configuration for AgentMux cloud service.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PollerConfig {
-    // ARCH-001: the Rust identifier is `muxbus_*`; the wire key stays
-    // `agentmux_url`/`agentmux_token` (the cloud poller protocol rename is a
-    // separate, coordinated phase) and `muxbus_*` is accepted as a forward-
-    // compat alias on input.
-    #[serde(rename = "agentmux_url", alias = "muxbus_url", default, skip_serializing_if = "Option::is_none")]
+    // ARCH-001: the wire key is now `muxbus_url`/`muxbus_token` (matches the
+    // Rust identifier). The legacy `agentmux_*` keys are still accepted as a
+    // back-compat deserialize alias on input.
+    #[serde(rename = "muxbus_url", alias = "agentmux_url", default, skip_serializing_if = "Option::is_none")]
     pub muxbus_url: Option<String>,
-    #[serde(rename = "agentmux_token", alias = "muxbus_token", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "muxbus_token", alias = "agentmux_token", default, skip_serializing_if = "Option::is_none")]
     pub muxbus_token: Option<String>,
     #[serde(default)]
     pub poll_interval_secs: u64,

--- a/frontend/app/view/term/termosc.ts
+++ b/frontend/app/view/term/termosc.ts
@@ -184,7 +184,7 @@ type Osc16162Command =
     | { command: "I"; data: { inputempty?: boolean } }
     | { command: "R"; data: {} }
     | { command: "E"; data: { [key: string]: string } }
-    | { command: "X"; data: { agentmux_url?: string; agentmux_token?: string } };
+    | { command: "X"; data: { muxbus_url?: string; muxbus_token?: string } };
 
 export function handleOsc16162Command(data: string, blockId: string, loaded: boolean, terminal: Terminal): boolean {
     if (!loaded) {
@@ -299,8 +299,8 @@ export function handleOsc16162Command(data: string, blockId: string, loaded: boo
                         method: "POST",
                         headers,
                         body: JSON.stringify({
-                            agentmux_url: cmd.data.agentmux_url || "",
-                            agentmux_token: cmd.data.agentmux_token || "",
+                            muxbus_url: cmd.data.muxbus_url || "",
+                            muxbus_token: cmd.data.muxbus_token || "",
                         }),
                     });
                     if (!response.ok) {


### PR DESCRIPTION
Flip the cloud-poller wire to muxbus: OSC keys (termosc.ts) + PollerConfig serde primary key → muxbus_url/muxbus_token (agentmux_* kept as deserialize alias). Rename validate_agentmux_url → validate_muxbus_url. /agentmux/reactive/* endpoint paths unchanged (app prefix). cargo check + frontend build pass.

<!-- agentmux:agent_id=agentc -->