### PR TITLE
feat(app-api): IdentityLink MCP tool — bind owned account into default bundle

### DIFF
--- a/.changesets/1782858157-feat-app-api-identity-link-mcp-tool-b4a2.md
+++ b/.changesets/1782858157-feat-app-api-identity-link-mcp-tool-b4a2.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(app-api): IdentityLink MCP tool — bind owned account into default bundle

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -368,6 +368,19 @@ const IDENTITY_VALIDATE_TOOL: &str = r#"{
   }
 }"#;
 
+const IDENTITY_LINK_TOOL: &str = r#"{
+  "name": "IdentityLink",
+  "description": "Bind one of your own linked accounts (from IdentityAccounts) into your default identity bundle so the credential injects into your environment at next launch. No secret is supplied — the account must already exist and be linked to you. Returns bundle_id, provider, and account_id on success.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "account_id": { "type": "string", "description": "One of your linked accounts (from IdentityAccounts)" },
+      "provider":   { "type": "string", "description": "Provider for this account (e.g. \"github\", \"aws\", \"anthropic\")" }
+    },
+    "required": ["account_id", "provider"]
+  }
+}"#;
+
 #[tokio::main]
 async fn main() {
     let local_url = std::env::var("AGENTMUX_LOCAL_URL").unwrap_or_default();
@@ -478,10 +491,12 @@ async fn main() {
                     serde_json::from_str(IDENTITY_ACCOUNTS_TOOL).expect("static json");
                 let identity_validate: Value =
                     serde_json::from_str(IDENTITY_VALIDATE_TOOL).expect("static json");
+                let identity_link: Value =
+                    serde_json::from_str(IDENTITY_LINK_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate, identity_link] }
                 })
             }
             "tools/call" => {
@@ -1507,6 +1522,43 @@ async fn call_tool(
                 let status = resp.status();
                 let text = resp.text().await.unwrap_or_default();
                 anyhow::bail!("identity/validate failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "IdentityLink" => {
+            let account_id = arguments
+                .get("account_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: account_id"))?;
+            let provider = arguments
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: provider"))?;
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/identity/link", local_url.trim_end_matches('/'));
+            let body = json!({
+                "agent_id": agent_id,
+                "account_id": account_id,
+                "provider": provider,
+            });
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("identity/link failed: HTTP {status} — {text}");
             }
             let result: Value = resp
                 .json()

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -1339,12 +1339,11 @@ async fn call_tool(
         }
         "MemoryList" => {
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/memory/list", local_url.trim_end_matches('/'));
             let resp = client
                 .get(&url)
                 .header("X-AuthKey", auth_key)
-                .query(&[("agent_id", agent_id.as_str())])
+                .header("X-Block-Id", block_id)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -1366,12 +1365,12 @@ async fn call_tool(
                 .filter(|s| !s.is_empty())
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: filename"))?;
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/memory/read", local_url.trim_end_matches('/'));
             let resp = client
                 .get(&url)
                 .header("X-AuthKey", auth_key)
-                .query(&[("agent_id", agent_id.as_str()), ("filename", filename)])
+                .header("X-Block-Id", block_id)
+                .query(&[("filename", filename)])
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -1404,16 +1403,15 @@ async fn call_tool(
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: content"))?;
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/memory/write", local_url.trim_end_matches('/'));
             let body = json!({
-                "agent_id": agent_id,
                 "filename": filename,
                 "content": content,
             });
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
+                .header("X-Block-Id", block_id)
                 .json(&body)
                 .send()
                 .await
@@ -1431,6 +1429,7 @@ async fn call_tool(
             let resp = client
                 .get(&url)
                 .header("X-AuthKey", auth_key)
+                .header("X-Block-Id", block_id)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -1447,11 +1446,10 @@ async fn call_tool(
         }
         "PresetGet" => {
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/preset/get", local_url.trim_end_matches('/'));
             // id/name are both optional; with neither set the server returns the
-            // agent's own bound preset ("self"), resolved from agent_id.
-            let mut query: Vec<(&str, &str)> = vec![("agent_id", agent_id.as_str())];
+            // agent's own bound preset ("self"), resolved from X-Block-Id.
+            let mut query: Vec<(&str, &str)> = vec![];
             if let Some(pid) = arguments.get("id").and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
                 query.push(("id", pid));
             }
@@ -1461,6 +1459,7 @@ async fn call_tool(
             let resp = client
                 .get(&url)
                 .header("X-AuthKey", auth_key)
+                .header("X-Block-Id", block_id)
                 .query(&query)
                 .send()
                 .await
@@ -1478,12 +1477,11 @@ async fn call_tool(
         }
         "IdentityAccounts" => {
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/identity/accounts", local_url.trim_end_matches('/'));
             let resp = client
                 .get(&url)
                 .header("X-AuthKey", auth_key)
-                .query(&[("agent_id", agent_id.as_str())])
+                .header("X-Block-Id", block_id)
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -1505,15 +1503,14 @@ async fn call_tool(
                 .filter(|s| !s.is_empty())
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: account_id"))?;
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/identity/validate", local_url.trim_end_matches('/'));
             let body = json!({
-                "agent_id": agent_id,
                 "account_id": account_id,
             });
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
+                .header("X-Block-Id", block_id)
                 .json(&body)
                 .send()
                 .await
@@ -1541,16 +1538,15 @@ async fn call_tool(
                 .filter(|s| !s.is_empty())
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: provider"))?;
             require_agent_env(local_url, auth_key, block_id)?;
-            let agent_id = agent_slug()?;
             let url = format!("{}/api/v1/agent/identity/link", local_url.trim_end_matches('/'));
             let body = json!({
-                "agent_id": agent_id,
                 "account_id": account_id,
                 "provider": provider,
             });
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
+                .header("X-Block-Id", block_id)
                 .json(&body)
                 .send()
                 .await
@@ -1671,8 +1667,9 @@ mod tests {
             PRESET_GET_TOOL,
             IDENTITY_ACCOUNTS_TOOL,
             IDENTITY_VALIDATE_TOOL,
+            IDENTITY_LINK_TOOL,
         ];
-        assert_eq!(defs.len(), 26, "tools/list advertises 26 tools (11 original + 3 Loop + 5 Cron + 7 agent-API)");
+        assert_eq!(defs.len(), 27, "tools/list advertises 27 tools (11 original + 3 Loop + 5 Cron + 8 agent-API)");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -292,6 +292,82 @@ const CRON_RESUME_TOOL: &str = r#"{
   }
 }"#;
 
+const MEMORY_LIST_TOOL: &str = r#"{
+  "name": "MemoryList",
+  "description": "List your own native memory (brain) markdown files. Returns each file's filename, whether it is the index, its metadata_type, size in bytes, and last-modified time. Use it to see what you've remembered before reading or writing a specific file. Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const MEMORY_READ_TOOL: &str = r#"{
+  "name": "MemoryRead",
+  "description": "Read one of your own native memory (brain) markdown files by filename. Returns its content. Get valid filenames from MemoryList.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "filename": { "type": "string", "description": "The memory file to read (from MemoryList)" }
+    },
+    "required": ["filename"]
+  }
+}"#;
+
+const MEMORY_WRITE_TOOL: &str = r#"{
+  "name": "MemoryWrite",
+  "description": "Create or overwrite one of your own native memory (brain) markdown files. The write is atomic. Use it to persist notes/context for your future self across conversations.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "filename": { "type": "string", "description": "The memory file to write (created if absent, overwritten if present)" },
+      "content":  { "type": "string", "description": "Full markdown content to store in the file" }
+    },
+    "required": ["filename", "content"]
+  }
+}"#;
+
+const PRESET_LIST_TOOL: &str = r#"{
+  "name": "PresetList",
+  "description": "List the presets available to you (summary fields only). A preset is a provider-agnostic config bundle — instructions, context files, MCP servers, and skills. Use it to discover presets before fetching one in full with PresetGet. Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const PRESET_GET_TOOL: &str = r#"{
+  "name": "PresetGet",
+  "description": "Fetch a full preset object by id or name. With BOTH id and name omitted, returns your OWN bound preset (the one you are currently configured with). Use PresetList to discover ids/names.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id":   { "type": "string", "description": "Preset id to fetch (optional)" },
+      "name": { "type": "string", "description": "Preset name to fetch (optional)" }
+    }
+  }
+}"#;
+
+const IDENTITY_ACCOUNTS_TOOL: &str = r#"{
+  "name": "IdentityAccounts",
+  "description": "List your own linked identity accounts. Returns each account's account_id, provider, name, kind, status, masked_tail, and updated_at. Secrets are never returned — only masked tails. Use it to see which provider accounts you can use and to get account_ids for IdentityValidate. Takes no arguments.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  }
+}"#;
+
+const IDENTITY_VALIDATE_TOOL: &str = r#"{
+  "name": "IdentityValidate",
+  "description": "Live-probe one of your own linked accounts against its provider using the stored key, to confirm the credential still works. You never supply a secret — pass an account_id from IdentityAccounts. Returns valid, status, masked_tail, and error.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "account_id": { "type": "string", "description": "One of your linked accounts (from IdentityAccounts)" }
+    },
+    "required": ["account_id"]
+  }
+}"#;
+
 #[tokio::main]
 async fn main() {
     let local_url = std::env::var("AGENTMUX_LOCAL_URL").unwrap_or_default();
@@ -393,10 +469,19 @@ async fn main() {
                 let cron_list: Value = serde_json::from_str(CRON_LIST_TOOL).expect("static json");
                 let cron_pause: Value = serde_json::from_str(CRON_PAUSE_TOOL).expect("static json");
                 let cron_resume: Value = serde_json::from_str(CRON_RESUME_TOOL).expect("static json");
+                let memory_list: Value = serde_json::from_str(MEMORY_LIST_TOOL).expect("static json");
+                let memory_read: Value = serde_json::from_str(MEMORY_READ_TOOL).expect("static json");
+                let memory_write: Value = serde_json::from_str(MEMORY_WRITE_TOOL).expect("static json");
+                let preset_list: Value = serde_json::from_str(PRESET_LIST_TOOL).expect("static json");
+                let preset_get: Value = serde_json::from_str(PRESET_GET_TOOL).expect("static json");
+                let identity_accounts: Value =
+                    serde_json::from_str(IDENTITY_ACCOUNTS_TOOL).expect("static json");
+                let identity_validate: Value =
+                    serde_json::from_str(IDENTITY_VALIDATE_TOOL).expect("static json");
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume] }
+                    "result": { "tools": [shell, shell_stop, open_editor, send_message, discover_agents, whoami, layout, set_name, set_active_tab, new_tab, focus_window, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, memory_list, memory_read, memory_write, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -444,6 +529,23 @@ fn require_agent_env(local_url: &str, auth_key: &str, block_id: &str) -> Result<
         );
     }
     Ok(())
