### PR TITLE
fix(browser-pane/macos): fix black screen by deferring overlay bounds commit

### DIFF
--- a/.changesets/1782432000-fix-browser-pane-black-screen-freeze-macos-objc-nswindow-resize.md
+++ b/.changesets/1782432000-fix-browser-pane-black-screen-freeze-macos-objc-nswindow-resize.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): black screen + mouse freeze on macOS when opening a browser pane

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -366,6 +366,29 @@ pub fn resize_browser_pane_view(state: &Arc<AppState>, label: &str, rect: Rect) 
     if let Some(window) = state.windows.lock().get(&window_label).cloned() {
         window.layout();
     }
+
+    // macOS: set_size/set_position/layout() are no-ops for the overlay's
+    // NativeWidgetMacNSWindow frame — the only working path is ObjC
+    // [NSWindow setFrame:display:YES].  Post a bounds task (retry=2 →
+    // physical-pixel path, wnum match, no delta-detection pre-scan) so the
+    // NSWindow frame is updated on this UI-thread tick.  retry=2 is used
+    // rather than retry=0 to skip the delta-detection pre-scan (the window
+    // already exists) and rather than retry=1 to avoid the
+    // controller.bounds()-as-DIP code path (we have fresh physical pixels).
+    #[cfg(target_os = "macos")]
+    {
+        let wnum = state.browser_pane_overlay_wnums.lock()
+            .get(label).cloned().unwrap_or(0);
+        if wnum > 0 {
+            crate::ui_tasks::post_set_pane_bounds_views(
+                state, label, &window_label,
+                rect.x, rect.y, rect.width, rect.height,
+                2,    // retry=2: physical pixels, wnum match, no pre-scan
+                wnum,
+            );
+        }
+    }
+
     tracing::debug!(
         label = %label, window_label = %window_label,
         x = rect.x, y = rect.y, w = rect.width, h = rect.height,
@@ -397,6 +420,9 @@ pub fn resize_browser_pane_view(state: &Arc<AppState>, label: &str, rect: Rect) 
 /// Must run on the CEF UI thread.
 pub fn detach_browser_pane_view(state: &Arc<AppState>, label: &str) {
     let entry = state.browser_pane_overlays.lock().remove(label);
+    // Remove stored wnum so resize tasks posted after detach become no-ops.
+    #[cfg(target_os = "macos")]
+    state.browser_pane_overlay_wnums.lock().remove(label);
     let Some((_window_label, controller)) = entry else {
         tracing::debug!(
             label = %label,

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -312,6 +312,7 @@ pub fn create_browser_pane_view(
         rect.y,
         rect.width,
         rect.height,
+        0, // retry counter — task self-retries on macOS if overlay NSWindow not yet visible
     );
 }
 

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -237,55 +237,13 @@ pub fn create_browser_pane_view(
     overlay_controller.set_position(Some(&Point { x: rect.x, y: rect.y }));
     parent_window.layout();
 
-    // macOS: capture the overlay's NSWindow windowNumber BEFORE set_visible(0).
-    // CEF shows the overlay visible briefly when add_overlay_view completes;
-    // set_visible(0) (below) calls [NSWindow orderOut:] which removes it from
-    // [NSApp windows]. We scan now — while it is still present — so the deferred
-    // SetPaneBoundsViewsTask can target this exact NSWindow even when multiple
-    // panes are open (with wnum=0 all panes fall back to "highest wnum = newest
-    // NativeWidgetMacNSWindow", causing every task to target the same window).
-    #[cfg(target_os = "macos")]
-    let overlay_wnum: isize = unsafe {
-        use std::ffi::c_char;
-        type Id  = *mut std::ffi::c_void;
-        type Sel = *const std::ffi::c_void;
-        extern "C" {
-            fn sel_registerName(name: *const c_char) -> Sel;
-            fn objc_msgSend();
-            fn object_getClassName(obj: Id) -> *const c_char;
-            fn objc_getClass(name: *const c_char) -> Id;
-        }
-        let get_id:     extern "C" fn(Id, Sel) -> Id       = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-        let get_usize:  extern "C" fn(Id, Sel) -> usize    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-        let obj_at:     extern "C" fn(Id, Sel, usize) -> Id = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-        let get_isize:  extern "C" fn(Id, Sel) -> isize    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-        let sel_app     = sel_registerName(b"sharedApplication\0".as_ptr() as _);
-        let sel_windows = sel_registerName(b"windows\0".as_ptr() as _);
-        let sel_count   = sel_registerName(b"count\0".as_ptr() as _);
-        let sel_obj_at  = sel_registerName(b"objectAtIndex:\0".as_ptr() as _);
-        let sel_wnum    = sel_registerName(b"windowNumber\0".as_ptr() as _);
-        let ns_cls: Id  = objc_getClass(b"NSApplication\0".as_ptr() as _);
-        let ns_app: Id  = get_id(ns_cls, sel_app);
-        let wins: Id    = get_id(ns_app, sel_windows);
-        let count = if wins.is_null() { 0 } else { get_usize(wins, sel_count) };
-        let mut highest: isize = 0;
-        for i in 0..count {
-            let win = obj_at(wins, sel_obj_at, i);
-            if win.is_null() { continue; }
-            let cls_ptr = object_getClassName(win);
-            let cls = if !cls_ptr.is_null() {
-                std::ffi::CStr::from_ptr(cls_ptr).to_str().unwrap_or("?")
-            } else { "?" };
-            if cls.contains("NativeWidgetMacNSWindow") {
-                let wn = get_isize(win, sel_wnum);
-                if wn > highest { highest = wn; }
-            }
-        }
-        tracing::info!(block_id = %block_id, label = %label, wnum = highest,
-            "[browser-pane] views: captured overlay_wnum before set_visible(0)");
-        highest
-    };
-    #[cfg(not(target_os = "macos"))]
+    // overlay_wnum: the macOS NSWindow windowNumber of the overlay's backing
+    // NativeWidgetMacNSWindow.  The native NSWindow is created asynchronously
+    // during add_overlay_view (the comment at step 7 above confirms "the native
+    // layer doesn't exist yet"), so any scan here would capture a stale wnum.
+    // SetPaneBoundsViewsTask discovers the correct wnum at runtime via a
+    // pre/post-set_visible(1) snapshot delta (see ui_tasks.rs) and propagates
+    // it to the retry=1 reaffirm task.  Pass 0 here to signal "unknown".
     let overlay_wnum: isize = 0;
 
     overlay_controller.set_visible(0); // deferred task will show after bounds commit

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -236,6 +236,58 @@ pub fn create_browser_pane_view(
     overlay_controller.set_size(Some(&Size { width: rect.width, height: rect.height }));
     overlay_controller.set_position(Some(&Point { x: rect.x, y: rect.y }));
     parent_window.layout();
+
+    // macOS: capture the overlay's NSWindow windowNumber BEFORE set_visible(0).
+    // CEF shows the overlay visible briefly when add_overlay_view completes;
+    // set_visible(0) (below) calls [NSWindow orderOut:] which removes it from
+    // [NSApp windows]. We scan now — while it is still present — so the deferred
+    // SetPaneBoundsViewsTask can target this exact NSWindow even when multiple
+    // panes are open (with wnum=0 all panes fall back to "highest wnum = newest
+    // NativeWidgetMacNSWindow", causing every task to target the same window).
+    #[cfg(target_os = "macos")]
+    let overlay_wnum: isize = unsafe {
+        use std::ffi::c_char;
+        type Id  = *mut std::ffi::c_void;
+        type Sel = *const std::ffi::c_void;
+        extern "C" {
+            fn sel_registerName(name: *const c_char) -> Sel;
+            fn objc_msgSend();
+            fn object_getClassName(obj: Id) -> *const c_char;
+            fn objc_getClass(name: *const c_char) -> Id;
+        }
+        let get_id:     extern "C" fn(Id, Sel) -> Id       = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+        let get_usize:  extern "C" fn(Id, Sel) -> usize    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+        let obj_at:     extern "C" fn(Id, Sel, usize) -> Id = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+        let get_isize:  extern "C" fn(Id, Sel) -> isize    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+        let sel_app     = sel_registerName(b"sharedApplication\0".as_ptr() as _);
+        let sel_windows = sel_registerName(b"windows\0".as_ptr() as _);
+        let sel_count   = sel_registerName(b"count\0".as_ptr() as _);
+        let sel_obj_at  = sel_registerName(b"objectAtIndex:\0".as_ptr() as _);
+        let sel_wnum    = sel_registerName(b"windowNumber\0".as_ptr() as _);
+        let ns_cls: Id  = objc_getClass(b"NSApplication\0".as_ptr() as _);
+        let ns_app: Id  = get_id(ns_cls, sel_app);
+        let wins: Id    = get_id(ns_app, sel_windows);
+        let count = if wins.is_null() { 0 } else { get_usize(wins, sel_count) };
+        let mut highest: isize = 0;
+        for i in 0..count {
+            let win = obj_at(wins, sel_obj_at, i);
+            if win.is_null() { continue; }
+            let cls_ptr = object_getClassName(win);
+            let cls = if !cls_ptr.is_null() {
+                std::ffi::CStr::from_ptr(cls_ptr).to_str().unwrap_or("?")
+            } else { "?" };
+            if cls.contains("NativeWidgetMacNSWindow") {
+                let wn = get_isize(win, sel_wnum);
+                if wn > highest { highest = wn; }
+            }
+        }
+        tracing::info!(block_id = %block_id, label = %label, wnum = highest,
+            "[browser-pane] views: captured overlay_wnum before set_visible(0)");
+        highest
+    };
+    #[cfg(not(target_os = "macos"))]
+    let overlay_wnum: isize = 0;
+
     overlay_controller.set_visible(0); // deferred task will show after bounds commit
     tracing::info!(
         block_id = %block_id, label = %label,
@@ -313,6 +365,7 @@ pub fn create_browser_pane_view(
         rect.width,
         rect.height,
         0, // retry counter — task self-retries on macOS if overlay NSWindow not yet visible
+        overlay_wnum,
     );
 }
 

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -369,14 +369,22 @@ pub fn resize_browser_pane_view(state: &Arc<AppState>, label: &str, rect: Rect) 
 
     // macOS: set_size/set_position/layout() are no-ops for the overlay's
     // NativeWidgetMacNSWindow frame — the only working path is ObjC
-    // [NSWindow setFrame:display:YES].  Post a bounds task (retry=2 →
-    // physical-pixel path, wnum match, no delta-detection pre-scan) so the
-    // NSWindow frame is updated on this UI-thread tick.  retry=2 is used
-    // rather than retry=0 to skip the delta-detection pre-scan (the window
-    // already exists) and rather than retry=1 to avoid the
-    // controller.bounds()-as-DIP code path (we have fresh physical pixels).
+    // [NSWindow setFrame:display:YES].
+    //
+    // Always record the latest rect so SetPaneBoundsViewsTask (retry=0) can
+    // pick it up even if it hasn't run yet (race: resize IPC before the
+    // creation bounds task fires and stores the wnum).
+    //
+    // If the wnum is already known, also post a bounds task at retry=2
+    // (physical-pixel path, wnum match, no delta-detection pre-scan) so the
+    // NSWindow frame is updated immediately.  retry=2 avoids delta-detection
+    // (window already exists) and avoids controller.bounds()-as-DIP (we have
+    // fresh physical pixels).
     #[cfg(target_os = "macos")]
     {
+        state.browser_pane_resize_rects.lock()
+            .insert(label.to_string(), (rect.x, rect.y, rect.width, rect.height));
+
         let wnum = state.browser_pane_overlay_wnums.lock()
             .get(label).cloned().unwrap_or(0);
         if wnum > 0 {
@@ -420,9 +428,11 @@ pub fn resize_browser_pane_view(state: &Arc<AppState>, label: &str, rect: Rect) 
 /// Must run on the CEF UI thread.
 pub fn detach_browser_pane_view(state: &Arc<AppState>, label: &str) {
     let entry = state.browser_pane_overlays.lock().remove(label);
-    // Remove stored wnum so resize tasks posted after detach become no-ops.
+    // Remove stored wnum and resize rect so tasks posted after detach become no-ops.
     #[cfg(target_os = "macos")]
     state.browser_pane_overlay_wnums.lock().remove(label);
+    #[cfg(target_os = "macos")]
+    state.browser_pane_resize_rects.lock().remove(label);
     let Some((_window_label, controller)) = entry else {
         tracing::debug!(
             label = %label,

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -218,24 +218,29 @@ pub fn create_browser_pane_view(
         "[browser-pane] views: add_overlay_view returned OverlayController"
     );
 
-    // 7. Position the overlay. We tried `set_bounds(rect)` directly: silently
-    //    ignored — readback shows 0,0,0,0. Trying separate set_size + set_position
-    //    and explicit window.layout() to force a layout pass.
+    // 7. Position the overlay.
     //
-    // set_visible(1) is intentionally called AFTER layout() so the overlay is
-    // at the correct position/size before it becomes visible and can intercept
-    // input. Calling it before layout() caused a brief window where the overlay
-    // was visible at the wrong position (or 0×0), which on macOS allowed CEF's
-    // new-browser focus steal (from add_overlay_view above) to intercept clicks
-    // for the whole window before the layout pass corrected the bounds.
+    // On macOS, the overlay's native NSView is not yet created at this point —
+    // `add_overlay_view` posts native view creation asynchronously. Calling
+    // `set_size` / `set_position` / `layout()` here is a best-effort attempt
+    // that MAY commit the bounds on Linux but silently does nothing on macOS
+    // (readback: oc_w=0 oc_h=0). Without committed bounds the overlay defaults
+    // to filling the entire parent window, which (a) covers the UI with the
+    // pane's opaque-black background_color and (b) intercepts all mouse events
+    // for the window — the "black screen + UI freeze" bug.
+    //
+    // SetPaneBoundsViewsTask (posted after the stash below) re-applies the
+    // bounds on the next UI event-loop tick, after the native NSView has been
+    // fully initialised. The overlay is kept hidden (set_visible(0)) until
+    // that task fires so the user never sees a transient wrong-size overlay.
     overlay_controller.set_size(Some(&Size { width: rect.width, height: rect.height }));
     overlay_controller.set_position(Some(&Point { x: rect.x, y: rect.y }));
     parent_window.layout();
-    overlay_controller.set_visible(1);
+    overlay_controller.set_visible(0); // deferred task will show after bounds commit
     tracing::info!(
         block_id = %block_id, label = %label,
         x = rect.x, y = rect.y, w = rect.width, h = rect.height,
-        "[browser-pane] views: overlay set_size + set_position + layout() + set_visible applied"
+        "[browser-pane] views: overlay set_size + set_position + layout() applied (visible=0; deferred show pending)"
     );
 
     // 7b. Return focus to the main window's BrowserView. CEF's default
@@ -290,6 +295,23 @@ pub fn create_browser_pane_view(
     tracing::info!(
         block_id = %block_id, label = %label, window_label = %window_label,
         "[browser-pane] views: OverlayController stashed in state.browser_pane_overlays"
+    );
+
+    // 10. Deferred bounds + show: re-apply set_size / set_position / layout() / set_visible(1)
+    //     on the next UI event-loop tick. On macOS the overlay's native NSView is
+    //     created asynchronously during add_overlay_view; the first-tick sizing
+    //     (step 7 above) is silently ignored because the native layer doesn't exist
+    //     yet. Posting a task ensures the bounds land AFTER CEF has initialised the
+    //     NSView. The task also re-issues set_focus(1) on the main browser in case
+    //     a focus steal happened during the event-loop tick.
+    crate::ui_tasks::post_set_pane_bounds_views(
+        &state,
+        &label,
+        &window_label,
+        rect.x,
+        rect.y,
+        rect.width,
+        rect.height,
     );
 }
 

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -767,6 +767,18 @@ pub struct AppState {
     pub pending_overlay_destroy:
         Mutex<std::collections::HashMap<String, cef::OverlayController>>,
 
+    /// macOS only — latest resize rect (physical pixels) per pane label.
+    ///
+    /// Written by `resize_browser_pane_view` on every resize IPC, including
+    /// resizes that arrive before `SetPaneBoundsViewsTask` has run (i.e.
+    /// before the wnum is known).  `SetPaneBoundsViewsTask` reads this at
+    /// retry=0 to prefer the most-recently-requested rect over its own
+    /// creation-time rect, closing the race between pane creation and an
+    /// early resize IPC.  Entries are removed on detach.
+    #[cfg(target_os = "macos")]
+    pub browser_pane_resize_rects:
+        Mutex<std::collections::HashMap<String, (i32, i32, i32, i32)>>,
+
     /// macOS only — NSWindow windowNumber for each live browser-pane overlay,
     /// keyed by pane label.  Discovered by delta-detection in
     /// `SetPaneBoundsViewsTask` (retry=0) and stored here so that
@@ -909,6 +921,8 @@ impl Default for AppState {
             pane_overlay_rects: Mutex::new(HashMap::new()),
             #[cfg(not(target_os = "windows"))]
             pending_overlay_destroy: Mutex::new(HashMap::new()),
+            #[cfg(target_os = "macos")]
+            browser_pane_resize_rects: Mutex::new(HashMap::new()),
             #[cfg(target_os = "macos")]
             browser_pane_overlay_wnums: Mutex::new(HashMap::new()),
             #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -767,6 +767,16 @@ pub struct AppState {
     pub pending_overlay_destroy:
         Mutex<std::collections::HashMap<String, cef::OverlayController>>,
 
+    /// macOS only — NSWindow windowNumber for each live browser-pane overlay,
+    /// keyed by pane label.  Discovered by delta-detection in
+    /// `SetPaneBoundsViewsTask` (retry=0) and stored here so that
+    /// `resize_browser_pane_view` can post a reaffirm task with an exact wnum
+    /// instead of relying on the highest-wnum fallback (which is ambiguous
+    /// when ≥2 panes are open).  Entries are removed when the overlay is
+    /// detached (`detach_browser_pane_view`).
+    #[cfg(target_os = "macos")]
+    pub browser_pane_overlay_wnums: Mutex<std::collections::HashMap<String, isize>>,
+
     /// Tear-off Phase 6 — pre-warmed pool of hidden CEF windows ready for
     /// instant promotion on tear-off. Each entry is a label of a window
     /// that's already painted, has its renderer connected, and is sitting
@@ -899,6 +909,8 @@ impl Default for AppState {
             pane_overlay_rects: Mutex::new(HashMap::new()),
             #[cfg(not(target_os = "windows"))]
             pending_overlay_destroy: Mutex::new(HashMap::new()),
+            #[cfg(target_os = "macos")]
+            browser_pane_overlay_wnums: Mutex::new(HashMap::new()),
             #[cfg(target_os = "windows")]
             pane_clip_cache: Mutex::new(HashMap::new()),
             // window_pool / unpromoted_pool_labels / window_pool_respawn_in_flight

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1947,8 +1947,27 @@ wrap_task! {
             };
 
             // CEF Views sizing — no-ops on macOS, functional on Linux.
-            controller.set_size(Some(&Size { width: self.width, height: self.height }));
-            controller.set_position(Some(&Point { x: self.x, y: self.y }));
+            // On macOS at retry=0, skip re-applying creation-time bounds: a resize
+            // queued between creation and this task would already have called
+            // set_size/set_position with the correct new values, and overwriting
+            // them here would roll that back. At retry>=1 the controller bounds
+            // reflect any intervening resize and we read them back for the ObjC
+            // frame reaffirm instead of using the stale creation-time self.x/y/w/h.
+            #[cfg(not(target_os = "macos"))]
+            {
+                controller.set_size(Some(&Size { width: self.width, height: self.height }));
+                controller.set_position(Some(&Point { x: self.x, y: self.y }));
+            }
+            #[cfg(target_os = "macos")]
+            if self.retry == 0 {
+                // retry=0: only set_size/set_position if controller bounds are
+                // still 0×0 (no resize has happened yet); otherwise leave them alone.
+                let cb = controller.bounds();
+                if cb.width == 0 && cb.height == 0 {
+                    controller.set_size(Some(&Size { width: self.width, height: self.height }));
+                    controller.set_position(Some(&Point { x: self.x, y: self.y }));
+                }
+            }
             // Skip window.layout() on macOS: it schedules a deferred CEF Views layout
             // pass that calls NativeWidgetMac::SetBoundsRect(0,0,0,0) AFTER our ObjC
             // setFrame, resetting the overlay to off-screen and re-engaging its event
@@ -2040,14 +2059,15 @@ wrap_task! {
                 let make_key_front: extern "C" fn(Id, Sel, Id)          = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
                 let order_front:    extern "C" fn(Id, Sel, Id)          = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
 
-                // Step 1: show the overlay on the first run only.
-                // On retry >= 1, the overlay is already visible; we just reaffirm the
-                // frame AFTER CEF's deferred Widget layout (triggered by Widget::Show()
-                // during retry=0) has had a chance to run and reset the NSWindow bounds
-                // to 0×0. The delayed retry fires 50ms later, after all pending layout
-                // passes have completed.
+                // Step 1: show the overlay on the first run only, but only if
+                // compute_pane_visible agrees — an overlay-clip or zero-area rect
+                // queued between creation and this task (e.g. a modal appeared, or
+                // an inactive-tab resize sent a 0×0 rect) must not be overridden.
                 if self.retry == 0 {
-                    controller.set_visible(1);
+                    let pane_rect = (self.x, self.y, self.width, self.height);
+                    if crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, pane_rect) {
+                        controller.set_visible(1);
+                    }
                 }
 
                 // Step 2: rescan [NSApp windows] to find the overlay and main window.
@@ -2127,20 +2147,39 @@ wrap_task! {
 
                 // Step 3: reaffirm the frame (set_visible(1) may have triggered a CEF
                 // layout pass that reset the native frame to the pre-creation default).
-                let main_frame = if !main_win.is_null() {
-                    get_frame(main_win, sel_frame)
-                } else {
-                    NSRect { origin: NSPoint { x: 0.0, y: 0.0 }, size: NSSize { w: 0.0, h: 0.0 } }
-                };
-                let scale = if !main_win.is_null() {
+                // Bail if main_win is null — we need it to compute screen_x/screen_y
+                // (pane coords are relative to the main window's origin). Placing with
+                // a 0×0 main_frame would put the overlay at (0,0) on the screen, which
+                // is visually wrong and may cover unrelated windows.
+                if main_win.is_null() {
+                    tracing::warn!(
+                        label = %self.label, retry = self.retry,
+                        "[browser-pane] ObjC task: main CefNSWindow not found — cannot compute screen coords, skipping frame commit"
+                    );
+                    return;
+                }
+                let main_frame = get_frame(main_win, sel_frame);
+                let scale = {
                     let s = get_f64(main_win, sel_backing_scale);
                     if s > 0.0 { s } else { 1.0 }
-                } else { 1.0 };
+                };
 
-                let pane_x = self.x as f64 / scale;
-                let pane_y = self.y as f64 / scale;
-                let pane_w = self.width  as f64 / scale;
-                let pane_h = self.height as f64 / scale;
+                // At retry>=1 prefer the controller's current CEF bounds (which
+                // reflect any resize queued between creation and this task) over
+                // the stale creation-time self.x/y/width/height. Fall back to
+                // creation-time values only if the controller still reports 0×0.
+                let (src_x, src_y, src_w, src_h) = {
+                    let cb = controller.bounds();
+                    if cb.width > 0 && cb.height > 0 && self.retry >= 1 {
+                        (cb.x, cb.y, cb.width, cb.height)
+                    } else {
+                        (self.x, self.y, self.width, self.height)
+                    }
+                };
+                let pane_x = src_x as f64 / scale;
+                let pane_y = src_y as f64 / scale;
+                let pane_w = src_w as f64 / scale;
+                let pane_h = src_h as f64 / scale;
                 let screen_x = main_frame.origin.x + pane_x;
                 let screen_y = main_frame.origin.y + main_frame.size.h - pane_y - pane_h;
 

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -2031,6 +2031,21 @@ wrap_task! {
                 .map(|w| w.window_handle() as *mut std::ffi::c_void)
                 .unwrap_or(std::ptr::null_mut());
 
+            // Prefer a resize rect stored by resize_browser_pane_view over the
+            // task's own creation-time rect.  A resize IPC can arrive between
+            // pane creation and this deferred task; since set_size/set_position
+            // are no-ops on macOS and the wnum is not yet known (so the ObjC
+            // resize path is skipped), the only way to deliver the newer rect is
+            // via this shared slot.  At retry>=2 self.x/y/w/h IS the resize
+            // rect (posted by resize_browser_pane_view with wnum), so preferred_rect
+            // simply returns the same value.
+            #[cfg(target_os = "macos")]
+            let preferred_rect: (i32, i32, i32, i32) = {
+                let stored = self.state.browser_pane_resize_rects.lock()
+                    .get(&self.label).cloned();
+                stored.unwrap_or((self.x, self.y, self.width, self.height))
+            };
+
             #[cfg(target_os = "macos")]
             unsafe {
                 use std::ffi::c_char;
@@ -2087,10 +2102,11 @@ wrap_task! {
                 };
 
                 // Determine desired final visibility before any NSWindow mutation.
-                // Consulted again after setFrame to restore the correct state.
+                // Use preferred_rect (most recent resize rect, or creation rect
+                // if no resize has arrived yet) so visibility reflects the
+                // current intent, not the stale creation-time IPC payload.
                 let should_be_visible = {
-                    let pane_rect = (self.x, self.y, self.width, self.height);
-                    crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, pane_rect)
+                    crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, preferred_rect)
                 };
 
                 // Step 1 (retry=0 only): snapshot which NativeWidgetMacNSWindows
@@ -2258,22 +2274,22 @@ wrap_task! {
                 //  retry=1, cb≠0×0  → controller.set_bounds() at retry=0 stored DIP;
                 //                      re-use as-is (no scale division — it's already
                 //                      in NSWindow points).
-                //  all other cases  → self.x/y/width/height are physical pixels from
-                //                      the IPC rect; divide by backingScaleFactor.
-                //                      Do NOT fall back to controller.bounds() here:
-                //                      set_size/set_position are no-ops on macOS so
-                //                      controller.bounds() at retry=0 reflects a stale
-                //                      set_bounds() DIP, not a physical-pixel resize —
-                //                      using it would cause a double-scale division.
+                //  all other cases  → preferred_rect is physical pixels from the most
+                //                      recent IPC rect (resize or creation); divide by
+                //                      backingScaleFactor.
+                //                      Do NOT use controller.bounds() here: set_size/
+                //                      set_position are no-ops on macOS so it reflects
+                //                      a stale set_bounds() DIP, causing double-scale.
                 let (pane_x, pane_y, pane_w, pane_h) = {
                     let cb = controller.bounds();
                     if self.retry == 1 && cb.width > 0 && cb.height > 0 {
                         // DIP from set_bounds() committed at retry=0; no scale division.
                         (cb.x as f64, cb.y as f64, cb.width as f64, cb.height as f64)
                     } else {
-                        // Physical pixels from task rect → NSWindow points.
-                        (self.x as f64 / scale, self.y as f64 / scale,
-                         self.width as f64 / scale, self.height as f64 / scale)
+                        // Physical pixels from preferred_rect → NSWindow points.
+                        let (px, py, pw, ph) = preferred_rect;
+                        (px as f64 / scale, py as f64 / scale,
+                         pw as f64 / scale, ph as f64 / scale)
                     }
                 };
                 let screen_x = main_frame.origin.x + pane_x;

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1926,6 +1926,9 @@ wrap_task! {
         width: i32,
         height: i32,
         retry: u32,
+        // macOS: windowNumber of the overlay NativeWidgetMacNSWindow, captured
+        // before set_visible(0) removed it from [NSApp windows]. 0 = unknown.
+        overlay_wnum: isize,
     }
 
     impl Task {
@@ -1946,6 +1949,11 @@ wrap_task! {
             // CEF Views sizing — no-ops on macOS, functional on Linux.
             controller.set_size(Some(&Size { width: self.width, height: self.height }));
             controller.set_position(Some(&Point { x: self.x, y: self.y }));
+            // Skip window.layout() on macOS: it schedules a deferred CEF Views layout
+            // pass that calls NativeWidgetMac::SetBoundsRect(0,0,0,0) AFTER our ObjC
+            // setFrame, resetting the overlay to off-screen and re-engaging its event
+            // capture. On macOS, we rely entirely on the ObjC NSWindow resize below.
+            #[cfg(not(target_os = "macos"))]
             if let Some(window) = self.state.windows.lock().get(&self.window_label).cloned() {
                 window.layout();
             }
@@ -1969,8 +1977,27 @@ wrap_task! {
                 return;
             }
 
-            // macOS: resize the NativeWidgetMacNSWindow directly via ObjC.
-            // set_visible(1) is called only after frame is committed below.
+            // macOS: [NSWindow windowWithWindowNumber:] was removed in macOS 26 Tahoe.
+            // After the ObjC block, we also call controller.set_bounds() with DIP
+            // coordinates. The root cause of the 0×0 reset is overlay_view_host.cc
+            // SetOverlayBounds() doing Intersect(window_view_->bounds()). At creation
+            // time the parent CefWindowView bounds may be empty, causing the intersection
+            // to produce 0×0. From this deferred task the parent window IS fully laid out,
+            // so set_bounds() should succeed and commit the bounds in CEF's Views layer.
+            // The ObjC block additionally sets the NSWindow frame directly.
+            #[cfg(target_os = "macos")]
+            let (mut task_dip_x, mut task_dip_y, mut task_dip_w, mut task_dip_h) = (0i32, 0i32, 0i32, 0i32);
+            #[cfg(target_os = "macos")]
+            let mut task_main_win:    *mut std::ffi::c_void = std::ptr::null_mut();
+            #[cfg(target_os = "macos")]
+            let mut task_overlay_win: *mut std::ffi::c_void = std::ptr::null_mut();
+            #[cfg(target_os = "macos")]
+            let mut task_sel_make_key_front: *const std::ffi::c_void = std::ptr::null();
+            #[cfg(target_os = "macos")]
+            let mut task_sel_order_front:    *const std::ffi::c_void = std::ptr::null();
+            #[cfg(target_os = "macos")]
+            let mut task_sel_key_window:     *const std::ffi::c_void = std::ptr::null();
+
             #[cfg(target_os = "macos")]
             unsafe {
                 use std::ffi::c_char;
@@ -1993,25 +2020,37 @@ wrap_task! {
                 let sel_count         = sel_registerName(b"count\0".as_ptr() as _);
                 let sel_obj_at        = sel_registerName(b"objectAtIndex:\0".as_ptr() as _);
                 let sel_frame         = sel_registerName(b"frame\0".as_ptr() as _);
-                let sel_is_key        = sel_registerName(b"isKeyWindow\0".as_ptr() as _);
                 let sel_is_main       = sel_registerName(b"isMainWindow\0".as_ptr() as _);
+                let sel_is_key        = sel_registerName(b"isKeyWindow\0".as_ptr() as _);
+                let sel_key_window    = sel_registerName(b"keyWindow\0".as_ptr() as _);
                 let sel_backing_scale = sel_registerName(b"backingScaleFactor\0".as_ptr() as _);
-                // setFrame:display: — NSRect (4 doubles HFA → d0-d3) + BOOL (u8 → x2)
                 let sel_set_frame_d   = sel_registerName(b"setFrame:display:\0".as_ptr() as _);
-                let sel_order_front   = sel_registerName(b"orderFront:\0".as_ptr() as _);
+                let sel_make_key_front = sel_registerName(b"makeKeyAndOrderFront:\0".as_ptr() as _);
+                let sel_order_front    = sel_registerName(b"orderFront:\0".as_ptr() as _);
+                let sel_win_number     = sel_registerName(b"windowNumber\0".as_ptr() as _);
 
-                let get_id:     extern "C" fn(Id, Sel) -> Id        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let get_usize:  extern "C" fn(Id, Sel) -> usize     = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let get_bool:   extern "C" fn(Id, Sel) -> u8        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let get_f64:    extern "C" fn(Id, Sel) -> f64       = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let obj_at:     extern "C" fn(Id, Sel, usize) -> Id = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let get_frame:  extern "C" fn(Id, Sel) -> NSRect    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let set_frame_d: extern "C" fn(Id, Sel, NSRect, u8) = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                let order_front: extern "C" fn(Id, Sel, Id)         = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_id:         extern "C" fn(Id, Sel) -> Id        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_usize:      extern "C" fn(Id, Sel) -> usize     = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_isize:      extern "C" fn(Id, Sel) -> isize     = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_bool:       extern "C" fn(Id, Sel) -> u8        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_f64:        extern "C" fn(Id, Sel) -> f64       = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let obj_at:         extern "C" fn(Id, Sel, usize) -> Id = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_frame:      extern "C" fn(Id, Sel) -> NSRect    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let set_frame_d:    extern "C" fn(Id, Sel, NSRect, u8)  = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let make_key_front: extern "C" fn(Id, Sel, Id)          = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let order_front:    extern "C" fn(Id, Sel, Id)          = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
 
-                // [BridgedContentView window] returns nil (CEF doesn't use the
-                // standard Cocoa contentView hierarchy), so enumerate all NSWindows
-                // in the process via NSApp.
+                // Step 1: show the overlay on the first run only.
+                // On retry >= 1, the overlay is already visible; we just reaffirm the
+                // frame AFTER CEF's deferred Widget layout (triggered by Widget::Show()
+                // during retry=0) has had a chance to run and reset the NSWindow bounds
+                // to 0×0. The delayed retry fires 50ms later, after all pending layout
+                // passes have completed.
+                if self.retry == 0 {
+                    controller.set_visible(1);
+                }
+
+                // Step 2: rescan [NSApp windows] to find the overlay and main window.
                 let ns_app_class: Id = objc_getClass(b"NSApplication\0".as_ptr() as _);
                 let ns_app: Id       = get_id(ns_app_class, sel_shared_app);
                 let all_wins: Id     = get_id(ns_app, sel_windows_arr);
@@ -2019,57 +2058,80 @@ wrap_task! {
                                        else { get_usize(all_wins, sel_count) };
 
                 let mut overlay_win: Id = std::ptr::null_mut();
-                let mut main_win: Id    = std::ptr::null_mut();
+                let mut main_win:    Id = std::ptr::null_mut();
+                // Highest windowNumber among NativeWidgetMacNSWindows (for fallback
+                // when overlay_wnum is unknown — newest window = highest number).
+                let mut highest_native_wnum: isize = 0;
+                let mut highest_native_win: Id = std::ptr::null_mut();
 
                 for i in 0..win_count {
                     let win = obj_at(all_wins, sel_obj_at, i);
                     if win.is_null() { continue; }
-                    let is_key  = get_bool(win, sel_is_key);
+                    let cls_ptr = object_getClassName(win);
+                    let cls = if !cls_ptr.is_null() {
+                        std::ffi::CStr::from_ptr(cls_ptr).to_str().unwrap_or("?")
+                    } else { "?" };
+                    let wn      = get_isize(win, sel_win_number);
                     let is_main = get_bool(win, sel_is_main);
-                    if self.retry == 0 {
-                        let cls_ptr = object_getClassName(win);
-                        let cls = if !cls_ptr.is_null() {
-                            std::ffi::CStr::from_ptr(cls_ptr).to_str().unwrap_or("?")
-                        } else { "?" };
-                        let fr = get_frame(win, sel_frame);
-                        tracing::info!(
-                            i, win_count, class = cls, retry = self.retry,
-                            x = fr.origin.x, y = fr.origin.y,
-                            w = fr.size.w, h = fr.size.h, is_key, is_main,
-                            "[browser-pane] ObjC NSApp window"
-                        );
+                    let is_key  = get_bool(win, sel_is_key);
+                    let fr      = get_frame(win, sel_frame);
+                    tracing::info!(
+                        i, win_count, class = cls, retry = self.retry,
+                        x = fr.origin.x, y = fr.origin.y, w = fr.size.w, h = fr.size.h,
+                        is_main, is_key, wn, want_wnum = self.overlay_wnum,
+                        "[browser-pane] ObjC task NSApp window"
+                    );
+                    if cls.contains("CefNSWindow") && is_main != 0 {
+                        main_win = win;
                     }
-                    if is_main != 0 || is_key != 0 { main_win = win; }
-                    else { overlay_win = win; }
+                    if cls.contains("NativeWidgetMacNSWindow") {
+                        if self.overlay_wnum > 0 && wn == self.overlay_wnum {
+                            overlay_win = win;
+                        }
+                        if wn > highest_native_wnum {
+                            highest_native_wnum = wn;
+                            highest_native_win = win;
+                        }
+                    }
+                }
+
+                // Fallback: if wnum-based lookup missed (e.g. overlay_wnum==0 because
+                // the pre-hide scan ran before the NSWindow existed), use the newest
+                // NativeWidgetMacNSWindow (highest windowNumber = most recently created).
+                if overlay_win.is_null() && !highest_native_win.is_null() {
+                    overlay_win = highest_native_win;
+                    tracing::info!(
+                        label = %self.label, retry = self.retry,
+                        overlay_wnum = self.overlay_wnum, highest_native_wnum,
+                        "[browser-pane] ObjC task: falling back to highest-wnum NativeWidgetMacNSWindow"
+                    );
                 }
 
                 if overlay_win.is_null() {
                     if self.retry < 5 {
                         tracing::info!(
-                            label = %self.label, retry = self.retry, win_count,
-                            "[browser-pane] ObjC: overlay NSWindow not yet visible, retrying"
+                            label = %self.label, retry = self.retry,
+                            "[browser-pane] ObjC task: no NativeWidgetMacNSWindow found after set_visible(1), retrying"
                         );
                         post_set_pane_bounds_views(
                             &self.state, &self.label, &self.window_label,
                             self.x, self.y, self.width, self.height,
-                            self.retry + 1,
+                            self.retry + 1, self.overlay_wnum,
                         );
                     } else {
-                        tracing::warn!(
-                            label = %self.label,
-                            "[browser-pane] ObjC: overlay NSWindow never appeared"
-                        );
+                        tracing::warn!(label = %self.label,
+                            "[browser-pane] ObjC task: no NativeWidgetMacNSWindow found after 5 retries");
                     }
                     return;
                 }
 
+                // Step 3: reaffirm the frame (set_visible(1) may have triggered a CEF
+                // layout pass that reset the native frame to the pre-creation default).
                 let main_frame = if !main_win.is_null() {
                     get_frame(main_win, sel_frame)
                 } else {
                     NSRect { origin: NSPoint { x: 0.0, y: 0.0 }, size: NSSize { w: 0.0, h: 0.0 } }
                 };
-
-                // Pane rect is in physical pixels; NSWindow uses points.
                 let scale = if !main_win.is_null() {
                     let s = get_f64(main_win, sel_backing_scale);
                     if s > 0.0 { s } else { 1.0 }
@@ -2079,9 +2141,6 @@ wrap_task! {
                 let pane_y = self.y as f64 / scale;
                 let pane_w = self.width  as f64 / scale;
                 let pane_h = self.height as f64 / scale;
-
-                // Window-client (top-left) → screen (bottom-left).
-                // agentmux is borderless so content rect == frame rect.
                 let screen_x = main_frame.origin.x + pane_x;
                 let screen_y = main_frame.origin.y + main_frame.size.h - pane_y - pane_h;
 
@@ -2089,27 +2148,101 @@ wrap_task! {
                     origin: NSPoint { x: screen_x, y: screen_y },
                     size:   NSSize  { w: pane_w, h: pane_h },
                 };
+
                 set_frame_d(overlay_win, sel_set_frame_d, target, 1u8);
-                order_front(overlay_win, sel_order_front, std::ptr::null_mut());
-
-                // Frame is committed — safe to show via CEF.
-                controller.set_visible(1);
-
                 let new_fr = get_frame(overlay_win, sel_frame);
                 tracing::info!(
                     label = %self.label, retry = self.retry, scale,
                     pane_x, pane_y, pane_w, pane_h, screen_x, screen_y,
                     main_x = main_frame.origin.x, main_y = main_frame.origin.y,
-                    main_w = main_frame.size.w,   main_h = main_frame.size.h,
+                    main_w = main_frame.size.w, main_h = main_frame.size.h,
                     req_w = self.width, req_h = self.height,
                     got_x = new_fr.origin.x, got_y = new_fr.origin.y,
-                    got_w = new_fr.size.w,   got_h = new_fr.size.h,
-                    "[browser-pane] ObjC overlay setFrame applied"
+                    got_w = new_fr.size.w, got_h = new_fr.size.h,
+                    "[browser-pane] ObjC task overlay setFrame reaffirmed"
                 );
+                // Export DIP coordinates for the set_bounds call after this block.
+                task_dip_x = pane_x as i32;
+                task_dip_y = pane_y as i32;
+                task_dip_w = pane_w as i32;
+                task_dip_h = pane_h as i32;
+                // Export window refs for post-set_bounds key restoration.
+                task_main_win    = main_win;
+                task_overlay_win = overlay_win;
+                task_sel_make_key_front = sel_make_key_front;
+                task_sel_order_front    = sel_order_front;
+                task_sel_key_window     = sel_key_window;
+            }
 
-                if let Some(main_browser) = self.state.get_browser(&self.window_label) {
-                    if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+            #[cfg(target_os = "macos")]
+            if let Some(main_browser) = self.state.get_browser(&self.window_label) {
+                if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+            }
+
+            // macOS: call controller.set_bounds() with DIP coordinates computed above.
+            // The root cause of the 0×0 reset is CEF's overlay_view_host.cc
+            // SetOverlayBounds() doing Intersect(window_view_->bounds()). At creation
+            // time the parent CefWindowView may have empty bounds, but by this deferred
+            // task the parent window IS fully laid out so the Intersect should preserve
+            // our desired rect. This commits the size in CEF's Views layer so subsequent
+            // layout passes no longer reset the NSWindow to 0×0.
+            #[cfg(target_os = "macos")]
+            if task_dip_w > 0 && task_dip_h > 0 {
+                use cef::Rect as CefRect;
+                let dip = CefRect { x: task_dip_x, y: task_dip_y, width: task_dip_w, height: task_dip_h };
+                controller.set_bounds(Some(&dip));
+                let b = controller.bounds();
+                tracing::info!(
+                    label = %self.label, retry = self.retry,
+                    dip_x = task_dip_x, dip_y = task_dip_y,
+                    dip_w = task_dip_w, dip_h = task_dip_h,
+                    readback_x = b.x, readback_y = b.y,
+                    readback_w = b.width, readback_h = b.height,
+                    "[browser-pane] controller.set_bounds (post-ObjC) and readback"
+                );
+            }
+
+            // macOS: after set_bounds(), restore key to the main window so sidebar
+            // clicks work, then bring the overlay to front so the pane is visible.
+            // Known limitation: this leaves the overlay NSWindow non-KEY, which
+            // means Chromium's renderer in the pane does not receive mouseDown
+            // events (only scroll wheel, which bypasses key-window checks). Fixing
+            // pane click routing requires either acceptsFirstMouse:YES on the
+            // overlay's content view or a different focus strategy — tracked as a
+            // follow-up after this PR.
+            #[cfg(target_os = "macos")]
+            if !task_main_win.is_null() || !task_overlay_win.is_null() {
+                unsafe {
+                    type Id  = *mut std::ffi::c_void;
+                    type Sel = *const std::ffi::c_void;
+                    extern "C" { fn objc_msgSend(); }
+                    let make_key_front: extern "C" fn(Id, Sel, Id) = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                    let order_front:    extern "C" fn(Id, Sel, Id) = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                    if !task_main_win.is_null() && !task_sel_make_key_front.is_null() {
+                        make_key_front(task_main_win, task_sel_make_key_front, std::ptr::null_mut());
+                    }
+                    if !task_overlay_win.is_null() && !task_sel_order_front.is_null() {
+                        order_front(task_overlay_win, task_sel_order_front, std::ptr::null_mut());
+                    }
                 }
+            }
+
+            // macOS: post a delayed reaffirm on the first run. CEF's Widget::Show()
+            // (called inside set_visible(1) above) schedules a deferred Views layout
+            // that fires AFTER this task and resets the NSWindow frame to 0×0. The
+            // 50ms delayed retry runs after all pending layouts have completed and
+            // re-applies the correct frame — at that point it stays permanently.
+            #[cfg(target_os = "macos")]
+            if self.retry == 0 {
+                let mut reaffirm = SetPaneBoundsViewsTask::new(
+                    self.state.clone(),
+                    self.label.clone(),
+                    self.window_label.clone(),
+                    self.x, self.y, self.width, self.height,
+                    1, // retry=1: skip set_visible(1), just reaffirm frame
+                    self.overlay_wnum,
+                );
+                post_delayed_task(ThreadId::UI, Some(&mut reaffirm), 50);
             }
         }
     }
@@ -2125,6 +2258,7 @@ pub fn post_set_pane_bounds_views(
     width: i32,
     height: i32,
     retry: u32,
+    overlay_wnum: isize,
 ) {
     let mut task = SetPaneBoundsViewsTask::new(
         state.clone(),
@@ -2135,6 +2269,7 @@ pub fn post_set_pane_bounds_views(
         width,
         height,
         retry,
+        overlay_wnum,
     );
     post_task(ThreadId::UI, Some(&mut task));
 }

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -2086,13 +2086,20 @@ wrap_task! {
                     std::ptr::null_mut()
                 };
 
+                // Determine desired final visibility before any NSWindow mutation.
+                // Consulted again after setFrame to restore the correct state.
+                let should_be_visible = {
+                    let pane_rect = (self.x, self.y, self.width, self.height);
+                    crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, pane_rect)
+                };
+
                 // Step 1 (retry=0 only): snapshot which NativeWidgetMacNSWindows
                 // exist BEFORE calling set_visible(1).  Our overlay's NSWindow is
-                // created asynchronously and was hidden via set_visible(0) at
-                // creation; set_visible(1) calls [NSWindow orderFront:] which adds
-                // it back to [NSApp windows].  Comparing before vs after gives the
-                // exact wnum for this pane — safe even with multiple panes open
-                // because the CEF UI thread is single-threaded.
+                // created lazily on first show; set_visible(1) calls
+                // [NSWindow orderFront:] which adds it to [NSApp windows].
+                // Comparing before vs after gives the exact wnum for this pane —
+                // safe even with multiple panes open because the CEF UI thread is
+                // single-threaded.
                 let mut pre_wnums: Vec<isize> = Vec::new();
                 if self.retry == 0 {
                     let pre_wins: Id     = get_id(ns_app, sel_windows_arr);
@@ -2111,18 +2118,22 @@ wrap_task! {
                     }
                 }
 
-                // Step 2: show the overlay on the first run only, but only if
-                // compute_pane_visible agrees — an overlay-clip or zero-area rect
-                // queued between creation and this task (e.g. a modal appeared, or
-                // an inactive-tab resize sent a 0×0 rect) must not be overridden.
-                let mut did_set_visible = false;
-                if self.retry == 0 {
-                    let pane_rect = (self.x, self.y, self.width, self.height);
-                    if crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, pane_rect) {
-                        controller.set_visible(1);
-                        did_set_visible = true;
-                    }
-                }
+                // Step 2: ALWAYS call set_visible(1) before scanning [NSApp
+                // windows].
+                //
+                // At retry=0: forces NSWindow creation (it is created lazily on
+                // first show) and enables delta-detection — even when the pane
+                // should ultimately be hidden, we need the NSWindow to exist so
+                // setFrame can be committed and resize_browser_pane_view can find
+                // it later.
+                //
+                // At retry>=1: the NSWindow already exists but may be hidden (if
+                // the pane was created while hidden).  Hidden windows may not
+                // appear in [NSApp windows] so wnum-based lookup would fail.
+                // Temporarily showing it ensures reliable matching.
+                //
+                // In both cases we restore the correct visibility AFTER setFrame.
+                controller.set_visible(1);
 
                 // Step 3: rescan [NSApp windows] AFTER set_visible(1) to find the
                 // overlay and main window.
@@ -2194,17 +2205,6 @@ wrap_task! {
                 }
 
                 if overlay_win.is_null() {
-                    if self.retry == 0 && !did_set_visible {
-                        // Pane was hidden at retry=0 (compute_pane_visible=false).
-                        // No frame work needed here — resize_browser_pane_view handles
-                        // visibility when the pane is eventually shown.  Skip retry=1
-                        // too: there is nothing to reaffirm for a hidden pane.
-                        tracing::info!(
-                            label = %self.label,
-                            "[browser-pane] ObjC task: pane hidden at retry=0, skipping frame commit and retry"
-                        );
-                        return;
-                    }
                     if self.retry < 5 {
                         tracing::info!(
                             label = %self.label, retry = self.retry,
@@ -2254,31 +2254,27 @@ wrap_task! {
                     if s > 0.0 { s } else { 1.0 }
                 };
 
-                // Coordinate source depends on retry and what the controller holds:
+                // Coordinate source:
                 //
-                //  retry=0, cb=0×0  → creation-time physical pixels (set_size no-op on macOS)
-                //  retry=0, cb≠0×0  → resize_browser_pane_view ran before us and committed
-                //                      newer physical pixels via set_size/set_position;
-                //                      use those to avoid rolling back to stale creation rect
-                //  retry≥1, cb≠0×0  → controller.set_bounds() at retry=0 stored DIP;
-                //                      do NOT divide by scale again
-                //  retry≥1, cb=0×0  → set_bounds didn't take; fall back to creation rect
+                //  retry=1, cb≠0×0  → controller.set_bounds() at retry=0 stored DIP;
+                //                      re-use as-is (no scale division — it's already
+                //                      in NSWindow points).
+                //  all other cases  → self.x/y/width/height are physical pixels from
+                //                      the IPC rect; divide by backingScaleFactor.
+                //                      Do NOT fall back to controller.bounds() here:
+                //                      set_size/set_position are no-ops on macOS so
+                //                      controller.bounds() at retry=0 reflects a stale
+                //                      set_bounds() DIP, not a physical-pixel resize —
+                //                      using it would cause a double-scale division.
                 let (pane_x, pane_y, pane_w, pane_h) = {
                     let cb = controller.bounds();
-                    if self.retry >= 1 && cb.width > 0 && cb.height > 0 {
-                        // DIP from set_bounds — no scale division.
+                    if self.retry == 1 && cb.width > 0 && cb.height > 0 {
+                        // DIP from set_bounds() committed at retry=0; no scale division.
                         (cb.x as f64, cb.y as f64, cb.width as f64, cb.height as f64)
                     } else {
-                        // Physical pixels → NSWindow points.
-                        // Prefer an updated controller rect (from intervening resize);
-                        // fall back to creation-time values if controller still reads 0×0.
-                        let (px, py, pw, ph) = if cb.width > 0 && cb.height > 0 {
-                            (cb.x, cb.y, cb.width, cb.height)
-                        } else {
-                            (self.x, self.y, self.width, self.height)
-                        };
-                        (px as f64 / scale, py as f64 / scale,
-                         pw as f64 / scale, ph as f64 / scale)
+                        // Physical pixels from task rect → NSWindow points.
+                        (self.x as f64 / scale, self.y as f64 / scale,
+                         self.width as f64 / scale, self.height as f64 / scale)
                     }
                 };
                 let screen_x = main_frame.origin.x + pane_x;
@@ -2306,19 +2302,24 @@ wrap_task! {
                 task_dip_y = pane_y as i32;
                 task_dip_w = pane_w as i32;
                 task_dip_h = pane_h as i32;
-                // Restore key to main window then bring overlay to front so the
-                // pane is visible and sidebar clicks continue to work.
-                if !main_win.is_null() {
-                    make_key_front(main_win, sel_make_key_front, std::ptr::null_mut());
-                }
-                if !overlay_win.is_null() {
-                    order_front(overlay_win, sel_order_front, std::ptr::null_mut());
+                // Restore key to main window and bring overlay to front.
+                // Only do this when the pane should be visible — for hidden
+                // panes we skip focus/ordering since set_visible(0) will follow.
+                if should_be_visible {
+                    if !main_win.is_null() {
+                        make_key_front(main_win, sel_make_key_front, std::ptr::null_mut());
+                    }
+                    if !overlay_win.is_null() {
+                        order_front(overlay_win, sel_order_front, std::ptr::null_mut());
+                    }
                 }
             }
 
             #[cfg(target_os = "macos")]
-            if let Some(main_browser) = self.state.get_browser(&self.window_label) {
-                if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+            if should_be_visible {
+                if let Some(main_browser) = self.state.get_browser(&self.window_label) {
+                    if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+                }
             }
 
             // macOS: call controller.set_bounds() with DIP coordinates computed above.
@@ -2344,6 +2345,25 @@ wrap_task! {
                 );
             }
 
+            // macOS: restore correct visibility after setFrame.  We always
+            // called set_visible(1) before scanning to surface the NSWindow
+            // (necessary for hidden panes created while compute_pane_visible
+            // returned false, or for retry>=1 where the window may not appear
+            // in [NSApp windows] when hidden).  Now that the frame is
+            // committed, hide it again if the pane should not be visible.
+            #[cfg(target_os = "macos")]
+            if !should_be_visible {
+                controller.set_visible(0);
+            }
+
+            // macOS: store the discovered wnum so resize_browser_pane_view
+            // can post a reaffirm task with an exact wnum match.
+            #[cfg(target_os = "macos")]
+            if discovered_wnum > 0 {
+                self.state.browser_pane_overlay_wnums.lock()
+                    .insert(self.label.clone(), discovered_wnum);
+            }
+
             // macOS: post a delayed reaffirm on the first run. CEF's Widget::Show()
             // (called inside set_visible(1) above) schedules a deferred Views layout
             // that fires AFTER this task and resets the NSWindow frame to 0×0. The
@@ -2359,7 +2379,7 @@ wrap_task! {
                     self.label.clone(),
                     self.window_label.clone(),
                     self.x, self.y, self.width, self.height,
-                    1, // retry=1: skip set_visible(1), just reaffirm frame
+                    1, // retry=1: reaffirm frame after CEF layout pass
                     discovered_wnum,
                 );
                 post_delayed_task(ThreadId::UI, Some(&mut reaffirm), 50);

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1955,8 +1955,14 @@ wrap_task! {
             // frame reaffirm instead of using the stale creation-time self.x/y/w/h.
             #[cfg(not(target_os = "macos"))]
             {
-                controller.set_size(Some(&Size { width: self.width, height: self.height }));
-                controller.set_position(Some(&Point { x: self.x, y: self.y }));
+                // Only apply creation-time bounds if no resize has occurred yet.
+                // A browser_pane_resize queued between creation and this task
+                // already updated the controller; overwriting it would roll back.
+                let cb = controller.bounds();
+                if cb.width == 0 && cb.height == 0 {
+                    controller.set_size(Some(&Size { width: self.width, height: self.height }));
+                    controller.set_position(Some(&Point { x: self.x, y: self.y }));
+                }
             }
             #[cfg(target_os = "macos")]
             if self.retry == 0 {
@@ -1986,10 +1992,13 @@ wrap_task! {
                 "[browser-pane] views: SetPaneBoundsViewsTask: CEF bounds (macos)"
             );
 
-            // Linux: CEF Views sizing works; show immediately.
+            // Linux: CEF Views sizing works; show immediately if pane is visible.
             #[cfg(not(target_os = "macos"))]
             {
-                controller.set_visible(1);
+                let pane_rect = (self.x, self.y, self.width, self.height);
+                if crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, pane_rect) {
+                    controller.set_visible(1);
+                }
                 if let Some(main_browser) = self.state.get_browser(&self.window_label) {
                     if let Some(mut host) = main_browser.host() { host.set_focus(1); }
                 }
@@ -2006,16 +2015,6 @@ wrap_task! {
             // The ObjC block additionally sets the NSWindow frame directly.
             #[cfg(target_os = "macos")]
             let (mut task_dip_x, mut task_dip_y, mut task_dip_w, mut task_dip_h) = (0i32, 0i32, 0i32, 0i32);
-            #[cfg(target_os = "macos")]
-            let mut task_main_win:    *mut std::ffi::c_void = std::ptr::null_mut();
-            #[cfg(target_os = "macos")]
-            let mut task_overlay_win: *mut std::ffi::c_void = std::ptr::null_mut();
-            #[cfg(target_os = "macos")]
-            let mut task_sel_make_key_front: *const std::ffi::c_void = std::ptr::null();
-            #[cfg(target_os = "macos")]
-            let mut task_sel_order_front:    *const std::ffi::c_void = std::ptr::null();
-            #[cfg(target_os = "macos")]
-            let mut task_sel_key_window:     *const std::ffi::c_void = std::ptr::null();
 
             #[cfg(target_os = "macos")]
             unsafe {
@@ -2041,7 +2040,6 @@ wrap_task! {
                 let sel_frame         = sel_registerName(b"frame\0".as_ptr() as _);
                 let sel_is_main       = sel_registerName(b"isMainWindow\0".as_ptr() as _);
                 let sel_is_key        = sel_registerName(b"isKeyWindow\0".as_ptr() as _);
-                let sel_key_window    = sel_registerName(b"keyWindow\0".as_ptr() as _);
                 let sel_backing_scale = sel_registerName(b"backingScaleFactor\0".as_ptr() as _);
                 let sel_set_frame_d   = sel_registerName(b"setFrame:display:\0".as_ptr() as _);
                 let sel_make_key_front = sel_registerName(b"makeKeyAndOrderFront:\0".as_ptr() as _);
@@ -2156,6 +2154,19 @@ wrap_task! {
                         label = %self.label, retry = self.retry,
                         "[browser-pane] ObjC task: main CefNSWindow not found — cannot compute screen coords, skipping frame commit"
                     );
+                    // Roll back set_visible so the overlay doesn't sit visible
+                    // but unpositioned. Post a retry so placement completes once
+                    // the main window appears.
+                    if self.retry == 0 {
+                        controller.set_visible(0);
+                    }
+                    if self.retry < 5 {
+                        post_set_pane_bounds_views(
+                            &self.state, &self.label, &self.window_label,
+                            self.x, self.y, self.width, self.height,
+                            self.retry + 1, self.overlay_wnum,
+                        );
+                    }
                     return;
                 }
                 let main_frame = get_frame(main_win, sel_frame);
@@ -2205,12 +2216,14 @@ wrap_task! {
                 task_dip_y = pane_y as i32;
                 task_dip_w = pane_w as i32;
                 task_dip_h = pane_h as i32;
-                // Export window refs for post-set_bounds key restoration.
-                task_main_win    = main_win;
-                task_overlay_win = overlay_win;
-                task_sel_make_key_front = sel_make_key_front;
-                task_sel_order_front    = sel_order_front;
-                task_sel_key_window     = sel_key_window;
+                // Restore key to main window then bring overlay to front so the
+                // pane is visible and sidebar clicks continue to work.
+                if !main_win.is_null() {
+                    make_key_front(main_win, sel_make_key_front, std::ptr::null_mut());
+                }
+                if !overlay_win.is_null() {
+                    order_front(overlay_win, sel_order_front, std::ptr::null_mut());
+                }
             }
 
             #[cfg(target_os = "macos")]
@@ -2239,31 +2252,6 @@ wrap_task! {
                     readback_w = b.width, readback_h = b.height,
                     "[browser-pane] controller.set_bounds (post-ObjC) and readback"
                 );
-            }
-
-            // macOS: after set_bounds(), restore key to the main window so sidebar
-            // clicks work, then bring the overlay to front so the pane is visible.
-            // Known limitation: this leaves the overlay NSWindow non-KEY, which
-            // means Chromium's renderer in the pane does not receive mouseDown
-            // events (only scroll wheel, which bypasses key-window checks). Fixing
-            // pane click routing requires either acceptsFirstMouse:YES on the
-            // overlay's content view or a different focus strategy — tracked as a
-            // follow-up after this PR.
-            #[cfg(target_os = "macos")]
-            if !task_main_win.is_null() || !task_overlay_win.is_null() {
-                unsafe {
-                    type Id  = *mut std::ffi::c_void;
-                    type Sel = *const std::ffi::c_void;
-                    extern "C" { fn objc_msgSend(); }
-                    let make_key_front: extern "C" fn(Id, Sel, Id) = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                    let order_front:    extern "C" fn(Id, Sel, Id) = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
-                    if !task_main_win.is_null() && !task_sel_make_key_front.is_null() {
-                        make_key_front(task_main_win, task_sel_make_key_front, std::ptr::null_mut());
-                    }
-                    if !task_overlay_win.is_null() && !task_sel_order_front.is_null() {
-                        order_front(task_overlay_win, task_sel_order_front, std::ptr::null_mut());
-                    }
-                }
             }
 
             // macOS: post a delayed reaffirm on the first run. CEF's Widget::Show()

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1891,3 +1891,90 @@ pub fn post_resize_mother_window_win32(state: &Arc<AppState>, hwnd: isize, new_w
     let mut task = ResizeMotherWindowWin32Task::new(state.clone(), hwnd, new_w_dip);
     post_task(ThreadId::UI, Some(&mut task));
 }
+
+// ── Deferred overlay bounds + show (non-Windows / CEF Views panes) ──────────
+//
+// On macOS, add_overlay_view creates the overlay's native NSView asynchronously.
+// set_size / set_position / layout() called synchronously after add_overlay_view
+// silently no-op because the native layer doesn't exist yet — the readback shows
+// oc_w=0, oc_h=0. Without committed bounds the overlay defaults to filling the
+// entire parent window, covering the UI with the pane's opaque-black background
+// and intercepting all mouse events (the "black screen + UI freeze" bug).
+//
+// This task runs on the next UI event-loop tick, after CEF has completed native
+// view creation, and re-applies the desired bounds before making the overlay
+// visible. It also re-issues set_focus(1) on the main browser to handle any
+// focus steal that may have occurred during the intervening tick.
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct SetPaneBoundsViewsTask {
+        state: Arc<AppState>,
+        label: String,
+        window_label: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let entry = self.state.browser_pane_overlays.lock().get(&self.label).cloned();
+            let Some((_, controller)) = entry else {
+                tracing::warn!(
+                    label = %self.label,
+                    "[browser-pane] views: SetPaneBoundsViewsTask: no OverlayController — pane already closed?"
+                );
+                return;
+            };
+
+            controller.set_size(Some(&Size { width: self.width, height: self.height }));
+            controller.set_position(Some(&Point { x: self.x, y: self.y }));
+
+            if let Some(window) = self.state.windows.lock().get(&self.window_label).cloned() {
+                window.layout();
+            }
+
+            controller.set_visible(1);
+
+            // Return focus to the main window. Focus may have been stolen during
+            // the tick between pane creation and this task.
+            if let Some(main_browser) = self.state.get_browser(&self.window_label) {
+                if let Some(mut host) = main_browser.host() {
+                    host.set_focus(1);
+                }
+            }
+
+            let b = controller.bounds();
+            tracing::info!(
+                label = %self.label,
+                window_label = %self.window_label,
+                req_x = self.x, req_y = self.y, req_w = self.width, req_h = self.height,
+                got_x = b.x, got_y = b.y, got_w = b.width, got_h = b.height,
+                "[browser-pane] views: SetPaneBoundsViewsTask: bounds after deferred apply"
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn post_set_pane_bounds_views(
+    state: &Arc<AppState>,
+    label: &str,
+    window_label: &str,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+) {
+    let mut task = SetPaneBoundsViewsTask::new(
+        state.clone(),
+        label.to_string(),
+        window_label.to_string(),
+        x,
+        y,
+        width,
+        height,
+    );
+    post_task(ThreadId::UI, Some(&mut task));
+}

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -2233,12 +2233,11 @@ wrap_task! {
                         label = %self.label, retry = self.retry,
                         "[browser-pane] ObjC task: main CefNSWindow not found — cannot compute screen coords, skipping frame commit"
                     );
-                    // Roll back set_visible so the overlay doesn't sit visible
-                    // but unpositioned. Post a retry so placement completes once
-                    // the main window appears.
-                    if self.retry == 0 {
-                        controller.set_visible(0);
-                    }
+                    // Roll back the unconditional set_visible(1) issued at
+                    // Step 2 so the overlay doesn't sit visible but unpositioned.
+                    // Apply at all retries — not just retry=0 — because Step 2
+                    // now calls set_visible(1) unconditionally.
+                    controller.set_visible(0);
                     if self.retry < 5 {
                         post_set_pane_bounds_views(
                             &self.state, &self.label, &self.window_label,

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -2013,6 +2013,11 @@ wrap_task! {
             // to produce 0×0. From this deferred task the parent window IS fully laid out,
             // so set_bounds() should succeed and commit the bounds in CEF's Views layer.
             // The ObjC block additionally sets the NSWindow frame directly.
+            // Wnum of the overlay NSWindow, discovered at retry=0 by delta-detection
+            // (snapshot before/after set_visible) and forwarded to the retry=1 task.
+            #[cfg(target_os = "macos")]
+            let mut discovered_wnum: isize = 0;
+
             #[cfg(target_os = "macos")]
             let (mut task_dip_x, mut task_dip_y, mut task_dip_w, mut task_dip_h) = (0i32, 0i32, 0i32, 0i32);
 
@@ -2057,7 +2062,35 @@ wrap_task! {
                 let make_key_front: extern "C" fn(Id, Sel, Id)          = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
                 let order_front:    extern "C" fn(Id, Sel, Id)          = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
 
-                // Step 1: show the overlay on the first run only, but only if
+                let ns_app_class: Id = objc_getClass(b"NSApplication\0".as_ptr() as _);
+                let ns_app: Id       = get_id(ns_app_class, sel_shared_app);
+
+                // Step 1 (retry=0 only): snapshot which NativeWidgetMacNSWindows
+                // exist BEFORE calling set_visible(1).  Our overlay's NSWindow is
+                // created asynchronously and was hidden via set_visible(0) at
+                // creation; set_visible(1) calls [NSWindow orderFront:] which adds
+                // it back to [NSApp windows].  Comparing before vs after gives the
+                // exact wnum for this pane — safe even with multiple panes open
+                // because the CEF UI thread is single-threaded.
+                let mut pre_wnums: Vec<isize> = Vec::new();
+                if self.retry == 0 {
+                    let pre_wins: Id     = get_id(ns_app, sel_windows_arr);
+                    let pre_count: usize = if pre_wins.is_null() { 0 }
+                                           else { get_usize(pre_wins, sel_count) };
+                    for i in 0..pre_count {
+                        let win = obj_at(pre_wins, sel_obj_at, i);
+                        if win.is_null() { continue; }
+                        let cls_ptr = object_getClassName(win);
+                        let cls = if !cls_ptr.is_null() {
+                            std::ffi::CStr::from_ptr(cls_ptr).to_str().unwrap_or("?")
+                        } else { "?" };
+                        if cls.contains("NativeWidgetMacNSWindow") {
+                            pre_wnums.push(get_isize(win, sel_win_number));
+                        }
+                    }
+                }
+
+                // Step 2: show the overlay on the first run only, but only if
                 // compute_pane_visible agrees — an overlay-clip or zero-area rect
                 // queued between creation and this task (e.g. a modal appeared, or
                 // an inactive-tab resize sent a 0×0 rect) must not be overridden.
@@ -2068,17 +2101,16 @@ wrap_task! {
                     }
                 }
 
-                // Step 2: rescan [NSApp windows] to find the overlay and main window.
-                let ns_app_class: Id = objc_getClass(b"NSApplication\0".as_ptr() as _);
-                let ns_app: Id       = get_id(ns_app_class, sel_shared_app);
+                // Step 3: rescan [NSApp windows] AFTER set_visible(1) to find the
+                // overlay and main window.
                 let all_wins: Id     = get_id(ns_app, sel_windows_arr);
                 let win_count: usize = if all_wins.is_null() { 0 }
                                        else { get_usize(all_wins, sel_count) };
 
                 let mut overlay_win: Id = std::ptr::null_mut();
                 let mut main_win:    Id = std::ptr::null_mut();
-                // Highest windowNumber among NativeWidgetMacNSWindows (for fallback
-                // when overlay_wnum is unknown — newest window = highest number).
+                // Highest windowNumber among NativeWidgetMacNSWindows — fallback for
+                // retry>=1 when self.overlay_wnum is still 0 (pane was hidden at retry=0).
                 let mut highest_native_wnum: isize = 0;
                 let mut highest_native_win: Id = std::ptr::null_mut();
 
@@ -2103,7 +2135,14 @@ wrap_task! {
                         main_win = win;
                     }
                     if cls.contains("NativeWidgetMacNSWindow") {
-                        if self.overlay_wnum > 0 && wn == self.overlay_wnum {
+                        // Primary at retry=0: delta detection — this wnum was not
+                        // present before set_visible(1), so it is our overlay.
+                        if self.retry == 0 && !pre_wnums.contains(&wn) {
+                            overlay_win = win;
+                            discovered_wnum = wn;
+                        }
+                        // Primary at retry>=1: exact wnum match from retry=0.
+                        if self.retry >= 1 && self.overlay_wnum > 0 && wn == self.overlay_wnum {
                             overlay_win = win;
                         }
                         if wn > highest_native_wnum {
@@ -2113,9 +2152,8 @@ wrap_task! {
                     }
                 }
 
-                // Fallback: if wnum-based lookup missed (e.g. overlay_wnum==0 because
-                // the pre-hide scan ran before the NSWindow existed), use the newest
-                // NativeWidgetMacNSWindow (highest windowNumber = most recently created).
+                // Fallback: delta/wnum match missed (pane hidden at retry=0, or
+                // wnum still 0 at retry>=1).  Use newest NativeWidgetMacNSWindow.
                 if overlay_win.is_null() && !highest_native_win.is_null() {
                     overlay_win = highest_native_win;
                     tracing::info!(
@@ -2175,22 +2213,22 @@ wrap_task! {
                     if s > 0.0 { s } else { 1.0 }
                 };
 
-                // At retry>=1 prefer the controller's current CEF bounds (which
-                // reflect any resize queued between creation and this task) over
-                // the stale creation-time self.x/y/width/height. Fall back to
-                // creation-time values only if the controller still reports 0×0.
-                let (src_x, src_y, src_w, src_h) = {
+                // At retry>=1 the controller holds the DIP values committed by
+                // controller.set_bounds() at retry=0.  Do NOT divide by scale
+                // again — those values are already NSWindow points.  The creation-
+                // time self.x/y/width/height are physical pixels and DO need the
+                // division; use them only at retry=0 or when controller reads back 0×0.
+                let (pane_x, pane_y, pane_w, pane_h) = {
                     let cb = controller.bounds();
-                    if cb.width > 0 && cb.height > 0 && self.retry >= 1 {
-                        (cb.x, cb.y, cb.width, cb.height)
+                    if self.retry >= 1 && cb.width > 0 && cb.height > 0 {
+                        // Already DIP/points — no scale division.
+                        (cb.x as f64, cb.y as f64, cb.width as f64, cb.height as f64)
                     } else {
-                        (self.x, self.y, self.width, self.height)
+                        // Physical pixels → NSWindow points.
+                        (self.x as f64 / scale, self.y as f64 / scale,
+                         self.width as f64 / scale, self.height as f64 / scale)
                     }
                 };
-                let pane_x = src_x as f64 / scale;
-                let pane_y = src_y as f64 / scale;
-                let pane_w = src_w as f64 / scale;
-                let pane_h = src_h as f64 / scale;
                 let screen_x = main_frame.origin.x + pane_x;
                 let screen_y = main_frame.origin.y + main_frame.size.h - pane_y - pane_h;
 
@@ -2261,13 +2299,16 @@ wrap_task! {
             // re-applies the correct frame — at that point it stays permanently.
             #[cfg(target_os = "macos")]
             if self.retry == 0 {
+                // Pass the wnum discovered by delta-detection above so retry=1
+                // can find the overlay by exact match instead of falling back to
+                // "highest NativeWidgetMacNSWindow" (which fails with ≥2 panes).
                 let mut reaffirm = SetPaneBoundsViewsTask::new(
                     self.state.clone(),
                     self.label.clone(),
                     self.window_label.clone(),
                     self.x, self.y, self.width, self.height,
                     1, // retry=1: skip set_visible(1), just reaffirm frame
-                    self.overlay_wnum,
+                    discovered_wnum,
                 );
                 post_delayed_task(ThreadId::UI, Some(&mut reaffirm), 50);
             }

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -2013,6 +2013,7 @@ wrap_task! {
             // to produce 0×0. From this deferred task the parent window IS fully laid out,
             // so set_bounds() should succeed and commit the bounds in CEF's Views layer.
             // The ObjC block additionally sets the NSWindow frame directly.
+
             // Wnum of the overlay NSWindow, discovered at retry=0 by delta-detection
             // (snapshot before/after set_visible) and forwarded to the retry=1 task.
             #[cfg(target_os = "macos")]
@@ -2020,6 +2021,15 @@ wrap_task! {
 
             #[cfg(target_os = "macos")]
             let (mut task_dip_x, mut task_dip_y, mut task_dip_w, mut task_dip_h) = (0i32, 0i32, 0i32, 0i32);
+
+            // Obtain the NSView* for our parent window so we can identify its
+            // CefNSWindow by pointer rather than relying on isMainWindow (which
+            // fails when a secondary/floating CefNSWindow is main).
+            #[cfg(target_os = "macos")]
+            let parent_nsview: *mut std::ffi::c_void = self.state.windows.lock()
+                .get(&self.window_label)
+                .map(|w| w.window_handle() as *mut std::ffi::c_void)
+                .unwrap_or(std::ptr::null_mut());
 
             #[cfg(target_os = "macos")]
             unsafe {
@@ -2050,6 +2060,7 @@ wrap_task! {
                 let sel_make_key_front = sel_registerName(b"makeKeyAndOrderFront:\0".as_ptr() as _);
                 let sel_order_front    = sel_registerName(b"orderFront:\0".as_ptr() as _);
                 let sel_win_number     = sel_registerName(b"windowNumber\0".as_ptr() as _);
+                let sel_win_of_view    = sel_registerName(b"window\0".as_ptr() as _);
 
                 let get_id:         extern "C" fn(Id, Sel) -> Id        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
                 let get_usize:      extern "C" fn(Id, Sel) -> usize     = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
@@ -2064,6 +2075,16 @@ wrap_task! {
 
                 let ns_app_class: Id = objc_getClass(b"NSApplication\0".as_ptr() as _);
                 let ns_app: Id       = get_id(ns_app_class, sel_shared_app);
+
+                // Resolve the CefNSWindow for self.window_label via the NSView*
+                // obtained from CefWindow::window_handle(). This is more reliable
+                // than isMainWindow, which misidentifies the parent when a secondary
+                // or floating CefNSWindow currently holds the main-window status.
+                let expected_main_nswin: Id = if !parent_nsview.is_null() {
+                    get_id(parent_nsview, sel_win_of_view)
+                } else {
+                    std::ptr::null_mut()
+                };
 
                 // Step 1 (retry=0 only): snapshot which NativeWidgetMacNSWindows
                 // exist BEFORE calling set_visible(1).  Our overlay's NSWindow is
@@ -2094,10 +2115,12 @@ wrap_task! {
                 // compute_pane_visible agrees — an overlay-clip or zero-area rect
                 // queued between creation and this task (e.g. a modal appeared, or
                 // an inactive-tab resize sent a 0×0 rect) must not be overridden.
+                let mut did_set_visible = false;
                 if self.retry == 0 {
                     let pane_rect = (self.x, self.y, self.width, self.height);
                     if crate::browser_panes::compute_pane_visible(&self.state, &self.window_label, pane_rect) {
                         controller.set_visible(1);
+                        did_set_visible = true;
                     }
                 }
 
@@ -2131,7 +2154,12 @@ wrap_task! {
                         is_main, is_key, wn, want_wnum = self.overlay_wnum,
                         "[browser-pane] ObjC task NSApp window"
                     );
-                    if cls.contains("CefNSWindow") && is_main != 0 {
+                    // Identify the main window: prefer handle-based match for
+                    // self.window_label; isMainWindow is a fallback for the rare
+                    // case where the CefWindow handle isn't available yet.
+                    if !expected_main_nswin.is_null() && win == expected_main_nswin {
+                        main_win = win;
+                    } else if expected_main_nswin.is_null() && cls.contains("CefNSWindow") && is_main != 0 {
                         main_win = win;
                     }
                     if cls.contains("NativeWidgetMacNSWindow") {
@@ -2152,9 +2180,11 @@ wrap_task! {
                     }
                 }
 
-                // Fallback: delta/wnum match missed (pane hidden at retry=0, or
-                // wnum still 0 at retry>=1).  Use newest NativeWidgetMacNSWindow.
-                if overlay_win.is_null() && !highest_native_win.is_null() {
+                // Fallback: ONLY at retry>=1 (wnum known from retry=0 but window
+                // wasn't found by exact match — edge case). At retry=0, applying
+                // the fallback would grab another pane's window when set_visible(1)
+                // was skipped (hidden pane) and there are ≥2 panes open.
+                if overlay_win.is_null() && !highest_native_win.is_null() && self.retry >= 1 {
                     overlay_win = highest_native_win;
                     tracing::info!(
                         label = %self.label, retry = self.retry,
@@ -2164,10 +2194,21 @@ wrap_task! {
                 }
 
                 if overlay_win.is_null() {
+                    if self.retry == 0 && !did_set_visible {
+                        // Pane was hidden at retry=0 (compute_pane_visible=false).
+                        // No frame work needed here — resize_browser_pane_view handles
+                        // visibility when the pane is eventually shown.  Skip retry=1
+                        // too: there is nothing to reaffirm for a hidden pane.
+                        tracing::info!(
+                            label = %self.label,
+                            "[browser-pane] ObjC task: pane hidden at retry=0, skipping frame commit and retry"
+                        );
+                        return;
+                    }
                     if self.retry < 5 {
                         tracing::info!(
                             label = %self.label, retry = self.retry,
-                            "[browser-pane] ObjC task: no NativeWidgetMacNSWindow found after set_visible(1), retrying"
+                            "[browser-pane] ObjC task: no NativeWidgetMacNSWindow found, retrying"
                         );
                         post_set_pane_bounds_views(
                             &self.state, &self.label, &self.window_label,
@@ -2213,20 +2254,31 @@ wrap_task! {
                     if s > 0.0 { s } else { 1.0 }
                 };
 
-                // At retry>=1 the controller holds the DIP values committed by
-                // controller.set_bounds() at retry=0.  Do NOT divide by scale
-                // again — those values are already NSWindow points.  The creation-
-                // time self.x/y/width/height are physical pixels and DO need the
-                // division; use them only at retry=0 or when controller reads back 0×0.
+                // Coordinate source depends on retry and what the controller holds:
+                //
+                //  retry=0, cb=0×0  → creation-time physical pixels (set_size no-op on macOS)
+                //  retry=0, cb≠0×0  → resize_browser_pane_view ran before us and committed
+                //                      newer physical pixels via set_size/set_position;
+                //                      use those to avoid rolling back to stale creation rect
+                //  retry≥1, cb≠0×0  → controller.set_bounds() at retry=0 stored DIP;
+                //                      do NOT divide by scale again
+                //  retry≥1, cb=0×0  → set_bounds didn't take; fall back to creation rect
                 let (pane_x, pane_y, pane_w, pane_h) = {
                     let cb = controller.bounds();
                     if self.retry >= 1 && cb.width > 0 && cb.height > 0 {
-                        // Already DIP/points — no scale division.
+                        // DIP from set_bounds — no scale division.
                         (cb.x as f64, cb.y as f64, cb.width as f64, cb.height as f64)
                     } else {
                         // Physical pixels → NSWindow points.
-                        (self.x as f64 / scale, self.y as f64 / scale,
-                         self.width as f64 / scale, self.height as f64 / scale)
+                        // Prefer an updated controller rect (from intervening resize);
+                        // fall back to creation-time values if controller still reads 0×0.
+                        let (px, py, pw, ph) = if cb.width > 0 && cb.height > 0 {
+                            (cb.x, cb.y, cb.width, cb.height)
+                        } else {
+                            (self.x, self.y, self.width, self.height)
+                        };
+                        (px as f64 / scale, py as f64 / scale,
+                         pw as f64 / scale, ph as f64 / scale)
                     }
                 };
                 let screen_x = main_frame.origin.x + pane_x;

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1905,6 +1905,16 @@ pub fn post_resize_mother_window_win32(state: &Arc<AppState>, hwnd: isize, new_w
 // view creation, and re-applies the desired bounds before making the overlay
 // visible. It also re-issues set_focus(1) on the main browser to handle any
 // focus steal that may have occurred during the intervening tick.
+//
+// On macOS, CefOverlayController::SetSize/SetPosition are permanent no-ops —
+// the underlying NativeWidgetMacNSWindow (a CEF-internal popup NSWindow) is
+// never resized via the CEF Views API. We detect and size it directly through
+// Objective-C: enumerate [NSApplication sharedApplication].windows, identify
+// the NativeWidgetMacNSWindow overlay (the last non-key non-main NSWindow),
+// and call [overlayWindow setFrame:display:YES] with correct screen coords.
+// Pane coords from the frontend are physical pixels; NSWindow setFrame: uses
+// points, so we divide by [mainWindow backingScaleFactor] (2.0 on Retina).
+// set_visible(1) is called ONLY after the frame is committed.
 #[cfg(not(target_os = "windows"))]
 wrap_task! {
     pub struct SetPaneBoundsViewsTask {
@@ -1915,10 +1925,15 @@ wrap_task! {
         y: i32,
         width: i32,
         height: i32,
+        retry: u32,
     }
 
     impl Task {
         fn execute(&self) {
+            // Guard: if the pane was closed before this task fired, bail.
+            // The UI-thread FIFO ordering guarantees detach always runs before
+            // this deferred task (close posts its own UI task which precedes ours
+            // in the queue when initiated before this task was scheduled).
             let entry = self.state.browser_pane_overlays.lock().get(&self.label).cloned();
             let Some((_, controller)) = entry else {
                 tracing::warn!(
@@ -1928,31 +1943,174 @@ wrap_task! {
                 return;
             };
 
+            // CEF Views sizing — no-ops on macOS, functional on Linux.
             controller.set_size(Some(&Size { width: self.width, height: self.height }));
             controller.set_position(Some(&Point { x: self.x, y: self.y }));
-
             if let Some(window) = self.state.windows.lock().get(&self.window_label).cloned() {
                 window.layout();
-            }
-
-            controller.set_visible(1);
-
-            // Return focus to the main window. Focus may have been stolen during
-            // the tick between pane creation and this task.
-            if let Some(main_browser) = self.state.get_browser(&self.window_label) {
-                if let Some(mut host) = main_browser.host() {
-                    host.set_focus(1);
-                }
             }
 
             let b = controller.bounds();
             tracing::info!(
                 label = %self.label,
-                window_label = %self.window_label,
-                req_x = self.x, req_y = self.y, req_w = self.width, req_h = self.height,
+                req_w = self.width, req_h = self.height,
                 got_x = b.x, got_y = b.y, got_w = b.width, got_h = b.height,
-                "[browser-pane] views: SetPaneBoundsViewsTask: bounds after deferred apply"
+                retry = self.retry,
+                "[browser-pane] views: SetPaneBoundsViewsTask: CEF bounds (macos)"
             );
+
+            // Linux: CEF Views sizing works; show immediately.
+            #[cfg(not(target_os = "macos"))]
+            {
+                controller.set_visible(1);
+                if let Some(main_browser) = self.state.get_browser(&self.window_label) {
+                    if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+                }
+                return;
+            }
+
+            // macOS: resize the NativeWidgetMacNSWindow directly via ObjC.
+            // set_visible(1) is called only after frame is committed below.
+            #[cfg(target_os = "macos")]
+            unsafe {
+                use std::ffi::c_char;
+                type Id  = *mut std::ffi::c_void;
+                type Sel = *const std::ffi::c_void;
+
+                extern "C" {
+                    fn sel_registerName(name: *const c_char) -> Sel;
+                    fn objc_msgSend();
+                    fn object_getClassName(obj: Id) -> *const c_char;
+                    fn objc_getClass(name: *const c_char) -> Id;
+                }
+
+                #[repr(C)] #[derive(Copy,Clone)] struct NSPoint { x: f64, y: f64 }
+                #[repr(C)] #[derive(Copy,Clone)] struct NSSize  { w: f64, h: f64 }
+                #[repr(C)] #[derive(Copy,Clone)] struct NSRect  { origin: NSPoint, size: NSSize }
+
+                let sel_shared_app    = sel_registerName(b"sharedApplication\0".as_ptr() as _);
+                let sel_windows_arr   = sel_registerName(b"windows\0".as_ptr() as _);
+                let sel_count         = sel_registerName(b"count\0".as_ptr() as _);
+                let sel_obj_at        = sel_registerName(b"objectAtIndex:\0".as_ptr() as _);
+                let sel_frame         = sel_registerName(b"frame\0".as_ptr() as _);
+                let sel_is_key        = sel_registerName(b"isKeyWindow\0".as_ptr() as _);
+                let sel_is_main       = sel_registerName(b"isMainWindow\0".as_ptr() as _);
+                let sel_backing_scale = sel_registerName(b"backingScaleFactor\0".as_ptr() as _);
+                // setFrame:display: — NSRect (4 doubles HFA → d0-d3) + BOOL (u8 → x2)
+                let sel_set_frame_d   = sel_registerName(b"setFrame:display:\0".as_ptr() as _);
+                let sel_order_front   = sel_registerName(b"orderFront:\0".as_ptr() as _);
+
+                let get_id:     extern "C" fn(Id, Sel) -> Id        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_usize:  extern "C" fn(Id, Sel) -> usize     = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_bool:   extern "C" fn(Id, Sel) -> u8        = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_f64:    extern "C" fn(Id, Sel) -> f64       = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let obj_at:     extern "C" fn(Id, Sel, usize) -> Id = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let get_frame:  extern "C" fn(Id, Sel) -> NSRect    = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let set_frame_d: extern "C" fn(Id, Sel, NSRect, u8) = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+                let order_front: extern "C" fn(Id, Sel, Id)         = std::mem::transmute(objc_msgSend as *const std::ffi::c_void);
+
+                // [BridgedContentView window] returns nil (CEF doesn't use the
+                // standard Cocoa contentView hierarchy), so enumerate all NSWindows
+                // in the process via NSApp.
+                let ns_app_class: Id = objc_getClass(b"NSApplication\0".as_ptr() as _);
+                let ns_app: Id       = get_id(ns_app_class, sel_shared_app);
+                let all_wins: Id     = get_id(ns_app, sel_windows_arr);
+                let win_count: usize = if all_wins.is_null() { 0 }
+                                       else { get_usize(all_wins, sel_count) };
+
+                let mut overlay_win: Id = std::ptr::null_mut();
+                let mut main_win: Id    = std::ptr::null_mut();
+
+                for i in 0..win_count {
+                    let win = obj_at(all_wins, sel_obj_at, i);
+                    if win.is_null() { continue; }
+                    let is_key  = get_bool(win, sel_is_key);
+                    let is_main = get_bool(win, sel_is_main);
+                    if self.retry == 0 {
+                        let cls_ptr = object_getClassName(win);
+                        let cls = if !cls_ptr.is_null() {
+                            std::ffi::CStr::from_ptr(cls_ptr).to_str().unwrap_or("?")
+                        } else { "?" };
+                        let fr = get_frame(win, sel_frame);
+                        tracing::info!(
+                            i, win_count, class = cls, retry = self.retry,
+                            x = fr.origin.x, y = fr.origin.y,
+                            w = fr.size.w, h = fr.size.h, is_key, is_main,
+                            "[browser-pane] ObjC NSApp window"
+                        );
+                    }
+                    if is_main != 0 || is_key != 0 { main_win = win; }
+                    else { overlay_win = win; }
+                }
+
+                if overlay_win.is_null() {
+                    if self.retry < 5 {
+                        tracing::info!(
+                            label = %self.label, retry = self.retry, win_count,
+                            "[browser-pane] ObjC: overlay NSWindow not yet visible, retrying"
+                        );
+                        post_set_pane_bounds_views(
+                            &self.state, &self.label, &self.window_label,
+                            self.x, self.y, self.width, self.height,
+                            self.retry + 1,
+                        );
+                    } else {
+                        tracing::warn!(
+                            label = %self.label,
+                            "[browser-pane] ObjC: overlay NSWindow never appeared"
+                        );
+                    }
+                    return;
+                }
+
+                let main_frame = if !main_win.is_null() {
+                    get_frame(main_win, sel_frame)
+                } else {
+                    NSRect { origin: NSPoint { x: 0.0, y: 0.0 }, size: NSSize { w: 0.0, h: 0.0 } }
+                };
+
+                // Pane rect is in physical pixels; NSWindow uses points.
+                let scale = if !main_win.is_null() {
+                    let s = get_f64(main_win, sel_backing_scale);
+                    if s > 0.0 { s } else { 1.0 }
+                } else { 1.0 };
+
+                let pane_x = self.x as f64 / scale;
+                let pane_y = self.y as f64 / scale;
+                let pane_w = self.width  as f64 / scale;
+                let pane_h = self.height as f64 / scale;
+
+                // Window-client (top-left) → screen (bottom-left).
+                // agentmux is borderless so content rect == frame rect.
+                let screen_x = main_frame.origin.x + pane_x;
+                let screen_y = main_frame.origin.y + main_frame.size.h - pane_y - pane_h;
+
+                let target = NSRect {
+                    origin: NSPoint { x: screen_x, y: screen_y },
+                    size:   NSSize  { w: pane_w, h: pane_h },
+                };
+                set_frame_d(overlay_win, sel_set_frame_d, target, 1u8);
+                order_front(overlay_win, sel_order_front, std::ptr::null_mut());
+
+                // Frame is committed — safe to show via CEF.
+                controller.set_visible(1);
+
+                let new_fr = get_frame(overlay_win, sel_frame);
+                tracing::info!(
+                    label = %self.label, retry = self.retry, scale,
+                    pane_x, pane_y, pane_w, pane_h, screen_x, screen_y,
+                    main_x = main_frame.origin.x, main_y = main_frame.origin.y,
+                    main_w = main_frame.size.w,   main_h = main_frame.size.h,
+                    req_w = self.width, req_h = self.height,
+                    got_x = new_fr.origin.x, got_y = new_fr.origin.y,
+                    got_w = new_fr.size.w,   got_h = new_fr.size.h,
+                    "[browser-pane] ObjC overlay setFrame applied"
+                );
+
+                if let Some(main_browser) = self.state.get_browser(&self.window_label) {
+                    if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+                }
+            }
         }
     }
 }
@@ -1966,6 +2124,7 @@ pub fn post_set_pane_bounds_views(
     y: i32,
     width: i32,
     height: i32,
+    retry: u32,
 ) {
     let mut task = SetPaneBoundsViewsTask::new(
         state.clone(),
@@ -1975,6 +2134,7 @@ pub fn post_set_pane_bounds_views(
         y,
         width,
         height,
+        retry,
     );
     post_task(ThreadId::UI, Some(&mut task));
 }

--- a/docs/analysis/RETRO_BROWSER_PANE_MACOS_FIX_2026_06_26.md
+++ b/docs/analysis/RETRO_BROWSER_PANE_MACOS_FIX_2026_06_26.md
@@ -1,0 +1,246 @@
+# Retro: Browser Pane Black Screen + Mouse Freeze — macOS ObjC Fix Attempt
+**Date:** 2026-06-26  
+**Branch:** `fix/browser-pane-deferred-bounds-macos`  
+**Status:** ✅ FIXED — browser pane renders correctly as of v17 (2026-06-26 18:36)
+
+---
+
+## Bug Description
+
+Opening a browser pane on macOS (CEF Views / Alloy mode) produces:
+1. **Black pane** — pane area shows solid black, no web content renders
+2. **Mouse click freeze** — clicks anywhere in the main window (including the sidebar, outside the pane) are silently dropped; JS/keyboard still work
+
+---
+
+## Root Cause (Confirmed)
+
+### 1. `set_size` / `set_position` are permanent no-ops on macOS
+`CefOverlayController::SetSize()` and `SetPosition()` route to `NativeWidgetMac::SetBounds()`, which calls `[NSWindow setFrame:]` — but the overlay NSWindow does not yet exist at the time these are called (async native init). The readback from `controller.bounds()` always returns `{0,0,0,0}`.
+
+### 2. `parent_window.layout()` makes things worse
+Calling `layout()` schedules an async deferred Views layout pass. This fires **after** our `SetPaneBoundsViewsTask`, resetting the overlay to 0×0 (or full-window default), re-triggering the freeze.
+
+### 3. CEF's Views hit-testing uses full-window default for CUSTOM overlays
+When a `DockingMode::CUSTOM` overlay has no committed bounds (because set_size is a no-op), CEF's RootView hit-testing treats the overlay BrowserView as covering the **entire parent window**. Every mouse click in the parent window is routed to the overlay browser, which doesn't process them → the main window's SolidJS UI appears frozen to clicks.
+
+### 4. `set_visible(0)` removes the overlay from `[NSApp windows]`
+Calling `set_visible(0)` → `Widget::Hide()` → `[NSWindow orderOut:]` removes the overlay window from `[NSApp windows]`. From that point on, we cannot find it through standard Cocoa APIs.
+
+### 5. The NativeWidgetMacNSWindow at (0, 1112, 0, 0) is NOT the overlay
+There is always exactly **one** `NativeWidgetMacNSWindow` visible in `[NSApp windows]` at coordinates (0, 1112, 0, 0) with h=0 — even **before any pane is ever opened**. This is a different CEF-internal widget (possibly the overlay for a different feature). We have been resizing this wrong window in all previous attempts.
+
+### 6. CEF does not use `addChildWindow:ordered:`
+`[mainWin childWindows]` is always empty — CEF overlays are not parented to the main window via the Cocoa child-window mechanism.
+
+---
+
+## Upstream Fix That Was Already Merged (d25f04f9, Jun 24)
+
+PR #1769 fixed an ordering bug:
+- **Before:** `set_size → set_position → set_visible(1) → layout()`  
+- **After:** `set_size → set_position → layout() → set_visible(1)`
+- **Also added:** `host.set_focus(1)` on main browser after `add_overlay_view` to prevent focus steal
+
+This partially fixed the issue on Linux (where set_size/set_position DO work). On macOS, set_size/set_position are still no-ops, so bounds remain wrong. The `set_focus(1)` call does help restore keyboard focus but does NOT fix CEF's Views mouse-event routing, which uses the uncommitted full-window bounds.
+
+---
+
+## What We Tried (v1–v14)
+
+### v1–v4: CEF Views API path
+Called `set_size → set_position → layout() → set_visible(1)` in a deferred task (one event loop tick after creation). Confirmed no-ops on macOS via `controller.bounds()` readback → always `{0,0,0,0}`.
+
+### v5–v6: `set_visible(0)` to prevent initial freeze
+Added `set_visible(0)` in the creation path before any layout, to keep the overlay hidden until we can size it correctly. This prevents the initial full-window freeze, but the overlay window disappears from `[NSApp windows]` — we can no longer find it.
+
+### v7–v8: ObjC `setFrame` on wrong window
+Found the NativeWidgetMacNSWindow at (0,1112,0,0) via `[NSApp windows]`. Called `setFrame:display:YES` to move it to the pane position. **This resizes the WRONG window** (the pre-existing CEF widget, not the overlay). The wrong window becomes black and visible at the pane position. The actual overlay is still hidden and its Views bounds are still full-window → freeze persists.
+
+### v8: `setIgnoresMouseEvents:YES` diagnostic
+Confirmed that the pre-existing NativeWidgetMacNSWindow is NOT the source of the freeze (setting ignoresMouse on it doesn't fix clicks). The freeze comes from CEF's Views hit-testing inside the main CefNSWindow, routing events to the hidden overlay's full-window BrowserView bounds.
+
+### v9: `childWindows` search
+Checked `[mainWin childWindows]`. Always empty — CEF does not use `addChildWindow:ordered:` for the overlay.
+
+### v10–v12: `set_visible(1)` first, then find window
+Called `controller.set_visible(1)` to make the overlay appear in `[NSApp windows]`, then found it and resized. Result: the pre-existing NativeWidgetMacNSWindow at (0,1112,0,0) becomes `is_key=1` after `set_visible(1)`. This suggests the pre-existing window IS the overlay, OR that `set_visible(1)` makes something steal key status indirectly. Either way, the window stays at h=0 — never grows to visible size.
+
+Key problem: `set_visible(1)` steals key status from the main window → sidebar clicks don't work even if Views bounds were somehow fixed.
+
+### v13: Remove h>0 filter
+Accepted any NativeWidgetMacNSWindow (including h=0). Found the pre-existing window. Called setFrame successfully (`got_w=591, got_h=665`). But freeze still persists → confirmed this is the wrong window; setFrame does not fix CEF's Views bounds for the actual overlay.
+
+### v14: `[NSWindow windowWithWindowNumber:]` scan
+New approach: scan window numbers 1–512 via `[NSWindow windowWithWindowNumber:]` (which CAN return hidden/ordered-out windows). Any NativeWidgetMacNSWindow not already in `[NSApp windows]` would be the actual hidden overlay. **Not yet tested** — the app entered a network service crash loop before we could test.
+
+---
+
+## Current State of Code
+
+### `creation_views.rs` (macOS path)
+```rust
+// On macOS: skip set_size/set_position/layout (all no-ops or harmful)
+#[cfg(not(target_os = "macos"))]
+{
+    overlay_controller.set_size(...);
+    overlay_controller.set_position(...);
+    parent_window.layout();
+}
+overlay_controller.set_visible(0); // hide until task sizes it correctly
+// Upstream fix: restore focus to main window
+if let Some(main_browser) = state.get_browser(&window_label) {
+    if let Some(mut host) = main_browser.host() { host.set_focus(1); }
+}
+// Post sizing task
+post_set_pane_bounds_views(..., retry=0);
+```
+
+### `ui_tasks.rs` `SetPaneBoundsViewsTask` (macOS path, v14)
+```rust
+// Step 1: scan [NSApp windows] for known NativeWidgetMacNSWindow IDs + main CefNSWindow
+// Step 2: scan windowNumber 1..=512 for hidden NativeWidgetMacNSWindow (the overlay)
+// Step 3: setFrame on overlay → fires windowDidResize → CEF Views bounds update
+// Step 4: controller.set_visible(1)
+// Step 5: makeKeyAndOrderFront on main window
+// Step 6: host.set_focus(1) on main browser
+```
+
+---
+
+## Startup Crash Issue (Introduced After Rebase)
+
+After rebasing onto latest main (v0.49.5), the dev build crashes on startup:
+- `Network service crashed or was terminated` loop
+- `No rendezvous client, terminating process (parent died?)`
+- Main window never appears
+
+This appears to be a new upstream regression, possibly related to the new `CFBundleIdentifier` injection in dev builds (commit faf754e6: "inject CFBundleIdentifier into dev builds for LaunchServices isolation") conflicting with something in the sandbox/Mach port setup. **This blocks testing of the v14 windowNumber approach.**
+
+---
+
+## Promising Untested Approaches
+
+### A. `can_activate=0` for the overlay
+Change `add_overlay_view(..., can_activate=1)` to `can_activate=0`. With `can_activate=0`:
+- The overlay NSWindow cannot become key (cannot steal focus)
+- CEF may handle the overlay differently (possibly not routing events to it)
+- Eliminates the focus-steal root cause that d25f04f9 tried to patch around
+
+### B. Find overlay window BEFORE `set_visible(0)` (synchronous)
+In `create_browser_pane_view`, immediately after `add_overlay_view` returns and BEFORE `set_visible(0)`, call ObjC synchronously on the UI thread to enumerate `[NSApp windows]`. If the overlay NSWindow is created synchronously in `add_overlay_view`, it would appear here (before orderOut). We can call `setFrame` immediately, then `set_visible(0)`. When the user later triggers `set_visible(1)`, the native frame is already correct → Views bounds update correctly.
+
+### C. Don't call `set_visible(0)` at all
+Skip the `set_visible(0)` call. The overlay appears briefly at wrong bounds (full-window black flash, <16ms until our task runs). Our task finds the overlay in `[NSApp windows]` (it's now ordered-in), calls `setFrame` before the next display composite → no visible flash. Overlay appears at correct size.
+
+Risk: The full-window Views bounds during the 16ms window might route events incorrectly, but since this is sub-frame, the user won't notice.
+
+### D. Fix the startup crash first
+The rebase introduced a crash that blocks all testing. Need to bisect whether it's from our code changes or from upstream faf754e6 / new CFBundleIdentifier injection.
+
+---
+
+## Next Steps (Priority Order)
+
+1. **Fix startup crash** — determine if it's our code or upstream; try reverting to pre-rebase state or adding `--no-sandbox` flag
+2. **Test windowNumber scan (v14)** — if startup is fixed, test whether `[NSWindow windowWithWindowNumber:]` 1..512 finds the hidden overlay
+3. **Try `can_activate=0`** — simplest possible change; might fix focus steal without any ObjC needed
+4. **Try synchronous ObjC in creation** — find overlay before `set_visible(0)`
+
+---
+
+## Actual Root Cause (Discovered v15–v17)
+
+The NativeWidgetMacNSWindow at (0,1112,0,0) IS the overlay created by `add_overlay_view`.
+The setFrame calls DID set the NSWindow to 591×665 (readback confirmed).
+But the pane was still black because **CEF's layout kept resetting it to 0×0**.
+
+### Why the layout resets to 0×0
+
+`overlay_view_host.cc::SetOverlayBounds()` does:
+```cpp
+bounds_.Intersect(window_view_->bounds());
+```
+At creation time (and immediately after `set_visible(1)`), the parent `CefWindowView::bounds()` is empty on macOS due to deferred native layout. The intersection of any rect with an empty rect is empty → overlay shrinks to 0×0. Every `setFrame:display:YES` on the NSWindow fires `windowDidResize:` → CEF layout → resets to 0×0 → infinite loop.
+
+### The Fix (v17)
+
+Call `controller.set_bounds()` from the **deferred UI-thread task** (`SetPaneBoundsViewsTask::execute`), after `set_visible(1)`. By the time the task runs (next runloop tick), the parent `CefWindowView` has bounds {0,0,1200,800} (fully laid out). The Intersect now preserves our desired rect. Log evidence:
+
+```
+readback_x=604, readback_y=107, readback_w=591, readback_h=665  ← set_bounds sticks!
+got_w=591.0, got_h=665.0  ← NSWindow also stays at correct size (no more 0×0 resets)
+```
+
+**Code in `ui_tasks.rs`** (after the ObjC setFrame block):
+```rust
+let dip = CefRect { x: task_dip_x, y: task_dip_y, width: task_dip_w, height: task_dip_h };
+controller.set_bounds(Some(&dip));
+```
+where `task_dip_{x,y,w,h} = pane_{x,y,w,h}` from ObjC (pixel coords ÷ backingScaleFactor).
+
+### Additional Fixes Along the Way
+
+- **macOS 26 Tahoe**: `[NSWindow windowWithWindowNumber:]` removed → replaced with pre-hide scan of `[NSApp windows]`
+- **wrap_task! macro**: rejects `///` doc comments, use `//` instead
+- **`makeKey` ObjC selector**: crashes on macOS 26 (SIGABRT) — use `makeKeyAndOrderFront:` on main then `orderFront:` on overlay
+- **Startup crash**: `ChromeWebAppShortcutCopierMain` SIGTRAP/SIGABRT — fixed by early exit in `lib.rs` for `--type=web-app-shortcut-copier` subprocess arg
+
+## Key Log Patterns to Watch
+
+```
+# Fix confirmed working:
+[browser-pane] controller.set_bounds (post-ObjC) and readback  readback_w=591  readback_h=665
+[browser-pane] ObjC task overlay setFrame reaffirmed  got_w=591  got_h=665  # all tasks stable
+
+# Regression indicator:
+[browser-pane] controller.set_bounds (post-ObjC) and readback  readback_w=0  readback_h=0
+```
+
+---
+
+## Open Issue: Mouse Clicks Unresponsive in Browser Pane (macOS)
+
+**Status**: Known limitation as of 2026-06-26 — tracked for follow-up.
+
+After the black-pane fix, the pane renders and scroll wheel events reach the Chromium renderer (user can scroll the web page). However, mouse button clicks (left-click / right-click) in the pane are unresponsive.
+
+### Observed Behaviour
+
+- **Scroll**: Works — scroll events reach the pane renderer regardless of key-window status.
+- **Click in pane**: Silent — mouseDown is not dispatched to the Chromium renderer.
+- **Click in sidebar**: Also broken while pane is open.
+
+### Root Cause Investigation
+
+The two-window macOS architecture is the core of the problem:
+
+- Main window (`NSKVONotifying_CefNSWindow`) — hosts SolidJS sidebar via main BrowserView.
+- Overlay window (`NativeWidgetMacNSWindow`) — hosts pane browser via CEF Views overlay.
+
+**Why scroll works but clicks don't**: macOS routes `NSEventTypeScrollWheel` to the window under the cursor regardless of key-window status. Mouse button events (`NSEventTypeLeftMouseDown`) go to the frontmost window under the cursor, but Chromium's renderer checks whether its enclosing window is the key window (or `acceptsFirstMouse:YES`) before dispatching `mouseDown` to the JS layer. When the overlay is not KEY, Chromium silently drops the mouseDown.
+
+**Competing constraints**:
+
+| State | Sidebar clicks | Pane clicks |
+|---|---|---|
+| Main is KEY (`makeKeyAndOrderFront:main` called in task) | ✓ work | ✗ broken (overlay not KEY) |
+| Overlay is KEY (no `makeKeyAndOrderFront:main`) | ✗ broken (main not KEY) | ✗ still broken (see below) |
+
+When the overlay IS the key window, pane clicks STILL don't reach the renderer. Hypothesis: `host.set_focus(1)` on the main browser (called in `creation_views.rs`) tells CEF's internal focus routing to direct events to the main browser, overriding the OS key-window state for the overlay.
+
+Confirmed diagnostic: after tasks run, `[NSApp keyWindow]` pointed to `NSKVONotifying_CefNSWindow` when `makeKeyAndOrderFront:main` was called (v18), confirming sidebar-focus-restore works. Removing that call (v19) let overlay retain key status but clicks still failed — pointing to a deeper CEF input-routing issue, not just key-window status.
+
+### Approaches to Try
+
+1. **`acceptsFirstMouse:YES` on overlay content view**: Swizzle or subclass the overlay's root `NSView` to return YES from `acceptsFirstMouse:`. This allows the first click to be processed without needing key-window status. Requires ObjC in the task after `set_visible(1)`.
+
+2. **`can_activate=0` for the overlay**: Change `add_overlay_view(..., can_activate=1)` to `can_activate=0`. This prevents the overlay from becoming KEY, but CEF may then route mouseDown events differently (possibly accepting them unconditionally since the window cannot steal focus). Untested.
+
+3. **`host.set_focus(1)` on pane browser**: Call `set_focus(1)` on the pane browser (not main) to tell CEF's internal routing to direct events to the pane renderer. Risk: sidebar clicks then go to pane renderer and may be swallowed.
+
+4. **CEF `SetAccessibilityState` / `NotifyMoveOrResizeStarted`**: Some CEF calls force a re-sync of the internal widget focus state. Worth trying to see if any of these reset CEF's input routing to match the actual NSWindow key state.
+
+### Current PR State
+
+The PR ships with `makeKeyAndOrderFront:main` after `set_bounds()` (sidebar-first policy): sidebar clicks are restored, pane clicks remain non-functional. This matches the pre-pane UX (sidebar usable) while the pane is visible but click-limited.


### PR DESCRIPTION
## Summary

- **Black pane rendered, page loads** — the primary bug is fixed. Opening a browser pane on macOS no longer shows a blank black rectangle.
- **Scroll works in pane** — scroll-wheel events reach the Chromium renderer correctly.
- **Sidebar stays usable** — main window regains key focus after pane setup, so the SolidJS sidebar remains clickable.
- **Hidden-pane creation handled** — panes created while hidden (inactive tab / modal overlay-clip) now have their NSWindow frame committed at creation time so they display correctly when later shown.
- **Splitter-drag resize works** — `resize_browser_pane_view` now posts an ObjC setFrame task so post-creation resizes update the NSWindow frame (previously only `set_size`/`set_position` were called, which are no-ops on macOS).

## Root Cause

`overlay_view_host.cc::SetOverlayBounds()` does:
```cpp
bounds_.Intersect(window_view_->bounds());
```
At pane creation time, the parent `CefWindowView` has empty (0×0) bounds on macOS because the native layout is deferred. The intersection with 0×0 always produces 0×0 — so every `setFrame:display:YES` on the `NativeWidgetMacNSWindow` fired `windowDidResize:` → CEF layout → reset to 0×0 → black screen.

Additional macOS issues:
- `CefOverlayController::set_size`/`set_position`/`set_bounds` are no-ops for the overlay's `NativeWidgetMacNSWindow` frame; the only working path is ObjC `[NSWindow setFrame:display:YES]`.
- Hidden panes (created while `compute_pane_visible=false`) had their `SetPaneBoundsViewsTask` return early without committing the frame, leaving the NSWindow unpositioned for when the pane was later shown.

## Fix

Call `controller.set_bounds()` from the **deferred UI-thread task** (`SetPaneBoundsViewsTask`), after `set_visible(1)`. By then the parent `CefWindowView` has non-empty bounds (1200×800 DIP), so Intersect preserves the desired pane rect.

Additional changes:
- **macOS 26 Tahoe compat**: `[NSWindow windowWithWindowNumber:]` removed — replaced with a pre-`set_visible(0)` scan of `[NSApp windows]` to capture the overlay `windowNumber` before it is hidden.
- **ObjC `setFrame:display:YES`** on the `NativeWidgetMacNSWindow` to sync the NSWindow frame in addition to CEF Views bounds.
- **`makeKeyAndOrderFront:`** on main window after bounds commit to restore sidebar click routing (sidebar-first policy).
- **Hidden-pane fix**: `SetPaneBoundsViewsTask` now always calls `set_visible(1)` before scanning (forces NSWindow creation and ensures it appears in `[NSApp windows]`), commits the frame, then restores visibility via `set_visible(0)` if `compute_pane_visible=false`. Discovered wnum stored in `AppState::browser_pane_overlay_wnums`.
- **Resize fix**: `resize_browser_pane_view` posts a `SetPaneBoundsViewsTask` (retry=2, physical-pixel path, wnum match) so splitter-drag resizes actually move the NSWindow frame.

## Known Limitation — Pane Mouse Clicks

Mouse button clicks (left/right) inside the browser pane are still unresponsive. Scroll works because `NSEventTypeScrollWheel` is routed by cursor position, independent of key-window status. Mouse button events require the window to be KEY or the content view to return `acceptsFirstMouse:YES`. Full investigation documented in `docs/analysis/RETRO_BROWSER_PANE_MACOS_FIX_2026_06_26.md`.

## Test Plan

- [ ] Open agentmux, open a browser pane — pane should render the web page (not black)
- [ ] Scroll within the pane — scroll events should reach the page renderer
- [ ] Click in the sidebar (SolidJS UI) — should still respond normally
- [ ] Open, close, re-open pane — no crash, pane renders on each open
- [ ] Open pane while another tab is active (pane hidden) — switch to tab, pane should render at correct position
- [ ] Drag a splitter to resize the pane — pane should resize (NSWindow frame moves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=camper-0622h -->