### PR TITLE
fix(launcher): migrate stdout reader hangs forever when migrate process stalls on Tokio shutdown

### DIFF
--- a/.changesets/1782458192-fix-launcher-migrate-stdout-reader-hangs-forever-if-migrate--pd24.md
+++ b/.changesets/1782458192-fix-launcher-migrate-stdout-reader-hangs-forever-if-migrate--pd24.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): migrate stdout reader hangs forever if migrate process stalls on Tokio shutdown

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -129,8 +129,12 @@ pub async fn run_migrate(
     }
 
     // Read stdout inline so sub-events arrive before stage_end is sent.
+    // We break as soon as we see the "complete" event — the process may hang
+    // in Tokio shutdown (crash-monitor task) after flushing its last line,
+    // so waiting for stdout EOF would block forever.
     let mut applied = 0u32;
     let mut skipped = 0u32;
+    let mut migration_complete = false;
     if let Some(stdout) = child.stdout.take() {
         let mut reader = tokio::io::BufReader::new(stdout).lines();
         while let Ok(Some(line)) = reader.next_line().await {
@@ -151,10 +155,19 @@ pub async fn run_migrate(
                 Some(MigrationLine::Complete { applied: a, skipped: s }) => {
                     applied = a;
                     skipped = s;
+                    migration_complete = true;
+                    break; // Don't wait for EOF — kill below.
                 }
                 None => {}
             }
         }
+    }
+
+    // If the process signalled complete via stdout we know it succeeded.
+    // Kill it now so we don't hang on wait() if its Tokio runtime shutdown
+    // stalls (crash-monitor interaction, background tasks with long timeouts).
+    if migration_complete {
+        let _ = child.start_kill();
     }
 
     let status = child
@@ -163,7 +176,11 @@ pub async fn run_migrate(
         .map_err(|e| SrvSpawnError::SpawnFailed(format!("migrate wait: {}", e)))?;
 
     let duration_ms = t.elapsed().as_millis() as u64;
-    if status.success() {
+    // migration_complete means the process emitted {"event":"complete"} on
+    // stdout before we killed it — that is the authoritative success signal.
+    // status.success() may be false when we force-killed the process after
+    // seeing complete (crash-monitor Tokio shutdown hung).
+    if migration_complete || status.success() {
         let detail = if applied > 0 {
             Some(format!("{} applied, {} current", applied, skipped))
         } else if skipped > 0 {


### PR DESCRIPTION
## Summary

- Diagnosed a startup hang where the splash screen would show "Migrations" indefinitely
- Root cause: `run_migrate` reads the migrate subprocess stdout until EOF, but the process never exits because its Tokio runtime stalls on shutdown (crash-monitor task holds the runtime alive)
- Fix: break the stdout loop on `{"event":"complete"}`, then `start_kill()` the migrate process before `wait()` — process exits within milliseconds instead of hanging forever
- Use `migration_complete || status.success()` so the force-kill non-zero exit code doesn't falsely report migration failure

## Diagnosis

The migrate subprocess (`agentmux-srv --migrate`) prints all JSON events including `{"event":"complete"}` to stdout, then stalls. The `--crash-monitor` subprocess it spawns (confirmed via `Get-CimInstance` to have `CommandLine: ... --crash-monitor`) never completes its async wait, keeping the parent Tokio runtime alive, keeping the parent process alive, keeping stdout open. The launcher's `BufReader::lines()` loop blocks waiting for EOF that never arrives. `stage_end("migrations")` is never called so the splash never advances to "Backend startup".

Observed: 12+ minutes stuck, launcher (pid 275300) alive, crash monitor (pid 190372) alive, no srv ever spawned.

<!-- agentmux:agent_id=camper-0622h -->