### PR TITLE
feat(tab-chrome): Phase 2+3 folder boundary line and recessed strip

### DIFF
--- a/.changesets/1782315895-feat-tab-chrome-phase-2-3-folder-boundary-line-and-recessed--lkfc.md
+++ b/.changesets/1782315895-feat-tab-chrome-phase-2-3-folder-boundary-line-and-recessed--lkfc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tab-chrome): Phase 2+3 folder boundary line and recessed strip

--- a/docs/specs/SPEC_TAB_CONTENT_FOLDER_SURFACE_2026_06_03.md
+++ b/docs/specs/SPEC_TAB_CONTENT_FOLDER_SURFACE_2026_06_03.md
@@ -171,3 +171,79 @@ negative-margin boundary-break) is deferred.
 
 Deferred: recessed strip (Layer A), gap-only surface, the negative-margin
 boundary-break, editor-strip token unification (§7 Q4).
+
+---
+
+## 10. Online triangulation — 2026-06-23
+
+Research against browser source + CSS community (CSS-Tricks, MDN, GitHub VSCode issues)
+before implementing Phase 2 + 3.
+
+### 10.1 Canonical CSS folder-tab technique
+
+Confirmed: the universal technique is `border-bottom` on the strip container +
+`margin-bottom: -1px` on the active tab + matching `border-bottom-color` (or no
+`border-bottom`) on the active tab. This is identical to §5 Phase 2.
+
+**Constraint discovered:** CSS forbids `overflow-x: auto` + `overflow-y: visible` on
+the same element — the browser coerces `overflow-y` to `auto`. Since `.tab-bar-scroll`
+has `overflow-x: auto` (horizontal tab scrolling), `overflow-y` cannot be `visible`,
+so `margin-bottom: -1px` on a child tab is *always clipped* by the scroll container
+regardless of `.tab-bar`'s own overflow setting. The negative-margin approach as written
+in §5 Phase 2 does not work without restructuring the scroll container.
+
+**Revised Phase 2 approach:** apply `border-bottom: 1px solid var(--border-color)` to
+each non-tab element in the strip individually: `.tab-bar-fill`, `.system-status`,
+`.window-drag`. Combined with the existing `.tab:not(.active) { border-bottom }`, the
+boundary line is complete across the full header width — absent only under the active
+tab. No negative margins, no overflow changes, no layout shift.
+
+One adjustment required for Win32+Linux: `.window-action-buttons` uses
+`height: calc(100% + var(--space-1-5))` to reach the full header height including the
+6px `padding-top`. When `.system-status` gains `border-bottom: 1px`, the containing
+block shrinks by 1px and the formula must become
+`calc(100% + var(--space-1-5) + 1px)` to keep buttons flush to the bottom edge.
+
+### 10.2 VSCode reference model
+
+VSCode (verified via GitHub issues #29333, #130394, #146421) achieves folder continuity
+via **colour-match only**: `tab.activeBackground === editorGroupHeader.background`. There
+is no negative-margin geometric overlap in VSCode. The spec's §5 Phase 2 negative-margin
+was aspirational beyond VSCode's model; the per-element border approach lands the same
+visual result with zero layout risk.
+
+### 10.3 Win32 DWM 1px border
+
+The 1px window edge the user perceives is drawn by DWM (Desktop Window Manager), not CSS.
+AgentMux uses `enable_standard_title_bar=false` which gives a frameless client area, but
+DWM still renders a system-drawn 1px border around the window on Win11. This border is
+non-addressable from the frontend. Ensuring `DWMWA_USE_IMMERSIVE_DARK_MODE` is set
+(host-side Rust, already in place) makes the DWM border render dark on dark theme, which
+is the only lever available.
+
+### 10.4 Subpixel / zoom
+
+The `--snap-chrome: calc(1px / (var(--dpr) * var(--zoomfactor, 1)))` token already exists
+for device-pixel-accurate sizing inside the zoomed `.window-header`. If a future revision
+adds the negative-margin approach (post scroll-container restructure), use
+`margin-bottom: calc(-1 * var(--snap-chrome))` instead of `-1px`.
+
+### 10.5 macOS gap
+
+On macOS, `.traffic-lights { align-self: center }` and `.hamburger-btn.--right { align-self: center }`
+place both elements at mid-height, not bottom-aligned. Their `border-bottom` would land at
+the wrong y-position. The boundary line therefore has a gap under the ~68px traffic-light
+cluster (left) and ~36px hamburger (right) on macOS. Acceptable for now; a follow-up can
+change both to `align-self: stretch` with `align-items: center` to make them full-height
+containers while keeping content centered.
+
+### 10.6 Shipped (Phase 2 + Layer A) — 2026-06-23
+
+- **Boundary line (Phase 2 — revised):** `border-bottom: 1px solid var(--border-color)` on
+  `.tab-bar-fill`, `.system-status`, and `.window-drag`. Win32+Linux button height formula
+  updated to `calc(100% + var(--space-1-5) + 1px)`. Full-width line absent only under the
+  active tab.
+- **Recessed strip (Layer A):** `background: var(--tab-strip-bg)` on `.window-header`
+  (all platforms). The `--tab-strip-bg: rgba(255,255,255,0.03)` value is intentionally
+  subtle — a near-transparent white tint that makes the strip slightly lighter than Layer B
+  (`--workspace-surface = rgba(0,0,0,0.5)`), so the folder content advances visually.

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -168,6 +168,10 @@
         min-width: 0;
         height: 100%;
         align-self: stretch;
+        // Folder boundary continuation (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6):
+        // extends the 1px hairline that .tab:not(.active) draws across the fill
+        // area so the full-width line is unbroken except under the active tab.
+        border-bottom: 1px solid var(--border-color);
     }
 
 }

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -10,6 +10,10 @@
     justify-content: flex-end;
     margin-left: auto;
     margin-right: var(--space-1-5);
