### PR TITLE
proposal: composable agent model for the Trust Center

### DIFF
--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -68,7 +68,7 @@ Center.
 
 The base mechanism is **direct binding**: an agent binds the primitives it needs
 (any number of MCP servers + skills, one Brief, ≤1 Account per provider, a Memory).
-An **Bundle** is **not a required wrapper** — it's a *named, reusable collection*
+A **Bundle** is **not a required wrapper** — it's a *named, reusable collection*
 of those same bindings, for "apply this whole set in one step" and "share it across
 agents." It's convenience + reuse, not a new layer the agent must have.
 
@@ -202,14 +202,14 @@ precisely what *frees* the word for its natural use. `db_memory_bundles` →
 Trust Center
 ├─ Bundles      ← named collections you apply to agents (optional, reusable)
 ├─ Accounts        ← provider logins / credentials (per-account CLAUDE_CONFIG_DIR)
-├─ Brains          ← memory stores
+├─ Memories        ← memory stores
 ├─ MCP Servers     ← external tool/connection surfaces  (NEW: broken out)
 ├─ Skills          ← instruction/knowledge modules       (NEW: broken out)
 └─ Briefs          ← the opening message a pane loads with (no standing prompt)
 ```
 
 No **Identities** tab — Account is the primitive; "identity" is a derived view
-(§3.3). An **Bundle** view shows reference slots and lets you pick from the
+(§3.3). A **Bundle** view shows reference slots and lets you pick from the
 primitive lists; "create new" from a slot deep-links to the primitive editor. An
 agent binds primitives directly and/or includes Bundles, plus picks model +
 workspace.

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -57,7 +57,7 @@ Center.
 | **Memory** | Persistent learned knowledge (native memory store; the `memory.*` App API / `memory/` dir) | colloquially "the brain", per-account | Trust Center › **Memories** |
 | **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Trust Center › **MCP Servers** (break out) |
 | **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Trust Center › **Skills** (break out) |
-| **Brief** (instructions/context) | The **always-on** standing instructions + context — what loads the moment the agent loads (the `soul`/`agentmd` → CLAUDE.md, plus the injected startup instructions). Distinct from Skills, which are on-demand. | the `startup` / `soul` / `agentmd` content types | Trust Center › **Briefs** |
+| **Brief** | **The first message** injected when an agent pane opens — the startup payload (session context / identity / kickoff). That is *all* it is. It is **not** a standing instruction set; there is no always-on instruction blob. Behavioral/instructional content lives in **Skills** (on-demand). | the `startup` content type | Trust Center › **Briefs** |
 
 > Each primitive carries its own **ownership/sharing** (agent-owned vs **global**,
 > mirroring the App API's existing global-preset guard) and its own audit trail.
@@ -121,32 +121,34 @@ instance → bundle → binding → account) is the one real refactor; flag it t
 
 ### 3.4 What loads when (verified against the spawn path)
 
-The Brief is precisely *"what loads when the agent loads."* Traced through the
+**The Brief is *just the first message* the pane opens with** — nothing more. There
+is deliberately **no always-on standing-instruction blob**. Traced through the
 current spawn path:
 
 | Primitive | When | Mechanism (today) |
 |---|---|---|
-| **Brief** | **always, at startup** | two paths, both always-on: the `startup` instructions are injected as the **first user message** (`buildStartupPayload()` → `AgentInputCommand` → CLI stdin, `subprocess.rs:494`); `soul`+`agentmd` are written to **`CLAUDE.md`** in the workdir (`agent_config.rs:55-96`), auto-read by Claude Code |
-| **Memory** | recalled at startup | native memory store (the brain), per-account `CLAUDE_CONFIG_DIR` |
-| **Skill** | **on-demand** | indexed in CLAUDE.md + `.claude/commands/<trigger>.md`; loaded only when invoked — the lean-core vs. on-demand split |
+| **Brief** | **the first message, at pane open** | the `startup` content is injected as the **first user message** (`buildStartupPayload()` → `AgentInputCommand` → CLI stdin, `subprocess.rs:494`) — session context / identity / kickoff |
+| **Memory** | recalled at startup | native memory store, per-account `CLAUDE_CONFIG_DIR` |
+| **Skill** | **on-demand** | indexed + `.claude/commands/<trigger>.md`; loaded only when invoked. **Instructional/behavioral content lives here** — not in an always-on prompt |
 | **MCP server** | connection at startup, tools on-demand | `.mcp.json` (`build_mcp_config`, auto-injects the `agentmux-mcp` entry) |
-| **Account** | at startup | "Assigned Accounts" in the startup payload + identity resolution (`resolver.rs`) |
+| **Account** | at pane open | "Assigned Accounts" in the startup payload + identity resolution (`resolver.rs`) |
 
-> This confirms the **Brief = always-on / Skill = on-demand** distinction concretely
-> — the `startup`+`soul`+`agentmd` content is read every launch; skills are not.
+> **Deliberate stance: no always-on instruction set.** Today the `soul`+`agentmd`
+> content is written to an always-loaded **`CLAUDE.md`** (`agent_config.rs:55-96`).
+> We are **retiring that** — heavy standing instructions ("that terminality") are
+> not wanted. **Brief = the first message; everything instructional moves to
+> Skills** (on-demand). So `soul`/`agentmd` migrate into Skills, not into Brief.
 > (Citations: `frontend/.../startup/buildStartupPayload.ts`, `subprocess.rs:494`,
-> `server/agent_config.rs:55-96`, `server/app_api.rs:2299-2405` `write_agent_config_files`.)
+> `server/agent_config.rs:55-96`, `server/app_api.rs:2299-2405`.)
 
-**Two content types the 5-primitive model doesn't yet place** (surfaced by the
-trace — decide their home, §9):
-- **`hooks` + `settings`/permissions** → `.claude/settings.json`. These are
-  behavior/safety config that also loads at startup. Candidate: a separate
-  **Policy** primitive (permissions are a trust decision → Trust Center fit), or
-  fold into the Brief. *Recommend a distinct `Policy` primitive* — permissions
-  deserve their own review surface, not burial in instructions.
-- **the static `memory` content blob** (baked into CLAUDE.md today) is **not** the
-  native Memory store. It's really just more standing context → **merge it into the
-  Brief** (or migrate into native Memory); don't carry two "memory" concepts.
+**Two content types the model must place** (surfaced by the trace — §9):
+- **`hooks` + `settings`/permissions** → `.claude/settings.json`. Behavior/safety
+  config that loads at startup. *Recommend a distinct **Policy** primitive* —
+  permissions are a trust decision and deserve their own review surface.
+- **`soul` / `agentmd` (today's CLAUDE.md instructions)** → **migrate into Skills**
+  (on-demand), per the stance above — not Brief, not a standing prompt.
+- **the static `memory` content blob** (in CLAUDE.md today) is **not** the native
+  Memory store → migrate into native **Memory**; don't carry two "memory" concepts.
 
 ## 4. Naming (the crux of the question)
 
@@ -172,11 +174,11 @@ Keep them concrete and singular: **Account, Memory, MCP Server, Skill, Brief**.
 (**Memory** matches the native concept + the `memory.*` App API — no UI/backend
 split; "the brain" stays a colloquial nickname, not the canonical term. The reason
 "Brain" was ever needed — disambiguating from `db_memory_bundles` — is removed by
-this proposal's `db_memory_bundles` → `db_bundles` rename. "Brief" is a crisp word for the standing
-instructions + context that "instructions" or "rules" undersell.) Open to
-"Instructions" instead of "Brief" if you prefer the literal term. Note: **there is
-no "Identity" primitive** — Account is the primitive; "identity" is a derived view
-(§3.3).
+this proposal's `db_memory_bundles` → `db_bundles` rename. **`Brief` is the name —
+not "Instructions"**: it is deliberately *not* a standing instruction set, it's the
+opening message; "Instructions" would mislabel it and re-imply the always-on prompt
+we're removing.) Note: **there is no "Identity" primitive** — Account is the
+primitive; "identity" is a derived view (§3.3).
 
 ### 4.3 Why "Bundle" works now (the collision is removed, not worked around)
 
@@ -203,7 +205,7 @@ Trust Center
 ├─ Brains          ← memory stores
 ├─ MCP Servers     ← external tool/connection surfaces  (NEW: broken out)
 ├─ Skills          ← instruction/knowledge modules       (NEW: broken out)
-└─ Briefs          ← standing instructions + context files
+└─ Briefs          ← the opening message a pane loads with (no standing prompt)
 ```
 
 No **Identities** tab — Account is the primitive; "identity" is a derived view
