### PR TITLE
fix(host-panel): show correct DevTools port and host badge per instance

### DIFF
--- a/.changesets/1782546301-fix-host-panel-show-correct-devtools-port-and-host-badge-per-i1s7.md
+++ b/.changesets/1782546301-fix-host-panel-show-correct-devtools-port-and-host-badge-per-i1s7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(host-panel): show correct DevTools port and host badge per instance

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -235,6 +235,7 @@ pub fn get_host_info(state: &Arc<AppState>) -> serde_json::Value {
     let version = env!("CARGO_PKG_VERSION");
     let endpoints = state.backend_endpoints.lock();
     let ipc_port = *state.ipc_port.lock();
+    let debug_port = *state.debug_port.lock();
     let data_dir = state.version_data_dir.lock().clone().unwrap_or_default();
     let pid = std::process::id();
 
@@ -258,13 +259,13 @@ pub fn get_host_info(state: &Arc<AppState>) -> serde_json::Value {
         "instanceId": format!("v{}", version),
         "version": version,
         "dataDir": data_dir,
-        "hostType": "CEF 148",
+        "hostType": "host",
         "pid": pid,
         "ports": {
             "ipc": format!("127.0.0.1:{}", ipc_port),
             "web": endpoints.web_endpoint,
             "ws": endpoints.ws_endpoint,
-            "devtools": "127.0.0.1:9222",
+            "devtools": format!("127.0.0.1:{}", debug_port),
         }
     })
 }


### PR DESCRIPTION
## Summary

Two bugs in `get_host_info()` (`agentmux-cef/src/commands/platform.rs`):

- **DevTools port hardcoded to 9222** — all instances showed the same port in the status-bar host panel, even when a second instance fell back to an ephemeral port. Fixed to read `state.debug_port` (the actual bound port).
- **`hostType: "CEF 148"` caused a question-mark icon** — `RuntimeBadge` only knows `"host"` and `"container"`; any other value renders `fa-circle-question` + raw string. CEF *is* the host runtime, so now emits `"host"`.

## Test plan

- [ ] Launch two AgentMux instances; open host panel on each — verify distinct DevTools ports shown
- [ ] Host badge shows server icon with "Host" label, no question mark
- [ ] Single instance: DevTools port matches `--remote-debugging-port` / actual bound port in logs

<!-- agentmux:agent_id=smark -->