+}
+
+/// The calling agent's slug (its `AGENTMUX_AGENT_ID`), injected by AgentMux into
+/// this MCP server's trusted environment. The App API identity/preset/memory
+/// REST endpoints stamp their `agent_id` from this — the agent's own model
+/// output cannot reach those endpoints (no auth key in the PTY) nor override
+/// this value, so the slug cannot be forged. See
+/// SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md §5.
+fn agent_slug() -> Result<String> {
+    let slug = std::env::var("AGENTMUX_AGENT_ID").unwrap_or_default();
+    if slug.is_empty() {
+        anyhow::bail!(
+            "AGENTMUX_AGENT_ID is not set — cannot resolve this agent's identity. \
+             Is this agent pane opened via AgentMux?"
+        );
+    }
+    Ok(slug)
 }
 
 async fn call_tool(
@@ -1220,6 +1322,198 @@ async fn call_tool(
                 .ok_or_else(|| anyhow::anyhow!("missing required parameter: id"))?;
             cron_set_enabled(client, local_url, auth_key, id, "resume").await
         }
+        "MemoryList" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/memory/list", local_url.trim_end_matches('/'));
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .query(&[("agent_id", agent_id.as_str())])
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("memory/list failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "MemoryRead" => {
+            let filename = arguments
+                .get("filename")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: filename"))?;
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/memory/read", local_url.trim_end_matches('/'));
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .query(&[("agent_id", agent_id.as_str()), ("filename", filename)])
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("memory/read failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            // Surface the file content directly when present; fall back to the raw body.
+            Ok(result
+                .get("content")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string())
+                }))
+        }
+        "MemoryWrite" => {
+            let filename = arguments
+                .get("filename")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: filename"))?;
+            let content = arguments
+                .get("content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: content"))?;
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/memory/write", local_url.trim_end_matches('/'));
+            let body = json!({
+                "agent_id": agent_id,
+                "filename": filename,
+                "content": content,
+            });
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("memory/write failed: HTTP {status} — {text}");
+            }
+            Ok(format!("Wrote memory file \"{filename}\""))
+        }
+        "PresetList" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let url = format!("{}/api/v1/agent/preset/list", local_url.trim_end_matches('/'));
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("preset/list failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "PresetGet" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/preset/get", local_url.trim_end_matches('/'));
+            // id/name are both optional; with neither set the server returns the
+            // agent's own bound preset ("self"), resolved from agent_id.
+            let mut query: Vec<(&str, &str)> = vec![("agent_id", agent_id.as_str())];
+            if let Some(pid) = arguments.get("id").and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
+                query.push(("id", pid));
+            }
+            if let Some(pname) = arguments.get("name").and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
+                query.push(("name", pname));
+            }
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .query(&query)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("preset/get failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "IdentityAccounts" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/identity/accounts", local_url.trim_end_matches('/'));
+            let resp = client
+                .get(&url)
+                .header("X-AuthKey", auth_key)
+                .query(&[("agent_id", agent_id.as_str())])
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("identity/accounts failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "IdentityValidate" => {
+            let account_id = arguments
+                .get("account_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: account_id"))?;
+            require_agent_env(local_url, auth_key, block_id)?;
+            let agent_id = agent_slug()?;
+            let url = format!("{}/api/v1/agent/identity/validate", local_url.trim_end_matches('/'));
+            let body = json!({
+                "agent_id": agent_id,
+                "account_id": account_id,
+            });
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("identity/validate failed: HTTP {status} — {text}");
+            }
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
         _ => anyhow::bail!("unknown tool: {name}"),
     }
 }
@@ -1318,8 +1612,15 @@ mod tests {
             CRON_LIST_TOOL,
             CRON_PAUSE_TOOL,
             CRON_RESUME_TOOL,
+            MEMORY_LIST_TOOL,
+            MEMORY_READ_TOOL,
+            MEMORY_WRITE_TOOL,
+            PRESET_LIST_TOOL,
+            PRESET_GET_TOOL,
+            IDENTITY_ACCOUNTS_TOOL,
+            IDENTITY_VALIDATE_TOOL,
         ];
-        assert_eq!(defs.len(), 19, "tools/list advertises 19 tools (11 original + 3 Loop + 5 Cron)");
+        assert_eq!(defs.len(), 26, "tools/list advertises 26 tools (11 original + 3 Loop + 5 Cron + 7 agent-API)");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3539,11 +3539,11 @@ fn register_memory_write(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // Shared App API implementations.
 //
 // Each is called by both (a) the WebSocket RPC closure above — after the S1
-// check validates the agent-supplied `agent_id` against `ctx.agent_id` — and
-// (b) the REST handlers in `mod.rs`, which resolve the agent slug server-side
-// from the trusted `AGENTMUX_BLOCKID` and pass it as `agent_id`. On the REST
-// path S1 holds by construction (the slug is server-derived, not agent input),
-// so these fns take an already-trusted `agent_id` and never re-check S1.
+// check validates `ctx.agent_id` (connection-scoped) against `req.agent_id` —
+// and (b) the REST handlers in `mod.rs`, which derive the agent slug from the
+// `X-Block-Id` header via `app_api_agent_slug()`. On the REST path S1 holds
+// by construction: agentmux-mcp stamps the header from its trusted
+// `AGENTMUX_BLOCKID` env and the server resolves `agentId` from the block.
 // See SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md §5.
 // ---------------------------------------------------------------------------
 
@@ -3564,8 +3564,8 @@ pub(crate) async fn identity_bundle_link_impl(
         .id_store
         .agent_identity_list_for_agent(agent_id)
         .map_err(|e| format!("identity.bundle.link: {e}"))?;
-    if !links.iter().any(|l| l.account_id == account_id) {
-        return Err("FORBIDDEN: account not linked to this agent".to_string());
+    if !links.iter().any(|l| l.account_id == account_id && l.provider == provider) {
+        return Err("FORBIDDEN: account not linked to this agent for the given provider".to_string());
     }
 
     // Find or create the agent's default identity bundle.

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3558,6 +3558,7 @@ pub(crate) async fn identity_bundle_link_impl(
     agent_id: &str,
     account_id: &str,
     provider: &str,
+    bundle_id: &str,
 ) -> Result<serde_json::Value, String> {
     // S1: account must already be linked to this agent.
     let links = state
@@ -3568,12 +3569,10 @@ pub(crate) async fn identity_bundle_link_impl(
         return Err("FORBIDDEN: account not linked to this agent for the given provider".to_string());
     }
 
-    // Bind into the shared default bundle. All instances use DEFAULT_BUNDLE_ID
-    // ("default") as their identity_id (set by backfill at migration time and
-    // as the default in the launch modal). Per-agent bundle selection is G3 work.
-    let bundle_id = crate::identity::migration::DEFAULT_BUNDLE_ID;
-
     // Bind the account into the bundle for the given provider.
+    // bundle_id comes from the caller (= instance.identity_id for this block,
+    // falling back to DEFAULT_BUNDLE_ID). The resolver reads whichever bundle
+    // the instance is bound to, so the bind must land there.
     state
         .id_store
         .bundle_identity_bind(bundle_id, provider, account_id)

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3568,36 +3568,15 @@ pub(crate) async fn identity_bundle_link_impl(
         return Err("FORBIDDEN: account not linked to this agent for the given provider".to_string());
     }
 
-    // Find or create the agent's default identity bundle.
-    let bundle_id = format!("bundle-{agent_id}-default");
-    if state
-        .id_store
-        .bundle_identity_get(&bundle_id)
-        .map_err(|e| format!("identity.bundle.link: bundle lookup: {e}"))?
-        .is_none()
-    {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as i64)
-            .unwrap_or(0);
-        let bundle = crate::backend::storage::identities::Identity {
-            id: bundle_id.clone(),
-            name: format!("{agent_id} Default"),
-            description: String::new(),
-            is_blank: false,
-            created_at: now,
-            updated_at: now,
-        };
-        state
-            .id_store
-            .bundle_identity_upsert(&bundle)
-            .map_err(|e| format!("identity.bundle.link: create bundle: {e}"))?;
-    }
+    // Bind into the shared default bundle. All instances use DEFAULT_BUNDLE_ID
+    // ("default") as their identity_id (set by backfill at migration time and
+    // as the default in the launch modal). Per-agent bundle selection is G3 work.
+    let bundle_id = crate::identity::migration::DEFAULT_BUNDLE_ID;
 
     // Bind the account into the bundle for the given provider.
     state
         .id_store
-        .bundle_identity_bind(&bundle_id, provider, account_id)
+        .bundle_identity_bind(bundle_id, provider, account_id)
         .map_err(|e| format!("identity.bundle.link: bind: {e}"))?;
 
     Ok(json!({

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3547,6 +3547,68 @@ fn register_memory_write(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // See SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md §5.
 // ---------------------------------------------------------------------------
 
+/// Bind an account the agent already owns (via `db_agent_identity_links`) into
+/// its default identity bundle so the resolver injects the credential at next
+/// launch. Creates the bundle if it does not yet exist.
+///
+/// Security: ownership is verified (the account must be linked to `agent_id`)
+/// before the bundle write. No secret is touched.
+pub(crate) async fn identity_bundle_link_impl(
+    state: &AppState,
+    agent_id: &str,
+    account_id: &str,
+    provider: &str,
+) -> Result<serde_json::Value, String> {
+    // S1: account must already be linked to this agent.
+    let links = state
+        .id_store
+        .agent_identity_list_for_agent(agent_id)
+        .map_err(|e| format!("identity.bundle.link: {e}"))?;
+    if !links.iter().any(|l| l.account_id == account_id) {
+        return Err("FORBIDDEN: account not linked to this agent".to_string());
+    }
+
+    // Find or create the agent's default identity bundle.
+    let bundle_id = format!("bundle-{agent_id}-default");
+    if state
+        .id_store
+        .bundle_identity_get(&bundle_id)
+        .map_err(|e| format!("identity.bundle.link: bundle lookup: {e}"))?
+        .is_none()
+    {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let bundle = crate::backend::storage::identities::Identity {
+            id: bundle_id.clone(),
+            name: format!("{agent_id} Default"),
+            description: String::new(),
+            is_blank: false,
+            created_at: now,
+            updated_at: now,
+        };
+        state
+            .id_store
+            .bundle_identity_upsert(&bundle)
+            .map_err(|e| format!("identity.bundle.link: create bundle: {e}"))?;
+    }
+
+    // Bind the account into the bundle for the given provider.
+    state
+        .id_store
+        .bundle_identity_bind(&bundle_id, provider, account_id)
+        .map_err(|e| format!("identity.bundle.link: bind: {e}"))?;
+
+    Ok(json!({
+        "bundle_id": bundle_id,
+        "provider": provider,
+        "account_id": account_id,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+
 pub(crate) async fn identity_self_accounts_impl(
     state: &AppState,
     agent_id: &str,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -3020,43 +3020,18 @@ fn check_s1(ctx: &RpcContext, req_agent_id: &str) -> Result<(), String> {
 // ---------------------------------------------------------------------------
 
 fn register_identity_self_accounts(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let id_store = state.id_store.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_IDENTITY_SELF_ACCOUNTS,
         Box::new(move |data, ctx| {
-            let id_store = id_store.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("identity.self.accounts: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-
-                let links = id_store
-                    .agent_identity_list_for_agent(&req.agent_id)
-                    .map_err(|e| format!("identity.self.accounts: {e}"))?;
-
-                let mut accounts = Vec::new();
-                for link in &links {
-                    if let Some(acct) = id_store.identity_get(&link.account_id)
-                        .map_err(|e| format!("identity.self.accounts: {e}"))? {
-                        let masked_tail = acct.context
-                            .get("masked_tail")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        accounts.push(json!({
-                            "account_id": acct.id,
-                            "provider":   acct.provider,
-                            "name":       acct.name,
-                            "kind":       acct.kind,
-                            "status":     acct.status,
-                            "masked_tail": masked_tail,
-                            "updated_at": acct.updated_at,
-                        }));
-                    }
-                }
-                Ok(Some(json!({ "accounts": accounts })))
+                Ok(Some(identity_self_accounts_impl(&state, &req.agent_id).await?))
             })
         }),
     );
@@ -3229,11 +3204,11 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
 // ---------------------------------------------------------------------------
 
 fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let id_store = state.id_store.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_IDENTITY_ACCOUNT_VALIDATE,
         Box::new(move |data, ctx| {
-            let id_store = id_store.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize, Default)]
                 #[serde(rename_all = "snake_case")]
@@ -3246,43 +3221,27 @@ fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppSta
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("identity.account.validate: {e}"))?;
 
-                let (provider, secret, masked_tail) = if !req.account_id.is_empty() {
-                    // Stored-account path: S1 check + ownership verification so
-                    // callers can't probe another agent's credential by account UUID.
+                if !req.account_id.is_empty() {
+                    // Stored-account path: S1 + ownership verification, then probe
+                    // using the stored keychain secret (shared with the REST path).
                     check_s1(&ctx, &req.agent_id)?;
-                    let links = id_store
-                        .agent_identity_list_for_agent(&req.agent_id)
-                        .map_err(|e| format!("identity.account.validate: {e}"))?;
-                    if !links.iter().any(|l| l.account_id == req.account_id) {
-                        return Err("FORBIDDEN: account not linked to this agent".to_string());
-                    }
-                    let acct = id_store.identity_get(&req.account_id)
-                        .map_err(|e| format!("identity.account.validate: {e}"))?
-                        .ok_or_else(|| format!("identity.account.validate: account {} not found", req.account_id))?;
-                    let aid = req.account_id.clone();
-                    let plaintext = tokio::task::spawn_blocking(move || {
-                        crate::identity::secret_store::get(&aid)
-                    })
-                    .await
-                    .map_err(|e| format!("identity.account.validate: keychain task: {e}"))?
-                    .map_err(|e| format!("identity.account.validate: keychain: {e}"))?;
-                    let tail = crate::identity::key_validator::masked_tail(&plaintext);
-                    (acct.provider.clone(), plaintext.to_string(), tail)
-                } else if !req.provider.is_empty() && !req.secret.is_empty() {
-                    // Ad-hoc probe — caller supplies their own secret, nothing stored.
-                    let tail = crate::identity::key_validator::masked_tail(&req.secret);
-                    (req.provider.clone(), req.secret.clone(), tail)
-                } else {
-                    return Err("identity.account.validate: provide account_id or (provider + secret)".to_string());
-                };
-
-                let outcome = crate::identity::key_validator::validate(&provider, &secret).await;
-                Ok(Some(json!({
-                    "valid":       outcome.valid,
-                    "status":      if outcome.valid { "valid" } else { "invalid" },
-                    "masked_tail": masked_tail,
-                    "error":       outcome.error,
-                })))
+                    return Ok(Some(
+                        identity_account_validate_stored_impl(&state, &req.agent_id, &req.account_id).await?,
+                    ));
+                }
+                if !req.provider.is_empty() && !req.secret.is_empty() {
+                    // Ad-hoc probe — caller supplies their own secret, nothing
+                    // stored. WS-only; not exposed over REST/MCP (no inline secret).
+                    let masked_tail = crate::identity::key_validator::masked_tail(&req.secret);
+                    let outcome = crate::identity::key_validator::validate(&req.provider, &req.secret).await;
+                    return Ok(Some(json!({
+                        "valid": outcome.valid,
+                        "status": if outcome.valid { "valid" } else { "invalid" },
+                        "masked_tail": masked_tail,
+                        "error": outcome.error,
+                    })));
+                }
+                Err("identity.account.validate: provide account_id or (provider + secret)".to_string())
             })
         }),
     );
@@ -3327,27 +3286,12 @@ fn register_identity_self_unlink(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // ---------------------------------------------------------------------------
 
 fn register_preset_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let id_store = state.id_store.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_PRESET_LIST,
         Box::new(move |_data, _ctx| {
-            let id_store = id_store.clone();
-            Box::pin(async move {
-                let memories = id_store
-                    .bundle_memory_list()
-                    .map_err(|e| format!("preset.list: {e}"))?;
-                // Return summary fields only — no instruction/context blobs.
-                let presets: Vec<_> = memories.iter().map(|m| json!({
-                    "id":          m.id,
-                    "name":        m.name,
-                    "description": m.description,
-                    "provider":    m.provider,
-                    "model":       m.model,
-                    "is_blank":    m.is_blank,
-                    "updated_at":  m.updated_at,
-                })).collect();
-                Ok(Some(json!({ "presets": presets })))
-            })
+            let state = state.clone();
+            Box::pin(async move { Ok(Some(preset_list_impl(&state).await?)) })
         }),
     );
 }
@@ -3357,11 +3301,11 @@ fn register_preset_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // ---------------------------------------------------------------------------
 
 fn register_preset_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let id_store = state.id_store.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_PRESET_GET,
         Box::new(move |data, _ctx| {
-            let id_store = id_store.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize, Default)]
                 struct Req {
@@ -3370,23 +3314,7 @@ fn register_preset_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("preset.get: {e}"))?;
-
-                let memory = if !req.id.is_empty() {
-                    id_store.bundle_memory_get(&req.id)
-                        .map_err(|e| format!("preset.get: {e}"))?
-                        .ok_or_else(|| format!("preset.get: not found id={}", req.id))?
-                } else if !req.name.is_empty() {
-                    // Name lookup: list + filter, pick most-recently-updated.
-                    let all = id_store.bundle_memory_list()
-                        .map_err(|e| format!("preset.get: {e}"))?;
-                    all.into_iter()
-                        .filter(|m| m.name == req.name)
-                        .max_by_key(|m| m.updated_at)
-                        .ok_or_else(|| format!("preset.get: not found name={}", req.name))?
-                } else {
-                    return Err("preset.get: provide id or name".to_string());
-                };
-                Ok(Some(serde_json::to_value(&memory).map_err(|e| e.to_string())?))
+                Ok(Some(preset_get_impl(&state, &req.id, &req.name).await?))
             })
         }),
     );
