### PR TITLE
fix(layout): solo-column pane slips header into adjacent column on minimize

### DIFF
--- a/.changesets/1782311382-fix-layout-solo-column-pane-slips-header-into-adjacent-colum-a17h.md
+++ b/.changesets/1782311382-fix-layout-solo-column-pane-slips-header-into-adjacent-colum-a17h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): solo-column pane slips header into adjacent column on minimize instead of going thin

--- a/docs/specs/SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md
+++ b/docs/specs/SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md
@@ -1,0 +1,278 @@
+# SPEC — Pane Minimize Refinements
+
+**Date:** 2026-06-24
+**Status:** Proposed
+**Builds on:** SPEC_PANE_MINIMIZE_AND_TOOLCALL_FAILCOLLAPSE_2026_06_21.md
+
+---
+
+## Overview
+
+Two refinements to the pane minimize button introduced in the prior spec:
+
+1. **Caret direction** — the minimize button's chevron should flip to point upward when the pane is collapsed, signaling "click to expand."
+2. **Solo-column slip behavior** — a pane that occupies its own column slot (no vertical sibling) should collapse vertically and slip its header into the adjacent column rather than shrinking horizontally into a thin strip.
+
+---
+
+## Background: current implementation
+
+The minimize button lives in `frontend/app/block/blockframe.tsx` (`OptMinimizeButton`, line 179). It is visible when `numLeafs() > 1` (more than one pane in the workspace) and the pane is not magnified or ephemeral.
+
+Collapse is implemented in `frontend/layout/lib/layoutMinimize.ts` (`minimizeNodeToggle`). It:
+
+1. Finds the node's **parent** in the layout tree.
+2. Picks an **adjacent sibling** (right-neighbor preferred, else left).
+3. Stores the original `node.size` in `node.minimizedSize` and sets `node.size = headerSizeUnits` (33px + gap in flex-units).
+4. Gives the freed units to the sibling.
+
+The critical flaw: `node.size` is the size **along the parent's flex direction**. When `parentNode.flexDirection === Row`, `node.size` is **width** — so minimize makes the pane horizontally narrow (thin strip) instead of vertically short (header bar). This is the "thin pane" bug.
+
+### Layout tree structure for the solo-column case
+
+```
+rootNode  (FlexDirection.Row)
+├── soloPane  (leaf, size = W₁)   ← minimize button visible because total numLeafs > 1
+└── adjacentColumn  (FlexDirection.Column, size = W₂)
+    ├── paneB  (leaf)
+    └── paneC  (leaf)
+```
+
+With current code, minimizing soloPane sets `soloPane.size = headerSizeUnits` where `pixelToSizeRatio` is from the **Row** parent — so soloPane becomes ~38px **wide**, not ~38px tall.
+
+---
+
+## Refinement 1 — Caret direction
+
+### Desired behavior
+
+| Pane state | Chevron | Tooltip |
+|---|---|---|
+| Expanded (default) | `chevron-down` ▾ | "Minimize" |
+| Collapsed | `chevron-up` ▴ | "Restore" |
+
+### Current code status
+
+`OptMinimizeButton` (blockframe.tsx:182) already reads:
+
+```typescript
+icon: props.minimized ? "chevron-up" : "chevron-down",
+title: props.minimized ? "Restore" : "Minimize",
+```
+
+`props.minimized` is passed as a reactive getter from `EndIcons`:
+
+```typescript
+const minimized = () => props.nodeModel.isMinimized();
+// ...
+<OptMinimizeButton minimized={minimized()} ... />
+```
+
+`isMinimized()` is a `createMemo` that reads `model.minimizedNodeIds` (a `SignalAtom`). The signal is updated synchronously in `minimizeNodeToggle`. The reactive chain is: signal → memo → prop getter → inner memo → icon string.
+
+**Conclusion:** The caret toggle is already implemented correctly in code on main. If the icon is observed to not flip, verify that `model.minimizedNodeIds._set(...)` is firing (add a console.log in `minimizeNodeToggle` lines 64–72) and that `rebuildMinimizedSet` is called on tree load.
+
+No code change required for Refinement 1 unless a reactivity gap is found.
+
+---
+
+## Refinement 2 — Solo-column slip behavior
+
+### Desired behavior
+
+When a pane's immediate parent in the layout tree is a **Row** node (meaning the pane occupies a horizontal column slot with no vertical neighbors), clicking minimize should:
+
+1. **Collapse vertically** to header-bar height (33px).
+2. **Slip** the pane's header to the **top** of the nearest adjacent column.
+3. **Release** its column-slot width to the adjacent column, which expands to fill the gap.
+
+On **restore**:
+1. Remove the pane from the adjacent column.
+2. Re-insert it in the root Row at its original position with its original width.
+3. Shrink the adjacent column back to its pre-collapse width.
+
+The pane header appears pinned above the adjacent column's top pane during the minimized state. It takes the full width of that column and only the header height.
+
+### New type field
+
+Extend `LayoutNode` in `frontend/layout/lib/types.ts`:
+
+```typescript
+export interface LayoutNode {
+    id: string;
+    data?: TabLayoutData;
+    children?: LayoutNode[];
+    flexDirection: FlexDirection;
+    size: number;
+    /** Present when node is minimized in-column (vertical collapse). */
+    minimizedSize?: number;
+    /**
+     * Present when node was minimized from a solo Row slot and slipped into
+     * an adjacent column. Stores restore context so the operation is fully
+     * reversible. Never coexists with `minimizedSize`.
+     */
+    slipMinimize?: {
+        /** Node ID of the Column the pane slipped into. */
+        targetColumnId: string;
+        /** Original Row-slot size (width) before slip. */
+        originalRowSize: number;
+        /** Original index in the Row's children array. */
+        originalRowIndex: number;
+    };
+}
+```
+
+### Detection — when to slip vs when to collapse normally
+
+In `minimizeNodeToggle` (`layoutMinimize.ts`), after finding `parentNode`:
+
+```typescript
+const isSoloRowSlot = parentNode.flexDirection === FlexDirection.Row;
+```
+
+If `isSoloRowSlot`, run the slip path. Otherwise, run the existing column-collapse path unchanged.
+
+> **Note:** A pane in a Row with a Row sibling (two panes side-by-side sharing width) also hits this branch. That is intentional — any pane whose parent is a Row should slip rather than thin. The "solo" descriptor in the spec title refers to the common UX case; the code predicate is simply parent-is-Row.
+
+### Slip-minimize algorithm
+
+```typescript
+if (isSoloRowSlot) {
+    // 1. Identify the adjacent column that will absorb the slip.
+    //    Pick the same neighbor as the normal path (right preferred).
+    const sibling = siblings[nodeIdx + 1] ?? siblings[nodeIdx - 1];
+    if (!sibling) return;
+
+    // 2. Record restore context.
+    node.slipMinimize = {
+        targetColumnId: sibling.id,
+        originalRowSize: node.size,
+        originalRowIndex: nodeIdx,
+    };
+
+    // 3. Give width to sibling; remove node from Row.
+    sibling.size += node.size;
+    parentNode.children!.splice(nodeIdx, 1);
+
+    // 4. Insert node at top of sibling column.
+    //    Get column's pixelToSizeRatio to convert header height to column units.
+    const colProps = addlProps[sibling.id];
+    const colRatio = colProps?.pixelToSizeRatio ?? pixelToSizeRatio;
+    const headerInColUnits = (HeaderHeightPx + gapSizePx) * colRatio;
+
+    if (!sibling.children) {
+        // Column has no children yet — shouldn't happen in practice.
+        sibling.data = undefined;
+        sibling.children = [];
+    }
+    // Steal header-height from the first child so total column size is preserved.
+    const firstChild = sibling.children[0];
+    if (firstChild) firstChild.size = Math.max(firstChild.size - headerInColUnits, headerInColUnits);
+    node.size = headerInColUnits;
+    sibling.children.unshift(node);
+}
+```
+
+### Slip-restore algorithm
+
+On the second toggle, detect restore via `node.slipMinimize !== undefined`:
+
+```typescript
+if (node.slipMinimize !== undefined) {
+    const { targetColumnId, originalRowSize, originalRowIndex } = node.slipMinimize;
+
+    // 1. Find the target column by id.
+    const targetCol = findNode(model.treeState.rootNode, targetColumnId);
+    if (!targetCol?.children) return;
+
+    // 2. Remove node from column; return its size to the next sibling.
+    const slipIdx = targetCol.children.findIndex((c) => c.id === nodeId);
+    if (slipIdx !== -1) {
+        const reclaimUnits = node.size;
+        targetCol.children.splice(slipIdx, 1);
+        const nextChild = targetCol.children[slipIdx] ?? targetCol.children[slipIdx - 1];
+        if (nextChild) nextChild.size += reclaimUnits;
+    }
+
+    // 3. Shrink sibling (the target column) back by originalRowSize.
+    targetCol.size -= originalRowSize;
+    if (targetCol.size < 0) targetCol.size = 0; // safety clamp
+
+    // 4. Re-insert node in the Row at its original index.
+    node.size = originalRowSize;
+    node.slipMinimize = undefined;
+    const rowNode = findParent(model.treeState.rootNode, targetColumnId);
+    if (!rowNode?.children) return;
+    const clampedIdx = Math.min(originalRowIndex, rowNode.children.length);
+    rowNode.children.splice(clampedIdx, 0, node);
+}
+```
+
+### `minimizedNodeIds` set — both paths
+
+After either branch (normal or slip), the `minimizedNodeIds` set must reflect the node's new minimized state. The existing set-update block at lines 64–72 already reads `node.minimizedSize !== undefined`, so extend it:
+
+```typescript
+model.minimizedNodeIds._set((prev) => {
+    const next = new Set(prev);
+    const isMinimized = node.minimizedSize !== undefined || node.slipMinimize !== undefined;
+    if (isMinimized) {
+        next.add(nodeId);
+    } else {
+        next.delete(nodeId);
+    }
+    return next;
+});
+```
+
+### `rebuildMinimizedSet` — include slip nodes
+
+In `rebuildMinimizedSet` (layoutMinimize.ts:83), extend the walk to include slip nodes:
+
+```typescript
+if (node.minimizedSize !== undefined || node.slipMinimize !== undefined) ids.add(node.id);
+```
+
+### Edge cases
+
+| Scenario | Handling |
+|---|---|
+| Adjacent column has no children | Treat column as sole occupant; skip first-child resize. Node becomes the column's only child with full size. |
+| Restore when target column no longer exists (deleted) | Detect `targetCol === undefined`; fall back to reinserting at a heuristic Row position (after last child). Log a warning. |
+| Multiple slip-minimized panes into the same column | Each inserts at index 0 sequentially — last one wins top position. Order is preserved per insertion. |
+| Restoring when target column's children have been resized | Restore only reclaims `node.size` (header-height in column units) from the next sibling — it does not try to fully restore the column's original internal distribution. |
+| Adjacent sibling is itself a leaf (not a column) | The same slip algorithm applies: the sibling is promoted to hold both the slipped header and its own content. An intermediate Column node must be inserted via `addIntermediateNode` before the `children.unshift` call. |
+
+#### Adjacent sibling is a leaf — intermediate column insertion
+
+When `!sibling.children` (the sibling is a leaf, not a branch), use `addIntermediateNode` to wrap it before inserting:
+
+```typescript
+if (!sibling.children) {
+    // sibling is a leaf; wrap it in a Column so we can prepend the slipped header.
+    addIntermediateNode(sibling); // mutates sibling: data → child, adds Column wrapper
+}
+```
+
+After this, `sibling.children` is defined and the `unshift` proceeds normally.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `frontend/layout/lib/types.ts` | Add `slipMinimize` field to `LayoutNode` |
+| `frontend/layout/lib/layoutMinimize.ts` | Add `isSoloRowSlot` branch in `minimizeNodeToggle`; extend `minimizedNodeIds` update; extend `rebuildMinimizedSet` |
+| `frontend/layout/lib/layoutNode.ts` | No change — `addIntermediateNode`, `removeChild`, `findNode`, `findParent` are reused as-is |
+| `frontend/app/block/blockframe.tsx` | No change needed — caret toggle already implemented |
+
+---
+
+## Out of scope
+
+- Animated transition (the header sliding from old position to top of adjacent column).
+- Keyboard shortcut for minimize.
+- Minimized state in tab strip thumbnails.
+- Slip behavior for panes in a floating (torn-off) window — floating windows have a single column, so `numLeafs() > 1` is typically false there already.
+- Preserving the internal size distribution of the adjacent column on restore.

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -24,17 +24,14 @@ export const HeaderHeightPx = 33;
  * pane "slips" its header to the top of the nearest adjacent column, giving its
  * full width to that column. `node.slipMinimize` stores restore context.
  *
