### PR TITLE
chore: release v0.49.9

### DIFF
--- a/.changesets/1782586628-fix-floating-pane-dragging-a-torn-off-floating-pane-is-broke-qd24.md
+++ b/.changesets/1782586628-fix-floating-pane-dragging-a-torn-off-floating-pane-is-broke-qd24.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): dragging a torn-off floating pane is broken on Linux — get_window_position returns {0,0} post-load

--- a/.changesets/1782590232-fix-wrr-exclude-window-pool-from-locationchange-pool-move-cl-lst5.md
+++ b/.changesets/1782590232-fix-wrr-exclude-window-pool-from-locationchange-pool-move-cl-lst5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(wrr): exclude window-pool-* from LOCATIONCHANGE pool-move close detection

--- a/.changesets/1782609493-fix-floating-pane-halve-browser-edge-resize-border-from-12px-qud6.md
+++ b/.changesets/1782609493-fix-floating-pane-halve-browser-edge-resize-border-from-12px-qud6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): reduce browser edge-resize border from 12px to 4px

--- a/.changesets/1782609493-fix-floating-pane-macos-implement-get-set-window-rect-for-ce-38lq.md
+++ b/.changesets/1782609493-fix-floating-pane-macos-implement-get-set-window-rect-for-ce-38lq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane/macos): implement get/set_window_rect for CEF Views (macOS+Linux resize)

--- a/.changesets/1782680000-spec-agent-header-name-bb02.md
+++ b/.changesets/1782680000-spec-agent-header-name-bb02.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-spec(agent-pane): agent pane header name precedence + drop "continued" chip

--- a/.changesets/1782681000-fix-msstore-spec-security-cc03.md
+++ b/.changesets/1782681000-fix-msstore-spec-security-cc03.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-fix(spec): address script injection, dead input, and missing permissions in MS Store release spec

--- a/.changesets/1782682000-fix-unified-release-cicd-dd04.md
+++ b/.changesets/1782682000-fix-unified-release-cicd-dd04.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-fix(ci): correct VH_VER extraction, installer URL, version gate message, and changelog exit code in unified release workflow

--- a/.changesets/1782683000-fix-column-dissolve-bugs-ee05.md
+++ b/.changesets/1782683000-fix-column-dissolve-bugs-ee05.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-fix(layout): correct 6 P1 bugs in column dissolve — rollback guards, allCollapsed cascade, size budget, and slip-anchor teardown

--- a/.changesets/1782786622-fix-windows-artifacts-rust-cache-cef-dlls.md
+++ b/.changesets/1782786622-fix-windows-artifacts-rust-cache-cef-dlls.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): stage CEF DLLs from OUT_DIR on rust-cache hit (Windows artifacts)

--- a/.changesets/1782791255-feat-ci-unified-release-workflow-build-publish-winget-ms-sto-0g9g.md
+++ b/.changesets/1782791255-feat-ci-unified-release-workflow-build-publish-winget-ms-sto-0g9g.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ci): unified release workflow — build, publish, winget, MS Store, landing page

--- a/.changesets/1782791574-ci-macos-consume-patched-cef-framework-from-agentmuxai-cef-a-i1gg.md
+++ b/.changesets/1782791574-ci-macos-consume-patched-cef-framework-from-agentmuxai-cef-a-i1gg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci(macos): consume patched CEF framework from agentmuxai/cef + add BeginWindowDrag patch gate

--- a/.changesets/1782791896-chore-statusbar-drop-oom-kills-wording-from-pf-commit-charge-dc2u.md
+++ b/.changesets/1782791896-chore-statusbar-drop-oom-kills-wording-from-pf-commit-charge-dc2u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(statusbar): drop 'OOM kills' wording from PF commit-charge chip tooltip

--- a/.changesets/1782793345-feat-splash-wire-startup-telemetry-to-linux-splash-stage-lis-gp0c.md
+++ b/.changesets/1782793345-feat-splash-wire-startup-telemetry-to-linux-splash-stage-lis-gp0c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(splash): wire startup telemetry to Linux splash stage list

