### PR TITLE
feat(srv): port balanceNode tree-normalization to Rust (strong reducer-authority keystone)

### DIFF
--- a/.changesets/1782843804-feat-srv-port-balancenode-tree-normalization-to-rust-strong--9ukl.md
+++ b/.changesets/1782843804-feat-srv-port-balancenode-tree-normalization-to-rust-strong--9ukl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): port balanceNode tree-normalization to Rust (strong-reducer-authority keystone)

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -29,6 +29,10 @@ pub enum LayoutError {
     InvalidSize { node_id: String, size: f32 },
     /// index_arr was empty or led to a non-existent location.
     InvalidIndexPath,
+    /// A node failed the leaf-XOR-branch invariant during balance — it has
+    /// both `data` and `children`, or neither. The TS oracle (`validateNode`
+    /// in `layoutNode.ts`) throws "Invalid node" here.
+    InvalidNode { id: String },
 }
 
 impl std::fmt::Display for LayoutError {
@@ -39,6 +43,7 @@ impl std::fmt::Display for LayoutError {
             Self::RootCannotBeTarget => write!(f, "root node cannot be the target of this operation"),
             Self::InvalidSize { node_id, size } => write!(f, "invalid size {:.2} for node {}", size, node_id),
             Self::InvalidIndexPath => write!(f, "index_arr is empty or points to a non-existent location"),
+            Self::InvalidNode { id } => write!(f, "invalid node (leaf-XOR-branch violated): {}", id),
         }
     }
 }
@@ -598,6 +603,86 @@ fn split_impl(
 /// actual clearing in the reducer just sets root = None.
 pub fn clear_tree_node(_root: &mut Option<LayoutNode>) {
     *_root = None;
+}
+
+// ── Tree normalization (balanceNode) ────────────────────────────────────────
+
+/// Validate the leaf-XOR-branch invariant. Mirrors `validateNode` in
+/// `frontend/layout/lib/layoutNode.ts`: a node must have **either** `data`
+/// **or** `children`, never both and never neither. (In TS the "empty
+/// children array" case is a separate check; here an empty `children` vec
+/// with no `data` is the same "neither" case and is rejected by the single
+/// XOR below.)
+fn validate_node(node: &LayoutNode) -> bool {
+    let has_children = !node.children.is_empty();
+    let has_data = node.data.is_some();
+    has_children != has_data
+}
+
+/// Port of `balanceNode` in `frontend/layout/lib/layoutNode.ts`. Recursively
+/// normalizes the tree: validates each node, alternates child flex direction,
+/// hoists redundant single-child-branch chains, drops empty branches, and
+/// collapses a branch with a single leaf child into that leaf.
+///
+/// Returns `Err(InvalidNode)` where the TS oracle throws "Invalid node", so
+/// the reducer can surface an `Event::Error` rather than panic.
+///
+/// Faithfulness notes (matched to the TS oracle, deliberately NOT "improved"):
+/// - The direction flip mutates only the *iterated* child; hoisted
+///   grandchildren are returned unflipped (a later pass alternates them) —
+///   matches the TS `flatMap`.
+/// - `_slipAnchor` (read from the untyped `extra` catch-all, where the
+///   frontend stores it) suppresses the single-child-branch hoist.
+/// - The single-leaf collapse copies the child's `data` + `id` only; the node
+///   keeps its own `size` / `flex_direction` / `extra` — exactly as TS does.
+pub fn balance_node(node: &mut LayoutNode) -> Result<(), LayoutError> {
+    // BEFORE-walk: validate, then rebuild children (flip / hoist / drop).
+    if !validate_node(node) {
+        return Err(LayoutError::InvalidNode { id: node.id.clone() });
+    }
+    let parent_flex = node.flex_direction;
+    let mut rebuilt: Vec<LayoutNode> = Vec::with_capacity(node.children.len());
+    for mut child in std::mem::take(&mut node.children) {
+        if child.flex_direction == parent_flex {
+            child.flex_direction = reverse_flex_direction(parent_flex);
+        }
+        let slip_anchor = child
+            .extra
+            .get("_slipAnchor")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        // Hoist: child has exactly one child and that grandchild is itself a
+        // branch (TS `child.children[0].children` truthy) — replace `child`
+        // with the grandchild's children. Suppressed for slip anchors.
+        if child.children.len() == 1 && !child.children[0].children.is_empty() && !slip_anchor {
+            let grandchild = child.children.remove(0);
+            rebuilt.extend(grandchild.children);
+            continue;
+        }
+        // Drop an empty branch (no data, no children). A leaf (data present,
+        // children empty) is kept — TS `children?.length === 0` is false for a
+        // leaf whose `children` is `undefined`.
+        if child.children.is_empty() && child.data.is_none() {
+            continue;
+        }
+        rebuilt.push(child);
+    }
+    node.children = rebuilt;
+
+    // Recurse into the rebuilt children (walkNodes' `forEach`, which iterates
+    // the post-rebuild children because the before-callback ran first).
+    for child in &mut node.children {
+        balance_node(child)?;
+    }
+
+    // AFTER-walk: collapse a single leaf child into this node.
+    if node.children.len() == 1 && node.children[0].children.is_empty() {
+        let only = node.children.remove(0);
+        node.data = only.data;
+        node.id = only.id;
+        node.children = Vec::new();
+    }
+    Ok(())
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -34,6 +34,217 @@ fn group(id: &str, dir: FlexDirection, size: f32, children: Vec<LayoutNode>) -> 
     }
 }
 
