### PR TITLE
chore: release v0.49.5

### DIFF
--- a/.changesets/1782432000-fix-browser-pane-black-screen-freeze-macos-objc-nswindow-resize.md
+++ b/.changesets/1782432000-fix-browser-pane-black-screen-freeze-macos-objc-nswindow-resize.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): black screen + mouse freeze on macOS when opening a browser pane

--- a/.changesets/1782432583-fix-srv-bind-to-0-0-0-0-when-lan-discovery-is-enabled-so-rea-5gto.md
+++ b/.changesets/1782432583-fix-srv-bind-to-0-0-0-0-when-lan-discovery-is-enabled-so-rea-5gto.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): bind to 0.0.0.0 when LAN discovery is enabled so real devices can connect

--- a/.changesets/1782433463-feat-cron-loop-persistent-cron-scheduler-croncreate-delete-l-3qlx.md
+++ b/.changesets/1782433463-feat-cron-loop-persistent-cron-scheduler-croncreate-delete-l-3qlx.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(cron+loop): persistent cron scheduler (CronCreate/Delete/List/Pause/Resume) + LoopList + max_iterations on Loop

--- a/.changesets/1782458192-fix-launcher-migrate-stdout-reader-hangs-forever-if-migrate--pd24.md
+++ b/.changesets/1782458192-fix-launcher-migrate-stdout-reader-hangs-forever-if-migrate--pd24.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher): migrate stdout reader hangs forever if migrate process stalls on Tokio shutdown

--- a/.changesets/1782461638-feat-tool-preview-remove-word-wrap-distortion-and-add-indepe-ug4c.md
+++ b/.changesets/1782461638-feat-tool-preview-remove-word-wrap-distortion-and-add-indepe-ug4c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tool-preview): remove word-wrap distortion and add independent Ctrl+Scroll zoom

--- a/.changesets/1782495431-feat-lifecycle-oom-hardening-saga-cancel-wal-checkpoint-comm-wnzb.md
+++ b/.changesets/1782495431-feat-lifecycle-oom-hardening-saga-cancel-wal-checkpoint-comm-wnzb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(lifecycle): OOM hardening — saga cancel, WAL checkpoint, commit gauge

--- a/.changesets/1782512531-feat-startup-defer-migrations-and-saga-vacuum-to-upgrade-pan-k9xm.md
+++ b/.changesets/1782512531-feat-startup-defer-migrations-and-saga-vacuum-to-upgrade-pan-k9xm.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(startup): run migrations in-process at srv startup for near-instant launch

--- a/.changesets/1782529685-fix-agent-zoom-persists-immediately-drop-300ms-debounce-that-fse0.md
+++ b/.changesets/1782529685-fix-agent-zoom-persists-immediately-drop-300ms-debounce-that-fse0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): zoom persists immediately — drop 300ms debounce that caused race on pane close

--- a/.changesets/1782534857-fix-window-count-retry-reconcile-on-racing-event-30s-periodi-ldc9.md
+++ b/.changesets/1782534857-fix-window-count-retry-reconcile-on-racing-event-30s-periodi-ldc9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window-count): retry reconcile on racing event + 30s periodic safety-net

--- a/.changesets/1782535243-fix-window-count-report-os-level-window-closes-via-win-event-6i64.md
+++ b/.changesets/1782535243-fix-window-count-report-os-level-window-closes-via-win-event-6i64.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window-count): detect OS-level window closes via LOCATIONCHANGE pool-move

--- a/.changesets/1782537051-fix-statusbar-popover-position-windows-avoidnativepanes-false-8kzm.md
+++ b/.changesets/1782537051-fix-statusbar-popover-position-windows-avoidnativepanes-false-8kzm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): status-bar popovers (CPU, token breakdown) now position correctly when a browser pane is open on Windows

--- a/.changesets/1782540223-fix-claude-md-use-lowercase-bash-expansion-for-agentmux-agen-0uyv.md
+++ b/.changesets/1782540223-fix-claude-md-use-lowercase-bash-expansion-for-agentmux-agen-0uyv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(claude-md): use lowercase bash expansion for agentmux:agent_id PR tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.4"
+version = "0.49.5"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.49.4"
+version = "0.49.5"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,21 @@
 # AgentMux Version History
 
+## 0.49.5 — 2026-06-27
+
+- fix(browser-pane): black screen + mouse freeze on macOS when opening a browser pane
+- fix(srv): bind to 0.0.0.0 when LAN discovery is enabled so real devices can connect
+- feat(cron+loop): persistent cron scheduler (CronCreate/Delete/List/Pause/Resume) + LoopList + max_iterations on Loop
+- fix(launcher): migrate stdout reader hangs forever if migrate process stalls on Tokio shutdown
+- feat(tool-preview): remove word-wrap distortion and add independent Ctrl+Scroll zoom
+- feat(lifecycle): OOM hardening — saga cancel, WAL checkpoint, commit gauge
+- feat(startup): run migrations in-process at srv startup for near-instant launch
+- fix(agent): zoom persists immediately — drop 300ms debounce that caused race on pane close
+- fix(window-count): retry reconcile on racing event + 30s periodic safety-net
+- fix(window-count): detect OS-level window closes via LOCATIONCHANGE pool-move
+- fix(statusbar): status-bar popovers (CPU, token breakdown) now position correctly when a browser pane is open on Windows
+- fix(claude-md): use lowercase bash expansion for agentmux:agent_id PR tag
+
+
 ## 0.49.4 — 2026-06-25
 
 - fix(agent-stream): force StreamUnsubscribe after process crash so Working clears immediately

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.4",
+      "version": "0.49.5",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -4451,7 +4451,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11720,8 +11719,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release consuming 12 pending changesets:

- fix(browser-pane): black screen + mouse freeze on macOS when opening a browser pane
- fix(srv): bind to 0.0.0.0 when LAN discovery is enabled so real devices can connect
- feat(cron+loop): persistent cron scheduler (CronCreate/Delete/List/Pause/Resume) + LoopList + max_iterations on Loop
- fix(launcher): migrate stdout reader hangs forever if migrate process stalls on Tokio shutdown
- feat(tool-preview): remove word-wrap distortion and add independent Ctrl+Scroll zoom
- feat(lifecycle): OOM hardening — saga cancel, WAL checkpoint, commit gauge
- feat(startup): run migrations in-process at srv startup for near-instant launch
- fix(agent): zoom persists immediately — drop 300ms debounce that caused race on pane close
- fix(window-count): retry reconcile on racing event + 30s periodic safety-net
- fix(window-count): detect OS-level window closes via LOCATIONCHANGE pool-move
- fix(statusbar): status-bar popovers now position correctly when a browser pane is open on Windows
- fix(claude-md): use lowercase bash expansion for agentmux:agent_id PR tag

## Version

`0.49.4` → `0.49.5`

Note: changesets included minor-level entries; bumped as patch per explicit `--as patch` override.

## Test plan

- [ ] Verify VERSION_HISTORY.md top entry is `## 0.49.5`
- [ ] Verify package.json, Cargo.toml, Cargo.lock, package-lock.json all show `0.49.5`
- [ ] Verify all 12 changeset files are deleted from `.changesets/`

<!-- agentmux:agent_id=mazs -->