### PR TITLE
fix(browser-pane): unsubclass HWNDs on pane close to prevent focus storm

### DIFF
--- a/.changesets/1782861450-fix-browser-pane-unsubclass-hwnds-on-pane-close-to-prevent-f-xm6x.md
+++ b/.changesets/1782861450-fix-browser-pane-unsubclass-hwnds-on-pane-close-to-prevent-f-xm6x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): unsubclass HWNDs on pane close to prevent focus storm after switching to external browser

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -139,13 +139,16 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
     state.browser_panes.drain_closed_label(state, label);
 
     // Labels are `browser-pane-<uuid>-<seq>`; strip prefix + trailing `-<seq>`
-    // to recover the block_id, then wipe any HWND context entries the
-    // WndProc subclass registered for that block.
+    // to recover the block_id, then:
+    //   1. Restore WndProcs for all subclassed HWNDs (must run first, before
+    //      remove_contexts_for_block wipes the outer-HWND lookup).
+    //   2. Wipe BROWSER_PANE_HWND_CONTEXT entries for the block.
     #[cfg(target_os = "windows")]
     {
         if let Some(rest) = label.strip_prefix("browser-pane-") {
             if let Some(dash) = rest.rfind('-') {
                 let block_id = &rest[..dash];
+                crate::browser_pane::hwnd::uninstall_focus_redirect_for_block(block_id);
                 crate::browser_pane::hwnd::remove_contexts_for_block(block_id);
             }
         }

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -76,12 +76,29 @@ pub fn uninstall_focus_redirect_for_block(block_id: &str) {
         return;
     }
 
-    // Build the full set of HWNDs to restore: the outer HWND itself, plus any
-    // live children currently tracked in BROWSER_PANE_WNDPROCS.
+    // Build the full set of HWNDs to restore:
+    //   1. The outer HWND(s) themselves (may already be destroyed — that's fine,
+    //      map.remove still drains their BROWSER_PANE_WNDPROCS entry).
+    //   2. Live children found via EnumChildWindows (outer alive path).
+    //   3. Dead children still in BROWSER_PANE_WNDPROCS (outer destroyed path) —
+    //      we can't walk the HWND tree for a dead outer, so we drain every entry
+    //      from BROWSER_PANE_WNDPROCS whose HWND is no longer a valid window.
+    //      Those dead entries can only belong to the closed pane (no other code
+    //      leaves dead HWNDs in the map), so removing them is safe and closes the
+    //      recycled-child-HWND gap described in §3 of the analysis.
     let mut candidates: Vec<usize> = outer_hwnds.clone();
     for &outer in &outer_hwnds {
         let outer_ptr = outer as *mut std::ffi::c_void;
         if unsafe { IsWindow(outer_ptr) } == 0 {
+            // Outer is gone — collect all BROWSER_PANE_WNDPROCS keys that are
+            // also dead; they must be children of this (now-destroyed) pane.
+            if let Ok(map) = BROWSER_PANE_WNDPROCS.lock() {
+                for &hwnd in map.keys() {
+                    if unsafe { IsWindow(hwnd as *mut std::ffi::c_void) } == 0 {
+                        candidates.push(hwnd);
+                    }
+                }
+            }
             continue;
         }
         unsafe extern "system" fn collect_children(

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -40,6 +40,108 @@ static BROWSER_PANE_HWND_CONTEXT: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<usize, BrowserPaneContext>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
+/// Restore the original WndProc for every HWND (outer + children) that was
+/// subclassed by `install_browser_pane_focus_redirect` for the given `block_id`,
+/// and clear any `LAST_FOCUSED_BY_ROOT` entries that point at those HWNDs.
+///
+/// Call this from `on_before_close_browser_pane` **before**
+/// `remove_contexts_for_block` — we still need `BROWSER_PANE_HWND_CONTEXT` to
+/// locate the outer HWND.
+///
+/// If an HWND has already been destroyed by the time this runs, the
+/// `SetWindowLongPtrW` call is skipped (guarded by `IsWindow`) but the entry
+/// is still removed from `BROWSER_PANE_WNDPROCS` and `LAST_FOCUSED_BY_ROOT` is
+/// still cleared. This prevents the closed pane's HWND value from being picked
+/// as the "main render widget" by `find_main_render_widget` if the value is
+/// later recycled by a new `Chrome_RenderWidgetHostHWND`.
+pub fn uninstall_focus_redirect_for_block(block_id: &str) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumChildWindows, IsWindow, SetWindowLongPtrW, GWLP_WNDPROC,
+    };
+
+    // Collect outer HWND(s) for this block from BROWSER_PANE_HWND_CONTEXT.
+    let outer_hwnds: Vec<usize> = BROWSER_PANE_HWND_CONTEXT
+        .lock()
+        .ok()
+        .map(|m| {
+            m.iter()
+                .filter(|(_, ctx)| ctx.block_id == block_id)
+                .map(|(&hwnd, _)| hwnd)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if outer_hwnds.is_empty() {
+        tracing::debug!(block_id = %block_id, "[pane-unsubclass] no outer HWNDs in context for block — already cleaned up?");
+        return;
+    }
+
+    // Build the full set of HWNDs to restore: the outer HWND itself, plus any
+    // live children currently tracked in BROWSER_PANE_WNDPROCS.
+    let mut candidates: Vec<usize> = outer_hwnds.clone();
+    for &outer in &outer_hwnds {
+        let outer_ptr = outer as *mut std::ffi::c_void;
+        if unsafe { IsWindow(outer_ptr) } == 0 {
+            continue;
+        }
+        unsafe extern "system" fn collect_children(
+            child: *mut std::ffi::c_void,
+            lparam: isize,
+        ) -> i32 {
+            let acc = &mut *(lparam as *mut Vec<usize>);
+            acc.push(child as usize);
+            1
+        }
+        unsafe {
+            EnumChildWindows(
+                outer_ptr,
+                Some(collect_children),
+                &mut candidates as *mut Vec<usize> as isize,
+            );
+        }
+    }
+
+    let mut restored = 0usize;
+    if let Ok(mut map) = BROWSER_PANE_WNDPROCS.lock() {
+        for hwnd in candidates {
+            if let Some(orig) = map.remove(&hwnd) {
+                let hwnd_ptr = hwnd as *mut std::ffi::c_void;
+                unsafe {
+                    if IsWindow(hwnd_ptr) != 0 {
+                        SetWindowLongPtrW(hwnd_ptr, GWLP_WNDPROC, orig);
+                    }
+                    // Clear focus record regardless of liveness — prevents
+                    // WM_ACTIVATE from restoring focus to a dead/recycled HWND.
+                    forget_focus_for_child(hwnd_ptr);
+                }
+                restored += 1;
+            }
+        }
+    }
+
+    tracing::info!(
+        block_id = %block_id,
+        restored = restored,
+        "[pane-unsubclass] restored WndProcs and cleared LAST_FOCUSED_BY_ROOT for {} HWNDs on pane close",
+        restored,
+    );
+}
+
+/// Return the outer HWND for every pane currently tracked in
+/// `BROWSER_PANE_HWND_CONTEXT`, regardless of whether that pane is still
+/// registered in `state.browsers`. Used by `MainFocusReclaimTask` as a
+/// defence-in-depth supplement to the `state.list_browsers` source so that
+/// panes which have been `BrowserUnregistered` but whose HWNDs are still live
+/// (deferred CEF teardown window) are still excluded from
+/// `find_main_render_widget`.
+pub fn pane_outer_hwnds_from_context() -> Vec<*mut std::ffi::c_void> {
+    BROWSER_PANE_HWND_CONTEXT
+        .lock()
+        .ok()
+        .map(|m| m.keys().map(|&h| h as *mut std::ffi::c_void).collect())
+        .unwrap_or_default()
+}
+
 /// Remove every `BROWSER_PANE_HWND_CONTEXT` entry whose context refers to the given
 /// `block_id`. Called from `on_before_close_browser_pane` so the map doesn't grow
 /// unbounded as panes are opened and closed over the session. Keyed by

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -2129,19 +2129,37 @@ wrap_task! {
                 // Views top-level, so a naive EnumChildWindows would pick up
                 // their Chrome_RenderWidgetHostHWND and SetFocus on the wrong
                 // target.
+                //
+                // Two sources are combined:
+                // 1. Live registered panes from state.list_browsers().
+                // 2. Pane outer HWNDs still tracked in BROWSER_PANE_HWND_CONTEXT
+                //    — covers the window between BrowserUnregistered and CEF's
+                //    on_before_close (deferred teardown), during which the HWND
+                //    is still live but the label is gone from state.browsers.
+                //    Without this, panes_excluded=0 and find_main_render_widget
+                //    picks the pane's render widget → infinite focus storm.
+                //
                 // Phase H.2.b — reducer-aware iteration with fallback.
-                let pane_outer_hwnds: Vec<*mut std::ffi::c_void> = self
-                    .state
-                    .list_browsers()
-                    .into_iter()
-                    .filter(|(k, _)| k.starts_with("browser-pane-"))
-                    .filter_map(|(_, mut b)| {
-                        b.host().and_then(|h| {
-                            let wh = h.window_handle();
-                            if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
+                let pane_outer_hwnds: Vec<*mut std::ffi::c_void> = {
+                    let mut hwnds: Vec<*mut std::ffi::c_void> = self
+                        .state
+                        .list_browsers()
+                        .into_iter()
+                        .filter(|(k, _)| k.starts_with("browser-pane-"))
+                        .filter_map(|(_, mut b)| {
+                            b.host().and_then(|h| {
+                                let wh = h.window_handle();
+                                if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
+                            })
                         })
-                    })
-                    .collect();
+                        .collect();
+                    for h in crate::browser_pane::hwnd::pane_outer_hwnds_from_context() {
+                        if !hwnds.contains(&h) {
+                            hwnds.push(h);
+                        }
+                    }
+                    hwnds
+                };
 
                 match views_top_hwnd {
                     Some(top_hwnd) => unsafe {

--- a/docs/analysis/ANALYSIS_BROWSER_PANE_CLOSE_FOCUS_STORM_2026_06_30.md
+++ b/docs/analysis/ANALYSIS_BROWSER_PANE_CLOSE_FOCUS_STORM_2026_06_30.md
@@ -1,0 +1,242 @@
+# Analysis: Browser pane close → stale WndProc subclass → infinite focus storm
+
+**Date:** 2026-06-30
+**Against:** local-main-b28b7a @ v0.49.8
+**Log:** `~/.agentmux/channels/local-main-b28b7a-50e8c174/versions/0.49.8/logs/agentmux-host-v0.49.8.log.2026-06-30`
+
+**Symptom (reported):** After opening a browser pane and then closing it, switching to an external browser and returning to the AgentMux window causes typing to stop everywhere. Recovery requires opening a new AgentMux window, selecting it, typing in it, then returning to the working window.
+
+---
+
+## 0. Executive summary
+
+Two bugs combine to produce an infinite focus storm once any browser pane has been opened and closed in the session:
+
+| # | Defect | Symptom | Layer |
+|---|--------|---------|-------|
+| **A** | **Stale WndProc subclass on closed pane HWNDs** — when a pane closes, `on_before_close_browser_pane` removes its entry from `BROWSER_PANE_HWND_CONTEXT` and `BROWSER_PANE_WNDPROCS` for the outer HWND only. Child HWNDs (`Chrome_RenderWidgetHostHWND`, `Chrome_WidgetWin_1`) subclassed during `on_load_end_browser_pane` are never unsubclassed. Their focus-redirect WndProc survives the HWND value being recycled by Windows, or the HWND remaining live during deferred CEF teardown. | Redirect hook fires on what should be the main render widget | Host — `browser_pane/hwnd.rs`, `browser_pane/callbacks.rs` |
+| **B** | **`find_main_render_widget` filter blind to unregistered panes** — `MainFocusReclaimTask` builds `pane_outer_hwnds` from `state.list_browsers()` filtered to `"browser-pane-*"` labels. After `BrowserUnregistered`, no label matches, so `pane_outer_hwnds` is empty. The ancestor-chain filter in `find_main_render_widget` sees no panes to exclude, and returns the first `Chrome_RenderWidgetHostHWND` found — which may be a still-live child of the closed pane. | `panes_excluded=0` → wrong HWND targeted | Host — `ui_tasks.rs` |
+
+---
+
+## 1. Observed timeline (from host log, 2026-06-30)
+
+```
+01:50:10  Startup. Browser pane at outer HWND 0x40926 created, subclassed.
+          LAST_FOCUSED_BY_ROOT[0x10914] not yet set.
+
+01:50:23  MainFocusReclaimTask: target=0x10916 (correct main render widget)
+          panes_excluded=0 ← already 0 at startup; at this point 0x40926 is the
+          pane outer HWND but the filter checks host.window_handle() which may
+          return the outer HWND (not tracked via the render-widget enumeration).
+
+17:50:37  Two browser panes opened:
+          - browser-pane-d290b541 → https://web.whatsapp.com/
+          - browser-pane-986761d2 → https://agentmux.ai/
+
+17:50:53  Chrome_RenderWidgetHostHWND 0x2d709a0 subclassed
+          (child of one of the above panes, registered via on_load_end_browser_pane)
+
+17:53:33  BrowserUnregistered label=browser-pane-d290b541-...-1
+17:54:26  BrowserUnregistered label=browser-pane-986761d2-...-2
+          Both panes removed from state.browsers.
+          HWND 0x2d709a0 subclass NOT removed — wndproc_hook still installed.
+
+~17:54 – 22:22  (gap) HWND 0x2d709a0 remains live with redirect WndProc installed.
+
+22:22:49  User returns to AgentMux from external browser.
+          WM_ACTIVATE on 0x10914 → focus-restore → SetFocus(LAST_FOCUSED_BY_ROOT)
+          → storm begins.
+```
+
+---
+
+## 2. Storm mechanics
+
+Every storm iteration follows this exact pattern (confirmed in log at 22:22:49 onwards):
+
+```
+[ipc] main_window_focus window_label=main
+  ↓
+MainFocusReclaimTask::execute (ui_tasks.rs:2080)
+  host.set_focus(1) on label=main         ← Chromium: main browser focused
+  [pane-wndproc] WM_KILLFOCUS hwnd=0x2d709a0   ← pane render widget loses Chromium focus
+  find_main_render_widget(top, panes=[])
+    → EnumChildWindows scans Views subtree
+    → finds 0x2d709a0 (Chrome_RenderWidgetHostHWND, panes=[] so no filter applies)
+    → returns Some(0x2d709a0)
+  record_intentional_focus(0x2d709a0)
+    → LAST_FOCUSED_BY_ROOT[0x10914] = 0x2d709a0   ← cements wrong target
+  Win32 SetFocus(0x2d709a0)
+    → wndproc_hook WM_SETFOCUS fires
+    → ALLOW_BROWSER_PANE_FOCUS_ONCE=false → redirect
+    → SetFocus(GetAncestor(0x2d709a0, GA_ROOT)) = SetFocus(0x10914)
+    → Chromium on_got_focus → frontend emits main_window_focus IPC
+  defocus_all (no live panes → no-op)
+  ↑ loop
+```
+
+Log evidence:
+```
+[ipc] main_window_focus window_label=main
+[main-focus-reclaim] host.set_focus(1) on label=main
+[pane-wndproc] WM_KILLFOCUS hwnd=0x2d709a0
+[focus-track] LAST_FOCUSED_BY_ROOT[root=0x10914] <= child=0x2d709a0
+[main-focus-reclaim] Win32 SetFocus target=0x2d709a0 render_found=true panes_excluded=0
+```
+This repeats continuously from 22:22:49 to end of log (22:35:36+, log still running).
+
+---
+
+## 3. Defect A — stale WndProc on closed pane child HWNDs
+
+### What closes cleanly
+`on_before_close_browser_pane` (`browser_pane/callbacks.rs:122`) calls:
+- `state.browser_panes.drain_closed_label(state, label)` — reducer cleanup
+- `remove_contexts_for_block(block_id)` (`hwnd.rs:49`) — removes from `BROWSER_PANE_HWND_CONTEXT`
+
+`remove_contexts_for_block` operates on `BROWSER_PANE_HWND_CONTEXT` (keyed by outer pane HWND), not `BROWSER_PANE_WNDPROCS`.
+
+### What is NOT cleaned up
+`BROWSER_PANE_WNDPROCS` (`hwnd.rs:24`) maps every subclassed HWND → original WndProc. It is written during:
+- `install_browser_pane_focus_redirect` at `on_after_created_browser_pane` (outer HWND)
+- `on_load_end_browser_pane` → `install_browser_pane_focus_redirect` again (picks up any new `Chrome_RenderWidgetHostHWND` children)
+- `enum_children` inside `install_browser_pane_focus_redirect` (all child HWNDs at install time)
+
+None of these are reversed on close. The `SetWindowLongPtrW` that installed the hook is never undone with a matching `SetWindowLongPtrW(hwnd, GWLP_WNDPROC, original)`.
+
+### Why the HWND lives past `BrowserUnregistered`
+CEF browser teardown is asynchronous. `BrowserUnregistered` fires when the browser object is removed from `state.browsers`, but the underlying HWND tree (owned by the CEF browser process) can remain live until the renderer process exits. For a pre-warmed pool browser the HWND may survive for the full session.
+
+Additionally, Windows recycles HWND values. If the old HWND IS destroyed, a new `Chrome_RenderWidgetHostHWND` for any browser (including the main window's renderer) may receive the same value `0x2d709a0` from the allocator. Because `BROWSER_PANE_WNDPROCS` keyed on `usize` (the raw HWND value), it would register the new HWND as still-subclassed when `already_hooked` is checked — and `wndproc_hook` would fire on the new HWND's messages.
+
+### Fix (Defect A)
+In `on_before_close_browser_pane`, or in `destroy_hwnd` in `browser_panes.rs`, restore the original WndProc for every HWND in the closing block before the HWND tree is destroyed:
+
+```rust
+// Proposed addition to on_before_close_browser_pane (Windows-only):
+#[cfg(target_os = "windows")]
+{
+    if let Some(rest) = label.strip_prefix("browser-pane-") {
+        if let Some(dash) = rest.rfind('-') {
+            let block_id = &rest[..dash];
+            crate::browser_pane::hwnd::uninstall_focus_redirect_for_block(block_id);
+        }
+    }
+}
+```
+
+New function `uninstall_focus_redirect_for_block`:
+```rust
+pub fn uninstall_focus_redirect_for_block(block_id: &str) {
+    // Find outer HWNDs for this block, then walk BROWSER_PANE_WNDPROCS
+    // restoring every original WndProc and removing the entry.
+    // Need to cross-reference BROWSER_PANE_HWND_CONTEXT (block_id → outer HWND)
+    // with BROWSER_PANE_WNDPROCS (outer HWND + children → original proc).
+    //
+    // Simplest approach: collect outer HWND from BROWSER_PANE_HWND_CONTEXT,
+    // then enumerate its children to find all subclassed descendants.
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        SetWindowLongPtrW, EnumChildWindows, GWLP_WNDPROC,
+    };
+    let outer: Option<usize> = BROWSER_PANE_HWND_CONTEXT.lock().ok().and_then(|m| {
+        m.iter()
+            .find(|(_, ctx)| ctx.block_id == block_id)
+            .map(|(&hwnd, _)| hwnd)
+    });
+    let Some(outer) = outer else { return };
+    let hwnds_to_restore: Vec<(usize, isize)> = {
+        let mut v = vec![];
+        if let Ok(map) = BROWSER_PANE_WNDPROCS.lock() {
+            // outer itself
+            if let Some(&orig) = map.get(&outer) { v.push((outer, orig)); }
+            // children: enumerate and check map
+            // (EnumChildWindows would need unsafe; collect keys from map that
+            // are descendants — simpler: restore all entries whose HWND is a
+            // descendant of outer)
+        }
+        v
+    };
+    unsafe {
+        for (hwnd, orig) in hwnds_to_restore {
+            let proc_fn: unsafe extern "system" fn(*mut std::ffi::c_void, u32, usize, isize) -> isize =
+                std::mem::transmute(orig);
+            SetWindowLongPtrW(hwnd as _, GWLP_WNDPROC, orig);
+        }
+    }
+    // Clean up maps
+    if let Ok(mut map) = BROWSER_PANE_WNDPROCS.lock() {
+        map.retain(|hwnd, _| /* not in outer's subtree */ true); // fill in real check
+    }
+    // BROWSER_PANE_HWND_CONTEXT is already cleaned by remove_contexts_for_block
+}
+```
+
+Also clear `LAST_FOCUSED_BY_ROOT` for any root whose recorded child was part of the closing block — call `forget_focus_for_child` for each subclassed HWND being uninstalled. This prevents the `WM_ACTIVATE` restore path from trying to focus a stale HWND.
+
+---
+
+## 4. Defect B — `find_main_render_widget` filter blind to unregistered panes
+
+### The filter
+`MainFocusReclaimTask::execute` (`ui_tasks.rs:2133`):
+```rust
+let pane_outer_hwnds: Vec<*mut std::ffi::c_void> = self
+    .state
+    .list_browsers()
+    .into_iter()
+    .filter(|(k, _)| k.starts_with("browser-pane-"))
+    .filter_map(|(_, mut b)| {
+        b.host().and_then(|h| { … Some(wh.0 as *mut _) })
+    })
+    .collect();
+```
+
+After `BrowserUnregistered`, no `"browser-pane-*"` labels remain → `pane_outer_hwnds = []` → `panes_excluded=0` in log.
+
+`find_main_render_widget` with an empty exclusion list returns the first `Chrome_RenderWidgetHostHWND` found under the Views top HWND — which may be the stale pane render widget.
+
+### Fix (Defect B)
+Two complementary approaches:
+
+**B1 (defence-in-depth):** Also source pane HWND candidates from `BROWSER_PANE_HWND_CONTEXT`, which still has entries for panes that are live at the HWND level even if unregistered from `state.browsers`. Any HWND found in `BROWSER_PANE_HWND_CONTEXT` that is a parent of a `Chrome_RenderWidgetHostHWND` should be treated as a pane outer HWND.
+
+**B2 (primary fix = Defect A):** If Defect A's fix properly unsubclasses HWNDs on close, `find_main_render_widget` will return the correct HWND regardless — the stale redirect hook will not fire even if the wrong HWND is focused momentarily.
+
+---
+
+## 5. Why the new-window workaround sometimes helps
+
+Opening a new AgentMux window and typing in it causes:
+1. `main_window_focus` IPC for the NEW window's label
+2. `MainFocusReclaimTask` for the new window — no pane HWNDs in that window → `find_main_render_widget` correctly finds the new window's main render widget
+3. `record_intentional_focus(correct_hwnd)` for the new window's root → `LAST_FOCUSED_BY_ROOT[new_root] = correct`
+
+When you return to the main window, `WM_ACTIVATE` fires again on `0x10914`. `LAST_FOCUSED_BY_ROOT[0x10914]` still points at `0x2d709a0` so the storm fires again — but `defocus_all` running in each storm iteration eventually causes the redirect to stop firing (Chromium's internal focus state settles), OR a user click lands on a non-subclassed HWND, seating focus correctly and breaking the cycle.
+
+The recovery is fragile: a second switch to an external browser and back will restart the storm.
+
+---
+
+## 6. Fix order
+
+1. **(Highest impact) Defect A:** unsubclass all child HWNDs on pane close + call `forget_focus_for_child` for each. ~40–60 LOC in `hwnd.rs` + `callbacks.rs`.
+2. **(Defence-in-depth) Defect B:** augment `pane_outer_hwnds` with entries from `BROWSER_PANE_HWND_CONTEXT`. ~10 LOC in `ui_tasks.rs`.
+
+---
+
+## 7. References
+
+**Code**
+- `agentmux-cef/src/browser_pane/hwnd.rs` — `BROWSER_PANE_WNDPROCS`, `install_browser_pane_focus_redirect`, `remove_contexts_for_block`, `forget_focus_for_child`
+- `agentmux-cef/src/browser_pane/callbacks.rs` — `on_before_close_browser_pane`, `on_load_end_browser_pane`
+- `agentmux-cef/src/ui_tasks.rs:2080` — `MainFocusReclaimTask::execute`
+- `agentmux-cef/src/ui_tasks.rs:2179` — `find_main_render_widget`
+
+**Related analysis**
+- `docs/analysis/ANALYSIS_BROWSER_PANE_REDOCK_BLACK_TYPING_LOCK_2026_06_15.md` — same Defect A class (focus orphaning), different trigger (redock vs. close)
+- `docs/analysis/ANALYSIS_BROWSER_PANE_REDOCK_LOAD_RACE_2026_05_29.md`
+
+**Issues**
+- #768 — Phantom browser pane lifecycle divergence (lifecycle events still missing)
+- #1190 — Browser pane: native CEF child windows; keystrokes bypass host WebView


### PR DESCRIPTION
## Summary

- **Defect A (primary):** `on_before_close_browser_pane` never restored the WndProc subclass installed on pane child HWNDs (`Chrome_RenderWidgetHostHWND`, etc.). After a pane closed, the stale redirect hook survived on still-live HWNDs. When the user returned to AgentMux from an external browser, `MainFocusReclaimTask` targeted one of these stale HWNDs, the hook fired and redirected focus back to the root, which re-triggered `main_window_focus` IPC — producing an infinite focus storm that made typing a no-op.
- **Defect B (defence-in-depth):** `pane_outer_hwnds` in `MainFocusReclaimTask` was built solely from `state.list_browsers()`, which is empty after `BrowserUnregistered`. Added `pane_outer_hwnds_from_context()` as a supplemental source so the exclusion filter remains effective during the CEF teardown window.

**Files changed:**
- `agentmux-cef/src/browser_pane/hwnd.rs` — added `uninstall_focus_redirect_for_block` and `pane_outer_hwnds_from_context`
- `agentmux-cef/src/browser_pane/callbacks.rs` — wired `uninstall_focus_redirect_for_block` into `on_before_close_browser_pane` before `remove_contexts_for_block`
- `agentmux-cef/src/ui_tasks.rs` — supplemented `pane_outer_hwnds` with `pane_outer_hwnds_from_context()`

Full root-cause analysis: `docs/analysis/ANALYSIS_BROWSER_PANE_CLOSE_FOCUS_STORM_2026_06_30.md`

<!-- agentmux:agent_id=agent2 -->