### PR TITLE
feat(ui): visual color palette expansion and pane header swatches

### DIFF
--- a/.changesets/1782861210-feat-ui-expand-tab-palette-to-14-colors-add-reusable-colorsw-8dc8.md
+++ b/.changesets/1782861210-feat-ui-expand-tab-palette-to-14-colors-add-reusable-colorsw-8dc8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(ui): expand tab palette to 14 colors, add reusable ColorSwatchPalette, and show visual pane color panel on all pane header right-clicks

--- a/docs/specs/SPEC_COLOR_PALETTE_EXPANSION_REUSE_2026_06_30.md
+++ b/docs/specs/SPEC_COLOR_PALETTE_EXPANSION_REUSE_2026_06_30.md
@@ -1,0 +1,337 @@
+# SPEC: Color Palette Expansion & Reuse
+Date: 2026-06-30  
+Status: Ready for implementation
+
+---
+
+## Problem
+
+1. **Tab palette has room for 4 more colors.** The current 5×2 grid (10 swatches)
+   fits 14 if expanded to 7×2. The existing 10 colors are spaced 36° apart on the
+   hue wheel; 4 new colors should fill notable perceptual gaps.
+
+2. **Tab color palette is not reusable.** `TabContextPanel` in `tab.tsx` renders
+   the swatch grid inline. The pane header needs the same visual palette, so it
+   must be extracted into a shared module.
+
+3. **Pane header has text-based color submenu only.** Right-clicking any pane header
+   shows a native context menu with "Pane Color ▸" as a 2nd-level text list
+   (`buildPaneColorSubmenu` in `pane-color-menu.ts`). The desired UX is visual
+   color swatches at the **1st level** — directly visible without opening a submenu.
+
+---
+
+## Decisions (confirmed)
+
+| # | Decision |
+|---|----------|
+| D1 | Remove `buildPaneColorSubmenu` entirely — no fallback text submenu |
+| D2 | Visual pane color panel applies to **all pane types**, not just agent panes |
+| D3 | Pane palette = **12 hues** in a **4 wide × 3 high** swatch grid |
+| D4 | Panel layout (bottom-up): clear button → swatch grid → separator bar → (rest of panel content above) |
+
+---
+
+## Current State
+
+### Tab palette — `frontend/app/tab/tab.tsx`
+
+```ts
+// 10 colors at 36° intervals
+export const TAB_COLORS: { name: string; hex: string }[] = [
+    { name: "Red",    hex: "#ef4444" },
+    { name: "Orange", hex: "#f97316" },
+    { name: "Yellow", hex: "#eab308" },
+    { name: "Lime",   hex: "#84cc16" },
+    { name: "Green",  hex: "#22c55e" },
+    { name: "Teal",   hex: "#14b8a6" },
+    { name: "Blue",   hex: "#3b82f6" },
+    { name: "Violet", hex: "#8b5cf6" },
+    { name: "Pink",   hex: "#ec4899" },
+    { name: "Rose",   hex: "#f43f5e" },
+];
+```
+
+Grid in SCSS: `grid-template-columns: repeat(5, 20px)` → 5 cols × 2 rows.
+
+### Pane header context menu — `frontend/app/block/blockframe.tsx`
+
+```ts
+// Currently: agent panes only, 2nd-level text submenu
+if (blockData?.meta?.view === "agent") {
+    menu.push({ type: "separator" }, buildPaneColorSubmenu(blockData, blockData.oid));
+}
+ContextMenuModel.showContextMenu(menu, e);  // native OS/CEF context menu
+```
+
+`buildPaneColorSubmenu` returns `{ type: "submenu", label: "Pane Color", submenu: [...radio items] }`.
+
+Pane color stored as `"frame:hue"` (integer 0–360). Existing helper functions:
+- `hueToHeaderBg(hue)` → `hsl(hue, 28%, 16%)`
+- `hueToActiveBorder(hue)` → `hsl(hue, 65%, 52%)`
+
+Current 8 hues in `PANE_HUE_OPTIONS`:
+Cobalt(218), Emerald(150), Amber(38), Rose(352), Violet(270), Cyan(188), Coral(14), Mint(163).  
+These are unevenly spaced — largest gap is 38° → 150° (112°).
+
+### Custom HTML context menu — `frontend/app/components/context-menu.tsx`
+
+Exists but is text-only (`"action" | "separator"` item types). NOT used on pane
+headers; those use native `ContextMenuModel.showContextMenu`.
+
+---
+
+## Proposed Changes
+
+### 1. Add 4 new colors to the tab palette (10 → 14)
+
+Insert 4 Tailwind-500 values at the most visually distinct gaps:
+
+| Name    | Hex       | Approx hue | Gap filled |
+|---------|-----------|------------|------------|
+| Amber   | `#f59e0b` | ~43°       | Orange (24°) → Yellow (54°) |
+| Cyan    | `#06b6d4` | ~187°      | Teal (174°) → Blue (217°)   |
+| Indigo  | `#6366f1` | ~239°      | Blue (217°) → Violet (263°) |
+| Fuchsia | `#d946ef` | ~292°      | Violet (263°) → Pink (322°) |
+
+Updated `TAB_COLORS` (14 entries, hue-ascending order):
+
+```ts
+export const TAB_COLORS: { name: string; hex: string }[] = [
+    { name: "Red",     hex: "#ef4444" },  // ~0°
+    { name: "Orange",  hex: "#f97316" },  // ~24°
+    { name: "Amber",   hex: "#f59e0b" },  // ~43°  ← NEW
+    { name: "Yellow",  hex: "#eab308" },  // ~54°
+    { name: "Lime",    hex: "#84cc16" },  // ~84°
+    { name: "Green",   hex: "#22c55e" },  // ~142°
+    { name: "Teal",    hex: "#14b8a6" },  // ~174°
+    { name: "Cyan",    hex: "#06b6d4" },  // ~187° ← NEW
+    { name: "Blue",    hex: "#3b82f6" },  // ~217°
+    { name: "Indigo",  hex: "#6366f1" },  // ~239° ← NEW
+    { name: "Violet",  hex: "#8b5cf6" },  // ~263°
+    { name: "Fuchsia", hex: "#d946ef" },  // ~292° ← NEW
+    { name: "Pink",    hex: "#ec4899" },  // ~322°
+    { name: "Rose",    hex: "#f43f5e" },  // ~350°
+];
+```
+
+**SCSS change** in `tab.scss`:
+```scss
+// was: grid-template-columns: repeat(5, 20px);
+grid-template-columns: repeat(7, 20px);
+```
+Result: 7 cols × 2 rows = 14 swatches, same 20px swatch size, same gap.
+
+---
+
+### 2. Extract reusable `ColorSwatchPalette` module
+
+**New file:** `frontend/app/components/color-swatch-palette.tsx`
+
+```tsx
+export interface SwatchColor {
+    name: string;
+    hex: string;
+}
+
+interface ColorSwatchPaletteProps {
+    colors: SwatchColor[];
+    columns: number;                          // drives grid-template-columns
+    currentColor: string | null | undefined;
+    onSelect: (hex: string | null) => void;
+    showClear?: boolean;                      // default: true
+}
+
+export function ColorSwatchPalette(props: ColorSwatchPaletteProps): JSX.Element {
+    // renders:
+    //   .color-swatch-grid  (grid of swatches)
+    //   .color-swatch-clear (optional "✕ Clear color" button)
+}
+```
+
+**New file:** `frontend/app/components/color-swatch-palette.scss`  
+Contains `.color-swatch-grid`, `.color-swatch`, and `.color-swatch-clear` rules,
+extracted and generalized from the tab-specific rules in `tab.scss`.
+
+The `.color-swatch-grid` uses an inline CSS var for columns:
+```scss
+.color-swatch-grid {
+    display: grid;
+    gap: var(--space-1);
+    // columns driven by style={{ "--swatch-cols": props.columns }}
+    grid-template-columns: repeat(var(--swatch-cols, 5), 20px);
+}
+```
+
+**Update `TabContextPanel`** in `tab.tsx`:  
+Replace the inline `<For each={TAB_COLORS}>` block and the "Clear color" button with:
+```tsx
+<ColorSwatchPalette
+    colors={TAB_COLORS}
+    columns={7}
+    currentColor={props.currentColor}
+    onSelect={props.onColorSelect}
+/>
+```
+
+---
+
+### 3. Pane palette: 12 hues at 30° intervals
+
+Replace `PANE_HUE_OPTIONS` (8 uneven hues) with 12 hues equally spaced at 30°.
+This fills the large gaps (e.g. 38° → 150°) and gives a consistent spectral spread.
+
+**Updated `PANE_HUE_OPTIONS`** in `pane-color-menu.ts`:
+
+```ts
+export const PANE_HUE_OPTIONS: ReadonlyArray<PaneHueOption> = [
+    { label: "Crimson",    hue:   0 },
+    { label: "Coral",      hue:  30 },
+    { label: "Amber",      hue:  60 },
+    { label: "Chartreuse", hue:  90 },
+    { label: "Green",      hue: 120 },
+    { label: "Emerald",    hue: 150 },
+    { label: "Teal",       hue: 180 },
+    { label: "Sky",        hue: 210 },
+    { label: "Blue",       hue: 240 },
+    { label: "Violet",     hue: 270 },
+    { label: "Fuchsia",    hue: 300 },
+    { label: "Pink",       hue: 330 },
+];
+```
+
+Add `PANE_SWATCH_COLORS` derived from the above, providing a vivid preview hex for
+each hue (so `ColorSwatchPalette` can render them):
+
+```ts
+export interface PaneSwatch extends PaneHueOption {
+    preview: string;   // vivid hex for swatch face
+}
+
+export const PANE_SWATCH_COLORS: ReadonlyArray<PaneSwatch> = PANE_HUE_OPTIONS.map(
+    ({ label, hue }) => ({ label, hue, preview: hueToActiveBorder(hue) })
+);
+```
+
+`hueToActiveBorder(hue)` = `hsl(hue, 65%, 52%)` — already vivid enough for swatch
+display without introducing a new formula.
+
+---
+
+### 4. Add 1st-level visual swatches to pane header right-click
+
+#### Architecture: companion swatch panel
+
+`ContextMenuModel.showContextMenu()` renders a native OS/CEF menu that cannot
+embed custom HTML. The solution is a **companion `PaneColorPanel`** — a Portal-based
+custom HTML panel that appears at the header's position when the user right-clicks.
+The native context menu still appears at the cursor position (for split, close, etc.).
+
+The two elements are independently dismissible (click-outside or Escape closes both).
+
+#### `PaneColorPanel` component
+
+**New file:** `frontend/app/block/pane-color-panel.tsx`
+
+Visual layout (bottom section of the panel):
+
+```
+┌─────────────────────────────┐
+│  ─────────────────────────  │  ← separator bar (top of color section)
+│  ■  ■  ■  ■                 │  ← row 1
+│  ■  ■  ■  ■                 │  ← row 2  (4 × 3 swatch grid)
+│  ■  ■  ■  ■                 │  ← row 3
+│ [    ✕ Clear color    ]     │  ← clear button (full width)
+└─────────────────────────────┘
+```
+
+```tsx
+interface PaneColorPanelProps {
+    anchor: DOMRect;           // getBoundingClientRect() of the pane header element
+    currentHue: number | null;
+    blockId: string;
+    onClose: () => void;
+}
+
+export function PaneColorPanel(props: PaneColorPanelProps): JSX.Element {
+    // Positioned: top = anchor.bottom + 4, left = anchor.left
+    // z-index: 9999  (same as tab-context-panel)
+    //
+    // Structure:
+    //   <div class="pane-color-panel">
+    //     <div class="pane-color-panel-sep" />          ← top separator
+    //     <ColorSwatchPalette
+    //         colors={PANE_SWATCH_COLORS.map(s => ({ name: s.label, hex: s.preview }))}
+    //         columns={4}
+    //         currentColor={currentPreviewHex}          ← derived from currentHue
+    //         onSelect={handleSelect}
+    //         showClear={false}                         ← clear is handled separately below
+    //     />
+    //     <button class="pane-color-clear-btn" onClick={handleClear}>
+    //         ✕ Clear color
+    //     </button>
+    //   </div>
+    //
+    // handleSelect(hex): reverse-lookup hue from PANE_SWATCH_COLORS by hex,
+    //   call setHue(blockId, hue); props.onClose()
+    // handleClear(): setHue(blockId, null); props.onClose()
+    // click-outside / Escape → props.onClose()
+}
+```
+
+**New file:** `frontend/app/block/pane-color-panel.scss`  
+Styles for `.pane-color-panel`, `.pane-color-panel-sep`, `.pane-color-clear-btn`.
+`.pane-color-panel` uses the same `@include menuFrame.menu-frame` mixin as
+`tab-context-panel` for visual consistency.
+
+#### Integration in `blockframe.tsx`
+
+```ts
+// 1. Remove the agent-pane-only guard and buildPaneColorSubmenu call entirely:
+//    DELETE: if (blockData?.meta?.view === "agent") { menu.push(...) }
+
+// 2. Add a signal for the panel anchor:
+const [colorPanelAnchor, setColorPanelAnchor] = createSignal<DOMRect | null>(null);
+
+// 3. In handleHeaderContextMenu, capture header rect BEFORE showing native menu:
+const headerEl = e.currentTarget as HTMLElement;
+setColorPanelAnchor(headerEl.getBoundingClientRect());
+
+// 4. Native context menu fires as before (no color submenu in it now).
+
+// 5. In JSX, alongside the existing block content:
+<Show when={colorPanelAnchor()}>
+    <PaneColorPanel
+        anchor={colorPanelAnchor()!}
+        currentHue={(blockData()?.meta?.["frame:hue"] as number | undefined) ?? null}
+        blockId={blockData()!.oid}
+        onClose={() => setColorPanelAnchor(null)}
+    />
+</Show>
+```
+
+**`buildPaneColorSubmenu` in `pane-color-menu.ts`:** Delete the function entirely
+(D1). `setHue` becomes a local unexported helper — keep it, used by `PaneColorPanel`.
+
+---
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `frontend/app/tab/tab.tsx` | Expand `TAB_COLORS` to 14; replace inline swatch block with `<ColorSwatchPalette columns={7} />` |
+| `frontend/app/tab/tab.scss` | `repeat(5, 20px)` → `repeat(7, 20px)`; remove swatch styles (move to palette scss) |
+| `frontend/app/components/color-swatch-palette.tsx` | **NEW** reusable swatch grid + clear button |
+| `frontend/app/components/color-swatch-palette.scss` | **NEW** extracted + generalized swatch styles |
+| `frontend/app/block/pane-color-menu.ts` | Replace 8-hue `PANE_HUE_OPTIONS` with 12 at 30° steps; add `PANE_SWATCH_COLORS`; delete `buildPaneColorSubmenu` |
+| `frontend/app/block/pane-color-panel.tsx` | **NEW** `PaneColorPanel` portal component (separator + 4×3 grid + clear button) |
+| `frontend/app/block/pane-color-panel.scss` | **NEW** panel frame styles |
+| `frontend/app/block/blockframe.tsx` | Wire `colorPanelAnchor` signal; show `<PaneColorPanel>` for all pane types; remove `buildPaneColorSubmenu` call |
+
+---
+
+## Non-Goals
+
+- Replacing the native pane context menu with a full custom HTML menu.
+- Unifying tab and pane color metadata (`"tab:color"` hex vs `"frame:hue"` integer)
+  — they serve different visual roles and changing the storage format is out of scope.

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -32,7 +32,8 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show }
 import { CopyButton } from "../element/copybutton";
 import { detectAgentColor, detectAgentFromEnv, detectAgentTextColor, getEffectiveTitle, isUsableFocusRingColor } from "./autotitle";
 import { buildPaneContextMenu } from "./pane-actions";
