### PR TITLE
fix(pool): enable pane pool on Windows — remove stale spawn guard

### DIFF
--- a/.changesets/1782567520-fix-pool-remove-stale-windows-guard-from-spawn-pane-pool-win-il5e.md
+++ b/.changesets/1782567520-fix-pool-remove-stale-windows-guard-from-spawn-pane-pool-win-il5e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(pool): remove stale Windows guard from spawn_pane_pool_window

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -1332,14 +1332,10 @@ pub(crate) const PANE_POOL_HEIGHT: i32 = 600;
 /// Spawn a single pre-warmed frameless pane window. Follows the same
 /// single-flight + refill chain pattern as `spawn_pool_window`.
 pub fn spawn_pane_pool_window(state: &Arc<AppState>) {
-    // The pane pool promote path on Windows uses a dedicated WS_POPUP + WS_EX_TOOLWINDOW
-    // approach (PR #1612). In this PR the Windows promote still returns None, so spawning
-    // a pool window on Windows would produce an undrainable ~75 MB window. Skip on Windows
-    // until #1612 lands.
-    #[cfg(target_os = "windows")]
-    {
-        return;
-    }
+    // PR #1612 landed (merged 2026-06-20) — Windows promote_pane_pool_window
+    // now uses the WS_POPUP+WS_EX_TOOLWINDOW HWND approach and returns Some
+    // instead of None. The early-return guard that blocked spawning on Windows
+    // was not removed in that PR; removing it here enables the pool on Windows.
     if state.is_quitting() {
         return;
     }


### PR DESCRIPTION
## Summary

- Removes a stale `#[cfg(target_os = \"windows\")] { return; }` guard from `spawn_pane_pool_window` that was blocking pane pool pre-warming on Windows.
- The guard was added before PR #1612 ("feat(pool): Windows pane tear-off pool", merged 2026-06-20) because the Windows promote path wasn't ready. PR #1612 implemented the WS_POPUP+WS_EX_TOOLWINDOW promote approach, but the guard was never removed.
- Effect: every floating pane tear-off on Windows was taking the cold path (CreateWindowExW + fresh browser + renderer bootstrap), adding ~150-300 ms of blank-window latency. With the guard removed, one window is pre-warmed at startup and promoted instantly on tear-off.

## Root Cause

```rust
// BEFORE (spawn_pane_pool_window):
#[cfg(target_os = \"windows\")]
{
    return;  // blocks all pool spawning on Windows
}
```

The comment said "until #1612 lands" — #1612 merged on 2026-06-20. The Windows creation path (`post_create_pane_pool_window_win32`) was already present at the bottom of the same function, unreachable.

## Test Plan

- [ ] Open agentmux on Windows, tear off a tab to float it — should appear near-instantly (pool promotion) instead of after a ~200-300 ms blank-window pause
- [ ] Check host log for `[pane-pool] spawning pane pool window` at startup
- [ ] Check host log for `[pane-pool] promoting pane pool window (Windows)` on tear-off
- [ ] Tear off multiple times in succession — second tear-off uses refilled pool slot

<!-- agentmux:agent_id=camper -->