### PR TITLE
fix(providers): pin all CLI providers to specific versions

### DIFF
--- a/.changesets/1782430196-fix-providers-pin-all-cli-providers-to-specific-versions-mov-57ma.md
+++ b/.changesets/1782430196-fix-providers-pin-all-cli-providers-to-specific-versions-mov-57ma.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(providers): pin all CLI providers to specific versions; move muxcode to agentmuxai scope

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -143,7 +143,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &["CLAUDECODE"],
     npm_package: "@anthropic-ai/claude-code",
-    pinned_version: "latest",
+    pinned_version: "2.1.185",
     icon: "sparkles",
     docs_url: "https://docs.anthropic.com/claude-code",
 };
@@ -224,7 +224,7 @@ static QWEN: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@qwen-code/qwen-code",
-    pinned_version: "latest",
+    pinned_version: "0.19.2",
     icon: "feather",
     docs_url: "https://qwenlm.github.io/qwen-code-docs",
 };
@@ -283,7 +283,7 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "openclaw",
-    pinned_version: "latest",
+    pinned_version: "2026.6.10",
     icon: "lobster",
     docs_url: "https://docs.openclaw.ai",
 };
@@ -303,7 +303,7 @@ static PI: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@mariozechner/pi-coding-agent",
-    pinned_version: "latest",
+    pinned_version: "0.73.1",
     icon: "terminal",
     docs_url: "https://github.com/badlogic/pi-mono",
 };
@@ -313,7 +313,7 @@ static PI: ProviderConfig = ProviderConfig {
 // OpenAI, OpenAI-compat). Emits claude-compatible stream-json NDJSON
 // (same `session_id` field, same event envelope), so ClaudeTranslator
 // handles it without modification.  `--resume <id>` resumes a prior
-// session.  npm: `@a5af/muxcode`.
+// session.  npm: `@agentmuxai/muxcode`.
 static MUX_CODE: ProviderConfig = ProviderConfig {
     id: "muxcode",
     display_name: "Mux Code",
@@ -332,8 +332,8 @@ static MUX_CODE: ProviderConfig = ProviderConfig {
     auth_dir_name: "muxcode",
     auth_extra_env: &[],
     unset_env: &[],
-    npm_package: "@a5af/muxcode",
-    pinned_version: "latest",
+    npm_package: "@agentmuxai/muxcode",
+    pinned_version: "0.1.0",
     icon: "brain",
     docs_url: "https://github.com/agentmuxai/muxcode",
 };
@@ -357,7 +357,7 @@ static COPILOT: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@github/copilot",
-    pinned_version: "latest",
+    pinned_version: "1.0.65",
     icon: "github",
     docs_url: "https://docs.github.com/copilot/concepts/agents/about-copilot-cli",
 };
@@ -464,7 +464,7 @@ mod tests {
         assert_eq!(p.cli_command, "muxcode");
         assert_eq!(p.session_id_field, "session_id");
         assert_eq!(p.resume_flag, Some("--resume"));
-        assert_eq!(p.npm_package, "@a5af/muxcode");
+        assert_eq!(p.npm_package, "@agentmuxai/muxcode");
         assert_eq!(p.launch_args, &["run", "-p"]);
         assert!(p.persistent_launch_args.is_none());
     }

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -226,7 +226,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
     // muxcode — AgentMux's first-party agentic coding CLI.
     // Supports local GGUF inference via llama-server, Anthropic, OpenAI, and
     // OpenAI-compatible backends. Emits claude-stream-json NDJSON output.
-    // npm: @a5af/muxcode
+    // npm: @agentmuxai/muxcode
     muxcode: {
         id: "muxcode",
         displayName: "Mux Code",
@@ -243,11 +243,11 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["auth", "status"],
         // `auth login` pulls a default local model when no backend is configured.
         authLoginCommand: ["auth", "login"],
-        npmPackage: "@a5af/muxcode",
-        pinnedVersion: "latest",
+        npmPackage: "@agentmuxai/muxcode",
+        pinnedVersion: "0.1.0",
         docsUrl: "https://github.com/agentmuxai/muxcode",
-        windowsInstallCommand: "npm install -g @a5af/muxcode",
-        unixInstallCommand: "npm install -g @a5af/muxcode",
+        windowsInstallCommand: "npm install -g @agentmuxai/muxcode",
+        unixInstallCommand: "npm install -g @agentmuxai/muxcode",
         icon: "brain",
         authConfigDirEnvVar: "MUXCODE_CONFIG_DIR",
         authDirName: "muxcode",
@@ -310,7 +310,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["auth", "status"],
         authLoginCommand: ["auth"],
         npmPackage: "@qwen-code/qwen-code",
-        pinnedVersion: "latest",
+        pinnedVersion: "0.19.2",
         docsUrl: "https://qwenlm.github.io/qwen-code-docs",
         windowsInstallCommand: "npm install -g @qwen-code/qwen-code",
         unixInstallCommand: "npm install -g @qwen-code/qwen-code",
@@ -363,7 +363,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // only the args here. Kimi's `["login"]` is the convention.
         authLoginCommand: ["models", "auth", "login", "--provider", "openai-codex"],
         npmPackage: "openclaw",
-        pinnedVersion: "latest",
+        pinnedVersion: "2026.6.10",
         docsUrl: "https://docs.openclaw.ai",
         windowsInstallCommand: "npm install -g openclaw",
         unixInstallCommand: "npm install -g openclaw",
@@ -428,7 +428,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["auth", "status"],
         authLoginCommand: ["auth", "login"],
         npmPackage: "@github/copilot",
-        pinnedVersion: "latest",
+        pinnedVersion: "1.0.65",
         docsUrl: "https://docs.github.com/copilot/concepts/agents/about-copilot-cli",
         windowsInstallCommand: "npm install -g @github/copilot",
         unixInstallCommand: "npm install -g @github/copilot",
@@ -456,7 +456,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["config", "get", "provider"],
         authLoginCommand: ["config"],
         npmPackage: "@mariozechner/pi-coding-agent",
-        pinnedVersion: "latest",
+        pinnedVersion: "0.73.1",
         docsUrl: "https://github.com/badlogic/pi-mono",
         windowsInstallCommand: "npm install -g @mariozechner/pi-coding-agent",
         unixInstallCommand: "npm install -g @mariozechner/pi-coding-agent",


### PR DESCRIPTION
## Summary

Replaces every `pinnedVersion: "latest"` with a concrete version — prerequisite for the install modal version display (coming next). With `"latest"`, users would just see "latest" in the modal rather than the actual version.

| Provider | Package | Before | After |
|---|---|---|---|
| qwen | `@qwen-code/qwen-code` | `latest` | `0.19.2` |
| openclaw | `openclaw` | `latest` | `2026.6.10` |
| copilot | `@github/copilot` | `latest` | `1.0.65` |
| pi | `@mariozechner/pi-coding-agent` | `latest` | `0.73.1` |
| muxcode | `@a5af/muxcode` → `@agentmuxai/muxcode` | `latest` | `0.1.0` |

**muxcode:** Repo is already public at `agentmuxai/muxcode` at v0.1.0. Scope updated from `@a5af` → `@agentmuxai`. Version pinned to `0.1.0`. Npm publish to GitHub Packages is a separate step.

<!-- agentmux:agent_id=lark-06209 -->