--- a/.changesets/1782793779-feat-lifecycle-compute-level-triggered-quit-decision-in-redu-i9j3.md
+++ b/.changesets/1782793779-feat-lifecycle-compute-level-triggered-quit-decision-in-redu-i9j3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(lifecycle): compute level-triggered quit decision in reducer (Pillar 2 stage 1)

--- a/.changesets/1782818885-feat-srv-commit-aware-agent-admission-refuse-new-agent-spawn-u9nt.md
+++ b/.changesets/1782818885-feat-srv-commit-aware-agent-admission-refuse-new-agent-spawn-u9nt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): commit-aware agent admission — refuse new agent spawn under low system commit (Pillar 3)

--- a/.changesets/1782822877-fix-windows-cfg-gate-state-windows-fallback-in-getwindowposi-835a.md
+++ b/.changesets/1782822877-fix-windows-cfg-gate-state-windows-fallback-in-getwindowposi-835a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(windows): cfg-gate state.windows fallback in GetWindowPositionTask — fixes Windows build break from #1823

--- a/.changesets/1782837421-fix-ci-remove-fabricated-dl-agentmux-ai-s3-mirror-from-relea-c0im.md
+++ b/.changesets/1782837421-fix-ci-remove-fabricated-dl-agentmux-ai-s3-mirror-from-relea-c0im.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): remove fabricated dl.agentmux.ai S3 mirror from release workflow

--- a/.changesets/1782839674-fix-ci-release-yml-consumes-patched-macos-cef-filters-linux--ae2u.md
+++ b/.changesets/1782839674-fix-ci-release-yml-consumes-patched-macos-cef-filters-linux--ae2u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): release.yml consumes patched macOS CEF + filters Linux CEF tag by platform

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.8"
+version = "0.49.9"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.8"
+version = "0.49.9"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,27 @@
 # AgentMux Version History
 
+## 0.49.9 — 2026-06-30
+
+- fix(floating-pane): dragging a torn-off floating pane is broken on Linux — get_window_position returns {0,0} post-load
+- fix(wrr): exclude window-pool-* from LOCATIONCHANGE pool-move close detection
+- fix(floating-pane): reduce browser edge-resize border from 12px to 4px
+- fix(floating-pane/macos): implement get/set_window_rect for CEF Views (macOS+Linux resize)
+- spec(agent-pane): agent pane header name precedence + drop "continued" chip
+- fix(spec): address script injection, dead input, and missing permissions in MS Store release spec
+- fix(ci): correct VH_VER extraction, installer URL, version gate message, and changelog exit code in unified release workflow
+- fix(layout): correct 6 P1 bugs in column dissolve — rollback guards, allCollapsed cascade, size budget, and slip-anchor teardown
+- fix(ci): stage CEF DLLs from OUT_DIR on rust-cache hit (Windows artifacts)
+- feat(ci): unified release workflow — build, publish, winget, MS Store, landing page
+- ci(macos): consume patched CEF framework from agentmuxai/cef + add BeginWindowDrag patch gate
+- chore(statusbar): drop 'OOM kills' wording from PF commit-charge chip tooltip
+- feat(splash): wire startup telemetry to Linux splash stage list
+- feat(lifecycle): compute level-triggered quit decision in reducer (Pillar 2 stage 1)
+- feat(srv): commit-aware agent admission — refuse new agent spawn under low system commit (Pillar 3)
+- fix(windows): cfg-gate state.windows fallback in GetWindowPositionTask — fixes Windows build break from #1823
+- fix(ci): remove fabricated dl.agentmux.ai S3 mirror from release workflow
+- fix(ci): release.yml consumes patched macOS CEF + filters Linux CEF tag by platform
+
+
 ## 0.49.8 — 2026-06-28
 
 - feat(trust-center): responsive layout from phone strip to desktop

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.8",
+      "version": "0.49.9",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Bumps version `0.49.8 → 0.49.9` (forced patch over 18 pending changesets)
- Consumes all pending changesets (floating pane fixes, Windows cfg gate, CEF platform resolution, unified release CI/CD wiring, commit-aware admission, lifecycle quit, splash telemetry, column dissolve, MS Store spec)

## Test plan
- [ ] Merge triggers reagent review → merge on approval
- [ ] Tag `v0.49.9` on main to exercise full `release.yml` end-to-end

<!-- agentmux:agent_id=camper-0622h -->