### PR TITLE
feat(lifecycle): Pillar 2 stage 1 — level-triggered quit decision in reducer

### DIFF
--- a/.changesets/1782793779-feat-lifecycle-compute-level-triggered-quit-decision-in-redu-i9j3.md
+++ b/.changesets/1782793779-feat-lifecycle-compute-level-triggered-quit-decision-in-redu-i9j3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(lifecycle): compute level-triggered quit decision in reducer (Pillar 2 stage 1)

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -850,6 +850,14 @@ pub struct DispatchOutput {
     pub pane_pool_size_after: Option<usize>,
     pub pane_pool_destroyed_was_unpromoted: bool,
     pub promoted_pane_pool_label: Option<String>,
+    /// Pillar 2 (level-triggered quit) — set by `update()` after any quit-relevant
+    /// command when the host should begin draining NOW (no live user window, no
+    /// user creation in flight, still `Running`). The UI-thread drain executor
+    /// consumes this and posts the Stage-1 cascade. `None` in the common case.
+    /// This is the level-triggered replacement for the edge-triggered gate that
+    /// previously lived only in `client::on_before_close` and could miss a
+    /// concurrent pool-refill race (SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md).
+    pub request_drain: Option<crate::state::QuitReason>,
 }
 
 // Manual Debug — `cef::Browser` doesn't impl Debug.
@@ -874,6 +882,7 @@ impl std::fmt::Debug for DispatchOutput {
             .field("pool_size_after", &self.pool_size_after)
             .field("pool_destroyed_was_unpromoted", &self.pool_destroyed_was_unpromoted)
             .field("promoted_pool_label", &self.promoted_pool_label)
+            .field("request_drain", &self.request_drain)
             .finish()
     }
 }
@@ -897,8 +906,37 @@ mod top_level;
 /// internal to `quit` — used by `count_live_user_windows` and its tests.)
 pub(crate) use quit::count_live_user_windows;
 
+/// Whether a command can change the quit decision's inputs — the live
+/// user-window count (`browsers`), pending user-initiated creations, or
+/// `quit_state`. **Negative guard:** only known high-frequency / clearly
+/// quit-irrelevant commands are excluded, so any command NOT listed here
+/// defaults to relevant. That fail-safe is deliberate — silently missing a
+/// window/pool transition is exactly the edge-triggered bug Pillar 2 replaces,
+/// whereas an extra cheap `reconcile_quit` read on an irrelevant command is
+/// harmless (it just returns `None`). The excluded set is the genuine hot path
+/// (drag-opacity ticks) plus the browser-pane lifecycle (panes live in the
+/// separate `browser_panes` map and never affect `count_live_user_windows`).
+fn is_quit_relevant(cmd: &HostCommand) -> bool {
+    !matches!(
+        cmd,
+        HostCommand::SetWindowOpacity { .. }
+            | HostCommand::StartDrag { .. }
+            | HostCommand::EndDrag { .. }
+            | HostCommand::ToggleFloatingMaximize { .. }
+            | HostCommand::EvictFloatingPaneWindowState { .. }
+            | HostCommand::EnqueueBrowserPaneCreate { .. }
+            | HostCommand::TryRegisterBrowserPaneLive { .. }
+            | HostCommand::CompleteBrowserPaneCreate { .. }
+            | HostCommand::EnqueueBrowserPaneClose { .. }
+            | HostCommand::CompleteBrowserPaneClose { .. }
+            | HostCommand::DrainBrowserPaneByLabel { .. }
+            | HostCommand::AbortBrowserPaneCreate { .. }
+    )
+}
+
 pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
