### PR TITLE
fix(swarm): cross-window agent focus and full selection box

### DIFF
--- a/.changesets/1782433013-fix-swarm-cross-window-agent-focus-and-full-selection-box-6c16.md
+++ b/.changesets/1782433013-fix-swarm-cross-window-agent-focus-and-full-selection-box-6c16.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): cross-window agent focus and full selection box

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -91,7 +91,10 @@
 
     &--active {
         background: var(--highlight-bg);
-        outline: 1px solid var(--accent-color, #5b8dd9);
+        // inset box-shadow draws on all four sides inside the element and is
+        // never clipped by ancestor overflow:hidden (unlike outline which
+        // renders outside the box and is cut at the swarm-view edge).
+        box-shadow: inset 0 0 0 1px var(--accent-color, #5b8dd9);
         border-radius: 0;
     }
 

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -32,24 +32,25 @@ async function focusBlock(blockId: string): Promise<void> {
         }
     }
     // Slow path: agent is in a different window — query all workspaces.
+    // Layout models for other-window tabs may be empty if never visited, so use
+    // Tab.blockids from WOS cache (populated for any tab the other window has fetched,
+    // including its active tab).  focusNode is intentionally omitted: a layout model
+    // in another renderer process cannot be driven from this side.
     const allWorkspaces = await RpcApi.WorkspaceListCommand(TabRpcClient);
     for (const wsInfo of allWorkspaces) {
         if (wsInfo.workspacedata.oid === ws?.oid) continue;
         const wsData = wsInfo.workspacedata;
         const allTabIds = [...(wsData.pinnedtabids ?? []), ...(wsData.tabids ?? [])];
         for (const tabId of allTabIds) {
-            const layoutModel = getLayoutModelForTabById(tabId);
-            const node = layoutModel?.getNodeByBlockId(blockId);
-            if (node?.id != null) {
-                await WorkspaceService.SetActiveTab(wsData.oid, tabId);
-                const instances = await getApi().listWindowInstances();
-                const instance = instances.find((i) => i.windowId === wsInfo.windowid);
-                if (instance?.label) {
-                    await getApi().focusWindow(instance.label);
-                }
-                layoutModel.focusNode(node.id);
-                return;
+            const tab = WOS.getObjectValue<Tab>(WOS.makeORef("tab", tabId));
+            if (!tab?.blockids?.includes(blockId)) continue;
+            await WorkspaceService.SetActiveTab(wsData.oid, tabId);
+            const instances = await getApi().listWindowInstances();
+            const instance = instances.find((i) => i.windowId === wsInfo.windowid);
+            if (instance?.label) {
+                await getApi().focusWindow(instance.label);
             }
+            return;
         }
     }
 }

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -32,17 +32,21 @@ async function focusBlock(blockId: string): Promise<void> {
         }
     }
     // Slow path: agent is in a different window — query all workspaces.
