### PR TITLE
chore: release v0.49.3

### DIFF
--- a/.changesets/1750808000-feat-tab-chrome-boundary-line.md
+++ b/.changesets/1750808000-feat-tab-chrome-boundary-line.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tab-chrome): full-width boundary line below tab strip via container border-bottom

--- a/.changesets/1782284857-fix-agent-move-activity-dock-from-top-to-above-composer-gdhj.md
+++ b/.changesets/1782284857-fix-agent-move-activity-dock-from-top-to-above-composer-gdhj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): move activity dock from top to above composer

--- a/.changesets/1782333370-feat-statusbar-muxbus-cloud-login-chip-sign-in-button-when-n-2ddu.md
+++ b/.changesets/1782333370-feat-statusbar-muxbus-cloud-login-chip-sign-in-button-when-n-2ddu.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(statusbar): MuxBus Cloud login chip — sign-in button when not connected, email chip + disconnect popover when signed in

--- a/.changesets/1782335820-fix-agent-remove-session-digest-fix-per-turn-haiku-summary-i-b7yl.md
+++ b/.changesets/1782335820-fix-agent-remove-session-digest-fix-per-turn-haiku-summary-i-b7yl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove session digest, fix per-turn Haiku summary in pane header

--- a/.changesets/1782336818-fix-cef-clone-initial-view-before-move-into-promote-pool-win-dl08.md
+++ b/.changesets/1782336818-fix-cef-clone-initial-view-before-move-into-promote-pool-win-dl08.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): clone initial_view before move into promote_pool_window_for_new_window

--- a/.changesets/1782337061-docs-cef-add-the-package-upload-to-release-step-sandbox-chro-9pdp.md
+++ b/.changesets/1782337061-docs-cef-add-the-package-upload-to-release-step-sandbox-chro-9pdp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(cef): add the package + upload-to-release step + sandbox/chrome-sandbox notes to the libcef build guide

--- a/.changesets/1782355794-fix-identity-deduplicate-identity-accounts-sharing-the-same--022l.md
+++ b/.changesets/1782355794-fix-identity-deduplicate-identity-accounts-sharing-the-same--022l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): deduplicate identity accounts sharing the same credential in shared store

--- a/.changesets/1782379655-fix-transparency-gate-transparent-cef-flags-on-window-transp-2te4.md
+++ b/.changesets/1782379655-fix-transparency-gate-transparent-cef-flags-on-window-transp-2te4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(transparency): gate transparent CEF flags on window:transparent setting, fix startup opacity flash for opaque windows

--- a/.changesets/1782381364-fix-iconbutton-stop-destructuring-decl-prop-caret-flips-on-m-6zkf.md
+++ b/.changesets/1782381364-fix-iconbutton-stop-destructuring-decl-prop-caret-flips-on-m-6zkf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(iconbutton): stop destructuring decl prop — caret flips on minimize, clicks no longer swallowed

--- a/.changesets/1782381814-fix-widgets-use-fontawesome-brand-icons-for-messaging-widget-s9li.md
+++ b/.changesets/1782381814-fix-widgets-use-fontawesome-brand-icons-for-messaging-widget-s9li.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(widgets): use FontAwesome brand icons for messaging widgets (Discord, Slack, Telegram, WhatsApp, Teams)

--- a/.changesets/1782405556-fix-midnight-user-input-color-reads-amber-not-brown-on-pure--hm1y.md
+++ b/.changesets/1782405556-fix-midnight-user-input-color-reads-amber-not-brown-on-pure--hm1y.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(midnight): user-input color reads amber not brown on pure-black agent pane

--- a/.changesets/1782407335-fix-agent-rename-shell-log-button-wire-to-activity-log-remov-hpij.md
+++ b/.changesets/1782407335-fix-agent-rename-shell-log-button-wire-to-activity-log-remov-hpij.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): rename Shell→Log button, wire to activity log, remove chevron/strip-click expand, add RuntimeBadge to HostPopover

--- a/.changesets/1782407979-fix-term-eliminate-1hz-typing-jerk-caused-by-sysinfo-blockin-5c34.md
+++ b/.changesets/1782407979-fix-term-eliminate-1hz-typing-jerk-caused-by-sysinfo-blockin-5c34.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): eliminate 1Hz typing jerk caused by sysinfo blocking Tokio worker threads

