### PR TITLE
docs(architecture): OOM + lifecycle health analysis & refactor proposal

### DIFF
--- a/.changesets/1782791896-chore-statusbar-drop-oom-kills-wording-from-pf-commit-charge-dc2u.md
+++ b/.changesets/1782791896-chore-statusbar-drop-oom-kills-wording-from-pf-commit-charge-dc2u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(statusbar): drop 'OOM kills' wording from PF commit-charge chip tooltip

--- a/docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md
+++ b/docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md
@@ -1,0 +1,114 @@
+# Discussion / Decision Record — Lifecycle & Crash Architecture
+
+**Date:** 2026-06-29
+**Type:** Decision record (captures a working discussion; not yet a committed plan)
+**Status:** Direction agreed in discussion; pillars not yet scheduled
+**Owner:** asaf
+
+> Purpose: pin down the architecture-level conclusions reached in discussion so the two
+> intertwined threads — **lifecycle/teardown** and **crashes/OOM** — don't get lost or
+> re-litigated. This is the index that ties together the specs written today and the existing
+> tracking issues. Read `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` for the full audit.
+
+---
+
+## 1. The core realization (one root, two threads)
+
+The lifecycle/teardown churn and the crash/OOM churn are **the same defect seen from two angles:**
+
+> **The CEF host is both the component most likely to die (Chromium aborts on any failed
+> allocation, `0xE0000008`) and the authoritative in-memory owner of session/UI/lifecycle state.
+> Fragile + irreplaceable = every death is catastrophic and every recovery is hand-built.**
+
+That single inversion is why we keep shipping mitigations on both threads (gated recovery, memory
+supervisor, crash budgets, pause pages, graceful-exit on the crash side; orphan reconciliation,
+quit-decision rewrites, saga compensation on the lifecycle side).
+
+## 2. The decided direction — disposability symmetry
+
+Three-tier authority model:
+
+```
+srv       = the ONE durable authority (SQLite). Source of truth. Survives everything.
+host      = projects srv's logical topology into native OS objects (windows/panes/pool). DISPOSABLE.
+renderer  = projects srv's state into UI (SolidJS frontend).                              DISPOSABLE.
+```
+
+**Rule:** host and renderer each hold only a *projection* of srv's truth — never the truth itself.
+If either dies, a fresh instance reprojects from srv.
+
+### Where we are vs. where we're going
+- **Renderer — already disposable.** Its state is a projection of srv; on crash, gated recovery
+  reprojects. This is why renderer death is already survivable.
+- **Host — NOT disposable today.** It owns pane/window/pool/drag/lifecycle state in volatile Rust
+  memory. Host death loses the truth → catastrophe.
+- **Goal:** make the host disposable the same way the renderer is — the asymmetry *is* the defect.
+
+### Clarifications captured from the discussion (so they're not re-debated)
+- **"Disposable," not literally "stateless."** The host always holds native OS handles (HWNDs, CEF
+  browser objects, GPU process, window pool) that *can't* live in srv. srv owns the **logical**
+  topology (which windows/panes exist, layout, agent bindings); the host rebuilds the native objects
+  from that on reproject. The renderer is closer to truly stateless (owns no native resources).
+- **A reproject is just an involuntary restart.** The host already rebuilds all windows from srv on a
+  normal cold launch. "Make host death survivable" = "make the existing startup-restore path good
+  enough to fire unplanned, mid-session."
+- **Flicker is a crash-path concern only — NOT normal operation.** Steady-state use never rebuilds
+  windows, so nothing flickers. Reconstruction is visible only on the reproject (crash/restart) event.
+- **The steady-state tax is invisible write-through, not UX.** Making srv authoritative means host
+  state mutations (pane move, window open, focus) persist to srv. Must be async/batched so it never
+  stalls interaction. srv already persists layout, so this extends an existing path.
+
+## 3. What this collapses (why it's a refactor, not more patches)
+- Host OOM → reproject instead of catastrophe → kills the crash-catastrophe class.
+- Nothing unsaved to compensate → the ~4,000-line **saga durability layer collapses** to an
+  in-memory registry.
+- "Is state durable or do I flush on close?" incoherence disappears → always "durable in srv,
+  reproject." Removes the contract that forced `orphan_reconcile` into existence.
+- Overcommit prevented at the source → the supervisor ladder / crash budgets / magic floors collapse.
+
+## 4. The two threads, mapped to existing tracking
+
+### Thread A — Lifecycle / teardown
+- **Root:** quit decision fragmented across `on_before_close` (edge), WRR `maybe_quit_on_last_user_window`,
+  `orphan_reconcile.rs`; the principled fix `reducer/quit.rs::reconcile_quit` is **written, tested, and
+  `#[allow(dead_code)]` — NOT WIRED.**
+- Related issues: **#768** (host/frontend lifecycle divergence), **#1681** (floating-pane DnD lifecycle
+  rethink), **#1461** (redock state-reducer/native-HWND lifecycle), **#1662** (pool redock empty spot),
+  **#864** (retire wcore-direct layout path — the layout split-brain).
+- Related docs: `retro-lifecycle-teardown-churn-2026-06-22.md`,
+  `SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md`.
+
+### Thread B — Crashes / OOM
+- **Root:** Chromium aborts on OOM; host is the stateful victim; no proactive admission control.
+- Related issues: **#942** (Service Supervision & Recovery umbrella), **#376** (renderer death + host
+  hang), **#778** (GPU crash → black panes).
+- Related docs (today): `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md`,
+  `SPEC_GRACEFUL_OOM_EXIT_2026_06_29.md`. Prior: `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md`,
+  `SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`, `INCIDENT_2026_06_26_APP_CLOSED.md`,
+  `SPEC_MEMORY_ANALYSIS_2026_06_26.md`, `retro-oom-crash-2026-06-16.md`.
+
+## 5. The trend that justifies the rethink (from the historical audit)
+- ~45–55 of every 100 PRs touch memory/lifecycle/crash; rate **flat-to-rising over ~1,000 PRs**.
+- ~**1 in 5 commits is a follow-up or revert.**
+- Renderer-OOM recovery re-fixed **6+ times**; replaceChild **4×** (last named `FULL_ANALYSIS_AND_FIX`);
+  cross-channel continuity **15** commits with a *"fixed then broke again"* retro.
+- 29+ dated memory/lifecycle/crash docs, continuous **2026-03-26 → today**, densest in June.
+
+## 6. Decisions
+- **D1.** Adopt the three-tier disposability model (srv authority; host & renderer disposable projections).
+- **D2.** Treat lifecycle and crash as one program of work, not two patch streams.
+- **D3.** Pause net-new OOM/lifecycle band-aids beyond cheap P0 wins until the pillars are sequenced.
+  (The `SPEC_GRACEFUL_OOM_EXIT` work shrinks substantially once host death is a reproject — ship only
+  its P0 "suppress the ugly OS box + native dialog" now.)
+
+## 7. Open questions (to resolve before scheduling Pillar 1)
+- **Q1.** What exactly is the host's authoritative state set that must move to srv? (pane topology,
+  window→pane mapping, pool warm-state, focus/magnify, drag intent) — enumerate it.
+- **Q2.** Reproject UX bar: acceptable reconstruction time and visual treatment on crash-restore?
+- **Q3.** Write-through mechanism: event-sourced through the reducer (ties into **#864**) vs. snapshot?
+- **Q4.** Can admission control (Pillar 3) ship independently and early, before the host rework? (Likely yes.)
+
+## 8. Next steps — see §"Best next steps" in the closing discussion / `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR` §6.
+Sequence: **Pillar 2 (wire `reconcile_quit`)** → **Pillar 3 (admission control)** → **Pillar 1 (host
+reproject)** → saga collapse + persistence pay-down (#864, agents Phase 3b/3c). Add the missing E2E
+test ("close last window ⇒ tree exits", "host OOM ⇒ session reprojects").

--- a/docs/specs/SPEC_AGENT_STATUS_LABELS_2026_06_27.md
+++ b/docs/specs/SPEC_AGENT_STATUS_LABELS_2026_06_27.md
@@ -1,0 +1,279 @@
+# Agent Status Labels — Richer Working State UX
+
+**Date:** 2026-06-27  
+**Status:** Draft  
+**Files touched:** `AgentFooter.tsx`, `agent-pane-state/types.ts`, `agent-pane-state/reducer.ts`, `agent-view.tsx`
+
+---
+
+## 1. Problem
+
+`pickThinkingPhrase()` always returns `"Working"`. Every agent activity — user message, background shell output, another agent pinging back, rate-limit retry, tool use — shows the same label. This is low-information and creates a spurious UX problem:
+
+- A background shell producing stdout re-invokes the agent. The user sees `"Working…"` appear unprompted, with no explanation, then disappear a second later.
+- A long tool chain (`bash` → `read` → `edit`) shows `"Working…"` throughout with no indication of what step is running.
+- Rate-limit back-off and a productive tool call look identical.
+
+---
+
+## 2. Goals
+
+1. **Status label is always informative** — a user who glances at the footer can answer "what is Claude doing right now?"
+2. **Background-triggered turns are distinguishable** from user-initiated ones — no more mystery `"Working…"` popups.
+3. **Tool-level activity is surfaced** — reading, editing, running a terminal, searching.
+4. **Zero regression** on the core state machine — all changes are additive, label derivation is pure.
+
+---
+
+## 3. Trigger Context (new field)
+
+### 3.1 Why it's needed
+
+The `TurnPhase` discriminated union currently has no record of *why* the turn started. We need to distinguish:
+
+| Trigger | Current display | Desired display |
+|---------|----------------|-----------------|
+| User typed a message | `Working…` | `Thinking…` |
+| Background shell output flushed | `Working…` | `Responding to shell` |
+| Another agent sent a message | `Working…` | `Responding to agent` |
+| Cron / scheduled run | `Working…` | `Running scheduled task` |
+| MCP tool callback | `Working…` | `Responding to tool` |
+
+### 3.2 Proposed type
+
+Add `triggerContext` to the `Submitting` and `Streaming` phases:
+
+```typescript
+export type TurnTrigger =
+    | { kind: "user" }                          // user sent a message
+    | { kind: "shell"; shellId: string; title?: string }  // shell stdout flushed
+    | { kind: "agent"; agentId: string; name?: string }   // another agent replied
+    | { kind: "cron"; cronName: string }        // scheduled run
+    | { kind: "tool"; toolName: string }        // MCP tool callback
+    | { kind: "unknown" };                      // fallback / legacy
+```
+
+Add to `Submitting` and `Streaming` phases:
+
+```typescript
+| {
+      kind: "Streaming";
+      bufferSize: number;
+      toolsActive: number;
+      lastEventMs: number;
+      trigger: TurnTrigger;          // ← new
+      waitingReason?: "rate_limited";
+      retryAfterMs?: number | null;
+  }
+```
+
+### 3.3 Where trigger is set
+
+- **`TurnStart` command** (user sends message) → `{ kind: "user" }`
+- **`StreamFlushObserved` command** (shell stdout re-invokes agent) → `{ kind: "shell", shellId, title }` — shellId and title already available in the flush event payload
+- **Agent-to-agent message event** → `{ kind: "agent", agentId, name }`
+- All others → `{ kind: "unknown" }` initially, refined as new triggers are identified
+
+---
+
+## 4. Status Label Dictionary
+
+### 4.1 Derivation function
+
+Replace `pickThinkingPhrase()` with a pure function:
+
+```typescript
+export function deriveStatusLabel(
+    phase: TurnPhase,
+    currentTool: string | null,
+    currentToolArg: string | null,
+): string
+```
+
+### 4.2 Priority order
+
+Labels are derived by checking from most-specific to least-specific:
+
+```
+1. Phase is Interrupting              → "Stopping…"
+2. Phase is Submitting                → label from trigger (see §4.3)
+3. Phase is Streaming + rate-limited  → "Waiting for rate limit…"
+4. Phase is Streaming + currentTool   → label from tool map (see §4.4)
+5. Phase is Streaming + trigger       → label from trigger context (see §4.3)
+6. Phase is Streaming, no tool        → "Thinking…"
+```
+
+### 4.3 Trigger → label map
+
+| `trigger.kind` | Label (no tool active) | Label (submitting) |
+|---------------|------------------------|-------------------|
+| `"user"`      | `"Thinking…"`          | `"Sending…"` |
+| `"shell"`     | `"Responding to shell"` | `"Waking for shell…"` |
+| `"agent"`     | `"Responding to agent"` | `"Waking for agent…"` |
+| `"cron"`      | `"Running scheduled task"` | `"Starting scheduled run…"` |
+| `"tool"`      | `"Responding to tool"` | `"Waking for tool…"` |
+| `"unknown"`   | `"Working…"` | `"Working…"` |
+
+When `trigger.kind === "shell"` and `trigger.title` is set: `"Responding to shell: ${trigger.title}"` (truncated to ~30 chars).
+
+When `trigger.kind === "agent"` and `trigger.name` is set: `"Responding to ${trigger.name}"`.
+
+### 4.4 Tool → label map
+
+When `currentTool` is set during `Streaming`, use this map. `currentToolArg` (file path or command) is appended when short (≤ 30 chars) and meaningful.
+
+| Tool name (or prefix) | Label |
+|----------------------|-------|
+| `Bash` | `"Running terminal"` — with truncated command if short |
+| `mcp__agentmux__Shell` | `"Starting shell"` |
+| `mcp__agentmux__ShellStop` | `"Stopping shell"` |
+| `Read` | `"Reading file"` — with basename of path |
+| `Write` | `"Writing file"` — with basename |
+| `Edit` | `"Editing file"` — with basename |
+| `Glob` | `"Finding files"` |
+| `Grep` | `"Searching code"` |
+| `WebFetch` | `"Fetching URL"` |
+| `WebSearch` | `"Searching the web"` |
+| `Agent` | `"Spawning agent"` |
+| `Workflow` | `"Running workflow"` |
+| `mcp__agentmux__NewTab` | `"Creating tab"` |
+| `mcp__agentmux__Layout` | `"Reading layout"` |
+| `mcp__agentmux__SendMessage` | `"Sending message"` |
+| `TaskCreate` | `"Creating task"` |
+| `TaskUpdate` | `"Updating task"` |
+| `AskUserQuestion` | `"Asking you a question"` |
+| `NotebookEdit` | `"Editing notebook"` |
+| `mcp__*` (generic MCP) | `"Using tool: ${toolName}"` (strip `mcp__` prefix) |
+| *(anything else)* | `"Working…"` |
+
+### 4.5 "Background" badge
+
+When `trigger.kind !== "user"`, show a small badge or alternate color on the status row to signal that this turn was not user-initiated. Exact visual TBD in design pass. Suggested: dim the row or show a small icon (⚙ for shell, ↩ for agent).
+
+---
+
+## 5. Streaming phase sub-states
+
+The existing `Streaming` phase already carries:
+
+```typescript
+toolsActive: number     // concurrent tools in flight
+bufferSize: number      // queued output chunks
+lastEventMs: number     // timestamp of last stream event
+```
+
+### 5.1 Stall detection
+
+If `Date.now() - lastEventMs > STALL_THRESHOLD_MS` (suggested: 8000ms) while still `Streaming`:
+- Label: `"Working… (no activity for Xs)"`
+- This surfaces hung tool calls or silent network issues without a false alarm.
+
+### 5.2 Multi-tool label
+
+If `toolsActive > 1`: prefix label with `"[${toolsActive} tools] "`.  
+E.g. `"[3 tools] Running terminal"`.
+
+---
+
+## 6. Done phase
+
+Already shows `"✓ Worked · 42s"`. Extend with trigger context:
+
+| Trigger | Done label |
+|---------|-----------|
+| `"user"` | `"✓ Done · 42s"` |
+| `"shell"` | `"✓ Shell response · 1s"` |
+| `"agent"` | `"✓ Agent response · 3s"` |
+| `"cron"` | `"✓ Scheduled run · 2m 10s"` |
+| `"unknown"` | `"✓ Done · 42s"` |
+
+---
+
+## 7. Implementation plan
+
+### Phase 1 — Label derivation (no trigger context yet)
+1. Add `TOOL_LABEL_MAP` constant to `AgentFooter.tsx`.
+2. Replace `pickThinkingPhrase()` with `deriveStatusLabel(phase, currentTool, currentToolArg)`.
+3. Pass `turnPhase` (already available at call site in `agent-view.tsx:1101`) into `AgentWorkingRow`.
+4. **Tests:** pure-function unit tests for `deriveStatusLabel` covering all cases.
+
+### Phase 2 — Trigger context
+5. Add `TurnTrigger` type to `types.ts`.
+6. Extend `Submitting`, `Streaming`, and `StreamFlushObserved` command shapes with `trigger: TurnTrigger`.
+7. Populate trigger at dispatch sites:
+   - `TurnStart` (user sends message) → `{ kind: "user" }`
+   - `StreamFlushObserved` (shell stdout) → enrich payload in `useAgentStream.ts` with `shellId`/`shellTitle` from the document store *before* dispatch (see Q1 resolution); reducer constructs `{ kind: "shell", shellId, title }`.
+   - Agent-to-agent turns → `{ kind: "agent", agentId }` (needs follow-up to identify the exact dispatch site — see Q2 resolution).
+8. Agent display name resolved at render time from agent registry atom, not stored in trigger.
+9. Thread trigger through to `AgentWorkingRow` props and `deriveStatusLabel`.
+10. Label text alone signals background turns (no badge for Phase 2 — see Q4 resolution).
+
+### Phase 3 — Done phase and stall detection
+10. Extend done-label with trigger context.
+11. Add stall detection timer to `AgentWorkingRow` using `useTick()` (already present).
+
+---
+
+## 8. Non-goals
+
+- Not a full activity log replacement (that's `ActivityDock`/`AgentComposerStrip`).
+- Not changing the state machine itself — the discriminated union is already correct.
+- Not showing shell stdout in the status label.
+- No changes to the `TurnOutcome` or `Done` state lifecycle.
+
+---
+
+## 9. Open questions — RESOLVED
+
+### Q1 ✅ Shell title availability
+**Answer:** The title is **not in the `StreamFlushObserved` payload** — it only carries `addedCount: number` and `at: number`. The shell title lives in `ShellNode` in the document/block store.
+
+**Resolution:** At the point where `StreamFlushObserved` is dispatched (in `useAgentStream.ts`), the document store *is* accessible. Enrich the payload there before dispatch:
+
+```typescript
+// useAgentStream.ts — when emitting StreamFlushObserved
+const activeShell = docNodes.findLast(n => n.type === "shell" && n.status === "running");
+dispatch({
+    type: "StreamFlushObserved",
+    addedCount,
+    at: Date.now(),
+    shellId: activeShell?.id ?? null,      // ← new
+    shellTitle: activeShell?.title ?? null, // ← new
+});
+```
+
+Update `StreamFlushObserved` command type in `types.ts` accordingly. The reducer uses these to construct `trigger: { kind: "shell", shellId, title }`. No block-store lookup needed downstream.
+
+---
+
+### Q2 ✅ Agent name at TurnStart
+**Answer:** `AgentMessageEvent.from` carries only the sender's **agent ID**, not a display name. Additionally, agent-to-agent messages currently don't route through `TurnStart` — that command is user-initiated only.
+
+**Resolution:**
+- Store the sender `agentId` in the trigger: `{ kind: "agent", agentId: from }`.
+- Resolve the display name **at render time** (not in the reducer) by looking up the agent registry atom: `agentRegistry[agentId]?.name ?? agentId`. This keeps the reducer pure and avoids stale-name bugs.
+- A separate investigation is needed to confirm which event causes the receiving agent's turn to start when an agent-to-agent message arrives (not `TurnStart` — likely a `StreamFlushObserved` or a new command). Track under a follow-up task.
+
+---
+
+### Q3 ✅ `pickThinkingPhrase` rotation
+**Answer:** Rotation was **intentionally removed**. The function previously cycled a 100+ phrase array (`"Accomplishing"`, `"Baking"`, `"Muxing"`, `"Swarmifying"`, …) every 30 seconds, with `_exclude` preventing back-to-back repeats. It was simplified to `return "Working"` in a deliberate refactor. The `_exclude` and `_phrase` underscore params are now dead signatures.
+
+**Resolution for Phase 1:**
+- Delete `pickThinkingPhrase` and `ingToEd` entirely.
+- Replace with `deriveStatusLabel(phase, currentTool, currentToolArg, trigger?)`.
+- No rotation fallback — the new label map covers all known states; `"unknown"` trigger falls back to `"Working…"` which is no worse than today.
+- Remove `_exclude` call sites in `AgentWorkingRow` (the interval-based rotation can be removed or simplified to a static label).
+
+---
+
+### Q4 🎨 Visual design for background badge
+**Status: Needs design decision.**
+
+Options:
+- **A) Muted italic label** — `"Responding to shell"` rendered in a lighter/italic style, no icon. Minimal change, purely typographic.
+- **B) Small icon prefix** — ⚙ for shell, ↩ for agent, 🕐 for cron. High information density, may feel noisy.
+- **C) Color shift** — Use a distinct CSS variable (e.g. `--status-bg-shell`) for the working row background on non-user turns. Subtle, doesn't change label layout.
+- **D) No badge, label only** — The label text itself (`"Responding to shell"`) is sufficient; no extra visual treatment.
+
+**Recommendation:** Option D for Phase 2 launch — the label change alone is the signal. Badge/color can be a follow-up after user testing.

