### PR TITLE
fix(cef): clone initial_view before move into promote_pool_window_for_new_window

### DIFF
--- a/.changesets/1782336818-fix-cef-clone-initial-view-before-move-into-promote-pool-win-dl08.md
+++ b/.changesets/1782336818-fix-cef-clone-initial-view-before-move-into-promote-pool-win-dl08.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): clone initial_view before move into promote_pool_window_for_new_window

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -264,7 +264,7 @@ pub fn open_new_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     let (pos_x, pos_y) = get_offset_position();
     let (win_w, win_h) = get_secondary_window_size(pos_x, pos_y);
     if let Some(label) = crate::commands::window_pool::promote_pool_window_for_new_window(
-        state, pos_x, pos_y, win_w, win_h, initial_view, initial_meta.clone(),
+        state, pos_x, pos_y, win_w, win_h, initial_view.clone(), initial_meta.clone(),
     ) {
         tracing::info!(
             target: "pool:new-window",


### PR DESCRIPTION
## Summary

- `initial_view` was moved into `promote_pool_window_for_new_window()` (pool-fast path, line 267) then borrowed via `.as_deref()` at line 282 (cold path), causing `E0382: borrow of moved value`
- Fix: `.clone()` at the call site — the clone goes to the pool path, the original survives for the cold path

Blocked the local build (`task package:local`) — discovered when clearing disk space and rebuilding from scratch.

## Test plan
- [ ] `cargo check -p agentmux-cef` passes (verified clean)
- [ ] "Open in New Window" still works via pool path and cold path

🤖 Generated with [Claude Code](https://claude.com/claude-code)