### PR TITLE
feat(agent): /terminal slash command opens agent CWD in terminal pane below

### DIFF
--- a/.changesets/1782405556-fix-midnight-user-input-color-reads-amber-not-brown-on-pure--hm1y.md
+++ b/.changesets/1782405556-fix-midnight-user-input-color-reads-amber-not-brown-on-pure--hm1y.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(midnight): user-input color reads amber not brown on pure-black agent pane

--- a/.changesets/1782408148-feat-agent-terminal-slash-command-opens-agent-cwd-in-a-new-t-745o.md
+++ b/.changesets/1782408148-feat-agent-terminal-slash-command-opens-agent-cwd-in-a-new-t-745o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): /terminal slash command opens agent CWD in a new terminal pane below

--- a/docs/specs/SPEC_SLASH_TERMINAL_COMMAND_2026_06_25.md
+++ b/docs/specs/SPEC_SLASH_TERMINAL_COMMAND_2026_06_25.md
@@ -1,0 +1,176 @@
+# SPEC: `/terminal` Slash Command — Open Agent CWD in New Terminal Pane
+
+**Date:** 2026-06-25
+**Status:** Draft
+**Scope:** New slash command + one registration line
+
+---
+
+## Goal
+
+Typing `/terminal` in an agent pane opens a new terminal block in a pane **below**
+the agent (vertical split, "after" position), pre-seeded with the agent's current
+working directory.
+
+---
+
+## Why not to the side
+
+The existing pane-action helpers default to horizontal splits (right). For a
+terminal that supplements a running agent session, "below" is more ergonomic:
+
+- The agent conversation is tall and narrow; a side terminal compresses both panes.
+- "Below" mirrors the conventional IDE layout (editor above, terminal below).
+- Horizontal splits already exist in the right-click header menu; this command
+  fills the gap for the vertical/below case.
+
+---
+
+## System map
+
+### Slash command pipeline
+
+```
+AgentComposerInput
+  → useAgentCommands.sendMessage()
+  → dispatchSlashCommand(input, registry, ctx)   ← commands/dispatch.ts
+  → registry.lookup("terminal")
+  → terminalCommand.handler(ctx)
+```
+
+### Key files
+
+| Role | File |
+|---|---|
+| Command type + context interface | `frontend/app/view/agent/commands/types.ts` |
+| Registry class + buildRegistry() | `frontend/app/view/agent/commands/registry.ts` |
+| Global command registration | `frontend/app/view/agent/commands/global/index.ts` |
+| Block split helpers | `frontend/app/store/global.ts` — `createBlockSplitVertically()` |
+| Agent CWD storage | `meta["cmd:cwd"]` set in `agent-model.ts:555` during `launchAgent()` |
+| Terminal view meta key | `meta.view = "term"` (standard block meta) |
+
+---
+
+## Split direction mapping (pane-actions.ts:12–95)
+
+```
+"down" → createBlockSplitVertically(blockDef, targetBlockId, "after")
+"up"   → createBlockSplitVertically(blockDef, targetBlockId, "before")
+"right"→ createBlockSplitHorizontally(blockDef, targetBlockId, "after")   ← default
+"left" → createBlockSplitHorizontally(blockDef, targetBlockId, "before")
+```
+
+We want `createBlockSplitVertically(…, "after")` — splits below the agent pane.
+
+---
+
+## CWD resolution
+
+```typescript
+const cwd = ctx.block()?.meta?.["cmd:cwd"];
+```
+
+`ctx.block()` returns the raw WOS block object for the agent pane. `cmd:cwd` is
+written at agent launch time (`agent-model.ts:555`). It is always an absolute path.
+
+If the field is absent (agent never launched, or block not found), the terminal
+opens without a `cwd` override — the OS default applies.
+
+### Terminal CWD handoff
+
+The terminal view reads its starting directory from `meta["cmd:cwd"]` on the block
+(same key, different block). Setting this on the `BlockDef` before creation causes
+the subprocess to `cd` to that path on spawn.
+
+---
+
+## Implementation
+
+### 1 — New file: `frontend/app/view/agent/commands/global/terminal.ts`
+
+```typescript
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createBlockSplitVertically } from "@/app/store/global";
+import type { SlashCommand, SlashResult } from "../types";
+
+export const terminalCommand: SlashCommand = {
+    name: "terminal",
+    category: "session",
+    description: "Open the agent's working directory in a new terminal pane below",
+    arg: { kind: "none" },
+    availability: "any-agent",
+    handler: async (ctx): Promise<SlashResult> => {
+        const cwd = ctx.block()?.meta?.["cmd:cwd"] as string | undefined;
+        const blockDef = {
+            meta: {
+                view: "term",
+                ...(cwd ? { "cmd:cwd": cwd } : {}),
+            },
+        };
+        await createBlockSplitVertically(blockDef, ctx.blockId, "after");
+        return {
+            kind: "ok",
+            message: cwd ? `Terminal opened at ${cwd}` : "Terminal opened",
+        };
+    },
+};
+```
+
+### 2 — Register in `frontend/app/view/agent/commands/global/index.ts`
+
+```typescript
+import { terminalCommand } from "./terminal";
+
+export function registerGlobalCommands(registry: SlashCommandRegistry): void {
+    registry.register(loginCommand);
+    registry.register(clearCommand);
+    registry.register(helpCommand);
+    registry.register(toolsCommand);
+    registry.register(terminalCommand);   // ← add
+    // ...RUNTIME_COMMANDS
+}
+```
+
+---
+
+## Error handling
+
+| Condition | Behaviour |
+|---|---|
+| `cmd:cwd` absent (agent not yet started) | Terminal opens; no `cmd:cwd` on block; OS default CWD applies |
+| `createBlockSplitVertically` throws | Exception propagates to `dispatchSlashCommand` → logged as error result in conversation |
+| `/terminal someArg` typed | `arg: { kind: "none" }` → dispatcher strips unknown args; handler receives no arg |
+
+---
+
+## Files to create / change
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/commands/global/terminal.ts` | New — 28 lines |
+| `frontend/app/view/agent/commands/global/index.ts` | +1 import, +1 `registry.register()` call |
+
+No changes needed to:
+- `commands/types.ts` — `SlashCommandContext.block()` already exposes raw meta
+- `commands/registry.ts` — no new category or dispatch path
+- `store/global.ts` — `createBlockSplitVertically` already exists and is exported
+- Terminal view model — reads `cmd:cwd` from block meta already on spawn
+
+---
+
+## Open questions
+
+1. **Should `/terminal` accept an optional path arg?**
+   e.g. `/terminal ~/projects/foo` — would override `cmd:cwd`. Useful but adds
+   path validation complexity. Defer to v2.
+
+2. **Focus after open?**
+   After split, focus moves to the new terminal pane automatically (layout default).
+   Confirm this is the desired UX — alternative is to keep focus on the agent.
+
+3. **What if the pane is already in a vertical split (multiple rows)?**
+   `createBlockSplitVertically` adds another row within the same column. This is
+   correct — terminal goes below the agent in the same column regardless of existing
+   layout.

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -57,17 +57,14 @@
     --widget-icon-hover-color: var(--main-text-color);
     --widget-icon-active-color: var(--accent-color);
 
-    // User-input highlight — complementary to --accent-color (blue hue ~210°)
-    // so that user messages read as visually distinct from agent content and
-    // link-blue UI chrome. Hue ~28° (warm amber) is the colour-wheel complement
-    // of the accent; contrast ~6:1 on dark surfaces (WCAG AA). Per-theme
-    // overrides land in `frontend/app/themes/*.scss`.
-    // See docs/specs/SPEC_AGENT_COMPOSER_STRIP_REDESIGN_2026_06_23.md §7.
+    // User-input highlight — complementary to --accent-color (blue hue ~210°).
+    // Hue ~28° (warm amber) is the colour-wheel complement of the accent.
+    // Used as the solid border and as the INPUT to color-mix() in
+    // _document-nodes.scss, which blends it with --block-bg-solid-color in
+    // oklab space (NOT with transparent). oklab mixing preserves hue identity
+    // so the result is always visibly amber on any dark surface — no alpha
+    // compositing, no brown-on-black degradation.
     --user-input-color: #e07832;
-    // Background tint alpha for user-message bubbles (used in color-mix()).
-    // Themes with darker/pure-black backgrounds should increase this so the
-    // tint reads as amber rather than brown at low opacity over black.
-    --user-input-bg-alpha: 14%;
 
     --panel-bg-color: rgba(31, 33, 31, 0.5);
     --highlight-bg-color: rgba(255, 255, 255, 0.2);

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -64,6 +64,10 @@
     // overrides land in `frontend/app/themes/*.scss`.
     // See docs/specs/SPEC_AGENT_COMPOSER_STRIP_REDESIGN_2026_06_23.md §7.
     --user-input-color: #e07832;
+    // Background tint alpha for user-message bubbles (used in color-mix()).
+    // Themes with darker/pure-black backgrounds should increase this so the
+    // tint reads as amber rather than brown at low opacity over black.
+    --user-input-bg-alpha: 14%;
 
     --panel-bg-color: rgba(31, 33, 31, 0.5);
     --highlight-bg-color: rgba(255, 255, 255, 0.2);

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -67,11 +67,9 @@
     --color-border: var(--border-color);
     --color-modalbg: var(--modal-bg-color);
 
-    // On pure-black agent pane, the default amber (#e07832) at 14% alpha
-    // composites to dark brown. Brighter amber + higher alpha stays amber.
-    // Hue ~38° is the complement of midnight's blue accent (~218°).
+    // Brighter amber for midnight — complement of the blue accent (~218° → ~38°).
+    // The default #e07832 is too dark on pure-black to distinguish from brown.
     --user-input-color: #ffaa33;
-    --user-input-bg-alpha: 25%;
 
     .agent-view,
     .agent-view .agent-document {

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -67,6 +67,12 @@
     --color-border: var(--border-color);
     --color-modalbg: var(--modal-bg-color);
 
+    // On pure-black agent pane, the default amber (#e07832) at 14% alpha
+    // composites to dark brown. Brighter amber + higher alpha stays amber.
+    // Hue ~38° is the complement of midnight's blue accent (~218°).
+    --user-input-color: #ffaa33;
+    --user-input-bg-alpha: 25%;
+
     .agent-view,
     .agent-view .agent-document {
         background: #000;

--- a/frontend/app/view/agent/commands/global/index.ts
+++ b/frontend/app/view/agent/commands/global/index.ts
@@ -12,6 +12,7 @@ import { clearCommand } from "./clear";
 import { helpCommand } from "./help";
 import { loginCommand } from "./login";
 import { RUNTIME_COMMANDS } from "./runtime";
+import { terminalCommand } from "./terminal";
 import { toolsCommand } from "./tools";
 
 export function registerGlobalCommands(registry: SlashCommandRegistry): void {
@@ -22,4 +23,5 @@ export function registerGlobalCommands(registry: SlashCommandRegistry): void {
     registry.register(clearCommand);
     registry.register(helpCommand);
     registry.register(toolsCommand);
+    registry.register(terminalCommand);
 }

--- a/frontend/app/view/agent/commands/global/terminal.ts
+++ b/frontend/app/view/agent/commands/global/terminal.ts
@@ -15,6 +15,7 @@ export const terminalCommand: SlashCommand = {
         const blockDef = {
             meta: {
                 view: "term",
+                controller: "shell",
                 ...(cwd ? { "cmd:cwd": cwd } : {}),
             },
         };

--- a/frontend/app/view/agent/commands/global/terminal.ts
+++ b/frontend/app/view/agent/commands/global/terminal.ts
@@ -1,0 +1,24 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createBlockSplitVertically } from "@/app/store/global";
+import type { SlashCommand, SlashResult } from "../types";
+
+export const terminalCommand: SlashCommand = {
+    name: "terminal",
+    aliases: ["term"],
+    category: "session",
+    description: "Open the agent's working directory in a new terminal pane below",
+    arg: { kind: "none" },
+    handler: async (ctx): Promise<SlashResult> => {
+        const cwd = ctx.block()?.meta?.["cmd:cwd"] as string | undefined;
+        const blockDef = {
+            meta: {
+                view: "term",
+                ...(cwd ? { "cmd:cwd": cwd } : {}),
+            },
+        };
+        await createBlockSplitVertically(blockDef, ctx.blockId, "after");
+        return { kind: "ok", message: cwd ? `Terminal opened at ${cwd}` : "Terminal opened" };
+    },
+};

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -828,7 +828,7 @@
     // `components/UserMessageBlock.tsx` for the JSX side.
     .agent-user-message {
         padding: 3px var(--space-1);
-        background: color-mix(in srgb, var(--user-input-color) 14%, transparent);
+        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 14%), transparent);
         border-left: 3px solid var(--user-input-color);
         border-radius: 0;
         user-select: text;
@@ -1040,7 +1040,7 @@
 
                     &:hover {
                         opacity: 1;
-                        background: color-mix(in srgb, var(--user-input-color) 15%, transparent);
+                        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 15%), transparent);
                     }
                     &:focus-visible {
                         outline: 2px solid var(--user-input-color);
@@ -1055,7 +1055,7 @@
         // a slightly deeper background so the user knows this is a
         // hover-preview, not a permanent expansion.
         &--expanded.agent-user-message--startup {
-            background: color-mix(in srgb, var(--user-input-color) 18%, transparent);
+            background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 18%), transparent);
         }
 
         // Pinned state — thicker left border mirrors ToolBlock.pinned.

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -828,7 +828,7 @@
     // `components/UserMessageBlock.tsx` for the JSX side.
     .agent-user-message {
         padding: 3px var(--space-1);
-        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 14%), transparent);
+        background: color-mix(in oklab, var(--user-input-color) 30%, var(--block-bg-solid-color));
         border-left: 3px solid var(--user-input-color);
         border-radius: 0;
         user-select: text;
@@ -1040,7 +1040,7 @@
 
                     &:hover {
                         opacity: 1;
-                        background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 15%), transparent);
+                        background: color-mix(in oklab, var(--user-input-color) 35%, var(--block-bg-solid-color));
                     }
                     &:focus-visible {
                         outline: 2px solid var(--user-input-color);
@@ -1055,7 +1055,7 @@
         // a slightly deeper background so the user knows this is a
         // hover-preview, not a permanent expansion.
         &--expanded.agent-user-message--startup {
-            background: color-mix(in srgb, var(--user-input-color) var(--user-input-bg-alpha, 18%), transparent);
+            background: color-mix(in oklab, var(--user-input-color) 38%, var(--block-bg-solid-color));
         }
 
         // Pinned state — thicker left border mirrors ToolBlock.pinned.


### PR DESCRIPTION
## Summary

- Adds `/terminal` (alias `/term`) as a global slash command in the agent pane
- Opens a new terminal block in a pane **below** the agent (`createBlockSplitVertically + "after"`) — not to the side
- Reads `cmd:cwd` from the agent block's meta and passes it to the new terminal block; the terminal view already reads `cmd:cwd` on spawn so the CWD handoff needs no other changes
- If the agent hasn't launched yet (`cmd:cwd` absent), the terminal opens with the OS default directory

## How it works

```
/terminal  →  ctx.block()?.meta?.["cmd:cwd"]
           →  createBlockSplitVertically({ meta: { view: "term", "cmd:cwd": cwd } }, blockId, "after")
           →  terminal pane appears below agent, starts in agent's working directory
```

<!-- agentmux:agent_id=lark-06209 -->