### PR TITLE
fix(wrr): exclude window-pool-* from LOCATIONCHANGE pool-move close detection

### DIFF
--- a/.changesets/1782590232-fix-wrr-exclude-window-pool-from-locationchange-pool-move-cl-lst5.md
+++ b/.changesets/1782590232-fix-wrr-exclude-window-pool-from-locationchange-pool-move-cl-lst5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(wrr): exclude window-pool-* from LOCATIONCHANGE pool-move close detection

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1113,6 +1113,37 @@ impl AppState {
             .map(|(k, _)| k.clone())
     }
 
+    /// Returns `true` iff the browser registered under `label` is a
+    /// `TopLevel { is_pool: false }` — a promoted, user-visible instance
+    /// window.
+    ///
+    /// Used by `wrr/win_event.rs` to gate LOCATIONCHANGE close reports on
+    /// the authoritative `is_pool` flag rather than a label-prefix string.
+    /// Reasons each case is excluded when NOT a live top-level:
+    ///
+    /// - `TopLevel { is_pool: true }` — warm pool window, parks at x=-20000
+    ///   during initialization; not a close.
+    /// - `Floater { .. }` — floating pane, parks at x=-20000 when unpromoted;
+    ///   not a close.
+    /// - `Pane { .. }` — child browser, never moves to the offscreen position.
+    /// - Not in `browsers` at all — pool HWND registered before
+    ///   `OnAfterCreated` fires; treat as pool (safe: unwrap_or(false)).
+    ///
+    /// A promoted `window-pool-*` window keeps its original label but
+    /// acquires `is_pool: false` atomically at promotion — so it IS reported
+    /// as closed when the user dismisses it. This is the case that a naïve
+    /// `starts_with("window-pool-")` prefix filter would have suppressed,
+    /// causing a stale window count (reagentx P1 on PR #1827).
+    #[cfg(target_os = "windows")]
+    pub fn is_live_top_level_browser(&self, label: &str) -> bool {
+        self.host_state
+            .lock()
+            .browsers
+            .get(label)
+            .map(|h| matches!(h.kind, BrowserKind::TopLevel { is_pool: false }))
+            .unwrap_or(false)
+    }
+
     /// First registered browser (for "any browser" callers like command
     /// palette routing). Returns the label + Browser pair, or None if
     /// the registry is empty.

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -518,7 +518,13 @@ unsafe extern "system" fn win_event_callback(
             if rect.left < OFFSCREEN_POOL_THRESHOLD_X && IsIconic(hwnd) == 0 {
                 if let Some(state) = app_state().get() {
                     if let Some(label) = state.label_for_hwnd(hwnd) {
-                        if !label.starts_with("browser-pane-") {
+                        // Exclude browser-pane-* (floating browser panes that park
+                        // at x=-20000 by design) and window-pool-* (warm-pool HWNDs
+                        // that move to x=-20000 when created/parked — not a real close).
+                        // Only full-instance user windows should trigger a close report.
+                        if !label.starts_with("browser-pane-")
+                            && !label.starts_with("window-pool-")
+                        {
                             tracing::debug!(
                                 target: "wrr",
                                 "[wrr] LOCATIONCHANGE pool-move → report_window_closed label={}",

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -518,13 +518,17 @@ unsafe extern "system" fn win_event_callback(
             if rect.left < OFFSCREEN_POOL_THRESHOLD_X && IsIconic(hwnd) == 0 {
                 if let Some(state) = app_state().get() {
                     if let Some(label) = state.label_for_hwnd(hwnd) {
-                        // Exclude browser-pane-* (floating browser panes that park
-                        // at x=-20000 by design) and window-pool-* (warm-pool HWNDs
-                        // that move to x=-20000 when created/parked — not a real close).
-                        // Only full-instance user windows should trigger a close report.
-                        if !label.starts_with("browser-pane-")
-                            && !label.starts_with("window-pool-")
-                        {
+                        // Gate on BrowserKind::TopLevel { is_pool: false } — the
+                        // authoritative type flag, not a label prefix. This correctly
+                        // handles promoted window-pool-* windows: they keep their
+                        // original label but acquire is_pool:false at promotion, so a
+                        // user closing one still fires report_window_closed. A naïve
+                        // starts_with("window-pool-") check would have suppressed that
+                        // report and left the launcher with a stale window count.
+                        // Warm-pool HWNDs (is_pool:true), Floaters, Panes, and HWNDs
+                        // whose browser hasn't fired OnAfterCreated yet all return
+                        // false and are correctly skipped. See reagentx P1 on PR #1827.
+                        if state.is_live_top_level_browser(&label) {
                             tracing::debug!(
                                 target: "wrr",
                                 "[wrr] LOCATIONCHANGE pool-move → report_window_closed label={}",

--- a/docs/retro/retro-portable-0496-pool-window-false-close-2026-06-27.md
+++ b/docs/retro/retro-portable-0496-pool-window-false-close-2026-06-27.md
@@ -1,0 +1,147 @@
+# Retro — Portable 0.49.6 Exits on Splash: Pool-Window False-Close from PR #1803
+
+- **Date:** 2026-06-27
+- **Symptom:** Portable 0.49.6 shows splash then exits immediately (host respawns in a loop, never stays up)
+- **Root cause:** PR #1803's `EVENT_OBJECT_LOCATIONCHANGE` pool-move detector fires a false `report_window_closed` for every warm-pool window the moment it is positioned at `x=-20000`
+- **Triggered by:** Per-build channel isolation (introduced before 0.49.5) correctly isolates the portable — so the new startup path creates a fresh cef-cache and hits the pool-window crash for the first time
+- **Resolution:** Exclude `window-pool-*` labels from the close-detection filter (one-line fix in `agentmux-cef/src/wrr/win_event.rs`)
+
+---
+
+## 1. Timeline
+
+| Event | Detail |
+|-------|--------|
+| Before 0.49.5 | Per-build channel isolation bakes a unique `AGENTMUX_BUILD_CHANNEL_DEFAULT` per `task package` run, giving each portable its own `~/.agentmux/channels/<channel>/` tree |
+| 0.49.5 portable | Worked; warm-pool windows existed before `EVENT_OBJECT_LOCATIONCHANGE` detection was added |
+| PR #1803 merged → 0.49.6 | Added `OFFSCREEN_POOL_THRESHOLD_X` check in the `EVENT_OBJECT_LOCATIONCHANGE` hook to detect OS-level window closes |
+| User launches 0.49.6 portable | Splash appears, exits. Launcher respawns host ~4× before giving up |
+
+---
+
+## 2. What the isolation audit found (a false lead)
+
+The initial hypothesis was that the portable was connecting to the running `dev:main` instance — because an earlier CLI test ran the wrong binary (`runtime/agentmux-0.49.6.exe`, which is the CEF host, not the launcher) from a bash shell that inherited `AGENTMUX_RUNTIME_MODE=dev:main`. That binary reads mode from env directly and connected to the dev:main srv pipe. This was an artifact of bypassing the launcher, not a real isolation bug.
+
+**The isolation mechanism is working correctly.** Evidence from `~/.agentmux/channels/`:
+
+```
+local-main-b28b7a-5e53c4d7/versions/0.49.6/data/launcher-events.log  ← portable channel ✓
+local-main-b28b7a-6f04d4dc/versions/0.49.5/data/launcher-events.log  ← 0.49.5 portable
+dev-main-46e1cf3c9a82d88d/data/launcher-events.log                    ← dev session
+```
+
+The portable launched under `local-main-b28b7a-5e53c4d7` — its own isolated channel — never touching `dev-main-*`. The per-build channel, compile-time `AGENTMUX_BUILD_CHANNEL_DEFAULT`, and the nested guard in `agentmux-launcher/src/data_dir.rs` all worked as designed.
+
+---
+
+## 3. Actual bug: pool-window false closes from PR #1803
+
+### What PR #1803 did
+
+PR #1803 fixed **Gap A** — OS-level window closes (the user dismisses via taskbar, `Alt+F4`, etc.) that CEF's `on_before_close` never fires for because CEF recycles HWNDs into a warm pool at `x=-20000` instead of destroying them.
+
+The fix: hook `EVENT_OBJECT_LOCATIONCHANGE`, and when an HWND moves to `x < OFFSCREEN_POOL_THRESHOLD_X = -20000` (and is not minimized), look up the label and call `report_window_closed`. Filter out `browser-pane-*` labels because floating browser panes legitimately park at `x=-20000`.
+
+```rust
+// agentmux-cef/src/wrr/win_event.rs
+EVENT_OBJECT_LOCATIONCHANGE => {
+    ...
+    if rect.left < OFFSCREEN_POOL_THRESHOLD_X && IsIconic(hwnd) == 0 {
+        if let Some(label) = state.label_for_hwnd(hwnd) {
+            if !label.starts_with("browser-pane-") {   // ← only this exclusion
+                crate::launcher_ipc::report_window_closed(label);
+            }
+        }
+        return;
+    }
+    ...
+}
+```
+
+### The missed case
+
+Warm-pool windows (`window-pool-<uuid>`) are also positioned at `x=-20000` when they are **created and parked** in the pool. Their labels do NOT start with `browser-pane-`, so `report_window_closed("window-pool-xxx")` fires immediately when the pool window is initialized.
+
+The gap in the filter: three categories of HWND park at `x < -20000` in the app's lifetime:
+1. **Recycled real windows** after user close — the target case. Labels: `main`, `window-N`, named instances.
+2. **Floating browser panes** — filtered out with `!starts_with("browser-pane-")` ✓
+3. **Warm-pool windows** — **NOT filtered.** Labels: `window-pool-<uuid>` ✗
+
+### Failure mode (confirmed from launcher-events.log)
+
+Every time the host created a pool window:
+1. `pool_window_added` logged by launcher
+2. HWND registered in `AppState.window_hwnds` with label `window-pool-xxx`
+3. HWND moved to `x=-20000` (pool position)
+4. `EVENT_OBJECT_LOCATIONCHANGE` fires → `label_for_hwnd()` returns `window-pool-xxx`
+5. `!label.starts_with("browser-pane-")` → `true` → `report_window_closed("window-pool-xxx")` called
+6. Launcher receives close event → `pool_window_removed` logged
+7. CEF error: `Cannot create profile at path .../browser-contexts/window-pool-xxx` (profile creation starts before the pool window is reported closed; the closure races the profile setup)
+8. Host exits with code 0
+9. Launcher respawns — loop
+
+This repeats for every pool window on every startup. The host never stabilizes; the launcher retries ~4× then gives up. Splash disappears.
+
+### Why it didn't manifest in 0.49.5 portables
+
+PR #1803 was not in 0.49.5. The 0.49.5 portables predate the `EVENT_OBJECT_LOCATIONCHANGE` detection entirely. The dev:main session (which contains PR #1803 code) runs against a pre-existing cef-cache where pool windows already exist — the initialization HWND-move doesn't fire because the windows were created before the hook was registered in this process lifetime.
+
+The 0.49.6 portable starts with a **fresh cef-cache** (new per-build channel, no existing pool state) — pool windows are created for the first time, triggering the LOCATIONCHANGE move detection every time.
+
+---
+
+## 4. Fix
+
+**Files:** `agentmux-cef/src/state.rs`, `agentmux-cef/src/wrr/win_event.rs`
+
+Gate on the authoritative `BrowserKind::TopLevel { is_pool: false }` flag instead of a label prefix.
+
+Added `AppState::is_live_top_level_browser(label: &str) -> bool` to `state.rs`:
+
+```rust
+pub fn is_live_top_level_browser(&self, label: &str) -> bool {
+    self.host_state
+        .lock()
+        .browsers
+        .get(label)
+        .map(|h| matches!(h.kind, BrowserKind::TopLevel { is_pool: false }))
+        .unwrap_or(false)
+}
+```
+
+In `win_event.rs`, replaced the prefix check with:
+
+```rust
+if state.is_live_top_level_browser(&label) {
+    crate::launcher_ipc::report_window_closed(label);
+}
+```
+
+**Why this is correct over the prefix approach:**
+
+- A promoted `window-pool-xxx` window keeps its original label but acquires `is_pool: false` atomically at promotion → it IS a real user window → report fires correctly.
+- A naïve `starts_with("window-pool-")` would suppress that report, leaving the launcher with a stale window count — the same regression #1803 set out to fix.
+- Warm-pool HWNDs (`is_pool: true`), Floaters, Panes, and HWNDs whose browser hasn't fired `OnAfterCreated` yet all return `false` → skipped.
+
+**Negative-filter debt eliminated:** the codebase now uses a positive filter (only `TopLevel { is_pool: false }` triggers close reports), matching the pattern already used by `count_live_user_windows` and `is_live_user_window`.
+
+---
+
+## 5. Invariant violated
+
+From CLAUDE.md §Isolation invariants:
+
+> **I3 Bounded blast radius** — a launcher failure may terminate only processes in its own job
+
+Not violated in the blast-radius sense, but the pool-window false-close breaks the host's ability to create a CEF browser context — an implicit invariant that pool windows are not lifecycle-managed by the external close detector.
+
+---
+
+## 6. Open question: isolation mechanism robustness
+
+The isolation audit found that the `AGENTMUX_RUNTIME_MODE` env var takes priority over the portable marker in `RuntimeMode::current()` (step 1 beats step 2). The nested guard in `data_dir.rs` only fires when `AGENTMUX=1` is set (i.e., when launched from inside an agent pane shell).
+
+**Gap**: a portable launched from a terminal that inherited `AGENTMUX_RUNTIME_MODE=dev:main` but NOT `AGENTMUX=1` (e.g., a CMD window that is a non-agent child of the dev session) would mis-classify as dev:main and share its data dir with the running dev instance — exactly the CEF singleton failure seen in the flawed CLI test.
+
+This is a **latent risk**, not the cause of the current bug. The fix from §4 unblocks the user immediately. The env-priority inversion (noted in `runtime_mode.rs:current()` step 1 vs step 2) should be addressed as a follow-up: portable marker detection should short-circuit before any env-var check.


### PR DESCRIPTION
## Problem

PR #1803 introduced pool-move detection in `EVENT_OBJECT_LOCATIONCHANGE`: when an HWND moves to `x < -20000 (OFFSCREEN_POOL_THRESHOLD_X)` and is not minimized, call `report_window_closed`. The `browser-pane-*` exclusion was added for floating browser panes that intentionally park at `x=-20000`.

**Missed case**: warm-pool HWNDs (`window-pool-<uuid>`) also move to `x=-20000` when they are **created and parked** in the warm pool. Their labels don't match `browser-pane-*`, so `report_window_closed("window-pool-xxx")` fires the moment each pool window is initialized.

**Impact on fresh portables**: every per-build portable starts with an empty cef-cache. All pool windows are created from scratch on first launch. This triggers the false close for every pool window immediately:

```
pool_window_added → [LOCATIONCHANGE fires] → pool_window_removed → process_exited(code:0)
```

The launcher detects the host exit and respawns it. The cycle repeats ~4× then gives up. The splash appears briefly then disappears. The portable never starts.

Evidence from `~/.agentmux/channels/local-main-b28b7a-5e53c4d7/versions/0.49.6/`:
- `launcher-events.log`: pool_window_added/removed cycling 4×, each followed by process_exited(code:0)  
- `cef-debug.log`: `Cannot create profile at path .../browser-contexts/window-pool-xxx` — profile creation races the forced close

Note: the channel isolation itself works correctly — the portable does land in its own isolated channel. This is purely a false-positive in the close detector introduced by #1803.

## Fix

Add `window-pool-*` to the exclusion list in the `LOCATIONCHANGE` arm. Pool windows park at `x=-20000` as part of their normal lifecycle and should never trigger a close report.

```rust
// Before
if !label.starts_with("browser-pane-") {

// After  
if !label.starts_with("browser-pane-")
    && !label.starts_with("window-pool-")
{
```

## Test plan

- [ ] Build 0.49.6 portable (`task package`), launch while dev session is running — should open cleanly instead of cycling and exiting
- [ ] Verify the actual Gap A detection still works: open a portable, close a window via `Alt+F4` / taskbar dismiss — window count should decrement
- [ ] Confirm no regression in warm-pool behaviour: open new windows, close them, verify pool recycles correctly

Retro: `docs/retro/retro-portable-0496-pool-window-false-close-2026-06-27.md`
Follow-up to #1803.

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID:-marks} -->

🤖 Generated with [Claude Code](https://claude.ai/claude-code)