-import { buildPaneColorSubmenu, hueToHeaderBg, hueToActiveBorder } from "./pane-color-menu";
+import { hueToHeaderBg, hueToActiveBorder } from "./pane-color-menu";
+import { PaneColorPanel } from "./pane-color-panel";
 import { BlockFrameProps } from "./blocktypes";
 import { PaneSizeBadge } from "./pane-size-badge";
 import { TitleBar } from "./titlebar";
@@ -61,11 +62,6 @@ function handleHeaderContextMenu(
     // Header-only: view-specific settings (font size, theme, etc.)
     const extraItems = viewModel?.getSettingsMenuItems?.();
     if (extraItems && extraItems.length > 0) menu.push({ type: "separator" }, ...extraItems);
-
-    // Agent panes: Pane Color hue picker
-    if (blockData?.meta?.view === "agent") {
-        menu.push({ type: "separator" }, buildPaneColorSubmenu(blockData, blockData.oid));
-    }
 
     // Header-only: title management + Copy BlockId
     menu.push(
@@ -374,7 +370,10 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
         return util.useAtomValueSafe(props.viewModel?.viewText);
     });
 
+    const [colorPanelAnchor, setColorPanelAnchor] = createSignal<DOMRect | null>(null);
+
     const onContextMenu = (e: MouseEvent) => {
+        setColorPanelAnchor((e.currentTarget as HTMLElement).getBoundingClientRect());
         handleHeaderContextMenu(e, blockData(), props.viewModel, props.nodeModel.isMagnified(), props.nodeModel.toggleMagnify, props.nodeModel.onClose);
     };
     const viewFaviconUrl = createMemo(() => util.useAtomValueSafe(props.viewModel?.viewFaviconUrl));
