### PR TITLE
fix(statusbar): channel row + floating panes section in instance panel

### DIFF
--- a/.changesets/1782316149-fix-statusbar-channel-row-missing-from-instance-panel-about--o4yd.md
+++ b/.changesets/1782316149-fix-statusbar-channel-row-missing-from-instance-panel-about--o4yd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): channel row missing from instance panel — about() memo omitted channel field

--- a/.changesets/1782316537-feat-statusbar-floating-panes-section-in-instance-panel-clic-k1xx.md
+++ b/.changesets/1782316537-feat-statusbar-floating-panes-section-in-instance-panel-clic-k1xx.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(statusbar): floating panes section in instance panel — click version chip to see and focus open floating panes

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -175,6 +175,8 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         sysinfo: "System Info",
         drone: "Drone",
         swarm: "Swarm",
+        help: "Help",
+        warden: "Warden",
     };
 
     const resolveFloatingName = (entry: FloatingPaneEntry, idx: number): string => {

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -15,7 +15,7 @@
  * Per-window token totals deferred until token-usage is per-window.
  */
 
-import { atoms, getApi, isDev, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
+import { atoms, getApi, isDev, openFloatingPaneEntriesAtom, openWindowEntriesAtom, type FloatingPaneEntry, type WindowEntry } from "@/store/global";
 import { reconcileKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
 import { launcherEventsActive } from "@/util/launcher-events";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
@@ -27,6 +27,7 @@ import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-
 import {
     DISPLAY_NAME_MAX_LEN,
     DISPLAY_NAME_META_KEY,
+    resolveFloatingPaneName,
     resolveWindowName,
 } from "@/util/window-title";
 
@@ -74,6 +75,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     };
 
     const entries = openWindowEntriesAtom;
+    const floatingEntries = openFloatingPaneEntriesAtom;
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
 
@@ -151,6 +153,50 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         } catch (e) {
             console.error("[InstancePanel] focusWindow failed:", e);
         }
+    };
+
+    const handleFocusPane = async (label: string) => {
+        try {
+            await getApi().focusWindow(label);
+        } catch (e) {
+            console.error("[InstancePanel] focusPane failed:", e);
+        }
+    };
+
+    // Readable label for a floating pane. Resolution order:
+    //   1. block view type (title-cased, e.g. "Agent", "Terminal")
+    //   2. workspace name
+    //   3. positional fallback "Pane N"
+    const PANE_VIEW_LABELS: Record<string, string> = {
+        agent: "Agent",
+        term: "Terminal",
+        browser: "Browser",
+        editor: "Editor",
+        sysinfo: "System Info",
+        drone: "Drone",
+        swarm: "Swarm",
+    };
+
+    const resolveFloatingName = (entry: FloatingPaneEntry, idx: number): string => {
+        let blockViewLabel: string | undefined;
+        let workspaceName: string | undefined;
+        if (entry.windowId) {
+            const win = getObjectValue<WaveWindow>(makeORef("window", entry.windowId));
+            if (win?.workspaceid) {
+                const ws = getObjectValue<Workspace>(makeORef("workspace", win.workspaceid));
+                workspaceName = ws?.name;
+                const tab = ws?.activetabid
+                    ? getObjectValue<Tab>(makeORef("tab", ws.activetabid))
+                    : null;
+                const blockId = tab?.blockids?.[0];
+                if (blockId) {
+                    const block = getObjectValue<Block>(makeORef("block", blockId));
+                    const view = block?.meta?.view as string | undefined;
+                    if (view) blockViewLabel = PANE_VIEW_LABELS[view] ?? view;
+                }
+            }
+        }
+        return resolveFloatingPaneName({ blockViewLabel, workspaceName, indexInOpenPanes: idx });
     };
 
     // For THIS window's row, fall back to atoms.waveWindow()?.oid when
@@ -520,6 +566,41 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                         );
                     }}
                 </For>
+            </div>
+            <div class="instance-panel-divider" />
+            <div class="instance-panel-section">
+                <div class="instance-panel-section-title">
+                    Floating panes — {floatingEntries().length}
+                </div>
+                <Show
+                    when={floatingEntries().length > 0}
+                    fallback={
+                        <div class="instance-panel-pane-empty">No floating panes</div>
+                    }
+                >
+                    <For each={floatingEntries()}>
+                        {(entry, i) => (
+                            <div
+                                class="instance-panel-pane-row"
+                                onClick={() => handleFocusPane(entry.label)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter" || e.key === " ") {
+                                        e.preventDefault();
+                                        handleFocusPane(entry.label);
+                                    }
+                                }}
+                                title="Click to focus"
+                                role="button"
+                                tabIndex={0}
+                            >
+                                <span class="instance-panel-pane-icon">◈</span>
+                                <span class="instance-panel-pane-name">
+                                    {resolveFloatingName(entry, i())}
+                                </span>
+                            </div>
+                        )}
+                    </For>
+                </Show>
             </div>
             <div class="instance-panel-divider" />
             <div class="instance-panel-footer">

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -50,6 +50,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         const d = getApi().getAboutModalDetails();
         return {
             version: d?.version ?? "unknown",
+            channel: d?.channel ?? null,
             buildLabel: (d as any)?.buildLabel ?? null,
             gitHash: d?.gitHash ?? null,
             buildTime: typeof d?.buildTime === "number" && d.buildTime > 0 ? d.buildTime : null,

--- a/frontend/app/statusbar/_instance-panel.scss
+++ b/frontend/app/statusbar/_instance-panel.scss
@@ -163,6 +163,52 @@
     }
 }
 
