### PR TITLE
fix(activity-summary): never clear haiku label; flash briefly on update

### DIFF
--- a/.changesets/1782562498-fix-activity-summary-never-clear-haiku-label-flash-on-update-rhal.md
+++ b/.changesets/1782562498-fix-activity-summary-never-clear-haiku-label-flash-on-update-rhal.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(activity-summary): never clear haiku label; flash on update

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -169,6 +169,14 @@
                         overflow: hidden;
                         text-overflow: ellipsis;
                         white-space: nowrap;
+                        &.term-activity--flash {
+                            animation: term-activity-flash 0.5s ease-out;
+                        }
+                    }
+
+                    @keyframes term-activity-flash {
+                        0%   { opacity: 1; color: var(--accent-color, #6c9ef8); }
+                        100% { opacity: 0.6; color: inherit; }
                     }
                 }
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -1,7 +1,7 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignal, createEffect } from "solid-js";
+import { createSignal, createEffect, onCleanup } from "solid-js";
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -85,17 +85,22 @@ export class AgentViewModel implements ViewModel {
         this.blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
         this.viewComponent = AgentViewWrapper as any;
 
-        // Flash signal: set true briefly when a new activity summary lands.
+        // Flash signal: set true briefly when term:activity changes to a new
+        // non-empty value. Compare to previous so unrelated meta writes (status,
+        // agentName, etc.) during an active turn don't trigger spurious flashes.
         const [activityFlash, setActivityFlash] = createSignal(false);
         let flashTimer: ReturnType<typeof setTimeout> | undefined;
+        let prevActivity: string | undefined;
         createEffect(() => {
-            const activity = this.blockAtom()?.meta?.["term:activity"];
-            if (activity) {
+            const activity = this.blockAtom()?.meta?.["term:activity"] as string | undefined;
+            if (activity && activity !== prevActivity) {
                 clearTimeout(flashTimer);
                 setActivityFlash(true);
                 flashTimer = setTimeout(() => setActivityFlash(false), 600);
             }
+            prevActivity = activity;
         });
+        onCleanup(() => clearTimeout(flashTimer));
         this._activityFlash = activityFlash;
 
         // Drive the pane's title from block meta — launching an agent sets

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -1,6 +1,7 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createSignal, createEffect } from "solid-js";
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -71,6 +72,7 @@ export class AgentViewModel implements ViewModel {
     // currently-active pane wrote it just now). useHistoryPagination
     // sets this on snapshot restore.
     continuedFromMsAtom: SignalAtom<number> = createSignalAtom(0);
+    _activityFlash: () => boolean = () => false;
 
     voiceHandle = (): PaneVoiceHandle => ({
         appendFinal: (text: string) => this.voiceTargetRef.current?.appendFinal(text),
@@ -82,6 +84,19 @@ export class AgentViewModel implements ViewModel {
         this.nodeModel = nodeModel;
         this.blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
         this.viewComponent = AgentViewWrapper as any;
+
+        // Flash signal: set true briefly when a new activity summary lands.
+        const [activityFlash, setActivityFlash] = createSignal(false);
+        let flashTimer: ReturnType<typeof setTimeout> | undefined;
+        createEffect(() => {
+            const activity = this.blockAtom()?.meta?.["term:activity"];
+            if (activity) {
+                clearTimeout(flashTimer);
+                setActivityFlash(true);
+                flashTimer = setTimeout(() => setActivityFlash(false), 600);
+            }
+        });
+        this._activityFlash = activityFlash;
 
         // Drive the pane's title from block meta — launching an agent sets
         // `agentName` / `agentIcon` and the frame title automatically picks
@@ -116,14 +131,14 @@ export class AgentViewModel implements ViewModel {
             const elems: HeaderElem[] = [];
 
             // Per-turn live mini-summary from useAgentActivitySummary (Haiku on
-            // every turn completion). Cleared to null on Submitting so the header
-            // goes blank while the agent is working.
+            // every turn completion). Persists across turns; flashes briefly when
+            // a new summary lands.
             const activity = this.blockAtom()?.meta?.["term:activity"] as string | undefined;
             if (activity && activity.length > 0) {
                 elems.push({
                     elemtype: "text",
                     text: activity,
-                    className: "term-activity",
+                    className: this._activityFlash() ? "term-activity term-activity--flash" : "term-activity",
                 });
             }
 

--- a/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
+++ b/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
@@ -12,9 +12,9 @@
  * Word target is derived from pane width so narrow panes get ~5 words and wide
  * panes can accommodate up to 12.
  *
- * On turn start (Submitting phase) the stale label is cleared. A turn counter
- * ensures a slow Haiku response from a superseded turn cannot overwrite the
- * cleared header once a new turn has already started.
+ * The summary is never cleared — it persists across turns so the header always
+ * shows the last known activity. A turn counter ensures a slow Haiku response
+ * from a superseded turn cannot overwrite a newer summary.
  */
 
 import { createEffect, on, type Accessor } from "solid-js";
@@ -42,11 +42,6 @@ export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): v
     createEffect(on(turnPhase, (phase) => {
         if (phase.kind === "Submitting") {
             activeTurnId++;
-            fireAndForget(() =>
-                ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
-                    "term:activity": null,
-                } as any)
-            );
             return;
         }
 

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -176,6 +176,14 @@
     line-height: 1.4;
     word-break: break-word;
     overflow-wrap: break-word;
+    &.swarm-activity-summary--flash {
+        animation: swarm-activity-flash 0.5s ease-out;
+    }
+}
+
+@keyframes swarm-activity-flash {
+    0%   { opacity: 1; color: var(--accent-color, #6c9ef8); }
+    100% { opacity: 1; color: var(--secondary-text-color); }
 }
 
 // ── Status chip ──────────────────────────────────────────────────────────

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createMemo, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, createEffect, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
@@ -193,6 +193,16 @@ function AgentRow({
         phaseToDisplayStatus(node.blockId, node.agentStatus)
     );
 
+    const [summaryFlash, setSummaryFlash] = createSignal(false);
+    let flashTimer: ReturnType<typeof setTimeout> | undefined;
+    createEffect(() => {
+        if (node.activitySummary) {
+            clearTimeout(flashTimer);
+            setSummaryFlash(true);
+            flashTimer = setTimeout(() => setSummaryFlash(false), 600);
+        }
+    });
+
     return (
         <div class="swarm-agent-group">
             <div
@@ -215,7 +225,9 @@ function AgentRow({
                     <AgentStatusChip status={displayStatus()} />
                 </div>
                 <Show when={node.activitySummary}>
-                    <div class="swarm-activity-summary">{node.activitySummary}</div>
+                    <div classList={{ "swarm-activity-summary": true, "swarm-activity-summary--flash": summaryFlash() }}>
+                        {node.activitySummary}
+                    </div>
                 </Show>
             </div>
             <div class="swarm-children">

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createMemo, createSignal, createEffect, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
@@ -195,13 +195,17 @@ function AgentRow({
 
     const [summaryFlash, setSummaryFlash] = createSignal(false);
     let flashTimer: ReturnType<typeof setTimeout> | undefined;
+    let prevSummary: string | null = node.activitySummary; // don't flash existing summary on mount
     createEffect(() => {
-        if (node.activitySummary) {
+        const summary = node.activitySummary;
+        if (summary && summary !== prevSummary) {
             clearTimeout(flashTimer);
             setSummaryFlash(true);
             flashTimer = setTimeout(() => setSummaryFlash(false), 600);
         }
+        prevSummary = summary;
     });
+    onCleanup(() => clearTimeout(flashTimer));
 
     return (
         <div class="swarm-agent-group">


### PR DESCRIPTION
## Summary

- The activity summary was set to `null` on every `Submitting` phase, blanking the pane header and swarm row for the entire duration of the next agent turn. Since the summary is stale-safe (guarded by turn counter), there's no reason to blank it.
- Remove the `term:activity: null` write from `useAgentActivitySummary`; the `activeTurnId` counter still prevents a slow response from a superseded turn overwriting a newer one.
- Add a `_activityFlash` signal in `AgentViewModel`: when `term:activity` changes to a non-empty value, briefly apply `term-activity--flash` (0.5s accent-color fade) so the pane header visually acknowledges the new summary.
- Same flash pattern in `AgentRow` in swarm-view for the `swarm-activity-summary` row.

## Test plan

- [ ] Start an agent turn — the previous summary stays visible the whole time (no blank)
- [ ] When a turn completes and a new summary arrives, the header text briefly flashes to accent color then fades back
- [ ] Same flash in the swarm view agent row
- [ ] Slow/no-summary turns: existing summary stays; no flash if summary unchanged

<!-- agentmux:agent_id=smark -->