### PR TITLE
ci(macos): consume patched CEF framework + BeginWindowDrag patch gate

### DIFF
--- a/.changesets/1782791574-ci-macos-consume-patched-cef-framework-from-agentmuxai-cef-a-i1gg.md
+++ b/.changesets/1782791574-ci-macos-consume-patched-cef-framework-from-agentmuxai-cef-a-i1gg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+ci(macos): consume patched CEF framework from agentmuxai/cef + add BeginWindowDrag patch gate

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -109,8 +109,15 @@ jobs:
         run: |
           TAG="${{ steps.in.outputs.cef_tag }}"
           if [ -z "$TAG" ]; then
-            TAG=$(gh release list --repo agentmuxai/cef --limit 1 \
-                    --json tagName --jq '.[0].tagName')
+            # agentmuxai/cef now holds BOTH platforms' releases — filter to the
+            # Linux x86_64 prefix (a bare --limit 1 would grab whichever platform
+            # released most recently, e.g. a macOS framework).
+            TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+                    --json tagName \
+                    --jq '[.[].tagName | select(startswith("cef-linux-x86_64-"))][0]')
+          fi
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "ERROR: no cef-linux-x86_64-* release found in agentmuxai/cef"; exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved patched libcef.so tag: $TAG"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -26,9 +26,13 @@ on:
         description: "GitHub release tag to upload the DMG to (blank = skip upload)"
         required: false
         default: ""
+      cef-runtime-tag:
+        description: "agentmuxai/cef release tag for patched framework (blank = latest macOS)"
+        required: false
+        default: ""
   repository_dispatch:
     types: [build-macos]
-    # client_payload: { ref: "vX.Y.Z", release_tag: "vX.Y.Z" }
+    # client_payload: { ref: "vX.Y.Z", release_tag: "vX.Y.Z", cef_runtime_tag: "" }
 
 permissions:
   contents: write   # needed to upload release assets via GITHUB_TOKEN
@@ -39,6 +43,7 @@ jobs:
     runs-on: macos-latest   # Apple Silicon arm64 (M-series)
     env:
       OUT: ${{ github.workspace }}/artifacts
+      CEF_RUNTIME_DIR_DARWIN: ${{ github.workspace }}/cef-runtime-darwin
 
     steps:
       - name: Resolve inputs
@@ -46,11 +51,13 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "ref=${{ github.event.client_payload.ref }}"              >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.client_payload.ref }}"                 >> "$GITHUB_OUTPUT"
             echo "release_tag=${{ github.event.client_payload.release_tag }}" >> "$GITHUB_OUTPUT"
+            echo "cef_tag=${{ github.event.client_payload.cef_runtime_tag }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=${{ inputs.ref }}"                 >> "$GITHUB_OUTPUT"
             echo "release_tag=${{ inputs.release-tag }}" >> "$GITHUB_OUTPUT"
+            echo "cef_tag=${{ inputs.cef-runtime-tag }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout agentmux source
@@ -78,6 +85,63 @@ jobs:
 
       - name: Install go-task
         run: brew install go-task