-    // Layout models for other-window tabs may be empty if never visited, so use
-    // Tab.blockids from WOS cache (populated for any tab the other window has fetched,
-    // including its active tab).  focusNode is intentionally omitted: a layout model
-    // in another renderer process cannot be driven from this side.
+    // We need Tab.blockids to find which tab holds the block. Layout models for
+    // other-window tabs are not available from this renderer. We fetch each Tab
+    // from the server (cache hit is instant; miss triggers one server round-trip).
+    // focusNode is intentionally omitted: a layout model in another renderer
+    // process cannot be driven from this side.
     const allWorkspaces = await RpcApi.WorkspaceListCommand(TabRpcClient);
     for (const wsInfo of allWorkspaces) {
         if (wsInfo.workspacedata.oid === ws?.oid) continue;
         const wsData = wsInfo.workspacedata;
         const allTabIds = [...(wsData.pinnedtabids ?? []), ...(wsData.tabids ?? [])];
         for (const tabId of allTabIds) {
-            const tab = WOS.getObjectValue<Tab>(WOS.makeORef("tab", tabId));
+            const oref = WOS.makeORef("tab", tabId);
+            // Use cached value when available; reloadWaveObject on cache miss.
+            const cached = WOS.getObjectValue<Tab>(oref);
+            const tab = cached ?? (await WOS.reloadWaveObject<Tab>(oref));
             if (!tab?.blockids?.includes(blockId)) continue;
             await WorkspaceService.SetActiveTab(wsData.oid, tabId);
             const instances = await getApi().listWindowInstances();

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -7,25 +7,49 @@ import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { WOS, workspace, setActiveTab, atoms } from "@/app/store/global";
+import { WOS, workspace, setActiveTab, atoms, getApi } from "@/app/store/global";
 import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
 import { getBlockTurnPhase } from "@/app/store/agentActivity";
+import { WorkspaceService } from "@/app/store/services";
 import "./swarm-view.scss";
 
-// Navigate to the pane for a given block ID, switching tabs if needed.
-// Uses layout models (always cached for visited tabs) rather than Tab.blockids
-// (which requires the Tab object to be in the WOS cache).
+// Navigate to the pane for a given block ID, switching tabs and windows as needed.
+// Tries the current window first (fast path), then searches all other workspaces
+// and brings the containing window to focus.
 async function focusBlock(blockId: string): Promise<void> {
+    // Fast path: search the current window's workspace.
     const ws = workspace();
-    if (!ws) return;
-    const allTabIds = [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])];
-    for (const tabId of allTabIds) {
-        const layoutModel = getLayoutModelForTabById(tabId);
-        const node = layoutModel?.getNodeByBlockId(blockId);
-        if (node?.id != null) {
-            await setActiveTab(tabId);
-            layoutModel.focusNode(node.id);
-            return;
+    if (ws) {
+        const allTabIds = [...(ws.pinnedtabids ?? []), ...(ws.tabids ?? [])];
+        for (const tabId of allTabIds) {
+            const layoutModel = getLayoutModelForTabById(tabId);
+            const node = layoutModel?.getNodeByBlockId(blockId);
+            if (node?.id != null) {
+                await setActiveTab(tabId);
+                layoutModel.focusNode(node.id);
+                return;
+            }
+        }
+    }
+    // Slow path: agent is in a different window — query all workspaces.
+    const allWorkspaces = await RpcApi.WorkspaceListCommand(TabRpcClient);
+    for (const wsInfo of allWorkspaces) {
+        if (wsInfo.workspacedata.oid === ws?.oid) continue;
+        const wsData = wsInfo.workspacedata;
+        const allTabIds = [...(wsData.pinnedtabids ?? []), ...(wsData.tabids ?? [])];
+        for (const tabId of allTabIds) {
+            const layoutModel = getLayoutModelForTabById(tabId);
+            const node = layoutModel?.getNodeByBlockId(blockId);
+            if (node?.id != null) {
+                await WorkspaceService.SetActiveTab(wsData.oid, tabId);
+                const instances = await getApi().listWindowInstances();
+                const instance = instances.find((i) => i.windowId === wsInfo.windowid);
+                if (instance?.label) {
+                    await getApi().focusWindow(instance.label);
+                }
+                layoutModel.focusNode(node.id);
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Cross-window focus:** clicking an agent in the Swarm that lives in a different window was a silent no-op — `focusBlock()` only searched the current window's workspace tabs. Added a slow path: call `WorkspaceListCommand` to enumerate all workspaces, find the tab containing the block, call `WorkspaceService.SetActiveTab` to switch to that tab, then `listWindowInstances + focusWindow` to bring the other window to the foreground
- **Full selection box:** the `--active` row style used `outline` which renders *outside* the element's border box and is clipped by `.swarm-view { overflow: hidden }`. Left and right sides were silently discarded, leaving only a top and bottom bar. Replaced with `box-shadow: inset 0 0 0 1px var(--accent-color)` which draws on all four sides inside the element and is never clipped by overflow

## Test plan

- [ ] Open an agent in Window A, open Swarm in Window B — click the agent row in the Swarm → Window A should come to focus with the agent pane active
- [ ] Click an agent row for a pane in the **same** window — still works (fast path unchanged)  
- [ ] Active agent row in Swarm has a solid 1px accent-color box on all four sides, not just top + bottom

<!-- agentmux:agent_id=camper -->