### PR TITLE
fix(sysinfo): instant first paint on dock/float + fix crossing-line gradient artifact

### DIFF
--- a/.changesets/1782262189-fix-sysinfo-instant-first-paint-on-dock-float-fix-gradient-i-u0t0.md
+++ b/.changesets/1782262189-fix-sysinfo-instant-first-paint-on-dock-float-fix-gradient-i-u0t0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(sysinfo): instant first paint on dock/float + fix gradient id collision causing crossing-line artifact

--- a/frontend/app/view/sysinfo/sysinfo-plot.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-plot.tsx
@@ -22,18 +22,35 @@ type SingleLinePlotProps = {
     intervalSecs: number;
 };
 
+// Module-level counter so each SingleLinePlot instance gets a unique gradient
+// id even if two instances with the same blockId+yval briefly coexist in the
+// DOM during dock/float transitions. Document-scoped SVG ids conflict across
+// SVGs; a per-instance suffix prevents the wrong gradient being resolved.
+let _gradientSeq = 0;
+
 function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
     let containerRef!: HTMLDivElement;
     const [plotWidth, setPlotWidth] = createSignal(0);
     const [plotHeight, setPlotHeight] = createSignal(0);
+    // Stable unique id for this component instance — set once, never changes.
+    const gradientId = `gradient-${props.blockId}-${props.yval}-${++_gradientSeq}`;
 
     onMount(() => {
         if (!containerRef) return;
-        // Debounce so dock/undock animations don't trigger a re-render on every
-        // intermediate frame, which caused overlapping SVGs sharing the same
-        // gradient id to produce a sliding line artifact across the chart.
         let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+        let hasFirstSize = false;
         const rszObs = new ResizeObserver((entries) => {
+            if (!hasFirstSize) {
+                // First event after mount: apply immediately for instant first paint.
+                // Subsequent events during dock/undock animations are debounced to
+                // prevent overlapping SVGs from sharing the same gradient id.
+                hasFirstSize = true;
+                for (const entry of entries) {
+                    setPlotWidth(entry.contentRect.width);
+                    setPlotHeight(entry.contentRect.height);
+                }
+                return;
+            }
             if (resizeTimer) clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => {
                 for (const entry of entries) {
@@ -69,7 +86,7 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
 
         marks.push(
             () => htl.svg`<defs>
-      <linearGradient id="gradient-${blockId}-${yval}" gradientTransform="rotate(90)">
+      <linearGradient id="${gradientId}" gradientTransform="rotate(90)">
         <stop offset="0%" stop-color="${color}" stop-opacity="0.7" />
         <stop offset="100%" stop-color="${color}" stop-opacity="0" />
       </linearGradient>
@@ -87,7 +104,7 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
 
         marks.push(
             Plot.areaY(plotData, {
-                fill: `url(#gradient-${blockId}-${yval})`,
+                fill: `url(#${gradientId})`,
                 x: "ts",
                 y: yval,
             })


### PR DESCRIPTION
## Root cause analysis

### Issue 1 — slow first paint on dock/redock

The `ResizeObserver` debounce applied to **every** resize event, including the very first one after mount. This guaranteed a 150ms+ blank window every time the sysinfo pane mounted (dock, float, redock). Initial app load was fine only because the chart was pre-warmed.

**Fix:** Fire the first `ResizeObserver` event immediately (`hasFirstSize` flag). Subsequent events during dock/undock animations are still debounced at 150ms to prevent the rapid-fire intermediate frames.

### Issue 2 — long line crossing the chart ("data mangled")

SVG `linearGradient` ids were keyed on `blockId+yval`: `gradient-${blockId}-${yval}`. SVG ids are **document-global** in HTML. When a pane docks/floats, the old and new `SingleLinePlot` component instances briefly coexist in the DOM with the **same gradient id**. The `areaY` fill `url(#gradient-...)` resolves document-wide and picks up the wrong gradient definition, painting a full-height stripe across the chart.

The 150ms debounce was supposed to prevent this by avoiding intermediate SVG renders during animation, but it doesn't cover the mount/unmount overlap during pane transitions.

**Fix:** A module-level sequence counter (`_gradientSeq`) gives each component instance a unique gradient id (`gradient-${blockId}-${yval}-${N}`) that's stable across re-renders of that instance but distinct from any other instance, even concurrent ones with the same block/metric.

## Test plan

- [ ] Open a sysinfo pane — chart should render immediately with no blank window
- [ ] Dock the pane → undock it → chart should appear instantly on each transition
- [ ] Float the pane → re-dock → no crossing line / full-height stripe artifact visible
- [ ] Verify chart data and gradient fill still look correct after multiple dock/float cycles

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-marks} -->

🤖 Generated with [Claude Code](https://claude.ai/claude-code)