### PR TITLE
fix(ci): release.yml CEF resolution — patched macOS framework + platform-filtered Linux tag

### DIFF
--- a/.changesets/1782839674-fix-ci-release-yml-consumes-patched-macos-cef-filters-linux--ae2u.md
+++ b/.changesets/1782839674-fix-ci-release-yml-consumes-patched-macos-cef-filters-linux--ae2u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): release.yml consumes patched macOS CEF + filters Linux CEF tag by platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
         run: |
-          TAG=$(gh release list --repo agentmuxai/cef --limit 1 \
-                  --json tagName --jq '.[0].tagName')
+          # agentmuxai/cef holds BOTH platforms' releases — filter to the Linux
+          # x86_64 prefix (a bare --limit 1 would grab whichever platform released
+          # most recently, e.g. a macOS framework, and break the libcef.so lookup).
+          TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+                  --json tagName \
+                  --jq '[.[].tagName | select(startswith("cef-linux-x86_64-"))][0]')
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "❌ no cef-linux-x86_64-* release found in agentmuxai/cef" >&2
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Cache patched libcef.so
@@ -272,6 +280,7 @@ jobs:
       contents: write
     env:
       OUT: ${{ github.workspace }}/artifacts
+      CEF_RUNTIME_DIR_DARWIN: ${{ github.workspace }}/cef-runtime-darwin
     steps:
       - uses: actions/checkout@v4
         with:
@@ -295,6 +304,60 @@ jobs:
 
       - name: Install go-task
         run: brew install go-task
+
+      # ── Patched CEF framework ─────────────────────────────────────────────
+      # The upstream cef-dll-sys framework lacks CefWindow::BeginWindowDrag, so
+      # native window drag / floating-pane resize silently no-ops on macOS. Download
+      # the pre-built PATCHED framework (agentmuxai/cef release) and point
+      # AGENTMUX_CEF_RUNTIME_DIR_DARWIN at it — the macOS analogue of build-linux's
+      # patched-libcef.so download. package-macos.sh's patch gate then verifies the
+      # framework carries BeginWindowDrag before signing.
+      # See docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md.
+      - name: Resolve patched CEF framework tag
+        id: cef
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          # agentmuxai/cef holds BOTH platforms' releases — filter to macOS arm64
+          # (a bare --limit 1 would grab whichever platform released most recently).
+          TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+                  --json tagName \
+                  --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "❌ no cef-macos-arm64-* release found in agentmuxai/cef" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved patched CEF framework tag: $TAG"
+
+      - name: Cache patched CEF framework
+        id: cef-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CEF_RUNTIME_DIR_DARWIN }}
+          key: cef-runtime-darwin-${{ steps.cef.outputs.tag }}
+
+      - name: Download patched CEF framework
+        if: steps.cef-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR_DARWIN"
+          gh release download "${{ steps.cef.outputs.tag }}" \
+            --repo agentmuxai/cef \
+            --pattern "*.tar.gz" \
+            --dir /tmp/cef-extract \
+            --clobber
+          tar -xzf /tmp/cef-extract/*.tar.gz -C /tmp/cef-extract
+          # Find the .framework regardless of whether the tarball has a top-level dir
+          FW=$(find /tmp/cef-extract -maxdepth 3 -name "Chromium Embedded Framework.framework" -type d | head -1)
+          if [ -z "$FW" ]; then echo "❌ framework not found in tarball"; exit 1; fi
+          # ditto preserves the Versions/Current symlink chain the CEF loader follows.
+          ditto "$FW" "$CEF_RUNTIME_DIR_DARWIN/Chromium Embedded Framework.framework"
+          rm -rf /tmp/cef-extract
+
+      - name: Set AGENTMUX_CEF_RUNTIME_DIR_DARWIN
+        run: echo "AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$CEF_RUNTIME_DIR_DARWIN" >> "$GITHUB_ENV"
 
       - name: Import Developer ID certificate
         env:


### PR DESCRIPTION
## Summary

`agentmuxai/cef` now holds **both** platforms' patched-CEF releases (the macOS arm64 framework was published 2026-06-30). The release workflow (merged in #1846) predates that and breaks two ways:

### 1. Linux tag resolution grabs the wrong platform
`build-linux` resolved the CEF tag with `gh release list --limit 1`, which now returns `cef-macos-arm64-148.0.9` (`isLatest=true`). The Linux job would download the **macOS** tarball, fail to find `libcef.so`, and break. Fixed by filtering to the `cef-linux-x86_64-` prefix — mirrors the canonical `build-linux.yml`.

### 2. macOS never downloads the patched framework
`build-macos` only ran `task package:macos`, so `resolve-cef-runtime-darwin.sh` fell back to the stock `cef-dll-sys` framework (no `BeginWindowDrag` slot) and `package-macos.sh`'s patch gate **correctly refused to package**. Added the patched-framework download + `AGENTMUX_CEF_RUNTIME_DIR_DARWIN` wiring — mirrors the canonical `build-macos.yml`.

## Scope

`release.yml` only. The same staleness exists in `ci-nightly-artifacts.yml` (Linux `--limit 1` + macOS no-download), but that workflow is owned by the macOS-CI owner, who is migrating builds into the reusable `build-linux.yml` / `build-macos.yml` workflows. Flagged for them separately.

## Note

The macOS build job remains gated behind the `APPLE_CEF_AVAILABLE` secret (added by #1849), so it is skipped — not failed — until that secret is set.

<!-- agentmux:agent_id=camper -->