### PR TITLE
feat(cron+loop): persistent cron scheduler + LoopList + max_iterations

### DIFF
--- a/.changesets/1782433463-feat-cron-loop-persistent-cron-scheduler-croncreate-delete-l-3qlx.md
+++ b/.changesets/1782433463-feat-cron-loop-persistent-cron-scheduler-croncreate-delete-l-3qlx.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(cron+loop): persistent cron scheduler (CronCreate/Delete/List/Pause/Resume) + LoopList + max_iterations on Loop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "chrono",
  "clap",
  "crash-handler",
+ "cron",
  "dirs",
  "encoding_rs",
  "flate2",
@@ -1080,6 +1081,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]
@@ -2465,6 +2477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2538,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -241,7 +241,7 @@ const CRON_CREATE_TOOL: &str = r#"{
       "expression": { "type": "string",  "description": "5-field UTC cron expression: 'min hour dom month dow' (e.g. '0 9 * * 1-5' = 9am weekdays). Standard cron syntax; ranges, lists, and step values are supported." },
       "prompt":     { "type": "string",  "description": "The prompt or slash command to inject at each scheduled fire" },
       "to":         { "type": "string",  "description": "Target agent id to inject into. Required." },
-      "max_fires":  { "type": "integer", "description": "Auto-delete after this many fires. Omit for unlimited." }
+      "max_fires":  { "type": "integer", "description": "Auto-disable after this many fires (the job row stays in DB for audit; use CronDelete to remove it). Omit for unlimited." }
     },
     "required": ["name", "expression", "prompt", "to"]
   }

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -24,8 +24,8 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use agentmux_common::api_types::{
     InjectRequest, PaneOpenRequest, PaneOpenResponse, ShellCreateRequest, ShellCreateResponse,
@@ -37,10 +37,21 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 
-/// In-process registry of running loops (loop_id → task handle), used by
-/// `Loop` (insert) and `LoopStop` (remove + abort). Loops live in this MCP
-/// process, so they stop automatically when the agent pane / session ends.
-type LoopRegistry = Mutex<HashMap<String, JoinHandle<()>>>;
+/// Metadata kept alongside each running loop's task handle.
+struct LoopEntry {
+    handle: JoinHandle<()>,
+    prompt: String,
+    target: String,
+    interval_secs: u64,
+    max_iterations: Option<u64>,
+    fire_count: Arc<AtomicU64>,
+    started_at: u64,
+}
+
+/// In-process registry of running loops, keyed by loop_id. Lives for this MCP
+/// process's lifetime (== the agent session), so loops are reaped automatically
+/// when the agent pane closes.
+type LoopRegistry = Mutex<HashMap<String, LoopEntry>>;
 
 const SHELL_TOOL: &str = r#"{
   "name": "Shell",
@@ -185,14 +196,15 @@ const OPEN_EDITOR_TOOL: &str = r#"{
 
 const LOOP_TOOL: &str = r#"{
   "name": "Loop",
-  "description": "Run a prompt or slash command on a recurring interval by re-injecting it into a conversation. AgentMux's analogue of Claude's /loop. Returns immediately with a loop_id; the prompt is injected on a fixed schedule until you stop it with LoopStop(loop_id). Use for polling/babysitting tasks ('check the deploy every 5m', 'keep running /babysit-prs'). Loops stop automatically when the agent pane closes. Do NOT use for one-off tasks.",
+  "description": "Run a prompt or slash command on a recurring interval by re-injecting it into a conversation. AgentMux's analogue of Claude's /loop. Returns immediately with a loop_id; the prompt is injected on a fixed schedule until you call LoopStop(loop_id) or it exhausts max_iterations. Use for polling/babysitting tasks ('check the deploy every 5m', 'keep running /babysit-prs'). Loops stop automatically when the agent pane closes. Do NOT use for one-off tasks — use ScheduleWakeup for that.",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "prompt":    { "type": "string", "description": "The prompt or slash command to inject each interval (e.g. 'check the PR status' or '/babysit-prs')" },
-      "interval":  { "type": "string", "description": "How often to run: a number with optional unit s/m/h (e.g. '30s', '5m', '1h'). A bare number is minutes. Default '10m'. Minimum 10s." },
-      "to":        { "type": "string", "description": "Target agent name (its AGENTMUX_AGENT_ID) to inject into. Defaults to this agent itself (a self-loop)." },
-      "immediate": { "type": "boolean", "description": "Run once immediately on start in addition to every interval. Default false (first run after one interval)." }
+      "prompt":         { "type": "string",  "description": "The prompt or slash command to inject each interval (e.g. 'check the PR status' or '/babysit-prs')" },
+      "interval":       { "type": "string",  "description": "How often to run: a number with optional unit s/m/h (e.g. '30s', '5m', '1h'). A bare number is minutes. Default '10m'. Minimum 10s." },
+      "to":             { "type": "string",  "description": "Target agent name (its AGENTMUX_AGENT_ID) to inject into. Defaults to this agent itself (a self-loop)." },
+      "immediate":      { "type": "boolean", "description": "Run once immediately on start in addition to every interval. Default false (first run after one interval)." },
+      "max_iterations": { "type": "integer", "description": "Stop automatically after this many fires. Omit or set to 0 for unlimited." }
     },
     "required": ["prompt"]
   }
@@ -200,13 +212,83 @@ const LOOP_TOOL: &str = r#"{
 
 const LOOP_STOP_TOOL: &str = r#"{
   "name": "LoopStop",
-  "description": "Stop a recurring loop started by Loop(). Pass the loop_id it returned. Loops also stop automatically when the agent pane closes.",
+  "description": "Stop a recurring loop started by Loop(). Pass the loop_id it returned. Loops also stop automatically when the agent pane closes or max_iterations is reached.",
   "inputSchema": {
     "type": "object",
     "properties": {
       "loop_id": { "type": "string", "description": "The loop_id returned by a prior Loop() call" }
     },
     "required": ["loop_id"]
+  }
+}"#;
+
+const LOOP_LIST_TOOL: &str = r#"{
+  "name": "LoopList",
+  "description": "List all currently running loops in this agent session. Returns each loop's id, prompt, target, interval, fire count, and remaining iterations (if capped). Like 'ps' for loops.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const CRON_CREATE_TOOL: &str = r#"{
+  "name": "CronCreate",
+  "description": "Create a persistent scheduled cron job that survives agent pane restarts. Fires the prompt on a UTC cron schedule by injecting it into the target agent. Unlike Loop, cron jobs persist as long as agentmux-srv is running. Returns a job id and the next scheduled fire time.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "name":       { "type": "string",  "description": "Human-readable label for the job (e.g. 'daily-standup-check')" },
+      "expression": { "type": "string",  "description": "5-field UTC cron expression: 'min hour dom month dow' (e.g. '0 9 * * 1-5' = 9am weekdays). Standard cron syntax; ranges, lists, and step values are supported." },
+      "prompt":     { "type": "string",  "description": "The prompt or slash command to inject at each scheduled fire" },
+      "to":         { "type": "string",  "description": "Target agent id to inject into. Required." },
+      "max_fires":  { "type": "integer", "description": "Auto-delete after this many fires. Omit for unlimited." }
+    },
+    "required": ["name", "expression", "prompt", "to"]
+  }
+}"#;
+
+const CRON_DELETE_TOOL: &str = r#"{
+  "name": "CronDelete",
+  "description": "Delete a persistent cron job by id. Stops all future fires immediately.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "description": "The job id returned by CronCreate or CronList" }
+    },
+    "required": ["id"]
+  }
+}"#;
+
+const CRON_LIST_TOOL: &str = r#"{
+  "name": "CronList",
+  "description": "List all persistent cron jobs (enabled and disabled). Returns each job's id, name, expression, next fire time, fire count, and enabled state.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const CRON_PAUSE_TOOL: &str = r#"{
+  "name": "CronPause",
+  "description": "Pause a persistent cron job. The job definition is kept in the DB but no fires occur until CronResume is called.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "description": "The job id to pause" }
+    },
+    "required": ["id"]
+  }
+}"#;
+
+const CRON_RESUME_TOOL: &str = r#"{
+  "name": "CronResume",
+  "description": "Resume a paused cron job. The job will fire at its next scheduled UTC time.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "description": "The job id to resume" }
+    },
+    "required": ["id"]
   }
 }"#;
 
@@ -305,10 +387,16 @@ async fn main() {
                     serde_json::from_str(FOCUS_WINDOW_TOOL).expect("static json");
                 let loop_tool: Value = serde_json::from_str(LOOP_TOOL).expect("static json");
                 let loop_stop: Value = serde_json::from_str(LOOP_STOP_TOOL).expect("static json");
+                let loop_list: Value = serde_json::from_str(LOOP_LIST_TOOL).expect("static json");
+                let cron_create: Value = serde_json::from_str(CRON_CREATE_TOOL).expect("static json");
+                let cron_delete: Value = serde_json::from_str(CRON_DELETE_TOOL).expect("static json");
+                let cron_list: Value = serde_json::from_str(CRON_LIST_TOOL).expect("static json");
+                let cron_pause: Value = serde_json::from_str(CRON_PAUSE_TOOL).expect("static json");
+                let cron_resume: Value = serde_json::from_str(CRON_RESUME_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume] }
                 })
             }
             "tools/call" => {
@@ -894,7 +982,6 @@ async fn call_tool(
                 );
             }
 
-            // Target: explicit `to`, else self (this agent's AGENTMUX_AGENT_ID).
             let self_id = std::env::var("AGENTMUX_AGENT_ID")
                 .ok()
                 .filter(|s| !s.is_empty());
