### PR TITLE
fix(agent-footer): exempt caretVisualEdge mirror-div reads from layout-read lint gate

### DIFF
--- a/.changesets/1782282341-fix-agent-footer-exempt-caretvisualedge-mirror-div-reads-fro-qc6q.md
+++ b/.changesets/1782282341-fix-agent-footer-exempt-caretvisualedge-mirror-div-reads-fro-qc6q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-footer): exempt caretVisualEdge mirror-div reads from layout-read lint gate

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -221,10 +221,10 @@ function caretVisualEdge(ta: HTMLTextAreaElement): { first: boolean; last: boole
     const needsLast  = !val.slice(pos).includes("\n");
     if (!needsFirst && !needsLast) return { first: false, last: false };
 
-    const cs = window.getComputedStyle(ta);
+    const cs = window.getComputedStyle(ta); // perf:allow-layout-read — mirror-div caret detection; runs only on ArrowUp/Down when no physical \n exists, not on every keystroke
     const baseCss =
         "position:absolute;visibility:hidden;overflow:hidden;top:-9999px;left:-9999px;" +
-        `width:${ta.clientWidth}px;white-space:pre-wrap;word-wrap:break-word;` +
+        `width:${ta.clientWidth}px;white-space:pre-wrap;word-wrap:break-word;` + // perf:allow-layout-read — same as above; synchronous read required for mirror-div width match
         `font:${cs.font};` +
         `padding:${cs.paddingTop} ${cs.paddingRight} ${cs.paddingBottom} ${cs.paddingLeft};` +
         `box-sizing:${cs.boxSizing};`;
@@ -237,7 +237,7 @@ function caretVisualEdge(ta: HTMLTextAreaElement): { first: boolean; last: boole
         span.textContent = "​"; // zero-width space — marks the caret position
         div.appendChild(span);
         document.body.appendChild(div);
-        const y = span.offsetTop;
+        const y = span.offsetTop; // perf:allow-layout-read — reads detached mirror div; synchronous result needed to decide ArrowUp/Down behavior
         document.body.removeChild(div);
         return y;
     };


### PR DESCRIPTION
## Problem

`task package` (and `build:frontend`) was blocked by the `check:input-handler-layout` lint gate introduced in `SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29 §4`. The gate flags any layout read in an input-handler-scoped file without an explicit exemption comment.

Three lines in `AgentFooter.tsx` were flagged:

```
AgentFooter.tsx:224  window.getComputedStyle(ta)
AgentFooter.tsx:227  ta.clientWidth
AgentFooter.tsx:240  span.offsetTop
```

These are all inside `caretVisualEdge()`, a helper added by the ArrowUp/Down soft-wrap history fix.

## Why these reads are legitimate

`caretVisualEdge()` uses a **detached mirror div** to determine whether the caret sits on the first or last **visual** row of soft-wrapped text. This is how ArrowUp/Down decides whether to navigate sent-message history or let the cursor move naturally within a multi-visual-line composer.

The three reads are:
- `getComputedStyle(ta)` — copies the textarea's font, padding, and box-sizing into the mirror div so word-wrapping is byte-identical
- `ta.clientWidth` — sets the mirror div's width to match the textarea's rendered width
- `span.offsetTop` — reads the zero-width-space marker's Y position in the mirror div to identify the visual row

**Why they can't be deferred to RAF:** the result is needed synchronously inside the `keydown` event handler — deferring would mean the key event fires and the history navigation decision is already made before the measurement completes.

**Why the per-keystroke cost is bounded:** `caretVisualEdge()` has a fast-path (line 222) that returns immediately whenever a physical `\n` exists before or after the cursor. DOM reads only happen for single-logical-line text that visually soft-wraps, and only on ArrowUp/ArrowDown — not on every character keystroke.

## Fix

Added `// perf:allow-layout-read — <rationale>` exemption comments on each of the three lines, per the escape-hatch documented in the lint script.

## Test plan

- [ ] `task package` completes without the lint gate firing
- [ ] ArrowUp/Down history navigation still works correctly in a soft-wrapped composer (no regression)
- [ ] ArrowUp/Down cursor movement still works on multi-line messages with physical newlines

<!-- agentmux:agent_id=mazs-0527n -->