### PR TITLE
feat(messaging): bridge framework + Discord Gateway integration

### DIFF
--- a/.changesets/1782317686-feat-messaging-bridge-framework-discord-integration-lku8.md
+++ b/.changesets/1782317686-feat-messaging-bridge-framework-discord-integration-lku8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat: messaging bridge framework + discord integration

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -297,6 +297,31 @@ pub struct SettingsType {
     #[serde(rename = "notify:tooltones:scope", default, skip_serializing_if = "Option::is_none")]
     pub notify_tooltones_scope: Option<String>,
 
+    // -- Messaging bridge settings --
+
+    /// Master enable for the Discord messaging bridge.
+    /// When true, the bridge connects to the Discord Gateway at startup.
+    #[serde(rename = "messaging:discord:enabled", default, skip_serializing_if = "is_false")]
+    pub messaging_discord_enabled: bool,
+
+    /// Discord bot token. Treat as a secret — do not log. Obtain from
+    /// discord.com/developers/applications → Bot → Token.
+    #[serde(rename = "messaging:discord:token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_discord_token: Option<String>,
+
+    /// Channel ID to filter inbound messages and use as the default send target.
+    #[serde(rename = "messaging:discord:channel", default, skip_serializing_if = "String::is_empty")]
+    pub messaging_discord_channel: String,
+
+    /// Agent ID that receives inbound Discord messages via the reactive bus.
+    /// Absent → messages are logged but not forwarded to any agent.
+    #[serde(rename = "messaging:discord:target", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_discord_target: Option<String>,
+
+    /// Guild ID for guild-scoped slash command registration (Phase 2).
+    #[serde(rename = "messaging:discord:guild", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_discord_guild: Option<String>,
+
     /// Catch-all for unknown/dynamic keys (e.g. `widget:hidden@defwidget@sysinfo`).
     /// These pass through serde unchanged so the frontend can access them as flat settings keys.
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -117,5 +117,75 @@
                 "view": "warden"
             }
         }
+    },
+    "defwidget@discord": {
+        "display:order": 10,
+        "display:pinned": false,
+        "icon": "message-circle",
+        "color": "#5865f2",
+        "label": "Discord",
+        "description": "Discord — real interface, agent-connected via background bridge",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": "https://discord.com/app"
+            }
+        }
+    },
+    "defwidget@slack": {
+        "display:order": 11,
+        "display:pinned": false,
+        "icon": "hash",
+        "color": "#4a154b",
+        "label": "Slack",
+        "description": "Slack — real interface, agent-connected (bridge Phase 2)",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": "https://app.slack.com/"
+            }
+        }
+    },
+    "defwidget@telegram": {
+        "display:order": 12,
+        "display:pinned": false,
+        "icon": "send",
+        "color": "#229ed9",
+        "label": "Telegram",
+        "description": "Telegram Web — real interface, agent-connected (bridge Phase 2)",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": "https://web.telegram.org/"
+            }
+        }
+    },
+    "defwidget@whatsapp": {
+        "display:order": 13,
+        "display:pinned": false,
+        "icon": "message-square",
+        "color": "#25d366",
+        "label": "WhatsApp",
+        "description": "WhatsApp Web — real interface, agent-connected (bridge Phase 3)",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": "https://web.whatsapp.com/"
+            }
+        }
+    },
+    "defwidget@teams": {
+        "display:order": 14,
+        "display:pinned": false,
+        "icon": "users",
+        "color": "#6264a7",
+        "label": "Teams",
+        "description": "Microsoft Teams Web — real interface, agent-connected (bridge Phase 3)",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": "https://teams.microsoft.com/"
+            }
+        }
     }
 }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -16,6 +16,7 @@ mod server;
 mod srv_ipc;
 mod state;
 mod drone;
+mod messaging;
 mod muxbus;
 #[cfg(windows)]
 mod crash_monitor;
@@ -947,6 +948,32 @@ async fn main() {
     // uses to push reactive injections instead of polling.
     // No-op until the user connects via muxbus.login.
     crate::muxbus::cloud_subscriber::CloudSubscriber::init_global(id_store.clone());
+
+    // Discord messaging bridge — connects to Discord Gateway if configured.
+    // Set messaging:discord:enabled + messaging:discord:token in settings.json to activate.
+    {
+        let settings = config_watcher.get_settings();
+        if settings.messaging_discord_enabled {
+            match settings.messaging_discord_token.clone() {
+                Some(token) if !token.is_empty() => {
+                    messaging::discord::DiscordBridge::init_global(
+                        messaging::discord::DiscordConfig {
+                            token,
+                            channel_id: settings.messaging_discord_channel.clone(),
+                            target_agent: settings.messaging_discord_target.clone(),
+                            guild_id: settings.messaging_discord_guild.clone(),
+                        },
+                        reqwest::Client::new(),
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        "discord bridge: enabled but messaging:discord:token is not set in settings.json"
+                    );
+                }
+            }
+        }
+    }
 
     // Set up docsite directory
     if let Some(app_path) = base::get_wave_app_path() {

--- a/agentmux-srv/src/messaging/discord/gateway.rs
+++ b/agentmux-srv/src/messaging/discord/gateway.rs
@@ -1,0 +1,452 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Discord Gateway WebSocket client.
+//!
+//! Protocol flow: connect → HELLO → IDENTIFY (or RESUME) → READY → event loop.
+//!
+//! On disconnect:
+//!   - If we have a stored session_id + last_seq, attempt RESUME using the
+//!     `resume_gateway_url` from the prior READY payload.
+//!   - On INVALID_SESSION(resumable=false) or RECONNECT, drop session and re-IDENTIFY.
+//!
+//! Heartbeat:
+//!   - HELLO provides `heartbeat_interval` in milliseconds.
+//!   - We send HEARTBEAT every interval, tracking ACK. If the prior heartbeat
+//!     was not ACK'd, the connection is a zombie — close and reconnect.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async_tls_with_config, tungstenite::Message};
+
+use crate::backend::reactive::handler::get_global_handler;
+use crate::backend::reactive::types::InjectionRequest;
+use crate::messaging::{BridgeHealth, BridgeStatus, OutboundMsg};
+
+use super::rest;
+use super::types::{
+    opcode, GatewayPayload, HeartbeatPayload, IdentifyData, IdentifyPayload, IdentifyProperties,
+    MessageCreate, ReadyEvent, ResumeData, ResumePayload, INTENTS,
+};
+
+const GATEWAY_URL: &str = "wss://gateway.discord.gg/?v=10&encoding=json";
+const RECONNECT_DELAY_SECS: u64 = 5;
+const MAX_RECONNECT_DELAY_SECS: u64 = 60;
+
+#[derive(Clone)]
+struct Session {
+    session_id: String,
+    resume_url: String,
+    last_seq: u64,
+}
+
+pub async fn run_gateway_loop(
+    token: String,
+    channel_id: String,
+    target_agent: Option<String>,
+    http: reqwest::Client,
+    mut outbound_rx: mpsc::UnboundedReceiver<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+) {
+    let mut delay_secs = RECONNECT_DELAY_SECS;
+    let mut session: Option<Session> = None;
+
+    loop {
+        {
+            let mut h = health.lock().unwrap();
+            h.status = BridgeStatus::Connecting;
+        }
+
+        let connect_url = session
+            .as_ref()
+            .map(|s| {
+                // Append gateway params if the resume URL doesn't include them.
+                if s.resume_url.contains("?v=") {
+                    s.resume_url.clone()
+                } else {
+                    format!("{}?v=10&encoding=json", s.resume_url)
+                }
+            })
+            .unwrap_or_else(|| GATEWAY_URL.to_string());
+
+        tracing::info!("discord_bridge: connecting to {}", connect_url);
+        let session_start = std::time::Instant::now();
+
+        match run_session(
+            &token,
+            &channel_id,
+            &target_agent,
+            &connect_url,
+            &http,
+            &mut outbound_rx,
+            &health,
+            session.take(),
+        )
+        .await
+        {
+            Ok(new_session) => {
+                session = new_session;
+                if session_start.elapsed().as_secs() > 30 {
+                    delay_secs = RECONNECT_DELAY_SECS;
+                }
+                tracing::info!("discord_bridge: session ended cleanly");
+            }
+            Err(e) => {
+                session = None;
+                if session_start.elapsed().as_secs() > 30 {
+                    delay_secs = RECONNECT_DELAY_SECS;
+                }
+                tracing::warn!("discord_bridge: session error: {e}");
+                {
+                    let mut h = health.lock().unwrap();
+                    h.status = BridgeStatus::Error;
+                    h.error = Some(e);
+                    h.reconnect_count += 1;
+                }
+            }
+        }
+
+        {
+            let mut h = health.lock().unwrap();
+            if h.status != BridgeStatus::Error {
+                h.status = BridgeStatus::Disconnected;
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+        delay_secs = (delay_secs * 2).min(MAX_RECONNECT_DELAY_SECS);
+    }
+}
+
+/// Run a single Gateway session. Returns:
+///   Ok(Some(session)) — clean disconnect, can attempt RESUME
+///   Ok(None)          — clean disconnect, session is invalid (re-IDENTIFY)
+///   Err(e)            — unexpected error, will re-IDENTIFY after backoff
+async fn run_session(
+    token: &str,
+    channel_id: &str,
+    target_agent: &Option<String>,
+    connect_url: &str,
+    http: &reqwest::Client,
+    outbound_rx: &mut mpsc::UnboundedReceiver<OutboundMsg>,
+    health: &Arc<Mutex<BridgeHealth>>,
+    resume_session: Option<Session>,
+) -> Result<Option<Session>, String> {
+    use tokio_tungstenite::tungstenite::http::Request;
+
+    let request = Request::builder()
+        .uri(connect_url)
+        .body(())
+        .map_err(|e| format!("build ws request: {e}"))?;
+
+    let (ws_stream, _) = connect_async_tls_with_config(request, None, false, None)
+        .await
+        .map_err(|e| format!("ws connect: {e}"))?;
+
+    let (mut write, mut read) = ws_stream.split();
+
+    // Heartbeat: starts as pending, replaced with a timed sleep on HELLO.
+    // Using Box<dyn Future> avoids pinning complexity inside the select! arms.
+    let mut hb_sleep: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
+        Box::pin(std::future::pending());
+    let mut hb_interval_ms: u64 = 0;
+    let mut last_hb_acked = true;
+
+    let mut session: Option<Session> = None;
+    let mut identified = false;
+
+    loop {
+        tokio::select! {
+            // Heartbeat tick
+            _ = &mut hb_sleep, if hb_interval_ms > 0 => {
+                if !last_hb_acked {
+                    tracing::warn!("discord_bridge: heartbeat zombie — reconnecting");
+                    let _ = write.send(Message::Close(None)).await;
+                    return Ok(session);
+                }
+                let seq = session.as_ref().map(|s| s.last_seq);
+                let payload = serde_json::to_string(&HeartbeatPayload {
+                    op: opcode::HEARTBEAT,
+                    d: seq,
+                })
+                .unwrap_or_default();
+                if let Err(e) = write.send(Message::Text(payload.into())).await {
+                    return Err(format!("heartbeat send: {e}"));
+                }
+                last_hb_acked = false;
+                hb_sleep = Box::pin(tokio::time::sleep(Duration::from_millis(hb_interval_ms)));
+            }
+
+            // Outbound message from agent → Discord REST
+            msg = outbound_rx.recv() => {
+                match msg {
+                    None => return Ok(session),
+                    Some(outbound) => {
+                        let ch = if outbound.channel_id.is_empty() {
+                            channel_id
+                        } else {
+                            outbound.channel_id.as_str()
+                        };
+                        if let Err(e) = rest::send_message(http, token, ch, &outbound).await {
+                            tracing::warn!("discord_bridge: send failed: {e}");
+                        }
+                    }
+                }
+            }
+
+            // Incoming Gateway frame
+            frame = read.next() => {
+                match frame {
+                    None => return Ok(session),
+                    Some(Err(e)) => return Err(format!("ws recv: {e}")),
+                    Some(Ok(Message::Text(text))) => {
+                        let payload: GatewayPayload = match serde_json::from_str(&text) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                tracing::warn!("discord_bridge: parse error: {e}");
+                                continue;
+                            }
+                        };
+
+                        // Track sequence number on every dispatch
+                        if let (Some(seq), Some(sess)) = (payload.seq, session.as_mut()) {
+                            if seq > sess.last_seq {
+                                sess.last_seq = seq;
+                            }
+                        }
+
+                        match payload.opcode {
+                            opcode::HELLO => {
+                                hb_interval_ms = payload.data
+                                    .as_ref()
+                                    .and_then(|d| d.get("heartbeat_interval"))
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(41_250);
+
+                                // First heartbeat fires after one full interval
+                                hb_sleep = Box::pin(tokio::time::sleep(
+                                    Duration::from_millis(hb_interval_ms),
+                                ));
+                                last_hb_acked = true;
+
+                                if let Some(prev) = resume_session.as_ref().filter(|_| !identified) {
+                                    let payload = serde_json::to_string(&ResumePayload {
+                                        op: opcode::RESUME,
+                                        d: ResumeData {
+                                            token: token.to_string(),
+                                            session_id: prev.session_id.clone(),
+                                            seq: prev.last_seq,
+                                        },
+                                    })
+                                    .unwrap_or_default();
+                                    write.send(Message::Text(payload.into()))
+                                        .await
+                                        .map_err(|e| format!("resume send: {e}"))?;
+                                    session = Some(prev.clone());
+                                } else {
+                                    let payload = serde_json::to_string(&IdentifyPayload {
+                                        op: opcode::IDENTIFY,
+                                        d: IdentifyData {
+                                            token: token.to_string(),
+                                            intents: INTENTS,
+                                            properties: IdentifyProperties {
+                                                os: std::env::consts::OS.to_string(),
+                                                browser: "agentmux".to_string(),
+                                                device: "agentmux".to_string(),
+                                            },
+                                        },
+                                    })
+                                    .unwrap_or_default();
+                                    write.send(Message::Text(payload.into()))
+                                        .await
+                                        .map_err(|e| format!("identify send: {e}"))?;
+                                }
+                                identified = true;
+                            }
+
+                            opcode::HEARTBEAT_ACK => {
+                                last_hb_acked = true;
+                                let now = unix_secs();
+                                let mut h = health.lock().unwrap();
+                                h.status = BridgeStatus::Connected;
+                                h.error = None;
+                                h.last_event_at = Some(now);
+                            }
+
+                            opcode::HEARTBEAT => {
+                                // Server-initiated heartbeat request
+                                let seq = session.as_ref().map(|s| s.last_seq);
+                                let payload = serde_json::to_string(&HeartbeatPayload {
+                                    op: opcode::HEARTBEAT,
+                                    d: seq,
+                                })
+                                .unwrap_or_default();
+                                let _ = write.send(Message::Text(payload.into())).await;
+                            }
+
+                            opcode::RECONNECT => {
+                                tracing::info!("discord_bridge: server requested reconnect (RESUME eligible)");
+                                let _ = write.send(Message::Close(None)).await;
+                                return Ok(session);
+                            }
+
+                            opcode::INVALID_SESSION => {
+                                let resumable = payload.data
+                                    .as_ref()
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(false);
+                                tracing::warn!(
+                                    "discord_bridge: invalid session (resumable={resumable})"
+                                );
+                                let _ = write.send(Message::Close(None)).await;
+                                return Ok(if resumable { session } else { None });
+                            }
+
+                            opcode::DISPATCH => {
+                                handle_dispatch(
+                                    payload.event_type.as_deref(),
+                                    payload.data,
+                                    channel_id,
+                                    target_agent,
+                                    &mut session,
+                                    health,
+                                );
+                            }
+
+                            op => {
+                                tracing::debug!("discord_bridge: unhandled opcode {op}");
+                            }
+                        }
+                    }
+
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = write.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Close(_))) => return Ok(session),
+                    Some(Ok(_)) => {}
+                }
+            }
+        }
+    }
+}
+
+fn handle_dispatch(
+    event_type: Option<&str>,
+    data: Option<Value>,
+    channel_id: &str,
+    target_agent: &Option<String>,
+    session: &mut Option<Session>,
+    health: &Arc<Mutex<BridgeHealth>>,
+) {
+    match event_type {
+        Some("READY") => {
+            if let Some(data) = data {
+                if let Ok(ready) = serde_json::from_value::<ReadyEvent>(data) {
+                    let username = ready
+                        .user
+                        .as_ref()
+                        .map(|u| u.username.as_str())
+                        .unwrap_or("unknown");
+                    tracing::info!(
+                        "discord_bridge: READY as {}, session {}",
+                        username,
+                        ready.session_id
+                    );
+                    *session = Some(Session {
+                        session_id: ready.session_id.clone(),
+                        resume_url: ready.resume_gateway_url.clone(),
+                        last_seq: 0,
+                    });
+                    let mut h = health.lock().unwrap();
+                    h.status = BridgeStatus::Connected;
+                    h.error = None;
+                }
+            }
+        }
+
+        Some("RESUMED") => {
+            tracing::info!("discord_bridge: session RESUMED");
+            let mut h = health.lock().unwrap();
+            h.status = BridgeStatus::Connected;
+            h.error = None;
+        }
+
+        Some("MESSAGE_CREATE") => {
+            let data = match data {
+                Some(d) => d,
+                None => return,
+            };
+            let msg: MessageCreate = match serde_json::from_value(data) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!("discord_bridge: parse MESSAGE_CREATE: {e}");
+                    return;
+                }
+            };
+
+            // Ignore bot messages (including our own bot)
+            if msg.author.bot.unwrap_or(false) {
+                return;
+            }
+
+            // Only process messages from the configured channel
+            if msg.channel_id != channel_id {
+                return;
+            }
+
+            {
+                let mut h = health.lock().unwrap();
+                h.last_event_at = Some(unix_secs());
+            }
+
+            let Some(target) = target_agent else {
+                tracing::debug!(
+                    "discord_bridge: message from {} (no target agent configured)",
+                    msg.author.username
+                );
+                return;
+            };
+
+            let envelope = format!("[Discord @{}]: {}", msg.author.username, msg.content);
+            let handler = get_global_handler();
+            let req = InjectionRequest {
+                target_agent: target.clone(),
+                message: envelope,
+                source_agent: Some("discord".to_string()),
+                request_id: Some(msg.id.clone()),
+                priority: None,
+                wait_for_idle: false,
+            };
+            let result = handler.inject_message(req);
+            if result.success {
+                tracing::debug!(
+                    "discord_bridge: injected msg from {} to agent {}",
+                    msg.author.username,
+                    target
+                );
+            } else {
+                tracing::warn!(
+                    "discord_bridge: inject to agent {} failed: {:?}",
+                    target,
+                    result.error
+                );
+            }
+        }
+
+        Some(t) => {
+            tracing::debug!("discord_bridge: unhandled event {t}");
+        }
+        None => {}
+    }
+}
+
+fn unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/agentmux-srv/src/messaging/discord/mod.rs
+++ b/agentmux-srv/src/messaging/discord/mod.rs
@@ -1,0 +1,96 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Discord messaging bridge — Gateway WebSocket + REST send.
+//!
+//! Lifecycle:
+//!   1. `DiscordBridge::init_global(config, http)` — call once at startup.
+//!   2. The gateway loop runs in a background tokio task (auto-reconnects).
+//!   3. `DiscordBridge::get()` returns the singleton for HTTP handler use.
+//!   4. `bridge.send(msg)` enqueues a message for the REST client.
+//!   5. `bridge.health()` returns the current connection status.
+
+mod gateway;
+pub mod rest;
+pub mod types;
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::mpsc;
+
+use crate::messaging::{BridgeHealth, OutboundMsg};
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct DiscordConfig {
+    /// Discord bot token (obtain from discord.com/developers/applications).
+    pub token: String,
+    /// Default channel ID — inbound messages are filtered to this channel;
+    /// outbound messages target it when `OutboundMsg.channel_id` is empty.
+    pub channel_id: String,
+    /// Agent ID to inject inbound Discord messages into via the reactive bus.
+    /// If None, inbound messages are logged but not forwarded.
+    pub target_agent: Option<String>,
+    /// Guild ID for guild-scoped slash command registration (Phase 2).
+    #[allow(dead_code)]
+    pub guild_id: Option<String>,
+}
+
+// ── Bridge ─────────────────────────────────────────────────────────────────
+
+pub struct DiscordBridge {
+    outbound_tx: mpsc::UnboundedSender<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+}
+
+static GLOBAL_BRIDGE: OnceLock<DiscordBridge> = OnceLock::new();
+
+impl DiscordBridge {
+    /// Initialize the global Discord bridge and start the Gateway background task.
+    /// No-op if already initialized.
+    pub fn init_global(config: DiscordConfig, http: reqwest::Client) {
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<OutboundMsg>();
+        let health = Arc::new(Mutex::new(BridgeHealth::connecting("discord")));
+
+        let bridge = DiscordBridge {
+            outbound_tx,
+            health: health.clone(),
+        };
+
+        if GLOBAL_BRIDGE.set(bridge).is_err() {
+            return; // already initialized
+        }
+
+        let token = config.token.clone();
+        let channel_id = config.channel_id.clone();
+        let target_agent = config.target_agent.clone();
+
+        tokio::spawn(async move {
+            gateway::run_gateway_loop(token, channel_id, target_agent, http, outbound_rx, health)
+                .await;
+        });
+
+        tracing::info!(
+            "discord_bridge: initialized (channel={}, target={:?})",
+            config.channel_id,
+            config.target_agent
+        );
+    }
+
+    pub fn get() -> Option<&'static DiscordBridge> {
+        GLOBAL_BRIDGE.get()
+    }
+
+    /// Enqueue a message for delivery via Discord REST.
+    /// Returns error if the bridge task has exited (should not happen in normal operation).
+    pub fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        self.outbound_tx
+            .send(msg)
+            .map_err(|_| "discord_bridge: outbound channel closed".to_string())
+    }
+
+    pub fn health(&self) -> BridgeHealth {
+        self.health.lock().unwrap().clone()
+    }
+}