@@ -3531,49 +3459,18 @@ fn register_preset_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // ---------------------------------------------------------------------------
 
 fn register_preset_self_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
-    let id_store = state.id_store.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_PRESET_SELF_GET,
         Box::new(move |data, ctx| {
-            let wstore = wstore.clone();
-            let id_store = id_store.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("preset.self.get: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-
-                // Resolve agent slug → instance row → memory_id.
-                let instance = wstore
-                    .instance_get_by_name(&req.agent_id)
-                    .map_err(|e| format!("preset.self.get: {e}"))?;
-
-                let memory_id = instance.as_ref().and_then(|i| {
-                    if i.memory_id.is_empty() { None } else { Some(i.memory_id.clone()) }
-                });
-
-                let memory = if let Some(mid) = memory_id {
-                    id_store.bundle_memory_get(&mid)
-                        .map_err(|e| format!("preset.self.get: {e}"))?
-                        .ok_or_else(|| format!("preset.self.get: memory_id {mid} not found"))?
-                } else {
-                    // No preset bound: return the blank singleton.
-                    // listmemories returns summary only, so two steps:
-                    // (1) find blank id, (2) getmemory for full object.
-                    let all = id_store.bundle_memory_list()
-                        .map_err(|e| format!("preset.self.get: {e}"))?;
-                    let blank_id = all.into_iter()
-                        .find(|m| m.is_blank)
-                        .map(|m| m.id)
-                        .ok_or_else(|| "preset.self.get: blank singleton not found".to_string())?;
-                    id_store.bundle_memory_get(&blank_id)
-                        .map_err(|e| format!("preset.self.get: {e}"))?
-                        .ok_or_else(|| "preset.self.get: blank singleton row missing".to_string())?
-                };
-
-                Ok(Some(serde_json::to_value(&memory).map_err(|e| e.to_string())?))
+                Ok(Some(preset_self_get_impl(&state, &req.agent_id).await?))
             })
         }),
     );
@@ -3584,151 +3481,284 @@ fn register_preset_self_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // ---------------------------------------------------------------------------
 
 fn register_memory_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_MEMORY_LIST,
         Box::new(move |data, ctx| {
-            let wstore = wstore.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("memory.list: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-
-                let memory_dir = crate::server::native_memory_handlers::memory_dir_for_agent(
-                    &wstore, &req.agent_id,
-                ).map_err(|e| format!("memory.list: {e}"))?;
-
-                let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
-                let entries = match std::fs::read_dir(&memory_dir) {
-                    Ok(e) => e,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        return Ok(Some(json!({ "files": [] })));
-                    }
-                    Err(e) => return Err(format!("memory.list: read_dir: {e}")),
-                };
-                for entry in entries {
-                    let entry = entry.map_err(|e| format!("memory.list: {e}"))?;
-                    let name = entry.file_name().to_string_lossy().into_owned();
-                    if !name.ends_with(".md") { continue; }
-                    let file_type = entry.file_type()
-                        .map_err(|e| format!("memory.list: file_type {name}: {e}"))?;
-                    if !file_type.is_file() { continue; }
-                    let meta = match entry.metadata() {
-                        Ok(m) => m,
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-                        Err(e) => return Err(format!("memory.list: metadata {name}: {e}")),
-                    };
-                    let preview_content = {
-                        use std::io::Read;
-                        std::fs::File::open(entry.path())
-                            .map(|f| {
-                                let mut buf = Vec::with_capacity(512);
-                                f.take(512).read_to_end(&mut buf).ok();
-                                String::from_utf8_lossy(&buf).into_owned()
-                            })
-                            .unwrap_or_default()
-                    };
-                    files.push(NativeMemoryFileMeta {
-                        is_index: name == "MEMORY.md",
-                        metadata_type: crate::server::native_memory_handlers::parse_memory_frontmatter_type(&preview_content),
-                        size_bytes: meta.len(),
-                        modified_at: meta.modified().ok()
-                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                            .map(|d| d.as_millis() as i64)
-                            .unwrap_or(0),
-                        filename: name,
-                    });
-                }
-                files.sort_by(|a, b| b.is_index.cmp(&a.is_index).then(a.filename.cmp(&b.filename)));
-                Ok(Some(serde_json::to_value(NativeMemoryListResult { files }).map_err(|e| e.to_string())?))
+                Ok(Some(memory_list_impl(&state, &req.agent_id)?))
             })
         }),
     );
 }
 
 fn register_memory_read(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_MEMORY_READ,
         Box::new(move |data, ctx| {
-            let wstore = wstore.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, filename: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("memory.read: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                crate::server::native_memory_handlers::validate_memory_filename(&req.filename)
-                    .map_err(|e| format!("memory.read: {e}"))?;
-
-                let path = crate::server::native_memory_handlers::memory_dir_for_agent(
-                    &wstore, &req.agent_id,
-                ).map_err(|e| format!("memory.read: {e}"))?.join(&req.filename);
-
-                let file_type = std::fs::symlink_metadata(&path)
-                    .map_err(|e| format!("memory.read: {}: {e}", req.filename))?.file_type();
-                if !file_type.is_file() {
-                    return Err(format!("memory.read: {} is not a regular file", req.filename));
-                }
-                const MAX: u64 = 10 * 1024 * 1024;
-                let mut buf = Vec::new();
-                std::fs::File::open(&path)
-                    .and_then(|f| { use std::io::Read; f.take(MAX).read_to_end(&mut buf) })
-                    .map_err(|e| format!("memory.read: {}: {e}", req.filename))?;
-                let content = String::from_utf8_lossy(&buf).into_owned();
-                Ok(Some(serde_json::to_value(NativeMemoryReadFileResult { content }).map_err(|e| e.to_string())?))
+                Ok(Some(memory_read_impl(&state, &req.agent_id, &req.filename)?))
             })
         }),
     );
 }
 
 fn register_memory_write(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
-    let broker = state.broker.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_MEMORY_WRITE,
         Box::new(move |data, ctx| {
-            let wstore = wstore.clone();
-            let broker = broker.clone();
+            let state = state.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, filename: String, content: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("memory.write: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                crate::server::native_memory_handlers::validate_memory_filename(&req.filename)
-                    .map_err(|e| format!("memory.write: {e}"))?;
-                const MAX: usize = 10 * 1024 * 1024;
-                if req.content.len() > MAX {
-                    return Err(format!("memory.write: content too large ({} bytes, max {MAX})", req.content.len()));
-                }
-
-                let dir = crate::server::native_memory_handlers::memory_dir_for_agent(
-                    &wstore, &req.agent_id,
-                ).map_err(|e| format!("memory.write: {e}"))?;
-                std::fs::create_dir_all(&dir)
-                    .map_err(|e| format!("memory.write: mkdir: {e}"))?;
-
-                let dest = dir.join(&req.filename);
-                let tmp = dir.join(format!(".{}.{}.tmp", req.filename, uuid::Uuid::new_v4()));
-                if let Err(e) = std::fs::write(&tmp, &req.content) {
-                    let _ = std::fs::remove_file(&tmp);
-                    return Err(format!("memory.write: write tmp: {e}"));
-                }
-                if let Err(e) = std::fs::rename(&tmp, &dest) {
-                    let _ = std::fs::remove_file(&tmp);
-                    return Err(format!("memory.write: rename: {e}"));
-                }
-                broker.publish(crate::backend::wps::WaveEvent {
-                    event: format!("agent:memory:changed:{}", req.agent_id),
-                    scopes: vec![], sender: String::new(), persist: 0, data: None,
-                });
+                memory_write_impl(&state, &req.agent_id, &req.filename, &req.content)?;
                 Ok(None)
             })
         }),
     );
