### PR TITLE
feat(toolchain): Check latest versions button

### DIFF
--- a/.changesets/1751338000-feat-toolchain-check-latest-versions-c3d1.md
+++ b/.changesets/1751338000-feat-toolchain-check-latest-versions-c3d1.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(toolchain): Check latest versions button — fetch latest npm versions for provider CLIs

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -626,6 +626,53 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+
+    // toolchain.versions — fetch the latest published version for a list of npm
+    // packages from the npm registry. Input: { packages: [{id, package}] }.
+    // Output: { id: "x.y.z" | null, ... }. Each lookup is independent — a
+    // network error for one package yields null for that entry, not a failure.
+    // 5-second per-request timeout; all lookups run concurrently.
+    engine.register_handler(
+        "toolchain.versions",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Pkg { id: String, package: String }
+                let packages: Vec<Pkg> = data
+                    .get("packages")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_default();
+
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(5))
+                    .user_agent("agentmux/toolchain-versions")
+                    .build()
+                    .map_err(|e| e.to_string())?;
+
+                let futs: Vec<_> = packages.into_iter().map(|pkg| {
+                    let c = client.clone();
+                    async move {
+                        let url = format!("https://registry.npmjs.org/{}/latest", pkg.package);
+                        let version = match c.get(&url).send().await {
+                            Ok(resp) if resp.status().is_success() => {
+                                resp.json::<serde_json::Value>().await.ok()
+                                    .and_then(|v| v.get("version").and_then(|s| s.as_str()).map(|s| s.to_string()))
+                            }
+                            _ => None,
+                        };
+                        (pkg.id, version)
+                    }
+                }).collect();
+
+                let results = futures_util::future::join_all(futs).await;
+                let mut out = serde_json::Map::new();
+                for (id, version) in results {
+                    out.insert(id, version.map(serde_json::Value::String).unwrap_or(serde_json::Value::Null));
+                }
+                Ok(Some(serde_json::Value::Object(out)))
+            })
+        }),
+    );
 }
 
 /// Re-export from shared crate for internal use.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -1287,6 +1287,17 @@ class RpcApiType {
         return client.rpcCall("toolchain.env", {}, opts);
     }
 
+    // command "toolchain.versions" [call] — fetch latest published npm versions for
+    // a list of packages. Input: { packages: [{id, package}] }. Output: {id: version|null}.
+    // Each lookup is independent; a network error yields null for that entry.
+    ToolchainVersionsCommand(
+        client: RpcClient,
+        data: { packages: Array<{ id: string; package: string }> },
+        opts?: RpcOpts,
+    ): Promise<Record<string, string | null>> {
+        return client.rpcCall("toolchain.versions", data, opts);
+    }
+
     // command "widget.health" [call] — HTTP liveness probe for an external widget
     // server on localhost. Returns { healthy, status_code } — never throws on
     // connection failure so the UI can show a "not running" pill gracefully.

--- a/frontend/app/view/toolchain/toolchain-view.scss
+++ b/frontend/app/view/toolchain/toolchain-view.scss
@@ -15,6 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    gap: var(--space-1, 6px);
     padding: var(--space-2, 8px) var(--space-3, 12px);
     border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
@@ -212,6 +213,10 @@
     }
     &--muted {
         opacity: 0.7;
+    }
+    &--update {
+        background: rgba(219, 154, 4, 0.18);
+        color: var(--warning-color, #d29922);
     }
 }
 

--- a/frontend/app/view/toolchain/toolchain-view.tsx
+++ b/frontend/app/view/toolchain/toolchain-view.tsx
@@ -115,7 +115,7 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
     const providerRows: ToolRow[] = getProviderList().map((p) => ({
         id: p.id, label: p.displayName, icon: p.icon, kind: "provider",
         loading: true, found: false, docsUrl: p.docsUrl, installUrl: p.docsUrl,
-        npmPackage: (p as any).npmPackage as string | undefined,
+        npmPackage: p.npmPackage,
     }));
     const [rows, setRows] = createStore<ToolRow[]>([...coreRows, ...providerRows]);
 
@@ -223,7 +223,7 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                         <Show when={row.source === "local_install"}>
                             <span class="toolchain-pill toolchain-pill--muted">managed</span>
                         </Show>
-                        <Show when={row.latestVersion !== undefined}>
+                        <Show when={row.latestVersion !== undefined && row.version !== undefined}>
                             <span
                                 class={`toolchain-pill ${row.version === row.latestVersion ? "toolchain-pill--muted" : "toolchain-pill--update"}`}
                                 title={`Latest: ${row.latestVersion}`}

