### PR TITLE
feat(tab-chrome): full-width boundary line below tab strip

### DIFF
--- a/.changesets/1750808000-feat-tab-chrome-boundary-line.md
+++ b/.changesets/1750808000-feat-tab-chrome-boundary-line.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tab-chrome): full-width boundary line below tab strip via container border-bottom

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -68,6 +68,13 @@
             left: unset;
             transform: none;
             -webkit-app-region: no-drag;
+
+            // Folder boundary on inactive tabs only — cheap `:not(.active)`
+            // (NOT `:has()`, which retrips the tab-switch long-task gate). The
+            // active tab omits the line so it opens into the surface below.
+            &:not(.active) {
+                border-bottom: var(--snap-chrome) solid var(--border-color);
+            }
         }
 
         // Constant inter-tab separator. Uses the v-separator mixin which
@@ -161,6 +168,10 @@
         min-width: 0;
         height: 100%;
         align-self: stretch;
+        // Folder boundary continuation (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6):
+        // extends the hairline that .tab:not(.active) draws across the fill
+        // area so the full-width line is unbroken except under the active tab.
+        border-bottom: var(--snap-chrome) solid var(--border-color);
     }
 
 }

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -68,13 +68,6 @@
             left: unset;
             transform: none;
             -webkit-app-region: no-drag;
-
-            // Folder boundary on inactive tabs only — cheap `:not(.active)`
-            // (NOT `:has()`, which retrips the tab-switch long-task gate). The
-            // active tab omits the line so it opens into the surface below.
-            &:not(.active) {
-                border-bottom: 1px solid var(--border-color);
-            }
         }
 
         // Constant inter-tab separator. Uses the v-separator mixin which
@@ -168,10 +161,6 @@
         min-width: 0;
         height: 100%;
         align-self: stretch;
-        // Folder boundary continuation (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6):
-        // extends the 1px hairline that .tab:not(.active) draws across the fill
-        // area so the full-width line is unbroken except under the active tab.
-        border-bottom: 1px solid var(--border-color);
     }
 
 }

--- a/frontend/app/tab/tabcontent.tsx
+++ b/frontend/app/tab/tabcontent.tsx
@@ -93,7 +93,6 @@ function TabContent(props: { tabId: string }): JSX.Element {
     const isEmpty = createMemo(() => (tabData()?.blockids?.length ?? 0) === 0);
 
     const rootStyle = (): JSX.CSSProperties => ({
-        "padding-top": "1px",
         background: "var(--workspace-surface)",
     });
 

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -10,6 +10,10 @@
     justify-content: flex-end;
     margin-left: auto;
     margin-right: var(--space-1-5);
+    // Folder boundary continuation (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6):
+    // the right-side chrome needs the same bottom hairline as the tab strip
+    // so the boundary line is unbroken across the full header width.
+    border-bottom: var(--snap-chrome) solid var(--border-color);
 
     .config-error-button {
         color: black;

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -10,10 +10,6 @@
     justify-content: flex-end;
     margin-left: auto;
     margin-right: var(--space-1-5);
-    // Folder boundary continuation (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6):
-    // the right-side chrome needs the same 1px bottom hairline as the tab
-    // strip so the boundary line is unbroken across the full header width.
-    border-bottom: 1px solid var(--border-color);
 
     .config-error-button {
         color: black;

--- a/frontend/app/window/window-controls.win32.scss
+++ b/frontend/app/window/window-controls.win32.scss
@@ -35,9 +35,10 @@
     // title bar, or the hover background leaves a 6-px strip at the top
     // uncovered. Pull the container up with a negative margin and grow
     // its height by the same amount so flex still respects it.
-    // var(--snap-chrome) compensates for `.window-header { border-bottom: var(--snap-chrome) }`
-    // shrinking the containing-block by that same physical pixel so `100%` resolves shorter;
-    // the added snap-chrome restores the buttons to full header height so hover backgrounds
+    // var(--snap-chrome) compensates for `.system-status { border-bottom: var(--snap-chrome) }`
+    // (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): that border reduces the
+    // containing-block by snap-chrome, so `100%` resolves shorter; the added
+    // snap-chrome restores the buttons to full header height so hover backgrounds
     // reach the window's bottom edge.
     margin-top: calc(-1 * var(--space-1-5));
     height: calc(100% + var(--space-1-5) + var(--snap-chrome));

--- a/frontend/app/window/window-controls.win32.scss
+++ b/frontend/app/window/window-controls.win32.scss
@@ -35,13 +35,12 @@
     // title bar, or the hover background leaves a 6-px strip at the top
     // uncovered. Pull the container up with a negative margin and grow
     // its height by the same amount so flex still respects it.
-    // The extra `+ 1px` compensates for `.system-status { border-bottom: 1px }`
-    // (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): that border reduces the
-    // containing-block by 1px, so `100%` resolves 1px shorter; the +1px
-    // restores the buttons to full header height so hover backgrounds
+    // var(--snap-chrome) compensates for `.window-header { border-bottom: var(--snap-chrome) }`
+    // shrinking the containing-block by that same physical pixel so `100%` resolves shorter;
+    // the added snap-chrome restores the buttons to full header height so hover backgrounds
     // reach the window's bottom edge.
     margin-top: calc(-1 * var(--space-1-5));
-    height: calc(100% + var(--space-1-5) + 1px);
+    height: calc(100% + var(--space-1-5) + var(--snap-chrome));
 
     // Butt up against the edge — Win11 caption buttons have no
     // right-margin padding.

--- a/frontend/app/window/window-header.darwin.scss
+++ b/frontend/app/window/window-header.darwin.scss
@@ -47,16 +47,12 @@
     cursor: default;
     // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
     background: var(--tab-strip-bg);
+    // Folder boundary — single rule on the container for a full-width gap-free line.
+    border-bottom: var(--snap-chrome) solid var(--border-color);
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
-        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): closes the
-        // gap between the traffic-light cluster and the first tab.
-        // Note: .traffic-lights uses align-self: center so a gap remains
-        // under the ~68px traffic-light area on the far left — tracked as
-        // follow-up in §10.5.
-        border-bottom: 1px solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.darwin.scss
+++ b/frontend/app/window/window-header.darwin.scss
@@ -47,12 +47,16 @@
     cursor: default;
     // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
     background: var(--tab-strip-bg);
-    // Folder boundary — single rule on the container for a full-width gap-free line.
-    border-bottom: var(--snap-chrome) solid var(--border-color);
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): closes the
+        // gap between the traffic-light cluster and the first tab.
+        // Note: .traffic-lights uses align-self: center so a gap remains
+        // under the ~68px traffic-light area on the far left — tracked as
+        // follow-up in §10.5.
+        border-bottom: var(--snap-chrome) solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.linux.scss
+++ b/frontend/app/window/window-header.linux.scss
@@ -36,8 +36,6 @@
     cursor: default;
     // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
     background: var(--tab-strip-bg);
-    // Folder boundary — single rule on the container for a full-width gap-free line.
-    border-bottom: var(--snap-chrome) solid var(--border-color);
     // Window drag is JS-driven (NOT -webkit-app-region: drag). Chromium
     // architecturally suppresses ALL events on drag regions before they
     // enter the renderer (verified 2026-05-02 via document capture-phase
@@ -56,5 +54,8 @@
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): 0px wide
+        // on Linux so this is a no-op visually, but kept for parity.
+        border-bottom: var(--snap-chrome) solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.linux.scss
+++ b/frontend/app/window/window-header.linux.scss
@@ -36,6 +36,8 @@
     cursor: default;
     // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
     background: var(--tab-strip-bg);