+}
+
+// ---------------------------------------------------------------------------
+// Shared App API implementations.
+//
+// Each is called by both (a) the WebSocket RPC closure above — after the S1
+// check validates the agent-supplied `agent_id` against `ctx.agent_id` — and
+// (b) the REST handlers in `mod.rs`, which resolve the agent slug server-side
+// from the trusted `AGENTMUX_BLOCKID` and pass it as `agent_id`. On the REST
+// path S1 holds by construction (the slug is server-derived, not agent input),
+// so these fns take an already-trusted `agent_id` and never re-check S1.
+// See SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md §5.
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn identity_self_accounts_impl(
+    state: &AppState,
+    agent_id: &str,
+) -> Result<serde_json::Value, String> {
+    let links = state.id_store.agent_identity_list_for_agent(agent_id)
+        .map_err(|e| format!("identity.self.accounts: {e}"))?;
+    let mut accounts = Vec::new();
+    for link in &links {
+        if let Some(acct) = state.id_store.identity_get(&link.account_id)
+            .map_err(|e| format!("identity.self.accounts: {e}"))? {
+            let masked_tail = acct.context.get("masked_tail")
+                .and_then(|v| v.as_str()).unwrap_or("").to_string();
+            accounts.push(json!({
+                "account_id": acct.id, "provider": acct.provider, "name": acct.name,
+                "kind": acct.kind, "status": acct.status, "masked_tail": masked_tail,
+                "updated_at": acct.updated_at,
+            }));
+        }
+    }
+    Ok(json!({ "accounts": accounts }))
+}
+
+/// Validate one of the agent's own linked accounts by probing the provider with
+/// the stored keychain secret. Ownership is verified (the account must be linked
+/// to `agent_id`) before the secret is read.
+pub(crate) async fn identity_account_validate_stored_impl(
+    state: &AppState,
+    agent_id: &str,
+    account_id: &str,
+) -> Result<serde_json::Value, String> {
+    let links = state.id_store.agent_identity_list_for_agent(agent_id)
+        .map_err(|e| format!("identity.account.validate: {e}"))?;
+    if !links.iter().any(|l| l.account_id == account_id) {
+        return Err("FORBIDDEN: account not linked to this agent".to_string());
+    }
+    let acct = state.id_store.identity_get(account_id)
+        .map_err(|e| format!("identity.account.validate: {e}"))?
+        .ok_or_else(|| format!("identity.account.validate: account {account_id} not found"))?;
+    let aid = account_id.to_string();
+    let plaintext = tokio::task::spawn_blocking(move || crate::identity::secret_store::get(&aid))
+        .await.map_err(|e| format!("identity.account.validate: keychain task: {e}"))?
+        .map_err(|e| format!("identity.account.validate: keychain: {e}"))?;
+    let tail = crate::identity::key_validator::masked_tail(&plaintext);
+    let outcome = crate::identity::key_validator::validate(&acct.provider, &plaintext).await;
+    Ok(json!({
+        "valid": outcome.valid,
+        "status": if outcome.valid { "valid" } else { "invalid" },
+        "masked_tail": tail,
+        "error": outcome.error,
+    }))
+}
+
+pub(crate) async fn preset_list_impl(state: &AppState) -> Result<serde_json::Value, String> {
+    let memories = state.id_store.bundle_memory_list().map_err(|e| format!("preset.list: {e}"))?;
+    let presets: Vec<_> = memories.iter().map(|m| json!({
+        "id": m.id, "name": m.name, "description": m.description,
+        "provider": m.provider, "model": m.model, "is_blank": m.is_blank, "updated_at": m.updated_at,
+    })).collect();
+    Ok(json!({ "presets": presets }))
+}
+
+pub(crate) async fn preset_get_impl(
+    state: &AppState,
+    id: &str,
+    name: &str,
+) -> Result<serde_json::Value, String> {
+    let memory = if !id.is_empty() {
+        state.id_store.bundle_memory_get(id).map_err(|e| format!("preset.get: {e}"))?
+            .ok_or_else(|| format!("preset.get: not found id={id}"))?
+    } else if !name.is_empty() {
+        let all = state.id_store.bundle_memory_list().map_err(|e| format!("preset.get: {e}"))?;
+        all.into_iter().filter(|m| m.name == name).max_by_key(|m| m.updated_at)
+            .ok_or_else(|| format!("preset.get: not found name={name}"))?
+    } else {
+        return Err("preset.get: provide id or name".to_string());
+    };
+    serde_json::to_value(&memory).map_err(|e| e.to_string())
+}
+
+pub(crate) async fn preset_self_get_impl(
+    state: &AppState,
+    agent_id: &str,
+) -> Result<serde_json::Value, String> {
+    let instance = state.wstore.instance_get_by_name(agent_id)
+        .map_err(|e| format!("preset.self.get: {e}"))?;
+    let memory_id = instance.as_ref()
+        .and_then(|i| if i.memory_id.is_empty() { None } else { Some(i.memory_id.clone()) });
+    let memory = if let Some(mid) = memory_id {
+        state.id_store.bundle_memory_get(&mid).map_err(|e| format!("preset.self.get: {e}"))?
+            .ok_or_else(|| format!("preset.self.get: memory_id {mid} not found"))?
+    } else {
+        // No preset bound: return the blank singleton (two-step — list to find
+        // the blank id, then fetch the full object).
+        let all = state.id_store.bundle_memory_list().map_err(|e| format!("preset.self.get: {e}"))?;
+        let blank_id = all.into_iter().find(|m| m.is_blank).map(|m| m.id)
+            .ok_or_else(|| "preset.self.get: blank singleton not found".to_string())?;
+        state.id_store.bundle_memory_get(&blank_id).map_err(|e| format!("preset.self.get: {e}"))?
+            .ok_or_else(|| "preset.self.get: blank singleton row missing".to_string())?
+    };
+    serde_json::to_value(&memory).map_err(|e| e.to_string())
+}
+
+pub(crate) fn memory_list_impl(
+    state: &AppState,
+    agent_id: &str,
+) -> Result<serde_json::Value, String> {
+    let memory_dir = crate::server::native_memory_handlers::memory_dir_for_agent(
+        &state.wstore, agent_id,
+    ).map_err(|e| format!("memory.list: {e}"))?;
+
+    let mut files: Vec<NativeMemoryFileMeta> = Vec::new();
+    let entries = match std::fs::read_dir(&memory_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(json!({ "files": [] }));
+        }
+        Err(e) => return Err(format!("memory.list: read_dir: {e}")),
+    };
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("memory.list: {e}"))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.ends_with(".md") { continue; }
+        let file_type = entry.file_type()
+            .map_err(|e| format!("memory.list: file_type {name}: {e}"))?;
+        if !file_type.is_file() { continue; }
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(format!("memory.list: metadata {name}: {e}")),
+        };
+        let preview_content = {
+            use std::io::Read;
+            std::fs::File::open(entry.path())
+                .map(|f| {
+                    let mut buf = Vec::with_capacity(512);
+                    f.take(512).read_to_end(&mut buf).ok();
+                    String::from_utf8_lossy(&buf).into_owned()
+                })
+                .unwrap_or_default()
+        };
+        files.push(NativeMemoryFileMeta {
+            is_index: name == "MEMORY.md",
+            metadata_type: crate::server::native_memory_handlers::parse_memory_frontmatter_type(&preview_content),
+            size_bytes: meta.len(),
+            modified_at: meta.modified().ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0),
+            filename: name,
+        });
+    }
+    files.sort_by(|a, b| b.is_index.cmp(&a.is_index).then(a.filename.cmp(&b.filename)));
+    serde_json::to_value(NativeMemoryListResult { files }).map_err(|e| e.to_string())
+}
+
+pub(crate) fn memory_read_impl(
+    state: &AppState,
+    agent_id: &str,
+    filename: &str,
+) -> Result<serde_json::Value, String> {
+    crate::server::native_memory_handlers::validate_memory_filename(filename)
+        .map_err(|e| format!("memory.read: {e}"))?;
+    let path = crate::server::native_memory_handlers::memory_dir_for_agent(
+        &state.wstore, agent_id,
+    ).map_err(|e| format!("memory.read: {e}"))?.join(filename);
+
+    let file_type = std::fs::symlink_metadata(&path)
+        .map_err(|e| format!("memory.read: {filename}: {e}"))?.file_type();
+    if !file_type.is_file() {
+        return Err(format!("memory.read: {filename} is not a regular file"));
+    }
+    const MAX: u64 = 10 * 1024 * 1024;
+    let mut buf = Vec::new();
+    std::fs::File::open(&path)
+        .and_then(|f| { use std::io::Read; f.take(MAX).read_to_end(&mut buf) })
+        .map_err(|e| format!("memory.read: {filename}: {e}"))?;
+    let content = String::from_utf8_lossy(&buf).into_owned();
+    serde_json::to_value(NativeMemoryReadFileResult { content }).map_err(|e| e.to_string())
+}
+
+pub(crate) fn memory_write_impl(
+    state: &AppState,
+    agent_id: &str,
+    filename: &str,
+    content: &str,
+) -> Result<(), String> {
+    crate::server::native_memory_handlers::validate_memory_filename(filename)
+        .map_err(|e| format!("memory.write: {e}"))?;
+    const MAX: usize = 10 * 1024 * 1024;
+    if content.len() > MAX {
+        return Err(format!("memory.write: content too large ({} bytes, max {MAX})", content.len()));
+    }
+    let dir = crate::server::native_memory_handlers::memory_dir_for_agent(
+        &state.wstore, agent_id,
+    ).map_err(|e| format!("memory.write: {e}"))?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("memory.write: mkdir: {e}"))?;
+
+    let dest = dir.join(filename);
+    let tmp = dir.join(format!(".{}.{}.tmp", filename, uuid::Uuid::new_v4()));
+    if let Err(e) = std::fs::write(&tmp, content) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("memory.write: write tmp: {e}"));
+    }
+    if let Err(e) = std::fs::rename(&tmp, &dest) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("memory.write: rename: {e}"));
+    }
+    state.broker.publish(crate::backend::wps::WaveEvent {
+        event: format!("agent:memory:changed:{agent_id}"),
+        scopes: vec![], sender: String::new(), persist: 0, data: None,
+    });
+    Ok(())
 }
 
 /// Parse + validate a saved per-agent `ui:zoom` content blob for seeding a new

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -702,15 +702,37 @@ fn app_api_agent_slug(
             )
                 .into_response()
         })?;
