### PR TITLE
fix(agent): zoom persistence broken — mirror term:zoom via WebSocket setmeta path

### DIFF
--- a/.changesets/1782410512-fix-agent-zoom-persistence-broken-mirror-term-zoom-via-webso-lqd2.md
+++ b/.changesets/1782410512-fix-agent-zoom-persistence-broken-mirror-term-zoom-via-webso-lqd2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): zoom persistence broken — mirror term:zoom via WebSocket setmeta path

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2835,7 +2835,7 @@ fn zoom_mirror_gen() -> &'static std::sync::Mutex<std::collections::HashMap<Stri
 /// Debounced trailing mirror of an agent block's `term:zoom` into the per-agent
 /// `ui:zoom` content blob. `zoom = Some(z)` upserts; `zoom = None` (term:zoom
 /// reset to null / 1.0) deletes the row so a default agent persists nothing.
-fn schedule_agent_zoom_mirror(
+pub(crate) fn schedule_agent_zoom_mirror(
     store: std::sync::Arc<crate::backend::storage::store::Store>,
     agent_id: String,
     zoom: Option<f64>,

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -29,7 +29,7 @@ use crate::backend::rpc_types::{
     CommandAgentAnswerData,
 };
 use crate::backend::obj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
-use super::service::update_object_meta;
+use super::service::{update_object_meta, schedule_agent_zoom_mirror};
 
 use super::AppState;
 
@@ -626,6 +626,22 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                 let meta_keys: Vec<&String> = cmd.meta.keys().collect();
                 tracing::info!(oref = %oref_str, keys = ?meta_keys, "SetMeta");
                 update_object_meta(&wstore, &oref_str, &cmd.meta)?;
+                // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE): the
+                // frontend writes term:zoom via this WebSocket path, not the HTTP
+                // UpdateObjectMeta handler where the mirror was originally placed.
+                // Mirror term:zoom → ui:zoom here so the zoom survives pane close.
+                let oref_parsed = crate::backend::ORef::parse(&oref_str)
+                    .map_err(|e| e.to_string())?;
+                if oref_parsed.otype == "block" && cmd.meta.contains_key("term:zoom") {
+                    if let Ok(block) = wstore.must_get::<Block>(&oref_parsed.oid) {
+                        let agent_id = block.meta.get("agentId")
+                            .and_then(|v| v.as_str()).unwrap_or("").to_string();
+                        if !agent_id.is_empty() {
+                            let zoom = cmd.meta.get("term:zoom").and_then(|v| v.as_f64());
+                            schedule_agent_zoom_mirror(wstore.clone(), agent_id, zoom);
+                        }
+                    }
+                }
                 // Read the updated object and broadcast a proper WaveObjUpdate
                 // so all WS clients refresh their atoms with the new data.
                 let oref = crate::backend::ORef::parse(&oref_str)


### PR DESCRIPTION
## Summary

- PRs #1700 and #1754 built correct zoom persistence infrastructure but wired the `term:zoom → ui:zoom` mirror into the **HTTP** `UpdateObjectMeta` handler only
- The frontend always writes zoom via `RpcApi.SetMetaCommand` → **WebSocket** `"setmeta"` handler, which calls `update_object_meta()` directly and returns — the mirror was never reached
- Result: `ui:zoom` was never written; reopening an agent always reset to 1.0×
- Fix: add the identical debounced mirror call (`schedule_agent_zoom_mirror`) to the WebSocket `setmeta` handler in `websocket.rs`, right after `update_object_meta()`
- Make `schedule_agent_zoom_mirror` `pub(crate)` so `websocket.rs` can call it
- The restore path (`app_api.rs:341-349`) and the mirror/debounce/cross-channel logic (`#1754`) were already correct — only the trigger site was missing

## Test plan

- [ ] Open an agent pane, Ctrl+Wheel to zoom to e.g. 130%
- [ ] Close the pane (close tab or close block)
- [ ] Reopen the same agent — it should come back at 130%
- [ ] Reset zoom to 100% (Ctrl+0), close, reopen — should come back at 100% (no stored value)
- [ ] Verify no regression: zooming terminal or editor panes still works

<!-- agentmux:agent_id=camper -->