### PR TITLE
feat(ci): unified release workflow — builds, GitHub Release, S3, winget, MS Store, landing page

### DIFF
--- a/.changesets/1782682000-fix-unified-release-cicd-dd04.md
+++ b/.changesets/1782682000-fix-unified-release-cicd-dd04.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+fix(ci): correct VH_VER extraction, installer URL, version gate message, and changelog exit code in unified release workflow

--- a/.changesets/1782791255-feat-ci-unified-release-workflow-build-publish-winget-ms-sto-0g9g.md
+++ b/.changesets/1782791255-feat-ci-unified-release-workflow-build-publish-winget-ms-sto-0g9g.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(ci): unified release workflow — build, publish, winget, MS Store, landing page

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,481 @@
+name: Release
+
+# Triggered by pushing a semver tag (v0.50.0) or via workflow_dispatch for
+# emergency reruns. Verifies version consistency, builds all three platform
+# artifacts, publishes a GitHub Release + S3 mirror, submits to WinGet and
+# the Microsoft Store (non-blocking), and triggers the landing page deploy.
+#
+# See docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md for the full design.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.50.0) — must already exist'
+        required: true
+
+jobs:
+  # ── Phase 1: Version consistency guard ───────────────────────────────────
+  verify:
+    name: Verify version consistency
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Check version consistency
+        id: check
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VER="${TAG#v}"
+          PKG_VER=$(node -p "require('./package.json').version")
+          CARGO_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"//;s/".*//')
+          VH_VER=$(grep -m1 '^## ' VERSION_HISTORY.md | sed 's/## //' | tr -d '[:space:]')
+          echo "tag=$VER  pkg=$PKG_VER  cargo=$CARGO_VER  vh=$VH_VER"
+          if [ "$VER" != "$PKG_VER" ] || [ "$VER" != "$CARGO_VER" ] || [ "$VER" != "$VH_VER" ]; then
+            echo "❌ Version mismatch — all five locations must agree before release"
+            echo "   tag=$VER  package.json=$PKG_VER  Cargo.toml=$CARGO_VER  VERSION_HISTORY=$VH_VER"
+            exit 1
+          fi
+          echo "✓ Version $VER consistent across all locations"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+  # ── Phase 2: Build all platforms (parallel) ───────────────────────────────
+  build-windows:
+    name: Build — Windows portable + installer + MSIX
+    needs: verify
+    runs-on: windows-latest
+    env:
+      OUT: ${{ github.workspace }}/artifacts
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Auth npm for @a5af GitHub Packages
+        shell: bash
+        run: |
+          {
+            echo "@a5af:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.A5AF_PACKAGES_TOKEN }}"
+          } >> .npmrc
+
+      - run: npm install
+
+      - name: Install build tools (Ninja, go-task, Inno Setup)
+        shell: pwsh
+        run: choco install ninja go-task innosetup -y
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build portable (RELEASE_CHANNEL=stable, STRIP_MAPS=1)
+        shell: bash
+        run: |
+          mkdir -p "$OUT"
+          STRIP_MAPS=1 RELEASE_CHANNEL=stable bash scripts/package.sh "$OUT"
+
+      - name: Build installer
+        shell: pwsh
+        run: |
+          $portableDir = Get-ChildItem "$env:OUT" -Directory -Filter "agentmux-*-x64-portable" |
+                         Sort-Object LastWriteTime -Descending |
+                         Select-Object -First 1 -ExpandProperty FullName
+          if (-not $portableDir) { throw "portable dir not found in $env:OUT" }
+          & "${{ github.workspace }}\scripts\package-installer.ps1" `
+            -PortableDir $portableDir `
+            -OutputDir "$env:OUT"
+
+      - name: Build MSIX (unsigned — Store re-signs on ingest)
+        shell: pwsh
+        run: |
+          $msixOut = Join-Path "$env:OUT" "msix"
+          New-Item -ItemType Directory -Force -Path $msixOut | Out-Null
+          $portableDir = Get-ChildItem "$env:OUT" -Directory -Filter "agentmux-*-x64-portable" |
+                         Sort-Object LastWriteTime -Descending |
+                         Select-Object -First 1 -ExpandProperty FullName
+          & "${{ github.workspace }}\scripts\package-msix.ps1" `
+            -PortableDir $portableDir `
+            -OutputDir $msixOut `
+            -SkipBuild
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-portable
+          path: ${{ env.OUT }}/agentmux-*-x64-portable.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: ${{ env.OUT }}/AgentMux-*-x64-setup.exe
+          if-no-files-found: error
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-msix
+          path: ${{ env.OUT }}/msix/AgentMux_*_x64.msix
+          if-no-files-found: error
+          retention-days: 7
+
+  build-linux:
+    name: Build — Linux AppImage
+    needs: verify
+    runs-on: ubuntu-22.04
+    env:
+      OUT: ${{ github.workspace }}/artifacts
+      CEF_RUNTIME_DIR: ${{ github.workspace }}/cef-runtime
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-ubuntu22-release"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Auth npm for @a5af GitHub Packages
+        run: |
+          {
+            echo "@a5af:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.A5AF_PACKAGES_TOKEN }}"
+          } >> .npmrc
+
+      - run: npm install
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build \
+            libwayland-dev libxkbcommon-dev libgtk-3-dev \
+            libglib2.0-dev libpango1.0-dev libcairo2-dev \
+            libgdk-pixbuf2.0-dev libatk1.0-dev
+
+      - name: Install go-task
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
+      - name: Resolve patched libcef.so tag
+        id: cef
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          TAG=$(gh release list --repo agentmuxai/cef --limit 1 \
+                  --json tagName --jq '.[0].tagName')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Cache patched libcef.so
+        id: cef-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CEF_RUNTIME_DIR }}
+          key: cef-runtime-${{ steps.cef.outputs.tag }}
+
+      - name: Download patched libcef.so
+        if: steps.cef-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR"
+          gh release download "${{ steps.cef.outputs.tag }}" \
+            --repo agentmuxai/cef --pattern "*.tar.gz" \
+            --dir /tmp/cef-extract --clobber
+          tar -xzf /tmp/cef-extract/*.tar.gz -C /tmp/cef-extract
+          LIBCEF=$(find /tmp/cef-extract -name "libcef.so" | head -1)
+          if [ -z "$LIBCEF" ]; then echo "ERROR: libcef.so not found in tarball"; exit 1; fi
+          cp -r "$(dirname "$LIBCEF")/." "$CEF_RUNTIME_DIR/"
+          rm -rf /tmp/cef-extract
+
+      - name: Set AGENTMUX_CEF_RUNTIME_DIR
+        run: echo "AGENTMUX_CEF_RUNTIME_DIR=$CEF_RUNTIME_DIR" >> "$GITHUB_ENV"
+
+      - name: Install appimagetool
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o "$HOME/.local/bin/appimagetool" \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x "$HOME/.local/bin/appimagetool"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "APPIMAGE_EXTRACT_AND_RUN=1" >> "$GITHUB_ENV"
+
+      - name: Build AppImage
+        run: |
+          mkdir -p "$OUT"
+          RELEASE_CHANNEL=stable bash scripts/package-linux.sh "$OUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-appimage
+          path: ${{ env.OUT }}/AgentMux_*_amd64.AppImage
+          if-no-files-found: error
+          retention-days: 7
+
+  build-macos:
+    name: Build — macOS arm64 DMG
+    needs: verify
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    env:
+      OUT: ${{ github.workspace }}/artifacts
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Auth npm for @a5af GitHub Packages
+        run: |
+          {
+            echo "@a5af:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.A5AF_PACKAGES_TOKEN }}"
+          } >> .npmrc
+
+      - run: npm install
+
+      - name: Install go-task
+        run: brew install go-task
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build-${{ github.run_id }}.keychain"
+          KEYCHAIN_PASS="$(uuidgen)"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASS=$KEYCHAIN_PASS" >> "$GITHUB_ENV"
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+          security set-keychain-settings -t 3600 -u "$KEYCHAIN_PATH"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > /tmp/cert.p12
+          security import /tmp/cert.p12 \
+            -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          rm -f /tmp/cert.p12
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+
+      - name: Store notarytool credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool store-credentials "notarytool" \
+            --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" --keychain "$KEYCHAIN_PATH" --no-validate
+
+      - name: Build, sign, and notarize DMG
+        run: |
+          mkdir -p "$OUT"
+          task package:macos -- "$OUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: ${{ env.OUT }}/AgentMux_*_arm64.dmg
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Delete temp keychain
+        if: always()
+        run: security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+
+  # ── Phase 3: Publish GitHub Release + S3 mirror ──────────────────────────
+  publish:
+    name: Publish release
+    needs: [verify, build-windows, build-linux, build-macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      S3_RELEASES: s3://dl.agentmux.ai/releases
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Flatten artifact tree
+        run: |
+          mkdir -p dist-flat
+          find release-artifacts -type f \( -name "*.zip" -o -name "*.exe" -o -name "*.msix" -o -name "*.AppImage" -o -name "*.dmg" \) -exec cp {} dist-flat/ \;
+          echo "--- Release artifacts ---"
+          ls -lh dist-flat/
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          NOTES=$(bash scripts/extract-changelog.sh "$VERSION")
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v${VERSION}"
+          fi
+          # Write to file to safely pass multiline content to gh release create
+          echo "$NOTES" > /tmp/release-notes.md
+          echo "Release notes:"
+          cat /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "AgentMux v${VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            dist-flat/*
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Mirror artifacts to S3 (versioned path)
+        run: |
+          for f in dist-flat/*; do
+            aws s3 cp "$f" "${S3_RELEASES}/${VERSION}/$(basename "$f")" \
+              --cache-control "public, max-age=31536000, immutable"
+          done
+
+      - name: Mirror artifacts to S3 (latest/ unversioned stable URLs)
+        run: |
+          # Unversioned names match the map in agentmux-landing/scripts/fetch-release.mjs
+          declare -A UNVERSIONED=(
+            ["setup.exe"]="AgentMux_x64-setup.exe"
+            ["portable.zip"]="agentmux-x64-portable.zip"
+            ["amd64.AppImage"]="AgentMux_amd64.AppImage"
+            ["arm64.dmg"]="AgentMux_aarch64.dmg"
+            ["x64.msix"]="AgentMux_x64.msix"
+          )
+          for f in dist-flat/*; do
+            BASENAME=$(basename "$f")
+            LOWER="${BASENAME,,}"
+            for suffix in "${!UNVERSIONED[@]}"; do
+              if [[ "$LOWER" == *"${suffix,,}"* ]]; then
+                DEST="${UNVERSIONED[$suffix]}"
+                aws s3 cp "$f" "${S3_RELEASES}/latest/${DEST}" \
+                  --cache-control "public, max-age=300"
+                echo "  $BASENAME → latest/$DEST"
+                break
+              fi
+            done
+          done
+
+      - name: Trigger landing page deploy
+        env:
+          GH_TOKEN: ${{ secrets.LANDING_DEPLOY_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/agentmuxai/agentmux-landing/dispatches \
+            -f event_type=release \
+            -F client_payload[version]="${VERSION}"
+
+  # ── Phase 4: Distribution channels (non-blocking, parallel) ───────────────
+  winget:
+    name: Submit WinGet update
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+    steps:
+      - name: Install wingetcreate
+        run: |
+          curl -fsSL -o wingetcreate \
+            "https://github.com/microsoft/winget-create/releases/latest/download/wingetcreate-linux"
+          chmod +x wingetcreate
+
+      - name: Submit WinGet manifest PR
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          INSTALLER_URL="https://dl.agentmux.ai/releases/${VERSION}/AgentMux_x64-setup.exe"
+          ./wingetcreate update AgentMux.AgentMux \
+            --version "${VERSION}" \
+            --urls "$INSTALLER_URL" \
+            --submit \
+            --token "$WINGET_TOKEN"
+
+  ms-store:
+    name: Submit Microsoft Store update
+    needs: [verify, publish]
+    runs-on: windows-latest
+    continue-on-error: true
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+    steps:
+      - name: Install msstore CLI
+        shell: pwsh
+        run: winget install Microsoft.StoreCLI --silent --accept-package-agreements --accept-source-agreements
+
+      - name: Configure msstore credentials
+        shell: pwsh
+        env:
+          MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
+          MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+          MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+          MSSTORE_SELLER_ID: ${{ secrets.MSSTORE_SELLER_ID }}
+        run: |
+          msstore settings --tenantId $env:MSSTORE_TENANT_ID `
+            --clientId $env:MSSTORE_CLIENT_ID `
+            --clientSecret $env:MSSTORE_CLIENT_SECRET `
+            --sellerId $env:MSSTORE_SELLER_ID
+
+      - name: Download MSIX from GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "v${VERSION}" \
+            --repo agentmuxai/agentmux \
+            --pattern "*.msix" \
+            --dir msix-download
+
+      - name: Submit to Microsoft Store
+        shell: pwsh
+        run: |
+          $msix = Get-ChildItem msix-download -Filter "*.msix" | Select-Object -First 1
+          msstore publish $msix.FullName --no-confirmation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,18 @@ jobs:
           PKG_VER=$(node -p "require('./package.json').version")
           CARGO_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"//;s/".*//')
           VH_VER=$(grep -m1 '^## ' VERSION_HISTORY.md | sed 's/## //' | tr -d '[:space:]')