--- a/docs/specs/SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md
+++ b/docs/specs/SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md
@@ -1,0 +1,127 @@
+# Architecture Health Assessment & Refactor Proposal
+
+**Date:** 2026-06-29
+**Status:** Assessment + recommendation (decision doc)
+**Scope:** Process/memory model, lifecycle ownership, state durability — the substrate under the recurring OOM and teardown failures.
+**Method:** Four parallel deep audits (process/memory, lifecycle/sagas, state/persistence, historical trend), cross-referenced against the existing memory-pressure corpus.
+
+---
+
+## 0. TL;DR
+
+The recurring OOM crashes and the lifecycle/teardown churn are **not two problems — they're one root cause with two faces.** That root is a single architectural decision:
+
+> **The CEF host is simultaneously (a) the component most likely to die — Chromium aborts the process on any failed allocation (`0xE0000008`) — and (b) the authoritative in-memory owner of session, UI, and lifecycle state.**
+
+Because the fragile thing is also the irreplaceable thing, **every death is catastrophic and every recovery is a hand-built special case.** That is why we keep shipping band-aids (gated recovery, memory supervisor, crash budgets, pause pages, graceful-exit) — each one papers over one consequence of the same inversion.
+
+**Verdict:** Two subsystems are **NEEDS-REFACTOR** (process/memory admission model; lifecycle quit-authority). One is **STRAINED / pay-down-debt** (persistence). This warrants a **targeted structural refactor, not a rewrite** — and notably, the two highest-value fixes are *already written or specced by the team and sitting unmerged.*
+
+---
+
+## 1. The evidence is no longer anecdotal — it's a measured trend
+
+From the historical audit (PR-number proxy, since the repo is squash-imported with useless timestamps):
+
+- **~45–55 of every 100 PRs** touch memory/lifecycle/crash — and that rate is **flat-to-rising over ~1,000 PRs**, never tapering. A stabilizing system shows decline; this doesn't.
+- **~1 in 5 commits is a `follow-up` (147) or `revert` (40).**
+- **Repeated re-fixes of the same bug class:** renderer-OOM recovery fixed **6+ times** (#1120→#1124→#1121→#1229→#1230→#1493→#1799); replaceChild crash **4 times** (the 4th literally named `FULL_ANALYSIS_AND_FIX`); cross-channel continuity **15 commits** with a retro titled *"fixed then broke again"*; zoom **8 docs** with per-platform re-breakage.
+- **29+ dated memory/lifecycle/crash docs span 2026-03-26 → today, with no gap**, densest in June. **The two newest specs in the entire repo are both OOM specs** written today.
+
+This is the signature of mitigation on an unstable base, not polish on a stable one.
+
+---
+
+## 2. Per-subsystem findings
+
+### 2.1 Process & memory model — **NEEDS-REFACTOR**
+- **No proactive admission control.** Agent turns spawn `claude.exe` **unconditionally** (`agents/runner.rs:142`, `drone/executor/blocks/agent.rs:96`). The only process that reads system commit (`mem_supervisor.rs:110`) does so **after** the host has already died, to classify the corpse. The model is **spawn → overcommit → Chromium aborts → relaunch.** Reactive by construction.
+- **The host is a single point of total UI-state loss.** All pane/window/drag/pool state lives in volatile host memory (`agentmux-cef/src/state.rs`, `reducer/mod.rs`). The 2026-06-26 incident: host working set was ~120 MB while the box was 99.9% committed — **the host was the victim, not the cause**, yet it's the thing that dies and loses everything.
+- **Agents are tracked but never capped.** Job Objects guarantee reap (a real strength) but nothing kills an agent on memory pressure; an overnight `claude.exe` is what filled the pagefile.
+- **The team specced the fix and hasn't built it:** a "commit-aware turn scheduler — gate spawn on commit headroom" is listed **P0** in `SPEC_WIN10_PAGEFILE_OOM_CRASH` and is **not shipped.**
+- *Honest admission in-tree* (`mem_supervisor.rs:4-16`): the relaunch ladder is "memory-blind: on a system OOM it relaunches straight back into the same commit-starved condition, burns the budget in seconds, and gives up — a silent vanish."
+
+### 2.2 Lifecycle ownership & sagas — **NEEDS-REFACTOR**
+- **Spawn/reap is sound** (launcher + Windows Job Object `KILL_ON_JOB_CLOSE`, never regressed). The rot is in the **quit decision**, which is split across **3–4 competing sites**: `client::on_before_close` (edge-triggered), the WRR `maybe_quit_on_last_user_window` path, `orphan_reconcile.rs`, and the intended replacement `reducer/quit.rs::reconcile_quit` — **which is written, tested, and `#[allow(dead_code)]` / "NOT YET WIRED."**
+- **The central regression is understood and unreverted:** close was changed from authoritative `host.try_close_browser()` to an HWND-guess `PostMessage(WM_CLOSE)` that returns NULL on CEF Views → frame hides without closing → `on_before_close` never fires → Job Object never drops → **whole tree orphans** (`retro-lifecycle-teardown-churn-2026-06-22`).
+- **Recovery philosophy is incoherent — both "let-it-crash" and "never-crash" in the same file.** The crash path asserts srv state is durable ("Resume re-projects everything"); the graceful path asserts it is *not* durable and must synchronously flush shells before close. They don't compose — which is *why* `orphan_reconcile.rs` had to be invented.
+- **The saga layer is over-engineered for the job:** ~**3,986 lines** of SQLite-durable distributed-transaction machinery (journal, per-step log, restart walker) for **only 2 saga types**, and it **doesn't even compensate** — on restart it marks sagas `failed_compensation` for an operator to read. ~38 phase-markers / 4 full re-architectures of the quit path in ~9 months.
+
+### 2.3 State & persistence — **STRAINED (pay down debt, no rethink)**
+- Foundation is actually decent: four well-bounded SQLite stores, schema-version safety locks, pre-migration snapshots, and — notably — **no duplicated domain state in the frontend** (caches are in-memory only).
+- **Two concentrated strains:**
+  1. **Stalled agents dual-write migration.** `db_agent_definitions/_instances` (old, still the read source) are mirrored into `db_agents` on every mutation across **11+ call sites**; `dual_write.rs` (679 lines) + `agents_consolidate.rs` (942 lines) + a **per-startup `repair_def_gaps()`** exist solely to bridge a cutover whose Phase 3b/3c **are written but unmerged.** ~1,600 lines of transitional scaffolding waiting on two PRs.
+  2. **Layout split-brain.** One `db_layout` record written through **two paths** (reducer for focus/magnify, "wcore-direct" for the tree) and mirrored into 3 in-memory copies, kept consistent by hand-ordered code rather than an invariant.
+- **Durability gap on abrupt kill:** WAL checkpoint runs only on a 30-min timer (no checkpoint on shutdown) → WAL bloat (not data loss); in-flight PTY buffer and queued messages are explicitly lost on kill.
+
+---
+
+## 3. The unifying diagnosis
+
+Map the four audits onto one picture:
+
+```
+        Chromium aborts on OOM (0xE0000008)         ← substrate we can't change
+                     │
+   the HOST is the process that dies ───────────────┐
+                     │                               │
+   …but the HOST also OWNS, in volatile memory:      │
+     • session/pane/window/pool/drag state           │  ⇒ every host death is
+     • the lifecycle "should we quit?" decision        catastrophic + bespoke
+     • the contract that shells/state are flushed     │
+                     │                               │
+   ⇒ recovery must be hand-built per failure ────────┘
+   ⇒ saga layer exists to compensate for lost work
+   ⇒ no admission control, because "just relaunch the owner"
+```
+
+Every band-aid we've shipped is a local fix to one arrow in that diagram. The arrows all originate from one node: **the fragile process is the stateful authority.**
+
+---
+
+## 4. Refactor thesis (the structural move)
+
+**Invert the relationship: make the durable backend the authority, and make the host a disposable projection.** Three pillars, each of which *collapses* a class of current band-aids rather than adding another.
+
+### Pillar 1 — Host becomes stateless & reprojectable (kills the "catastrophe" class)
+Persist the full session/UI/window topology to srv (which already survives host death). The host holds only a projection it can rebuild at any instant. Then **host OOM stops being a catastrophe** — it's a reproject, the same as a renderer crash.
+- *Collapses:* the graceful-shutdown-vs-crash incoherence (always crash-and-reproject), the synchronous shell-flush contract, and most of the bespoke recovery pages.
+- *Builds on:* the existing "srv is durable, Resume re-projects" assumption — just make it actually true for **all** host state, not most.
+
+### Pillar 2 — Single level-triggered lifecycle authority (kills the "teardown churn" class)
+Wire `reconcile_quit` (already written/tested) as the **sole** writer of quit state, re-evaluated after every window/pool/creation transition. Demote `on_before_close`, the WRR path, and `orphan_reconcile` to pure executors.
+- *Collapses:* the 3–4-way quit split-brain, the orphan-reconciliation module, the pool-refill-vs-last-window race that's resurfaced under new symptoms 5+ times.
+- *And then:* with the host stateless (Pillar 1) there is **nothing to compensate**, so the ~4,000-line saga durability layer can collapse to an in-memory registry.
+
+### Pillar 3 — Proactive admission control + per-agent caps (kills the "OOM" class at the source)
+One budget owner (srv) gates `claude.exe`/turn spawning on **available commit before launching**, queues when headroom is short, and enforces a per-agent working-set cap with kill-and-reproject. Track free disk on the pagefile volume (the variable today's gauge misses).
+- *Collapses:* the memory supervisor's relaunch ladder, crash budgets, pause-page budgets, magic floors (`RESUME_FLOOR_MB`/`PAINT_FLOOR_MB`) — overcommit simply stops happening.
+- *Builds on:* the P0 "commit-aware turn scheduler" the team already specced.
+
+### Pay-down (not a pillar, but bundle it): land agents Phase 3b/3c, unify the layout write path.
+
+---
+
+## 5. Why this is a refactor, not a rewrite
+- Pillars 1–3 reuse what's sound: Job Object reap, the four SQLite stores, the reducer pattern, the srv websocket projection.
+- **The two highest-leverage pieces already exist:** `reconcile_quit` (written, unwired) and the commit-aware scheduler (specced, P0). This is finishing started work, not greenfield.
+- The saga collapse is a *deletion*, which is the safest kind of change.
+
+## 6. Recommendation
+1. **Stop adding OOM/lifecycle band-aids** (including pausing the just-written `SPEC_GRACEFUL_OOM_EXIT` beyond its cheap P0 dialog) until Pillars 1–3 are sequenced. The graceful-exit work becomes *much* smaller once host death is a reproject.
+2. **Sequence:** Pillar 2 first (it's mostly wiring already-written code and stops active orphan/teardown bleeding) → Pillar 3 (stops the OOM at the source) → Pillar 1 (the deepest change; makes the rest collapse) → saga collapse + persistence pay-down.
+3. **Add the missing E2E test** ("close last window ⇒ tree exits", "host OOM ⇒ session reprojects") — the teardown retro notes every regression shipped silently for lack of one.
+
+## 7. Risks / honest caveats
+- **Pillar 1 is genuinely deep** — serializing all host UI state to srv and reprojecting cleanly is the hard part; do it last, behind the cheaper wins.
+- The persistence audit rated state **STRAINED, not refactor** — don't over-rotate into rewriting the data layer; it mostly needs the stalled migration *finished*.
+- CEF coupling stays deep regardless; this proposal makes it *tolerable* (host disposable) rather than removing it.
+- Estimates are not in this doc on purpose — this is a direction decision; each pillar needs its own sized spec.
+
+## 8. Sources / supporting docs
+- `docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md`, `docs/specs/SPEC_GRACEFUL_OOM_EXIT_2026_06_29.md`
+- `docs/incident/INCIDENT_2026_06_26_APP_CLOSED.md`, `docs/specs/SPEC_MEMORY_ANALYSIS_2026_06_26.md`
+- `docs/retro/retro-lifecycle-teardown-churn-2026-06-22.md`, `docs/specs/SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md`
+- `docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md`, `docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`
+- `reducer/quit.rs` (the unwired `reconcile_quit`), `agentmux-launcher/src/saga/` (the collapsible layer)
+- Phase 3b/3c agents migration (unmerged), `agents_consolidate.rs` / `dual_write.rs` (transitional scaffolding)

--- a/docs/specs/SPEC_GRACEFUL_OOM_EXIT_2026_06_29.md
+++ b/docs/specs/SPEC_GRACEFUL_OOM_EXIT_2026_06_29.md
@@ -28,7 +28,7 @@ ugly OS fault box, and show one clear native message stating the reason.
 | Symptom | Root cause | Code |
 |---------|-----------|------|
 | **Half-broken Reload screen** | The recovery / low-memory pause page is **HTML rendered by a freshly-spawned CEF renderer** (`frame.load_url("data:text/html;base64,…")`). Under true commit exhaustion that new renderer *also* can't get memory, so it paints partially or crash-loops. The recovery UI depends on the exact resource that's exhausted. | `agentmux-cef/src/client/mod.rs` `on_render_process_terminated` (~1547), `memory_paused_page` (~2211), `crash_loop_terminal_page` |
-| **Raw Windows fault box w/ memory address** | The **host and CEF subprocesses don't suppress the GPF error box**. Only the launcher sets `SEM_FAILCRITICALERRORS`; nothing sets `SEM_NOGPFAULTERRORBOX`, and there's **no `SetUnhandledExceptionFilter`**. So an unhandled `0xE0000008` / `0xC0000005` falls through to Windows' default crash dialog. | `agentmux-cef/src/lib.rs` init (no SEH filter); launcher `main.rs:~72` (`SEM_FAILCRITICALERRORS` only) |
+| **Raw Windows fault box w/ memory address** | Partly already handled — `suppress_os_crash_dialogs()` runs in both host and launcher and calls `WerSetFlags(WER_FAULT_REPORTING_NO_UI)` (UI off, **dumps kept**) + `SEM_FAILCRITICALERRORS`. It **deliberately avoids `SEM_NOGPFAULTERRORBOX`** because that also kills WER/LocalDumps. So the standard WER "stopped working" box should already be suppressed. The dialog the user saw is therefore **either** a surface WER-no-UI doesn't cover (a `__fastfail`/hard-error, or a `0xC0000005` "memory could not be read" box) **or** a process/timing where `suppress_os_crash_dialogs()` hadn't run yet (e.g. a CEF subprocess faulting before its early-init). There is **no `SetUnhandledExceptionFilter`**. | `agentmux-cef/src/lib.rs:52-68` & `agentmux-launcher/src/main.rs:59-74` (`suppress_os_crash_dialogs`); no SEH filter anywhere |
 | **No reason / unclear if saved** | The one good native dialog (`show_fatal_dialog` → `MessageBoxW`, with reassuring text) only fires in the launcher **after a 5-minute relaunch-deadline expires** — not at the moment of death, and not when the host hard-crashes vs. is supervised. | `agentmux-launcher/src/main.rs` `show_fatal_dialog` (~2155), `OOM_GIVEUP_BODY` |
 
 **Key architectural asset:** the **launcher is a tiny, separate process that survives OOM** (the
@@ -37,14 +37,25 @@ not the dying host — should own the "explain + verify cleanup" step.
 
 ## 3. Design — four pillars
 
-### Pillar A — Suppress the ugly OS fault box; install our own last-resort handler
-On **every** AgentMux process (host + each CEF subprocess + launcher), at the earliest entry point:
-- `SetErrorMode(prev | SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS)` — augment, never overwrite
-  (the classic bug: overwriting clobbers other flags — read-modify-write). Also consider
-  `WerSetFlags(WER_FAULT_REPORTING_NO_UI)` to keep WER silent.
-- `SetUnhandledExceptionFilter(amx_last_breath)` — a minimal SEH filter that runs on `0xE0000008`
-  (Chromium OOM) and `0xC0000005` (AV). It must do the **least possible work** (see Pillar B) and
-  then signal the launcher, returning `EXCEPTION_EXECUTE_HANDLER` so Windows shows nothing.
+### Pillar A — Close the gaps in the *existing* suppression; install our own last-resort handler
+**Do NOT add `SEM_NOGPFAULTERRORBOX`.** The codebase already made the correct call: `suppress_os_crash_dialogs()`
+(`lib.rs:52-68`, `main.rs:59-74`) uses `WerSetFlags(WER_FAULT_REPORTING_NO_UI)` + `SEM_FAILCRITICALERRORS`
+and explicitly avoids `SEM_NOGPFAULTERRORBOX` so WER/LocalDumps crash dumps keep getting collected — the
+postmortem diagnostics this stability work depends on. Adding that flag would silence the box **and** blind
+us. (Credit: Codex review on PR #1847.)
+
+So Pillar A is not "add a flag" — it's **find why a box still reached the user despite suppression**:
+- **Coverage audit:** confirm `suppress_os_crash_dialogs()` runs in **every** process — especially each
+  **CEF subprocess** (renderer/GPU/utility) — and runs **before** any code that can fault. The comment
+  claims it's "process-wide; also covers the CEF subprocesses," but a subprocess that faults during very
+  early init (before the call) would still show a box. Verify the actual subprocess entry order.
+- **Identify the surface:** `WER_FAULT_REPORTING_NO_UI` suppresses the WER "stopped working" dialog, but
+  **not** necessarily a `__fastfail`/hard-error or the classic `0xC0000005` "the memory could not be read"
+  box. Capture which one the user hit (the "memory address" detail points at an AV hard-error, not WER).
+- **Add `SetUnhandledExceptionFilter(amx_last_breath)`** — a minimal SEH filter on `0xE0000008` (Chromium
+  OOM) / `0xC0000005` (AV) that does the least possible work (see Pillar B), signals the launcher, and
+  returns `EXCEPTION_EXECUTE_HANDLER` so nothing further is shown. This is the piece that genuinely doesn't
+  exist yet, and it's WER-friendly (the filter can still let WER write the dump first if we choose).
 
 ### Pillar B — A pre-allocated "parachute" so cleanup can run when the heap is exhausted
 At startup, reserve a small **committed** block (e.g. 8–16 MB) in the host and launcher. The
@@ -102,7 +113,7 @@ Native dialog (launcher), shown **at the moment of unrecoverable exit** (not aft
 
 | Phase | Scope | Effort | Files |
 |-------|-------|--------|-------|
-| **P0** | **Kill the ugly box.** `SetErrorMode(+SEM_NOGPFAULTERRORBOX)` + `SetUnhandledExceptionFilter` (minimal, no parachute yet) on host + CEF subprocesses + launcher. Filter just signals launcher + returns EXECUTE_HANDLER. | small | `agentmux-cef/src/lib.rs`, subprocess entry, `agentmux-launcher/src/main.rs` |
+| **P0** | **Close the suppression gap** (NOT a new flag). Audit that `suppress_os_crash_dialogs()` runs in every CEF subprocess before any fault; identify the actual dialog surface the user hit; add `SetUnhandledExceptionFilter` (minimal, no parachute yet) that signals the launcher + returns EXECUTE_HANDLER. **Keep `WER_FAULT_REPORTING_NO_UI`; never `SEM_NOGPFAULTERRORBOX`** (it kills LocalDumps). | small | `agentmux-cef/src/lib.rs:52`, subprocess entry, `agentmux-launcher/src/main.rs:59` |
 | **P0** | **Move the native dialog to the moment of death.** Fire `show_fatal_dialog` from the launcher as soon as it classifies host exit as OOM, with the reason text — not only after the 5-min deadline. | small | `mem_supervisor.rs`, `main.rs` |
 | **P1** | **Renderer-independent path.** Add `PAINT_FLOOR_MB`; below it, skip HTML recovery and go straight to launcher native dialog. | medium | `client/mod.rs` `on_render_process_terminated` |
 | **P1** | **Parachute reserve** in host + launcher; free-on-fault so the last-breath handler/closeout has heap. | medium | new `agentmux-cef/src/last_breath.rs`, launcher |
@@ -128,12 +139,13 @@ explain — all from the surviving launcher.
 - Force the condition: shrink the pagefile + spawn a memory balloon until commit < `PAINT_FLOOR_MB`,
   trigger a renderer OOM. Expect: **no raw Windows fault box**, no half-painted HTML, one native
   dialog with the reason, WAL truncated, sagas closed, clean relaunch.
-- Confirm `SetErrorMode` is read-modify-write (doesn't clobber `SEM_FAILCRITICALERRORS`).
+- Confirm crash dumps (WER/LocalDumps) are still collected after the change — the suppression must stay
+  dump-preserving (`WER_FAULT_REPORTING_NO_UI`, never `SEM_NOGPFAULTERRORBOX`).
 - Confirm the parachute is actually freed in the filter (instrument the handler).
 - Confirm the dialog fires at death, not after the 5-minute deadline.
 
 ## 9. Sources
 - [Chromium — Investigating OOM crashes](https://chromium.googlesource.com/chromium/src/+/main/docs/memory/oom.md) — allocators prefer crashing over null; `OnNoMemoryInternal`.
 - [OOM crashes for Chromium browsers (memory-dev)](https://groups.google.com/a/chromium.org/g/memory-dev/c/mPeec9KEc74) — `0xE0000008`, allocation size in exception record.
-- [The Old New Thing — Disabling the program crash dialog](https://devblogs.microsoft.com/oldnewthing/20040727-00/?p=38323) — `SEM_NOGPFAULTERRORBOX`, read-modify-write the error mode.
+- [The Old New Thing — Disabling the program crash dialog](https://devblogs.microsoft.com/oldnewthing/20040727-00/?p=38323) — background on `SEM_NOGPFAULTERRORBOX` (which we deliberately do **not** use — it kills WER/LocalDumps; we use `WER_FAULT_REPORTING_NO_UI` instead).
 - [libuv suppresses Windows Error Reporting (#1327)](https://github.com/libuv/libuv/issues/1327) — practical WER/error-mode suppression.

--- a/docs/specs/SPEC_GRACEFUL_OOM_EXIT_2026_06_29.md
+++ b/docs/specs/SPEC_GRACEFUL_OOM_EXIT_2026_06_29.md
@@ -1,0 +1,139 @@
+# Graceful OOM Exit — Own the Death, Explain the Reason
+
+**Date:** 2026-06-29
+**Status:** Draft — design + phased plan
+**Affected:** AgentMux on Windows (CEF/Chromium 148). Extends the memory-pressure corpus.
+
+> **Builds on:** `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md`, `SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md`,
+> `SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`. Read those first — this assumes the shipped
+> gated recovery, `mem_supervisor.rs`, and commit gauge.
+
+---
+
+## 1. The problem (observed)
+
+User returned to a Win10 box that had been under commit pressure overnight. Traktor (a memory hog)
+was fine. AgentMux was **unrecoverable**:
+1. The **Reload/recovery screen was half-rendered** — broken UI.
+2. Windows showed a **raw OS error dialog with a memory address** (an access-violation / fault box).
+3. No clear explanation of *why* AgentMux died or whether anything was saved.
+
+We can't make Chromium tolerate OOM — it is configured to **crash rather than return null** from any
+allocation (`base::internal::OnNoMemoryInternal` on the stack; exception `0xE0000008`). See §7. So the
+goal is not "don't die" — it's **die gracefully and legibly**: clean up durable state, suppress the
+ugly OS fault box, and show one clear native message stating the reason.
+
+## 2. Why each symptom happens (root cause, mapped to code)
+
+| Symptom | Root cause | Code |
+|---------|-----------|------|
+| **Half-broken Reload screen** | The recovery / low-memory pause page is **HTML rendered by a freshly-spawned CEF renderer** (`frame.load_url("data:text/html;base64,…")`). Under true commit exhaustion that new renderer *also* can't get memory, so it paints partially or crash-loops. The recovery UI depends on the exact resource that's exhausted. | `agentmux-cef/src/client/mod.rs` `on_render_process_terminated` (~1547), `memory_paused_page` (~2211), `crash_loop_terminal_page` |
+| **Raw Windows fault box w/ memory address** | The **host and CEF subprocesses don't suppress the GPF error box**. Only the launcher sets `SEM_FAILCRITICALERRORS`; nothing sets `SEM_NOGPFAULTERRORBOX`, and there's **no `SetUnhandledExceptionFilter`**. So an unhandled `0xE0000008` / `0xC0000005` falls through to Windows' default crash dialog. | `agentmux-cef/src/lib.rs` init (no SEH filter); launcher `main.rs:~72` (`SEM_FAILCRITICALERRORS` only) |
+| **No reason / unclear if saved** | The one good native dialog (`show_fatal_dialog` → `MessageBoxW`, with reassuring text) only fires in the launcher **after a 5-minute relaunch-deadline expires** — not at the moment of death, and not when the host hard-crashes vs. is supervised. | `agentmux-launcher/src/main.rs` `show_fatal_dialog` (~2155), `OOM_GIVEUP_BODY` |
+
+**Key architectural asset:** the **launcher is a tiny, separate process that survives OOM** (the
+srv survived the 6/26 kill too). It has memory headroom when the CEF fleet does not. The launcher —
+not the dying host — should own the "explain + verify cleanup" step.
+
+## 3. Design — four pillars
+
+### Pillar A — Suppress the ugly OS fault box; install our own last-resort handler
+On **every** AgentMux process (host + each CEF subprocess + launcher), at the earliest entry point:
+- `SetErrorMode(prev | SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS)` — augment, never overwrite
+  (the classic bug: overwriting clobbers other flags — read-modify-write). Also consider
+  `WerSetFlags(WER_FAULT_REPORTING_NO_UI)` to keep WER silent.
+- `SetUnhandledExceptionFilter(amx_last_breath)` — a minimal SEH filter that runs on `0xE0000008`
+  (Chromium OOM) and `0xC0000005` (AV). It must do the **least possible work** (see Pillar B) and
+  then signal the launcher, returning `EXCEPTION_EXECUTE_HANDLER` so Windows shows nothing.
+
+### Pillar B — A pre-allocated "parachute" so cleanup can run when the heap is exhausted
+At startup, reserve a small **committed** block (e.g. 8–16 MB) in the host and launcher. The
+`amx_last_breath` filter's **first action is to free the parachute**, giving the handler enough heap
+to: write a one-line crash-reason file, flush nothing heavy, and post a message to the launcher over
+the existing host-pipe (or a named event + a tiny shared-memory reason struct that needs no
+allocation). This is the standard "release reserve to die gracefully" pattern — without it, the
+handler itself OOMs and you're back to the raw fault box.
+
+### Pillar C — Native, renderer-independent fatal UI (don't ask Chromium to paint your apology)
+Introduce a **commit floor below which we never attempt an HTML recovery page** (call it
+`PAINT_FLOOR_MB`, below the existing `RESUME_FLOOR_MB`). Below `PAINT_FLOOR_MB`:
+- Do **not** call `frame.load_url(data:…)` — a fresh renderer can't paint.
+- Instead the **launcher** shows a native **Task Dialog / `MessageBoxW`** (no CEF, no renderer, no
+  GPU) explaining the situation, with a single **Reopen** action.
+
+Decision ladder on renderer death:
+```
+renderer OOM (PROCESS_OOM)
+ ├─ commit_free ≥ RESUME_FLOOR_MB ........ HTML recovery page (current behavior — fine, memory exists)
+ ├─ PAINT_FLOOR_MB ≤ free < RESUME_FLOOR . HTML pause page, one attempt; if it re-OOMs once → escalate
+ └─ free < PAINT_FLOOR_MB ............... SKIP html; signal launcher → native dialog + clean teardown
+```
+
+### Pillar D — Guaranteed durable cleanup on abnormal exit (not just clean exit)
+Today WAL checkpoint + saga-cancel run only on **clean** shutdown. On an OOM abort they're skipped
+(recovered lazily next launch). Make the **launcher** — which observes host death and has headroom —
+run the durable closeout when it classifies the exit as `SystemOom`/`Abnormal`:
+- `PRAGMA wal_checkpoint(TRUNCATE)` on `objects.db` / `filestore.db` (srv may already be dead — the
+  launcher can open them read-write briefly, or signal a surviving srv to do it).
+- `cancel_all_in_flight` saga closeout (already exists — ensure it runs on the abnormal branch).
+- Job-object `KILL_ON_JOB_CLOSE` already tree-kills orphans — keep, but sequence it **after** the
+  closeout + dialog so nothing is reaped before state is flushed.
+
+## 4. The message the user should see
+
+Native dialog (launcher), shown **at the moment of unrecoverable exit** (not after a 5-min wait):
+
+> **AgentMux had to close — out of memory**
+> Windows ran out of memory, so AgentMux couldn't keep running. This isn't a crash in your work —
+> your panes, agents, and sign-ins are saved.
+>
+> At the time, the most memory was used by: *Traktor (0.9 GB), 3 agents (1.6 GB), AgentMux.*
+> Free up memory (close some apps) or free disk so Windows can grow its page file, then reopen.
+> [ Reopen AgentMux ]   [ Details… ]
+
+- "Details…" links to the crash-reason file / the Win10 pagefile spec.
+- Reason fields (`exit_code`, `commit_free_at_death`, top consumers) flow from the host's last-breath
+  struct → launcher. Top-consumer list comes from a cheap `GlobalMemoryStatusEx` + a process snapshot
+  the launcher takes when it sees the host die.
+- Optionally also raise a **Windows toast** (`PushNotification`-style) so the reason survives even if
+  the user already walked away and dismissed the modal.
+
+## 5. Phased plan
+
+| Phase | Scope | Effort | Files |
+|-------|-------|--------|-------|
+| **P0** | **Kill the ugly box.** `SetErrorMode(+SEM_NOGPFAULTERRORBOX)` + `SetUnhandledExceptionFilter` (minimal, no parachute yet) on host + CEF subprocesses + launcher. Filter just signals launcher + returns EXECUTE_HANDLER. | small | `agentmux-cef/src/lib.rs`, subprocess entry, `agentmux-launcher/src/main.rs` |
+| **P0** | **Move the native dialog to the moment of death.** Fire `show_fatal_dialog` from the launcher as soon as it classifies host exit as OOM, with the reason text — not only after the 5-min deadline. | small | `mem_supervisor.rs`, `main.rs` |
+| **P1** | **Renderer-independent path.** Add `PAINT_FLOOR_MB`; below it, skip HTML recovery and go straight to launcher native dialog. | medium | `client/mod.rs` `on_render_process_terminated` |
+| **P1** | **Parachute reserve** in host + launcher; free-on-fault so the last-breath handler/closeout has heap. | medium | new `agentmux-cef/src/last_breath.rs`, launcher |
+| **P1** | **Abnormal-exit durable closeout** (WAL checkpoint + saga cancel) driven by launcher on OOM classification. | medium | launcher + srv ipc |
+| **P2** | **Reason propagation + top-consumer snapshot + toast.** Structured reason struct host→launcher; process snapshot; optional Windows toast. | medium | host-pipe, launcher |
+| **P2** | **Crash reporter** (Breakpad/Crashpad) for aggregated OOM signatures — separate effort, enables fleet-wide visibility. | large | build + host |
+
+## 6. Non-goals
+- Making Chromium survive OOM (impossible by design — see §7).
+- Replacing the existing gated recovery for the *common* transient renderer crash **with memory
+  available** — that HTML path stays; we only add the no-memory fallback.
+- A full crash-telemetry backend (P2 stub only).
+
+## 7. Why "just handle the allocation failure" isn't an option
+Chromium "configures its memory allocators to prefer crashing rather than returning `nullptr`, so an
+OOM crash can be triggered from anywhere in the code" — the OOM intercept (`OnNoMemoryInternal`)
+calls `RaiseException(0xE0000008, EXCEPTION_NONCONTINUABLE)`. You cannot catch-and-continue past a
+non-continuable exception, and partition_alloc won't hand back null for us to check. Hence the design
+is **own the death**, not prevent it: free a reserve, suppress the OS box, flush durable state, and
+explain — all from the surviving launcher.
+
+## 8. Verification
+- Force the condition: shrink the pagefile + spawn a memory balloon until commit < `PAINT_FLOOR_MB`,
+  trigger a renderer OOM. Expect: **no raw Windows fault box**, no half-painted HTML, one native
+  dialog with the reason, WAL truncated, sagas closed, clean relaunch.
+- Confirm `SetErrorMode` is read-modify-write (doesn't clobber `SEM_FAILCRITICALERRORS`).
+- Confirm the parachute is actually freed in the filter (instrument the handler).
+- Confirm the dialog fires at death, not after the 5-minute deadline.
+
+## 9. Sources
+- [Chromium — Investigating OOM crashes](https://chromium.googlesource.com/chromium/src/+/main/docs/memory/oom.md) — allocators prefer crashing over null; `OnNoMemoryInternal`.
+- [OOM crashes for Chromium browsers (memory-dev)](https://groups.google.com/a/chromium.org/g/memory-dev/c/mPeec9KEc74) — `0xE0000008`, allocation size in exception record.
+- [The Old New Thing — Disabling the program crash dialog](https://devblogs.microsoft.com/oldnewthing/20040727-00/?p=38323) — `SEM_NOGPFAULTERRORBOX`, read-modify-write the error mode.
+- [libuv suppresses Windows Error Reporting (#1327)](https://github.com/libuv/libuv/issues/1327) — practical WER/error-mode suppression.

--- a/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
+++ b/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
@@ -1,0 +1,152 @@
+# Pillar 2 — Wire `reconcile_quit` as the Single Lifecycle Authority
+
+**Date:** 2026-06-29
+**Status:** Implementation spec (ready to build)
+**Parent:** `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` (Pillar 2),
+`DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md`
+**Prior art:** `SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md` (§5.1, §10), `retro-lifecycle-teardown-churn-2026-06-22.md`
+**Issues:** #768 (host/frontend lifecycle divergence), #1681, #1461, #1662
+
+---
+
+## 1. Goal
+
+Make the **quit decision** level-triggered and single-authority. The pure decision function
+`reducer::quit::reconcile_quit` is already written, tested, and `#[allow(dead_code)]` (`reducer/quit.rs:151`).
+This spec **wires it in** behind the existing UI-thread drain executor, and **demotes the three
+current edge-triggered decision sites to pure executors.** No new decision logic — this is the
+"connect the already-built fix + add the safety-net test" step the code comments explicitly defer to
+(`reducer/quit.rs:56-60`).
+
+**Non-goals:** changing the Stage-1 (close pool browsers) / Stage-2 (`quit_message_loop`) executor;
+touching the saga layer; the host-reproject work (Pillar 1). This is the smallest change that stops
+the active orphan/teardown bleeding.
+
+## 2. The bug being fixed (why edge-triggered fails)
+
+Today the "should we quit?" decision is computed **only at the moment a browser closes**, inside
+`client::on_before_close` (`client/mod.rs:1008,1084`): after `UnregisterBrowser`, it counts live user
+windows and, if 0, dispatches `BeginDrain`. This is **edge-triggered** — evaluated once, at one event.
+
+Failure mechanism (confirmed in the orphan host log, retro §3): if a concurrent pool refill/promote
+keeps `count_live_user_windows()` from reading 0 at that exact instant, `BeginDrain` never fires, and
+**nothing re-evaluates the decision** when the racing pool window later settles → host never drains →
+Job Object never drops → whole process tree orphans. The same race resurfaced under new symptoms 5+
+times (#601, #702, #1612, #1647/#1650/#1676).
+
+`reconcile_quit` fixes this by being a **pure function of current `HostState`** that can be re-run
+after *any* transition and always reaches the right answer — so a later transition catches what the
+close-edge missed.
+
+## 3. The wiring design — one chokepoint, not scattered calls
+
+### 3.1 Trigger: reconcile after every quit-relevant reducer transition
+`reconcile_quit` must run after any reducer command that can change its three inputs
+(`count_live_user_windows`, `user_creation_in_flight`, `quit_state`). Rather than sprinkle calls at
+each call site, add a **single post-dispatch hook in the reducer dispatch path** (`reducer/mod.rs`,
+where `host_dispatch` applies a command and returns `DispatchOutput`). After applying a command in
+the quit-relevant set, run `reconcile_quit(state)` (pure, already under the host-state lock) and, if
+it returns `Some(reason)`, emit a new `DispatchOutput` signal requesting drain.
+
+Quit-relevant command set (the only ones that can flip the answer):
+| Command | Why it matters | Site |
+|---------|----------------|------|
+| `UnregisterBrowser` | a window/pane went away (the classic last-close) | `client/mod.rs:825` |
+| `RegisterBrowser` | a promote produced a real `TopLevel{is_pool:false}` (must NOT drain) | `client/mod.rs:459` |
+| `PromotePoolWindow` / pop+promote | pool → real window flips `is_pool` (`reducer/mod.rs` H.4 arm ~344) | reducer |
+| `Enqueue/DequeuePendingWindowCreation` | a user "New Window" started / resolved / aborted | `client/mod.rs:382`, reducer |
+| `DropUnpromotedPoolWindow` | a pre-warm window died externally | reducer H.4 |
+
+All other commands skip the check (cheap guard — match on the variant).
+
+### 3.2 Action: route through the EXISTING UI-thread drain executor
+**Critical threading contract** (`reducer/quit.rs:49-54`, spec §10.1): `reconcile_quit` only DECIDES.
+It must not call `quit_message_loop()`, re-lock `host_state`, or close anything. Calling
+`quit_message_loop` from inside `on_before_close` **deadlocks the UI thread** (confirmed v0.33.498,
+`client/mod.rs:1066`).
+
+So the decision and the action are separated:
+1. **Decision (any thread, under lock):** post-dispatch hook computes `reconcile_quit`.
+2. **Action (UI thread, posted task):** if drain is requested, post a CEF UI-thread task that runs a
+   single extracted function:
+
+```
+fn begin_drain_and_cascade(state, reason):
+    state.host_dispatch(BeginDrain { reason })   // idempotent; flips QuitState→Draining, suppresses refill
+    // Stage 1: PostMessage(WM_CLOSE) to every window-pool-*/floating-pool-* browser
+    //          (the EXACT code currently inline in on_before_close:1107+)
+    // Stage 2 stays where it is: when browser_list empties, quit_message_loop()
+```
+
+This function is **extracted verbatim** from the current `on_before_close` Stage-1 block
+(`client/mod.rs:1084-1180ish`) so behavior is identical — it's just now callable from both the
+close-edge path and the reconcile path. Idempotency is already guaranteed: `handle_begin_drain` early-
+returns once not `Running` (`quit.rs:15`), and `BeginDrain` is documented idempotent
+(`client/mod.rs:1090`).
+
+### 3.3 Result: the three decision sites become executors
+- **`client::on_before_close`** — keep the `UnregisterBrowser` dispatch; **delete the inline
+  `count_live_user_windows()==0` gate + inline `BeginDrain`** (lines ~1084-1097). The post-dispatch
+  hook now fires `reconcile_quit` after the `UnregisterBrowser` it just dispatched. The Stage-1 body
+  moves into `begin_drain_and_cascade`.
+- **`wrr::win_event::maybe_quit_on_last_user_window`** — remove as a *decision*; if it still needs to
+  exist for OS-event reasons, it calls the same reconcile path, never its own count.
+- **`commands::orphan_reconcile`** — its `plan.begin_drain` computation (`orphan_reconcile.rs:189,345`)
+  is now redundant with `reconcile_quit`; have it call the shared executor instead of duplicating the
+  drain-safety predicate. (Keep its *close-plan* execution; drop its independent drain *decision*.)
+
+## 4. Exact code changes
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `reducer/quit.rs` | Remove `#[allow(dead_code)]` from `reconcile_quit`, `should_begin_drain`, `user_creation_in_flight`, `is_background_pending_creation_label`. |
+| 2 | `reducer/mod.rs` | In the dispatch path, after applying a quit-relevant command, call `reconcile_quit(state)`; surface `Some(reason)` via a `DispatchOutput { request_drain: Some(reason), .. }` field (new). |
+| 3 | `client/mod.rs` | Extract Stage-1 drain body into `begin_drain_and_cascade(reason)` (UI-thread-posted). Delete the inline edge gate in `on_before_close`. When `DispatchOutput.request_drain` is set, post `begin_drain_and_cascade`. |
+| 4 | `commands/orphan_reconcile.rs` | Drop independent `begin_drain` decision; call shared executor. Keep close-plan. |
+| 5 | `wrr/win_event.rs` | `maybe_quit_on_last_user_window` → route to reconcile path or delete if now dead. |
+
+**Key invariant preserved:** the `is_pool`-flag classification (`is_live_user_window`, `quit.rs:98`)
+remains the single source of truth — a promoted pool window keeps its `window-pool-*` label but is
+`is_pool:false` and correctly counts as a live window (the reagent P1 #1676 fix). Do not reintroduce
+label-prefix counting.
+
+## 5. Tests — the safety net the regression slipped through
+
+The retro (§7.4) notes **zero E2E coverage** for "close last window ⇒ tree exits." Add:
+
+1. **Reducer unit tests (pure, fast)** — already partly present for `should_begin_drain`'s truth table.
+   Add: reconcile returns `Some` after `UnregisterBrowser` drops the last live window; returns `None`
+   while a `window-pool-*` promote is mid-flight; returns `None` with a user pending creation; returns
+   `Some` once that pending creation resolves to nothing.
+2. **The race regression test (the important one):** simulate close-last-window **concurrent with** a
+   pool refill that briefly keeps the count non-zero, then the refill settling → assert reconcile
+   eventually returns `Some` and drain fires. This is the exact scenario edge-triggering missed.
+3. **E2E (gated in CI):** launch → open 2 windows → close both → assert the process tree exits within
+   N seconds (no orphaned host/srv). Mirror for "host killed → relaunch → windows restore" once Pillar 1
+   lands.
+
+## 6. Risks & mitigations
+- **Deadlock (highest risk):** never run the action inline — always via the posted UI-thread task. The
+  post-dispatch hook returns a *request*, it does not act. (Contract: `quit.rs:49-54`.)
+- **Double-drain:** idempotent by construction (`handle_begin_drain` early-return). A reconcile firing
+  after `BeginDrain` already flipped `QuitState` returns `None`.
+- **macOS/Linux parity:** Stage-1 uses `PostMessage` (Win), `performClose:` (mac), `WM_DELETE_WINDOW`
+  (X11). `begin_drain_and_cascade` must keep the existing per-platform branch (`client/mod.rs:1080-1083`)
+  — extract, don't rewrite. The pane-pool startup window means `browser_list` must include
+  `floating-pool-*` or Stage-2 never empties on mac/Linux (`client/mod.rs:1101-1106`) — preserve.
+- **Over-triggering:** the quit-relevant command guard keeps reconcile off the hot path (most dispatches
+  skip it).
+
+## 7. Rollout
+1. Land #1 (un-dead-code) + #2 (reducer hook + `request_drain`) + tests #5.1/#5.2 — pure, no behavior
+   change yet (hook computed but executor still the old inline path).
+2. Land #3 (extract executor, delete inline gate, wire `request_drain`).
+3. Land #4/#5 (demote orphan_reconcile + WRR; E2E test).
+4. Verify against the retro's reproduction (#1647/#1650/#1676 scenarios) and the orphan-log signature
+   (drain marker now always present).
+
+## 8. Definition of done
+- `reconcile_quit` is the only place "should we drain?" is decided; the other sites are executors.
+- The race regression test fails on `main` (pre-wire) and passes after.
+- Closing the last window always exits the process tree (E2E green); no orphan host logs.
+- Net deletion of duplicated drain-decision code in `on_before_close` / `orphan_reconcile` / `wrr`.

--- a/docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md
+++ b/docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md
@@ -1,0 +1,178 @@
+# Win10 Commit-Limit OOM — Addendum: Free-Disk Regression & the 0xE0000008 Crash Class
+
+**Date:** 2026-06-29
+**Status:** Addendum to existing memory-pressure corpus — corrects a stale premise, adds two new findings
+**Affected:** AgentMux (CEF/Chromium 148) on Windows 10 22H2 (build 19045).
+
+> **Read first — this builds on prior work, it does not replace it:**
+> - `docs/incident/INCIDENT_2026_06_26_APP_CLOSED.md` — the overnight silent OOM kill
+> - `docs/specs/SPEC_MEMORY_ANALYSIS_2026_06_26.md` — process inventory, commit math, P0–P3 list
+> - `docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md` — `mem_supervisor.rs` design
+> - `docs/specs/SPEC_GATED_RENDERER_RECOVERY_2026_06_01.md` — renderer OOM recovery
+> - `docs/specs/SPEC_WINDOWS_LIFECYCLE_ROBUSTNESS_2026_06_26.md`
+>
+> **Already shipped** (confirmed in tree): commit gauge in StatusBar (`SystemStats.tsx`, #1799);
+> launcher memory-aware relaunch (`mem_supervisor.rs`, #1493); `CreateMemoryResourceNotification`
+> watcher (`agentmux-launcher/src/main.rs`); gated renderer OOM recovery (`memory_heartbeat.rs`,
+> `client/mod.rs`, #1229); proactive `--disable-gpu` under low commit (#1496); WAL checkpoint +
+> saga cancel (#1799); `avail_page_gb` heartbeat (`backend/sysinfo.rs`).
+
+This addendum exists because new machine data shows the **commit budget the prior analysis
+assumed (87.7 GB) has since collapsed to ~52–56 GB**, and because the Windows Event Log reveals
+a **second, distinct crash manifestation** (`0xE0000008`) not covered by the 6/26 incident.
+
+---
+
+## 1. What changed since 2026-06-26 — the premise is now stale
+
+`SPEC_MEMORY_ANALYSIS_2026_06_26.md` computed everything against:
+
+```
+Commit budget (RAM + page file): 31.9 + 55.8 = 87.7 GB
+→ "Max safe concurrent agents: 3 (leaves 17.7 GB margin)"
+```
+
+That 55.8 GB page file assumed C: had room to host it. **It no longer does.** Today's readings:
+
+| Metric | 2026-06-26 (prior spec) | 2026-06-29 (now) | Change |
+|--------|------------------------|------------------|--------|
+| C: free space | (enough for 55.8 GB pf) | **20.1 GB free** / 446 GB | drive filled up |
+| Page file allocated | 55.8 GB | **~20.75 GB** | shrank ~35 GB |
+| System commit limit | 87.7 GB | **~52–56 GB** | **nearly halved** |
+| Pagefile growth ceiling `min(3×RAM, ⅛ vol)` | ~55.8 GB | ~55.8 GB wanted, **gated by 20 GB free disk** | blocked |
+
+**The system-managed page file cannot grow.** It wants to climb toward ~55 GB when commit hits
+90%, but there is only ~20 GB of free disk, so it is physically stuck near 20 GB. The commit
+limit ceiling is therefore pinned at roughly RAM (32 GB) + ~20 GB ≈ **52 GB and cannot rise**.
+
+**Consequence:** every "safe concurrent agents" number in the 6/26 spec is now optimistic by
+roughly the ratio 52/87.7 ≈ 0.6×. With a tighter budget the system reaches the wall faster and
+more often — consistent with the user's report that Win10 now crashes "like clockwork, even
+idle." The single most impactful variable today is **free disk on the pagefile volume**, which
+none of the prior specs tracked.
+
+---
+
+## 2. New finding — the `0xE0000008` crash class (distinct from the 6/26 silent kill)
+
+The 6/26 incident was a **silent Windows OOM process-kill** (no dump, no WER entry — Windows
+reclaimed memory by terminating the host). That is failure mode **(A)**.
+
+The Application event log shows a **second** mode **(B)** that recurs across *every* version
+(0.43.2 → 0.49.6), independent of 6/26:
+
+```
+Faulting application: agentmux-0.49.6.exe (libcef 148.0.9)
+Faulting module:      KERNELBASE.dll +0x25369   ← RaiseException (the raiser, not the cause)
+Exception code:       0xE0000008                ← Chromium kOomExceptionCode (out of memory)
+OS:                   10.0.19045 (Win10 22H2)
+```
+
+`0xE0000008` is **Chromium's hard-coded OOM exception** (`base::win::kOomExceptionCode`; chosen
+because `0x8 = ERROR_NOT_ENOUGH_MEMORY`, top nibble `E` to avoid collisions). When any
+allocation fails, `base::TerminateBecauseOutOfMemory` calls
+`::RaiseException(0xE0000008, EXCEPTION_NONCONTINUABLE, …)` and the CEF process self-aborts.
+Breakpad labels it `MD_EXCEPTION_OUT_OF_MEMORY`. (Sources §6.)
+
+So mode (B) is the app's **own renderer/host process hitting a failed commit and aborting
+itself** — the same root pressure as (A), surfaced as a real WER crash rather than a silent
+kill. The existing gated-renderer-recovery (#1229) is meant to catch renderer deaths, but these
+`0xE0000008` faults still reach WER, so either (i) they're hitting the host/browser process (not
+recoverable as a renderer), or (ii) recovery isn't firing for this exception code. **Action:
+verify whether mode (B) crashes are classified and recovered by `memory_heartbeat` / the gated
+recovery path, or whether they bypass it.**
+
+Secondary codes also present, all downstream of pressure: `0x80000003` (Chromium
+`IMMEDIATE_CRASH`/breakpoint, in `libcef.dll`), `0xC0000409` (`__fastfail`), `0xC0000602`
+(`FAST_FAIL_FATAL_APP_EXIT`).
+
+### Note on the 6/26 commit attribution
+The 6/26 spec attributed ~10.5 GB *commit* to each `claude.exe`, derived from
+`VirtualMemorySize64`. The `Resource-Exhaustion-Detector` (Event 2004) data from the same
+morning lists each `claude.exe` at **~0.49–0.67 GB** of consumed virtual memory, and `Traktor.exe`
+at ~0.9 GB. `VirtualMemorySize64` counts reserved address space (not commit); the true
+per-agent **private commit** is sub-GB, not 10.5 GB. This doesn't change the conclusion (the
+budget was exhausted) but it means the dominant consumer was the **aggregate of many processes
+against a now-smaller budget**, not a few giant agent processes. Worth re-measuring with
+`PrivateUsage` before sizing the commit-aware scheduler's reserve.
+
+---
+
+## 3. New finding — runaway logging is eating the scarce disk (feedback loop)
+
+`~/.agentmux/logs/agentmux-launcher.log` is **244 MB**, dominated by per-second repeats of:
+
+```
+agentmux_srv::server::websocket: SetMeta oref=block:…   (INFO, many/sec)
+```
+
+On a drive with only ~20 GB free, this directly **tightens the page-file ceiling** that mode
+(A)/(B) crashes depend on — a self-reinforcing loop (more uptime → bigger log → less disk →
+smaller commit budget → earlier OOM). Not the root cause, but a cheap, high-leverage fix that
+also protects the pagefile headroom.
+
+**Action:** throttle/sample the `SetMeta` INFO line; enforce rotation + size cap on
+`agentmux-launcher.log` (e.g. 50 MB × 3).
+
+---
+
+## 4. Why Windows 11 is unaffected (updated)
+
+Not a kernel-version bug. The Win11 box almost certainly has **more free disk**, so its
+system-managed page file actually grows toward 3×RAM and the commit limit stays ahead of demand
+— the allocation that aborts on Win10 never fails there. Lower steady-state commit charge
+(fewer concurrent agents / no Traktor) and marginally more aggressive Win11 memory compression
+add headroom but are secondary. The dominant lever is environmental (free disk → pagefile
+growth), which is exactly the variable that regressed on this Win10 machine since 6/26.
+
+---
+
+## 5. Recommendations
+
+### 5.1 Immediate (user, no code) — should stop the crashes today
+1. **Free C: to ≥ 60–80 GB.** Quick wins: the 244 MB launcher log, old portable build folders
+   on the Desktop (`agentmux-0.49.x+…-portable`), stale dev instances under `~/.agentmux/dev`.
+   This lets the page file grow back toward ~55 GB and restores the 87.7 GB budget the prior
+   analysis assumed.
+2. **Or set an explicit page file** (e.g. 32 GB init / 48 GB max) on a volume with room, so it
+   can't get stuck mid-grow. Requires the disk first.
+3. Keep concurrent agents ≤ what the *current* budget supports (≈ 2 until disk is freed).
+
+### 5.2 Code — gaps still open after the shipped corpus
+| Pri | Item | Why it's still needed | Where |
+|-----|------|----------------------|-------|
+| **P0** | **Track free disk on the pagefile volume**, not just `avail_page_gb`. Warn when free disk < ~15% *and* page file is system-managed ("Windows can't grow virtual memory — crash risk"). | The entire regression here is invisible to the current `avail_page` gauge — it only sees the symptom (commit near limit), not the cause (disk can't back a bigger pagefile). | `backend/sysinfo.rs` + StatusBar |
+| **P0** | **Confirm `0xE0000008` is caught by gated renderer recovery.** If these faults hit the host/browser process, they bypass `memory_heartbeat` recovery and kill the session. | Mode (B) crashes still reach WER across all versions despite #1229. | `agentmux-cef/src/client/mod.rs`, `memory_heartbeat.rs` |
+| **P0** | **Commit-aware turn scheduler** — gate new agent spawn on commit headroom (6/26 P0). Re-derive the reserve from `PrivateUsage`, not `VirtualMemorySize64`. | Verify whether this actually shipped or only monitoring landed; the 6/26 reserve (12 GB) was sized off the inflated 10.5 GB/agent figure. | `agentmux-srv` |
+| **P1** | Throttle `SetMeta` INFO firehose + rotate/cap `agentmux-launcher.log`. | Disk-eating feedback loop (§3). | srv logging + launcher |
+| **P1** | Shut down old version on upgrade (6/26 P1 — still see multiple versions coexisting). | Stacks CEF overhead across months. | launcher |
+| **P2** | Per-agent commit (`PrivateUsage`) in Swarm; first-run budget advisory **driven by free disk**, not a static RAM table. | The static "3 agents" table is wrong once disk shrinks the budget. | srv + frontend |
+
+---
+
+## 6. Sources
+- [Chromium `base/process/memory.h`](https://chromium.googlesource.com/chromium/src/base/+/master/process/memory.h)
+- [Add OOM exception code for Chromium (breakpad-dev)](https://groups.google.com/g/google-breakpad-dev/c/PJOG-iLhSjg) — `kOomExceptionCode = 0xe0000008`
+- [`base::TerminateBecauseOutOfMemory` → `RaiseException` on Windows (codereview 2173463002)](https://codereview.chromium.org/2173463002)
+- [Page file sizing for 64-bit Windows (MS Learn)](https://learn.microsoft.com/en-us/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size-for-64-bit-versions-of-windows) — auto-grow at 90% commit, ceiling `min(3×RAM, ⅛ volume)`
+- [Introduction to the page file (MS Learn)](https://learn.microsoft.com/en-us/troubleshoot/windows-client/performance/introduction-to-the-page-file) — commit limit = RAM + page files
+
+---
+
+## 7. Verification
+- **Confirm the disk lever (single-variable test):** free C: to ≥ 80 GB, run idle 24 h → expect
+  no `0xE0000008`. Refill to ~20 GB free → expect the crash to return. This proves disk/pagefile
+  is the regression vs. the shipped supervision corpus.
+- **Re-measure per-agent commit with `PrivateUsage`** (not `VirtualMemorySize64`) to correctly
+  size the scheduler reserve.
+- **Watch both failure modes:**
+  ```powershell
+  # Mode B — Chromium OOM self-abort (WER)
+  Get-WinEvent -FilterHashtable @{LogName='Application';Id=1000} |
+    Where Message -match 'agentmux.*e0000008' | Select TimeCreated
+  # Pressure precursor (fires before either mode)
+  Get-WinEvent -FilterHashtable @{LogName='System';
+    ProviderName='Microsoft-Windows-Resource-Exhaustion-Detector'}
+  # The regressed variable the gauge doesn't track
+  Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'" | Select Size,FreeSpace
+  ```

--- a/frontend/app/statusbar/SystemStats.tsx
+++ b/frontend/app/statusbar/SystemStats.tsx
@@ -164,7 +164,7 @@ const SystemStats = (): JSX.Element => {
                         <span
                             class="stat-mono stat-commit"
                             style={{ color: commitColor(s().commitUsed, s().commitTotal) }}
-                            data-tip="Commit charge used and total (RAM + page file budget). High commit causes OOM kills."
+                            data-tip="Commit charge used and total (RAM + page file budget)."
                             aria-label="Commit charge"
                         >
                             PF {formatMemBytes(s().commitUsed)}/{formatMemBytes(s().commitTotal)}


### PR DESCRIPTION
## Summary

Captures a multi-part investigation into AgentMux's recurring Windows OOM crashes and lifecycle/teardown churn, and proposes a refactor direction. Pure docs + one tooltip change — no behavior change.

The throughline: the recurring **OOM crashes** and the **lifecycle/teardown churn** are one root cause with two faces — the CEF host is both the thing most likely to die (Chromium aborts on any failed allocation, `0xE0000008`) **and** the authoritative in-memory owner of session/UI/lifecycle state. Fragile + irreplaceable ⇒ every death is catastrophic and every recovery is hand-built.

## What's here

**Specs / records (docs/)**
- `SPEC_WIN10_PAGEFILE_OOM_CRASH` — free-disk regression collapses the system commit budget (87.7→~52 GB); `0xE0000008` is Chromium's OOM self-abort, not a logic bug. Addendum to the existing memory-pressure corpus.
- `SPEC_GRACEFUL_OOM_EXIT` — when the app must die: suppress the raw OS fault box (`SEM_NOGPFAULTERRORBOX` + `SetUnhandledExceptionFilter`), a pre-reserved memory "parachute", a native renderer-independent dialog stating the reason, and durable cleanup from the surviving launcher.
- `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR` — four-dimension audit (process/memory, lifecycle/sagas, persistence, historical trend). Verdict: **NEEDS-REFACTOR** for the process/memory admission model and lifecycle quit-authority; **STRAINED** (pay-down) for persistence.
- `DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE` — decision record: three-tier disposability (srv = durable authority; host & renderer = disposable projections that reproject from srv). The renderer already follows this; the host doesn't — the asymmetry is the defect.
- `SPEC_PILLAR2_WIRE_RECONCILE_QUIT` — implementation spec to wire the already-written, tested, but `#[allow(dead_code)]` level-triggered quit reconciler (`reducer/quit.rs`) as the single lifecycle authority, demoting the 3 current edge-triggered decision sites to executors.
- `SPEC_AGENT_STATUS_LABELS` — richer agent status labels (the "Working…" → tool-aware labels work).

**Code**
- `SystemStats.tsx`: removed "High commit causes OOM kills." from the PF chip tooltip.

## Related issues
Refs #942 (service supervision/recovery), #768 (host/frontend lifecycle divergence), #864 (retire wcore-direct layout path — Pillar-1 groundwork), #376 (renderer death + host hang), #1681 (floating-pane lifecycle rethink).

## Notes
- The historical audit quantifies the "patches on an unsteady foundation" pattern: ~45–55 of every 100 PRs touch memory/lifecycle/crash with a flat-to-rising rate; ~1 in 5 commits is a follow-up/revert; renderer-OOM recovery re-fixed 6+ times.
- Recommended next step (in the spec): build Pillar 2 (wire `reconcile_quit`) first — it's mostly connecting already-written code and stops the active orphan/teardown bleeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)