@@ -517,6 +516,14 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                     blockView={blockData()?.meta?.view}
                 />
             </div>
+            <Show when={colorPanelAnchor()}>
+                <PaneColorPanel
+                    anchor={colorPanelAnchor()!}
+                    currentHue={(blockData()?.meta?.["frame:hue"] as number | undefined) ?? null}
+                    blockId={blockData()!.oid}
+                    onClose={() => setColorPanelAnchor(null)}
+                />
+            </Show>
         </div>
     );
 }

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -520,7 +520,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                 <PaneColorPanel
                     anchor={colorPanelAnchor()!}
                     currentHue={(blockData()?.meta?.["frame:hue"] as number | undefined) ?? null}
-                    blockId={blockData()!.oid}
+                    blockId={blockData()?.oid ?? ""}
                     onClose={() => setColorPanelAnchor(null)}
                 />
             </Show>

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -516,7 +516,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                     blockView={blockData()?.meta?.view}
                 />
             </div>
-            <Show when={colorPanelAnchor()}>
+            <Show when={colorPanelAnchor() && blockData()?.oid}>
                 <PaneColorPanel
                     anchor={colorPanelAnchor()!}
                     currentHue={(blockData()?.meta?.["frame:hue"] as number | undefined) ?? null}

--- a/frontend/app/block/pane-color-menu.ts
+++ b/frontend/app/block/pane-color-menu.ts
@@ -10,15 +10,20 @@ export interface PaneHueOption {
     hue: number;
 }
 