@@ -920,19 +1007,25 @@ async fn call_tool(
                 .get("immediate")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
+            let max_iterations: Option<u64> = arguments
+                .get("max_iterations")
+                .and_then(|v| v.as_u64())
+                .filter(|&n| n > 0);
 
             let n = loop_counter.fetch_add(1, Ordering::Relaxed) + 1;
             let loop_id = format!("loop-{n}");
 
-            // Each loop is an independent task that re-injects the prompt on the
-            // fixed interval (fire-and-forget; no idle-wait — InjectionRequest
-            // .wait_for_idle is dead scaffolding that srv never reads).
             let interval_display = format_duration(interval);
             let url = format!("{}/agentmux/reactive/inject", local_url.trim_end_matches('/'));
             let task_client = client.clone();
             let task_auth = auth_key.to_string();
             let task_target = target.clone();
             let task_source = self_id;
+            let task_prompt = prompt.clone();
+            let fire_count = Arc::new(AtomicU64::new(0));
+            let task_fire_count = Arc::clone(&fire_count);
+            let task_max = max_iterations;
+
             let handle = tokio::spawn(async move {
                 if !immediate {
                     tokio::time::sleep(interval).await;
@@ -940,7 +1033,7 @@ async fn call_tool(
                 loop {
                     let req = InjectRequest {
                         target_agent: task_target.clone(),
-                        message: prompt.clone(),
+                        message: task_prompt.clone(),
                         source_agent: task_source.clone(),
                     };
                     let _ = task_client
@@ -949,19 +1042,39 @@ async fn call_tool(
                         .json(&req)
                         .send()
                         .await;
+                    let fired = task_fire_count.fetch_add(1, Ordering::Relaxed) + 1;
+                    if let Some(max) = task_max {
+                        if fired >= max {
+                            break;
+                        }
+                    }
                     tokio::time::sleep(interval).await;
                 }
             });
 
-            loops
-                .lock()
-                .unwrap()
-                .insert(loop_id.clone(), handle);
+            let started_at = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
 
+            loops.lock().unwrap().insert(loop_id.clone(), LoopEntry {
+                handle,
+                prompt,
+                target: target.clone(),
+                interval_secs: interval.as_secs(),
+                max_iterations,
+                fire_count,
+                started_at,
+            });
+
+            let cap_note = match max_iterations {
+                Some(n) => format!(", auto-stops after {n} fires"),
+                None => String::new(),
+            };
             Ok(format!(
-                "Started {loop_id}: injecting to '{target}' every {interval_display}\
-                 {}. Stop with LoopStop({loop_id}).",
-                if immediate { " (first run now)" } else { "" }
+                "Started {loop_id}: injecting to '{target}' every {interval_display}{cap_note}\
+                 {}. Stop with LoopStop({loop_id}) or use LoopList() to see all running loops.",
+                if immediate { ", first run now" } else { "" }
             ))
         }
         "LoopStop" => {
@@ -973,15 +1086,164 @@ async fn call_tool(
 
             let removed = loops.lock().unwrap().remove(loop_id);
             match removed {
-                Some(handle) => {
-                    handle.abort();
-                    Ok(format!("stopped {loop_id}"))
+                Some(entry) => {
+                    entry.handle.abort();
+                    Ok(format!(
+                        "stopped {loop_id} (fired {} time(s))",
+                        entry.fire_count.load(Ordering::Relaxed)
+                    ))
                 }
                 None => Ok(format!("{loop_id} was not running (unknown or already stopped)")),
             }
         }
+        "LoopList" => {
+            let reg = loops.lock().unwrap();
+            if reg.is_empty() {
+                return Ok("No loops running in this session.".to_string());
+            }
+            let mut lines = vec![format!("{} loop(s) in this session:", reg.len())];
+            for (id, entry) in reg.iter() {
+                let fired = entry.fire_count.load(Ordering::Relaxed);
+                let status = match entry.max_iterations {
+                    Some(max) if fired >= max => format!("DONE ({fired}/{max})"),
+                    Some(max) => format!("running ({fired}/{max})"),
+                    None => format!("running ({fired} fired, unlimited)"),
+                };
+                let interval = format_duration(Duration::from_secs(entry.interval_secs));
+                let prompt_preview: String = entry.prompt.chars().take(60).collect();
+                let age_secs = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0)
+                    .saturating_sub(entry.started_at);
+                lines.push(format!(
+                    "  {id}  every={interval}  to='{}'  status={status}  age={age_secs}s  prompt='{prompt_preview}'",
+                    entry.target,
+                ));
+            }
+            Ok(lines.join("\n"))
+        }
+        "CronCreate" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let name = arguments.get("name").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: name"))?;
+            let expression = arguments.get("expression").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: expression"))?;
+            let prompt = arguments.get("prompt").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: prompt"))?;
+            let target = arguments.get("to").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: to (target agent id)"))?;
+            let max_fires = arguments.get("max_fires").and_then(|v| v.as_i64()).filter(|&n| n > 0);
+            let self_id = std::env::var("AGENTMUX_AGENT_ID").ok().filter(|s| !s.is_empty()).unwrap_or_default();
+
+            let url = format!("{}/agentmux/cron", local_url.trim_end_matches('/'));
+            let body = serde_json::json!({
+                "name": name, "expression": expression, "prompt": prompt,
+                "target": target, "created_by": self_id, "max_fires": max_fires,
+            });
+            let resp = client.post(&url).header("X-AuthKey", auth_key).json(&body).send().await
+                .map_err(|e| anyhow::anyhow!("cron create request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                anyhow::bail!("CronCreate failed: HTTP {status} — {text}");
+            }
+            let v: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+            let job = &v["job"];
+            Ok(format!(
+                "Created cron job '{}' (id={})\nExpression: {} UTC\nNext fire: {}\nTarget: {}",
+                job["name"].as_str().unwrap_or(name),
+                job["id"].as_str().unwrap_or("?"),
+                expression,
+                job["next_fire"].as_str().unwrap_or("unknown"),
+                target,
+            ))
+        }
+        "CronDelete" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let id = arguments.get("id").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: id"))?;
+            let url = format!("{}/agentmux/cron/{}", local_url.trim_end_matches('/'), id);
+            let resp = client.delete(&url).header("X-AuthKey", auth_key).send().await
+                .map_err(|e| anyhow::anyhow!("cron delete request failed: {e}"))?;
+            let status = resp.status();
+            if status.as_u16() == 404 {
+                return Ok(format!("Job '{id}' not found (already deleted or wrong id)"));
+            }
+            if !status.is_success() {
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("CronDelete failed: HTTP {status} — {text}");
+            }
+            Ok(format!("Deleted cron job {id}"))
+        }
+        "CronList" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let url = format!("{}/agentmux/cron", local_url.trim_end_matches('/'));
+            let resp = client.get(&url).header("X-AuthKey", auth_key).send().await
+                .map_err(|e| anyhow::anyhow!("cron list request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                anyhow::bail!("CronList failed: HTTP {status} — {text}");
+            }
+            let v: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+            let jobs = v["jobs"].as_array().cloned().unwrap_or_default();
+            if jobs.is_empty() {
+                return Ok("No cron jobs configured.".to_string());
+            }
+            let mut lines = vec![format!("{} cron job(s):", jobs.len())];
+            for j in &jobs {
+                let status_str = if j["enabled"].as_bool().unwrap_or(false) { "enabled" } else { "paused" };
+                let next = j["next_fire"].as_str().unwrap_or("—");
+                let fires = j["fire_count"].as_i64().unwrap_or(0);
+                let max = j["max_fires"].as_i64().map(|n| format!("/{n}")).unwrap_or_default();
+                lines.push(format!(
+                    "  {}  {}  [{}]  fires={fires}{max}  next={}  expr='{}'",
+                    j["id"].as_str().unwrap_or("?"),
+                    j["name"].as_str().unwrap_or("?"),
+                    status_str,
+                    next,
+                    j["expression"].as_str().unwrap_or("?"),
+                ));
+            }
+            Ok(lines.join("\n"))
+        }
+        "CronPause" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let id = arguments.get("id").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: id"))?;
+            cron_set_enabled(client, local_url, auth_key, id, "pause").await
+        }
+        "CronResume" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let id = arguments.get("id").and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: id"))?;
+            cron_set_enabled(client, local_url, auth_key, id, "resume").await
+        }
         _ => anyhow::bail!("unknown tool: {name}"),
     }
+}
+
+async fn cron_set_enabled(
+    client: &reqwest::Client,
+    local_url: &str,
+    auth_key: &str,
+    id: &str,
+    action: &str,
+) -> Result<String> {
+    let url = format!("{}/agentmux/cron/{}", local_url.trim_end_matches('/'), id);
+    let body = serde_json::json!({"action": action});
+    let resp = client.patch(&url).header("X-AuthKey", auth_key).json(&body).send().await
+        .map_err(|e| anyhow::anyhow!("cron {action} request failed: {e}"))?;
+    let status = resp.status();
+    if status.as_u16() == 404 {
+        return Ok(format!("Job '{id}' not found"));
+    }
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Cron{} failed: HTTP {status} — {text}", if action == "pause" { "Pause" } else { "Resume" });
+    }
+    Ok(format!("Cron job {id} {}", if action == "pause" { "paused" } else { "resumed" }))
 }
 
 /// Parse a loop interval string into a `Duration`. Accepts a number with an
@@ -1050,8 +1312,14 @@ mod tests {
             FOCUS_WINDOW_TOOL,
             LOOP_TOOL,
             LOOP_STOP_TOOL,
+            LOOP_LIST_TOOL,
+            CRON_CREATE_TOOL,
+            CRON_DELETE_TOOL,
+            CRON_LIST_TOOL,
+            CRON_PAUSE_TOOL,
+            CRON_RESUME_TOOL,
         ];
