### PR TITLE
feat(statusbar): copy button on Build row + replace Label with Channel

### DIFF
--- a/.changesets/1782260465-feat-statusbar-add-copy-button-to-build-row-and-replace-labe-w862.md
+++ b/.changesets/1782260465-feat-statusbar-add-copy-button-to-build-row-and-replace-labe-w862.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(statusbar): add copy button to Build row and replace Label with Channel in instance panel

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -195,10 +195,18 @@ fn read_build_label() -> Option<String> {
     None
 }
 
+const BUILD_CHANNEL_DEFAULT: &str = match option_env!("AGENTMUX_BUILD_CHANNEL_DEFAULT") {
+    Some(s) => s,
+    None => "stable",
+};
+
 /// Get details for the About modal.
 pub fn get_about_modal_details(state: &Arc<AppState>) -> serde_json::Value {
     let version = env!("CARGO_PKG_VERSION");
     let endpoints = state.backend_endpoints.lock();
+    let channel = agentmux_common::DataPaths::from_env()
+        .map(|p| p.channel)
+        .unwrap_or_else(|| BUILD_CHANNEL_DEFAULT.to_string());
 
     serde_json::json!({
         "version": version,
@@ -208,6 +216,7 @@ pub fn get_about_modal_details(state: &Arc<AppState>) -> serde_json::Value {
         "buildLabel": read_build_label(),
         "gitHash": env!("AGENTMUX_GIT_HASH"),
         "buildTime": env!("AGENTMUX_BUILD_TIME").parse::<i64>().unwrap_or(0),
+        "channel": channel,
         "platform": match std::env::consts::OS {
             "macos" => "darwin",
             "windows" => "win32",

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -312,20 +312,15 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                         ⧉
                     </button>
                 </div>
-                {/* Local-build label — the exact string in this portable's
-                    folder/ZIP name. Only present for `task package` builds;
-                    copyable so it can be pasted to match the on-disk artifact. */}
-                <Show when={about().buildLabel}>
+                <Show when={about().channel}>
                     <div class="instance-panel-row instance-panel-row-meta">
-                        <span class="instance-panel-label">Label</span>
-                        <span class="instance-panel-value instance-panel-mono">{about().buildLabel}</span>
+                        <span class="instance-panel-label">Channel</span>
+                        <span class="instance-panel-value instance-panel-mono">{about().channel}</span>
                         <button
                             type="button"
                             class="instance-panel-copy"
-                            title="Copy build label"
-                            // Raw label (no "label: " prefix) so it pastes
-                            // straight into a folder-name match / grep.
-                            onClick={() => clipboardWriteText(about().buildLabel!)}
+                            title="Copy channel"
+                            onClick={() => clipboardWriteText(about().channel!)}
                         >
                             ⧉
                         </button>
@@ -335,6 +330,14 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                     <div class="instance-panel-row instance-panel-row-meta">
                         <span class="instance-panel-label">Build</span>
                         <span class="instance-panel-value instance-panel-mono">{about().gitHash}</span>
+                        <button
+                            type="button"
+                            class="instance-panel-copy"
+                            title="Copy build hash"
+                            onClick={() => clipboardWriteText(about().gitHash!)}
+                        >
+                            ⧉
+                        </button>
                     </div>
                 </Show>
                 <Show when={about().buildTime}>

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -489,6 +489,10 @@ declare global {
         version: string;
         gitHash?: string;
         buildTime: number;
+        buildLabel?: string;
+        channel?: string;
+        platform?: string;
+        arch?: string;
     }
 
     type BlockComponentModel = {


### PR DESCRIPTION
## Summary

- **Build row** in the instance panel expansion now has a copy (`⧉`) button — quick access to the git hash for bug reports / log correlation
- **Label row** replaced with **Channel row** — shows the active channel (`stable`, `local-*`, `dev-*`) with a copy button
- Backend: `get_about_modal_details` now includes `channel`, resolved via `DataPaths::from_env()` (honors the `AGENTMUX_CHANNEL` runtime override, falls back to compile-time `BUILD_CHANNEL_DEFAULT`)
- Frontend types: `AboutModalDetails` now declares the fields the backend already sent (`buildLabel`, `channel`, `platform`, `arch`)

## Test plan

- [ ] Open the status bar instance panel and verify the Build row shows a `⧉` copy button
- [ ] Click the copy button — paste should give the raw git hash
- [ ] Verify Channel row appears (replacing Label) showing the correct channel name
- [ ] Click the Channel copy button — paste should give the raw channel string
- [ ] Test on a `task package` build: channel should be `local-<branch>-<hash>-<stamp>`
- [ ] Test on a released/installed build: channel should be `stable`

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-marks} -->

🤖 Generated with [Claude Code](https://claude.ai/claude-code)