### PR TITLE
fix(claude-translator): emit session_end per turn in persistent mode

### DIFF
--- a/.changesets/1782280161-fix-editor-markdown-preview-source-hidden-guards-aria.md
+++ b/.changesets/1782280161-fix-editor-markdown-preview-source-hidden-guards-aria.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): guard sourceHidden display behind isMarkdown(), fix Mod+F in preview-only, add aria-label to </> toggle, restore previewOpen on exit

--- a/.changesets/1782283245-fix-swarm-provider-icon-idle-status.md
+++ b/.changesets/1782283245-fix-swarm-provider-icon-idle-status.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): show provider logo instead of hexagon; fix persistent agents always showing "working" when idle

--- a/.changesets/1782310742-fix-claude-translator-emit-session-end-for-per-turn-completi-4hk7.md
+++ b/.changesets/1782310742-fix-claude-translator-emit-session-end-for-per-turn-completi-4hk7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(claude-translator): emit session_end for per-turn completion in persistent mode

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1301,12 +1301,21 @@ fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, String> {
                 .ok_or_else(|| "MISSING_ARG: view=editor requires 'file'".to_string())?;
             meta.insert("view".to_string(), json!("editor"));
             meta.insert("file".to_string(), json!(file));
-            // Optional initial file-tree state. Only write when explicitly
-            // requested; absent leaves the frontend default (expanded). The
-            // frontend collapses iff this is literally `false`
-            // (EditorViewModel restore: `meta["editor:tree_expanded"] === false`).
+
+            let is_markdown = file.to_ascii_lowercase().ends_with(".md");
+
+            // Tree state: explicit caller value wins; for markdown default to
+            // collapsed so the rendered preview gets full horizontal width.
             if let Some(expanded) = cmd.tree_expanded {
                 meta.insert("editor:tree_expanded".to_string(), json!(expanded));
+            } else if is_markdown {
+                meta.insert("editor:tree_expanded".to_string(), json!(false));
+            }
+
+            // Markdown files default to preview-only (source editor hidden).
+            // Agents open .md files to surface documentation, not to edit.
+            if is_markdown {
+                meta.insert("editor:source_hidden".to_string(), json!(true));
             }
         }
         "term" => {

--- a/docs/retro/retro-editor-markdown-preview-regression-2026-06-23.md
+++ b/docs/retro/retro-editor-markdown-preview-regression-2026-06-23.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-23  
 **Discovered by:** Manual test — agents opening `.md` files via `pane.open` App API  
 **PRs involved:** #1522 (styled markdown preview + toggle), #1655 (collapsible split panel)  
-**Status:** Not yet fixed
+**Status:** Fixed in PR #1743
 
 ---
 

--- a/docs/retro/retro-editor-markdown-preview-regression-2026-06-23.md
+++ b/docs/retro/retro-editor-markdown-preview-regression-2026-06-23.md
@@ -1,0 +1,146 @@
+# Retro: Editor markdown preview regressions — split layout, missing toggle, tree state
+
+**Date:** 2026-06-23  
+**Discovered by:** Manual test — agents opening `.md` files via `pane.open` App API  
+**PRs involved:** #1522 (styled markdown preview + toggle), #1655 (collapsible split panel)  
+**Status:** Not yet fixed
+
+---
+
+## What happened
+
+PR #1522 (`feat(editor): styled markdown preview with rendered/source toggle`) shipped a
+full-overlay markdown preview: opening a `.md` file showed rendered markdown occupying the
+full pane, with a "Source" / "Preview" toggle button to switch modes. CodeMirror was hidden
+when in preview mode.
+
+PR #1655 (`feat(editor): collapsible live markdown preview panel`) replaced this with a
+persistent top/bottom split panel — CodeMirror always on top, rendered markdown in a
+collapsible bottom pane that can be dragged to resize or dismissed with Mod+Shift+V.
+
+The replacement introduced three regressions:
+
+---
+
+## Regression 1 — Split-screen layout is unexpected
+
+**Old behavior:** Opening a `.md` file showed a full-screen rendered preview. CodeMirror
+was completely hidden. The pane felt like a reading surface.
+
+**New behavior:** Opening a `.md` file shows a top/bottom split — CodeMirror editor on top,
+rendered markdown below. Both panels are always visible. There is no "reading mode."
+
+**Impact:** The UX intent changed from "view this document" to "edit this document with a
+live preview." Agents that open `.md` files to surface documentation or a plan now expose the
+raw source to the user, degrading signal-to-noise.
+
+**Root cause:** PR #1655 was designed as an editing aid (live preview while writing), not as
+a viewer mode replacement. The original viewer-first contract — `.md` opens in rendered mode
+by default — was not preserved.
+
+---
+
+## Regression 2 — Preview/code toggle button removed
+
+**Old behavior:** A toolbar button labeled "Source" / "Preview" toggled between full-overlay
+rendered markdown and full CodeMirror source view. The `mdSourceTabs` signal tracked
+per-tab mode. `showRendered()` = `!mdSourceTabs().has(currentTabId)` drove what was visible.
+
+**New behavior:** The toggle button no longer exists. The chevron button in the preview panel
+header collapses the bottom pane (height → 28px header-only), but CodeMirror on top is always
+visible. There is no path to a code-only or preview-only full-pane view.
+
+**Impact:** Users who want to read a markdown file without the editor gutter/syntax
+highlighting have no option. Users who want to edit without the preview panel taking vertical
+space must drag the handle all the way up (awkward) or use Mod+Shift+V to collapse the
+bottom panel — but then the code pane still occupies only the top half of the frame until
+the split is manually dragged back.
+
+**Root cause:** The `mdSourceTabs` signal and `toggleMdMode()` function were deleted as part
+of the PR #1655 rewrite. The new architecture has no equivalent of "hide one side entirely."
+
+---
+
+## Regression 3 — File tree opens expanded when it should start collapsed
+
+**Old behavior:** Agents could open an editor with `tree_expanded: false` and the tree
+would start collapsed, giving the markdown content full horizontal width.
+
+**Current state:** The `build_pane_meta()` handler in `app_api.rs` (line 1308) only writes
+`editor:tree_expanded` when the caller explicitly passes `tree_expanded`. The MCP tool
+`OpenEditor` passes `tree_expanded: None` by default (line 3233), so the key is absent from
+meta and the frontend defaults to `true` (expanded).
+
+**Impact:** When agents open `.md` files, the tree occupies the left column by default,
+consuming ~240px of horizontal space. Combined with the split-screen layout, the user sees
+three regions (tree, code editor, preview) instead of the intended "preview-first" single
+column.
+
+**Root cause:** The App API is correctly wired — the opt-in mechanism works — but nothing
+sets the default to collapsed when the opened file is markdown and no explicit tree state
+was requested. Previously this wasn't visible because the old full-overlay preview rendered
+over the tree.
+
+---
+
+## Why the old behavior worked
+
+In the pre-#1655 world:
+- Opening a `.md` file defaulted to preview mode (full-overlay rendered markdown).
+- The full-overlay covered the tree panel visually — whether the tree was expanded or not was irrelevant.
+- Users never needed a toggle because the opening mode was the right default.
+
+PR #1655 broke the implicit contract: it assumed both panels would always be visible, which
+exposed the tree-state and source-visibility problems that the overlay had previously masked.
+
+---
+
+## What needs to be fixed
+
+### Fix A — Restore a full-preview / full-source toggle
+
+Add back a mode signal per tab: `"preview-only" | "source-only" | "split"`.
+
+- Default for `.md` files: `"preview-only"` (rendered markdown fills the pane, CodeMirror hidden).
+- Default for all other files: `"source-only"` (current behavior, no bottom panel).
+- Toggle button in the header switches between modes; keyboard shortcut Mod+Shift+V retained.
+- The split panel is the `"split"` mode and remains available.
+
+Alternatively: the split panel can stay as the architecture, but `.md` files should default
+to a very tall preview height (e.g. 80% of pane) with the CodeMirror strip collapsed to a
+minimal strip (or fully hidden) — approximating the old full-screen feel.
+
+### Fix B — Default tree to collapsed for markdown files opened via App API
+
+In `build_pane_meta()` (`app_api.rs`), detect `.md` extension and default
+`editor:tree_expanded` to `false` when not explicitly set:
+
+```rust
+// In build_pane_meta, editor branch:
+if let Some(expanded) = cmd.tree_expanded {
+    meta.insert("editor:tree_expanded".to_string(), json!(expanded));
+} else if file.ends_with(".md") {
+    // Markdown files are opened for reading; start with tree collapsed.
+    meta.insert("editor:tree_expanded".to_string(), json!(false));
+}
+```
+
+Or push this decision into the MCP `OpenEditor` tool so agents calling it for markdown
+automatically get a collapsed tree without having to know the convention.
+
+### Fix C — Preserve App API field for initial preview mode
+
+Add `preview_open: Option<bool>` to `CommandPaneOpenData`. Map to `editor:preview_open` in
+`build_pane_meta`. Agents that want preview-only mode can pass `preview_open: true` and
+(once Fix A lands) `source_hidden: true` or similar.
+
+---
+
+## Action items
+
+| # | What | Owner |
+|---|------|-------|
+| 1 | Restore full-preview / full-source modes alongside split — default `.md` to preview-only | — |
+| 2 | Default `editor:tree_expanded = false` for `.md` files in `build_pane_meta` | — |
+| 3 | Add preview-mode field to `CommandPaneOpenData` so agents can set it via App API | — |
+| 4 | Write regression test: open `.md` via App API, assert tree collapsed + source hidden | — |

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -190,8 +190,10 @@ export class ClaudeTranslator implements OutputTranslator {
         if (!message || !Array.isArray(message.content)) return [];
 
         const events: StreamEvent[] = [];
+        let hasToolUse = false;
         for (const block of message.content) {
             if (block.type === "tool_use") {
+                hasToolUse = true;
                 this.currentToolCallId = block.id;
                 this.currentToolName = block.name;
                 if (block.id && block.name) {
@@ -206,6 +208,16 @@ export class ClaudeTranslator implements OutputTranslator {
                         : {},
                 });
             }
+        }
+        // In persistent/interactive mode the process never exits between turns,
+        // so "result" is only emitted at session teardown. Detect per-turn
+        // completion here: a non-partial assistant message with no tool_use
+        // blocks is always the final text response of a turn. Emit session_end
+        // so TurnPhase transitions to Done → idle. In subprocess (--print) mode
+        // the "result" event fires a duplicate TurnEnd, which is a no-op
+        // (first-done-wins in the reducer).
+        if (!hasToolUse) {
+            events.push({ type: "session_end", stats: {} });
         }
         return events;
     }

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -852,7 +852,12 @@ export class EditorViewModel implements ViewModel {
     async toggleSourceHidden(): Promise<void> {
         const next = !this._sourceHidden[0]();
         this._sourceHidden[1](next);
-        await this.persistMeta({ [META_SOURCE_HIDDEN]: next });
+        if (!next && !this._previewOpen[0]()) {
+            this._previewOpen[1](true);
+            await this.persistMeta({ [META_SOURCE_HIDDEN]: next, [META_PREVIEW_OPEN]: true });
+        } else {
+            await this.persistMeta({ [META_SOURCE_HIDDEN]: next });
+        }
     }
 
     setPreviewHeight(height: number): void {

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -41,6 +41,7 @@ const META_SHOW_HIDDEN = "editor:show_hidden";
 const META_TREE_WIDTH = "editor:tree_width";
 const META_PREVIEW_OPEN = "editor:preview_open";
 const META_PREVIEW_HEIGHT = "editor:preview_height";
+const META_SOURCE_HIDDEN = "editor:source_hidden";
 const META_LEGACY_FILE = "file";
 const META_SCRATCH = "editor:scratch";
 const TREE_WIDTH_DEFAULT = 240;
@@ -143,6 +144,10 @@ export class EditorViewModel implements ViewModel {
 
     private _previewHeight = createSignal<number>(PREVIEW_HEIGHT_DEFAULT);
     previewHeightAtom: Accessor<number> = this._previewHeight[0];
+
+    /** When true the CodeMirror editor is hidden and the preview fills the full pane. */
+    private _sourceHidden = createSignal<boolean>(false);
+    sourceHiddenAtom: Accessor<boolean> = this._sourceHidden[0];
 
     treeModel = new FileTreeModel();
 
@@ -295,6 +300,9 @@ export class EditorViewModel implements ViewModel {
         }
         if (meta?.[META_PREVIEW_OPEN] === false) {
             this._previewOpen[1](false);
+        }
+        if (meta?.[META_SOURCE_HIDDEN] === true) {
+            this._sourceHidden[1](true);
         }
         const persistedPreviewH = meta?.[META_PREVIEW_HEIGHT];
         if (typeof persistedPreviewH === "number") {
@@ -839,6 +847,12 @@ export class EditorViewModel implements ViewModel {
         const next = !this._previewOpen[0]();
         this._previewOpen[1](next);
         await this.persistMeta({ [META_PREVIEW_OPEN]: next });
+    }
+
+    async toggleSourceHidden(): Promise<void> {
+        const next = !this._sourceHidden[0]();
+        this._sourceHidden[1](next);
+        await this.persistMeta({ [META_SOURCE_HIDDEN]: next });
     }
 
     setPreviewHeight(height: number): void {

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -620,7 +620,14 @@
     letter-spacing: 0.05em;
 }
 
-.editor-preview-chevron {
+.editor-preview-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.editor-preview-chevron,
+.editor-preview-source-toggle {
     background: none;
     border: none;
     color: var(--main-text-color);
@@ -632,6 +639,12 @@
     &:hover {
         opacity: 1;
     }
+}
+
+.editor-preview-source-toggle {
+    font-family: var(--fixed-font, monospace);
+    font-size: 9px;
+    letter-spacing: -0.02em;
 }
 
 .editor-preview-content {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -140,7 +140,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             // there's nothing editable to search. See
             // docs/specs/SPEC_EDITOR_AND_APP_FIND_2026_06_17.md.
             if (!ev.shiftKey && (ev.key === "f" || ev.key === "F")) {
-                if (!cmView) return;
+                if (!cmView || model.sourceHiddenAtom()) return;
                 ev.preventDefault();
                 ev.stopPropagation();
                 openSearchPanel(cmView);
@@ -844,7 +844,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         <div
                             class="editor-codemirror"
                             ref={setContainerRef}
-                            style={{ display: model.sourceHiddenAtom() ? "none" : undefined }}
+                            style={{ display: (model.sourceHiddenAtom() && isMarkdown()) ? "none" : undefined }}
                         />
                         <Show when={isMarkdown()}>
                             <Show when={model.previewOpenAtom() && !model.sourceHiddenAtom()}>
@@ -875,6 +875,7 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                                             type="button"
                                             class="editor-preview-source-toggle"
                                             title={model.sourceHiddenAtom() ? "Show source" : "Preview only (Mod+Shift+V)"}
+                                            aria-label={model.sourceHiddenAtom() ? "Show source" : "Preview only (Mod+Shift+V)"}
                                             onClick={() => void model.toggleSourceHidden()}
                                         >
                                             {"</>"}

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -146,12 +146,18 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                 openSearchPanel(cmView);
                 return;
             }
-            // Mod-Shift-V toggles the markdown preview panel.
+            // Mod-Shift-V: cycle through preview modes.
+            // In preview-only (sourceHidden) → exit to split view.
+            // In split or source-only → toggle the split panel.
             if (ev.shiftKey && (ev.key === "v" || ev.key === "V")) {
                 if (!isMarkdown()) return;
                 ev.preventDefault();
                 ev.stopPropagation();
-                void model.togglePreview();
+                if (model.sourceHiddenAtom()) {
+                    void model.toggleSourceHidden();
+                } else {
+                    void model.togglePreview();
+                }
             }
         };
         rootRef.addEventListener("keydown", handleEditorKeys, { capture: true });
@@ -835,9 +841,13 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                     fallback={<EmptyEditor />}
                 >
                     <div class="editor-body-wrap">
-                        <div class="editor-codemirror" ref={setContainerRef} />
+                        <div
+                            class="editor-codemirror"
+                            ref={setContainerRef}
+                            style={{ display: model.sourceHiddenAtom() ? "none" : undefined }}
+                        />
                         <Show when={isMarkdown()}>
-                            <Show when={model.previewOpenAtom()}>
+                            <Show when={model.previewOpenAtom() && !model.sourceHiddenAtom()}>
                                 <div
                                     class="editor-preview-divider"
                                     onMouseDown={handlePreviewResizeMouseDown}
@@ -846,32 +856,48 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                             </Show>
                             <div
                                 class="editor-preview-pane"
-                                classList={{ "editor-preview-pane--collapsed": !model.previewOpenAtom() }}
+                                classList={{
+                                    "editor-preview-pane--collapsed": !model.previewOpenAtom() && !model.sourceHiddenAtom(),
+                                }}
                                 style={
-                                    model.previewOpenAtom()
-                                        ? { height: `${model.previewHeightAtom()}px` }
-                                        : undefined
+                                    model.sourceHiddenAtom()
+                                        ? { flex: "1 1 auto" }
+                                        : model.previewOpenAtom()
+                                            ? { height: `${model.previewHeightAtom()}px` }
+                                            : undefined
                                 }
                                 id={`editor-preview-panel-${model.blockId}`}
                             >
                                 <div class="editor-preview-header">
                                     <span class="editor-preview-header-label">Preview</span>
-                                    <button
-                                        type="button"
-                                        class="editor-preview-chevron"
-                                        aria-expanded={model.previewOpenAtom()}
-                                        aria-controls={`editor-preview-panel-${model.blockId}`}
-                                        aria-label={
-                                            model.previewOpenAtom()
-                                                ? "Collapse preview"
-                                                : "Expand preview (Ctrl+Shift+V)"
-                                        }
-                                        onClick={() => void model.togglePreview()}
-                                    >
-                                        {model.previewOpenAtom() ? "▴" : "▾"}
-                                    </button>
+                                    <div class="editor-preview-header-actions">
+                                        <button
+                                            type="button"
+                                            class="editor-preview-source-toggle"
+                                            title={model.sourceHiddenAtom() ? "Show source" : "Preview only (Mod+Shift+V)"}
+                                            onClick={() => void model.toggleSourceHidden()}
+                                        >
+                                            {"</>"}
+                                        </button>
+                                        <Show when={!model.sourceHiddenAtom()}>
+                                            <button
+                                                type="button"
+                                                class="editor-preview-chevron"
+                                                aria-expanded={model.previewOpenAtom()}
+                                                aria-controls={`editor-preview-panel-${model.blockId}`}
+                                                aria-label={
+                                                    model.previewOpenAtom()
+                                                        ? "Collapse preview"
+                                                        : "Expand preview"
+                                                }
+                                                onClick={() => void model.togglePreview()}
+                                            >
+                                                {model.previewOpenAtom() ? "▴" : "▾"}
+                                            </button>
+                                        </Show>
+                                    </div>
                                 </div>
-                                <Show when={model.previewOpenAtom()}>
+                                <Show when={model.previewOpenAtom() || model.sourceHiddenAtom()}>
                                     <div class="editor-preview-content">
                                         <Markdown textAtom={() => liveDoc()} />
                                     </div>

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -28,6 +28,7 @@ export interface ActiveSubagent {
 export interface AgentTreeNode {
     blockId: string | null;
     agentName: string;
+    agentProvider: string | null;
     activitySummary: string | null;
     agentStatus: "running" | "idle";
     subagents: ActiveSubagent[];
@@ -214,13 +215,15 @@ export class SwarmViewModel implements ViewModel {
             const agentName =
                 (block?.meta?.["agentName"] as string | undefined)?.trim() ||
                 "Agent";
+            const agentProvider =
+                (block?.meta?.["agentProvider"] as string | undefined)?.trim() || null;
             const activitySummary =
                 (block?.meta?.["term:activity"] as string | undefined)?.trim() || null;
             const agentStatus = statuses.get(blockId) ?? "idle";
             const children = subagents
                 .filter((s) => s.parent_block_id === blockId)
                 .sort((a, b) => b.last_event_at - a.last_event_at);
-            return { blockId, agentName, activitySummary, agentStatus, subagents: children };
+            return { blockId, agentName, agentProvider, activitySummary, agentStatus, subagents: children };
         });
     }
 

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -96,9 +96,9 @@
     }
 
     .swarm-agent-icon {
-        font-size: 14px;
         flex-shrink: 0;
-        opacity: 0.6;
+        display: inline-flex;
+        align-items: center;
     }
 
     .swarm-agent-label {

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -3,6 +3,7 @@
 
 import { createMemo, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent } from "./swarm-model";
+import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -130,9 +131,11 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
 
 type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected";
 
-function phaseToDisplayStatus(blockId: string, fallback: "running" | "idle"): AgentDisplayStatus {
+function phaseToDisplayStatus(blockId: string, _fallback: "running" | "idle"): AgentDisplayStatus {
     const phaseAccessor = getBlockTurnPhase(blockId);
-    if (!phaseAccessor) return fallback === "running" ? "working" : "idle";
+    // shellprocstatus "running" only means the process is alive, not that it's
+    // doing LLM work. Without a registered TurnPhase, default to idle.
+    if (!phaseAccessor) return "idle";
     const phase = phaseAccessor();
     switch (phase.kind) {
         case "Submitting":    return "working";
@@ -168,7 +171,9 @@ function AgentRow({
                 onClick={() => node.blockId && void focusBlock(node.blockId)}
                 title={node.agentName}
             >
-                <span class="swarm-agent-icon">⬡</span>
+                <span class="swarm-agent-icon">
+                    <ProviderLogo provider={node.agentProvider ?? "agentmux"} size={16} />
+                </span>
                 <span class="swarm-agent-label">{node.agentName}</span>
                 <AgentStatusChip status={displayStatus()} />
             </div>


### PR DESCRIPTION
## Summary

- **Root cause:** In interactive/persistent mode, Claude Code only emits `{"type":"result"}` on process exit, not at the end of each turn. This left `TurnPhase` stuck in `Submitting` permanently, causing the swarm pane to show "working" indefinitely after a response finished.
- **Fix:** `handleAssistantMessage` now detects turn completion: a non-partial `assistant` message with no `tool_use` blocks is always the final text response of a turn. It emits a synthetic `session_end` so `TurnPhase` transitions `Done → idle`.
- **Subprocess mode safety:** In `--print` mode, the `result` event fires a second `TurnEnd` dispatch — this is a no-op due to first-done-wins in the reducer.

## How it works

```
assistant event (tool_use blocks) → tool call in progress → no session_end
assistant event (text/thinking only) → turn complete → emit session_end → TurnPhase = Done
```

## Test plan

- [ ] Send a message to a persistent agent; verify swarm shows "working" during response and transitions to "idle" when done
- [ ] Send a message that triggers tool calls; verify swarm stays "working" through all tool call rounds, then goes "idle" on the final text response
- [ ] Send a message in subprocess (--print) mode; verify swarm still transitions to idle correctly (no regression from duplicate TurnEnd)

<!-- agentmux:agent_id=lark -->