### PR TITLE
fix(sound): waiting-ambient tone triggers only on AskUserQuestion, not any turn ending with ?

### DIFF
--- a/.changesets/1782286680-fix-sound-waiting-ambient-tone-now-triggers-only-on-askuserq-f44o.md
+++ b/.changesets/1782286680-fix-sound-waiting-ambient-tone-now-triggers-only-on-askuserq-f44o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(sound): waiting-ambient tone now triggers only on AskUserQuestion panel, not on any turn ending with ?

--- a/.changesets/1782307784-fix-sound-fire-waiting-ended-only-on-component-unmount-not-o-nj5x.md
+++ b/.changesets/1782307784-fix-sound-fire-waiting-ended-only-on-component-unmount-not-o-nj5x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(sound): fire waiting-ended only on component unmount, not on every pendingQuestions change

--- a/frontend/app/notification/sound/__tests__/waiting-sound-service.test.ts
+++ b/frontend/app/notification/sound/__tests__/waiting-sound-service.test.ts
@@ -4,12 +4,13 @@
 /**
  * Policy tests for the waiting-ambient-sound subsystem:
  *   • sound-service startWaiting / stopWaiting gating
- *   • reducer endsWithQuestion heuristic (via lastTurnHadQuestion)
  *
- * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4, §6, §9.
+ * The tone is now triggered by AskUserQuestion panel visibility
+ * (agent-view fires waiting-for-input / waiting-ended via fireEvent
+ * when pendingQuestions changes), not by the text-ends-with-? heuristic.
  */
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Module mocks ─────────────────────────────────────────────────────
 
@@ -168,58 +169,3 @@ describe("waiting-sound-service: startWaiting gating", () => {
     });
 });
 
-// ─── Reducer endsWithQuestion heuristic ───────────────────────────────
-
-describe("endsWithQuestion heuristic (via reducer)", () => {
-    // We test endsWithQuestion indirectly by importing the reducer and
-    // checking the state it produces, so no mocks needed beyond imports.
-    let update: typeof import("@/app/store/agent-pane-state/reducer").update;
-    let initialState: typeof import("@/app/store/agent-pane-state/types").initialState;
-
-    beforeAll(async () => {
-        ({ update } = await import("@/app/store/agent-pane-state/reducer"));
-        ({ initialState } = await import("@/app/store/agent-pane-state/types"));
-    });
-
-    function completedTurn(lastAssistantText?: string) {
-        const state = initialState("agent-1");
-        // Fake a streaming state so TurnEnd is valid
-        const streaming = { ...state, turnPhase: { kind: "Streaming", bufferSize: 0, toolsActive: 0, lastEventMs: 0 } } as typeof state;
-        return update(streaming, { type: "TurnEnd", stats: null, lastAssistantText });
-    }
-
-    it("sets lastTurnHadQuestion=true when text ends with ?", () => {
-        expect(completedTurn("What would you like to do?").state.lastTurnHadQuestion).toBe(true);
-    });
-
-    it("sets lastTurnHadQuestion=false when text does not end with ?", () => {
-        expect(completedTurn("I've finished the task.").state.lastTurnHadQuestion).toBe(false);
-    });
-
-    it("sets lastTurnHadQuestion=false when lastAssistantText is absent", () => {
-        expect(completedTurn(undefined).state.lastTurnHadQuestion).toBe(false);
-    });
-
-    it("handles trailing quotes before the question mark", () => {
-        expect(completedTurn("Is this correct?\"").state.lastTurnHadQuestion).toBe(true);
-    });
-
-    it("handles trailing closing parens before the question mark", () => {
-        expect(completedTurn("Ready to proceed?)").state.lastTurnHadQuestion).toBe(true);
-    });
-
-    it("sets lastTurnHadQuestion=false for non-completed outcome even with ?", () => {
-        const state = initialState("agent-1");
-        const interrupting = { ...state, turnPhase: { kind: "Interrupting", reason: "user", sigintSentAt: 0 } } as typeof state;
-        const result = update(interrupting, { type: "TurnEnd", stats: null, lastAssistantText: "Do you want me to stop?" });
-        // outcome is "stopped" → flag should be false
-        expect(result.state.lastTurnHadQuestion).toBe(false);
-    });
-
-    it("TurnReset clears lastTurnHadQuestion", () => {
-        const withQuestion = completedTurn("Should I continue?").state;
-        expect(withQuestion.lastTurnHadQuestion).toBe(true);
-        const reset = update(withQuestion, { type: "TurnReset" });
-        expect(reset.state.lastTurnHadQuestion).toBe(false);
-    });
-});

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -160,21 +160,6 @@ export function registerPane(
  * `unregisterPane` from `agent-pane-registration.ts`.
  */
 export function unregisterPane(blockId: string): void {
-    // If the pane was in a waiting-for-input state, notify listeners so the
-    // sound service can stop the looping tone before the slot is gone.
-    const slot = slots.get(blockId);
-    if (
-        slot &&
-        slot.state.turnPhase.kind === "Done" &&
-        slot.state.turnPhase.outcome === "completed" &&
-        slot.state.lastTurnHadQuestion
-    ) {
-        const ev: AgentPaneEvent = { type: "waiting-ended", reason: "closed" };
-        eventSink(blockId, ev);
-        for (const l of extraListeners) {
-            try { l(blockId, ev); } catch { /* isolate */ }
-        }
-    }
     slots.delete(blockId);
 }
 
@@ -240,47 +225,7 @@ export function dispatch(
         );
     }
 
