### PR TITLE
spec: agent pane header — name precedence + drop "continued" chip

### DIFF
--- a/.changesets/1782680000-spec-agent-header-name-bb02.md
+++ b/.changesets/1782680000-spec-agent-header-name-bb02.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+spec(agent-pane): agent pane header name precedence + drop "continued" chip

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -317,11 +317,16 @@
                 &--agent {
                     .block-frame-default-header-iconview {
                         flex-shrink: 0;
-                        max-width: 60%;
                     }
 
                     .block-frame-textelems-wrapper {
                         flex-shrink: 100;
+                    }
+                }
+
+                &--agent&--has-summary {
+                    .block-frame-default-header-iconview {
+                        max-width: 60%;
                     }
                 }
             }

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -304,6 +304,26 @@
                         flex-shrink: 0;
                     }
                 }
+
+                // Agent header name precedence (SPEC_AGENT_PANE_HEADER_NAME_
+                // PRECEDENCE_2026_06_29). By default the name region
+                // (.block-frame-default-header-iconview) has flex-shrink:3 and
+                // the summary region (.block-frame-textelems-wrapper) flex:1 2,
+                // so the agent name truncated *before* the per-turn activity
+                // summary. Scoped to agent panes only (other views keep the
+                // shared behavior): pin the name and make the summary absorb
+                // the squeeze + ellipsize first. The max-width cap stops a long
+                // name from monopolizing the whole header.
+                &--agent {
+                    .block-frame-default-header-iconview {
+                        flex-shrink: 0;
+                        max-width: 60%;
+                    }
+
+                    .block-frame-textelems-wrapper {
+                        flex-shrink: 100;
+                    }
+                }
             }
 
             .block-frame-preview {

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -307,26 +307,25 @@
 
                 // Agent header name precedence (SPEC_AGENT_PANE_HEADER_NAME_
                 // PRECEDENCE_2026_06_29). By default the name region
-                // (.block-frame-default-header-iconview) has flex-shrink:3 and
-                // the summary region (.block-frame-textelems-wrapper) flex:1 2,
-                // so the agent name truncated *before* the per-turn activity
-                // summary. Scoped to agent panes only (other views keep the
-                // shared behavior): pin the name and make the summary absorb
-                // the squeeze + ellipsize first. The max-width cap stops a long
-                // name from monopolizing the whole header.
+                // (.block-frame-default-header-iconview) has flex-shrink:3 so it
+                // yields space to end-icon controls before the summary region
+                // (.block-frame-textelems-wrapper) does. When a summary IS present
+                // we pin the name (flex-shrink:0) and cap it at 60% so the summary
+                // absorbs the squeeze first. Scoped to agent panes only.
                 &--agent {
                     .block-frame-default-header-iconview {
-                        flex-shrink: 0;
+                        flex-shrink: 3;
                     }
 
                     .block-frame-textelems-wrapper {
                         flex-shrink: 100;
                     }
-                }
 
-                &--agent&--has-summary {
-                    .block-frame-default-header-iconview {
-                        max-width: 60%;
+                    &.block-frame-default-header--has-summary {
+                        .block-frame-default-header-iconview {
+                            flex-shrink: 0;
+                            max-width: 60%;
+                        }
                     }
                 }
             }

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -439,6 +439,16 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
         }
         return elems;
     });
