### PR TITLE
feat(layout): column dissolve — minimize all panes to slip into adjacent column

### DIFF
--- a/.changesets/1782683000-fix-column-dissolve-bugs-ee05.md
+++ b/.changesets/1782683000-fix-column-dissolve-bugs-ee05.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+fix(layout): correct 6 P1 bugs in column dissolve — rollback guards, allCollapsed cascade, size budget, and slip-anchor teardown

--- a/.changesets/1782683000-fix-column-dissolve-bugs-ee05.md
+++ b/.changesets/1782683000-fix-column-dissolve-bugs-ee05.md
@@ -1,4 +1,4 @@
 ---
-type: patch
+type: minor
 ---
 fix(layout): correct 6 P1 bugs in column dissolve — rollback guards, allCollapsed cascade, size budget, and slip-anchor teardown

--- a/docs/specs/SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md
+++ b/docs/specs/SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md
@@ -1,0 +1,306 @@
+# SPEC — Pane Minimize: Column Dissolve on Full-Column Collapse
+
+**Date:** 2026-06-27
+**Status:** Proposed
+**Builds on:** SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md
+
+---
+
+## Problem
+
+When all panes in a column are individually minimized, the column does not dissolve —
+it stays in the layout as a narrow strip of stacked header bars. The user's intent when
+collapsing every pane in a column is to reclaim that column's width for adjacent content.
+
+### Current behavior
+
+```
+root (Row)
+├── colA (Column, width=400px)        ← colA stays, just 2 header bars tall
+│   ├── pane1 (minimized, 33px tall)
+│   └── pane2 (minimized, 33px tall)
+└── colB (Column, width=600px)
+    └── pane3 (normal)
+```
+
+### Desired behavior
+
+When pane2 is minimized (making colA fully collapsed), colA dissolves:
+its headers slip to the top of colB, and colA's 400 px of width is given to colB.
+
+```
+root (Row, _slipAnchor)
+└── colB (Column, width=1000px)
+    ├── pane1 (minimized header, 33px)
+    ├── pane2 (minimized header, 33px)
+    └── pane3 (normal, fills remainder)
+```
+
+### Cascading
+
+This keeps going: if the user then minimizes pane3, colB becomes fully collapsed and
+(if there is a further adjacent column) dissolves in turn. When there is only one
+column left, all panes inside it are in the normal minimized state — no further
+dissolve is possible (no adjacent column to accept them).
+
+---
+
+## Definitions
+
+| Term | Meaning |
+|---|---|
+| **Full collapse** | Every leaf child of a Column node has `minimizedSize !== undefined` |
+| **Column dissolve** | The full-collapse action that moves a Column's minimized headers into an adjacent column and removes the Column from its Row |
+| **columnDissolve** | New field on `LayoutNode` that stores restore context for a dissolved column |
+
+---
+
+## Data model change
+
+Add to `LayoutNode` in `frontend/layout/lib/types.ts`:
+
+```typescript
+/**
+ * Present when this Column node was dissolved because all its children became
+ * minimized. The column was removed from the root Row and re-inserted as a
+ * child of `targetColumnId`. Stores restore context.
+ *
+ * Invariants:
+ *   - Never coexists with `minimizedSize` or `slipMinimize` (those are leaf-only).
+ *   - Only set on branch (Column) nodes.
+ *   - The column's children retain their individual `minimizedSize` values.
+ */
+columnDissolve?: {
+    /** ID of the Column this branch was inserted into. */
+    targetColumnId: string;
+    /** Original width (Row-slot size) before dissolve. */
+    originalRowSize: number;
+    /** Original index in the root Row's children array. */
+    originalRowIndex: number;
+};
+```
+
+The existing `_slipAnchor` field on the root Row continues to serve the same role:
+preventing `balanceNode` from hoisting when the Row has exactly one child.
+
+---
+
+## Trigger condition
+
+Inside `minimizeNodeToggle`, after the normal Column-parent collapse is applied to
+the node, check:
+
+```typescript
+const parentNode = findParent(model.treeState.rootNode, nodeId);
+if (parentNode?.flexDirection === FlexDirection.Column) {
+    // Just collapsed nodeId. Check if the column is now fully minimized.
+    const allMinimized = parentNode.children!.every(
+        (c) => c.minimizedSize !== undefined || c.slipMinimize !== undefined
+    );
+    if (allMinimized) {
+        _dissolveColumn(model, parentNode, addlProps, gapSizePx);
+    }
+}
+```
+
+The dissolve check runs **after** the normal collapse so that `node.minimizedSize` is
+already set when we evaluate `allMinimized`.
+
+---
+
+## Dissolve algorithm (`_dissolveColumn`)
+
+```
+function _dissolveColumn(model, colNode, addlProps, gapSizePx):
+
+1.  Find colNode's parent (must be a Row — the root Row or an intermediate Row).
+    If no Row parent, bail (column is the root — no dissolve possible).
+
+2.  Find the adjacent sibling in the Row (right-neighbor preferred, else left).
+    If none exists, bail (only child of Row — nothing to dissolve into).
+
+3.  Compute total header height for colNode in the TARGET column's flex-unit space:
+        headerCount  = colNode.children.length
+        totalPx      = headerCount × (HeaderHeightPx + gapSizePx)
+        colRatio     = target's pixelToSizeRatio (from addlProps)
+        headerUnits  = totalPx × colRatio
+    If colRatio is unavailable, bail (same guard as _slipMinimize).
+
+4.  Ensure target has children (convert leaf to Column via addIntermediateNode if
+    needed — same as _slipMinimize's targetWasLeaf path).
+
+5.  Steal space from target's first child so the target's total size is unchanged:
+        firstChild.size = max(firstChild.size - headerUnits, headerInColUnits_min)
+    where headerInColUnits_min = (HeaderHeightPx + gapSizePx) × colRatio.
+
+6.  Record restore context on colNode:
+        colNode.columnDissolve = {
+            targetColumnId: target.id,
+            originalRowSize: colNode.size,
+            originalRowIndex: nodeIdx,
+        }
+
+7.  Give colNode's Row-slot width to the sibling:
+        target.size += colNode.size
+
+8.  Remove colNode from the Row:
+        rowNode.children.splice(nodeIdx, 1)
+
+9.  Set _slipAnchor on rowNode (prevents balanceNode hoist):
+        rowNode._slipAnchor = true
+
+10. Insert colNode at the TOP of target's children:
+        colNode.size = headerUnits
+        target.children.unshift(colNode)
+
+11. Call _finishToggle for each child of colNode:
+    No — individual children are already in minimizedNodeIds.
+    No additional _finishToggle call needed; the dissolved column is not itself
+    a "minimized node" in the sense of minimizedNodeIds (it's a branch, not a leaf).
+    The column's collapse is observable through columnDissolve being set.
+```
+
+---
+
+## Restore algorithm
+
+### Trigger
+
+Restoring any individual pane that lives inside a dissolved column should first
+undissolve the column, then apply the normal pane restore.
+
+In `minimizeNodeToggle`, at the top of the function, before any other path:
+
+```typescript
+// Check if node is inside a dissolved column.
+const parent = findParent(model.treeState.rootNode, nodeId);
+if (parent?.columnDissolve !== undefined) {
+    _undissolveColumn(model, parent, addlProps);
+    // Fall through to normal restore for nodeId.
+}
+```
+
+### Undissolve algorithm (`_undissolveColumn`)
+
+```
+function _undissolveColumn(model, colNode, addlProps):
+
+1.  Read colNode.columnDissolve:
+        { targetColumnId, originalRowSize, originalRowIndex }
+
+2.  Find targetCol by id. If not found, log warning and clear columnDissolve; return.
+
+3.  Remove colNode from targetCol.children:
+        idx = targetCol.children.findIndex(c => c.id === colNode.id)
+        reclaimUnits = colNode.size
+        targetCol.children.splice(idx, 1)
+        neighbor = targetCol.children[idx] ?? targetCol.children[idx-1]
+        if (neighbor) neighbor.size += reclaimUnits
+
+4.  Shrink targetCol back by originalRowSize:
+        targetCol.size = max(targetCol.size - originalRowSize, 1)
+
+5.  Find the Row that owns targetCol (same as findParent(root, targetColumnId)).
+    If found and it has children:
+        colNode.size = originalRowSize
+        colNode.columnDissolve = undefined
+        rowNode._slipAnchor = undefined
+        clampedIdx = min(originalRowIndex, rowNode.children.length)
+        rowNode.children.splice(clampedIdx, 0, colNode)
+
+6.  After undissolve, colNode's children all retain their minimizedSize — the column
+    is back in the layout but still fully collapsed (all panes are header-height bars).
+    The user can then individually restore each pane.
+```
+
+---
+
+## `rebuildMinimizedSet` — include dissolved columns
+
+`rebuildMinimizedSet` currently walks nodes and adds IDs where `minimizedSize !== undefined || slipMinimize !== undefined`. No change needed for the column case: the branch node itself is not added to `minimizedNodeIds` (it's not a leaf). Individual leaf children still have their `minimizedSize` and will be included.
+
+However, `rebuildMinimizedSet` must also restore `_slipAnchor` on the parent Row
+when it encounters a branch node with `columnDissolve` set:
+
+```typescript
+function walk(node: LayoutNode) {
+    if (node.minimizedSize !== undefined || node.slipMinimize !== undefined) ids.add(node.id);
+    if (node.columnDissolve !== undefined) {
+        // The Row that owns the target column must have _slipAnchor re-applied.
+        const targetCol = findNode(root, node.columnDissolve.targetColumnId);
+        const targetRow = findParent(root, node.columnDissolve.targetColumnId);
+        if (targetRow) targetRow._slipAnchor = true;
+    }
+    node.children?.forEach(walk);
+}
+```
+
+---
+
+## Edge cases
+
+| Scenario | Handling |
+|---|---|
+| Only one Column child in the Row (no sibling to accept the dissolve) | Bail silently — no dissolve. The column stays as stacked header bars. The minimize action still completes normally for the individual pane. |
+| Multiple columns dissolve into the same target | Each inserts at target's `children[0]` in sequence. Last dissolved column ends up at the visual top. Order of dissolve = insertion order. |
+| Target column is itself fully minimized (all its leaves have `minimizedSize`) | Dissolve proceeds normally — the dissolved branch is still prepended to the target's children. The target column's leaves remain minimized. No cascade of the target is triggered (the target itself was not just minimized). |
+| Target column has `columnDissolve` set (it's already dissolved into a further column) | This is a degenerate case — the "target" is currently a child of another column. Dissolve bails: do not dissolve into a node that is itself dissolved. Log a warning. |
+| Restore when `targetColumnId` no longer exists | Clear `columnDissolve`, log warning, return. The pane will be stuck as minimized within a column that has no restore context. The user can still restore individual panes manually. |
+| Column with a single pane becomes fully minimized | Same path — `allMinimized` fires after that one pane collapses. The column dissolves as normal. |
+| User restores pane inside dissolved column before undissolve | `_undissolveColumn` runs first, column is re-inserted into the Row, then normal restore proceeds. The other panes in the column remain minimized. |
+
+---
+
+## Visual result — step by step
+
+**Start:** 3 columns, A (2 panes), B (1 pane), C (1 pane).
+
+```
+root (Row)
+├── colA (Column)  ←→ pane1, pane2
+├── colB (Column)  ←→ pane3
+└── colC (Column)  ←→ pane4
+```
+
+1. Minimize pane1 → normal column collapse. pane1 = header, pane2 grows.
+2. Minimize pane2 → normal collapse, then `allMinimized` fires. colA dissolves into colB.
+   - Layout: `root(Row)[colB(Column)[colA(headers), pane3], colC]`
+   - Visually: colB shows pane1 header, pane2 header, pane3. colC unchanged.
+3. Minimize pane3 → normal column collapse. pane3 = header. colB now fully minimized → dissolve into colC.
+   - Layout: `root(Row)[colC(Column)[colB(Column[colA(headers), pane3-header]), pane4]]`
+   - Visually: colC shows pane1 header, pane2 header, pane3 header, pane4.
+4. Result: one visible column (colC) with all minimized headers stacked above pane4. ✓
+
+**Restore pane2** (from step 3 state):
+1. pane2 is inside colA, which has `columnDissolve` (nested inside colB, which is inside colC).
+   - First: undissolve colB (re-inserts into root Row at its original index; colA is still inside colB as a dissolved branch).
+   - Then: detect pane2's parent (colA) has `columnDissolve`.
+   - Undissolve colA (re-inserts colA into the Row or wherever colB was? — actually colA is inside colB.children so it's removed from colB and re-inserted into the Row per colA's originalRowIndex).
+   - Then: normal pane2 restore within colA.
+
+---
+
+## Interaction with balanceNode
+
+`balanceNode` currently respects `_slipAnchor`. No additional changes needed — the
+dissolve sets `_slipAnchor` on the parent Row, same as the existing slip path.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `frontend/layout/lib/types.ts` | Add `columnDissolve` field to `LayoutNode` |
+| `frontend/layout/lib/layoutMinimize.ts` | Add `_dissolveColumn`, `_undissolveColumn`; trigger dissolve check after normal column collapse; check for dissolved parent at top of `minimizeNodeToggle`; extend `rebuildMinimizedSet` to restore `_slipAnchor` on dissolved column's owner |
+| `frontend/layout/lib/layoutNode.ts` | No change — `findNode`, `findParent`, `addIntermediateNode` reused as-is |
+| `frontend/app/block/blockframe.tsx` | No change — minimize button and caret behavior unchanged |
+
+---
+
+## Out of scope
+
+- Animated transition (headers sliding from old column to new position).
+- A "restore whole column" affordance on the dissolved column block — individual pane restore triggers undissolve implicitly.
+- Dissolving a column into a floating (torn-off) window's column.
+- Dissolving nested intermediate rows (non-root Row parents) — spec assumes root Row as the parent of top-level columns. The `findParent` guard catches non-root cases and bails.

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -308,7 +308,7 @@ function _dissolveColumn(
         console.warn("[layoutMinimize] dissolve: cannot determine column ratio, skipping");
         if (targetWasLeaf) {
             const only = sibling.children?.[0];
-            if (only?.data) {
+            if (only) {
                 sibling.data = only.data;
                 sibling.children = undefined;
                 sibling.flexDirection = FlexDirection.Row;
@@ -317,14 +317,23 @@ function _dissolveColumn(
         return false;
     }
 
-    // One header per leaf child.
-    const leafCount = colNode.children!.length;
+    // One header per leaf child — count recursively: a dissolved sub-column
+    // (with columnDissolve set) represents multiple collapsed headers and should
+    // count as its children.length, not 1, so cascade dissolve heights are correct.
+    const leafCount = colNode.children!.reduce((sum, c) =>
+        sum + (c.columnDissolve !== undefined && c.children ? c.children.length : 1), 0);
     const totalHeaderUnits = leafCount * (HeaderHeightPx + gapSizePx) * colRatio;
 
     // Steal from sibling's first child so sibling's total flex-size stays constant.
+    // Track actualStolen separately: if firstChild.size is clamped to the floor,
+    // less than totalHeaderUnits is stolen, so colNode.size must reflect that.
     const firstChild = sibling.children![0];
+    let actualStolen = totalHeaderUnits;
     if (firstChild) {
-        firstChild.size = Math.max(firstChild.size - totalHeaderUnits, (HeaderHeightPx + gapSizePx) * colRatio);
+        const floorUnits = (HeaderHeightPx + gapSizePx) * colRatio;
+        const prevSize = firstChild.size;
+        firstChild.size = Math.max(firstChild.size - totalHeaderUnits, floorUnits);
+        actualStolen = prevSize - firstChild.size;
     }
 
     // Record dissolve context.
@@ -341,7 +350,9 @@ function _dissolveColumn(
     rowNode._slipAnchor = true;
 
     // Insert the dissolved column branch at the top of the sibling column.
-    colNode.size = totalHeaderUnits;
+    // Use actualStolen (not totalHeaderUnits) to keep the size budget honest
+    // when firstChild.size was clamped to the floor value.
+    colNode.size = actualStolen;
     sibling.children!.unshift(colNode);
 
     return true;
@@ -357,13 +368,15 @@ function _dissolveColumn(
  */
 function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
     const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = colNode.columnDissolve!;
-    colNode.columnDissolve = undefined;
 
     const targetCol = findNode(model.treeState.rootNode, targetColumnId);
     if (!targetCol?.children) {
         console.warn(`[layoutMinimize] undissolve: target column ${targetColumnId} not found`);
         return;
     }
+    // Clear dissolve context only after confirming targetCol exists — clearing
+    // it before the check would permanently lose restore context on a missing target.
+    colNode.columnDissolve = undefined;
 
     // Remove colNode from the host column; give its height back to the neighbor.
     const slipIdx = targetCol.children.findIndex((c) => c.id === colNode.id);
@@ -377,7 +390,7 @@ function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
     // If the target was originally a leaf that got wrapped, unwrap it.
     if (targetWasLeaf && targetCol.children.length === 1) {
         const only = targetCol.children[0];
-        if (only.data && !only.children) {
+        if (!only.children) {
             targetCol.data = only.data;
             targetCol.children = undefined;
             targetCol.flexDirection = FlexDirection.Row;
@@ -391,7 +404,13 @@ function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
     const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
     if (rowNode.children) {
         colNode.size = originalRowSize;
-        rowNode._slipAnchor = undefined;
+        // Only clear _slipAnchor if no remaining sibling has a concurrent slipMinimize
+        // that also depends on it — undissolving one column must not remove an anchor
+        // that a slip-minimized pane on the same row still needs.
+        const stillNeedsAnchor = rowNode.children.some((c) => c.slipMinimize !== undefined);
+        if (!stillNeedsAnchor) {
+            rowNode._slipAnchor = undefined;
+        }
         const idx = Math.min(originalRowIndex, rowNode.children.length);
         rowNode.children.splice(idx, 0, colNode);
     }

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -359,6 +359,22 @@ function _dissolveColumn(
 }
 
 /**
+ * Walk up the ancestor chain from `nodeId` and return the first ancestor whose
+ * `flexDirection` is `FlexDirection.Row`.  Returns `undefined` if none is found
+ * (e.g. the node is already at the root level with no Row ancestor).
+ *
+ * Used by `_undissolveColumn` to locate the correct Row insertion point in
+ * cascade-dissolve scenarios where the host column is itself nested inside
+ * another dissolved column.
+ */
+function _findRowAncestor(root: LayoutNode, nodeId: string): LayoutNode | undefined {
+    const parent = findParent(root, nodeId);
+    if (!parent) return undefined;
+    if (parent.flexDirection === FlexDirection.Row) return parent;
+    return _findRowAncestor(root, parent.id);
+}
+
+/**
  * Restore a dissolved column to its original Row slot.
  *
  * Removes `colNode` from its host column, shrinks the host back by the original
@@ -401,7 +417,13 @@ function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
     targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
 
     // Re-insert colNode into the Row at its original index.
-    const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
+    // IMPORTANT: In a cascade-dissolve scenario, targetCol may itself be
+    // nested inside another column (dissolved into a third column).
+    // findParent(root, targetColumnId) would return that outer column rather
+    // than the Row — causing colNode to be spliced in as a Column-in-Column
+    // instead of going back to its Row slot. We must walk up the ancestor
+    // chain from targetCol until we reach a Row-direction node.
+    const rowNode = _findRowAncestor(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
     if (rowNode.children) {
         colNode.size = originalRowSize;
         // Only clear _slipAnchor if no remaining sibling has a concurrent slipMinimize

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -100,8 +100,32 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
     // undissolves the parent column (returns it to its Row slot), then falls through
     // to the normal restore path so both the undissolve and the individual pane
     // restore happen in a single click.
+    //
+    // In a cascade (A→B→C, 3-deep): colA dissolves into colB, then colB dissolves
+    // into colC. When the user restores a pane in colA, the immediate parent (colA)
+    // has columnDissolve set, but colA's targetColumnId (colB) is itself still
+    // dissolved inside colC. We must undissolve ancestor columns from outermost to
+    // innermost before undissolving the immediate parent, otherwise _undissolveColumn
+    // cannot find the correct Row insertion point and colB.size underflows.
     const parentForDissolveCheck = findParent(model.treeState.rootNode, nodeId);
     if (parentForDissolveCheck?.columnDissolve !== undefined) {
+        // Collect all dissolved ancestors of parentForDissolveCheck from innermost
+        // to outermost by walking up via the columnDissolve.targetColumnId chain.
+        const dissolvedAncestors: LayoutNode[] = [];
+        let cursor: LayoutNode | undefined = parentForDissolveCheck;
+        while (cursor?.columnDissolve !== undefined) {
+            const targetCol = findNode(model.treeState.rootNode, cursor.columnDissolve.targetColumnId);
+            if (targetCol?.columnDissolve !== undefined) {
+                dissolvedAncestors.push(targetCol);
+            }
+            cursor = targetCol;
+        }
+        // Undissolve from outermost to innermost so each column is returned to its
+        // Row slot before its inner neighbour tries to use it as an insertion target.
+        for (const ancestor of dissolvedAncestors.reverse()) {
+            _undissolveColumn(model, ancestor);
+        }
+        // Now undissolve the immediate parent of the clicked pane.
         _undissolveColumn(model, parentForDissolveCheck);
         // Fall through — node still has minimizedSize set; normal restore runs below.
     }

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -13,20 +13,28 @@ export const HeaderHeightPx = 33;
 /**
  * Toggle minimize for a given leaf node.
  *
- * There are two minimize paths depending on the node's parent flex direction:
+ * There are three minimize paths:
  *
  * **Column parent (normal path):** The node collapses vertically to its header bar.
  * Freed space is given to the adjacent sibling. `node.minimizedSize` stores the
- * original height for restore.
+ * original height for restore. After collapsing, if ALL children of the parent
+ * column are now minimized, the column itself dissolves (see below).
  *
  * **Row parent (slip path):** Shrinking the node's Row-slot size would make it
  * horizontally narrow (thin strip) rather than vertically collapsed. Instead the
  * pane "slips" its header to the top of the nearest adjacent column, giving its
  * full width to that column. `node.slipMinimize` stores restore context.
  *
+ * **Column dissolve:** When every leaf in a Column is minimized, the column is
+ * pulled out of the root Row and re-inserted as a branch at the top of the adjacent
+ * column. The column's Row-slot width is given to that adjacent column. On restore,
+ * clicking any child's minimize button undissolves the column first, returning it to
+ * its original Row position with all children still minimized. `colNode.columnDissolve`
+ * stores restore context.
+ *
  * ### balanceNode and the _slipAnchor invariant
  *
- * After a slip, the parentRow has exactly one child (the target Column). Normally
+ * After a slip or dissolve, the parentRow may have exactly one child. Normally
  * `balanceNode` would hoist that column's children into the grandparent (single-
  * child-branch flatMap rule), scattering them and losing `targetColumnId`. We
  * prevent this by setting `parentRow._slipAnchor = true`, which `balanceNode`
@@ -86,6 +94,18 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
         return;
     }
 
+    // ── Pre-check: parent column dissolved — undissolve before toggling ───────
+    // A node inside a dissolved column has `minimizedSize` set and lives inside a
+    // column that itself has `columnDissolve`. Clicking restore on that node first
+    // undissolves the parent column (returns it to its Row slot), then falls through
+    // to the normal restore path so both the undissolve and the individual pane
+    // restore happen in a single click.
+    const parentForDissolveCheck = findParent(model.treeState.rootNode, nodeId);
+    if (parentForDissolveCheck?.columnDissolve !== undefined) {
+        _undissolveColumn(model, parentForDissolveCheck);
+        // Fall through — node still has minimizedSize set; normal restore runs below.
+    }
+
     // ── Need parent for minimize and normal restore ───────────────────────────
     const parentNode = findParent(model.treeState.rootNode, nodeId);
     if (!parentNode?.children?.length) return;
@@ -132,6 +152,15 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
         node.minimizedSize = node.size;
         node.size = headerSizeUnits;
         sibling.size += freedUnits;
+
+        // If all leaves in the column are now minimized, dissolve the column into
+        // the adjacent Row sibling so the layout consolidates to fewer columns.
+        const allCollapsed = parentNode.children.every(
+            (c) => c.minimizedSize !== undefined || c.slipMinimize !== undefined
+        );
+        if (allCollapsed) {
+            _dissolveColumn(model, parentNode, addlProps, gapSizePx);
+        }
     }
 
     _finishToggle(model, nodeId, true);
@@ -223,6 +252,150 @@ function _slipMinimize(
     return true;
 }
 
+/**
+ * Dissolve a fully-collapsed column into an adjacent column.
+ *
+ * Called after the last leaf in `colNode` is minimized. Removes `colNode` from its
+ * Row slot, gives its width to the adjacent sibling column, and re-inserts `colNode`
+ * as a branch at the top of that sibling. The column's leaf children retain their
+ * individual `minimizedSize` values.
+ *
+ * Returns true on success; false if bailing without mutating the tree (no Row parent,
+ * no adjacent sibling, or column-ratio unavailable).
+ */
+function _dissolveColumn(
+    model: LayoutModel,
+    colNode: LayoutNode,
+    addlProps: Record<string, LayoutNodeAdditionalProps>,
+    gapSizePx: number,
+): boolean {
+    const rowNode = findParent(model.treeState.rootNode, colNode.id);
+    if (!rowNode?.children?.length || rowNode.flexDirection !== FlexDirection.Row) return false;
+
+    const nodeIdx = rowNode.children.findIndex((c) => c.id === colNode.id);
+    const sibling = rowNode.children[nodeIdx + 1] ?? rowNode.children[nodeIdx - 1];
+    if (!sibling) return false;
+
+    // Don't dissolve into a column that is itself dissolved (it's nested elsewhere).
+    if (sibling.columnDissolve !== undefined) return false;
+
+    const siblingProps = addlProps[sibling.id];
+    let targetWasLeaf = false;
+
+    // Convert a plain leaf sibling into a Column container so we can prepend the branch.
+    if (!sibling.children) {
+        targetWasLeaf = true;
+        const heightPx = siblingProps?.rect?.height;
+        const totalUnits = DefaultNodeSize;
+        const headerUnitsEst = heightPx
+            ? ((HeaderHeightPx + gapSizePx) * totalUnits) / heightPx
+            : totalUnits * 0.05;
+        const contentUnits = Math.max(totalUnits - headerUnitsEst, headerUnitsEst);
+        const contentNode = newLayoutNode(FlexDirection.Row, contentUnits, undefined, sibling.data);
+        sibling.data = undefined;
+        sibling.flexDirection = FlexDirection.Column;
+        sibling.children = [contentNode];
+    }
+
+    // Compute dissolved column's height in the sibling column's flex-unit space.
+    const colRatio: number | undefined = siblingProps?.pixelToSizeRatio
+        ?? (siblingProps?.rect?.height && sibling.children
+            ? sibling.children.reduce((s, c) => s + c.size, 0) / siblingProps.rect.height
+            : undefined);
+
+    if (colRatio == null) {
+        console.warn("[layoutMinimize] dissolve: cannot determine column ratio, skipping");
+        if (targetWasLeaf) {
+            const only = sibling.children?.[0];
+            if (only?.data) {
+                sibling.data = only.data;
+                sibling.children = undefined;
+                sibling.flexDirection = FlexDirection.Row;
+            }
+        }
+        return false;
+    }
+
+    // One header per leaf child.
+    const leafCount = colNode.children!.length;
+    const totalHeaderUnits = leafCount * (HeaderHeightPx + gapSizePx) * colRatio;
+
+    // Steal from sibling's first child so sibling's total flex-size stays constant.
+    const firstChild = sibling.children![0];
+    if (firstChild) {
+        firstChild.size = Math.max(firstChild.size - totalHeaderUnits, (HeaderHeightPx + gapSizePx) * colRatio);
+    }
+
+    // Record dissolve context.
+    colNode.columnDissolve = {
+        targetColumnId: sibling.id,
+        originalRowSize: colNode.size,
+        originalRowIndex: nodeIdx,
+        targetWasLeaf,
+    };
+
+    // Give the dissolved column's Row-slot width to the sibling; remove from Row.
+    sibling.size += colNode.size;
+    rowNode.children.splice(nodeIdx, 1);
+    rowNode._slipAnchor = true;
+
+    // Insert the dissolved column branch at the top of the sibling column.
+    colNode.size = totalHeaderUnits;
+    sibling.children!.unshift(colNode);
+
+    return true;
+}
+
+/**
+ * Restore a dissolved column to its original Row slot.
+ *
+ * Removes `colNode` from its host column, shrinks the host back by the original
+ * width, and re-inserts `colNode` into the root Row at its original index. The
+ * column's children retain their `minimizedSize` values — they remain visually
+ * collapsed within the restored column.
+ */
+function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
+    const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = colNode.columnDissolve!;
+    colNode.columnDissolve = undefined;
+
+    const targetCol = findNode(model.treeState.rootNode, targetColumnId);
+    if (!targetCol?.children) {
+        console.warn(`[layoutMinimize] undissolve: target column ${targetColumnId} not found`);
+        return;
+    }
+
+    // Remove colNode from the host column; give its height back to the neighbor.
+    const slipIdx = targetCol.children.findIndex((c) => c.id === colNode.id);
+    if (slipIdx !== -1) {
+        const reclaimUnits = colNode.size;
+        targetCol.children.splice(slipIdx, 1);
+        const neighbor = targetCol.children[slipIdx] ?? targetCol.children[slipIdx - 1];
+        if (neighbor) neighbor.size += reclaimUnits;
+    }
+
+    // If the target was originally a leaf that got wrapped, unwrap it.
+    if (targetWasLeaf && targetCol.children.length === 1) {
+        const only = targetCol.children[0];
+        if (only.data && !only.children) {
+            targetCol.data = only.data;
+            targetCol.children = undefined;
+            targetCol.flexDirection = FlexDirection.Row;
+        }
+    }
+
+    // Shrink the host column back to its pre-dissolve width.
+    targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
+
+    // Re-insert colNode into the Row at its original index.
+    const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
+    if (rowNode.children) {
+        colNode.size = originalRowSize;
+        rowNode._slipAnchor = undefined;
+        const idx = Math.min(originalRowIndex, rowNode.children.length);
+        rowNode.children.splice(idx, 0, colNode);
+    }
+}
+
 /** Commit tree changes and update the minimized-node-id reactive set. */
 function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
     model.minimizedNodeIds._set((prev) => {
@@ -241,16 +414,23 @@ function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
 
 /**
  * Scan the loaded tree for nodes that carry a `minimizedSize` or `slipMinimize`
- * field and rebuild the in-memory `minimizedNodeIds` set.
+ * field and rebuild the in-memory `minimizedNodeIds` set. Also restores `_slipAnchor`
+ * on any Row that owns the host column of a dissolved branch.
  * Called once during `initializeFromWaveObject`.
  */
 export function rebuildMinimizedSet(model: LayoutModel) {
     const ids = new Set<string>();
-    function walk(node: typeof model.treeState.rootNode) {
+    const root = model.treeState.rootNode;
+    function walk(node: typeof root) {
         if (!node) return;
         if (node.minimizedSize !== undefined || node.slipMinimize !== undefined) ids.add(node.id);
+        if (node.columnDissolve !== undefined) {
+            // Restore _slipAnchor on the Row that owns the dissolved column's host.
+            const targetRow = findParent(root, node.columnDissolve.targetColumnId);
+            if (targetRow) targetRow._slipAnchor = true;
+        }
         node.children?.forEach(walk);
     }
-    walk(model.treeState.rootNode);
+    walk(root);
     model.minimizedNodeIds._set(ids);
 }

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -153,10 +153,11 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
         node.size = headerSizeUnits;
         sibling.size += freedUnits;
 
-        // If all leaves in the column are now minimized, dissolve the column into
-        // the adjacent Row sibling so the layout consolidates to fewer columns.
+        // If all children of the column are now minimized (leaves via minimizedSize/
+        // slipMinimize, or previously dissolved sub-columns via columnDissolve),
+        // dissolve this column into the adjacent Row sibling.
         const allCollapsed = parentNode.children.every(
-            (c) => c.minimizedSize !== undefined || c.slipMinimize !== undefined
+            (c) => c.minimizedSize !== undefined || c.slipMinimize !== undefined || c.columnDissolve !== undefined
         );
         if (allCollapsed) {
             _dissolveColumn(model, parentNode, addlProps, gapSizePx);

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -207,6 +207,24 @@ export interface LayoutNode {
         targetWasLeaf: boolean;
     };
     /**
+     * Set when this Column branch was dissolved because all its leaf children became
+     * minimized. The column is removed from its Row slot and re-inserted at the top of
+     * an adjacent column. Individual leaf children retain their `minimizedSize` values.
+     * Clicking any child's minimize button undissolves this column first, then restores
+     * the child. Never coexists with `minimizedSize` or `slipMinimize` (those are
+     * leaf-only fields).
+     */
+    columnDissolve?: {
+        /** ID of the Column this branch was inserted into. */
+        targetColumnId: string;
+        /** Original width (Row-slot size) before dissolve. */
+        originalRowSize: number;
+        /** Original index in the Row's children array. */
+        originalRowIndex: number;
+        /** True when the target was a plain leaf converted to a Column during dissolve — restore must unwrap it. */
+        targetWasLeaf: boolean;
+    };
+    /**
      * Prevents `balanceNode` from hoisting this branch's single grandchild when the
      * branch has exactly one child that is itself a branch. Set on the Row parent of a
      * slipped pane so the Row(→Column) direction-alternation is preserved even though

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -286,6 +286,76 @@ describe("cascade dissolve — multiple columns collapse into one", () => {
         expect(paneC.minimizedSize).toBeDefined();
         expect(root.children).toHaveLength(1); // dissolve bails (no Row sibling) — correct
     });
+
+    it("restores pane from 3-deep cascade (A→B→C → restore colA pane)", () => {
+        // root (Row)
+        // ├── colA (Column) → paneA1, paneA2
+        // ├── colB (Column) → paneB
+        // └── colC (Column) → paneC
+        const paneA1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA1" });
+        const paneA2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA2" });
+        const colA   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
+        const paneB  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
+        const colB   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
+        const paneC  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneC" });
+        const colC   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneC]);
+        const root   = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB, colC]);
+
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+            [colC.id]: { pixelToSizeRatio: 1 },
+        });
+
+        // Step 1: Dissolve colA into colB (minimize all panes in colA)
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+        expect(colA.columnDissolve).toBeDefined();
+        expect(root.children).toHaveLength(2); // colB + colC remain
+
+        // Step 2: Dissolve colB into colC (colB now has [colA-dissolved, paneB]; minimizing paneB collapses it)
+        minimizeNodeToggle(model as any, paneB.id);
+        expect(colB.columnDissolve).toBeDefined();
+        expect(root.children).toHaveLength(1); // only colC remains
+        expect(root.children![0].id).toBe(colC.id);
+
+        // Step 3: Restore paneA1 from the deeply dissolved colA.
+        // The recursive-undissolve-ancestors path must undissolve colB (outermost) then colA
+        // (immediate parent) before restoring paneA1 — exercising the path added in commit 360dd82.
+        minimizeNodeToggle(model as any, paneA1.id);
+
+        // All three columns must be back in the root Row
+        expect(root.children).toHaveLength(3);
+        const rootIds = root.children!.map((c) => c.id);
+        expect(rootIds).toContain(colA.id);
+        expect(rootIds).toContain(colB.id);
+        expect(rootIds).toContain(colC.id);
+
+        // No column retains a columnDissolve marker
+        expect(colA.columnDissolve).toBeUndefined();
+        expect(colB.columnDissolve).toBeUndefined();
+        expect(colC.columnDissolve).toBeUndefined();
+
+        // Each column is restored to its original Row-slot size
+        expect(colA.size).toBe(PANE_SIZE);
+        expect(colB.size).toBe(PANE_SIZE);
+        expect(colC.size).toBe(PANE_SIZE);
+
+        // root Row no longer needs the slip anchor
+        expect(root._slipAnchor).toBeUndefined();
+
+        // paneA1 is restored (the pane we clicked)
+        expect(paneA1.minimizedSize).toBeUndefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(false);
+
+        // paneA2 remains minimized inside colA
+        expect(paneA2.minimizedSize).toBeDefined();
+        expect(model.getMinimizedSet().has(paneA2.id)).toBe(true);
+
+        // paneB remains minimized inside colB
+        expect(paneB.minimizedSize).toBeDefined();
+        expect(model.getMinimizedSet().has(paneB.id)).toBe(true);
+    });
 });
 
 // ── Bail case — no adjacent sibling ─────────────────────────────────────────

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -1,0 +1,265 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { newLayoutNode } from "../lib/layoutNode";
+import { minimizeNodeToggle, rebuildMinimizedSet, HeaderHeightPx } from "../lib/layoutMinimize";
+import { FlexDirection, type LayoutNode, type LayoutNodeAdditionalProps } from "../lib/types";
+
+// ── Minimal LayoutModel mock ─────────────────────────────────────────────────
+
+function makeMockModel(
+    rootNode: LayoutNode,
+    addlProps: Record<string, Partial<LayoutNodeAdditionalProps>> = {},
+    gapSizePx = 0,
+) {
+    let minimizedSet = new Set<string>();
+    const treeState = { rootNode, pendingBackendActions: [] };
+    const model = {
+        treeState,
+        getter: (_sig: unknown) => addlProps as Record<string, LayoutNodeAdditionalProps>,
+        additionalProps: {} as any,
+        gapSizePx: () => gapSizePx,
+        minimizedNodeIds: {
+            // Real SignalAtom._set accepts both a value and an updater function.
+            _set: (updaterOrValue: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+                minimizedSet = typeof updaterOrValue === "function"
+                    ? updaterOrValue(minimizedSet)
+                    : updaterOrValue;
+            },
+        },
+        updateTree: () => {},
+        localTreeStateAtom: { _set: () => {} },
+        persistToBackend: () => {},
+        getMinimizedSet: () => minimizedSet,
+    };
+    return model;
+}
+
+// Sizes must exceed HeaderHeightPx (33) so freedUnits > 0 and minimize doesn't no-op.
+const PANE_SIZE = 200;
+
+// ── Helper: build a 2-column layout ─────────────────────────────────────────
+//
+//   root (Row)
+//   ├── colA (Column, size=200)
+//   │   ├── paneA1 (leaf, size=200)
+//   │   └── paneA2 (leaf, size=200)
+//   └── colB (Column, size=200)
+//       └── paneB  (leaf, size=200)
+
+function buildTwoColumnLayout() {
+    const paneA1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA1" });
+    const paneA2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA2" });
+    const colA   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
+
+    const paneB  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
+    const colB   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
+
+    const root   = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB]);
+    return { root, colA, paneA1, paneA2, colB, paneB };
+}
+
+// ── Normal column-collapse (no dissolve) ─────────────────────────────────────
+
+describe("normal column collapse (partial — dissolve not triggered)", () => {
+    it("collapses the pane to header height, gives freed space to sibling", () => {
+        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+
+        expect(paneA1.minimizedSize).toBe(PANE_SIZE);
+        expect(paneA1.size).toBe(HeaderHeightPx);
+        expect(paneA2.size).toBe(PANE_SIZE + (PANE_SIZE - HeaderHeightPx));
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+        // colA stays in root Row — paneA2 still expanded
+        expect(root.children).toHaveLength(2);
+    });
+
+    it("restores pane to its original size", () => {
+        const { root, colA, paneA1 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA1.id);
+
+        expect(paneA1.minimizedSize).toBeUndefined();
+        expect(paneA1.size).toBe(PANE_SIZE);
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(false);
+        void root;
+    });
+});
+
+// ── Column dissolve ───────────────────────────────────────────────────────────
+
+describe("column dissolve — all panes minimized triggers dissolve into adjacent column", () => {
+    it("dissolves colA into colB when both panes in colA are minimized", () => {
+        const { root, colA, paneA1, paneA2, colB, paneB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        expect(root.children).toHaveLength(2); // no dissolve yet
+
+        minimizeNodeToggle(model as any, paneA2.id); // triggers dissolve
+
+        // Root Row now holds only colB
+        expect(root.children).toHaveLength(1);
+        expect(root.children![0].id).toBe(colB.id);
+        expect(root._slipAnchor).toBe(true);
+
+        // colA is now the first child of colB
+        expect(colB.children![0].id).toBe(colA.id);
+        expect(colA.columnDissolve).toBeDefined();
+        expect(colA.columnDissolve!.targetColumnId).toBe(colB.id);
+        expect(colA.columnDissolve!.originalRowSize).toBe(PANE_SIZE);
+        expect(colA.columnDissolve!.originalRowIndex).toBe(0);
+
+        // colB absorbed colA's Row-slot width
+        expect(colB.size).toBe(PANE_SIZE * 2);
+
+        // paneB is still in colB (after dissolved colA)
+        expect(colB.children![1].id).toBe(paneB.id);
+
+        // Both panes inside colA retain their minimizedSize
+        expect(paneA1.minimizedSize).toBeDefined();
+        expect(paneA2.minimizedSize).toBeDefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+        expect(model.getMinimizedSet().has(paneA2.id)).toBe(true);
+    });
+
+    it("colA occupies 2 × HeaderHeightPx flex-units inside colB after dissolve", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+
+        expect(colA.size).toBe(2 * HeaderHeightPx);
+        void colB;
+    });
+});
+
+// ── Undissolve on restore ─────────────────────────────────────────────────────
+
+describe("undissolve — clicking a pane in a dissolved column restores the column", () => {
+    it("undissolves colA and restores the clicked pane in a single toggle", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+        expect(root.children).toHaveLength(1);
+
+        // One toggle on paneA2: undissolves colA AND restores paneA2
+        minimizeNodeToggle(model as any, paneA2.id);
+
+        // colA is back in the root Row at its original index
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].id).toBe(colA.id);
+        expect(colA.columnDissolve).toBeUndefined();
+        expect(root._slipAnchor).toBeUndefined();
+
+        // colB width is restored
+        expect(colB.size).toBe(PANE_SIZE);
+
+        // paneA2 is restored
+        expect(paneA2.minimizedSize).toBeUndefined();
+        expect(model.getMinimizedSet().has(paneA2.id)).toBe(false);
+
+        // paneA1 remains minimized inside colA
+        expect(paneA1.minimizedSize).toBeDefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+    });
+
+    it("undissolves via paneA1 as well", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+
+        minimizeNodeToggle(model as any, paneA1.id);
+
+        expect(root.children).toHaveLength(2);
+        expect(colA.columnDissolve).toBeUndefined();
+        expect(paneA1.minimizedSize).toBeUndefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(false);
+        expect(paneA2.minimizedSize).toBeDefined();
+        void colB;
+    });
+});
+
+// ── rebuildMinimizedSet ───────────────────────────────────────────────────────
+
+describe("rebuildMinimizedSet", () => {
+    it("rebuilds minimizedNodeIds from minimizedSize fields after tree load", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+
+        // Simulate fresh load: clear the set, then rebuild
+        model.minimizedNodeIds._set(new Set<string>());
+        rebuildMinimizedSet(model as any);
+
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+        expect(model.getMinimizedSet().has(paneA2.id)).toBe(true);
+    });
+
+    it("restores _slipAnchor on the owning Row for a dissolved column", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+
+        root._slipAnchor = undefined; // simulate stale serialised state
+        rebuildMinimizedSet(model as any);
+
+        expect(root._slipAnchor).toBe(true);
+    });
+});
+
+// ── Bail case — no adjacent sibling ─────────────────────────────────────────
+
+describe("dissolve bail cases", () => {
+    it("does not dissolve when the column is the only child in the Row", () => {
+        const pane1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "p1" });
+        const pane2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "p2" });
+        const col   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [pane1, pane2]);
+        const root  = newLayoutNode(FlexDirection.Row, PANE_SIZE, [col]);
+
+        const model = makeMockModel(root, { [col.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, pane1.id);
+        minimizeNodeToggle(model as any, pane2.id);
+
+        // col stays in root Row — dissolve bailed (no Row sibling)
+        expect(root.children).toHaveLength(1);
+        expect(col.columnDissolve).toBeUndefined();
+        // Both panes are still individually minimized
+        expect(pane1.minimizedSize).toBeDefined();
+        expect(pane2.minimizedSize).toBeDefined();
+    });
+});
+

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -240,6 +240,54 @@ describe("rebuildMinimizedSet", () => {
     });
 });
 
+// ── Cascade dissolve — 3 columns → 2 → 1 ────────────────────────────────────
+
+describe("cascade dissolve — multiple columns collapse into one", () => {
+    it("colA dissolves into colB, then colB dissolves into colC when all minimized", () => {
+        // root (Row)
+        // ├── colA (Column) → paneA1, paneA2
+        // ├── colB (Column) → paneB
+        // └── colC (Column) → paneC
+        const paneA1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA1" });
+        const paneA2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA2" });
+        const colA   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
+        const paneB  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
+        const colB   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
+        const paneC  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneC" });
+        const colC   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneC]);
+        const root   = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB, colC]);
+
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+            [colC.id]: { pixelToSizeRatio: 1 },
+        });
+
+        // Minimize colA's panes → colA dissolves into colB
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+        expect(root.children).toHaveLength(2); // colA gone, root has colB + colC
+        expect(colA.columnDissolve).toBeDefined();
+        expect(colB.children![0].id).toBe(colA.id);
+
+        // Minimize colB's pane (colB now has [colA-dissolved, paneB]) →
+        // allCollapsed includes columnDissolve, so colB dissolves into colC
+        minimizeNodeToggle(model as any, paneB.id);
+        expect(root.children).toHaveLength(1); // only colC remains
+        expect(root.children![0].id).toBe(colC.id);
+        expect(colB.columnDissolve).toBeDefined();
+        expect(colC.children![0].id).toBe(colB.id);
+
+        // colB (inside colC) still contains colA-dissolved
+        expect(colB.children!.some(c => c.id === colA.id)).toBe(true);
+
+        // paneC can still be minimized (colB-dissolved is its sibling)
+        minimizeNodeToggle(model as any, paneC.id);
+        expect(paneC.minimizedSize).toBeDefined();
+        expect(root.children).toHaveLength(1); // dissolve bails (no Row sibling) — correct
+    });
+});
+
 // ── Bail case — no adjacent sibling ─────────────────────────────────────────
 
 describe("dissolve bail cases", () => {


### PR DESCRIPTION
## Summary

- When all panes in a column are minimized, the column **dissolves** into the adjacent column instead of leaving a strip of stacked header bars. The column is removed from the root Row, its width is given to the adjacent column, and it re-inserts itself as a branch at the top of that column.
- **Restore** with one click: toggling any pane inside a dissolved column undissolves the parent column (returns it to the Row) and restores the clicked pane in the same action. Other panes in the column stay minimized.
- **Bail cases**: skipped when there's no adjacent Row sibling (solo column), or when the target is itself dissolved.
- Extends `rebuildMinimizedSet` to restore `_slipAnchor` on the owning Row after a serialise/reload cycle.

## Changes

| File | What |
|---|---|
| `frontend/layout/lib/types.ts` | Add `columnDissolve` to `LayoutNode` |
| `frontend/layout/lib/layoutMinimize.ts` | `_dissolveColumn`, `_undissolveColumn`; dissolve trigger after normal collapse; pre-check for dissolved parent; updated `rebuildMinimizedSet` |
| `frontend/layout/tests/layoutMinimize.test.ts` | 9 new tests (collapse, dissolve, undissolve, rebuild, bail) |
| `docs/specs/SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md` | Spec |

Builds on: SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24 (slip path for Row-parent panes).

## Test plan

- [ ] 2-column layout: minimize both panes in the left column → left column disappears, its headers appear stacked at top of right column, right column expands to fill
- [ ] Click either minimized header inside dissolved column → column re-appears in original position with the clicked pane restored, other pane stays minimized
- [ ] 3-column cascade: minimize all panes in A→B→C, ending with one visible column
- [ ] Solo column (no adjacent sibling): minimize all panes → they stay as header strips within the column, no dissolve
- [ ] Reload app mid-dissolved state → `_slipAnchor` and `columnDissolve` survive serialisation
- [ ] `npx vitest run frontend/layout` → 69 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)