-    // Synthetic waiting-for-input / waiting-ended events injected after
-    // the reducer result events — not emitted by the pure reducer because
-    // they span two state snapshots (prev vs next).
-    const extraEvents: AgentPaneEvent[] = [];
-    const prevPhase = prev.turnPhase;
-    const nextPhase = slot.state.turnPhase;
-
-    // Entering waiting state: turn just completed with a question, no pending.
-    if (
-        nextPhase.kind === "Done" &&
-        nextPhase.outcome === "completed" &&
-        slot.state.lastTurnHadQuestion &&
-        slot.state.pending.length === 0 &&
-        !(prevPhase.kind === "Done" && prevPhase.outcome === "completed" && prev.lastTurnHadQuestion)
-    ) {
-        extraEvents.push({ type: "waiting-for-input" });
-    }
-
-    // Leaving waiting state: user submitted a new message.
-    if (
-        prevPhase.kind === "Done" &&
-        prevPhase.outcome === "completed" &&
-        prev.lastTurnHadQuestion &&
-        nextPhase.kind === "Submitting"
-    ) {
-        extraEvents.push({ type: "waiting-ended", reason: "submitted" });
-    }
-
-    // Leaving waiting state: user started typing (WaitingTypingStarted clears the flag).
-    // Guard to Done→Done ensures TurnReset (Done→Idle) isn't mislabeled as "typing".
-    if (
-        prev.lastTurnHadQuestion &&
-        !slot.state.lastTurnHadQuestion &&
-        prevPhase.kind === "Done" &&
-        nextPhase.kind === "Done"
-    ) {
-        extraEvents.push({ type: "waiting-ended", reason: "typing" });
-    }
-
-    const allEvents = [...result.events, ...extraEvents];
-    for (const ev of allEvents) {
+    for (const ev of result.events) {
         eventSink(blockId, ev);
         for (const l of extraListeners) {
             try {
@@ -297,11 +242,11 @@ export function dispatch(
         slice: "agent-pane-state",
         key: blockId,
         command,
-        events: allEvents,
+        events: result.events,
         source,
         at: Date.now(),
     });
-    return allEvents;
+    return result.events;
 }
 
 /**
@@ -323,6 +268,19 @@ export function dispatchIfRegistered(
 ): AgentPaneEvent[] {
     if (!slots.has(blockId)) return [];
     return dispatch(blockId, command, source);
+}
+
+/**
+ * Fire a synthetic event directly to the multicast listeners (e.g. the sound
+ * service) without going through the reducer. Used by components that have
+ * their own reactive state (e.g. `pendingQuestions` in agent-view) and need
+ * to drive audio without coupling the reducer to document-layer detail.
+ */
+export function fireEvent(blockId: string, event: AgentPaneEvent): void {
+    eventSink(blockId, event);
+    for (const l of extraListeners) {
+        try { l(blockId, event); } catch { /* isolate */ }
+    }
 }
 
 /** Snapshot — diagnostics + tests only. */

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -395,17 +395,6 @@ export function update(
             const finishedAt = phase.kind === "Done"
                 ? phase.finishedAt
                 : nowMs;
-            // When outcome is completed and text is supplied, run the heuristic.
-            // When text is absent (tool-only or empty final block), conservatively
-            // treat it as no question — do NOT carry the prior value forward.
-            // Non-completed outcomes always clear the flag.
-            // First-done-wins: a late/duplicate TurnEnd (phase already Done)
-            // must not overwrite the flag — the initial TurnEnd was authoritative.
-            const lastTurnHadQuestion = phase.kind === "Done"
-                ? state.lastTurnHadQuestion
-                : outcome === "completed" && command.lastAssistantText != null
-                    ? endsWithQuestion(command.lastAssistantText)
-                    : false;
             return {
                 state: {
                     ...state,
@@ -413,7 +402,6 @@ export function update(
                     currentTool: null,
                     currentToolArg: null,
                     turnTokens: null,
-                    lastTurnHadQuestion,
                     turnPhase: {
                         kind: "Done",
                         outcome,
@@ -440,7 +428,6 @@ export function update(
                     currentToolArg: null,
                     turnTokens: null,
                     lastContextTokens: 0,
-                    lastTurnHadQuestion: false,
                     // TurnReset is a wholesale clear → Idle. The
                     // working/stopping cascade lives entirely on
                     // turnPhase since PR G.
@@ -842,18 +829,6 @@ export function update(
                 events: [],
             };
         }
-        case "WaitingTypingStarted": {
-            // No-op if not in the waiting state (idempotent, safe to fire
-            // on every keystroke since the store uses dispatchIfRegistered).
-            if (!state.lastTurnHadQuestion) {
-                return { state, events: [] };
-            }
-            return {
-                state: { ...state, lastTurnHadQuestion: false },
-                events: [],
-            };
-        }
-
         case "LogEntryArrived": {
             // No-op when the panel is open (user already sees the
             // entry). Increments the unread counter when closed so
@@ -938,17 +913,6 @@ function bumpEvent(
  * usage (hence `||`, not `??`). Codex emits usage only on the stats
  * branch (no live tokens), so it's unaffected.
  */
-/**
- * Returns true if the assistant's last message text ended with a question.
- * Trims trailing whitespace and common closing punctuation (`"`, `'`, `)`)
- * before checking the final character.
- * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4 (heuristic C).
- */
-function endsWithQuestion(text: string): boolean {
-    const trimmed = text.trimEnd().replace(/["')]+$/, "").trimEnd();
-    return trimmed.endsWith("?");
-}
-
 function mergeStats(
     stats: AgentPaneState["sessionStats"],
     tokens: AgentPaneState["turnTokens"],

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -255,13 +255,6 @@ export interface AgentPaneState {
     /** Resolved model id that produced `lastContextWindow` — used to re-seed the
      *  window when the user switches models mid-session (`/model`). */
     lastContextModel: string | null;
-    /**
-     * True iff the most recently completed turn ended with the agent asking
-     * a question (heuristic: last text block's trimmed content ends with `?`).
-     * Drives the waiting-ambient-sound trigger.
-     * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4.
-     */
-    lastTurnHadQuestion: boolean;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
@@ -280,7 +273,6 @@ export const initialState = (agentId: string): AgentPaneState => ({
     detailsOpen: false,
     shellOpen: false,
     composerUnreadCount: 0,
-    lastTurnHadQuestion: false,
 });
 
 /**
@@ -523,13 +515,7 @@ export type AgentPaneCommand =
      * open, no-op (the user sees the new entry directly).
      */
     | { type: "LogEntryArrived" }
-    /**
-     * User started typing in the composer while the pane was in the
-     * waiting-for-input state. Clears `lastTurnHadQuestion` so the
-     * store can emit `waiting-ended` with reason `"typing"`.
-     * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §6.6.
-     */
-    | { type: "WaitingTypingStarted" };
+    ;
 
 export type AgentPaneEvent =
     | { type: "init-ready" }

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -396,15 +396,6 @@ export type AgentPaneCommand =
     | {
           type: "TurnEnd";
           stats: SessionStats | null;
-          /**
-           * The trimmed text of the last assistant message block, if the
-           * caller can supply it cheaply. Used to set `lastTurnHadQuestion`
-           * via the trailing-`?` heuristic. Optional — absence conservatively
-           * clears `lastTurnHadQuestion` (treated as no question) so a
-           * tool-only or empty final block never re-triggers the waiting tone.
-           * Spec: SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md §4.
-           */
-          lastAssistantText?: string;
       }
     /**
      * Truncate path: the doc was reset (or whatever caused the local

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -544,18 +544,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Play the waiting-ambient tone when an AskUserQuestion panel is active
     // (agent blocked waiting for the user to pick an option). Stop it when
     // all questions are answered or the pane closes.
+    let waitingToneActive = false;
     createEffect(on(pendingQuestions, (qs, prevQs) => {
         const hadAny = (prevQs?.length ?? 0) > 0;
         const hasAny = qs.length > 0;
         if (hasAny && !hadAny) {
+            waitingToneActive = true;
             firePaneEvent(model.blockId, { type: "waiting-for-input" });
         } else if (!hasAny && hadAny) {
+            waitingToneActive = false;
             firePaneEvent(model.blockId, { type: "waiting-ended", reason: "submitted" });
         }
-        onCleanup(() => {
-            if (hasAny) firePaneEvent(model.blockId, { type: "waiting-ended", reason: "closed" });
-        });
     }));
+    onCleanup(() => {
+        if (waitingToneActive) {
+            firePaneEvent(model.blockId, { type: "waiting-ended", reason: "closed" });
+            waitingToneActive = false;
+        }
+    });
 
     // Root element ref — declared before useAgentControllerStatus so its
     // getInitialTermSize closure can read the laid-out pane width when the

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { writeText as clipboardWriteText } from "@/util/clipboard";
-import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { AgentViewModel } from "./agent-model";
 import { getProvider } from "./providers";
 import { createAgentAtoms } from "./state";
@@ -13,6 +13,7 @@ import {
 import {
     dispatch as dispatchPane,
     dispatchIfRegistered as dispatchPaneIfRegistered,
+    fireEvent as firePaneEvent,
     snapshot as paneSnapshot,
 } from "@/app/store/agent-pane-state-store";
 import {
@@ -539,6 +540,22 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         }
         return out;
     };
+
+    // Play the waiting-ambient tone when an AskUserQuestion panel is active
+    // (agent blocked waiting for the user to pick an option). Stop it when
+    // all questions are answered or the pane closes.
+    createEffect(on(pendingQuestions, (qs, prevQs) => {
+        const hadAny = (prevQs?.length ?? 0) > 0;
+        const hasAny = qs.length > 0;
+        if (hasAny && !hadAny) {
+            firePaneEvent(model.blockId, { type: "waiting-for-input" });
+        } else if (!hasAny && hadAny) {
+            firePaneEvent(model.blockId, { type: "waiting-ended", reason: "submitted" });
+        }
+        onCleanup(() => {
+            if (hasAny) firePaneEvent(model.blockId, { type: "waiting-ended", reason: "closed" });
+        });
+    }));
 
     // Root element ref — declared before useAgentControllerStatus so its
     // getInitialTermSize closure can read the laid-out pane width when the
@@ -1324,21 +1341,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onSendMessage={handleSendMessage}
                     onTyping={() => {
                         scrollToBottomFn?.();
-                        // Guard: only dispatch while a waiting tone is active.
-                        // WaitingTypingStarted is gated on lastTurnHadQuestion in
-                        // the reducer, but dispatching on every RAF-debounced frame
-                        // would still flood recordDispatch with no-op records.
-                        const s = paneSnapshot(model.blockId);
-                        if (
-                            s != null &&
-                            s.lastTurnHadQuestion &&
-                            s.turnPhase.kind === "Done" &&
-                            s.turnPhase.outcome === "completed"
-                        ) {
-                            dispatchPaneIfRegistered(model.blockId, {
-                                type: "WaitingTypingStarted",
-                            });
-                        }
                     }}
                     onStopAgent={commands.stopAgent}
                     onRecallLatestQueued={commands.recallLatestHeld}

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -452,23 +452,7 @@ export function useAgentStream({
             // in one shot: merges live tokens into stats, clears
             // tool/tokens, and transitions the phase to Done.
             const wasStopping = getTurnPhase().kind === "Interrupting";
-            // Extract last assistant text for the waiting-sound heuristic.
-            // We scan backward through the current document nodes for the
-            // last markdown/text node with non-empty content.
-            const lastAssistantText = (() => {
-                const nodes = documentAtom[0]();
-                for (let i = nodes.length - 1; i >= 0; i--) {
-                    const n = nodes[i];
-                    if (
-                        n.type === "markdown" &&
-                        typeof n.content === "string"
-                    ) {
-                        return n.content;
-                    }
-                }
-                return undefined;
-            })();
-            model.dispatchPane({ type: "TurnEnd", stats, lastAssistantText });
+            model.dispatchPane({ type: "TurnEnd", stats });
             if (wasStopping) {
                 const interruptedNode: DocumentNode = {
                     type: "markdown",


### PR DESCRIPTION
## Summary

- **Root cause**: The spec (`SPEC_AGENT_WAITING_AMBIENT_SOUND_2026_06_19.md`) was implemented with a question-mark heuristic (any turn whose last text block ended with `?` triggered the looping tone). The actual intent is for the tone to play only when the agent is structurally blocked at an `AskUserQuestion` tool call — the interactive multi-choice panel.
- **Removed**: `lastTurnHadQuestion` field, `endsWithQuestion()` heuristic, `WaitingTypingStarted` command, all heuristic-based `waiting-for-input`/`waiting-ended` emission from the store.
- **Added**: `fireEvent()` export on `agent-pane-state-store`; a `createEffect(on(pendingQuestions, ...))` in `agent-view.tsx` that fires `waiting-for-input` when a `ToolNode` enters `awaiting_answer` (AskUserQuestion panel appears) and `waiting-ended` when all questions are answered or the pane closes.
- The sound service itself (`startWaiting`/`stopWaiting`) is unchanged — only the trigger source changed.

## Test plan
- [ ] Agent finishes a turn ending with `?` in plain text — tone must NOT play
- [ ] Agent calls `AskUserQuestion` tool (multi-choice panel appears) — tone MUST play
- [ ] User picks an option — tone stops
- [ ] Pane closed while AskUserQuestion is showing — tone stops
- [ ] `npx tsc --noEmit` reports no errors in changed files
- [ ] Existing sound-service tests pass (heuristic tests removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=naki -->