+    // Folder boundary — single rule on the container for a full-width gap-free line.
+    border-bottom: var(--snap-chrome) solid var(--border-color);
     // Window drag is JS-driven (NOT -webkit-app-region: drag). Chromium
     // architecturally suppresses ALL events on drag regions before they
     // enter the renderer (verified 2026-05-02 via document capture-phase
@@ -54,8 +56,5 @@
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
-        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): 0px wide
-        // on Linux so this is a no-op visually, but kept for parity.
-        border-bottom: 1px solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.win32.scss
+++ b/frontend/app/window/window-header.win32.scss
@@ -38,14 +38,15 @@
     // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
     // Slightly lighter than --workspace-surface so the folder content advances.
     background: var(--tab-strip-bg);
+    // Folder boundary — single rule on the container so the full-width 1px line
+    // has no gaps (hamburger, separators, right margin were all missed by the
+    // per-element approach). Active tab uses --block-bg-color to color-match the
+    // content surface below, maintaining the visual connection.
+    border-bottom: var(--snap-chrome) solid var(--border-color);
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
-        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): the 2px left
-        // drag spacer needs its own bottom hairline to close the gap before the
-        // first tab.
-        border-bottom: 1px solid var(--border-color);
     }
 }

--- a/frontend/app/window/window-header.win32.scss
+++ b/frontend/app/window/window-header.win32.scss
@@ -38,15 +38,14 @@
     // Layer A — recessed strip (SPEC_TAB_CONTENT_FOLDER_SURFACE §3, §10.6).
     // Slightly lighter than --workspace-surface so the folder content advances.
     background: var(--tab-strip-bg);
-    // Folder boundary — single rule on the container so the full-width 1px line
-    // has no gaps (hamburger, separators, right margin were all missed by the
-    // per-element approach). Active tab uses --block-bg-color to color-match the
-    // content surface below, maintaining the visual connection.
-    border-bottom: var(--snap-chrome) solid var(--border-color);
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        // Folder boundary (SPEC_TAB_CONTENT_FOLDER_SURFACE §10.6): the 2px left
+        // drag spacer needs its own bottom hairline to close the gap before the
+        // first tab.
+        border-bottom: var(--snap-chrome) solid var(--border-color);
     }
 }


### PR DESCRIPTION
## Summary

- Moves the tab-strip/content separator from per-element `border-bottom` properties (which had gaps at the hamburger button, tab separators, and system-status right margin) to a single `border-bottom` on `.window-header` itself — one rule, zero gaps, all platforms
- Uses `var(--snap-chrome)` for the border width so it snaps to exactly 1 physical pixel inside the header's zoom context at any DPR/zoom factor, eliminating the thinner-border artifact at 125% DPI
- Updates Win32 caption-button height compensation from hardcoded `1px` to `var(--snap-chrome)` to match the border width precisely
- Removes leftover per-element `border-bottom` from `.tab:not(.active)`, `.tab-bar-fill`, `.system-status`, and `tabcontent.tsx` padding workaround

## Test plan

- [ ] Win32: verify a single continuous `--border-color` line appears full-width below the tab strip with no gaps
- [ ] Win32 at 125% DPI: line should be exactly 1 physical pixel (no thinner/thicker inconsistency)
- [ ] Caption button hover backgrounds should still reach the full header height (compensation formula)
- [ ] macOS / Linux: same continuous line via their respective platform SCSS files

<!-- agentmux:agent_id=camper -->