### PR TITLE
fix(composer): ArrowUp/Down respects soft-wrapped visual lines

### DIFF
--- a/.changesets/1782259316-fix-composer-use-mirror-div-for-visual-line-detection-in-arr-nnsq.md
+++ b/.changesets/1782259316-fix-composer-use-mirror-div-for-visual-line-detection-in-arr-nnsq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(composer): use mirror-div for visual line detection in ArrowUp/Down history nav

--- a/docs/retros/RETRO_COMPOSER_ARROWKEY_HISTORY_SOFT_WRAP_2026_06_23.md
+++ b/docs/retros/RETRO_COMPOSER_ARROWKEY_HISTORY_SOFT_WRAP_2026_06_23.md
@@ -1,0 +1,146 @@
+# Retro: Composer Arrow-Key History Navigation Breaks on Soft-Wrapped Input
+
+**Date:** 2026-06-23  
+**Component:** `AgentFooter` — sent-message history recall (ArrowUp / ArrowDown)  
+**Severity:** UX regression — medium (affects any multi-line message typed without explicit newlines)  
+**Status:** Fixed
+
+---
+
+## What Happened
+
+When a user typed a long message that visually wrapped to 2+ lines in the agent
+pane composer (without pressing Enter/Shift+Enter — i.e. no `\n` in the text),
+pressing ArrowUp at any visual position would immediately replace the composer
+content with the previous sent message.
+
+Expected: ArrowUp moves the cursor up one visual line within the current text;
+only when the cursor is already on the first visual line does it navigate to the
+previous sent message.
+
+---
+
+## Root Cause
+
+`AgentFooter.tsx` computed "cursor is on first line" as:
+
+```typescript
+const caretOnFirstLine = !textareaRef.value.slice(0, textareaRef.selectionStart).includes("\n");
+```
+
+This checks whether there is a physical newline character (`\n`) anywhere before
+the cursor. For soft-wrapped text — a single paragraph that the browser word-wraps
+visually into multiple rows — there are no `\n` characters, so the check always
+returns `true`. The textarea thought the cursor was permanently on "the first
+line" regardless of where the user had navigated within a visually multi-line
+message.
+
+The same bug existed in the symmetric `caretOnLastLine` check, meaning ArrowDown
+on a soft-wrapped message that had no trailing `\n` would also immediately jump
+forward to the next history entry instead of moving down one visual row.
+
+### Why the original code appeared to work
+
+For the most common case — a user pressing ArrowUp on an **empty** composer, or
+on a single-line message — the check is correct: no `\n` before the cursor, Y
+position is 0, cursor is on the first line. The bug only surfaces when the
+composer has a paragraph long enough to soft-wrap.
+
+---
+
+## The Fix
+
+Replaced the `\n` scan with a visual-line measurement using a temporary mirror
+div that replicates the textarea's CSS layout:
+
+```typescript
+function caretVisualEdge(ta: HTMLTextAreaElement): { first: boolean; last: boolean } {
+    const pos = ta.selectionStart;
+    const val = ta.value;
+    const needsFirst = !val.slice(0, pos).includes("\n");
+    const needsLast  = !val.slice(pos).includes("\n");
+    // Fast path: physical newlines settle it without DOM measurement.
+    if (!needsFirst && !needsLast) return { first: false, last: false };
+
+    // Mirror div replicates textarea layout so the browser word-wraps
+    // text identically. The zero-width-space span marks the caret position;
+    // its offsetTop is the visual line's Y offset within the content area.
+    const cs = window.getComputedStyle(ta);
+    const baseCss = /* ... copy font, padding, width, white-space:pre-wrap ... */;
+    const measureY = (text: string): number => { /* ... */ };
+
+    const caretY = measureY(val.slice(0, pos));
+    return {
+        first: needsFirst && caretY <= measureY(""),      // Y matches line 0
+        last:  needsLast  && caretY >= measureY(val),     // Y matches last line
+    };
+}
+```
+
+**Key design decisions:**
+- `\n` fast-path: avoids any DOM mutation when the answer is already known from
+  character data (physical newlines). The mirror-div path only runs for single-
+  paragraph (no-`\n`) text that might soft-wrap.
+- Compare caretY to `measureY("")` (the baseline Y at the start of content —
+  equivalent to `paddingTop`) rather than `=== 0`, so the check is
+  padding-agnostic.
+- Compare caretY to `measureY(val)` (Y at end of text) for last-line detection,
+  using `>=` for floating-point safety.
+- At most 3 DOM elements are created and immediately removed per ArrowUp/ArrowDown
+  event. Cost is negligible at human typing rates.
+
+---
+
+## Best Practices
+
+### For textarea keyboard navigation with history
+
+1. **Never use character-counting alone to infer visual line position.** A
+   `<textarea>` breaks lines both at `\n` characters AND at word-wrap boundaries
+   (CSS `white-space: pre-wrap; word-wrap: break-word`). A string with no `\n`
+   can still span 10 visual rows if it is long enough.
+
+2. **Use the mirror-div technique for visual caret position in textareas.**  
+   `window.getSelection()` and `Range.getClientRects()` do not work on `<textarea>`
+   elements — they only work on `contenteditable`. The mirror-div approach is the
+   industry-standard alternative: clone the textarea's CSS into a `position:absolute`
+   `div`, insert the text up to the caret position as `textContent`, append a
+   zero-width-space `<span>` as the caret marker, and read `span.offsetTop`.
+
+3. **Prefer `contenteditable` for rich chat inputs if multi-line editing matters.**
+   `<textarea>` was designed for plain-text forms. Rich editors (Slack, Discord,
+   Linear) use `contenteditable` or a headless ProseMirror/Lexical instance
+   because `window.getSelection()` gives pixel-accurate caret coordinates for
+   free. If the composer ever needs syntax highlighting, mention-autocomplete, or
+   other inline decorations, migrating to `contenteditable` removes the need for
+   the mirror-div workaround entirely.
+
+4. **Guard physical-newline fast paths before expensive DOM measurements.**  
+   When the user HAS typed `\n`, the simple `includes("\n")` check is both correct
+   and zero-cost. Reserve the DOM measurement for the ambiguous soft-wrap case.
+
+5. **Write unit tests for the edge cases** (`empty`, `single-line`, `multi-physical-line`,
+   `single-long-paragraph-that-soft-wraps`) at the time of initial implementation,
+   not after a bug is reported. The `useHistoryPagination.test.ts` file in this
+   repo shows the pattern: `createSignal` stubs, jsdom fixtures, and synchronous
+   event dispatch.
+
+---
+
+## Timeline
+
+| Time | Event |
+|------|-------|
+| Sometime before 2026-06-23 | `caretOnFirstLine` implemented with `includes("\n")` shortcut |
+| 2026-06-23 | User reports ArrowUp jumps to previous message while cursor is on line 4 of a soft-wrapped composer |
+| 2026-06-23 | Root cause identified: `\n` scan cannot detect visual line position |
+| 2026-06-23 | Fix implemented: mirror-div `caretVisualEdge()` helper replaces the `\n` scan |
+
+---
+
+## What Went Well
+
+- The existing guard structure (`caretOnFirstLine` / `caretOnLastLine`) was
+  correct in intent — the bug was only in the implementation of those booleans.
+- Fix is surgical: one helper function, two one-line replacements. No change to
+  the history state machine or the surrounding keyboard handler.

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -185,6 +185,55 @@ interface AgentFooterProps {
     viewModel?: AgentViewModel;
 }
 
