### PR TITLE
feat(statusbar): MuxBus Cloud login chip

### DIFF
--- a/.changesets/1782333370-feat-statusbar-muxbus-cloud-login-chip-sign-in-button-when-n-2ddu.md
+++ b/.changesets/1782333370-feat-statusbar-muxbus-cloud-login-chip-sign-in-button-when-n-2ddu.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(statusbar): MuxBus Cloud login chip — sign-in button when not connected, email chip + disconnect popover when signed in

--- a/frontend/app/statusbar/MuxBusLoginChip.tsx
+++ b/frontend/app/statusbar/MuxBusLoginChip.tsx
@@ -128,9 +128,9 @@ const MuxBusPopover = (props: MuxBusPopoverProps): JSX.Element => {
     const style = (): string => {
         const r = props.anchorRect;
         if (!r) return "";
-        // Anchor bottom-right of chip → top-right of popover.
         const right = window.innerWidth - r.right;
-        return `right: ${right}px; bottom: calc(100% + 4px);`;
+        const bottom = window.innerHeight - r.top;
+        return `position: fixed; right: ${right}px; bottom: ${bottom}px;`;
     };
 
     return (

--- a/frontend/app/statusbar/MuxBusLoginChip.tsx
+++ b/frontend/app/statusbar/MuxBusLoginChip.tsx
@@ -1,0 +1,158 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { useMuxBusStatus } from "@/app/view/accounts/AgentMuxConnectPanel";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+
+/**
+ * Status-bar chip that surfaces MuxBus Cloud account state.
+ *
+ * Three visible states:
+ *   - Hidden: build has no VITE_MUXBUS_CLIENT_ID (dev/internal).
+ *   - "Sign in to MuxBus Cloud" button: not signed in or token expired.
+ *   - Email chip + popover: signed in and valid.
+ *
+ * Uses the same `useMuxBusStatus` controller as the Trust Center panel —
+ * a connect/disconnect here is immediately reflected there and vice-versa
+ * because each controller independently polls `muxbus.status` on mount.
+ */
+export const MuxBusLoginChip = (): JSX.Element => {
+    const muxbus = useMuxBusStatus();
+    onMount(() => void muxbus.refresh());
+
+    const [popoverOpen, setPopoverOpen] = createSignal(false);
+    const [anchorRect, setAnchorRect] = createSignal<DOMRect | null>(null);
+    let chipRef!: HTMLButtonElement;
+    let popoverRef: HTMLDivElement | undefined;
+
+    usePaneOverlay(() => popoverRef);
+
+    const handleChipClick = () => {
+        if (popoverOpen()) {
+            setPopoverOpen(false);
+            return;
+        }
+        setAnchorRect(chipRef?.getBoundingClientRect() ?? null);
+        setPopoverOpen(true);
+    };
+
+    createEffect(() => {
+        if (!popoverOpen()) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setPopoverOpen(false);
+        };
+        const onDown = (e: MouseEvent) => {
+            const t = e.target as Node;
+            if (chipRef?.contains(t)) return;
+            if (popoverRef?.contains(t)) return;
+            setPopoverOpen(false);
+        };
+        document.addEventListener("keydown", onKey);
+        document.addEventListener("mousedown", onDown);
+        onCleanup(() => {
+            document.removeEventListener("keydown", onKey);
+            document.removeEventListener("mousedown", onDown);
+        });
+    });
+
+    // Not configured in this build — show nothing.
+    if (!muxbus.isConfigured()) return <></>;
+
+    const isSignedIn = () => muxbus.status()?.connected && muxbus.status()?.valid;
+    const isExpired = () => muxbus.status()?.connected && !muxbus.status()?.valid;
+
+    return (
+        <>
+            <Show
+                when={isSignedIn()}
+                fallback={
+                    <button
+                        type="button"
+                        class="muxbus-login-chip muxbus-login-chip-signin"
+                        disabled={muxbus.loading()}
+                        data-tip={isExpired() ? "MuxBus Cloud session expired — click to re-login" : "Sign in to MuxBus Cloud"}
+                        aria-label="Sign in to MuxBus Cloud"
+                        onClick={() => void muxbus.connect()}
+                    >
+                        {muxbus.loading() ? "●···" : isExpired() ? "MuxBus (expired)" : "Sign in"}
+                    </button>
+                }
+            >
+                <button
+                    ref={chipRef!}
+                    type="button"
+                    class="muxbus-login-chip muxbus-login-chip-connected clickable"
+                    data-tip="MuxBus Cloud account"
+                    aria-label="MuxBus Cloud account — open options"
+                    aria-haspopup="menu"
+                    aria-expanded={popoverOpen()}
+                    onClick={handleChipClick}
+                >
+                    <span class="muxbus-login-chip-dot" aria-hidden="true" />
+                    <span class="muxbus-login-chip-email">{muxbus.status()?.email}</span>
+                </button>
+            </Show>
+
+            <Show when={popoverOpen()}>
+                <MuxBusPopover
+                    ref={(el) => (popoverRef = el)}
+                    anchorRect={anchorRect()}
+                    email={muxbus.status()?.email ?? ""}
+                    loading={muxbus.loading()}
+                    onDisconnect={async () => {
+                        await muxbus.disconnect();
+                        setPopoverOpen(false);
+                    }}
+                />
+            </Show>
+
+            <Show when={muxbus.error()}>
+                <span class="muxbus-login-chip-error" title={muxbus.error()!}>!</span>
+            </Show>
+        </>
+    );
+};
+
+MuxBusLoginChip.displayName = "MuxBusLoginChip";
+
+interface MuxBusPopoverProps {
+    ref: (el: HTMLDivElement) => void;
+    anchorRect: DOMRect | null;
+    email: string;
+    loading: boolean;
+    onDisconnect: () => void;
+}
+
+const MuxBusPopover = (props: MuxBusPopoverProps): JSX.Element => {
+    const style = (): string => {
+        const r = props.anchorRect;
+        if (!r) return "";
+        // Anchor bottom-right of chip → top-right of popover.
+        const right = window.innerWidth - r.right;
+        return `right: ${right}px; bottom: calc(100% + 4px);`;
+    };
+
+    return (
+        <div
+            ref={props.ref}
+            class="status-bar-popover host-popover muxbus-login-popover"
+            role="menu"
+            style={style()}
+        >
+            <div class="status-bar-popover-row">
+                <span class="status-bar-popover-label">Signed in as</span>
+                <span class="status-bar-popover-mono muxbus-popover-email">{props.email}</span>
+            </div>
+            <div class="status-bar-popover-divider" />
+            <button
+                type="button"
+                class="muxbus-popover-disconnect-btn"
+                disabled={props.loading}
+                onClick={() => props.onDisconnect()}
+            >
+                {props.loading ? "Disconnecting…" : "Disconnect"}
+            </button>
+        </div>
+    );
+};

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -395,6 +395,114 @@
     }
 }
 
