### PR TITLE
feat(settings): responsive layout — phone strip to desktop

### DIFF
--- a/.changesets/1782586008-feat-settings-responsive-layout-from-phone-strip-to-desktop-yzqg.md
+++ b/.changesets/1782586008-feat-settings-responsive-layout-from-phone-strip-to-desktop-yzqg.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(settings): responsive layout from phone strip to desktop

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -390,6 +390,7 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
                     {(item) => (
                         <button
                             type="button"
+                            aria-label={item.label}
                             classList={{ "is-active": section() === item.id }}
                             aria-pressed={section() === item.id}
                             onClick={() => setSection(item.id)}

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -337,6 +337,7 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
     };
 
     return (
+        <div class="settings-view-container">
         <div class="settings-view">
             <nav class="settings-rail" aria-label="Settings section">
                 <For each={RAIL}>
@@ -400,6 +401,7 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
                     )}
                 </For>
             </nav>
+        </div>
         </div>
     );
 }

--- a/frontend/app/view/settings/settings-view.tsx
+++ b/frontend/app/view/settings/settings-view.tsx
@@ -385,6 +385,20 @@ export function SettingsView(props: ViewComponentProps<SettingsViewModel>): JSX.
                     </button>
                 </footer>
             </div>
+            <nav class="settings-tab-bar" aria-label="Settings section">
+                <For each={RAIL}>
+                    {(item) => (
+                        <button
+                            type="button"
+                            classList={{ "is-active": section() === item.id }}
+                            aria-pressed={section() === item.id}
+                            onClick={() => setSection(item.id)}
+                        >
+                            <i class={`fa-solid fa-${item.icon}`} aria-hidden="true" />
+                        </button>
+                    )}
+                </For>
+            </nav>
         </div>
     );
 }

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -6,6 +6,8 @@
     flex-direction: row;
     height: 100%;
     overflow: hidden;
+    container-type: inline-size;
+    container-name: settings;
 }
 
 // ── Left rail ─────────────────────────────────────────────────────────────────
@@ -297,5 +299,119 @@
     &:hover {
         opacity: 1;
         background: var(--panel-bg-alt, rgba(127, 127, 127, 0.08));
+    }
+}
+
+// ── Bottom tab bar (xs only) ──────────────────────────────────────────────────
+
+.settings-tab-bar {
+    display: none;
+    flex-direction: row;
+    align-items: stretch;
+    border-top: 1px solid var(--border-color);
+    background: var(--panel-bg-color, var(--main-bg-color));
+    flex-shrink: 0;
+    overflow-x: auto;
+
+    button {
+        flex: 1;
+        min-width: 40px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 8px 2px;
+        border: none;
+        border-top: 2px solid transparent;
+        background: transparent;
+        color: var(--main-text-color);
+        cursor: default;
+        opacity: 0.6;
+
+        i { font-size: 14px; }
+
+        &.is-active {
+            opacity: 1;
+            color: var(--accent-color);
+            border-top-color: var(--accent-color);
+        }
+
+        &:hover:not(.is-active) {
+            opacity: 0.85;
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+        }
+    }
+}
+
+// ── Responsive container queries ──────────────────────────────────────────────
+
+// lg: cap section body width for comfortable reading
+@container settings (min-width: 1024px) {
+    .settings-section-body {
+        max-width: 720px;
+    }
+}
+
+// sm: icon-only left rail (48px)
+@container settings (max-width: 767px) {
+    .settings-rail {
+        flex: 0 0 48px;
+        padding: 8px 4px;
+
+        span { display: none; }
+    }
+
+    .settings-rail-item {
+        justify-content: center;
+        padding: 10px 0;
+
+        i { width: auto; }
+    }
+}
+
+// xs: bottom tab bar, stacked rows, full-width controls
+@container settings (max-width: 479px) {
+    .settings-view {
+        flex-direction: column;
+    }
+
+    .settings-rail {
+        display: none;
+    }
+
+    .settings-tab-bar {
+        display: flex;
+    }
+
+    // Stack label above control
+    .setting-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 6px;
+    }
+
+    .setting-row-control {
+        align-self: stretch;
+    }
+
+    // Full-width controls
+    .setting-select {
+        width: 100%;
+        min-width: unset;
+    }
+
+    .setting-text {
+        width: 100%;
+    }
+
+    // Slider stretches to fill available space
+    .setting-slider {
+        width: 100%;
+
+        input[type="range"] {
+            flex: 1 1 auto;
+            width: auto;
+            min-width: 80px;
+        }
     }
 }

--- a/frontend/app/view/settings/settings.scss
+++ b/frontend/app/view/settings/settings.scss
@@ -1,13 +1,19 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+.settings-view-container {
+    width: 100%;
+    height: 100%;
+    container-type: inline-size;
+    container-name: settings;
+}
+
 .settings-view {
     display: flex;
     flex-direction: row;
+    width: 100%;
     height: 100%;
     overflow: hidden;
-    container-type: inline-size;
-    container-name: settings;
 }
 
 // ── Left rail ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

CSS container queries (measured at the **pane**, not the viewport) on the Settings pane. The tab bar is always in the DOM — CSS shows/hides it, zero JS changes.

- **xs (<480px):** 160px side rail hidden, bottom tab bar shown (icon-only); setting rows stack label-above-control; `select`/`input[type=text]` go `width: 100%`; slider stretches with `flex: 1 1 auto`
- **sm (480–767px):** rail compresses to 48px icon-only; rows stay side-by-side
- **lg (≥1024px):** section body `max-width: 720px` for comfortable reading

### Files changed
- `settings.scss` — `container-type: inline-size` + tab bar styles + container query breakpoints
- `settings-view.tsx` — adds `settings-tab-bar` nav after `.settings-body` (shown at xs via CSS)

<!-- agentmux:agent_id=smark -->