### PR TITLE
fix(muxbus): use fixed port 9379 for PKCE callback listener

### DIFF
--- a/.changesets/1782545678-fix-muxbus-use-fixed-port-9379-for-pkce-callback-listener-ayt2.md
+++ b/.changesets/1782545678-fix-muxbus-use-fixed-port-9379-for-pkce-callback-listener-ayt2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): use fixed port 9379 for PKCE callback listener

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -54,7 +54,7 @@ pub async fn run_pkce_login(
     let redirect_uri = format!("http://127.0.0.1:{CALLBACK_PORT}/callback");
     let listener = TcpListener::bind(format!("127.0.0.1:{CALLBACK_PORT}"))
         .await
-        .map_err(|e| format!("failed to bind callback port {CALLBACK_PORT}: {e} — is another muxbus login in progress?"))?;
+        .map_err(|e| format!("failed to bind callback port {CALLBACK_PORT}: {e} — another process may be holding the port"))?;
 
     // 5. Build auth URL
     let scopes = "openid+email+profile+https%3A%2F%2Fmuxbus.agentmux.ai%2Fread+https%3A%2F%2Fmuxbus.agentmux.ai%2Fwrite";

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -79,54 +79,72 @@ pub async fn run_pkce_login(
         "muxbus: PKCE login started, awaiting browser callback"
     );
 
-    // 7. Accept one connection (with timeout)
-    let (mut stream, _) = tokio::time::timeout(
+    // 7. Accept connections until the valid Cognito callback arrives (5-min overall timeout).
+    //    On a fixed well-known port, stray requests (browser prefetch, health probes) can
+    //    arrive before Cognito's redirect; loop until /callback with matching state+code.
+    let code = tokio::time::timeout(
         std::time::Duration::from_secs(LOGIN_TIMEOUT_SECS),
-        listener.accept(),
+        async {
+            loop {
+                let (mut stream, _) = listener
+                    .accept()
+                    .await
+                    .map_err(|e| format!("callback accept failed: {e}"))?;
+
+                let mut buf = [0u8; 4096];
+                let n = match tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    stream.read(&mut buf),
+                )
+                .await
+                {
+                    Ok(Ok(n)) => n,
+                    _ => continue, // stray connection with read timeout/error — keep waiting
+                };
+                let request = std::str::from_utf8(&buf[..n]).unwrap_or("");
+
+                let first_line = request.lines().next().unwrap_or("");
+                let raw_path = first_line.split_whitespace().nth(1).unwrap_or("");
+                let (path_only, query) = raw_path.split_once('?').unwrap_or((raw_path, ""));
+
+                if path_only != "/callback" {
+                    let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\n\r\n").await;
+                    continue;
+                }
+
+                let returned_state = query_param(query, "state").unwrap_or_default();
+                if returned_state != state {
+                    // Wrong state — could be a replayed or unrelated request; keep waiting
+                    let _ = stream.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+                    continue;
+                }
+
+                let html: &[u8] = if query_param(query, "code").is_some() {
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
+                      <html><body><h2>Connected to AgentMux Cloud.</h2>\
+                      <p>You can close this tab.</p></body></html>"
+                } else {
+                    b"HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
+                      <html><body><h2>Login failed.</h2><p>Please retry from AgentMux.</p></body></html>"
+                };
+                let _ = stream.write_all(html).await;
+
+                match query_param(query, "code") {
+                    Some(c) => return Ok::<_, String>(c),
+                    None => {
+                        let err = query_param(query, "error")
+                            .unwrap_or_else(|| "unknown".to_string());
+                        return Err(format!("Cognito returned error: {err}"));
+                    }
+                }
+            }
+        },
     )
     .await
-    .map_err(|_| "login timed out (5 min) — please try again")?
-    .map_err(|e| format!("callback accept failed: {e}"))?;
+    .map_err(|_| "login timed out (5 min) — please try again".to_string())?
+    .map_err(|e| e)?;
 
-    // 8. Read HTTP request and extract code + state
-    let mut buf = [0u8; 4096];
-    let n = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
-        stream.read(&mut buf),
-    )
-    .await
-    .map_err(|_| "callback read timed out")?
-    .map_err(|e| format!("callback read failed: {e}"))?;
-    let request = std::str::from_utf8(&buf[..n]).unwrap_or("");
-
-    // Respond to the browser immediately
-    let html = if request.contains("code=") {
-        b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
-          <html><body><h2>Connected to AgentMux Cloud.</h2>\
-          <p>You can close this tab.</p></body></html>" as &[u8]
-    } else {
-        b"HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
-          <html><body><h2>Login failed.</h2><p>Please retry from AgentMux.</p></body></html>"
-    };
-    let _ = stream.write_all(html).await;
-
-    // Parse query from first line: GET /callback?code=xxx&state=yyy HTTP/1.1
-    let query = request
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .and_then(|path| path.split_once('?').map(|(_, q)| q))
-        .unwrap_or("");
-
-    let code = query_param(query, "code")
-        .ok_or_else(|| "callback missing 'code' parameter")?;
-    let returned_state = query_param(query, "state").unwrap_or_default();
-
-    if returned_state != state {
-        return Err("CSRF mismatch — state parameter did not match".to_string());
-    }
-
-    // 9. Exchange code for tokens
+    // 8. Exchange code for tokens
     let token_url = format!("{cognito_domain}/oauth2/token");
     let params = [
         ("grant_type", "authorization_code"),
@@ -169,7 +187,7 @@ pub async fn run_pkce_login(
         .as_secs() as i64)
         + expires_in;
 
-    // 10. Extract email + sub from id_token payload (no re-verification needed)
+    // 9. Extract email + sub from id_token payload (no re-verification needed)
     let (user_email, user_sub) = extract_jwt_claims(&id_token);
 
     tracing::info!(

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -16,7 +16,7 @@
 use base64::Engine as _;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::TcpSocket;
 
 use crate::backend::storage::muxbus::MuxBusCredentials;
 
@@ -49,12 +49,22 @@ pub async fn run_pkce_login(
     // 3. State (CSRF)
     let state = uuid::Uuid::new_v4().to_string();
 
-    // 4. Bind fixed port 9379 — must match Cognito callbackUrls exactly
+    // 4. Bind fixed port 9379 — must match Cognito callbackUrls exactly.
+    //    SO_REUSEADDR allows immediate re-login after a cancelled attempt whose
+    //    socket is still in TIME_WAIT (would otherwise hit EADDRINUSE).
     const CALLBACK_PORT: u16 = 9379;
     let redirect_uri = format!("http://127.0.0.1:{CALLBACK_PORT}/callback");
-    let listener = TcpListener::bind(format!("127.0.0.1:{CALLBACK_PORT}"))
-        .await
+    let tcp_sock = TcpSocket::new_v4()
+        .map_err(|e| format!("failed to create callback socket: {e}"))?;
+    tcp_sock
+        .set_reuseaddr(true)
+        .map_err(|e| format!("failed to set SO_REUSEADDR: {e}"))?;
+    tcp_sock
+        .bind(format!("127.0.0.1:{CALLBACK_PORT}").parse().unwrap())
         .map_err(|e| format!("failed to bind callback port {CALLBACK_PORT}: {e} — another process may be holding the port"))?;
+    let listener = tcp_sock
+        .listen(10)
+        .map_err(|e| format!("failed to listen on callback port {CALLBACK_PORT}: {e}"))?;
 
     // 5. Build auth URL
     let scopes = "openid+email+profile+https%3A%2F%2Fmuxbus.agentmux.ai%2Fread+https%3A%2F%2Fmuxbus.agentmux.ai%2Fwrite";
@@ -80,69 +90,79 @@ pub async fn run_pkce_login(
     );
 
     // 7. Accept connections until the valid Cognito callback arrives (5-min overall timeout).
-    //    On a fixed well-known port, stray requests (browser prefetch, health probes) can
-    //    arrive before Cognito's redirect; loop until /callback with matching state+code.
+    //    On a fixed well-known port, stray connections (browser prefetch, port probes) can
+    //    arrive before Cognito's redirect. Each accepted connection is spawned into a task
+    //    so slow/idle strays don't block accept() and delay the real callback.
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<Result<String, String>>(1);
     let code = tokio::time::timeout(
         std::time::Duration::from_secs(LOGIN_TIMEOUT_SECS),
-        async {
+        async move {
             loop {
-                let (mut stream, _) = listener
-                    .accept()
-                    .await
-                    .map_err(|e| format!("callback accept failed: {e}"))?;
+                tokio::select! {
+                    biased;
+                    result = result_rx.recv() => {
+                        return result.unwrap_or_else(|| Err("callback channel closed".to_string()));
+                    }
+                    accept_res = listener.accept() => {
+                        let (mut stream, _) = accept_res
+                            .map_err(|e| format!("callback accept failed: {e}"))?;
+                        let state_val = state.clone();
+                        let tx = result_tx.clone();
+                        tokio::spawn(async move {
+                            let mut buf = [0u8; 4096];
+                            let n = match tokio::time::timeout(
+                                std::time::Duration::from_secs(2),
+                                stream.read(&mut buf),
+                            )
+                            .await
+                            {
+                                Ok(Ok(n)) => n,
+                                _ => return,
+                            };
+                            let request = std::str::from_utf8(&buf[..n]).unwrap_or("");
+                            let first_line = request.lines().next().unwrap_or("");
+                            let raw_path = first_line.split_whitespace().nth(1).unwrap_or("");
+                            let (path_only, query) =
+                                raw_path.split_once('?').unwrap_or((raw_path, ""));
 
-                let mut buf = [0u8; 4096];
-                let n = match tokio::time::timeout(
-                    std::time::Duration::from_secs(10),
-                    stream.read(&mut buf),
-                )
-                .await
-                {
-                    Ok(Ok(n)) => n,
-                    _ => continue, // stray connection with read timeout/error — keep waiting
-                };
-                let request = std::str::from_utf8(&buf[..n]).unwrap_or("");
+                            if path_only != "/callback" {
+                                let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\n\r\n").await;
+                                return;
+                            }
 
-                let first_line = request.lines().next().unwrap_or("");
-                let raw_path = first_line.split_whitespace().nth(1).unwrap_or("");
-                let (path_only, query) = raw_path.split_once('?').unwrap_or((raw_path, ""));
+                            let returned_state = query_param(query, "state").unwrap_or_default();
+                            if returned_state != state_val {
+                                let _ = stream.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+                                return;
+                            }
 
-                if path_only != "/callback" {
-                    let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\n\r\n").await;
-                    continue;
-                }
+                            let html: &[u8] = if query_param(query, "code").is_some() {
+                                b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
+                                  <html><body><h2>Connected to AgentMux Cloud.</h2>\
+                                  <p>You can close this tab.</p></body></html>"
+                            } else {
+                                b"HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
+                                  <html><body><h2>Login failed.</h2><p>Please retry from AgentMux.</p></body></html>"
+                            };
+                            let _ = stream.write_all(html).await;
 
-                let returned_state = query_param(query, "state").unwrap_or_default();
-                if returned_state != state {
-                    // Wrong state — could be a replayed or unrelated request; keep waiting
-                    let _ = stream.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
-                    continue;
-                }
-
-                let html: &[u8] = if query_param(query, "code").is_some() {
-                    b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
-                      <html><body><h2>Connected to AgentMux Cloud.</h2>\
-                      <p>You can close this tab.</p></body></html>"
-                } else {
-                    b"HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
-                      <html><body><h2>Login failed.</h2><p>Please retry from AgentMux.</p></body></html>"
-                };
-                let _ = stream.write_all(html).await;
-
-                match query_param(query, "code") {
-                    Some(c) => return Ok::<_, String>(c),
-                    None => {
-                        let err = query_param(query, "error")
-                            .unwrap_or_else(|| "unknown".to_string());
-                        return Err(format!("Cognito returned error: {err}"));
+                            let result = match query_param(query, "code") {
+                                Some(c) => Ok(c),
+                                None => {
+                                    let err = query_param(query, "error")
+                                        .unwrap_or_else(|| "unknown".to_string());
+                                    Err(format!("Cognito returned error: {err}"))
+                                }
+                            };
+                            let _ = tx.send(result).await;
+                        });
                     }
                 }
             }
         },
     )
     .await
-    .map_err(|_| "login timed out (5 min) — please try again".to_string())?
-    .map_err(|e| e)?;
+    .map_err(|_| "login timed out (5 min) — please try again".to_string())??;
 
     // 8. Exchange code for tokens
     let token_url = format!("{cognito_domain}/oauth2/token");

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -5,7 +5,8 @@
 //!
 //! Flow:
 //!   1. Generate code_verifier + code_challenge (S256).
-//!   2. Bind a random local TCP port for the redirect_uri.
+//!   2. Bind fixed port 9379 for the redirect_uri (Cognito does exact-string
+//!      matching only — no wildcard port support despite RFC 8252 §8.3).
 //!   3. Open browser to Cognito hosted UI.
 //!   4. Await HTTP callback (code + state).
 //!   5. Exchange code for tokens via /oauth2/token.
@@ -48,16 +49,12 @@ pub async fn run_pkce_login(
     // 3. State (CSRF)
     let state = uuid::Uuid::new_v4().to_string();
 
-    // 4. Bind a random port
-    let listener = TcpListener::bind("127.0.0.1:0")
+    // 4. Bind fixed port 9379 — must match Cognito callbackUrls exactly
+    const CALLBACK_PORT: u16 = 9379;
+    let redirect_uri = format!("http://127.0.0.1:{CALLBACK_PORT}/callback");
+    let listener = TcpListener::bind(format!("127.0.0.1:{CALLBACK_PORT}"))
         .await
-        .map_err(|e| format!("failed to bind callback listener: {e}"))?;
-    let port = listener
-        .local_addr()
-        .map_err(|e| format!("listener addr: {e}"))?
-        .port();
-
-    let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+        .map_err(|e| format!("failed to bind callback port {CALLBACK_PORT}: {e} — is another muxbus login in progress?"))?;
 
     // 5. Build auth URL
     let scopes = "openid+email+profile+https%3A%2F%2Fmuxbus.agentmux.ai%2Fread+https%3A%2F%2Fmuxbus.agentmux.ai%2Fwrite";
@@ -78,7 +75,7 @@ pub async fn run_pkce_login(
 
     tracing::info!(
         cognito_domain = cognito_domain,
-        port = port,
+        port = CALLBACK_PORT,
         "muxbus: PKCE login started, awaiting browser callback"
     );
 


### PR DESCRIPTION
## Summary

- Cognito hosted UI does **exact-string URL matching only** — it does not implement RFC 8252 §8.3 wildcard port matching for loopback addresses despite the RFC requiring it
- Binding a random ephemeral port (`127.0.0.1:0`) always produced a `redirect_uri` that didn't match the Cognito allowlist, causing `redirect_mismatch` on every login attempt
- Switch to fixed port **9379** so `http://127.0.0.1:9379/callback` can be registered in the Cognito DesktopClient `callbackUrls` list (see companion PR in agentmux-cloud)
- Improved error message when port is already in use (e.g. concurrent login attempt)

## Test plan

- [ ] Build and launch AgentMux desktop
- [ ] Click "Connect" in the status-bar host panel
- [ ] Browser should open Cognito hosted UI (Google sign-in), not an error page
- [ ] Complete sign-in → browser shows "Connected to AgentMux Cloud." success page
- [ ] Verify token saved; muxbus WebSocket connects (check logs for "PKCE login succeeded")
- [ ] Verify `http://127.0.0.1:9379/callback` is in the Cognito DesktopClient callbackUrls after agentmux-cloud CDK redeploy

<!-- agentmux:agent_id=smark -->