+/// Leaf with an explicit flex direction (the `leaf` helper hardcodes Row;
+/// the balance oracle cares about each leaf's own direction).
+fn leaf_dir(id: &str, block_id: &str, dir: FlexDirection) -> LayoutNode {
+    LayoutNode {
+        id: id.into(),
+        flex_direction: dir,
+        size: DEFAULT_NODE_SIZE,
+        data: Some(LayoutNodeData {
+            block_id: block_id.into(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+// ── balanceNode (ported from frontend/layout/tests/layoutNode.test.ts) ──────
+
+#[test]
+fn balance_corrects_flex_directions() {
+    // Row[ Row-leaf, Row-leaf ] → children flipped to Column.
+    let mut node = group(
+        "n",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![
+            leaf_dir("a", "node1Inner1", FlexDirection::Row),
+            leaf_dir("b", "node1Inner2", FlexDirection::Row),
+        ],
+    );
+    balance_node(&mut node).unwrap();
+    assert!(node.data.is_none(), "root should remain a branch");
+    assert_ne!(node.children[0].flex_direction, node.flex_direction);
+}
+
+#[test]
+fn balance_collapses_single_grandchild_1() {
+    // Row[ Column[ Row-leaf node1 ] ] → collapses to leaf node1.
+    let mut node = group(
+        "n",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![group(
+            "c",
+            FlexDirection::Column,
+            DEFAULT_NODE_SIZE,
+            vec![leaf_dir("g", "node1", FlexDirection::Row)],
+        )],
+    );
+    balance_node(&mut node).unwrap();
+    assert!(node.children.is_empty(), "should collapse to a leaf");
+    assert_eq!(node.data.unwrap().block_id, "node1");
+}
+
+#[test]
+fn balance_collapses_single_grandchild_2() {
+    // Row[ Column[ Row[ Column-leaf i1, Column-leaf i2 ] ] ] → hoist to 2 children.
+    let mut node = group(
+        "n",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![group(
+            "c",
+            FlexDirection::Column,
+            DEFAULT_NODE_SIZE,
+            vec![group(
+                "gc",
+                FlexDirection::Row,
+                DEFAULT_NODE_SIZE,
+                vec![
+                    leaf_dir("i1", "node2Inner1", FlexDirection::Column),
+                    leaf_dir("i2", "node2Inner2", FlexDirection::Column),
+                ],
+            )],
+        )],
+    );
+    balance_node(&mut node).unwrap();
+    assert_eq!(node.children.len(), 2);
+    assert_eq!(
+        node.children[0].data.as_ref().unwrap().block_id,
+        "node2Inner1"
+    );
+}
+
+#[test]
+fn balance_collapses_single_grandchild_3() {
+    // Row[ Column[ Row[ Column-leaf node3 ] ] ] → collapses to leaf node3.
+    let mut node = group(
+        "n",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![group(
+            "c",
+            FlexDirection::Column,
+            DEFAULT_NODE_SIZE,
+            vec![group(
+                "gc",
+                FlexDirection::Row,
+                DEFAULT_NODE_SIZE,
+                vec![leaf_dir("ggc", "node3", FlexDirection::Column)],
+            )],
+        )],
+    );
+    balance_node(&mut node).unwrap();
+    assert!(node.children.is_empty());
+    assert_eq!(node.data.unwrap().block_id, "node3");
+}
+
+#[test]
+fn balance_collapses_single_grandchild_4() {
+    // Row[ Column[ Row[ Column[ Row-leaf i1, Row-leaf i2 ] ] ] ]
+    // → node.children.len()==1, grandchildren len==2.
+    let mut node = group(
+        "n",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![group(
+            "c",
+            FlexDirection::Column,
+            DEFAULT_NODE_SIZE,
+            vec![group(
+                "gc",
+                FlexDirection::Row,
+                DEFAULT_NODE_SIZE,
+                vec![group(
+                    "ggc",
+                    FlexDirection::Column,
+                    DEFAULT_NODE_SIZE,
+                    vec![
+                        leaf_dir("i1", "node4Inner1", FlexDirection::Row),
+                        leaf_dir("i2", "node4Inner2", FlexDirection::Row),
+                    ],
+                )],
+            )],
+        )],
+    );
+    balance_node(&mut node).unwrap();
+    assert_eq!(node.children.len(), 1);
+    assert_eq!(node.children[0].children.len(), 2);
+    assert_eq!(
+        node.children[0].children[0].data.as_ref().unwrap().block_id,
+        "node4Inner1"
+    );
+}
+
+#[test]
+fn balance_rejects_invalid_node() {
+    // A node with BOTH data and children violates leaf-XOR-branch.
+    let mut bad = LayoutNode {
+        id: "bad".into(),
+        flex_direction: FlexDirection::Row,
+        size: DEFAULT_NODE_SIZE,
+        children: vec![leaf("x", "b", 1.0)],
+        data: Some(LayoutNodeData {
+            block_id: "both".into(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    assert!(matches!(
+        balance_node(&mut bad),
+        Err(LayoutError::InvalidNode { .. })
+    ));
+}
+
+#[test]
+fn balance_slip_anchor_suppresses_hoist() {
+    // Row[ Column(_slipAnchor)[ Row[ leaf1, leaf2 ] ] ] — without the slip
+    // anchor the single-child-branch chain would hoist/collapse; the anchor
+    // preserves it.
+    let mut anchored = group(
+        "c",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![group(
+            "gc",
+            FlexDirection::Row,
+            DEFAULT_NODE_SIZE,
+            vec![
+                leaf_dir("l1", "b1", FlexDirection::Column),
+                leaf_dir("l2", "b2", FlexDirection::Column),
+            ],
+        )],
+    );
+    anchored
+        .extra
+        .insert("_slipAnchor".into(), serde_json::Value::Bool(true));
+    let mut node = group("n", FlexDirection::Row, DEFAULT_NODE_SIZE, vec![anchored]);
+    balance_node(&mut node).unwrap();
+    // The anchored Column wrapper survives (not hoisted), still wrapping gc.
+    assert_eq!(node.children.len(), 1);
+    assert_eq!(node.children[0].children.len(), 1, "chain preserved by anchor");
+}
+
+#[test]
+fn balance_drops_empty_branch_child() {
+    // Row[ leaf1, leaf2, empty-branch ] → empty branch dropped, 2 remain.
+    let mut node = group(
+        "n",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![
+            leaf_dir("l1", "b1", FlexDirection::Column),
+            leaf_dir("l2", "b2", FlexDirection::Column),
+            group("empty", FlexDirection::Row, DEFAULT_NODE_SIZE, vec![]),
+        ],
+    );
+    balance_node(&mut node).unwrap();
+    assert_eq!(node.children.len(), 2);
+    assert!(node.children.iter().all(|c| c.data.is_some()));
+}
+
 // ── isInstanceLabel filter (JS analogue: insert location) ──────────────────
 
 #[test]


### PR DESCRIPTION
## What

Ports `balanceNode` (the layout tree-normalization pass) from
`frontend/layout/lib/layoutNode.ts` to a pure Rust `balance_node` in
`backend/layout/mod.rs`, plus `validate_node`. This is the **keystone** of
strong reducer-authority over layout (`SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT`).

## Why it's the keystone

The Rust reducer already has the full tree *algebra* (`move_node`, `swap_nodes`,
`split_*`, …) but **no normalization**. Without `balance_node`, the reducer
would emit un-normalized trees that the frontend would re-`balanceNode` and push
back — silently **reintroducing the second writer** this whole program removes.

## Invariants (identical to the TS oracle)

leaf-XOR-branch validation · child flex-direction alternation · single-child-
branch hoist (with the `_slipAnchor` exemption) · empty-branch drop · single-
leaf-child collapse.

Faithful to the oracle, deliberately **not** "improved":
- the direction flip mutates only the iterated child; hoisted grandchildren are
  returned unflipped (a later pass alternates them) — matches the TS `flatMap`.
- `_slipAnchor` is read from the untyped `extra` catch-all (where the frontend
  stores it today); typing it is a later phase.
- single-leaf collapse copies the child's `data`+`id` only — node keeps its own
  `size`/`flex`/`extra`, exactly as TS does.
- `validate` failure returns `Err(InvalidNode)` where TS throws, so the reducer
  surfaces `Event::Error` rather than panicking.

## Behavior-neutral

Pure addition — `balance_node` has **no callers yet** (the `Layout*` reducer
arms that will call it are wired in a later phase).

## Tests

All **5 `balanceNode` oracle cases** ported verbatim from
`frontend/layout/tests/layoutNode.test.ts`, plus invalid-node, slip-anchor-
suppresses-hoist, and drop-empty-branch.

> Note: no idempotency test on purpose — `balanceNode` is **not** idempotent in
> the oracle (hoisted children are left unflipped in one pass, so a second pass
> can flip them). Asserting idempotency would be a false claim.

- `cargo test -p agentmux-srv` `backend::layout` → **48 passed, 0 failed**
- full srv suite green; `cargo check --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)