### PR TITLE
feat(ui): Settings pane with reactive Appearance + Terminal controls

### DIFF
--- a/.changesets/1782432676-feat-ui-settings-pane-reactive-in-app-form-replacing-raw-jso-1ba0.md
+++ b/.changesets/1782432676-feat-ui-settings-pane-reactive-in-app-form-replacing-raw-jso-1ba0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(ui): Settings pane — reactive in-app form replacing raw JSON editor

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -216,5 +216,17 @@
                 "view": "trust"
             }
         }
+    },
+    "defwidget@settings": {
+        "display:order": 99,
+        "display:pinned": false,
+        "icon": "cog",
+        "label": "Settings",
+        "description": "App settings — appearance, terminal, agent, sounds, and more",
+        "blockdef": {
+            "meta": {
+                "view": "settings"
+            }
+        }
     }
 }

--- a/frontend/app/block/block-registry.ts
+++ b/frontend/app/block/block-registry.ts
@@ -12,6 +12,7 @@ import { EditorViewModel } from "@/app/view/editor/editor";
 import { IdentityPaneViewModel } from "@/app/view/identity/identity-pane";
 import { LauncherViewModel } from "@/app/view/launcher/launcher";
 import { MemoryViewModel } from "@/app/view/memory/memory";
+import { SettingsViewModel } from "@/app/view/settings/settings";
 import { SubagentViewModel } from "@/app/view/subagent/subagent";
 import { SwarmViewModel } from "@/app/view/swarm/swarm";
 import { SysinfoViewModel } from "@/app/view/sysinfo/sysinfo";
@@ -39,6 +40,7 @@ blockViewRegistry.set("drone", DroneViewModel as any);
 blockViewRegistry.set("warden", WardenViewModel as any);
 blockViewRegistry.set("toolchain", ToolchainViewModel as any);
 blockViewRegistry.set("trust", TrustViewModel as any);
+blockViewRegistry.set("settings", SettingsViewModel as any);
 
 export function registerBlockView(viewType: string, cls: ViewModelClass): void {
     blockViewRegistry.set(viewType, cls);

--- a/frontend/app/view/settings/settings-model.ts
+++ b/frontend/app/view/settings/settings-model.ts
@@ -1,0 +1,35 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createSignal } from "solid-js";
+
+export type SettingsSection =
+    | "appearance"
+    | "terminal"
+    | "agent"
+    | "sounds"
+    | "network"
+    | "files"
+    | "advanced";
+
+export class SettingsViewModel implements ViewModel {
+    viewType = "settings";
+    blockId: string;
+    nodeModel: BlockNodeModel;
+
+    viewIcon = () => "cog";
+    viewName = () => "Settings";
+    // wired in settings.tsx to avoid circular import
+    declare viewComponent: ViewComponent<SettingsViewModel>;
+
+    activeSection: () => SettingsSection;
+    setSection: (s: SettingsSection) => void;
+
+    constructor(blockId: string, nodeModel: BlockNodeModel) {
+        this.blockId = blockId;
+        this.nodeModel = nodeModel;
+        const [section, setSection] = createSignal<SettingsSection>("appearance");
+        this.activeSection = section;
+        this.setSection = setSection;
+    }
+}

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -93,8 +93,8 @@ function ConfigErrorsBanner(): JSX.Element {
                         <div class="settings-config-error">
                             <i class="fa-solid fa-circle-exclamation" />
                             {" "}{e.err}
-                            <Show when={e.filename}>
-                                {" "}<span class="mono">{e.filename}{e.linenum ? `:${e.linenum}` : ""}</span>
+                            <Show when={e.file}>
+                                {" "}<span class="mono">{e.file}</span>
                             </Show>
                         </div>
                     )}