-          echo "tag=$VER  pkg=$PKG_VER  cargo=$CARGO_VER  vh=$VH_VER"
-          if [ "$VER" != "$PKG_VER" ] || [ "$VER" != "$CARGO_VER" ] || [ "$VER" != "$VH_VER" ]; then
+          # Cargo.lock: workspace member version (e.g. agentmux-cef)
+          LOCK_VER=$(awk '/^name = "agentmux-cef"/{found=1} found && /^version =/{gsub(/[" ]*/,"",$NF); print $NF; exit}' Cargo.lock)
+          # package-lock.json: root "version" field
+          PKGLOCK_VER=$(node -p "require('./package-lock.json').version")
+          echo "tag=$VER  pkg=$PKG_VER  cargo=$CARGO_VER  vh=$VH_VER  lock=$LOCK_VER  pkglock=$PKGLOCK_VER"
+          MISMATCH=0
+          for v in "$PKG_VER" "$CARGO_VER" "$VH_VER" "$LOCK_VER" "$PKGLOCK_VER"; do
+            if [ "$v" != "$VER" ]; then MISMATCH=1; fi
+          done
+          if [ "$MISMATCH" = "1" ]; then
             echo "❌ Version mismatch — all five locations must agree before release"
-            echo "   tag=$VER  package.json=$PKG_VER  Cargo.toml=$CARGO_VER  VERSION_HISTORY=$VH_VER"
+            echo "   tag=$VER  package.json=$PKG_VER  Cargo.toml=$CARGO_VER  VERSION_HISTORY=$VH_VER  Cargo.lock=$LOCK_VER  package-lock.json=$PKGLOCK_VER"
             exit 1
           fi
           echo "✓ Version $VER consistent across all locations"
