### PR TITLE
feat(app-api): implement identity, preset, and memory namespaces

### DIFF
--- a/.changesets/1782635266-feat-app-api-implement-identity-preset-and-memory-namespaces-4ibc.md
+++ b/.changesets/1782635266-feat-app-api-implement-identity-preset-and-memory-namespaces-4ibc.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(app-api): implement identity, preset, and memory namespaces for agents

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -384,6 +384,20 @@ pub const COMMAND_BLOCKFILE_READ_RANGE: &str = "blockfile:read_range";
 pub const COMMAND_BLOCKFILE_READ_STATE: &str = "blockfile:read_state";
 pub const COMMAND_BLOCKFILE_WRITE_STATE: &str = "blockfile:write_state";
 
+// App API — identity/preset/memory namespaces
+pub const COMMAND_IDENTITY_SELF_ACCOUNTS: &str = "identity.self.accounts";
+pub const COMMAND_IDENTITY_ACCOUNT_UPSERT: &str = "identity.account.upsert";
+pub const COMMAND_IDENTITY_ACCOUNT_VALIDATE: &str = "identity.account.validate";
+pub const COMMAND_IDENTITY_SELF_UNLINK: &str = "identity.self.unlink";
+pub const COMMAND_PRESET_LIST: &str = "preset.list";
+pub const COMMAND_PRESET_GET: &str = "preset.get";
+pub const COMMAND_PRESET_UPSERT: &str = "preset.upsert";
+pub const COMMAND_PRESET_DELETE: &str = "preset.delete";
+pub const COMMAND_PRESET_SELF_GET: &str = "preset.self.get";
+pub const COMMAND_MEMORY_LIST: &str = "memory.list";
+pub const COMMAND_MEMORY_READ: &str = "memory.read";
+pub const COMMAND_MEMORY_WRITE: &str = "memory.write";
+
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";
 pub const COMMAND_SESSION_RESTORE: &str = "session:restore";
