### PR TITLE
fix(ci): stage CEF DLLs from OUT_DIR on rust-cache hit (Windows artifacts)

### DIFF
--- a/.changesets/1782786622-fix-windows-artifacts-rust-cache-cef-dlls.md
+++ b/.changesets/1782786622-fix-windows-artifacts-rust-cache-cef-dlls.md
@@ -1,0 +1,11 @@
+---
+patch: "fix(ci): stage CEF DLLs from OUT_DIR on rust-cache hit (Windows artifacts)"
+---
+
+On a rust-cache hit the cef-dll-sys build script does not re-run, so its
+side-effect of copying libcef.dll/icudtl.dat to target/release/ never
+happens — causing the bundle:windows guard to fail with "incomplete CEF
+runtime". The CEF SDK is still intact in the build OUT_DIR
+(target/release/build/cef-dll-sys-*/out/), which rust-cache preserves.
+bundle:windows now falls back to that dir and copies the DLLs when
+target/release/ is missing them.

--- a/.changesets/1782786622-fix-windows-artifacts-rust-cache-cef-dlls.md
+++ b/.changesets/1782786622-fix-windows-artifacts-rust-cache-cef-dlls.md
@@ -1,11 +1,5 @@
 ---
-patch: "fix(ci): stage CEF DLLs from OUT_DIR on rust-cache hit (Windows artifacts)"
+type: patch
 ---
 
-On a rust-cache hit the cef-dll-sys build script does not re-run, so its
-side-effect of copying libcef.dll/icudtl.dat to target/release/ never
-happens — causing the bundle:windows guard to fail with "incomplete CEF
-runtime". The CEF SDK is still intact in the build OUT_DIR
-(target/release/build/cef-dll-sys-*/out/), which rust-cache preserves.
-bundle:windows now falls back to that dir and copies the DLLs when
-target/release/ is missing them.
+fix(ci): stage CEF DLLs from OUT_DIR on rust-cache hit (Windows artifacts)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -571,11 +571,20 @@ tasks:
                   # full platform dir to target/release/ — same files the build
                   # script would have copied (copy_cef_runtime_files in
                   # cef-dll-sys/sys/build.rs).
+                  # Glob may match multiple OUT_DIRs (e.g. stale build from a
+                  # previous CEF major alongside the current one — exactly the
+                  # hazard the Taskfile comment above warns about). Run
+                  # verify-cef-version.sh against each candidate and take the
+                  # first that passes, so a stale 146 directory is skipped when
+                  # the linked crate expects 148.
                   cefOutDir=""
                   for dll in target/release/build/cef-dll-sys-*/out/*/libcef.dll; do
                     if [ -f "$dll" ]; then
-                      cefOutDir="$(dirname "$dll")"
-                      break
+                      candidate="$(dirname "$dll")"
+                      if bash scripts/verify-cef-version.sh "$candidate" 2>/dev/null; then
+                        cefOutDir="$candidate"
+                        break
+                      fi
                     fi
                   done
                   if [ -n "$cefOutDir" ]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -590,6 +590,14 @@ tasks:
                   if [ -n "$cefOutDir" ]; then
                     echo "rust-cache hit: staging CEF DLLs from OUT_DIR ($cefOutDir) → $cefDir"
                     cp -rf "$cefOutDir/." "$cefDir/"
+                    # Re-assert both required files are now present — an OUT_DIR
+                    # that has libcef.dll but not icudtl.dat (e.g. a partial
+                    # extract) would pass the version check above but still
+                    # produce a broken bundle.
+                    if [ ! -f "$cefDir/icudtl.dat" ]; then
+                      echo "❌ OUT_DIR copy succeeded but icudtl.dat still missing in $cefDir" >&2
+                      exit 1
+                    fi
                   else
                     echo "❌ incomplete CEF runtime in $cefDir (need libcef.dll + icudtl.dat) — run 'task build:host' first"
                     exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -564,8 +564,27 @@ tasks:
                 # uses a limited Go coreutils that rejects those flags.)
                 cefDir=target/release
                 if [ ! -f "$cefDir/libcef.dll" ] || [ ! -f "$cefDir/icudtl.dat" ]; then
-                  echo "❌ incomplete CEF runtime in $cefDir (need libcef.dll + icudtl.dat) — run 'task build:host' first"
-                  exit 1
+                  # rust-cache hit: cef-dll-sys build script didn't re-run →
+                  # DLLs not staged to target/release/. The CEF SDK is still in
+                  # the build OUT_DIR (rust-cache preserves
+                  # target/release/build/). Find libcef.dll there and copy the
+                  # full platform dir to target/release/ — same files the build
+                  # script would have copied (copy_cef_runtime_files in
+                  # cef-dll-sys/sys/build.rs).
+                  cefOutDir=""
+                  for dll in target/release/build/cef-dll-sys-*/out/*/libcef.dll; do
+                    if [ -f "$dll" ]; then
+                      cefOutDir="$(dirname "$dll")"
+                      break
+                    fi
+                  done
+                  if [ -n "$cefOutDir" ]; then
+                    echo "rust-cache hit: staging CEF DLLs from OUT_DIR ($cefOutDir) → $cefDir"
+                    cp -rf "$cefOutDir/." "$cefDir/"
+                  else
+                    echo "❌ incomplete CEF runtime in $cefDir (need libcef.dll + icudtl.dat) — run 'task build:host' first"
+                    exit 1
+                  fi
                 fi
                 echo "Found runtime binaries in: $cefDir"
                 # Guard: the bundled libcef.dll MUST match the linked `cef` crate


### PR DESCRIPTION
## Problem

The `ci-nightly-artifacts` Windows job has been failing since June 27 with:

```
❌ incomplete CEF runtime in target/release (need libcef.dll + icudtl.dat) — run 'task build:host' first
task: Failed to run task "bundle:windows": exit status 1
```

**Root cause:** `Swatinem/rust-cache@v2` restores the Rust build cache, so on a cache hit `cargo build` skips all crates — including `cef-dll-sys`. The `cef-dll-sys` build script (`sys/build.rs`) copies `libcef.dll`, `icudtl.dat`, and the rest of the CEF runtime from its download location into `target/release/` as a side effect of compilation (`copy_cef_runtime_files`). When the build script doesn't run, those files are never staged and `bundle:windows` fails its guard.

## Fix

When `target/release/libcef.dll` is missing, `bundle:windows` now searches `target/release/build/cef-dll-sys-*/out/*/` for `libcef.dll` and copies the full platform directory to `target/release/`. rust-cache **does** preserve the build `OUT_DIR` (it caches `target/release/build/`), so the CEF SDK is intact there even on a cache hit — we just need to copy it across.

This is equivalent to what `copy_cef_runtime_files()` does at build time, applied lazily at bundle time when the build script was skipped.

The existing version-integrity guard (`verify-cef-version.sh`) still runs after staging, so a stale DLL from a previous CEF version can't slip through.

## What changes

- `Taskfile.yml`: `bundle:windows` falls back to OUT_DIR when DLLs are absent from `target/release/`
- `.changesets/...`: patch changeset

No CI workflow changes needed — the fix is in the Taskfile that runs on all platforms.

<!-- agentmux:agent_id=camper-0622h -->