### PR TITLE
feat(statusbar): Maintenance section in InstancePanel

### DIFF
--- a/.changesets/1782565931-feat-statusbar-add-maintenance-section-to-instancepanel-9yie.md
+++ b/.changesets/1782565931-feat-statusbar-add-maintenance-section-to-instancepanel-9yie.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(statusbar): add Maintenance section to InstancePanel

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -215,6 +215,14 @@ pub async fn run_migrations(state: Arc<AppState>) -> Result<serde_json::Value, S
                 &serde_json::json!({ "error": e, "failedId": null }),
             );
         }
+
+        // Always restart srv — we killed the sidecar above regardless of outcome.
+        // This applies to success (applied>0 or applied==0), subprocess failure,
+        // and internal errors equally; without this the session has no working backend.
+        if let Err(e) = restart_backend(state.clone()).await {
+            tracing::warn!("[run_migrations] srv restart after migration: {}", e);
+        }
+
         *state.migration_running.lock() = false;
     });
 
@@ -322,15 +330,6 @@ async fn run_migrations_inner(
             "upgrade:migrations-complete",
             &serde_json::json!({ "applied": applied }),
         );
-        // Only restart when something was actually applied; applied==0 means the
-        // DB was already current and id_store is already correct.
-        // Production is blocked at run_migrations entry, so restart_backend is
-        // always safe here (we own the sidecar and already killed it above).
-        if applied > 0 {
-            if let Err(e) = restart_backend(state.clone()).await {
-                tracing::warn!("[run_migrations] srv restart after migrations failed: {}", e);
-            }
-        }
         Ok(())
     } else {
         let err = if !stderr_output.is_empty() {

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -50,7 +50,6 @@ pub fn get_backend_info(state: &Arc<AppState>) -> serde_json::Value {
     let pid = *state.backend_pid.lock();
     let started_at = state.backend_started_at.lock().clone();
     let pending_migrations = *state.pending_migrations.lock();
-    let srv_restart_required = *state.srv_restart_required.lock();
 
     serde_json::json!({
         "pid": pid,
@@ -58,7 +57,6 @@ pub fn get_backend_info(state: &Arc<AppState>) -> serde_json::Value {
         "web_endpoint": endpoints.web_endpoint,
         "version": current_version,
         "pending_migrations": pending_migrations,
-        "srv_restart_required": srv_restart_required,
     })
 }
 

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -50,6 +50,7 @@ pub fn get_backend_info(state: &Arc<AppState>) -> serde_json::Value {
     let pid = *state.backend_pid.lock();
     let started_at = state.backend_started_at.lock().clone();
     let pending_migrations = *state.pending_migrations.lock();
+    let srv_restart_required = *state.srv_restart_required.lock();
 
     serde_json::json!({
         "pid": pid,
@@ -57,6 +58,7 @@ pub fn get_backend_info(state: &Arc<AppState>) -> serde_json::Value {
         "web_endpoint": endpoints.web_endpoint,
         "version": current_version,
         "pending_migrations": pending_migrations,
+        "srv_restart_required": srv_restart_required,
     })
 }
 
@@ -176,6 +178,21 @@ pub async fn run_migrations(state: Arc<AppState>) -> Result<serde_json::Value, S
         })?;
 
     tokio::spawn(async move {
+        // In dev mode (no AGENTMUX_BACKEND_PID) kill the existing sidecar srv before
+        // spawning the migrate subprocess. Both processes share the same SQLite files;
+        // running them concurrently risks lock contention and mid-backfill write races.
+        if std::env::var("AGENTMUX_BACKEND_PID").is_err() {
+            let mut sidecar = state.sidecar_child.lock();
+            if let Some(ref mut child) = *sidecar {
+                let _ = child.kill();
+                tracing::info!("[run_migrations] killed sidecar srv before migration (dev mode)");
+            }
+            *sidecar = None;
+            // Small delay so the OS releases file locks before we open the DB.
+            drop(sidecar);
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        }
+
         if let Err(e) = run_migrations_inner(state.clone(), srv_path, data_dir).await {
             tracing::error!("[run_migrations] subprocess error: {}", e);
             crate::events::emit_event_to_top_level_windows(
@@ -291,18 +308,23 @@ async fn run_migrations_inner(
             "upgrade:migrations-complete",
             &serde_json::json!({ "applied": applied }),
         );
-        // Restart srv so id_store rebinds from per-channel fallback to shared store.
-        // In launcher-managed runs (AGENTMUX_BACKEND_PID set) the host cannot safely
-        // spawn a replacement srv — emit srv-restart-required so the frontend can
-        // prompt the user. In dev mode (no AGENTMUX_BACKEND_PID) restart directly.
-        if std::env::var("AGENTMUX_BACKEND_PID").is_ok() {
-            crate::events::emit_event_to_top_level_windows(
-                &state,
-                "upgrade:srv-restart-required",
-                &serde_json::json!({}),
-            );
-        } else if let Err(e) = restart_backend(state.clone()).await {
-            tracing::warn!("[run_migrations] srv restart after migrations failed: {}", e);
+        // Only restart/notify when something was actually applied; applied==0
+        // means the DB was already current and id_store is already correct.
+        if applied > 0 {
+            // Restart srv so id_store rebinds from per-channel fallback to shared store.
+            // In launcher-managed runs (AGENTMUX_BACKEND_PID set) the host cannot safely
+            // spawn a replacement srv — emit srv-restart-required so the frontend can
+            // prompt the user. In dev mode (no AGENTMUX_BACKEND_PID) restart directly.
+            if std::env::var("AGENTMUX_BACKEND_PID").is_ok() {
+                *state.srv_restart_required.lock() = true;
+                crate::events::emit_event_to_top_level_windows(
+                    &state,
+                    "upgrade:srv-restart-required",
+                    &serde_json::json!({}),
+                );
+            } else if let Err(e) = restart_backend(state.clone()).await {
+                tracing::warn!("[run_migrations] srv restart after migrations failed: {}", e);
+            }
         }
         Ok(())
     } else {

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -6,6 +6,8 @@
 
 use std::sync::Arc;
 
+use tokio::io::AsyncBufReadExt as _;
+
 use crate::state::AppState;
 
 /// Get the backend WebSocket and HTTP endpoints.
@@ -143,6 +145,162 @@ pub async fn restart_backend(state: Arc<AppState>) -> Result<serde_json::Value, 
     );
 
     Ok(serde_json::Value::Null)
+}
+
+/// Trigger an on-demand migration run via `agentmux-srv … migrate`.
+///
+/// Returns `{"started": true}` immediately; progress events are pushed to the
+/// frontend as `upgrade:migration-event` / `upgrade:migrations-complete` /
+/// `upgrade:migrations-failed` CEF events so the Maintenance panel can render
+/// a live stage list without polling.
+pub async fn run_migrations(state: Arc<AppState>) -> Result<serde_json::Value, String> {
+    // Guard: only one run at a time.
+    {
+        let mut running = state.migration_running.lock();
+        if *running {
+            return Err("Migration already in progress".to_string());
+        }
+        *running = true;
+    }
+
+    let data_dir = state.version_data_dir.lock().clone().ok_or_else(|| {
+        *state.migration_running.lock() = false;
+        "Data directory not initialized".to_string()
+    })?;
+
+    let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
+    let srv_path = crate::sidecar::resolve_backend_binary_pub("agentmux-srv", exe_suffix)
+        .map_err(|e| {
+            *state.migration_running.lock() = false;
+            e
+        })?;
+
+    tokio::spawn(async move {
+        if let Err(e) = run_migrations_inner(state.clone(), srv_path, data_dir).await {
+            tracing::error!("[run_migrations] subprocess error: {}", e);
+            crate::events::emit_event_from_state(
+                &state,
+                "upgrade:migrations-failed",
+                &serde_json::json!({ "error": e, "failedId": null }),
+            );
+        }
+        *state.migration_running.lock() = false;
+    });
+
+    Ok(serde_json::json!({ "started": true }))
+}
+
+async fn run_migrations_inner(
+    state: Arc<AppState>,
+    srv_path: std::path::PathBuf,
+    data_dir: String,
+) -> Result<(), String> {
+    use tokio::process::Command;
+    use tokio::io::BufReader;
+
+    let mut child = Command::new(&srv_path)
+        .arg("--wavedata")
+        .arg(&data_dir)
+        .arg("migrate")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn agentmux-srv migrate: {}", e))?;
+
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    let mut lines = BufReader::new(stdout).lines();
+    let mut applied = 0usize;
+    let mut last_error: Option<String> = None;
+    let mut failed_id: Option<String> = None;
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let val: serde_json::Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let event_kind = val.get("event").and_then(|v| v.as_str()).unwrap_or("");
+        match event_kind {
+            "migration_start" => {
+                crate::events::emit_event_from_state(
+                    &state,
+                    "upgrade:migration-event",
+                    &serde_json::json!({
+                        "kind": "start",
+                        "id": val.get("id"),
+                        "label": val.get("description"),
+                    }),
+                );
+            }
+            "migration_done" => {
+                crate::events::emit_event_from_state(
+                    &state,
+                    "upgrade:migration-event",
+                    &serde_json::json!({
+                        "kind": "done",
+                        "id": val.get("id"),
+                        "duration_ms": val.get("duration_ms"),
+                    }),
+                );
+                applied += 1;
+            }
+            "complete" => {
+                let a = val.get("applied").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                applied = a;
+                crate::events::emit_event_from_state(
+                    &state,
+                    "upgrade:migration-event",
+                    &serde_json::json!({
+                        "kind": "complete",
+                        "applied": a,
+                        "skipped": val.get("skipped"),
+                    }),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    let status = child.wait().await.map_err(|e| format!("wait failed: {}", e))?;
+
+    if status.success() && last_error.is_none() {
+        *state.pending_migrations.lock() = 0;
+        crate::events::emit_event_from_state(
+            &state,
+            "upgrade:migrations-complete",
+            &serde_json::json!({ "applied": applied }),
+        );
+        Ok(())
+    } else {
+        let err = last_error.unwrap_or_else(|| {
+            format!("agentmux-srv migrate exited with code {:?}", status.code())
+        });
+        crate::events::emit_event_from_state(
+            &state,
+            "upgrade:migrations-failed",
+            &serde_json::json!({ "error": err, "failedId": failed_id }),
+        );
+        Err(err)
+    }
+}
+
+/// Trigger an on-demand saga log vacuum.
+///
+/// Stubbed: the `agentmux-srv saga-vacuum` subcommand is not yet implemented.
+/// Returns `{"rows_deleted": 0}` and emits `upgrade:saga-vacuum-done` so the
+/// Maintenance panel's vacuum state machine completes correctly.
+pub async fn run_saga_vacuum(state: Arc<AppState>) -> Result<serde_json::Value, String> {
+    // TODO: spawn `agentmux-srv --wavedata <path> saga-vacuum` once the subcommand exists.
+    tracing::info!("[run_saga_vacuum] stub — returning rows_deleted=0");
+    crate::events::emit_event_from_state(
+        &state,
+        "upgrade:saga-vacuum-done",
+        &serde_json::json!({ "rows_deleted": 0 }),
+    );
+    Ok(serde_json::json!({ "rows_deleted": 0 }))
 }
 
 /// Set the window initialization status.

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -203,15 +203,30 @@ async fn run_migrations_inner(
         .arg(&data_dir)
         .arg("migrate")
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("Failed to spawn agentmux-srv migrate: {}", e))?;
 
     let stdout = child.stdout.take().ok_or("no stdout")?;
+    let stderr = child.stderr.take().ok_or("no stderr")?;
+
+    // Drain stderr concurrently; failure reasons are written there only.
+    let stderr_task = tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        let mut buf = String::new();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if !buf.is_empty() {
+                buf.push('\n');
+            }
+            buf.push_str(&line);
+        }
+        buf
+    });
+
     let mut lines = BufReader::new(stdout).lines();
     let mut applied = 0usize;
-    let mut last_error: Option<String> = None;
-    let mut failed_id: Option<String> = None;
+    // Tracks the migration currently in flight; becomes failed_id if the process exits non-zero.
+    let mut current_migration_id: Option<String> = None;
 
     while let Ok(Some(line)) = lines.next_line().await {
         let trimmed = line.trim();
@@ -225,6 +240,7 @@ async fn run_migrations_inner(
         let event_kind = val.get("event").and_then(|v| v.as_str()).unwrap_or("");
         match event_kind {
             "migration_start" => {
+                current_migration_id = val.get("id").and_then(|v| v.as_str()).map(str::to_owned);
                 crate::events::emit_event_from_state(
                     &state,
                     "upgrade:migration-event",
@@ -236,6 +252,7 @@ async fn run_migrations_inner(
                 );
             }
             "migration_done" => {
+                current_migration_id = None;
                 crate::events::emit_event_from_state(
                     &state,
                     "upgrade:migration-event",
@@ -265,8 +282,9 @@ async fn run_migrations_inner(
     }
 
     let status = child.wait().await.map_err(|e| format!("wait failed: {}", e))?;
+    let stderr_output = stderr_task.await.unwrap_or_default();
 
-    if status.success() && last_error.is_none() {
+    if status.success() {
         *state.pending_migrations.lock() = 0;
         crate::events::emit_event_from_state(
             &state,
@@ -275,9 +293,12 @@ async fn run_migrations_inner(
         );
         Ok(())
     } else {
-        let err = last_error.unwrap_or_else(|| {
+        let err = if !stderr_output.is_empty() {
+            stderr_output
+        } else {
             format!("agentmux-srv migrate exited with code {:?}", status.code())
-        });
+        };
+        let failed_id = current_migration_id;
         crate::events::emit_event_from_state(
             &state,
             "upgrade:migrations-failed",

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -178,7 +178,7 @@ pub async fn run_migrations(state: Arc<AppState>) -> Result<serde_json::Value, S
     tokio::spawn(async move {
         if let Err(e) = run_migrations_inner(state.clone(), srv_path, data_dir).await {
             tracing::error!("[run_migrations] subprocess error: {}", e);
-            crate::events::emit_event_from_state(
+            crate::events::emit_event_to_top_level_windows(
                 &state,
                 "upgrade:migrations-failed",
                 &serde_json::json!({ "error": e, "failedId": null }),
@@ -241,7 +241,7 @@ async fn run_migrations_inner(
         match event_kind {
             "migration_start" => {
                 current_migration_id = val.get("id").and_then(|v| v.as_str()).map(str::to_owned);
-                crate::events::emit_event_from_state(
+                crate::events::emit_event_to_top_level_windows(
                     &state,
                     "upgrade:migration-event",
                     &serde_json::json!({
@@ -253,7 +253,7 @@ async fn run_migrations_inner(
             }
             "migration_done" => {
                 current_migration_id = None;
-                crate::events::emit_event_from_state(
+                crate::events::emit_event_to_top_level_windows(
                     &state,
                     "upgrade:migration-event",
                     &serde_json::json!({
@@ -267,7 +267,7 @@ async fn run_migrations_inner(
             "complete" => {
                 let a = val.get("applied").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
                 applied = a;
-                crate::events::emit_event_from_state(
+                crate::events::emit_event_to_top_level_windows(
                     &state,
                     "upgrade:migration-event",
                     &serde_json::json!({
@@ -286,11 +286,15 @@ async fn run_migrations_inner(
 
     if status.success() {
         *state.pending_migrations.lock() = 0;
-        crate::events::emit_event_from_state(
+        crate::events::emit_event_to_top_level_windows(
             &state,
             "upgrade:migrations-complete",
             &serde_json::json!({ "applied": applied }),
         );
+        // Restart srv so id_store rebinds from per-channel fallback to shared store.
+        if let Err(e) = restart_backend(state.clone()).await {
+            tracing::warn!("[run_migrations] srv restart after migrations failed: {}", e);
+        }
         Ok(())
     } else {
         let err = if !stderr_output.is_empty() {
@@ -299,7 +303,7 @@ async fn run_migrations_inner(
             format!("agentmux-srv migrate exited with code {:?}", status.code())
         };
         let failed_id = current_migration_id;
-        crate::events::emit_event_from_state(
+        crate::events::emit_event_to_top_level_windows(
             &state,
             "upgrade:migrations-failed",
             &serde_json::json!({ "error": err, "failedId": failed_id }),
@@ -316,7 +320,7 @@ async fn run_migrations_inner(
 pub async fn run_saga_vacuum(state: Arc<AppState>) -> Result<serde_json::Value, String> {
     // TODO: spawn `agentmux-srv --wavedata <path> saga-vacuum` once the subcommand exists.
     tracing::info!("[run_saga_vacuum] stub — returning rows_deleted=0");
-    crate::events::emit_event_from_state(
+    crate::events::emit_event_to_top_level_windows(
         &state,
         "upgrade:saga-vacuum-done",
         &serde_json::json!({ "rows_deleted": 0 }),

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -292,7 +292,16 @@ async fn run_migrations_inner(
             &serde_json::json!({ "applied": applied }),
         );
         // Restart srv so id_store rebinds from per-channel fallback to shared store.
-        if let Err(e) = restart_backend(state.clone()).await {
+        // In launcher-managed runs (AGENTMUX_BACKEND_PID set) the host cannot safely
+        // spawn a replacement srv — emit srv-restart-required so the frontend can
+        // prompt the user. In dev mode (no AGENTMUX_BACKEND_PID) restart directly.
+        if std::env::var("AGENTMUX_BACKEND_PID").is_ok() {
+            crate::events::emit_event_to_top_level_windows(
+                &state,
+                "upgrade:srv-restart-required",
+                &serde_json::json!({}),
+            );
+        } else if let Err(e) = restart_backend(state.clone()).await {
             tracing::warn!("[run_migrations] srv restart after migrations failed: {}", e);
         }
         Ok(())

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -156,6 +156,20 @@ pub async fn restart_backend(state: Arc<AppState>) -> Result<serde_json::Value, 
 /// `upgrade:migrations-failed` CEF events so the Maintenance panel can render
 /// a live stage list without polling.
 pub async fn run_migrations(state: Arc<AppState>) -> Result<serde_json::Value, String> {
+    // In launcher-managed production runs (AGENTMUX_BACKEND_PID set) the live srv
+    // cannot be quiesced before the migrate subprocess runs. Both touch the same
+    // SQLite files, so concurrent writes during the backfill window would be
+    // stranded after the srv restarts. The startup path in agentmux-launcher
+    // srv_spawner.rs already runs migrations before srv starts — restart AgentMux
+    // to apply pending migrations safely from a clean pre-start state.
+    if std::env::var("AGENTMUX_BACKEND_PID").is_ok() {
+        return Err(
+            "Cannot run migrations while the backend is launcher-managed. \
+             Restart AgentMux — the startup migration will run cleanly on next boot."
+                .to_string(),
+        );
+    }
+
     // Guard: only one run at a time.
     {
         let mut running = state.migration_running.lock();
@@ -178,23 +192,25 @@ pub async fn run_migrations(state: Arc<AppState>) -> Result<serde_json::Value, S
         })?;
 
     tokio::spawn(async move {
-        // In dev mode (no AGENTMUX_BACKEND_PID) kill the existing sidecar srv before
-        // spawning the migrate subprocess. Both processes share the same SQLite files;
-        // running them concurrently risks lock contention and mid-backfill write races.
-        if std::env::var("AGENTMUX_BACKEND_PID").is_err() {
+        // Kill the existing sidecar srv before spawning the migrate subprocess.
+        // Both share the same SQLite files; running them concurrently risks lock
+        // contention and mid-backfill write races. Production is blocked above, so
+        // sidecar_child is always the dev-mode owned process here.
+        {
             let mut sidecar = state.sidecar_child.lock();
             if let Some(ref mut child) = *sidecar {
                 let _ = child.kill();
-                tracing::info!("[run_migrations] killed sidecar srv before migration (dev mode)");
+                tracing::info!("[run_migrations] killed sidecar srv before migration");
             }
             *sidecar = None;
-            // Small delay so the OS releases file locks before we open the DB.
-            drop(sidecar);
-            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         }
+        // Small delay so the OS releases file locks before we open the DB.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
         if let Err(e) = run_migrations_inner(state.clone(), srv_path, data_dir).await {
-            tracing::error!("[run_migrations] subprocess error: {}", e);
+            // run_migrations_inner only Errs for internal/spawn failures — subprocess
+            // failures emit upgrade:migrations-failed themselves and return Ok(()).
+            tracing::error!("[run_migrations] internal error: {}", e);
             crate::events::emit_event_to_top_level_windows(
                 &state,
                 "upgrade:migrations-failed",
@@ -308,21 +324,12 @@ async fn run_migrations_inner(
             "upgrade:migrations-complete",
             &serde_json::json!({ "applied": applied }),
         );
-        // Only restart/notify when something was actually applied; applied==0
-        // means the DB was already current and id_store is already correct.
+        // Only restart when something was actually applied; applied==0 means the
+        // DB was already current and id_store is already correct.
+        // Production is blocked at run_migrations entry, so restart_backend is
+        // always safe here (we own the sidecar and already killed it above).
         if applied > 0 {
-            // Restart srv so id_store rebinds from per-channel fallback to shared store.
-            // In launcher-managed runs (AGENTMUX_BACKEND_PID set) the host cannot safely
-            // spawn a replacement srv — emit srv-restart-required so the frontend can
-            // prompt the user. In dev mode (no AGENTMUX_BACKEND_PID) restart directly.
-            if std::env::var("AGENTMUX_BACKEND_PID").is_ok() {
-                *state.srv_restart_required.lock() = true;
-                crate::events::emit_event_to_top_level_windows(
-                    &state,
-                    "upgrade:srv-restart-required",
-                    &serde_json::json!({}),
-                );
-            } else if let Err(e) = restart_backend(state.clone()).await {
+            if let Err(e) = restart_backend(state.clone()).await {
                 tracing::warn!("[run_migrations] srv restart after migrations failed: {}", e);
             }
         }
@@ -339,7 +346,9 @@ async fn run_migrations_inner(
             "upgrade:migrations-failed",
             &serde_json::json!({ "error": err, "failedId": failed_id }),
         );
-        Err(err)
+        // Return Ok(()) — event already emitted above. The outer wrapper must not
+        // re-emit a second upgrade:migrations-failed with failedId:null.
+        Ok(())
     }
 }
 

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -215,6 +215,8 @@ async fn route_command(
         // ---- Tier 2: Core functionality ----
         "get_backend_info" => Ok(commands::backend::get_backend_info(state)),
         "restart_backend" => commands::backend::restart_backend(state.clone()).await,
+        "run_migrations" => commands::backend::run_migrations(state.clone()).await,
+        "run_saga_vacuum" => commands::backend::run_saga_vacuum(state.clone()).await,
         "close_window" => commands::window::close_window(state, args),
         "minimize_window" => commands::window::minimize_window(state, args),
         "maximize_window" => commands::window::maximize_window(state, args),

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -423,6 +423,14 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
 ///   2. Same dir as CEF host: {name}.exe (dev mode — cargo build output)
 ///   3. Workspace dist/bin/: {name}-{version}-{os}.{arch}.exe
 ///   4. Workspace dist/bin/: {name}.exe (plain fallback)
+/// Public re-export for on-demand command spawns (e.g. maintenance panel's run_migrations).
+pub fn resolve_backend_binary_pub(
+    backend_name: &str,
+    exe_suffix: &str,
+) -> Result<std::path::PathBuf, String> {
+    resolve_backend_binary(backend_name, exe_suffix)
+}
+
 fn resolve_backend_binary(
     backend_name: &str,
     exe_suffix: &str,

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -534,11 +534,6 @@ pub struct AppState {
     /// Guard against concurrent `run_migrations` invocations from the maintenance panel.
     pub migration_running: Mutex<bool>,
 
-    /// Set to true after a successful on-demand migration run where the running srv
-    /// could not be automatically restarted (launcher-managed production path).
-    /// Persists for the session so getBackendInfo can re-derive the notice on panel reopen.
-    pub srv_restart_required: Mutex<bool>,
-
     /// Current zoom factor
     pub zoom_factor: Mutex<f64>,
 
@@ -907,7 +902,6 @@ impl Default for AppState {
                     .unwrap_or(0)
             ),
             migration_running: Mutex::new(false),
-            srv_restart_required: Mutex::new(false),
             zoom_factor: Mutex::new(1.0),
             client_id: Mutex::new(None),
             window_id: Mutex::new(None),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -531,6 +531,9 @@ pub struct AppState {
     /// the status-bar shows "Migration failed — restart to retry."
     pub pending_migrations: Mutex<usize>,
 
+    /// Guard against concurrent `run_migrations` invocations from the maintenance panel.
+    pub migration_running: Mutex<bool>,
+
     /// Current zoom factor
     pub zoom_factor: Mutex<f64>,
 
@@ -898,6 +901,7 @@ impl Default for AppState {
                     .and_then(|v| v.parse::<usize>().ok())
                     .unwrap_or(0)
             ),
+            migration_running: Mutex::new(false),
             zoom_factor: Mutex::new(1.0),
             client_id: Mutex::new(None),
             window_id: Mutex::new(None),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -534,6 +534,11 @@ pub struct AppState {
     /// Guard against concurrent `run_migrations` invocations from the maintenance panel.
     pub migration_running: Mutex<bool>,
 
+    /// Set to true after a successful on-demand migration run where the running srv
+    /// could not be automatically restarted (launcher-managed production path).
+    /// Persists for the session so getBackendInfo can re-derive the notice on panel reopen.
+    pub srv_restart_required: Mutex<bool>,
+
     /// Current zoom factor
     pub zoom_factor: Mutex<f64>,
 
@@ -902,6 +907,7 @@ impl Default for AppState {
                     .unwrap_or(0)
             ),
             migration_running: Mutex::new(false),
+            srv_restart_required: Mutex::new(false),
             zoom_factor: Mutex::new(1.0),
             client_id: Mutex::new(None),
             window_id: Mutex::new(None),

--- a/frontend/app/statusbar/BackendStatus.tsx
+++ b/frontend/app/statusbar/BackendStatus.tsx
@@ -206,9 +206,16 @@ const BackendStatus = (): JSX.Element => {
                                 </span>
                             </div>
                             <div class="status-bar-popover-row">
-                                <span class="status-bar-popover-mono" style={{ "font-size": "0.85em" }}>
-                                    Migration failed at startup — check logs, then restart to retry.
-                                </span>
+                                <button
+                                    type="button"
+                                    class="status-bar-restart-btn"
+                                    onClick={() => {
+                                        setPopoverOpen(false);
+                                        window.dispatchEvent(new CustomEvent("agentmux:open-version-panel"));
+                                    }}
+                                >
+                                    Open Maintenance ↗
+                                </button>
                             </div>
                         </Show>
                         {/* GPU / WebGL rendering — enabled/disabled + driver info.

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import { atoms, getApi, isDev, openFloatingPaneEntriesAtom, openWindowEntriesAtom, type FloatingPaneEntry, type WindowEntry } from "@/store/global";
+import { MaintenanceSection } from "./MaintenanceSection";
 import { reconcileKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
 import { launcherEventsActive } from "@/util/launcher-events";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
@@ -603,6 +604,10 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                         )}
                     </For>
                 </Show>
+            </div>
+            <div class="instance-panel-divider" />
+            <div class="instance-panel-section">
+                <MaintenanceSection />
             </div>
             <div class="instance-panel-divider" />
             <div class="instance-panel-footer">

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -111,11 +111,13 @@ export const MaintenanceSection = (): JSX.Element => {
 
     onMount(() => {
         let unlisten: (() => void) | null = null;
-        getApi().listen("upgrade:migrations-complete", (_payload: any) => {
+        getApi().listen("upgrade:migrations-complete", (payload: any) => {
+            const applied: number = payload?.applied ?? 0;
             setMigState((prev) => {
-                const steps = prev.kind === "running" ? prev.steps : [];
-                const applied = prev.kind === "running" ? steps.filter((s) => s.status === "done").length : 0;
-                return { kind: "complete", steps, applied };
+                // migration-event kind:"complete" may have already transitioned state;
+                // preserve it — don't reset steps/applied with this fallback event.
+                if (prev.kind !== "running") return prev;
+                return { kind: "complete", steps: prev.steps, applied };
             });
         }).then((fn) => { unlisten = fn; });
 
@@ -289,14 +291,6 @@ export const MaintenanceSection = (): JSX.Element => {
                                 {(migState() as Extract<MigState, {kind: "complete"}>).applied} applied
                             </span>
                         </div>
-                        <Show when={srvRestartRequired()}>
-                            <div class="maintenance-alert-row maintenance-restart-notice">
-                                <span class="maintenance-icon maintenance-icon--warn">↺</span>
-                                <span class="maintenance-row-text maintenance-row-text--warn">
-                                    Restart AgentMux to complete identity store rebind
-                                </span>
-                            </div>
-                        </Show>
                     </Show>
                     <Show when={migState().kind === "failed"}>
                         <div class="maintenance-stage-header">
@@ -334,6 +328,17 @@ export const MaintenanceSection = (): JSX.Element => {
                             Retry
                         </button>
                     </Show>
+                </div>
+            </Show>
+
+            {/* ── srv-restart-required notice ────────────────────────────── */}
+            {/* Shown independently of migState so it persists after panel close/reopen. */}
+            <Show when={srvRestartRequired()}>
+                <div class="maintenance-alert-row maintenance-restart-notice">
+                    <span class="maintenance-icon maintenance-icon--warn">↺</span>
+                    <span class="maintenance-row-text maintenance-row-text--warn">
+                        Restart AgentMux to complete identity store rebind
+                    </span>
                 </div>
             </Show>
 

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atoms, getApi } from "@/store/global";
+import { WpsEvent } from "@/store/wps-events";
 import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import "./_maintenance-section.scss";
 
@@ -71,7 +72,7 @@ export const MaintenanceSection = (): JSX.Element => {
     // Subscribe to migration progress events (from CEF, not WPS WebSocket)
     onMount(() => {
         let unlisten: (() => void) | null = null;
-        getApi().listen("upgrade:migration-event", (payload: any) => {
+        getApi().listen(WpsEvent.UpgradeMigrationEvent, (payload: any) => {
             const kind: string = payload?.kind ?? "";
             if (kind === "start") {
                 const id: string = payload.id ?? "";
@@ -105,7 +106,7 @@ export const MaintenanceSection = (): JSX.Element => {
 
     onMount(() => {
         let unlisten: (() => void) | null = null;
-        getApi().listen("upgrade:migrations-complete", (payload: any) => {
+        getApi().listen(WpsEvent.UpgradeMigrationsComplete, (payload: any) => {
             const applied: number = payload?.applied ?? 0;
             setMigState((prev) => {
                 // migration-event kind:"complete" may have already transitioned state;
@@ -120,7 +121,7 @@ export const MaintenanceSection = (): JSX.Element => {
 
     onMount(() => {
         let unlisten: (() => void) | null = null;
-        getApi().listen("upgrade:migrations-failed", (payload: any) => {
+        getApi().listen(WpsEvent.UpgradeMigrationsFailed, (payload: any) => {
             const error: string = payload?.error ?? "Migration failed";
             const failedId: string | null = payload?.failedId ?? null;
             setMigState((prev) => {
@@ -134,7 +135,7 @@ export const MaintenanceSection = (): JSX.Element => {
 
     onMount(() => {
         let unlisten: (() => void) | null = null;
-        getApi().listen("upgrade:saga-vacuum-done", (payload: any) => {
+        getApi().listen(WpsEvent.UpgradeSagaVacuumDone, (payload: any) => {
             const rowsDeleted: number = payload?.rows_deleted ?? 0;
             const ranAtMs = Date.now();
             setVacState({ kind: "done", rowsDeleted, ranAtMs });

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -205,7 +205,7 @@ export const MaintenanceSection = (): JSX.Element => {
             <div class="instance-panel-section-title">
                 Maintenance
                 <Show when={badge() != null}>
-                    <span class="maintenance-badge">{badge()}</span>
+                    <span class={`maintenance-badge${migState().kind === "failed" ? " maintenance-badge--error" : ""}`}>{badge()}</span>
                 </Show>
             </div>
 

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -49,6 +49,7 @@ export const MaintenanceSection = (): JSX.Element => {
     const [migState, setMigState] = createSignal<MigState>({ kind: "idle", pendingCount: 0 });
     const [vacState, setVacState] = createSignal<VacState>({ kind: "idle", lastRunMs: null });
     const [nowMs, setNowMs] = createSignal(Date.now());
+    const [srvRestartRequired, setSrvRestartRequired] = createSignal(false);
 
     // Fetch pending_migrations count from backend info on mount
     onMount(() => {
@@ -125,6 +126,15 @@ export const MaintenanceSection = (): JSX.Element => {
                 const steps = prev.kind === "running" ? prev.steps : [];
                 return { kind: "failed", steps, error, failedId };
             });
+        }).then((fn) => { unlisten = fn; });
+
+        onCleanup(() => unlisten?.());
+    });
+
+    onMount(() => {
+        let unlisten: (() => void) | null = null;
+        getApi().listen("upgrade:srv-restart-required", (_payload: any) => {
+            setSrvRestartRequired(true);
         }).then((fn) => { unlisten = fn; });
 
         onCleanup(() => unlisten?.());
@@ -274,6 +284,14 @@ export const MaintenanceSection = (): JSX.Element => {
                                 {(migState() as Extract<MigState, {kind: "complete"}>).applied} applied
                             </span>
                         </div>
+                        <Show when={srvRestartRequired()}>
+                            <div class="maintenance-alert-row maintenance-restart-notice">
+                                <span class="maintenance-icon maintenance-icon--warn">↺</span>
+                                <span class="maintenance-row-text maintenance-row-text--warn">
+                                    Restart AgentMux to complete identity store rebind
+                                </span>
+                            </div>
+                        </Show>
                     </Show>
                     <Show when={migState().kind === "failed"}>
                         <div class="maintenance-stage-header">

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -1,0 +1,388 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { atoms, getApi } from "@/store/global";
+import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import "./_maintenance-section.scss";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type MigStep = {
+    id: string;
+    label: string;
+    status: "running" | "done";
+    durationMs: number | null;
+    startedAtMs: number;
+};
+
+type MigState =
+    | { kind: "idle"; pendingCount: number }
+    | { kind: "running"; steps: MigStep[] }
+    | { kind: "complete"; steps: MigStep[]; applied: number }
+    | { kind: "failed"; steps: MigStep[]; error: string; failedId: string | null };
+
+type VacState =
+    | { kind: "idle"; lastRunMs: number | null }
+    | { kind: "running" }
+    | { kind: "done"; rowsDeleted: number; ranAtMs: number };
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmtDate(ms: number): string {
+    return new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function elapsedSecs(startedAtMs: number, nowMs: number): string {
+    return `${((nowMs - startedAtMs) / 1000).toFixed(1)}s`;
+}
+
+function fmtDuration(ms: number): string {
+    return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export const MaintenanceSection = (): JSX.Element => {
+    const updaterStatus = atoms.updaterStatusAtom;
+    const updaterVersion = atoms.updaterVersionAtom;
+
+    const [migState, setMigState] = createSignal<MigState>({ kind: "idle", pendingCount: 0 });
+    const [vacState, setVacState] = createSignal<VacState>({ kind: "idle", lastRunMs: null });
+    const [nowMs, setNowMs] = createSignal(Date.now());
+
+    // Fetch pending_migrations count from backend info on mount
+    onMount(() => {
+        getApi().getBackendInfo().then((info) => {
+            const pending = info?.pending_migrations ?? 0;
+            setMigState({ kind: "idle", pendingCount: pending });
+        }).catch(() => {});
+    });
+
+    // Timer — ticks every 500ms only while a migration is running to drive elapsed timers.
+    onMount(() => {
+        const id = setInterval(() => {
+            if (migState().kind === "running") {
+                setNowMs(Date.now());
+            }
+        }, 500);
+        onCleanup(() => clearInterval(id));
+    });
+
+    // Subscribe to migration progress events (from CEF, not WPS WebSocket)
+    onMount(() => {
+        let unlisten: (() => void) | null = null;
+        getApi().listen("upgrade:migration-event", (payload: any) => {
+            const kind: string = payload?.kind ?? "";
+            if (kind === "start") {
+                const id: string = payload.id ?? "";
+                const label: string = payload.label ?? id;
+                setMigState((prev) => {
+                    const steps: MigStep[] = prev.kind === "running" ? [...prev.steps] : [];
+                    steps.push({ id, label, status: "running", durationMs: null, startedAtMs: Date.now() });
+                    return { kind: "running", steps };
+                });
+            } else if (kind === "done") {
+                const id: string = payload.id ?? "";
+                const durationMs: number | null = payload.duration_ms ?? null;
+                setMigState((prev) => {
+                    if (prev.kind !== "running") return prev;
+                    const steps = prev.steps.map((s) =>
+                        s.id === id ? { ...s, status: "done" as const, durationMs } : s
+                    );
+                    return { ...prev, steps };
+                });
+            } else if (kind === "complete") {
+                const applied: number = payload.applied ?? 0;
+                setMigState((prev) => {
+                    const steps = prev.kind === "running" ? prev.steps : [];
+                    return { kind: "complete", steps, applied };
+                });
+            } else if (kind === "error") {
+                const error: string = payload.error ?? "Unknown error";
+                const failedId: string | null = payload.id ?? null;
+                setMigState((prev) => {
+                    const steps = prev.kind === "running"
+                        ? prev.steps.map((s) =>
+                            s.id === failedId ? { ...s, status: "done" as const } : s
+                          )
+                        : [];
+                    return { kind: "failed", steps, error, failedId };
+                });
+            }
+        }).then((fn) => { unlisten = fn; });
+
+        onCleanup(() => unlisten?.());
+    });
+
+    onMount(() => {
+        let unlisten: (() => void) | null = null;
+        getApi().listen("upgrade:migrations-complete", (_payload: any) => {
+            setMigState((prev) => {
+                const steps = prev.kind === "running" ? prev.steps : [];
+                const applied = prev.kind === "running" ? steps.filter((s) => s.status === "done").length : 0;
+                return { kind: "complete", steps, applied };
+            });
+        }).then((fn) => { unlisten = fn; });
+
+        onCleanup(() => unlisten?.());
+    });
+
+    onMount(() => {
+        let unlisten: (() => void) | null = null;
+        getApi().listen("upgrade:migrations-failed", (payload: any) => {
+            const error: string = payload?.error ?? "Migration failed";
+            const failedId: string | null = payload?.failedId ?? null;
+            setMigState((prev) => {
+                const steps = prev.kind === "running" ? prev.steps : [];
+                return { kind: "failed", steps, error, failedId };
+            });
+        }).then((fn) => { unlisten = fn; });
+
+        onCleanup(() => unlisten?.());
+    });
+
+    onMount(() => {
+        let unlisten: (() => void) | null = null;
+        getApi().listen("upgrade:saga-vacuum-done", (payload: any) => {
+            const rowsDeleted: number = payload?.rows_deleted ?? 0;
+            const ranAtMs = Date.now();
+            setVacState({ kind: "done", rowsDeleted, ranAtMs });
+            setTimeout(() => {
+                setVacState({ kind: "idle", lastRunMs: ranAtMs });
+            }, 3000);
+        }).then((fn) => { unlisten = fn; });
+
+        onCleanup(() => unlisten?.());
+    });
+
+    // ── Actions ───────────────────────────────────────────────────────────────
+
+    const handleRunMigrations = async () => {
+        if (migState().kind === "running") return;
+        setMigState({ kind: "running", steps: [] });
+        try {
+            await getApi().runMigrations();
+        } catch (e: any) {
+            setMigState({ kind: "failed", steps: [], error: String(e?.message ?? e), failedId: null });
+        }
+    };
+
+    const handleRunVacuum = async () => {
+        if (vacState().kind === "running") return;
+        setVacState({ kind: "running" });
+        try {
+            await getApi().runSagaVacuum();
+        } catch {
+            setVacState({ kind: "idle", lastRunMs: null });
+        }
+    };
+
+    const handleInstallUpdate = () => {
+        getApi().installAppUpdate();
+    };
+
+    // ── Derived ───────────────────────────────────────────────────────────────
+
+    const badge = (): string | null => {
+        const mig = migState();
+        if (mig.kind === "failed") return `✗ failed`;
+        if (mig.kind === "idle" && mig.pendingCount > 0) return `⚠ ${mig.pendingCount} pending`;
+        if (mig.kind === "running") return "·running";
+        const upd = updaterStatus();
+        if (upd === "available") {
+            const ver = updaterVersion();
+            return ver ? `↓ ${ver}` : "↓ update";
+        }
+        if (upd === "downloading") return "↓ …";
+        if (upd === "ready") return "↑ ready";
+        return null;
+    };
+
+    // ── Render ────────────────────────────────────────────────────────────────
+
+    return (
+        <>
+            <div class="instance-panel-section-title">
+                Maintenance
+                <Show when={badge() != null}>
+                    <span class="maintenance-badge">{badge()}</span>
+                </Show>
+            </div>
+
+            {/* ── Update row ─────────────────────────────────────────────── */}
+            <Show when={updaterStatus() !== "up-to-date" && updaterStatus() !== "checking"}>
+                <div class="maintenance-update-row">
+                    <Show when={updaterStatus() === "available"}>
+                        <span class="maintenance-icon maintenance-icon--update">↓</span>
+                        <span class="maintenance-row-text">
+                            {updaterVersion() ? `v${updaterVersion()} available` : "Update available"}
+                        </span>
+                        <button
+                            type="button"
+                            class="maintenance-btn maintenance-btn--primary"
+                            onClick={handleInstallUpdate}
+                        >
+                            Download
+                        </button>
+                    </Show>
+                    <Show when={updaterStatus() === "downloading"}>
+                        <span class="maintenance-icon maintenance-icon--working">↓</span>
+                        <span class="maintenance-row-text maintenance-row-text--dim">Downloading…</span>
+                    </Show>
+                    <Show when={updaterStatus() === "ready"}>
+                        <span class="maintenance-icon maintenance-icon--update">↑</span>
+                        <span class="maintenance-row-text">
+                            {updaterVersion() ? `v${updaterVersion()} ready` : "Ready to install"}
+                        </span>
+                        <button
+                            type="button"
+                            class="maintenance-btn maintenance-btn--primary"
+                            onClick={handleInstallUpdate}
+                        >
+                            Restart
+                        </button>
+                    </Show>
+                    <Show when={updaterStatus() === "error"}>
+                        <span class="maintenance-icon maintenance-icon--error">✗</span>
+                        <span class="maintenance-row-text maintenance-row-text--error">Update failed</span>
+                    </Show>
+                </div>
+            </Show>
+
+            {/* ── Migration rows ─────────────────────────────────────────── */}
+            <Show when={migState().kind === "idle" && (migState() as Extract<MigState, {kind: "idle"}>).pendingCount > 0}>
+                <div class="maintenance-alert-row">
+                    <span class="maintenance-icon maintenance-icon--warn">⚠</span>
+                    <span class="maintenance-row-text maintenance-row-text--warn">
+                        {(migState() as Extract<MigState, {kind: "idle"}>).pendingCount} migration{
+                            (migState() as Extract<MigState, {kind: "idle"}>).pendingCount !== 1 ? "s" : ""
+                        } pending
+                    </span>
+                    <button
+                        type="button"
+                        class="maintenance-btn maintenance-btn--primary"
+                        onClick={handleRunMigrations}
+                    >
+                        Run
+                    </button>
+                </div>
+            </Show>
+
+            <Show when={migState().kind === "running" || migState().kind === "complete" || migState().kind === "failed"}>
+                <div class="maintenance-migration-block">
+                    <Show when={migState().kind === "running"}>
+                        <div class="maintenance-stage-header">
+                            <span class="maintenance-icon maintenance-icon--working maintenance-pulse">●</span>
+                            <span>Migrations running…</span>
+                        </div>
+                    </Show>
+                    <Show when={migState().kind === "complete"}>
+                        <div class="maintenance-stage-header">
+                            <span class="maintenance-icon maintenance-icon--ok">✓</span>
+                            <span>
+                                Migrations complete
+                                {" — "}
+                                {(migState() as Extract<MigState, {kind: "complete"}>).applied} applied
+                            </span>
+                        </div>
+                    </Show>
+                    <Show when={migState().kind === "failed"}>
+                        <div class="maintenance-stage-header">
+                            <span class="maintenance-icon maintenance-icon--error">✗</span>
+                            <span class="maintenance-row-text--error">
+                                Migration failed
+                            </span>
+                        </div>
+                        <div class="maintenance-error-detail">
+                            {(migState() as Extract<MigState, {kind: "failed"}>).error}
+                        </div>
+                    </Show>
+                    <For each={(migState() as Extract<MigState, {kind: "running" | "complete" | "failed"}>).steps ?? []}>
+                        {(step) => (
+                            <div class="maintenance-sub-row">
+                                <span class={`maintenance-icon ${step.status === "done" ? "maintenance-icon--ok" : "maintenance-icon--working maintenance-pulse"}`}>
+                                    {step.status === "done" ? "✓" : "·"}
+                                </span>
+                                <span class="maintenance-sub-id">{step.id}</span>
+                                <span class="maintenance-sub-label">{step.label}</span>
+                                <span class="maintenance-timer">
+                                    {step.durationMs != null
+                                        ? fmtDuration(step.durationMs)
+                                        : elapsedSecs(step.startedAtMs, nowMs())}
+                                </span>
+                            </div>
+                        )}
+                    </For>
+                    <Show when={migState().kind === "failed"}>
+                        <button
+                            type="button"
+                            class="maintenance-btn maintenance-btn--primary maintenance-retry-btn"
+                            onClick={handleRunMigrations}
+                        >
+                            Retry
+                        </button>
+                    </Show>
+                </div>
+            </Show>
+
+            {/* ── Summary rows (shown when idle / after-complete) ─────────── */}
+            <Show when={migState().kind === "idle"}>
+                <div class="maintenance-summary-row">
+                    <Show
+                        when={(migState() as Extract<MigState, {kind: "idle"}>).pendingCount === 0}
+                        fallback={
+                            <>
+                                <span class="maintenance-icon maintenance-icon--warn">⚠</span>
+                                <span class="maintenance-row-label">Migrations</span>
+                                <span class="maintenance-row-text--warn">
+                                    {(migState() as Extract<MigState, {kind: "idle"}>).pendingCount} pending
+                                </span>
+                            </>
+                        }
+                    >
+                        <span class="maintenance-icon maintenance-icon--ok">✓</span>
+                        <span class="maintenance-row-label">Migrations</span>
+                        <span class="maintenance-row-text--dim">up to date</span>
+                    </Show>
+                </div>
+            </Show>
+
+            {/* ── Saga vacuum row ────────────────────────────────────────── */}
+            <div class="maintenance-summary-row">
+                <Show when={vacState().kind === "idle"}>
+                    <span class="maintenance-icon maintenance-icon--neutral">○</span>
+                    <span class="maintenance-row-label">Vacuum</span>
+                    <span class="maintenance-row-text--dim">
+                        {(vacState() as Extract<VacState, {kind: "idle"}>).lastRunMs
+                            ? `last run: ${fmtDate((vacState() as Extract<VacState, {kind: "idle"}>).lastRunMs!)}`
+                            : "not run"}
+                    </span>
+                    <button
+                        type="button"
+                        class="maintenance-btn"
+                        onClick={handleRunVacuum}
+                    >
+                        Run
+                    </button>
+                </Show>
+                <Show when={vacState().kind === "running"}>
+                    <span class="maintenance-icon maintenance-icon--working maintenance-pulse">·</span>
+                    <span class="maintenance-row-label">Vacuum</span>
+                    <span class="maintenance-row-text--dim">running…</span>
+                </Show>
+                <Show when={vacState().kind === "done"}>
+                    <span class="maintenance-icon maintenance-icon--ok">✓</span>
+                    <span class="maintenance-row-label">Vacuum</span>
+                    <span class="maintenance-row-text--dim">
+                        {(vacState() as Extract<VacState, {kind: "done"}>).rowsDeleted === 0
+                            ? "nothing to clean"
+                            : `${(vacState() as Extract<VacState, {kind: "done"}>).rowsDeleted} rows removed`}
+                    </span>
+                    <button type="button" class="maintenance-btn" onClick={handleRunVacuum}>Run</button>
+                </Show>
+            </div>
+        </>
+    );
+};
+
+MaintenanceSection.displayName = "MaintenanceSection";

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atoms, getApi } from "@/store/global";
-import { WpsEvent } from "@/store/wps-events";
 import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import "./_maintenance-section.scss";
 
@@ -50,17 +49,12 @@ export const MaintenanceSection = (): JSX.Element => {
     const [migState, setMigState] = createSignal<MigState>({ kind: "idle", pendingCount: 0 });
     const [vacState, setVacState] = createSignal<VacState>({ kind: "idle", lastRunMs: null });
     const [nowMs, setNowMs] = createSignal(Date.now());
-    const [srvRestartRequired, setSrvRestartRequired] = createSignal(false);
 
-    // Fetch pending_migrations count and persisted srv_restart_required flag from backend info on mount.
-    // srv_restart_required is stored in AppState so it survives panel close/reopen.
+    // Fetch pending_migrations count from backend info on mount
     onMount(() => {
         getApi().getBackendInfo().then((info) => {
             const pending = info?.pending_migrations ?? 0;
             setMigState({ kind: "idle", pendingCount: pending });
-            if (info?.srv_restart_required) {
-                setSrvRestartRequired(true);
-            }
         }).catch(() => {});
     });
 
@@ -133,15 +127,6 @@ export const MaintenanceSection = (): JSX.Element => {
                 const steps = prev.kind === "running" ? prev.steps : [];
                 return { kind: "failed", steps, error, failedId };
             });
-        }).then((fn) => { unlisten = fn; });
-
-        onCleanup(() => unlisten?.());
-    });
-
-    onMount(() => {
-        let unlisten: (() => void) | null = null;
-        getApi().listen(WpsEvent.UpgradeSrvRestartRequired, (_payload: any) => {
-            setSrvRestartRequired(true);
         }).then((fn) => { unlisten = fn; });
 
         onCleanup(() => unlisten?.());
@@ -328,17 +313,6 @@ export const MaintenanceSection = (): JSX.Element => {
                             Retry
                         </button>
                     </Show>
-                </div>
-            </Show>
-
-            {/* ── srv-restart-required notice ────────────────────────────── */}
-            {/* Shown independently of migState so it persists after panel close/reopen. */}
-            <Show when={srvRestartRequired()}>
-                <div class="maintenance-alert-row maintenance-restart-notice">
-                    <span class="maintenance-icon maintenance-icon--warn">↺</span>
-                    <span class="maintenance-row-text maintenance-row-text--warn">
-                        Restart AgentMux to complete identity store rebind
-                    </span>
                 </div>
             </Show>
 

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { atoms, getApi } from "@/store/global";
+import { WpsEvent } from "@/store/wps-events";
 import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import "./_maintenance-section.scss";
 
@@ -51,11 +52,15 @@ export const MaintenanceSection = (): JSX.Element => {
     const [nowMs, setNowMs] = createSignal(Date.now());
     const [srvRestartRequired, setSrvRestartRequired] = createSignal(false);
 
-    // Fetch pending_migrations count from backend info on mount
+    // Fetch pending_migrations count and persisted srv_restart_required flag from backend info on mount.
+    // srv_restart_required is stored in AppState so it survives panel close/reopen.
     onMount(() => {
         getApi().getBackendInfo().then((info) => {
             const pending = info?.pending_migrations ?? 0;
             setMigState({ kind: "idle", pendingCount: pending });
+            if (info?.srv_restart_required) {
+                setSrvRestartRequired(true);
+            }
         }).catch(() => {});
     });
 
@@ -133,7 +138,7 @@ export const MaintenanceSection = (): JSX.Element => {
 
     onMount(() => {
         let unlisten: (() => void) | null = null;
-        getApi().listen("upgrade:srv-restart-required", (_payload: any) => {
+        getApi().listen(WpsEvent.UpgradeSrvRestartRequired, (_payload: any) => {
             setSrvRestartRequired(true);
         }).then((fn) => { unlisten = fn; });
 

--- a/frontend/app/statusbar/MaintenanceSection.tsx
+++ b/frontend/app/statusbar/MaintenanceSection.tsx
@@ -97,17 +97,6 @@ export const MaintenanceSection = (): JSX.Element => {
                     const steps = prev.kind === "running" ? prev.steps : [];
                     return { kind: "complete", steps, applied };
                 });
-            } else if (kind === "error") {
-                const error: string = payload.error ?? "Unknown error";
-                const failedId: string | null = payload.id ?? null;
-                setMigState((prev) => {
-                    const steps = prev.kind === "running"
-                        ? prev.steps.map((s) =>
-                            s.id === failedId ? { ...s, status: "done" as const } : s
-                          )
-                        : [];
-                    return { kind: "failed", steps, error, failedId };
-                });
             }
         }).then((fn) => { unlisten = fn; });
 

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -4,6 +4,7 @@
 @use "./token-usage";
 @use "./instance-panel";
 @use "./cpu-cores-popover";
+@use "./maintenance-section";
 
 .status-bar {
     // Responsive 2-row wrap (§4.4 of SPEC_STATUSBAR_TOKEN_USAGE).

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getApi, windowCountAtom, backendStatusAtom, isDev } from "@/store/global";
-import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { BackendStatus } from "./BackendStatus";
 import { ConfigStatus } from "./ConfigStatus";
 import { GpuStatus } from "./GpuStatus";
@@ -29,6 +29,16 @@ const StatusBar = (): JSX.Element => {
         setAnchorRect(versionRef?.getBoundingClientRect() ?? null);
         setPanelOpen(true);
     };
+
+    // BackendStatus dot can request the version panel to open (e.g. "Open Maintenance ↗").
+    onMount(() => {
+        const handler = () => {
+            setAnchorRect(versionRef?.getBoundingClientRect() ?? null);
+            setPanelOpen(true);
+        };
+        window.addEventListener("agentmux:open-version-panel", handler);
+        onCleanup(() => window.removeEventListener("agentmux:open-version-panel", handler));
+    });
 
     // Esc + click-outside close. Mirrors TokenBreakdownPopover precedent.
     createEffect(() => {

--- a/frontend/app/statusbar/_maintenance-section.scss
+++ b/frontend/app/statusbar/_maintenance-section.scss
@@ -15,7 +15,7 @@
     letter-spacing: 0;
     text-transform: none;
 
-    &:has-text("✗") {
+    &--error {
         color: var(--error-color);
     }
 }

--- a/frontend/app/statusbar/_maintenance-section.scss
+++ b/frontend/app/statusbar/_maintenance-section.scss
@@ -1,0 +1,171 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Maintenance section — embedded inside InstancePanel.
+// Spec: specs/SPEC_UPGRADE_PANEL_2026_06_27.md
+
+// ── Badge on section title ───────────────────────────────────────────────────
+
+.maintenance-badge {
+    display: inline-block;
+    margin-left: var(--space-1-5);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--warning-color);
+    letter-spacing: 0;
+    text-transform: none;
+
+    &:has-text("✗") {
+        color: var(--error-color);
+    }
+}
+
+// ── Shared row geometry ──────────────────────────────────────────────────────
+
+.maintenance-update-row,
+.maintenance-alert-row,
+.maintenance-summary-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 3px var(--space-1-5);
+    font-size: 11px;
+    min-height: 24px;
+}
+
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+.maintenance-icon {
+    flex: 0 0 12px;
+    text-align: center;
+    font-size: 11px;
+    line-height: 1;
+
+    &--ok      { color: var(--success-color, #5cb85c); }
+    &--warn    { color: var(--warning-color); }
+    &--error   { color: var(--error-color); }
+    &--update  { color: var(--accent-color); }
+    &--working { color: var(--accent-color); }
+    &--neutral { color: var(--secondary-text-color); opacity: 0.5; }
+}
+
+@keyframes maintenance-pulse {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.25; }
+}
+
+.maintenance-pulse {
+    animation: maintenance-pulse 1.4s ease-in-out infinite;
+}
+
+// ── Row text ─────────────────────────────────────────────────────────────────
+
+.maintenance-row-label {
+    flex: 0 0 62px;
+    color: var(--secondary-text-color);
+    font-size: 11px;
+}
+
+.maintenance-row-text {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &--dim   { color: var(--secondary-text-color); }
+    &--warn  { color: var(--warning-color); }
+    &--error { color: var(--error-color); }
+}
+
+// ── Buttons ──────────────────────────────────────────────────────────────────
+
+.maintenance-btn {
+    flex: 0 0 auto;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--main-text-color);
+    padding: 1px 8px;
+    border-radius: 0;
+    font-size: 11px;
+    cursor: default;
+    white-space: nowrap;
+
+    &:hover { background: var(--hover-bg-color); }
+
+    &--primary {
+        background: var(--accent-color);
+        border-color: var(--accent-color);
+        color: var(--button-text-color);
+        font-weight: 600;
+        &:hover { filter: brightness(1.1); }
+    }
+}
+
+// ── Migration stage block ────────────────────────────────────────────────────
+
+.maintenance-migration-block {
+    display: flex;
+    flex-direction: column;
+    padding: 4px var(--space-1-5);
+    gap: 2px;
+}
+
+.maintenance-stage-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: 11px;
+    font-weight: 500;
+    padding-bottom: 2px;
+}
+
+.maintenance-error-detail {
+    font-size: 10px;
+    color: var(--error-color);
+    padding: 0 0 4px 20px;
+    line-height: 1.4;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+.maintenance-retry-btn {
+    margin-top: 4px;
+    align-self: flex-start;
+}
+
+// ── Migration sub-rows ───────────────────────────────────────────────────────
+
+.maintenance-sub-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding-left: 16px;
+    font-size: 10px;
+    min-height: 18px;
+}
+
+.maintenance-sub-id {
+    flex: 0 0 36px;
+    font-family: var(--font-mono, monospace);
+    color: var(--secondary-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.maintenance-sub-label {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--secondary-text-color);
+}
+
+.maintenance-timer {
+    flex: 0 0 auto;
+    font-family: var(--font-mono, monospace);
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    opacity: 0.6;
+    white-space: nowrap;
+}

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -23,10 +23,11 @@ export const WpsEvent = {
     ShellNodeCreate: "shell_node_create",
     ShellChunk: "shell_chunk",
     BlockActivity: "block:activity",
-    UpgradeMigrationEvent:     "upgrade:migration-event",
-    UpgradeMigrationsComplete: "upgrade:migrations-complete",
-    UpgradeMigrationsFailed:   "upgrade:migrations-failed",
-    UpgradeSagaVacuumDone:     "upgrade:saga-vacuum-done",
+    UpgradeMigrationEvent:      "upgrade:migration-event",
+    UpgradeMigrationsComplete:  "upgrade:migrations-complete",
+    UpgradeMigrationsFailed:    "upgrade:migrations-failed",
+    UpgradeSagaVacuumDone:      "upgrade:saga-vacuum-done",
+    UpgradeSrvRestartRequired:  "upgrade:srv-restart-required",
 } as const;
 
 export type WpsEventName = (typeof WpsEvent)[keyof typeof WpsEvent];

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -23,11 +23,10 @@ export const WpsEvent = {
     ShellNodeCreate: "shell_node_create",
     ShellChunk: "shell_chunk",
     BlockActivity: "block:activity",
-    UpgradeMigrationEvent:      "upgrade:migration-event",
-    UpgradeMigrationsComplete:  "upgrade:migrations-complete",
-    UpgradeMigrationsFailed:    "upgrade:migrations-failed",
-    UpgradeSagaVacuumDone:      "upgrade:saga-vacuum-done",
-    UpgradeSrvRestartRequired:  "upgrade:srv-restart-required",
+    UpgradeMigrationEvent:     "upgrade:migration-event",
+    UpgradeMigrationsComplete: "upgrade:migrations-complete",
+    UpgradeMigrationsFailed:   "upgrade:migrations-failed",
+    UpgradeSagaVacuumDone:     "upgrade:saga-vacuum-done",
 } as const;
 
 export type WpsEventName = (typeof WpsEvent)[keyof typeof WpsEvent];

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -23,6 +23,10 @@ export const WpsEvent = {
     ShellNodeCreate: "shell_node_create",
     ShellChunk: "shell_chunk",
     BlockActivity: "block:activity",
+    UpgradeMigrationEvent:     "upgrade:migration-event",
+    UpgradeMigrationsComplete: "upgrade:migrations-complete",
+    UpgradeMigrationsFailed:   "upgrade:migrations-failed",
+    UpgradeSagaVacuumDone:     "upgrade:saga-vacuum-done",
 } as const;
 
 export type WpsEventName = (typeof WpsEvent)[keyof typeof WpsEvent];

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -274,6 +274,11 @@ declare global {
         releaseDragCapture: () => Promise<void>;
         getMouseButtonState: () => Promise<boolean>;
         setJsDragActive: (active: boolean) => Promise<void>;
+        /** Trigger on-demand migration run (maintenance panel retry).
+         *  Returns immediately; progress arrives via `upgrade:migration-event` CEF events. */
+        runMigrations: () => Promise<{ started: boolean }>;
+        /** Trigger on-demand saga log vacuum. Returns rows deleted. */
+        runSagaVacuum: () => Promise<{ rows_deleted: number }>;
     };
 
     type NativeContextMenuItem = {

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -630,6 +630,14 @@ export function buildCefApi(): AppApi {
             return unlisten;
         },
 
+        // --- Maintenance panel ---
+        runMigrations: async () => {
+            return await invokeCommand<{ started: boolean }>("run_migrations");
+        },
+        runSagaVacuum: async () => {
+            return await invokeCommand<{ rows_deleted: number }>("run_saga_vacuum");
+        },
+
         // --- Cross-window drag ---
         startCrossDrag: async (
             dragType: "pane" | "tab",

--- a/specs/SPEC_UPGRADE_PANEL_2026_06_27.md
+++ b/specs/SPEC_UPGRADE_PANEL_2026_06_27.md
@@ -1,0 +1,600 @@
+# Maintenance Section in InstancePanel
+
+**Status:** Spec — not yet implemented  
+**Date:** 2026-06-27  
+**Placement:** Inside `InstancePanel` (opens when clicking the `v0.49.5` chip in the
+bottom-right status bar)  
+**Depends on:** PR #1800 (`pending_migrations` in ESTART), `specs/app-update-check.md`
+
+---
+
+## Overview
+
+All maintenance operations live in a single **Maintenance** section appended to the
+existing InstancePanel (just before the footer buttons). No new panel is needed.
+
+**Operations covered:**
+
+| # | Operation | Trigger | Duration |
+|---|-----------|---------|----------|
+| 1 | Code update | User-initiated (UpdateStatus dot → panel) | Varies (download) |
+| 2 | Pre-migration DB snapshot | Automatic at startup | 100–500ms |
+| 3 | Database migrations | Automatic at startup / on-demand retry | 8ms–5s |
+| 4 | Channel pruning | Automatic at launcher startup | < 50ms |
+| 5 | Saga log vacuum | On-demand button in panel | < 100ms |
+
+The UpdateStatus dot in the status bar stays as-is (a quick visual indicator). The
+InstancePanel is where you *act* — download, install, run migrations, vacuum.
+
+---
+
+## Full Panel Layout
+
+The panel is 320px wide (`POPOVER_WIDTH = 320`). The Maintenance section is inserted
+between the Floating panes section and the footer.
+
+```
+┌──────────────────────────────────────────────┐  320px
+│ Version      v0.49.5                    ⧉   │  header
+│ Channel      stable                          │
+│ Build        a1b2c3d                   ⧉   │
+│ Time         Jun 27, 2026 9:14AM            │
+│ Runtime      windows-x64                    │
+├──────────────────────────────────────────────┤  divider
+│ This process — 2 windows                    │  windows section
+│ ● My Workspace                    [this]    │
+│   [████████████████████████████░] 100%      │
+│ ○ Second Window                             │
+│   [████████████████████████████░]  85%      │
+├──────────────────────────────────────────────┤  divider
+│ Floating panes — 0                          │  panes section
+│ No floating panes                           │
+├──────────────────────────────────────────────┤  divider
+│ Maintenance                                 │  ← NEW SECTION
+│ ···                                         │
+├──────────────────────────────────────────────┤  divider
+│ [+ Open another window]          [Close]    │  footer
+└──────────────────────────────────────────────┘
+```
+
+---
+
+## ASCII Art: Maintenance Section States
+
+### State A — All clear (nothing pending)
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance                                  │
+│                                              │
+│  ✓  Up to date      v0.49.5                 │
+│  ✓  Migrations      11 applied              │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- `✓` green, `○` grey neutral dot.
+- "Run Vacuum" is a small inline button (secondary style, same as existing `instance-panel-btn`).
+- No badge on the section title.
+
+---
+
+### State B — Code update available
+
+The UpdateStatus dot in the status bar turns green and shows `↓ v0.49.6`. The
+Maintenance section also reflects this, with a download action:
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance  ↓ 0.49.6                        │
+│                                              │
+│  ↓  Update v0.49.6 available                │
+│     [Download Update]                        │
+│                                              │
+│  ✓  Migrations      11 applied              │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- Section title badge: `↓ 0.49.6` in accent color.
+- "Download Update" is a primary button (filled).
+- Other rows still visible below so the panel doesn't change structure dramatically.
+
+---
+
+### State C — Downloading update
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance  ↓ 34%                           │
+│                                              │
+│  ↓  Downloading v0.49.6…  34%              │
+│     [████████░░░░░░░░░░░░░░░░░░░░░░]        │
+│                                              │
+│  ✓  Migrations      11 applied              │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- Badge updates to the percentage.
+- Progress bar uses existing CSS variable colors (no hard-coded values).
+- "Download Update" button is absent (replaced by the progress bar row).
+
+---
+
+### State D — Update downloaded, ready to restart
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance  ↑ ready                         │
+│                                              │
+│  ↑  v0.49.6 ready to install                │
+│     [Restart to Install]                     │
+│                                              │
+│  ✓  Migrations      11 applied              │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- Badge: `↑ ready` in green.
+- "Restart to Install" is a primary button.
+- Matches the existing `UpdateStatus.tsx` "ready" state so they agree.
+
+---
+
+### State E — Migrations pending (startup failure)
+
+Startup reported `pending_migrations:3` in ESTART. Existing `BackendStatus.tsx` shows
+the static warning; that static block is replaced by a link to open the panel.
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance  ⚠ 3 pending                    │
+│                                              │
+│  ⚠  3 migrations did not apply at startup.  │
+│     [Run Migrations]                         │
+│                                              │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- Section title badge: `⚠ 3 pending` in warning color.
+- Migrations row is absent from the summary table (it's the alert itself).
+- "Run Migrations" is a primary button.
+
+---
+
+### State F — Migrations running (live stage list)
+
+User clicked "Run Migrations" (or auto-triggered on-demand). Live events stream from
+the CEF subprocess via WPS `upgrade:migration-event`.
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance  ·running·                       │
+│                                              │
+│  ●  Migrations running…          2.4s       │
+│     ✓  0011  Shared store backfill   1.1s   │
+│     ✓  0012  Agent session index     0.8s   │
+│     ·  0013  Transcript index        0.5s   │
+│                                              │
+│  ✓  Channels        clean                   │
+│  ·  Saga vacuum     —                       │
+│                                              │
+```
+
+Icons:
+- `●` blue — parent stage active (pulsing animation)
+- `✓` green — sub-step complete
+- `·` blue (pulsing) — sub-step currently running
+
+Timers show elapsed seconds, updated every 500ms via `setInterval`.
+
+No cancel button — migrations are not safely interruptible.
+
+---
+
+### State G — Migrations complete
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance                                  │
+│                                              │
+│  ✓  Migrations complete   3 applied         │
+│     ✓  0011  Shared store backfill   1.1s   │
+│     ✓  0012  Agent session index     0.8s   │
+│     ✓  0013  Transcript index        2.8s   │
+│                                             │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- Sub-row list collapses after ~5 seconds (or on panel reopen) into the normal
+  summary row: `✓  Migrations  14 applied`.
+- Badge clears.
+
+---
+
+### State H — Migration failed
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance  ✗ 1 failed                      │
+│                                              │
+│  ✗  Migration 0012 failed                   │
+│     ✓  0011  Shared store backfill   1.1s   │
+│     ✗  0012  Agent session index     1.0s   │
+│             foreign key constraint failed    │
+│     Check ~/.agentmux/logs/ for details.     │
+│     [Retry]                                  │
+│                                              │
+│  ✓  Channels        clean                   │
+│  ○  Saga vacuum     last run: Jun 20        │
+│                              [Run Vacuum]   │
+│                                              │
+```
+
+- Badge: `✗ 1 failed` in error color.
+- Error text (one line from the JSON event `error` field) appears under the failed row.
+- "Retry" button re-triggers the same on-demand migration flow.
+
+---
+
+### State I — Saga vacuum running
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance                                  │
+│                                              │
+│  ✓  Up to date      v0.49.5                 │
+│  ✓  Migrations      11 applied              │
+│  ✓  Channels        clean                   │
+│  ·  Saga vacuum     running…                │
+│                                              │
+```
+
+- `·` pulsing blue dot.
+- "Run Vacuum" button replaced by "running…" text.
+- Returns to normal state (State A) once the command resolves, with a transient:
+
+---
+
+### State J — Saga vacuum done (transient, ~3s)
+
+```
+├──────────────────────────────────────────────┤
+│ Maintenance                                  │
+│                                              │
+│  ✓  Up to date      v0.49.5                 │
+│  ✓  Migrations      11 applied              │
+│  ✓  Channels        clean                   │
+│  ✓  Saga vacuum     247 rows removed        │
+│                              [Run Again]    │
+│                                              │
+```
+
+After 3 seconds the `✓  Saga vacuum  last run: Jun 27  [Run Vacuum]` row replaces it.
+
+---
+
+### State K — Channel prune not yet implemented (placeholder row)
+
+While `SPEC_LOCAL_CHANNEL_PRUNER_2026_06_25.md` is unimplemented, the Channels row
+shows a neutral dash:
+
+```
+│  —  Channels        not yet checked         │
+```
+
+Once the pruner lands, it updates the row on first run to show:
+```
+│  ✓  Channels        2 removed (143 MB)      │
+```
+or
+```
+│  ✓  Channels        clean (0 dead)          │
+```
+
+---
+
+## BackendStatus.tsx Change
+
+The static migration-failure block (lines 198–213) becomes a button that opens the
+InstancePanel. The InstancePanel itself shows the Maintenance section which has the
+"Run Migrations" call-to-action.
+
+**Before (current):**
+```tsx
+<div class="status-bar-popover-row">
+    <span>Migration failed at startup — check logs, then restart to retry.</span>
+</div>
+```
+
+**After:**
+```tsx
+<Show when={(backendInfo()?.pending_migrations ?? 0) > 0}>
+    <div class="status-bar-popover-divider" />
+    <div class="status-bar-popover-row">
+        <span style={{ color: "var(--warning-color)" }}>
+            ⚠ {backendInfo()!.pending_migrations} migrations pending
+        </span>
+    </div>
+    <div class="status-bar-popover-row">
+        <button class="status-bar-restart-btn" onClick={() => {
+            setPopoverOpen(false);
+            openVersionPanel();   // triggers StatusBar to open InstancePanel
+        }}>
+            Open Maintenance ↗
+        </button>
+    </div>
+</Show>
+```
+
+The `openVersionPanel()` function calls up to `StatusBar` via a callback prop or
+stores a signal — exact wiring TBD in implementation.
+
+---
+
+## Data Flow
+
+### Code update
+
+```
+App launch + 10s
+  → agentmux-srv: GET github.com/agentmuxai/agentmux/releases/latest
+  → WPS "app-update-status" event → UpdateStatus.tsx (dot in status bar)
+  → Also: InstancePanel Maintenance section reads same atom
+
+User clicks [Download Update] in InstancePanel
+  → getApi().installAppUpdate()   (currently stubbed in stubs.rs)
+  → CEF: download to temp, emit WPS "app-update-status" { state: "downloading", pct }
+  → InstancePanel: live progress bar update
+
+Download complete
+  → WPS "app-update-status" { state: "ready" }
+  → InstancePanel: [Restart to Install] button
+
+User clicks [Restart to Install]
+  → getApi().installAppUpdate() with { phase: "install" }
+  → CEF: launch installer / replace binary → exit
+```
+
+### Post-restart migrations (automatic)
+
+```
+Launcher starts agentmux-srv
+  → srv: maybe_snapshot_pre_migration() → ~/.agentmux/snapshots/
+  → srv: count_pending_migrations() > 0 → emit AGENTMUXSRV-MIGRATING to stderr
+  → launcher: extend ESTART deadline to 30 min
+  → srv: run_pending_migrations() → JSON events to stderr
+      { "event": "migration_start", "id": "0013", "label": "..." }
+      { "event": "migration_done",  "id": "0013", "duration_ms": 2800 }
+      { "event": "complete", "applied": 3, "skipped": 11 }
+  → launcher: parse events → (currently: splash stage list)
+  → srv: emit AGENTMUXSRV-ESTART pending_migrations:0   (or N on failure)
+  → frontend: backendInfo().pending_migrations determines Maintenance section state
+```
+
+### On-demand migration retry (user clicks "Run Migrations")
+
+```
+User clicks [Run Migrations] in InstancePanel
+  → getApi().runMigrations()
+  → CEF "run_migrations" command (backend.rs)
+  → Guard: Mutex<bool> — reject if already running
+  → Spawn: agentmux-srv --wavedata <path> migrate  (stdout piped)
+  → Background task: read stdout line-by-line
+      → each JSON line → WPS "upgrade:migration-event" (scope: local)
+  → InstancePanel: waveEventSubscribe → State F live stage list
+  → On process exit:
+      success → update state.pending_migrations → 0
+                emit WPS "upgrade:migrations-complete"
+                InstancePanel → State G (complete)
+      failure → emit WPS "upgrade:migrations-failed" { error, failed_id }
+                InstancePanel → State H (failed)
+```
+
+### Saga vacuum
+
+```
+User clicks [Run Vacuum]
+  → getApi().runSagaVacuum()
+  → CEF "run_saga_vacuum" command
+  → spawn_blocking: saga_log.vacuum_older_than(cutoff)
+  → return { rows_deleted: N }
+  → InstancePanel → State J (done, transient)
+  → after 3s → State A with updated "last run" timestamp
+```
+
+---
+
+## WPS Events (new)
+
+**File:** `frontend/app/store/wps-events.ts`
+
+```typescript
+UpgradeMigrationEvent:     "upgrade:migration-event",
+UpgradeMigrationsComplete: "upgrade:migrations-complete",
+UpgradeMigrationsFailed:   "upgrade:migrations-failed",
+UpgradeSagaVacuumDone:     "upgrade:saga-vacuum-done",
+```
+
+### `upgrade:migration-event` payload
+
+```typescript
+interface MigrationProgressEvent {
+    kind: "start" | "done" | "error" | "complete";
+    id?: string;            // migration id (start / done / error)
+    label?: string;         // human label (start)
+    duration_ms?: number;   // elapsed (done / complete)
+    applied?: number;       // total applied (complete)
+    skipped?: number;       // already-applied count (complete)
+    error?: string;         // one-line error detail (error)
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 — CEF backend commands
+
+**`agentmux-cef/src/commands/backend.rs`**
+
+**`run_migrations(state)`:**
+1. Lock `state.migration_running: Mutex<bool>` — return early if already locked
+2. Resolve `agentmux-srv` path (reuse `resolve_srv_binary`)
+3. Spawn `agentmux-srv --wavedata <path> migrate` with `stdout: Stdio::piped()`
+4. Tokio task: read stdout line-by-line, forward each valid JSON line as WPS
+   `upgrade:migration-event` via the existing `emit_wps_event` helper
+5. On exit:
+   - success: set `state.pending_migrations = 0`, emit `upgrade:migrations-complete`
+   - failure: emit `upgrade:migrations-failed { error, failed_id }`
+6. Return `Ok(json!({"started": true}))` immediately (non-blocking)
+
+**`run_saga_vacuum(state)`:**
+1. Read saga DB path from `state.data_paths.saga_db`
+2. `tokio::task::spawn_blocking(|| vacuum_older_than(cutoff))`
+3. Return `Ok(json!({"rows_deleted": N}))`
+
+**`agentmux-cef/src/ipc.rs`** — add routes:
+```rust
+"run_migrations"  => commands::backend::run_migrations(state.clone()).await,
+"run_saga_vacuum" => commands::backend::run_saga_vacuum(state.clone()).await,
+```
+
+### Phase 2 — WPS event constants
+
+**`frontend/app/store/wps-events.ts`** — add the 4 constants listed above.
+
+### Phase 3 — Frontend API
+
+**`frontend/util/cef-api.ts`:**
+```typescript
+runMigrations: async () =>
+    invokeCommand<{ started: boolean }>("run_migrations"),
+runSagaVacuum: async () =>
+    invokeCommand<{ rows_deleted: number }>("run_saga_vacuum"),
+```
+
+**`frontend/types/custom.d.ts`** — add both methods to the `AppApi` interface.
+
+### Phase 4 — Maintenance section component
+
+**`frontend/app/statusbar/MaintenanceSection.tsx`** (new)
+
+Props: none — reads global atoms directly.
+
+Internal state machine (SolidJS signals):
+
+```typescript
+type MigrationState =
+  | { kind: "idle"; pendingCount: number }
+  | { kind: "running"; steps: MigrationStep[] }
+  | { kind: "complete"; steps: MigrationStep[]; applied: number }
+  | { kind: "failed"; steps: MigrationStep[]; error: string; failedId: string };
+
+type UpdateState =
+  | { kind: "none" }
+  | { kind: "available"; version: string }
+  | { kind: "downloading"; version: string; pct: number }
+  | { kind: "ready"; version: string };
+
+type VacuumState =
+  | { kind: "idle"; lastRunMs: number | null }
+  | { kind: "running" }
+  | { kind: "done"; rowsDeleted: number; ranAtMs: number };
+```
+
+- Subscribes to `upgrade:migration-event`, `upgrade:migrations-complete`,
+  `upgrade:migrations-failed`, `upgrade:saga-vacuum-done` via `waveEventSubscribe`
+- Reads `backendInfo().pending_migrations` from global atoms for initial state
+- Reads the `app-update-status` atom (same source as `UpdateStatus.tsx`)
+- `setInterval` (500ms) for elapsed timers while `migrationState.kind === "running"`
+- Vacuum "done" state reverts after 3000ms via `setTimeout`
+
+**`frontend/app/statusbar/MaintenanceSection.scss`** (new)
+
+Classes: `.maintenance-section`, `.maintenance-row`, `.maintenance-sub-row`,
+`.maintenance-icon`, `.maintenance-timer`, `.maintenance-badge`, `.maintenance-btn`
+
+Follow the existing InstancePanel CSS variable conventions (`--main-text-color`,
+`--secondary-text-color`, `--warning-color`, `--error-color`, `--accent-color`,
+`--highlight-bg`, `--border-color`).
+
+### Phase 5 — Wire into InstancePanel
+
+**`frontend/app/statusbar/InstancePanel.tsx`:**
+
+1. Import `MaintenanceSection`
+2. Add a `<div class="instance-panel-divider" />` after the floating panes section
+3. Add `<div class="instance-panel-section"><MaintenanceSection /></div>`
+
+The existing footer (`+ Open another window` + `Close`) stays last.
+
+### Phase 6 — BackendStatus.tsx cleanup
+
+Replace the static migration-failure text (lines 198–213) with the
+`⚠ N migrations pending  [Open Maintenance ↗]` row described above.
+
+The "Open Maintenance ↗" button needs a way to programmatically open the
+InstancePanel. Options (pick during implementation):
+- Lift InstancePanel open-state to `StatusBar.tsx` and pass a setter down to
+  `BackendStatus.tsx` via context or prop
+- Emit a custom DOM event that `StatusBar.tsx` listens for (simpler, no prop
+  threading)
+- Signal in a tiny `maintenancePanelOpenAtom` in a new store file
+
+### Phase 7 — Code update (implement `install_update`)
+
+Wire the existing `install_update` stub per `specs/app-update-check.md`:
+1. Detect install type (NSIS / portable / AppImage / DMG / MSIX / unknown)
+2. Download platform asset to temp / Downloads, stream `pct` progress as
+   `app-update-status` events (already consumed by `UpdateStatus.tsx`)
+3. On "ready": launch installer (NSIS, DMG) or replace binary + exit (portable,
+   AppImage)
+
+---
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Panel closed mid-migration | CEF subprocess continues. WPS events still fire. On reopen the component reads `pending_migrations` from `backendInfo()` to decide initial state — if still > 0 it shows State E |
+| Double-click "Run Migrations" | `Mutex<bool>` in CEF rejects the second call; button disabled while `migrationState.kind === "running"` |
+| Migrations already current | `agentmux-srv migrate` emits `{"event":"complete","applied":0,"skipped":14}` instantly; panel skips to State G without showing an empty stage list |
+| Migration partial then process killed | Migrations are idempotent; retry resumes from the first unapplied ID |
+| Saga vacuum: nothing to delete | `rows_deleted: 0` → show "Nothing to clean up" instead of "0 rows removed" |
+| Channel pruner not implemented | Row shows `— Channels  not yet checked` (neutral dash, no warning) |
+| Snapshot row | Not shown in the panel summary — it's a silent background operation with no user action. If users want to find snapshots they check `~/.agentmux/snapshots/` |
+| UpdateStatus.tsx conflict | Both UpdateStatus and MaintenanceSection read the same `app-update-status` atom. They stay in sync by construction. UpdateStatus stays in the status bar as the quick indicator; InstancePanel has the action buttons |
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `agentmux-cef/src/commands/backend.rs` | Add `run_migrations`, `run_saga_vacuum` |
+| `agentmux-cef/src/ipc.rs` | Route both commands |
+| `agentmux-cef/src/commands/stubs.rs` | Remove `run_migrations` / `run_saga_vacuum` stubs if present; keep `install_update` stub until Phase 7 |
+| `frontend/app/store/wps-events.ts` | Add 4 `upgrade:*` event constants |
+| `frontend/util/cef-api.ts` | Add `runMigrations`, `runSagaVacuum` |
+| `frontend/types/custom.d.ts` | Add both to `AppApi` interface |
+| `frontend/app/statusbar/MaintenanceSection.tsx` | New component |
+| `frontend/app/statusbar/MaintenanceSection.scss` | New styles |
+| `frontend/app/statusbar/InstancePanel.tsx` | Add `<MaintenanceSection />` before footer |
+| `frontend/app/statusbar/BackendStatus.tsx` | Replace static migration text with "Open Maintenance ↗" button |
+| `agentmux-cef/src/commands/stubs.rs` | Remove `install_update` stub (Phase 7 only) |


### PR DESCRIPTION
## Summary

- **New `MaintenanceSection` component** embedded inside the version-chip popover (InstancePanel), showing all maintenance operations in one place: code updates, migration status/retry, saga vacuum, channel prune
- **CEF backend**: `run_migrations` command spawns `agentmux-srv … migrate`, streams JSON progress events to the frontend as `upgrade:migration-event` / `upgrade:migrations-complete` / `upgrade:migrations-failed` CEF events; `run_saga_vacuum` stub (subcommand TBD in agentmux-srv)
- **State machine**: idle → running (live per-step stage list with elapsed timers) → complete / failed (with Retry button)
- **BackendStatus cleanup**: replaces the static "Migration failed at startup" text with an "Open Maintenance ↗" button that dispatches `agentmux:open-version-panel` to open the version popover
- **Spec**: `specs/SPEC_UPGRADE_PANEL_2026_06_27.md` updated with full ASCII art for all 11 UI states and revised 7-phase implementation plan

## Files changed

| File | Change |
|------|--------|
| `agentmux-cef/src/state.rs` | Add `migration_running: Mutex<bool>` |
| `agentmux-cef/src/sidecar.rs` | Expose `resolve_backend_binary_pub` |
| `agentmux-cef/src/commands/backend.rs` | Add `run_migrations`, `run_saga_vacuum` |
| `agentmux-cef/src/ipc.rs` | Route both commands |
| `frontend/app/store/wps-events.ts` | Add 4 `upgrade:*` event constants |
| `frontend/util/cef-api.ts` | Add `runMigrations`, `runSagaVacuum` |
| `frontend/types/custom.d.ts` | Add both to `AppApi` |
| `frontend/app/statusbar/MaintenanceSection.tsx` | New component |
| `frontend/app/statusbar/_maintenance-section.scss` | New styles |
| `frontend/app/statusbar/StatusBar.scss` | Import new styles |
| `frontend/app/statusbar/StatusBar.tsx` | Listen for `agentmux:open-version-panel` |
| `frontend/app/statusbar/InstancePanel.tsx` | Wire in `MaintenanceSection` |
| `frontend/app/statusbar/BackendStatus.tsx` | Replace static migration text |

## Test plan

- [ ] Open version panel (click `v0.49.x` in status bar) → Maintenance section visible at bottom
- [ ] With no pending migrations: shows `✓ Migrations  up to date` and `○ Vacuum  not run [Run]`
- [ ] Click "Run" vacuum → row shows pulsing `·  Vacuum  running…`, then `✓ Vacuum  nothing to clean` for 3s, then reverts to idle with `last run: Jun 27`
- [ ] With `pending_migrations > 0` (simulate via env `AGENTMUX_PENDING_MIGRATIONS=3`): shows `⚠ 3 migrations pending [Run]` in section title badge and alert row
- [ ] BackendStatus dot → click → popover shows `⚠ 3 pending` and "Open Maintenance ↗" button → clicking it opens the version panel to the maintenance section
- [ ] Rust: `cargo check -p agentmux-cef` passes clean

<!-- agentmux:agent_id=agentx -->