+// 12 hues at 30° intervals — full spectrum, evenly spaced
 export const PANE_HUE_OPTIONS: ReadonlyArray<PaneHueOption> = [
-    { label: "Cobalt",  hue: 218 },
-    { label: "Emerald", hue: 150 },
-    { label: "Amber",   hue:  38 },
-    { label: "Rose",    hue: 352 },
-    { label: "Violet",  hue: 270 },
-    { label: "Cyan",    hue: 188 },
-    { label: "Coral",   hue:  14 },
-    { label: "Mint",    hue: 163 },
+    { label: "Crimson",    hue:   0 },
+    { label: "Coral",      hue:  30 },
+    { label: "Amber",      hue:  60 },
+    { label: "Chartreuse", hue:  90 },
+    { label: "Green",      hue: 120 },
+    { label: "Emerald",    hue: 150 },
+    { label: "Teal",       hue: 180 },
+    { label: "Sky",        hue: 210 },
+    { label: "Blue",       hue: 240 },
+    { label: "Violet",     hue: 270 },
+    { label: "Fuchsia",    hue: 300 },
+    { label: "Pink",       hue: 330 },
 ];
 
 /** Derive the muted header background from a hue (0–360). */
@@ -31,38 +36,18 @@ export function hueToActiveBorder(hue: number): string {
     return `hsl(${hue}, 65%, 52%)`;
 }
 