-    let agent_id = crate::backend::obj::meta_get_string(&block.meta, "agentId", "");
-    if agent_id.is_empty() {
+    let def_id = crate::backend::obj::meta_get_string(&block.meta, "agentId", "");
+    if def_id.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({ "error": "block has no agentId" })),
         )
             .into_response());
     }
-    Ok(agent_id)
+    // agentId meta holds the definition UUID; resolve to slug for impl functions.
+    let agent = state
+        .wstore
+        .agent_def_get(&def_id)
+        .map_err(|e| {
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e.to_string() })))
+                .into_response()
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("agent not found: {def_id}") })),
+            )
+                .into_response()
+        })?;
+    if agent.slug.is_empty() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "agent has no slug" })),
+        )
+            .into_response());
+    }
+    Ok(agent.slug)
 }
 
 /// Classify an app-API impl error string into an HTTP status. FORBIDDEN and
@@ -718,7 +740,7 @@ fn app_api_agent_slug(
 fn app_api_error_status(e: &str) -> StatusCode {
     if e.starts_with("FORBIDDEN") {
         StatusCode::FORBIDDEN
-    } else if (e.starts_with("memory:") && e.contains("not found"))
+    } else if (e.starts_with("memory.") && e.contains("not found"))
         || e.contains("provide ")
         || e.contains("not a regular file")
         || e.contains("too large")
@@ -879,8 +901,22 @@ async fn handle_agent_identity_link(
         Ok(id) => id,
         Err(resp) => return resp,
     };
+    let block_id = headers
+        .get("X-Block-Id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    // Use this instance's identity_id so the bind lands in the bundle the
+    // resolver will actually read at next launch, not always the shared default.
+    let bundle_id = state
+        .wstore
+        .instance_get_active_for_block(block_id)
+        .ok()
+        .flatten()
+        .map(|inst| inst.identity_id)
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| crate::identity::migration::DEFAULT_BUNDLE_ID.to_string());
     app_api_response(
-        app_api::identity_bundle_link_impl(&state, &agent_id, &req.account_id, &req.provider).await,
+        app_api::identity_bundle_link_impl(&state, &agent_id, &req.account_id, &req.provider, &bundle_id).await,
     )
 }
 

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -304,6 +304,19 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tab/activate", post(handle_tab_activate))
         .route("/api/v1/tab/new", post(handle_tab_new))
         .route("/api/v1/window/focus", post(handle_window_focus))
+        // Agent App API — identity / preset / memory namespaces, the MCP-facing
+        // slice of the app-API RPC surface (SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28).
+        // The agent identity (`agent_id`) is supplied by agentmux-mcp from its
+        // trusted AGENTMUX_AGENT_ID env; an agent's PTY has no auth key to reach
+        // these directly, so the slug cannot be forged. Each handler calls the
+        // same `app_api::*_impl` the WebSocket RPC handlers use.
+        .route("/api/v1/agent/memory/list", get(handle_agent_memory_list))
+        .route("/api/v1/agent/memory/read", get(handle_agent_memory_read))
+        .route("/api/v1/agent/memory/write", post(handle_agent_memory_write))
+        .route("/api/v1/agent/preset/list", get(handle_agent_preset_list))
+        .route("/api/v1/agent/preset/get", get(handle_agent_preset_get))
+        .route("/api/v1/agent/identity/accounts", get(handle_agent_identity_accounts))
+        .route("/api/v1/agent/identity/validate", post(handle_agent_identity_validate))
         .route("/api/messaging/status", get(messaging_handlers::handle_status))
         .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
         // Persistent cron scheduler (SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2.4).
@@ -644,6 +657,156 @@ async fn handle_pane_open(
             (status, Json(json!({ "error": e }))).into_response()
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Agent App API REST handlers (identity / preset / memory).
+//
+// `agent_id` is the agent slug, supplied by agentmux-mcp from its trusted
+// AGENTMUX_AGENT_ID env. Each handler maps a 4xx for caller/validation errors
+// (FORBIDDEN, "not found", "provide …", "not a regular file") and 5xx otherwise,
+// then delegates to the shared `app_api::*_impl`.
+// ---------------------------------------------------------------------------
+
+/// Classify an app-API impl error string into an HTTP status. FORBIDDEN and
+/// argument/not-found errors are the caller's fault (4xx); the rest are 5xx.
+fn app_api_error_status(e: &str) -> StatusCode {
+    if e.starts_with("FORBIDDEN") {
+        StatusCode::FORBIDDEN
+    } else if e.contains("not found")
+        || e.contains("provide ")
+        || e.contains("not a regular file")
+        || e.contains("too large")
+        || e.contains("invalid")
+    {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+}
+
+fn app_api_response(result: Result<serde_json::Value, String>) -> axum::response::Response {
+    match result {
+        Ok(v) => (StatusCode::OK, Json(v)).into_response(),
+        Err(e) => (app_api_error_status(&e), Json(json!({ "error": e }))).into_response(),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct AgentMemoryListQuery {
+    agent_id: String,
+}
+
+/// `GET /api/v1/agent/memory/list?agent_id=<slug>` — list the agent's own
+/// native-memory markdown files. Backs the `MemoryList` MCP tool.
+async fn handle_agent_memory_list(
+    State(state): State<AppState>,
+    Query(q): Query<AgentMemoryListQuery>,
+) -> impl IntoResponse {
+    app_api_response(app_api::memory_list_impl(&state, &q.agent_id))
+}
+
+#[derive(serde::Deserialize)]
+struct AgentMemoryReadQuery {
+    agent_id: String,
+    filename: String,
+}
+
+/// `GET /api/v1/agent/memory/read?agent_id=<slug>&filename=<f>` — read one of
+/// the agent's own memory files. Backs the `MemoryRead` MCP tool.
+async fn handle_agent_memory_read(
+    State(state): State<AppState>,
+    Query(q): Query<AgentMemoryReadQuery>,
+) -> impl IntoResponse {
+    app_api_response(app_api::memory_read_impl(&state, &q.agent_id, &q.filename))
+}
+
+#[derive(serde::Deserialize)]
+struct AgentMemoryWriteRequest {
+    agent_id: String,
+    filename: String,
+    content: String,
+}
+
+/// `POST /api/v1/agent/memory/write` — create/overwrite one of the agent's own
+/// memory files (atomic tmp→rename). Backs the `MemoryWrite` MCP tool.
+async fn handle_agent_memory_write(
+    State(state): State<AppState>,
+    Json(req): Json<AgentMemoryWriteRequest>,
+) -> impl IntoResponse {
+    match app_api::memory_write_impl(&state, &req.agent_id, &req.filename, &req.content) {
+        Ok(()) => (StatusCode::OK, Json(json!({ "ok": true }))).into_response(),
+        Err(e) => (app_api_error_status(&e), Json(json!({ "error": e }))).into_response(),
+    }
+}
+
+/// `GET /api/v1/agent/preset/list` — list all presets (shared catalog, summary
+/// fields only). Backs the `PresetList` MCP tool.
+async fn handle_agent_preset_list(State(state): State<AppState>) -> impl IntoResponse {
+    app_api_response(app_api::preset_list_impl(&state).await)
+}
+
+#[derive(serde::Deserialize)]
+struct AgentPresetGetQuery {
+    #[serde(default)]
+    agent_id: String,
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+}
+
+/// `GET /api/v1/agent/preset/get?agent_id=<slug>&id=&name=` — fetch a preset by
+/// id or name; with neither, return the agent's own bound preset (self).
+/// Backs the `PresetGet` MCP tool.
+async fn handle_agent_preset_get(
+    State(state): State<AppState>,
+    Query(q): Query<AgentPresetGetQuery>,
+) -> impl IntoResponse {
+    if q.id.is_empty() && q.name.is_empty() {
+        if q.agent_id.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "preset.get: provide id, name, or agent_id (for self)" })),
+            )
+                .into_response();
+        }
+        return app_api_response(app_api::preset_self_get_impl(&state, &q.agent_id).await);
+    }
+    app_api_response(app_api::preset_get_impl(&state, &q.id, &q.name).await)
+}
+
+#[derive(serde::Deserialize)]
+struct AgentIdentityAccountsQuery {
+    agent_id: String,
+}
+
+/// `GET /api/v1/agent/identity/accounts?agent_id=<slug>` — list the agent's own
+/// linked credential accounts (masked tails only, never secrets). Backs the
+/// `IdentityAccounts` MCP tool.
+async fn handle_agent_identity_accounts(
+    State(state): State<AppState>,
+    Query(q): Query<AgentIdentityAccountsQuery>,
+) -> impl IntoResponse {
+    app_api_response(app_api::identity_self_accounts_impl(&state, &q.agent_id).await)
+}
+
+#[derive(serde::Deserialize)]
+struct AgentIdentityValidateRequest {
+    agent_id: String,
+    account_id: String,
+}
+
+/// `POST /api/v1/agent/identity/validate` — live-probe one of the agent's own
+/// linked accounts using its stored keychain secret (the agent never supplies a
+/// secret). Backs the `IdentityValidate` MCP tool.
+async fn handle_agent_identity_validate(
+    State(state): State<AppState>,
+    Json(req): Json<AgentIdentityValidateRequest>,
+) -> impl IntoResponse {
+    app_api_response(
+        app_api::identity_account_validate_stored_impl(&state, &req.agent_id, &req.account_id).await,
+    )
 }
 
 #[derive(serde::Deserialize)]

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -663,11 +663,55 @@ async fn handle_pane_open(
 // ---------------------------------------------------------------------------
 // Agent App API REST handlers (identity / preset / memory).
 //
-// `agent_id` is the agent slug, supplied by agentmux-mcp from its trusted
-// AGENTMUX_AGENT_ID env. Each handler maps a 4xx for caller/validation errors
-// (FORBIDDEN, "not found", "provide …", "not a regular file") and 5xx otherwise,
-// then delegates to the shared `app_api::*_impl`.
+// S1: `agent_id` is derived server-side from the `X-Block-Id` header, which
+// agentmux-mcp stamps from its trusted `AGENTMUX_BLOCKID` env. The server
+// reads `agentId` from the block's metadata — the caller cannot forge the
+// slug. Each handler maps a 4xx for caller/validation errors and 5xx
+// otherwise, then delegates to the shared `app_api::*_impl`.
 // ---------------------------------------------------------------------------
+
+/// Derive the calling agent's slug from the `X-Block-Id` header.
+/// agentmux-mcp stamps the header from its trusted `AGENTMUX_BLOCKID` env;
+/// the server resolves `agentId` from the block — S1 holds by construction.
+fn app_api_agent_slug(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+) -> Result<String, axum::response::Response> {
+    let block_id = headers
+        .get("X-Block-Id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if block_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "missing X-Block-Id header" })),
+        )
+            .into_response());
+    }
+    let block = state
+        .wstore
+        .get::<crate::backend::obj::Block>(block_id)
+        .map_err(|e| {
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e.to_string() })))
+                .into_response()
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("block not found: {block_id}") })),
+            )
+                .into_response()
+        })?;
+    let agent_id = crate::backend::obj::meta_get_string(&block.meta, "agentId", "");
+    if agent_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "block has no agentId" })),
+        )
+            .into_response());
+    }
+    Ok(agent_id)
+}
 
 /// Classify an app-API impl error string into an HTTP status. FORBIDDEN and
 /// argument/not-found errors are the caller's fault (4xx); the rest are 5xx.