- * ### balanceNode hazard
+ * ### balanceNode and the _slipAnchor invariant
  *
- * `_finishToggle` calls `model.updateTree()` which runs `balanceNode`. That function's
- * `beforeWalkCallback` hoists a child's grandchildren into the parent whenever the
- * child has exactly one grandchild that is itself a branch:
- *   `if (child.children?.length == 1 && child.children[0].children) return child.children[0].children`
- *
- * After a slip on a two-pane Row (A + B), removing A leaves the Row with one child (B,
- * a column with children). `balanceNode` would hoist B's children into the Row's parent,
- * scattering them and invalidating `targetColumnId`. To prevent this we hoist B ourselves
- * before `updateTree` runs and record the Row's restore context in `slipMinimize.promotedRow`.
+ * After a slip, the parentRow has exactly one child (the target Column). Normally
+ * `balanceNode` would hoist that column's children into the grandparent (single-
+ * child-branch flatMap rule), scattering them and losing `targetColumnId`. We
+ * prevent this by setting `parentRow._slipAnchor = true`, which `balanceNode`
+ * checks before applying the hoist. The Row(→Column) direction alternation is
+ * preserved, and the tree is stable through serialise/reload cycles.
  */
 export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
     const node = findNode(model.treeState.rootNode, nodeId);