@@ -254,7 +256,8 @@ workspace.
 
 The `a5af/claw` "AgentX/AgentY" scheme maps **cleanly** onto this model — it stops
 being an awkward "dump it in memory" and becomes:
-- **Brief:** the claw `CLAUDE.md` + startup instructions
+- **Brief:** the claw startup message only (the kickoff). The claw `CLAUDE.md` /
+  startup-prompt *instructions* become **Skills** (on-demand), not the Brief
 - **Skills:** the claw `templates/skills/*` (each a first-class Skill)
 - **MCP Servers:** the claw `.mcp.json` entries (each a first-class MCP server)
 - **Account:** AgentX's Claude login (the per-agent provisioning work)
@@ -269,7 +272,8 @@ building blocks — not config smeared across three stores.
 
 1. **Collection name:** `Bundle` (recommended; product owner's call) vs. `Profile`
    / `Assembly`. Confirm.
-2. **"Brief" vs "Instructions"** for the standing-instructions primitive.
+2. ~~"Brief" vs "Instructions"~~ — **settled: `Brief`, defined as the opening
+   message only**; no "Instructions" concept; standing instructions → Skills.
 3. **Scope of v1:** break out **MCP + Skills** first (the explicit ask), or land the
    whole primitives + Bundle IA at once?
 4. **Drop the identity-bundle layer** (Account direct, §3.3) — confirmed direction;

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -33,10 +33,10 @@ Center.
 
 - **Primitives are first-class and reusable.** Define an MCP server, a skill, an
   identity, a brain, an instruction set **once**; reference it from many agents.
-- **One assembly object is the "one-stop shop."** A single named thing answers
+- **One bundle object is the "one-stop shop."** A single named thing answers
   "what is this agent's full setup" — by **referencing** primitives, not inlining
   them.
-- **Reference, don't copy.** The assembly stores pointers; edit a primitive once
+- **Reference, don't copy.** The bundle stores pointers; edit a primitive once
   and every agent using it updates.
 - **The Trust Center is the trust + capability surface.** Accounts (credentials),
   MCP (external reach), and skills (injected instructions) are all *trust
@@ -54,7 +54,7 @@ Center.
 | Primitive | What it is | Today | Proposed home |
 |---|---|---|---|
 | **Account** | The provider login + credential the agent authenticates as (OAuth/key, per-account `CLAUDE_CONFIG_DIR`) | `db_identity_accounts`, wrapped in a redundant identity-**bundle** layer | Trust Center › **Accounts** (drop the bundle wrapper — §3.3) |
-| **Brain** (memory) | Persistent learned knowledge (native memory store) | "the brain", per-account | Trust Center › **Brains** |
+| **Memory** | Persistent learned knowledge (native memory store; the `memory.*` App API / `memory/` dir) | colloquially "the brain", per-account | Trust Center › **Memories** |
 | **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Trust Center › **MCP Servers** (break out) |
 | **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Trust Center › **Skills** (break out) |
 | **Brief** (instructions/context) | Standing system-level instructions + context files (the CLAUDE.md-equivalent) | the rest of "preset" | Trust Center › **Briefs** |
@@ -64,50 +64,50 @@ Center.
 > Accounts and MCP servers especially are security-sensitive — first-class status
 > gives them proper review, not burial inside a preset blob.
 
-### 3.2 Direct binding is the base; an Assembly is just a named collection
+### 3.2 Direct binding is the base; a Bundle is just a named collection
 
 The base mechanism is **direct binding**: an agent binds the primitives it needs
-(any number of MCP servers + skills, one Brief, ≤1 Account per provider, a Brain).
-An **Assembly** is **not a required wrapper** — it's a *named, reusable collection*
+(any number of MCP servers + skills, one Brief, ≤1 Account per provider, a Memory).
+An **Bundle** is **not a required wrapper** — it's a *named, reusable collection*
 of those same bindings, for "apply this whole set in one step" and "share it across
 agents." It's convenience + reuse, not a new layer the agent must have.
 
 ```
-Assembly "AgentX"            (a saved collection — optional)
+Bundle "AgentX"            (a saved collection — optional)
   ├─ accounts: [Accounts/AgentX-claude, Accounts/AgentX-github, Accounts/AgentX-aws]
-  ├─ brain:    → Brains/AgentX
+  ├─ memory:   → Memories/AgentX
   ├─ mcp:      → [MCP/github, MCP/agentmux, MCP/aws]
   ├─ skills:   → [Skills/git-workflow, Skills/reagent, …]
   └─ brief:    → Briefs/host-agent
 ```
 
 - It holds **references**, not copies (principle: reference, don't copy).
-- **An Agent's effective config = its direct bindings ∪ the Assemblies it
-  includes.** Precedence: a direct binding overrides the same item from an Assembly
-  (so an Assembly is a baseline you can locally tweak).
+- **An Agent's effective config = its direct bindings ∪ the Bundles it
+  includes.** Precedence: a direct binding overrides the same item from a Bundle
+  (so a Bundle is a baseline you can locally tweak).
 - Provider/model and workspace stay on the **agent** (not portable across
   machines/providers the way the bound primitives are) — preserving the current
   "provider/model belong to the agent" rule.
 
-**Yes — an Assembly is the one-stop shop when you want one.** But because primitives
-bind directly, you can also run an agent with no Assembly at all (ad-hoc bindings),
-or mix an Assembly with a couple of direct overrides. That flexibility is the
+**Yes — a Bundle is the one-stop shop when you want one.** But because primitives
+bind directly, you can also run an agent with no Bundle at all (ad-hoc bindings),
+or mix a Bundle with a couple of direct overrides. That flexibility is the
 difference from today's mandatory, inline preset.
 
 ### 3.3 Do we still need "Identity"? No — Account is the primitive
 
 Identity today is **three layers**: `bundle → bindings → accounts`, where a
 **bundle is itself a collection** — exactly one account *per provider*
-(claude→A, github→B, aws→C). That is *literally an assembly of accounts*. Once the
-Assembly concept exists, the identity-bundle layer is **redundant**:
+(claude→A, github→B, aws→C). That is *literally a bundle of accounts*. Once the
+Bundle concept exists, the identity-bundle layer is **redundant**:
 
 - The real primitive is the **Account** (provider + credential). Drop the
   identity-**bundle** object entirely.
 - Agents bind **accounts directly**. The only invariant the bundle used to enforce
   — **≤1 account per provider** — moves to **resolution time** (the resolver picks
-  the single account per provider from the agent's direct bindings + assemblies;
+  the single account per provider from the agent's direct bindings + bundles;
   a conflict is a validation error, surfaced like any other).
-- A named, reusable set of accounts is just an **Assembly** (which can hold accounts
+- A named, reusable set of accounts is just an **Bundle** (which can hold accounts
   alongside MCP/skills/brief).
 - "**Identity**" survives only as a *user-facing descriptor* — "what is this agent
   running as" — a derived view over the agent's bound accounts, **not a stored
@@ -121,41 +121,55 @@ instance → bundle → binding → account) is the one real refactor; flag it t
 
 ## 4. Naming (the crux of the question)
 
-Two things need names: **the assembly** and **the broken-out primitives**.
+Two things need names: **the bundle** and **the broken-out primitives**.
 
 ### 4.1 The collection — candidates
 
 | Name | For | Against |
 |---|---|---|
-| **Assembly** *(recommended — product owner leaning here)* | Literally means "a collection assembled from parts" — accurate for a named set of bound primitives; no collision; reads well ("the AgentX assembly") | newish word in this domain (minor) |
-| **Profile** | "Agent profile" groups capabilities; familiar (browser profiles, **AWS_PROFILE** — claw uses it per agent) | connotes a *persona* more than a *collection*; less precise now that it's an optional collection, not a mandatory wrapper |
-| **Preset** (redefine) | incumbent | currently the *narrow* inline thing; stretching it to a reference-based collection muddies the rename |
-| **Bundle / Preset bundle** | matches an early instinct | **collides** — "bundle" already means two things; a third meaning compounds the debt — **not recommended** |
+| **Bundle** *(recommended — product owner's call)* | The plain English word for "a set of things shipped/applied together" — exactly what this is; familiar; and *freed of collision* by this proposal (see §4.3) | had a collision under the old names — removed below |
+| **Profile** | groups capabilities; familiar (browser profiles, **AWS_PROFILE**) | connotes a *persona* more than a *collection*; less apt now that it's an optional collection, not a wrapper |
+| **Assembly** | accurately means "a collection assembled from parts" | a touch jargony; loses to "Bundle" on plainness once the collision is gone |
+| **Preset** (redefine) | incumbent | currently the *narrow* inline thing; stretching it muddies the rename |
 
-**Recommendation: name the collection an `Assembly`.** It precisely denotes "a
-collection" (which is what it is, now that primitives bind directly and the
-Assembly is optional), and it collides with nothing. Retire "preset" (keep as a
+**Recommendation: name the collection a `Bundle`.** It is the most natural word for
+the concept, and — critically — this proposal *eliminates every other meaning of
+"bundle"* (§4.3), so it lands on exactly one referent. Retire "preset" (keep as a
 read alias for one release).
 
 ### 4.2 The primitives — naming
 
-Keep them concrete and singular: **Account, Brain, MCP Server, Skill, Brief**.
-("Brain" is already in use for memory; "Brief" is a crisp word for the standing
+Keep them concrete and singular: **Account, Memory, MCP Server, Skill, Brief**.
+(**Memory** matches the native concept + the `memory.*` App API — no UI/backend
+split; "the brain" stays a colloquial nickname, not the canonical term. The reason
+"Brain" was ever needed — disambiguating from `db_memory_bundles` — is removed by
+this proposal's `db_memory_bundles` → `db_bundles` rename. "Brief" is a crisp word for the standing
 instructions + context that "instructions" or "rules" undersell.) Open to
 "Instructions" instead of "Brief" if you prefer the literal term. Note: **there is
 no "Identity" primitive** — Account is the primitive; "identity" is a derived view
 (§3.3).
 
-### 4.3 Why NOT "bundle"
-"Bundle" is already two things (`db_identity_bundles`, `db_memory_bundles`).
-Reusing it for the assembly would mean three meanings of "bundle." Pick a fresh
-word for the assembly and reserve "bundle" for nothing new.
+### 4.3 Why "Bundle" works now (the collision is removed, not worked around)
+
+The earlier objection to "bundle" was **collision** — it already meant two things
+(`db_identity_bundles`, `db_memory_bundles`). But this proposal **deletes both of
+those meanings**:
+
+- `db_identity_bundles` → **gone** (the identity-bundle layer collapses to Accounts,
+  §3.3).
+- `db_memory_bundles` → renamed (it was never memory and never a real "bundle").
+
+So instead of *adding* a third meaning, we **consolidate to one**: after the
+cleanup, "bundle" refers to exactly **the collection** — its plain English sense.
+That inverts the old objection: removing `_bundles` from the legacy names is
+precisely what *frees* the word for its natural use. `db_memory_bundles` →
+**`db_bundles`** (the collection store); "bundle" means the collection, full stop.
 
 ## 5. Trust Center information architecture
 
 ```
 Trust Center
-├─ Assemblies      ← named collections you apply to agents (optional, reusable)
+├─ Bundles      ← named collections you apply to agents (optional, reusable)
 ├─ Accounts        ← provider logins / credentials (per-account CLAUDE_CONFIG_DIR)
 ├─ Brains          ← memory stores
 ├─ MCP Servers     ← external tool/connection surfaces  (NEW: broken out)
@@ -164,9 +178,9 @@ Trust Center
 ```
 
 No **Identities** tab — Account is the primitive; "identity" is a derived view
-(§3.3). An **Assembly** view shows reference slots and lets you pick from the
+(§3.3). An **Bundle** view shows reference slots and lets you pick from the
 primitive lists; "create new" from a slot deep-links to the primitive editor. An
-agent binds primitives directly and/or includes Assemblies, plus picks model +
+agent binds primitives directly and/or includes Bundles, plus picks model +
 workspace.
 
 ## 6. Trust & sharing model
@@ -179,32 +193,33 @@ workspace.
 - **Accounts** and **MCP servers** carry the heaviest trust weight (credentials +
   external reach). First-class status means they get explicit grant/review in the
   Trust Center instead of riding hidden inside a preset.
-- An Assembly referencing a global primitive can't silently fork it; it points at
+- An Bundle referencing a global primitive can't silently fork it; it points at
   the shared definition.
 
 ## 7. Backend / migration sketch
 
-- **Reference model:** Assemblies store primitive **IDs**, not inline JSON. Migrate
+- **Reference model:** Bundles store primitive **IDs**, not inline JSON. Migrate
   today's inline presets by extracting their MCP/skills into standalone
   `mcp_servers` / `skills` rows and rewriting the preset as references → an
-  `Assembly`.
-- **Drop the `_bundles` suffix — it's legacy and misleading:**
-  - `db_memory_bundles` → `db_assemblies` (it's presets, *not* memory, and not a
-    "bundle" — doubly wrong today).
+  `Bundle`.
+- **Consolidate "bundle" to one meaning** — today it's spread across two misleading
+  tables; collapse to a single correct one:
+  - `db_memory_bundles` → `db_bundles` — today's name says "memory" but it holds
+    presets; the renamed table *is* the collection store, so "bundle" finally fits.
   - `db_identity_bundles` → **removed**: the identity-bundle layer collapses (§3.3);
-    agents/assemblies reference accounts directly.
+    agents/bundles reference accounts directly.
   - `db_identity_accounts` → `db_accounts`.
   - Phase it: rename the **concept/UI now** (cheap), do the **storage migration**
     behind the App API later so agents only ever see the clean surface.
 - **Resolver change:** spawn resolution moves from `instance → identity_bundle →
-  binding → account` to `instance/assembly → account` directly (one account per
+  binding → account` to `instance/bundle → account` directly (one account per
   provider, enforced at resolve). Reconcile with
   `SPEC_PER_AGENT_IDENTITY_PROVISIONING_2026_06_30.md`.
 - **Compatibility:** keep "preset" / `db_memory_bundles` as a read alias for one
-  release; new writes go to Assemblies.
+  release; new writes go to Bundles.
 - **App API:** add `mcp.*`, `skill.*`, and `account.*` agent commands paralleling
   the existing `memory.*`, with the same S1 + ownership/global guards. `preset.*`
-  becomes `assembly.*`.
+  becomes `bundle.*`.
 
 ## 8. What this unlocks (incl. the claw import)
 
@@ -214,8 +229,8 @@ being an awkward "dump it in memory" and becomes:
 - **Skills:** the claw `templates/skills/*` (each a first-class Skill)
 - **MCP Servers:** the claw `.mcp.json` entries (each a first-class MCP server)
 - **Account:** AgentX's Claude login (the per-agent provisioning work)
-- **Brain:** AgentX's accumulated memory
-- → collected into an **Assembly "AgentX"**, applied to the AgentX agent (and shared
+- **Memory:** AgentX's accumulated memory
+- → collected into a **Bundle "AgentX"**, applied to the AgentX agent (and shared
   with AgentY where identical).
 
 That's the "clean model" the import wanted: reusable, shareable, reviewable
@@ -223,29 +238,30 @@ building blocks — not config smeared across three stores.
 
 ## 9. Open decisions (need product-owner input)
 
-1. **Collection name:** `Assembly` (recommended; product owner leaning here) vs.
-   `Profile`. *Not* "bundle."
+1. **Collection name:** `Bundle` (recommended; product owner's call) vs. `Profile`
+   / `Assembly`. Confirm.
 2. **"Brief" vs "Instructions"** for the standing-instructions primitive.
 3. **Scope of v1:** break out **MCP + Skills** first (the explicit ask), or land the
-   whole primitives + Assembly IA at once?
+   whole primitives + Bundle IA at once?
 4. **Drop the identity-bundle layer** (Account direct, §3.3) — confirmed direction;
    schedule the resolver refactor + `_bundles` rename.
-5. **Rename `db_memory_bundles` → `db_assemblies` / `db_identity_accounts` →
+5. **Rename `db_memory_bundles` → `db_bundles` / `db_identity_accounts` →
    `db_accounts`** now (clean) or defer the storage migration and rename the
    concept/UI first?
 
 ## 10. Recommendation
 
-Adopt the **primitives + Assembly** model:
+Adopt the **primitives + Bundle** model:
 
 - **Account is the primitive**; drop the identity-bundle layer; "identity" is a
-  derived view. Bind primitives **directly** to agents; an **Assembly** is an
-  optional named **collection** for reuse/sharing.
-- Name the collection **`Assembly`**; **remove the `_bundles` suffix** everywhere
-  (`db_memory_bundles` → `db_assemblies`, `db_identity_accounts` → `db_accounts`,
-  `db_identity_bundles` removed). Never "bundle" for a new concept.
+  derived view. Bind primitives **directly** to agents; a **Bundle** is an optional
+  named **collection** for reuse/sharing.
+- Name the collection **`Bundle`** — and consolidate "bundle" to that one meaning:
+  `db_memory_bundles` → `db_bundles` (the collection store), `db_identity_accounts`
+  → `db_accounts`, `db_identity_bundles` removed. After cleanup "bundle" refers to
+  exactly one thing.
 
 Sequence: **(1)** break out MCP + Skills as first-class primitives (highest value,
-lowest risk, the explicit ask) → **(2)** introduce **Assembly** as the reference-
+lowest risk, the explicit ask) → **(2)** introduce **Bundle** as the reference-
 based successor to Preset → **(3)** collapse identity-bundle → Account-direct +
 resolver refactor → **(4)** backend `_bundles` rename + storage migration.

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -1,0 +1,199 @@
+# Proposal: A Composable Agent Model for the Trust Center
+
+**Date:** 2026-06-30
+**Status:** Proposal — for discussion (naming + IA decisions needed)
+**Author:** AgentX
+**Driver:** "I'd like a cleaner model… break out skills and MCP into the Trust Center… should we call them bundles? preset bundles? would a preset be a one-stop shop?"
+**Related:** CLAUDE.md "Not widgets" (Identity / Presets); `db_memory_bundles`, `db_identity_bundles`; the per-agent identity provisioning work (`SPEC_PER_AGENT_IDENTITY_PROVISIONING_2026_06_30.md`); the agent App API identity/preset/memory handlers.
+
+---
+
+## 1. The problem
+
+Today "**preset**" is an opaque, inline grab-bag — it bundles *instructions +
+context files + MCP servers + skills* in one record, while **identity** and
+**memory (the brain)** are separate concepts living elsewhere. Three pains follow:
+
+1. **"Preset" is overloaded and inline.** MCP servers and skills are buried *inside*
+   a preset, so you can't define an MCP server or a skill **once** and reuse it
+   across agents — you re-embed it per preset, and copies drift.
+2. **The grouping is incomplete and implicit.** What a user actually wants to
+   reason about — *"who is this agent (identity), what does it know (brain/skills),
+   what can it reach (MCP), how does it behave (instructions)"* — is split across
+   "preset" + "identity" + "memory" with no single coherent object.
+3. **Naming debt.** Presets are stored in `db_memory_bundles` (but a preset is
+   **not** the brain), and identities in `db_identity_bundles` — two different
+   "bundles." Adding "preset bundle" on top would compound the collision.
+
+The fix is not a bigger preset. It's to **separate the reusable building blocks
+from the thing that assembles them**, and give each a clear home in the Trust
+Center.
+
+## 2. Design principles
+
+- **Primitives are first-class and reusable.** Define an MCP server, a skill, an
+  identity, a brain, an instruction set **once**; reference it from many agents.
+- **One assembly object is the "one-stop shop."** A single named thing answers
+  "what is this agent's full setup" — by **referencing** primitives, not inlining
+  them.
+- **Reference, don't copy.** The assembly stores pointers; edit a primitive once
+  and every agent using it updates.
+- **The Trust Center is the trust + capability surface.** Identity (credentials),
+  MCP (external reach), and skills (injected instructions) are all *trust
+  decisions* — they belong together where you grant and review capability.
+- **Names should not collide.** Avoid reusing "bundle" for a new concept (already
+  means identity bundle / the legacy `db_memory_bundles`).
+
+## 3. Proposed model — primitives + one assembly
+
+### 3.1 The five primitives (Trust Center, each independently managed & shareable)
+
+| Primitive | What it is | Today | Proposed home |
+|---|---|---|---|
+| **Identity** | Account + credential the agent authenticates as (OAuth/key, per-account `CLAUDE_CONFIG_DIR`) | Agent-pane tab; `db_identity_bundles` | Trust Center › **Identities** |
+| **Brain** (memory) | Persistent learned knowledge (native memory store) | "the brain", per-identity | Trust Center › **Brains** |
+| **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Trust Center › **MCP Servers** (break out) |
+| **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Trust Center › **Skills** (break out) |
+| **Brief** (instructions/context) | Standing system-level instructions + context files (the CLAUDE.md-equivalent) | the rest of "preset" | Trust Center › **Briefs** |
+
+> Each primitive carries its own **ownership/sharing** (agent-owned vs **global**,
+> mirroring the App API's existing global-preset guard) and its own audit trail.
+> MCP servers and identities especially are security-sensitive — first-class
+> status gives them proper review, not burial inside a preset blob.
+
+### 3.2 The assembly — the "one-stop shop"
+
+One named object answers *"what is this agent's full setup"* by **referencing** a
+selection of primitives:
+
+```
+Assembly "AgentX-standard"
+  ├─ identity:   → Identities/AgentX
+  ├─ brain:      → Brains/AgentX
+  ├─ mcp:        → [MCP/github, MCP/agentmux, MCP/aws]
+  ├─ skills:     → [Skills/git-workflow, Skills/reagent, …]
+  └─ brief:      → Briefs/host-agent
+```
+
+- It holds **references**, not copies (principle: reference, don't copy).
+- Apply it to an agent in one step → the agent inherits all five.
+- An **Agent** = an Assembly **+** provider/model **+** workspace. (Provider/model
+  and workspace stay on the agent — they're not portable across machines/providers
+  the way the assembly is. This preserves the current "provider/model belong to the
+  agent" rule.)
+
+**Yes — the assembly is the one-stop shop.** But it's a *thin* assembler over
+independently-managed primitives, not a monolith. That's the difference from
+today's inline preset.
+
+## 4. Naming (the crux of the question)
+
+Two things need names: **the assembly** and **the broken-out primitives**.
+
+### 4.1 The assembly — candidates
+
+| Name | For | Against |
+|---|---|---|
+| **Profile** *(recommended)* | "Agent profile" naturally groups identity + memory + capabilities; familiar (browser profiles, **AWS_PROFILE** — which claw already uses per agent); no collision | one more new word vs. keeping "preset" |
+| **Preset** (redefine) | incumbent; "your agent's preset setup" | currently means the *narrow* inline thing; expanding it to include identity (credentials) + brain stretches "preset"; still stored in `db_memory_bundles` |
+| **Loadout** | evocative of "equipped capabilities" | identity/brain aren't quite "loadout items"; informal |
+| **Bundle / Preset bundle** | matches the user's instinct | **collides** with identity bundles + `db_memory_bundles`; "preset bundle" stacks two overloaded terms — **not recommended** |
+
+**Recommendation: rename the assembly to `Profile`** and retire "preset" (or keep
+"preset" as a deprecated alias for one release). A Profile = identity + brain +
+MCP + skills + brief. If you prefer minimal churn, the fallback is **keep "Preset"
+as the assembly** but redefine it as reference-based and add identity + brain — I'd
+still avoid "bundle" either way.
+
+### 4.2 The primitives — naming
+
+Keep them concrete and singular: **Identity, Brain, MCP Server, Skill, Brief**.
+("Brain" is already in use for memory; "Brief" is a crisp word for the standing
+instructions + context that "instructions" or "rules" undersell.) Open to
+"Instructions" instead of "Brief" if you prefer the literal term.
+
+### 4.3 Why NOT "bundle"
+"Bundle" is already two things (`db_identity_bundles`, `db_memory_bundles`).
+Reusing it for the assembly would mean three meanings of "bundle." Pick a fresh
+word for the assembly and reserve "bundle" for nothing new.
+
+## 5. Trust Center information architecture
+
+```
+Trust Center
+├─ Profiles        ← the one-stop assemblies (apply to agents)
+├─ Identities      ← accounts / credentials (per-account CLAUDE_CONFIG_DIR)
+├─ Brains          ← memory stores
+├─ MCP Servers     ← external tool/connection surfaces  (NEW: broken out)
+├─ Skills          ← instruction/knowledge modules       (NEW: broken out)
+└─ Briefs          ← standing instructions + context files
+```
+
+A **Profile** view shows the five reference slots and lets you pick from the
+primitive lists; "create new" from within a slot deep-links to the primitive
+editor. Agents pick a Profile + model + workspace.
+
+## 6. Trust & sharing model
+
+- Each primitive is **agent-owned** or **global** (shared). The App API already
+  guards global presets (`preset.upsert` rejects modifying `is_global`); generalize
+  that guard to **every** primitive: an agent may write its own, never another's or
+  a global one without authorization. (Ties directly to the S1/S4 work in the agent
+  App API.)
+- **MCP** and **Identity** carry the heaviest trust weight (external reach +
+  credentials). First-class status means they get explicit grant/review in the
+  Trust Center instead of riding hidden inside a preset.
+- A Profile referencing a global primitive can't silently fork it; it points at the
+  shared definition.
+
+## 7. Backend / migration sketch
+
+- **Reference model:** Profiles store primitive **IDs**, not inline JSON. Migrate
+  today's inline presets by extracting their MCP/skills into standalone
+  `mcp_servers` / `skills` rows and rewriting the preset as references → a `Profile`.
+- **Naming debt:** plan to rename `db_memory_bundles` → `db_profiles` (or keep the
+  table, rename the concept) so "memory bundle" stops meaning "preset." Keep
+  `db_identity_bundles` as **Identities** (or rename to `db_identities`). This is a
+  storage migration; do it behind the App API so agents see only the new surface.
+- **Compatibility:** keep "preset" as a read alias for one release; new writes go to
+  Profiles.
+- **App API:** add `mcp.*` and `skill.*` agent commands paralleling the existing
+  `preset.*` / `memory.*`, with the same S1 + ownership/global guards. The
+  `preset.*` surface becomes `profile.*`.
+
+## 8. What this unlocks (incl. the claw import)
+
+The `a5af/claw` "AgentX/AgentY" scheme maps **cleanly** onto this model — it stops
+being an awkward "dump it in memory" and becomes:
+- **Brief:** the claw `CLAUDE.md` + startup instructions
+- **Skills:** the claw `templates/skills/*` (each a first-class Skill)
+- **MCP Servers:** the claw `.mcp.json` entries (each a first-class MCP server)
+- **Identity:** AgentX's account (the per-agent identity work)
+- **Brain:** AgentX's accumulated memory
+- → assembled into a **Profile "AgentX"**, applied to the AgentX agent (and shared
+  with AgentY where identical).
+
+That's the "clean model" the import wanted: a reusable, shareable, reviewable
+loadout — not config smeared across three stores.
+
+## 9. Open decisions (need product-owner input)
+
+1. **Assembly name:** `Profile` (recommended) vs. redefine `Preset` vs. other.
+   *Not* "bundle."
+2. **"Brief" vs "Instructions"** for the standing-instructions primitive.
+3. **Scope of v1:** break out **MCP + Skills** first (the user's explicit ask), or
+   land the whole five-primitive + Profile IA at once?
+4. **Identity in the assembly?** Reference it from the Profile (recommended), or
+   keep identity selected separately at launch (status quo)?
+5. **Rename `db_memory_bundles`** now (clean) or defer the storage migration and
+   only rename the concept/UI first?
+
+## 10. Recommendation
+
+Adopt the **primitives + Profile** model. Name the assembly **Profile**; break out
+**MCP Servers** and **Skills** as first-class Trust Center primitives first (the
+highest-value, lowest-risk slice and the user's explicit ask), then fold
+identity + brain references into the Profile. Avoid "bundle" for any new concept.
+Sequence: (1) break out MCP + Skills, (2) introduce Profile as a reference-based
+rename of Preset, (3) wire identity + brain references, (4) backend rename +
+migration.

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -57,7 +57,7 @@ Center.
 | **Memory** | Persistent learned knowledge (native memory store; the `memory.*` App API / `memory/` dir) | colloquially "the brain", per-account | Trust Center › **Memories** |
 | **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Trust Center › **MCP Servers** (break out) |
 | **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Trust Center › **Skills** (break out) |
-| **Brief** (instructions/context) | Standing system-level instructions + context files (the CLAUDE.md-equivalent) | the rest of "preset" | Trust Center › **Briefs** |
+| **Brief** (instructions/context) | The **always-on** standing instructions + context — what loads the moment the agent loads (the `soul`/`agentmd` → CLAUDE.md, plus the injected startup instructions). Distinct from Skills, which are on-demand. | the `startup` / `soul` / `agentmd` content types | Trust Center › **Briefs** |
 
 > Each primitive carries its own **ownership/sharing** (agent-owned vs **global**,
 > mirroring the App API's existing global-preset guard) and its own audit trail.
@@ -118,6 +118,35 @@ This also **simplifies the in-flight provisioning spec**
 its own `OAuthConfigDir`, so there is no bundle to provision — log in → get an
 Account → bind it. The resolver change (instance → account directly, instead of
 instance → bundle → binding → account) is the one real refactor; flag it there.
+
+### 3.4 What loads when (verified against the spawn path)
+
+The Brief is precisely *"what loads when the agent loads."* Traced through the
+current spawn path:
+
+| Primitive | When | Mechanism (today) |
+|---|---|---|
+| **Brief** | **always, at startup** | two paths, both always-on: the `startup` instructions are injected as the **first user message** (`buildStartupPayload()` → `AgentInputCommand` → CLI stdin, `subprocess.rs:494`); `soul`+`agentmd` are written to **`CLAUDE.md`** in the workdir (`agent_config.rs:55-96`), auto-read by Claude Code |
+| **Memory** | recalled at startup | native memory store (the brain), per-account `CLAUDE_CONFIG_DIR` |
+| **Skill** | **on-demand** | indexed in CLAUDE.md + `.claude/commands/<trigger>.md`; loaded only when invoked — the lean-core vs. on-demand split |
+| **MCP server** | connection at startup, tools on-demand | `.mcp.json` (`build_mcp_config`, auto-injects the `agentmux-mcp` entry) |
+| **Account** | at startup | "Assigned Accounts" in the startup payload + identity resolution (`resolver.rs`) |
+
+> This confirms the **Brief = always-on / Skill = on-demand** distinction concretely
+> — the `startup`+`soul`+`agentmd` content is read every launch; skills are not.
+> (Citations: `frontend/.../startup/buildStartupPayload.ts`, `subprocess.rs:494`,
+> `server/agent_config.rs:55-96`, `server/app_api.rs:2299-2405` `write_agent_config_files`.)
+
+**Two content types the 5-primitive model doesn't yet place** (surfaced by the
+trace — decide their home, §9):
+- **`hooks` + `settings`/permissions** → `.claude/settings.json`. These are
+  behavior/safety config that also loads at startup. Candidate: a separate
+  **Policy** primitive (permissions are a trust decision → Trust Center fit), or
+  fold into the Brief. *Recommend a distinct `Policy` primitive* — permissions
+  deserve their own review surface, not burial in instructions.
+- **the static `memory` content blob** (baked into CLAUDE.md today) is **not** the
+  native Memory store. It's really just more standing context → **merge it into the
+  Brief** (or migrate into native Memory); don't carry two "memory" concepts.
 
 ## 4. Naming (the crux of the question)
 
@@ -248,6 +277,11 @@ building blocks — not config smeared across three stores.
 5. **Rename `db_memory_bundles` → `db_bundles` / `db_identity_accounts` →
    `db_accounts`** now (clean) or defer the storage migration and rename the
    concept/UI first?
+6. **Home for hooks + permissions** (`.claude/settings.json`): a distinct **Policy**
+   primitive (recommended — permissions are a trust decision) vs. fold into Brief?
+7. **Static `memory` content blob** (in CLAUDE.md today): merge into Brief
+   (recommended) vs. migrate into the native Memory store? Either way, retire the
+   second "memory" concept.
 
 ## 10. Recommendation
 

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -38,79 +38,113 @@ Center.
   them.
 - **Reference, don't copy.** The assembly stores pointers; edit a primitive once
   and every agent using it updates.
-- **The Trust Center is the trust + capability surface.** Identity (credentials),
+- **The Trust Center is the trust + capability surface.** Accounts (credentials),
   MCP (external reach), and skills (injected instructions) are all *trust
   decisions* — they belong together where you grant and review capability.
-- **Names should not collide.** Avoid reusing "bundle" for a new concept (already
-  means identity bundle / the legacy `db_memory_bundles`).
+- **Primitives bind directly; collections are optional.** An agent can bind
+  primitives ad-hoc; a named **collection** is sugar for reuse, not a required
+  wrapper.
+- **Names should not collide, and shed legacy.** Don't reuse "bundle" for any new
+  concept, and drop the misleading `_bundles` suffix on the storage names.
 
-## 3. Proposed model — primitives + one assembly
+## 3. Proposed model — primitives + an optional collection
 
-### 3.1 The five primitives (Trust Center, each independently managed & shareable)
+### 3.1 The primitives (Trust Center, each independently managed & shareable)
 
 | Primitive | What it is | Today | Proposed home |
 |---|---|---|---|
-| **Identity** | Account + credential the agent authenticates as (OAuth/key, per-account `CLAUDE_CONFIG_DIR`) | Agent-pane tab; `db_identity_bundles` | Trust Center › **Identities** |
-| **Brain** (memory) | Persistent learned knowledge (native memory store) | "the brain", per-identity | Trust Center › **Brains** |
+| **Account** | The provider login + credential the agent authenticates as (OAuth/key, per-account `CLAUDE_CONFIG_DIR`) | `db_identity_accounts`, wrapped in a redundant identity-**bundle** layer | Trust Center › **Accounts** (drop the bundle wrapper — §3.3) |
+| **Brain** (memory) | Persistent learned knowledge (native memory store) | "the brain", per-account | Trust Center › **Brains** |
 | **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Trust Center › **MCP Servers** (break out) |
 | **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Trust Center › **Skills** (break out) |
 | **Brief** (instructions/context) | Standing system-level instructions + context files (the CLAUDE.md-equivalent) | the rest of "preset" | Trust Center › **Briefs** |
 
 > Each primitive carries its own **ownership/sharing** (agent-owned vs **global**,
 > mirroring the App API's existing global-preset guard) and its own audit trail.
-> MCP servers and identities especially are security-sensitive — first-class
-> status gives them proper review, not burial inside a preset blob.
+> Accounts and MCP servers especially are security-sensitive — first-class status
+> gives them proper review, not burial inside a preset blob.
 
-### 3.2 The assembly — the "one-stop shop"
+### 3.2 Direct binding is the base; an Assembly is just a named collection
 
-One named object answers *"what is this agent's full setup"* by **referencing** a
-selection of primitives:
+The base mechanism is **direct binding**: an agent binds the primitives it needs
+(any number of MCP servers + skills, one Brief, ≤1 Account per provider, a Brain).
+An **Assembly** is **not a required wrapper** — it's a *named, reusable collection*
+of those same bindings, for "apply this whole set in one step" and "share it across
+agents." It's convenience + reuse, not a new layer the agent must have.
 
 ```
-Assembly "AgentX-standard"
-  ├─ identity:   → Identities/AgentX
-  ├─ brain:      → Brains/AgentX
-  ├─ mcp:        → [MCP/github, MCP/agentmux, MCP/aws]
-  ├─ skills:     → [Skills/git-workflow, Skills/reagent, …]
-  └─ brief:      → Briefs/host-agent
+Assembly "AgentX"            (a saved collection — optional)
+  ├─ accounts: [Accounts/AgentX-claude, Accounts/AgentX-github, Accounts/AgentX-aws]
+  ├─ brain:    → Brains/AgentX
+  ├─ mcp:      → [MCP/github, MCP/agentmux, MCP/aws]
+  ├─ skills:   → [Skills/git-workflow, Skills/reagent, …]
+  └─ brief:    → Briefs/host-agent
 ```
 
 - It holds **references**, not copies (principle: reference, don't copy).
-- Apply it to an agent in one step → the agent inherits all five.
-- An **Agent** = an Assembly **+** provider/model **+** workspace. (Provider/model
-  and workspace stay on the agent — they're not portable across machines/providers
-  the way the assembly is. This preserves the current "provider/model belong to the
-  agent" rule.)
+- **An Agent's effective config = its direct bindings ∪ the Assemblies it
+  includes.** Precedence: a direct binding overrides the same item from an Assembly
+  (so an Assembly is a baseline you can locally tweak).
+- Provider/model and workspace stay on the **agent** (not portable across
+  machines/providers the way the bound primitives are) — preserving the current
+  "provider/model belong to the agent" rule.
 
-**Yes — the assembly is the one-stop shop.** But it's a *thin* assembler over
-independently-managed primitives, not a monolith. That's the difference from
-today's inline preset.
+**Yes — an Assembly is the one-stop shop when you want one.** But because primitives
+bind directly, you can also run an agent with no Assembly at all (ad-hoc bindings),
+or mix an Assembly with a couple of direct overrides. That flexibility is the
+difference from today's mandatory, inline preset.
+
+### 3.3 Do we still need "Identity"? No — Account is the primitive
+
+Identity today is **three layers**: `bundle → bindings → accounts`, where a
+**bundle is itself a collection** — exactly one account *per provider*
+(claude→A, github→B, aws→C). That is *literally an assembly of accounts*. Once the
+Assembly concept exists, the identity-bundle layer is **redundant**:
+
+- The real primitive is the **Account** (provider + credential). Drop the
+  identity-**bundle** object entirely.
+- Agents bind **accounts directly**. The only invariant the bundle used to enforce
+  — **≤1 account per provider** — moves to **resolution time** (the resolver picks
+  the single account per provider from the agent's direct bindings + assemblies;
+  a conflict is a validation error, surfaced like any other).
+- A named, reusable set of accounts is just an **Assembly** (which can hold accounts
+  alongside MCP/skills/brief).
+- "**Identity**" survives only as a *user-facing descriptor* — "what is this agent
+  running as" — a derived view over the agent's bound accounts, **not a stored
+  object**.
+
+This also **simplifies the in-flight provisioning spec**
+(`SPEC_PER_AGENT_IDENTITY_PROVISIONING_2026_06_30.md`): an Account already carries
+its own `OAuthConfigDir`, so there is no bundle to provision — log in → get an
+Account → bind it. The resolver change (instance → account directly, instead of
+instance → bundle → binding → account) is the one real refactor; flag it there.
 
 ## 4. Naming (the crux of the question)
 
 Two things need names: **the assembly** and **the broken-out primitives**.
 
-### 4.1 The assembly — candidates
+### 4.1 The collection — candidates
 
 | Name | For | Against |
 |---|---|---|
-| **Profile** *(recommended)* | "Agent profile" naturally groups identity + memory + capabilities; familiar (browser profiles, **AWS_PROFILE** — which claw already uses per agent); no collision | one more new word vs. keeping "preset" |
-| **Preset** (redefine) | incumbent; "your agent's preset setup" | currently means the *narrow* inline thing; expanding it to include identity (credentials) + brain stretches "preset"; still stored in `db_memory_bundles` |
-| **Loadout** | evocative of "equipped capabilities" | identity/brain aren't quite "loadout items"; informal |
-| **Bundle / Preset bundle** | matches the user's instinct | **collides** with identity bundles + `db_memory_bundles`; "preset bundle" stacks two overloaded terms — **not recommended** |
+| **Assembly** *(recommended — product owner leaning here)* | Literally means "a collection assembled from parts" — accurate for a named set of bound primitives; no collision; reads well ("the AgentX assembly") | newish word in this domain (minor) |
+| **Profile** | "Agent profile" groups capabilities; familiar (browser profiles, **AWS_PROFILE** — claw uses it per agent) | connotes a *persona* more than a *collection*; less precise now that it's an optional collection, not a mandatory wrapper |
+| **Preset** (redefine) | incumbent | currently the *narrow* inline thing; stretching it to a reference-based collection muddies the rename |
+| **Bundle / Preset bundle** | matches an early instinct | **collides** — "bundle" already means two things; a third meaning compounds the debt — **not recommended** |
 
-**Recommendation: rename the assembly to `Profile`** and retire "preset" (or keep
-"preset" as a deprecated alias for one release). A Profile = identity + brain +
-MCP + skills + brief. If you prefer minimal churn, the fallback is **keep "Preset"
-as the assembly** but redefine it as reference-based and add identity + brain — I'd
-still avoid "bundle" either way.
+**Recommendation: name the collection an `Assembly`.** It precisely denotes "a
+collection" (which is what it is, now that primitives bind directly and the
+Assembly is optional), and it collides with nothing. Retire "preset" (keep as a
+read alias for one release).
 
 ### 4.2 The primitives — naming
 
-Keep them concrete and singular: **Identity, Brain, MCP Server, Skill, Brief**.
+Keep them concrete and singular: **Account, Brain, MCP Server, Skill, Brief**.
 ("Brain" is already in use for memory; "Brief" is a crisp word for the standing
 instructions + context that "instructions" or "rules" undersell.) Open to
-"Instructions" instead of "Brief" if you prefer the literal term.
+"Instructions" instead of "Brief" if you prefer the literal term. Note: **there is
+no "Identity" primitive** — Account is the primitive; "identity" is a derived view
+(§3.3).
 
 ### 4.3 Why NOT "bundle"
 "Bundle" is already two things (`db_identity_bundles`, `db_memory_bundles`).
@@ -121,17 +155,19 @@ word for the assembly and reserve "bundle" for nothing new.
 
 ```
 Trust Center
-├─ Profiles        ← the one-stop assemblies (apply to agents)
-├─ Identities      ← accounts / credentials (per-account CLAUDE_CONFIG_DIR)
+├─ Assemblies      ← named collections you apply to agents (optional, reusable)
+├─ Accounts        ← provider logins / credentials (per-account CLAUDE_CONFIG_DIR)
 ├─ Brains          ← memory stores
 ├─ MCP Servers     ← external tool/connection surfaces  (NEW: broken out)
 ├─ Skills          ← instruction/knowledge modules       (NEW: broken out)
 └─ Briefs          ← standing instructions + context files
 ```
 
-A **Profile** view shows the five reference slots and lets you pick from the
-primitive lists; "create new" from within a slot deep-links to the primitive
-editor. Agents pick a Profile + model + workspace.
+No **Identities** tab — Account is the primitive; "identity" is a derived view
+(§3.3). An **Assembly** view shows reference slots and lets you pick from the
+primitive lists; "create new" from a slot deep-links to the primitive editor. An
+agent binds primitives directly and/or includes Assemblies, plus picks model +
+workspace.
 
 ## 6. Trust & sharing model
 
@@ -140,26 +176,35 @@ editor. Agents pick a Profile + model + workspace.
   that guard to **every** primitive: an agent may write its own, never another's or
   a global one without authorization. (Ties directly to the S1/S4 work in the agent
   App API.)
-- **MCP** and **Identity** carry the heaviest trust weight (external reach +
-  credentials). First-class status means they get explicit grant/review in the
+- **Accounts** and **MCP servers** carry the heaviest trust weight (credentials +
+  external reach). First-class status means they get explicit grant/review in the
   Trust Center instead of riding hidden inside a preset.
-- A Profile referencing a global primitive can't silently fork it; it points at the
-  shared definition.
+- An Assembly referencing a global primitive can't silently fork it; it points at
+  the shared definition.
 
 ## 7. Backend / migration sketch
 
-- **Reference model:** Profiles store primitive **IDs**, not inline JSON. Migrate
+- **Reference model:** Assemblies store primitive **IDs**, not inline JSON. Migrate
   today's inline presets by extracting their MCP/skills into standalone
-  `mcp_servers` / `skills` rows and rewriting the preset as references → a `Profile`.
-- **Naming debt:** plan to rename `db_memory_bundles` → `db_profiles` (or keep the
-  table, rename the concept) so "memory bundle" stops meaning "preset." Keep
-  `db_identity_bundles` as **Identities** (or rename to `db_identities`). This is a
-  storage migration; do it behind the App API so agents see only the new surface.
-- **Compatibility:** keep "preset" as a read alias for one release; new writes go to
-  Profiles.
-- **App API:** add `mcp.*` and `skill.*` agent commands paralleling the existing
-  `preset.*` / `memory.*`, with the same S1 + ownership/global guards. The
-  `preset.*` surface becomes `profile.*`.
+  `mcp_servers` / `skills` rows and rewriting the preset as references → an
+  `Assembly`.
+- **Drop the `_bundles` suffix — it's legacy and misleading:**
+  - `db_memory_bundles` → `db_assemblies` (it's presets, *not* memory, and not a
+    "bundle" — doubly wrong today).
+  - `db_identity_bundles` → **removed**: the identity-bundle layer collapses (§3.3);
+    agents/assemblies reference accounts directly.
+  - `db_identity_accounts` → `db_accounts`.
+  - Phase it: rename the **concept/UI now** (cheap), do the **storage migration**
+    behind the App API later so agents only ever see the clean surface.
+- **Resolver change:** spawn resolution moves from `instance → identity_bundle →
+  binding → account` to `instance/assembly → account` directly (one account per
+  provider, enforced at resolve). Reconcile with
+  `SPEC_PER_AGENT_IDENTITY_PROVISIONING_2026_06_30.md`.
+- **Compatibility:** keep "preset" / `db_memory_bundles` as a read alias for one
+  release; new writes go to Assemblies.
+- **App API:** add `mcp.*`, `skill.*`, and `account.*` agent commands paralleling
+  the existing `memory.*`, with the same S1 + ownership/global guards. `preset.*`
+  becomes `assembly.*`.
 
 ## 8. What this unlocks (incl. the claw import)
 
@@ -168,32 +213,39 @@ being an awkward "dump it in memory" and becomes:
 - **Brief:** the claw `CLAUDE.md` + startup instructions
 - **Skills:** the claw `templates/skills/*` (each a first-class Skill)
 - **MCP Servers:** the claw `.mcp.json` entries (each a first-class MCP server)
-- **Identity:** AgentX's account (the per-agent identity work)
+- **Account:** AgentX's Claude login (the per-agent provisioning work)
 - **Brain:** AgentX's accumulated memory
-- → assembled into a **Profile "AgentX"**, applied to the AgentX agent (and shared
+- → collected into an **Assembly "AgentX"**, applied to the AgentX agent (and shared
   with AgentY where identical).
 
-That's the "clean model" the import wanted: a reusable, shareable, reviewable
-loadout — not config smeared across three stores.
+That's the "clean model" the import wanted: reusable, shareable, reviewable
+building blocks — not config smeared across three stores.
 
 ## 9. Open decisions (need product-owner input)
 
-1. **Assembly name:** `Profile` (recommended) vs. redefine `Preset` vs. other.
-   *Not* "bundle."
+1. **Collection name:** `Assembly` (recommended; product owner leaning here) vs.
+   `Profile`. *Not* "bundle."
 2. **"Brief" vs "Instructions"** for the standing-instructions primitive.
-3. **Scope of v1:** break out **MCP + Skills** first (the user's explicit ask), or
-   land the whole five-primitive + Profile IA at once?
-4. **Identity in the assembly?** Reference it from the Profile (recommended), or
-   keep identity selected separately at launch (status quo)?
-5. **Rename `db_memory_bundles`** now (clean) or defer the storage migration and
-   only rename the concept/UI first?
+3. **Scope of v1:** break out **MCP + Skills** first (the explicit ask), or land the
+   whole primitives + Assembly IA at once?
+4. **Drop the identity-bundle layer** (Account direct, §3.3) — confirmed direction;
+   schedule the resolver refactor + `_bundles` rename.
+5. **Rename `db_memory_bundles` → `db_assemblies` / `db_identity_accounts` →
+   `db_accounts`** now (clean) or defer the storage migration and rename the
+   concept/UI first?
 
 ## 10. Recommendation
 
-Adopt the **primitives + Profile** model. Name the assembly **Profile**; break out
-**MCP Servers** and **Skills** as first-class Trust Center primitives first (the
-highest-value, lowest-risk slice and the user's explicit ask), then fold
-identity + brain references into the Profile. Avoid "bundle" for any new concept.
-Sequence: (1) break out MCP + Skills, (2) introduce Profile as a reference-based
-rename of Preset, (3) wire identity + brain references, (4) backend rename +
-migration.
+Adopt the **primitives + Assembly** model:
+
+- **Account is the primitive**; drop the identity-bundle layer; "identity" is a
+  derived view. Bind primitives **directly** to agents; an **Assembly** is an
+  optional named **collection** for reuse/sharing.
+- Name the collection **`Assembly`**; **remove the `_bundles` suffix** everywhere
+  (`db_memory_bundles` → `db_assemblies`, `db_identity_accounts` → `db_accounts`,
+  `db_identity_bundles` removed). Never "bundle" for a new concept.
+
+Sequence: **(1)** break out MCP + Skills as first-class primitives (highest value,
+lowest risk, the explicit ask) → **(2)** introduce **Assembly** as the reference-
+based successor to Preset → **(3)** collapse identity-bundle → Account-direct +
+resolver refactor → **(4)** backend `_bundles` rename + storage migration.


### PR DESCRIPTION
## Summary

Proposal for the composable agent model powering the Trust Center. Replaces the
current overloaded \"preset\" concept with six named primitives: **Account**,
**Memory**, **MCP Server**, **Skill**, **Brief**, and **Bundle** (the optional
named collection — not a required wrapper).

Key decisions:
- **Bundle** = named reusable collection (previously debated: Profile, Assembly — Bundle chosen by product owner)
- **Account** = the credential primitive; "Identity" is a derived view only, no separate Identity tab
- **Brief** = the startup payload first message only (not standing instructions)
- **Skills** = on-demand instructional/behavioral modules
- **Memories** = native memory stores (Trust Center tab: "Memories")

Closes the conceptual gap that motivated #1852 (now closed as superseded).

<!-- agentmux:agent_id=agentx -->