@@ -198,7 +198,8 @@ function AppearanceSection(): JSX.Element {
 
 function TerminalSection(): JSX.Element {
     const s = () => settingsAtom() ?? ({} as any);
-    const termThemes = () => (fullConfigAtom()?.termthemes as Record<string, unknown>[] | undefined) ?? [];
+    const termThemes = () => Object.entries((fullConfigAtom()?.termthemes as Record<string, any>) ?? {})
+        .sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));
 
     return (
         <div class="settings-section-body">
@@ -236,12 +237,12 @@ function TerminalSection(): JSX.Element {
                     control={
                         <select
                             class="setting-select"
-                            value={(s()["term:theme"] as string) ?? "default"}
-                            onChange={(e) => set("term:theme", e.currentTarget.value)}
+                            value={(s()["term:theme"] as string) ?? ""}
+                            onChange={(e) => set("term:theme", e.currentTarget.value || null)}
                         >
-                            <option value="default">Default</option>
+                            <option value="">Default</option>
                             <For each={termThemes()}>
-                                {(t: any) => <option value={t.name}>{t.label ?? t.name}</option>}
+                                {([key, theme]) => <option value={key}>{theme["display:name"] ?? key}</option>}
                             </For>
                         </select>
                     }

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -294,12 +294,12 @@ function TerminalSection(): JSX.Element {
                 }
             />
             <SettingRow
-                label="Terminal opacity"
-                description="Terminal background opacity (0–1)"
+                label="Terminal transparency"
+                description="Terminal background transparency (0 = opaque, 1 = fully transparent)"
                 control={
                     <SliderControl
                         min={0} max={1} step={0.05}
-                        value={(s()["term:transparency"] as number) ?? 1}
+                        value={(s()["term:transparency"] as number) ?? 0}
                         onChange={(v) => set("term:transparency", v)}
                     />
                 }

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -1,0 +1,395 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createSignal, For, Match, Show, Switch, type JSX } from "solid-js";
+
+import { fullConfigAtom, settingsAtom } from "@/app/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { invokeCommand } from "@/app/platform/ipc";
+import { THEME_OPTIONS } from "@/app/menu/base-menus";
+import type { SettingsSection, SettingsViewModel } from "./settings-model";
+import "./settings.scss";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function set(key: string, value: unknown): void {
+    void RpcApi.SetConfigCommand(TabRpcClient, { [key]: value } as any);
+}
+
+function makeDebounce(ms: number) {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    return (fn: () => void) => {
+        if (timer != null) clearTimeout(timer);
+        timer = setTimeout(() => { timer = null; fn(); }, ms);
+    };
+}
+
+const sliderDebounce = makeDebounce(180);
+
+// ── SettingRow primitive ──────────────────────────────────────────────────────
+
+function SettingRow(p: { label: string; description?: string; control: JSX.Element; indent?: boolean }): JSX.Element {
+    return (
+        <div class="setting-row" classList={{ "setting-row--indent": p.indent }}>
+            <div class="setting-row-label">
+                <span class="setting-row-name">{p.label}</span>
+                <Show when={p.description}>
+                    <span class="setting-row-desc">{p.description}</span>
+                </Show>
+            </div>
+            <div class="setting-row-control">{p.control}</div>
+        </div>
+    );
+}
+
+function ToggleControl(p: { checked: boolean; onChange: (v: boolean) => void }): JSX.Element {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={p.checked}
+            class="setting-toggle"
+            classList={{ "setting-toggle--on": p.checked }}
+            onClick={() => p.onChange(!p.checked)}
+        >
+            <span class="setting-toggle-thumb" />
+        </button>
+    );
+}
+
+function SliderControl(p: { min: number; max: number; step: number; value: number; onChange: (v: number) => void }): JSX.Element {
+    const [local, setLocal] = createSignal(p.value);
+    return (
+        <div class="setting-slider">
+            <input
+                type="range"
+                min={p.min} max={p.max} step={p.step}
+                value={local()}
+                onInput={(e) => {
+                    const v = parseFloat(e.currentTarget.value);
+                    setLocal(v);
+                    sliderDebounce(() => p.onChange(v));
+                }}
+            />
+            <span class="setting-slider-val">{Math.round(local() * 100) / 100}</span>
+        </div>
+    );
+}
+
+// ── Config error banner ───────────────────────────────────────────────────────
+
+function ConfigErrorsBanner(): JSX.Element {
+    const errors = () => fullConfigAtom()?.configerrors ?? [];
+    const openRaw = async () => {
+        const path = await invokeCommand<string>("ensure_settings_file");
+        await invokeCommand("open_in_editor", { path });
+    };
+    return (
+        <Show when={errors().length > 0}>
+            <div class="settings-config-errors">
+                <For each={errors()}>
+                    {(e: any) => (
+                        <div class="settings-config-error">
+                            <i class="fa-solid fa-circle-exclamation" />
+                            {" "}{e.err}
+                            <Show when={e.filename}>
+                                {" "}<span class="mono">{e.filename}{e.linenum ? `:${e.linenum}` : ""}</span>
+                            </Show>
+                        </div>
+                    )}
+                </For>
+                <button class="settings-config-error-fix" onClick={() => void openRaw()}>
+                    Fix in editor
+                </button>
+            </div>
+        </Show>
+    );
+}
+
+// ── Section: Appearance ───────────────────────────────────────────────────────
+
+function AppearanceSection(): JSX.Element {
+    const s = () => settingsAtom() ?? ({} as any);
+    const transparent = () => !!(s()["window:transparent"] as boolean);
+
+    return (
+        <div class="settings-section-body">
+            <SettingRow
+                label="Theme"
+                description="UI color theme for all windows"
+                control={
+                    <select
+                        class="setting-select"
+                        value={(s()["window:theme"] as string) ?? "default"}
+                        onChange={(e) => set("window:theme", e.currentTarget.value)}
+                    >
+                        <For each={THEME_OPTIONS}>
+                            {(t) => <option value={t.id}>{t.label}</option>}
+                        </For>
+                    </select>
+                }
+            />
+            <SettingRow
+                label="Window transparency"
+                description="Enable background transparency and blur"
+                control={
+                    <ToggleControl
+                        checked={transparent()}
+                        onChange={(v) => set("window:transparent", v)}
+                    />
+                }
+            />
+            <Show when={transparent()}>
+                <SettingRow
+                    indent
+                    label="Opacity"
+                    description="Window background opacity (35–100%)"
+                    control={
+                        <SliderControl
+                            min={0.35} max={1} step={0.05}
+                            value={(s()["window:opacity"] as number) ?? 1}
+                            onChange={(v) => set("window:opacity", v)}
+                        />
+                    }
+                />
+                <SettingRow
+                    indent
+                    label="Background blur"
+                    description="Blur the content behind the window"
+                    control={
+                        <ToggleControl
+                            checked={!!(s()["window:blur"] as boolean)}
+                            onChange={(v) => set("window:blur", v)}
+                        />
+                    }
+                />
+            </Show>
+            <SettingRow
+                label="Pane gap size"
+                description="Pixels between tiled panes (0–20)"
+                control={
+                    <input
+                        class="setting-number"
+                        type="number" min={0} max={20}
+                        value={(s()["window:tilegapsize"] as number) ?? 4}
+                        onBlur={(e) => {
+                            const v = parseInt(e.currentTarget.value, 10);
+                            if (!isNaN(v) && v >= 0 && v <= 20) set("window:tilegapsize", v);
+                        }}
+                    />
+                }
+            />
+            <SettingRow
+                label="Reduce motion"
+                description="Disable CSS animations and transitions"
+                control={
+                    <ToggleControl
+                        checked={!!(s()["window:reducedmotion"] as boolean)}
+                        onChange={(v) => set("window:reducedmotion", v)}
+                    />
+                }
+            />
+        </div>
+    );
+}
+
+// ── Section: Terminal ─────────────────────────────────────────────────────────
+
+function TerminalSection(): JSX.Element {
+    const s = () => settingsAtom() ?? ({} as any);
+    const termThemes = () => (fullConfigAtom()?.termthemes as Record<string, unknown>[] | undefined) ?? [];
+
+    return (
+        <div class="settings-section-body">
+            <SettingRow
+                label="Font size"
+                description="Terminal font size in pixels (8–32)"
+                control={
+                    <input
+                        class="setting-number"
+                        type="number" min={8} max={32}
+                        value={(s()["term:fontsize"] as number) ?? 14}
+                        onBlur={(e) => {
+                            const v = parseInt(e.currentTarget.value, 10);
+                            if (!isNaN(v) && v >= 8 && v <= 32) set("term:fontsize", v);
+                        }}
+                    />
+                }
+            />
+            <SettingRow
+                label="Font family"
+                description="Comma-separated font fallback list"
+                control={
+                    <input
+                        class="setting-text"
+                        type="text"
+                        value={(s()["term:fontfamily"] as string) ?? ""}
+                        placeholder="JetBrains Mono, monospace"
+                        onBlur={(e) => set("term:fontfamily", e.currentTarget.value)}
+                    />
+                }
+            />
+            <Show when={termThemes().length > 0}>
+                <SettingRow
+                    label="Terminal color theme"
+                    control={
+                        <select
+                            class="setting-select"
+                            value={(s()["term:theme"] as string) ?? "default"}
+                            onChange={(e) => set("term:theme", e.currentTarget.value)}
+                        >
+                            <option value="default">Default</option>
+                            <For each={termThemes()}>
+                                {(t: any) => <option value={t.name}>{t.label ?? t.name}</option>}
+                            </For>
+                        </select>
+                    }
+                />
+            </Show>
+            <SettingRow
+                label="Scrollback lines"
+                description="Number of lines kept in terminal scrollback (1000–100000)"
+                control={
+                    <input
+                        class="setting-number setting-number--wide"
+                        type="number" min={1000} max={100000} step={1000}
+                        value={(s()["term:scrollback"] as number) ?? 10000}
+                        onBlur={(e) => {
+                            const v = parseInt(e.currentTarget.value, 10);
+                            if (!isNaN(v) && v >= 1000 && v <= 100000) set("term:scrollback", v);
+                        }}
+                    />
+                }
+            />
+            <SettingRow
+                label="Copy on select"
+                description="Automatically copy selected text to clipboard"
+                control={
+                    <ToggleControl
+                        checked={!!(s()["term:copyonselect"] as boolean)}
+                        onChange={(v) => set("term:copyonselect", v)}
+                    />
+                }
+            />
+            <SettingRow
+                label="Shift+Enter → new line"
+                description="In agent composer: Shift+Enter inserts a newline instead of submitting"
+                control={
+                    <ToggleControl
+                        checked={!!(s()["term:shiftenternewline"] as boolean)}
+                        onChange={(v) => set("term:shiftenternewline", v)}
+                    />
+                }
+            />
+            <SettingRow
+                label="Bracketed paste"
+                description="Allow programs to detect pasted text vs. typed text"
+                control={
+                    <ToggleControl
+                        checked={s()["term:allowbracketedpaste"] !== false}
+                        onChange={(v) => set("term:allowbracketedpaste", v)}
+                    />
+                }
+            />
+            <SettingRow
+                label="Terminal opacity"
+                description="Terminal background opacity (0–1)"
+                control={
+                    <SliderControl
+                        min={0} max={1} step={0.05}
+                        value={(s()["term:transparency"] as number) ?? 1}
+                        onChange={(v) => set("term:transparency", v)}
+                    />
+                }
+            />
+        </div>
+    );
+}
+
+// ── Section stubs (Phases 3–4) ────────────────────────────────────────────────
+
+function StubSection(p: { label: string }): JSX.Element {
+    return (
+        <div class="settings-section-body settings-section-stub">
+            <i class="fa-solid fa-screwdriver-wrench" />
+            <span>{p.label} settings coming soon.</span>
+        </div>
+    );
+}
+
+// ── Rail ──────────────────────────────────────────────────────────────────────
+
+const RAIL: { id: SettingsSection; label: string; icon: string }[] = [
+    { id: "appearance", label: "Appearance",    icon: "palette" },
+    { id: "terminal",   label: "Terminal",      icon: "square-terminal" },
+    { id: "agent",      label: "Agent",         icon: "sparkles" },
+    { id: "sounds",     label: "Sounds",        icon: "volume-high" },
+    { id: "network",    label: "Network",       icon: "wifi" },
+    { id: "files",      label: "Files",         icon: "folder-open" },
+    { id: "advanced",   label: "Advanced",      icon: "sliders" },
+];
+
+// ── Main view ─────────────────────────────────────────────────────────────────
+
+export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.Element {
+    const section = () => props.model.activeSection();
+    const setSection = (s: SettingsSection) => props.model.setSection(s);
+
+    const openRaw = async () => {
+        const path = await invokeCommand<string>("ensure_settings_file");
+        await invokeCommand("open_in_editor", { path });
+    };
+
+    return (
+        <div class="settings-view">
+            <nav class="settings-rail" aria-label="Settings section">
+                <For each={RAIL}>
+                    {(item) => (
+                        <button
+                            type="button"
+                            class="settings-rail-item"
+                            classList={{ "is-active": section() === item.id }}
+                            aria-pressed={section() === item.id}
+                            onClick={() => setSection(item.id)}
+                        >
+                            <i class={`fa-solid fa-${item.icon}`} aria-hidden="true" />
+                            <span>{item.label}</span>
+                        </button>
+                    )}
+                </For>
+            </nav>
+            <div class="settings-body">
+                <ConfigErrorsBanner />
+                <Switch>
+                    <Match when={section() === "appearance"}>
+                        <AppearanceSection />
+                    </Match>
+                    <Match when={section() === "terminal"}>
+                        <TerminalSection />
+                    </Match>
+                    <Match when={section() === "agent"}>
+                        <StubSection label="Agent" />
+                    </Match>
+                    <Match when={section() === "sounds"}>
+                        <StubSection label="Sounds & Notifications" />
+                    </Match>
+                    <Match when={section() === "network"}>
+                        <StubSection label="Network" />
+                    </Match>
+                    <Match when={section() === "files"}>
+                        <StubSection label="Files & Drag-Drop" />
+                    </Match>
+                    <Match when={section() === "advanced"}>
+                        <StubSection label="Advanced" />
+                    </Match>
+                </Switch>
+                <footer class="settings-footer">
+                    <button class="settings-footer-btn" onClick={() => void openRaw()}>
+                        <i class="fa-solid fa-file-code" /> Open raw settings.json
+                    </button>
+                </footer>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignal, For, Match, Show, Switch, type JSX } from "solid-js";
+import { createEffect, createSignal, For, Match, onCleanup, Show, Switch, type JSX } from "solid-js";
 
 import { fullConfigAtom, settingsAtom } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -16,16 +16,6 @@ import "./settings.scss";
 function set(key: string, value: unknown): void {
     void RpcApi.SetConfigCommand(TabRpcClient, { [key]: value } as any);
 }
-
-function makeDebounce(ms: number) {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    return (fn: () => void) => {
-        if (timer != null) clearTimeout(timer);
-        timer = setTimeout(() => { timer = null; fn(); }, ms);
-    };
-}
-
-const sliderDebounce = makeDebounce(180);
 
 // ── SettingRow primitive ──────────────────────────────────────────────────────
 
@@ -60,6 +50,9 @@ function ToggleControl(p: { checked: boolean; onChange: (v: boolean) => void }):
 
 function SliderControl(p: { min: number; max: number; step: number; value: number; onChange: (v: number) => void }): JSX.Element {
     const [local, setLocal] = createSignal(p.value);
+    createEffect(() => setLocal(p.value));
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    onCleanup(() => { if (timer != null) clearTimeout(timer); });
     return (
         <div class="setting-slider">
             <input
@@ -69,7 +62,8 @@ function SliderControl(p: { min: number; max: number; step: number; value: numbe
                 onInput={(e) => {
                     const v = parseFloat(e.currentTarget.value);
                     setLocal(v);
-                    sliderDebounce(() => p.onChange(v));
+                    if (timer != null) clearTimeout(timer);
+                    timer = setTimeout(() => { timer = null; p.onChange(v); }, 180);
                 }}
             />
             <span class="setting-slider-val">{Math.round(local() * 100) / 100}</span>
@@ -299,7 +293,7 @@ function TerminalSection(): JSX.Element {
                 control={
                     <SliderControl
                         min={0} max={1} step={0.05}
-                        value={(s()["term:transparency"] as number) ?? 0}
+                        value={(s()["term:transparency"] as number) ?? 0.5}
                         onChange={(v) => set("term:transparency", v)}
                     />
                 }

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -1,0 +1,301 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.settings-view {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow: hidden;
+}
+
+// ── Left rail ─────────────────────────────────────────────────────────────────
+
+.settings-rail {
+    flex: 0 0 160px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px;
+    border-right: 1px solid var(--border-color);
+    background: var(--panel-bg-color, var(--main-bg-color));
+    overflow-y: auto;
+}
+
+.settings-rail-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--main-text-color);
+    font-size: 13px;
+    text-align: left;
+    cursor: default;
+
+    i {
+        width: 16px;
+        text-align: center;
+        opacity: 0.7;
+    }
+
+    &:hover {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
+    }
+
+    &.is-active {
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+
+        i {
+            opacity: 1;
+        }
+    }
+}
+
+// ── Right content ─────────────────────────────────────────────────────────────
+
+.settings-body {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.settings-section-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.settings-section-stub {
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-direction: row;
+    opacity: 0.5;
+    font-size: 0.9rem;
+}
+
+// ── Config error banner ───────────────────────────────────────────────────────
+
+.settings-config-errors {
+    padding: 8px 16px;
+    background: rgba(219, 58, 58, 0.12);
+    border-bottom: 1px solid rgba(219, 58, 58, 0.3);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+}
+
+.settings-config-error {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    color: var(--error-color, #f85149);
+
+    .mono {
+        font-family: monospace;
+        font-size: 0.75rem;
+        opacity: 0.8;
+    }
+}
+
+.settings-config-error-fix {
+    align-self: flex-end;
+    margin-top: 4px;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border: 1px solid var(--error-color, #f85149);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--error-color, #f85149);
+    cursor: default;
+
+    &:hover {
+        background: rgba(219, 58, 58, 0.12);
+    }
+}
+
+// ── Setting rows ──────────────────────────────────────────────────────────────
+
+.setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px 4px;
+    border-bottom: 1px solid var(--border-color, rgba(127, 127, 127, 0.12));
+
+    &:last-of-type {
+        border-bottom: none;
+    }
+
+    &--indent {
+        padding-left: 24px;
+        opacity: 0.9;
+    }
+}
+
+.setting-row-label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.setting-row-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.setting-row-desc {
+    font-size: 0.73rem;
+    opacity: 0.55;
+    line-height: 1.3;
+}
+
+.setting-row-control {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+}
+
+// ── Controls ──────────────────────────────────────────────────────────────────
+
+.setting-select {
+    font-size: 0.82rem;
+    padding: 3px 6px;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    color: inherit;
+    min-width: 140px;
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color, rgba(88, 166, 255, 0.6));
+    }
+}
+
+.setting-number {
+    width: 64px;
+    font-size: 0.82rem;
+    padding: 3px 6px;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    color: inherit;
+    text-align: right;
+
+    &--wide {
+        width: 88px;
+    }
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color, rgba(88, 166, 255, 0.6));
+    }
+}
+
+.setting-text {
+    font-size: 0.82rem;
+    padding: 3px 8px;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    color: inherit;
+    width: 200px;
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color, rgba(88, 166, 255, 0.6));
+    }
+}
+
+// ── Toggle switch ─────────────────────────────────────────────────────────────
+
+.setting-toggle {
+    position: relative;
+    width: 36px;
+    height: 20px;
+    border: none;
+    border-radius: 10px;
+    background: var(--toggle-off-bg, rgba(127, 127, 127, 0.35));
+    cursor: default;
+    transition: background 0.15s;
+    padding: 0;
+
+    &--on {
+        background: var(--accent-color, #58a6ff);
+    }
+}
+
+.setting-toggle-thumb {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.15s;
+
+    .setting-toggle--on & {
+        transform: translateX(16px);
+    }
+}
+
+// ── Slider ────────────────────────────────────────────────────────────────────
+
+.setting-slider {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    input[type="range"] {
+        width: 120px;
+        accent-color: var(--accent-color, #58a6ff);
+    }
+}
+
+.setting-slider-val {
+    font-size: 0.75rem;
+    min-width: 28px;
+    text-align: right;
+    opacity: 0.65;
+}
+
+// ── Footer ────────────────────────────────────────────────────────────────────
+
+.settings-footer {
+    flex-shrink: 0;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border-color);
+}
+
+.settings-footer-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    padding: 4px 10px;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+    opacity: 0.7;
+
+    &:hover {
+        opacity: 1;
+        background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    }
+}

