### PR TITLE
fix(tests): add missing struct fields to agentmux-srv test fixtures

### DIFF
--- a/.changesets/1782635759-fix-tests-add-missing-struct-fields-to-agentmux-srv-test-fix-1omf.md
+++ b/.changesets/1782635759-fix-tests-add-missing-struct-fields-to-agentmux-srv-test-fix-1omf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tests): add missing struct fields to agentmux-srv test fixtures

--- a/agentmux-srv/src/config.rs
+++ b/agentmux-srv/src/config.rs
@@ -132,7 +132,7 @@ mod tests {
     fn missing_auth_key_errors() {
         let _lock = lock();
         clear_env();
-        let args = CliArgs { wavedata: None, instance: "default".to_string() };
+        let args = CliArgs { wavedata: None, instance: "default".to_string(), command: None };
         let result = Config::from_env_and_args(&args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("AGENTMUX_AUTH_KEY"));
@@ -143,7 +143,7 @@ mod tests {
         let _lock = lock();
         clear_env();
         std::env::set_var("AGENTMUX_AUTH_KEY", "");
-        let args = CliArgs { wavedata: None, instance: "default".to_string() };
+        let args = CliArgs { wavedata: None, instance: "default".to_string(), command: None };
         let result = Config::from_env_and_args(&args);
         assert!(result.is_err());
         clear_env();
@@ -158,6 +158,7 @@ mod tests {
         let args = CliArgs {
             wavedata: Some("/from/cli".to_string()),
             instance: "default".to_string(),
+            command: None,
         };
         let config = Config::from_env_and_args(&args).unwrap();
         assert_eq!(config.data_home, "/from/cli");
@@ -174,7 +175,7 @@ mod tests {
         std::env::set_var("AGENTMUX_CONFIG_DIR", "/config");
         std::env::set_var("AGENTMUX_APP_PATH", "/app");
         std::env::set_var("AGENTMUX_RUNTIME_MODE", "dev:main");
-        let args = CliArgs { wavedata: None, instance: "default".to_string() };
+        let args = CliArgs { wavedata: None, instance: "default".to_string(), command: None };
         let config = Config::from_env_and_args(&args).unwrap();
         assert_eq!(config.data_home, "/data");
         assert_eq!(config.config_home, "/config");

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -3728,6 +3728,8 @@ mod recent_sessions_tests {
             version: "test".to_string(),
             app_path: String::new(),
             wstore: wstore.clone(),
+            shared_store: None,
+            id_store: wstore.clone(),
             filestore: filestore.clone(),
             global_transcript_store: None,
             event_bus: event_bus.clone(),
@@ -3758,6 +3760,12 @@ mod recent_sessions_tests {
             install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
             container_manager: None,
             shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
+            cron_scheduler: crate::backend::cron::CronScheduler::new(
+                None,
+                reqwest::Client::new(),
+                String::new(),
+                "test".to_string(),
+            ),
         };
 
         // Seed: 1 SEEDED definition (template), 1 identity bundle, 1
@@ -4018,6 +4026,8 @@ mod recent_sessions_tests {
             version: "test".to_string(),
             app_path: String::new(),
             wstore: wstore.clone(),
+            shared_store: None,
+            id_store: wstore.clone(),
             filestore: filestore.clone(),
             global_transcript_store: None,
             event_bus: event_bus.clone(),
@@ -4048,6 +4058,12 @@ mod recent_sessions_tests {
             install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
             container_manager: None,
             shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
+            cron_scheduler: crate::backend::cron::CronScheduler::new(
+                None,
+                reqwest::Client::new(),
+                String::new(),
+                "test".to_string(),
+            ),
         };
 
         // One seeded template + one already-user-owned definition.

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -2961,6 +2961,7 @@ mod pane_open_reducer_tests {
             focus: None,
             tree_expanded: None,
             floating: None,
+            meta: None,
         };
         let res = open_pane(&state, cmd).await.expect("open_pane docked");
 

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -38,7 +38,9 @@ pub(crate) fn test_state() -> AppState {
         auth_key: "test-secret-key".to_string(),
         version: "0.28.20".to_string(),
         app_path: String::new(),
-        wstore,
+        wstore: wstore.clone(),
+        shared_store: None,
+        id_store: wstore,
         filestore,
         global_transcript_store: None,
         event_bus: event_bus.clone(),
@@ -73,6 +75,12 @@ pub(crate) fn test_state() -> AppState {
         install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
         container_manager: None,
         shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
+        cron_scheduler: crate::backend::cron::CronScheduler::new(
+            None,
+            reqwest::Client::new(),
+            String::new(),
+            "test-secret-key".to_string(),
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary

- AppState gained `shared_store`, `id_store`, and `cron_scheduler` in recent cron/shared-store commits; test struct initializers were not updated
- CliArgs gained `command: Option<SrvCommand>`; four test usages in config.rs were not updated  
- CommandPaneOpenData gained `meta`; one test usage in app_api.rs was not updated
- Fixes all E0063 compile errors on the macOS nightly CI job

## Changes

- `config.rs`: add `command: None` to 4 test CliArgs literals
- `server/tests.rs`: add `shared_store`, `id_store`, `cron_scheduler` to test_state()
- `server/agent_handlers.rs`: same three fields in the two AppState literals in test modules
- `server/app_api.rs`: add `meta: None` to CommandPaneOpenData in the open_pane test

Note: the E0425 errors (Windows/Ubuntu) were already fixed by #1832 which landed before this PR.

<!-- agentmux:agent_id=camper -->