-        assert_eq!(defs.len(), 13, "tools/list advertises 13 tools (11 original + Loop + LoopStop)");
+        assert_eq!(defs.len(), 19, "tools/list advertises 19 tools (11 original + 3 Loop + 5 Cron)");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -56,6 +56,8 @@ tempfile = "3"
 bollard = { version = "0.18", features = ["chrono"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+# Cron expression parsing for the persistent cron scheduler
+cron = "0.12"
 
 [target.'cfg(windows)'.dependencies]
 # Out-of-process crash dump capture via VEH + named-pipe IPC.

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -109,9 +109,12 @@ impl CronScheduler {
         let job_prompt = job.prompt.clone();
         let job_target = job.target.clone();
         let job_max_fires = job.max_fires;
+        // Seed from persisted fire_count so a srv restart doesn't reset the
+        // per-lifetime counter and allow a capped job to over-fire.
+        let job_fire_count = job.fire_count;
 
         let handle = tokio::spawn(async move {
-            let mut fires: i64 = 0;
+            let mut fires: i64 = job_fire_count;
             loop {
                 let next = match schedule.upcoming(Utc).next() {
                     Some(t) => t,

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persistent cron scheduler for AgentMux.
+//!
+//! Backs each enabled `CronJob` with a tokio task that sleeps until the
+//! next scheduled fire time (computed from the 5-field UTC cron expression),
+//! POSTs to `/agentmux/reactive/inject`, and records the fire in the DB.
+//!
+//! On startup, runs one catch-up fire for any job whose `last_fired` is
+//! more than one interval behind (FIRE_ONCE_NOW misfire policy — never
+//! replay all missed fires, never cause a cron storm).
+//!
+//! See `docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2`.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+
+use agentmux_common::api_types::InjectRequest;
+use chrono::Utc;
+use cron::Schedule;
+
+use crate::backend::storage::store::Store;
+use crate::backend::storage::cron::CronJob;
+
+/// Abort handles for every currently scheduled cron task.
+type HandleMap = Mutex<HashMap<String, tokio::task::AbortHandle>>;
+
+pub struct CronScheduler {
+    handles: HandleMap,
+    shared_store: Option<Arc<Store>>,
+    http_client: reqwest::Client,
+    local_url: String,
+    auth_key: String,
+}
+
+impl CronScheduler {
+    pub fn new(
+        shared_store: Option<Arc<Store>>,
+        http_client: reqwest::Client,
+        local_url: String,
+        auth_key: String,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            handles: Mutex::new(HashMap::new()),
+            shared_store,
+            http_client,
+            local_url,
+            auth_key,
+        })
+    }
+
+    /// Load all enabled jobs from the DB and schedule them. Call once at startup.
+    pub async fn start(self: &Arc<Self>) {
+        let store = match &self.shared_store {
+            Some(s) => s.clone(),
+            None => {
+                tracing::warn!("cron: no shared store — cron scheduler disabled");
+                return;
+            }
+        };
+
+        let jobs = match store.cron_list_enabled() {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::error!(error = %e, "cron: failed to load jobs on startup");
+                return;
+            }
+        };
+
+        let now_secs = Utc::now().timestamp();
+        let count = jobs.len();
+
+        for job in jobs {
+            // FIRE_ONCE_NOW: if the job missed its window (last_fired is more
+            // than one interval ago), fire once immediately as catch-up.
+            if should_catchup(&job, now_secs) {
+                let sched = self.clone();
+                let job_id = job.id.clone();
+                let job_prompt = job.prompt.clone();
+                let job_target = job.target.clone();
+                tokio::spawn(async move {
+                    sched.fire(&job_id, &job_prompt, &job_target).await;
+                });
+            }
+
+            self.schedule_job(&job);
+        }
+
+        tracing::info!(count, "cron: scheduled {} job(s) from DB", count);
+    }
+
+    /// Schedule a single job (or reschedule it after a DB change). Replaces
+    /// any existing task for the same `job.id`.
+    pub fn schedule_job(self: &Arc<Self>, job: &CronJob) {
+        self.cancel_job(&job.id);
+
+        let schedule = match Schedule::from_str(&format!("0 {}", job.expression)) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(id = %job.id, expr = %job.expression, error = %e, "cron: invalid expression — skipping job");
+                return;
+            }
+        };
+
+        let sched = self.clone();
+        let job_id = job.id.clone();
+        let job_prompt = job.prompt.clone();
+        let job_target = job.target.clone();
+
+        let handle = tokio::spawn(async move {
+            // Iterate over upcoming fire times. `schedule.upcoming(Utc)` is an
+            // infinite iterator; each `.next()` call computes the next UTC
+            // datetime after `Utc::now()`.
+            loop {
+                let next = match schedule.upcoming(Utc).next() {
+                    Some(t) => t,
+                    None => break,
+                };
+                let delay = (next - Utc::now()).to_std().unwrap_or_default();
+                tokio::time::sleep(delay).await;
+                sched.fire(&job_id, &job_prompt, &job_target).await;
+            }
+        });
+
+        self.handles.lock().unwrap().insert(job.id.clone(), handle.abort_handle());
+    }
+
+    /// Stop (abort) a job's scheduled task without removing it from the DB.
+    pub fn cancel_job(&self, id: &str) {
+        if let Some(handle) = self.handles.lock().unwrap().remove(id) {
+            handle.abort();
+        }
+    }
+
+    /// Fire a cron job: POST to reactive inject and record the fire in DB.
+    async fn fire(&self, id: &str, prompt: &str, target: &str) {
+        if self.local_url.is_empty() || self.auth_key.is_empty() {
+            tracing::warn!(id, "cron: no local_url/auth_key — skipping fire");
+            return;
+        }
+
+        let url = format!("{}/agentmux/reactive/inject", self.local_url.trim_end_matches('/'));
+        let req = InjectRequest {
+            target_agent: target.to_string(),
+            message: prompt.to_string(),
+            source_agent: Some("cron".to_string()),
+        };
+
+        match self.http_client.post(&url).header("X-AuthKey", &self.auth_key).json(&req).send().await {
+            Ok(r) if r.status().is_success() => {
+                tracing::debug!(id, target, "cron: fired");
+            }
+            Ok(r) => {
+                tracing::warn!(id, status = %r.status(), "cron: inject returned non-2xx");
+            }
+            Err(e) => {
+                tracing::warn!(id, error = %e, "cron: inject request failed");
+            }
+        }
+
+        if let Some(store) = &self.shared_store {
+            let now = Utc::now().timestamp();
+            if let Err(e) = store.cron_record_fire(id, now) {
+                tracing::warn!(id, error = %e, "cron: failed to record fire in DB");
+            }
+        }
+    }
+}
+
+/// Determine if a job needs a catch-up fire on startup. True when the job
+/// has never fired or missed its most recent window by more than the expected
+/// cycle (approximated as 60s minimum — any job that was due more than a
+/// minute ago and hasn't fired yet gets one immediate catch-up run).
+fn should_catchup(job: &CronJob, now_secs: i64) -> bool {
+    let Some(last) = job.last_fired else {
+        // Never fired before — check if it was scheduled to fire before now.
+        // We don't have a "created_at as first expected fire" without parsing
+        // the expression, so we skip the catch-up for brand-new jobs. They'll
+        // fire at the next scheduled time naturally.
+        return false;
+    };
+    let elapsed = now_secs.saturating_sub(last);
+    elapsed > 120 // missed by more than 2 minutes → one catch-up
+}

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use agentmux_common::api_types::InjectRequest;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use cron::Schedule;
 
 use crate::backend::storage::store::Store;
@@ -69,13 +69,16 @@ impl CronScheduler {
             }
         };
 
-        let now_secs = Utc::now().timestamp();
+        let now_dt = Utc::now();
         let count = jobs.len();
 
         for job in jobs {
-            // FIRE_ONCE_NOW: if the job missed its window (last_fired is more
-            // than one interval ago), fire once immediately as catch-up.
-            if should_catchup(&job, now_secs) {
+            // FIRE_ONCE_NOW: if the job missed its window, fire once immediately
+            // as catch-up. did_catchup is passed to schedule_job so the live
+            // task's fires counter is seeded at fire_count+1 and the catch-up
+            // fire counts toward max_fires.
+            let did_catchup = should_catchup(&job, now_dt);
+            if did_catchup {
                 let sched = self.clone();
                 let job_id = job.id.clone();
                 let job_prompt = job.prompt.clone();
@@ -85,15 +88,21 @@ impl CronScheduler {
                 });
             }
 
-            self.schedule_job(&job);
+            let initial_fires = job.fire_count + if did_catchup { 1 } else { 0 };
+            self.schedule_job_with_fires(&job, initial_fires);
         }
 
         tracing::info!(count, "cron: scheduled {} job(s) from DB", count);
     }
 
     /// Schedule a single job (or reschedule it after a DB change). Replaces