@@ -381,10 +389,11 @@ jobs:
       - name: Mirror artifacts to S3 (latest/ unversioned stable URLs)
         run: |
           # Unversioned names match the map in agentmux-landing/scripts/fetch-release.mjs
+          # Note: no .deb — only AppImage is produced by the Linux build job.
           declare -A UNVERSIONED=(
-            ["setup.exe"]="AgentMux_x64-setup.exe"
+            ["x64-setup.exe"]="AgentMux_x64-setup.exe"
             ["portable.zip"]="agentmux-x64-portable.zip"
-            ["amd64.AppImage"]="AgentMux_amd64.AppImage"
+            [".AppImage"]="AgentMux_amd64.AppImage"
             ["arm64.dmg"]="AgentMux_aarch64.dmg"
             ["x64.msix"]="AgentMux_x64.msix"
           )
@@ -431,8 +440,20 @@ jobs:
       - name: Submit WinGet manifest PR
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          INSTALLER_URL="https://dl.agentmux.ai/releases/${VERSION}/AgentMux_x64-setup.exe"
+          # Resolve the actual installer filename from the GitHub Release assets
+          # (package-installer.ps1 produces AgentMux-<ver>-x64-setup.exe with dashes,
+          # not underscores — the versioned S3 path uses the same name as the artifact).
+          INSTALLER_NAME=$(gh release view "v${VERSION}" \
+            --repo agentmuxai/agentmux \
+            --json assets --jq '.assets[].name' | grep -i 'setup\.exe$' | head -1)
+          if [ -z "$INSTALLER_NAME" ]; then
+            echo "❌ No setup.exe asset found in GitHub Release v${VERSION}" >&2
+            exit 1
+          fi
+          INSTALLER_URL="https://dl.agentmux.ai/releases/${VERSION}/${INSTALLER_NAME}"
+          echo "WinGet installer URL: $INSTALLER_URL"
           ./wingetcreate update AgentMux.AgentMux \
             --version "${VERSION}" \
             --urls "$INSTALLER_URL" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,10 +241,29 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # check-macos probes the APPLE_CEF_AVAILABLE secret and exposes it as a job