-    match cmd {
+    let quit_relevant = is_quit_relevant(&cmd);
+    let mut out = match cmd {
         HostCommand::EnqueuePendingWindowCreation { entry } => {
             handle_enqueue_pending_window_creation(state, entry)
         }
@@ -980,7 +1018,19 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         HostCommand::EvictFloatingPaneWindowState { label } => {
             pane_window::handle_evict_floating_pane_window_state(state, label)
         }
+    };
+    // Pillar 2 — level-triggered quit reconciliation. After any transition that
+    // can change the decision's inputs, recompute the pure `reconcile_quit` over
+    // the resulting state. A drain that an edge-triggered close gate missed
+    // (e.g. raced by a concurrent pool refill) is caught here, on the very next
+    // transition that settles the count. Pure read; the actual close cascade is
+    // posted to the UI thread by the consumer (never run inline — that would
+    // deadlock, see client::on_before_close). `reconcile_quit` is monotonic:
+    // once Draining/Quit it returns None, so this can't re-fire or loop.
+    if quit_relevant {
+        out.request_drain = quit::reconcile_quit(state);
     }
+    out
 }
 
 fn handle_enqueue_pending_window_creation(

--- a/agentmux-cef/src/reducer/quit.rs
+++ b/agentmux-cef/src/reducer/quit.rs
@@ -53,11 +53,14 @@ pub(super) fn handle_confirm_drained(state: &mut HostState) -> DispatchOutput {
 // executor that actually closes pool browsers (Stage 1) and exits the message
 // loop (Stage 2) stays exactly where it is today. `reconcile_quit` only DECIDES.
 //
-// NOT YET WIRED: this PR lands the decision + its test coverage (the safety net
-// the regression slipped through). Calling it from the browser-deregister /
-// promote-complete / creation-abort transitions — behind the §10.1 UI-thread
-// executor — is the explicit next step. Hence `#[allow(dead_code)]`, matching the
-// reducer-scaffolding convention documented in `state.rs`.
+// WIRED (Pillar 2, Stage 1 — SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md):
+// `reducer::update` now calls `reconcile_quit` after every quit-relevant command
+// (gated by `is_quit_relevant`) and surfaces the result via
+// `DispatchOutput::request_drain`. The decision is computed here, under the
+// host-state lock, as a pure read. The UI-thread executor that consumes
+// `request_drain` and runs the Stage-1 close cascade is wired in Stage 2; until
+// then the legacy edge-triggered gate in `client::on_before_close` still drives
+// the actual drain, so Stage 1 is behavior-neutral.
 
 /// Background PENDING-CREATION labels — warm-pool tab refills (`window-pool-`),
 /// browser-pane children (`browser-pane-`), and floating panes (`floating-`, the
@@ -70,7 +73,6 @@ pub(super) fn handle_confirm_drained(state: &mut HostState) -> DispatchOutput {
 ///
 /// Used ONLY for pending creations. Registered browsers are classified by
 /// `is_live_user_window` (the `is_pool` flag), NOT by label — see its doc.
-#[allow(dead_code)]
 fn is_background_pending_creation_label(label: &str) -> bool {
     label.starts_with("window-pool-")
         || label.starts_with("browser-pane-")
@@ -117,7 +119,6 @@ pub(crate) fn count_live_user_windows(state: &HostState) -> usize {
 /// consult the PRE-registration `pending_window_creations` queue (spec §10.2):
 /// draining while a user's "New Window" is still loading would quit the instance
 /// out from under it. Background creations (pool refill / panes) do not block drain.
-#[allow(dead_code)]
 pub(super) fn user_creation_in_flight(state: &HostState) -> bool {
     state
         .pending_window_creations
@@ -130,7 +131,6 @@ pub(super) fn user_creation_in_flight(state: &HostState) -> bool {
 /// creation is in flight. Safe to call after every transition — once
 /// `Draining`/`Quit` it returns `None` (the transition is monotonic — see
 /// `handle_begin_drain`). CEF-free so the full truth table is unit-testable.
-#[allow(dead_code)]
 pub(super) fn should_begin_drain(
     live_user_windows: usize,
     user_creation_in_flight: bool,
@@ -147,7 +147,6 @@ pub(super) fn should_begin_drain(
 
 /// Level-triggered quit reconciliation over the full `HostState`. Composes the
 /// three reads above. Returns the drain reason iff it is safe to begin draining.
-#[allow(dead_code)]
 pub(super) fn reconcile_quit(state: &HostState) -> Option<QuitReason> {
     should_begin_drain(
         count_live_user_windows(state),

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -961,3 +961,49 @@ fn reconcile_quit_noop_once_draining() {
     update(&mut state, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
     assert_eq!(reconcile_quit(&state), None);
 }
+
+// ── Pillar 2 Stage 1 — the reducer hook (`is_quit_relevant` + `request_drain`) ──
+//
+// The hook is the wiring that makes the level-triggered decision fire after every
+// quit-relevant transition. These pin (a) the negative guard's membership and
+// (b) that `update` surfaces the decision via `DispatchOutput::request_drain`
+// only for relevant commands. Stage 1 is behavior-neutral — nothing consumes
+// `request_drain` yet — so these are the safety net for the wiring itself.
+
+/// The negative guard: window/pool/pending/quit commands are relevant (default
+/// true); the drag-opacity hot path and the browser-pane lifecycle are excluded.
+#[test]
+fn is_quit_relevant_guard_membership() {
+    use super::is_quit_relevant;
+    // Relevant — change live-window count / pending creations / quit_state.
+    assert!(is_quit_relevant(&HostCommand::UnregisterBrowser { label: "w".into() }));
+    assert!(is_quit_relevant(&HostCommand::DequeuePendingWindowCreation));
+    assert!(is_quit_relevant(&HostCommand::PoolDrainAll));
+    assert!(is_quit_relevant(&HostCommand::BeginDrain {
+        reason: QuitReason::LastWindowClosed
+    }));
+    // Irrelevant — hot path + pane lifecycle (panes never affect the window count).
+    assert!(!is_quit_relevant(&HostCommand::EvictFloatingPaneWindowState { label: "f".into() }));
+    assert!(!is_quit_relevant(&HostCommand::EnqueueBrowserPaneClose { block_id: "b".into() }));
+}
+
+/// `update` surfaces the level-triggered drain decision on a quit-relevant
+/// command, and skips it on a quit-irrelevant one even when the state would drain.
+#[test]
+fn update_surfaces_request_drain_only_for_relevant_commands() {
+    let mut state = HostState::default(); // Running, no windows, no pending → drainable
+    let out = update(&mut state, HostCommand::DequeuePendingWindowCreation);
+    assert_eq!(
+        out.request_drain,
+        Some(QuitReason::LastWindowClosed),
+        "quit-relevant command must surface the reconcile decision"
+    );
+    let out2 = update(
+        &mut state,
+        HostCommand::EvictFloatingPaneWindowState { label: "missing".into() },
+    );
+    assert_eq!(
+        out2.request_drain, None,
+        "quit-irrelevant command must not compute a drain request"
+    );
+}

--- a/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
+++ b/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
@@ -59,7 +59,34 @@ Quit-relevant command set (the only ones that can flip the answer):
 
 All other commands skip the check (cheap guard — match on the variant).
 
+> **Stage 1 implementation note (landed):** the guard is implemented as a **negative**
+> match (`is_quit_relevant`) — only the drag-opacity hot path and the browser-pane lifecycle
+> are excluded; everything else defaults to relevant. This is fail-safe: a future window/pool
+> command can't silently miss reconciliation. `DispatchOutput` gained `request_drain:
+> Option<QuitReason>`; `update()` sets it after relevant commands. Behavior-neutral until Stage 2
+> consumes it. Tests: `is_quit_relevant_guard_membership`, `update_surfaces_request_drain_only_for_relevant_commands` (reducer suite green, 51 passed).
+
 ### 3.2 Action: route through the EXISTING UI-thread drain executor
+
+> **Stage 2 design decision (resolved during Stage 1 — IMPORTANT, supersedes the "post from
+> host_dispatch" sketch below):** `host_dispatch` is a `&self` method on `AppState` and `AppState`
+> holds **no `Arc<Self>`/`Weak<Self>` handle**, so it cannot cheaply construct a CEF task to post
+> the cascade cross-thread. Centralizing consumption there would require threading an `Arc<AppState>`
+> through (a wider change). Instead, **Stage 2 consumes `request_drain` at the UI-thread CEF
+> callbacks** that dispatch quit-relevant commands — `client::on_before_close` (window/pool close)
+> **and the pool spawn/promote/destroy completion callbacks** (the transitions that *settle* the
+> count to zero after a refill race). Those run on the UI thread already, so a `Client` method
+> `begin_drain_and_cascade(&self, reason)` (the extracted Stage-1 cascade) can be called **inline**
+> — no cross-thread post, no new task type, no Arc plumbing. The level-triggered guarantee comes
+> from consuming at *every* settling callback, not from a single chokepoint.
+>
+> **The correctness obligation for Stage 2:** enumerate *all* UI-thread callbacks that can drive
+> `count_live_user_windows`→0 (close, pool-ready, promote, pool-destroy) and consume `request_drain`
+> at each. Missing one reintroduces the orphan race; acting inline on the wrong one (e.g. calling
+> `quit_message_loop` from `on_before_close`) reintroduces the deadlock. This is the deadlock-
+> sensitive core and is deliberately a **separate, focused PR** from Stage 1.
+
+The (now-superseded) original sketch, kept for context:
 **Critical threading contract** (`reducer/quit.rs:49-54`, spec §10.1): `reconcile_quit` only DECIDES.
 It must not call `quit_message_loop()`, re-lock `host_state`, or close anything. Calling
 `quit_message_loop` from inside `on_before_close` **deadlocks the UI thread** (confirmed v0.33.498,


### PR DESCRIPTION
## Summary

**Stage 1 of 3** of Pillar 2 (`SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md`) — the lifecycle refactor from the merged architecture analysis (#1847). Wires the already-written, tested `reconcile_quit` into the reducer as a **pure, level-triggered** decision. **Behavior-neutral** — this lands the decision + safety-net tests; the legacy edge gate still drives the actual drain until Stage 2.

### Background
Closing the last window could orphan the whole process tree because the "should we quit?" decision was **edge-triggered** inside `client::on_before_close` — computed once, at one event, with nothing to re-evaluate it when a concurrent pool refill settled the count later. `reconcile_quit` is the level-triggered replacement (a pure function of `HostState`), already written and tested but previously `#[allow(dead_code)]`. This PR connects it.

## Changes
- **`DispatchOutput`** gains `request_drain: Option<QuitReason>`.
- **`update()`** runs `reconcile_quit(state)` after any quit-relevant command, gated by a new **negative guard** `is_quit_relevant` — only the drag-opacity hot path and the browser-pane lifecycle are excluded, so any unlisted command defaults to relevant. That fail-safe is deliberate: silently missing a window/pool transition is the exact bug this replaces.
- **Un-dead-code** `reconcile_quit` / `should_begin_drain` / `user_creation_in_flight` / `is_background_pending_creation_label`.
- **Tests:** `is_quit_relevant_guard_membership`, `update_surfaces_request_drain_only_for_relevant_commands`; full reducer suite green (**51 passed, 0 failed**).

## Why behavior-neutral
Nothing consumes `request_drain` yet — `client::on_before_close`'s inline gate still drives the drain. This isolates the decision + the test coverage the original regression slipped through into a low-risk commit.

## Next (separate PRs, per the spec)
- **Stage 2:** extract the `on_before_close` Stage-1 cascade into `Client::begin_drain_and_cascade`, consume `request_drain` at the UI-thread CEF callbacks (close + pool-settle), delete the inline gate. Resolved during this PR: `host_dispatch` has no `Arc<Self>` handle, so consumption is at the UI-thread callbacks inline (not a cross-thread post from `host_dispatch`) — see the spec's Stage 2 design note. This is the deadlock-sensitive core, deliberately separate.
- **Stage 3:** demote `orphan_reconcile` + WRR to executors; E2E "close last window ⇒ tree exits" test.

Refs #768. Part of the lifecycle/OOM refactor program (#1847, #942).

🤖 Generated with [Claude Code](https://claude.com/claude-code)