--- a/agentmux-srv/src/messaging/discord/rest.rs
+++ b/agentmux-srv/src/messaging/discord/rest.rs
@@ -1,0 +1,71 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Discord REST API client — message send only.
+//!
+//! Rate limiting: Discord returns X-RateLimit-* headers. We log 429s and
+//! return an error; the caller (gateway loop) logs a warning. Full rate-limit
+//! header handling is deferred to Phase 2.
+
+use crate::messaging::{EmbedField, MsgEmbed, OutboundMsg};
+
+use super::types::{DiscordEmbed, DiscordEmbedField, DiscordEmbedFooter, SendMessageBody};
+
+const DISCORD_API: &str = "https://discord.com/api/v10";
+
+/// POST /channels/{channel_id}/messages
+pub async fn send_message(
+    http: &reqwest::Client,
+    token: &str,
+    channel_id: &str,
+    msg: &OutboundMsg,
+) -> Result<(), String> {
+    let embeds = msg.embed.as_ref().map(to_discord_embed).into_iter().collect();
+
+    let body = SendMessageBody {
+        content: msg.text.clone(),
+        embeds,
+    };
+
+    let url = format!("{}/channels/{}/messages", DISCORD_API, channel_id);
+    let resp = http
+        .post(&url)
+        .header("Authorization", format!("Bot {}", token))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("discord rest: http error: {e}"))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("discord rest: rate limited: {body}"));
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("discord rest: {status}: {body}"));
+    }
+
+    Ok(())
+}
+
+fn to_discord_embed(embed: &MsgEmbed) -> DiscordEmbed {
+    DiscordEmbed {
+        title: embed.title.clone(),
+        description: embed.description.clone(),
+        color: embed.color,
+        fields: embed.fields.iter().map(to_discord_field).collect(),
+        footer: embed
+            .footer
+            .as_ref()
+            .map(|t| DiscordEmbedFooter { text: t.clone() }),
+    }
+}
+
+fn to_discord_field(f: &EmbedField) -> DiscordEmbedField {
+    DiscordEmbedField {
+        name: f.name.clone(),
+        value: f.value.clone(),
+        inline: f.inline,
+    }
+}