-function setHue(blockId: string, hue: number | null): void {
+export interface PaneSwatch extends PaneHueOption {
+    preview: string;
+}
+
+// Vivid preview hex for each hue — used by PaneColorPanel swatches
+export const PANE_SWATCH_COLORS: ReadonlyArray<PaneSwatch> = PANE_HUE_OPTIONS.map(
+    ({ label, hue }) => ({ label, hue, preview: hueToActiveBorder(hue) })
+);
+
+export function setHue(blockId: string, hue: number | null): void {
     void RpcApi.SetMetaCommand(TabRpcClient, {
         oref: WOS.makeORef("block", blockId),
         meta: { "frame:hue": hue } as any,
     });
-}
-
-export function buildPaneColorSubmenu(
-    blockData: Block | null,
-    blockId: string,
-): ContextMenuItem {
-    const currentHue = (blockData?.meta?.["frame:hue"] as number | undefined) ?? null;
-
-    const items: ContextMenuItem[] = [
-        {
-            label: "None",
-            type: "radio",
-            checked: currentHue === null,
-            click: () => setHue(blockId, null),
-        },
-        { type: "separator" },
-        ...PANE_HUE_OPTIONS.map(({ label, hue }) => ({
-            label,
-            type: "radio" as const,
-            checked: currentHue === hue,
-            click: () => setHue(blockId, hue),
-        })),
-    ];
-
-    return {
-        label: "Pane Color",
-        type: "submenu",
-        submenu: items,
-    };
 }

--- a/frontend/app/block/pane-color-panel.scss
+++ b/frontend/app/block/pane-color-panel.scss
@@ -1,0 +1,40 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+@use "../element/menu-frame" as menuFrame;
+
+.pane-color-panel {
+    @include menuFrame.menu-frame;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+    padding: var(--space-2);
+    user-select: none;
+}
+
+.pane-color-panel-sep {
+    height: 1px;
+    background: var(--border-color);
+    margin: 0 calc(-1 * var(--space-2));
+}
+
+.pane-color-panel-clear {
+    display: flex;
+
+    button {
+        flex: 1;
+        padding: 3px var(--space-1-5);
+        background: transparent;
+        border: 1px solid var(--border-color);
+        border-radius: 0;
+        color: var(--secondary-text-color);
+        font-size: 10px;
+        cursor: default;
+        white-space: nowrap;
+
+        &:hover {
+            background: var(--highlight-bg-color);
+            color: var(--main-text-color);
+        }
+    }
+}

--- a/frontend/app/block/pane-color-panel.tsx
+++ b/frontend/app/block/pane-color-panel.tsx
@@ -42,17 +42,45 @@ export function PaneColorPanel(props: PaneColorPanelProps): JSX.Element {
         });
     });
 
-    const style = (): JSX.CSSProperties => ({
-        position: "fixed",
-        top: `${props.anchor.bottom + 4}px`,
-        left: `${props.anchor.left}px`,
-        "z-index": 9999,
-    });
+    const style = (): JSX.CSSProperties => {
+        // Panel is ~180px wide × ~160px tall (4-col × 3-row swatch + sep + clear).
+        // Clamp so it never renders off the right or bottom edge of the viewport.
+        const PANEL_W = 188;
+        const PANEL_H = 168;
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const rawLeft = props.anchor.left;
+        const rawTop = props.anchor.bottom + 4;
+        const left = Math.min(rawLeft, vw - PANEL_W - 4);
+        const top = rawTop + PANEL_H > vh ? props.anchor.top - PANEL_H - 4 : rawTop;
+        return {
+            position: "fixed",
+            top: `${Math.max(4, top)}px`,
+            left: `${Math.max(4, left)}px`,
+            "z-index": 9999,
+        };
+    };
 
