### PR TITLE
fix(srv): bind to 0.0.0.0 when LAN discovery is enabled

### DIFF
--- a/.changesets/1782432583-fix-srv-bind-to-0-0-0-0-when-lan-discovery-is-enabled-so-rea-5gto.md
+++ b/.changesets/1782432583-fix-srv-bind-to-0-0-0-0-when-lan-discovery-is-enabled-so-rea-5gto.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): bind to 0.0.0.0 when LAN discovery is enabled so real devices can connect

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -751,6 +751,15 @@ async fn main() {
     // visibility. Bind to 0.0.0.0 so devices on the same network can reach the
     // port that mDNS advertises. The auth_key (X-AuthKey header, broadcast in
     // the mDNS TXT record) gates every API route.
+    //
+    // Known limitation: `bind_addr` is resolved once at startup. If the user
+    // enables LAN discovery via the settings toggle AFTER the sidecar has
+    // started (server/websocket.rs `setconfig` handler calls `lan.apply()`),
+    // the mDNS daemon re-advertises the host's LAN IP but the TCP listeners
+    // remain on 127.0.0.1 until the next restart. The toggle is therefore
+    // fully effective only when set before launch (settings.json) or after
+    // a sidecar restart. A future improvement would re-bind the listeners on
+    // toggle; deferred because rebinding an active axum server is non-trivial.
     let bind_addr = if config_watcher.get_settings().network_lan_discovery {
         "0.0.0.0:0"
     } else {

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -746,11 +746,20 @@ async fn main() {
         tracing::warn!("session archiver: home dir unavailable, archiver disabled");
     }
 
-    // 5. Bind 2 TCP listeners on 127.0.0.1:0 (web + ws — separate ports matching Go)
-    let web_listener = TcpListener::bind("127.0.0.1:0")
+    // 5. Bind 2 TCP listeners (web + ws — separate ports matching Go).
+    // When LAN discovery is enabled the user has explicitly opted in to network
+    // visibility. Bind to 0.0.0.0 so devices on the same network can reach the
+    // port that mDNS advertises. The auth_key (X-AuthKey header, broadcast in
+    // the mDNS TXT record) gates every API route.
+    let bind_addr = if config_watcher.get_settings().network_lan_discovery {
+        "0.0.0.0:0"
+    } else {
+        "127.0.0.1:0"
+    };
+    let web_listener = TcpListener::bind(bind_addr)
         .await
         .expect("failed to bind web listener");
-    let ws_listener = TcpListener::bind("127.0.0.1:0")
+    let ws_listener = TcpListener::bind(bind_addr)
         .await
         .expect("failed to bind ws listener");
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1035,8 +1035,8 @@ async fn main() {
 
     // 6. Emit AGENTMUXSRV-ESTART on stderr (exact format from cmd/server/main-server.go:617)
     eprintln!(
-        "AGENTMUXSRV-ESTART ws:{} web:{} version:{} buildtime:{} instance:{}",
-        ws_addr, web_addr, version, build_time, config.instance_id
+        "AGENTMUXSRV-ESTART ws:127.0.0.1:{} web:127.0.0.1:{} version:{} buildtime:{} instance:{}",
+        ws_addr.port(), web_addr.port(), version, build_time, config.instance_id
     );
 
     // 7. Build router and serve on both listeners

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -752,14 +752,15 @@ async fn main() {
     // port that mDNS advertises. The auth_key (X-AuthKey header, broadcast in
     // the mDNS TXT record) gates every API route.
     //
-    // Known limitation: `bind_addr` is resolved once at startup. If the user
-    // enables LAN discovery via the settings toggle AFTER the sidecar has
-    // started (server/websocket.rs `setconfig` handler calls `lan.apply()`),
-    // the mDNS daemon re-advertises the host's LAN IP but the TCP listeners
-    // remain on 127.0.0.1 until the next restart. The toggle is therefore
-    // fully effective only when set before launch (settings.json) or after
-    // a sidecar restart. A future improvement would re-bind the listeners on
-    // toggle; deferred because rebinding an active axum server is non-trivial.
+    // Known limitation: `bind_addr` is resolved once at startup. The toggle is
+    // therefore only fully effective before launch (settings.json) or after a
+    // sidecar restart. Both directions are affected:
+    //   OFF→ON: mDNS re-advertises the LAN IP but listeners stay on 127.0.0.1,
+    //           so remote devices cannot connect until restart.
+    //   ON→OFF: mDNS is stopped but listeners remain on 0.0.0.0 and are still
+    //           reachable on the LAN until restart (auth_key still gates routes).
+    // A future improvement would re-bind listeners on toggle; deferred because
+    // rebinding an active axum server is non-trivial.
     let bind_addr = if config_watcher.get_settings().network_lan_discovery {
         "0.0.0.0:0"
     } else {

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -774,7 +774,10 @@ async fn main() {
 
     let web_addr = web_listener.local_addr().unwrap();
     let ws_addr = ws_listener.local_addr().unwrap();
-    let local_web_url = format!("http://{}", web_addr);
+    // Always use 127.0.0.1 for the local URL regardless of bind address.
+    // When bound to 0.0.0.0, local_addr() returns 0.0.0.0:PORT which is not a
+    // valid connect destination (fails on Windows and some Linux configs).
+    let local_web_url = format!("http://127.0.0.1:{}", web_addr.port());
 
     // Make local backend URL available to child processes (PTY shells).
     // the muxbus client (agentbus-client package) reads AGENTMUX_LOCAL_URL for local PTY delivery


### PR DESCRIPTION
## Summary

- When `network:lan_discovery = true`, `agentmux-srv` now binds to `0.0.0.0:0` instead of `127.0.0.1:0`
- Previously mDNS would advertise the host's LAN IP but the HTTP server was loopback-only, so real phones on the same WiFi got connection refused after resolving the mDNS A record
- The `auth_key` (in `X-AuthKey` header and broadcast in the mDNS TXT record) continues to gate every API route — binding to all interfaces does not change the access-control model

## Why this is safe

The LAN discovery toggle is explicitly opt-in (defaults off, triggers Windows Firewall dialog). The `lan_discovery.rs` security comment already documents that LAN traffic is trusted: "anyone on the LAN who can already intercept mDNS multicast can intercept the HTTP traffic too, so the key adds no exposure beyond what already exists." Binding to `0.0.0.0` is the natural completion of that design.

## Test plan

- [ ] LAN discovery OFF (default): verify sidecar still binds `127.0.0.1` (local-only)
- [ ] LAN discovery ON: verify sidecar binds `0.0.0.0` — `netstat` shows `0.0.0.0:<port>`
- [ ] Mobile app on same WiFi: mDNS discovers instance, HTTP connects successfully to `<host-lan-ip>:<port>`
- [ ] Auth check: requests without `X-AuthKey` still get 401

<!-- agentmux:agent_id=mazs-0527n -->