### PR TITLE
fix(midnight): user-input color reads amber not brown on pure-black agent pane

### DIFF
--- a/.changesets/1782405556-fix-midnight-user-input-color-reads-amber-not-brown-on-pure--hm1y.md
+++ b/.changesets/1782405556-fix-midnight-user-input-color-reads-amber-not-brown-on-pure--hm1y.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(midnight): user-input color reads amber not brown on pure-black agent pane

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -57,17 +57,14 @@
     --widget-icon-hover-color: var(--main-text-color);
     --widget-icon-active-color: var(--accent-color);
 
-    // User-input highlight — complementary to --accent-color (blue hue ~210°)
-    // so that user messages read as visually distinct from agent content and
-    // link-blue UI chrome. Hue ~28° (warm amber) is the colour-wheel complement
-    // of the accent; contrast ~6:1 on dark surfaces (WCAG AA). Per-theme
-    // overrides land in `frontend/app/themes/*.scss`.
-    // See docs/specs/SPEC_AGENT_COMPOSER_STRIP_REDESIGN_2026_06_23.md §7.
+    // User-input highlight — complementary to --accent-color (blue hue ~210°).
+    // Hue ~28° (warm amber) is the colour-wheel complement of the accent.
+    // Used as the solid border and as the INPUT to color-mix() in
+    // _document-nodes.scss, which blends it with --block-bg-solid-color in
+    // oklab space (NOT with transparent). oklab mixing preserves hue identity
+    // so the result is always visibly amber on any dark surface — no alpha
+    // compositing, no brown-on-black degradation.
     --user-input-color: #e07832;
-    // Background tint alpha for user-message bubbles (used in color-mix()).
-    // Themes with darker/pure-black backgrounds should increase this so the
-    // tint reads as amber rather than brown at low opacity over black.
-    --user-input-bg-alpha: 14%;
 
     --panel-bg-color: rgba(31, 33, 31, 0.5);
     --highlight-bg-color: rgba(255, 255, 255, 0.2);

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -64,6 +64,10 @@
     // overrides land in `frontend/app/themes/*.scss`.
     // See docs/specs/SPEC_AGENT_COMPOSER_STRIP_REDESIGN_2026_06_23.md §7.
     --user-input-color: #e07832;
+    // Background tint alpha for user-message bubbles (used in color-mix()).
+    // Themes with darker/pure-black backgrounds should increase this so the
+    // tint reads as amber rather than brown at low opacity over black.
+    --user-input-bg-alpha: 14%;
 
     --panel-bg-color: rgba(31, 33, 31, 0.5);
     --highlight-bg-color: rgba(255, 255, 255, 0.2);

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -67,11 +67,9 @@
     --color-border: var(--border-color);
     --color-modalbg: var(--modal-bg-color);
 
-    // On pure-black agent pane, the default amber (#e07832) at 14% alpha
-    // composites to dark brown. Brighter amber + higher alpha stays amber.
-    // Hue ~38° is the complement of midnight's blue accent (~218°).
+    // Brighter amber for midnight — complement of the blue accent (~218° → ~38°).
+    // The default #e07832 is too dark on pure-black to distinguish from brown.
     --user-input-color: #ffaa33;
-    --user-input-bg-alpha: 25%;
 
     .agent-view,
     .agent-view .agent-document {

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -67,6 +67,12 @@
     --color-border: var(--border-color);
     --color-modalbg: var(--modal-bg-color);
 
+    // On pure-black agent pane, the default amber (#e07832) at 14% alpha
+    // composites to dark brown. Brighter amber + higher alpha stays amber.
+    // Hue ~38° is the complement of midnight's blue accent (~218°).
+    --user-input-color: #ffaa33;
+    --user-input-bg-alpha: 25%;
+
     .agent-view,
     .agent-view .agent-document {
         background: #000;

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -828,7 +828,7 @@
     // `components/UserMessageBlock.tsx` for the JSX side.
     .agent-user-message {
         padding: 3px var(--space-1);
-        background: color-mix(in srgb, var(--user-input-color) 14%, transparent);
+        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 14%), transparent);
         border-left: 3px solid var(--user-input-color);
         border-radius: 0;
         user-select: text;
@@ -1040,7 +1040,7 @@
 
                     &:hover {
                         opacity: 1;
-                        background: color-mix(in srgb, var(--user-input-color) 15%, transparent);
+                        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 15%), transparent);
                     }
                     &:focus-visible {
                         outline: 2px solid var(--user-input-color);
@@ -1055,7 +1055,7 @@
         // a slightly deeper background so the user knows this is a
         // hover-preview, not a permanent expansion.
         &--expanded.agent-user-message--startup {
-            background: color-mix(in srgb, var(--user-input-color) 18%, transparent);
+            background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 18%), transparent);
         }
 
         // Pinned state — thicker left border mirrors ToolBlock.pinned.

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -828,7 +828,7 @@
     // `components/UserMessageBlock.tsx` for the JSX side.
     .agent-user-message {
         padding: 3px var(--space-1);
-        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 14%), transparent);
+        background: color-mix(in oklab, var(--user-input-color) 30%, var(--block-bg-solid-color));
         border-left: 3px solid var(--user-input-color);
         border-radius: 0;
         user-select: text;
@@ -1040,7 +1040,7 @@
 
                     &:hover {
                         opacity: 1;
-                        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 15%), transparent);
+                        background: color-mix(in oklab, var(--user-input-color) 35%, var(--block-bg-solid-color));
                     }
                     &:focus-visible {
                         outline: 2px solid var(--user-input-color);
@@ -1055,7 +1055,7 @@
         // a slightly deeper background so the user knows this is a
         // hover-preview, not a permanent expansion.
         &--expanded.agent-user-message--startup {
-            background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 18%), transparent);
+            background: color-mix(in oklab, var(--user-input-color) 38%, var(--block-bg-solid-color));
         }
 
         // Pinned state — thicker left border mirrors ToolBlock.pinned.


### PR DESCRIPTION
## Summary

- The midnight theme sets `.agent-view { background: #000 }` but had no override for `--user-input-color`, so the default `#e07832` (amber) composited at 14% alpha over pure black: `rgb(31, 17, 7)` — dark brown
- Introduce `--user-input-bg-alpha` (default `14%`) in `theme.scss` so any theme can raise the tint level without changing SCSS
- Override in `midnight.scss`: `--user-input-color: #ffaa33` (brighter amber, hue ~38° — complement of midnight's blue accent ~218°) + `--user-input-bg-alpha: 25%`
- At 25% over black: `rgb(64, 43, 13)` — reads as dark amber, not brown; solid 3px border remains vivid `#ffaa33`

<!-- agentmux:agent_id=lark-06209 -->