-    /// any existing task for the same `job.id`.
+    /// any existing task for the same `job.id`. Call sites that don't need to
+    /// account for a simultaneous catch-up fire should pass `job.fire_count`.
     pub fn schedule_job(self: &Arc<Self>, job: &CronJob) {
+        self.schedule_job_with_fires(job, job.fire_count);
+    }
+
+    fn schedule_job_with_fires(self: &Arc<Self>, job: &CronJob, initial_fires: i64) {
         self.cancel_job(&job.id);
 
         let schedule = match Schedule::from_str(&format!("0 {}", job.expression)) {
@@ -109,12 +118,12 @@ impl CronScheduler {
         let job_prompt = job.prompt.clone();
         let job_target = job.target.clone();
         let job_max_fires = job.max_fires;
-        // Seed from persisted fire_count so a srv restart doesn't reset the
-        // per-lifetime counter and allow a capped job to over-fire.
-        let job_fire_count = job.fire_count;
 
         let handle = tokio::spawn(async move {
-            let mut fires: i64 = job_fire_count;
+            // `initial_fires` is seeded from the persisted fire_count (plus 1
+            // if a catch-up fire was also dispatched at startup) so max_fires
+            // is enforced across restarts, not per process run.
+            let mut fires: i64 = initial_fires;
             loop {
                 let next = match schedule.upcoming(Utc).next() {
                     Some(t) => t,
@@ -184,18 +193,29 @@ impl CronScheduler {
     }
 }
 
-/// Determine if a job needs a catch-up fire on startup. True when the job
-/// has never fired or missed its most recent window by more than the expected
-/// cycle (approximated as 60s minimum — any job that was due more than a
-/// minute ago and hasn't fired yet gets one immediate catch-up run).
-fn should_catchup(job: &CronJob, now_secs: i64) -> bool {
-    let Some(last) = job.last_fired else {
-        // Never fired before — check if it was scheduled to fire before now.
-        // We don't have a "created_at as first expected fire" without parsing
-        // the expression, so we skip the catch-up for brand-new jobs. They'll
-        // fire at the next scheduled time naturally.
+/// Determine if a job needs a catch-up fire on startup.
+///
+/// True when there is a scheduled fire time that falls strictly between
+/// `last_fired` and `now` — i.e., the first occurrence of the cron expression
+/// after `last_fired` is already in the past. This is correct regardless of
+/// schedule granularity: a daily job that ran at 09:00 and is restarted at
+/// 09:05 yields a next-after-last of TOMORROW 09:00, which is NOT < now, so
+/// no spurious catch-up fires.
+///
+/// Jobs that have never fired are skipped (they'll fire at the next naturally
+/// scheduled time without any missed-window concept).
+fn should_catchup(job: &CronJob, now_dt: DateTime<Utc>) -> bool {
+    let Some(last) = job.last_fired else { return false; };
+    let last_dt = match DateTime::from_timestamp(last, 0) {
+        Some(dt) => dt,
+        None => return false,
+    };
+    let Ok(schedule) = Schedule::from_str(&format!("0 {}", job.expression)) else {
         return false;
     };
-    let elapsed = now_secs.saturating_sub(last);
-    elapsed > 120 // missed by more than 2 minutes → one catch-up
+    // First scheduled time after last_fired — if it's already past, a fire was missed.
+    match schedule.after(&last_dt).next() {
+        Some(next_after_last) => next_after_last < now_dt,
+        None => false,
+    }
 }

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -108,11 +108,10 @@ impl CronScheduler {
         let job_id = job.id.clone();
         let job_prompt = job.prompt.clone();
         let job_target = job.target.clone();
+        let job_max_fires = job.max_fires;
 
         let handle = tokio::spawn(async move {
-            // Iterate over upcoming fire times. `schedule.upcoming(Utc)` is an
-            // infinite iterator; each `.next()` call computes the next UTC
-            // datetime after `Utc::now()`.
+            let mut fires: i64 = 0;
             loop {
                 let next = match schedule.upcoming(Utc).next() {
                     Some(t) => t,
@@ -121,6 +120,19 @@ impl CronScheduler {
                 let delay = (next - Utc::now()).to_std().unwrap_or_default();
                 tokio::time::sleep(delay).await;
                 sched.fire(&job_id, &job_prompt, &job_target).await;
+                fires += 1;
+                // Enforce max_fires in the live task — don't rely on the DB
+                // flag alone, which only takes effect on the next srv restart.
+                if let Some(max) = job_max_fires {
+                    if fires >= max {
+                        tracing::info!(id = %job_id, fires, "cron: max_fires reached — disabling job");
+                        if let Some(store) = &sched.shared_store {
+                            let _ = store.cron_set_enabled(&job_id, false);
+                        }
+                        sched.handles.lock().unwrap().remove(&job_id);
+                        break;
+                    }
+                }
             }
         });
 

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -7,9 +7,9 @@
 //! next scheduled fire time (computed from the 5-field UTC cron expression),
 //! POSTs to `/agentmux/reactive/inject`, and records the fire in the DB.
 //!
-//! On startup, runs one catch-up fire for any job whose `last_fired` is
-//! more than one interval behind (FIRE_ONCE_NOW misfire policy — never
-//! replay all missed fires, never cause a cron storm).
+//! On startup, runs one catch-up fire for any job whose next scheduled time
+//! after `last_fired` is already in the past (FIRE_ONCE_NOW misfire policy —
+//! never replay all missed fires, never cause a cron storm).
 //!
 //! See `docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2`.
 
@@ -125,6 +125,20 @@ impl CronScheduler {
             // is enforced across restarts, not per process run.
             let mut fires: i64 = initial_fires;
             loop {
+                // Guard at top of loop: if fires was seeded at or above max_fires
+                // (e.g. a catch-up fire brought the persisted count to the cap),
+                // don't fire again before sleeping — this prevents one extra fire
+                // on restart when the catch-up itself hits the limit.
+                if let Some(max) = job_max_fires {
+                    if fires >= max {
+                        tracing::info!(id = %job_id, fires, "cron: max_fires reached — disabling job");
+                        if let Some(store) = &sched.shared_store {
+                            let _ = store.cron_set_enabled(&job_id, false);
+                        }
+                        sched.handles.lock().unwrap().remove(&job_id);
+                        break;
+                    }
+                }
                 let next = match schedule.upcoming(Utc).next() {
                     Some(t) => t,
                     None => break,
@@ -133,8 +147,9 @@ impl CronScheduler {
                 tokio::time::sleep(delay).await;
                 sched.fire(&job_id, &job_prompt, &job_target).await;
                 fires += 1;
-                // Enforce max_fires in the live task — don't rely on the DB
-                // flag alone, which only takes effect on the next srv restart.
+                // Post-fire check: enforce max_fires. The top-of-loop guard
+                // handles the restart/seeded-at-cap case; this handles the
+                // normal live-run case.
                 if let Some(max) = job_max_fires {
                     if fires >= max {
                         tracing::info!(id = %job_id, fires, "cron: max_fires reached — disabling job");

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -42,6 +42,7 @@ pub mod wps;
 pub mod osc_extractor;
 pub mod tool_store;
 pub mod container;
+pub mod cron;
 pub mod shell_node;
 
 pub use oref::ORef;

--- a/agentmux-srv/src/backend/storage/cron.rs
+++ b/agentmux-srv/src/backend/storage/cron.rs
@@ -1,0 +1,138 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persistent cron job storage — CRUD methods on `db_cron_jobs` in the
+//! global shared store. See `docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md`.
+
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use super::error::StoreError;
+use super::store::Store;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CronJob {
+    pub id: String,
+    pub name: String,
+    /// Standard 5-field cron expression evaluated in UTC.
+    pub expression: String,
+    pub prompt: String,
+    /// Target agent id for injection.
+    pub target: String,
+    pub created_by: String,
+    pub enabled: bool,
+    pub last_fired: Option<i64>,
+    pub fire_count: i64,
+    /// `None` = unlimited.
+    pub max_fires: Option<i64>,
+    pub created_at: i64,
+}
+
+impl Store {
+    pub fn cron_create(&self, job: &CronJob) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_cron_jobs
+                (id, name, expression, prompt, target, created_by, enabled,
+                 last_fired, fire_count, max_fires, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                job.id,
+                job.name,
+                job.expression,
+                job.prompt,
+                job.target,
+                job.created_by,
+                job.enabled as i64,
+                job.last_fired,
+                job.fire_count,
+                job.max_fires,
+                job.created_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn cron_list(&self) -> Result<Vec<CronJob>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, expression, prompt, target, created_by, enabled,
+                    last_fired, fire_count, max_fires, created_at
+             FROM db_cron_jobs ORDER BY created_at ASC",
+        )?;
+        let iter = stmt.query_map([], map_row)?;
+        iter.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn cron_list_enabled(&self) -> Result<Vec<CronJob>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, expression, prompt, target, created_by, enabled,
+                    last_fired, fire_count, max_fires, created_at
+             FROM db_cron_jobs WHERE enabled = 1 ORDER BY created_at ASC",
+        )?;
+        let iter = stmt.query_map([], map_row)?;
+        iter.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn cron_get(&self, id: &str) -> Result<Option<CronJob>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, expression, prompt, target, created_by, enabled,
+                    last_fired, fire_count, max_fires, created_at
+             FROM db_cron_jobs WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![id], map_row)?;
+        match rows.next() {
+            Some(r) => Ok(Some(r?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn cron_set_enabled(&self, id: &str, enabled: bool) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE db_cron_jobs SET enabled = ?1 WHERE id = ?2",
+            params![enabled as i64, id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    pub fn cron_record_fire(&self, id: &str, now: i64) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE db_cron_jobs
+             SET last_fired = ?1,
+                 fire_count = fire_count + 1,
+                 enabled    = CASE
+                     WHEN max_fires IS NOT NULL AND fire_count + 1 >= max_fires THEN 0
+                     ELSE enabled
+                 END
+             WHERE id = ?2",
+            params![now, id],
+        )?;
+        Ok(())
+    }
+
+    pub fn cron_delete(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute("DELETE FROM db_cron_jobs WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
+    Ok(CronJob {
+        id:          row.get(0)?,
+        name:        row.get(1)?,
+        expression:  row.get(2)?,
+        prompt:      row.get(3)?,
+        target:      row.get(4)?,
+        created_by:  row.get(5)?,
+        enabled:     row.get::<_, i64>(6)? != 0,
+        last_fired:  row.get(7)?,
+        fire_count:  row.get(8)?,
+        max_fires:   row.get(9)?,
+        created_at:  row.get(10)?,
+    })
+}

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -25,7 +25,8 @@ use super::error::StoreError;
 /// `run_shared_store_schema`. Versioned independently from `objects.db`.
 ///   v1 — initial: identity accounts/bundles/bindings/links, memory
 ///         bundles, drone definitions, muxbus credentials
-pub const SHARED_STORE_SCHEMA_VERSION: i64 = 1;
+///   v2 — db_cron_jobs: persistent scheduled injection jobs
+pub const SHARED_STORE_SCHEMA_VERSION: i64 = 2;
 
 /// `user_version` value stamped into `objects.db` after `run_object_schema`.
 /// The flat schema reset the counter to 1 (the pre-flatten chain never set
@@ -665,7 +666,23 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
             applied_at  TEXT NOT NULL,
             duration_ms INTEGER NOT NULL DEFAULT 0,
             scope       TEXT NOT NULL DEFAULT 'global'
-        );",
+        );
+
+        CREATE TABLE IF NOT EXISTS db_cron_jobs (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            expression  TEXT NOT NULL,
+            prompt      TEXT NOT NULL,
+            target      TEXT NOT NULL,
+            created_by  TEXT NOT NULL DEFAULT '',
+            enabled     INTEGER NOT NULL DEFAULT 1,
+            last_fired  INTEGER,
+            fire_count  INTEGER NOT NULL DEFAULT 0,
+            max_fires   INTEGER,
+            created_at  INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_ss_cron_jobs_enabled
+            ON db_cron_jobs(enabled);",
     )?;
 
     // Seed the blank Identity / Memory singletons — same fixed ids as objects.db

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -7,6 +7,7 @@
 pub mod agents;
 pub mod agents_consolidate;
 pub mod content;
+pub mod cron;
 pub mod def_registry_mirror;
 pub mod dual_write;
 pub mod error;
@@ -23,6 +24,7 @@ pub mod store;
 
 pub use agents::{AgentDefinition, AgentInstance, InstanceStatus, InstanceUpdate};
 pub use content::AgentContent;
+pub use cron::CronJob;
 pub use error::StoreError;
 #[allow(unused_imports)]
 pub use history::AgentHistory;

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -869,6 +869,9 @@ async fn main() {
         }
     });
 
+    // Clone before move into AppState for cron_scheduler construction.
+    let shared_store_for_cron = shared_store.clone();
+
     let state = AppState {
         auth_key: config.auth_key.clone(),
         version: version.clone(),
@@ -929,7 +932,17 @@ async fn main() {
             }
         },
         shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
+        cron_scheduler: crate::backend::cron::CronScheduler::new(
+            shared_store_for_cron,
+            reqwest::Client::new(),
+            local_web_url.clone(),
+            config.auth_key.clone(),
+        ),
     };
+
+    // Start persistent cron scheduler — load enabled jobs from DB, fire any
+    // that missed their window (FIRE_ONCE_NOW), schedule all for future fires.
+    state.cron_scheduler.start().await;
 
     // Saga durability PR 2 — resume-on-startup. Walk any sagas the
     // durable log says are unresolved (running / compensating /

--- a/agentmux-srv/src/server/cron.rs
+++ b/agentmux-srv/src/server/cron.rs
@@ -1,0 +1,200 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP handlers for the persistent cron scheduler.
+//!
+//! Routes (all auth-gated via `X-AuthKey`):
+//!   POST   /agentmux/cron          — create a job
+//!   DELETE /agentmux/cron/:id      — delete a job
+//!   GET    /agentmux/cron          — list all jobs
+//!   PATCH  /agentmux/cron/:id      — pause / resume
+
+use std::str::FromStr;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::Json;
+use chrono::Utc;
+use cron::Schedule;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::backend::storage::cron::CronJob;
+use super::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct CronCreateRequest {
+    pub name: String,
+    /// 5-field UTC cron expression: "min hour dom mon dow"
+    pub expression: String,
+    pub prompt: String,
+    /// Target agent id. Required — no implicit self-targeting from HTTP.
+    pub target: String,
+    #[serde(default)]
+    pub created_by: String,
+    pub max_fires: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CronPatchRequest {
+    /// "pause" or "resume"
+    pub action: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CronJobView {
+    pub id: String,
+    pub name: String,
+    pub expression: String,
+    pub prompt: String,
+    pub target: String,
+    pub enabled: bool,
+    pub last_fired: Option<i64>,
+    pub fire_count: i64,
+    pub max_fires: Option<i64>,
+    pub created_at: i64,
+    /// ISO-8601 string of the next scheduled fire (UTC), or null if disabled.
+    pub next_fire: Option<String>,
+}
+
+fn to_view(job: &CronJob) -> CronJobView {
+    let next_fire = if job.enabled {
+        next_fire_utc(&job.expression)
+    } else {
+        None
+    };
+    CronJobView {
+        id: job.id.clone(),
+        name: job.name.clone(),
+        expression: job.expression.clone(),
+        prompt: job.prompt.clone(),
+        target: job.target.clone(),
+        enabled: job.enabled,
+        last_fired: job.last_fired,
+        fire_count: job.fire_count,
+        max_fires: job.max_fires,
+        created_at: job.created_at,
+        next_fire,
+    }
+}
+
+/// Compute the next UTC fire time for a 5-field cron expression, returned
+/// as an ISO-8601 string. Returns `None` on parse error.
+fn next_fire_utc(expression: &str) -> Option<String> {
+    let full = format!("0 {}", expression);
+    let schedule = Schedule::from_str(&full).ok()?;
+    let next = schedule.upcoming(chrono::Utc).next()?;
+    Some(next.to_rfc3339())
+}
+
+pub(super) async fn handle_cron_create(
+    State(state): State<AppState>,
+    Json(req): Json<CronCreateRequest>,
+) -> (StatusCode, Json<Value>) {
+    // Validate expression.
+    let full_expr = format!("0 {}", req.expression);
+    if Schedule::from_str(&full_expr).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid cron expression: '{}'", req.expression)})),
+        );
+    }
+
+    let store = match &state.shared_store {
+        Some(s) => s.clone(),
+        None => return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"error": "shared store unavailable"}))),
+    };
+
+    let job = CronJob {
+        id: Uuid::new_v4().to_string(),
+        name: req.name.clone(),
+        expression: req.expression.clone(),
+        prompt: req.prompt.clone(),
+        target: req.target.clone(),
+        created_by: req.created_by.clone(),
+        enabled: true,
+        last_fired: None,
+        fire_count: 0,
+        max_fires: req.max_fires,
+        created_at: Utc::now().timestamp(),
+    };
+
+    if let Err(e) = store.cron_create(&job) {
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()})));
+    }
+
+    // Register the new job with the live scheduler.
+    state.cron_scheduler.schedule_job(&job);
+
+    (StatusCode::CREATED, Json(json!({"job": to_view(&job)})))
+}
+
+pub(super) async fn handle_cron_list(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    let store = match &state.shared_store {
+        Some(s) => s.clone(),
+        None => return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"error": "shared store unavailable"}))),
+    };
+
+    match store.cron_list() {
+        Ok(jobs) => {
+            let views: Vec<_> = jobs.iter().map(to_view).collect();
+            (StatusCode::OK, Json(json!({"jobs": views})))
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))),
+    }
+}
+
+pub(super) async fn handle_cron_delete(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let store = match &state.shared_store {
+        Some(s) => s.clone(),
+        None => return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"error": "shared store unavailable"}))),
+    };
+
+    // Cancel live task first.
+    state.cron_scheduler.cancel_job(&id);
+
+    match store.cron_delete(&id) {
+        Ok(true) => (StatusCode::OK, Json(json!({"ok": true}))),
+        Ok(false) => (StatusCode::NOT_FOUND, Json(json!({"error": "job not found"}))),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))),
+    }
+}
+
+pub(super) async fn handle_cron_patch(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<CronPatchRequest>,
+) -> (StatusCode, Json<Value>) {
+    let store = match &state.shared_store {
+        Some(s) => s.clone(),
+        None => return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"error": "shared store unavailable"}))),
+    };
+
+    let enabled = match req.action.as_str() {
+        "resume" => true,
+        "pause" => false,
+        other => return (StatusCode::BAD_REQUEST, Json(json!({"error": format!("unknown action '{}' (use 'pause' or 'resume')", other)}))),
+    };
+
+    match store.cron_set_enabled(&id, enabled) {
+        Ok(true) => {}
+        Ok(false) => return (StatusCode::NOT_FOUND, Json(json!({"error": "job not found"}))),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))),
+    }
+
+    if enabled {
+        if let Ok(Some(job)) = store.cron_get(&id) {
+            state.cron_scheduler.schedule_job(&job);
+        }
+    } else {
+        state.cron_scheduler.cancel_job(&id);
+    }
+
+    (StatusCode::OK, Json(json!({"ok": true, "enabled": enabled})))
+}

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -18,6 +18,7 @@ mod voice;
 pub(crate) mod wave_obj_bridge;
 mod websocket;
 mod drone_handlers;
