### PR TITLE
fix(wrr): gate last-window quit on HAD_VISIBLE_USER_WINDOW; tighten ActivityDock height

### DIFF
--- a/.changesets/1782586493-fix-wrr-gate-last-window-quit-on-had-visible-user-window-tig-jemq.md
+++ b/.changesets/1782586493-fix-wrr-gate-last-window-quit-on-had-visible-user-window-tig-jemq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(wrr): gate last-window quit on HAD_VISIBLE_USER_WINDOW; tighten ActivityDock height

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -286,18 +286,20 @@ unsafe fn maybe_quit_on_last_user_window() {
     if QUIT_INITIATED.load(SeqCst) {
         return;
     }
-    // "Have we ever had a real user window?" — gate primarily on the CEF
-    // registry: `main` registers as a `is_pool:false` top-level at startup and
-    // STAYS registered through the recycle-on-close (the browser is hidden, not
-    // destroyed; `on_before_close` never fires), so this is ≥1 at close time
-    // yet 0 during early startup before `main` registers — preventing a
-    // premature quit. `HAD_VISIBLE_USER_WINDOW` (armed when a user window is
-    // shown/created-visible) is kept as a belt-and-suspenders OR.
+    // Gate on whether a user window has EVER been shown — prevents a premature
+    // quit when a pool window fails during startup before the main window has
+    // loaded. `main` registers in CEF state (count_live_user_windows ≥ 1) at
+    // on_after_created time, which is BEFORE the main window is visible.
+    // Using `registered > 0` as the armed gate would fire quit when a pool
+    // window fails during that gap (main registered but not yet shown, visible=0).
+    // `HAD_VISIBLE_USER_WINDOW` is set only on EVENT_OBJECT_SHOW, so it stays
+    // false until the page actually loads and the host calls ShowWindow — the
+    // correct moment to arm the last-window quit.
     let registered = app_state()
         .get()
         .map(|s| s.count_live_user_windows())
         .unwrap_or(0);
-    let armed = registered > 0 || HAD_VISIBLE_USER_WINDOW.load(SeqCst);
+    let armed = HAD_VISIBLE_USER_WINDOW.load(SeqCst);
     if !armed {
         return;
     }

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -217,12 +217,11 @@
 
 .agent-activity-summary {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: var(--space-1);
-    padding: var(--space-1) var(--space-2);
+    padding: 2px var(--space-2);
     cursor: default;
     user-select: none;
-    min-height: 24px;
 
     &:hover { background: var(--hover-bg-color, rgba(255, 255, 255, 0.04)); }
 }
@@ -277,12 +276,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    // The summary row is `align-items: baseline` (so the text baselines line up);
-    // without this the taller button hangs off the text baseline. Center it in
-    // the row instead.
-    align-self: center;
-    min-width: 32px;
-    height: 32px;
+    align-self: stretch;
+    min-width: 28px;
     appearance: none;
     border: 1px solid transparent;
     background: transparent;


### PR DESCRIPTION
## Summary

- **Root cause of `task dev` never loading**: `maybe_quit_on_last_user_window` was armed by `registered > 0` (live CEF browser count), which rises when `on_after_created` fires for `main` (~200ms before `install_hooks` installs WinEventHooks). During startup, a pool window can fail with ERR_ABORTED on its fresh isolated Chromium profile. The resulting `EVENT_OBJECT_DESTROY` called the quit check with `registered=1, visible=0` → premature quit, killing the still-loading main window. Splash screen appeared but the dev window never finished loading.
- **Fix**: Gate the quit on `HAD_VISIBLE_USER_WINDOW` only. It's set on `EVENT_OBJECT_SHOW` (when the page loads and `ShowWindow` is called) — the correct moment to arm the quit path. Before the main window is shown, the gate stays disarmed even if pool windows fail.
- **ActivityDock height**: `align-items: center` on summary row (was `baseline`), `padding: 2px var(--space-2)` (was `var(--space-1)`), `align-self: stretch` on stop/dismiss buttons instead of fixed `height: 32px` + `align-self: center`, `min-width: 28px` (was 32px).

## Test plan

- [ ] `task dev` now loads the dev window after build (confirmed in this session — pool window `PoolWindowEntered` appears in log, frontend reaches `Init Bare Done`)
- [ ] Closing the dev window still quits the host cleanly (normal shutdown path: `HAD_VISIBLE_USER_WINDOW=true` after window shows, `visible=0` after close → quit)
- [ ] ActivityDock rows are visually tight — button height matches text row height

🤖 Generated with [Claude Code](https://claude.com/claude-code)