+
+      # ── Patched CEF framework ─────────────────────────────────────────────
+      # The upstream cef-dll-sys framework lacks CefWindow::BeginWindowDrag, so
+      # native window drag / floating-pane resize silently no-ops on macOS. We
+      # download a pre-built PATCHED framework (agentmuxai/cef release) and point
+      # AGENTMUX_CEF_RUNTIME_DIR_DARWIN at it — the macOS analogue of build-linux's
+      # patched-libcef.so download. The package-macos.sh patch gate then verifies
+      # the framework carries BeginWindowDrag before signing.
+      # See docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md.
+      - name: Resolve patched CEF framework tag
+        id: cef
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          TAG="${{ steps.in.outputs.cef_tag }}"
+          if [ -z "$TAG" ]; then
+            # agentmuxai/cef holds BOTH platforms' releases — filter to macOS arm64
+            # (a bare --limit 1 would grab whichever platform released most recently).
+            TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+                    --json tagName \
+                    --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
+          fi
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "❌ no cef-macos-arm64-* release found in agentmuxai/cef" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved patched CEF framework tag: $TAG"
+
+      - name: Cache patched CEF framework
+        id: cef-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CEF_RUNTIME_DIR_DARWIN }}
+          key: cef-runtime-darwin-${{ steps.cef.outputs.tag }}
+
+      - name: Download patched CEF framework
+        if: steps.cef-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR_DARWIN"
+          gh release download "${{ steps.cef.outputs.tag }}" \
+            --repo agentmuxai/cef \
+            --pattern "*.tar.gz" \
+            --dir /tmp/cef-extract \
+            --clobber
+          tar -xzf /tmp/cef-extract/*.tar.gz -C /tmp/cef-extract
+          # Find the .framework regardless of whether the tarball has a top-level dir
+          FW=$(find /tmp/cef-extract -maxdepth 3 -name "Chromium Embedded Framework.framework" -type d | head -1)
+          if [ -z "$FW" ]; then echo "❌ framework not found in tarball"; exit 1; fi
+          # ditto preserves the Versions/Current symlink chain the CEF loader follows.
+          ditto "$FW" "$CEF_RUNTIME_DIR_DARWIN/Chromium Embedded Framework.framework"
+          rm -rf /tmp/cef-extract
+
+      - name: Set AGENTMUX_CEF_RUNTIME_DIR_DARWIN
+        run: echo "AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$CEF_RUNTIME_DIR_DARWIN" >> "$GITHUB_ENV"
 
       # ── Apple Developer ID codesigning setup ──────────────────────────────
       # Creates a short-lived keychain that is torn down in the cleanup step.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -630,6 +630,11 @@ tasks:
                     echo "❌ resolve-cef-runtime-darwin.sh did not yield a usable CEF framework" >&2
                     exit 1
                 fi
+                # Advisory BeginWindowDrag-patch check — non-fatal here so `task dev`
+                # still works on the upstream cef-dll-sys fallback (no multi-hour CEF
+                # build required). Must run on the UNSTRIPPED framework, before the
+                # packaging strip. The hard release gate is in package-macos.sh.
+                bash scripts/verify-cef-framework-darwin.sh "$CEF_DIR" || true
                 mkdir -p dist/Frameworks dist/cef
                 rm -rf "dist/Frameworks/Chromium Embedded Framework.framework"
                 # `ditto` preserves the Versions/Current symlink chain that the

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -1,0 +1,189 @@
+# Building the Patched CEF Framework for AgentMux (macOS arm64)
+
+**Audience:** AgentMux maintainers building a macOS release that needs native
+window drag / floating-pane edge-resize.
+**Time:** First build ~3-6 hours wall-clock (CPU-bound chromium compile).
+**Disk:** ~99 GB chromium working tree + build output.
+**Output:** A `Chromium Embedded Framework.framework` (~545 MB unstripped) with the
+AgentMux `BeginWindowDrag` patch that upstream CEF / its prebuilt binary
+distribution lack.
+
+This is the macOS counterpart to `build-patched-libcef.md` (Linux). Read that doc
+for the shared chromium/CEF/depot_tools mechanics; this doc covers only the
+macOS-specific deltas.
+
+---
+
+## Why this exists
+
+The upstream `cef-dll-sys` framework lacks `CefWindow::BeginWindowDrag()`. Without
+it, macOS native window drag no-ops — which is exactly why the floating-pane header
+drag and edge-resize fall back to JS-polled `get/set_window_position` /
+`set_window_rect` workarounds (`floating-pane-workspace.tsx`,
+`jsDrivenDrag = isMacOS() || isLinux()`). Shipping the patched framework is the
+prerequisite for moving macOS onto the native drag path.
+
+The patches live in the same fork/branch as Linux:
+- **Repo:** https://github.com/agentmuxai/cef
+- **Branch:** `agentmux/7778-drag-rightclick-and-transparency`
+- **Base:** Chromium 148 (CEF branch 7778)
+- **Rust binding:** `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag` (pinned in
+  `Cargo.toml` `[patch]`; the binding's `_cef_window_t` carries `begin_window_drag`
+  for both linux and macos arch dirs).
+
+---
+
+## What the verified artifact looks like
+
+The framework currently referenced by the release pipeline (verified 2026-06-29):
+
+| Property | Value |
+|----------|-------|
+| Path | `~/cef-build/chromium/chromium/src/out/Release_GN_arm64/Chromium Embedded Framework.framework` |
+| Arch | Mach-O 64-bit arm64 |
+| Size (unstripped) | 545 MB |
+| Version (`Info.plist` `CFBundleShortVersionString`) | 148.0.9 |
+| Patch symbol | `__ZN13CefWindowImpl15BeginWindowDragEv` (local symbol, `nm` type `t`) |
+
+> ⚠️ The patch symbol is **local**, not exported. Verify with full `nm` —
+> `nm -gU` (external-only) will MISS it. `scripts/verify-cef-framework-darwin.sh`
+> handles this; don't "optimize" it to `nm -gU`.
+
+---
+
+## Prerequisites (macOS deltas)
+
+- macOS arm64 host (Apple Silicon) with Xcode + command-line tools.
+- ≥ 32 GB RAM, ≥ 120 GB free disk.
+- `depot_tools` on PATH; the chromium hooks pull the macOS toolchain automatically.
+
+The depot_tools / automate-git / fork-checkout / patcher steps are **identical to
+Linux** — follow `build-patched-libcef.md` §1–§3, with `--branch=7778`.
+
+---
+
+## Configure the build (macOS args)
+
+The canonical GN args are version-controlled at **`scripts/cef-build/args-darwin.gn`**
+— the configuration that produced the verified arm64 framework. Key deltas from the
+Linux `args.gn`:
+
+- `target_cpu="arm64"`
+- `is_official_build=false` (the captured build; see the size follow-up note in the
+  args file — flipping this to `true` + `use_thin_lto=true` should roughly halve the
+  binary, tracked as a follow-up)
+- `symbol_level=1` (stripped by `package-macos.sh` at bundle time)
+- no Linux-only knobs (`use_sysroot`, `use_qt*`)
+
+```bash
+cd ~/cef-build/chromium/chromium/src
+# Regenerate the gitignored C-API wrappers FIRST (same gotcha as Linux)
+( cd cef && python3 tools/translator.py --root-dir . )
+cp /path/to/agentmux/scripts/cef-build/args-darwin.gn out/Release_GN_arm64/args.gn
+./buildtools/mac/gn gen out/Release_GN_arm64
+```
+
+---
+
+## Build
+
+```bash
+cd ~/cef-build/chromium/chromium/src
+# macOS doesn't need the systemd-run cgroup isolation Linux uses; ninja directly.
+# Build the framework target (NOT the phony `cef` meta-target, which won't relink
+# after a source-only change).
+third_party/ninja/ninja -j 12 -l 16 -C out/Release_GN_arm64 cef
+```
+
+Output: `out/Release_GN_arm64/Chromium Embedded Framework.framework` (~545 MB
+unstripped). Do **not** strip it here — `package-macos.sh` strips at bundle time, and
+the patch-verify gate keys on the local symbol that `strip -S -x` removes.
+
+---
+
+## Verify the patch
+
+```bash
+bash /path/to/agentmux/scripts/verify-cef-framework-darwin.sh \
+  ~/cef-build/chromium/chromium/src/out/Release_GN_arm64
+# exit 0 = patched · exit 1 = unpatched upstream · exit 2 = stripped/unverifiable
+```
+
+- `task bundle:darwin` runs this **advisorily** (a warning — so `task dev` still
+  works on the upstream cef-dll-sys fallback).
+- `scripts/package-macos.sh` runs it as a **hard release gate** before signing
+  (override with `AGENTMUX_SKIP_CEF_PATCH_CHECK=1` for a deliberate upstream-CEF
+  package). The gate runs on `dist/Frameworks/` — unstripped at that point; the
+  `strip -S -x` happens later inside the assembled `.app`.
+
+---
+
+## Using the built framework in AgentMux
+
+### Option A: Default location
+If you built at `~/cef-build/darwin/<arch>/` (the standard layout
+`resolve-cef-runtime-darwin.sh` looks for at tier 2), `task bundle:darwin` picks it
+up automatically. Copy/symlink the framework there:
+```bash
+mkdir -p ~/cef-build/darwin/aarch64
+ditto ~/cef-build/chromium/chromium/src/out/Release_GN_arm64/"Chromium Embedded Framework.framework" \
+      ~/cef-build/darwin/aarch64/"Chromium Embedded Framework.framework"
+```
+
+### Option B: Explicit override
+```bash
+export AGENTMUX_CEF_RUNTIME_DIR_DARWIN=~/cef-build/chromium/chromium/src/out/Release_GN_arm64
+task bundle:darwin
+```
+`resolve-cef-runtime-darwin.sh` treats this as a hard requirement (tier 1) — a typo
+fails fast rather than silently falling through to the unpatched cargo cache.
+
+---
+
+## Package + upload as a GitHub release (for CI)
+
+Local builds resolve the framework from `~/cef-build/...` directly, so this step is
+**only for CI** — which has no build tree and pulls the patched framework from a
+release in `agentmuxai/cef` (consumed by `build-macos.yml`).
+
+**Do NOT strip first.** `package-macos.sh` strips at bundle time, and the verify gate
+keys on the local symbol that `strip` removes — upload the **unstripped** framework.
+
+```bash
+CEF_OUT=~/cef-build/chromium/chromium/src/out/Release_GN_arm64
+# CEF version from Info.plist CFBundleShortVersionString (e.g. 148.0.9).
+CEF_VERSION="148.0.9"
+
+bash /path/to/agentmux/scripts/verify-cef-framework-darwin.sh "$CEF_OUT"   # must exit 0
+
+cd "$CEF_OUT"
+# tar preserves the Versions/Current symlink chain on macOS by default. Verify after
+# upload that the extracted tree still has the
+# `Chromium Embedded Framework -> Versions/Current/Chromium Embedded Framework`
+# symlink; if BSD tar mangles it, use `ditto -c -k --keepParent` (zip) instead and
+# adjust the CI extract step to `ditto -x -k`.
+tar -czf "cef-macos-arm64-${CEF_VERSION}.tar.gz" "Chromium Embedded Framework.framework"
+
+gh release create "cef-macos-arm64-${CEF_VERSION}" --repo agentmuxai/cef \
+  --title "Patched CEF framework — macOS arm64 CEF ${CEF_VERSION}" \
+  --notes "BeginWindowDrag + drag-rightclick + transparency. Branch: agentmux/7778-drag-rightclick-and-transparency. Unstripped (~545 MB); packager strips at bundle time." \
+  "cef-macos-arm64-${CEF_VERSION}.tar.gz"
+```
+
+**Naming convention** (parallels Linux `cef-linux-x86_64-<ver>`):
+- Tag: `cef-macos-arm64-<CEF_VERSION>`
+- Asset: `cef-macos-arm64-<CEF_VERSION>.tar.gz`
+
+`build-macos.yml` auto-detects the latest `cef-macos-arm64-*` release (or takes an
+explicit `cef-runtime-tag` input), downloads + caches it, sets
+`AGENTMUX_CEF_RUNTIME_DIR_DARWIN`, and the package gate verifies the patch.
+
+---
+
+## Version skew with Linux (follow-up)
+
+The Linux release is at CEF `148.0.20`; this macOS framework is `148.0.9`. Functional
+parity for `BeginWindowDrag` is fine, but matching versions is cleaner for support.
+**Tracked follow-up:** rebuild macOS arm64 at `148.0.20` (and with
+`is_official_build=true` for the size win) and re-cut the release so both platforms
+converge.

--- a/docs/specs/SPEC_BUILDER_MACOS_LINUX_CI_2026_06_24.md
+++ b/docs/specs/SPEC_BUILDER_MACOS_LINUX_CI_2026_06_24.md
@@ -55,14 +55,29 @@ all required by `scripts/package-macos.sh`.
 1. Checkout agentmuxai/agentmux at <ref> (AGENTMUX_CHECKOUT_TOKEN)
 2. Install Rust (stable) + dtolnay/rust-toolchain
 3. Install Node 22 + npm ci (A5AF_PACKAGES_TOKEN for @a5af packages)
-4. Import Developer ID certificate into a temporary keychain
-5. Store notarytool credentials in the temporary keychain
-6. task package:macos -- "$OUTDIR"
-7. gh release upload <release-tag> <DMG> (AGENTMUX_RELEASE_TOKEN)
-8. Cleanup: delete temp keychain
+4. Download + extract patched CEF framework from agentmuxai/cef release;
+   set AGENTMUX_CEF_RUNTIME_DIR_DARWIN  (CEF_RUNTIME_TOKEN)
+5. Import Developer ID certificate into a temporary keychain
+6. Store notarytool credentials in the temporary keychain
+7. task package:macos -- "$OUTDIR"   (package-macos.sh hard-gates the patch)
+8. gh release upload <release-tag> <DMG> (AGENTMUX_RELEASE_TOKEN)
+9. Cleanup: delete temp keychain
 ```
 
-### 2.4 Certificate Import (Step 4)
+> **Patched CEF framework (Step 4) — added 2026-06-29.** The upstream
+> `cef-dll-sys` framework lacks `CefWindow::BeginWindowDrag()`, so macOS native
+> window drag / floating-pane resize silently no-ops (the JS-polled workaround in
+> `floating-pane-workspace.tsx` exists precisely because of this). macOS now
+> mirrors Linux: it downloads a **pre-built patched framework** from an
+> `agentmuxai/cef` release (`cef-macos-arm64-<ver>.tar.gz`), sets
+> `AGENTMUX_CEF_RUNTIME_DIR_DARWIN`, and `package-macos.sh` verifies the patch
+> before signing via `scripts/verify-cef-framework-darwin.sh`. The
+> `cef-runtime-tag` input (auto-detects the latest `cef-macos-arm64-*` when blank)
+> selects the release. See
+> `SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md` and
+> `docs/cef-build/build-patched-framework-macos.md`.
+
+### 2.4 Certificate Import (Step 5)
 
 The standard CI pattern for Apple codesigning — creates a short-lived keychain
 that is torn down after the job:
@@ -144,9 +159,12 @@ Only runs when `release-tag` input is non-empty.
 | `APPLE_ID` | Apple ID email for notarytool | ✅ |
 | `APPLE_PASSWORD` | App-specific password | ✅ |
 | `APPLE_TEAM_ID` | 10-char Apple Team ID | ✅ |
+| `CEF_RUNTIME_TOKEN` | PAT (`contents:read`) for agentmuxai/cef | shared with Linux (§3.10) |
 
-All secrets are already present in `agentmux-builder` per the README. No new
-secrets need to be created.
+All Apple/npm secrets are already present in `agentmux-builder` per the README.
+The macOS workflow additionally needs `CEF_RUNTIME_TOKEN` — the **same** secret the
+Linux workflow uses (§3.10) to download patched CEF assets from the private
+`agentmuxai/cef` repo; no new secret beyond the one Linux already introduced.
 
 ---
 
@@ -336,8 +354,10 @@ settings → Secrets.
 1. `chore: release vX.Y.Z` PR merged → tag `vX.Y.Z` pushed to `agentmuxai/agentmux`
 2. GitHub Release created for `vX.Y.Z` (draft or pre-release; Windows build
    attaches the signed installer)
-3. Patched `libcef.so` for the current CEF version is available as a release in
-   `agentmuxai/cef` (only changes when CEF version bumps)
+3. Patched `libcef.so` (Linux) AND patched `Chromium Embedded Framework.framework`
+   (macOS arm64) for the current CEF version are available as releases in
+   `agentmuxai/cef` — `cef-linux-x86_64-<ver>` and `cef-macos-arm64-<ver>`
+   (only change when CEF version bumps)
 
 ### 4.2 Triggering the three builds
 
@@ -379,8 +399,15 @@ using `AGENTMUX_RELEASE_TOKEN`.
 
 ## 5. Not in Scope
 
-- **Intel Mac (x86_64)**: all builds target Apple Silicon (arm64). `cef-dll-sys`
-  resolves the aarch64 framework; x86_64 support would need a separate CEF build.
+- **Building the patched macOS framework from source in CI**: like the Linux
+  `libcef.so`, the arm64 framework is built out-of-band (multi-hour Chromium
+  compile) and stored as an `agentmuxai/cef` release; CI only downloads + verifies
+  it. The build recipe is `docs/cef-build/build-patched-framework-macos.md`. (This
+  revises the original spec's implicit assumption that macOS used the stock
+  `cef-dll-sys` framework — as of 2026-06-29 it consumes the patched framework,
+  per `SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md`.)
+- **Intel Mac (x86_64)**: all builds target Apple Silicon (arm64). The patched CEF
+  framework is built for arm64 only; x86_64 support would need a separate CEF build.
 - **Linux arm64**: `build-appimage-linux.sh` targets x86_64; arm64 AppImage deferred.
 - **Windows code signing** (SignPath): deferred per `docs/windows-code-signing.md`.
 - **macOS App Store**: direct distribution only; notarized Developer ID path.

--- a/docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md
+++ b/docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md
@@ -1,0 +1,283 @@
+# SPEC: Patched macOS CEF Framework — Release Pipeline + CI Wiring
+
+**Date:** 2026-06-29
+**Status:** Plan (awaiting review — no code written yet)
+**Repos:** `agentmuxai/agentmux`, `agentmuxai/cef`
+**Tracks:** macOS parity with the Linux patched-libcef pipeline
+**Related:** `SPEC_BUILDER_MACOS_LINUX_CI_2026_06_24.md`,
+`SPEC_MACOS_CEF_FRAMEWORK_BUNDLING_2026_05_28.md`,
+`patched-libcef-bundling-2026-05-08.md`, `build-patched-libcef.md`
+
+---
+
+## 1. Problem
+
+**Linux** ships a *patched* CEF that adds `CefWindow::BeginWindowDrag()`
+(+ drag-rightclick + transparency). **macOS does not** — the macOS DMG silently
+ships the **upstream** CEF framework that lacks `BeginWindowDrag`. This is the
+root cause of the floating-pane drag/resize fragility on macOS: with no native
+`BeginWindowDrag`, the floater header drag and edge-resize are driven by
+JS-polled `get/set_window_position` / `set_window_rect` workarounds
+(`floating-pane-workspace.tsx`), which are racier than the native path Windows
+and (patched) Linux use.
+
+### 1.1 How Linux closes the gap (reference: `build-linux.yml`)
+
+1. Downloads a pre-built patched `libcef.so` from an `agentmuxai/cef` **release**
+   (`cef-linux-x86_64-<ver>.tar.gz`).
+2. Sets `AGENTMUX_CEF_RUNTIME_DIR` → `scripts/resolve-cef-runtime.sh` injects it
+   into `task bundle:linux`.
+3. `scripts/verify-cef-patch.sh` gates the build so an unpatched `.so` can't ship.
+
+### 1.2 What macOS does today (the gap)
+
+- `build-macos.yml` runs `task package:macos` with **no CEF override**.
+- `task bundle:darwin` → `scripts/resolve-cef-runtime-darwin.sh` falls through its
+  three-tier resolution to the **`cef-dll-sys` cargo cache** (tier 3) = upstream
+  framework, **no `BeginWindowDrag`**.
+- There is **no macOS patch-verification gate**, so the unpatched framework ships
+  silently.
+
+### 1.3 What already exists (so this is wiring, not new architecture)
+
+- `resolve-cef-runtime-darwin.sh` **already honors `AGENTMUX_CEF_RUNTIME_DIR_DARWIN`**
+  (tier 1, hard-fail on a set-but-invalid path). The injection hook exists; it is
+  simply never fed in CI.
+- `task bundle:darwin` already `ditto`s the framework (preserving the
+  `Versions/Current` symlink chain) and copies the GL dylibs next to the host exe.
+- `package-macos.sh` already assumes "the patched CEF 148 framework" (helper-app
+  spawning, mach-port peer disable).
+- `cef-dll-sys` (fork `AgentU-asaf/cef-rs`, pinned in `Cargo.toml`) provides the
+  Rust *bindings* exposing the `BeginWindowDrag` slot — but the **native framework
+  binary** behind it is still upstream. The patched framework is the missing half.
+
+---
+
+## 2. The artifact already exists locally
+
+A patched arm64 framework has already been built on this dev machine:
+
+```
+~/cef-build/chromium/chromium/src/out/Release_GN_arm64/Chromium Embedded Framework.framework
+```
+
+Verified 2026-06-29:
+
+| Property | Value |
+|----------|-------|
+| Arch | Mach-O 64-bit arm64 |
+| Size (unstripped) | **545 MB** |
+| Version (`Info.plist` `CFBundleShortVersionString`) | **148.0.9.0** |
+| Patch symbol | `__ZN13CefWindowImpl15BeginWindowDragEv` present |
+| Symbol binding | **local** (`nm` type `t`, lowercase) — NOT exported |
+
+> ⚠️ **Version skew:** the existing **Linux** release is CEF `148.0.20`; this
+> macOS framework is `148.0.9`. Decide whether to (a) cut the macOS release at
+> `148.0.9` as-is, or (b) rebuild macOS at `148.0.20` to match Linux. Functional
+> parity is fine at 148.0.9 for `BeginWindowDrag`; matching versions is cleaner
+> for support. **Recommendation:** ship `148.0.9` now to unblock, track a
+> `148.0.20` rebuild as a follow-up so both platforms converge.
+
+> ⚠️ **Verification must run UNSTRIPPED.** Because `BeginWindowDrag` is a *local*
+> symbol, `nm -gU` (external-only) will not find it — only a full `nm` over an
+> unstripped binary will. The release asset must therefore be uploaded
+> **unstripped** (matching the Linux "packager strips it at bundle time"
+> convention), and the verify gate must run **before** `package-macos.sh`'s strip
+> step.
+
+---
+
+## 3. Work items
+
+Four pieces. Pieces 1–2 + 4 are writable now; Piece 3 documents the (already-done)
+build and the release-cut recipe.
+
+### Piece 1 — Cut the `agentmuxai/cef` macOS release
+
+The release asset, produced once per CEF version bump (not per AgentMux release):
+
+```bash
+cd ~/cef-build/chromium/chromium/src/out/Release_GN_arm64
+# Tar the framework UNSTRIPPED, preserving the Versions/Current symlink chain.
+# Use ditto (or gnutar with --no-mac-metadata off) so the symlinks survive.
+tar -czf /tmp/cef-macos-arm64-148.0.9.tar.gz "Chromium Embedded Framework.framework"
+
+gh release create cef-macos-arm64-148.0.9 \
+  --repo agentmuxai/cef \
+  --title "Patched CEF framework — macOS arm64 CEF 148.0.9" \
+  --notes "BeginWindowDrag + drag-rightclick + transparency. Built from agentmux/7778-drag-rightclick-and-transparency. Unstripped (~545 MB); packager strips at bundle time." \
+  /tmp/cef-macos-arm64-148.0.9.tar.gz
+```
+
+> Tarball preservation: the framework contains a `Versions/Current` symlink chain
+> the CEF loader follows. `tar -czf` on macOS preserves symlinks by default; verify
+> after upload that the extracted tree still has `Chromium Embedded Framework ->
+> Versions/Current/Chromium Embedded Framework`. If BSD tar mangles it, fall back
+> to `ditto -c -k --keepParent` (zip) and adjust the CI extract step to `ditto -x -k`.
+
+**Naming convention** (parallels Linux `cef-linux-x86_64-<ver>`):
+- Tag: `cef-macos-arm64-<CEF_VERSION>` → `cef-macos-arm64-148.0.9`
+- Asset: `cef-macos-arm64-<CEF_VERSION>.tar.gz`
+
+### Piece 2 — `build-macos.yml` CI wiring
+
+Mirror the Linux CEF block. Insert **after** the npm-auth step, **before**
+`task package:macos`.
+
+**New workflow inputs** (parallel to Linux):
+```yaml
+workflow_dispatch.inputs.cef-runtime-tag:
+  description: "agentmuxai/cef release tag for patched framework (blank = latest macOS)"
+  required: false
+  default: ""
+repository_dispatch.client_payload.cef_runtime_tag   # threaded in the Resolve-inputs step
+```
+
+**New steps:**
+1. **Resolve cef tag** (`id: cef`): if `cef_tag` input is blank, auto-detect —
+   but **filter by the macOS prefix**, since `agentmuxai/cef` now holds both
+   platforms:
+   ```bash
+   TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+           --json tagName --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
+   ```
+   > Also fix `build-linux.yml`'s resolver the same way — its bare `--limit 1`
+   > would now grab whichever platform released most recently. (Tracked as a
+   > one-line follow-up in that file.)
+2. **Cache** (`actions/cache@v4`, key `cef-runtime-darwin-<tag>`, path
+   `$CEF_RUNTIME_DIR_DARWIN`).
+3. **Download + extract** (only on cache miss), auth via `CEF_RUNTIME_TOKEN`:
+   ```bash
+   mkdir -p /tmp/cef-x "$CEF_RUNTIME_DIR_DARWIN"
+   gh release download "${{ steps.cef.outputs.tag }}" \
+     --repo agentmuxai/cef --pattern "*.tar.gz" --dir /tmp/cef-x --clobber
+   tar -xzf /tmp/cef-x/*.tar.gz -C /tmp/cef-x
+   FW=$(find /tmp/cef-x -name "Chromium Embedded Framework.framework" -maxdepth 3 | head -1)
+   [ -z "$FW" ] && { echo "framework not found in tarball"; exit 1; }
+   ditto "$FW" "$CEF_RUNTIME_DIR_DARWIN/Chromium Embedded Framework.framework"
+   ```
+4. **Export the override:**
+   ```bash
+   echo "AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$CEF_RUNTIME_DIR_DARWIN" >> "$GITHUB_ENV"
+   ```
+   With this set, `resolve-cef-runtime-darwin.sh` returns it as tier 1 and never
+   touches the upstream cargo cache.
+
+**Job-level env:** `CEF_RUNTIME_DIR_DARWIN: ${{ github.workspace }}/cef-runtime-darwin`
+
+**New secret:** `CEF_RUNTIME_TOKEN` (fine-grained PAT, `contents:read` on
+`agentmuxai/cef`). Per `SPEC_BUILDER_MACOS_LINUX_CI` this already exists in the
+builder repo for Linux; it must be present wherever `build-macos.yml` runs.
+
+> **OPEN QUESTION — workflow home.** `build-macos.yml` currently lives in
+> **this repo** (`.github/workflows/build-macos.yml`), but
+> `SPEC_BUILDER_MACOS_LINUX_CI` describes the macOS/Linux release workflows as
+> living in **`agentmuxai/agentmux-builder`**. These appear to have diverged.
+> Confirm the canonical home before landing — the diff + the `CEF_RUNTIME_TOKEN`
+> secret must go there. The diff below is written against this repo's copy.
+
+### Piece 3 — `docs/cef-build/build-patched-framework-macos.md`
+
+New doc paralleling `build-patched-libcef.md` (which is Linux-only). Captures the
+already-done build so it's reproducible at the next CEF bump:
+
+- **Source:** branch `agentmux/7778-drag-rightclick-and-transparency` in
+  `agentmuxai/cef`.
+- **GN args:** the macOS variant of `docs/cef-build/args.gn`
+  (`target_os="mac"`, `target_cpu="arm64"`, `is_official_build=true`,
+  `symbol_level=1`, `is_component_build=false`, …). Capture the actual
+  `args.gn` used for the `Release_GN_arm64` build on this machine.
+- **Output:** `out/Release_GN_arm64/Chromium Embedded Framework.framework`
+  (545 MB unstripped).
+- **Release-cut recipe:** the Piece 1 `tar` + `gh release create` block.
+- **Note:** upload **unstripped** — both the verify gate (Piece 4) and the
+  package strip depend on symbols being present at download time.
+
+### Piece 4 — macOS patch-verify gate
+
+New `scripts/verify-cef-framework-darwin.sh`, analogue of `verify-cef-patch.sh`:
+
+- **Target:** the Mach-O dylib `"<framework>/Chromium Embedded Framework"`
+  (resolve the `Versions/Current` symlink).
+- **Detection:** `nm "<binary>" 2>/dev/null | grep -q 'BeginWindowDrag'`.
+  Use **full `nm`** (whole symbol table) — NOT `nm -gU` — because the patch symbol
+  is a *local* (`t`) symbol, not exported.
+- **Exit codes** mirror Linux:
+  - `0` — patched (`BeginWindowDrag` found)
+  - `1` — UNPATCHED: symbol table present but no `BeginWindowDrag` (the real alarm)
+  - `2` — cannot verify: stripped binary (no symbol table), missing file, or no
+    `nm` available
+- **Wire into `task bundle:darwin`** immediately after `resolve-cef-runtime-darwin.sh`
+  yields `CEF_DIR`, **before** the `ditto` — and before `package-macos.sh`'s strip.
+  Gate behind `AGENTMUX_SKIP_CEF_PATCH_CHECK` (same escape hatch as Linux) so a
+  local dev intentionally on upstream CEF isn't blocked. In CI the gate is on by
+  default → an unpatched framework hard-fails the build instead of shipping.
+
+> A stripped framework returns exit 2 ("cannot verify"). Decide CI policy: treat
+> exit 2 as failure in CI (we control the asset and require it unstripped) but as
+> a soft warning locally (a dev may legitimately point at a stripped framework).
+
+---
+
+## 4. Why the bundle path already works (no `bundle:darwin` logic change)
+
+`task bundle:darwin` resolves `CEF_DIR` via `resolve-cef-runtime-darwin.sh`,
+checks `"$CEF_DIR/Chromium Embedded Framework.framework"` exists, then `ditto`s it
+into `dist/Frameworks/` and copies `Libraries/*.dylib` next to the host exe. Once
+`AGENTMUX_CEF_RUNTIME_DIR_DARWIN` points at the downloaded framework, this path is
+unchanged except for the inserted verify call. No restructuring required.
+
+---
+
+## 5. Validation plan
+
+1. **Local dry-run:** `AGENTMUX_CEF_RUNTIME_DIR_DARWIN=~/cef-build/chromium/chromium/src/out/Release_GN_arm64 task package:macos -- /tmp/out`
+   → confirm the DMG's framework carries `BeginWindowDrag` (`nm` on the bundled
+   binary pre-strip) and that the verify gate passes.
+2. **Native drag smoke test:** with the patched framework bundled, confirm the
+   floating-pane header drag + edge-resize can move to the native
+   `BeginWindowDrag` path (separate follow-up: the frontend currently hard-codes
+   `jsDrivenDrag = isMacOS() || isLinux()`; flipping macOS off is a *future* change
+   gated on this framework shipping — out of scope here, but this release is its
+   prerequisite).
+3. **CI:** trigger `build-macos.yml` with `cef-runtime-tag=cef-macos-arm64-148.0.9`,
+   confirm download+cache+verify+package all green and the DMG uploads.
+
+---
+
+## 6. Sequencing
+
+1. **Piece 1** — cut the `cef-macos-arm64-148.0.9` release (unblocks everything;
+   the artifact is already built locally).
+2. **Piece 4** — verify script + `bundle:darwin` wiring (testable locally against
+   the local framework immediately).
+3. **Piece 2** — `build-macos.yml` wiring (testable only once Piece 1's release
+   exists + `CEF_RUNTIME_TOKEN` is present in the workflow's repo).
+4. **Piece 3** — build doc (parallel; documents Piece 1).
+5. Update `SPEC_BUILDER_MACOS_LINUX_CI_2026_06_24.md` §2/§4.1/§5 to fold in the
+   macOS patched-framework path (its §5 currently defers from-source macOS CEF —
+   revise to "consume pre-built patched framework, like Linux").
+
+---
+
+## 7. Open questions (need answers before landing)
+
+1. **Workflow home** — is `build-macos.yml` canonical in this repo or in
+   `agentmux-builder`? (Determines where the diff + `CEF_RUNTIME_TOKEN` go.)
+2. **CEF version** — ship macOS at `148.0.9` now, or rebuild to match Linux's
+   `148.0.20`? (Recommendation: ship 148.0.9, track 148.0.20 convergence.)
+3. **Stripped-framework CI policy** — verify-gate exit 2 = hard fail in CI? (Yes,
+   recommended, since we require the unstripped asset.)
+4. **Out of scope here, confirm tracked separately:** flipping
+   `jsDrivenDrag` off for macOS once the patched framework ships in releases — the
+   actual payoff of this work.
+
+---
+
+## 8. Not in scope
+
+- Building the framework from source (already done; documented in Piece 3 for the
+  next bump).
+- Intel macOS (x86_64) — arm64 only, matching the rest of the macOS pipeline.
+- Changing the frontend drag path (`jsDrivenDrag`) — a dependent follow-up.
+- Windows (already ships its own patched CEF via the launcher bundle).

--- a/scripts/cef-build/args-darwin.gn
+++ b/scripts/cef-build/args-darwin.gn
@@ -1,0 +1,49 @@
+# Canonical GN args for the AgentMux patched CEF framework (macOS arm64).
+#
+# This is the configuration that produced the
+# `Chromium Embedded Framework.framework` verified in
+# docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md
+# (arm64, 545 MB unstripped, CEF 148.0.9, carries CefWindowImpl::BeginWindowDrag).
+# Treat it as the source of truth; `docs/cef-build/build-patched-framework-macos.md`
+# defers to this file.
+#
+# Counterpart to `args.gn` (Linux x64). Notable differences from Linux:
+#   - target_cpu="arm64"            (Apple Silicon)
+#   - is_official_build=false       (the captured build did NOT use official-build;
+#                                     hence 545 MB unstripped. See size note below.)
+#   - symbol_level=1                (line-table symbols; package-macos.sh strips
+#                                     them with `strip -S -x` at bundle time)
+#   - no use_sysroot / use_qt*      (Linux-only knobs)
+
+alternate_cdm_storage_id_key="968b476909da4373b08903c28e859454"
+clang_use_chrome_plugins=false
+enable_background_mode=false
+enable_cdm_host_verification=true
+enable_cdm_storage_id=true
+enable_downgrade_processing=false
+enable_resource_allowlist_generation=false
+enable_rlz=true
+enable_widevine=true
+forbid_non_component_debug_builds=false
+is_component_build=false
+is_debug=false
+is_official_build=false
+optimize_webui=true
+symbol_level=1
+dcheck_always_on=false
+target_cpu="arm64"
+
+# --- size reduction (FOLLOW-UP, not yet applied to the shipped framework) ------
+# The captured build used is_official_build=false → 545 MB unstripped. Linux flips
+# is_official_build=true (thin-LTO + ICF + full opt), roughly halving the binary.
+# Doing the same on macOS should bring the framework down substantially. This is a
+# tracked follow-up: re-build arm64 with is_official_build=true + use_thin_lto=true
+# and re-cut the agentmuxai/cef release. Until then we ship the larger framework;
+# package-macos.sh's `strip -S -x` already removes the symbol_level=1 symbols at
+# bundle time so the in-DMG size is much smaller than 545 MB regardless.
+#
+# Gotcha (same as Linux): is_official_build rebuilds V8, so a re-build MUST ship a
+# fresh snapshot_blob.bin / v8_context_snapshot.bin inside the framework Resources/
+# or the host crashes on a checksum mismatch.
+# is_official_build=true
+# use_thin_lto=true

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -80,6 +80,26 @@ require dist/schema/settings.json
 require "dist/Frameworks/Chromium Embedded Framework.framework"
 [ -f "$ENTITLEMENTS" ] || { echo "❌ missing entitlements: $ENTITLEMENTS" >&2; exit 1; }
 
+# ── Hard BeginWindowDrag-patch gate ───────────────────────────────────────────
+# Release builds MUST ship the patched CEF framework (agentmuxai/cef fork) — the
+# upstream cef-dll-sys framework lacks CefWindow::BeginWindowDrag(), so native
+# window drag / floating-pane resize silently no-ops. This is the macOS analogue
+# of the Linux gate in build-appimage-linux.sh. It runs on dist/Frameworks/ —
+# UNSTRIPPED at this point; the strip (which removes the local patch symbol) runs
+# later, inside the assembled .app. Escape hatch: AGENTMUX_SKIP_CEF_PATCH_CHECK=1
+# for a deliberate upstream-CEF package (e.g. local smoke test without the patch).
+if [ "${AGENTMUX_SKIP_CEF_PATCH_CHECK:-0}" = "1" ]; then
+    echo "⚠️  AGENTMUX_SKIP_CEF_PATCH_CHECK=1 — skipping the BeginWindowDrag patch gate" >&2
+else
+    if ! bash scripts/verify-cef-framework-darwin.sh "dist/Frameworks/Chromium Embedded Framework.framework"; then
+        echo "❌ CEF framework patch gate failed — refusing to package an unpatched/unverifiable" >&2
+        echo "   framework. Point AGENTMUX_CEF_RUNTIME_DIR_DARWIN at the patched framework and" >&2
+        echo "   re-run task bundle:darwin, or set AGENTMUX_SKIP_CEF_PATCH_CHECK=1 to override." >&2
+        echo "   See docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md." >&2
+        exit 1
+    fi
+fi
+
 echo "==> Assembling AgentMux.app v$VERSION ($ARCH)"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Frameworks" "$APP/Contents/Resources"

--- a/scripts/verify-cef-framework-darwin.sh
+++ b/scripts/verify-cef-framework-darwin.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Verify a macOS "Chromium Embedded Framework.framework" carries AgentMux's
+# BeginWindowDrag patch.
+#
+# Why
+# ---
+# Native window drag / floating-pane edge-resize on macOS calls
+# CefWindow::BeginWindowDrag() via raw FFI (agentmux-cef/src/ui_tasks.rs). That
+# struct slot exists ONLY in a framework built from the agentmuxai/cef fork
+# (branch agentmux/7778-drag-rightclick-and-transparency). Bundle the upstream
+# prebuilt CEF (the cef-dll-sys cargo cache) instead and the native drag path
+# silently no-ops — which is exactly why the macOS floater drag/resize has had to
+# fall back to JS-polled get/set_window_position workarounds. This is the build/
+# release-time guard that catches a regressed (unpatched) framework before it ships
+# in a DMG.
+#
+# Detection
+# ---------
+# The patch compiles in the symbol `CefWindowImpl::BeginWindowDrag`. On macOS the
+# mangled name is `__ZN13CefWindowImpl15BeginWindowDragEv` and it is emitted as a
+# LOCAL symbol (nm type `t`, lowercase) — NOT exported. So `nm -gU` (external/
+# defined-only) will MISS it; we must read the FULL symbol table with plain `nm`.
+# Local symbols live in the unstripped build output and are GONE after `strip`, so
+# this check is only meaningful on the UNSTRIPPED framework (the cef-build tree, or
+# the freshly-downloaded release asset), BEFORE package-macos.sh strips it.
+#
+# Usage:  verify-cef-framework-darwin.sh <dir-containing-framework | framework path | framework binary>
+#   Accepts any of:
+#     - a directory that contains "Chromium Embedded Framework.framework"
+#     - the "…/Chromium Embedded Framework.framework" bundle itself
+#     - the inner Mach-O binary directly
+#
+# Exit:   0  patch present (symbol found)
+#         1  UNPATCHED — symbol table present but no BeginWindowDrag slot (the
+#            upstream prebuilt CEF; native drag will silently no-op)
+#         2  cannot verify — stripped binary, missing file, or no nm available
+#
+# NOTE: no `set -o pipefail` — `grep -q` short-circuits on first match and SIGPIPEs
+# the symbol reader, which pipefail would surface as a spurious pipeline failure.
+set -eu
+
+FW_NAME="Chromium Embedded Framework.framework"
+BIN_NAME="Chromium Embedded Framework"
+
+arg="${1:-}"
+if [ -z "$arg" ]; then
+    echo "usage: verify-cef-framework-darwin.sh <dir | framework | binary>" >&2
+    exit 2
+fi
+
+# Resolve <arg> to the inner Mach-O binary. Three accepted shapes:
+#   1. a directory holding the .framework  → <arg>/<FW_NAME>/<BIN_NAME>
+#   2. the .framework bundle               → <arg>/<BIN_NAME>
+#   3. the Mach-O binary itself            → <arg>
+if [ -d "$arg/$FW_NAME" ]; then
+    BIN="$arg/$FW_NAME/$BIN_NAME"
+elif [ -d "$arg" ] && [ "$(basename "$arg")" = "$FW_NAME" ]; then
+    BIN="$arg/$BIN_NAME"
+else
+    BIN="$arg"
+fi
+
+# The framework binary is a Versions/Current symlink chain; nm follows it.
+if [ ! -e "$BIN" ]; then
+    echo "verify-cef-framework-darwin: framework binary not found at $BIN" >&2
+    exit 2
+fi
+
+if ! command -v nm >/dev/null 2>&1; then
+    echo "verify-cef-framework-darwin: nm not available — cannot verify $BIN" >&2
+    exit 2
+fi
+
+PATTERN='BeginWindowDrag'
+
+# Plain nm = full symbol table (local + external). REQUIRED: the patch symbol is
+# a local symbol; nm -gU would not see it.
+read_syms() { nm "$BIN" 2>/dev/null; }
+
+if read_syms | grep -qE "$PATTERN"; then
+    echo "verify-cef-framework-darwin: ✓ $BIN carries the BeginWindowDrag patch" >&2
+    exit 0
+fi
+
+# No match. Distinguish "has symbols but unpatched" from "stripped (no symtab)".
+if read_syms | grep -q .; then
+    echo "verify-cef-framework-darwin: ✗ $BIN has a symbol table but NO BeginWindowDrag slot." >&2
+    echo "                  This is the UNPATCHED upstream CEF — native window drag /" >&2
+    echo "                  floating-pane resize will silently no-op. Use the patched" >&2
+    echo "                  framework (docs/cef-build/build-patched-framework-macos.md), or" >&2
+    echo "                  point AGENTMUX_CEF_RUNTIME_DIR_DARWIN at a patched Release_GN_arm64." >&2
+    exit 1
+fi
+
+echo "verify-cef-framework-darwin: ? $BIN is stripped (no symbol table) — cannot verify" >&2
+echo "                  the BeginWindowDrag patch by symbol. Run the check on the UNSTRIPPED" >&2
+echo "                  framework (the patch check must precede the packaging strip)." >&2
+exit 2


### PR DESCRIPTION
## Problem
macOS ships the **upstream** `cef-dll-sys` CEF framework, which lacks `CefWindow::BeginWindowDrag()`. So macOS native window drag / floating-pane resize silently no-ops — which is exactly why `floating-pane-workspace.tsx` falls back to JS-polled `get/set_window_position` / `set_window_rect` workarounds (`jsDrivenDrag = isMacOS() || isLinux()`). Linux already solves this by downloading a patched `libcef.so` from an `agentmuxai/cef` release. **This brings macOS to parity.**

Verified locally: this very dev build is currently running the **unpatched** framework (the gate returns exit 1 on its `dist/Frameworks/`).

## Changes
- **`scripts/verify-cef-framework-darwin.sh`** — new patch gate (macOS analogue of `verify-cef-patch.sh`). Uses **full `nm`** (not `-gU`): the patch symbol `CefWindowImpl::BeginWindowDrag` is a **local** symbol, so it must be read from the full table on the **unstripped** framework. Exit 0 patched / 1 unpatched / 2 unverifiable.
- **`bundle:darwin`** (Taskfile) — advisory check (`|| true`) so `task dev` still works on the upstream fallback; mirrors `bundle:linux`.
- **`package-macos.sh`** — **hard** release gate before signing (escape hatch `AGENTMUX_SKIP_CEF_PATCH_CHECK=1`), runs on `dist/Frameworks/` pre-strip.
- **`build-macos.yml`** — download + cache the patched framework from an `agentmuxai/cef` release (`cef-macos-arm64-<ver>`), set `AGENTMUX_CEF_RUNTIME_DIR_DARWIN`. New `cef-runtime-tag` input; reuses the `CEF_RUNTIME_TOKEN` secret Linux already needs.
- **`build-linux.yml`** — filter release auto-detect to `cef-linux-x86_64-*` (the cef repo now holds both platforms; a bare `--limit 1` would cross platforms).
- **`scripts/cef-build/args-darwin.gn`** + **`docs/cef-build/build-patched-framework-macos.md`** — reproduce the arm64 framework build + release-cut recipe.
- **specs** — `SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md` (full plan) + folded the macOS patched-framework path into `SPEC_BUILDER_MACOS_LINUX_CI`.

## Follow-ups (not in this PR)
- **Piece 1 — cut the `agentmuxai/cef` macOS release.** Per review decision, the framework will be **rebuilt at CEF 148.0.20** (matching Linux, with `is_official_build=true` for the size win) before cutting `cef-macos-arm64-148.0.20`. CI can't find an asset until that release exists.
- Flip `jsDrivenDrag` off for macOS once the patched framework ships — the actual payoff.
- Confirm whether `build-macos.yml` is canonical here vs `agentmux-builder` (they appear to have diverged); the `CEF_RUNTIME_TOKEN` secret must live wherever it runs.

<!-- agentmux:agent_id=maop -->