-    // Map hue to swatch preview hex for currentColor comparison
+    // Map hue to swatch preview hex for currentColor comparison.
+    // If the stored hue doesn't match any current swatch (retired hue from an
+    // older palette), fall back to the nearest swatch so one is shown selected.
     const currentPreview = (): string | null => {
         if (props.currentHue == null) return null;
-        return PANE_SWATCH_COLORS.find((s) => s.hue === props.currentHue)?.preview ?? null;
+        const exact = PANE_SWATCH_COLORS.find((s) => s.hue === props.currentHue);
+        if (exact) return exact.preview;
+        // Nearest hue by circular distance (mod 360)
+        const nearest = PANE_SWATCH_COLORS.reduce((best, s) => {
+            const d = Math.min(
+                Math.abs(s.hue - props.currentHue!),
+                360 - Math.abs(s.hue - props.currentHue!)
+            );
+            const bd = Math.min(
+                Math.abs(best.hue - props.currentHue!),
+                360 - Math.abs(best.hue - props.currentHue!)
+            );
+            return d < bd ? s : best;
+        });
+        return nearest.preview;
     };
 
     const swatchColors = PANE_SWATCH_COLORS.map((s) => ({ name: s.label, hex: s.preview }));

--- a/frontend/app/block/pane-color-panel.tsx
+++ b/frontend/app/block/pane-color-panel.tsx
@@ -27,11 +27,18 @@ export function PaneColorPanel(props: PaneColorPanelProps): JSX.Element {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === "Escape") props.onClose();
         };
+        // CEF native context menus steal OS focus while open and do not fire DOM
+        // mousedown when an item is selected. Listening for window focus returning
+        // catches the close of the native menu (regardless of whether the user
+        // picked an item or dismissed it) so the swatch panel doesn't linger.
+        const handleWindowFocus = () => props.onClose();
         document.addEventListener("mousedown", handleClickOutside);
         document.addEventListener("keydown", handleKeyDown);
+        window.addEventListener("focus", handleWindowFocus);
         onCleanup(() => {
             document.removeEventListener("mousedown", handleClickOutside);
             document.removeEventListener("keydown", handleKeyDown);
+            window.removeEventListener("focus", handleWindowFocus);
         });
     });
 

--- a/frontend/app/block/pane-color-panel.tsx
+++ b/frontend/app/block/pane-color-panel.tsx
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ColorSwatchPalette } from "@/app/components/color-swatch-palette";
+import { onCleanup, onMount } from "solid-js";
+import { Portal } from "solid-js/web";
+import type { JSX } from "solid-js";
+import { PANE_SWATCH_COLORS, setHue } from "./pane-color-menu";
+import "./pane-color-panel.scss";
+
+interface PaneColorPanelProps {
+    anchor: DOMRect;
+    currentHue: number | null;
+    blockId: string;
+    onClose: () => void;
+}
+
+export function PaneColorPanel(props: PaneColorPanelProps): JSX.Element {
+    let panelRef!: HTMLDivElement;
+
+    onMount(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (panelRef && !panelRef.contains(e.target as Node)) {
+                props.onClose();
+            }
+        };
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") props.onClose();
+        };
+        document.addEventListener("mousedown", handleClickOutside);
+        document.addEventListener("keydown", handleKeyDown);
+        onCleanup(() => {
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("keydown", handleKeyDown);
+        });
+    });
+
+    const style = (): JSX.CSSProperties => ({
+        position: "fixed",
+        top: `${props.anchor.bottom + 4}px`,
+        left: `${props.anchor.left}px`,
+        "z-index": 9999,
+    });
+
+    // Map hue to swatch preview hex for currentColor comparison
+    const currentPreview = (): string | null => {
+        if (props.currentHue == null) return null;
+        return PANE_SWATCH_COLORS.find((s) => s.hue === props.currentHue)?.preview ?? null;
+    };
+
+    const swatchColors = PANE_SWATCH_COLORS.map((s) => ({ name: s.label, hex: s.preview }));
+
+    const handleSelect = (hex: string | null) => {
+        if (hex == null) {
+            setHue(props.blockId, null);
+        } else {
+            const match = PANE_SWATCH_COLORS.find((s) => s.preview === hex);
+            if (match) setHue(props.blockId, match.hue);
+        }
+        props.onClose();
+    };
+
+    return (
+        <Portal>
+            <div ref={panelRef!} class="pane-color-panel" style={style()} data-pane-overlay>
+                <div class="pane-color-panel-sep" />
+                <ColorSwatchPalette
+                    colors={swatchColors}
+                    columns={4}
+                    currentColor={currentPreview()}
+                    onSelect={handleSelect}
+                    showClear={false}
+                />
+                <div class="pane-color-panel-clear">
+                    <button onClick={() => handleSelect(null)}>✕ Clear color</button>
+                </div>
+            </div>
+        </Portal>
+    );
+}

