### PR TITLE
feat(srv): persist LayoutCleared/LayoutTreeReplaced via the subscriber (layout single-writer, phase 1)

### DIFF
--- a/.changesets/1782842759-feat-srv-persist-layoutcleared-layouttreereplaced-via-the-pe-m2ln.md
+++ b/.changesets/1782842759-feat-srv-persist-layoutcleared-layouttreereplaced-via-the-pe-m2ln.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): persist LayoutCleared/LayoutTreeReplaced via the persist subscriber + bridge (layout single-writer, phase 1; behavior-neutral)

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -292,6 +292,22 @@ pub(crate) fn apply_event_to_wstore(
         Event::MagnifiedNodeChanged { tab_id, node_id, .. } => {
             apply_magnified_node_changed(wstore, tab_id, node_id)
         }
+        // Phase E.4.B — layout-tree persistence. These two are the
+        // first tree-mutating layout events to persist through the
+        // subscriber (rather than wcore-direct). They are behaviour-
+        // neutral until a production caller dispatches LayoutClear /
+        // LayoutSetTree (the Layout* arms are still dormant per
+        // reducer.rs §"4 of 11"); they land the persistence path that
+        // the UpdateObject→LayoutSetTree reroute (next phase) needs.
+        // Insert/Delete are deliberately NOT here yet — their events
+        // carry op params, not the resulting tree, so persisting them
+        // would require re-running the algebra in the subscriber (a new
+        // divergence surface). That is resolved in a later phase by
+        // having those events carry the reducer's resulting tree.
+        Event::LayoutCleared { tab_id, .. } => apply_layout_cleared(wstore, tab_id),
+        Event::LayoutTreeReplaced {
+            tab_id, new_tree, ..
+        } => apply_layout_tree_replaced(wstore, tab_id, new_tree),
         // All other event variants are not domain-state mutations
         // (lifecycle, errors, snapshots). The subscriber ignores them.
         _ => Ok(()),
@@ -711,6 +727,90 @@ fn apply_magnified_node_changed(
         return Ok(());
     }
     layout.magnifiednodeid = node_id.to_string();
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+
+/// Phase E.4.B — apply a `LayoutCleared` event: wipe the tab's persisted
+/// layout tree and the focus/magnify ids (and the leaforder cache — an
+/// empty tree has no leaves). Mirrors
+/// `reducer::layout::handle_layout_clear`. Idempotent: silent no-op when
+/// the tab is unknown, the layout row is missing, or it is already clear
+/// (so a double-apply — once synchronously from the RPC handler, once
+/// from the broadcast — does not churn the version).
+fn apply_layout_cleared(
+    wstore: &Store,
+    tab_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if tab.layoutstate.is_empty() {
+        return Ok(());
+    }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else {
+        return Ok(());
+    };
+    if layout.rootnode.is_none()
+        && layout.focusednodeid.is_empty()
+        && layout.magnifiednodeid.is_empty()
+        && layout.leaforder.is_none()
+    {
+        return Ok(());
+    }
+    layout.rootnode = None;
+    layout.focusednodeid = String::new();
+    layout.magnifiednodeid = String::new();
+    layout.leaforder = None;
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+
+/// Phase E.4.B — apply a `LayoutTreeReplaced` event: write the reducer-
+/// supplied tree onto `LayoutState.rootnode`. Mirrors
+/// `reducer::layout::handle_layout_set_tree` — when the new tree is
+/// empty, also clear the focus/magnify ids (and leaforder) so they don't
+/// dangle at nodes that no longer exist.
+///
+/// When a tree IS present, `leaforder` is intentionally left untouched:
+/// it is a frontend-recomputed geometry cache (`getLeafOrder` in
+/// `layoutGeometry.ts`, sorted by render `treeKey`) and is NOT read on
+/// reproject — `persist::bootstrap_state_from_wstore` reads
+/// rootnode/focus/magnify only. The next phase extends LayoutSetTree to
+/// carry the frontend's leaforder when the UpdateObject push routes
+/// through it. Idempotent: no-op (no version bump) when nothing changes.
+fn apply_layout_tree_replaced(
+    wstore: &Store,
+    tab_id: &str,
+    new_tree: &Option<agentmux_common::LayoutNode>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if tab.layoutstate.is_empty() {
+        return Ok(());
+    }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else {
+        return Ok(());
+    };
+    let clears = new_tree.is_none();
+    // Idempotent short-circuit: skip the write (and version bump) when the
+    // tree already matches and, for the empty-tree case, focus/magnify/
+    // leaforder are already cleared.
+    let already = layout.rootnode == *new_tree
+        && (!clears
+            || (layout.focusednodeid.is_empty()
+                && layout.magnifiednodeid.is_empty()
+                && layout.leaforder.is_none()));
+    if already {
+        return Ok(());
+    }
+    layout.rootnode = new_tree.clone();
+    if clears {
+        layout.focusednodeid = String::new();
+        layout.magnifiednodeid = String::new();
+        layout.leaforder = None;
+    }
     wstore.update(&mut layout)?;
     Ok(())
 }
@@ -1219,6 +1319,197 @@ mod tests {
             .unwrap()
             .expect("layout row must exist");
         assert_eq!(layout.oid, tab.layoutstate);
+    }
+
+    // ── Layout-tree persistence (Phase E.4.B) ───────────────────────────
+    fn leaf(id: &str, block: &str) -> agentmux_common::LayoutNode {
+        agentmux_common::LayoutNode {
+            id: id.into(),
+            data: Some(agentmux_common::LayoutNodeData {
+                block_id: block.into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Create ws-1 + tab-1 (which provisions a real LayoutState row) and
+    /// return the tab id.
+    fn ws_tab(s: &Store) -> String {
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "A".into(),
+                version: 1,
+            },
+            s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "T".into(),
+                version: 2,
+            },
+            s,
+        )
+        .unwrap();
+        "tab-1".to_string()
+    }
+
+    fn layout_of(s: &Store, tab_id: &str) -> PersistedLayoutState {
+        let tab = s.get::<Tab>(tab_id).unwrap().unwrap();
+        s.get::<PersistedLayoutState>(&tab.layoutstate)
+            .unwrap()
+            .unwrap()
+    }
+
+    #[test]
+    fn layout_tree_replaced_persists_rootnode() {
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n1", "b1")),
+                correlation_id: "c1".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let root = layout_of(&s, &tab).rootnode.expect("rootnode set");
+        assert_eq!(root.id, "n1");
+        assert_eq!(root.data.unwrap().block_id, "b1");
+    }
+
+    #[test]
+    fn layout_cleared_wipes_tree_and_ids() {
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n1", "b1")),
+                correlation_id: "c".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::FocusedNodeChanged {
+                tab_id: tab.clone(),
+                node_id: "n1".into(),
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::MagnifiedNodeChanged {
+                tab_id: tab.clone(),
+                node_id: "n1".into(),
+                version: 5,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::LayoutCleared {
+                tab_id: tab.clone(),
+                correlation_id: "c".into(),
+                version: 6,
+            },
+            &s,
+        )
+        .unwrap();
+        let layout = layout_of(&s, &tab);
+        assert!(layout.rootnode.is_none());
+        assert!(layout.focusednodeid.is_empty());
+        assert!(layout.magnifiednodeid.is_empty());
+        assert!(layout.leaforder.is_none());
+    }
+
+    #[test]
+    fn layout_tree_replaced_empty_clears_focus_magnify() {
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n1", "b1")),
+                correlation_id: "c".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::FocusedNodeChanged {
+                tab_id: tab.clone(),
+                node_id: "n1".into(),
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: None,
+                correlation_id: "c".into(),
+                version: 5,
+            },
+            &s,
+        )
+        .unwrap();
+        let layout = layout_of(&s, &tab);
+        assert!(layout.rootnode.is_none());
+        assert!(layout.focusednodeid.is_empty());
+        assert!(layout.magnifiednodeid.is_empty());
+    }
+
+    #[test]
+    fn layout_tree_replaced_idempotent_no_version_churn() {
+        let s = store();
+        let tab = ws_tab(&s);
+        let ev = Event::LayoutTreeReplaced {
+            tab_id: tab.clone(),
+            new_tree: Some(leaf("n1", "b1")),
+            correlation_id: "c".into(),
+            version: 3,
+        };
+        apply_event_to_wstore(&ev, &s).unwrap();
+        let v1 = layout_of(&s, &tab).version;
+        apply_event_to_wstore(&ev, &s).unwrap();
+        let v2 = layout_of(&s, &tab).version;
+        assert_eq!(v1, v2, "idempotent re-apply must not bump version");
+    }
+
+    #[test]
+    fn layout_events_silent_when_tab_missing() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::LayoutCleared {
+                tab_id: "ghost".into(),
+                correlation_id: "c".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: "ghost".into(),
+                new_tree: Some(leaf("n", "b")),
+                correlation_id: "c".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -431,21 +431,27 @@ async fn dispatch_event(event: Event, wstore: Arc<Store>, event_bus: Arc<EventBu
         }
 
         // ----- Layout (Phase 2 — partial) -----
-        // ONLY the focused/magnified events are persisted by
-        // `apply_event_to_wstore` (persist_subscriber.rs:289-292).
-        // The other 11 layout-tree events (Insert/Delete/Move/Swap/
-        // Resize/Replace/Split*/Clear/TreeReplaced) are persisted via
-        // wcore-direct in their RPC handlers — they DON'T appear in
-        // `apply_event_to_wstore`. If the bridge tried to broadcast
-        // LayoutState for those, `wstore.get<LayoutState>` could return
-        // pre-event tree state (subscriber and bridge race; only this
-        // one is the unsafe direction). Tracked as a follow-up issue
-        // for the layout-tree-event persistence migration. Until then,
-        // those handlers' existing `success_with_updates(...)` response
-        // broadcasts cover the frontend (Codex P2 on PR #861).
+        // Focused/Magnified + Cleared/TreeReplaced are now persisted by
+        // `apply_event_to_wstore` (persist_subscriber.rs), so the bridge
+        // can safely re-read LayoutState and broadcast it: the HTTP RPC
+        // path applies SQLite synchronously before publishing the event
+        // (see the post-event-state guarantee above), so the read sees
+        // post-event tree state.
+        //
+        // The remaining tree events (Insert/Delete/Move/Swap/Resize/
+        // Replace/Split*) are still persisted via wcore-direct in their
+        // RPC handlers — they DON'T yet appear in `apply_event_to_wstore`.
+        // If the bridge broadcast LayoutState for those, the read could
+        // race ahead of the wcore-direct write. They remain covered by
+        // their handlers' existing `success_with_updates(...)` response
+        // broadcasts (Codex P2 on PR #861) until their persistence
+        // migrates here in a later phase.
         Event::FocusedNodeChanged { tab_id, .. }
         | Event::MagnifiedNodeChanged { tab_id, .. } => {
             emit_layout_for_tab(&wstore, &event_bus, tab_id, "Focused/MagnifiedNodeChanged").await;
+        }
+        Event::LayoutCleared { tab_id, .. } | Event::LayoutTreeReplaced { tab_id, .. } => {
+            emit_layout_for_tab(&wstore, &event_bus, tab_id, "LayoutCleared/TreeReplaced").await;
         }
 
         // Saga lifecycle, launcher-domain events, OS facts, etc. — not

--- a/docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md
+++ b/docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md
@@ -108,6 +108,35 @@ If either dies, a fresh instance reprojects from srv.
 - **Q3.** Write-through mechanism: event-sourced through the reducer (ties into **#864**) vs. snapshot?
 - **Q4.** Can admission control (Pillar 3) ship independently and early, before the host rework? (Likely yes.)
 
+**Q1–Q4 RESOLVED 2026-06-30** — see `docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md`
+(grounded in crash-only software / microreboot / event-sourcing-snapshot literature). Summary: Q1 only
+logical topology moves (layout tree, per-window opacity, floating placement/restore-rects); Q2 visible
+bounded rebuild (<~1.5s + overlay), not invisible recovery; Q3 snapshot write-through via the reducer
+as sole writer (NOT event sourcing), **#864 promoted to a hard prerequisite** — see
+`SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md`; Q4 yes, Pillar 3 already shipped (#1853).
+
+## 7a. Clarification (2026-06-30) — authority belongs ONLY to the durable tier
+Captured from discussion. There are **two reducers**: the **srv reducer** (`agentmux-srv/src/reducer/`,
+durable, owns domain state) and the **host reducer** (`agentmux-cef/src/reducer/`, *disposable* tier —
+where `reconcile_quit` was wired). That asymmetry is a deeper split-brain than #864's (which is purely
+intra-srv write-coherence on one `db_layout` row).
+
+**Decided principle:** a disposable component must not own *authority*. Split the concept:
+- **Authority** (source of truth; decisions that must survive death) → **launcher + srv only.**
+  launcher owns process/OS-window identity (`instance_registry`, `backend_window_ids`, window meta);
+  srv owns logical/domain content (layout tree, tabs, agents / SQLite).
+- **Mechanism** (translate authoritative decisions into native CEF/OS calls; react to native
+  callbacks) → **host + renderer**, as pure executors/projectors.
+
+The host reducer is therefore **demoted from decider to projector**, not deleted — it keeps only
+ephemeral, reconstructable coordination state (native handles, pool, in-flight queues) and may run
+real-time native coordination, **provided every decision it makes is a pure function of launcher/srv
+truth that the durable tier could recompute** (a derived cache, never a source). `reconcile_quit` is
+legitimate host-side under this rule because it's derived from window topology (launcher's truth). The
+host's existing `shadow_*` fields are the reference pattern (read-only projections of launcher truth).
+This demotion = Pillar 2 Stage 3 (demote `orphan_reconcile` + WRR to pure executors) + Pillar 1 (host
+topology becomes a projection).
+
 ## 8. Next steps — see §"Best next steps" in the closing discussion / `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR` §6.
 Sequence: **Pillar 2 (wire `reconcile_quit`)** → **Pillar 3 (admission control)** → **Pillar 1 (host
 reproject)** → saga collapse + persistence pay-down (#864, agents Phase 3b/3c). Add the missing E2E

--- a/docs/specs/SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md
+++ b/docs/specs/SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md
@@ -1,0 +1,209 @@
+# SPEC #864 — Collapse the Layout Split-Brain to a Single Writer
+
+**Date:** 2026-06-30
+**Type:** Implementation spec (sized)
+**Status:** Ready to schedule
+**Owner:** asaf
+**Issue:** #864 (retire the wcore-direct layout path)
+**SUPERSEDED IN SCOPE (2026-06-30):** This spec's "single writer" is now **Phase 1** of the committed
+end-goal in `SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md` (strong reducer-authority). The
+"weak authority" path described here (frontend computes tree, reducer persists) is the low-risk
+stepping stone; the full intent-driven reducer is the target. Read both; this one for the Phase-1
+mechanics, the other for the destination.
+
+**Why now:** Promoted from "pay-down" to a **hard prerequisite for Pillar 1** by
+`SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md` §4/§7 — host-reproject durability is incoherent
+while two writers race one `db_layout` row. This must land before Pillar 1.
+
+> Goal: make the **srv reducer the sole writer** of `db_layout` (`rootnode` / `leaforder` /
+> `focusednodeid` / `magnifiednodeid` / `pendingbackendactions`), so the persisted layout record is
+> coherent, the reducer's `TabRecord` is authoritative (not a passive shadow), and the
+> reproject-from-srv read path reads a single, race-free source.
+
+---
+
+## 0. TL;DR
+
+The layout tree is already persisted in srv (`db_layout`), so it survives host death. The problem
+#864 fixes is **internal to srv**: that one `db_layout` row is written by **two paths** —
+
+- **Path A (reducer):** writes only the focus/magnify slice (`SetFocusedNode` / `SetMagnifiedNode`),
+- **Path B (wcore-direct):** writes the tree itself (`rootnode` / `leaforder` /
+  `pendingbackendactions`) by calling `Store::update`/`update_raw` directly, bypassing the reducer.
+
+The single `UpdateObject` RPC fires **both** on every frontend push (two SQLite writes, two `version`
+bumps, per push), and Path B leaves the reducer's `TabRecord.rootnode` a stale shadow for the rest of
+the session. The fix is **not greenfield** — the migration scaffolding already exists (Phase E.4.B:
+dormant `Layout*` reducer arms, "4 of 11 shipped"; the deferred "Option B" decision in
+`SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`). #864 = **finish that migration**: complete the 7
+remaining reducer arms, add the matching persist-subscriber + bridge arms, then reroute ~9
+wcore-direct call sites through the reducer.
+
+**Size:** Medium. ~7 reducer handlers + ~4–6 subscriber/bridge arms + ~9 caller reroutes, landed in
+**5 incremental, independently-shippable phases** behind the already-present scaffolding.
+
+---
+
+## 1. The split-brain, concretely (verified against source)
+
+**The persisted record** — `LayoutState` (`backend/obj.rs:398-416`), one row per tab, otype
+`OTYPE_LAYOUT`, joined via `Tab.layoutstate`. Fields: `rootnode` (the tree), `leaforder` (parallel
+flat leaf index), `focusednodeid`, `magnifiednodeid`, `pendingbackendactions`, `version` (optimistic
+lock). Lowest-level writers: `Store::update<LayoutState>` and `Store::update_raw`
+(`backend/storage/store.rs:381-424`).
+
+**Read-back / reproject path:** `persist::bootstrap_state_from_wstore` (`persist.rs:141-152`) reads
+`rootnode` + `focusednodeid` + `magnifiednodeid` into the reducer's `TabRecord` on startup. **This is
+the path Pillar 1 fires on crash** — so its source must be coherent.
+
+**Three in-memory copies** (audit's "~3", confirmed):
+1. SQLite `db_layout.rootnode` — session-authoritative (`persist.rs:11-16`).
+2. Reducer `TabRecord.rootnode` (`state.rs:106`) — **passive shadow**, written only at bootstrap;
+   diverges the instant any Path-B write lands mid-session (acknowledged `state.rs:98-106`).
+3. Frontend `LayoutModel` tree — pushes via `UpdateObject`; backend tree writes are invisible to it
+   (the reason redock must use `pendingbackendactions`, `service.rs:2945-2955`).
+   (`leaforder` is effectively a 4th parallel copy; `heal_layout` exists to repair its drift.)
+
+**The double-write** (`service.rs:448-531`, verified): `UpdateObject` writes the **whole row**
+(including `rootnode`) via `update_raw`, then on success dispatches `SetFocusedNode` +
+`SetMagnifiedNode` to the reducer, whose subscriber **re-updates the same row's** focus/magnify
+columns (`persist_subscriber.rs:671-716`). Two writes, two version bumps, per single push. Ordering
+("DB write THEN dispatch, only on success") is hand-enforced for atomicity (codex P2 PR #632).
+
+**Divergence backstops that exist *because* of the split-brain** (all deletable once collapsed):
+- `heal_layout` startup + on-activation rewrite of `rootnode`/`leaforder` (`wcore/block.rs:122`,
+  `main.rs:1320`, `service.rs:1517`) — "last defense" against drift.
+- Relaxed reducer validation for tab order: `handle_reorder_tabs_bulk` drops set/length checks
+  (`reducer/tab.rs:263-279`) + test `reorder_tabs_bulk_accepts_unknown_ids_during_migration`.
+- `resync_workspaces` deliberately refuses to touch tab/block/layout on `Lagged`
+  (`persist_subscriber.rs:108-128`).
+
+---
+
+## 2. Target end-state (the invariant)
+
+> **Invariant:** every mutation of `db_layout` flows through exactly one channel — the reducer's
+> `Layout*` command arms. The persist subscriber is the **only** code that writes `db_layout` to
+> SQLite (mirroring reducer events). `wcore`/`service`/`app_api` never call `Store::update` /
+> `update_raw` on an `OTYPE_LAYOUT` row.
+
+Consequences:
+- `TabRecord.rootnode` becomes **authoritative**, not a shadow → reproject reads one coherent source.
+- The `UpdateObject` double-write collapses to one reducer dispatch (`LayoutSetTree`) → one write,
+  one version bump.
+- `heal_layout`, the relaxed-validation shims, and the resync carve-outs become removable.
+
+The frontend stays the **editor** (user interaction lives in the renderer); it expresses intent via
+`UpdateObject`, which the RPC translates into a reducer command. The renderer remains a disposable
+projection — this spec does not move layout *editing* out of the frontend, only makes srv's
+*persistence* single-writer.
+
+---
+
+## 3. Surface area to migrate (verified inventory)
+
+### 3.1 Reducer arms — finish 7 of 11 (`reducer/layout.rs`)
+Shipped (dormant): `LayoutClear`, `LayoutSetTree`, `LayoutInsertNode`, `LayoutDeleteNode`
+(`reducer.rs:92-123`). Remaining 7 (`reducer.rs:86-91`): `insert_at_index`, `move`, `swap`, `resize`,
+`replace`, `split_horizontal`, `split_vertical` — "structurally identical." Most callers can route
+through `LayoutSetTree` (full-tree replace) initially; the granular arms are an optimization, not a
+blocker (see §4 Phase ordering).
+
+### 3.2 Persist-subscriber + bridge arms — add 4+ (`persist_subscriber.rs:187-298`)
+Events `LayoutCleared` / `LayoutTreeReplaced` / `LayoutNodeInserted` / `LayoutNodeDeleted` currently
+have **no** subscriber persist arms and **no** bridge arms (`wave_obj_bridge.rs:440-443`). Add
+`apply_layout_*` writing `db_layout` via `Store::update<LayoutState>`, plus bridge broadcast arms so
+the frontend still receives `waveobj:update`.
+
+### 3.3 wcore-direct callers to reroute — ~9 sites
+| # | Call site | Current write | Reroute to |
+|---|---|---|---|
+| 1 | `service.rs:495` `UpdateObject`/`update_object`→`update_raw` | full `rootnode`+`leaforder` (**highest frequency**) | `LayoutSetTree`; collapses double-write at `:501-519` |
+| 2 | `service.rs:931` `CreateWindow` seed → `write_default_three_pane_layout` | seed `rootnode` | `LayoutSetTree` |
+| 3 | `wcore/mod.rs:116` `ensure_initial_data` first-launch seed | seed `rootnode` | runs pre-bootstrap — may stay store-only or seed post-bootstrap via reducer (note existing two-path split `wcore/mod.rs:168-181`) |
+| 4 | `service.rs:2912` `setup_torn_off_block_layout` | `rootnode`+`leaforder` | `LayoutSetTree` |
+| 5 | `service.rs:2956`, `app_api.rs:448`, `app_api.rs:1057` `pendingbackendactions` queues (3 sites) | `pendingbackendactions` | reducer-routed insert/delete action arm |
+| 6 | `wcore/block.rs:36` `delete_block` prune | `rootnode`+`leaforder` | `LayoutDeleteNode` (saga already partly reducer-driven) |
+| 7 | `wcore/block.rs:122` `heal_layout` (2 callers: `main.rs:1333`, `service.rs:1517`) | `rootnode`+`leaforder` | route through `LayoutSetTree`, or keep as explicit reducer-bootstrap repair, then **delete** once drift source is gone |
+| 8 | `wcore/dnd.rs:195` `tear_off_block` tree write | `rootnode`+`leaforder` | `LayoutSetTree` (reducer-state portion already in `sagas::tear_off_block`) |
+
+**Single highest-leverage change: site #1** (`service.rs:448-531`). Routing `UpdateObject` through
+`LayoutSetTree` collapses both the dual-writer-on-one-row hazard (§1) and copy #2's divergence in one
+move. Do it first.
+
+---
+
+## 4. Phased plan (each phase independently shippable + testable)
+
+**Phase 1 — close the persistence gap for the existing arms.** Add the 4 `apply_layout_*` subscriber
+arms + bridge arms for the already-shipped `LayoutClear/SetTree/InsertNode/DeleteNode` events. No
+caller changes yet → behavior-neutral, but now the dormant arms can actually persist. *Unit-testable:
+dispatch each command, assert `db_layout` row + emitted `waveobj:update`.*
+
+**Phase 2 — reroute `UpdateObject` (site #1).** Replace the `update_raw` full-row write + separate
+focus/magnify dispatch with a single `LayoutSetTree` (carrying focus/magnify in the command). Delete
+the double-write. *This is the load-bearing change — verify one write/one version bump per push, and
+that `TabRecord.rootnode` now matches `db_layout` mid-session.* **Highest-value, highest-risk single
+step.**
+
+**Phase 3 — reroute the seeders + tear-off + delete (sites #2, #4, #6, #8).** Route
+`CreateWindow`/`setup_torn_off_block_layout`/`delete_block` prune/`tear_off_block` through
+`LayoutSetTree`/`LayoutDeleteNode`. *E2E: new window, tear-off, delete-block all persist via reducer.*
+
+**Phase 4 — reroute `pendingbackendactions` (site #5, 3 sites).** Add a reducer action arm for the
+backend→frontend command queue; route the 3 queue writers through it.
+
+**Phase 5 — delete the backstops.** Once no Path-B writer remains: remove `heal_layout` + its 2
+callers, the relaxed `reorder_tabs_bulk` validation + its migration test, and the resync carve-out
+comments. *This is the payoff phase — a deletion, the safest kind of change. Assert the heal pass is
+no longer needed by running a session and confirming no `rootnode`/`leaforder` drift.*
+
+The 7 remaining granular arms (§3.1) are **not required** for the collapse — every caller can route
+through `LayoutSetTree` (full-tree replace). Add the granular arms later as a write-amplification
+optimization if `db_layout` row size makes full-tree writes costly. **Do not gate #864 on them.**
+
+---
+
+## 5. Risks / honest caveats
+- **Phase 2 is the sharp edge.** `UpdateObject` is the highest-frequency layout writer; a regression
+  here breaks every split/resize/move. Needs the app-running E2E pass, not just unit tests — treat it
+  like Pillar 2 Stage 2: **do not auto-merge on bot approval.**
+- **`ensure_initial_data` runs pre-bootstrap** (site #3) — the reducer/subscriber may not be live yet
+  at first-launch seed. Likely must stay a direct store seed OR re-seed through the reducer
+  immediately post-bootstrap. Resolve during Phase 3; don't force it through the reducer if it
+  inverts the init order.
+- **Frontend↔backend overwrite race is partly out of scope.** Single-writer *within srv* makes
+  `db_layout` coherent, but the frontend `LayoutModel` still pushes full trees and is blind to
+  backend writes (`service.rs:2945-2955`). This spec keeps `pendingbackendactions` as the
+  backend→frontend channel; fully unifying cross-process layout authority is a Pillar 1 follow-on,
+  not #864.
+- **`version` optimistic-lock semantics** must be preserved through the reducer path — confirm the
+  subscriber's `Store::update` still bumps/checks `version` so concurrent pushes can't silently
+  clobber.
+- **Migration-era shims have tests pinned to current behavior** (e.g.
+  `reorder_tabs_bulk_accepts_unknown_ids_during_migration`) — Phase 5 must delete the test with the
+  shim, not leave it asserting removed behavior.
+
+---
+
+## 6. Definition of done
+1. No `Store::update`/`update_raw` on an `OTYPE_LAYOUT` row exists outside the persist subscriber.
+2. `UpdateObject` produces exactly one `db_layout` write + one version bump per push.
+3. `TabRecord.rootnode` equals `db_layout.rootnode` at all times mid-session (new invariant test).
+4. `heal_layout`, the relaxed `reorder_tabs_bulk` validation, and the resync layout carve-out are
+   deleted.
+5. E2E: split / resize / move / tear-off / delete-block / new-window all persist via the reducer;
+   app-running verification of Phase 2 passes.
+6. Unblocks Pillar 1: reproject's `bootstrap_state_from_wstore` reads a single coherent writer.
+
+---
+
+## 7. Sources
+- Internal map (this session): `reducer.rs:80-123`, `reducer/layout.rs`, `service.rs:448-531`,
+  `persist.rs:130-165`, `persist_subscriber.rs:187-298,664-716`, `backend/obj.rs:398-416`,
+  `backend/storage/store.rs:381-424`, `backend/wcore/{mod,block,dnd,tab,window}.rs`,
+  `server/wave_obj_bridge.rs:184-244,440-443`, `main.rs:1320-1349`.
+- `docs/specs/SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md` (the deferred "Option B" decision this
+  finishes), `docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md` §4/§7 (why this gates
+  Pillar 1), `docs/specs/SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` §2.3 (layout
+  split-brain finding).

--- a/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
+++ b/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
@@ -1,0 +1,220 @@
+# Pillar 1 — Host Reproject: Open-Question Resolutions & Design Foundation
+
+**Date:** 2026-06-30
+**Type:** Design resolution (answers the four open questions gating Pillar 1)
+**Status:** Conclusions agreed — ready to turn into a sized implementation spec
+**Owner:** asaf
+**Resolves:** Q1–Q4 in `docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md` §7
+**Builds on:** `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` (Pillar 1), Pillar 2/3 merged work
+
+> Purpose: close the four open questions that gate Pillar 1 (host becomes a disposable
+> projection of srv), grounded in (a) the actual host state inventory and (b) the
+> recovery-architecture literature, so we can write a sized implementation spec next.
+
+---
+
+## 0. TL;DR
+
+Pillar 1 is, in the literature's terms, making the host a **crash-only, microrebootable,
+soft-state component** (Candea & Fox). The host already *is* a projection on cold start — it
+rebuilds every window from srv. Pillar 1 = make that startup-restore path fire **unplanned,
+mid-session**, and make it cover **all** host topology, not most.
+
+Four resolutions:
+- **Q1 (what moves to srv):** Only the **logical topology** (Category A) — window set + kind +
+  parent linkage, layout tree, per-window opacity, floating-pane placement/restore-rects, and the
+  pool *target size* (not pool contents). Native handles (Category B) and in-flight queues
+  (Category C) are **rebuilt or dropped**, never serialized. Most of the topology is *already*
+  mirrored in srv/launcher; the gap is small and enumerable (below).
+- **Q2 (UX bar):** Reproject is a **visible, deliberate, one-shot rebuild** — target < ~1.5 s to
+  first painted topology, covered by a branded "Restoring session…" overlay, never a raw OS fault
+  box. Flicker is crash-path only. We **do not** chase invisible/instant recovery (that's the trap
+  that produced 6× renderer-OOM re-fixes).
+- **Q3 (write-through mechanism):** **State-store snapshot write-through**, not an event-sourced
+  log. The host writes its current logical topology to srv's existing `db_layout`/window stores
+  through **one path** (the reducer), async/batched, last-writer-wins per key. This deliberately
+  ties into **#864** (retire the wcore-direct second write path). Event-sourcing is rejected as
+  over-engineering for soft state that has no audit/replay requirement.
+- **Q4 (admission control independence):** **Yes — already proven.** Pillar 3 shipped (#1853)
+  independently of the host rework. Confirmed answer: admission control neither needs nor waits on
+  Pillar 1.
+
+---
+
+## 1. Framing — what the literature says this actually is
+
+The refactor direction maps cleanly onto three well-studied ideas. We are not inventing; we are
+applying a known pattern that the codebase half-implements already.
+
+- **Crash-only software** (Candea & Fox, HotOS-IX 2003): a component should have *one* way to stop
+  (crash) and *one* way to start (recover). Separate shutdown/startup code is where bugs breed.
+  **Prerequisite:** program state lives in dedicated **state stores**, not inside the crashable
+  component. → Our host's "graceful flush vs. crash" incoherence (audit §2.2) is exactly the
+  separate-shutdown-path smell; the fix is to make srv the state store so the host has *only* the
+  crash/recover path.
+- **Microreboot / Recovery-Oriented Computing** (Candea et al., OSDI 2004): restart fine-grained
+  components instead of the whole system; requires **separation of logic execution from state
+  management, loose coupling, soft state, and lease-based resources.** Demonstrated >95% reduction
+  in failure *duration*. → A host reproject is a microreboot of the single most failure-prone
+  component. The host's data must be **soft state** (reconstructable, leased), which the inventory
+  below confirms it nearly is.
+- **Event-sourcing snapshotting** (industry practice): replaying a long event log to rebuild state
+  is slow; snapshots bound it; and write-through should be **async/background so the client never
+  eats the persistence latency.** → Informs Q3: we want the snapshot half (current-state
+  write-through), not the log half (we have no replay/audit need).
+
+The throughline: **soft state in a dedicated store + one recover path = cheap, safe restart.**
+That is precisely the three-tier model already decided.
+
+---
+
+## 2. Q1 — The host's authoritative state set (what must move to srv)
+
+Full field inventory from `agentmux-cef/src/state.rs` + `reducer/`, grouped by disposition.
+
+### 2.A — LOGICAL TOPOLOGY → **must be authoritative in srv** (the actual Pillar 1 work)
+| Host field | What it is | In srv today? | Action |
+|---|---|---|---|
+| window set (via `shadow_window_meta` / `window_meta`) | which top-level windows exist, kind, parent linkage | **Yes** — launcher owns `instance_registry`, `backend_window_ids`, `windows`; host already projects them | Confirm completeness; close any host-only window facts |
+| layout tree (pane topology) | the split/tab structure per window | **Partially** — `db_layout` exists but is written via **two paths** (reducer + wcore-direct) | **#864**: collapse to one write path; this is the core gap |
+| `window_opacities: HashMap<String,f32>` | per-window opacity | **No** | Persist to window metadata |
+| `pane_window_states: HashMap<String,PaneWindowState>` | floating-pane Normal/Max/Min + `last_known_normal_rect` | **No** | Persist restore-rects + placement |
+| pool **target size** | how many warm windows/panes to keep | config | Keep in config (already durable) |
+
+### 2.B — NATIVE / EPHEMERAL HANDLES → **rebuilt on reproject, never serialized**
+`browsers: HashMap<String,BrowserHandle>` (CEF `Browser` FFI objects), GPU/renderer processes,
+`pool.queue` / `pool.unpromoted` / `pane_pool.*` (warm-window live handles), `active_drag:
+Option<DragSession>`. Only the *label/kind/metadata* of a browser has logical meaning; the handle
+itself is recreated by replaying topology through `post_create_window`. **Pools rebuild empty** —
+correct and acceptable (a fresh host warms them from target size). **Drag cannot outlive a restart
+— dropped by definition.**
+
+### 2.C — TRANSIENT / IN-FLIGHT → **dropped on reproject** (must be *resumable from topology*, not preserved)
+`pending_window_creations`, `pending_browser_pane_creates`, `browser_panes` Live/Closing lifecycle,
+`pool.respawn_in_flight` / `pane_pool.respawn_in_flight`, `quit_state` (Draining), dormant
+`top_level_creation`. These are mid-flight operations. **Design rule:** the reproject must derive
+the *desired* end state from srv topology and re-drive creation idempotently — it must **not** try
+to resume a half-finished create. (This is the soft-state requirement: in-flight work is
+reconstructed from durable intent, not checkpointed.)
+
+### 2.D — already-projected metadata (no work)
+`shadow_instance_registry`, `shadow_backend_window_ids`, `shadow_window_meta` are already read-only
+projections of launcher truth. They *validate the model* — the asymmetry is that topology in 2.A
+isn't yet treated the same way.
+
+**Q1 answer:** the authoritative set that must move is **small and mostly already there** — it is
+{layout tree via one write path (#864), per-window opacity, floating-pane placement/restore-rects}.
+Everything else is either already in srv (2.D), a rebuildable native handle (2.B), or in-flight
+work that must be re-derived rather than preserved (2.C). This is why Pillar 1 is "deep but not
+huge": the hard part is *discipline* (one write path, no host-only truth), not volume.
+
+---
+
+## 3. Q2 — Reproject UX bar
+
+**Decision: reproject is an honest, bounded, covered rebuild — not invisible recovery.**
+
+- **Latency target:** < ~1.5 s from host (re)launch to first-painted topology (windows + layout in
+  place), pools warming in the background after. Justification: cold start already does this; we're
+  reusing that path, not adding a slower one.
+- **Visual treatment:** a single branded **"Restoring session…"** overlay on reproject, then the
+  topology paints in. **Never** the raw `0xE0000008` OS fault box (that's the
+  `WER_FAULT_REPORTING_NO_UI` + native-dialog work already specced in `SPEC_GRACEFUL_OOM_EXIT`).
+- **Explicitly NOT a goal:** zero-flicker / seamless in-place recovery. The audit shows chasing
+  invisibility is what produced the 6×-refixed renderer-OOM saga. Per crash-only doctrine, a clean
+  visible restart beats a clever invisible one. **Flicker is a crash-path event only** — steady
+  state never rebuilds, so users see the overlay only when something actually died.
+- **Acceptance:** the E2E test "host OOM ⇒ session reprojects" asserts topology equivalence
+  (same windows/panes/layout) within the latency budget, with the overlay shown and no orphaned
+  Job-Object tree (ties to Pillar 2 Stage 3's exit test).
+
+---
+
+## 4. Q3 — Write-through mechanism
+
+**Decision: snapshot-style state-store write-through through the reducer — NOT event sourcing.**
+
+Why not event-sourced log:
+- Host topology is **soft state with no audit, time-travel, or replay-from-zero requirement.** An
+  event log's payoff (full history, temporal queries, rebuild-from-events) is value we'd never use.
+- The literature's own caveat: a growing event log *adds* recovery latency and forces you to bolt
+  on snapshots anyway. We'd be paying the log's complexity to immediately neutralize it. Skip to
+  the snapshot.
+
+What we do instead:
+- The reducer is the **single writer.** Every topology-mutating `HostCommand` (window open/close,
+  layout change, opacity, floating placement) write-throughs the affected keys to srv's existing
+  stores (`db_layout`, window metadata) **last-writer-wins per key**, async + batched so it never
+  stalls the UI thread (the "background write-through" pattern — client never eats persistence
+  latency).
+- This is **not a new store** — it extends the path srv already uses for layout. The required move
+  is **#864: retire the wcore-direct second write path** so the reducer is the *only* writer.
+  Pillar 1's durability correctness is impossible while two writers race one record (audit §2.3
+  "layout split-brain"); fixing #864 is therefore a **hard prerequisite**, not a nice-to-have.
+- **Reproject read path = the existing cold-start restore.** No new deserialization code; the host
+  already reads srv topology on launch. Pillar 1 makes that read fire on crash and cover 2.A fully.
+
+**Consequence for sequencing:** #864 is pulled *into* Pillar 1's critical path (it was previously
+"pay-down"). Single-write-path first, then opacity/placement persistence, then fire-restore-on-crash.
+
+---
+
+## 5. Q4 — Can admission control ship independently/early?
+
+**Answer: Yes — already done and proven.** Pillar 3 (commit-aware admission gate) merged in #1853
+with zero dependency on the host rework: `sysinfo::available_commit_gb()` + pure
+`runner::admit_spawn()` gate in `run_agent`, refusing spawn below
+`AGENTMUX_AGENT_COMMIT_RESERVE_GB`. It stops overcommit at the source regardless of whether the
+host is disposable yet. Q4 is closed empirically. Remaining Pillar 3 follow-ons (queue-and-drain
+instead of hard refuse, per-agent working-set cap, frontend "memory full" badge) are likewise
+independent of Pillar 1 and can land anytime.
+
+---
+
+## 6. Resulting Pillar 1 implementation sequence (for the sized spec next)
+
+1. **#864 — collapse layout to one write path** (reducer is sole writer; delete wcore-direct).
+   *Hard prerequisite — durability is incoherent with two writers.*
+2. **Persist the two host-only topology facts** to srv: per-window opacity, floating-pane
+   placement + `last_known_normal_rect`.
+3. **Audit window-set completeness** — confirm no host-only window truth beyond what
+   `shadow_*` already projects; close gaps.
+4. **Fire the cold-start restore path on crash** (mid-session reproject) + the "Restoring session…"
+   overlay; ensure in-flight (2.C) work is **re-derived from topology, not resumed**.
+5. **E2E test:** "host OOM ⇒ session reprojects" (topology equivalence within budget, overlay
+   shown, no orphan tree).
+6. **Then the collapses land:** graceful-flush-vs-crash incoherence deleted (one recover path);
+   saga layer collapses to an in-memory registry (nothing durable left to compensate).
+
+---
+
+## 7. Risks / honest caveats
+- **#864 is now blocking, not optional** — if the layout split-brain proves hairy, Pillar 1 stalls
+  behind it. That's the right place for the risk to surface (durability *requires* a single writer).
+- **In-flight re-derivation (2.C) is the subtle part** — a reproject that tries to *resume* a
+  half-finished create instead of re-deriving from topology reintroduces the orphan class. The
+  design rule (derive desired end-state, re-drive idempotently) must be enforced in review.
+- **Pools rebuild empty** — a reproject momentarily has cold pools; first new-window/pane after a
+  crash is slower until warm. Acceptable (crash-path only), but note it so it isn't "fixed" with
+  pool-state serialization (which would re-introduce ephemeral-handle persistence — an anti-goal).
+- This remains a **refactor, not a rewrite** — it reuses cold-start restore, the SQLite stores, the
+  reducer, and the launcher projection. The work is discipline (one writer, no host-only truth),
+  not new machinery.
+
+---
+
+## 8. Sources
+- George Candea & Armando Fox, *Crash-Only Software*, HotOS-IX, 2003 —
+  https://www.usenix.org/conference/hotos-ix/crash-only-software ·
+  https://dslab.epfl.ch/pubs/crashonly.pdf
+- George Candea et al., *Microreboot — A Technique for Cheap Recovery*, OSDI 2004 —
+  https://www.usenix.org/legacy/event/osdi04/tech/full_papers/candea/candea.pdf ·
+  https://en.wikipedia.org/wiki/Microreboot
+- *Recovery-Oriented Computing: Building Multitier Dependability* —
+  http://www.engr.newpaltz.edu/~bai/EGE534/can04.pdf
+- Event-sourcing snapshotting / background write-through latency —
+  https://www.kurrent.io/blog/snapshots-in-event-sourcing/ ·
+  https://domaincentric.net/blog/event-sourcing-snapshotting
+- Internal: `docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md` §7 (Q1–Q4),
+  `docs/specs/SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` (Pillar 1), `state.rs` inventory,
+  issue **#864** (layout single write path).

--- a/docs/specs/SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md
+++ b/docs/specs/SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md
@@ -1,0 +1,340 @@
+# SPEC — Strong Reducer-Authority for Layout (Intent-Driven srv Reducer)
+
+**Date:** 2026-06-30
+**Type:** Implementation spec (full analysis)
+**Status:** Ready to schedule
+**Owner:** asaf
+**Supersedes scope of:** `SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md` (that spec's "weak" single-writer
+becomes Phase 1 here; this spec is the committed end-goal)
+**Depends on / relates to:** #864 (retire wcore-direct), Pillar 1 host-reproject
+(`SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md`), the authority principle in
+`DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md` §7a.
+
+> **Goal:** make the **srv reducer the sole authority over layout** — the frontend sends *intents*
+> ("split node X horizontally", "move A into B", "resize these"), the reducer **computes** the
+> resulting tree, enforces all invariants, persists via one write path, and projects the result back.
+> Layout *logic* leaves the disposable renderer and lives in the durable tier, where it belongs.
+
+---
+
+## 0. TL;DR — the decision and the surprise
+
+**Decision (asaf, 2026-06-30):** reducer-as-authority is **critical, not optional**. Weak authority
+(frontend computes the tree, reducer rubber-stamps it via `LayoutSetTree`) leaves the layout algebra
+in the disposable renderer — the same smell as the host-reducer problem, one layer up. We commit to
+**strong** authority: the reducer owns the algebra.
+
+**The surprise (from the source audit):** this is ~70% already built and dormant.
+- The **IPC command surface already exists** — all 11 layout intents are defined in
+  `agentmux-common/src/ipc.rs` (`LayoutMoveNode`, `LayoutSwapNodes`, `LayoutResizeNodes`,
+  `LayoutReplaceNode`, `LayoutSplitHorizontal/Vertical`, `LayoutInsertNodeAtIndex`,
+  `LayoutInsertNode`, `LayoutDeleteNode`, `LayoutClear`, `LayoutSetTree`) — `ipc.rs:506-588`.
+- The **pure tree algebra is already ported to Rust**, with a 30-test oracle against the frontend
+  (`backend/layout/mod.rs`): `insert_node`, `insert_node_at_index`, `delete_node`, `move_node`,
+  `swap_nodes`, `resize_nodes`, `replace_node`, `split_horizontal`, `split_vertical`,
+  `clear_tree_node` + traversal helpers. Intent helper types `ResizeOp`/`SplitPosition` exist in
+  common (`layout_types.rs:98-111`).
+- Only **4 of 11 reducer arms are wired** (`reducer/layout.rs`: clear/set_tree/insert/delete; the
+  "4 of 11 shipped" comment at `reducer.rs:86-91`). The other 7 commands are defined but **un-dispatched**.
+
+**What's genuinely missing** (the real work):
+1. **`balanceNode` is not ported to Rust** — the tree-normalization keystone. Only
+   `reverse_flex_direction` exists; no single-child hoist, no leaf-collapse, no `validateNode`, no
+   `_slipAnchor` exemption. **Without it the reducer can't be authoritative** — it would produce
+   un-normalized trees the frontend would then "correct," reintroducing a second writer.
+2. **Wire the remaining 7 reducer arms** to the existing pure fns + emit events.
+3. **The frontend must send intents, not full trees** — flip `persistToBackend`'s full-tree
+   `UpdateObject` push to per-action intent RPCs, and apply results via the existing
+   `pendingbackendactions` channel.
+4. **The minimize/slip/dissolve algebra** (`layoutMinimize.ts`, ~500 lines, depends on **render
+   pixel ratios**) — the hard part; needs a logical/geometric split (§6).
+5. **Single write path + coherence-by-construction** (the #864 work: reroute wcore-direct callers;
+   CAS + derived `leaforder` as defense-in-depth).
+
+---
+
+## 1. Current architecture (verified)
+
+### 1.1 Where the algebra lives today — the frontend
+`frontend/layout/lib/`: pure tree fns in `layoutTree.ts` (13 reducers) + `layoutNode.ts` (primitives
++ `balanceNode`); the stateful dispatcher `LayoutModel.treeReducer` (`layoutModel.ts:522`); minimize
+in `layoutMinimize.ts`; persistence in `layoutPersistence.ts`.
+
+**Flow today (full-tree push):** user action → app builds an action object → `treeReducer` mutates
+`rootNode` in place → `updateTree()` runs `balanceNode` → `persistToBackend()`
+(`layoutPersistence.ts:281-299`, debounced 100ms) copies the **entire tree** onto the `LayoutState`
+WaveObject → `ObjectService.UpdateObject(value)` (`wos.ts:312`). The frontend pushes the *computed
+result*, through the generic object RPC. There is **no** frontend→srv layout-intent RPC for in-tab ops.
+
+**Backend→frontend channel (already intent-shaped):** `pendingbackendactions` on the same
+`LayoutState`; the frontend's `onBackendUpdate` → `processPendingBackendActions` →
+`handleBackendAction` (`layoutPersistence.ts:52-275`) dedupes by `actionid` and applies each via
+`treeReducer`. Seven action types already have a wire-intent form (`LayoutActionData`,
+`gotypes.d.ts:1088`) — but only backend→frontend, not the reverse.
+
+### 1.2 Where the algebra already exists — Rust srv
+- **Commands:** all 11, `ipc.rs:506-588`. **Events:** partial — `LayoutSplitHorizontalApplied`,
+  `LayoutSplitVerticalApplied`, `LayoutCleared`, … (`ipc.rs:1462+`); the rest need adding.
+- **Pure fns:** `backend/layout/mod.rs` — full set, oracle-tested against
+  `frontend/layout/tests/layoutTree.test.ts` (30 tests, PR #686). Handles `extra` catch-all
+  preservation, single-child collapse on delete, ancestor/descendant guards on move/swap, atomic
+  resize validation.
+- **Wired arms:** `reducer/layout.rs` — `handle_set_focused_node`, `handle_set_magnified_node`,
+  `handle_layout_clear`, `handle_layout_set_tree`, `handle_layout_insert_node`,
+  `handle_layout_delete_node`. The insert/delete arms already do focus/magnify reconciliation
+  correctly (e.g. delete walks the post-delete tree to clear orphaned focus ids,
+  `reducer/layout.rs:296-312`).
+- **Shared type:** `LayoutNode` (`layout_types.rs:55-75`) — `id`, `flex_direction`, `size`,
+  `children`, `data`, and a `#[serde(flatten)] extra` catch-all. **The minimize fields
+  (`minimizedSize`, `slipMinimize`, `columnDissolve`, `_slipAnchor`) are NOT modeled** — they
+  currently round-trip through `extra` untyped, so the Rust reducer is blind to them today.
+
+### 1.3 The gap, exactly
+The reducer can already *compute* every structural operation. It cannot yet be *authoritative*
+because: (a) nothing normalizes its output (`balanceNode` missing), (b) 7 arms are unwired, (c) the
+frontend doesn't send intents, and (d) minimize/dissolve is geometry-coupled and unmodeled.
+
+---
+
+## 2. Target architecture — intent in, normalized tree out, projected back
+
+```
+ user action (split/move/resize/minimize/…)
+        │  frontend builds an INTENT (no local tree mutation)
+        ▼
+ frontend → srv RPC:  Layout<Intent> { tab_id, target ids, params, correlation_id }
+        │
+        ▼
+ srv REDUCER (sole authority)
+   1. resolve targets against tab.rootnode
+   2. call the pure algebra fn (backend/layout/mod.rs)
+   3. balance_node()  ← NEW: enforce normalization invariants
+   4. reconcile focus/magnify
+   5. emit Layout<Intent>Applied event (carries new tree or a structural delta)
+        │
+        ├─► persist subscriber  → ONE write to db_layout (rootnode+leaforder), version-CAS
+        └─► wave_obj_bridge      → waveobj:update / pendingbackendactions → frontend projects result
+        │
+        ▼
+ frontend RENDERER (disposable projection)
+   - applies the result (already supported via handleBackendAction)
+   - derives PIXEL geometry locally (sizes, minimize realization)
+```
+
+**Invariants of the target state:**
+- The reducer is the **only** producer of layout trees. The frontend never computes a persisted tree.
+- The persist subscriber is the **only** writer of `db_layout` (kills the double-write + wcore-direct).
+- The renderer holds only **derived/geometric** state it can recompute on reproject (pixel sizes,
+  minimize realization) — consistent with Pillar 1 disposability.
+
+---
+
+## 3. The `balanceNode` port (the keystone — §new Rust work)
+
+The frontend runs `balanceNode` (`layoutNode.ts:200-232`) after **every** committed action via
+`updateTree(balanceTree=true)`. The Rust reducer must run an equivalent `balance_node` at the end of
+every structural arm, or it cannot own normalized output. The six invariants to port (oracle:
+`frontend/layout/tests/` balance tests + the live `balanceNode`):
+
+1. **Direction alternation** — any child with `flex_direction == parent.flex_direction` is flipped to
+   the reverse. Sibling axes alternate Row/Column down the tree.
+2. **Single-child-branch hoisting** — if a child has exactly one child that is itself a branch, hoist
+   the grandchild's children up one level — **unless** the node carries `_slipAnchor` (the explicit
+   opt-out for slip/dissolve subtrees).
+3. **Empty-children pruning** — drop any node whose `children` is empty (and has no `data`).
+4. **Undefined filtering** — compact the children vec after pruning.
+5. **Single-child-leaf collapse** — a node with exactly one leaf child *absorbs* that child's `data`
+   and `id`, dropping `children` (branch-with-one-leaf becomes the leaf). NB: `delete_recursive`
+   already does a localized version of this (`backend/layout/mod.rs:273-281`) — `balance_node`
+   generalizes it to the whole tree post-action.
+6. **`validate_node` (leaf-XOR-branch)** — every node has *either* `data` or `children`, never both,
+   never neither; no empty `children`. The Rust port should return a `LayoutError` (not panic) so a
+   malformed intent is rejected with an `Event::Error`, not a crash.
+
+**Critical detail — `_slipAnchor` and the minimize fields:** invariant #2's exemption keys off
+`_slipAnchor`, which lives in `extra` today. To port balance faithfully the reducer must *read*
+`_slipAnchor` — so either (a) promote `_slipAnchor` (and the other minimize fields) to typed
+`LayoutNode` fields, or (b) have `balance_node` peek into `extra`. **Recommend (a)** — model the
+minimize fields explicitly (see §6); untyped `extra`-peeking is the kind of by-convention coupling
+this whole program is trying to delete.
+
+**Test strategy:** the frontend `balanceNode` tests become the Rust oracle (same input tree → same
+normalized output). Add a differential test harness: feed N random trees through both the TS and Rust
+`balance` and assert byte-equal JSON (the `serialize_size_smallest` shim already guarantees integer
+size round-trips, `layout_types.rs:81-93`).
+
+---
+
+## 4. The intent protocol (frontend → srv)
+
+### 4.1 Commands — already defined, need RPC surfacing
+All 11 exist in `ipc.rs`. The work is a thin RPC entrypoint that accepts a layout intent and dispatches
+it to the reducer (mirroring how `UpdateObject` currently dispatches `SetFocusedNode`). Each intent
+carries `tab_id`, the relevant target node id(s), params, and a `correlation_id` (for the frontend to
+match the echoed result and dedupe — the `processedActionIds` path already exists,
+`layoutPersistence.ts:74-98`).
+
+### 4.2 Per-action migration table (the full surface)
+| User action | Today | Target intent | Pure fn (exists) | Notes |
+|---|---|---|---|---|
+| Split H/V (Cmd+D / chord / menu) | local + full push | `LayoutSplitHorizontal/Vertical` | `split_horizontal/vertical` ✅ | events exist (`*Applied`) |
+| Drag-to-dock move | `computeMoveNode`→`moveNode`, full push | `LayoutMoveNode` | `move_node` ✅ | drag *preview* stays frontend (ephemeral); only the **commit** is an intent |
+| Swap (center drop) | local, full push | `LayoutSwapNodes` | `swap_nodes` ✅ | |
+| Resize divider | `onResizeEnd`, full push | `LayoutResizeNodes` | `resize_nodes` ✅ | send on commit (drag-end), not per-mousemove |
+| New pane / ephemeral | local `InsertNode`, full push | `LayoutInsertNode` | `insert_node` ✅ | arm wired |
+| Insert at index | backend-only today | `LayoutInsertNodeAtIndex` | `insert_node_at_index` ✅ | |
+| Replace | local, full push | `LayoutReplaceNode` | `replace_node` ✅ | |
+| Close pane | local `DeleteNode` + `DeleteBlock` | `LayoutDeleteNode` (+ block delete) | `delete_node` ✅ | arm wired; keep block-destroy ordering |
+| Magnify / Focus | local toggle, full push | `LayoutSetMagnifiedNode`/`SetFocusedNode` | n/a | arms wired |
+| Clear | backend-only | `LayoutClear` | n/a | arm wired |
+| **Minimize / slip / dissolve** | **entirely frontend, pixel-coupled** | **new intents (§6)** | **not ported** | the hard part |
+
+### 4.3 Drag preview stays local (important)
+Drag *preview* (`computeMoveNode` running on every dragover) must remain renderer-local for latency —
+it's ephemeral view state, not a mutation. Only the **drop commit** becomes a `LayoutMoveNode` intent.
+This respects the §7a rule: the renderer may run real-time coordination as long as the *authoritative*
+mutation goes through the reducer.
+
+---
+
+## 5. Single write path + coherence-by-construction (the #864 fold-in)
+
+This spec absorbs `SPEC_864_LAYOUT_SINGLE_WRITER`. Once intents flow through the reducer:
+- **Persist subscriber becomes the only `db_layout` writer.** Add `apply_layout_*` arms for every
+  layout event (`persist_subscriber.rs:187-298`) + bridge broadcast arms
+  (`wave_obj_bridge.rs:440-443`). Reroute the ~9 wcore-direct callers (the `UpdateObject` raw-tree
+  write `service.rs:495`, seeders, tear-off, heal, prune, redock queues) to dispatch intents.
+- **Defense-in-depth (mechanical coherence):**
+  1. Make `version` a **real CAS** — `store.rs:394` currently does `SET version = version + 1` with
+     no `WHERE version = ?` guard (verified): it's a blind counter mislabeled "optimistic locking."
+     Add the guard + reject/retry. Benefits every otype.
+  2. Make `leaforder` a **pure derivation of `rootnode`**, computed once in the subscriber on write —
+     drift becomes impossible by construction, removing the main reason `heal_layout` exists.
+- These two are *necessary but not sufficient* (they fix mechanical coherence, not authority) — they
+  sit **beneath** the single writer, never instead of it.
+
+---
+
+## 6. The hard part — minimize / slip / dissolve (`layoutMinimize.ts`)
+
+This is the highest-risk surface and deserves its own design pass; this spec scopes the problem and
+sets direction, but flags the sub-design as open.
+
+**Why it's hard:** `layoutMinimize.ts` (~500 lines) is stateful on `LayoutModel`, has three paths
+(Column-collapse → `minimizedSize`; Row-slip → `slipMinimize` + `_slipAnchor`; column-dissolve →
+`columnDissolve`, which **restructures** the tree by re-inserting a column atop an adjacent one), a
+cascade undissolve (A→B→C), and — critically — it reads **render pixel ratios**
+(`pixelToSizeRatio`, `rect.height`, `MinNodeSizePx=40`) to compute the collapsed sizes. srv has no
+pixel geometry.
+
+**Recommended direction — split logical state from geometric realization:**
+- **Authoritative (srv reducer):** the *logical* facts —
+  - *which* nodes are minimized (a boolean/flag per node),
+  - the *structural* dissolve relationships (`columnDissolve` is a real topology change → must be a
+    reducer intent: `LayoutDissolveColumn` / `LayoutUndissolveColumn` computing the restructure),
+  - the slip linkage (`slipMinimize` target column).
+  These become **typed `LayoutNode` fields** (not `extra`), so `balance_node` and reproject see them.
+- **Derived (renderer):** the *pixel sizes* a minimized/slipped node collapses to. The renderer
+  recomputes these from its current viewport on each layout and on reproject — exactly the
+  disposable-projection model. srv stays geometry-free.
+
+**The subtlety to resolve in the sub-design:** today the size value and the restructure are computed
+together. Separating them means the reducer performs the *restructure* with size values expressed in
+**flex units / conventions** (e.g. a collapsed leaf gets a small fixed flex unit, sibling absorbs the
+remainder), and the renderer maps that to pixels. This will not be byte-identical to today's
+pixel-exact behavior — acceptable if the visual result matches within tolerance, but it needs its own
+spec + visual verification. **Until that lands, minimize/dissolve can remain a frontend-computed
+operation that still routes its *result* through `LayoutSetTree`** (weak authority for this one
+operation) so it doesn't block the rest — explicitly the one place we tolerate weak authority
+temporarily, logged as debt.
+
+---
+
+## 7. Phased plan
+
+**Phase 1 — single writer (weak authority), low risk.** Land `SPEC_864` Phase 1–2: persist-subscriber
++ bridge arms for the 4 existing events; reroute `UpdateObject` to `LayoutSetTree`; add CAS +
+derived-leaforder. *Outcome:* one write path, double-write gone, coherence-by-construction — but the
+frontend still computes trees. Behavior-neutral, fully unit-testable. **This is the stepping stone.**
+
+**Phase 2 — port `balance_node` to Rust (the keystone).** Implement + differential-test against the
+TS oracle. No behavior change yet (not called on the hot path until Phase 3), but it unblocks
+authority. *Gated on the differential harness passing.*
+
+**Phase 3 — wire the 7 remaining reducer arms.** `LayoutMove/Swap/Resize/Replace/SplitH/SplitV/
+InsertAtIndex` → existing pure fns → `balance_node` → emit event → subscriber persists. Add the
+missing `*Applied` events. *Unit-tested per arm against the oracle.*
+
+**Phase 4 — flip the frontend to intents (strong authority).** Per the §4.2 table, replace local
+`treeReducer` + full-push with intent RPCs; apply echoed results via the existing
+`handleBackendAction`/`pendingbackendactions` path; keep drag-preview local. **This is the
+behavior-changing core — needs app-running E2E verification (split/move/resize/swap/insert/delete/
+replace all round-trip through srv). Do NOT auto-merge on bot approval.**
+
+**Phase 5 — model the minimize fields + dissolve intents** (§6). Promote `minimizedSize`/
+`slipMinimize`/`columnDissolve`/`_slipAnchor` to typed fields; add `LayoutDissolveColumn`/
+`Undissolve` intents with the logical/geometric split. *Own sub-spec + visual verification.* Until
+done, minimize routes its result via `LayoutSetTree` (tracked debt).
+
+**Phase 6 — delete the backstops.** Remove `heal_layout` + callers, the relaxed `reorder_tabs_bulk`
+validation + its migration test, the resync layout carve-out. The payoff deletion.
+
+---
+
+## 8. Test strategy
+- **Oracle parity:** the 30 `layoutTree.test.ts` cases + the `balanceNode` tests are the cross-language
+  oracle. Rust arms must reproduce TS state transitions byte-for-byte (JSON-equal).
+- **Differential fuzz:** random tree generator → run identical intent through TS and Rust → assert
+  equal normalized output. The keystone safety net for `balance_node`.
+- **Reducer unit tests:** per arm — happy path, target-not-found → `Event::Error` (not panic),
+  focus/magnify reconciliation, root-as-target guards.
+- **E2E (Phase 4+):** "every in-tab layout action mutates only via srv"; "close last pane ⇒ tree
+  exits" (ties Pillar 2); "reproject restores identical topology" (ties Pillar 1).
+- **Coherence:** assert exactly one `db_layout` write + one version bump per intent; assert
+  `TabRecord.rootnode == db_layout.rootnode` mid-session (the new invariant).
+
+---
+
+## 9. Risks / honest caveats
+- **`balance_node` fidelity is make-or-break.** If the Rust normalization diverges from TS even
+  slightly, the frontend will "fix" the tree on receipt and push it back → a second writer returns
+  silently. The differential fuzz harness is mandatory, not optional.
+- **Minimize/dissolve geometry coupling (§6) is genuinely unsolved here** — scoped, directioned, but
+  needs its own spec + visual verification. Do not let it block Phases 1–4; carry it as explicit debt
+  with the `LayoutSetTree` escape hatch.
+- **Latency:** every layout action becomes a round-trip to srv. Resize especially must send on
+  drag-*end*, not per-mousemove, and drag-preview must stay local, or interaction will feel laggy.
+  The 100ms debounce on the current push is the budget to respect.
+- **Phase 4 is behavior-changing and broad** — touches every layout interaction. Gate on app-running
+  E2E; land behind the already-built pure layer so the risk is wiring, not algebra.
+- **Frontend `layoutTree.ts` becomes vestigial** after Phase 4 (except drag-preview math) — plan its
+  deletion so two implementations don't drift in the interim.
+
+---
+
+## 10. Definition of done
+1. Every in-tab layout mutation flows through a reducer intent; the frontend computes no persisted
+   tree (except the minimize escape hatch, tracked).
+2. `balance_node` ported, differential-fuzz-equal to TS.
+3. All 11 reducer arms wired + evented; persist subscriber is the sole `db_layout` writer.
+4. `version` is a real CAS; `leaforder` is a pure derivation; `heal_layout` + relaxed-validation
+   shims + resync carve-out deleted.
+5. `TabRecord.rootnode == db_layout.rootnode` invariant holds mid-session (test).
+6. Minimize fields typed; dissolve is a reducer intent (or explicitly tracked as remaining debt).
+7. Unblocks Pillar 1: reproject reads a single authoritative, coherent layout source.
+
+---
+
+## 11. Sources / evidence
+- Rust: `agentmux-common/src/ipc.rs:506-588` (commands), `:1462+` (events);
+  `agentmux-common/src/layout_types.rs:55-111` (`LayoutNode`, `ResizeOp`, `SplitPosition`);
+  `agentmux-srv/src/backend/layout/mod.rs` (full pure algebra + oracle note);
+  `agentmux-srv/src/reducer/layout.rs` (4 wired arms); `reducer.rs:86-91` ("4 of 11");
+  `backend/storage/store.rs:394` (blind-increment version, not CAS).
+- Frontend: `frontend/layout/lib/{types.ts,layoutNode.ts,layoutTree.ts,layoutMinimize.ts,
+  layoutPersistence.ts,layoutModel.ts}`; oracle `frontend/layout/tests/layoutTree.test.ts`.
+- Program docs: `SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md`,
+  `SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md`,
+  `DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md` §7a (authority principle),
+  `srv-phase-e4b-formal-spec-2026-05-03.md` (the original E.4.B port spec this finishes).
+```

--- a/docs/status/STATUS_LIFECYCLE_OOM_REFACTOR_2026_06_30.md
+++ b/docs/status/STATUS_LIFECYCLE_OOM_REFACTOR_2026_06_30.md
@@ -16,8 +16,10 @@ projections. See `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` and
 | Architecture analysis + decision | ✅ Merged (#1847) |
 | OOM crash diagnosis + graceful-exit design | ✅ Merged (specs in #1847) |
 | **Pillar 2 — single lifecycle authority** | 🟡 Stage 1 merged (#1850); Stage 2 designed, blocked on runtime verification; Stage 3 pending |
-| Pillar 3 — commit-aware admission control | ⬜ Specced (P0), not started |
-| Pillar 1 — host reproject | ⬜ Deepest; deliberately last |
+| Pillar 3 — commit-aware admission control | ✅ Merged (#1853); follow-ons (queue-and-drain, per-agent cap, badge) pending |
+| Pillar 1 — host reproject | 🟡 Q1–Q4 resolved (`SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30`); blocked on #864 |
+| #864 — layout single writer (Pillar 1 prereq) | 🟡 = **Phase 1** of strong reducer-authority (below); spec `SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30` |
+| **Strong reducer-authority (layout)** | 🟡 Full spec `SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30`; ~70% prebuilt (algebra+commands exist), keystone = port `balance_node`; 6-phase plan, not started. **Decided critical, not optional.** |
 | Saga collapse + persistence paydown | ⬜ After Pillars 1–3 |
 | Disk cleanup + tooling | ✅ Done (~107 GB reclaimed; `bin/clean-agentmux-builds.ps1`) |
 


### PR DESCRIPTION
## What

Phase 1 of the **layout single-writer / strong reducer-authority** program
(specs: `SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30`,
`SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30`, gated by Pillar 1
`SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30`).

Adds the first two **tree-mutating** layout events to the
reducer→persist-subscriber path (instead of wcore-direct):

- `apply_layout_cleared` — wipes the persisted tree + focus/magnify + leaforder.
- `apply_layout_tree_replaced` — writes the reducer-supplied tree onto
  `LayoutState.rootnode`; clears focus/magnify/leaforder when the tree is empty.
- Matching `wave_obj_bridge` arms so the new `LayoutState` is broadcast to the
  frontend (safe: the HTTP RPC path applies SQLite synchronously before
  publishing, so the bridge re-read sees post-event state).

## Why this is behavior-neutral

The `Layout*` reducer arms still have **no production callers**
(`reducer.rs` "4 of 11"), so `LayoutCleared` / `LayoutTreeReplaced` are not
emitted in production yet. This PR lands the **persistence landing pad** that
the next phase needs — rerouting the `UpdateObject` full-tree push through
`LayoutSetTree` (that phase is behavior-changing and will be gated on
app-running E2E, separately).

## Deliberate scope boundaries

- **`leaforder` is not derived in Rust.** It is a frontend-recomputed geometry
  cache (`getLeafOrder`, sorted by render `treeKey`) and is **not** read on
  reproject (`bootstrap_state_from_wstore` reads rootnode/focus/magnify only).
  The next phase extends `LayoutSetTree` to carry the frontend's leaforder.
- **Insert/Delete arms deferred.** Their events carry op *params*, not the
  resulting tree, so persisting them would re-run the algebra in the subscriber
  — a *new* divergence surface, the exact thing this program removes. Resolved
  later by having those events carry the reducer's resulting tree.
- Arms are **idempotent** (no version churn on the sync-apply + broadcast
  double-delivery).

## Tests

5 new subscriber tests: persist rootnode, clear wipes tree+ids, empty-tree
clears focus/magnify, idempotency (no version churn), silent-when-tab-missing.

- `cargo test -p agentmux-srv` → **1244 passed, 0 failed**
- `cargo check --workspace` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)