### PR TITLE
feat(srv): Pillar 3 — commit-aware agent admission control

### DIFF
--- a/.changesets/1782818885-feat-srv-commit-aware-agent-admission-refuse-new-agent-spawn-u9nt.md
+++ b/.changesets/1782818885-feat-srv-commit-aware-agent-admission-refuse-new-agent-spawn-u9nt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): commit-aware agent admission — refuse new agent spawn under low system commit (Pillar 3)

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -58,6 +58,44 @@ pub enum AgentError {
     InvalidRef(String),
     #[error("agent runner: spawn failed: {0}")]
     Spawn(String),
+    /// System commit headroom is below the reserve required to safely start
+    /// another agent. Refusing here prevents a new `claude.exe` from tipping the
+    /// system commit charge into its limit, where a failed allocation aborts the
+    /// CEF host (Chromium OOM, `0xE0000008`). Callers should surface a transient
+    /// "memory full — try again when memory frees" rather than a hard failure.
+    /// Pillar 3 (`SPEC_WIN10_PAGEFILE_OOM_CRASH` / `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR`).
+    #[error("agent runner: insufficient memory to start agent ({avail_gb:.1} GB commit free, need {reserve_gb:.1} GB headroom)")]
+    CommitPressure { avail_gb: f64, reserve_gb: f64 },
+}
+
+/// Minimum free system commit (GB) required to admit a new agent spawn. Below
+/// this, launching another `claude.exe` (~0.5–0.7 GB private commit plus tooling
+/// overhead) risks pushing the system commit charge to its limit, where a failed
+/// allocation aborts the CEF host (Chromium OOM). Conservative floor; tune from
+/// measured per-agent `PrivateUsage`. Overridable via
+/// `AGENTMUX_AGENT_COMMIT_RESERVE_GB` (e.g. 0 disables the gate on a host with a
+/// huge page file; higher on a constrained box).
+const DEFAULT_AGENT_COMMIT_RESERVE_GB: f64 = 2.0;
+
+fn agent_commit_reserve_gb() -> f64 {
+    std::env::var("AGENTMUX_AGENT_COMMIT_RESERVE_GB")
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|v| *v >= 0.0)
+        .unwrap_or(DEFAULT_AGENT_COMMIT_RESERVE_GB)
+}
+
+/// Pure admission decision: is there enough free system commit to spawn another
+/// agent? `None` available (non-Windows, or the read failed) ⇒ admit — there's no
+/// cheap commit limit to enforce. Strict `<` so a value exactly at the reserve is
+/// admitted. CEF-free / OS-free so it is fully unit-testable.
+fn admit_spawn(avail_commit_gb: Option<f64>, reserve_gb: f64) -> Result<(), AgentError> {
+    match avail_commit_gb {
+        Some(avail) if avail < reserve_gb => {
+            Err(AgentError::CommitPressure { avail_gb: avail, reserve_gb })
+        }
+        _ => Ok(()),
+    }
 }
 
 /// Spawn `claude --print --output-format=stream-json` per the given
@@ -80,6 +118,15 @@ pub async fn run_agent(
     task: AgentTask,
     tx: mpsc::UnboundedSender<AgentEvent>,
 ) -> Result<AgentRunHandle, AgentError> {
+    // Pillar 3 — commit-aware admission control. Refuse to spawn another agent
+    // when system commit headroom is below the reserve, rather than letting the
+    // new claude.exe push the box into an OOM abort. Gated here (the production
+    // entry) not in `run_agent_with_bin`, so the unit tests that inject a binary
+    // path bypass the gate and stay deterministic across hosts.
+    admit_spawn(
+        crate::backend::sysinfo::available_commit_gb(),
+        agent_commit_reserve_gb(),
+    )?;
     let bin = std::env::var(ENV_CLAUDE_BIN)
         .unwrap_or_else(|_| DEFAULT_CLAUDE_BIN.to_string());
     run_agent_with_bin(&bin, agent_ref, task, tx).await
@@ -392,6 +439,40 @@ mod tests {
 "#
         ));
         s.into_bytes()