+  # output, because the `secrets` context is not available in job-level `if`
+  # expressions (only github, needs, vars, inputs, and status functions are).
+  check-macos:
+    name: Check macOS build availability
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.check.outputs.available }}
+    steps:
+      - id: check
+        env:
+          APPLE_CEF_AVAILABLE: ${{ secrets.APPLE_CEF_AVAILABLE }}
+        run: |
+          if [ -n "$APPLE_CEF_AVAILABLE" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
   build-macos:
     name: Build — macOS arm64 DMG
-    needs: verify
-    if: ${{ secrets.APPLE_CEF_AVAILABLE != '' }}
+    needs: [verify, check-macos]
+    if: needs.check-macos.outputs.available == 'true'
     runs-on: macos-latest
     permissions:
       contents: write
@@ -324,7 +343,7 @@ jobs:
   # ── Phase 3: Publish GitHub Release + S3 mirror ──────────────────────────
   publish:
     name: Publish release
-    needs: [verify, build-windows, build-linux, build-macos]
+    needs: [verify, check-macos, build-windows, build-linux, build-macos]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
@@ -356,10 +375,10 @@ jobs:
       - name: Extract changelog for this version
         id: changelog
         run: |
+          # extract-changelog.sh exits non-zero on a missing entry, so an
+          # empty-NOTES fallback here is dead code — the step would already
+          # have failed under set -e before reaching it.
           NOTES=$(bash scripts/extract-changelog.sh "$VERSION")
-          if [ -z "$NOTES" ]; then
-            NOTES="Release v${VERSION}"
-          fi
           # Write to file to safely pass multiline content to gh release create
           echo "$NOTES" > /tmp/release-notes.md
           echo "Release notes:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           VER="${TAG#v}"
           PKG_VER=$(node -p "require('./package.json').version")
           CARGO_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"//;s/".*//')
-          VH_VER=$(grep -m1 '^## ' VERSION_HISTORY.md | sed 's/## //' | tr -d '[:space:]')
+          VH_VER=$(grep -m1 '^## ' VERSION_HISTORY.md | awk '{print $2}')
           # Cargo.lock: workspace member version (e.g. agentmux-cef)
           LOCK_VER=$(awk '/^name = "agentmux-cef"/{found=1} found && /^version =/{gsub(/[" ]*/,"",$NF); print $NF; exit}' Cargo.lock)
           # package-lock.json: root "version" field

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,10 +388,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${VERSION}" \
-            --title "AgentMux v${VERSION}" \
-            --notes-file /tmp/release-notes.md \
-            dist-flat/*
+          if ! gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "v${VERSION}" \
+              --title "AgentMux v${VERSION}" \
+              --notes-file /tmp/release-notes.md \
+              dist-flat/*
+          else
+            echo "Release v${VERSION} already exists -- uploading/overwriting artifacts only"
+            gh release upload "v${VERSION}" dist-flat/* --clobber
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,7 @@ jobs:
   build-macos:
     name: Build — macOS arm64 DMG
     needs: verify
+    if: ${{ secrets.APPLE_CEF_AVAILABLE != '' }}
     runs-on: macos-latest
     permissions:
       contents: write
@@ -324,6 +325,7 @@ jobs:
   publish:
     name: Publish release
     needs: [verify, build-windows, build-linux, build-macos]
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md
+++ b/docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md
@@ -52,7 +52,7 @@ git tag v0.50.0 → push
   │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐    │
   │  │ build:win    │  │ build:linux  │  │ build:macos  │    │
   │  │ portable.zip │  │ AppImage     │  │ DMG arm64    │    │
-  │  │ setup.exe    │  │ .deb         │  │              │    │
+  │  │ setup.exe    │  │              │  │              │    │
   │  │ .msix        │  │              │  │              │    │
   │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘   │
   │         └──────────────────┴──────────────────┘          │
@@ -137,7 +137,7 @@ _Windows_ (`windows-latest`):
 
 _Linux_ (`ubuntu-22.04`):
 - Same steps as `ci-nightly-artifacts.yml` linux job (patched CEF download)
-- Outputs: AppImage, .deb
+- Outputs: AppImage
 
 _macOS_ (`macos-latest`):
 - Same steps as `ci-nightly-artifacts.yml` macos job (Apple cert, notarize, patched CEF TBD)

--- a/docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md
+++ b/docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md
@@ -1,0 +1,259 @@
+# Unified Release CI/CD — agentmux + MS Store + Landing Page
+**Date:** 2026-06-29  
+**Status:** Draft  
+**Scope:** agentmuxai/agentmux, agentmuxai/agentmux-landing, a5af/shared-infrastructure
+
+---
+
+## 1. Problem Statement
+
+Three delivery surfaces exist but are not connected into a single release flow:
+
+| Surface | Current state |
+|---|---|
+| **agentmuxai/agentmux** builds | Nightly artifacts CI passes (Linux/macOS); Windows fixed by PR #1845; no release workflow |
+| **Microsoft Store** | Spec'd in PR #1843 (not yet wired); requires Partner Center setup first |
+| **agentmux.ai landing page** | CDK + `fetch-release.mjs` deployed manually; no CI/CD workflow |
+| **gh-reporter nightly email** | Lambda healthy; `infrastructure-weekly-analysts` stack in `UPDATE_ROLLBACK_COMPLETE` |
+
+Today a release requires manual execution of at least five independent steps across four repos/systems. Gaps: artifacts not published to GitHub Releases, landing page not auto-updated, MS Store submission manual.
+
+---
+
+## 2. Design Dimensions Considered
+
+| Dimension | Option A | Option B | **Chosen** |
+|---|---|---|---|
+| Release trigger | Separate per-surface triggers | Manual dispatch only | **`v*` tag → single fan-out workflow** |
+| Artifact source | Rebuild on release | Reuse nightly artifacts | **Rebuild: nightly uses local-label channel, release needs `stable` channel baked in** |
+| Landing page wiring | Polling / cron | Repository dispatch from agentmux | **`repository_dispatch` event from release workflow** |
+| MS Store timing | Same job as release | Separate, non-blocking | **Non-blocking parallel job: cert failure must not block the release** |
+| Infrastructure fix | Leave rollback stack | Delete + redeploy | **Rename SSM docs (no delete) → clean update** |
+
+**Rationale for single-tag-trigger fan-out:** a release is an atomic event — version bump, changelog, all artifacts, all channels should ship together or be clearly tracked as failing. Separate triggers (one per surface) create version skew risk where the landing page shows v0.49.8 while the Store still shows v0.48.x.
+
+---
+
+## 3. Target Architecture
+
+```
+git tag v0.50.0 → push
+          │
+          ▼
+  ┌───────────────────────────────────────────────────────────┐
+  │       release.yml  (agentmuxai/agentmux)                  │
+  │                                                           │
+  │  ┌──────────────┐                                         │
+  │  │ verify       │  assert tag == VERSION_HISTORY ==       │
+  │  │              │  package.json == Cargo.toml             │
+  │  └──────┬───────┘                                         │
+  │         │ (pass)                                          │
+  │         ▼                                                 │
+  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐    │
+  │  │ build:win    │  │ build:linux  │  │ build:macos  │    │
+  │  │ portable.zip │  │ AppImage     │  │ DMG arm64    │    │
+  │  │ setup.exe    │  │ .deb         │  │              │    │
+  │  │ .msix        │  │              │  │              │    │
+  │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘   │
+  │         └──────────────────┴──────────────────┘          │
+  │                            │                              │
+  │                            ▼                              │
+  │  ┌─────────────────────────────────────────────────────┐  │
+  │  │ publish                                             │  │
+  │  │  1. Create GitHub Release + changelog               │  │
+  │  │  2. Upload artifacts to GH Release                  │  │
+  │  │  3. Mirror to S3 dl.agentmux.ai/releases/<ver>/     │  │
+  │  │  4. Mirror to S3 dl.agentmux.ai/releases/latest/    │  │
+  │  └──────────────────────────┬──────────────────────────┘  │
+  │                             │                              │
+  │    ┌────────────────────────┼────────────────────────┐    │
+  │    ▼                        ▼                        ▼    │
+  │ ┌──────────┐         ┌───────────┐          ┌──────────┐  │
+  │ │ winget   │         │ ms-store  │          │ landing  │  │
+  │ │ PR via   │         │ msstore   │          │ dispatch │  │
+  │ │ winget-  │         │ publish   │          │ event →  │  │
+  │ │ create   │         │ (non-     │          │ landing  │  │
+  │ │          │         │ blocking) │          │ deploy   │  │
+  │ └──────────┘         └───────────┘          └──────────┘  │
+  └───────────────────────────────────────────────────────────┘
+                                                      │
+                                                      ▼
+                                    ┌─────────────────────────────┐
+                                    │  landing-deploy.yml          │
+                                    │  (agentmuxai/agentmux-landing│
+                                    │                              │
+                                    │  1. fetch-release.mjs        │
+                                    │     → public/release.json    │
+                                    │  2. vite build               │
+                                    │  3. CDK deploy               │
+                                    │  4. CloudFront invalidation  │
+                                    └─────────────────────────────┘
+```
+
+---
+
+## 4. Implementation Plan
+
+### 4.1 Fix: `infrastructure-weekly-analysts` stuck stack
+
+**Root cause:** CDK renamed two SSM Documents (`weekly-security-researcher`, `weekly-architecture-analyst`) with explicit `documentName` properties. CloudFormation cannot replace a custom-named resource in-place — it requires create-new + delete-old, which it won't do if the old name is still in use.
+
+**Fix** (in `a5af/shared-infrastructure`):
+1. Remove `documentName` props from both SSM Document constructs in `weekly-analysts` CDK stack (let CDK generate unique names).
+2. `cdk deploy infrastructure-weekly-analysts` — without custom names, CloudFormation can replace by creating new names first.
+3. Verify stack reaches `UPDATE_COMPLETE`.
+
+No user-visible impact: these are internal SSM automation documents, not exposed externally.
+
+---
+
+### 4.2 New: `release.yml` (agentmuxai/agentmux)
+
+**Trigger:**
+```yaml
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.50.0)'
+        required: true
+```
+
+**Job: `verify`** (ubuntu-latest, fast)
+- Checkout at tag
+- Assert `package.json` version == tag suffix == `VERSION_HISTORY.md` top entry == `Cargo.toml` workspace version
+- Fail loudly if any mismatch (release-consistency invariant, see `scripts/release.sh`)
+
+**Jobs: `build-windows`, `build-linux`, `build-macos`** (parallel, depend on `verify`)
+
+_Windows_ (`windows-latest`):
+- Same steps as `ci-nightly-artifacts.yml` windows job (Ninja, go-task, Inno Setup, rust-cache)
+- `STRIP_MAPS=1 RELEASE_CHANNEL=stable bash scripts/package.sh`
+- Package installer: `scripts/package-installer.ps1`
+- Package MSIX: `scripts/package-msix.ps1` (unsigned — Store re-signs)
+- Upload: portable.zip, setup.exe, AgentMux_<ver>_x64.msix
+
+_Linux_ (`ubuntu-22.04`):
+- Same steps as `ci-nightly-artifacts.yml` linux job (patched CEF download)
+- Outputs: AppImage, .deb
+
+_macOS_ (`macos-latest`):
+- Same steps as `ci-nightly-artifacts.yml` macos job (Apple cert, notarize, patched CEF TBD)
+- Output: AgentMux_<ver>_arm64.dmg
+- **Note:** macOS CI currently uses stock CEF (no patched framework uploaded to `agentmuxai/cef` yet). This is a known gap — macOS DMG will crash on macOS 26 until the patched framework is published. Gate the macOS release job on `APPLE_CEF_AVAILABLE` secret or a required input.
+
+**Job: `publish`** (ubuntu-latest, depends on all three build jobs)
+```
+needs: [build-windows, build-linux, build-macos]
+```
+Steps:
+1. Download all build artifacts
+2. Verify artifact filenames contain the expected version
+3. `gh release create v<ver> --notes "$(scripts/extract-changelog.sh)"` with all artifacts attached
+4. `aws s3 cp` each artifact → `s3://dl.agentmux.ai/releases/<ver>/`
+5. `aws s3 cp` each artifact → `s3://dl.agentmux.ai/releases/latest/` (unversioned names per `UNVERSIONED_NAMES` map in `fetch-release.mjs`)
+6. `repository_dispatch` to `agentmuxai/agentmux-landing` with `event_type: release` and `client_payload: { version: "<ver>" }`
+
+**Job: `winget`** (ubuntu-latest, depends on `publish`)
+- `wingetcreate update AgentMux.AgentMux --version <ver> --urls <installer-url> --token $WINGET_TOKEN`
+- Non-blocking: `continue-on-error: true`
+
+**Job: `ms-store`** (windows-latest, depends on `publish`)  
+- `msstore publish` the MSIX from S3 or GitHub Release URL
+- Non-blocking: `continue-on-error: true`
+- Full details: see PR #1843 (`agentx/spec-msstore-automated-release`)
+- **Prerequisite:** Partner Center app registered, service principal created, four `MSSTORE_*` secrets added to repo
+
+---
+
+### 4.3 New: `landing-deploy.yml` (agentmuxai/agentmux-landing)
+
+**Trigger:**
+```yaml
+on:
+  repository_dispatch:
+    types: [release]          # fired by agentmux release.yml publish job
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (leave blank for latest)'
+        required: false
+```
+
+**Job: `deploy-prod`** (ubuntu-latest)
+Steps:
+1. Checkout `agentmuxai/agentmux-landing` main
+2. `npm ci`
+3. `node scripts/fetch-release.mjs` (writes `public/release.json` with S3 URLs)
+4. `npm run build` (vite build, `VITE_ENV=prod`)
+5. `npx cdk deploy landing-prod --require-approval never`
+6. CloudFront invalidation: `aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/*"`
+
+**Secrets needed:**  
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (existing deploy role), `GITHUB_TOKEN` (for `fetch-release.mjs` gh CLI calls)
+
+---
+
+### 4.4 Fix: `scripts/extract-changelog.sh` (new helper)
+
+The `publish` job needs the changelog entry for the current version from `VERSION_HISTORY.md`. Add a small script that extracts the block between `## <ver>` and the next `##` heading — used for `gh release create --notes`.
+
+---
+
+## 5. Sequencing / Prerequisites
+
+```
+Week 1
+  ├── Fix infrastructure-weekly-analysts CFN stack (a5af/shared-infrastructure)
+  ├── Add landing-deploy.yml to agentmuxai/agentmux-landing
+  └── Add extract-changelog.sh to agentmuxai/agentmux
+
+Week 2
+  ├── Add release.yml (verify + build + publish + winget jobs) to agentmuxai/agentmux
+  ├── Wire repository_dispatch → landing-deploy.yml
+  └── Test with a patch release tag (v0.49.9 dry-run dispatch)
+
+Week 3 (after Partner Center setup)
+  └── Add ms-store job to release.yml, add MSSTORE_* secrets
+```
+
+**MS Store prerequisites (manual, one-time):**
+1. Reserve "AgentMux" name in Partner Center
+2. Complete first manual submission (age ratings, category, screenshots)
+3. Create Entra service principal with Store Publisher Manager role
+4. Add four secrets: `MSSTORE_TENANT_ID`, `MSSTORE_CLIENT_ID`, `MSSTORE_CLIENT_SECRET`, `MSSTORE_SELLER_ID`
+
+---
+
+## 6. Open Questions
+
+| # | Question | Owner |
+|---|---|---|
+| OQ1 | macOS patched CEF: gate release on `PATCHED_CEF_AVAILABLE` secret, or always ship stock + warn? | Needs decision |
+| OQ2 | `dl.agentmux.ai` S3 bucket — is it under `a5af/shared-infrastructure` CDK or separate? Confirm IAM permissions for release workflow | Needs audit |
+| OQ3 | gh-reporter email delivery: zero bounces/rejects from SES, not in spam. Is there a Gmail filter? | Still open |
+| OQ4 | Should `ci-nightly-artifacts.yml` stay separate from `release.yml`? Recommendation: yes — nightly is a health signal on HEAD, release is a publishing event on a tag. | Recommend: keep separate |
+| OQ5 | Landing page QA deploy — should it auto-deploy on every `main` push too, not just release events? | Needs decision |
+
+---
+
+## 7. Files to Create / Modify
+
+| File | Repo | Action |
+|---|---|---|
+| `.github/workflows/release.yml` | agentmuxai/agentmux | **Create** |
+| `scripts/extract-changelog.sh` | agentmuxai/agentmux | **Create** |
+| `.github/workflows/landing-deploy.yml` | agentmuxai/agentmux-landing | **Create** |
+| `weekly-analysts/lib/weekly-analysts-stack.ts` | a5af/shared-infrastructure | **Edit** — remove custom `documentName` props |
+| `gh-reporter/` | a5af/shared-infrastructure | No change needed (stack healthy) |
+
+---
+
+## 8. What Is NOT in Scope
+
+- **Nightly build/test CI** (`ci-nightly-build.yml`, `ci-nightly-artifacts.yml`) — kept separate, not merged into release
+- **Auto-versioning** — version bump continues to go through `task release` + changesets; this spec only wires the post-bump publication
+- **macOS patched CEF CI** — tracked separately; the patched framework must be built locally and uploaded to `agentmuxai/cef` before CI can use it
+- **gh-reporter email delivery investigation** — SES is healthy; root cause TBD

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -3,6 +3,7 @@
 # Usage: bash scripts/extract-changelog.sh [version]
 # If version is omitted, reads it from package.json.
 # Outputs the markdown body between "## <version>" and the next "## " heading.
+# Exits 1 if the version entry is missing — never silently ships empty notes.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -13,5 +14,12 @@ if [ -z "$VERSION" ]; then
   VERSION=$(node -p "require('$REPO_ROOT/package.json').version")
 fi
 
-awk "/^## ${VERSION}([[:space:]]|$)/{found=1; next} found && /^## /{exit} found{print}" \
-  "$REPO_ROOT/VERSION_HISTORY.md" | sed '/^[[:space:]]*$/d; 1s/^[[:space:]]*//'
+NOTES=$(awk "/^## ${VERSION}([[:space:]]|$)/{found=1; next} found && /^## /{exit} found{print}" \
+  "$REPO_ROOT/VERSION_HISTORY.md" | sed '/^[[:space:]]*$/d')
+
+if [ -z "$NOTES" ]; then
+  echo "❌ extract-changelog: no entry for v${VERSION} in VERSION_HISTORY.md — run 'task release' before tagging" >&2
+  exit 1
+fi
+
+echo "$NOTES"

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Extract the changelog block for a given version from VERSION_HISTORY.md.
+# Usage: bash scripts/extract-changelog.sh [version]
+# If version is omitted, reads it from package.json.
+# Outputs the markdown body between "## <version>" and the next "## " heading.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  VERSION=$(node -p "require('$REPO_ROOT/package.json').version")
+fi
+
+awk "/^## ${VERSION}([[:space:]]|$)/{found=1; next} found && /^## /{exit} found{print}" \
+  "$REPO_ROOT/VERSION_HISTORY.md" | sed '/^[[:space:]]*$/d; 1s/^[[:space:]]*//'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml`: a single `v*` tag triggers the full release pipeline
- Adds `scripts/extract-changelog.sh`: extracts the VERSION_HISTORY.md block for a version (used for GitHub Release notes)
- Adds `docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md`: full design doc

## Pipeline shape

```
v0.50.0 tag push
  → verify (version consistency guard)
  → build-windows + build-linux + build-macos (parallel)
  → publish (GH Release + S3 mirror + repository_dispatch → landing page)
  → winget + ms-store (non-blocking, continue-on-error)
```

## What each job does

**verify** — asserts tag == `package.json` == `Cargo.toml` == `VERSION_HISTORY.md`; fails fast before any build starts.

**build-windows/linux/macos** — identical steps to `ci-nightly-artifacts.yml` but with `RELEASE_CHANNEL=stable` baked in. Windows also produces MSIX for Store submission.

**publish** — creates GitHub Release with changelog extracted from `VERSION_HISTORY.md`, uploads all artifacts, mirrors to `s3://dl.agentmux.ai/releases/<ver>/` (immutable) and `/latest/` (short TTL unversioned names), fires `repository_dispatch` to `agentmuxai/agentmux-landing`.

**winget** — `wingetcreate update` PR. `continue-on-error: true` — a WinGet review delay never blocks the release.

**ms-store** — `msstore publish` MSIX. `continue-on-error: true`. Requires `MSSTORE_*` secrets (Partner Center setup needed first — see spec §5).

## Secrets needed (new)
- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — S3 upload to `dl.agentmux.ai`
- `LANDING_DEPLOY_TOKEN` — PAT with `repo` scope on `agentmuxai/agentmux-landing` for `repository_dispatch`
- `WINGET_TOKEN` — existing pattern
- `MSSTORE_*` — after Partner Center setup (job is non-blocking until then)

## Test plan
- [ ] Verify `extract-changelog.sh` outputs correctly for current version
- [ ] Dry-run `verify` job against an existing tag
- [ ] Confirm `LANDING_DEPLOY_TOKEN` and `AWS_*` secrets are added before first tag push

<!-- agentmux:agent_id=camper-0622h -->