### PR TITLE
fix(agent-pane): liveness watchdog clears stuck "Working" for persistent agents

### DIFF
--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -10,10 +10,17 @@ import {
     isDisconnected,
     isInitReady,
     isWorking,
+    LIVENESS_RECOVERY_MS,
     STUCK_THRESHOLD_MS,
     SUBMIT_TIMEOUT_MS,
     TurnPhase,
 } from "./types";
+
+/** Bring a fresh state into a live `Streaming` turn (toolsActive 0). */
+const streaming = (atMs = 100) => {
+    const s1 = update(ready(atMs), { type: "TurnStart", at: atMs }).state;
+    return update(s1, { type: "StreamFlushObserved", addedCount: 1, at: atMs }).state;
+};
 
 const mk = () => initialState("test-agent");
 /**
@@ -468,8 +475,50 @@ describe("agent-pane-state reducer", () => {
                 idleSinceMs: tick,
                 thresholdMs: STUCK_THRESHOLD_MS,
             });
-            // Watchdog never mutates state.
+            // Below LIVENESS_RECOVERY_MS the watchdog only diagnoses — no mutation.
             expect(r.state).toBe(s0);
+        });
+
+        it("StreamWatchdogTick past LIVENESS_RECOVERY_MS recovers a hung Streaming turn to Idle", () => {
+            const s0 = streaming(1_000); // Streaming, toolsActive 0, lastEventMs 1000
+            expect(isWorking(s0)).toBe(true);
+            const tick = 1_000 + LIVENESS_RECOVERY_MS + 1_000;
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(isWorking(r.state)).toBe(false);
+            expect(r.state.currentTool).toBeNull();
+            expect(r.state.turnTokens).toBeNull();
+            expect(r.events[0]).toMatchObject({
+                type: "working-recovered",
+                thresholdMs: LIVENESS_RECOVERY_MS,
+            });
+        });
+
+        it("StreamWatchdogTick does NOT recover while a tool is active (emits stream-stuck)", () => {
+            const base = streaming(1_000);
+            // A running tool keeps the turn alive; lastEventMs bumped to 2000.
+            const s0 = update(base, { type: "ToolStart", name: "Bash" }, 2_000).state;
+            expect((s0.turnPhase as Extract<TurnPhase, { kind: "Streaming" }>).toolsActive).toBe(1);
+            const tick = 2_000 + LIVENESS_RECOVERY_MS + 5_000;
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events[0]).toMatchObject({ type: "stream-stuck" });
+        });
+
+        it("StreamWatchdogTick does NOT recover while rate-limited (waitingReason set)", () => {
+            const base = streaming(1_000);
+            const s0 = update(base, {
+                type: "ProviderWaiting",
+                reason: "rate_limited",
+                retryAfterMs: 30_000,
+                at: 2_000,
+            }).state;
+            const phase = s0.turnPhase as Extract<TurnPhase, { kind: "Streaming" }>;
+            expect(phase.waitingReason).toBe("rate_limited");
+            const tick = (s0.lastEventMs ?? 2_000) + LIVENESS_RECOVERY_MS + 5_000;
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events[0]).toMatchObject({ type: "stream-stuck" });
         });
 
         it("ToolStart bumps lastEventMs (resets watchdog clock)", () => {

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -16,7 +16,8 @@
  *   4. pending FIFO; accepting/rejecting/expiring unknown ids is no-op.
  *   5. StreamFlushObserved is a no-op when the stream is unsubscribed.
  *   6. StreamWatchdogTick is a no-op when the stream is unsubscribed or
- *      lastEventMs is null (no events seen yet).
+ *      lastEventMs is null (no events seen yet); past LIVENESS_RECOVERY_MS it
+ *      force-recovers a hung Streaming turn (no tool, not rate-limited) to Idle.
  *   7. Init lifecycle transitions are one-way: InitStart / InitReady /
  *      InitFailed are no-ops once the pane has reached a terminal init
  *      state (InitReady / InitFailed). Re-entering pending requires a
@@ -36,6 +37,7 @@ import {
     AgentPaneState,
     INTERRUPT_TIMEOUT_MS,
     KindBeforeDisconnect,
+    LIVENESS_RECOVERY_MS,
     ReducerResult,
     STUCK_THRESHOLD_MS,
     SUBMIT_TIMEOUT_MS,
@@ -262,6 +264,42 @@ export function update(
             const idleSinceMs = command.nowMs - state.lastEventMs;
             if (idleSinceMs < STUCK_THRESHOLD_MS) {
                 return { state, events: [] };
+            }
+            // Liveness recovery (SPEC_WORKING_STATE_LIVENESS_MODEL_2026_06_29).
+            // A `Streaming` turn idle past the longer LIVENESS_RECOVERY_MS — with
+            // no tool running and not rate-limited — is hung: its terminal
+            // `session_end` was never observed. For persistent agents no
+            // `ControllerStatus: done` will ever arrive to clear it (the process
+            // doesn't exit between turns), so the watchdog itself transitions out
+            // of "Working". Land in `Idle` (turn abandoned) — NOT a synthetic
+            // `Done.completed`, which would feed false stats to session digests.
+            // Guarded to Streaming-with-no-tool-and-not-waiting so a running tool
+            // or a 429 backoff (both of which keep `lastEventMs` fresh anyway) can
+            // never be mistaken for a hang. Interrupting/Submitting are left to
+            // their own bounded timers (INTERRUPT_TIMEOUT_MS / SUBMIT_TIMEOUT_MS).
+            const phase = state.turnPhase;
+            if (
+                phase.kind === "Streaming" &&
+                phase.toolsActive === 0 &&
+                phase.waitingReason === undefined &&
+                idleSinceMs >= LIVENESS_RECOVERY_MS
+            ) {
+                return {
+                    state: {
+                        ...state,
+                        currentTool: null,
+                        currentToolArg: null,
+                        turnTokens: null,
+                        turnPhase: { kind: "Idle" },
+                    },
+                    events: [
+                        {
+                            type: "working-recovered",
+                            idleSinceMs,
+                            thresholdMs: LIVENESS_RECOVERY_MS,
+                        },
+                    ],
+                };
             }
             return {
                 state,

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -353,8 +353,11 @@ export type AgentPaneCommand =
     | { type: "StreamFlushObserved"; addedCount: number; at: number }
     /**
      * Periodic tick from useAgentStream's watchdog interval. Emits a
-     * `stream-stuck` event when the active stream has been silent for
-     * more than `STUCK_THRESHOLD_MS`. No state mutation.
+     * `stream-stuck` diagnostic past `STUCK_THRESHOLD_MS`, and — past the
+     * longer `LIVENESS_RECOVERY_MS` — force-recovers a hung `Streaming` turn
+     * (no tool active, not rate-limited) to `Idle`, clearing a stuck
+     * "Working" that never received its terminal `session_end`. See
+     * SPEC_WORKING_STATE_LIVENESS_MODEL_2026_06_29.md.
      */
     | { type: "StreamWatchdogTick"; nowMs: number }
 