+    // Folder boundary continuation (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6):
+    // the right-side chrome needs the same 1px bottom hairline as the tab
+    // strip so the boundary line is unbroken across the full header width.
+    border-bottom: 1px solid var(--border-color);
 
     .config-error-button {
         color: black;

--- a/frontend/app/window/window-controls.win32.scss
+++ b/frontend/app/window/window-controls.win32.scss
@@ -35,8 +35,13 @@
     // title bar, or the hover background leaves a 6-px strip at the top
     // uncovered. Pull the container up with a negative margin and grow
     // its height by the same amount so flex still respects it.
+    // The extra `+ 1px` compensates for `.system-status { border-bottom: 1px }`
+    // (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): that border reduces the
+    // containing-block by 1px, so `100%` resolves 1px shorter; the +1px
+    // restores the buttons to full header height so hover backgrounds
+    // reach the window's bottom edge.
     margin-top: calc(-1 * var(--space-1-5));
-    height: calc(100% + var(--space-1-5));
+    height: calc(100% + var(--space-1-5) + 1px);
 
     // Butt up against the edge — Win11 caption buttons have no
     // right-margin padding.

--- a/frontend/app/window/window-header.darwin.scss
+++ b/frontend/app/window/window-header.darwin.scss
@@ -45,10 +45,18 @@
     height: 33px;
     zoom: var(--zoomfactor);
     cursor: default;
+    // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
+    background: var(--tab-strip-bg);
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): closes the
+        // gap between the traffic-light cluster and the first tab.
+        // Note: .traffic-lights uses align-self: center so a gap remains
+        // under the ~68px traffic-light area on the far left — tracked as
+        // follow-up in §10.5.
+        border-bottom: 1px solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.linux.scss
+++ b/frontend/app/window/window-header.linux.scss
@@ -34,6 +34,8 @@
     height: 33px;
     zoom: var(--zoomfactor);
     cursor: default;
+    // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
+    background: var(--tab-strip-bg);
     // Window drag is JS-driven (NOT -webkit-app-region: drag). Chromium
     // architecturally suppresses ALL events on drag regions before they
     // enter the renderer (verified 2026-05-02 via document capture-phase
@@ -52,5 +54,8 @@
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): 0px wide
+        // on Linux so this is a no-op visually, but kept for parity.
+        border-bottom: 1px solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.win32.scss
+++ b/frontend/app/window/window-header.win32.scss
@@ -35,10 +35,17 @@
     height: 33px;
     zoom: var(--zoomfactor);
     cursor: default;
+    // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
+    // Slightly lighter than --workspace-surface so the folder content advances.
+    background: var(--tab-strip-bg);
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): the 2px left
+        // drag spacer needs its own bottom hairline to close the gap before the
+        // first tab.
+        border-bottom: 1px solid var(--border-color);
     }
 }


### PR DESCRIPTION
## Summary

- **Boundary line (Phase 2):** `border-bottom: 1px solid var(--border-color)` added to `.tab-bar-fill`, `.system-status`, and `.window-drag` on all platforms. Combined with the existing `.tab:not(.active)` rule, the 1px hairline now runs unbroken across the full header width — absent only under the active tab, completing the folder look.
- **Win32+Linux button height:** bumped from `calc(100% + --space-1-5)` → `calc(100% + --space-1-5 + 1px)` so caption-button hover backgrounds still reach the window edge after `.system-status` gains its 1px border.
- **Recessed strip (Phase 3 / Layer A):** `background: var(--tab-strip-bg)` on `.window-header` — the near-transparent white tint (`rgba(255,255,255,0.03)`) makes the strip fractionally lighter than `--workspace-surface`, so the folder content visually advances.
- **Spec updated (§10):** documents online triangulation findings — why `margin-bottom: -1px` cannot work with `overflow-x: auto` scroll containers, VSCode colour-match reference, Win32 DWM border note, and macOS gap caveat (traffic-lights + hamburger use `align-self: center` and don't reach the bottom edge — tracked as follow-up in §10.5).

## Test plan

- [ ] Win32: boundary line visible at the bottom of the header, absent under active tab, present under inactive tabs / fill / system-status area
- [ ] Win32: caption button hover backgrounds (including close-button red) reach the window's bottom edge — no 1px gap
- [ ] Win32: Layer A strip is barely perceptibly lighter than the pane content (near-invisible at window:transparent=false, more noticeable at window:transparent=true)
- [ ] macOS: line present under tab fill and system-status; gap acceptable under traffic lights and hamburger
- [ ] No regressions in tab drag-and-drop, content-aware sizing, or tab switch performance

<!-- agentmux:agent_id=camper -->