--- a/frontend/app/view/settings/settings.tsx
+++ b/frontend/app/view/settings/settings.tsx
@@ -1,0 +1,15 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Settings module barrel — wires viewComponent to avoid circular import.
+
+import { SettingsViewModel } from "./settings-model";
+import { SettingsView } from "./settings-view";
+
+Object.defineProperty(SettingsViewModel.prototype, "viewComponent", {
+    get() {
+        return SettingsView;
+    },
+});
+
+export { SettingsViewModel };

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -17,6 +17,8 @@ import { FlyoutMenu } from "@/app/element/flyoutmenu";
 import { fireAndForget } from "@/util/util";
 import { openModal } from "@/app/store/modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
+import { openBundleManager } from "@/app/modals/bundle-manager-modal";
+import { openToolchainModal } from "@/app/modals/toolchain-modal";
 import { isMacOS } from "@/util/platformutil";
 import { createMemo, type JSX } from "solid-js";
 import "./hamburger-menu.scss";
@@ -64,12 +66,12 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
             {
                 label: "Trust Center",
                 icon: "id-card",
-                onClick: () => fireAndForget(() => openOrFocusPaneByView("trust")),
+                onClick: () => openBundleManager(),
             },
             {
-                label: "Toolchain",
+                label: "Toolchain Manager",
                 icon: "wrench",
-                onClick: () => fireAndForget(() => openOrFocusPaneByView("toolchain")),
+                onClick: () => openToolchainModal(),
             },
             {
                 label: "DevTools",

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -17,8 +17,6 @@ import { FlyoutMenu } from "@/app/element/flyoutmenu";
 import { fireAndForget } from "@/util/util";
 import { openModal } from "@/app/store/modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
-import { openBundleManager } from "@/app/modals/bundle-manager-modal";
-import { openToolchainModal } from "@/app/modals/toolchain-modal";
 import { isMacOS } from "@/util/platformutil";
 import { createMemo, type JSX } from "solid-js";
 import "./hamburger-menu.scss";
@@ -66,12 +64,12 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
             {
                 label: "Trust Center",
                 icon: "id-card",
-                onClick: () => openBundleManager(),
+                onClick: () => fireAndForget(() => openOrFocusPaneByView("trust")),
             },
             {
-                label: "Toolchain Manager",
+                label: "Toolchain",
                 icon: "wrench",
-                onClick: () => openToolchainModal(),
+                onClick: () => fireAndForget(() => openOrFocusPaneByView("toolchain")),
             },
             {
                 label: "DevTools",

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -12,12 +12,8 @@
 // Every menu action resolves to a module-level store/RPC primitive, so the
 // component is fully self-contained (no TabBar state coupling).
 
-import { createTab, getApi, openOrFocusPaneByView, settingsAtom } from "@/store/global";
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
-import { THEME_OPTIONS } from "@/app/menu/base-menus";
+import { createTab, getApi, openOrFocusPaneByView } from "@/store/global";
 import { FlyoutMenu } from "@/app/element/flyoutmenu";
-import { invokeCommand } from "@/app/platform/ipc";
 import { fireAndForget } from "@/util/util";
 import { openModal } from "@/app/store/modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
@@ -36,45 +32,6 @@ interface HamburgerMenuProps {
 
 export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
     const menuItems = createMemo((): MenuItem[] => {
-        const settings = settingsAtom() ?? ({} as any);
-
-        const currentTheme = (settings["window:theme"] as string) || "default";
-        const themeSubItems: MenuItem[] = THEME_OPTIONS.map((opt) => ({
-            label: opt.label,
-            checked: currentTheme === opt.id,
-            onClick: () => {
-                fireAndForget(() =>
-                    RpcApi.SetConfigCommand(TabRpcClient, { "window:theme": opt.id } as any),
-                );
-            },
-        }));
-
-        const rawOpacity = (settings["window:opacity"] as number) ?? 0.8;
-        const isTransparent = (settings["window:transparent"] as boolean) ?? false;
-        const effectiveOpacity = isTransparent ? rawOpacity : 1.0;
-        const opacityStep = Math.round(effectiveOpacity * 20) / 20;
-        const opacitySubItems: MenuItem[] = [];
-        for (let pct = 100; pct >= 35; pct -= 5) {
-            const value = pct / 100;
-            opacitySubItems.push({
-                label: `${pct}%`,
-                checked: Math.abs(value - opacityStep) < 0.001,
-                onClick: () => {
-                    fireAndForget(() =>
-                        value < 1.0
-                            ? RpcApi.SetConfigCommand(TabRpcClient, {
-                                  "window:opacity": value,
-                                  "window:transparent": true,
-                              } as any)
-                            : RpcApi.SetConfigCommand(TabRpcClient, {
-                                  "window:opacity": 1.0,
-                                  "window:transparent": false,
-                              } as any),
-                    );
-                },
-            });
-        }
-
         const mac = isMacOS();
         const kbd = (m: string, w: string) => (mac ? m : w);
 
@@ -94,24 +51,9 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
             },
             { label: "", divider: true },
             {
-                label: "Theme",
-                icon: "palette",
-                subItems: themeSubItems,
-            },
-            {
-                label: "Opacity",
-                icon: "circle-half-stroke",
-                subItems: opacitySubItems,
-            },
-            { label: "", divider: true },
-            {
                 label: "Settings",
                 icon: "cog",
-                onClick: () =>
-                    fireAndForget(async () => {
-                        const path = await invokeCommand<string>("ensure_settings_file");
-                        await invokeCommand("open_in_editor", { path });
-                    }),
+                onClick: () => fireAndForget(() => openOrFocusPaneByView("settings")),
             },
             {
                 label: "Command Palette",


### PR DESCRIPTION
## Summary

Replaces the hamburger Settings entry (which opened `settings.json` in the OS default editor) with a first-class widget pane registered in the block system.

- **`frontend/app/view/settings/`** — new SettingsViewModel + SettingsView barrel + 395-line view component + 301-line scss
- **7-section left-rail navigator** (Appearance, Terminal, Agent, Sounds, Network, Files, Advanced); active section held in model signal
- **Immediate-apply controls** — every change fires `SetConfigCommand` directly; sliders debounce 180ms to avoid saturation; no Save button
- **Appearance section** (fully wired): theme select, transparency toggle, opacity + blur sub-controls (shown only when transparent is on), pane gap, reduce-motion
- **Terminal section** (fully wired): font size/family, terminal color theme, scrollback, copy-on-select, shift+enter, bracketed paste, terminal opacity
- **Agent / Sounds / Network / Files / Advanced** — stub sections for follow-up phases per SPEC_SETTINGS_PANE_2026_06_25.md
- **configerrors banner** — shown at top when `fullConfigAtom().configerrors` has entries, with "Fix in editor" link
- **Raw settings.json escape hatch** — footer link calls `ensure_settings_file` + `open_in_editor` IPC for power users
- **hamburger-menu.tsx** — Settings now calls `openOrFocusPaneByView("settings")`; Theme and Opacity submenus removed (both live in Appearance section now)
- **`defwidget@settings`** (order 99, unpinned) added to `widgets.json`
- **`block-registry.ts`** — `"settings"` registered
- **`global.ts`** — `openOrFocusPaneByView()` added (also added in #1789; dedup on merge)

## Test plan

- [ ] Hamburger → Settings opens a Settings pane; clicking again focuses it instead of opening a second
- [ ] Appearance section: changing theme updates the UI immediately
- [ ] Appearance section: enabling transparency reveals opacity slider + blur toggle; disabling hides them
- [ ] Appearance section: opacity slider updates window opacity with visible debounce (~180ms delay)
- [ ] Terminal section: font size/family changes update open terminal panes
- [ ] Widget bar "More" → Settings opens the same pane
- [ ] Raw settings.json footer link opens the file in the OS editor
- [ ] configerrors banner appears when settings.json has a parse error
- [ ] No Theme or Opacity submenus in hamburger
- [ ] No compile errors; no stale imports

> **Note:** `openOrFocusPaneByView` is also added in PR #1789 — whichever merges second will have a trivial dedup conflict in `global.ts`.

<!-- agentmux:agent_id=agentx -->