### PR TITLE
fix(agent): seed term:zoom from ui:zoom when opening agent pane

### DIFF
--- a/.changesets/1782567778-fix-agent-seed-term-zoom-from-ui-zoom-when-opening-agent-pan-5ulx.md
+++ b/.changesets/1782567778-fix-agent-seed-term-zoom-from-ui-zoom-when-opening-agent-pan-5ulx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): seed term:zoom from ui:zoom when opening agent pane — zoom level now persists across close/reopen


### PR DESCRIPTION
## Summary

- The normal agent-open path (Rust CEF → `agentmux-open-agent` event → `createBlock`) never seeded `term:zoom` in the initial block meta, so the pane always opened at the default zoom level regardless of what was persisted
- The `agent.open` backend RPC handler (in `app_api.rs`) correctly reads `ui:zoom` and seeds `term:zoom`, but it is **dead code** from the user-facing open path — the frontend never calls it
- 4 prior PRs all fixed parts of the write path correctly; this PR fixes the missing read side

## Root cause

```
User clicks agent → Rust CEF dispatches agentmux-open-agent
→ command-registry.ts: createBlock({ meta: { view: "agent", agentId } })
                                                                  ^^^^ no term:zoom
```

## Fix

Before `createBlock`, call `GetAgentContentCommand(agentId, "ui:zoom")` and include `term:zoom` in the initial block meta when a valid persisted zoom exists (0.5–2.0, not exactly 1.0).

Note: commit is already on `main` (direct push); this PR is the proper review artifact.

## Test plan

- [ ] Open an agent pane (e.g. Lazo), zoom out with Ctrl+-, close the pane
- [ ] Reopen the same agent — zoom level should be restored, not reset to 100%
- [ ] Verify zoom=1.0 (default) still opens at default (not forced to 1.0 explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)