### PR TITLE
fix(macos): add #[cfg(target_os = "macos")] to display-name wrapper fns

### DIFF
--- a/.changesets/1782633076-fix-macos-add-cfg-guards-to-display-name-wrapper-fns-so-wind-ejcq.md
+++ b/.changesets/1782633076-fix-macos-add-cfg-guards-to-display-name-wrapper-fns-so-wind-ejcq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(macos): add cfg guards to display-name wrapper fns so Windows/Linux builds don't see unresolvable macOS-only impl

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -1438,10 +1438,12 @@ unsafe fn set_macos_app_display_name_impl(set_bundle_id: bool) {
     tracing::info!(app_name = name, "macOS: set app display name (Dock + app menu)");
 }
 
+#[cfg(target_os = "macos")]
 unsafe fn set_macos_app_display_name() {
     set_macos_app_display_name_impl(true);
 }
 
+#[cfg(target_os = "macos")]
 unsafe fn set_macos_app_display_name_pre_init() {
     set_macos_app_display_name_impl(false);
 }


### PR DESCRIPTION
## Summary

`set_macos_app_display_name()` and `set_macos_app_display_name_pre_init()` both call `set_macos_app_display_name_impl` which has a `#[cfg(target_os = "macos")]` guard — but the two wrapper functions themselves were not guarded, causing a compile error on Windows and Linux:

```
error[E0425]: cannot find function `set_macos_app_display_name_impl` in this scope
```

All call sites of the wrappers are already gated with `#[cfg(target_os = "macos")]`; this just adds the same attribute to the wrappers so non-macOS builds don't try to compile them.

Introduced in fcbcc8a9 (fix(macos): restore main browser clicks). Caught by the new nightly cross-platform build (`ci-nightly-build.yml`).

## Fix

```rust
+#[cfg(target_os = "macos")]
 unsafe fn set_macos_app_display_name() { ... }

+#[cfg(target_os = "macos")]
 unsafe fn set_macos_app_display_name_pre_init() { ... }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)