### PR TITLE
fix(floating-pane): drag broken on Linux after tearoff

### DIFF
--- a/.changesets/1782586628-fix-floating-pane-dragging-a-torn-off-floating-pane-is-broke-qd24.md
+++ b/.changesets/1782586628-fix-floating-pane-dragging-a-torn-off-floating-pane-is-broke-qd24.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): dragging a torn-off floating pane is broken on Linux — get_window_position returns {0,0} post-load

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1561,10 +1561,21 @@ wrap_task! {
 
     impl Task {
         fn execute(&self) {
-            let pos = get_window_on_ui(&self.state, &self.label).map(|w| {
+            // Primary: browser_view.window() — works on Windows and on non-Windows
+            // windows that haven't finished loading. On Linux/macOS the Views
+            // BrowserView loses its Window reference post-page-load, so
+            // browser_view.window() returns None. Fall back to state.windows,
+            // which is populated via on_window_created and stays valid for the
+            // lifetime of the window (same registry ResolveWindowAtCursorTask uses).
+            let pos = if let Some(w) = get_window_on_ui(&self.state, &self.label) {
                 let b = w.bounds();
-                (b.x, b.y)
-            });
+                Some((b.x, b.y))
+            } else if let Some(w) = self.state.windows.lock().get(&self.label) {
+                let b = w.bounds();
+                Some((b.x, b.y))
+            } else {
+                None
+            };
             // Capacity-1, freshly created per call → try_send never blocks
             // the UI thread.
             let _ = self.tx.try_send(pos);


### PR DESCRIPTION
## Root cause

On Linux, the JS-driven floating pane drag reads the window's current position before arming the drag loop (`get_window_position` IPC → `GetWindowPositionTask` on the UI thread). The task calls `get_window_on_ui()` → `browser_view.window()`, which returns `None` post-page-load on Linux (known CEF Views quirk: the BrowserView loses its Window reference after the first paint).

With no fallback, the IPC returns `{x:0, y:0}`. The frontend stores this as `jsDragInitWinX/Y = 0`, so every `set_window_position` call during mousemove sends `{x: 0+delta, y: 0+delta}` — snapping the floater to near screen-origin. The window disappears to the top-left.

Resize worked because Mutter handles edge-resize at the compositor level — no app IPC involved.

## Fix

`GetWindowPositionTask::execute` now falls back to `state.windows` if `get_window_on_ui()` returns `None`. `state.windows` is populated via `on_window_created` and stays valid for the window's lifetime — the same registry `ResolveWindowAtCursorTask` already uses correctly for floating-pane redocking.

```rust
// Before
let pos = get_window_on_ui(&self.state, &self.label).map(|w| {
    let b = w.bounds();
    (b.x, b.y)
});

// After
let pos = if let Some(w) = get_window_on_ui(&self.state, &self.label) {
    let b = w.bounds();
    Some((b.x, b.y))
} else if let Some(w) = self.state.windows.lock().get(&self.label) {
    let b = w.bounds();
    Some((b.x, b.y))
} else {
    None
};
```

## Testing

Tear off a pane → drag its header → floater follows cursor correctly. Resize still works. Windows unaffected (uses `GetWindowRect` directly, never reaches this path).

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-smike} -->