@@ -1351,6 +1365,11 @@ pub struct RpcContext {
     pub tabid: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub conn: String,
+    /// Slug of the authenticated agent from `bus:register`. Empty for non-agent
+    /// connections (plain WebSocket, CEF UI). App API handlers use this for S1
+    /// enforcement — reject if empty (unauthenticated), reject if ≠ request agent_id.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub agent_id: String,
 }
 
 /// Matches Go's `CommandVarData`

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3189,11 +3189,15 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
                 // Steps 2+4: replace provider link (unlink old, link new).
                 let _ = id_store.agent_identity_unlink(&req.agent_id, &req.provider);
                 if let Err(e) = id_store.agent_identity_link(&req.agent_id, &account_id, &req.provider) {
-                    // Unlink already ran — keychain secret is now orphaned. Best-effort delete.
-                    let aid = account_id.clone();
-                    let _ = tokio::task::spawn_blocking(move || {
-                        crate::identity::secret_store::delete(&aid)
-                    }).await;
+                    // Only clean up keychain for new accounts — on the update path the
+                    // account still exists in the DB and may be linked to other providers,
+                    // so deleting the keychain secret would destroy a valid credential.
+                    if is_new {
+                        let aid = account_id.clone();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            crate::identity::secret_store::delete(&aid)
+                        }).await;
+                    }
                     return Err(format!("identity.account.upsert: link: {e}"));
                 }
 

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3232,12 +3232,13 @@ fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppSta
     let id_store = state.id_store.clone();
     engine.register_handler(
         COMMAND_IDENTITY_ACCOUNT_VALIDATE,
-        Box::new(move |data, _ctx| {
+        Box::new(move |data, ctx| {
             let id_store = id_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize, Default)]
                 #[serde(rename_all = "snake_case")]
                 struct Req {
+                    #[serde(default)] agent_id: String,
                     #[serde(default)] account_id: String,
                     #[serde(default)] provider: String,
                     #[serde(default)] secret: String,
@@ -3246,7 +3247,15 @@ fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppSta
                     .map_err(|e| format!("identity.account.validate: {e}"))?;
 
                 let (provider, secret, masked_tail) = if !req.account_id.is_empty() {
-                    // Probe a stored account — fetch secret from keychain.
+                    // Stored-account path: S1 check + ownership verification so
+                    // callers can't probe another agent's credential by account UUID.
+                    check_s1(&ctx, &req.agent_id)?;
+                    let links = id_store
+                        .agent_identity_list_for_agent(&req.agent_id)
+                        .map_err(|e| format!("identity.account.validate: {e}"))?;
+                    if !links.iter().any(|l| l.account_id == req.account_id) {
+                        return Err("FORBIDDEN: account not linked to this agent".to_string());
+                    }
                     let acct = id_store.identity_get(&req.account_id)
                         .map_err(|e| format!("identity.account.validate: {e}"))?
                         .ok_or_else(|| format!("identity.account.validate: account {} not found", req.account_id))?;
@@ -3260,7 +3269,7 @@ fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppSta
                     let tail = crate::identity::key_validator::masked_tail(&plaintext);
                     (acct.provider.clone(), plaintext.to_string(), tail)
                 } else if !req.provider.is_empty() && !req.secret.is_empty() {
-                    // Ad-hoc probe — nothing stored.
+                    // Ad-hoc probe — caller supplies their own secret, nothing stored.
                     let tail = crate::identity::key_validator::masked_tail(&req.secret);
                     (req.provider.clone(), req.secret.clone(), tail)
                 } else {

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3188,9 +3188,14 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
 
                 // Steps 2+4: replace provider link (unlink old, link new).
                 let _ = id_store.agent_identity_unlink(&req.agent_id, &req.provider);
-                id_store
-                    .agent_identity_link(&req.agent_id, &account_id, &req.provider)
-                    .map_err(|e| format!("identity.account.upsert: link: {e}"))?;
+                if let Err(e) = id_store.agent_identity_link(&req.agent_id, &account_id, &req.provider) {
+                    // Unlink already ran — keychain secret is now orphaned. Best-effort delete.
+                    let aid = account_id.clone();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        crate::identity::secret_store::delete(&aid)
+                    }).await;
+                    return Err(format!("identity.account.upsert: link: {e}"));
+                }
 
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "identityaccounts:changed".to_string(),
@@ -3394,6 +3399,17 @@ fn register_preset_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // (which defaults false and can be omitted to bypass is_blank check).
                 if memory.id == "blank" || memory.id.starts_with("seed-") || memory.is_blank {
                     return Err("FORBIDDEN: cannot mutate a protected preset".to_string());
+                }
+                // Guard existing global presets: an agent must not be able to demote or
+                // corrupt a shared global brain bundle it doesn't own by supplying its id.
+                if !memory.id.is_empty() {
+                    if let Some(existing) = id_store.bundle_memory_get(&memory.id)
+                        .map_err(|e| format!("preset.upsert: {e}"))?
+                    {
+                        if existing.is_global {
+                            return Err("FORBIDDEN: cannot mutate a global preset".to_string());
+                        }
+                    }
                 }
                 if memory.id.is_empty() {
                     memory.id = uuid::Uuid::new_v4().to_string();

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3100,6 +3100,16 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
                 let account_id = if is_new {
                     uuid::Uuid::new_v4().to_string()
                 } else {
+                    // Ownership check: the supplied account_id must already be
+                    // linked to the calling agent, so callers can't overwrite
+                    // another agent's credentials by guessing a UUID.
+                    let links = id_store
+                        .agent_identity_list_for_agent(&req.agent_id)
+                        .map_err(|e| format!("identity.account.upsert: {e}"))?;
+                    let owned = links.iter().any(|l| l.account_id == req.account_id);
+                    if !owned {
+                        return Err("FORBIDDEN: account not linked to this agent".to_string());
+                    }
                     req.account_id.clone()
                 };
 
@@ -3380,8 +3390,10 @@ fn register_preset_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let mut memory: Memory = serde_json::from_value(data)
                     .map_err(|e| format!("preset.upsert: {e}"))?;
 
-                if memory.is_blank {
-                    return Err("FORBIDDEN: cannot mutate the blank preset".to_string());
+                // S4: guard on the target id, not the caller-supplied is_blank flag
+                // (which defaults false and can be omitted to bypass is_blank check).
+                if memory.id == "blank" || memory.id.starts_with("seed-") || memory.is_blank {
+                    return Err("FORBIDDEN: cannot mutate a protected preset".to_string());
                 }
                 if memory.id.is_empty() {
                     memory.id = uuid::Uuid::new_v4().to_string();

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -19,6 +19,8 @@ use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
 use crate::backend::session_archive;
 use crate::backend::storage::store::{Store, AgentContent, AgentDefinition, AgentInstance};
+use crate::backend::storage::identities::IdentityAccount;
+use crate::backend::storage::memory_bundles::Memory;
 
 use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
@@ -45,6 +47,19 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_session_archive_handler(engine, state);
     register_session_restore_handler(engine, state);
     register_session_export_handler(engine, state);
+    // identity.* / preset.* / memory.*
+    register_identity_self_accounts(engine, state);
+    register_identity_account_upsert(engine, state);
+    register_identity_account_validate(engine, state);
+    register_identity_self_unlink(engine, state);
+    register_preset_list(engine, state);
+    register_preset_get(engine, state);
+    register_preset_upsert(engine, state);
+    register_preset_delete(engine, state);
+    register_preset_self_get(engine, state);
+    register_memory_list(engine, state);
+    register_memory_read(engine, state);
+    register_memory_write(engine, state);
 }
 
 // ---------------------------------------------------------------------------
@@ -2984,6 +2999,663 @@ mod pane_open_reducer_tests {
         .await;
         assert!(r.is_ok(), "tear-off of an opened pane must succeed, got: {:?}", r.err());
     }
+}
+
+// ---------------------------------------------------------------------------
+// S1 enforcement helper
+// ---------------------------------------------------------------------------
+
+fn check_s1(ctx: &RpcContext, req_agent_id: &str) -> Result<(), String> {
+    if ctx.agent_id.is_empty() {
+        return Err("FORBIDDEN: unauthenticated agent connection".to_string());
+    }
+    if ctx.agent_id != req_agent_id {
+        return Err("FORBIDDEN: agent_id mismatch".to_string());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// identity.self.accounts
+// ---------------------------------------------------------------------------
+
+fn register_identity_self_accounts(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    engine.register_handler(
+        COMMAND_IDENTITY_SELF_ACCOUNTS,
+        Box::new(move |data, ctx| {
+            let id_store = id_store.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("identity.self.accounts: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+
+                let links = id_store
+                    .agent_identity_list_for_agent(&req.agent_id)
+                    .map_err(|e| format!("identity.self.accounts: {e}"))?;
+
+                let mut accounts = Vec::new();
+                for link in &links {
+                    if let Some(acct) = id_store.identity_get(&link.account_id)
+                        .map_err(|e| format!("identity.self.accounts: {e}"))? {
+                        let masked_tail = acct.context
+                            .get("masked_tail")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        accounts.push(json!({
+                            "account_id": acct.id,
+                            "provider":   acct.provider,
+                            "name":       acct.name,
+                            "kind":       acct.kind,
+                            "status":     acct.status,
+                            "masked_tail": masked_tail,
+                            "updated_at": acct.updated_at,
+                        }));
+                    }
+                }
+                Ok(Some(json!({ "accounts": accounts })))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// identity.account.upsert
+// ---------------------------------------------------------------------------
+
+fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_IDENTITY_ACCOUNT_UPSERT,
+        Box::new(move |data, ctx| {
+            let id_store = id_store.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                #[serde(rename_all = "snake_case")]
+                struct Req {
+                    agent_id: String,
+                    provider: String,
+                    name: String,
+                    #[serde(default)]
+                    kind: String,
+                    secret: String,
+                    #[serde(default)]
+                    validate: bool,
+                    #[serde(default)]
+                    account_id: String,
+                }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("identity.account.upsert: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                if req.secret.is_empty() {
+                    return Err("identity.account.upsert: secret must not be empty".to_string());
+                }
+
+                let is_new = req.account_id.is_empty();
+                let account_id = if is_new {
+                    uuid::Uuid::new_v4().to_string()
+                } else {
+                    req.account_id.clone()
+                };
+
+                // Step 1: store in keychain unconditionally.
+                {
+                    let aid = account_id.clone();
+                    let key = req.secret.clone();
+                    tokio::task::spawn_blocking(move || {
+                        crate::identity::secret_store::put(&aid, &key)
+                    })
+                    .await
+                    .map_err(|e| format!("identity.account.upsert: keychain task: {e}"))?
+                    .map_err(|e| format!("identity.account.upsert: keychain: {e}"))?;
+                }
+
+                // Step 1b: optional provider probe (validate controls this only).
+                let masked_tail = crate::identity::key_validator::masked_tail(&req.secret);
+                let (status, valid, error_msg) = if req.validate {
+                    let outcome = crate::identity::key_validator::validate(&req.provider, &req.secret).await;
+                    if outcome.valid {
+                        ("valid".to_string(), true, None)
+                    } else {
+                        ("invalid".to_string(), false, outcome.error)
+                    }
+                } else {
+                    ("unknown".to_string(), false, None)
+                };
+
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let existing = id_store.identity_get(&account_id).ok().flatten();
+                let created_at = existing.as_ref()
+                    .map(|a| a.created_at)
+                    .filter(|&c| c != 0)
+                    .unwrap_or(now);
+
+                let mut context = json!({ "masked_tail": masked_tail });
+                if let serde_json::Value::Object(ref mut m) = context {
+                    if let Some(existing_ctx) = existing.as_ref().map(|a| &a.context) {
+                        if let Some(obj) = existing_ctx.as_object() {
+                            for (k, v) in obj {
+                                m.entry(k).or_insert_with(|| v.clone());
+                            }
+                        }
+                    }
+                }
+
+                let account = IdentityAccount {
+                    id: account_id.clone(),
+                    name: req.name.clone(),
+                    provider: req.provider.clone(),
+                    kind: if req.kind.is_empty() { "api_key".to_string() } else { req.kind.clone() },
+                    display_name: String::new(),
+                    secret_ref: crate::backend::storage::identities::SecretRef::Keychain {
+                        service: crate::identity::secret_store::SERVICE.to_string(),
+                        account: crate::identity::secret_store::account_key(&account_id),
+                    },
+                    context,
+                    status: status.clone(),
+                    created_at,
+                    updated_at: now,
+                };
+
+                // Step 3 (upsert DB). Compensate on failure for new accounts.
+                if let Err(e) = id_store.identity_upsert(&account) {
+                    if is_new {
+                        let aid = account_id.clone();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            crate::identity::secret_store::delete(&aid)
+                        }).await;
+                    }
+                    return Err(format!("identity.account.upsert: db: {e}"));
+                }
+
+                // Steps 2+4: replace provider link (unlink old, link new).
+                let _ = id_store.agent_identity_unlink(&req.agent_id, &req.provider);
+                id_store
+                    .agent_identity_link(&req.agent_id, &account_id, &req.provider)
+                    .map_err(|e| format!("identity.account.upsert: link: {e}"))?;
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "identityaccounts:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agentidentities:changed:{}", req.agent_id),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+
+                Ok(Some(json!({
+                    "account_id":  account_id,
+                    "provider":    req.provider,
+                    "name":        req.name,
+                    "status":      status,
+                    "masked_tail": masked_tail,
+                    "valid":       valid,
+                    "error":       error_msg,
+                })))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// identity.account.validate
+// ---------------------------------------------------------------------------
+
+fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    engine.register_handler(
+        COMMAND_IDENTITY_ACCOUNT_VALIDATE,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize, Default)]
+                #[serde(rename_all = "snake_case")]
+                struct Req {
+                    #[serde(default)] account_id: String,
+                    #[serde(default)] provider: String,
+                    #[serde(default)] secret: String,
+                }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("identity.account.validate: {e}"))?;
+
+                let (provider, secret, masked_tail) = if !req.account_id.is_empty() {
+                    // Probe a stored account — fetch secret from keychain.
+                    let acct = id_store.identity_get(&req.account_id)
+                        .map_err(|e| format!("identity.account.validate: {e}"))?
+                        .ok_or_else(|| format!("identity.account.validate: account {} not found", req.account_id))?;
+                    let aid = req.account_id.clone();
+                    let plaintext = tokio::task::spawn_blocking(move || {
+                        crate::identity::secret_store::get(&aid)
+                    })
+                    .await
+                    .map_err(|e| format!("identity.account.validate: keychain task: {e}"))?
+                    .map_err(|e| format!("identity.account.validate: keychain: {e}"))?;
+                    let tail = crate::identity::key_validator::masked_tail(&plaintext);
+                    (acct.provider.clone(), plaintext.to_string(), tail)
+                } else if !req.provider.is_empty() && !req.secret.is_empty() {
+                    // Ad-hoc probe — nothing stored.
+                    let tail = crate::identity::key_validator::masked_tail(&req.secret);
+                    (req.provider.clone(), req.secret.clone(), tail)
+                } else {
+                    return Err("identity.account.validate: provide account_id or (provider + secret)".to_string());
+                };
+
+                let outcome = crate::identity::key_validator::validate(&provider, &secret).await;
+                Ok(Some(json!({
+                    "valid":       outcome.valid,
+                    "status":      if outcome.valid { "valid" } else { "invalid" },
+                    "masked_tail": masked_tail,
+                    "error":       outcome.error,
+                })))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// identity.self.unlink
+// ---------------------------------------------------------------------------
+
+fn register_identity_self_unlink(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_IDENTITY_SELF_UNLINK,
+        Box::new(move |data, ctx| {
+            let id_store = id_store.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, provider: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("identity.self.unlink: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+
+                let unlinked = id_store
+                    .agent_identity_unlink(&req.agent_id, &req.provider)
+                    .map_err(|e| format!("identity.self.unlink: {e}"))?;
+                if unlinked {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: format!("agentidentities:changed:{}", req.agent_id),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "unlinked": unlinked })))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// preset.list
+// ---------------------------------------------------------------------------
+
+fn register_preset_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    engine.register_handler(
+        COMMAND_PRESET_LIST,
+        Box::new(move |_data, _ctx| {
+            let id_store = id_store.clone();
+            Box::pin(async move {
+                let memories = id_store
+                    .bundle_memory_list()
+                    .map_err(|e| format!("preset.list: {e}"))?;
+                // Return summary fields only — no instruction/context blobs.
+                let presets: Vec<_> = memories.iter().map(|m| json!({
+                    "id":          m.id,
+                    "name":        m.name,
+                    "description": m.description,
+                    "provider":    m.provider,
+                    "model":       m.model,
+                    "is_blank":    m.is_blank,
+                    "updated_at":  m.updated_at,
+                })).collect();
+                Ok(Some(json!({ "presets": presets })))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// preset.get
+// ---------------------------------------------------------------------------
+
+fn register_preset_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    engine.register_handler(
+        COMMAND_PRESET_GET,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize, Default)]
+                struct Req {
+                    #[serde(default)] id: String,
+                    #[serde(default)] name: String,
+                }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("preset.get: {e}"))?;
+
+                let memory = if !req.id.is_empty() {
+                    id_store.bundle_memory_get(&req.id)
+                        .map_err(|e| format!("preset.get: {e}"))?
+                        .ok_or_else(|| format!("preset.get: not found id={}", req.id))?
+                } else if !req.name.is_empty() {
+                    // Name lookup: list + filter, pick most-recently-updated.
+                    let all = id_store.bundle_memory_list()
+                        .map_err(|e| format!("preset.get: {e}"))?;
+                    all.into_iter()
+                        .filter(|m| m.name == req.name)
+                        .max_by_key(|m| m.updated_at)
+                        .ok_or_else(|| format!("preset.get: not found name={}", req.name))?
+                } else {
+                    return Err("preset.get: provide id or name".to_string());
+                };
+                Ok(Some(serde_json::to_value(&memory).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// preset.upsert
+// ---------------------------------------------------------------------------
+
+fn register_preset_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_PRESET_UPSERT,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let mut memory: Memory = serde_json::from_value(data)
+                    .map_err(|e| format!("preset.upsert: {e}"))?;
+
+                if memory.is_blank {
+                    return Err("FORBIDDEN: cannot mutate the blank preset".to_string());
+                }
+                if memory.id.is_empty() {
+                    memory.id = uuid::Uuid::new_v4().to_string();
+                }
+                // S4a: strip caller-supplied escalation fields.
+                memory.is_global = false;
+                memory.sort_order = 0;
+
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if memory.created_at == 0 { memory.created_at = now; }
+                memory.updated_at = now;
+
+                id_store.bundle_memory_upsert(&memory)
+                    .map_err(|e| format!("preset.upsert: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "memories:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                Ok(Some(serde_json::to_value(&memory).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// preset.delete
+// ---------------------------------------------------------------------------
+
+fn register_preset_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_PRESET_DELETE,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("preset.delete: {e}"))?;
+
+                if req.id == "blank" {
+                    return Err("FORBIDDEN: cannot delete a seeded bundle".to_string());
+                }
+
+                match id_store.bundle_memory_delete(&req.id) {
+                    Ok(deleted) => {
+                        if deleted {
+                            broker.publish(crate::backend::wps::WaveEvent {
+                                event: "memories:changed".to_string(),
+                                scopes: vec![], sender: String::new(), persist: 0, data: None,
+                            });
+                        }
+                        Ok(Some(json!({ "deleted": deleted })))
+                    }
+                    Err(crate::backend::storage::error::StoreError::Other(msg))
+                        if msg.contains("seed") || msg.contains("seeded") =>
+                    {
+                        Err(format!("FORBIDDEN: cannot delete a seeded bundle"))
+                    }
+                    Err(e) => Err(format!("preset.delete: {e}")),
+                }
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// preset.self.get
+// ---------------------------------------------------------------------------
+
+fn register_preset_self_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let id_store = state.id_store.clone();
+    engine.register_handler(
+        COMMAND_PRESET_SELF_GET,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            let id_store = id_store.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("preset.self.get: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+
+                // Resolve agent slug → instance row → memory_id.
+                let instance = wstore
+                    .instance_get_by_name(&req.agent_id)
+                    .map_err(|e| format!("preset.self.get: {e}"))?;
+
+                let memory_id = instance.as_ref().and_then(|i| {
+                    if i.memory_id.is_empty() { None } else { Some(i.memory_id.clone()) }
+                });
+
+                let memory = if let Some(mid) = memory_id {
+                    id_store.bundle_memory_get(&mid)
+                        .map_err(|e| format!("preset.self.get: {e}"))?
+                        .ok_or_else(|| format!("preset.self.get: memory_id {mid} not found"))?
+                } else {
+                    // No preset bound: return the blank singleton.
+                    // listmemories returns summary only, so two steps:
+                    // (1) find blank id, (2) getmemory for full object.
+                    let all = id_store.bundle_memory_list()
+                        .map_err(|e| format!("preset.self.get: {e}"))?;
+                    let blank_id = all.into_iter()
+                        .find(|m| m.is_blank)
+                        .map(|m| m.id)
+                        .ok_or_else(|| "preset.self.get: blank singleton not found".to_string())?;
+                    id_store.bundle_memory_get(&blank_id)
+                        .map_err(|e| format!("preset.self.get: {e}"))?
+                        .ok_or_else(|| "preset.self.get: blank singleton row missing".to_string())?
+                };
+
+                Ok(Some(serde_json::to_value(&memory).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// memory.list / memory.read / memory.write
+// ---------------------------------------------------------------------------
+
+fn register_memory_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MEMORY_LIST,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("memory.list: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+
+                let memory_dir = crate::server::native_memory_handlers::memory_dir_for_agent(
+                    &wstore, &req.agent_id,
+                ).map_err(|e| format!("memory.list: {e}"))?;
+
+                let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
+                let entries = match std::fs::read_dir(&memory_dir) {
+                    Ok(e) => e,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        return Ok(Some(json!({ "files": [] })));
+                    }
+                    Err(e) => return Err(format!("memory.list: read_dir: {e}")),
+                };
+                for entry in entries {
+                    let entry = entry.map_err(|e| format!("memory.list: {e}"))?;
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    if !name.ends_with(".md") { continue; }
+                    let file_type = entry.file_type()
+                        .map_err(|e| format!("memory.list: file_type {name}: {e}"))?;
+                    if !file_type.is_file() { continue; }
+                    let meta = match entry.metadata() {
+                        Ok(m) => m,
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                        Err(e) => return Err(format!("memory.list: metadata {name}: {e}")),
+                    };
+                    let preview_content = {
+                        use std::io::Read;
+                        std::fs::File::open(entry.path())
+                            .map(|f| {
+                                let mut buf = Vec::with_capacity(512);
+                                f.take(512).read_to_end(&mut buf).ok();
+                                String::from_utf8_lossy(&buf).into_owned()
+                            })
+                            .unwrap_or_default()
+                    };
+                    files.push(NativeMemoryFileMeta {
+                        is_index: name == "MEMORY.md",
+                        metadata_type: crate::server::native_memory_handlers::parse_memory_frontmatter_type(&preview_content),
+                        size_bytes: meta.len(),
+                        modified_at: meta.modified().ok()
+                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|d| d.as_millis() as i64)
+                            .unwrap_or(0),
+                        filename: name,
+                    });
+                }
+                files.sort_by(|a, b| b.is_index.cmp(&a.is_index).then(a.filename.cmp(&b.filename)));
+                Ok(Some(serde_json::to_value(NativeMemoryListResult { files }).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_memory_read(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MEMORY_READ,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, filename: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("memory.read: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                crate::server::native_memory_handlers::validate_memory_filename(&req.filename)
+                    .map_err(|e| format!("memory.read: {e}"))?;
+
+                let path = crate::server::native_memory_handlers::memory_dir_for_agent(
+                    &wstore, &req.agent_id,
+                ).map_err(|e| format!("memory.read: {e}"))?.join(&req.filename);
+
+                let file_type = std::fs::symlink_metadata(&path)
+                    .map_err(|e| format!("memory.read: {}: {e}", req.filename))?.file_type();
+                if !file_type.is_file() {
+                    return Err(format!("memory.read: {} is not a regular file", req.filename));
+                }
+                const MAX: u64 = 10 * 1024 * 1024;
+                let mut buf = Vec::new();
+                std::fs::File::open(&path)
+                    .and_then(|f| { use std::io::Read; f.take(MAX).read_to_end(&mut buf) })
+                    .map_err(|e| format!("memory.read: {}: {e}", req.filename))?;
+                let content = String::from_utf8_lossy(&buf).into_owned();
+                Ok(Some(serde_json::to_value(NativeMemoryReadFileResult { content }).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_memory_write(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_MEMORY_WRITE,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, filename: String, content: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("memory.write: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                crate::server::native_memory_handlers::validate_memory_filename(&req.filename)
+                    .map_err(|e| format!("memory.write: {e}"))?;
+                const MAX: usize = 10 * 1024 * 1024;
+                if req.content.len() > MAX {
+                    return Err(format!("memory.write: content too large ({} bytes, max {MAX})", req.content.len()));
+                }
+
+                let dir = crate::server::native_memory_handlers::memory_dir_for_agent(
+                    &wstore, &req.agent_id,
+                ).map_err(|e| format!("memory.write: {e}"))?;
+                std::fs::create_dir_all(&dir)
+                    .map_err(|e| format!("memory.write: mkdir: {e}"))?;
+
+                let dest = dir.join(&req.filename);
+                let tmp = dir.join(format!(".{}.{}.tmp", req.filename, uuid::Uuid::new_v4()));
+                if let Err(e) = std::fs::write(&tmp, &req.content) {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(format!("memory.write: write tmp: {e}"));
+                }
+                if let Err(e) = std::fs::rename(&tmp, &dest) {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(format!("memory.write: rename: {e}"));
+                }
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agent:memory:changed:{}", req.agent_id),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                Ok(None)
+            })
+        }),
+    );
 }
 
 /// Parse + validate a saved per-agent `ui:zoom` content blob for seeding a new

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -30,19 +30,25 @@ use crate::backend::rpc_types::{
 
 use super::AppState;
 
-/// Compute `~/.claude/projects/<sanitized>/memory/` for the given working directory.
+/// Compute `$CLAUDE_CONFIG_DIR/projects/<sanitized>/memory/` for the given
+/// working directory and Claude config dir.
 ///
-/// Mirrors Claude Code's `sessionStoragePortable.ts` algorithm:
+/// `claude_config_dir` is the value of `CLAUDE_CONFIG_DIR` from the agent's
+/// stored env blob. When empty, falls back to
+/// `~/.agentmux/shared/providers/claude/` — the default isolated home that
+/// `app_api.rs` sets at agent spawn time. We never write to the global
+/// `~/.claude/projects/` because AgentMux always sets `CLAUDE_CONFIG_DIR`.
+///
+/// Sanitization mirrors Claude Code's `sessionStoragePortable.ts`:
 /// 1. Replace every non-alphanumeric char with `-`.
 /// 2. If the result is longer than 200 chars, truncate at 200 and append a
-///    base-36 hash of the *raw* working_directory (before sanitization) as a suffix.
-fn memory_dir_for_cwd(working_directory: &str) -> PathBuf {
+///    base-36 hash of the *raw* working_directory (before sanitization).
+fn memory_dir_for_cwd(claude_config_dir: &str, working_directory: &str) -> PathBuf {
     let sanitized: String = working_directory
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
 
-    // Spec §5.2: hash is computed on the raw working_directory (before sanitization).
     let folder_name = if sanitized.len() > 200 {
         let hash = djb2_hash(working_directory);
         let truncated = &sanitized[..200];
@@ -51,9 +57,60 @@ fn memory_dir_for_cwd(working_directory: &str) -> PathBuf {
         sanitized
     };
 
-    expand_home_dir_safe("~/.claude/projects")
-        .join(folder_name)
-        .join("memory")
+    let base = if claude_config_dir.is_empty() {
+        expand_home_dir_safe("~/.agentmux/shared/providers/claude")
+    } else {
+        expand_home_dir_safe(claude_config_dir)
+    };
+    base.join("projects").join(folder_name).join("memory")
+}
+
+/// Extract `CLAUDE_CONFIG_DIR` from a `KEY=VALUE\n…` env blob.
+fn parse_claude_config_dir(env_blob: &str) -> String {
+    for line in env_blob.lines() {
+        if let Some(val) = line.strip_prefix("CLAUDE_CONFIG_DIR=") {
+            return val.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Resolve the memory directory for `agent_id`. Reads the agent definition and
+/// its stored env blob to find `CLAUDE_CONFIG_DIR`. Returns an error if the
+/// agent is not found or has no working directory.
+///
+/// Shared by `native_memory_handlers` and the `memory.*` App API handlers.
+pub(crate) fn memory_dir_for_agent(
+    wstore: &crate::backend::storage::store::Store,
+    agent_id: &str,
+) -> Result<std::path::PathBuf, String> {
+    let agent = wstore
+        .agent_def_get(agent_id)
+        .map_err(|e| format!("memory: store: {e}"))?
+        .ok_or_else(|| format!("memory: agent {agent_id} not found"))?;
+
+    if agent.working_directory.is_empty() {
+        return Err(format!("memory: agent {agent_id} has no working directory"));
+    }
+
+    let config_dir = wstore
+        .agent_content_get(&agent.id, "env")
+        .ok()
+        .flatten()
+        .map(|c| parse_claude_config_dir(&c.content))
+        .unwrap_or_default();
+
+    Ok(memory_dir_for_cwd(&config_dir, &agent.working_directory))
+}
+
+/// Validate a memory filename.
+pub(crate) fn validate_memory_filename(filename: &str) -> Result<(), String> {
+    validate_filename(filename)
+}
+
+/// Parse `metadata.type` from YAML frontmatter (re-exported for App API).
+pub(crate) fn parse_memory_frontmatter_type(content: &str) -> Option<String> {
+    parse_frontmatter_type(content)
 }
 
 /// Hash matching Claude Code's sessionStoragePortable.ts implementation.
@@ -168,7 +225,12 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     return Ok(Some(serde_json::to_value(NativeMemoryListResult { files: vec![] }).map_err(|e| e.to_string())?));
                 }
 
-                let memory_dir = memory_dir_for_cwd(&agent.working_directory);
+                let config_dir = wstore
+                    .agent_content_get(&agent.id, "env")
+                    .ok().flatten()
+                    .map(|c| parse_claude_config_dir(&c.content))
+                    .unwrap_or_default();
+                let memory_dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
 
                 let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
                 // Treat both "dir doesn't exist" and the TOCTOU case where the dir
@@ -265,7 +327,12 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     return Err(format!("agent:memory:read_file: agent {} has no configured working directory", cmd.agent_id));
                 }
 
-                let path = memory_dir_for_cwd(&agent.working_directory).join(&cmd.filename);
+                let config_dir = wstore
+                    .agent_content_get(&agent.id, "env")
+                    .ok().flatten()
+                    .map(|c| parse_claude_config_dir(&c.content))
+                    .unwrap_or_default();
+                let path = memory_dir_for_cwd(&config_dir, &agent.working_directory).join(&cmd.filename);
                 // Reject symlinks — consistent with list handler's file_type check.
                 let file_type = std::fs::symlink_metadata(&path)
                     .map_err(|e| format!("agent:memory:read_file: {}: {e}", cmd.filename))?
@@ -320,7 +387,12 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     return Err(format!("agent:memory:write_file: agent {} has no configured working directory", cmd.agent_id));
                 }
 
-                let dir = memory_dir_for_cwd(&agent.working_directory);
+                let config_dir = wstore
+                    .agent_content_get(&agent.id, "env")
+                    .ok().flatten()
+                    .map(|c| parse_claude_config_dir(&c.content))
+                    .unwrap_or_default();
+                let dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
                 std::fs::create_dir_all(&dir)
                     .map_err(|e| format!("agent:memory:write_file: mkdir: {e}"))?;
 

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -84,23 +84,26 @@ pub(crate) fn memory_dir_for_agent(
     wstore: &crate::backend::storage::store::Store,
     agent_id: &str,
 ) -> Result<std::path::PathBuf, String> {
-    let agent = wstore
-        .agent_def_get(agent_id)
+    // agent_id arriving from App API is the agent slug (AGENTMUX_AGENT_ID /
+    // bus:register id), not a UUID — use instance_get_by_name for the slug
+    // lookup. agent_def_get queries by UUID and would always return None here.
+    let instance = wstore
+        .instance_get_by_name(agent_id)
         .map_err(|e| format!("memory: store: {e}"))?
         .ok_or_else(|| format!("memory: agent {agent_id} not found"))?;
 
-    if agent.working_directory.is_empty() {
+    if instance.working_directory.is_empty() {
         return Err(format!("memory: agent {agent_id} has no working directory"));
     }
 
     let config_dir = wstore
-        .agent_content_get(&agent.id, "env")
+        .agent_content_get(&instance.id, "env")
         .ok()
         .flatten()
         .map(|c| parse_claude_config_dir(&c.content))
         .unwrap_or_default();
 
-    Ok(memory_dir_for_cwd(&config_dir, &agent.working_directory))
+    Ok(memory_dir_for_cwd(&config_dir, &instance.working_directory))
 }
 
 /// Validate a memory filename.

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -364,6 +364,11 @@ async fn handle_incoming_text(
             "bus:register" => {
                 if let Some(ref agent_id) = incoming.agent_id {
                     let rx = state.messagebus.register(agent_id, "websocket");
+                    // Stamp agent_id on the RPC context so App API S1 checks work.
+                    engine.set_rpc_context(crate::backend::rpc_types::RpcContext {
+                        agent_id: agent_id.clone(),
+                        ..Default::default()
+                    });
                     let ack = json!({ "type": "bus:registered", "agent_id": agent_id });
                     let msg = serde_json::to_string(&ack).unwrap_or_default();
                     if socket.send(Message::Text(msg.into())).await.is_err() {

--- a/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
+++ b/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
@@ -38,7 +38,7 @@ Security rule that threads through all three: **writes are agent-scoped** (an ag
 
 ### OQ1 — How do handlers know which agent is calling? (S1 enforcement)
 
-`RpcContext` (`rpc_types.rs:1345`) currently carries `client_type`, `blockid`, `tabid`, `conn` — no `agent_id`. The agent slug IS tracked on the WebSocket connection as `bus_agent_id` (set when the client sends `bus:register`), but it is not forwarded into `RpcContext`.
+`RpcContext` (`agentmux-srv/src/backend/rpc_types.rs:1345`) currently carries `client_type`, `blockid`, `tabid`, `conn` — no `agent_id`. The agent slug IS tracked on the WebSocket connection as `bus_agent_id` (set when the client sends `bus:register`), but it is not forwarded into `RpcContext`.
 
 **Resolution:** Add an `agent_id: String` field to `RpcContext`. Populate it in `websocket.rs` when `set_rpc_context` is called, using the connection's `bus_agent_id` if available. App API handlers enforce S1 by comparing `ctx.agent_id` against the `agent_id` field in the request — they are equal or the call is rejected.
 
@@ -141,7 +141,8 @@ Create or update a credential account **and** link it to the calling agent for t
 
 Delegates (in order):
 1. `account.key.verify` — validates secret + stores in keychain
-2. `linkagentidentity { agent_id, account_id, provider }` — replaces existing link
+2. If the agent already has a link for `provider`: call `unlinkagentidentity { agent_id, provider }` to remove it (the App API handler must do this explicitly — `linkagentidentity` inserts, it does not replace)
+3. `linkagentidentity { agent_id, account_id, provider }` — creates the new link
 
 Fires: `identityaccounts:changed` (global) + `agentidentities:changed:<agent_id>`
 
@@ -225,7 +226,7 @@ Fetch a full preset (instructions, context_files, mcp_servers, skills) by `id` o
 // Response — full Memory object (see db_memory_bundles schema in memory.md)
 ```
 
-Delegates to: `getmemory { id }`. For `name` lookup: list + filter client-side (no name index on the table).
+Delegates to: `getmemory { id }`. For `name` lookup: list + filter client-side (no name index on the table). Preset names are not enforced unique — if multiple presets share a name, return the one with the most recent `updated_at`. If zero match, return a not-found error.
 
 ---
 
@@ -272,14 +273,14 @@ Fires: `memories:changed`
 
 #### `preset.self.get`
 
-Get the preset bound to the calling agent's current instance. Resolves via `memory_id` on `db_agent_instances`; returns the blank sentinel if unset.
+Get the preset bound to the calling agent's current instance. Resolves via `memory_id` on `db_agent_instances`; returns the blank singleton object (not null) if `memory_id` is unset.
 
 ```jsonc
 // Request  { "agent_id": "agentx" }
-// Response — full Memory object
+// Response — full Memory object (is_blank: true when no preset is bound)
 ```
 
-Delegates to: `getagentinstance` → `getmemory` on the resolved `memory_id`.
+Delegates to: `getagentinstance` → `getmemory` on the resolved `memory_id`. If `memory_id` is null, delegates to `listmemories` + filter `is_blank: true` to fetch the singleton.
 
 ---
 
@@ -299,7 +300,7 @@ List all memory files for the calling agent.
     {
       "filename":      "user_preferences.md",
       "is_index":      false,
-      "metadata_type": "feedback",   // from YAML frontmatter, null if absent
+      "metadata_type": "feedback",   // value of `metadata.type` YAML frontmatter key; null if absent or unparseable
       "size_bytes":    412,
       "modified_at":   1751020800000
     }
@@ -340,7 +341,7 @@ Write (create or replace) a memory file atomically. Max 10 MiB. Filename rules s
 
 Delegates to: `agent:memory:write_file { agent_id, filename, content }`
 
-Fires: `agent:memory:changed:<agent_id>` (fire-and-forget, persist=0)
+Fires: `agent:memory:changed:<agent_id>` (fire-and-forget, persist=0) — emitted only after the write succeeds. No event is fired on error.
 
 ---
 
@@ -364,7 +365,7 @@ Fires: `agent:memory:changed:<agent_id>` (fire-and-forget, persist=0)
 | App API command | Existing handler(s) | New logic |
 |-----------------|--------------------|-----------| 
 | `identity.self.accounts` | `listagentidentities` + `getidentityaccount` per entry | Join results, mask secret tail |
-| `identity.account.upsert` | `account.key.verify` → `linkagentidentity` | Sequential, S1 scope check |
+| `identity.account.upsert` | `account.key.verify` → `unlinkagentidentity` (if existing link) → `linkagentidentity` | Sequential, S1 scope check, explicit unlink-then-relink for provider replacement |
 | `identity.account.validate` | `account.key.verify { validate: true }` | Ad-hoc path skips write |
 | `identity.self.unlink` | `unlinkagentidentity` | Direct delegation |
 | `preset.list` | `listmemories` | Strip instruction/context blobs from response |
@@ -390,15 +391,17 @@ All handlers register in `register_app_api_handlers` in `app_api.rs`.
 
 **S4 — Blank preset singleton guard.** `preset.upsert` and `preset.delete` return `FORBIDDEN: cannot mutate the blank preset` when the target id is the `is_blank` singleton.
 
-**S5 — validate=true is non-destructive.** `identity.account.validate` never writes to keychain or DB. The only allowed side-effect is updating the `status` column on an existing account row when a probe succeeds and current status is `unknown`.
+**S5 — validate=true is minimally destructive.** `identity.account.validate` never writes a new keychain entry and never creates or deletes DB rows. The only permitted DB side-effect is updating the `status` column on an existing account row (when `account_id` is supplied and the probe result resolves a previously-`unknown` status). No write occurs for ad-hoc probes (no `account_id`).
 
 **S6 — Memory filename validation.** `memory.read` and `memory.write` enforce the existing `validate_filename` check from `native_memory_handlers.rs`: stem must be `[a-zA-Z0-9_-]+`, extension must be `.md`, no path separators, max 200-char stem. This blocks path traversal at the App API layer before the low-level handler can be reached.
+
+**Error format.** Security rejections return a string error in the existing RPC error convention: `"FORBIDDEN: <reason>"` (e.g. `"FORBIDDEN: agent_id mismatch"`, `"FORBIDDEN: cannot mutate the blank preset"`). This matches the string-error pattern used by other handlers in `app_api.rs` — no new error type is introduced.
 
 ---
 
 ## 9. RpcContext Extension (prerequisite)
 
-`rpc_types.rs` — add one field to `RpcContext`:
+`agentmux-srv/src/backend/rpc_types.rs` — add one field to `RpcContext`:
 
 ```rust
 pub struct RpcContext {
@@ -436,7 +439,7 @@ No wire-format break: `skip_serializing_if = "String::is_empty"` means existing 
 
 | Phase | Commands | Why first |
 |-------|----------|-----------|
-| **P0** | `RpcContext` extension | Prerequisite for S1 — must land before any identity/memory writes |
+| **P0** | `RpcContext` extension | Prerequisite for S1 — must land before any identity/memory writes. The change is a single struct field + one assignment; it can be bundled in the same PR as P1 rather than shipped as a bare prereq commit. |
 | **P1** | `identity.account.upsert`, `identity.self.accounts`, `identity.account.validate` | Unblocks agents registering their own credentials |
 | **P2** | `identity.self.unlink`, `preset.list`, `preset.get`, `preset.upsert`, `preset.delete`, `preset.self.get` | Preset management — agents that self-configure |
 | **P3** | `memory.list`, `memory.read`, `memory.write` | Thin wrappers over existing handlers; low risk, high value for memory-aware agents |

--- a/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
+++ b/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
@@ -14,7 +14,7 @@ The Agent App API (`app_api.rs`) is the only RPC surface agents can reach (the p
 This means an agent cannot:
 - Register or update its own GitHub/Anthropic/AWS credential so the Trust Center shows it as connected
 - Read or modify the Memory bundle (preset) it was launched with
-- Read or write its own native memory files (Claude Code's `~/.claude/projects/…/memory/*.md`)
+- Read or write its own native memory files (Claude Code's `$CLAUDE_CONFIG_DIR/projects/…/memory/*.md`)
 
 Every one of those operations currently requires either direct DB manipulation or calling low-level handlers that agents aren't allowed to reach.
 
@@ -28,7 +28,7 @@ Add three new namespaces to the App API with the highest-value endpoints first. 
 |-----------|---------|
 | `identity.*` | Credential accounts + agent-to-account links |
 | `preset.*` | Memory bundles (what Trust Center calls "Presets") |
-| `memory.*` | Native agent memory files (`~/.claude/projects/…/memory/*.md`) |
+| `memory.*` | Native agent memory files (`$CLAUDE_CONFIG_DIR/projects/…/memory/*.md`) |
 
 Security rule that threads through all three: **writes are agent-scoped** (an agent can only mutate its own records), **reads of shared catalogs are allowed** (list all presets), **enumeration of other agents' secrets is denied**.
 
@@ -48,9 +48,11 @@ This is a one-line struct change + one assignment at the `set_rpc_context` call 
 
 `native_memory_handlers.rs` operates on **files**, not a key/value store. Specifically:
 
-- Directory: `~/.claude/projects/<sanitized-cwd>/memory/`
+- Directory: `$CLAUDE_CONFIG_DIR/projects/<sanitized-cwd>/memory/`
 - Files: `*.md` (max 10 MiB each, atomic tmp→rename write)
 - Existing commands: `agent:memory:list`, `agent:memory:read_file`, `agent:memory:write_file`
+
+**`CLAUDE_CONFIG_DIR` isolation:** AgentMux sets `CLAUDE_CONFIG_DIR` at agent spawn time (`app_api.rs`) so that Claude Code never writes to the global `~/.claude/`. The actual root is `~/.agentmux/shared/providers/claude/` for default agents and `~/.agentmux/shared/identities/<bundle_id>/claude/` for per-identity bundles. `native_memory_handlers.rs` must resolve this path from the agent's stored env blob (`agent_content_get(agent_id, "env")` → parse `CLAUDE_CONFIG_DIR`) rather than hardcoding `~/.claude/projects`.
 
 The `memory.*` App API commands delegate directly to these handlers — no new storage layer. The only additions are: (a) routing through the App API permission boundary, and (b) emitting a `agent:memory:changed:<agent_id>` event after writes.
 
@@ -288,7 +290,7 @@ Delegates via: `instance_get_by_name(agent_id)` (storage layer — maps agent sl
 
 ### 5.3 `memory.*` — Native Agent Memories
 
-These delegate directly to the existing `agent:memory:*` handlers in `native_memory_handlers.rs`. The storage is Claude Code's native memory directory: `~/.claude/projects/<sanitized-cwd>/memory/*.md`. All three commands already exist at the low-level RPC layer — these wrappers add (a) App API permission enforcement and (b) the `agent:memory:changed` event.
+These delegate directly to the existing `agent:memory:*` handlers in `native_memory_handlers.rs`. The storage is Claude Code's native memory directory: `$CLAUDE_CONFIG_DIR/projects/<sanitized-cwd>/memory/*.md` — see OQ2 for isolation details. All three commands already exist at the low-level RPC layer — these wrappers add (a) App API permission enforcement and (b) the `agent:memory:changed` event.
 
 #### `memory.list`
 

--- a/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
+++ b/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
@@ -140,7 +140,7 @@ Create or update a credential account **and** link it to the calling agent for t
 ```
 
 Delegates (in order):
-1. `account.key.verify` — validates secret + stores in keychain (step 1 is non-atomic with respect to steps 2–3; see compensation note below)
+1. `account.key.verify` — stores the secret in the keychain unconditionally, then probes the provider if `validate: true`. The `validate` field in the request controls only whether the probe is attempted — not whether the keychain write happens. If `validate: false` (or omitted), the secret is stored and the response `status` is `"unknown"`. (Step 1 is non-atomic with respect to steps 2–3; see compensation note below.)
 2. If the agent already has a link for `provider`: call `unlinkagentidentity { agent_id, provider }` to remove it (the App API handler must do this explicitly — `linkagentidentity` inserts, it does not replace)
 3. `linkagentidentity { agent_id, account_id, provider }` — creates the new link
 
@@ -179,7 +179,7 @@ Delegates to: `account.key.verify { validate: true }`. Read-only — fires no ev
 Remove the agent's link to a provider account. The account record stays in the DB.
 
 ```jsonc
-// Request  { "agent_id": "agentx", "provider": "github" }
+// Request  { "agent_id": "agentx", "provider": "github" }  // agent_id must match ctx.agent_id (S1)
 // Response { "unlinked": true }
 ```
 
@@ -282,7 +282,7 @@ Get the preset bound to the calling agent's current instance. Resolves via `memo
 // Response — full Memory object (is_blank: true when no preset is bound)
 ```
 
-Delegates via: `instance_get_by_name(agent_id)` (storage layer — maps agent slug → `AgentInstance`) → read `memory_id` from the returned row → `getmemory { id: memory_id }`. `CommandGetAgentInstanceData` takes an instance UUID (`id: String`), not a slug, so the handler cannot call `getagentinstance` directly with the request's `agent_id`; `instance_get_by_name` is the correct intermediate. If `memory_id` is null, fall back to `listmemories` + filter `is_blank: true` to fetch the blank singleton.
+Delegates via: `instance_get_by_name(agent_id)` (storage layer — maps agent slug → `AgentInstance`) → read `memory_id` from the returned row → `getmemory { id: memory_id }`. `CommandGetAgentInstanceData` takes an instance UUID (`id: String`), not a slug, so the handler cannot call `getagentinstance` directly with the request's `agent_id`; `instance_get_by_name` is the correct intermediate. If `memory_id` is null, fall back to two steps: (1) `listmemories` + filter `is_blank: true` to retrieve the blank singleton's `id` (summary fields only — `listmemories` does not return `instructions`, `context_files`, `mcp_servers`, or `skills`), then (2) `getmemory { id: <blank_id> }` to fetch the full Memory object. Step 2 is required to satisfy the response contract — step 1 alone is insufficient.
 
 ---
 

--- a/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
+++ b/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
@@ -1,0 +1,442 @@
+# SPEC: Agent App API — Identity, Presets & Memories Namespaces
+
+**Date:** 2026-06-27  
+**Status:** Draft — open questions resolved  
+**Author:** AgentX  
+**Related:** `agentmux-srv/src/server/app_api.rs`, `agentmux-srv/src/server/agent_handlers.rs`, `agentmux-srv/src/server/identity_handlers.rs`, `agentmux-srv/src/server/native_memory_handlers.rs`
+
+---
+
+## 1. Problem
+
+The Agent App API (`app_api.rs`) is the only RPC surface agents can reach (the permission boundary in `docs/internals/agent-app-api.md` is explicit about this). It currently covers agent lifecycle, panes, file I/O, and sessions — but has **no identity, preset, or memory surface**.
+
+This means an agent cannot:
+- Register or update its own GitHub/Anthropic/AWS credential so the Trust Center shows it as connected
+- Read or modify the Memory bundle (preset) it was launched with
+- Read or write its own native memory files (Claude Code's `~/.claude/projects/…/memory/*.md`)
+
+Every one of those operations currently requires either direct DB manipulation or calling low-level handlers that agents aren't allowed to reach.
+
+---
+
+## 2. Goal
+
+Add three new namespaces to the App API with the highest-value endpoints first. All operations go through the existing storage + event-bus layer, so the Trust Center UI updates reactively without a reload.
+
+| Namespace | Surface |
+|-----------|---------|
+| `identity.*` | Credential accounts + agent-to-account links |
+| `preset.*` | Memory bundles (what Trust Center calls "Presets") |
+| `memory.*` | Native agent memory files (`~/.claude/projects/…/memory/*.md`) |
+
+Security rule that threads through all three: **writes are agent-scoped** (an agent can only mutate its own records), **reads of shared catalogs are allowed** (list all presets), **enumeration of other agents' secrets is denied**.
+
+---
+
+## 3. Resolved Open Questions
+
+### OQ1 — How do handlers know which agent is calling? (S1 enforcement)
+
+`RpcContext` (`rpc_types.rs:1345`) currently carries `client_type`, `blockid`, `tabid`, `conn` — no `agent_id`. The agent slug IS tracked on the WebSocket connection as `bus_agent_id` (set when the client sends `bus:register`), but it is not forwarded into `RpcContext`.
+
+**Resolution:** Add an `agent_id: String` field to `RpcContext`. Populate it in `websocket.rs` when `set_rpc_context` is called, using the connection's `bus_agent_id` if available. App API handlers enforce S1 by comparing `ctx.agent_id` against the `agent_id` field in the request — they are equal or the call is rejected.
+
+This is a one-line struct change + one assignment at the `set_rpc_context` call site. No wire-format break since the field is `skip_serializing_if = "String::is_empty"`.
+
+### OQ2 — What is the memory storage backend?
+
+`native_memory_handlers.rs` operates on **files**, not a key/value store. Specifically:
+
+- Directory: `~/.claude/projects/<sanitized-cwd>/memory/`
+- Files: `*.md` (max 10 MiB each, atomic tmp→rename write)
+- Existing commands: `agent:memory:list`, `agent:memory:read_file`, `agent:memory:write_file`
+
+The `memory.*` App API commands delegate directly to these handlers — no new storage layer. The only additions are: (a) routing through the App API permission boundary, and (b) emitting a `agent:memory:changed:<agent_id>` event after writes.
+
+### OQ3 — Should `agent:memory:changed` be persisted?
+
+The existing `agent:memory:write_file` returns `Ok(None)` — no event fired. Memory file reads are cheap (small `.md` files), so the event is **fire-and-forget** (`persist=0`). Any subscriber that missed the event can simply re-list to get current state.
+
+---
+
+## 4. Scope
+
+### In scope (this spec)
+
+- All commands in §5
+- `RpcContext` extension (§3 OQ1)
+- WPS events each command fires (§6)
+- Mapping to existing low-level handlers (§7)
+- Security invariants (§8)
+- Handler registration in `register_app_api_handlers`
+
+### Out of scope
+
+- OAuth flows (`auth.start` / `auth.poll`) — these remain in `identity_handlers.rs` and are not elevated to the App API yet; they require a TTY/browser handoff that doesn't fit the agent-call model
+- Bundle-level identity binding (`bindidentityaccount`) — bundle management stays user-facing; agents manage their own account links via `identity.account.upsert`
+- Cross-agent memory reads — an agent reads only its own memory directory
+
+---
+
+## 5. API Surface
+
+### 5.1 `identity.*` — Credentials
+
+#### `identity.self.accounts`
+
+List accounts currently linked to the calling agent.
+
+```jsonc
+// Request
+{ "agent_id": "agentx" }
+
+// Response
+{
+  "accounts": [
+    {
+      "account_id": "15f7fe0a-...",
+      "provider":   "github",
+      "name":       "agentx-github",
+      "kind":       "api_key",      // "api_key" | "oauth"
+      "status":     "valid",        // "valid" | "expired" | "unknown"
+      "masked_tail": "w528",        // last 4 chars of secret — never the secret itself
+      "updated_at": 1751020800000
+    }
+  ]
+}
+```
+
+Delegates to: `listagentidentities { agent_id }` → resolves account records via `getidentityaccount` per entry.
+
+---
+
+#### `identity.account.upsert`
+
+Create or update a credential account **and** link it to the calling agent for the given provider. Stores the secret in the OS keychain (never in SQLite). If `account_id` is omitted a new UUID is minted. If the agent already has an account linked for this provider, the existing link is replaced.
+
+```jsonc
+// Request
+{
+  "agent_id":   "agentx",          // must match ctx.agent_id (S1)
+  "provider":   "github",
+  "name":       "agentx-github",
+  "kind":       "api_key",
+  "secret":     "ghp_...",         // required for new account or key rotation
+  "validate":   true,              // probe the provider to confirm credential works
+  "account_id": "15f7fe0a-..."    // optional — omit to mint a new UUID
+}
+
+// Response
+{
+  "account_id":  "15f7fe0a-...",
+  "provider":    "github",
+  "name":        "agentx-github",
+  "status":      "valid",
+  "masked_tail": "w528",
+  "valid":       true,
+  "error":       null              // set if validate=true and probe failed
+}
+```
+
+Delegates (in order):
+1. `account.key.verify` — validates secret + stores in keychain
+2. `linkagentidentity { agent_id, account_id, provider }` — replaces existing link
+
+Fires: `identityaccounts:changed` (global) + `agentidentities:changed:<agent_id>`
+
+---
+
+#### `identity.account.validate`
+
+Probe an existing stored account (by `account_id`) or an ad-hoc secret without storing anything.
+
+```jsonc
+// Request — probe stored account:
+{ "account_id": "15f7fe0a-..." }
+
+// Request — probe ad-hoc (not stored):
+{ "provider": "github", "secret": "ghp_..." }
+
+// Response
+{
+  "valid":       false,
+  "status":      "expired",
+  "error":       "HTTP 401: Bad credentials",
+  "masked_tail": "w528"
+}
+```
+
+Delegates to: `account.key.verify { validate: true }`. Read-only — fires no events.
+
+---
+
+#### `identity.self.unlink`
+
+Remove the agent's link to a provider account. The account record stays in the DB.
+
+```jsonc
+// Request  { "agent_id": "agentx", "provider": "github" }
+// Response { "unlinked": true }
+```
+
+Delegates to: `unlinkagentidentity { agent_id, provider }`
+
+Fires: `agentidentities:changed:<agent_id>`
+
+---
+
+### 5.2 `preset.*` — Memory Bundles
+
+The Trust Center calls these "Presets". Backend table: `db_memory_bundles`. The blank singleton (`is_blank: true`) cannot be mutated or deleted.
+
+#### `preset.list`
+
+List all presets — summary fields only, no instruction/context blobs.
+
+```jsonc
+// Request  {} (no params)
+// Response
+{
+  "presets": [
+    {
+      "id":          "abc-123",
+      "name":        "AgentX Default",
+      "provider":    "claude",
+      "model":       "claude-sonnet-4-6",
+      "description": "AgentX's standard preset",
+      "is_blank":    false,
+      "updated_at":  1751020800000
+    }
+  ]
+}
+```
+
+Delegates to: `listmemories`
+
+---
+
+#### `preset.get`
+
+Fetch a full preset (instructions, context_files, mcp_servers, skills) by `id` or `name`.
+
+```jsonc
+// Request  { "id": "abc-123" }   OR   { "name": "AgentX Default" }
+// Response — full Memory object (see db_memory_bundles schema in memory.md)
+```
+
+Delegates to: `getmemory { id }`. For `name` lookup: list + filter client-side (no name index on the table).
+
+---
+
+#### `preset.upsert`
+
+Create or update a preset. Omit `id` to create. Guards blank singleton.
+
+```jsonc
+// Request
+{
+  "id":            "abc-123",        // omit to create
+  "name":          "AgentX Default",
+  "provider":      "claude",
+  "model":         "claude-sonnet-4-6",
+  "description":   "...",
+  "instructions":  "You are AgentX ...",
+  "context_files": [],
+  "mcp_servers":   {},
+  "skills":        []
+}
+// Response — full updated Memory object
+```
+
+Delegates to: `upsertmemory`
+
+Fires: `memories:changed`
+
+---
+
+#### `preset.delete`
+
+Delete a preset by id. Rejects blank singleton.
+
+```jsonc
+// Request  { "id": "abc-123" }
+// Response { "deleted": true }
+```
+
+Delegates to: `deletememory { id }`
+
+Fires: `memories:changed`
+
+---
+
+#### `preset.self.get`
+
+Get the preset bound to the calling agent's current instance. Resolves via `memory_id` on `db_agent_instances`; returns the blank sentinel if unset.
+
+```jsonc
+// Request  { "agent_id": "agentx" }
+// Response — full Memory object
+```
+
+Delegates to: `getagentinstance` → `getmemory` on the resolved `memory_id`.
+
+---
+
+### 5.3 `memory.*` — Native Agent Memories
+
+These delegate directly to the existing `agent:memory:*` handlers in `native_memory_handlers.rs`. The storage is Claude Code's native memory directory: `~/.claude/projects/<sanitized-cwd>/memory/*.md`. All three commands already exist at the low-level RPC layer — these wrappers add (a) App API permission enforcement and (b) the `agent:memory:changed` event.
+
+#### `memory.list`
+
+List all memory files for the calling agent.
+
+```jsonc
+// Request  { "agent_id": "agentx" }
+// Response
+{
+  "files": [
+    {
+      "filename":      "user_preferences.md",
+      "is_index":      false,
+      "metadata_type": "feedback",   // from YAML frontmatter, null if absent
+      "size_bytes":    412,
+      "modified_at":   1751020800000
+    }
+  ]
+}
+```
+
+Delegates to: `agent:memory:list { agent_id }`
+
+---
+
+#### `memory.read`
+
+Read one memory file by filename. Filenames must be `[a-zA-Z0-9_-]+.md`.
+
+```jsonc
+// Request  { "agent_id": "agentx", "filename": "user_preferences.md" }
+// Response { "content": "---\nmetadata:\n  type: feedback\n---\n..." }
+```
+
+Delegates to: `agent:memory:read_file { agent_id, filename }`
+
+---
+
+#### `memory.write`
+
+Write (create or replace) a memory file atomically. Max 10 MiB. Filename rules same as `memory.read`.
+
+```jsonc
+// Request
+{
+  "agent_id": "agentx",
+  "filename": "user_preferences.md",
+  "content":  "---\nmetadata:\n  type: feedback\n---\nUser prefers terse responses."
+}
+// Response  {} (empty on success)
+```
+
+Delegates to: `agent:memory:write_file { agent_id, filename, content }`
+
+Fires: `agent:memory:changed:<agent_id>` (fire-and-forget, persist=0)
+
+---
+
+## 6. WPS Events
+
+| Command | Event | Scope | Persist |
+|---------|-------|-------|---------|
+| `identity.account.upsert` | `identityaccounts:changed` | global | 1 |
+| `identity.account.upsert` | `agentidentities:changed:<agent_id>` | scoped | 1 |
+| `identity.self.unlink` | `agentidentities:changed:<agent_id>` | scoped | 1 |
+| `preset.upsert` | `memories:changed` | global | 1 |
+| `preset.delete` | `memories:changed` | global | 1 |
+| `memory.write` | `agent:memory:changed:<agent_id>` | scoped | 0 |
+
+`agent:memory:changed:<agent_id>` is a new event type. Subscribe via `eventsub` with scope `<agent_id>` to receive live updates when memory files change. Persist=0 means fire-and-forget — missed events require a `memory.list` re-poll (cheap for small memory dirs).
+
+---
+
+## 7. Implementation Map
+
+| App API command | Existing handler(s) | New logic |
+|-----------------|--------------------|-----------| 
+| `identity.self.accounts` | `listagentidentities` + `getidentityaccount` per entry | Join results, mask secret tail |
+| `identity.account.upsert` | `account.key.verify` → `linkagentidentity` | Sequential, S1 scope check |
+| `identity.account.validate` | `account.key.verify { validate: true }` | Ad-hoc path skips write |
+| `identity.self.unlink` | `unlinkagentidentity` | Direct delegation |
+| `preset.list` | `listmemories` | Strip instruction/context blobs from response |
+| `preset.get` | `getmemory` | Add name-based lookup via list+filter |
+| `preset.upsert` | `upsertmemory` | Guard blank singleton |
+| `preset.delete` | `deletememory` | Guard blank singleton |
+| `preset.self.get` | `getagentinstance` → `getmemory` | Resolve memory_id FK |
+| `memory.list` | `agent:memory:list` | S1 scope check, emit no event |
+| `memory.read` | `agent:memory:read_file` | S1 scope check |
+| `memory.write` | `agent:memory:write_file` | S1 scope check, emit `agent:memory:changed` |
+
+All handlers register in `register_app_api_handlers` in `app_api.rs`.
+
+---
+
+## 8. Security Invariants
+
+**S1 — Agent-scoped writes only.** For any command with an `agent_id` field, the handler MUST compare it against `ctx.agent_id` (populated from `bus_agent_id` per OQ1). If they differ, return `FORBIDDEN`. This requires the one-time `RpcContext` extension described in §3 OQ1.
+
+**S2 — No secret enumeration.** `identity.self.accounts` returns `masked_tail` (last 4 chars), never the plaintext secret. Plaintext lives only in the OS keychain.
+
+**S3 — No cross-agent memory reads.** `memory.*` commands reject `agent_id` values that differ from `ctx.agent_id`. The memory directory path is derived from the agent's `working_directory` in `db_agent_definitions` — an agent cannot path-traverse into another agent's directory.
+
+**S4 — Blank preset singleton guard.** `preset.upsert` and `preset.delete` return `FORBIDDEN: cannot mutate the blank preset` when the target id is the `is_blank` singleton.
+
+**S5 — validate=true is non-destructive.** `identity.account.validate` never writes to keychain or DB. The only allowed side-effect is updating the `status` column on an existing account row when a probe succeeds and current status is `unknown`.
+
+**S6 — Memory filename validation.** `memory.read` and `memory.write` enforce the existing `validate_filename` check from `native_memory_handlers.rs`: stem must be `[a-zA-Z0-9_-]+`, extension must be `.md`, no path separators, max 200-char stem. This blocks path traversal at the App API layer before the low-level handler can be reached.
+
+---
+
+## 9. RpcContext Extension (prerequisite)
+
+`rpc_types.rs` — add one field to `RpcContext`:
+
+```rust
+pub struct RpcContext {
+    #[serde(default, skip_serializing_if = "String::is_empty", rename = "ctype")]
+    pub client_type: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub blockid: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub tabid: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub conn: String,
+    // NEW: slug of the authenticated agent (from bus:register), empty for non-agent connections
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub agent_id: String,
+}
+```
+
+`websocket.rs` — populate it when calling `set_rpc_context`:
+
+```rust
+engine.set_rpc_context(RpcContext {
+    client_type: ...,
+    blockid: block_id.clone(),
+    tabid: tab_id.clone(),
+    conn: String::new(),
+    agent_id: bus_agent_id.clone().unwrap_or_default(), // NEW
+});
+```
+
+No wire-format break: `skip_serializing_if = "String::is_empty"` means existing clients that don't send `agent_id` get an empty string, which the S1 check treats as "unauthenticated agent connection → reject agent-scoped write commands".
+
+---
+
+## 10. Phasing
+
+| Phase | Commands | Why first |
+|-------|----------|-----------|
+| **P0** | `RpcContext` extension | Prerequisite for S1 — must land before any identity/memory writes |
+| **P1** | `identity.account.upsert`, `identity.self.accounts`, `identity.account.validate` | Unblocks agents registering their own credentials |
+| **P2** | `identity.self.unlink`, `preset.list`, `preset.get`, `preset.upsert`, `preset.delete`, `preset.self.get` | Preset management — agents that self-configure |
+| **P3** | `memory.list`, `memory.read`, `memory.write` | Thin wrappers over existing handlers; low risk, high value for memory-aware agents |

--- a/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
+++ b/specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md
@@ -140,9 +140,11 @@ Create or update a credential account **and** link it to the calling agent for t
 ```
 
 Delegates (in order):
-1. `account.key.verify` — validates secret + stores in keychain
+1. `account.key.verify` — validates secret + stores in keychain (step 1 is non-atomic with respect to steps 2–3; see compensation note below)
 2. If the agent already has a link for `provider`: call `unlinkagentidentity { agent_id, provider }` to remove it (the App API handler must do this explicitly — `linkagentidentity` inserts, it does not replace)
 3. `linkagentidentity { agent_id, account_id, provider }` — creates the new link
+
+**Compensation:** If step 3 fails (e.g. DB write error), the secret is already in the OS keychain with no agent link. The handler MUST attempt to delete the orphaned keychain entry via the existing keychain-delete path. If that also fails, log a warning and return an error to the caller — the caller can retry, which will re-enter at step 1 and overwrite the orphaned entry. This is the same best-effort-cleanup pattern used by other two-phase writes in `identity_handlers.rs`.
 
 Fires: `identityaccounts:changed` (global) + `agentidentities:changed:<agent_id>`
 
@@ -244,7 +246,7 @@ Create or update a preset. Omit `id` to create. Guards blank singleton.
   "description":   "...",
   "instructions":  "You are AgentX ...",
   "context_files": [],
-  "mcp_servers":   {},
+  "mcp_servers":   [],
   "skills":        []
 }
 // Response — full updated Memory object
@@ -258,14 +260,14 @@ Fires: `memories:changed`
 
 #### `preset.delete`
 
-Delete a preset by id. Rejects blank singleton.
+Delete a preset by id. Rejects blank singleton and `seed-` prefixed bundles (see S4).
 
 ```jsonc
 // Request  { "id": "abc-123" }
 // Response { "deleted": true }
 ```
 
-Delegates to: `deletememory { id }`
+Delegates to: `deletememory { id }`. The handler must catch `StoreError::Other` from `bundle_memory_delete` and re-surface it as `FORBIDDEN: cannot delete a seeded bundle` (not a raw storage error string).
 
 Fires: `memories:changed`
 
@@ -280,7 +282,7 @@ Get the preset bound to the calling agent's current instance. Resolves via `memo
 // Response — full Memory object (is_blank: true when no preset is bound)
 ```
 
-Delegates to: `getagentinstance` → `getmemory` on the resolved `memory_id`. If `memory_id` is null, delegates to `listmemories` + filter `is_blank: true` to fetch the singleton.
+Delegates via: `instance_get_by_name(agent_id)` (storage layer — maps agent slug → `AgentInstance`) → read `memory_id` from the returned row → `getmemory { id: memory_id }`. `CommandGetAgentInstanceData` takes an instance UUID (`id: String`), not a slug, so the handler cannot call `getagentinstance` directly with the request's `agent_id`; `instance_get_by_name` is the correct intermediate. If `memory_id` is null, fall back to `listmemories` + filter `is_blank: true` to fetch the blank singleton.
 
 ---
 
@@ -349,14 +351,16 @@ Fires: `agent:memory:changed:<agent_id>` (fire-and-forget, persist=0) — emitte
 
 | Command | Event | Scope | Persist |
 |---------|-------|-------|---------|
-| `identity.account.upsert` | `identityaccounts:changed` | global | 1 |
-| `identity.account.upsert` | `agentidentities:changed:<agent_id>` | scoped | 1 |
-| `identity.self.unlink` | `agentidentities:changed:<agent_id>` | scoped | 1 |
-| `preset.upsert` | `memories:changed` | global | 1 |
-| `preset.delete` | `memories:changed` | global | 1 |
+| `identity.account.upsert` | `identityaccounts:changed` | global | 0 |
+| `identity.account.upsert` | `agentidentities:changed:<agent_id>` | scoped | 0 |
+| `identity.self.unlink` | `agentidentities:changed:<agent_id>` | scoped | 0 |
+| `preset.upsert` | `memories:changed` | global | 0 |
+| `preset.delete` | `memories:changed` | global | 0 |
 | `memory.write` | `agent:memory:changed:<agent_id>` | scoped | 0 |
 
-`agent:memory:changed:<agent_id>` is a new event type. Subscribe via `eventsub` with scope `<agent_id>` to receive live updates when memory files change. Persist=0 means fire-and-forget — missed events require a `memory.list` re-poll (cheap for small memory dirs).
+All events are `persist=0` (fire-and-forget), matching the existing pattern in `agent_handlers.rs`. Subscribers that miss an event due to reconnect must re-poll: `identity.self.accounts` for identity events, `preset.list` for preset events, `memory.list` for memory events.
+
+`agent:memory:changed:<agent_id>` is a new event type. Subscribe via `eventsub` with scope `<agent_id>` to receive live updates when memory files change.
 
 ---
 
@@ -370,9 +374,9 @@ Fires: `agent:memory:changed:<agent_id>` (fire-and-forget, persist=0) — emitte
 | `identity.self.unlink` | `unlinkagentidentity` | Direct delegation |
 | `preset.list` | `listmemories` | Strip instruction/context blobs from response |
 | `preset.get` | `getmemory` | Add name-based lookup via list+filter |
-| `preset.upsert` | `upsertmemory` | Guard blank singleton |
-| `preset.delete` | `deletememory` | Guard blank singleton |
-| `preset.self.get` | `getagentinstance` → `getmemory` | Resolve memory_id FK |
+| `preset.upsert` | `upsertmemory` | Guard blank singleton; strip `is_global` and `sort_order` from request before delegating (S4a) |
+| `preset.delete` | `deletememory` | Guard blank singleton + `seed-` prefix; catch `StoreError::Other` and re-surface as `FORBIDDEN` |
+| `preset.self.get` | `instance_get_by_name(agent_id)` → `getmemory` | `instance_get_by_name` maps agent slug → instance row → `memory_id`; `getagentinstance` takes a UUID and cannot be used directly |
 | `memory.list` | `agent:memory:list` | S1 scope check, emit no event |
 | `memory.read` | `agent:memory:read_file` | S1 scope check |
 | `memory.write` | `agent:memory:write_file` | S1 scope check, emit `agent:memory:changed` |
@@ -383,13 +387,19 @@ All handlers register in `register_app_api_handlers` in `app_api.rs`.
 
 ## 8. Security Invariants
 
-**S1 — Agent-scoped writes only.** For any command with an `agent_id` field, the handler MUST compare it against `ctx.agent_id` (populated from `bus_agent_id` per OQ1). If they differ, return `FORBIDDEN`. This requires the one-time `RpcContext` extension described in §3 OQ1.
+**S1 — Agent-scoped writes only.** For any command with an `agent_id` field, the handler MUST:
+1. Reject with `FORBIDDEN: unauthenticated agent connection` if `ctx.agent_id` is empty (i.e., the connection never sent `bus:register`; `unwrap_or_default()` in §9 leaves it `""`).
+2. Reject with `FORBIDDEN: agent_id mismatch` if `ctx.agent_id != request.agent_id`.
+
+Both checks are required. Checking only for equality is insufficient because `ctx.agent_id = ""` and `request.agent_id = ""` would pass the equality check, allowing an unauthenticated connection to call any agent-scoped command with an empty agent_id. This requires the one-time `RpcContext` extension described in §3 OQ1.
 
 **S2 — No secret enumeration.** `identity.self.accounts` returns `masked_tail` (last 4 chars), never the plaintext secret. Plaintext lives only in the OS keychain.
 
 **S3 — No cross-agent memory reads.** `memory.*` commands reject `agent_id` values that differ from `ctx.agent_id`. The memory directory path is derived from the agent's `working_directory` in `db_agent_definitions` — an agent cannot path-traverse into another agent's directory.
 
-**S4 — Blank preset singleton guard.** `preset.upsert` and `preset.delete` return `FORBIDDEN: cannot mutate the blank preset` when the target id is the `is_blank` singleton.
+**S4 — Blank preset and seeded-bundle guard.** `preset.upsert` and `preset.delete` return `FORBIDDEN: cannot mutate the blank preset` when the target id is the `is_blank` singleton. `preset.delete` additionally returns `FORBIDDEN: cannot delete a seeded bundle` when the target id starts with `seed-` — `bundle_memory_delete` rejects these at the storage layer (`memory_bundles.rs:194`); the App API wrapper must catch the `StoreError::Other` and re-surface it as a clean `FORBIDDEN` rather than a raw storage error string.
+
+**S4a — `is_global` and `sort_order` strip.** `preset.upsert` MUST strip `is_global` and `sort_order` from the caller-supplied payload before delegating to `upsertmemory`. `bundle_memory_upsert` passes `is_global = excluded.is_global` straight through (`memory_bundles.rs:156`), so an agent sending `"is_global": true` would elevate its preset to global-brain status, injecting its instructions into every other agent's context at launch. These fields are not part of the `preset.upsert` API surface and must be silently ignored (not rejected) to allow future callers to pass extra fields without breaking.
 
 **S5 — validate=true is minimally destructive.** `identity.account.validate` never writes a new keychain entry and never creates or deletes DB rows. The only permitted DB side-effect is updating the `status` column on an existing account row (when `account_id` is supplied and the probe result resolves a previously-`unknown` status). No write occurs for ad-hoc probes (no `account_id`).
 


### PR DESCRIPTION
## Summary

Implements the `identity.*`, `preset.*`, and `memory.*` App API namespaces per `SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md` (spec also included on this branch).

### What's in this PR

- **Spec** (`specs/SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md`) — full design doc for all three namespaces
- **12 RPC handlers** in `app_api.rs` — identity.self.accounts, identity.account.upsert, identity.account.validate, identity.self.unlink, preset.list/get/upsert/delete/self.get, memory.list/read/write
- **S1 auth gate** on all identity and memory handlers — `ctx.agent_id` non-empty + matches `req.agent_id`
- **Keychain + optional probe** — `identity.account.upsert` writes to OS keychain first, optionally calls `key_validator::validate`, then DB-upserts with compensation on failure for new accounts
- **S4a field strip** — `preset.upsert` strips caller-supplied `is_global` / `sort_order`
- **Seed guard** — `preset.delete` catches `StoreError::Other("seed...")` → FORBIDDEN
- **Blank-singleton two-step** — `preset.self.get` lists all bundles to find `is_blank=true` id, then fetches full object
- **CLAUDE_CONFIG_DIR fix** — `native_memory_handlers.rs` now resolves the memory root from the agent's stored env blob instead of hardcoding `~/.claude/projects`
- **Atomic write** — `memory.write` writes to a `.tmp` then renames, fires `agent:memory:changed:<agent_id>`
- **WPS events** — upsert/unlink/write each publish the right wave events

### Files changed

| File | Change |
|------|--------|
| `rpc_types.rs` | Added `agent_id: String` to `RpcContext`; 12 `COMMAND_*` constants |
| `websocket.rs` | Stamp `agent_id` into `RpcContext` on `bus:register` |
| `native_memory_handlers.rs` | Resolve `CLAUDE_CONFIG_DIR` from agent env blob; pub helpers |
| `app_api.rs` | 12 handler registration functions + `check_s1` helper (~650 LOC) |

## Test plan

- [ ] `cargo build -p agentmux-srv` — 0 errors ✅
- [ ] `identity.self.accounts` returns empty list for agent with no linked provider
- [ ] `identity.account.upsert` stores key in keychain, links provider, fires WPS events
- [ ] `identity.account.validate` probes a stored or ad-hoc key
- [ ] `identity.self.unlink` removes link, fires event only if a link existed
- [ ] `preset.list` returns summary-only fields (no instructions blob)
- [ ] `preset.get` by id and by name (most-recent-updated tie-break)
- [ ] `preset.upsert` rejects blank preset, strips `is_global`/`sort_order`
- [ ] `preset.delete` rejects blank/seed bundles with FORBIDDEN
- [ ] `preset.self.get` falls back to blank singleton when instance has no `memory_id`
- [ ] `memory.list/read/write` use `CLAUDE_CONFIG_DIR` from agent env (not `~/.claude`)
- [ ] S1 check rejects empty `agent_id` or mismatched caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agentx -->