### PR TITLE
chore(ci): pin Claude Code to 2.1.197, add versioning spec

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -9,7 +9,7 @@ on:
       claude_version:
         description: 'Claude Code version to pin (empty = latest)'
         required: false
-        default: 'latest'
+        default: '2.1.197'
 
 env:
   REGISTRY: ghcr.io

--- a/docker/Dockerfile.agent-agentmux
+++ b/docker/Dockerfile.agent-agentmux
@@ -33,7 +33,7 @@ RUN usermod -l agent -d /home/agent -m node \
 
 # Claude Code — version pinned at build time for reproducible images.
 # Managed by rebuilding with a new CLAUDE_VERSION arg, not npm update.
-ARG CLAUDE_VERSION=latest
+ARG CLAUDE_VERSION=2.1.197
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 
 # Prevent in-container auto-updates — version is managed at the image level.

--- a/docs/spec-claude-code-versioning.md
+++ b/docs/spec-claude-code-versioning.md
@@ -29,8 +29,10 @@ Both pins must be updated together when bumping.
 1. Check the latest release: `npm view @anthropic-ai/claude-code version`
 2. In `docker/Dockerfile.agent-agentmux`: update `ARG CLAUDE_VERSION=<new>`
 3. In `.github/workflows/container-image.yml`: update `default: '<new>'`
-4. Open a PR; the CI workflow's `workflow_dispatch` on merge will build and push
-   the image tagged with the release version and `:latest`.
+4. Open a PR and merge it.
+5. To publish the image, either:
+   - **Push a `v*` git tag** (e.g. `git tag v0.50.0 && git push origin v0.50.0`) — this triggers the workflow automatically and publishes both the semver tag and `:latest`.
+   - **Manually dispatch** the `Container Agent Image` workflow — this builds and pushes a `dispatch-<sha>` tag only; `:latest` is *not* updated by a manual dispatch.
 
 ## Version history
 

--- a/docs/spec-claude-code-versioning.md
+++ b/docs/spec-claude-code-versioning.md
@@ -1,0 +1,52 @@
+# Spec: Claude Code Version Management
+
+**Status:** Active  
+**Current pinned version:** `2.1.197`  
+**Previous default:** `latest` (floating)
+
+## Problem
+
+The container image for `ghcr.io/agentmuxai/agent-claude` previously defaulted to
+installing whatever `@anthropic-ai/claude-code@latest` resolved to at image build
+time. This meant two builds triggered minutes apart could embed different Claude Code
+versions, breaking reproducibility and making regressions harder to bisect.
+
+## Version pins (two locations)
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `docker/Dockerfile.agent-agentmux` line 36 | `ARG CLAUDE_VERSION=2.1.197` | Fallback for local `docker build` without passing the arg |
+| `.github/workflows/container-image.yml` line 12 | `default: '2.1.197'` | Default used when CI is triggered via `workflow_dispatch` without an explicit version input |
+
+The CI workflow's "Resolve Claude Code version" step (`id: claude_ver`) has a special case:
+- Input non-empty and not `"latest"` → use the input value verbatim (shell injection safe via `env:`)
+- Input empty or `"latest"` → resolve via `npm view @anthropic-ai/claude-code version` at build time
+
+Both pins must be updated together when bumping.
+
+## How to bump
+
+1. Check the latest release: `npm view @anthropic-ai/claude-code version`
+2. In `docker/Dockerfile.agent-agentmux`: update `ARG CLAUDE_VERSION=<new>`
+3. In `.github/workflows/container-image.yml`: update `default: '<new>'`
+4. Open a PR; the CI workflow's `workflow_dispatch` on merge will build and push
+   the image tagged with the release version and `:latest`.
+
+## Version history
+
+| Version | Date | Notes |
+|---------|------|-------|
+| `2.1.197` | 2026-06-30 | First explicit pin; replaced floating `latest` default |
+
+## Escape hatch
+
+To build with a one-off version without changing the pins, trigger the
+`Container Agent Image` workflow manually and enter the version in the
+`claude_version` input field. This produces a `dispatch-<sha>` image tag.
+
+## Why `DISABLE_AUTOUPDATER=1`
+
+The Dockerfile sets `DISABLE_AUTOUPDATER=1` and `NO_UPDATE_NOTIFIER=1`. Version
+management is done at image build time only. In-container auto-updates are
+explicitly disabled so that a running agent's Claude Code version matches what the
+image tag advertises.


### PR DESCRIPTION
## Summary

- Replaces floating `latest` default with explicit pin `2.1.197` in two locations:
  - `docker/Dockerfile.agent-agentmux`: `ARG CLAUDE_VERSION=2.1.197`
  - `.github/workflows/container-image.yml`: workflow_dispatch `default: '2.1.197'`
- Adds `docs/spec-claude-code-versioning.md` documenting the two pin locations, bump procedure, escape hatch (one-off dispatch), and version history table

## Why pin

Floating `latest` caused non-reproducible builds — two CI runs minutes apart could embed different Claude Code versions, making regressions harder to bisect.

## Bump procedure (summary)

1. `npm view @anthropic-ai/claude-code version`
2. Update `ARG CLAUDE_VERSION=<new>` in Dockerfile
3. Update `default: '<new>'` in workflow
4. PR + merge triggers image rebuild

<!-- agentmux:agent_id=agenty-0629j -->