### PR TITLE
fix(browser-pane): black flash + UI freeze on macOS/Linux when opening browser pane

### DIFF
--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -70,7 +70,40 @@ pub fn on_after_created_browser_pane(state: &Arc<AppState>, browser: &Browser) {
     }
     #[cfg(not(target_os = "windows"))]
     {
-        let _ = (state, browser);
+        // On macOS/Linux, the focus redirect subclass used on Windows doesn't
+        // exist. CEF's on_after_created fires from inside add_overlay_view
+        // (when the BrowserView is added to the widget hierarchy) and gives
+        // focus to the new pane browser. creation_views::create_browser_pane_view
+        // immediately returns focus to the main window after add_overlay_view
+        // returns — this callback is an additional safety net for any navigation-
+        // driven focus steals that bypass that initial return (e.g. cross-origin
+        // redirects that recreate the renderer, hitting on_after_created again).
+        //
+        // Only refocus if we can identify the parent window; don't do a blanket
+        // "focus main" that would disrupt multi-window setups.
+        if let Some(block_id) = resolve_pane_block_id(state, browser) {
+            let parent_window_label = state
+                .browser_pane_overlays
+                .lock()
+                .iter()
+                .find(|(lbl, _)| {
+                    // label format: browser-pane-<block_id>-<seq>
+                    lbl.starts_with(&format!("browser-pane-{}-", block_id))
+                })
+                .map(|(_, (win_lbl, _))| win_lbl.clone());
+
+            if let Some(win_label) = parent_window_label {
+                if let Some(main_browser) = state.get_browser(&win_label) {
+                    if let Some(mut host) = main_browser.host() {
+                        host.set_focus(1);
+                        tracing::info!(
+                            block_id = %block_id, window_label = %win_label,
+                            "[browser-pane] macOS/Linux on_after_created: returned focus to main window"
+                        );
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -221,15 +221,42 @@ pub fn create_browser_pane_view(
     // 7. Position the overlay. We tried `set_bounds(rect)` directly: silently
     //    ignored — readback shows 0,0,0,0. Trying separate set_size + set_position
     //    and explicit window.layout() to force a layout pass.
+    //
+    // set_visible(1) is intentionally called AFTER layout() so the overlay is
+    // at the correct position/size before it becomes visible and can intercept
+    // input. Calling it before layout() caused a brief window where the overlay
+    // was visible at the wrong position (or 0×0), which on macOS allowed CEF's
+    // new-browser focus steal (from add_overlay_view above) to intercept clicks
+    // for the whole window before the layout pass corrected the bounds.
     overlay_controller.set_size(Some(&Size { width: rect.width, height: rect.height }));
     overlay_controller.set_position(Some(&Point { x: rect.x, y: rect.y }));
-    overlay_controller.set_visible(1);
     parent_window.layout();
+    overlay_controller.set_visible(1);
     tracing::info!(
         block_id = %block_id, label = %label,
         x = rect.x, y = rect.y, w = rect.width, h = rect.height,
-        "[browser-pane] views: overlay set_size + set_position + set_visible + layout() applied"
+        "[browser-pane] views: overlay set_size + set_position + layout() + set_visible applied"
     );
+
+    // 7b. Return focus to the main window's BrowserView. CEF's default
+    //     on_after_created behaviour (fired from add_overlay_view above when
+    //     the BrowserView is added to the widget hierarchy) gives focus to the
+    //     new pane browser. On Windows, AgentMuxHandler::on_after_created_browser_pane
+    //     installs a WM_SETFOCUS redirect subclass that catches this steal.
+    //     On macOS/Linux there is no equivalent subclass, so the OverlayController
+    //     holds focus after creation and its BrowserView intercepts all keyboard
+    //     (and, depending on CEF hit-test state, mouse) events for the parent window —
+    //     causing the "black pane + frozen UI" bug. Explicitly refocus the main
+    //     window browser here; the user can then click inside the pane to focus it.
+    if let Some(main_browser) = state.get_browser(&window_label) {
+        if let Some(mut host) = main_browser.host() {
+            host.set_focus(1);
+            tracing::info!(
+                window_label = %window_label,
+                "[browser-pane] views: returned focus to main window after pane creation"
+            );
+        }
+    }
 
     // 8. Diagnostic: read back what CEF thinks of the overlay state.
     //    If is_drawn=0 or is_visible=0 with our settings, something below

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -264,7 +264,7 @@ pub fn open_new_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     let (pos_x, pos_y) = get_offset_position();
     let (win_w, win_h) = get_secondary_window_size(pos_x, pos_y);
     if let Some(label) = crate::commands::window_pool::promote_pool_window_for_new_window(
-        state, pos_x, pos_y, win_w, win_h, initial_view, initial_meta.clone(),
+        state, pos_x, pos_y, win_w, win_h, initial_view.clone(), initial_meta.clone(),
     ) {
         tracing::info!(
             target: "pool:new-window",

--- a/docs/analysis/ANALYSIS_BROWSER_PANE_BLACK_FREEZE_MACOS_2026_06_24.md
+++ b/docs/analysis/ANALYSIS_BROWSER_PANE_BLACK_FREEZE_MACOS_2026_06_24.md
@@ -1,0 +1,135 @@
+# Browser Pane: Black Appearance + UI Freeze on macOS/Linux
+
+**Date:** 2026-06-24
+**Affected versions:** ≤ 0.47.4 (macOS/Linux only)
+**Symptom:** Opening a browser pane causes it to render solid black and freezes all
+click input in the parent window. The uptime clock and other animations continue
+(JS event loop is alive; only native input is blocked).
+**Fixed in:** This commit.
+
+---
+
+## Root Causes
+
+Two independent bugs combine to produce the symptom.
+
+### Bug 1 — `set_visible(1)` called before `layout()` (black flash + wrong-position input intercept)
+
+`creation_views.rs::create_browser_pane_view` previously ordered the overlay
+setup as:
+
+```rust
+overlay_controller.set_size(...);
+overlay_controller.set_position(...);
+overlay_controller.set_visible(1);   // ← visible before layout
+parent_window.layout();
+```
+
+CEF's `DockingMode::CUSTOM` overlays do not commit their `set_size` /
+`set_position` until the owning `Window::layout()` pass runs. Between
+`set_visible(1)` and `layout()` the overlay is therefore visible at an
+uncommitted position (empirically: 0×0 origin, varying size). During that
+window the opaque black `background_color: 0xFF000000` baseline is painted
+at the wrong location — visible to the user as a black flash. Worse, because
+the overlay is a native CEF View, it captures pointer events for the region it
+occupies, even at the wrong position, before layout corrects it.
+
+**Fix:** swap order — `layout()` first, `set_visible(1)` after.
+
+### Bug 2 — `on_after_created_browser_pane` is a no-op on macOS/Linux (full freeze)
+
+`callbacks.rs::on_after_created_browser_pane` is the callback that fires when
+the new pane's `CefBrowser` is created (triggered by `add_overlay_view` adding
+the `BrowserView` to the widget hierarchy). On Windows it installs a
+`WM_SETFOCUS` redirect subclass that intercepts Chromium's automatic focus
+grant to the new browser and redirects it back to the parent window. On
+macOS/Linux the body was:
+
+```rust
+#[cfg(not(target_os = "windows"))]
+{
+    let _ = (state, browser);  // complete no-op
+}
+```
+
+Without the redirect, CEF gives focus to the newly created pane
+`OverlayController`. On macOS, a focused `OverlayController` (created with
+`can_activate=1`) absorbs keyboard events and — depending on CEF hit-test
+state at the moment of creation — mouse events for the entire parent window
+content area. The result: the user can see the UI rendered correctly (the JS
+event loop is running, animations play, the uptime clock ticks) but no click
+reaches the SolidJS frontend. All input goes to the pane browser which is
+still loading (showing black).
+
+The key evidence:
+- Only 1 DOM element had `pointer-events: none` (`overlay-container`,
+  the layout drag placeholder — this is normal when `activeDrag = false`).
+- No block content elements were frozen at the CSS layer.
+- Sending `browser_pane_close` via the IPC immediately unfroze the window,
+  confirming the OverlayController was the sole input interceptor.
+
+**Fix:** in `create_browser_pane_view`, after `add_overlay_view` returns (by
+which point `on_after_created` has already fired), call
+`main_browser.host().set_focus(1)` to return focus to the parent window's
+browser. `on_after_created_browser_pane` now also has a non-Windows
+implementation as a safety net for navigation-driven focus re-steals
+(cross-origin redirects recreate the renderer process and can re-trigger
+`on_after_created`).
+
+---
+
+## Why `activeDrag` was not the cause
+
+An earlier hypothesis (documented in
+`agentmux-0.47.4-unresponsive-bug-report.md`) identified `activeDrag` stuck
+at `true` as a candidate, because `TileLayout.darwin.tsx` lacks the
+`window.addEventListener("dragend", resetDragState)` safety net present in
+`TileLayout.win32.tsx`. That path remains a latent risk (drag ending over
+the native overlay could still strand `activeDrag`), but it was **not** the
+cause of the reported freeze:
+
+- DOM inspection via CDP confirmed `activeDrag = false` (the `overlay-container`
+  had `pointer-events: none`, which is the correct state when NOT dragging).
+- No block content elements had `pointer-events: none`.
+- The freeze lifted immediately on `browser_pane_close`, not on a drag-reset.
+
+The `activeDrag` safety-net gap on darwin/Linux is a separate issue worth
+addressing but is out of scope for this fix.
+
+---
+
+## Fix Summary
+
+**`agentmux-cef/src/browser_pane/creation_views.rs`**
+
+1. Reorder `layout()` before `set_visible(1)` so the overlay is at the correct
+   position when it first becomes visible (eliminates black flash at wrong coords).
+2. After `add_overlay_view` returns, call `state.get_browser(&window_label)
+   .host().set_focus(1)` to return focus to the main window browser.
+
+**`agentmux-cef/src/browser_pane/callbacks.rs`**
+
+Replace the `#[cfg(not(target_os = "windows"))]` no-op in
+`on_after_created_browser_pane` with an implementation that looks up the pane's
+parent window via `state.browser_pane_overlays` and calls `set_focus(1)` on
+the parent browser — a safety net against navigation-driven focus re-steals.
+
+---
+
+## Recovery (without fix)
+
+For a frozen instance (before patching):
+
+```bash
+# 1. Find the browser pane block ID in the objects DB
+sqlite3 ~/.agentmux/channels/stable/versions/<ver>/data/db/objects.db \
+  "SELECT oid FROM db_block WHERE json_extract(data,'$.meta.view')='browser';"
+
+# 2. Close it via IPC (port and token from the window's URL params / CEF globals)
+curl -X POST http://127.0.0.1:<ipc_port>/ipc \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <ipc_token>" \
+  -d '{"cmd":"browser_pane_close","args":{"block_id":"<id>"}}'
+```
+
+All other state (agent sessions, layout, history) is preserved.


### PR DESCRIPTION
## Summary

- **Black flash on open**: `set_visible(1)` was called before `layout()` in `create_browser_pane_view`, making the OverlayController briefly visible at an uncommitted position with its opaque black baseline (`background_color: 0xFF000000`). Fixed by swapping order — `layout()` first, `set_visible(1)` after.
- **UI freeze after open**: `on_after_created_browser_pane` was a complete no-op on macOS/Linux (`let _ = (state, browser)`). On Windows a `WM_SETFOCUS` redirect subclass catches CEF's automatic focus grant to the new pane browser; nothing equivalent existed on macOS/Linux, so the `OverlayController` (`can_activate=1`) held focus and its `BrowserView` intercepted all input for the parent window. Fixed by explicitly calling `set_focus(1)` on the main window browser immediately after `add_overlay_view` returns, and adding a non-Windows `on_after_created_browser_pane` implementation as a safety net for navigation-driven focus re-steals.
- **Borrow-after-move in `creation.rs`**: pre-existing compile error introduced in the latest pull (`initial_view` moved into `promote_pool_window_for_new_window` then used again as `.as_deref()` on the cold path); fixed with `.clone()`.

## Root cause (how we found it)

Diagnosed via live CDP debugging of a frozen 0.47.4 instance:

1. Connected to the renderer on `--remote-debugging-port=9222`
2. DOM inspection confirmed `activeDrag = false` (only 1 element with `pointer-events: none`: the layout drag placeholder — correct when not dragging). The CSS layer was fine; the freeze was native.
3. Identified browser pane block ID (`view: browser`) from the SQLite objects DB
4. Called `browser_pane_close` via the IPC (`POST /ipc`) → freeze lifted immediately, confirming the `OverlayController` was the sole input interceptor

Full write-up: `docs/analysis/ANALYSIS_BROWSER_PANE_BLACK_FREEZE_MACOS_2026_06_24.md`

## Test plan

- [ ] Open a browser pane on macOS — no black flash, no UI freeze
- [ ] Click outside the browser pane immediately after opening — clicks reach the SolidJS UI
- [ ] Navigate to a cross-origin URL in the browser pane — focus returns to main window after redirect (safety net in `on_after_created_browser_pane`)
- [ ] Open a browser pane on Linux — same behaviour
- [ ] Windows behaviour unchanged (Windows path untouched)
- [ ] `cargo check -p agentmux-cef` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)