### PR TITLE
fix(auth): inline agent_error Login Again uses seedGlobalLogin for Claude

### DIFF
--- a/.changesets/1782257397-fix-auth-inline-agent-error-login-again-uses-seedgloballogin-vheu.md
+++ b/.changesets/1782257397-fix-auth-inline-agent-error-login-again-uses-seedgloballogin-vheu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): inline agent_error Login Again uses seedGlobalLogin for Claude (not relogin PTY)

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1067,8 +1067,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 authProviderId={provider()?.id ?? providerKey()}
                 onSubagentClick={handleSubagentClick}
                 onAgentErrorLogin={() => {
-                    log("auth", "Login Again (inline error node) — forcing a fresh provider login");
-                    void status.relogin();
+                    if (provider()?.id === "claude") {
+                        log("auth", "Use existing login (inline error node) — seeding from global Claude login");
+                        void status.useGlobalLogin();
+                    } else {
+                        log("auth", "Login Again (inline error node) — forcing a fresh provider login");
+                        void status.relogin();
+                    }
                 }}
                 onLoadOlder={history.loadOlder}
                 loadingOlder={history.loadingOlder}


### PR DESCRIPTION
The inline `agent_error` node (HTTP 401/403 from Claude API mid-turn) surfaced a "Login Again →" button that called `relogin()` → `forceProviderLogin` → PTY spawn → hangs silently for 15s on Claude v2.1.x (the CLI login TUI is headless, browser never opens).

For Claude specifically, route `onAgentErrorLogin` to `useGlobalLogin()` (seed-from-global) instead — same fix as the failure banner in #1732 but for the inline error path that was missed.

Non-Claude providers keep the existing `relogin()` path.

Follow-up to #1732.

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->