+// ── MuxBus Cloud login chip ─────────────────────────────────────────────────
+
+.muxbus-login-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 6px;
+    height: 100%;
+    font-size: 11px;
+    font-family: inherit;
+    color: inherit;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    cursor: default;
+    white-space: nowrap;
+    line-height: 1;
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+
+    // "Sign in" / expired states — muted, accent on hover.
+    &.muxbus-login-chip-signin {
+        opacity: 0.5;
+
+        &:hover:not(:disabled) {
+            opacity: 1;
+            background: var(--hover-bg-color);
+            color: var(--accent-color);
+        }
+    }
+
+    // Signed-in state — slightly more prominent than version chip.
+    &.muxbus-login-chip-connected {
+        opacity: 0.55;
+
+        &:hover {
+            opacity: 1;
+            background: var(--hover-bg-color);
+        }
+    }
+
+    // Green dot indicating live cloud connection.
+    .muxbus-login-chip-dot {
+        display: inline-block;
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background: var(--success-color, #4caf50);
+        flex-shrink: 0;
+    }
+
+    // Truncate long emails gracefully.
+    .muxbus-login-chip-email {
+        max-width: 140px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+// Inline error indicator (! badge) shown beside the chip when connect/disconnect fails.
+.muxbus-login-chip-error {
+    color: var(--error-color);
+    font-size: 11px;
+    cursor: default;
+    padding: 0 2px;
+}
+
+// Disconnect popover — inherits .status-bar-popover layout.
+.muxbus-login-popover {
+    min-width: 220px;
+
+    .muxbus-popover-email {
+        font-size: 0.95em;
+        max-width: 160px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.muxbus-popover-disconnect-btn {
+    width: 100%;
+    padding: var(--space-1) var(--space-2);
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    color: inherit;
+    font-size: 11px;
+    font-family: inherit;
+    cursor: default;
+    text-align: left;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+        color: var(--error-color);
+        border-color: var(--error-color);
+    }
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+}
+
 @keyframes status-icon-spin {
     from {
         transform: rotate(0deg);

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -8,6 +8,7 @@ import { ConfigStatus } from "./ConfigStatus";
 import { GpuStatus } from "./GpuStatus";
 import { HostPopover } from "./HostPopover";
 import { InstancePanel } from "./InstancePanel";
+import { MuxBusLoginChip } from "./MuxBusLoginChip";
 import { SystemStats } from "./SystemStats";
 import { TokenUsageIndicator } from "./TokenUsageIndicator";
 import { UpdateStatus } from "./UpdateStatus";
@@ -66,6 +67,7 @@ const StatusBar = (): JSX.Element => {
                 <ConfigStatus />
                 <UpdateStatus />
                 <HostPopover />
+                <MuxBusLoginChip />
                 <Show when={version}>
                     <Show
                         when={backendStatusAtom() !== "crashed"}


### PR DESCRIPTION
## Summary

- Adds `MuxBusLoginChip` to the status bar right side (left of the version chip)
- Three states: hidden (build not configured), "Sign in" button (not connected or expired), email + popover (signed in)
- Reuses the existing `useMuxBusStatus` controller and `muxbus.login` / `muxbus.status` / `muxbus.disconnect` RPCs — no new backend work
- Chip is hidden when `VITE_MUXBUS_CLIENT_ID` is empty (dev/internal builds without cloud configured)
- Expired token renders as "MuxBus (expired)" with a re-login click
- Popover shows signed-in email and a Disconnect button; click-outside and Esc to close

## Files changed

| File | Change |
|------|--------|
| `frontend/app/statusbar/MuxBusLoginChip.tsx` | New chip + popover component |
| `frontend/app/statusbar/StatusBar.tsx` | Import and insert `<MuxBusLoginChip />` |
| `frontend/app/statusbar/StatusBar.scss` | Styles for chip, dot, email truncation, popover, disconnect button |

## Test plan

- [ ] Build without `VITE_MUXBUS_CLIENT_ID` — chip does not render
- [ ] Build with client ID, not signed in — "Sign in" button appears, click opens browser PKCE flow
- [ ] After signing in — email chip appears with green dot, click opens popover
- [ ] Popover Disconnect — clears token, chip returns to "Sign in" state
- [ ] Expired token — chip shows "MuxBus (expired)", click re-triggers login
- [ ] Trust Center Accounts panel stays in sync (both use `useMuxBusStatus`, each refreshes independently on mount)

<!-- agentmux:agent_id=naki -->