+// Floating pane rows — same geometry as .instance-panel-window-row but the
+// leading icon uses secondary colour (panes are not primary windows) and
+// there is no "this" badge or opacity slider.
+.instance-panel-pane-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 0;
+    padding: var(--space-1) var(--space-1-5);
+    color: var(--main-text-color);
+    font-size: 12px;
+    text-align: left;
+    cursor: default;
+    line-height: 1.3;
+
+    &:hover {
+        background: var(--hover-bg-color);
+        border-color: var(--border-color);
+    }
+
+    .instance-panel-pane-icon {
+        flex: 0 0 auto;
+        color: var(--secondary-text-color);
+        font-size: 10px;
+        width: 10px;
+        text-align: center;
+    }
+
+    .instance-panel-pane-name {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.instance-panel-pane-empty {
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    padding: var(--space-1) var(--space-1-5);
+    font-style: italic;
+}
+
 // Per-window opacity slider (SPEC_PER_WINDOW_OPACITY_2026-05-14.md §3)
 .instance-panel-opacity-row {
     display: flex;

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -170,6 +170,15 @@ export const [openWindowLabelsAtom, setOpenWindowLabelsAtom] = createSignal<stri
 export type WindowEntry = { label: string; windowId: string | null };
 export const [openWindowEntriesAtom, setOpenWindowEntriesAtom] = createSignal<WindowEntry[]>([]);
 
+// Open floating panes in this process. Floating panes are process-scoped
+// (shared across all windows) so they live in a separate atom from the
+// per-window `openWindowEntriesAtom`. Updated by the launcher event reducer
+// and seeded from `listWindowInstances()` at boot.
+// See docs/specs/SPEC_INSTANCE_PANEL_FLOATING_PANES_SECTION_2026_06_24.md.
+export type FloatingPaneEntry = { label: string; windowId: string | null };
+export const [openFloatingPaneEntriesAtom, setOpenFloatingPaneEntriesAtom] =
+    createSignal<FloatingPaneEntry[]>([]);
+
 // ---------------------------------------------------------------------------
 // GlobalAtomsType-compatible export (used in wos.ts callBackendService)
 // ---------------------------------------------------------------------------

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -32,13 +32,16 @@ import { getApi } from "@/store/app-api";
 import {
     setOpenWindowEntriesAtom,
     setOpenWindowLabelsAtom,
+    setOpenFloatingPaneEntriesAtom,
     setWindowCountAtom,
+    type FloatingPaneEntry,
     type WindowEntry,
 } from "@/app/store/global";
 
 import { update } from "./launcher-event/reducer";
 import {
     initialState,
+    isFloatingPaneLabel,
     isInstanceLabel as isInstanceLabelFromTypes,
     LauncherEventCommand,
     LauncherEventReducerEvent,
@@ -55,6 +58,61 @@ export const isInstanceLabel = isInstanceLabelFromTypes;
 // ── State cell ─────────────────────────────────────────────────────────
 
 let state: LauncherEventState = initialState();
+
+// ── Floating pane state cell ───────────────────────────────────────────
+//
+// Tracked separately from the window reducer — floating panes don't need
+// the tombstone / seed-race machinery (they can't arrive before their own
+// window_opened event and the pre-seed close race doesn't apply to them).
+// Same event stream, different label filter: `isFloatingPaneLabel`.
+
+let floatingPanes: Map<string, FloatingPaneEntry> = new Map();
+
+function handleFloatingPaneEvent(evt: { event: string; label?: unknown; window_id?: unknown }): boolean {
+    const label = String(evt.label ?? "");
+    if (!label || !isFloatingPaneLabel(label)) return false;
+
+    switch (evt.event) {
+        case "window_opened":
+        case "window_instance_assigned": {
+            if (floatingPanes.has(label)) return false;
+            floatingPanes = new Map(floatingPanes);
+            floatingPanes.set(label, { label, windowId: null });
+            return true;
+        }
+        case "window_closed":
+        case "window_instance_released": {
+            if (!floatingPanes.has(label)) return false;
+            floatingPanes = new Map(floatingPanes);
+            floatingPanes.delete(label);
+            return true;
+        }
+        case "backend_window_id_registered": {
+            const windowId = typeof evt.window_id === "string" ? evt.window_id : null;
+            const existing = floatingPanes.get(label);
+            if (existing?.windowId === windowId) return false;
+            floatingPanes = new Map(floatingPanes);
+            // Ensure an entry exists even if window_opened was missed.
+            floatingPanes.set(label, { label, windowId });
+            return true;
+        }
+        case "backend_window_id_unregistered": {
+            const existing = floatingPanes.get(label);
+            if (!existing || existing.windowId === null) return false;
+            floatingPanes = new Map(floatingPanes);
+            floatingPanes.set(label, { label, windowId: null });
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+function projectFloating(): void {
+    setOpenFloatingPaneEntriesAtom(
+        [...floatingPanes.values()].sort((a, b) => a.label.localeCompare(b.label)),
+    );
+}
 
 // ── Echo-loop guard ────────────────────────────────────────────────────
 
@@ -130,6 +188,19 @@ export function seedKnownEntriesFromSnapshot(
     entries: ReadonlyArray<WindowEntry>,
 ): void {
     dispatch({ type: "ApplySeed", entries });
+    // Seed floating panes from the same snapshot (same dev-mode guard applies
+    // at the call site — only called when !launcherEventsActive()).
+    const nextFloating = new Map<string, FloatingPaneEntry>();
+    for (const e of entries) {
+        if (isFloatingPaneLabel(e.label)) {
+            nextFloating.set(e.label, { label: e.label, windowId: e.windowId });
+        }
+    }
+    if (nextFloating.size !== floatingPanes.size ||
+        [...nextFloating.keys()].some((k) => !floatingPanes.has(k))) {
+        floatingPanes = nextFloating;
+        projectFloating();
+    }
 }
 
 /**
@@ -148,6 +219,15 @@ export function reconcileKnownEntriesFromSnapshot(
     entries: ReadonlyArray<WindowEntry>,
 ): void {
     dispatch({ type: "ReconcileFromSnapshot", entries });
+    // Wholesale replace the floating panes map with the fresh snapshot.
+    const nextFloating = new Map<string, FloatingPaneEntry>();
+    for (const e of entries) {
+        if (isFloatingPaneLabel(e.label)) {
+            nextFloating.set(e.label, { label: e.label, windowId: e.windowId });
+        }
+    }
+    floatingPanes = nextFloating;
+    projectFloating();
 }
 
 /**
@@ -202,6 +282,7 @@ export function startLauncherEventReducer(): void {
         applyingRemote = true;
         try {
             dispatch({ type: "ApplyEvent", event: evt });
+            if (handleFloatingPaneEvent(evt)) projectFloating();
         } finally {
             applyingRemote = false;
         }
@@ -232,5 +313,6 @@ export function __snapshot(): LauncherEventState {
 /** Test-only: reset the state cell. Never call in production. */
 export function __resetState(): void {
     state = initialState();
+    floatingPanes = new Map();
     started = false;
 }

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -188,17 +188,21 @@ export function seedKnownEntriesFromSnapshot(
     entries: ReadonlyArray<WindowEntry>,
 ): void {
     dispatch({ type: "ApplySeed", entries });
-    // Seed floating panes from the same snapshot (same dev-mode guard applies
-    // at the call site — only called when !launcherEventsActive()).
-    const nextFloating = new Map<string, FloatingPaneEntry>();
+    // Seed floating panes from the same snapshot. Mirrors ApplySeed semantics:
+    // additive only — skip labels already in floatingPanes so a window_opened /
+    // backend_window_id_registered event that raced the snapshot RPC is not
+    // clobbered with a stale null windowId (same race as codex P1 #603).
+    // Called unconditionally at boot; dev-mode guard lives at the call site.
+    let changed = false;
+    const next = new Map(floatingPanes);
     for (const e of entries) {
-        if (isFloatingPaneLabel(e.label)) {
-            nextFloating.set(e.label, { label: e.label, windowId: e.windowId });
+        if (isFloatingPaneLabel(e.label) && !next.has(e.label)) {
+            next.set(e.label, { label: e.label, windowId: e.windowId });
+            changed = true;
         }
     }
-    if (nextFloating.size !== floatingPanes.size ||
-        [...nextFloating.keys()].some((k) => !floatingPanes.has(k))) {
-        floatingPanes = nextFloating;
+    if (changed) {
+        floatingPanes = next;
         projectFloating();
     }
 }

--- a/frontend/app/store/launcher-event/types.ts
+++ b/frontend/app/store/launcher-event/types.ts
@@ -147,7 +147,13 @@ export function isInstanceLabel(label: string): boolean {
     return label.startsWith("window-");
 }
 
-/** True for floating-pane subordinate windows (`"floating-{uuid}"` label scheme). */
+/**
+ * True for floating-pane subordinate windows (`"floating-{uuid}"` label scheme).
+ * Explicitly excludes `"floating-pool-*"` (warm pane-pool windows) — pool labels
+ * share the prefix but are never reported to the launcher until promoted, and a
+ * promoted pool floater keeps its pool label, not the user-facing floater label.
+ */
 export function isFloatingPaneLabel(label: string): boolean {
+    if (label.startsWith("floating-pool-")) return false;
     return label.startsWith("floating-");
 }

--- a/frontend/app/store/launcher-event/types.ts
+++ b/frontend/app/store/launcher-event/types.ts
@@ -146,3 +146,8 @@ export function isInstanceLabel(label: string): boolean {
     if (label.startsWith("browser-pane-")) return false;
     return label.startsWith("window-");
 }
+
+/** True for floating-pane subordinate windows (`"floating-{uuid}"` label scheme). */
+export function isFloatingPaneLabel(label: string): boolean {
+    return label.startsWith("floating-");
+}

--- a/frontend/util/window-title.ts
+++ b/frontend/util/window-title.ts
@@ -38,6 +38,29 @@ export function resolveWindowName(opts: ResolveWindowNameOpts): string {
     return `Window ${opts.indexInOpenWindows + 1}`;
 }
 
+export interface ResolveFloatingPaneNameOpts {
+    /** Value of `workspace.name` for the workspace hosted in this pane. */
+    workspaceName?: string | null;
+    /** Human-readable label derived from the pane's block (e.g. view type or agent name). */
+    blockViewLabel?: string | null;
+    /** 0-indexed position in `openFloatingPaneEntriesAtom`; rendered as "Pane N" where N = index + 1. */
+    indexInOpenPanes: number;
+}
+
+/**
+ * Two-tier resolution for floating pane display names:
+ *   1. block view label (e.g. "Agent", "Terminal", "Browser")
+ *   2. workspace name
+ *   3. positional fallback "Pane N"
+ */
+export function resolveFloatingPaneName(opts: ResolveFloatingPaneNameOpts): string {
+    const view = (opts.blockViewLabel ?? "").trim();
+    if (view) return view;
+    const ws = (opts.workspaceName ?? "").trim();
+    if (ws) return ws;
+    return `Pane ${opts.indexInOpenPanes + 1}`;
+}
+
 /**
  * Format the OS window title. Tab name omitted (no empty middle slot) when
  * absent, since not every init path has a tab loaded yet.


### PR DESCRIPTION
## Summary

- **Fix:** Channel row never rendered in the instance panel (regression from PR #1744) — `about()` createMemo extracted all fields from `getAboutModalDetails()` except `channel`, so `<Show when={about().channel}>` was always false
- **Feat:** Adds a "Floating panes" section below the windows list in the version-chip popover. Floating panes are process-scoped (shared across all windows) so they live in their own section

## Changes

### Bug fix (commit 1)
- `InstancePanel.tsx` `about()` memo: add `channel: d?.channel ?? null`
- Regression introduced in #1744 — backend + TS type were correct, only the memo was missing the field

### Feature (commit 2)
- `global.ts` — `FloatingPaneEntry` type + `openFloatingPaneEntriesAtom` signal
- `launcher-event/types.ts` — `isFloatingPaneLabel()` classifier (`"floating-"` prefix)
- `launcher-event-reducer.ts` — parallel lightweight floating-pane tracker, wired into same event stream + seed/reconcile paths (no tombstone machinery needed — floating panes can't race the seed)
- `util/window-title.ts` — `resolveFloatingPaneName()` (block view label → workspace name → "Pane N")
- `InstancePanel.tsx` — new "Floating panes — N" section with `◈` icon rows, click-to-focus, empty state ("No floating panes")
- `_instance-panel.scss` — `.instance-panel-pane-row`, `.instance-panel-pane-empty`

## Test plan

- [ ] Open the version chip popover → Channel row now shows (e.g. `stable` or `local-main-…`)
- [ ] Open a floating pane (tear off a block) → "Floating panes — 1" section appears with the pane's block view label or workspace name
- [ ] Click a floating pane row → pane focuses/raises
- [ ] Close the floating pane → count drops to 0 and empty state shows
- [ ] With no floating panes open → "Floating panes — 0 / No floating panes" empty state visible
- [ ] `task dev` mode (no launcher events) → snapshot reconcile seeds both sections correctly

Spec: `docs/specs/SPEC_INSTANCE_PANEL_FLOATING_PANES_SECTION_2026_06_24.md`

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-oozp} -->