--- a/frontend/app/components/color-swatch-palette.scss
+++ b/frontend/app/components/color-swatch-palette.scss
@@ -1,0 +1,50 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.color-swatch-grid {
+    display: grid;
+    gap: var(--space-1);
+    // columns driven by --swatch-cols CSS var set inline by ColorSwatchPalette
+    grid-template-columns: repeat(var(--swatch-cols, 5), 20px);
+}
+
+.color-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 0;
+    cursor: default;
+    border: 1.5px solid transparent;
+    transition: transform 0.1s ease, border-color 0.1s ease;
+
+    &:hover {
+        transform: scale(1.25);
+        border-color: rgba(255, 255, 255, 0.5);
+        z-index: 1;
+    }
+
+    &.color-swatch--selected {
+        border-color: rgba(255, 255, 255, 0.9);
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
+    }
+}
+
+.color-swatch-clear {
+    display: flex;
+
+    button {
+        flex: 1;
+        padding: 3px var(--space-1-5);
+        background: transparent;
+        border: 1px solid var(--border-color);
+        border-radius: 0;
+        color: var(--secondary-text-color);
+        font-size: 10px;
+        cursor: default;
+        white-space: nowrap;
+
+        &:hover {
+            background: var(--highlight-bg-color);
+            color: var(--main-text-color);
+        }
+    }
+}

--- a/frontend/app/components/color-swatch-palette.tsx
+++ b/frontend/app/components/color-swatch-palette.tsx
@@ -1,0 +1,53 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import clsx from "clsx";
+import { For, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import "./color-swatch-palette.scss";
+
+export interface SwatchColor {
+    name: string;
+    hex: string;
+}
+
+interface ColorSwatchPaletteProps {
+    colors: SwatchColor[];
+    columns: number;
+    currentColor: string | null | undefined;
+    onSelect: (hex: string | null) => void;
+    showClear?: boolean;
+}
+
+export function ColorSwatchPalette(props: ColorSwatchPaletteProps): JSX.Element {
+    const showClear = () => props.showClear !== false;
+
+    return (
+        <>
+            <div
+                class="color-swatch-grid"
+                style={{ "--swatch-cols": props.columns } as JSX.CSSProperties}
+            >
+                <For each={props.colors}>
+                    {({ name, hex }) => (
+                        <div
+                            class={clsx("color-swatch", {
+                                "color-swatch--selected": (props.currentColor ?? null) === hex,
+                            })}
+                            title={name}
+                            style={{ "background-color": hex }}
+                            onClick={() =>
+                                props.onSelect((props.currentColor ?? null) === hex ? null : hex)
+                            }
+                        />
+                    )}
+                </For>
+            </div>
+            <Show when={showClear()}>
+                <div class="color-swatch-clear">
+                    <button onClick={() => props.onSelect(null)}>✕ Clear color</button>
+                </div>
+            </Show>
+        </>
+    );
+}

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -251,7 +251,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
     user-select: none;
 }
 
-// .tab-context-colors and .tab-color-swatch moved to color-swatch-palette.scss
+// swatch grid moved to color-swatch-palette.scss as .color-swatch-grid / .color-swatch
 
 .tab-context-actions {
     display: flex;

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -251,21 +251,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
     user-select: none;
 }
 
-.tab-context-colors {
-    display: grid;
-    grid-template-columns: repeat(5, 20px);
-    gap: var(--space-1);
-}
-
-.tab-context-color-clear {
-    display: flex;
-
-    .tab-context-btn-clear {
-        flex: 1;
-        font-size: 10px;
-        padding: 3px var(--space-1-5);
-    }
-}
+// .tab-context-colors and .tab-color-swatch moved to color-swatch-palette.scss
 
 .tab-context-actions {
     display: flex;
@@ -296,33 +282,3 @@ body:not(.nohover) .tab.tab-colored.dragging {
     }
 }
 
-.tab-color-swatch {
-    width: 20px;
-    height: 20px;
-    border-radius: 0;
-    cursor: default;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 9px;
-    border: 1.5px solid transparent;
-    transition: transform 0.1s ease, border-color 0.1s ease;
-    color: var(--secondary-text-color);
-
-    &:hover {
-        transform: scale(1.25);
-        border-color: rgba(255, 255, 255, 0.5);
-        z-index: 1;
-    }
-
-    &.selected {
-        border-color: rgba(255, 255, 255, 0.9);
-        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
-    }
-
-    // "None" swatch (last item, no background)
-    &:last-child {
-        background: rgba(255, 255, 255, 0.06);
-        border-color: rgba(255, 255, 255, 0.1);
-    }
-}

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -251,7 +251,6 @@ body:not(.nohover) .tab.tab-colored.dragging {
     user-select: none;
 }
 
