### PR TITLE
fix(editor): restore preview/source toggle, remove split-screen default

### DIFF
--- a/.changesets/1782825787-fix-editor-restore-preview-source-toggle-remove-split-screen-gvyv.md
+++ b/.changesets/1782825787-fix-editor-restore-preview-source-toggle-remove-split-screen-gvyv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(editor): restore preview/source toggle, remove split-screen default

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1333,11 +1333,6 @@ fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, String> {
                 meta.insert("editor:tree_expanded".to_string(), json!(false));
             }
 
-            // Markdown files default to preview-only (source editor hidden).
-            // Agents open .md files to surface documentation, not to edit.
-            if is_markdown {
-                meta.insert("editor:source_hidden".to_string(), json!(true));
-            }
         }
         "term" => {
             meta.insert("view".to_string(), json!("term"));

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -188,6 +188,7 @@ export class EditorViewModel implements ViewModel {
                 if (ev.type === "TabClosed") {
                     this._contentByTab.delete(ev.tabId);
                     this._encodingByTab.delete(ev.tabId);
+                    this._tabModes.delete(ev.tabId);
                 }
                 for (const sub of this._eventSubscribers) sub(ev);
             }

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -39,10 +39,10 @@ import { FileTreeModel } from "./file-tree-model";
 const META_TREE_EXPANDED = "editor:tree_expanded";
 const META_SHOW_HIDDEN = "editor:show_hidden";
 const META_TREE_WIDTH = "editor:tree_width";
-const META_PREVIEW_OPEN = "editor:preview_open";
 const META_PREVIEW_HEIGHT = "editor:preview_height";
-const META_SOURCE_HIDDEN = "editor:source_hidden";
 const META_LEGACY_FILE = "file";
+
+export type EditorMode = "preview" | "source" | "split";
 const META_SCRATCH = "editor:scratch";
 const TREE_WIDTH_DEFAULT = 240;
 const TREE_WIDTH_MIN = 150;
@@ -139,15 +139,13 @@ export class EditorViewModel implements ViewModel {
     private _treeWidth = createSignal<number>(TREE_WIDTH_DEFAULT);
     treeWidthAtom: Accessor<number> = this._treeWidth[0];
 
-    private _previewOpen = createSignal<boolean>(true);
-    previewOpenAtom: Accessor<boolean> = this._previewOpen[0];
-
     private _previewHeight = createSignal<number>(PREVIEW_HEIGHT_DEFAULT);
     previewHeightAtom: Accessor<number> = this._previewHeight[0];
 
-    /** When true the CodeMirror editor is hidden and the preview fills the full pane. */
-    private _sourceHidden = createSignal<boolean>(false);
-    sourceHiddenAtom: Accessor<boolean> = this._sourceHidden[0];
+    // Per-tab editor mode: "preview" | "source" | "split".
+    // Not persisted — tabs return to their language-appropriate default on reopen.
+    private _tabModes = new Map<string, EditorMode>();
+    private _tabModesVersion = createSignal<number>(0);
 
     treeModel = new FileTreeModel();
 
@@ -297,12 +295,6 @@ export class EditorViewModel implements ViewModel {
         const persistedWidth = meta?.[META_TREE_WIDTH];
         if (typeof persistedWidth === "number") {
             this._treeWidth[1](clampTreeWidth(persistedWidth));
-        }
-        if (meta?.[META_PREVIEW_OPEN] === false) {
-            this._previewOpen[1](false);
-        }
-        if (meta?.[META_SOURCE_HIDDEN] === true) {
-            this._sourceHidden[1](true);
         }
         const persistedPreviewH = meta?.[META_PREVIEW_HEIGHT];
         if (typeof persistedPreviewH === "number") {
@@ -843,21 +835,24 @@ export class EditorViewModel implements ViewModel {
         await this.persistMeta({ [META_TREE_WIDTH]: this._treeWidth[0]() });
     }
 
-    async togglePreview(): Promise<void> {
-        const next = !this._previewOpen[0]();
-        this._previewOpen[1](next);
-        await this.persistMeta({ [META_PREVIEW_OPEN]: next });
+    editorMode(): EditorMode {
+        void this._tabModesVersion[0](); // reactive dependency
+        const tabId = this.activeIdAtom();
+        if (!tabId) return "source";
+        const stored = this._tabModes.get(tabId);
+        if (stored !== undefined) return stored;
+        return this.activeTabAtom()?.language === "markdown" ? "preview" : "source";
     }
 
-    async toggleSourceHidden(): Promise<void> {
-        const next = !this._sourceHidden[0]();
-        this._sourceHidden[1](next);
-        if (!next && !this._previewOpen[0]()) {
-            this._previewOpen[1](true);
-            await this.persistMeta({ [META_SOURCE_HIDDEN]: next, [META_PREVIEW_OPEN]: true });
-        } else {
-            await this.persistMeta({ [META_SOURCE_HIDDEN]: next });
-        }
+    setEditorMode(mode: EditorMode): void {
+        const tabId = this.activeIdAtom();
+        if (!tabId) return;
+        this._tabModes.set(tabId, mode);
+        this._tabModesVersion[1]((v) => v + 1);
+    }
+
+    toggleEditorMode(): void {
+        this.setEditorMode(this.editorMode() === "preview" ? "source" : "preview");
     }
 
     setPreviewHeight(height: number): void {

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -562,8 +562,43 @@
     }
 }
 
+// ── Markdown mode toolbar ─────────────────────────────────────────────
+// Segmented Preview | Source | Split toggle, shown only for .md tabs.
+
+.editor-mode-toolbar {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 1px;
+    padding: 3px 8px;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--secondary-bg-color, var(--block-bg-color));
+}
+
+.editor-mode-btn {
+    padding: 1px 8px;
+    font-size: 11px;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+    user-select: none;
+
+    &.active {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.1));
+        color: var(--main-text-color);
+    }
+
+    &:hover:not(.active) {
+        color: var(--main-text-color);
+    }
+}
+
 // ── Markdown live preview panel ───────────────────────────────────────
-// Split layout: CodeMirror on top (flex: 1), drag handle, preview below.
+// preview mode: CodeMirror hidden, preview pane fills full height.
+// source mode:  CodeMirror fills full height, no preview pane.
+// split mode:   CodeMirror on top (flex: 1), drag handle, preview below.
 
 .editor-body-wrap {
     flex: 1 1 0;
@@ -589,62 +624,11 @@
 }
 
 .editor-preview-pane {
-    flex: 0 0 auto;
     display: flex;
     flex-direction: column;
     border-top: 1px solid var(--border-color);
-    min-height: 28px;
-
-    &--collapsed {
-        height: 28px !important;
-    }
-}
-
-.editor-preview-header {
-    flex: 0 0 28px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 8px;
-    background: var(--panel-bg-color, var(--block-bg-color));
-    border-bottom: 1px solid var(--border-color);
-    user-select: none;
-}
-
-.editor-preview-header-label {
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--main-text-color);
-    opacity: 0.7;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.editor-preview-header-actions {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-}
-
-.editor-preview-chevron,
-.editor-preview-source-toggle {
-    background: none;
-    border: none;
-    color: var(--main-text-color);
-    opacity: 0.7;
-    cursor: pointer;
-    padding: 2px 4px;
-    font-size: 10px;
-
-    &:hover {
-        opacity: 1;
-    }
-}
-
-.editor-preview-source-toggle {
-    font-family: var(--fixed-font, monospace);
-    font-size: 9px;
-    letter-spacing: -0.02em;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .editor-preview-content {

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -140,24 +140,18 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
             // there's nothing editable to search. See
             // docs/specs/SPEC_EDITOR_AND_APP_FIND_2026_06_17.md.
             if (!ev.shiftKey && (ev.key === "f" || ev.key === "F")) {
-                if (!cmView || model.sourceHiddenAtom()) return;
+                if (!cmView || model.editorMode() === "preview") return;
                 ev.preventDefault();
                 ev.stopPropagation();
                 openSearchPanel(cmView);
                 return;
             }
-            // Mod-Shift-V: cycle through preview modes.
-            // In preview-only (sourceHidden) → exit to split view.
-            // In split or source-only → toggle the split panel.
+            // Mod-Shift-V: toggle between preview and source modes.
             if (ev.shiftKey && (ev.key === "v" || ev.key === "V")) {
                 if (!isMarkdown()) return;
                 ev.preventDefault();
                 ev.stopPropagation();
-                if (model.sourceHiddenAtom()) {
-                    void model.toggleSourceHidden();
-                } else {
-                    void model.togglePreview();
-                }
+                model.toggleEditorMode();
             }
         };
         rootRef.addEventListener("keydown", handleEditorKeys, { capture: true });
@@ -749,6 +743,32 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                     />
                 </Show>
 
+                <Show when={isMarkdown() && model.tabsAtom().length > 0}>
+                    <div class="editor-mode-toolbar" role="group" aria-label="View mode">
+                        <button
+                            type="button"
+                            class="editor-mode-btn"
+                            classList={{ active: model.editorMode() === "preview" }}
+                            onClick={() => model.setEditorMode("preview")}
+                            title="Rendered preview (Mod+Shift+V)"
+                        >Preview</button>
+                        <button
+                            type="button"
+                            class="editor-mode-btn"
+                            classList={{ active: model.editorMode() === "source" }}
+                            onClick={() => model.setEditorMode("source")}
+                            title="Source editor"
+                        >Source</button>
+                        <button
+                            type="button"
+                            class="editor-mode-btn"
+                            classList={{ active: model.editorMode() === "split" }}
+                            onClick={() => model.setEditorMode("split")}
+                            title="Split view"
+                        >Split</button>
+                    </div>
+                </Show>
+
                 <Show when={model.loadingAtom()}>
                     <div class="editor-loading">Loading...</div>
                 </Show>
@@ -844,65 +864,29 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
                         <div
                             class="editor-codemirror"
                             ref={setContainerRef}
-                            style={{ display: (model.sourceHiddenAtom() && isMarkdown()) ? "none" : undefined }}
+                            style={{
+                                display: isMarkdown() && model.editorMode() === "preview" ? "none" : undefined,
+                            }}
                         />
-                        <Show when={isMarkdown()}>
-                            <Show when={model.previewOpenAtom() && !model.sourceHiddenAtom()}>
-                                <div
-                                    class="editor-preview-divider"
-                                    onMouseDown={handlePreviewResizeMouseDown}
-                                    title="Drag to resize preview"
-                                />
-                            </Show>
+                        <Show when={isMarkdown() && model.editorMode() === "split"}>
+                            <div
+                                class="editor-preview-divider"
+                                onMouseDown={handlePreviewResizeMouseDown}
+                                title="Drag to resize preview"
+                            />
+                        </Show>
+                        <Show when={isMarkdown() && model.editorMode() !== "source"}>
                             <div
                                 class="editor-preview-pane"
-                                classList={{
-                                    "editor-preview-pane--collapsed": !model.previewOpenAtom() && !model.sourceHiddenAtom(),
-                                }}
                                 style={
-                                    model.sourceHiddenAtom()
-                                        ? { flex: "1 1 auto" }
-                                        : model.previewOpenAtom()
-                                            ? { height: `${model.previewHeightAtom()}px` }
-                                            : undefined
+                                    model.editorMode() === "split"
+                                        ? { height: `${model.previewHeightAtom()}px`, flex: "0 0 auto" }
+                                        : { flex: "1 1 auto" }
                                 }
-                                id={`editor-preview-panel-${model.blockId}`}
                             >
-                                <div class="editor-preview-header">
-                                    <span class="editor-preview-header-label">Preview</span>
-                                    <div class="editor-preview-header-actions">
-                                        <button
-                                            type="button"
-                                            class="editor-preview-source-toggle"
-                                            title={model.sourceHiddenAtom() ? "Show source" : "Preview only (Mod+Shift+V)"}
-                                            aria-label={model.sourceHiddenAtom() ? "Show source" : "Preview only (Mod+Shift+V)"}
-                                            onClick={() => void model.toggleSourceHidden()}
-                                        >
-                                            {"</>"}
-                                        </button>
-                                        <Show when={!model.sourceHiddenAtom()}>
-                                            <button
-                                                type="button"
-                                                class="editor-preview-chevron"
-                                                aria-expanded={model.previewOpenAtom()}
-                                                aria-controls={`editor-preview-panel-${model.blockId}`}
-                                                aria-label={
-                                                    model.previewOpenAtom()
-                                                        ? "Collapse preview"
-                                                        : "Expand preview"
-                                                }
-                                                onClick={() => void model.togglePreview()}
-                                            >
-                                                {model.previewOpenAtom() ? "▴" : "▾"}
-                                            </button>
-                                        </Show>
-                                    </div>
+                                <div class="editor-preview-content">
+                                    <Markdown textAtom={() => liveDoc()} />
                                 </div>
-                                <Show when={model.previewOpenAtom() || model.sourceHiddenAtom()}>
-                                    <div class="editor-preview-content">
-                                        <Markdown textAtom={() => liveDoc()} />
-                                    </div>
-                                </Show>
                             </div>
                         </Show>
                     </div>


### PR DESCRIPTION
## Summary

- Replaces the broken two-signal tangle (`sourceHiddenAtom` + `previewOpenAtom`) with a single per-tab `EditorMode` (`"preview" | "source" | "split"`)
- `.md` files now default to **full-pane rendered preview** (CodeMirror hidden) — restoring the #1522 behavior that an agent broke in #1655
- Adds a **Preview | Source | Split** segmented toolbar below the tab strip (markdown tabs only), replacing the buried `</>` + `▴▾` buttons in the old preview header strip
- `Mod+Shift+V` now cleanly toggles preview ↔ source
- Split mode is preserved as opt-in for live-editing workflows; drag resize still works
- Removes `editor:source_hidden` from `app_api.rs` (frontend per-tab default handles markdown correctly without the meta key)

Spec: `docs/specs/SPEC_EDITOR_RESTORE_PREVIEW_TOGGLE_2026_06_30.md`

<!-- agentmux:agent_id=lark -->