### PR TITLE
fix(windows): repair Windows build break in GetWindowPositionTask (#1823 regression)

### DIFF
--- a/.changesets/1782822877-fix-windows-cfg-gate-state-windows-fallback-in-getwindowposi-835a.md
+++ b/.changesets/1782822877-fix-windows-cfg-gate-state-windows-fallback-in-getwindowposi-835a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(windows): cfg-gate state.windows fallback in GetWindowPositionTask — fixes Windows build break from #1823

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -1570,11 +1570,23 @@ wrap_task! {
             let pos = if let Some(w) = get_window_on_ui(&self.state, &self.label) {
                 let b = w.bounds();
                 Some((b.x, b.y))
-            } else if let Some(w) = self.state.windows.lock().get(&self.label) {
-                let b = w.bounds();
-                Some((b.x, b.y))
             } else {
-                None
+                // Fall back to `state.windows` on Linux/macOS, where the Views
+                // BrowserView loses its Window reference post-page-load. That map
+                // is `cfg(not(windows))`-only (Windows uses native HWND lookup and
+                // never populates it), so on Windows the primary path above is the
+                // only source — gate the fallback to keep the Windows build green.
+                #[cfg(not(target_os = "windows"))]
+                {
+                    self.state.windows.lock().get(&self.label).map(|w| {
+                        let b = w.bounds();
+                        (b.x, b.y)
+                    })
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    None
+                }
             };
             // Capacity-1, freshly created per call → try_send never blocks
             // the UI thread.


### PR DESCRIPTION
## Summary

**Windows build is broken on `main`.** A post-merge smoke test (`cargo check --workspace`) caught it:

```
error[E0609]: no field `windows` on type `Arc<AppState>`  → agentmux-cef/src/ui_tasks.rs:1573
error[E0282]: type annotations needed                      → ui_tasks.rs:1574
```

`AppState.windows` is `#[cfg(not(target_os = "windows"))]` (Windows resolves windows via native HWND lookup and never populates that map). **#1823** ("floating pane drag broken on Linux post-tearoff", commit `10e4e422`) added an **unconditional** `self.state.windows.lock()` fallback in `GetWindowPositionTask::execute`, which doesn't compile on Windows. That PR's CI ran on macOS/Linux, so the Windows break slipped through. This affects `agentmux-cef` **lib + lib test** — the host won't build on Windows.

## Fix
cfg-gate the fallback: on Linux/macOS keep the `state.windows` lookup (where the Views `BrowserView` loses its Window ref post-page-load); on Windows the primary `get_window_on_ui` (native) path is authoritative, so the `else` yields `None`.

## Verification
- `cargo check -p agentmux-cef --tests` → **Finished, 0 errors** (was 2).
- `cargo check --workspace --tests` → **Finished, 0 errors** — whole workspace green on Windows.

The other `state.windows` uses (`app.rs`, `creation_views.rs`) are already correctly cfg-gated — this was the only unguarded one.

Found while smoke-testing `main` after a batch of merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)