### PR TITLE
fix(agent-stream): show 'Rate limited…' and keep Working state live on 429 retry

### DIFF
--- a/.changesets/fix-working-stuck-rate-limit.md
+++ b/.changesets/fix-working-stuck-rate-limit.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-stream): show "Rate limited…" and clear Working... on 429 retry

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -751,6 +751,23 @@ export function update(
         }
 
         // ── Composer details / Log panel ──────────────────────────
+        case "ProviderWaiting": {
+            if (state.lastEventMs == null) return { state, events: [] };
+            const next: AgentPaneState = { ...state, lastEventMs: command.at };
+            if (next.turnPhase.kind === "Streaming") {
+                next.turnPhase = {
+                    ...next.turnPhase,
+                    lastEventMs: command.at,
+                    waitingReason: command.reason,
+                    retryAfterMs: command.retryAfterMs,
+                };
+            }
+            return {
+                state: next,
+                events: [{ type: "provider-waiting", reason: command.reason }],
+            };
+        }
+
         case "DetailsToggle": {
             return {
                 state: { ...state, detailsOpen: !state.detailsOpen },
@@ -797,6 +814,8 @@ function bumpEvent(
             ...next.turnPhase,
             lastEventMs: nowMs,
             toolsActive: Math.max(0, next.turnPhase.toolsActive + toolsDelta),
+            waitingReason: undefined,
+            retryAfterMs: undefined,
         };
     } else if (
         next.turnPhase.kind === "Submitting" ||

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -118,6 +118,10 @@ export type TurnPhase =
           bufferSize: number;
           toolsActive: number;
           lastEventMs: number;
+          /** Set when the provider is rate-limited and retrying. Cleared on next real activity. */
+          waitingReason?: "rate_limited";
+          /** Milliseconds until the next retry, from the provider's Retry-After header. */
+          retryAfterMs?: number | null;
       }
     | {
           kind: "Interrupting";
@@ -437,6 +441,15 @@ export type AgentPaneCommand =
      */
     | { type: "PendingMessageExpired"; id: string }
 
+    /**
+     * Provider is rate-limited (429) and waiting to retry. Updates
+     * `lastEventMs` (keeps the stuck-stream watchdog quiet) and sets
+     * `waitingReason` on `Streaming` so the working row can show
+     * "Rate limited — retrying…" instead of the thinking phrase.
+     * Cleared automatically on the next real activity (bumpEvent).
+     */
+    | { type: "ProviderWaiting"; reason: "rate_limited"; retryAfterMs: number | null; at: number }
+
     // ── Composer details / Log panel ─────────────────────────────
     /** Toggle the log panel open/closed. */
     | { type: "DetailsToggle" }
@@ -505,6 +518,7 @@ export type AgentPaneEvent =
     | { type: "tool-ended" }
     | { type: "tokens-updated"; input: number | null; output: number | null }
     | { type: "context-compacted"; tokensBefore: number; tokensAfter: number }
+    | { type: "provider-waiting"; reason: "rate_limited" }
     | { type: "stop-requested"; at: number }
     | { type: "stop-failed" }
     /**

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1104,6 +1104,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     currentToolArg={agentAtoms().currentToolArgAtom[0]()}
                     sessionStats={agentAtoms().sessionStatsAtom[0]()}
                     turnTokens={agentAtoms().turnTokensAtom[0]()}
+                    waitingReason={
+                        (() => {
+                            const phase = agentAtoms().turnPhaseAtom[0]();
+                            return phase.kind === "Streaming" ? (phase.waitingReason ?? null) : null;
+                        })()
+                    }
+                    retryAfterMs={
+                        (() => {
+                            const phase = agentAtoms().turnPhaseAtom[0]();
+                            return phase.kind === "Streaming" ? (phase.retryAfterMs ?? null) : null;
+                        })()
+                    }
                 />
             </Show>
 

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -57,6 +57,10 @@ interface AgentWorkingRowProps {
     currentToolArg?: string | null;
     sessionStats?: SessionStats | null;
     turnTokens?: TurnTokens | null;
+    /** Set when the provider is rate-limited; shows "Rate limited…" in place of thinking phrase. */
+    waitingReason?: "rate_limited" | null;
+    /** Milliseconds until next retry (from provider Retry-After). Shown when waitingReason is set. */
+    retryAfterMs?: number | null;
 }
 
 export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
@@ -145,6 +149,10 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
                 <span class="agent-working-row-left">
                     {props.stopping
                         ? "Stopping…"
+                        : props.waitingReason === "rate_limited"
+                            ? props.retryAfterMs != null
+                                ? `Rate limited — retrying in ${Math.ceil(props.retryAfterMs / 1000)}s`
+                                : "Rate limited — retrying…"
                         : props.currentTool
                             ? props.currentToolArg
                                 ? `${props.currentTool}  ·  ${abbreviateArg(props.currentToolArg, 40)}`

--- a/frontend/app/view/agent/providers/claude-translator.test.ts
+++ b/frontend/app/view/agent/providers/claude-translator.test.ts
@@ -24,7 +24,10 @@ describe("ClaudeTranslator", () => {
                 type: "assistant",
                 message: { content: [{ type: "text", text: "hello world" }] },
             });
-            expect(events).toHaveLength(0);
+            // Text is not duplicated (arrived via streaming deltas), but session_end IS
+            // emitted — text-only assistant message signals turn completion in persistent mode.
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("session_end");
         });
 
         it("skips thinking blocks in final assistant event", () => {
@@ -33,7 +36,9 @@ describe("ClaudeTranslator", () => {
                 type: "assistant",
                 message: { content: [{ type: "thinking", thinking: "let me think..." }] },
             });
-            expect(events).toHaveLength(0);
+            // Thinking is not duplicated, but session_end IS emitted (thinking-only = turn done).
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("session_end");
         });
 
         it("preserves tool_use blocks in final assistant event", () => {
@@ -337,13 +342,32 @@ describe("ClaudeTranslator", () => {
                 type: "assistant",
                 message: { content: [] },
             });
-            expect(events).toHaveLength(0);
+            // Empty content = no tool_use = turn end; session_end emitted for persistent mode.
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("session_end");
         });
 
         it("handles assistant with no message", () => {
             const t = new ClaudeTranslator();
             const events = t.translate({ type: "assistant" });
             expect(events).toHaveLength(0);
+        });
+
+        it("translates rate_limit_event to provider_waiting", () => {
+            const t = new ClaudeTranslator();
+            const events = t.translate({ type: "rate_limit_event", retry_after_ms: 30000 });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("provider_waiting");
+            expect((events[0] as any).reason).toBe("rate_limited");
+            expect((events[0] as any).retryAfterMs).toBe(30000);
+        });
+
+        it("translates rate_limit_event without retry_after_ms", () => {
+            const t = new ClaudeTranslator();
+            const events = t.translate({ type: "rate_limit_event" });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("provider_waiting");
+            expect((events[0] as any).retryAfterMs).toBeNull();
         });
 
         it("reset clears all state", () => {

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -57,6 +57,17 @@ export class ClaudeTranslator implements OutputTranslator {
             return this.handleUserMessage(rawEvent.message, rawEvent.tool_use_result);
         }
 
+        // Case 5: rate_limit_event — CLI is waiting on a 429, will retry
+        if (rawEvent.type === "rate_limit_event") {
+            return [{
+                type: "provider_waiting",
+                reason: "rate_limited" as const,
+                retryAfterMs: typeof rawEvent.retry_after_ms === "number"
+                    ? rawEvent.retry_after_ms
+                    : null,
+            }];
+        }
+
         // Case 5a: Top-level "result" event — session complete with stats
         if (rawEvent.type === "result") {
             const events: StreamEvent[] = [];
@@ -132,6 +143,7 @@ export class ClaudeTranslator implements OutputTranslator {
             "agent_message",
             "user_message",
             "session_end",
+            "provider_waiting",
         ];
         return streamTypes.includes(event.type);
     }

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -403,7 +403,15 @@ export type StreamEvent =
     | UserMessageEvent
     | SessionEndEvent
     | ErrorResultEvent
-    | PermissionRequestEvent;
+    | PermissionRequestEvent
+    | ProviderWaitingEvent;
+
+/** Provider is rate-limited and retrying. Updates lastEventMs; shows "Rate limited…" in working row. */
+export interface ProviderWaitingEvent {
+    type: "provider_waiting";
+    reason: "rate_limited";
+    retryAfterMs: number | null;
+}
 
 /** API error from a `type:"result"` line with is_error:true + api_error_status. */
 export interface ErrorResultEvent {

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -842,6 +842,18 @@ export function useAgentStream({
                         finalizeTurn(event.stats ?? null);
                         continue;
                     }
+                    // Provider is rate-limited and retrying. Keep lastEventMs
+                    // live (suppresses false "stream-stuck" watchdog) and surface
+                    // "Rate limited…" in the working row instead of a thinking phrase.
+                    if (event.type === "provider_waiting") {
+                        model.dispatchPane({
+                            type: "ProviderWaiting",
+                            reason: event.reason,
+                            retryAfterMs: event.retryAfterMs,
+                            at: Date.now(),
+                        });
+                        continue;
+                    }
                     // Track the currently-running tool for the status line.
                     // Per-tool subscription open/close was removed — a single
                     // per-block subscription installed on mount above handles


### PR DESCRIPTION
## Summary

When Claude CLI hits a 429 rate limit it enters a retry-backoff loop and emits `rate_limit_event` NDJSON lines. The translator previously dropped these silently — `lastEventMs` never updated, `turnPhase` stayed `Streaming`, and the working row kept showing the generic thinking phrase indefinitely. On a 60s backoff the user saw no indication that the agent was rate-limited vs. genuinely computing.

**Root cause:** `claude-translator.ts` had no case for `rate_limit_event`. Documented in `docs/retro/retro-busy-animation-stuck-on-429-2026-06-24.md`.

**Changes:**
- `claude-translator.ts`: translate `rate_limit_event` → `{ type: "provider_waiting", reason: "rate_limited", retryAfterMs }` StreamEvent
- `types.ts` (StreamEvent union): add `ProviderWaitingEvent` interface
- `types.ts` (AgentPaneState): add `ProviderWaiting` command; add `waitingReason?` / `retryAfterMs?` to `Streaming` TurnPhase
- `reducer.ts`: `ProviderWaiting` handler bumps `lastEventMs` + sets `waitingReason`; `bumpEvent` clears `waitingReason` when real activity resumes
- `useAgentStream.ts`: dispatch `ProviderWaiting` on `provider_waiting` events
- `AgentFooter.tsx` / `agent-view.tsx`: working row reads `waitingReason` and shows **"Rate limited — retrying in 60s"** (or "…" when no Retry-After) instead of the thinking phrase

**Also fixed:** 3 pre-existing test failures in `claude-translator.test.ts` — tests expected 0 events from text/thinking-only assistant messages, but since PR #1757 these emit `session_end`. Tests now assert the correct behavior.

## Test plan

- [ ] Tests pass: `npx vitest run frontend/app/view/agent/providers/claude-translator.test.ts frontend/app/store/agent-pane-state/`
- [ ] TypeScript: `npx tsc --noEmit` clean
- [ ] Manual: with a rate-limited account, submit a message — working row should show "Rate limited — retrying in Xs" during backoff, then revert to normal once output resumes
- [ ] Confirmed working row returns to normal thinking phrase when the next token/tool arrives (bumpEvent clears waitingReason)

<!-- agentmux:agent_id=agentx -->