### PR TITLE
fix(bang-cmd): auto-open details panel and expand log on bang commands

### DIFF
--- a/.changesets/1782564419-fix-bang-cmd-auto-open-details-panel-and-expand-log-when-run-ar78.md
+++ b/.changesets/1782564419-fix-bang-cmd-auto-open-details-panel-and-expand-log-when-run-ar78.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(bang-cmd): auto-open details panel and expand log when running bang commands

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -719,6 +719,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Mark turn as active when the user sends a message — TurnStart
     // also clears stale sessionStats from the prior turn.
     const handleSendMessage = (message: string): Promise<void> => {
+        // Bang commands (`!cmd`) output goes to the ActivityLogPanel inside the
+        // details region. Auto-open the details panel so the output is immediately
+        // visible — without this, the user sees no feedback if the panel is closed.
+        if (message.trim().startsWith("!")) {
+            agentAtoms().detailsOpenAtom[1](true);
+        }
         // Capture working state BEFORE TurnStart so PendingMessageQueued can
         // mark whether this message is queued behind a running turn (true) or
         // is the message that initiated the turn (false). The panel only shows

--- a/frontend/app/view/agent/components/ActivityLogPanel.tsx
+++ b/frontend/app/view/agent/components/ActivityLogPanel.tsx
@@ -13,7 +13,7 @@
  * see `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { For, Show, createMemo, createSignal, type Accessor, type JSX } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, type Accessor, type JSX } from "solid-js";
 import type { LogLine } from "../types";
 
 interface ActivityLogPanelProps {
@@ -23,6 +23,16 @@ interface ActivityLogPanelProps {
 export const ActivityLogPanel = (props: ActivityLogPanelProps): JSX.Element => {
     const [isOpen, setIsOpen] = createSignal(false);
     const [expandedIds, setExpandedIds] = createSignal<Set<string>>(new Set());
+
+    // Auto-expand when new entries arrive so bang command output is immediately visible.
+    let prevLength = props.entries().length;
+    createEffect(() => {
+        const len = props.entries().length;
+        if (len > prevLength) {
+            setIsOpen(true);
+        }
+        prevLength = len;
+    });
 
     const mostRecent = createMemo(() => {
         const list = props.entries();


### PR DESCRIPTION
## Summary

- When a message starting with `!` is sent, `handleSendMessage` in `agent-view.tsx` now calls `detailsOpenAtom[1](true)` to ensure the details region is open before the command runs
- `ActivityLogPanel` now auto-expands (`setIsOpen(true)`) via a `createEffect` whenever new log entries arrive — so bash output is immediately visible without requiring a click

Without these two fixes, `!pwd` (and any other bang command) produced no visible response: the details panel might be closed (hiding the log entirely), and even if open, the log starts collapsed.

<!-- agentmux:agent_id=smark -->