### PR TITLE
chore: release v0.49.10

### DIFF
--- a/.changesets/1782825381-fix-agent-pane-watchdog-recovers-a-stalled-rate-limited-turn-91lt.md
+++ b/.changesets/1782825381-fix-agent-pane-watchdog-recovers-a-stalled-rate-limited-turn-91lt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): watchdog recovers a stalled rate-limited turn past retryAfterMs + liveness window

--- a/.changesets/1782842759-feat-srv-persist-layoutcleared-layouttreereplaced-via-the-pe-m2ln.md
+++ b/.changesets/1782842759-feat-srv-persist-layoutcleared-layouttreereplaced-via-the-pe-m2ln.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): persist LayoutCleared/LayoutTreeReplaced via the persist subscriber + bridge (layout single-writer, phase 1; behavior-neutral)

--- a/.changesets/1782843804-feat-srv-port-balancenode-tree-normalization-to-rust-strong--9ukl.md
+++ b/.changesets/1782843804-feat-srv-port-balancenode-tree-normalization-to-rust-strong--9ukl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): port balanceNode tree-normalization to Rust (strong-reducer-authority keystone)

--- a/.changesets/1782846970-feat-srv-wire-the-7-remaining-layout-reducer-arms-move-swap--gcrh.md
+++ b/.changesets/1782846970-feat-srv-wire-the-7-remaining-layout-reducer-arms-move-swap--gcrh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): wire the 7 remaining layout reducer arms (Move/Swap/Resize/Replace/Split/InsertAtIndex) through the pure algebra + balance_node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.9"
+version = "0.49.10"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.9"
+version = "0.49.10"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.49.10 — 2026-06-30
+
+- fix(agent-pane): watchdog recovers a stalled rate-limited turn past retryAfterMs + liveness window
+- feat(srv): persist LayoutCleared/LayoutTreeReplaced via the persist subscriber + bridge (layout single-writer, phase 1; behavior-neutral)
+- feat(srv): port balanceNode tree-normalization to Rust (strong-reducer-authority keystone)
+- feat(srv): wire the 7 remaining layout reducer arms (Move/Swap/Resize/Replace/Split/InsertAtIndex) through the pure algebra + balance_node
+
+
 ## 0.49.9 — 2026-06-30
 
 - fix(floating-pane): dragging a torn-off floating pane is broken on Linux — get_window_position returns {0,0} post-load

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.9",
+  "version": "0.49.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.9",
+      "version": "0.49.10",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.9",
+  "version": "0.49.10",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Bumps `0.49.9 → 0.49.10`
- Includes: agent pane watchdog fix, layout persist, layout reducer arms, tree normalization port
- First end-to-end release test with `cef-macos-arm64-148.23.20` (new macOS CEF from bot)

<!-- agentmux:agent_id=camper-0622h -->