### PR TITLE
fix(claude-md): emit lowercase agentmux:agent_id in PR body tag

### DIFF
--- a/.changesets/1782540223-fix-claude-md-use-lowercase-bash-expansion-for-agentmux-agen-0uyv.md
+++ b/.changesets/1782540223-fix-claude-md-use-lowercase-bash-expansion-for-agentmux-agen-0uyv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(claude-md): use lowercase bash expansion for agentmux:agent_id PR tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ git push -u origin feature-name
 gh pr create --title "Feature" --body "$(cat <<EOF
 Description of the change.
 
-<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->
+<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary

- Changes `${AGENTMUX_AGENT_ID:-smike}` to `${AGENTMUX_AGENT_ID,,}` in the CLAUDE.md PR template
- `AGENTMUX_AGENT_ID` is always injected at spawn time, so the fallback is unnecessary
- Bash `,,` lowercase operator ensures the tag matches the normalized key the cloud subscriber registers under (`add_agent()` lowercases agentName)
- Fixes agent notification routing: without lowercase, the tag could embed `Smark` while the sidecar polls for `smark`

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->