@@ -45,11 +42,11 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
 
     // ── Restore: slip path ────────────────────────────────────────────────────
     if (node.slipMinimize !== undefined) {
-        const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf, promotedRow } = node.slipMinimize;
+        const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = node.slipMinimize;
 
         const targetCol = findNode(model.treeState.rootNode, targetColumnId);
         if (targetCol?.children) {
-            // Remove the slipped header from the column; return its size to its neighbor.
+            // Remove the slipped header from the column; give its size back to the neighbor.
             const slipIdx = targetCol.children.findIndex((c) => c.id === nodeId);
             if (slipIdx !== -1) {
                 const reclaimUnits = node.size;
@@ -68,36 +65,17 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
                 }
             }
 
-            if (promotedRow) {
-                // The Row was hoisted during slip: targetCol is now a direct child of
-                // the grandparent. Re-wrap A and B in a new Row and replace targetCol
-                // in the grandparent.
-                const grandparent = findNode(model.treeState.rootNode, promotedRow.rowParentId);
-                if (grandparent?.children) {
-                    const bIdx = grandparent.children.findIndex((c) => c.id === targetColumnId);
-                    if (bIdx !== -1) {
-                        // Restore B's original Row-width and A's size.
-                        targetCol.size = promotedRow.originalTargetRowSize;
-                        node.size = originalRowSize;
-                        node.slipMinimize = undefined;
-                        // Re-create the Row in the original slot order.
-                        const rowChildren: LayoutNode[] =
-                            originalRowIndex === 0 ? [node, targetCol] : [targetCol, node];
-                        const newRow = newLayoutNode(FlexDirection.Row, promotedRow.rowSize, rowChildren);
-                        grandparent.children.splice(bIdx, 1, newRow);
-                    }
-                }
-            } else {
-                // Normal restore: Row still exists. Shrink B back to its original width
-                // and re-insert A at its original index.
-                targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
-                const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
-                if (rowNode.children) {
-                    node.size = originalRowSize;
-                    node.slipMinimize = undefined;
-                    const idx = Math.min(originalRowIndex, rowNode.children.length);
-                    rowNode.children.splice(idx, 0, node);
-                }
+            // Shrink column back to its original width.
+            targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
+
+            // Re-insert node in the Row and clear the slip anchor.
+            const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
+            if (rowNode.children) {
+                node.size = originalRowSize;
+                node.slipMinimize = undefined;
+                rowNode._slipAnchor = undefined;
+                const idx = Math.min(originalRowIndex, rowNode.children.length);
+                rowNode.children.splice(idx, 0, node);
             }
         } else {
             console.warn(`[layoutMinimize] slip restore: target column ${targetColumnId} not found; dropping slip state`);
@@ -163,10 +141,9 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
  * Slip a pane from its Row slot into the top of an adjacent column.
  * Returns true on success, false if the tree was not mutated (caller should bail).
  *
- * When the Row has exactly two children (this pane + the target), removing this pane
- * would leave a single-child Row that `balanceNode` would hoist — scattering the
- * target column's children and losing `targetColumnId`. We detect this and hoist
- * the target ourselves, recording the context in `slipMinimize.promotedRow`.
+ * Sets `_slipAnchor = true` on the parentRow so `balanceNode` skips the
+ * single-child-branch hoist rule, keeping the Row(→Column) direction alternation
+ * intact while the pane is in the slipped state.
  */
 function _slipMinimize(
     model: LayoutModel,
@@ -222,42 +199,23 @@ function _slipMinimize(
         firstChild.size = Math.max(firstChild.size - headerInColUnits, headerInColUnits);
     }
 
-    // Capture B's original Row-width before mutating sizes (needed for promotedRow restore).
-    const originalTargetRowSize = sibling.size;
-
-    // Give A's Row-width to B, then remove A from the Row.
-    sibling.size += node.size;
-    parentRow.children!.splice(nodeIdx, 1);
-
-    // Detect single-child Row and hoist B ourselves to prevent balanceNode from
-    // scattering B's children (which would invalidate targetColumnId on restore).
-    let promotedRow: NonNullable<LayoutNode["slipMinimize"]>["promotedRow"] | undefined;
-    if (parentRow.children!.length === 1) {
-        const grandparent = findParent(model.treeState.rootNode, parentRow.id);
-        if (grandparent?.children) {
-            const rowIdx = grandparent.children.findIndex((c) => c.id === parentRow.id);
-            if (rowIdx !== -1) {
-                promotedRow = {
-                    rowParentId: grandparent.id,
-                    rowIdx,
-                    rowSize: parentRow.size,
-                    originalTargetRowSize,
-                };
-                // Hoist: give B the Row's Column-slot size and replace the Row in grandparent.
-                sibling.size = parentRow.size;
-                grandparent.children.splice(rowIdx, 1, sibling);
-            }
-        }
-    }
-
     // Record slip state before modifying node.size.
     node.slipMinimize = {
         targetColumnId: sibling.id,
         originalRowSize: node.size,
         originalRowIndex: nodeIdx,
         targetWasLeaf,
-        promotedRow,
     };
+
+    // Remove from Row, give its width to the sibling.
+    sibling.size += node.size;
+    parentRow.children!.splice(nodeIdx, 1);
+
+    // Mark the Row so balanceNode skips the single-child hoist for this subtree.
+    // Without this, balanceNode's flatMap rule would see parentRow(1 child = B branch)
+    // and hoist B's children directly into grandparent, scattering them and losing
+    // targetColumnId. The Row(→Column) direction alternation stays correct.
+    parentRow._slipAnchor = true;
 
     // Insert at top of the column.
     node.size = headerInColUnits;

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -2,52 +2,97 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+import { newLayoutNode } from "./layoutNode";
 import { findNode, findParent } from "./layoutNode";
 import type { LayoutModel } from "./layoutModel";
+import { DefaultNodeSize, FlexDirection, type LayoutNodeAdditionalProps } from "./types";
 
 /** Height of the block header in CSS pixels (matches --header-height in theme.scss). */
 export const HeaderHeightPx = 33;
 
 /**
- * Toggle minimize for a given leaf node. Minimized panes collapse to their header
- * bar, redistributing freed space to an adjacent sibling. Restoring returns the
- * pane to its original size by reclaiming space from that same sibling.
+ * Toggle minimize for a given leaf node.
+ *
+ * There are two minimize paths depending on the node's parent flex direction:
+ *
+ * **Column parent (normal path):** The node collapses vertically to its header bar.
+ * Freed space is given to the adjacent sibling. `node.minimizedSize` stores the
+ * original height for restore.
+ *
+ * **Row parent (slip path):** Shrinking the node's Row-slot size would make it
+ * horizontally narrow (thin strip) rather than vertically collapsed. Instead the
+ * pane "slips" its header to the top of the nearest adjacent column, giving its
+ * full width to that column. `node.slipMinimize` stores restore context.
  */
 export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
     const node = findNode(model.treeState.rootNode, nodeId);
     if (!node) return;
 
+    const addlProps = model.getter(model.additionalProps);
+    const gapSizePx = model.gapSizePx();
+
+    // ── Restore: slip path ────────────────────────────────────────────────────
+    if (node.slipMinimize !== undefined) {
+        const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = node.slipMinimize;
+
+        const targetCol = findNode(model.treeState.rootNode, targetColumnId);
+        if (targetCol?.children) {
+            // Remove slipped header from column; give its size back to the next sibling.
+            const slipIdx = targetCol.children.findIndex((c) => c.id === nodeId);
+            if (slipIdx !== -1) {
+                const reclaimUnits = node.size;
+                targetCol.children.splice(slipIdx, 1);
+                const neighbor = targetCol.children[slipIdx] ?? targetCol.children[slipIdx - 1];
+                if (neighbor) neighbor.size += reclaimUnits;
+            }
+
+            // If the column was converted from a leaf during slip, unwrap it back.
+            if (targetWasLeaf && targetCol.children.length === 1) {
+                const only = targetCol.children[0];
+                if (only.data && !only.children) {
+                    targetCol.data = only.data;
+                    targetCol.children = undefined;
+                    targetCol.flexDirection = FlexDirection.Row;
+                }
+            }
+
+            // Shrink column back to its original width.
+            targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
+        } else {
+            console.warn(`[layoutMinimize] slip restore: target column ${targetColumnId} not found; dropping slip state`);
+        }
+
+        // Re-insert the pane in its original Row position.
+        // The Row is the parent of the target column (or grandparent of the target column's content).
+        const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
+        if (rowNode.children) {
+            node.size = originalRowSize;
+            node.slipMinimize = undefined;
+            const idx = Math.min(originalRowIndex, rowNode.children.length);
+            rowNode.children.splice(idx, 0, node);
+        }
+
+        _finishToggle(model, nodeId, false);
+        return;
+    }
+
+    // ── Need parent for minimize and normal restore ───────────────────────────
     const parentNode = findParent(model.treeState.rootNode, nodeId);
     if (!parentNode?.children?.length) return;
 
-    const addlProps = model.getter(model.additionalProps);
     const pixelToSizeRatio = addlProps[parentNode.id]?.pixelToSizeRatio;
     if (!pixelToSizeRatio) return;
 
     const siblings = parentNode.children;
     const nodeIdx = siblings.findIndex((c) => c.id === nodeId);
-
-    // Pick the adjacent sibling that will absorb or yield space.
     const sibling = siblings[nodeIdx + 1] ?? siblings[nodeIdx - 1];
-    if (!sibling) return;
 
-    // Add gap so the header isn't clipped by the tile-leaf's gap/2 inset padding on each side.
-    const gapSizePx = model.gapSizePx();
-    const headerSizeUnits = (HeaderHeightPx + gapSizePx) * pixelToSizeRatio;
-
-    if (node.minimizedSize === undefined) {
-        // --- Minimize ---
-        const freedUnits = node.size - headerSizeUnits;
-        if (freedUnits <= 0) return; // already tiny — no-op
-
-        node.minimizedSize = node.size;
-        node.size = headerSizeUnits;
-        sibling.size += freedUnits;
-    } else {
-        // --- Restore ---
+    // ── Restore: normal path ──────────────────────────────────────────────────
+    if (node.minimizedSize !== undefined) {
+        if (!sibling) return;
+        const headerSizeUnits = (HeaderHeightPx + gapSizePx) * pixelToSizeRatio;
         const reclaimUnits = node.minimizedSize - headerSizeUnits;
         const siblingAfterReclaim = sibling.size - reclaimUnits;
-        // Clamp: don't let sibling go below its own header height.
         const minSiblingUnits = HeaderHeightPx * pixelToSizeRatio;
         if (siblingAfterReclaim < minSiblingUnits) {
             const available = sibling.size - minSiblingUnits;
@@ -58,33 +103,141 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
             sibling.size = siblingAfterReclaim;
         }
         node.minimizedSize = undefined;
+        _finishToggle(model, nodeId, false);
+        return;
     }
 
-    // Update the minimized-node-id set for reactive isMinimized checks.
+    // ── Minimize ──────────────────────────────────────────────────────────────
+    if (!sibling) return;
+
+    if (parentNode.flexDirection === FlexDirection.Row) {
+        // Slip path: pane occupies a Row slot — slip header into adjacent column instead
+        // of making the pane horizontally narrow.
+        if (!_slipMinimize(model, node, nodeIdx, parentNode, sibling, addlProps, gapSizePx)) return;
+    } else {
+        // Normal path: pane is in a Column — collapse it vertically within the column.
+        const headerSizeUnits = (HeaderHeightPx + gapSizePx) * pixelToSizeRatio;
+        const freedUnits = node.size - headerSizeUnits;
+        if (freedUnits <= 0) return; // already tiny — no-op
+        node.minimizedSize = node.size;
+        node.size = headerSizeUnits;
+        sibling.size += freedUnits;
+    }
+
+    _finishToggle(model, nodeId, true);
+}
+
+/**
+ * Slip a pane from its Row slot into the top of an adjacent column.
+ * Handles both the case where the sibling is already a Column branch and the
+ * case where it is a plain leaf (converted to a Column in-place).
+ */
+/** Returns true on success, false if the tree was not mutated (caller should bail). */
+function _slipMinimize(
+    model: LayoutModel,
+    node: import("./types").LayoutNode,
+    nodeIdx: number,
+    parentRow: import("./types").LayoutNode,
+    sibling: import("./types").LayoutNode,
+    addlProps: Record<string, LayoutNodeAdditionalProps>,
+    gapSizePx: number,
+): boolean {
+    const siblingProps = addlProps[sibling.id];
+    let targetWasLeaf = false;
+
+    // Convert a plain leaf sibling into a Column container so we can prepend the header.
+    if (!sibling.children) {
+        targetWasLeaf = true;
+        const heightPx = siblingProps?.rect?.height;
+        // Choose a content size that keeps total = DefaultNodeSize so the ratio is computable.
+        const totalUnits = DefaultNodeSize;
+        const headerUnitsEst = heightPx
+            ? ((HeaderHeightPx + gapSizePx) * totalUnits) / heightPx
+            : totalUnits * 0.05; // fallback: ~5% for header if height unknown
+        const contentUnits = Math.max(totalUnits - headerUnitsEst, headerUnitsEst);
+
+        const contentNode = newLayoutNode(FlexDirection.Row, contentUnits, undefined, sibling.data);
+        sibling.data = undefined;
+        sibling.flexDirection = FlexDirection.Column;
+        sibling.children = [contentNode];
+        // We'll set the slipped node's size = headerUnitsEst; total = headerUnitsEst + contentUnits.
+        // The layout engine recomputes the ratio on the next frame, so the exact values just
+        // need to be in the right proportion.
+    }
+
+    // Compute header height in the column's flex-units.
+    const colRatio: number | undefined = siblingProps?.pixelToSizeRatio
+        ?? (siblingProps?.rect?.height && sibling.children
+            ? sibling.children.reduce((s, c) => s + c.size, 0) / siblingProps.rect.height
+            : undefined);
+
+    if (colRatio == null) {
+        // Can't determine column ratio — bail without mutating the tree.
+        console.warn("[layoutMinimize] slip: cannot determine column ratio, skipping");
+        if (targetWasLeaf) {
+            // Undo the leaf-to-column conversion.
+            const only = sibling.children?.[0];
+            if (only?.data) {
+                sibling.data = only.data;
+                sibling.children = undefined;
+                sibling.flexDirection = FlexDirection.Row;
+            }
+        }
+        return false;
+    }
+
+    const headerInColUnits = (HeaderHeightPx + gapSizePx) * colRatio;
+
+    // Steal header height from the first column child to keep total column size constant.
+    const firstChild = sibling.children![0];
+    if (firstChild) {
+        firstChild.size = Math.max(firstChild.size - headerInColUnits, headerInColUnits);
+    }
+
+    // Record slip state before modifying node.size.
+    node.slipMinimize = {
+        targetColumnId: sibling.id,
+        originalRowSize: node.size,
+        originalRowIndex: nodeIdx,
+        targetWasLeaf,
+    };
+
+    // Remove from Row, give its width to the sibling.
+    sibling.size += node.size;
+    parentRow.children!.splice(nodeIdx, 1);
+
+    // Insert at top of the column.
+    node.size = headerInColUnits;
+    sibling.children!.unshift(node);
+    return true;
+}
+
+/** Commit tree changes and update the minimized-node-id reactive set. */
+function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
     model.minimizedNodeIds._set((prev) => {
         const next = new Set(prev);
-        if (node.minimizedSize !== undefined) {
+        if (minimized) {
             next.add(nodeId);
         } else {
             next.delete(nodeId);
         }
         return next;
     });
-
     model.updateTree();
     model.localTreeStateAtom._set({ ...model.treeState });
     model.persistToBackend();
 }
 
 /**
- * Scan the loaded tree for nodes that carry a `minimizedSize` field and rebuild
- * the in-memory `minimizedNodeIds` set. Called once during `initializeFromWaveObject`.
+ * Scan the loaded tree for nodes that carry a `minimizedSize` or `slipMinimize`
+ * field and rebuild the in-memory `minimizedNodeIds` set.
+ * Called once during `initializeFromWaveObject`.
  */
 export function rebuildMinimizedSet(model: LayoutModel) {
     const ids = new Set<string>();
     function walk(node: typeof model.treeState.rootNode) {
         if (!node) return;
-        if (node.minimizedSize !== undefined) ids.add(node.id);
+        if (node.minimizedSize !== undefined || node.slipMinimize !== undefined) ids.add(node.id);
         node.children?.forEach(walk);
     }
     walk(model.treeState.rootNode);

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -5,7 +5,7 @@
 import { newLayoutNode } from "./layoutNode";
 import { findNode, findParent } from "./layoutNode";
 import type { LayoutModel } from "./layoutModel";
-import { DefaultNodeSize, FlexDirection, type LayoutNodeAdditionalProps } from "./types";
+import { DefaultNodeSize, FlexDirection, type LayoutNodeAdditionalProps, type LayoutNode } from "./types";
 
 /** Height of the block header in CSS pixels (matches --header-height in theme.scss). */
 export const HeaderHeightPx = 33;
@@ -23,6 +23,18 @@ export const HeaderHeightPx = 33;
  * horizontally narrow (thin strip) rather than vertically collapsed. Instead the
  * pane "slips" its header to the top of the nearest adjacent column, giving its
  * full width to that column. `node.slipMinimize` stores restore context.
+ *
+ * ### balanceNode hazard
+ *
+ * `_finishToggle` calls `model.updateTree()` which runs `balanceNode`. That function's
+ * `beforeWalkCallback` hoists a child's grandchildren into the parent whenever the
+ * child has exactly one grandchild that is itself a branch:
+ *   `if (child.children?.length == 1 && child.children[0].children) return child.children[0].children`
+ *
+ * After a slip on a two-pane Row (A + B), removing A leaves the Row with one child (B,
+ * a column with children). `balanceNode` would hoist B's children into the Row's parent,
+ * scattering them and invalidating `targetColumnId`. To prevent this we hoist B ourselves
+ * before `updateTree` runs and record the Row's restore context in `slipMinimize.promotedRow`.
  */
 export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
     const node = findNode(model.treeState.rootNode, nodeId);
@@ -33,11 +45,11 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
 
     // ── Restore: slip path ────────────────────────────────────────────────────
     if (node.slipMinimize !== undefined) {
-        const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = node.slipMinimize;
+        const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf, promotedRow } = node.slipMinimize;
 
         const targetCol = findNode(model.treeState.rootNode, targetColumnId);
         if (targetCol?.children) {
-            // Remove slipped header from column; give its size back to the next sibling.
+            // Remove the slipped header from the column; return its size to its neighbor.
             const slipIdx = targetCol.children.findIndex((c) => c.id === nodeId);
             if (slipIdx !== -1) {
                 const reclaimUnits = node.size;
@@ -56,20 +68,40 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
                 }
             }
 
-            // Shrink column back to its original width.
-            targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
+            if (promotedRow) {
+                // The Row was hoisted during slip: targetCol is now a direct child of
+                // the grandparent. Re-wrap A and B in a new Row and replace targetCol
+                // in the grandparent.
+                const grandparent = findNode(model.treeState.rootNode, promotedRow.rowParentId);
+                if (grandparent?.children) {
+                    const bIdx = grandparent.children.findIndex((c) => c.id === targetColumnId);
+                    if (bIdx !== -1) {
+                        // Restore B's original Row-width and A's size.
+                        targetCol.size = promotedRow.originalTargetRowSize;
+                        node.size = originalRowSize;
+                        node.slipMinimize = undefined;
+                        // Re-create the Row in the original slot order.
+                        const rowChildren: LayoutNode[] =
+                            originalRowIndex === 0 ? [node, targetCol] : [targetCol, node];
+                        const newRow = newLayoutNode(FlexDirection.Row, promotedRow.rowSize, rowChildren);
+                        grandparent.children.splice(bIdx, 1, newRow);
+                    }
+                }
+            } else {
+                // Normal restore: Row still exists. Shrink B back to its original width
+                // and re-insert A at its original index.
+                targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
+                const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
+                if (rowNode.children) {
+                    node.size = originalRowSize;
+                    node.slipMinimize = undefined;
+                    const idx = Math.min(originalRowIndex, rowNode.children.length);
+                    rowNode.children.splice(idx, 0, node);
+                }
+            }
         } else {
             console.warn(`[layoutMinimize] slip restore: target column ${targetColumnId} not found; dropping slip state`);
-        }
-
-        // Re-insert the pane in its original Row position.
-        // The Row is the parent of the target column (or grandparent of the target column's content).
-        const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
-        if (rowNode.children) {
-            node.size = originalRowSize;
             node.slipMinimize = undefined;
-            const idx = Math.min(originalRowIndex, rowNode.children.length);
-            rowNode.children.splice(idx, 0, node);
         }
 
         _finishToggle(model, nodeId, false);
@@ -129,16 +161,19 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
 
 /**
  * Slip a pane from its Row slot into the top of an adjacent column.
- * Handles both the case where the sibling is already a Column branch and the
- * case where it is a plain leaf (converted to a Column in-place).
+ * Returns true on success, false if the tree was not mutated (caller should bail).
+ *
+ * When the Row has exactly two children (this pane + the target), removing this pane
+ * would leave a single-child Row that `balanceNode` would hoist — scattering the
+ * target column's children and losing `targetColumnId`. We detect this and hoist
+ * the target ourselves, recording the context in `slipMinimize.promotedRow`.
  */
-/** Returns true on success, false if the tree was not mutated (caller should bail). */
 function _slipMinimize(
     model: LayoutModel,
-    node: import("./types").LayoutNode,
+    node: LayoutNode,
     nodeIdx: number,
-    parentRow: import("./types").LayoutNode,
-    sibling: import("./types").LayoutNode,
+    parentRow: LayoutNode,
+    sibling: LayoutNode,
     addlProps: Record<string, LayoutNodeAdditionalProps>,
     gapSizePx: number,
 ): boolean {
@@ -149,20 +184,15 @@ function _slipMinimize(
     if (!sibling.children) {
         targetWasLeaf = true;
         const heightPx = siblingProps?.rect?.height;
-        // Choose a content size that keeps total = DefaultNodeSize so the ratio is computable.
         const totalUnits = DefaultNodeSize;
         const headerUnitsEst = heightPx
             ? ((HeaderHeightPx + gapSizePx) * totalUnits) / heightPx
-            : totalUnits * 0.05; // fallback: ~5% for header if height unknown
+            : totalUnits * 0.05;
         const contentUnits = Math.max(totalUnits - headerUnitsEst, headerUnitsEst);
-
         const contentNode = newLayoutNode(FlexDirection.Row, contentUnits, undefined, sibling.data);
         sibling.data = undefined;
         sibling.flexDirection = FlexDirection.Column;
         sibling.children = [contentNode];
-        // We'll set the slipped node's size = headerUnitsEst; total = headerUnitsEst + contentUnits.
-        // The layout engine recomputes the ratio on the next frame, so the exact values just
-        // need to be in the right proportion.
     }
 
     // Compute header height in the column's flex-units.
@@ -172,10 +202,8 @@ function _slipMinimize(
             : undefined);
 
     if (colRatio == null) {
-        // Can't determine column ratio — bail without mutating the tree.
         console.warn("[layoutMinimize] slip: cannot determine column ratio, skipping");
         if (targetWasLeaf) {
-            // Undo the leaf-to-column conversion.
             const only = sibling.children?.[0];
             if (only?.data) {
                 sibling.data = only.data;
@@ -194,17 +222,42 @@ function _slipMinimize(
         firstChild.size = Math.max(firstChild.size - headerInColUnits, headerInColUnits);
     }
 
+    // Capture B's original Row-width before mutating sizes (needed for promotedRow restore).
+    const originalTargetRowSize = sibling.size;
+
+    // Give A's Row-width to B, then remove A from the Row.
+    sibling.size += node.size;
+    parentRow.children!.splice(nodeIdx, 1);
+
+    // Detect single-child Row and hoist B ourselves to prevent balanceNode from
+    // scattering B's children (which would invalidate targetColumnId on restore).
+    let promotedRow: NonNullable<LayoutNode["slipMinimize"]>["promotedRow"] | undefined;
+    if (parentRow.children!.length === 1) {
+        const grandparent = findParent(model.treeState.rootNode, parentRow.id);
+        if (grandparent?.children) {
+            const rowIdx = grandparent.children.findIndex((c) => c.id === parentRow.id);
+            if (rowIdx !== -1) {
+                promotedRow = {
+                    rowParentId: grandparent.id,
+                    rowIdx,
+                    rowSize: parentRow.size,
+                    originalTargetRowSize,
+                };
+                // Hoist: give B the Row's Column-slot size and replace the Row in grandparent.
+                sibling.size = parentRow.size;
+                grandparent.children.splice(rowIdx, 1, sibling);
+            }
+        }
+    }
+
     // Record slip state before modifying node.size.
     node.slipMinimize = {
         targetColumnId: sibling.id,
         originalRowSize: node.size,
         originalRowIndex: nodeIdx,
         targetWasLeaf,
+        promotedRow,
     };
-
-    // Remove from Row, give its width to the sibling.
-    sibling.size += node.size;
-    parentRow.children!.splice(nodeIdx, 1);
 
     // Insert at top of the column.
     node.size = headerInColUnits;

--- a/frontend/layout/lib/layoutNode.ts
+++ b/frontend/layout/lib/layoutNode.ts
@@ -210,7 +210,7 @@ export function balanceNode(
                 if (child.flexDirection === node.flexDirection) {
                     child.flexDirection = reverseFlexDirection(node.flexDirection);
                 }
-                if (child.children?.length == 1 && child.children[0].children) {
+                if (child.children?.length == 1 && child.children[0].children && !child._slipAnchor) {
                     return child.children[0].children;
                 }
                 if (child.children?.length === 0) return;

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -205,24 +205,15 @@ export interface LayoutNode {
         originalRowIndex: number;
         /** True when the target was a leaf converted to a Column during slip — restore must unwrap it. */
         targetWasLeaf: boolean;
-        /**
-         * Set when the Row parent had exactly two children (this pane + the target column),
-         * so after removal it had only one child. Rather than leaving a single-child Row for
-         * balanceNode to hoist (which scatters the column's children and loses targetColumnId),
-         * we hoist the target column ourselves during slip. This field stores what's needed
-         * to re-wrap it in a fresh Row on restore.
-         */
-        promotedRow?: {
-            /** ID of the grandparent node where the Row lived. */
-            rowParentId: string;
-            /** Index of the Row in the grandparent's children array. */
-            rowIdx: number;
-            /** The Row's size in the grandparent's flex units (its Column-slot height). */
-            rowSize: number;
-            /** The target column's original size in the Row's flex units (its width share). */
-            originalTargetRowSize: number;
-        };
     };
+    /**
+     * Prevents `balanceNode` from hoisting this branch's single grandchild when the
+     * branch has exactly one child that is itself a branch. Set on the Row parent of a
+     * slipped pane so the Row(→Column) direction-alternation is preserved even though
+     * the Row only has one child during the minimized state.
+     * Cleared on restore.
+     */
+    _slipAnchor?: true;
 }
 
 export type LayoutTreeStateSetter = (value: LayoutState) => void;

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -190,6 +190,22 @@ export interface LayoutNode {
     size: number;
     /** Original size before minimization. Presence indicates the node is minimized. */
     minimizedSize?: number;
+    /**
+     * Set when a pane was minimized from a solo Row slot (parent flex-direction = Row).
+     * Instead of shrinking horizontally, the pane slips its header into the adjacent
+     * column. Stores restore context so the operation is fully reversible.
+     * Never coexists with `minimizedSize`.
+     */
+    slipMinimize?: {
+        /** Node ID of the Column the pane slipped into. */
+        targetColumnId: string;
+        /** Original width (row-slot size) before the slip. */
+        originalRowSize: number;
+        /** Original index in the Row's children array. */
+        originalRowIndex: number;
+        /** True when the target was a leaf converted to a Column during slip — restore must unwrap it. */
+        targetWasLeaf: boolean;
+    };
 }
 
 export type LayoutTreeStateSetter = (value: LayoutState) => void;

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -205,6 +205,23 @@ export interface LayoutNode {
         originalRowIndex: number;
         /** True when the target was a leaf converted to a Column during slip — restore must unwrap it. */
         targetWasLeaf: boolean;
+        /**
+         * Set when the Row parent had exactly two children (this pane + the target column),
+         * so after removal it had only one child. Rather than leaving a single-child Row for
+         * balanceNode to hoist (which scatters the column's children and loses targetColumnId),
+         * we hoist the target column ourselves during slip. This field stores what's needed
+         * to re-wrap it in a fresh Row on restore.
+         */
+        promotedRow?: {
+            /** ID of the grandparent node where the Row lived. */
+            rowParentId: string;
+            /** Index of the Row in the grandparent's children array. */
+            rowIdx: number;
+            /** The Row's size in the grandparent's flex units (its Column-slot height). */
+            rowSize: number;
+            /** The target column's original size in the Row's flex units (its width share). */
+            originalTargetRowSize: number;
+        };
     };
 }
 


### PR DESCRIPTION
## Summary

- **Caret direction** — already correct on main (`chevron-up` when minimized, `chevron-down` when expanded via `OptMinimizeButton` in `blockframe.tsx:182`). No code change needed; confirmed via the reactive chain `minimizedNodeIds → isMinimized memo → EndIcons JSX prop → OptMinimizeButton createMemo`.

- **Solo-column minimize** — when a pane's layout-tree parent is a `Row` node, the previous code reduced `node.size` along the Row's flex direction, making the pane horizontally narrow (thin strip). Now it "slips" the header into the adjacent column instead:
  1. Pane is removed from the Row; its width goes to the sibling column.
  2. The pane's header is inserted at the top of that column at header-bar height.
  3. `node.slipMinimize` stores restore context (original Row index, width, whether the target was a leaf that needed column-conversion).
  4. Restore reverses: removes from column, re-inserts in Row at original index.

- Leaf-sibling edge case: when the adjacent Row slot is a plain leaf (not already a column branch), it is converted to a Column in-place during slip and unwrapped back to a leaf on restore.

- `rebuildMinimizedSet` extended to include `slipMinimize` nodes (needed for tree-reload after persistence).

## Test plan
- [ ] Open 2+ panes arranged side-by-side (horizontally). Click minimize on one — it should disappear from its column slot, and its header bar should appear at the top of the adjacent column.
- [ ] Click restore on the slipped header — it should re-appear at its original column position.
- [ ] Minimize a pane that shares a column with others (normal case) — should still collapse vertically to header height within the column (unchanged behavior).
- [ ] Verify the caret flips: chevron-down when expanded, chevron-up when minimized.
- [ ] Reload the app with a minimized pane in the slipped state — verify it restores correctly from persisted tree.

<!-- agentmux:agent_id=naki -->