@@ -488,6 +491,19 @@ export type AgentPaneEvent =
           idleSinceMs: number;
           thresholdMs: number;
       }
+    | {
+          /**
+           * The watchdog force-recovered a hung `Streaming` turn to `Idle`
+           * after `idleSinceMs` ≥ `LIVENESS_RECOVERY_MS` with no tool active
+           * and no rate-limit wait — i.e. a turn whose terminal `session_end`
+           * was never observed (the persistent-mode stuck-"Working" class).
+           * Surfaced for telemetry; the phase change is the real effect.
+           * See SPEC_WORKING_STATE_LIVENESS_MODEL_2026_06_29.md.
+           */
+          type: "working-recovered";
+          idleSinceMs: number;
+          thresholdMs: number;
+      }
     | { type: "turn-started"; at: number }
     | {
           /**
@@ -599,6 +615,19 @@ export interface ReducerResult {
  * positives. Issue #728 gap 3.
  */
 export const STUCK_THRESHOLD_MS = 45_000;
+
+/**
+ * Liveness-recovery threshold. A `Streaming` turn that has produced no
+ * observable activity for this many ms — with no tool running and not
+ * rate-limited — is treated as hung: its terminal `session_end` was never
+ * observed and no other signal will arrive to clear it. For persistent-mode
+ * agents the process never exits between turns, so `ControllerStatus: done`
+ * never fires and the process-exit grace timer can't recover the phase; the
+ * watchdog itself must transition out of "Working" (→ `Idle`). 3 min is well
+ * past `STUCK_THRESHOLD_MS` (45s) so a merely-quiet reasoning run is never
+ * mistaken for a hang. See SPEC_WORKING_STATE_LIVENESS_MODEL_2026_06_29.md.
+ */
+export const LIVENESS_RECOVERY_MS = 180_000;
 
 /**
  * Bounded `Interrupting → Done.{interrupted}` window. After `RequestStop`

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -245,6 +245,15 @@ export class ClaudeCodeStreamParser {
                 this.currentThinkingNode = null;
                 return this.errorResultToNode(event as ErrorResultEvent);
 
+            // Control events that intentionally produce no DocumentNode. The
+            // live consumer (useAgentStream) handles these ahead of the parser
+            // (`session_end` → finalizeTurn, `provider_waiting` → ProviderWaiting),
+            // but history replay re-parses every persisted line through here —
+            // returning null silently avoids a warn-spam flood (one per turn).
+            case "session_end":
+            case "provider_waiting":
+                return null;
+
             default:
                 console.warn("Unknown event type:", (event as any).type);
                 return null;


### PR DESCRIPTION
## Summary

Implements **step 1 + step 4** of the liveness design note (#1841) — the highest-value change that directly ends the 1286-minute stuck-"Working" class.

The stuck-stream watchdog was **diagnostic-only**: it emitted `stream-stuck` and returned state unchanged. For persistent agents the process never exits between turns, so `ControllerStatus: done` never fires and the process-exit grace timer can't recover the phase — the *only* exit from "Working" was a live `session_end`. Miss it (translator edge, WS-reconnect drop, stalled 429) and the agent hangs indefinitely.

## What changed

- **`StreamWatchdogTick` now acts** (`reducer.ts`): a `Streaming` turn idle past `LIVENESS_RECOVERY_MS` (3 min), **with no tool active and not rate-limited**, force-recovers to `Idle`. The guards matter — a running tool or a 429 backoff both keep `lastEventMs` fresh anyway, so neither can be mistaken for a hang. Recovers to `Idle` (turn abandoned), **not** a synthetic `Done.completed` that would feed false stats to session digests.
- **Replay noise silenced** (`stream-parser.ts`): returns null for `session_end` / `provider_waiting` (handled by the live consumer ahead of the parser; history replay was warn-spamming one per turn).
- `Interrupting` / `Submitting` keep their own bounded timers — untouched.

## Deferred to follow-ups (per spec §9)
- Step 2: constrain `bumpEvent` re-promotion to genuine new-turn evidence
- Step 3: remove the now-redundant grace/stop timers once this is proven in the field

## Test plan
- [x] 3 new watchdog tests (recovers; holds while tool active; holds while rate-limited)
- [x] 123 reducer + 37 parser tests pass; `tsc --noEmit` clean
- [ ] Field-confirm a persistent agent recovers from a missed `session_end` within ~3 min

<!-- agentmux:agent_id=agentx -->