-// swatch grid moved to color-swatch-palette.scss as .color-swatch-grid / .color-swatch
 
 .tab-context-actions {
     display: flex;

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -7,26 +7,31 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { Button } from "@/element/button";
 import { fireAndForget } from "@/util/util";
 import clsx from "clsx";
-import { createEffect, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import type { JSX } from "solid-js";
+import { ColorSwatchPalette } from "@/app/components/color-swatch-palette";
 import { ObjectService } from "../store/services";
 import { makeORef, useWaveObjectValue } from "../store/wos";
 import { measureTabWidth } from "./tab-measure";
 import "./tab.scss";
 
-// 10 equally-spaced hues (0°, 36°, 72°, … 324°) — full spectrum, no near-duplicates
+// 14 colors — 10 original hues + 4 new fills at perceptual midpoints
 export const TAB_COLORS: { name: string; hex: string }[] = [
-    { name: "Red",    hex: "#ef4444" },
-    { name: "Orange", hex: "#f97316" },
-    { name: "Yellow", hex: "#eab308" },
-    { name: "Lime",   hex: "#84cc16" },
-    { name: "Green",  hex: "#22c55e" },
-    { name: "Teal",   hex: "#14b8a6" },
-    { name: "Blue",   hex: "#3b82f6" },
-    { name: "Violet", hex: "#8b5cf6" },
-    { name: "Pink",   hex: "#ec4899" },
-    { name: "Rose",   hex: "#f43f5e" },
+    { name: "Red",     hex: "#ef4444" },
+    { name: "Orange",  hex: "#f97316" },
+    { name: "Amber",   hex: "#f59e0b" },
+    { name: "Yellow",  hex: "#eab308" },
+    { name: "Lime",    hex: "#84cc16" },
+    { name: "Green",   hex: "#22c55e" },
+    { name: "Teal",    hex: "#14b8a6" },
+    { name: "Cyan",    hex: "#06b6d4" },
+    { name: "Blue",    hex: "#3b82f6" },
+    { name: "Indigo",  hex: "#6366f1" },
+    { name: "Violet",  hex: "#8b5cf6" },
+    { name: "Fuchsia", hex: "#d946ef" },
+    { name: "Pink",    hex: "#ec4899" },
+    { name: "Rose",    hex: "#f43f5e" },
 ];
 
 interface TabContextPanelProps {
@@ -67,28 +72,12 @@ const TabContextPanel = (props: TabContextPanelProps): JSX.Element => {
     return (
         <Portal>
             <div ref={panelRef!} class="tab-context-panel" style={style()} data-pane-overlay>
-                <div class="tab-context-colors">
-                    <For each={TAB_COLORS}>
-                        {({ name, hex }) => (
-                            <div
-                                class={clsx("tab-color-swatch", { selected: (props.currentColor ?? null) === hex })}
-                                title={name}
-                                style={{ "background-color": hex }}
-                                onClick={() => props.onColorSelect(
-                                    (props.currentColor ?? null) === hex ? null : hex
-                                )}
-                            />
-                        )}
-                    </For>
-                </div>
-                <div class="tab-context-color-clear">
-                    <button
-                        class="tab-context-btn tab-context-btn-clear"
-                        onClick={() => props.onColorSelect(null)}
-                    >
-                        ✕ Clear color
-                    </button>
-                </div>
+                <ColorSwatchPalette
+                    colors={TAB_COLORS}
+                    columns={7}
+                    currentColor={props.currentColor}
+                    onSelect={props.onColorSelect}
+                />
                 <div class="tab-context-actions">
                     <button class="tab-context-btn" onClick={() => { props.onRename(); props.onClose(); }}>
                         ✏️ Rename


### PR DESCRIPTION
## Summary

- **Tab palette expanded 10 → 14 colors**: Added Amber `#f59e0b`, Cyan `#06b6d4`, Indigo `#6366f1`, Fuchsia `#d946ef` at perceptual midpoints in the hue wheel. Grid widens from 5×2 to 7×2 (same 20px swatch size).
- **Reusable `ColorSwatchPalette` component**: Extracted from `TabContextPanel` into `frontend/app/components/color-swatch-palette.tsx`. Accepts `colors[]`, `columns`, `currentColor`, `onSelect`, `showClear`. Both tab and pane panels now use it.
- **Pane palette: 8 uneven hues → 12 hues at 30° intervals**: Crimson, Coral, Amber, Chartreuse, Green, Emerald, Teal, Sky, Blue, Violet, Fuchsia, Pink. Fills the previous 112° gap. `buildPaneColorSubmenu` removed entirely.
- **`PaneColorPanel` for all pane types**: Right-clicking any pane header now shows a Portal-based visual swatch panel (separator bar → 4×3 grid → "✕ Clear color" button) anchored below the header. Native context menu still appears alongside for split/close/title actions.

## Test plan

- [ ] Right-click a tab — confirm 14 swatches in a 7×2 grid, all 4 new colors visible and selectable
- [ ] Right-click a pane header (agent, terminal, browser, editor) — confirm swatch panel appears below header with 4×3 grid and clear button
- [ ] Select a pane color — confirm header background updates to the chosen hue
- [ ] Click "✕ Clear color" — confirm header returns to default
- [ ] Click outside / press Escape — confirm panel dismisses
- [ ] Confirm no "Pane Color ▸" text submenu appears in the native context menu

<!-- agentmux:agent_id=agent1 -->