### PR TITLE
chore: release v0.49.6

### DIFF
--- a/.changesets/1782545678-fix-muxbus-use-fixed-port-9379-for-pkce-callback-listener-ayt2.md
+++ b/.changesets/1782545678-fix-muxbus-use-fixed-port-9379-for-pkce-callback-listener-ayt2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): use fixed port 9379 for PKCE callback listener

--- a/.changesets/1782546294-fix-blockframe-make-header-text-reactive-so-term-activity-up-tngw.md
+++ b/.changesets/1782546294-fix-blockframe-make-header-text-reactive-so-term-activity-up-tngw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(blockframe): make header text reactive so term:activity updates after mount

--- a/.changesets/1782546301-fix-host-panel-show-correct-devtools-port-and-host-badge-per-i1s7.md
+++ b/.changesets/1782546301-fix-host-panel-show-correct-devtools-port-and-host-badge-per-i1s7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(host-panel): show correct DevTools port and host badge per instance

--- a/.changesets/1782562498-fix-activity-summary-never-clear-haiku-label-flash-on-update-rhal.md
+++ b/.changesets/1782562498-fix-activity-summary-never-clear-haiku-label-flash-on-update-rhal.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(activity-summary): never clear haiku label; flash on update

--- a/.changesets/1782564419-fix-bang-cmd-auto-open-details-panel-and-expand-log-when-run-ar78.md
+++ b/.changesets/1782564419-fix-bang-cmd-auto-open-details-panel-and-expand-log-when-run-ar78.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bang-cmd): auto-open details panel and expand log when running bang commands

--- a/.changesets/1782565931-feat-statusbar-add-maintenance-section-to-instancepanel-9yie.md
+++ b/.changesets/1782565931-feat-statusbar-add-maintenance-section-to-instancepanel-9yie.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(statusbar): add Maintenance section to InstancePanel

--- a/.changesets/1782567520-fix-pool-remove-stale-windows-guard-from-spawn-pane-pool-win-il5e.md
+++ b/.changesets/1782567520-fix-pool-remove-stale-windows-guard-from-spawn-pane-pool-win-il5e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(pool): remove stale Windows guard from spawn_pane_pool_window

--- a/.changesets/1782567723-fix-ts-resolve-all-35-typescript-compiler-errors-missing-exp-zzba.md
+++ b/.changesets/1782567723-fix-ts-resolve-all-35-typescript-compiler-errors-missing-exp-zzba.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ts): resolve all 35 TypeScript compiler errors (missing exports, React type refs, rpcCall opts arg, implicit void returns, unsafe casts)

--- a/.changesets/1782567778-fix-agent-seed-term-zoom-from-ui-zoom-when-opening-agent-pan-5ulx.md
+++ b/.changesets/1782567778-fix-agent-seed-term-zoom-from-ui-zoom-when-opening-agent-pan-5ulx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): seed term:zoom from ui:zoom when opening agent pane — zoom level now persists across close/reopen

--- a/.changesets/1782567929-fix-dev-add-scripts-dev-agent-cmd-windows-bridge-for-agent-m-sue5.md
+++ b/.changesets/1782567929-fix-dev-add-scripts-dev-agent-cmd-windows-bridge-for-agent-m-sue5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dev): add scripts/dev-agent.cmd Windows bridge for agent MCP-Shell invocation of task dev

--- a/.changesets/1782571771-fix-bang-cmd-respect-user-collapse-in-activitylogpanel-fix-s-n7om.md
+++ b/.changesets/1782571771-fix-bang-cmd-respect-user-collapse-in-activitylogpanel-fix-s-n7om.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bang-cmd): respect user collapse in ActivityLogPanel; fix stale doc comment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.5"
+version = "0.49.6"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.49.5"
+version = "0.49.6"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.49.6 — 2026-06-27
+
+- fix(muxbus): use fixed port 9379 for PKCE callback listener
+- fix(blockframe): make header text reactive so term:activity updates after mount
+- fix(host-panel): show correct DevTools port and host badge per instance
+- fix(activity-summary): never clear haiku label; flash on update
+- fix(bang-cmd): auto-open details panel and expand log when running bang commands
+- feat(statusbar): add Maintenance section to InstancePanel
+- fix(pool): remove stale Windows guard from spawn_pane_pool_window
+- fix(ts): resolve all 35 TypeScript compiler errors (missing exports, React type refs, rpcCall opts arg, implicit void returns, unsafe casts)
+- fix(agent): seed term:zoom from ui:zoom when opening agent pane — zoom level now persists across close/reopen
+- fix(dev): add scripts/dev-agent.cmd Windows bridge for agent MCP-Shell invocation of task dev
+- fix(bang-cmd): respect user collapse in ActivityLogPanel; fix stale doc comment
+
+
 ## 0.49.5 — 2026-06-27
 
 - fix(browser-pane): black screen + mouse freeze on macOS when opening a browser pane

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.5",
+      "version": "0.49.6",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Release v0.49.6

Patch release consuming 11 pending changesets.

### Changes
- fix: muxbus use fixed port 9379 for pkce callback listener
- fix: blockframe make header text reactive so term activity updates
- fix: host panel show correct devtools port and host badge
- fix: activity summary never clear haiku label flash on update
- fix: bang cmd auto open details panel and expand log when run
- feat: statusbar add maintenance section to instancepanel
- fix: pool remove stale windows guard from spawn pane pool windows
- fix: resolve all 35 typescript compiler errors missing exports
- fix: agent seed term zoom from ui zoom when opening agent panel
- fix: dev add scripts/dev-agent.cmd windows bridge for agent mux
- fix: bang cmd respect user collapse in activitylogpanel

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-marks} -->