+mod cron;
 mod messaging_handlers;
 mod muxbus_handlers;
 mod native_memory_handlers;
@@ -33,7 +34,7 @@ use axum::{
     http::{header, Method, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
-    routing::{get, post},
+    routing::{delete, get, patch, post},
     Router,
 };
 use serde_json::json;
@@ -156,6 +157,11 @@ pub struct AppState {
     /// stop button can tree-kill a running persistent shell node. See
     /// `docs/specs/SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md`.
     pub shell_sessions: std::sync::Arc<crate::backend::shell_node::ShellSessionRegistry>,
+    /// Persistent cron scheduler — loaded from `db_cron_jobs` at startup.
+    /// Creates/cancels tokio tasks that fire on the specified UTC schedule and
+    /// POST to `/agentmux/reactive/inject`. See
+    /// `docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2`.
+    pub cron_scheduler: std::sync::Arc<crate::backend::cron::CronScheduler>,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.
@@ -300,6 +306,12 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/window/focus", post(handle_window_focus))
         .route("/api/messaging/status", get(messaging_handlers::handle_status))
         .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
+        // Persistent cron scheduler (SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2.4).
+        // Auth-gated like reactive routes.
+        .route("/agentmux/cron", post(cron::handle_cron_create))
+        .route("/agentmux/cron", get(cron::handle_cron_list))
+        .route("/agentmux/cron/:id", delete(cron::handle_cron_delete))
+        .route("/agentmux/cron/:id", patch(cron::handle_cron_patch))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(

--- a/docs/specs/SPEC_BUILDER_MACOS_LINUX_CI_2026_06_24.md
+++ b/docs/specs/SPEC_BUILDER_MACOS_LINUX_CI_2026_06_24.md
@@ -1,0 +1,395 @@
+# SPEC: agentmux-builder — macOS + Linux CI Release Workflows
+
+**Date:** 2026-06-24
+**Status:** Draft
+**Repo:** agentmuxai/agentmux-builder (private)
+**Tracks:** issue #1718 (nightly cross-platform artifacts Phase B)
+
+---
+
+## 1. Problem
+
+`agentmux-builder` currently only has `build-windows.yml`. macOS DMGs and Linux
+AppImages are still cut locally and uploaded by hand. The blockers described in
+`ci-nightly-artifacts.yml` are:
+
+- **macOS**: "`package:macos` hard-requires a Developer ID certificate — needs
+  secrets/keychain plumbing before it can run in CI."
+- **Linux**: "`libcef.so` BeginWindowDrag patch gate blocks packaging unless
+  `AGENTMUX_SKIP_CEF_PATCH_CHECK=1`; the upstream cef-dll-sys cache lacks the
+  patch."
+
+This spec resolves both blockers and adds two new workflows to `agentmux-builder`.
+
+---
+
+## 2. macOS Workflow (`build-macos.yml`)
+
+### 2.1 Trigger
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "agentmux ref to build (tag / branch / SHA)"
+        required: true
+        default: main
+      release-tag:
+        description: "GitHub release tag to upload the DMG to (blank = skip)"
+        required: false
+        default: ""
+  repository_dispatch:
+    types: [build-macos]
+```
+
+### 2.2 Runner
+
+`macos-latest` (GitHub-hosted, Apple Silicon arm64). GitHub's hosted macOS
+runners ship Xcode, `codesign`, `xcrun notarytool`, `hdiutil`, and `sips` —
+all required by `scripts/package-macos.sh`.
+
+### 2.3 Steps
+
+```
+1. Checkout agentmuxai/agentmux at <ref> (AGENTMUX_CHECKOUT_TOKEN)
+2. Install Rust (stable) + dtolnay/rust-toolchain
+3. Install Node 22 + npm ci (A5AF_PACKAGES_TOKEN for @a5af packages)
+4. Import Developer ID certificate into a temporary keychain
+5. Store notarytool credentials in the temporary keychain
+6. task package:macos -- "$OUTDIR"
+7. gh release upload <release-tag> <DMG> (AGENTMUX_RELEASE_TOKEN)
+8. Cleanup: delete temp keychain
+```
+
+### 2.4 Certificate Import (Step 4)
+
+The standard CI pattern for Apple codesigning — creates a short-lived keychain
+that is torn down after the job:
+
+```bash
+KEYCHAIN=build-$(uuidgen).keychain
+KEYCHAIN_PASS=$(uuidgen)
+
+security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+security default-keychain -s "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+
+echo "$APPLE_CERTIFICATE" | base64 --decode > cert.p12
+security import cert.p12 \
+    -k "$KEYCHAIN" \
+    -P "$APPLE_CERTIFICATE_PASSWORD" \
+    -T /usr/bin/codesign \
+    -T /usr/bin/security
+
+# Allow codesign to access the key without a UI prompt
+security set-key-partition-list \
+    -S apple-tool:,apple:,codesign: \
+    -s -k "$KEYCHAIN_PASS" "$KEYCHAIN"
+
+rm -f cert.p12
+```
+
+`package-macos.sh` calls `security find-identity -v -p codesigning` to auto-
+detect the Developer ID identity, so no explicit cert name needs to be threaded
+through once it's in the keychain.
+
+### 2.5 Notarytool Credential Store (Step 5)
+
+```bash
+xcrun notarytool store-credentials "notarytool" \
+  --apple-id  "$APPLE_ID" \
+  --password  "$APPLE_PASSWORD" \
+  --team-id   "$APPLE_TEAM_ID" \
+  --keychain "$KEYCHAIN"
+```
+
+`package-macos.sh` defaults to `NOTARY_PROFILE=notarytool` and passes
+`--keychain-profile notarytool` to `xcrun notarytool submit`. No script changes
+required.
+
+### 2.6 Build Command
+
+```bash
+OUTDIR="$GITHUB_WORKSPACE/artifacts"
+mkdir -p "$OUTDIR"
+task package:macos -- "$OUTDIR"
+```
+
+`task package:macos` runs `build:host`, `build:backend`, `build:frontend`,
+`bundle`, then `scripts/package-macos.sh`. Output:
+`AgentMux_{VERSION}_arm64.dmg`.
+
+### 2.7 Upload
+
+```bash
+DMG=$(ls "$OUTDIR"/AgentMux_*_arm64.dmg | head -1)
+gh release upload "$RELEASE_TAG" "$DMG" \
+  --repo agentmuxai/agentmux --clobber
+```
+
+Only runs when `release-tag` input is non-empty.
+
+### 2.8 Secrets Used
+
+| Secret | Value | Already in agentmux-builder |
+|--------|-------|------------------------------|
+| `AGENTMUX_CHECKOUT_TOKEN` | PAT (repo) to clone agentmuxai/agentmux | ✅ |
+| `AGENTMUX_RELEASE_TOKEN` | PAT (repo) to upload release assets | ✅ |
+| `A5AF_PACKAGES_TOKEN` | npm GitHub Packages token | ✅ |
+| `APPLE_CERTIFICATE` | Base64-encoded Developer ID .p12 | ✅ |
+| `APPLE_CERTIFICATE_PASSWORD` | .p12 export password | ✅ |
+| `APPLE_SIGNING_IDENTITY` | Full cert name (optional — auto-detected) | ✅ |
+| `APPLE_ID` | Apple ID email for notarytool | ✅ |
+| `APPLE_PASSWORD` | App-specific password | ✅ |
+| `APPLE_TEAM_ID` | 10-char Apple Team ID | ✅ |
+
+All secrets are already present in `agentmux-builder` per the README. No new
+secrets need to be created.
+
+---
+
+## 3. Linux Workflow (`build-linux.yml`)
+
+### 3.1 The Patched libcef.so Problem
+
+The `build-appimage-linux.sh` script requires a **patched** `libcef.so` built
+from the `agentmuxai/cef` fork (branch `agentmux/7778-drag-rightclick-and-
+transparency`) that adds `CefWindow::BeginWindowDrag()`. The upstream prebuilt
+libcef.so bundled by `cef-dll-sys` lacks this patch; bundling it ships with
+broken left-click window drag on Wayland.
+
+Building libcef.so from source in CI is not feasible (~3-6 hours wall-clock on
+a 32-core box, 99 GB disk, Chrome toolchain). The solution: **store a pre-built
+patched `libcef.so` as a release asset in `agentmuxai/cef`** and download it in
+CI via `AGENTMUX_CEF_RUNTIME_DIR`.
+
+### 3.2 Patched libcef.so Artifact
+
+**Location:** `agentmuxai/cef` — GitHub release tagged
+`cef-linux-x86_64-<CEF_VERSION>` (e.g. `cef-linux-x86_64-148.2.7`).
+
+**Artifact name:** `cef-linux-x86_64-<CEF_VERSION>.tar.gz`
+
+**Contents:**
+```
+libcef.so           ← the unstripped patched build (~613 MB; packager strips it)
+icudtl.dat
+snapshot_blob.bin
+v8_context_snapshot.bin
+chrome_100_percent.pak
+chrome_200_percent.pak
+resources.pak
+headless_command_resources.pak
+libEGL.so
+libGLESv2.so
+libvk_swiftshader.so
+libvulkan.so.1
+vk_swiftshader_icd.json
+chrome-sandbox
+chrome_crashpad_handler
+locales/
+```
+
+This archive is produced once per CEF version bump (not per AgentMux release) by
+whoever builds the patched CEF locally, and uploaded with:
+
+```bash
+gh release create "cef-linux-x86_64-148.2.7" \
+  --repo agentmuxai/cef \
+  --title "Patched libcef.so — Linux x86_64 CEF 148.2.7" \
+  cef-linux-x86_64-148.2.7.tar.gz
+```
+
+A new repo secret `CEF_RUNTIME_TOKEN` (PAT with `read:packages` or `contents:read`
+on `agentmuxai/cef`) is added to `agentmux-builder` to authenticate the download.
+
+### 3.3 Trigger
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "agentmux ref to build (tag / branch / SHA)"
+        required: true
+        default: main
+      release-tag:
+        description: "GitHub release tag to upload the AppImage to (blank = skip)"
+        required: false
+        default: ""
+      cef-runtime-tag:
+        description: "agentmuxai/cef release tag for the patched libcef.so"
+        required: false
+        default: ""   # blank = auto-detect from latest release
+  repository_dispatch:
+    types: [build-linux]
+    # client_payload: { ref, release_tag, cef_runtime_tag }
+```
+
+### 3.4 Runner
+
+`ubuntu-22.04` (GitHub-hosted, x86_64). Matches the libcef.so build target and
+the AppImage runtime baseline.
+
+### 3.5 Steps
+
+```
+1.  Checkout agentmuxai/agentmux at <ref> (AGENTMUX_CHECKOUT_TOKEN)
+2.  Install Rust (stable) + dtolnay/rust-toolchain
+3.  Install Node 22 + npm ci (A5AF_PACKAGES_TOKEN)
+4.  Install system deps (ninja-build cmake libwayland-dev libxkbcommon-dev libgtk-3-dev)
+5.  Download + extract patched libcef.so from agentmuxai/cef release
+6.  Set AGENTMUX_CEF_RUNTIME_DIR to the extracted directory
+7.  Download appimagetool to ~/.local/bin/appimagetool
+8.  task package:linux -- "$OUTDIR"
+9.  gh release upload <release-tag> <AppImage> (AGENTMUX_RELEASE_TOKEN)
+```
+
+### 3.6 libcef.so Download (Step 5)
+
+```bash
+# Resolve tag (explicit input or latest release in agentmuxai/cef)
+CEF_TAG="${CEF_RUNTIME_TAG:-}"
+if [ -z "$CEF_TAG" ]; then
+  CEF_TAG=$(gh release list --repo agentmuxai/cef --limit 1 \
+              --json tagName --jq '.[0].tagName')
+fi
+
+mkdir -p "$HOME/cef-runtime"
+gh release download "$CEF_TAG" \
+  --repo agentmuxai/cef \
+  --pattern "*.tar.gz" \
+  --dir "$HOME/cef-runtime" \
+  --clobber
+
+tar -xzf "$HOME/cef-runtime"/*.tar.gz -C "$HOME/cef-runtime"
+# Remove the archive; keep the extracted tree
+rm "$HOME/cef-runtime"/*.tar.gz
+
+echo "AGENTMUX_CEF_RUNTIME_DIR=$HOME/cef-runtime" >> "$GITHUB_ENV"
+```
+
+With `AGENTMUX_CEF_RUNTIME_DIR` set, `scripts/resolve-cef-runtime.sh` returns
+this path as its first candidate (explicit override) and skips the cargo cache
+fallback. The unstripped libcef.so passes `verify-cef-patch.sh`; the packager
+then strips it inside the AppDir.
+
+### 3.7 appimagetool Download (Step 7)
+
+```bash
+mkdir -p "$HOME/.local/bin"
+curl -L -o "$HOME/.local/bin/appimagetool" \
+  "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+chmod +x "$HOME/.local/bin/appimagetool"
+# AppImages need FUSE; on GitHub runners use --appimage-extract-and-run instead
+export APPIMAGETOOL_OPTS="--appimage-extract-and-run"
+# Re-export appimagetool itself via extract-and-run
+APPIMAGETOOL="$HOME/.local/bin/appimagetool --appimage-extract-and-run"
+```
+
+GitHub-hosted Ubuntu runners do not have FUSE. `appimagetool` supports
+`--appimage-extract-and-run` to run without mounting.
+
+### 3.8 Build Command
+
+```bash
+OUTDIR="$GITHUB_WORKSPACE/artifacts"
+mkdir -p "$OUTDIR"
+APPIMAGETOOL="$HOME/.local/bin/appimagetool --appimage-extract-and-run" \
+  task package:linux -- "$OUTDIR"
+```
+
+Output: `AgentMux_{VERSION}_amd64.AppImage`.
+
+### 3.9 Upload
+
+```bash
+APPIMAGE=$(ls "$OUTDIR"/AgentMux_*_amd64.AppImage | head -1)
+gh release upload "$RELEASE_TAG" "$APPIMAGE" \
+  --repo agentmuxai/agentmux --clobber
+```
+
+Only runs when `release-tag` input is non-empty.
+
+### 3.10 Secrets Used
+
+| Secret | Value | Already in agentmux-builder |
+|--------|-------|------------------------------|
+| `AGENTMUX_CHECKOUT_TOKEN` | PAT to clone agentmuxai/agentmux | ✅ |
+| `AGENTMUX_RELEASE_TOKEN` | PAT to upload release assets | ✅ |
+| `A5AF_PACKAGES_TOKEN` | npm GitHub Packages token | ✅ |
+| `CEF_RUNTIME_TOKEN` | PAT (`contents:read`) for agentmuxai/cef | ❌ **new** |
+
+One new secret: `CEF_RUNTIME_TOKEN` — a fine-grained PAT scoped to
+`agentmuxai/cef` with `contents:read` permission so the workflow can download
+release assets from the private CEF repo. Add it to `agentmux-builder` repo
+settings → Secrets.
+
+---
+
+## 4. Release Flow (All Three Platforms)
+
+### 4.1 Pre-release checklist
+
+1. `chore: release vX.Y.Z` PR merged → tag `vX.Y.Z` pushed to `agentmuxai/agentmux`
+2. GitHub Release created for `vX.Y.Z` (draft or pre-release; Windows build
+   attaches the signed installer)
+3. Patched `libcef.so` for the current CEF version is available as a release in
+   `agentmuxai/cef` (only changes when CEF version bumps)
+
+### 4.2 Triggering the three builds
+
+Trigger all three from `agentmuxai/agentmux-builder` → Actions tab, or via
+`repository_dispatch` from a release automation script:
+
+```bash
+VERSION="v0.49.1"
+
+# Windows (build-windows.yml)
+gh workflow run build-windows.yml \
+  --repo agentmuxai/agentmux-builder \
+  -f ref="$VERSION" -f release-tag="$VERSION"
+
+# macOS (build-macos.yml)
+gh workflow run build-macos.yml \
+  --repo agentmuxai/agentmux-builder \
+  -f ref="$VERSION" -f release-tag="$VERSION"
+
+# Linux (build-linux.yml)
+gh workflow run build-linux.yml \
+  --repo agentmuxai/agentmux-builder \
+  -f ref="$VERSION" -f release-tag="$VERSION"
+```
+
+All three upload directly to the `agentmuxai/agentmux` release for `$VERSION`
+using `AGENTMUX_RELEASE_TOKEN`.
+
+### 4.3 Expected release assets after all three complete
+
+| File | Platform | Size (approx) |
+|------|----------|---------------|
+| `agentmux-X.Y.Z-x64-portable.zip` | Windows | ~169 MB |
+| `AgentMux-X.Y.Z-x64-setup.exe` | Windows | ~130 MB |
+| `AgentMux_X.Y.Z_arm64.dmg` | macOS (Apple Silicon) | ~140 MB |
+| `AgentMux_X.Y.Z_amd64.AppImage` | Linux x86_64 | ~230 MB |
+
+---
+
+## 5. Not in Scope
+
+- **Intel Mac (x86_64)**: all builds target Apple Silicon (arm64). `cef-dll-sys`
+  resolves the aarch64 framework; x86_64 support would need a separate CEF build.
+- **Linux arm64**: `build-appimage-linux.sh` targets x86_64; arm64 AppImage deferred.
+- **Windows code signing** (SignPath): deferred per `docs/windows-code-signing.md`.
+- **macOS App Store**: direct distribution only; notarized Developer ID path.
+- **Auto-trigger on tag push**: the workflows are `workflow_dispatch` + 
+  `repository_dispatch` only. A tag-push trigger (listen for `vX.Y.Z` tags on 
+  `agentmux`) would require cross-repo webhook wiring — left for a future
+  `release-orchestrator.yml`.
+- **Nightly macOS/Linux artifacts** (non-release builds): the nightly 
+  `ci-nightly-artifacts.yml` in the main repo continues to produce Windows only.
+  Extending it to macOS/Linux would require cert secrets on the public repo's
+  runner — feasible but out of scope for this spec (the secrets live in the
+  private `agentmux-builder` precisely to avoid that).

--- a/docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md
+++ b/docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md
@@ -1,0 +1,233 @@
+# Cron & Loop Robustness — Research + Design
+
+**Date:** 2026-06-25  
+**Status:** Draft — pending implementation decision  
+**Context:** User-reported: cron jobs not firing reliably; uncertain whether Loop is implemented.
+
+---
+
+## 1. Current State
+
+### Loop — session-scoped recurring injection
+
+| Item | Status |
+|---|---|
+| `Loop` / `LoopStop` MCP tools | ✅ Implemented — `agentmux-mcp/src/main.rs` |
+| `LoopList` | ❌ Missing (noted in SPEC_MCP_LOOP_TOOL_2026_06_16.md §6) |
+| `max_iterations` | ❌ Missing |
+| Idle-aware firing | ❌ `InjectionRequest.wait_for_idle` field exists but is never read by srv |
+| Stuck-loop detection | ❌ Missing |
+| Persistence across MCP restart | ❌ By design — loops are session-scoped |
+
+**How it works today:**  
+`Loop(prompt, interval, to)` spawns a Tokio task in the MCP process that sleeps `interval`, then POSTs to `/agentmux/reactive/inject` and repeats. The loop lives exactly as long as the agent pane (MCP process lifetime). On MCP restart, all loops are gone — by design, matching Claude Code's `/loop` model.
+
+**Why it feels broken:**  
+- Fixed wall-clock interval fires regardless of whether the target agent is mid-turn. Inject hits a busy agent; the message may be queued behind in-progress output or dropped.
+- No `LoopList` → no visibility. You can't tell if a loop is running, how many are running, or how many times it has fired.
+- No `max_iterations` → a loop that fires every 10s on a noisy agent is impossible to contain without manually calling `LoopStop`.
+
+### Cron — persistent scheduled jobs
+
+**Does not exist.** There is no `CronCreate`, `CronDelete`, or `CronList` in AgentMux's MCP layer, no database schema for scheduled jobs, and no server-side scheduler.
+
+The confusion: Claude Code CLI exposes its own `CronCreate`/`CronList`/`CronDelete` tools (available to agents running in the CLI), but these are ephemeral — they live only while the CLI session is alive and are not persisted by AgentMux's server.
+
+---
+
+## 2. Industry Research
+
+### 2.1 Why Cron Jobs Miss Fires
+
+1. **Controller downtime** — when the scheduler process is down, firing times are silently missed. Jobs don't queue; they're gone.
+2. **Clock drift** — system clock skew causes wall-clock mismatches. GitHub Actions workflows averaged 4.5-hour drift by mid-2026 due to platform scheduling backlog.
+3. **No built-in failure alerting** — cron failures are silent until data is missing or a dead-man's switch trips.
+4. **Desktop-specific: app not running** — on a desktop app, if the process isn't alive there's nothing to fire.
+
+### 2.2 Industry Patterns for Reliable Scheduling
+
+**Quartz misfire model (the gold standard):**  
+Each trigger has a configurable "misfire instruction" defining catch-up behavior:
+- `DO_NOTHING` — skip missed occurrences, wait for next scheduled time (best for refresh/monitoring jobs)
+- `FIRE_ONCE_NOW` — execute one recovery run immediately, don't replay all misses (best after crash recovery)
+
+**Kubernetes CronJob model:**  
+- `startingDeadlineSeconds` defines how late a missed job can be created (e.g. 28800 = allow up to 8h late)
+- If >100 missed schedules detected, controller skips and logs an error — no cron storm
+- Concurrency policy: `Forbid` for long-running jobs, `Replace` for fire-and-forget
+
+**Desktop app patterns:**  
+- Persist scheduled task metadata in local DB; on startup, check for missed schedules, execute ONE recovery run
+- Use power-save-blocker only while agent is actively working; release after idle threshold
+- User notification when jobs skipped due to app downtime
+
+### 2.3 Agent Loop Best Practices
+
+From Claude Agent SDK and LiteLLM production patterns:
+
+| Control | Purpose | Recommended values |
+|---|---|---|
+| `max_turns` | Hard cap on tool-use round trips | 15–30 |
+| `max_iterations` | Cap total loop fires before auto-stop | 1–1000, caller-specified |
+| Early-stopping message | When hitting max, append "synthesize and stop" prompt | Always implement |
+| Stuck-loop detection | Hash last N tool calls; circuit-break if same hash appears 3× | N = 3–5 |
+| Per-tool timeout | Prevent hanging on slow tools | < scheduling interval |
+
+**Session persistence pattern:**  
+Session object is ephemeral; conversation log is source of truth. For loops that survive restarts, store loop definition in DB; re-create the Tokio task on server startup.
+
+### 2.4 Rust Scheduling Libraries
+
+| Crate | Notes |
+|---|---|
+| `tokio-cron-scheduler` | Async cron via Tokio; timezone-aware; no persistence layer; time drift possible over uptime |
+| `cronexpr` | Low-level cron expression parsing; used by higher-level frameworks |
+
+**Critical pitfall:** `tokio-cron-scheduler` has no durability. Jobs must be re-registered from DB on every startup. Tests must use `#[tokio::test(flavor = "multi_threaded")]` or `scheduler.add()` hangs.
+
+---
+
+## 3. Proposed Design
+
+### 3.1 Loop Improvements (agentmux-mcp — no DB changes)
+
+**Priority: High. Low risk. Fixes the immediate "loop feels broken" problem.**
+
+#### 3.1.1 `LoopList` tool
+
+```
+LoopList() → [{ id, prompt, interval_secs, target, fires_remaining, fire_count }]
+```
+
+Implementation: scan `LoopRegistry` (existing `HashMap`) and return entries. Each entry needs to be enriched at creation time with metadata (prompt, interval, target, optional max_iterations, fire_count atomic).
+
+#### 3.1.2 `max_iterations` on Loop
+
+```
+Loop(prompt, interval, to, immediate, max_iterations?)
+```
+
+- `max_iterations = None` → run forever (current behavior)
+- `max_iterations = Some(n)` → auto-`LoopStop` after n fires
+
+Implementation: pass an `Arc<AtomicU64>` counter into the task; decrement each fire; abort when it hits zero.
+
+#### 3.1.3 Idle-aware firing
+
+`InjectionRequest.wait_for_idle` currently exists as dead scaffolding. Wire it:
+
+- `agentmux-srv` reactive handler: before injecting, check if target agent's `last_turn_completed_at` is recent. If agent is mid-turn, queue the message or skip this fire.
+- Define "idle" as: no active stream in the last N seconds (configurable, default 5s).
+
+The handler already has `AgentRegistration` with `last_seen`; extend with `last_turn_start` / `last_turn_end` timestamps updated by the controller on turn boundaries.
+
+#### 3.1.4 Stuck-loop detection
+
+Track last 5 injection request hashes per loop. If the same hash appears 3× consecutively (meaning the agent is not making progress), auto-stop the loop and log a warning.
+
+---
+
+### 3.2 Cron System (agentmux-srv — new DB schema + scheduler)
+
+**Priority: Medium. Larger lift. Addresses "cron doesn't fire" for persistent jobs.**
+
+#### 3.2.1 Data model (SQLite, agentmux-srv)
+
+```sql
+CREATE TABLE cron_jobs (
+    id          TEXT PRIMARY KEY,        -- uuid
+    name        TEXT NOT NULL,
+    expression  TEXT NOT NULL,           -- cron expression "0 9 * * 1-5"
+    prompt      TEXT NOT NULL,
+    target      TEXT NOT NULL,           -- agent id
+    created_by  TEXT NOT NULL,
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    last_fired  INTEGER,                 -- unix timestamp
+    fire_count  INTEGER NOT NULL DEFAULT 0,
+    max_fires   INTEGER,                 -- null = unlimited
+    created_at  INTEGER NOT NULL
+);
+```
+
+#### 3.2.2 Server-side scheduler
+
+- On `agentmux-srv` startup: load all `enabled` cron jobs from DB, register with `tokio-cron-scheduler`
+- On each fire: POST to `/agentmux/reactive/inject` (existing endpoint), update `last_fired` + `fire_count`, auto-disable if `fire_count >= max_fires`
+- **Missed-fire recovery**: on startup, for each job where `last_fired < now - expected_interval`, execute ONE catch-up fire immediately (DO_NOTHING for jobs missed by < 1 interval; FIRE_ONCE_NOW for longer gaps)
+
+#### 3.2.3 MCP tools
+
+```
+CronCreate(name, expression, prompt, to?, max_fires?) → { id, next_fire }
+CronDelete(id)                                         → { ok }
+CronList()                                             → [{ id, name, expression, next_fire, fire_count, enabled }]
+CronPause(id)                                          → { ok }
+CronResume(id)                                         → { ok }
+```
+
+`expression` supports standard 5-field cron: `"0 9 * * 1-5"` (9am weekdays). Validate at creation time and return next 3 scheduled fires for confirmation.
+
+#### 3.2.4 HTTP endpoints (agentmux-srv)
+
+```
+POST   /agentmux/cron          CronCreate
+DELETE /agentmux/cron/:id      CronDelete
+GET    /agentmux/cron          CronList
+PATCH  /agentmux/cron/:id      CronPause / CronResume
+```
+
+All auth-gated with `X-AuthKey` (same pattern as reactive endpoints).
+
+#### 3.2.5 Reliability rules
+
+- **Idempotent delivery**: each fire generates a unique `request_id`; reactive handler deduplicates by `request_id` (add to existing audit log check)
+- **No cron storm**: if app was closed and >10 missed fires exist, execute one catch-up and log a warning — never replay all misses
+- **Timezone**: store all times as UTC in DB; `expression` evaluated in UTC by default; `timezone` field optional for user-local scheduling
+- **Max scheduler drift**: if `tokio-cron-scheduler` fires > 60s late (detectable by comparing `now` vs `expected`), log a warning
+
+---
+
+## 4. Implementation Order
+
+| Phase | Scope | Risk | Time estimate |
+|---|---|---|---|
+| **P1** | `LoopList` + `max_iterations` | Low — MCP only, no server changes | 1–2h |
+| **P2** | Idle-aware firing (`wait_for_idle`) | Medium — requires srv changes to track turn state | 3–4h |
+| **P3** | Stuck-loop detection | Low — MCP only | 1h |
+| **P4** | Cron DB schema + server scheduler | High — new DB migration, new routes, scheduler lifecycle | 4–6h |
+| **P5** | Cron MCP tools + CronList/Pause/Resume | Medium — depends on P4 | 2–3h |
+| **P6** | Frontend cron management UI | Medium — depends on P4+P5 | 4–6h |
+
+---
+
+## 5. Files to Touch
+
+### Loop (P1–P3)
+- `agentmux-mcp/src/main.rs` — `LoopRegistry`, tool handlers, `max_iterations`, stuck-loop tracking
+- `agentmux-srv/src/backend/reactive/handler.rs` — `wait_for_idle` check, turn-boundary timestamps
+- `agentmux-srv/src/backend/reactive/types.rs` — `AgentRegistration` turn timestamps
+- `agentmux-common/src/api_types.rs` — `InjectionRequest.wait_for_idle` (already exists, unused)
+
+### Cron (P4–P5)
+- `agentmux-srv/src/db/migrations/` — new migration for `cron_jobs` table
+- `agentmux-srv/src/backend/cron/` — new module: scheduler, job runner, missed-fire recovery
+- `agentmux-srv/src/server/cron.rs` — new HTTP handlers
+- `agentmux-srv/src/server/mod.rs` — route registration
+- `agentmux-mcp/src/main.rs` — `CronCreate`, `CronDelete`, `CronList`, `CronPause`, `CronResume` tools
+- `Cargo.toml` — add `tokio-cron-scheduler`, `cronexpr` (or equivalent)
+
+---
+
+## 6. Decisions (closed)
+
+1. **Cron timezone**: UTC-only for now. No `timezone` field in v1. Avoids DST bugs and saves scope; can add later.
+
+2. **Missed fires on startup**: FIRE_ONCE_NOW — execute one catch-up run immediately on `agentmux-srv` startup if a job missed its window. Never replay all misses (no cron storms).
+
+3. **Cron persistence scope**: Global — cron jobs survive the creating agent's pane being closed. That's the defining difference from Loop. A cron job fires as long as `agentmux-srv` is running, regardless of which (if any) agent panes are open.
+
+4. **Frontend UI**: Deferred. MCP-tool-only for v1 (`CronCreate`, `CronDelete`, `CronList`, `CronPause`, `CronResume`). Frontend management UI is a follow-up.
+
+5. **`LoopList` scope**: All loops across all agents (like `ps`). No filtering by caller.
+
+6. **P2 idle-aware firing**: Deferred to follow-up. Implementing turn-boundary timestamps in the reactive handler is significant scope. Ship P1 + P3 + Cron first.


### PR DESCRIPTION
## Summary

- **LoopList** MCP tool: inspect all running loops in a session (id, prompt, target, interval, fire count, age). Like `ps` for loops.
- **max_iterations on Loop**: `Loop(prompt, interval, max_iterations=5)` auto-stops after 5 fires; shows "DONE" in LoopList.
- **LoopStop** now reports the fire count on stop.
- **Persistent cron scheduler** (agentmux-srv + agentmux-mcp): 5 new MCP tools: `CronCreate`, `CronDelete`, `CronList`, `CronPause`, `CronResume`. Jobs survive agent pane restarts — fire as long as agentmux-srv is running.

### Architecture
- `db_cron_jobs` table in shared store (`store.db`) — `SHARED_STORE_SCHEMA_VERSION` bumped to 2
- `backend/cron/CronScheduler`: one tokio task per job, sleeps until next UTC cron fire time (computed via `cron` crate)
- FIRE_ONCE_NOW misfire policy: on startup, one catch-up fire for jobs that missed their window
- HTTP routes: `POST/GET /agentmux/cron`, `DELETE/PATCH /agentmux/cron/:id` — auth-gated

### Research basis
Design from `docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md` — covers Quartz misfire model, Kubernetes CronJob patterns, agent loop best practices.

## Test plan
- [ ] `Loop(prompt="test", interval="30s", max_iterations=3)` → fires 3 times then shows DONE in LoopList
- [ ] `LoopList()` → shows running loops with fire counts and ages
- [ ] `LoopStop(loop_id)` → reports fire count
- [ ] `CronCreate(name="test", expression="* * * * *", prompt="ping", to="<agent_id>")` → creates job, shows next fire
- [ ] `CronList()` → lists the job with expression, fire count, next_fire
- [ ] `CronPause(id)` / `CronResume(id)` → pauses/resumes scheduling
- [ ] `CronDelete(id)` → removes job and stops future fires
- [ ] Restart agentmux-srv → cron jobs reload from DB and resume scheduling
- [ ] `cargo test -p agentmux-mcp` → 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)