@@ -678,7 +722,7 @@ fn app_api_error_status(e: &str) -> StatusCode {
         || e.contains("provide ")
         || e.contains("not a regular file")
         || e.contains("too large")
-        || e.contains("invalid")
+        || e.starts_with("invalid ")
     {
         StatusCode::BAD_REQUEST
     } else {
@@ -693,38 +737,40 @@ fn app_api_response(result: Result<serde_json::Value, String>) -> axum::response
     }
 }
 
-#[derive(serde::Deserialize)]
-struct AgentMemoryListQuery {
-    agent_id: String,
-}
-
-/// `GET /api/v1/agent/memory/list?agent_id=<slug>` — list the agent's own
-/// native-memory markdown files. Backs the `MemoryList` MCP tool.
+/// `GET /api/v1/agent/memory/list` — list the agent's own native-memory
+/// markdown files. Backs the `MemoryList` MCP tool.
 async fn handle_agent_memory_list(
     State(state): State<AppState>,
-    Query(q): Query<AgentMemoryListQuery>,
+    headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
-    app_api_response(app_api::memory_list_impl(&state, &q.agent_id))
+    let agent_id = match app_api_agent_slug(&state, &headers) {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    app_api_response(app_api::memory_list_impl(&state, &agent_id))
 }
 
 #[derive(serde::Deserialize)]
 struct AgentMemoryReadQuery {
-    agent_id: String,
     filename: String,
 }
 
-/// `GET /api/v1/agent/memory/read?agent_id=<slug>&filename=<f>` — read one of
-/// the agent's own memory files. Backs the `MemoryRead` MCP tool.
+/// `GET /api/v1/agent/memory/read?filename=<f>` — read one of the agent's own
+/// memory files. Backs the `MemoryRead` MCP tool.
 async fn handle_agent_memory_read(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Query(q): Query<AgentMemoryReadQuery>,
 ) -> impl IntoResponse {
-    app_api_response(app_api::memory_read_impl(&state, &q.agent_id, &q.filename))
+    let agent_id = match app_api_agent_slug(&state, &headers) {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    app_api_response(app_api::memory_read_impl(&state, &agent_id, &q.filename))
 }
 
 #[derive(serde::Deserialize)]
 struct AgentMemoryWriteRequest {
-    agent_id: String,
     filename: String,
     content: String,
 }
@@ -733,9 +779,14 @@ struct AgentMemoryWriteRequest {
 /// memory files (atomic tmp→rename). Backs the `MemoryWrite` MCP tool.
 async fn handle_agent_memory_write(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<AgentMemoryWriteRequest>,
 ) -> impl IntoResponse {
-    match app_api::memory_write_impl(&state, &req.agent_id, &req.filename, &req.content) {
+    let agent_id = match app_api_agent_slug(&state, &headers) {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    match app_api::memory_write_impl(&state, &agent_id, &req.filename, &req.content) {
         Ok(()) => (StatusCode::OK, Json(json!({ "ok": true }))).into_response(),
         Err(e) => (app_api_error_status(&e), Json(json!({ "error": e }))).into_response(),
     }
@@ -750,51 +801,45 @@ async fn handle_agent_preset_list(State(state): State<AppState>) -> impl IntoRes
 #[derive(serde::Deserialize)]
 struct AgentPresetGetQuery {
     #[serde(default)]
-    agent_id: String,
-    #[serde(default)]
     id: String,
     #[serde(default)]
     name: String,
 }
 
-/// `GET /api/v1/agent/preset/get?agent_id=<slug>&id=&name=` — fetch a preset by
-/// id or name; with neither, return the agent's own bound preset (self).
+/// `GET /api/v1/agent/preset/get?id=&name=` — fetch a preset by id or name;
+/// with neither, return the agent's own bound preset (self).
 /// Backs the `PresetGet` MCP tool.
 async fn handle_agent_preset_get(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Query(q): Query<AgentPresetGetQuery>,
 ) -> impl IntoResponse {
     if q.id.is_empty() && q.name.is_empty() {
-        if q.agent_id.is_empty() {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": "preset.get: provide id, name, or agent_id (for self)" })),
-            )
-                .into_response();
-        }
-        return app_api_response(app_api::preset_self_get_impl(&state, &q.agent_id).await);
+        let agent_id = match app_api_agent_slug(&state, &headers) {
+            Ok(id) => id,
+            Err(resp) => return resp,
+        };
+        return app_api_response(app_api::preset_self_get_impl(&state, &agent_id).await);
     }
     app_api_response(app_api::preset_get_impl(&state, &q.id, &q.name).await)
 }
 
-#[derive(serde::Deserialize)]
-struct AgentIdentityAccountsQuery {
-    agent_id: String,
-}
-
-/// `GET /api/v1/agent/identity/accounts?agent_id=<slug>` — list the agent's own
-/// linked credential accounts (masked tails only, never secrets). Backs the
+/// `GET /api/v1/agent/identity/accounts` — list the agent's own linked
+/// credential accounts (masked tails only, never secrets). Backs the
 /// `IdentityAccounts` MCP tool.
 async fn handle_agent_identity_accounts(
     State(state): State<AppState>,
-    Query(q): Query<AgentIdentityAccountsQuery>,
+    headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
-    app_api_response(app_api::identity_self_accounts_impl(&state, &q.agent_id).await)
+    let agent_id = match app_api_agent_slug(&state, &headers) {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    app_api_response(app_api::identity_self_accounts_impl(&state, &agent_id).await)
 }
 
 #[derive(serde::Deserialize)]
 struct AgentIdentityValidateRequest {
-    agent_id: String,
     account_id: String,
 }
 
@@ -803,16 +848,20 @@ struct AgentIdentityValidateRequest {
 /// secret). Backs the `IdentityValidate` MCP tool.
 async fn handle_agent_identity_validate(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<AgentIdentityValidateRequest>,
 ) -> impl IntoResponse {
+    let agent_id = match app_api_agent_slug(&state, &headers) {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
     app_api_response(
-        app_api::identity_account_validate_stored_impl(&state, &req.agent_id, &req.account_id).await,
+        app_api::identity_account_validate_stored_impl(&state, &agent_id, &req.account_id).await,
     )
 }
 
 #[derive(serde::Deserialize)]
 struct AgentIdentityLinkRequest {
-    agent_id: String,
     account_id: String,
     provider: String,
 }
@@ -823,10 +872,15 @@ struct AgentIdentityLinkRequest {
 /// side). No secret is supplied — backs the `IdentityLink` MCP tool.
 async fn handle_agent_identity_link(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<AgentIdentityLinkRequest>,
 ) -> impl IntoResponse {
+    let agent_id = match app_api_agent_slug(&state, &headers) {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
     app_api_response(
-        app_api::identity_bundle_link_impl(&state, &req.agent_id, &req.account_id, &req.provider).await,
+        app_api::identity_bundle_link_impl(&state, &agent_id, &req.account_id, &req.provider).await,
     )
 }
 

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -718,7 +718,7 @@ fn app_api_agent_slug(
 fn app_api_error_status(e: &str) -> StatusCode {
     if e.starts_with("FORBIDDEN") {
         StatusCode::FORBIDDEN
-    } else if e.contains("not found")
+    } else if (e.starts_with("memory:") && e.contains("not found"))
         || e.contains("provide ")
         || e.contains("not a regular file")
         || e.contains("too large")

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -317,6 +317,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/agent/preset/get", get(handle_agent_preset_get))
         .route("/api/v1/agent/identity/accounts", get(handle_agent_identity_accounts))
         .route("/api/v1/agent/identity/validate", post(handle_agent_identity_validate))
+        .route("/api/v1/agent/identity/link", post(handle_agent_identity_link))
         .route("/api/messaging/status", get(messaging_handlers::handle_status))
         .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
         // Persistent cron scheduler (SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2.4).
@@ -806,6 +807,26 @@ async fn handle_agent_identity_validate(
 ) -> impl IntoResponse {
     app_api_response(
         app_api::identity_account_validate_stored_impl(&state, &req.agent_id, &req.account_id).await,
+    )
+}
+
+#[derive(serde::Deserialize)]
+struct AgentIdentityLinkRequest {
+    agent_id: String,
+    account_id: String,
+    provider: String,
+}
+
+/// `POST /api/v1/agent/identity/link` — bind one of the agent's own linked
+/// accounts into its default identity bundle so it injects at next launch.
+/// The account must already be linked to this agent (ownership enforced server-
+/// side). No secret is supplied — backs the `IdentityLink` MCP tool.
+async fn handle_agent_identity_link(
+    State(state): State<AppState>,
+    Json(req): Json<AgentIdentityLinkRequest>,
+) -> impl IntoResponse {
+    app_api_response(
+        app_api::identity_bundle_link_impl(&state, &req.agent_id, &req.account_id, &req.provider).await,
     )
 }
 

--- a/scripts/test-app-api.mjs
+++ b/scripts/test-app-api.mjs
@@ -5,6 +5,7 @@ import WebSocket from "ws";
 const PORT = process.env.AGENTMUX_LOCAL_URL?.split(":").pop() ?? "61018";
 const KEY = process.env.AGENTMUX_AUTH_KEY;
 const AGENT = process.env.AGENTMUX_AGENT_ID ?? "AgentX";
+const BLOCK_ID = process.env.AGENTMUX_BLOCKID ?? "";
 const url = `ws://127.0.0.1:${PORT}/ws?authkey=${KEY}`;
 
 const ws = new WebSocket(url);
@@ -42,11 +43,12 @@ ws.on("error", (e) => { console.error("WS error:", e.message); process.exit(1); 
 
 const show = (label, v) => console.log(`${label}:`, JSON.stringify(v, null, 2));
 
-// Hit the REST surface the way agentmux-mcp does (X-AuthKey header, /api/v1/...).
+// Hit the REST surface the way agentmux-mcp does (X-AuthKey + X-Block-Id headers, /api/v1/...).
+// BLOCK_ID must be set (via AGENTMUX_BLOCKID env) for REST calls to succeed.
 async function rest(method, path, body) {
     const res = await fetch(`http://127.0.0.1:${PORT}${path}`, {
         method,
-        headers: { "X-AuthKey": KEY, "Content-Type": "application/json" },
+        headers: { "X-AuthKey": KEY, "Content-Type": "application/json", "X-Block-Id": BLOCK_ID },
         body: body ? JSON.stringify(body) : undefined,
     });
     const text = await res.text();
@@ -104,15 +106,19 @@ async function run() {
         show("unlink", await call("identity.self.unlink", { agent_id: AGENT, provider: "anthropic" }));
 
         // ---- REST path (the MCP→REST→handler chain agentmux-mcp uses) ----
+        // agent_id is server-derived from X-Block-Id; no client-supplied agent_id needed.
+        if (!BLOCK_ID) { console.log("\n⚠ AGENTMUX_BLOCKID not set — skipping REST path tests"); }
+        else {
         console.log("\n=== REST /api/v1/agent/memory/list (server-stamped agent_id) ===");
-        await rest("GET", `/api/v1/agent/memory/list?agent_id=${encodeURIComponent(AGENT)}`);
+        await rest("GET", `/api/v1/agent/memory/list`);
         console.log("\n=== REST /api/v1/agent/preset/get (self — no id/name) ===");
-        await rest("GET", `/api/v1/agent/preset/get?agent_id=${encodeURIComponent(AGENT)}`);
+        await rest("GET", `/api/v1/agent/preset/get`);
         console.log("\n=== REST /api/v1/agent/identity/accounts ===");
-        await rest("GET", `/api/v1/agent/identity/accounts?agent_id=${encodeURIComponent(AGENT)}`);
+        await rest("GET", `/api/v1/agent/identity/accounts`);
         console.log("\n=== REST memory/write → read round-trip ===");
-        await rest("POST", `/api/v1/agent/memory/write`, { agent_id: AGENT, filename: "rest-smoke.md", content: "via REST\n" });
-        await rest("GET", `/api/v1/agent/memory/read?agent_id=${encodeURIComponent(AGENT)}&filename=rest-smoke.md`);
+        await rest("POST", `/api/v1/agent/memory/write`, { filename: "rest-smoke.md", content: "via REST\n" });
+        await rest("GET", `/api/v1/agent/memory/read?filename=rest-smoke.md`);
+        }
 
         console.log("\nAll calls completed.");
         ws.close();

--- a/scripts/test-app-api.mjs
+++ b/scripts/test-app-api.mjs
@@ -1,0 +1,100 @@
+// Ad-hoc App API smoke test — exercises identity.*, preset.*, memory.* as AgentX.
+// Run: node scripts/test-app-api.mjs
+import WebSocket from "ws";
+
+const PORT = process.env.AGENTMUX_LOCAL_URL?.split(":").pop() ?? "61018";
+const KEY = process.env.AGENTMUX_AUTH_KEY;
+const AGENT = process.env.AGENTMUX_AGENT_ID ?? "AgentX";
+const url = `ws://127.0.0.1:${PORT}/ws?authkey=${KEY}`;
+
+const ws = new WebSocket(url);
+const pending = new Map();
+let n = 0;
+
+function call(command, data) {
+    const reqid = `t${++n}`;
+    return new Promise((resolve, reject) => {
+        pending.set(reqid, { resolve, reject });
+        ws.send(JSON.stringify({ wscommand: "rpc", message: { command, reqid, data } }));
+        setTimeout(() => {
+            if (pending.has(reqid)) { pending.delete(reqid); reject(new Error(`timeout: ${command}`)); }
+        }, 8000);
+    });
+}
+
+ws.on("message", (buf) => {
+    let msg;
+    try { msg = JSON.parse(buf.toString()); } catch { return; }
+    if (msg.type === "bus:registered") { console.log(`✓ registered as ${msg.agent_id}\n`); run(); return; }
+    // RPC responses arrive wrapped: { eventtype: "rpc", data: <RpcMessage> }
+    const rpc = msg.eventtype === "rpc" ? msg.data : msg;
+    const resid = rpc?.resid;
+    if (resid && pending.has(resid)) {
+        const { resolve, reject } = pending.get(resid);
+        pending.delete(resid);
+        if (rpc.error) reject(new Error(rpc.error));
+        else resolve(rpc.data);
+    }
+});
+
+ws.on("open", () => ws.send(JSON.stringify({ type: "bus:register", agent_id: AGENT })));
+ws.on("error", (e) => { console.error("WS error:", e.message); process.exit(1); });
+
+const show = (label, v) => console.log(`${label}:`, JSON.stringify(v, null, 2));
+
+async function run() {
+    try {
+        console.log("=== identity.self.accounts (before) ===");
+        show("accounts", await call("identity.self.accounts", { agent_id: AGENT }));
+
+        console.log("\n=== identity.account.upsert (dummy, validate=false) ===");
+        const up = await call("identity.account.upsert", {
+            agent_id: AGENT, provider: "anthropic", name: "AgentX test key",
+            kind: "api_key", secret: "sk-ant-test-DUMMY-0123456789", validate: false,
+        });
+        show("upsert", up);
+
+        console.log("\n=== identity.self.accounts (after) ===");
+        show("accounts", await call("identity.self.accounts", { agent_id: AGENT }));
+
+        console.log("\n=== identity.account.validate (ad-hoc, no store) ===");
+        show("validate", await call("identity.account.validate", {
+            provider: "anthropic", secret: "sk-ant-adhoc-DUMMY",
+        }));
+
+        console.log("\n=== preset.list ===");
+        show("presets", await call("preset.list", {}));
+
+        console.log("\n=== preset.self.get ===");
+        show("self-preset", await call("preset.self.get", { agent_id: AGENT }));
+
+        console.log("\n=== memory.write ===");
+        show("write", await call("memory.write", {
+            agent_id: AGENT, filename: "app-api-smoke.md",
+            content: "---\nname: app-api-smoke\n---\nWritten via App API memory.write.\n",
+        }));
+
+        console.log("\n=== memory.list ===");
+        show("list", await call("memory.list", { agent_id: AGENT }));
+
+        console.log("\n=== memory.read ===");
+        show("read", await call("memory.read", { agent_id: AGENT, filename: "app-api-smoke.md" }));
+
+        console.log("\n=== S1 negative: mismatched agent_id (expect FORBIDDEN) ===");
+        try {
+            await call("identity.self.accounts", { agent_id: "SomeoneElse" });
+            console.log("✗ NO ERROR — S1 check failed to reject!");
+        } catch (e) { console.log("✓ rejected:", e.message); }
+
+        console.log("\n=== identity.self.unlink (cleanup) ===");
+        show("unlink", await call("identity.self.unlink", { agent_id: AGENT, provider: "anthropic" }));
+
+        console.log("\nAll calls completed.");
+        ws.close();
+        process.exit(0);
+    } catch (e) {
+        console.error("\n✗ FAILED:", e.message);
+        ws.close();
+        process.exit(1);
+    }
+}

--- a/scripts/test-app-api.mjs
+++ b/scripts/test-app-api.mjs
@@ -42,6 +42,20 @@ ws.on("error", (e) => { console.error("WS error:", e.message); process.exit(1); 
 
 const show = (label, v) => console.log(`${label}:`, JSON.stringify(v, null, 2));
 
+// Hit the REST surface the way agentmux-mcp does (X-AuthKey header, /api/v1/...).
+async function rest(method, path, body) {
+    const res = await fetch(`http://127.0.0.1:${PORT}${path}`, {
+        method,
+        headers: { "X-AuthKey": KEY, "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    let parsed; try { parsed = JSON.parse(text); } catch { parsed = text; }
+    console.log(`  ${method} ${path.split("?")[0]} → ${res.status}`, JSON.stringify(parsed, null, 2));
+    if (!res.ok) throw new Error(`REST ${path} → ${res.status}`);
+    return parsed;
+}
+
 async function run() {
     try {
         console.log("=== identity.self.accounts (before) ===");
@@ -88,6 +102,17 @@ async function run() {
 
         console.log("\n=== identity.self.unlink (cleanup) ===");
         show("unlink", await call("identity.self.unlink", { agent_id: AGENT, provider: "anthropic" }));
+
+        // ---- REST path (the MCP→REST→handler chain agentmux-mcp uses) ----
+        console.log("\n=== REST /api/v1/agent/memory/list (server-stamped agent_id) ===");
+        await rest("GET", `/api/v1/agent/memory/list?agent_id=${encodeURIComponent(AGENT)}`);
+        console.log("\n=== REST /api/v1/agent/preset/get (self — no id/name) ===");
+        await rest("GET", `/api/v1/agent/preset/get?agent_id=${encodeURIComponent(AGENT)}`);
+        console.log("\n=== REST /api/v1/agent/identity/accounts ===");
+        await rest("GET", `/api/v1/agent/identity/accounts?agent_id=${encodeURIComponent(AGENT)}`);
+        console.log("\n=== REST memory/write → read round-trip ===");
+        await rest("POST", `/api/v1/agent/memory/write`, { agent_id: AGENT, filename: "rest-smoke.md", content: "via REST\n" });
+        await rest("GET", `/api/v1/agent/memory/read?agent_id=${encodeURIComponent(AGENT)}&filename=rest-smoke.md`);
 
         console.log("\nAll calls completed.");
         ws.close();

--- a/specs/SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md
+++ b/specs/SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md
@@ -1,0 +1,274 @@
+# SPEC: Agent App API — MCP is the Agent Entry Point
+
+**Date:** 2026-06-28
+**Status:** Draft
+**Author:** AgentX
+**Related:** `agentmux-mcp/src/main.rs`, `agentmux-srv/src/server/app_api.rs`, `agentmux-srv/src/server/mod.rs` (REST router), `agentmux-srv/src/server/websocket.rs`, `agentmux-srv/src/backend/rpc_types.rs`
+**Predecessor:** [`SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md`](./SPEC_AGENT_APP_API_IDENTITY_PRESETS_BRAIN_2026_06_27.md) (shipped the `identity.*` / `preset.*` / `memory.*` RPC handlers)
+
+---
+
+## 1. Problem
+
+The predecessor spec added three agent-facing namespaces to the App API —
+`identity.*`, `preset.*`, `memory.*` — gated by the **S1 security invariant**
+(`ctx.agent_id` must be non-empty and equal the request's `agent_id`). Those
+handlers shipped, are registered in `app_api.rs`, and pass an end-to-end smoke
+test (see §9).
+
+But there is a transport gap. An agent running inside a pane reaches AgentMux
+through exactly one curated surface: the **MCP tools** that `agentmux-mcp`
+advertises (`WhoAmI`, `Layout`, `SetName`, `OpenEditor`, `Shell`, `SendMessage`,
+…). The new `identity.*` / `preset.*` / `memory.*` commands have **no MCP
+binding and no REST route** — they live only on the WebSocket JSON-RPC surface
+that the *frontend* uses.
+
+The consequence: the S1-gated, explicitly *agent-facing* API has no agent-facing
+door. To exercise it today an agent must:
+
+1. Scrape `AGENTMUX_LOCAL_URL` and the auth key from its environment,
+2. Hand-write a WebSocket client,
+3. Perform the `bus:register` handshake (which is what stamps `ctx.agent_id`),
+4. Learn the `{ eventtype: "rpc", data: <RpcMessage> }` response wrapping,
+5. Frame raw `RpcMessage` envelopes.
+
+That is the verification path used in §9 — useful for testing, wrong as a
+contract. `AGENTMUX_AUTH_KEY` is also *not* a PTY env var for trust reasons
+(`internals/env-vars.md`: "Available In Pane? No"), so an agent doing the raw-WS
+dance only works because this build leaks the key into the shell; the security
+model intends agents to reach privileged surfaces **only** through `agentmux-mcp`,
+which holds the key out-of-band.
+
+## 2. Goal
+
+Establish **MCP as the canonical, and only supported, entry point** for agents to
+reach the App API — and make that true for the new namespaces by adding the
+bindings.
+
+Concretely:
+
+1. Add MCP tools for the high-value `memory.*` / `preset.*` / `identity.*`
+   operations, routed the same way every other MCP tool is: tool → REST endpoint
+   on `$AGENTMUX_LOCAL_URL` → app-API handler.
+2. Add the REST routes those tools call, and have them stamp the agent identity
+   **server-side from a trusted source** so S1 holds without trusting agent
+   input.
+3. Make the docs (`internals/agent-app-api.md`) state plainly that MCP is the
+   entry point and that the raw WebSocket transport is internal/advanced, not the
+   agent contract. (Doc audit is a follow-up task — see §10.)
+
+Non-goal: changing the RPC handlers themselves. They are correct and tested. This
+spec is purely about the *transport and entry-point* layer in front of them.
+
+## 3. Background — how an MCP tool reaches a handler today
+
+```
+Agent CLI (claude / codex / gemini / …)
+  └─ spawns agentmux-mcp (stdio server)         ← holds AGENTMUX_AUTH_KEY + AGENTMUX_AGENT_ID + AGENTMUX_BLOCKID
+       ├─ advertises a curated TOOLS array (JSON schemas)
+       └─ dispatch: match tool name → POST {AGENTMUX_LOCAL_URL}/api/v1/<route>
+                                         with header  X-AuthKey: <key>
+                                         → agentmux-srv REST handler
+                                         → app-API logic
+```
+
+Verified in `agentmux-mcp/src/main.rs`: each tool is (a) a JSON-schema entry in
+the `TOOLS` array and (b) a `match` arm that builds an `{AGENTMUX_LOCAL_URL}/api/v1/…`
+request with the `X-AuthKey` header. The MCP server is the trust boundary: it is
+spawned by AgentMux with the auth key and the agent's identity in its *own*
+environment; the agent's model output cannot forge either, because the key is not
+in the agent's PTY.
+
+This is the lever that makes server-side identity stamping safe (§5).
+
+## 4. The new App-API commands to bind
+
+All shipped in the predecessor spec; names verified against
+`agentmux-srv/src/backend/rpc_types.rs` (`COMMAND_*` constants) and the
+`register_*` handlers in `app_api.rs`.
+
+| RPC command | Request shape (App API) | Reads/Writes | Sensitivity |
+|---|---|---|---|
+| `memory.list` | `{ agent_id }` | read | low |
+| `memory.read` | `{ agent_id, filename }` | read | low |
+| `memory.write` | `{ agent_id, filename, content }` | write (agent-scoped) | low |
+| `preset.list` | `{}` | read (shared catalog) | low |
+| `preset.get` | `{ id }` or `{ name }` | read | low |
+| `preset.self.get` | `{ agent_id }` | read | low |
+| `preset.upsert` | full `Memory` object | write (guards: blank/seed/global) | medium |
+| `preset.delete` | `{ id }` | write (guards: blank/seed) | medium |
+| `identity.self.accounts` | `{ agent_id }` | read (own links) | medium |
+| `identity.account.upsert` | `{ agent_id, provider, name, kind, secret, validate, account_id? }` | write + keychain | **high (secret)** |
+| `identity.account.validate` | `{ agent_id, account_id }` or `{ provider, secret }` | read + live probe | **high (secret)** |
+| `identity.self.unlink` | `{ agent_id, provider }` | write | medium |
+
+Every command except `preset.*` reads/`identity.account.validate` ad-hoc form
+carries an `agent_id` that S1 enforces against `ctx.agent_id`.
+
+## 5. Design — server-side identity stamping (the crux)
+
+The S1 invariant requires `ctx.agent_id` to be set and to match the request's
+`agent_id`. On the WebSocket path, `bus:register` stamps `ctx.agent_id`
+(`websocket.rs`). The REST path has no such handshake, so we must decide how the
+new REST endpoints establish `ctx.agent_id`.
+
+**Decision: the REST endpoint derives the agent identity from a trusted channel,
+never from agent-supplied JSON.**
+
+Two trusted inputs are available to `agentmux-mcp` and forwarded on every call:
+
+- `AGENTMUX_BLOCKID` — the pane UUID (already used as self-context by `WhoAmI`).
+- `AGENTMUX_AGENT_ID` — the agent slug.
+
+The MCP server injects these itself; the agent's model cannot override them. The
+REST handler resolves the canonical agent slug and stamps it:
+
+```
+POST /api/v1/agent/memory/write
+  X-AuthKey: <key>
+  { "block_id": "<AGENTMUX_BLOCKID>", "filename": "...", "content": "..." }
+
+  server:
+    1. auth_middleware verifies X-AuthKey
+    2. resolve slug = instance_for_block(block_id).instance_name   ← trusted, server-side
+    3. construct RpcContext { agent_id: slug, .. }
+    4. dispatch to the existing app_api handler with request.agent_id = slug
+```
+
+Because the slug is derived server-side from `block_id` (or, equivalently, taken
+from a dedicated stamped header), the request's `agent_id` and `ctx.agent_id` are
+the *same* value by construction — S1 passes, and an agent cannot target another
+agent's records. This is **stronger** than the raw-WS path, where the client
+supplies `agent_id` in the payload.
+
+> Implementation note: `block_id → slug` resolution mirrors
+> `memory_dir_for_agent`'s lookup. Prefer `block_id` over a stamped slug header so
+> a single trusted input drives both identity and (for memory) the working-dir /
+> `CLAUDE_CONFIG_DIR` resolution.
+
+### 5.1 Secrets over REST
+
+`identity.account.upsert` / `identity.account.validate` carry an API key in the
+request body. This is acceptable on the loopback REST channel for the same reason
+the existing tools are: `127.0.0.1` only, `X-AuthKey`-gated, key never logged. But
+two rules are mandatory:
+
+- The MCP tool description must **not** instruct the agent to paste a raw key
+  inline in a way that ends up in conversation transcripts. Prefer a flow where
+  the secret is provided out-of-band (env var name reference, or the Trust Center
+  UI) — see §7 open question.
+- Responses **never echo the secret back** — only `masked_tail` (already the
+  handler's behavior). The REST layer must not add the plaintext to any response
+  or log line.
+
+## 6. MCP tool surface to add
+
+Curated, not a 1:1 of every RPC command. First wave by value and safety:
+
+### 6.1 Memory (highest value, lowest risk) — add first
+
+| MCP tool | Routes to | Params |
+|---|---|---|
+| `MemoryList` | `memory.list` | none (self) |
+| `MemoryRead` | `memory.read` | `filename` |
+| `MemoryWrite` | `memory.write` | `filename`, `content` |
+
+`agent_id` is *not* a tool parameter — it is stamped server-side (§5). This is the
+autonomous fact-storage surface Claude Code already expects; giving agents a
+first-class tool for it is the biggest immediate win.
+
+### 6.2 Presets (read-only first)
+
+| MCP tool | Routes to | Params |
+|---|---|---|
+| `PresetList` | `preset.list` | none |
+| `PresetGet` | `preset.get` / `preset.self.get` | `id?` / `name?`; no args → self |
+
+Mutating preset tools (`preset.upsert` / `preset.delete`) are **deferred** —
+see §7.
+
+### 6.3 Identity (most sensitive — gated, possibly read-only)
+
+| MCP tool | Routes to | Params | Status |
+|---|---|---|---|
+| `IdentityAccounts` | `identity.self.accounts` | none (self) | propose |
+| `IdentityValidate` | `identity.account.validate` | `account_id` (own) | propose |
+| `IdentityUpsert` | `identity.account.upsert` | provider, name, secretRef | **open — see §7** |
+| `IdentityUnlink` | `identity.self.unlink` | provider | **open — see §7** |
+
+## 7. Open questions
+
+1. **Do agents get *mutating* identity/preset tools at all, or stay read + memory-write?**
+   Options: (a) read-only identity/preset for agents, mutations human-only via
+   Trust Center; (b) full agent CRUD with the S1 guards already implemented.
+   Recommendation: ship §6.1 + §6.2 read tools first; gate §6.3 mutations behind
+   an explicit per-agent capability flag before exposing.
+
+2. **Secret-passing ergonomics for `IdentityUpsert`.** Inline key in the tool call
+   lands in the transcript. Alternatives: reference an env-var name the MCP server
+   resolves; or keep credential creation in the Trust Center UI and let agents
+   only *link* / *validate* existing accounts. Recommendation: no inline-secret
+   agent tool in the first wave.
+
+3. **REST route shape.** New `/api/v1/agent/{memory,preset,identity}/*` routes vs.
+   a single generic `/api/v1/app-api` that takes `{ command, data }` and stamps
+   identity. Recommendation: explicit named routes (consistent with existing
+   `/api/v1/*`, easier to allow-list per capability later).
+
+## 8. Implementation plan
+
+1. **REST routes** in `agentmux-srv/src/server/mod.rs` (in `authed_routes`):
+   `/api/v1/agent/memory/{list,read,write}`, `/api/v1/agent/preset/{list,get}`,
+   and (pending §7) identity routes. Each handler resolves the slug from
+   `block_id` server-side, builds `RpcContext { agent_id }`, and calls the
+   matching `app_api` handler directly (no WS round-trip).
+2. **MCP tools** in `agentmux-mcp/src/main.rs`: add the `TOOLS` JSON-schema
+   entries and `match` arms (§6.1, §6.2), each forwarding `AGENTMUX_BLOCKID` +
+   the call params with `X-AuthKey`.
+3. **No handler changes** — `app_api.rs` logic is reused as-is.
+4. **Docs audit** (§10).
+
+## 9. Validation (already performed against 0.49.8)
+
+A raw-WS smoke client (`scripts/test-app-api.mjs`) exercised all twelve commands
+end to end as agent `AgentX`:
+
+- `identity.self.accounts` empty → `identity.account.upsert` (dummy, `validate:false`)
+  created a keychain-backed account with `masked_tail` → re-list showed the link.
+- `identity.account.validate` ad-hoc form live-probed Anthropic and correctly
+  returned `invalid` (401) for a dummy key.
+- `preset.list` returned the three seed presets + blank singleton; `preset.self.get`
+  for an unbound agent returned the blank singleton via the two-step fallback.
+- `memory.write` → `memory.list` → `memory.read` round-tripped, and the listing
+  resolved to the agent's **isolated** `CLAUDE_CONFIG_DIR` memory dir (it showed
+  the agent's real memory files), confirming the path-isolation fix.
+- S1 negative: a request with a mismatched `agent_id` was rejected with
+  `FORBIDDEN: agent_id mismatch`.
+
+The handlers are correct; this spec adds the *supported* way to call them.
+
+## 10. Docs follow-up (separate task)
+
+`agentmux-docs/src/content/docs/internals/agent-app-api.md` currently states that
+identity/memory are "driven by the frontend and internal tooling over the
+authenticated WebSocket transport." After §8 lands, audit that page to:
+
+- Add `memory.*` / `preset.*` / `identity.*` to the curated MCP-tool section.
+- State explicitly: **MCP is the agent entry point**; the raw WebSocket JSON-RPC
+  transport is internal/advanced and not the agent contract.
+- Add the new `/api/v1/agent/*` routes to the REST table with their MCP
+  equivalents.
+- Note server-side identity stamping in the Permission boundary section (agents
+  cannot target another agent's records because the slug is server-derived).
+
+## 11. Security summary
+
+- **S1 preserved and strengthened:** identity is stamped server-side from
+  `block_id`; agents cannot forge `agent_id`.
+- **Trust boundary unchanged:** only `agentmux-mcp` holds the auth key; agents
+  reach privileged surfaces solely through it. The raw-WS path is not a supported
+  agent contract.
+- **Secrets:** never echoed (only `masked_tail`); no inline-secret agent tool in
+  the first wave (§7.2).
+- **Capability gating:** mutating identity/preset tools deferred behind an
+  explicit per-agent flag (§7.1).


### PR DESCRIPTION
## Summary

Second-wave identity write tool, building on #1840 (`feat(app-api): MCP bindings`). **Merge after #1840.**

**The gap**: `identity.account.upsert` links an account via `db_agent_identity_links` (legacy), which `IdentityAccounts` reads. But the resolver at spawn reads `db_identity_bundles`/`db_identity_bindings`. An agent that owns an account via the App API never gets it injected at launch.

**The fix**: `IdentityLink` bridges the two systems — given an `account_id` (from `IdentityAccounts`) and a `provider`, it:
1. Verifies ownership (S1 — account must be in the agent's legacy links)
2. Finds or creates `bundle-<agent_id>-default`
3. Calls `bundle_identity_bind` so the resolver picks it up at next launch

**No secret in the tool call or transcript** — only `account_id` + `provider`. Closes the §7.2 concern from the spec.

### Files changed
- `agentmux-mcp/src/main.rs` — `IDENTITY_LINK_TOOL` schema + match arm → `POST /api/v1/agent/identity/link`
- `agentmux-srv/src/server/mod.rs` — route + `handle_agent_identity_link`
- `agentmux-srv/src/server/app_api.rs` — `identity_bundle_link_impl`

`cargo build -p agentmux-srv -p agentmux-mcp` — clean.

<!-- agentmux:agent_id=agenty -->