### PR TITLE
fix(layout): floating-pane redock lands in wrong slot on macOS

### DIFF
--- a/.changesets/1782285505-fix-layout-floating-pane-redock-ghost-direction-missing-on-m-q4g9.md
+++ b/.changesets/1782285505-fix-layout-floating-pane-redock-ghost-direction-missing-on-m-q4g9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): floating-pane redock ghost direction missing on macOS — set dwellCurrentHoverTarget from IPC response

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -839,6 +839,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                         // immediately after the ghost appears.
                         const prevTarget = dwellLastArmedTarget;
                         dwellLastArmedTarget = newTarget;
+                        dwellCurrentHoverTarget = newTarget; // Phase 4b: mirror for ghost capture in onMouseUp (Windows sets this via event; macOS must set it here)
                         dwellCurrentConfirmedAt = newTarget !== null ? performance.now() : null;
                         if (prevTarget !== null) dwellSlowSince = null;
                         if (hoverArmed || indicatorShowing) {


### PR DESCRIPTION
## Root cause

`dwellCurrentHoverTarget` — the variable `onMouseUp` reads to capture the ghost window before calling `get_floating_redock_target` — was **only ever written on Windows**, inside the `floating-redock:hover-state` event listener that is guarded by `if (isWindows())` (line ~692).

On macOS the JS-driven `mousemove` path updates `dwellLastArmedTarget` from the `update_floating_redock_hover` IPC response, but never mirrored that value into `dwellCurrentHoverTarget`. So on macOS:

```
const preGhostWindow = dwellCurrentHoverTarget;  // always null
capturedGhostForDrop = preGhostWindow            // → Promise.resolve({})
    ? invokeCommand("get_floating_redock_target", ...)
    : Promise.resolve({});
```

`RedockFloatingPane` received `null` for `targetBlockId` and `direction` (args 5/6) → fell back to `InsertNode` → default horizontal split → pane always landed to the right regardless of where the ghost previewed.

## Fix

One line in the macOS IPC `.then()` callback: set `dwellCurrentHoverTarget = newTarget` alongside `dwellLastArmedTarget = newTarget`. Both `onMouseUp` and `window_drag_ended` ghost captures now see the correct target window label on macOS.

## Test plan

- [ ] Drag a floating pane over another AgentMux window on macOS, hover until the ghost overlay appears in the top zone — drop: pane should land above the target pane (vertical split)
- [ ] Same for left, right, bottom, and outer-edge zones — each should match the ghost
- [ ] `muxlog srv grep "dnd:svc"` after a drop: `target_block_id` and `direction` should now be `Some(...)` instead of `None`
- [ ] Windows redock behavior unaffected (Windows path unchanged)

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID} -->