--- a/frontend/app/view/toolchain/toolchain-view.tsx
+++ b/frontend/app/view/toolchain/toolchain-view.tsx
@@ -52,6 +52,8 @@ interface ToolRow {
     docsUrl?: string;
     installUrl?: string;
     installCommand?: string;
+    npmPackage?: string;
+    latestVersion?: string;
 }
 
 interface WidgetRow {
@@ -113,6 +115,7 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
     const providerRows: ToolRow[] = getProviderList().map((p) => ({
         id: p.id, label: p.displayName, icon: p.icon, kind: "provider",
         loading: true, found: false, docsUrl: p.docsUrl, installUrl: p.docsUrl,
+        npmPackage: (p as any).npmPackage as string | undefined,
     }));
     const [rows, setRows] = createStore<ToolRow[]>([...coreRows, ...providerRows]);
 
@@ -179,6 +182,28 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
         wrows.forEach((_, i) => void probeWidget(i));
     };
 
+    const [latestLoading, setLatestLoading] = createSignal(false);
+
+    const checkLatestVersions = async () => {
+        const packages = rows
+            .filter((r) => r.npmPackage)
+            .map((r) => ({ id: r.id, package: r.npmPackage! }));
+        if (!packages.length) return;
+        setLatestLoading(true);
+        try {
+            const result = await RpcApi.ToolchainVersionsCommand(TabRpcClient, { packages }, { timeout: 15000 });
+            rows.forEach((r, i) => {
+                if (r.npmPackage && result[r.id] !== undefined) {
+                    setRows(i, "latestVersion", result[r.id] ?? undefined);
+                }
+            });
+        } catch {
+            // network failure — leave latestVersion undefined
+        } finally {
+            setLatestLoading(false);
+        }
+    };
+
     const open = (url?: string) => { if (url) getApi().openExternal(url); };
     const copy = (cmd?: string) => { if (cmd) void navigator.clipboard?.writeText(cmd); };
 
@@ -197,6 +222,15 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                         </span>
                         <Show when={row.source === "local_install"}>
                             <span class="toolchain-pill toolchain-pill--muted">managed</span>
+                        </Show>
+                        <Show when={row.latestVersion !== undefined}>
+                            <span
+                                class={`toolchain-pill ${row.version === row.latestVersion ? "toolchain-pill--muted" : "toolchain-pill--update"}`}
+                                title={`Latest: ${row.latestVersion}`}
+                            >
+                                <i class={`fa-solid ${row.version === row.latestVersion ? "fa-circle-check" : "fa-circle-up"}`} />
+                                {" "}{row.version === row.latestVersion ? "up to date" : `${row.latestVersion} available`}
+                            </span>
                         </Show>
                     </Show>
                     <Show when={!row.loading && !row.found}>
@@ -237,6 +271,15 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
             <div class="toolchain-view-header">
                 <button class="toolchain-btn toolchain-btn--ghost" onClick={refresh}>
                     <i class="fa-solid fa-rotate" /> Refresh
+                </button>
+                <button
+                    class="toolchain-btn toolchain-btn--ghost"
+                    onClick={() => void checkLatestVersions()}
+                    disabled={latestLoading()}
+                    title="Fetch latest published versions from npm registry"
+                >
+                    <i class={`fa-solid ${latestLoading() ? "fa-spinner fa-spin" : "fa-arrow-up"}`} />
+                    {latestLoading() ? " Checking…" : " Check latest versions"}
                 </button>
             </div>
             <div class="toolchain-body">


### PR DESCRIPTION
## Summary

- Adds `toolchain.versions` RPC handler in `cli_handlers.rs` — fetches latest published npm version for a list of packages concurrently from registry.npmjs.org (5s timeout per request, independent failures, `futures_util::join_all`)
- Adds `ToolchainVersionsCommand` RPC binding in `rpc-api.ts`
- Adds **"Check latest versions"** button to the toolchain pane header (alongside Refresh); shows a spinner while in-flight
- On completion, adds a pill to each provider CLI row: amber **"2.1.197 available"** (with up-arrow icon) if installed is behind, or muted **"up to date"** (with check icon) if versions match
- Only provider CLIs with an `npmPackage` are checked; core system tools (Git, Docker, Python) are unaffected

## Test plan
- [ ] Open toolchain pane, click "Check latest versions" — spinner shows, then pills appear on provider CLI rows
- [ ] With claude-code installed at a known version, verify pill correctly shows "available" vs "up to date"
- [ ] With no network, verify button completes gracefully with no error (pills just don't appear)

<!-- agentmux:agent_id=agenty-0629j -->