### PR TITLE
fix(agent-pane): re-enter Streaming from Done on tool-continuation rounds

### DIFF
--- a/.changesets/1782261020-fix-agent-pane-guard-done-streaming-promotion-to-outcome-com-d34v.md
+++ b/.changesets/1782261020-fix-agent-pane-guard-done-streaming-promotion-to-outcome-com-d34v.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): guard Done→Streaming promotion to outcome=completed only

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -207,11 +207,14 @@ export function update(
             // set. After a stream drop + resubscribe (e.g. an agent kill+respawn
             // during a long upstream stall) the phase lands in Idle/Disconnected,
             // and without this promotion the "in progress" indicator stays OFF
-            // while output streams in. Done is now included: session_end fires
-            // after every model API round, so Done can mean "first round of a
-            // multi-round tool-continuation turn finished" — live flush content
-            // arriving while Done is proof the agent picked up another round.
-            // Interrupting (user is stopping) is intentionally kept excluded.
+            // while output streams in. Done.completed is included: session_end
+            // fires after every model API round, so Done.completed can mean
+            // "first round of a multi-round tool-continuation finished" — live
+            // flush content arriving in that state is proof the agent picked up
+            // another round. Done.errored / Done.stopped / Done.interrupted are
+            // excluded: a submit-timeout or user-stop followed by a late stray
+            // flush must not re-activate the busy indicator on a failed turn.
+            // Interrupting (user is stopping) is also intentionally excluded.
             const nextPhase: TurnPhase =
                 state.turnPhase.kind === "Streaming"
                     ? {
@@ -222,7 +225,7 @@ export function update(
                     : state.turnPhase.kind === "Submitting"
                         || state.turnPhase.kind === "Idle"
                         || state.turnPhase.kind === "Disconnected"
-                        || state.turnPhase.kind === "Done"
+                        || (state.turnPhase.kind === "Done" && state.turnPhase.outcome === "completed")
                         ? {
                               kind: "Streaming",
                               bufferSize: newBuf,
@@ -869,7 +872,7 @@ function bumpEvent(
         next.turnPhase.kind === "Submitting" ||
         next.turnPhase.kind === "Idle" ||
         next.turnPhase.kind === "Disconnected" ||
-        next.turnPhase.kind === "Done"
+        (next.turnPhase.kind === "Done" && next.turnPhase.outcome === "completed")
     ) {
         // codex P1 on #987: `StreamSubscribe` fires once at mount, so
         // subsequent turns enter Submitting and then no transition
@@ -883,10 +886,11 @@ function bumpEvent(
         // (agent kill+respawn during a long upstream stall) the phase lands
         // in Idle/Disconnected; without this the working indicator stays off
         // while output streams.
-        // Done is now included: session_end fires after every model API round,
-        // so Done can mean "first round of a multi-round tool-continuation
-        // finished." Live tool/token activity arriving while Done means the
-        // backend picked up a continuation round — re-enter Streaming.
+        // Done.completed is included: session_end fires after every model API
+        // round, so Done.completed can mean "first round of a multi-round
+        // tool-continuation finished" — re-enter Streaming on next activity.
+        // Done.errored/stopped/interrupted excluded: a late stray event must
+        // not revive the indicator on a failed/aborted turn.
         // Interrupting is intentionally excluded (user is stopping).
         next.turnPhase = {
             kind: "Streaming",

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -207,8 +207,11 @@ export function update(
             // set. After a stream drop + resubscribe (e.g. an agent kill+respawn
             // during a long upstream stall) the phase lands in Idle/Disconnected,
             // and without this promotion the "in progress" indicator stays OFF
-            // while output streams in. Done (a completed turn) and Interrupting
-            // (user is stopping) are intentional and kept.
+            // while output streams in. Done is now included: session_end fires
+            // after every model API round, so Done can mean "first round of a
+            // multi-round tool-continuation turn finished" — live flush content
+            // arriving while Done is proof the agent picked up another round.
+            // Interrupting (user is stopping) is intentionally kept excluded.
             const nextPhase: TurnPhase =
                 state.turnPhase.kind === "Streaming"
                     ? {
@@ -219,6 +222,7 @@ export function update(
                     : state.turnPhase.kind === "Submitting"
                         || state.turnPhase.kind === "Idle"
                         || state.turnPhase.kind === "Disconnected"
+                        || state.turnPhase.kind === "Done"
                         ? {
                               kind: "Streaming",
                               bufferSize: newBuf,
@@ -864,7 +868,8 @@ function bumpEvent(
     } else if (
         next.turnPhase.kind === "Submitting" ||
         next.turnPhase.kind === "Idle" ||
-        next.turnPhase.kind === "Disconnected"
+        next.turnPhase.kind === "Disconnected" ||
+        next.turnPhase.kind === "Done"
     ) {
         // codex P1 on #987: `StreamSubscribe` fires once at mount, so
         // subsequent turns enter Submitting and then no transition
@@ -877,7 +882,12 @@ function bumpEvent(
         // proof the agent is working. After a stream drop + resubscribe
         // (agent kill+respawn during a long upstream stall) the phase lands
         // in Idle/Disconnected; without this the working indicator stays off
-        // while output streams. Done / Interrupting are intentional and kept.
+        // while output streams.
+        // Done is now included: session_end fires after every model API round,
+        // so Done can mean "first round of a multi-round tool-continuation
+        // finished." Live tool/token activity arriving while Done means the
+        // backend picked up a continuation round — re-enter Streaming.
+        // Interrupting is intentionally excluded (user is stopping).
         next.turnPhase = {
             kind: "Streaming",
             bufferSize: next.streaming.bufferSize,


### PR DESCRIPTION
## Summary

- `session_end` fires after every model API round, not just at the end of a user turn — after the first round, `TurnPhase` transitions to `Done`, and the next model round (driven by a tool result) had no way to re-enter `Streaming`
- `StreamFlushObserved` and `bumpEvent` now include `Done` in the set of phases that promote to `Streaming`, so the busy indicator and working row stay active through multi-round tool-continuation turns
- `Interrupting` remains excluded (an in-flight interrupt should not be un-done by a stray flush)

See `docs/retro/retro-busy-indicator-turnphase-gap-tool-continuation-2026-06-23.md` for full root-cause analysis.

## Test plan

- [ ] Send a message that triggers multiple tool calls in sequence — verify busy indicator (marching ants) stays active throughout all tool rounds, not just the first
- [ ] Interrupt mid-turn — verify indicator stops and does not re-activate spuriously
- [ ] Single-round turn (no tools) — verify indicator still clears normally on `TurnEnd`

<!-- agentmux:agent_id=mazs-0527n -->