+/**
+ * Returns whether the textarea caret is on the first and/or last *visual* line.
+ *
+ * `<textarea>` wraps text both at explicit `\n` characters and at soft-wrap
+ * word-boundaries determined by CSS layout. The simple `includes("\n")` test
+ * cannot detect soft-wrap line boundaries — a long single-paragraph message
+ * with no `\n` can span many visual rows but always looks like "one line" to a
+ * character scan. This function uses a mirror div that replicates the textarea's
+ * CSS so the browser word-wraps identically, then reads the zero-width-space
+ * marker's `offsetTop` to get the actual visual row Y.
+ *
+ * Fast-path: when a physical `\n` exists before (or after) the cursor, the
+ * answer is known from character data alone — no DOM measurement needed.
+ */
+function caretVisualEdge(ta: HTMLTextAreaElement): { first: boolean; last: boolean } {
+    const pos = ta.selectionStart;
+    const val = ta.value;
+    const needsFirst = !val.slice(0, pos).includes("\n");
+    const needsLast  = !val.slice(pos).includes("\n");
+    if (!needsFirst && !needsLast) return { first: false, last: false };
+
+    const cs = window.getComputedStyle(ta);
+    const baseCss =
+        "position:absolute;visibility:hidden;overflow:hidden;top:-9999px;left:-9999px;" +
+        `width:${ta.clientWidth}px;white-space:pre-wrap;word-wrap:break-word;` +
+        `font:${cs.font};` +
+        `padding:${cs.paddingTop} ${cs.paddingRight} ${cs.paddingBottom} ${cs.paddingLeft};` +
+        `box-sizing:${cs.boxSizing};`;
+
+    const measureY = (text: string): number => {
+        const div = document.createElement("div");
+        div.style.cssText = baseCss;
+        div.textContent = text;
+        const span = document.createElement("span");
+        span.textContent = "​"; // zero-width space — marks the caret position
+        div.appendChild(span);
+        document.body.appendChild(div);
+        const y = span.offsetTop;
+        document.body.removeChild(div);
+        return y;
+    };
+
+    const caretY = measureY(val.slice(0, pos));
+    return {
+        first: needsFirst && caretY <= measureY(""),   // matches baseline (first visual row)
+        last:  needsLast  && caretY >= measureY(val),  // matches Y at end of text
+    };
+}
+
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // Uncontrolled textarea — DOM owns the value. Reading via ref on send
     // avoids re-rendering the component tree on every keystroke.