--- a/.changesets/1782408148-feat-agent-terminal-slash-command-opens-agent-cwd-in-a-new-t-745o.md
+++ b/.changesets/1782408148-feat-agent-terminal-slash-command-opens-agent-cwd-in-a-new-t-745o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): /terminal slash command opens agent CWD in a new terminal pane below

--- a/.changesets/1782408301-feat-dev-task-dev-title-sets-os-window-title-for-dev-session-c50a.md
+++ b/.changesets/1782408301-feat-dev-task-dev-title-sets-os-window-title-for-dev-session-c50a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(dev): task dev TITLE= sets OS window title for dev sessions

--- a/.changesets/1782409839-fix-linux-per-build-channel-isolation-for-appimage-local-bui-vl47.md
+++ b/.changesets/1782409839-fix-linux-per-build-channel-isolation-for-appimage-local-bui-vl47.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(linux): per-build channel isolation for AppImage — local builds no longer collide with stable install

--- a/.changesets/1782410512-fix-agent-zoom-persistence-broken-mirror-term-zoom-via-webso-lqd2.md
+++ b/.changesets/1782410512-fix-agent-zoom-persistence-broken-mirror-term-zoom-via-webso-lqd2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): zoom persistence broken — mirror term:zoom via WebSocket setmeta path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.49.2"
+version = "0.49.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,26 @@
 # AgentMux Version History
 
+## 0.49.3 — 2026-06-25
+
+- feat(tab-chrome): full-width boundary line below tab strip via container border-bottom
+- fix(agent): move activity dock from top to above composer
+- feat(statusbar): MuxBus Cloud login chip — sign-in button when not connected, email chip + disconnect popover when signed in
+- fix(agent): remove session digest, fix per-turn Haiku summary in pane header
+- fix(cef): clone initial_view before move into promote_pool_window_for_new_window
+- docs(cef): add the package + upload-to-release step + sandbox/chrome-sandbox notes to the libcef build guide
+- fix(identity): deduplicate identity accounts sharing the same credential in shared store
+- fix(transparency): gate transparent CEF flags on window:transparent setting, fix startup opacity flash for opaque windows
+- fix(iconbutton): stop destructuring decl prop — caret flips on minimize, clicks no longer swallowed
+- fix(widgets): use FontAwesome brand icons for messaging widgets (Discord, Slack, Telegram, WhatsApp, Teams)
+- fix(midnight): user-input color reads amber not brown on pure-black agent pane
+- fix(agent): rename Shell→Log button, wire to activity log, remove chevron/strip-click expand, add RuntimeBadge to HostPopover
+- fix(term): eliminate 1Hz typing jerk caused by sysinfo blocking Tokio worker threads
+- feat(agent): /terminal slash command opens agent CWD in a new terminal pane below
+- feat(dev): task dev TITLE= sets OS window title for dev sessions
+- fix(linux): per-build channel isolation for AppImage — local builds no longer collide with stable install
+- fix(agent): zoom persistence broken — mirror term:zoom via WebSocket setmeta path
+
+
 ## 0.49.2 — 2026-06-24
 
 - feat(agent-pane): right-click header to set 2-tone hue color theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.2",
+      "version": "0.49.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release consuming 17 pending changesets (forced patch override — two changesets were minor-tier but shipping under patch).

**Highlights:**
- fix(agent): Log button replaces Shell, wired to activity log; chevron/strip-click expand removed; RuntimeBadge in HostPopover
- feat(dev): `task dev TITLE="..."` sets OS window title for parallel dev sessions
- fix(agent): zoom persistence fixed — mirror term:zoom via WebSocket setmeta path
- fix(term): eliminate 1Hz typing jerk caused by sysinfo blocking Tokio workers
- feat(agent): /terminal slash command opens agent CWD in terminal pane
- fix(linux): per-build channel isolation for AppImage
- fix(midnight): user-input color amber on pure-black pane
- fix(identity): deduplicate accounts sharing same credential
- feat(statusbar): MuxBus Cloud login chip
- fix(iconbutton): caret flip on minimize

Full changelog in VERSION_HISTORY.md §0.49.3.

## Test plan
- [ ] Verify version shows 0.49.3 in About modal
- [ ] CI passes

<!-- agentmux:agent_id=agentx -->