--- a/agentmux-srv/src/messaging/discord/types.rs
+++ b/agentmux-srv/src/messaging/discord/types.rs
@@ -1,0 +1,148 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Discord Gateway and REST API wire types.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Gateway intents bitmask: GUILDS (1<<0) | GUILD_MESSAGES (1<<9) | MESSAGE_CONTENT (1<<15).
+/// MESSAGE_CONTENT is a privileged intent — enable it in the Discord Developer Portal
+/// for private bots under 100 servers (no review required).
+pub const INTENTS: u32 = (1 << 0) | (1 << 9) | (1 << 15);
+
+// ── Gateway opcodes ──────────────────────────────────────────────────────
+
+pub mod opcode {
+    pub const DISPATCH: u8 = 0;
+    pub const HEARTBEAT: u8 = 1;
+    pub const IDENTIFY: u8 = 2;
+    pub const RESUME: u8 = 6;
+    pub const RECONNECT: u8 = 7;
+    pub const INVALID_SESSION: u8 = 9;
+    pub const HELLO: u8 = 10;
+    pub const HEARTBEAT_ACK: u8 = 11;
+}
+
+// ── Gateway wire types ─────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GatewayPayload {
+    #[serde(rename = "op")]
+    pub opcode: u8,
+    #[serde(rename = "d")]
+    pub data: Option<Value>,
+    #[serde(rename = "s")]
+    pub seq: Option<u64>,
+    #[serde(rename = "t")]
+    pub event_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IdentifyPayload {
+    pub op: u8,
+    pub d: IdentifyData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IdentifyData {
+    pub token: String,
+    pub intents: u32,
+    pub properties: IdentifyProperties,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IdentifyProperties {
+    pub os: String,
+    pub browser: String,
+    pub device: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HeartbeatPayload {
+    pub op: u8,
+    pub d: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResumePayload {
+    pub op: u8,
+    pub d: ResumeData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResumeData {
+    pub token: String,
+    pub session_id: String,
+    pub seq: u64,
+}
+
+// ── READY event ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct ReadyEvent {
+    pub session_id: String,
+    pub resume_gateway_url: String,
+    #[serde(default)]
+    pub user: Option<DiscordUser>,
+}
+
+// ── User ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiscordUser {
+    #[allow(dead_code)]
+    pub id: String,
+    pub username: String,
+    /// Present and true on bot accounts, absent on humans.
+    #[serde(default)]
+    pub bot: Option<bool>,
+}
+
+// ── MESSAGE_CREATE event ───────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct MessageCreate {
+    pub id: String,
+    pub channel_id: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub guild_id: Option<String>,
+    #[serde(default)]
+    pub content: String,
+    pub author: DiscordUser,
+}
+
+// ── REST send types ────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct SendMessageBody {
+    pub content: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub embeds: Vec<DiscordEmbed>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscordEmbed {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<u32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<DiscordEmbedField>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer: Option<DiscordEmbedFooter>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscordEmbedField {
+    pub name: String,
+    pub value: String,
+    pub inline: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscordEmbedFooter {
+    pub text: String,
+}

--- a/agentmux-srv/src/messaging/mod.rs
+++ b/agentmux-srv/src/messaging/mod.rs
@@ -1,0 +1,103 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Messaging bridge framework — common types shared by all platform bridges.
+//!
+//! Each bridge (Discord, Telegram, Slack, …) runs as a background tokio task.
+//! Inbound messages are injected into the reactive bus; outbound messages
+//! arrive via HTTP endpoint or MCP tool.
+
+pub mod discord;
+
+use serde::{Deserialize, Serialize};
+
+// ── Common message types ───────────────────────────────────────────────────
+
+/// A message received from a messaging platform, normalized for reactive bus injection.
+/// Constructed in Phase 2 when per-message metadata is surfaced to the frontend.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboundMsg {
+    pub platform: String,
+    pub platform_msg_id: String,
+    pub from_id: String,
+    pub from_name: String,
+    pub channel_id: String,
+    pub text: String,
+    #[serde(default)]
+    pub attachments: Vec<String>,
+    pub received_at: u64,
+}
+
+/// A message to send to a messaging platform.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundMsg {
+    pub text: String,
+    /// Target channel. Empty → use the bridge's default channel.
+    #[serde(default)]
+    pub channel_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embed: Option<MsgEmbed>,
+}
+
+/// Rich embed for platforms that support structured output (Discord, Slack).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MsgEmbed {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub description: String,
+    /// Platform-specific color integer (Discord: 0xRRGGBB).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<u32>,
+    #[serde(default)]
+    pub fields: Vec<EmbedField>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedField {
+    pub name: String,
+    pub value: String,
+    #[serde(default)]
+    pub inline: bool,
+}
+
+// ── Bridge health ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BridgeStatus {
+    Connected,
+    Connecting,
+    Disconnected,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHealth {
+    pub platform: String,
+    pub status: BridgeStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<u64>,
+    pub reconnect_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl BridgeHealth {
+    pub fn connecting(platform: &str) -> Self {
+        BridgeHealth {
+            platform: platform.to_string(),
+            status: BridgeStatus::Connecting,
+            latency_ms: None,
+            last_event_at: None,
+            reconnect_count: 0,
+            error: None,
+        }
+    }
+}

--- a/agentmux-srv/src/server/messaging_handlers.rs
+++ b/agentmux-srv/src/server/messaging_handlers.rs
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP handlers for the messaging bridge layer.
+//!
+//! Routes:
+//!   GET  /api/messaging/status         — health of all active bridges
+//!   POST /api/messaging/discord/send   — send a message via the Discord bridge
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use super::AppState;
+use crate::messaging::{EmbedField, MsgEmbed, OutboundMsg};
+use crate::messaging::discord::DiscordBridge;
+
+/// GET /api/messaging/status
+pub(super) async fn handle_status(State(_state): State<AppState>) -> impl IntoResponse {
+    let mut bridges = vec![];
+    if let Some(bridge) = DiscordBridge::get() {
+        bridges.push(bridge.health());
+    }
+    Json(json!({ "bridges": bridges }))
+}
+
+/// POST /api/messaging/discord/send
+#[derive(Deserialize)]
+pub(super) struct DiscordSendRequest {
+    /// Message text (may be empty when using embed only).
+    #[serde(default)]
+    pub text: String,
+    /// Override channel. Empty → use the bridge's default channel.
+    #[serde(default)]
+    pub channel_id: String,
+    /// Optional embed title.
+    pub title: Option<String>,
+    /// If present, creates a rich embed with this as the description.
+    pub embed_description: Option<String>,
+    /// Embed footer text (default: "via AgentMux").
+    pub footer: Option<String>,
+    /// Embed fields.
+    #[serde(default)]
+    pub fields: Vec<EmbedFieldRequest>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct EmbedFieldRequest {
+    pub name: String,
+    pub value: String,
+    #[serde(default)]
+    pub inline: bool,
+}
+
+pub(super) async fn handle_discord_send(
+    State(_state): State<AppState>,
+    Json(req): Json<DiscordSendRequest>,
+) -> impl IntoResponse {
+    let bridge = match DiscordBridge::get() {
+        Some(b) => b,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error": "discord bridge not initialized — set messaging:discord:enabled in settings"})),
+            )
+                .into_response();
+        }
+    };
+
+    let embed = req.embed_description.map(|desc| MsgEmbed {
+        title: req.title,
+        description: desc,
+        color: Some(5_763_719), // Discord green #57F287
+        fields: req
+            .fields
+            .into_iter()
+            .map(|f| EmbedField {
+                name: f.name,
+                value: f.value,
+                inline: f.inline,
+            })
+            .collect(),
+        footer: Some(req.footer.unwrap_or_else(|| "via AgentMux".to_string())),
+    });
+
+    let msg = OutboundMsg {
+        text: req.text,
+        channel_id: req.channel_id,
+        reply_to: None,
+        embed,
+    };
+
+    match bridge.send(msg) {
+        Ok(()) => Json(json!({ "ok": true })).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -18,6 +18,7 @@ mod voice;
 pub(crate) mod wave_obj_bridge;
 mod websocket;
 mod drone_handlers;
+mod messaging_handlers;
 mod muxbus_handlers;
 mod native_memory_handlers;
 
@@ -297,6 +298,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tab/activate", post(handle_tab_activate))
         .route("/api/v1/tab/new", post(handle_tab_new))
         .route("/api/v1/window/focus", post(handle_window_focus))
+        .route("/api/messaging/status", get(messaging_handlers::handle_status))
+        .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(

--- a/docs/analysis/ANALYSIS_PLUGIN_WIDGET_MESSAGING_INTEGRATION_2026_06_24.md
+++ b/docs/analysis/ANALYSIS_PLUGIN_WIDGET_MESSAGING_INTEGRATION_2026_06_24.md
@@ -1,0 +1,327 @@
+# Analysis: Plugin System, Widget Architecture & Messaging Integration Sizing
+
+**Date:** 2026-06-24  
+**Status:** Reference / Decision Document  
+**Covers:** Plugin system state, toolchain widget catalog, messaging integration sizing, installability options
+
+---
+
+## 1. Current Binary Baseline
+
+| Build | Size |
+|-------|------|
+| `agentmux-srv` debug (current) | **43 MB** |
+| `agentmux-srv` release (estimated) | **~10–15 MB** (no debug symbols, LTO enabled) |
+
+Debug builds carry full DWARF symbols and no optimization — the 43 MB is not indicative of shipped size. Release with `opt-level = "z"` + `lto = "thin"` + `strip = true` typically produces 3–5× smaller binaries for a Rust app of this complexity.
+
+---
+
+## 2. What agentmux-srv Already Ships (Relevant Primitives)
+
+This is the key fact for the messaging integration sizing question. The srv already compiles in every primitive needed to implement messaging bridges:
+
+| Already in Cargo.toml | Used for messaging |
+|-----------------------|-------------------|
+| `tokio-tungstenite` (with `rustls-tls-webpki-roots`) | Discord Gateway WS, Slack Socket Mode WS |
+| `reqwest` (with `rustls-tls`, `json`, `multipart`) | All REST API calls (Telegram, Discord, Slack, WhatsApp Graph API) |
+| `axum` (with `ws`) | WhatsApp webhook HTTP receiver, Teams Bot Framework receiver |
+| `serde_json` | All JSON encoding/decoding |
+| `sha2` + `hex` | WhatsApp `X-Hub-Signature-256` validation |
+| `keyring` | Storing bot tokens securely |
+| `tokio` full | Async runtime for all bridge event loops |
+
+**Conclusion: implementing all five messaging bridges using existing primitives adds zero new crate dependencies to the Rust binary.**
+
+---
+
+## 3. Messaging Bridge Sizes in agentmux-srv
+
+### If implemented raw (using existing primitives only)
+
+| Platform | New Rust LOC | New crates | Binary size increase |
+|----------|-------------|------------|---------------------|
+| Telegram | ~500 LOC | 0 | ~0.1–0.2 MB |
+| Discord | ~700 LOC | 0 | ~0.15–0.3 MB |
+| Slack | ~600 LOC | 0 | ~0.1–0.2 MB |
+| WhatsApp (Cloud API) | ~800 LOC | 0 | ~0.15–0.25 MB |
+| Teams | ~1,200 LOC | `jsonwebtoken` (JWT validation) | ~0.3–0.5 MB |
+| **Total (all 5)** | **~3,800 LOC** | **0–1 new crate** | **~0.8–1.4 MB** |
+
+Raw implementations are viable because the bridges are protocol state machines on top of existing HTTP/WS primitives. The logic is: connect → authenticate → event loop → normalize to AgentMux envelope → push to reactive bus.
+
+### If using framework crates (teloxide, twilight-rs, serenity)
+
+| Platform | Framework | New transitive crates | Binary size increase |
+|----------|-----------|----------------------|---------------------|
+| Telegram | `teloxide` | ~60–80 crates | +3–6 MB |
+| Discord | `twilight-gateway` + `twilight-http` + `twilight-model` | ~20–30 crates | +1–3 MB |
+| Discord | `serenity` | ~40–60 crates | +3–5 MB |
+| Slack | No official Rust SDK | — | — (raw only) |
+| WhatsApp | No Rust SDK | — | — (raw only) |
+| Teams | `botbuilder` (deprecated) | Not recommended | — |
+
+**Recommendation:** implement Telegram and Discord raw for the srv integration. The bridge protocol is simple enough that a framework adds more cost than convenience. Framework crates shine when you need the full feature surface (voice, caching, middleware); bridges only need event ingestion + REST send.
+
+### WhatsApp Baileys (Node.js path)
+
+Baileys runs as a Node.js subprocess (or in the Electron main process). It does not affect the Rust binary size. Its Node.js footprint:
+
+| Component | Size on disk |
+|-----------|-------------|
+| `@whiskeysockets/baileys` package | ~15–25 MB (includes libsignal, crypto deps) |
+| Runs as | Electron main process or Node subprocess |
+| Rust binary impact | 0 |
+
+### Slack (if Node.js path preferred)
+
+| Component | Size |
+|-----------|------|
+| `@slack/socket-mode` + `@slack/web-api` | ~8 MB |
+| Rust binary impact | 0 |
+
+---
+
+## 4. Plugin / Widget System — Current State
+
+### What exists today
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| `widgets.json` (server config) | ✅ Shipped | 9 built-in widgets defined here |
+| `block-registry.ts` (frontend) | ✅ Shipped | Static compile-time map, `registerBlockView()` hook exists |
+| `registerBlockView()` hook | ✅ Available | Runtime-callable; used for external widget dynamic registration |
+| `widget-catalog.ts` | ✅ Spec ready (not yet impl.) | External widget catalog (ComfyUI, JupyterLab, Grafana, n8n, etc.) |
+| `toolchain-modal.tsx` | ✅ Spec ready (not yet impl.) | Toolchain Manager modal with External Widgets section |
+| `widget.health` RPC | ✅ Spec ready | HTTP health check for localhost widget servers |
+| `widget.install` RPC | ✅ Spec ready | pip/npm install streaming |
+| Plugin manifest format | ❌ Not designed | No per-plugin `manifest.json` |
+| Plugin directory scanning | ❌ Not built | No `~/.agentmux/plugins/` discovery |
+| Plugin marketplace | ❌ Not built | Referenced as future work |
+| Third-party plugin API | ❌ Not spec'd | `RESEARCH_PLUGGABLE_WIDGET_API_2026_06_21.md` not written |
+
+### The two-tier widget model (existing architecture)
+
+**Tier 1 — Built-in widgets** (`widgets.json` + compiled into Rust binary + `block-registry.ts`)  
+Agent, Swarm, Browser, Editor, Terminal, Sysinfo, Drone, Help, Warden.  
+These are part of the application. Zero setup, always available.
+
+**Tier 2 — External widgets** (`widget-catalog.ts` + health-check + browser embed)  
+ComfyUI, JupyterLab, Open WebUI, LangFlow, Flowise, MLflow, n8n, Grafana, Qdrant, Portainer.  
+These run as independent localhost HTTP servers. AgentMux detects them via health check and embeds them in a CEF browser pane. No Rust binary changes needed — the browser widget handles the embed.
+
+---
+
+## 5. Toolchain System
+
+### SPEC_TOOLCHAIN_MANAGER_2026-06-15.md
+
+Solves the "GUI-launch PATH stripping" problem (macOS launchd gives agentmux-srv `/usr/bin:/bin:/usr/sbin:/sbin`, so nvm/Homebrew CLIs not found). Deliverables:
+
+- `resolve_login_path()` in `agentmux-common`: captures full login-shell PATH + well-known dirs
+- Called at host startup before srv spawns — one enrichment, everything downstream inherits
+- **Toolchain Manager modal** (hamburger → Toolchain Manager):
+
+```
+┌─ Toolchain Manager ─────────────────────────────────────────┐
+│  Environment     PATH: login-shell ✓  /opt/homebrew/bin … │
+│  Core Tools      Node 22 ✓  npm 10 ✓  Git 2.44 ✓  Docker ✓│
+│  Agent CLIs      Claude 2.1 ✓  Gemini ✓  Codex …          │
+│  External Widgets                                            │
+│    ComfyUI    [Installed ✓] [Running ✓]  [Open Pane]        │
+│    JupyterLab [Installed ✓] [Not running]  [Launch] [Open]  │
+│    Grafana    [Not installed]            [Install]           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### SPEC_TOOLCHAIN_MANAGER_EXTERNAL_WIDGETS_2026_06_22.md
+
+Extends the modal with external widgets. Each widget entry in `widget-catalog.ts` specifies:
+- `id`, `label`, `icon`
+- `healthCheckPath` + `defaultPort` (for detection)
+- `embedPath` (URL path to embed in CEF pane)
+- `install`: pip/npm/manual + package names
+- `requires`: prerequisite core tools (e.g., `["python"]`)
+- `cliCommand`: binary to detect on PATH
+
+Detection flow: `ResolveCliCommand()` → `widget.health` RPC → `registerBlockView()` → pane available.
+
+---
+
+## 6. Where Messaging Integrations Fit
+
+### Pane layer — zero new code needed
+
+Each messaging app is a pre-configured browser widget (CEF pane). Five new `widgets.json` entries using `"view": "browser"`:
+
+```json
+"defwidget@discord":   { "blockdef": { "meta": { "view": "browser", "url": "https://discord.com/app" } } }
+"defwidget@slack":     { "blockdef": { "meta": { "view": "browser", "url": "https://app.slack.com/" } } }
+"defwidget@telegram":  { "blockdef": { "meta": { "view": "browser", "url": "https://web.telegram.org/" } } }
+"defwidget@whatsapp":  { "blockdef": { "meta": { "view": "browser", "url": "https://web.whatsapp.com/" } } }
+"defwidget@teams":     { "blockdef": { "meta": { "view": "browser", "url": "https://teams.microsoft.com/" } } }
+```
+
+Cost: **~50 lines in widgets.json**. Drag/drop, layout, multi-pane, all inherited from the browser widget. User sees and uses the real app interface unchanged.
+
+### Bridge layer — background daemons for agent routing
+
+Bridges let the AgentMux agent participate in conversations visible in the CEF pane. Agent messages appear as the bot/integration account in the native UI.
+
+These bridges are a **new tier** beyond what the existing external widget catalog supports. External widgets are HTTP servers you embed; bridges are background daemons with no HTTP UI surface. The catalog model needs a `daemon: true` flag to accommodate this.
+
+---
+
+## 7. Three-Tier Widget Architecture (Proposed)
+
+| Tier | What | Examples | Integration method |
+|------|------|----------|-------------------|
+| **1 — Built-in** | Compiled into srv + in widgets.json | Agent, Warden, Drone, Browser | Always available |
+| **2 — External UI** | Localhost HTTP server embedded in CEF | ComfyUI, Grafana, JupyterLab, n8n | widget-catalog.ts + health check |
+| **3 — Background daemon** | Background process, no HTTP UI, agent integration | Telegram bridge, Discord bridge, Slack bridge | widget-catalog.ts + `daemon: true` |
+| **Future — Plugin** | Installable package (.amx or similar) | Community plugins | Plugin API (not yet designed) |
+
+Tier 3 extends the existing external widget catalog pattern with one new field:
+
+```typescript
+interface ExternalWidget {
+    id: string;
+    label: string;
+    icon: string;
+    daemon?: true;           // NEW: no embed URL, background process only
+    embedPath?: string;      // existing: for Tier 2 HTTP-server widgets
+    healthCheckPath?: string;
+    bridgeType?: 'rust' | 'node'; // which runtime hosts this daemon
+    ...
+}
+```
+
+---
+
+## 8. Installability Options by Platform
+
+### Option A — Built-in (Tier 1) for Telegram + Discord
+
+Bridges compiled into agentmux-srv. Cost: ~1,200 LOC Rust, 0 new crates, ~0.3–0.5 MB binary increase. Users with no interest in messaging pay a small binary size tax. Simplest path.
+
+**Best for:** Telegram, Discord (small, no public URL, no external deps, Rust primitives already present)
+
+### Option B — Toolchain catalog extension (Tier 3) for Slack + WhatsApp Baileys
+
+Slack bridge runs as a Node.js subprocess (no official Rust SDK; @slack/socket-mode is the right choice). WhatsApp Baileys runs as a Node.js subprocess. These map naturally to the external widget catalog extended with `daemon: true`.
+
+```typescript
+{
+    id: "slack-bridge",
+    label: "Slack",
+    daemon: true,
+    bridgeType: 'node',
+    requires: ["node"],
+    install: { method: "npm", packages: ["@slack/socket-mode", "@slack/web-api"] },
+    cliCommand: null,  // no standalone CLI; spawned directly
+}
+```
+
+**Best for:** Slack (Node.js ecosystem), WhatsApp Baileys (Baileys is Node.js-only)
+
+### Option C — Tier 3 with tunnel management for WhatsApp Cloud API + Teams
+
+These require a public HTTPS URL. Tunnel management (cloudflared subprocess, Dev Tunnels) is needed alongside the bridge. More setup friction; should be Tier 3 optional with clear setup guidance in Toolchain Manager.
+
+**Best for:** Users who want the official/compliant path for WhatsApp or already have an M365 tenant for Teams
+
+### Option D — Future plugin system
+
+Once `RESEARCH_PLUGGABLE_WIDGET_API_2026_06_21.md` is written and implemented, every messaging bridge becomes an installable `.amx` package (or similar). Community can build bridges for Signal, Matrix, iMessage, etc. without touching the AgentMux repo.
+
+---
+
+## 9. Recommended Integration Plan
+
+### Immediate (pane-only, one PR)
+
+Add 5 `widgets.json` entries. 50 lines. Zero risk. Users can open any messaging app in a pane immediately. No bridge, no agent integration yet — just the native UI in a tile.
+
+- Discord: `https://discord.com/app`
+- Slack: `https://app.slack.com/`
+- Telegram: `https://web.telegram.org/`
+- WhatsApp: `https://web.whatsapp.com/`
+- Teams: `https://teams.microsoft.com/`
+
+### Phase 1 (bridges, P1 — Telegram + Discord)
+
+Build raw Rust bridges in agentmux-srv under `src/messaging/`:
+
+```
+agentmux-srv/src/messaging/
+├── mod.rs              # BridgeTrait + BridgeHealth
+├── telegram/
+│   ├── mod.rs
+│   ├── poll.rs         # getUpdates long-polling loop
+│   ├── send.rs         # sendMessage REST calls
+│   └── types.rs        # Update, Message, InlineKeyboard
+└── discord/
+    ├── mod.rs
+    ├── gateway.rs      # WS connect, identify, heartbeat, resume
+    ├── rest.rs         # POST /channels/{id}/messages
+    └── types.rs        # GatewayEvent, Message, Embed
+```
+
+~1,200 LOC Rust, 0 new crates, ~0.3–0.5 MB binary increase. Settings UI: token input, channel/chat ID, allowed IDs allowlist.
+
+### Phase 2 (bridges, P2 — Slack + WhatsApp Baileys)
+
+Extend toolchain catalog with `daemon: true` Node.js bridges. Slack uses `@slack/socket-mode`. WhatsApp uses `@whiskeysockets/baileys`. Both spawned as managed Node.js subprocesses. No Rust binary impact.
+
+Requires: `daemon: true` field on `ExternalWidget` type + subprocess lifecycle management in Toolchain Manager.
+
+### Phase 3 (bridges, P3 — WhatsApp Cloud API + Teams)
+
+Both require tunnel management. Implement `TunnelManager` (cloudflared subprocess for WhatsApp, Dev Tunnels for Teams). These are the most complex integrations; serve enterprise users with existing M365 tenants or business WhatsApp accounts.
+
+### Future (plugin system)
+
+Design and implement `RESEARCH_PLUGGABLE_WIDGET_API_2026_06_21.md`. Community can then publish bridges for Signal, Matrix, iMessage, WeChat, etc. as installable packages.
+
+---
+
+## 10. Summary: Everything in One View
+
+```
+AgentMux Widget/Plugin Tiers
+├── Tier 1 — Built-in (compiled into srv)
+│   ├── Agent, Swarm, Browser, Editor, Terminal      ← shipped
+│   ├── Sysinfo, Drone, Help, Warden                 ← shipped
+│   ├── Telegram bridge                              ← Phase 1 (this work)
+│   └── Discord bridge                               ← Phase 1 (this work)
+│
+├── Tier 2 — External UI (Toolchain Manager → External Widgets)
+│   ├── ComfyUI, JupyterLab, Open WebUI              ← spec ready
+│   ├── LangFlow, Flowise, MLflow, n8n               ← spec ready
+│   ├── Grafana, Qdrant, Portainer                   ← spec ready
+│   └── [5 messaging pane entries]                   ← immediate (widgets.json only)
+│       discord.com/app, app.slack.com, web.telegram.org,
+│       web.whatsapp.com, teams.microsoft.com
+│
+├── Tier 3 — Background daemon (Toolchain Manager → daemon:true extension)
+│   ├── Slack bridge (Node.js, @slack/socket-mode)   ← Phase 2
+│   ├── WhatsApp Baileys (Node.js, baileys)          ← Phase 2
+│   ├── WhatsApp Cloud API + Cloudflare Tunnel       ← Phase 3
+│   └── Teams Bot + Dev Tunnel                       ← Phase 3
+│
+└── Future — Plugin packages (.amx)
+    ├── Community messaging: Signal, Matrix, iMessage ← requires plugin API
+    └── Community tools: anything                     ← requires plugin API
+```
+
+### Binary size budget (all messaging work)
+
+| Phase | Rust binary delta | Node.js disk |
+|-------|-----------------|--------------|
+| Immediate (pane entries) | 0 | 0 |
+| Phase 1 (Telegram + Discord raw) | **+0.3–0.5 MB** | 0 |
+| Phase 2 (Slack + WhatsApp Baileys) | 0 | +23–33 MB on disk (Node deps, not in binary) |
+| Phase 3 (WhatsApp Cloud + Teams) | +0.3–0.5 MB | 0 |
+| **Total Rust binary impact** | **~0.6–1.0 MB** | — |
+
+All Rust bridges implemented raw using existing `tokio-tungstenite` + `reqwest` + `axum` + `serde_json` primitives. Zero new crate dependencies for Phases 1 and 3. The entire messaging integration adds under **1 MB** to the release binary.

--- a/docs/specs/SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md
+++ b/docs/specs/SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md
@@ -1,0 +1,835 @@
+# Spec: Messaging App Integrations — Unified Plan
+
+**Date:** 2026-06-24  
+**Status:** Draft  
+**Scope:** Architecture and implementation plan for integrating the top 5 messaging platforms into AgentMux
+
+---
+
+## 1. Goal
+
+Extend AgentMux so that an agent can bidirectionally communicate with a user through the messaging app they already live in — **without changing how the user experiences that app**. The user sees the real, unmodified Discord/Slack/Telegram/WhatsApp/Teams interface inside an AgentMux pane. The agent participates in conversations through that same native interface. No custom chat UI, no reimplemented interface.
+
+The five platforms, in order of global reach:
+
+| Rank | Platform | Users | API Model | Desktop-App Friendly |
+|------|----------|-------|-----------|---------------------|
+| 1 | **WhatsApp** | 3B+ | Cloud API (webhooks) or unofficial WS | Medium (webhook complexity) |
+| 2 | **Telegram** | 900M+ | Bot API (long-polling) | Excellent (no public URL) |
+| 3 | **Discord** | 600M+ | Gateway WS + REST | Excellent (no public URL) |
+| 4 | **Slack** | 38M DAU | Socket Mode WS + Web API | Good (no public URL) |
+| 5 | **Microsoft Teams** | 320M MAU | Azure Bot Service relay | Poor (always needs cloud relay) |
+
+---
+
+## 2. Architecture
+
+### 2.1 Two-layer design: pane + bridge
+
+Each integration has exactly two layers:
+
+**Pane layer** — the user interface. A pre-configured browser widget (CEF pane) pointed at the web version of the messaging app. The user sees and uses the real app, unchanged, inside an AgentMux pane tile. Full drag/drop, layout management, and multi-pane positioning work exactly as they do for any other pane — because it is just the browser widget.
+
+**Bridge layer** — invisible background infrastructure. A Rust or Node.js process connecting to the platform's API (Gateway WebSocket, long-poll, Socket Mode, etc.) so that the agent can read inbound messages and post replies. Agent messages appear naturally inside the native web UI the user is looking at.
+
+```
+┌──────────────────────────────────────────┐
+│  AgentMux Pane (CEF browser widget)      │
+│                                          │
+│  ┌──────────────────────────────────┐    │
+│  │   discord.com/app                │    │
+│  │   (real Discord web UI)          │    │ ← user interacts here natively
+│  │   messages appear here naturally │    │
+│  └──────────────────────────────────┘    │
+└──────────────────────────────────────────┘
+              ↕ agent messages appear in-channel
+┌──────────────────────────────────────────┐
+│  Discord Bridge (background, invisible)  │
+│  twilight-rs Gateway WS                  │ ← agent reads/writes here
+│  ↕ AgentMux reactive bus                │
+│  ↕ Agent (via MCP send_message)         │
+└──────────────────────────────────────────┘
+```
+
+**What this means in practice:** The user opens a Discord pane in AgentMux. They see their real Discord. The agent is a bot in the same channel. The user types, the bot responds — all visible in the real Discord UI. There is no separate AgentMux chat UI; the messaging app IS the UI.
+
+### 2.2 Pane implementation — widgets.json entries
+
+Each messaging platform is a new entry in `widgets.json` using `"view": "browser"` with a pre-set URL. This is all that is needed on the frontend — no new ViewModel, no new ViewComponent, no new registry entry.
+
+```json
+"defwidget@discord": {
+    "display:order": 10,
+    "icon": "discord",
+    "label": "Discord",
+    "description": "Discord messaging — real interface, agent-connected",
+    "blockdef": { "meta": { "view": "browser", "url": "https://discord.com/app" } }
+},
+"defwidget@slack": {
+    "display:order": 11,
+    "icon": "slack",
+    "label": "Slack",
+    "description": "Slack messaging — real interface, agent-connected",
+    "blockdef": { "meta": { "view": "browser", "url": "https://app.slack.com/" } }
+},
+"defwidget@telegram": {
+    "display:order": 12,
+    "icon": "telegram",
+    "label": "Telegram",
+    "description": "Telegram Web — real interface, agent-connected",
+    "blockdef": { "meta": { "view": "browser", "url": "https://web.telegram.org/" } }
+},
+"defwidget@whatsapp": {
+    "display:order": 13,
+    "icon": "whatsapp",
+    "label": "WhatsApp",
+    "description": "WhatsApp Web — real interface, agent-connected",
+    "blockdef": { "meta": { "view": "browser", "url": "https://web.whatsapp.com/" } }
+},
+"defwidget@teams": {
+    "display:order": 14,
+    "icon": "teams",
+    "label": "Teams",
+    "description": "Microsoft Teams Web — real interface, agent-connected",
+    "blockdef": { "meta": { "view": "browser", "url": "https://teams.microsoft.com/" } }
+}
+```
+
+The icons (`discord`, `slack`, `telegram`, `whatsapp`, `teams`) need to be added to the icon set — or mapped to the closest existing ones temporarily.
+
+### 2.3 Drag/drop and in-app features
+
+Because messaging panes are browser widgets, they inherit everything the browser widget already supports:
+- **Drag/drop layout**: pane tiles can be repositioned, split, resized exactly like any other pane
+- **Multi-pane**: Discord and an agent pane side-by-side, or Telegram above Slack
+- **Pane header**: back/forward/reload nav bar, address bar (so user can also browse docs, etc.)
+- **Focus management**: click to focus the CEF pane, keyboard input routes to the web app
+- **Full web app features**: all in-app features of the messaging app work — reactions, threads, file upload, search, notifications — because it's running the real web app in CEF, not a stripped-down embed
+
+What does NOT work (CEF sandbox boundary):
+- Native desktop notifications from the messaging apps are scoped to the AgentMux process, not the system tray — unless AgentMux forwards them
+- Desktop OS integration (drag files from desktop into the pane) may require CEF drag-and-drop config to be enabled
+
+### 2.4 Bridge layer — background infrastructure
+
+Each bridge translates between a platform's wire protocol and the AgentMux reactive bus:
+
+```
+External Platform
+  │  (Discord Gateway WS / Telegram long-poll / Slack Socket Mode /
+  │   WhatsApp Cloud webhook / Teams Bot Framework)
+  ▼
+Platform Bridge (background, invisible to user)
+  │  inbound: platform message → AgentMux reactive bus → agent reads it
+  │  outbound: agent send_message → bridge → platform API → appears in CEF pane
+  ▼
+AgentMux Reactive Bus
+  POST /agentmux/reactive/send   ← bridge delivers inbound messages here
+  GET  /agentmux/reactive/read   ← bridge reads outbound messages here
+  ▼
+Agent (reads via MCP read_messages, sends via MCP send_message)
+```
+
+**Key design principle:** Bridges are opt-in, per-user configured, and isolated from each other. The existing reactive bus contract is unchanged. The bridge is an adapter on the outside.
+
+### 2.5 Common Bridge Interface
+
+Every bridge implements the same interface regardless of platform:
+
+```rust
+trait MessagingBridge: Send + Sync {
+    fn platform(&self) -> &'static str;         // "discord", "telegram", etc.
+    async fn start(&self) -> Result<()>;         // connect and begin event loop
+    async fn stop(&self);                        // clean disconnect
+    async fn send(&self, msg: OutboundMsg) -> Result<()>;
+    fn health(&self) -> BridgeHealth;           // for Warden widget
+}
+```
+
+Outbound routing: when an agent calls `send_message` with `target: "messaging:discord"` (or `"messaging:telegram"`, etc.), the reactive bus routes to the configured bridge for that platform. Only one bridge per platform is active at a time.
+
+### 2.6 Configuration Storage
+
+Stored in AgentMux user config under `[messaging.<platform>]`. Credentials (tokens, secrets) are stored in OS keychain — never plaintext. The config block is:
+
+```toml
+[messaging.discord]
+enabled = true
+guild_id = "..."
+channel_id = "..."
+agent_target = "<agent_id>"     # route inbound messages to this agent
+bot_token = "keychain://agentmux/discord-bot-token"
+
+[messaging.telegram]
+enabled = false
+bot_token = "keychain://agentmux/telegram-bot-token"
+allowed_chat_ids = [123456789]  # security allowlist
+
+[messaging.slack]
+enabled = false
+bot_token = "keychain://agentmux/slack-bot-token"
+app_token = "keychain://agentmux/slack-app-token"
+channel_id = "C..."
+
+[messaging.whatsapp]
+enabled = false
+mode = "cloud_api"              # or "bridge" (Baileys-based)
+phone_number_id = "..."
+access_token = "keychain://agentmux/whatsapp-token"
+tunnel = "cloudflare"          # required for cloud_api mode
+
+[messaging.teams]
+enabled = false
+app_id = "..."
+app_password = "keychain://agentmux/teams-app-password"
+tenant_id = "..."
+tunnel = "devtunnel"
+```
+
+### 2.7 Warden Widget — Internet Section
+
+The currently-stub "Internet" section in the Warden widget is the natural home for bridge status. Each enabled bridge gets a row:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Internet                  AgentBus cloud relay · opt-in │
+│                                                         │
+│  discord     ● connected   #agent-channel · 12ms ping  │
+│  telegram    ● connected   @agentmux_bot · polling     │
+│  slack       ○ disabled    —                            │
+│  whatsapp    ⚠ tunnel down  Reconnecting...            │
+│  teams       ○ disabled    —                            │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Platform Designs
+
+---
+
+### 3.1 Discord
+
+**Maturity: Production-ready.** Discord's Bot API is extremely stable, free, and well-suited to the AgentMux use case.
+
+#### Setup (one-time, user-performed)
+1. Create application at discord.com/developers
+2. Enable "Message Content" intent in Bot tab (no review needed for private bots <10,000 users)
+3. Copy bot token → AgentMux settings (stored in keychain)
+4. Invite bot to private server via OAuth2 URL: `?scope=bot+applications.commands&permissions=3072`
+
+#### Receiving (Gateway WebSocket)
+- Connect to `wss://gateway.discord.gg/?v=10&encoding=json`
+- Identify with intents bitmask: `GUILDS (1<<0) | GUILD_MESSAGES (1<<9) | MESSAGE_CONTENT (1<<15)` = `33281`
+- Store `session_id` and `resume_gateway_url` from READY payload
+- Track last `s` (sequence) on every dispatch
+- On disconnect: RESUME using `resume_gateway_url` + stored `session_id` + `seq`
+- OS power wake event (Windows `WM_POWERBROADCAST`) → proactive reconnect before zombie detection
+
+#### Sending (REST)
+```
+POST https://discord.com/api/v10/channels/{channel_id}/messages
+Authorization: Bot {token}
+{"content": "...", "embeds": [{...}]}
+```
+Rate limit: 50 req/s global; parse `X-RateLimit-*` headers dynamically.
+
+#### Slash Commands (intent-free alternative)
+Register guild-scoped `/ask <prompt>` command on startup:
+```
+PUT https://discord.com/api/v10/applications/{app_id}/guilds/{guild_id}/commands
+```
+For responses >3s: send `type: 5` (deferred) immediately, then PATCH `@original` within 15 min.
+
+#### Rich Output Format
+```json
+{
+  "embeds": [{
+    "title": "AgentMux",
+    "description": "Task output here",
+    "color": 5763719,
+    "fields": [
+      {"name": "Model", "value": "claude-sonnet-4-6", "inline": true},
+      {"name": "Duration", "value": "2.1s", "inline": true}
+    ],
+    "footer": {"text": "via AgentMux"}
+  }]
+}
+```
+
+#### Rust library
+- **`twilight-rs`** (`twilight-gateway` + `twilight-http`): modular, no hidden cache, best for embedding into existing Tokio runtime
+- Alternative: `serenity` (batteries-included, less surgical control)
+
+#### Rate Limits Summary
+| Limit | Value |
+|-------|-------|
+| Global REST | 50 req/s |
+| Gateway send | 120 events/60s |
+| Daily global command updates | 200 |
+| Session starts (Identify) | 1,000/24h |
+
+#### Known failure modes
+- **Heartbeat ghost**: no ACK → close + RESUME. Detection window: one heartbeat interval (~42s)
+- **Wake-from-sleep**: proactive reconnect on OS power resume event
+- **4014 close code**: disallowed intent → requires Developer Portal toggle, do not RESUME
+
+---
+
+### 3.2 Telegram
+
+**Maturity: Excellent.** The Bot API is the most developer-friendly of the five. No public URL required. Long polling works perfectly from a desktop app.
+
+#### Setup (one-time, user-performed)
+1. Open @BotFather in Telegram, send `/newbot`
+2. Set display name + username (must end in `bot`)
+3. Copy token → AgentMux settings
+4. Optionally: `/setprivacy off` if bot needs to see all group messages; `/setcommands` to register menu
+
+#### Receiving (Long Polling — no public URL needed)
+```
+GET https://api.telegram.org/bot{TOKEN}/getUpdates?timeout=30&offset={last_id+1}&allowed_updates=["message","callback_query"]
+```
+
+**Offset tracking (critical):** After processing a batch, advance offset to `last_update_id + 1`. Never advance before processing — failure before advancing re-delivers the same batch (handlers must be idempotent).
+
+**Single-instance guarantee:** Only one concurrent `getUpdates` per token (Telegram returns 409 Conflict otherwise). This enforces single-desktop-instance operation naturally.
+
+#### Sending
+```
+POST https://api.telegram.org/bot{TOKEN}/sendMessage
+{"chat_id": 123456789, "text": "<b>Agent output</b>", "parse_mode": "HTML", "reply_markup": {...}}
+```
+Use HTML parse mode for agent-generated content (simpler escaping than MarkdownV2 — only `<`, `>`, `&` need escaping).
+
+#### Rate Limits
+| Scope | Limit |
+|-------|-------|
+| Single chat | 1 message/second |
+| Group chat | 20 messages/minute |
+| Global | ~30 messages/second |
+
+On `429`: read `parameters.retry_after` and `parameters.scope` (added Bot API 7.8). Per-chat scope → pause only that chat's queue. Global scope → pause all outbound. Always add jitter. Never pre-throttle.
+
+#### Inline Keyboards — Agent Action Buttons
+```json
+{
+  "inline_keyboard": [
+    [{"text": "Approve", "callback_data": "approve"},
+     {"text": "Cancel", "callback_data": "cancel"}],
+    [{"text": "View log", "callback_data": "view_log"}]
+  ]
+}
+```
+After user taps: receive `callback_query` update → **must call `answerCallbackQuery`** within 60s (clears button spinner). Then optionally `editMessageReplyMarkup` to update buttons.
+
+#### Message Editing for Streaming Output
+Telegram allows bots to edit their own messages. Pattern for long-running tasks:
+1. `sendMessage` → get `message_id`
+2. `editMessageText` with `message_id` as task progresses
+3. Final `editMessageText` with complete output
+
+This simulates streaming without real-time infrastructure.
+
+#### Security Allowlist
+`allowed_chat_ids` in config. Every inbound update must have `message.chat.id` in the allowlist. Reject silently; do not reply to unknown chats (reduces enumeration surface).
+
+#### Rust Library
+**`teloxide`** (v0.13, Tokio-native, full Bot API 9.1 support). Spawn the dispatcher as a task on the existing Tokio runtime:
+```rust
+let bot = Bot::new(token);
+let dispatcher = Dispatcher::builder(bot, handler).build();
+dispatcher.dispatch().await;
+```
+
+---
+
+### 3.3 Slack
+
+**Maturity: Good.** Socket Mode makes Slack viable for desktop apps without a public URL, but connections refresh every ~1 hour and can silently stop delivering messages after days.
+
+#### Setup (one-time, user-performed)
+1. Create Slack app at api.slack.com/apps → "From an app manifest"
+2. Enable Socket Mode → generate App-Level Token (`xapp-`) with `connections:write` scope
+3. Enable event subscriptions: `app_mention`, `message.im`
+4. Add bot scopes: `chat:write`, `channels:read`, `im:history`, `im:read`, `im:write`, `app_mentions:read`, `commands`
+5. Register slash command `/agent`
+6. Install to workspace → copy Bot Token (`xoxb-`) → AgentMux settings
+
+Both tokens stored in keychain. Neither expires unless manually revoked.
+
+#### Receiving (Socket Mode WebSocket)
+```
+POST https://slack.com/api/apps.connections.open
+Authorization: Bearer xapp-{token}
+→ {"ok": true, "url": "wss://wss.slack.com/link/?ticket=..."}
+```
+Connect to the returned URL (ephemeral — do not cache). Receive envelope:
+```json
+{
+  "envelope_id": "...",
+  "type": "events_api",
+  "payload": { "event": { "type": "message", "text": "...", "channel": "..." } }
+}
+```
+**Must ACK within 3 seconds** by sending back `{"envelope_id": "..."}` on the same WebSocket.
+
+#### Reconnect Pattern
+- Slack sends `{"type": "disconnect", "reason": "warning"}` ~10s before refresh
+- On warning: call `apps.connections.open` immediately for new URL → open second WS in parallel
+- On `link_disabled`: close old connection, route acks to new connection
+- On unexpected close: exponential backoff (1s → 2s → 4s → capped at 60s)
+- **Heartbeat check**: if no event received for >5 minutes on an apparently-open WS, force reconnect (known silent-failure bug)
+
+#### Sending
+```
+POST https://slack.com/api/chat.postMessage
+Authorization: Bearer xoxb-{token}
+{"channel": "C...", "text": "fallback", "blocks": [...]}
+```
+Always include `text` as fallback for notifications. Rate: ~1 msg/s/channel (Special tier).
+
+#### Slash Command Deferred Pattern
+```
+1. ACK immediately (< 3s): {"envelope_id": "...", "payload": {"text": "Working...", "response_type": "ephemeral"}}
+2. Process (any duration)
+3. POST to response_url: {"text": "Result", "response_type": "in_channel", "blocks": [...]}
+   → Valid for 5 uses within 30 minutes
+```
+
+#### Block Kit — Agent Output Template
+```json
+{
+  "blocks": [
+    {"type": "header", "text": {"type": "plain_text", "text": "AgentMux Result"}},
+    {"type": "section", "text": {"type": "mrkdwn", "text": "*Model:* claude-sonnet-4-6  |  *Duration:* 2.1s"}},
+    {"type": "divider"},
+    {"type": "rich_text", "elements": [
+      {"type": "rich_text_preformatted",
+       "elements": [{"type": "text", "text": "output here"}],
+       "language": "text"}
+    ]},
+    {"type": "actions", "elements": [
+      {"type": "button", "text": {"type": "plain_text", "text": "Run Again"}, "action_id": "run_again", "style": "primary"}
+    ]}
+  ]
+}
+```
+
+#### Node.js Library (Electron Main Process)
+`@slack/web-api` + `@slack/socket-mode` — Slack-official, auto-reconnect, typed. Best fit for Electron. IPC bridge to Rust agent core for business logic.
+
+#### Rate Limits Summary
+| Method | Limit |
+|--------|-------|
+| `chat.postMessage` | ~1/s/channel (Special) |
+| Most read methods | 50+/min (Tier 3) |
+| `conversations.history` | 50+/min (internal apps) |
+| Socket Mode connections | 10 max per app |
+| Slash command `response_url` | 5 calls / 30 min |
+
+---
+
+### 3.4 WhatsApp
+
+**Maturity: Complex.** The official Cloud API requires business verification and a public HTTPS endpoint (no long-polling). The unofficial path (Baileys) is simpler to set up but carries ToS and ban risk.
+
+WhatsApp has two distinct integration paths. AgentMux should support both, with the user choosing based on their needs.
+
+#### Path A: Official Cloud API
+
+**Requirements:** Meta Business Account, business verification (2-10 days), dedicated phone number (cannot be used with regular WhatsApp app), public HTTPS webhook URL.
+
+**Setup:**
+1. Create Meta Business Account at business.facebook.com
+2. Add WhatsApp product to a developer app at developers.facebook.com
+3. Add + verify a phone number (separate from personal WhatsApp)
+4. Create System User token (permanent, never expires): Business Settings → System Users → Generate Token with `whatsapp_business_messaging` + `whatsapp_business_management` scopes
+5. Set up webhook (see below)
+
+**Public URL problem — Cloudflare Tunnel (recommended):**
+
+For a desktop app, the webhook needs a public HTTPS URL. Cloudflare Tunnel provides a permanent free named tunnel:
+
+```bash
+# One-time setup (user performs)
+cloudflared tunnel login
+cloudflared tunnel create agentmux-whatsapp
+cloudflared tunnel route dns agentmux-whatsapp wa.yourdomain.com
+```
+
+AgentMux manages the tunnel lifecycle (`cloudflared tunnel run agentmux-whatsapp`) as a subprocess. The resulting `https://wa.yourdomain.com` is registered once in Meta's dashboard and never changes.
+
+**Alternative tunnels:** ngrok (free tier: random URL on restart, must re-register each session), Hookdeck (stable URL + event queue/replay, free tier 10K events/month — useful since Meta drops events after 7 days of failed delivery).
+
+**Webhook verification:**
+```
+GET /webhook?hub.mode=subscribe&hub.verify_token={YOUR_TOKEN}&hub.challenge={RANDOM}
+→ return hub.challenge plaintext with HTTP 200
+```
+
+Every inbound POST: verify `X-Hub-Signature-256` header (HMAC-SHA256 of raw body using app secret, constant-time comparison).
+
+**Sending:**
+```
+POST https://graph.facebook.com/v25.0/{PHONE_NUMBER_ID}/messages
+Authorization: Bearer {SYSTEM_USER_TOKEN}
+{
+  "messaging_product": "whatsapp",
+  "to": "+1...",
+  "type": "text",
+  "text": {"body": "Agent output here"}
+}
+```
+
+Or template message when outside the 24-hour window:
+```json
+{"type": "template", "template": {"name": "agent_update", "language": {"code": "en_US"}, "components": [{"type": "body", "parameters": [{"type": "text", "text": "..."}]}]}}
+```
+
+**The 24-hour window rule:**
+- Free-form messages: only within 24h of last user message
+- After 24h: must use pre-approved template messages
+- Design: agent responds promptly; use templates for proactive notifications
+- Best pattern: user initiates → agent responds within window → conversation stays open
+
+**Pricing (as of 2026):**
+- Service messages (user-initiated, within window): **free**
+- Utility templates (within window): **free**
+- Utility templates (outside window): $0.004/message (US)
+- Marketing templates: $0.025/message (US); banned for US recipients since April 2025
+- At ~100 conversations/month: effectively $0-$0.40 in API charges
+
+**Policy note — AI chatbot ban (October 2025):** Meta prohibits using WhatsApp as the delivery channel for a general-purpose AI assistant distributed to others. A developer's private bot serving their own use (responding to their own messages, not distributing a product) is in a gray area — the ban targets "AI providers" distributing to end users. AgentMux should frame this as a personal productivity bridge, not a chatbot product.
+
+**Cloud API rate limits:**
+| Limit | Value |
+|-------|-------|
+| Messaging tier (default) | 1,000 unique users/24h (Tier 1) |
+| MPS (default) | 80 messages/second |
+| Per-user frequency cap | ~2 marketing/day (cross-business) |
+| Per-recipient burst | ~1 msg/6s burst; 45 in 6s then cooldown |
+
+**Rust library:** No official SDK. Use `reqwest` for REST calls. Implement webhook server with `axum` or `warp`. Run webhook receiver inside AgentMux process on a local port; expose via cloudflared.
+
+---
+
+#### Path B: Unofficial Bridge (Baileys)
+
+**Requirements:** Any WhatsApp number (including personal), Node.js, willingness to accept ToS risk.
+
+Baileys v7 implements WhatsApp Web's WebSocket protocol (Noise Protocol + Signal Protocol) directly — no browser, no Puppeteer. The desktop app maintains a linked-device session just like WhatsApp Web.
+
+**Key properties:**
+- No public URL needed (outbound WebSocket only)
+- No Meta account, no business verification, no templates
+- QR code scan or pairing code for initial auth (same as WhatsApp Web)
+- Session persists across restarts (saved to disk)
+
+**Ban risk:** Real but manageable for personal use:
+- Protocol fingerprinting detection exists; Baileys attempts to mimic legitimate client behavior
+- Bots that only respond to incoming messages: <2% ban rate over 12 months
+- Bots sending proactive messages to new contacts: 15-30% ban rate
+- v7.0.0 introduced improved protocol handling; `Bartender` test infrastructure now catches regressions
+- **Never use on a number you can't afford to lose**
+
+**In Electron:** Baileys runs in the Electron main process (pure Node.js). No subprocess needed.
+
+**Recommendation:** Support both paths. Cloud API for users who want the official route; Baileys bridge for personal use with appropriate warning about ToS risk.
+
+```
+User config:
+  mode = "cloud_api"   → official path, requires business account + tunnel
+  mode = "bridge"      → Baileys path, personal number, ToS risk acknowledged
+```
+
+---
+
+### 3.5 Microsoft Teams
+
+**Maturity: High friction for personal use.** Teams is enterprise-first by architecture. Every integration path requires an Azure subscription, an Entra ID tenant, a public HTTPS endpoint, and Azure Bot Service as a mandatory relay in the message path. There is no local-only Teams integration.
+
+**Viable for:** Users who already work in a Microsoft 365 organizational tenant (most corporate devs).  
+**Not viable for:** Personal use without an M365 org account or Azure.
+
+#### Prerequisites
+- Microsoft 365 organizational account (personal MSA accounts cannot use Teams bots)
+- Azure subscription (free tier F0 works; no message charges)
+- Entra ID (AAD) tenant — same as the M365 org
+- A publicly reachable HTTPS endpoint (bot endpoint must be accessible to Azure Bot Service)
+
+#### Setup
+1. Register app in Entra ID → get `Application ID` + `Client Secret`
+2. Create Azure Bot resource (F0 tier, free) → link Entra app → enable Teams channel
+3. Set messaging endpoint: `https://your-endpoint/api/messages`
+4. Build app package (manifest.json + two icons) → sideload to Teams
+
+**Sideloading requires an admin** to enable "Upload custom apps" in Teams Admin Center. For personal dev: join Microsoft 365 Developer Program (free E5 sandbox, requires qualifying subscription) or pay $6/month for M365 Business Basic.
+
+#### Public URL requirement — Azure Relay (no ngrok needed in production)
+
+Unlike the other platforms, Teams' Azure Bot Service relay means *your* endpoint only needs to be reachable by Azure's IP ranges. Options:
+- **Dev Tunnels** (Microsoft's tool, free with GitHub account): persistent named URLs, integrates with VS Code Teams Toolkit
+- **ngrok** (free random URL — must update Azure Bot registration each session; paid for stable URL)
+- **Azure App Service F1** (free tier, 60 CPU-min/day): host the bot endpoint in Azure itself → zero tunnel dependency in production
+
+#### Receiving (Azure Bot Service Relay)
+All Teams message traffic routes through Azure. Your endpoint receives `POST /api/messages` with Bot Framework Activity objects:
+```json
+{
+  "type": "message",
+  "from": {"id": "...", "name": "User Name"},
+  "conversation": {"id": "...", "tenantId": "..."},
+  "text": "Hello agent",
+  "serviceUrl": "https://smba.trafficmanager.net/teams/"
+}
+```
+Validate JWT (Bot Connector JWKS at `https://login.botframework.com/v1/.well-known/keys`).
+
+#### Sending — Proactive Messaging
+To message a user without them initiating first:
+1. Capture `conversationReference` on first contact → persist
+2. Use `adapter.continueConversation(ref, logic)` to send proactively
+
+Or create a new personal conversation:
+```
+POST https://smba.trafficmanager.net/teams/v3/conversations
+{
+  "bot": {"id": "APP_ID"},
+  "members": [{"id": "AAD_USER_OID"}],
+  "tenantId": "TENANT_ID"
+}
+```
+
+#### Adaptive Cards Output Format
+```json
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.4",
+  "body": [
+    {"type": "TextBlock", "text": "AgentMux Result", "weight": "Bolder", "size": "Medium"},
+    {"type": "FactSet", "facts": [
+      {"title": "Model", "value": "claude-sonnet-4-6"},
+      {"title": "Duration", "value": "2.1s"}
+    ]},
+    {"type": "CodeBlock", "codeSnippet": "output here", "language": "text"}
+  ],
+  "actions": [
+    {"type": "Action.Execute", "title": "Run Again", "verb": "run_again"}
+  ]
+}
+```
+
+#### SDK
+**Teams SDK** (GA for JS and C#, November 2025 rename of Teams AI Library) — absorbs botbuilder (archived Dec 2025), Graph, Adaptive Cards, and Teams JS into one SDK. Python in public preview.
+
+For Rust: no official SDK — raw HTTP with `reqwest` for outbound + `axum` to receive Bot Framework activities.
+
+#### Rate Limits
+| Scope | Limit |
+|-------|-------|
+| Per bot per thread | 7 sends/second, 60/30s, 1800/hour |
+| Global per app per tenant | 50 RPS |
+
+#### Verdict: Implement Last
+Teams should be the last integration implemented. The mandatory Azure relay, Azure subscription, and admin-gated sideloading make it impractical for users outside enterprise M365 tenants. The value/friction ratio is lowest of the five.
+
+---
+
+## 4. Implementation Roadmap
+
+### Phase 1: Telegram (Weeks 1-2)
+
+**Why first:** Simplest integration (no public URL, no cloud dependency, excellent Rust library, no approval process). Proves the bridge architecture before tackling more complex platforms.
+
+- `agentmux-srv/src/messaging/telegram/` — teloxide bridge
+  - Long-polling loop with offset tracking
+  - HTML parse mode for agent output
+  - Inline keyboard builder for action buttons
+  - `answerCallbackQuery` dispatch
+  - `editMessageText` for streaming simulation
+- Settings UI: token input (masked), allowed chat IDs
+- Warden widget: "Internet" section with bridge status rows
+- Changeset: `task changeset -- patch "feat: telegram messaging bridge"`
+
+### Phase 2: Discord (Weeks 2-3)
+
+**Why second:** Largest developer community for AgentMux users; clean architecture that validates the bridge interface for WebSocket platforms.
+
+- `agentmux-srv/src/messaging/discord/` — twilight-rs bridge
+  - Gateway client (twilight-gateway): identify, heartbeat, resume, reconnect
+  - REST client (twilight-http): send messages, deferred interactions
+  - OS power event hook for proactive reconnect on wake-from-sleep
+  - Slash command registration (guild-scoped) on startup
+  - Embed builder for rich agent output
+- Settings UI: token, guild ID, channel ID, slash command toggle
+- Changeset
+
+### Phase 3: Slack (Weeks 3-4)
+
+**Why third:** Socket Mode architecture is similar to Discord Gateway; code patterns transfer. Main delta is the App-Level Token dance and Block Kit formatting.
+
+- Electron main process: `@slack/socket-mode` + `@slack/web-api`
+  - Socket Mode client with auto-reconnect
+  - Proactive heartbeat liveness check (silent disconnect mitigation)
+  - Block Kit builder for rich output
+  - Slash command deferred response via `response_url`
+- IPC bridge to Rust reactive bus
+- Settings UI: two-token setup (xoxb- and xapp-)
+- Changeset
+
+### Phase 4: WhatsApp — Cloud API + Bridge (Weeks 4-6)
+
+**Why fourth:** Most complex setup; two paths to support; tunnel management to build.
+
+- `agentmux-srv/src/messaging/whatsapp/` — Cloud API bridge
+  - Webhook HTTP server (axum) on local port
+  - `X-Hub-Signature-256` validation
+  - Webhook verification GET handler
+  - Outbound via Graph API v25.0
+  - 24-hour window tracking (per-user state)
+  - Template fallback when window expired
+- Cloudflare Tunnel subprocess management: start/stop cloudflared, detect URL, register with AgentMux
+- Electron main process: Baileys bridge for `mode = "bridge"`
+  - QR code surface in Settings UI
+  - Session persistence to disk (encrypted)
+  - Warning banner: "Unofficial path — account ban risk accepted"
+- Settings UI: mode selector, phone number ID or QR, tunnel config
+- Changeset
+
+### Phase 5: Microsoft Teams (Weeks 6-8)
+
+**Why last:** Highest setup friction, Azure-dependent, narrowest target audience.
+
+- Bot Framework activity handler (axum endpoint)
+- JWT validation against Bot Connector JWKS
+- Adaptive Card builder
+- Proactive message with stored conversationReference
+- Dev Tunnel subprocess management (alternative to Cloudflare for Teams)
+- Settings UI: App ID, App Password, Tenant ID, tunnel config
+- Documentation: full setup walkthrough (Azure Bot creation, app manifest, sideloading)
+- Changeset
+
+---
+
+## 5. Common Abstractions
+
+### 5.1 Tunnel Manager
+
+Three platforms (WhatsApp Cloud API, Slack HTTP fallback, Teams) may need a public HTTPS URL. Rather than handling this per-bridge, a shared `TunnelManager` service manages this:
+
+```rust
+pub enum TunnelProvider {
+    CloudflareTunnel { name: String, domain: String },
+    DevTunnel { name: String },
+    NgrokFree,           // ephemeral
+    Manual { url: String }, // user provides their own
+}
+
+impl TunnelManager {
+    pub async fn ensure_url(&self) -> Result<Url>;
+    pub fn current_url(&self) -> Option<Url>;
+    pub fn status(&self) -> TunnelStatus;
+}
+```
+
+### 5.2 Message Envelope
+
+All inbound messages from any platform are normalized before entering the reactive bus:
+
+```rust
+pub struct InboundMessage {
+    pub platform: &'static str,          // "discord", "telegram", etc.
+    pub platform_msg_id: String,         // native message ID for reply threading
+    pub from_id: String,                 // platform user ID
+    pub from_name: String,
+    pub text: String,
+    pub attachments: Vec<Attachment>,
+    pub raw_payload: serde_json::Value,  // original for platform-specific handling
+    pub received_at: u64,               // unix ms
+}
+```
+
+### 5.3 Rich Output Builder
+
+Agent output needs to be rendered differently per platform. A shared `AgentOutput` struct gets rendered by each platform's bridge:
+
+```rust
+pub struct AgentOutput {
+    pub summary: String,               // plain text fallback
+    pub model: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub body: OutputBody,
+    pub actions: Vec<OutputAction>,
+}
+
+pub enum OutputBody {
+    Text(String),
+    Code { language: String, content: String },
+    Sections(Vec<Section>),
+}
+
+// Each bridge renders AgentOutput to its native format:
+// DiscordBridge: → Embed
+// TelegramBridge: → HTML message + InlineKeyboard
+// SlackBridge: → Block Kit
+// WhatsAppBridge: → text (no rich format) or template
+// TeamsBridge: → Adaptive Card
+```
+
+### 5.4 Bridge Health Reporting
+
+Each bridge reports to the Warden widget via a shared status channel:
+
+```rust
+pub struct BridgeHealth {
+    pub platform: &'static str,
+    pub status: BridgeStatus,           // Connected, Connecting, Disconnected, Error
+    pub latency_ms: Option<u32>,        // last ping latency
+    pub last_event_at: Option<u64>,     // last received event (ms)
+    pub reconnect_count: u32,
+    pub error: Option<String>,
+}
+```
+
+---
+
+## 6. Security Considerations (All Platforms)
+
+1. **All credentials in OS keychain.** Bot tokens, app passwords, system user tokens — never in config files, never in logs.
+
+2. **Allowlist-first.** Every platform: only process messages from explicitly configured sources (channel IDs, chat IDs, team IDs). Reject and do not respond to unknown sources — reduces enumeration, prevents unsolicited agent invocations.
+
+3. **Webhook signature validation.** For any webhook-based platform (WhatsApp, Slack HTTP mode, Teams): always validate the HMAC signature using constant-time comparison. Never trust a webhook without signature validation.
+
+4. **No secrets in platform messages.** Agent output flowing through any messaging bridge should never contain API keys, tokens, or private credentials. The bridge should scan outbound messages for common secret patterns and emit a warning if detected.
+
+5. **Per-platform rate limit handling.** Each bridge implements backoff independently. A rate-limited bridge should queue and retry, not drop messages silently.
+
+6. **WhatsApp ban risk disclosure.** The Baileys path shows a persistent warning in Settings UI. User must acknowledge before enabling.
+
+7. **ToS clarity.** Documentation for each integration notes which Terms of Service govern the integration. Users building on unofficial paths (WhatsApp Baileys, any unofficial WhatsApp gateway) are warned explicitly.
+
+---
+
+## 7. Future: OpenClaw Compatibility
+
+The `integration-vision.md` spec shows OpenClaw as the intended long-term external messaging layer. OpenClaw's ACP channel types (Discord, Telegram, Slack, Signal, iMessage, WhatsApp) overlap exactly with this spec.
+
+When OpenClaw ships, the bridge interface defined here (`MessagingBridge` trait) should be implementable by an `OpenClawBridge` that delegates to OpenClaw's ACP channel API — giving users who have OpenClaw running a single managed gateway instead of per-platform bridges.
+
+Until then, the per-platform bridges built here serve as the non-OpenClaw path and remain useful for users who want local-only, no-dependency messaging with no OpenClaw account required.
+
+---
+
+## 8. Summary: Platform Decision Matrix
+
+| Platform | Setup Friction | Needs Public URL | Desktop Friendly | Rust Library | Priority |
+|----------|----------------|-----------------|-----------------|--------------|----------|
+| Telegram | Very Low | No | Excellent | `teloxide` | P1 |
+| Discord | Low | No | Excellent | `twilight-rs` | P1 |
+| Slack | Medium | No (Socket Mode) | Good | `@slack/socket-mode` (Node) | P2 |
+| WhatsApp (Cloud) | High | Yes (tunnel) | Medium | Raw HTTP + `axum` | P2 |
+| WhatsApp (Baileys) | Low | No | Excellent (with ToS risk) | `@whiskeysockets/baileys` (Node) | P2 |
+| Teams | Very High | Yes (relay) | Poor | `Teams SDK` (JS) or raw | P3 |

--- a/docs/specs/SPEC_MESSAGING_INTEGRATION_DISCORD_POC_2026_06_24.md
+++ b/docs/specs/SPEC_MESSAGING_INTEGRATION_DISCORD_POC_2026_06_24.md
@@ -1,0 +1,271 @@
+# Spec: Messaging App Integration — Discord POC
+
+**Date:** 2026-06-24  
+**Status:** Draft  
+**Scope:** Research + POC design for extending AgentMux integrations to messaging apps, starting with Discord
+
+---
+
+## 1. Context
+
+AgentMux has two existing integration touchpoints relevant to messaging:
+
+**OpenClaw** (in `integration-vision.md`) is already designed as the external-channel bridge. Its ACP (Agent Communication Protocol) supports Discord, Telegram, Slack, Signal, iMessage, and WhatsApp as named channel types. The OpenClaw widget exists (`widgets.json`) and embeds the OpenClaw gateway as a WebView on `localhost:18789`, but the backend implementation is not yet active.
+
+**OAuth** already has Slack in `oauth_client.rs` (authorization code + PKCE flow for user identity). Discord OAuth is not yet wired up but Slack's presence confirms the pattern is understood.
+
+**Grafana context** (what prompted this spec): the Grafana integration analogy the user cited refers to the iframe-embedding pattern used in the browser widget — externally hosted UIs surfaced in pane tiles. This is Phase 1 of the browser widget; no custom Grafana protocol work was needed. Messaging apps require more than iframe embedding because bidirectional communication (agent sends → user replies → agent receives) requires a protocol bridge, not just a WebView.
+
+The goal: **POC that proves end-to-end bidirectionality between an AgentMux agent and a Discord channel, with no cloud server requirement.**
+
+---
+
+## 2. Stability Assessment of Existing Integration Surfaces
+
+### 2.1 OpenClaw Integration
+
+**Status: Planned but not yet active.**
+
+- OpenClaw widget is defined in `widgets.json` but the gateway process is not shipped or started
+- The ACP channel types (including Discord) are specified in `integration-vision.md` but have no implementation code in this repo
+- Stability: unknown — depends entirely on OpenClaw's roadmap
+
+**Assessment:** Cannot be relied on for a near-term POC. Worth building the AgentMux side to be OpenClaw-ready (use the same abstraction), but the POC must work without it.
+
+### 2.2 Reactive Message Bus
+
+**Status: Shipping and stable.** 4-tier architecture (local → HTTP loopback → LAN mDNS → cloud relay) is in production. The AgentMux MCP tools (`send_message`, `broadcast`, `list_agents`) are the stable inter-agent communication layer.
+
+**Assessment:** This is the correct internal bus. Discord messages, once received, should flow into the reactive bus so any agent can consume them via `read_messages` — not just the one that opened the Gateway connection.
+
+### 2.3 OAuth (Slack present, Discord absent)
+
+**Status: Slack OAuth is wired. Discord is not.**
+
+Discord OAuth uses the same RFC 8252 + PKCE pattern as Slack. Adding Discord to `oauth_client.rs` is a straightforward config addition. The bot-add flow doesn't require OAuth at all — it's a direct redirect with `scope=bot+applications.commands`.
+
+**Assessment:** Low-friction to add Discord OAuth when needed. Not required for the Gateway-bot POC (bot token stored in keychain is sufficient).
+
+---
+
+## 3. Discord API — Technical Assessment
+
+### 3.1 What to use (and what not to)
+
+| Mechanism | Use for | Don't use for |
+|---|---|---|
+| **Gateway WebSocket** | Receiving channel messages and slash command events | Anything that can be done via REST |
+| **REST API** | Sending messages, registering slash commands | Event delivery |
+| **Webhooks** | One-way notification pipelines (CI alerts, agent status) | Bidirectional use cases |
+
+**For an AI agent POC, the minimum viable surface is:** Gateway (receive) + REST (send). Webhooks alone are a dead end for bidirectionality.
+
+### 3.2 Intents and permissions
+
+The **Message Content intent** (`MESSAGE_CONTENT`) is privileged. For a private bot under 100 servers (which a personal agent deployment always will be), it can be enabled directly in the Discord Developer Portal with no review required. This covers 100% of personal/team agent deployments.
+
+Without it: the `content` field on `MESSAGE_CREATE` events is empty. Slash commands are the alternative — they carry user input as structured parameters without needing the intent.
+
+**Recommendation:** Enable `MESSAGE_CONTENT` in Developer Portal for the POC. Build slash commands as the primary interaction pattern for the shipped integration (avoids any review friction at scale).
+
+### 3.3 Gateway stability (known failure modes)
+
+1. **Heartbeat ghost state**: The process is alive but the bot stops receiving events. Requires external health monitoring; discord.js v14 has documented cases where heartbeat fails silently.
+2. **Session resumption**: On reconnect, always attempt RESUME with `session_id` + last `seq` using the `resume_gateway_url` from the READY payload. Fallback to re-IDENTIFY with exponential backoff.
+3. **App suspend (desktop-specific)**: When the laptop sleeps, the Gateway WS disconnects. The session is usually resumable if under ~60 seconds. If longer, re-IDENTIFY required. Buffer user-visible "reconnecting" state.
+4. **Identify rate limit**: 1 IDENTIFY per 5 seconds per shard. Violating → 4008 close code.
+
+**Mitigation**: Let discord.js handle reconnection (it implements resume + re-identify correctly since v14.x). Add health check: if `client.ws.ping` returns −1 or a timeout, force-reconnect. For a desktop app, wrap in a `createEffect` that reconnects when app regains focus after a suspend.
+
+### 3.4 API stability (versioning)
+
+Discord API v10 has been stable since 2022 with no v11 announced. Breaking changes within v10 are infrequent. One notable upcoming break: `PIN_MESSAGES` permission was split from `MANAGE_MESSAGES` in August 2025, effective February 2026. No impact on the POC (we're not pinning messages).
+
+`discord-api-types` publishes versioned sub-paths (`discord-api-types/v10`) that isolate API version changes. Pin to `~0.37.x` in production; upgrade deliberately.
+
+### 3.5 Slash commands vs. message-based commands
+
+**Use slash commands.** Discord's September 2022 policy makes `MESSAGE_CONTENT` privileged and the approval bar for verified bots is high. Slash commands require no privileged intents, have structured input via Discord's interaction payload, and support autocomplete. For a personal agent, the POC can use `MESSAGE_CONTENT` (enabled without review for private bots), but the shipped feature should be slash-command-first.
+
+---
+
+## 4. Comparison: Discord vs. Slack
+
+| Dimension | Discord Gateway | Slack Socket Mode | Verdict for AgentMux |
+|---|---|---|---|
+| Persistent WS required? | Yes | Yes (for no-server) | Tie |
+| HTTP event delivery option? | No (interactions endpoint only, needs public URL) | Yes (HTTP Events API) | Slack wins for serverless |
+| Stability risk | Heartbeat ghost state documented | Generally more stable (HTTP option) | Slack slightly more robust |
+| Message formatting | Rich embeds + components | Block Kit (more expressive) | Slack richer for structured output |
+| Community/bot ecosystem | Larger, gaming-focused | Business-focused | Discord better for personal agent UX |
+| Bot setup friction | Very low (Developer Portal) | Moderate (app configuration) | Discord wins |
+| User familiarity (dev community) | High | High | Tie |
+| OpenClaw support | Planned | Planned | Tie |
+
+**Decision for POC: Discord** — lower setup friction, OpenClaw already names it as a target channel type, and the user explicitly requested it.
+
+**Future Slack support**: The Slack Socket Mode architecture is nearly identical to Discord Gateway from the code's perspective. Once the Discord adapter is working, adding a Slack adapter is a configuration delta, not a rewrite.
+
+---
+
+## 5. POC Architecture
+
+### 5.1 Topology
+
+```
+AgentMux Desktop Process
+├── DiscordBridge (new service, runs as background Task)
+│   ├── GatewayClient (discord.js Client or raw WS)
+│   │   ├── Connects to wss://gateway.discord.gg (outbound only — no public URL)
+│   │   ├── Listens: MESSAGE_CREATE on configured channel(s)
+│   │   ├── Listens: APPLICATION_COMMAND_PERMISSIONS_UPDATE (slash command ACK)
+│   │   └── Reconnect/resume: handled by discord.js; health check on focus resume
+│   │
+│   └── MessageRouter
+│       ├── Inbound: Discord message → inject into AgentMux reactive bus
+│       │   (POST /agentmux/reactive/send to target agent, or broadcast)
+│       └── Outbound: reactive bus message → POST /channels/{id}/messages via REST
+│
+└── Agent Pane
+    ├── Consumes inbound messages via existing MCP read_messages tool
+    └── Sends outbound via existing MCP send_message → router → Discord REST
+```
+
+**No cloud server, no public URL.** The Gateway WebSocket is a client-side outbound connection. It works behind NAT and corporate firewalls.
+
+### 5.2 Configuration (stored in AgentMux settings)
+
+```json
+{
+  "discord": {
+    "enabled": false,
+    "botToken": "<keychain://agentmux/discord-bot-token>",
+    "guildId": "...",
+    "channelId": "...",
+    "agentTarget": "<agent_id to route inbound messages to>",
+    "intents": ["Guilds", "GuildMessages", "MessageContent"]
+  }
+}
+```
+
+Bot token stored in OS keychain (`keytar` in Electron; Windows Credential Manager via `keytar` native bindings). Never in plaintext config files.
+
+### 5.3 Agent-to-Discord message flow
+
+1. Agent calls `send_message` with `target: "discord"` (new target type in reactive bus)
+2. MessageRouter receives it, enriches with embed (agent name, timestamp, model)
+3. `POST https://discord.com/api/v10/channels/{channel_id}/messages`
+4. Discord renders the message in the configured channel
+
+### 5.4 Discord-to-agent message flow (with MESSAGE_CONTENT intent)
+
+1. User types in Discord channel: "Hey agent, check the build status"
+2. Gateway receives `MESSAGE_CREATE` with full `content` field (intent enabled)
+3. MessageRouter filters: only from non-bot users in the configured channel
+4. Wraps in AgentMux message envelope: `{ from: "discord:user#1234", content: "..." }`
+5. POSTs to `/agentmux/reactive/send` targeting the configured agent_id
+6. Agent receives via `read_messages`, responds via `send_message` → back to Discord
+
+### 5.5 Slash command flow (intent-free alternative)
+
+1. Register guild-scoped `/ask <prompt>` slash command on startup
+2. User types `/ask prompt:check the build status`
+3. Discord sends Interaction over Gateway (`INTERACTION_CREATE`)
+4. MessageRouter extracts `prompt` option value (no MESSAGE_CONTENT needed)
+5. Same routing as above; respond with `POST /webhooks/{app_id}/{token}` within 3s
+6. Use `deferred_channel_message_with_source` if agent response takes >3s
+
+---
+
+## 6. Implementation Plan
+
+### Phase 1: Foundation (POC — 1-2 PRs)
+
+**Deliverables:**
+- `agentmux-srv/src/discord/` — new Rust module (or Node.js sidecar if using discord.js)
+  - Architecture decision: discord.js runs in Node.js. AgentMux backend is Rust. Options:
+    - **Option A (recommended):** Rust sidecar using `serenity` crate (Rust Discord library, actively maintained, async-native). Integrates cleanly with existing Rust backend.
+    - **Option B:** Node.js subprocess running discord.js, communicating with main process via stdin/stdout JSON or local HTTP
+- `frontend/app/settings/DiscordSettings.tsx` — minimal settings pane: token input (masked), guild ID, channel ID, enable toggle
+- Token stored via OS keychain API
+
+**Success criteria:** Bot appears online in Discord, POSTs a "AgentMux connected" message to the configured channel on startup.
+
+### Phase 2: Bidirectional Bridge (1 PR)
+
+**Deliverables:**
+- Inbound: `MESSAGE_CREATE` → reactive bus → configured agent
+- Outbound: agent `send_message` to `discord` target → REST POST
+- Message formatting: plain text + embed with agent identity
+
+**Success criteria:** User types in Discord, agent receives it and can reply; reply appears in Discord.
+
+### Phase 3: Slash Commands (1 PR)
+
+**Deliverables:**
+- Guild-scoped `/ask` command registration on startup (auto-register if changed)
+- Slash command interaction handler (replaces `MESSAGE_CONTENT` dependency)
+- Deferred response pattern (ACK within 3s, follow-up after agent responds)
+- `/status` command: returns current agent status inline
+
+**Success criteria:** Full round-trip with no privileged intents required.
+
+### Phase 4: Warden integration (future)
+
+- Discord connection status surface in the Warden widget (Internet section)
+- Connection health: ping latency, events/min, reconnect count
+- Per-channel routing config (multiple agents, multiple channels)
+
+---
+
+## 7. Rust Library Recommendation: `serenity`
+
+For the Rust-native path (Option A):
+
+```toml
+[dependencies]
+serenity = { version = "0.12", features = ["client", "gateway", "model", "http"] }
+tokio = { version = "1", features = ["full"] }
+```
+
+- `serenity` 0.12 targets Discord API v10; maintained and widely used in production Rust bots
+- Handles Gateway connection, session resumption, heartbeat scheduling
+- `EventHandler` trait: implement `message()` and `interaction_create()` callbacks
+- REST via `serenity::http::Http` with automatic rate limit handling
+
+If Node.js sidecar is preferred (Option B), use `discord.js` v14 with TypeScript. The sidecar communicates with the Rust server via a local WebSocket or named pipe.
+
+---
+
+## 8. Security Considerations
+
+- **Bot token = credential**: store in OS keychain only; never log, never serialise to disk
+- **Webhook URL rotation**: if a webhook URL is ever leaked, rotate immediately (Developer Portal → channel → Integrations → Webhooks → Regenerate)
+- **Channel scoping**: only process messages from the configured guild + channel; reject all others at the router layer
+- **Bot permissions**: minimal — `Send Messages`, `Read Message History`, `Use Slash Commands`. No `Administrator`. No `Manage Channels`.
+- **User input sanitisation**: Discord message content flows into agent context; treat as untrusted user input (same as web UI input field)
+- **No embed-based secrets**: never include API keys or auth tokens in Discord embed fields
+
+---
+
+## 9. Scope Out of POC
+
+- Voice channels (not relevant for agent communication)
+- Multi-guild deployment (private bot, single guild)
+- Reaction-based interactions (slash commands are the correct pattern)
+- Telegram, Slack, Signal, WhatsApp (same architecture, follow-on work)
+- OpenClaw ACP channel integration (defer until OpenClaw ships; architecture is compatible)
+
+---
+
+## 10. Decision Points for Implementation
+
+| Decision | Default | Alternative |
+|---|---|---|
+| Backend language | Rust (`serenity`) | Node.js subprocess (`discord.js`) |
+| Initial input method | `MESSAGE_CONTENT` (intent, POC only) | Slash commands only (no intent, production-ready from day 1) |
+| Inbound routing | Single configured agent | Broadcast to all agents |
+| Message format | Plain text + embed | Embed only |
+| Settings surface | Settings pane | Warden widget Discord section |
+
+Recommend: Rust + serenity for the backend (avoids Node.js subprocess); slash commands only from day 1 (avoids privileged intent entirely, works for all deployment sizes).


### PR DESCRIPTION
## Summary

Adds the messaging bridge framework with Discord as the first integration. Two-layer architecture:

1. **Pane layer** — 5 browser widget entries in `widgets.json` (Discord, Slack, Telegram, WhatsApp, Teams). Users get the real native UI via CEF — no custom chat UI, no changes to the actual app interface.

2. **Bridge layer** — background Rust task that connects to the Discord Gateway WebSocket and routes messages to/from the reactive bus.

### New files

- `agentmux-srv/src/messaging/mod.rs` — common types: `OutboundMsg`, `MsgEmbed`, `BridgeHealth`, `BridgeStatus`
- `agentmux-srv/src/messaging/discord/types.rs` — Gateway protocol types (opcodes, Identify, Heartbeat, Resume, ReadyEvent, MessageCreate)
- `agentmux-srv/src/messaging/discord/gateway.rs` — raw `tokio-tungstenite` WS client: HELLO → IDENTIFY/RESUME → heartbeat loop → zombie detection → MESSAGE_CREATE → reactive bus inject; session resume via `resume_gateway_url` from READY
- `agentmux-srv/src/messaging/discord/rest.rs` — `POST /channels/{id}/messages` with embed support
- `agentmux-srv/src/messaging/discord/mod.rs` — `DiscordBridge` global singleton
- `agentmux-srv/src/server/messaging_handlers.rs` — `GET /api/messaging/status`, `POST /api/messaging/discord/send`

### Modified files

- `agentmux-srv/src/main.rs` — `mod messaging;` + `DiscordBridge::init_global` on startup
- `agentmux-srv/src/server/mod.rs` — messaging routes registered
- `agentmux-srv/src/backend/wconfig/types.rs` — `messaging:discord:{enabled,token,channel,target,guild}` settings
- `agentmux-srv/src/config/widgets.json` — 5 messaging pane entries

### Zero new crate dependencies

Uses existing `tokio-tungstenite` + `reqwest` + `serde_json` + `tokio`. Binary size impact: ~0.3–0.5 MB release.

### Activating the Discord bridge

Add to `settings.json`:
```json
{
  "messaging:discord:enabled": true,
  "messaging:discord:token": "Bot YOUR_BOT_TOKEN",
  "messaging:discord:channel": "YOUR_CHANNEL_ID",
  "messaging:discord:target": "your-agent-id"
}
```

Bot token comes from discord.com/developers/applications → Bot → Reset Token. Enable `MESSAGE_CONTENT` privileged intent in the portal (no review required for bots under 100 servers).

## Test plan

- [ ] Default (not configured) — srv starts cleanly, no bridge warning
- [ ] `enabled: true` but no token — warning logged, no crash
- [ ] Valid token — bot appears online in Discord, logs `READY as [botname]`
- [ ] User types in configured channel → agent receives `[Discord @user]: message` via reactive bus
- [ ] `POST /api/messaging/discord/send` → message appears in Discord channel
- [ ] `GET /api/messaging/status` → returns `{"bridges": [{"platform": "discord", "status": "connected", ...}]}`
- [ ] Laptop sleep → bridge reconnects via `resume_gateway_url` from READY
- [ ] Discord pane widget opens `discord.com/app` in CEF browser, shows real Discord UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=loap-06183 -->