### PR TITLE
perf(layout): remove 50ms debounce on window resize — live HWND tracking

### DIFF
--- a/.changesets/1782240141-perf-layout-remove-50ms-debounce-on-container-resize-hwnd-st-w68r.md
+++ b/.changesets/1782240141-perf-layout-remove-50ms-debounce-on-container-resize-hwnd-st-w68r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(layout): remove 50ms debounce on container resize — HWND stays in sync during window resize

--- a/frontend/layout/lib/layoutModelHooks.ts
+++ b/frontend/layout/lib/layoutModelHooks.ts
@@ -66,7 +66,7 @@ export function useTileLayout(tabAtom: () => Tab, tileContent: TileLayoutContent
     tabAtom();
     const layoutModel = useLayoutModel(tabAtom);
 
-    useOnResize(layoutModel?.displayContainerRef, layoutModel?.onContainerResize, 50);
+    useOnResize(layoutModel?.displayContainerRef, layoutModel?.onContainerResize);
 
     // Once the TileLayout is mounted, re-run the state update to get all nodes to flow into the layout.
     onMount(() => fireAndForget(() => layoutModel.onTreeStateAtomUpdated(true)));


### PR DESCRIPTION
## Summary

- Removes the 50ms trailing debounce from `useOnResize` on `displayContainerRef` in `useTileLayout` (`layoutModelHooks.ts:69`)
- `updateTree()` now fires on every ResizeObserver entry (≤1/frame, browser-batched) instead of once 50ms after the user stops dragging
- All downstream steps — placeholder rect update → browser pane ResizeObserver → `syncPosition()` → `browser_pane_resize` IPC — were already instant; the debounce was the sole latency source

## Why this is safe

ResizeObserver callbacks are already batched to once per animation frame by the browser, so removing the manual debounce doesn't amplify work — `onContainerResize` runs at most once per frame, the same cadence as `onResizeMove` during splitter drags (which has never had a debounce and has been fine).

## Test plan

- [ ] Resize the main window — pane borders should track the window edge in real time with no perceptible lag
- [ ] Splitter drag still works correctly
- [ ] Pane open/close/split still animates correctly
- [ ] No jank or runaway re-render under sustained resize

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-clamk} -->