+    // True when the textelems wrapper has visible content (summary text or an
+    // error indicator). Used to conditionally apply max-width to the name
+    // region — see block.scss .block-frame-default-header--has-summary.
+    const hasSummary = createMemo(() => {
+        if (props.error != null) return true;
+        const htu = headerTextUnion();
+        if (typeof htu === "string") return !util.isBlank(htu);
+        if (Array.isArray(htu)) return htu.length > 0;
+        return false;
+    });
     const headerStyle = createMemo<JSX.CSSProperties>(() => {
         const style: JSX.CSSProperties = {};
         const hue = blockData()?.meta?.["frame:hue"];
@@ -457,7 +467,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
     return (
         <div
             class="block-frame-default-header"
-            classList={{ "block-frame-default-header--agent": blockData()?.meta?.view === "agent" }}
+            classList={{ "block-frame-default-header--agent": blockData()?.meta?.view === "agent", "block-frame-default-header--has-summary": hasSummary() }}
             data-role="block-header"
             data-testid="block-header"
             ref={dragHandleRef ? (el) => { dragHandleRef.current = el; } : undefined}

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -457,6 +457,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
     return (
         <div
             class="block-frame-default-header"
+            classList={{ "block-frame-default-header--agent": blockData()?.meta?.view === "agent" }}
             data-role="block-header"
             data-testid="block-header"
             ref={dragHandleRef ? (el) => { dragHandleRef.current = el; } : undefined}

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -15,20 +15,6 @@ import { Logger } from "@/util/logger";
 import { buildInstanceSlug } from "./defaults/instance-slug";
 import type { LaunchOverrides } from "./components/AgentLaunchModal";
 
-/**
- * Compact relative-time label for the title-bar continuation chip.
- *
- * Mirrors the wording of `formatRelative` in `MyAgentsList.tsx`
- * (same "Xm ago" / "Xh ago" / "Xd ago" buckets) but lives here so the
- * model file has no UI-only dependency cycle. Exported for unit tests.
- */
-export function formatContinuationAgo(deltaMs: number): string {
-    if (deltaMs < 60_000) return "just now";
-    if (deltaMs < 3_600_000) return `${Math.floor(deltaMs / 60_000)}m ago`;
-    if (deltaMs < 86_400_000) return `${Math.floor(deltaMs / 3_600_000)}h ago`;
-    return `${Math.floor(deltaMs / 86_400_000)}d ago`;
-}
-
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
     blockId: string;
@@ -63,15 +49,6 @@ export class AgentViewModel implements ViewModel {
     // before AgentFooter mounts (or after it unmounts) it's a no-op.
     voiceTargetRef: { current: PaneVoiceHandle | null } = { current: null };
 
-    // Option E (PR #1007 backend, this PR frontend): when this pane
-    // mounted on an agent-anchored session zone (`agent:<defId>:current`)
-    // that already contained a snapshot, this holds the `modts` of that
-    // snapshot — the timestamp the previous owner pane last wrote.
-    // `viewText` projects it into a "· continued from Xm ago" chip in
-    // the pane title bar. Zero means "no continuation" (fresh agent or
-    // currently-active pane wrote it just now). useHistoryPagination
-    // sets this on snapshot restore.
-    continuedFromMsAtom: SignalAtom<number> = createSignalAtom(0);
     _activityFlash: () => boolean = () => false;
 
     voiceHandle = (): PaneVoiceHandle => ({
@@ -145,20 +122,6 @@ export class AgentViewModel implements ViewModel {
                     text: activity,
                     className: this._activityFlash() ? "term-activity term-activity--flash" : "term-activity",
                 });
-            }
-
-            // "· continued from Xm ago" chip — shown when this pane mounted
-            // on a non-empty agent session zone whose last write was >30s ago.
-            const continuedFromMs = this.continuedFromMsAtom();
-            if (continuedFromMs) {
-                const delta = Math.max(0, Date.now() - continuedFromMs);
-                if (delta >= 30_000) {
-                    elems.push({
-                        elemtype: "text",
-                        text: `· continued ${formatContinuationAgo(delta)}`,
-                        className: "agent-pane-continuation-chip",
-                    });
-                }
             }
 
             return elems;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -320,12 +320,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         model: paneModel,
         outputFormat,
         definitionId: agentId,
-        // Option E: snapshot read returns the modts of the previous
-        // owner's last write; project into the model so `viewText`
-        // renders a "· continued Xm ago" title-bar chip when the gap
-        // is >30s. Setter is a no-op if the pane unmounts before
-        // restore.
-        onContinuationModts: (ms) => model.continuedFromMsAtom._set(ms),
         onHistoryReady: () => historyReadyFn?.(),
         // Schema v2: apply DocumentState + pane overlay after NDJSON replay.
         onSnapshotOverlay: ({ documentState, detailsOpen }) => {

--- a/frontend/app/view/agent/hooks/useHistoryPagination.test.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.test.ts
@@ -90,7 +90,6 @@ describe("useHistoryPagination — Option E agent-anchored snapshot read", () =>
         });
 
         const model = makeMockModel();
-        const onContinuationModts = vi.fn();
 
         createRoot((d) => {
             dispose = d;
@@ -99,7 +98,6 @@ describe("useHistoryPagination — Option E agent-anchored snapshot read", () =>
                 model,
                 outputFormat: () => "claude-stream-json",
                 definitionId: "def-claude",
-                onContinuationModts,
                 log: () => {},
             });
         });
@@ -127,10 +125,6 @@ describe("useHistoryPagination — Option E agent-anchored snapshot read", () =>
 
         // InitReady fired.
         expect(model.paneEvents.some((e) => e.type === "InitReady")).toBe(true);
-
-        // modts surfaced for the continuation chip.
-        expect(onContinuationModts).toHaveBeenCalledTimes(1);
-        expect(onContinuationModts.mock.calls[0][0]).toBeGreaterThan(0);
     });
 
     it("falls through to NDJSON replay when AgentSessionRead returns no content", async () => {

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -68,14 +68,6 @@ export interface UseHistoryPaginationOptions {
      * straight through to the NDJSON ring-buffer replay.
      */
     definitionId?: string;
-    /**
-     * Option E: called with the `modts` (Unix ms) returned by
-     * `agent:session:read` when the pane successfully restores from a
-     * pre-existing snapshot. The view model projects this into the
-     * "· continued Xm ago" chip in the title bar. Called with 0 when
-     * the read returned no snapshot (fresh agent).
-     */
-    onContinuationModts?: (modts: number) => void;
     /** Called once when the initial history load is complete (or immediately
      *  for an empty document). Used to gate the new-message enter animation
      *  so history rows don't animate on open/restore. See PR #1212. */
@@ -233,7 +225,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 if (!mounted) return;
                 if (stateResp.content) {
                     const snapshot = JSON.parse(stateResp.content);
-                    const modts = typeof stateResp.modts === "number" ? stateResp.modts : 0;
 
                     // --- Schema v2: overlay only, reconstruct nodes from NDJSON ---
                     // Taken only for a SAME-BLOCK reopen with a usable high-water mark:
@@ -318,7 +309,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                         const clampedStart = Math.min(windowStart, available);
                         setHistoryOffset(clampedStart);
                         setHistoryTotal(available);
-                        opts.onContinuationModts?.(modts);
                         opts.log(
                             "history",
                             `v2 restore: ${nodes.length} nodes from lines [${clampedStart}, ${available})` +
@@ -361,7 +351,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             : 0;
                         setHistoryOffset(offset);
                         setHistoryTotal(typeof snapshot.highWaterMark === "number" ? snapshot.highWaterMark : snapshot.nodes.length);
-                        opts.onContinuationModts?.(modts);
                         opts.log(
                             "history",
                             `v1 restore: ${snapshot.nodes.length} nodes from snapshot ` +

--- a/specs/SPEC_AGENT_PANE_HEADER_NAME_PRECEDENCE_2026_06_29.md
+++ b/specs/SPEC_AGENT_PANE_HEADER_NAME_PRECEDENCE_2026_06_29.md
@@ -1,0 +1,126 @@
+# SPEC: Agent Pane Header — Name Precedence + Drop "continued" Chip
+
+**Date:** 2026-06-29
+**Status:** Draft
+**Author:** AgentX
+**Related:** `frontend/app/block/block.scss`, `frontend/app/block/blockframe.tsx`, `frontend/app/view/agent/agent-model.ts`, `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/hooks/useHistoryPagination.ts`
+
+---
+
+## 1. Problems
+
+Two issues in the agent pane's frame header:
+
+1. **The activity summary cuts off the agent name.** When the header is narrow,
+   the agent name truncates *before* the per-turn summary does — the opposite of
+   what we want. The name is the primary identifier and should win the space
+   contest.
+
+2. **The "· continued 5h" chip has no useful meaning.** It reports how long ago
+   the agent's session zone was last written before this pane mounted — an
+   implementation detail that reads as noise to the user. Remove it.
+
+## 2. Current behavior (why the name loses)
+
+The header (`blockframe.tsx:457-509`) is a flex row with these relevant siblings:
+
+| Region | Class | Contents | Flex |
+|---|---|---|---|
+| Name | `.block-frame-default-header-iconview` | icon + agent name (`viewName`) | `flex-shrink: 3` (`block.scss:96`) |
+| Summary | `.block-frame-textelems-wrapper` | `viewText` elems: `term:activity` summary + continued chip | `flex: 1 2 auto` (`block.scss:222`) |
+
+The name region shrinks at rate **3**, the summary region at rate **2**. Under
+space pressure the name therefore collapses *faster* than the summary — the agent
+name ellipsizes (down to `min-width: 17px`) while the summary keeps its width.
+That is the reported bug.
+
+`viewName` / `viewText` are produced by `AgentViewModel` (`agent-model.ts:129-165`):
+`viewName` → `meta.agentName` (fallback "Agent"); `viewText` → `[ term:activity
+summary, "· continued …" chip ]`.
+
+The "continued" chip (`agent-model.ts:150-162`) renders when `continuedFromMsAtom`
+is set and the gap ≥ 30 s. That atom is fed by `useHistoryPagination`'s
+`onContinuationModts` callback (`agent-view.tsx:328`; `useHistoryPagination.ts:78,
+321, 364`), formatted by `formatContinuationAgo` (`agent-model.ts:25`).
+
+## 3. Goals
+
+1. **Name precedence:** the agent name keeps its space; the activity summary is
+   what shrinks/ellipsizes first. The name only truncates once the summary has
+   collapsed to nothing.
+2. **Remove** the "continued" chip and its now-dead plumbing.
+
+## 4. Design
+
+### 4.1 Name precedence (CSS only)
+
+Invert the shrink priority between the two regions so the **summary yields first**:
+
+- `.block-frame-default-header-iconview` — stop shrinking the name ahead of the
+  summary. Set `flex-shrink: 0` (or a small value strictly **less** than the
+  summary's), and keep a sensible `min-width: 0` + ellipsis so a pathologically
+  long name still degrades gracefully rather than overflowing the row.
+- `.block-frame-textelems-wrapper` — raise its `flex-shrink` (e.g. `flex: 1 100
+  auto`) so it absorbs essentially all the squeeze. The inner `.term-activity`
+  already has `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`
+  (`block.scss:166-171`), so it ellipsizes cleanly as it loses width.
+
+**Trade-off (decided):** with the name at `flex-shrink: 0`, a very long agent name
+can push the summary out entirely. That is the intended precedence — the name is
+the identifier; the summary is ancillary. To avoid a name monopolizing the whole
+header, optionally cap the name region with a `max-width` (e.g. `60%`) so the
+summary always retains a sliver until the name itself needs to ellipsize. Pick
+**one** of:
+
+- **A (recommended):** name `flex-shrink: 0` + `max-width: 60%` of the header;
+  summary takes the rest and ellipsizes first. Name ellipsizes only past its cap.
+- **B (simplest):** name `flex-shrink: 1`, summary `flex-shrink: 100`. Name almost
+  never shrinks in practice; no cap. Slightly less predictable at extremes.
+
+Recommendation: **A** — bounded, predictable, the name always readable to ~60% of
+the header before it too ellipsizes.
+
+No TSX change is required for this part — it is purely the flex rules in
+`block.scss`.
+
+### 4.2 Remove the "continued" chip
+
+Delete the chip and its supporting code end-to-end:
+
+1. `agent-model.ts` — remove the chip block (`:150-162`), the
+   `continuedFromMsAtom` field (`:74`), and `formatContinuationAgo` (`:25`) if it
+   has no other caller.
+2. `agent-view.tsx` — remove the `onContinuationModts` wiring (`:328`) and the
+   nearby comment about the continuation chip (`~:324-328`).
+3. `useHistoryPagination.ts` — remove the `onContinuationModts` option (`:78`) and
+   its two invocation sites (`:321, :364`). **Verify first** that the `modts`
+   value computed there serves no other consumer; if it does, keep the
+   computation and only drop the callback.
+4. CSS — the `agent-pane-continuation-chip` class has no dedicated rule (it rides
+   `.block-frame-text`), so nothing to delete in `block.scss`; just stop emitting
+   the className.
+
+After removal, `viewText` returns only the `term:activity` summary (or `[]` when
+there is none).
+
+## 5. Out of scope
+
+- The `term:activity` summary content/generation (Haiku-per-turn) is unchanged —
+  only its layout priority changes.
+- The widget-bar / other view types' headers (`blockframe.tsx` is shared) — the
+  flex tweak is scoped to the agent header classes only; confirm no regression to
+  term/editor/browser headers that reuse `.block-frame-textelems-wrapper`. If the
+  wrapper rule is shared, scope the change with an agent-pane modifier class
+  rather than editing the shared rule.
+
+## 6. Test plan
+
+- Narrow the agent pane: the **agent name stays fully visible** while the activity
+  summary ellipsizes, then disappears; the name only ellipsizes past its cap
+  (option A).
+- A long agent name + long summary: name readable to its cap; summary degrades
+  first.
+- No "· continued …" chip ever appears; `tsc --noEmit` clean (no dangling refs to
+  the removed atom/callback/formatter).
+- Regression check: term / editor / browser pane headers still lay out correctly
+  (shared `blockframe.tsx`).


### PR DESCRIPTION
## Summary

Two agent-pane header fixes, with root cause traced to exact file:line.

### 1. Activity summary cuts off the agent name
The header name region (`.block-frame-default-header-iconview`, `flex-shrink: 3`, `block.scss:96`) shrinks **faster** than the summary region (`.block-frame-textelems-wrapper`, `flex: 1 2 auto`, `block.scss:222`) — so the name truncates before the summary. Backwards.

**Fix (CSS-only):** invert the priority so the summary ellipsizes first (it already has `text-overflow: ellipsis`). Recommended option A — name `flex-shrink: 0` + `max-width: 60%` so it stays fully readable to a cap, summary absorbs the squeeze.

### 2. "· continued 5h" chip is meaningless
It reports how long ago the session zone was last written before the pane mounted — an implementation detail. Remove the chip (`agent-model.ts:150-162`) and its plumbing (`continuedFromMsAtom`, `formatContinuationAgo`, the `onContinuationModts` wiring in `agent-view.tsx` + `useHistoryPagination.ts`).

## Notes
- `blockframe.tsx` is shared across pane types — spec flags scoping the flex tweak with an agent modifier class if the wrapper rule is shared, to avoid term/editor/browser header regressions.
- Verify `useHistoryPagination`'s `modts` has no other consumer before deleting the callback.

## Test plan
- [ ] Narrow agent pane: name stays visible, summary ellipsizes then disappears
- [ ] No "· continued …" chip; `tsc --noEmit` clean
- [ ] term/editor/browser headers unregressed

<!-- agentmux:agent_id=agentx -->