@@ -477,8 +526,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (textareaRef && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
             const empty = textareaRef.value.length === 0;
             const navigating = histPos < sentHistory.length;
-            const caretOnFirstLine = !textareaRef.value.slice(0, textareaRef.selectionStart).includes("\n");
-            const caretOnLastLine = !textareaRef.value.slice(textareaRef.selectionStart).includes("\n");
+            const { first: caretOnFirstLine, last: caretOnLastLine } = caretVisualEdge(textareaRef);
 
             // Empty composer: ArrowUp un-queues a held message before history.
             if (e.key === "ArrowUp" && empty) {


### PR DESCRIPTION
## Summary

- ArrowUp inside a multi-line soft-wrapped composer (no `\n`) immediately jumped to the previous sent message instead of moving the cursor up one visual row
- Root cause: `caretOnFirstLine` used `includes("\n")` — only detects physical newlines, not CSS word-wrap boundaries
- Fix: `caretVisualEdge()` helper uses a mirror div to measure actual visual row Y via `span.offsetTop`, so soft-wrapped lines are counted correctly

## How it works

`caretVisualEdge(ta)` replicates the textarea's CSS (font, padding, width, `white-space:pre-wrap`) in a temporary off-screen `div`, inserts text up to the caret position, and measures the zero-width-space marker's `offsetTop`. Comparing that Y to the baseline Y (position 0) detects "first visual line"; comparing to the end-of-text Y detects "last visual line".

Fast-path: when a physical `\n` exists before/after the cursor the answer is settled by character scan alone — no DOM element is created.

## Test plan

- [ ] Type a long message that soft-wraps to 3+ lines (no Shift+Enter). ArrowUp on line 3 should move cursor up, not load previous message
- [ ] ArrowUp when cursor is on the first visual row (even of a soft-wrapped message) should navigate to previous sent message
- [ ] ArrowDown on last visual row navigates to next history entry; on other rows moves cursor down
- [ ] Single-line message: ArrowUp navigates history as before
- [ ] Multi-line message with `\n` (Shift+Enter): ArrowUp on line 2 moves cursor up; ArrowUp on line 1 navigates history

Retro: `docs/retros/RETRO_COMPOSER_ARROWKEY_HISTORY_SOFT_WRAP_2026_06_23.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)