### PR TITLE
fix(agent-pane): watchdog recovers a stalled rate-limited turn

### DIFF
--- a/.changesets/1782825381-fix-agent-pane-watchdog-recovers-a-stalled-rate-limited-turn-91lt.md
+++ b/.changesets/1782825381-fix-agent-pane-watchdog-recovers-a-stalled-rate-limited-turn-91lt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): watchdog recovers a stalled rate-limited turn past retryAfterMs + liveness window

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -505,7 +505,10 @@ describe("agent-pane-state reducer", () => {
             expect(r.events[0]).toMatchObject({ type: "stream-stuck" });
         });
 
-        it("StreamWatchdogTick does NOT recover while rate-limited (waitingReason set)", () => {
+        it("StreamWatchdogTick does NOT recover a rate-limited turn within retryAfterMs + LIVENESS window", () => {
+            // A genuine 429 backoff re-emits provider_waiting within retryAfterMs,
+            // so the recovery threshold is retryAfterMs + LIVENESS_RECOVERY_MS. A
+            // tick past LIVENESS alone (but short of the sum) must NOT recover.
             const base = streaming(1_000);
             const s0 = update(base, {
                 type: "ProviderWaiting",
@@ -515,10 +518,50 @@ describe("agent-pane-state reducer", () => {
             }).state;
             const phase = s0.turnPhase as Extract<TurnPhase, { kind: "Streaming" }>;
             expect(phase.waitingReason).toBe("rate_limited");
+            // idle = LIVENESS + 5s, still < retryAfterMs(30s) + LIVENESS.
             const tick = (s0.lastEventMs ?? 2_000) + LIVENESS_RECOVERY_MS + 5_000;
             const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
             expect(r.state.turnPhase.kind).toBe("Streaming");
             expect(r.events[0]).toMatchObject({ type: "stream-stuck" });
+        });
+
+        it("StreamWatchdogTick recovers a stalled rate-limited turn past retryAfterMs + LIVENESS window", () => {
+            const base = streaming(1_000);
+            const retryAfterMs = 30_000;
+            const s0 = update(base, {
+                type: "ProviderWaiting",
+                reason: "rate_limited",
+                retryAfterMs,
+                at: 2_000,
+            }).state;
+            // idle past retryAfterMs + LIVENESS → the retry loop stalled (no
+            // follow-up provider_waiting / token / session_end); recover to Idle.
+            const tick = (s0.lastEventMs ?? 2_000) + retryAfterMs + LIVENESS_RECOVERY_MS + 1_000;
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(isWorking(r.state)).toBe(false);
+            expect(r.events[0]).toMatchObject({
+                type: "working-recovered",
+                thresholdMs: retryAfterMs + LIVENESS_RECOVERY_MS,
+            });
+        });
+
+        it("StreamWatchdogTick recovers a stalled rate-limited turn with null retryAfterMs at the LIVENESS window", () => {
+            const base = streaming(1_000);
+            const s0 = update(base, {
+                type: "ProviderWaiting",
+                reason: "rate_limited",
+                retryAfterMs: null,
+                at: 2_000,
+            }).state;
+            // null retryAfterMs → threshold falls back to LIVENESS_RECOVERY_MS.
+            const tick = (s0.lastEventMs ?? 2_000) + LIVENESS_RECOVERY_MS + 1_000;
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.events[0]).toMatchObject({
+                type: "working-recovered",
+                thresholdMs: LIVENESS_RECOVERY_MS,
+            });
         });
 
         it("ToolStart bumps lastEventMs (resets watchdog clock)", () => {

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -17,7 +17,8 @@
  *   5. StreamFlushObserved is a no-op when the stream is unsubscribed.
  *   6. StreamWatchdogTick is a no-op when the stream is unsubscribed or
  *      lastEventMs is null (no events seen yet); past LIVENESS_RECOVERY_MS it
- *      force-recovers a hung Streaming turn (no tool, not rate-limited) to Idle.
+ *      force-recovers a hung Streaming turn (no tool active) to Idle — and for a
+ *      stalled rate-limit wait, past retryAfterMs + LIVENESS_RECOVERY_MS.
  *   7. Init lifecycle transitions are one-way: InitStart / InitReady /
  *      InitFailed are no-ops once the pane has reached a terminal init
  *      state (InitReady / InitFailed). Re-entering pending requires a
@@ -266,40 +267,54 @@ export function update(
                 return { state, events: [] };
             }
             // Liveness recovery (SPEC_WORKING_STATE_LIVENESS_MODEL_2026_06_29).
-            // A `Streaming` turn idle past the longer LIVENESS_RECOVERY_MS — with
-            // no tool running and not rate-limited — is hung: its terminal
-            // `session_end` was never observed. For persistent agents no
-            // `ControllerStatus: done` will ever arrive to clear it (the process
-            // doesn't exit between turns), so the watchdog itself transitions out
-            // of "Working". Land in `Idle` (turn abandoned) — NOT a synthetic
-            // `Done.completed`, which would feed false stats to session digests.
-            // Guarded to Streaming-with-no-tool-and-not-waiting so a running tool
-            // or a 429 backoff (both of which keep `lastEventMs` fresh anyway) can
-            // never be mistaken for a hang. Interrupting/Submitting are left to
-            // their own bounded timers (INTERRUPT_TIMEOUT_MS / SUBMIT_TIMEOUT_MS).
+            // A `Streaming` turn that goes idle too long with no tool running is
+            // hung: its terminal `session_end` was never observed. For persistent
+            // agents no `ControllerStatus: done` will ever arrive to clear it (the
+            // process doesn't exit between turns), so the watchdog itself
+            // transitions out of "Working". Land in `Idle` (turn abandoned) — NOT
+            // a synthetic `Done.completed`, which would feed false stats to session
+            // digests. If real activity arrives after recovery, `bumpEvent`
+            // re-promotes Idle → Streaming, so a late recovery self-corrects.
+            //
+            // Threshold depends on the wait state:
+            //  - normal stall → LIVENESS_RECOVERY_MS (a running tool keeps
+            //    `lastEventMs` fresh, so an active tool never reaches it).
+            //  - rate-limit stall → retryAfterMs + LIVENESS_RECOVERY_MS. A genuine
+            //    429 backoff re-emits `provider_waiting` within `retryAfterMs`
+            //    (refreshing `lastEventMs`), so it only accumulates this much idle
+            //    if the retry loop itself stalled — the Claude CLI emitted one
+            //    `rate_limit_event` then went silent with no follow-up event,
+            //    `session_end`, or process exit. Waiting out the advertised retry
+            //    window PLUS the liveness window guarantees a long-but-live backoff
+            //    is never mistaken for a hang. (Pre-fix, rate-limited turns were
+            //    excluded from recovery entirely — see
+            //    docs/retro/retro-busy-animation-stuck-on-429-2026-06-24.md.)
+            // Interrupting/Submitting are left to their own bounded timers
+            // (INTERRUPT_TIMEOUT_MS / SUBMIT_TIMEOUT_MS).
             const phase = state.turnPhase;
-            if (
-                phase.kind === "Streaming" &&
-                phase.toolsActive === 0 &&
-                phase.waitingReason === undefined &&
-                idleSinceMs >= LIVENESS_RECOVERY_MS
-            ) {
-                return {
-                    state: {
-                        ...state,
-                        currentTool: null,
-                        currentToolArg: null,
-                        turnTokens: null,
-                        turnPhase: { kind: "Idle" },
-                    },
-                    events: [
-                        {
-                            type: "working-recovered",
-                            idleSinceMs,
-                            thresholdMs: LIVENESS_RECOVERY_MS,
+            if (phase.kind === "Streaming" && phase.toolsActive === 0) {
+                const recoverThresholdMs =
+                    phase.waitingReason === "rate_limited"
+                        ? (phase.retryAfterMs ?? 0) + LIVENESS_RECOVERY_MS
+                        : LIVENESS_RECOVERY_MS;
+                if (idleSinceMs >= recoverThresholdMs) {
+                    return {
+                        state: {
+                            ...state,
+                            currentTool: null,
+                            currentToolArg: null,
+                            turnTokens: null,
+                            turnPhase: { kind: "Idle" },
                         },
-                    ],
-                };
+                        events: [
+                            {
+                                type: "working-recovered",
+                                idleSinceMs,
+                                thresholdMs: recoverThresholdMs,
+                            },
+                        ],
+                    };
+                }
             }
             return {
                 state,


### PR DESCRIPTION
## Summary

Follow-up to the liveness watchdog (#1842). That watchdog force-recovers a hung `Streaming` turn to `Idle` past `LIVENESS_RECOVERY_MS`, but it **excluded any turn with `waitingReason !== undefined`** — so a *stalled* rate-limit wait (the "Rate limited — retrying…" banner) had **no recovery path at all**. It's the one stuck-"Working" class the liveness fix deliberately couldn't reach.

Surfaced while debugging my own pane stuck in "Rate limited — retrying…", then verified against the codebase and a pre-existing retro.

## Root cause (verified)

Per `docs/retro/retro-busy-animation-stuck-on-429-2026-06-24.md` + current code:
- Claude CLI emits a `rate_limit_event` **per backoff** → `claude-translator.ts` → `provider_waiting` → reducer sets `waitingReason: "rate_limited"` and refreshes `lastEventMs`.
- A **genuine** backoff re-emits within `retryAfterMs`, so it never accumulates much idle.
- A **stalled** retry loop (persistent CLI emits one `rate_limit_event` then goes silent — no follow-up event, no `session_end`, no process exit) leaves the flag set forever, and `reducer.ts` `StreamWatchdogTick` guarded `waitingReason === undefined`, so it never recovered.

## Fix

Recover a rate-limited `Streaming` turn too, but key the threshold off the advertised retry window:

```
recoverThreshold = waitingReason === "rate_limited"
    ? (retryAfterMs ?? 0) + LIVENESS_RECOVERY_MS
    : LIVENESS_RECOVERY_MS
```

A long-but-live backoff is **provably** never mistaken for a hang (it refreshes `lastEventMs` within `retryAfterMs`). Recovers to `Idle` (not synthetic `Done`); a late real event re-promotes via `bumpEvent`, so a late recovery self-corrects.

## Test plan
- [x] within `retryAfterMs + LIVENESS` → does NOT recover (still `stream-stuck`)
- [x] past `retryAfterMs + LIVENESS` → recovers to `Idle` + `working-recovered`
- [x] `null` retryAfterMs → falls back to flat `LIVENESS_RECOVERY_MS`
- [x] 125 reducer tests pass; `tsc --noEmit` clean
- [ ] field-confirm a persistent agent recovers from a stalled 429 within the window

<!-- agentmux:agent_id=agentx -->