### PR TITLE
fix(agent): move activity dock from top to above composer

### DIFF
--- a/.changesets/1782284857-fix-agent-move-activity-dock-from-top-to-above-composer-gdhj.md
+++ b/.changesets/1782284857-fix-agent-move-activity-dock-from-top-to-above-composer-gdhj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): move activity dock from top to above composer

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1058,14 +1058,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onRegenerate={() => digest.fetch(true)}
             />
 
-            {/* Pinned activity dock — long-running shells (and later crons /
-                subagents) stay glanceable at the top while the conversation
-                scrolls under it. SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15. */}
-            <ActivityDock
-                documentAtom={agentAtoms().documentAtom}
-                documentStateAtom={agentAtoms().documentStateAtom}
-            />
-
             <AgentDocumentView
                 documentAtom={agentAtoms().documentAtom}
                 documentStateAtom={agentAtoms().documentStateAtom}
@@ -1233,6 +1225,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                         "user",
                     );
                 }}
+            />
+
+            {/* Pinned activity dock — long-running shells (and later crons /
+                subagents) sit just above the composer so task status is adjacent
+                to where the user's attention already is. Moved from the top per
+                SPEC_ACTIVITY_DOCK_BOTTOM_MOVE_2026_06_20. */}
+            <ActivityDock
+                documentAtom={agentAtoms().documentAtom}
+                documentStateAtom={agentAtoms().documentStateAtom}
             />
 
             {/* Slim composer status strip — single 28-32px row replacing

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -192,13 +192,13 @@
     flex: 0 0 auto;
     display: flex;
     flex-direction: column;
-    // Stronger separation from the pane content below: a slightly elevated
-    // surface + a 2px accent-tinted divider make the pinned region read as a
-    // distinct "dock" rather than blending into the transcript.
-    border-bottom: 2px solid color-mix(in srgb, var(--accent-color) 35%, var(--border-color));
+    // Sits above the composer — border-top separates it from whatever is above
+    // (queue, working row, conversation). Moved from top per
+    // SPEC_ACTIVITY_DOCK_BOTTOM_MOVE_2026_06_20.
+    border-top: 2px solid color-mix(in srgb, var(--accent-color) 35%, var(--border-color));
     background: var(--elevated-bg-color, #1d1d20);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.28);
-    max-height: 45%;            // never let the dock eat the whole pane
+    box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.28);
+    max-height: 30%;            // tighter cap — at bottom, tall docks feel more intrusive
     overflow-y: auto;
     z-index: 2;
 }


### PR DESCRIPTION
## Summary

- Moves `ActivityDock` from the top of the agent pane (above the conversation) to just above `AgentComposerStrip`, implementing `SPEC_ACTIVITY_DOCK_BOTTOM_MOVE_2026_06_20`
- Flips `.agent-activity-dock` border from `border-bottom` to `border-top` and adjusts `box-shadow` direction accordingly
- Tightens `max-height` from `45%` to `30%` — at the bottom, a tall dock is more intrusive

## Test plan
- [ ] Shell activities appear above the composer, not at the top of the pane
- [ ] Error/stopped activities are still visible and dismissible
- [ ] Dock doesn't overlap the conversation

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-marks} -->