+    }
+
+    // ── Pillar 3 — commit-aware admission control (pure decision) ──────────────
+
+    #[test]
+    fn admit_spawn_allows_when_headroom_at_or_above_reserve() {
+        assert!(admit_spawn(Some(8.0), 2.0).is_ok());
+        // Exactly at the reserve admits (strict `<`).
+        assert!(admit_spawn(Some(2.0), 2.0).is_ok());
+    }
+
+    #[test]
+    fn admit_spawn_refuses_below_reserve() {
+        match admit_spawn(Some(1.0), 2.0) {
+            Err(AgentError::CommitPressure { avail_gb, reserve_gb }) => {
+                assert_eq!(avail_gb, 1.0);
+                assert_eq!(reserve_gb, 2.0);
+            }
+            other => panic!("expected CommitPressure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn admit_spawn_admits_when_commit_unknown() {
+        // None (non-Windows / read failure) ⇒ no cheap limit to enforce ⇒ admit.
+        assert!(admit_spawn(None, 2.0).is_ok());
+    }
+
+    #[test]
+    fn agent_commit_reserve_defaults_when_env_absent_or_invalid() {
+        // Not asserting on the env var (tests share a process); just verify the
+        // default is the documented conservative floor and is non-negative.
+        assert_eq!(DEFAULT_AGENT_COMMIT_RESERVE_GB, 2.0);
+        assert!(DEFAULT_AGENT_COMMIT_RESERVE_GB >= 0.0);
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -70,6 +70,24 @@ fn get_commit_data(_values: &mut HashMap<String, f64>) {
     }
 }
 
+/// Available system commit headroom in GB (Windows: `GlobalMemoryStatusEx`
+/// → `ullAvailPageFile`). Returns `None` where there's no cheap commit figure
+/// (non-Windows) or the read fails — callers treat `None` as "no limit / admit".
+/// This is the admission-control signal for Pillar 3 (commit-aware agent spawn):
+/// see `agents::runner::admit_spawn` and `SPEC_WIN10_PAGEFILE_OOM_CRASH`.
+pub fn available_commit_gb() -> Option<f64> {
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+        let mut mem: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+        mem.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+        if unsafe { GlobalMemoryStatusEx(&mut mem) } != 0 {
+            return Some(mem.ullAvailPageFile as f64 / BYTES_PER_GB);
+        }
+    }
+    None
+}
+
 /// Network I/O tracking state for rate calculations.
 struct NetState {
     prev_sent: u64,

--- a/agentmux-srv/src/drone/executor/blocks/agent.rs
+++ b/agentmux-srv/src/drone/executor/blocks/agent.rs
@@ -96,6 +96,9 @@ pub async fn run(node: &FlowNode, scope: &ExecutionScope) -> Result<Value, Strin
     let handle = run_agent(agent_ref, task, tx).await.map_err(|e| match e {
         AgentError::Spawn(msg) => format!("agent block: spawn failed: {msg}"),
         AgentError::InvalidRef(msg) => format!("agent block: invalid agent ref: {msg}"),
+        AgentError::CommitPressure { avail_gb, reserve_gb } => format!(
+            "agent block: memory full — {avail_gb:.1} GB commit free, need {reserve_gb:.1} GB; try again when memory frees"
+        ),
     })?;
 
     // Drain the event channel concurrently so the runner's sender


### PR DESCRIPTION
## Summary

**Pillar 3** of the lifecycle/OOM refactor (#1847). Attacks the OOM root cause at the source: gate new agent (`claude.exe`) spawns on **available system commit before launching**, instead of letting an over-spawn push the box into the commit-limit OOM abort (Chromium `0xE0000008`) that the gated-recovery / supervisor work keeps cleaning up *after the fact*.

Independent of Pillar 2 and fully unit-testable (pure decision, no CEF/deadlock surface).

## Changes
- **`sysinfo::available_commit_gb()`** — reusable read of Windows commit headroom (`GlobalMemoryStatusEx.ullAvailPageFile`). `None` off-Windows / on read failure; callers treat `None` as "no limit / admit".
- **`runner::admit_spawn(avail, reserve)`** — pure decision (strict `<`; `None` ⇒ admit). New `AgentError::CommitPressure { avail_gb, reserve_gb }`. Reserve `DEFAULT_AGENT_COMMIT_RESERVE_GB = 2.0`, overridable via `AGENTMUX_AGENT_COMMIT_RESERVE_GB` (0 disables; higher on constrained hosts).
- Gated in the **public `run_agent`** (production entry, e.g. the drone agent block) — the internal `run_agent_with_bin` test path stays **ungated and deterministic** across hosts.
- Drone agent block surfaces `CommitPressure` as a transient **"memory full — try again when memory frees"** message instead of a hard failure.

## Tests
`admit_spawn` allow / refuse / unknown + reserve default. Full runner suite **15 passed, 0 failed** (the real-`claude` e2e is `ignored` by default, so the new gate doesn't perturb the suite).

## Sizing note
Reserve defaults to a conservative 2 GB. The 6/26 analysis used 12 GB sized off an inflated 10.5 GB/agent figure (that was `VirtualMemorySize64`, not commit); real per-agent **private** commit is ~0.5–0.7 GB (Event 2004 data), so 2 GB headroom is a safer, less-blocking floor. Tunable via env.

## Follow-ons (documented, not in this PR)
- Queue-and-drain instead of refuse (hold the turn, retry as commit frees).
- Per-agent working-set cap with kill-and-reproject.
- Frontend "memory full — waiting" badge on the affected pane.

Refs #942, #1847. Part of the lifecycle/OOM refactor program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)