### PR TITLE
fix(floating-pane): relabel promoted pane-pool windows to floating-* (status-bar count)

### DIFF
--- a/.changesets/1782874440-fix-floating-pane-relabel-promoted-pane-pool-windows-floatin-6x2q.md
+++ b/.changesets/1782874440-fix-floating-pane-relabel-promoted-pane-pool-windows-floatin-6x2q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): relabel promoted pane-pool windows floating-pool-* -> floating-* so the status bar counts them (Windows)

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -1588,32 +1588,70 @@ pub fn promote_pane_pool_window(
             let _ = ShowWindow(outer_hwnd as HWND, SW_SHOWNORMAL);
         }
 
+        // Rename `floating-pool-<uuid>` → `floating-<uuid>` so the promoted
+        // pane is counted as a real user floater rather than filtered out as a
+        // warm pool window (SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30). Re-key
+        // every per-label store BEFORE the emit below — `emit_event_to_window`
+        // resolves the target via `get_browser(label)`, which after the reducer
+        // re-key lives under `new_label`.
+        let new_label = label.replacen("floating-pool-", "floating-", 1);
+        // Reducer state: `browsers` (+ the duplicated label field) and, if
+        // present, `window_opacities` / `pane_window_states`.
+        let _ = state.host_dispatch(crate::reducer::HostCommand::RelabelBrowser {
+            old_label: label.clone(),
+            new_label: new_label.clone(),
+        });
+        // AppState label maps (not reducer state).
+        {
+            let mut hwnds = state.window_hwnds.lock();
+            if let Some(h) = hwnds.remove(&label) {
+                hwnds.insert(new_label.clone(), h);
+            }
+        }
+        {
+            let mut meta = state.window_meta.lock();
+            if let Some(mut m) = meta.remove(&label) {
+                m.label = new_label.clone();
+                meta.insert(new_label.clone(), m);
+            }
+        }
+
         // Bind this floater to the source window's cascade hook. Deferred from
         // spawn time because the parent HWND is only known at tear-off.
         crate::floating_pane::register_floater_hwnd(
-            label.clone(),
+            new_label.clone(),
             outer_hwnd as isize,
             parent_hwnd,
         );
 
-        // Tell the renderer to bootstrap pane + workspace.
+        // Tell the renderer to bootstrap pane + workspace. Carry the new window
+        // label so `awaitPanePoolPromote` rewrites its `?windowLabel=` param —
+        // otherwise the renderer keeps addressing the host by the dead pool
+        // label (spec §5.2).
         crate::events::emit_event_to_window(
             state,
-            &label,
+            &new_label,
             "pool:pane-promote",
             &serde_json::json!({
                 "paneId": pane_id,
                 "workspaceId": workspace_id,
+                "windowLabel": new_label,
             }),
         );
 
         spawn_pane_pool_window(state);
 
-        return Some(label);
+        return Some(new_label);
     }
 
     #[cfg(not(target_os = "windows"))]
     {
+        // NOTE: the `floating-pool-*` → `floating-*` relabel
+        // (SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30) is currently applied on
+        // the Windows path only — that's where the bug was reported and where
+        // it can be runtime-verified. The equivalent re-key + payload
+        // `windowLabel` should be applied here (via `post_promote_pane_pool_window`)
+        // as a follow-up on macOS/Linux.
         let _ = parent_hwnd; // unused on non-Windows
         let dispatch = state.host_dispatch(
             crate::reducer::HostCommand::PopAndPromoteFrontPanePoolWindow,

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -1597,10 +1597,25 @@ pub fn promote_pane_pool_window(
         let new_label = label.replacen("floating-pool-", "floating-", 1);
         // Reducer state: `browsers` (+ the duplicated label field) and, if
         // present, `window_opacities` / `pane_window_states`.
-        let _ = state.host_dispatch(crate::reducer::HostCommand::RelabelBrowser {
+        let relabel = state.host_dispatch(crate::reducer::HostCommand::RelabelBrowser {
             old_label: label.clone(),
             new_label: new_label.clone(),
         });
+        if !relabel.relabel_ok {
+            // The browser vanished between promote and relabel (concurrent
+            // close-before-promote race). Bail rather than re-key the AppState
+            // maps under `new_label` while `browsers` still holds `old_label`
+            // — that split would make the emit below resolve no browser and
+            // leave dangling AppState entries. Clean up under the old label.
+            tracing::warn!(
+                target: "pool:pane",
+                old_label = %label,
+                new_label = %new_label,
+                "[relabel] relabel failed (browser gone?) — aborting promotion, orphan cleanup"
+            );
+            cleanup_failed_pane_promote_orphan(state, &label);
+            return None;
+        }
         // AppState label maps (not reducer state).
         {
             let mut hwnds = state.window_hwnds.lock();

--- a/agentmux-cef/src/reducer/browsers.rs
+++ b/agentmux-cef/src/reducer/browsers.rs
@@ -57,7 +57,12 @@ pub(super) fn handle_relabel_browser(
     new_label: String,
 ) -> DispatchOutput {
     if old_label == new_label {
-        return DispatchOutput::default();
+        // No-op: label already correct. Treated as success so the caller
+        // proceeds (nothing to re-key).
+        return DispatchOutput {
+            relabel_ok: true,
+            ..Default::default()
+        };
     }
     if !state.browsers.contains_key(&old_label) {
         return emit_error(
@@ -92,7 +97,10 @@ pub(super) fn handle_relabel_browser(
         new_label = %new_label,
         "[relabel] browser re-keyed on pane-pool promotion"
     );
-    DispatchOutput::default()
+    DispatchOutput {
+        relabel_ok: true,
+        ..Default::default()
+    }
 }
 
 pub(super) fn handle_unregister_browser(state: &mut HostState, label: String) -> DispatchOutput {

--- a/agentmux-cef/src/reducer/browsers.rs
+++ b/agentmux-cef/src/reducer/browsers.rs
@@ -42,6 +42,59 @@ pub(super) fn handle_register_browser(
     }
 }
 
+/// Rename a browser entry `old_label` → `new_label`, re-keying the per-label
+/// host state that persists for the window's life: the `browsers` map (and the
+/// duplicated `BrowserHandle.label` field), plus `window_opacities` and
+/// `pane_window_states` when an entry exists. `window_meta` / `window_hwnds`
+/// live on `AppState` and are re-keyed by the caller
+/// (`promote_pane_pool_window`). Errors if `old_label` is absent or `new_label`
+/// is already registered. Emits no event — the frontend learns the new label
+/// via the `pool:pane-promote` payload, not a host event.
+/// See `SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30`.
+pub(super) fn handle_relabel_browser(
+    state: &mut HostState,
+    old_label: String,
+    new_label: String,
+) -> DispatchOutput {
+    if old_label == new_label {
+        return DispatchOutput::default();
+    }
+    if !state.browsers.contains_key(&old_label) {
+        return emit_error(
+            state,
+            format!("relabel_browser: old label {} not found", old_label),
+        );
+    }
+    if state.browsers.contains_key(&new_label) {
+        return emit_error(
+            state,
+            format!("relabel_browser: new label {} already registered", new_label),
+        );
+    }
+    // Move the handle and update its duplicated `.label` field.
+    let mut handle = state
+        .browsers
+        .remove(&old_label)
+        .expect("presence checked above");
+    handle.label = new_label.clone();
+    state.browsers.insert(new_label.clone(), handle);
+    // Re-key sibling per-label state only when an entry exists (both are
+    // created lazily and are usually absent at promote time).
+    if let Some(opacity) = state.window_opacities.remove(&old_label) {
+        state.window_opacities.insert(new_label.clone(), opacity);
+    }
+    if let Some(win_state) = state.pane_window_states.remove(&old_label) {
+        state.pane_window_states.insert(new_label.clone(), win_state);
+    }
+    tracing::info!(
+        target: "pool:pane",
+        old_label = %old_label,
+        new_label = %new_label,
+        "[relabel] browser re-keyed on pane-pool promotion"
+    );
+    DispatchOutput::default()
+}
+
 pub(super) fn handle_unregister_browser(state: &mut HostState, label: String) -> DispatchOutput {
     // Atomic remove + return the Browser handle in `removed_browser`
     // (codex P2 PR #660). The pane close path in

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -312,6 +312,17 @@ pub enum HostCommand {
     /// Remove browser from `browsers` map. Idempotent; no-op if absent.
     UnregisterBrowser { label: String },
 
+    /// Rename a browser entry `old_label` → `new_label`, re-keying the
+    /// per-label host state that persists for the window's life
+    /// (`browsers` + the duplicated `BrowserHandle.label`, and, if present,
+    /// `window_opacities` / `pane_window_states`). Used when a pane-pool
+    /// window (`floating-pool-*`) is promoted into a user floating pane
+    /// (`floating-*`). Errors if `old_label` is absent or `new_label`
+    /// already exists. `window_meta` / `window_hwnds` live on `AppState`
+    /// and are re-keyed by the caller. See
+    /// `SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30`.
+    RelabelBrowser { old_label: String, new_label: String },
+
     // ── H.3 — drag state ────────────────────────────────────────────────
 
     /// Begin a cross-window drag session. Reject if one is already
@@ -487,6 +498,11 @@ impl std::fmt::Debug for HostCommand {
             HostCommand::UnregisterBrowser { label } => f
                 .debug_struct("UnregisterBrowser")
                 .field("label", label)
+                .finish(),
+            HostCommand::RelabelBrowser { old_label, new_label } => f
+                .debug_struct("RelabelBrowser")
+                .field("old_label", old_label)
+                .field("new_label", new_label)
                 .finish(),
             HostCommand::StartDrag { session } => f
                 .debug_struct("StartDrag")
@@ -931,6 +947,7 @@ fn is_quit_relevant(cmd: &HostCommand) -> bool {
             | HostCommand::CompleteBrowserPaneClose { .. }
             | HostCommand::DrainBrowserPaneByLabel { .. }
             | HostCommand::AbortBrowserPaneCreate { .. }
+            | HostCommand::RelabelBrowser { .. }
     )
 }
 
@@ -971,6 +988,9 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         }
         HostCommand::UnregisterBrowser { label } => {
             browsers::handle_unregister_browser(state, label)
+        }
+        HostCommand::RelabelBrowser { old_label, new_label } => {
+            browsers::handle_relabel_browser(state, old_label, new_label)
         }
         // H.3 drag
         HostCommand::StartDrag { session } => drag::handle_start_drag(state, session),

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -874,6 +874,15 @@ pub struct DispatchOutput {
     /// previously lived only in `client::on_before_close` and could miss a
     /// concurrent pool-refill race (SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md).
     pub request_drain: Option<crate::state::QuitReason>,
+
+    /// Set `true` by `RelabelBrowser` when the rename succeeded (or was a
+    /// no-op because `old_label == new_label`). Stays `false` on failure
+    /// (old label absent, or new label already registered — e.g. a
+    /// concurrent close removed the browser between promote and relabel).
+    /// The caller MUST gate the AppState `window_hwnds`/`window_meta` re-key
+    /// and the `pool:pane-promote` emit on this, else `browsers` and the
+    /// AppState maps would disagree and the emit would resolve no browser.
+    pub relabel_ok: bool,
 }
 
 // Manual Debug — `cef::Browser` doesn't impl Debug.

--- a/docs/specs/SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30.md
+++ b/docs/specs/SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30.md
@@ -1,0 +1,227 @@
+# SPEC — Rename Pool-Promoted Floating Panes to `floating-<uuid>` (Option A)
+
+**Date:** 2026-06-30
+**Type:** Implementation spec (fully scoped)
+**Status:** Ready to schedule
+**Owner:** asaf
+**Bug:** Status-bar InstancePanel reports **0 floating panes** while a user floating pane is
+visible on Windows.
+**Severity:** Cosmetic (miscount); the pane itself works. Not a regression — pre-existing, in the
+pane-pool + status-bar code (untouched by the srv layout program).
+
+> Goal: when a warm pane-pool window (`floating-pool-<uuid>`) is **promoted** into a user-visible
+> floating pane, rename it to a real `floating-<uuid>` label so it is counted like any cold-path
+> floater — **without stranding** any store, HWND cache, or renderer that keys off the old label.
+
+---
+
+## 1. Root cause (confirmed)
+
+1. On Windows, opening a floating pane takes the **pane-pool fast path**
+   (`commands/floating_pane.rs:219`, non-Windows `:272`) → `promote_pane_pool_window`
+   (`commands/window_pool.rs:1517`), which **reuses the pool label** `floating-pool-<uuid>` and
+   returns it verbatim (`window_pool.rs:1600` emit, `:1613`ish return). The cold-path label
+   `floating-{uuid}` allocated at `floating_pane.rs:130` is **discarded** when the pool path hits.
+2. `blockframe.tsx:246` renders floating chrome for any `label.startsWith("floating-")` — and
+   `"floating-pool-…".startsWith("floating-")` is **true** → the pane *looks* floating. ✓
+3. The status-bar counter uses `isFloatingPaneLabel` (`launcher-event/types.ts:157`), which does
+   `if (label.startsWith("floating-pool-")) return false` → the promoted pane is **excluded** →
+   panel shows **0**.
+
+### 1.1 How the count is actually fed (this determines whether a rename is sufficient — it is)
+The frontend's floating count comes from the **`list_window_instances` host snapshot**
+(`commands/window/meta.rs:102`), consumed by `seedKnownEntriesFromSnapshot` (boot) and the
+InstancePanel **reconcile** (`launcher-event-reducer.ts:187,229`), filtered through
+`isFloatingPaneLabel`. It is **not** fed by the launcher-event stream: **the host reports nothing
+about floating panes to the launcher** (no `report_window_opened`/`_instance_assigned`/
+`_backend_window_id` for floaters — verified). Cold-path `floating-<uuid>` floaters are counted via
+this same snapshot path (they pass `isFloatingPaneLabel`).
+
+`list_window_instances` returns a **promoted** pool pane (it's removed from the pool set at promote,
+so it survives the `!pool_labels.contains(l)` filter, `meta.rs:111`) — but under its
+`floating-pool-<uuid>` label, which the counter rejects. **Therefore renaming the promoted pane to
+`floating-<uuid>` is sufficient for the count** (it then appears in the snapshot under a countable
+label, at parity with cold-path floaters). No launcher-event wiring is required.
+
+> ⚠️ Timing note (pre-existing, out of scope): because floaters ride the snapshot/reconcile path,
+> not live launcher events, the floating count updates on reconcile, not instantly. The rename brings
+> pool floaters to the **same** timing as cold-path floaters — it does not make it worse, and fixing
+> the snapshot-lag is a separate concern.
+
+---
+
+## 2. Decision
+
+**Option A — rename on promotion.** Chosen over (B) making the counter promotion-aware or (C) a
+promotion marker, because the "pool" prefix is *semantically wrong* on a pane that is now a real user
+floater, and Option A makes every existing `startsWith("floating-")` / `isFloatingPaneLabel` /
+snapshot consumer correct with no new promotion-state plumbing. Its cost is entirely in re-keying —
+which this spec enumerates exhaustively.
+
+**New label:** reuse the pool pane's uuid, dropping the `pool-` segment:
+`floating-pool-<uuid>` → `floating-<uuid>`. (Same scheme as the cold path's `floating-{uuid}`;
+reusing the uuid keeps host/renderer logs correlatable across the rename.)
+
+---
+
+## 3. The window-pool precedent (why we can't just copy it)
+
+Regular windows are counted correctly despite *also* coming from a pool (`window-pool-<uuid>`). But
+the window path does **not** rename: `promote_pool_window` (`window_pool.rs:654`) keeps the
+`window-pool-*` label, and `isInstanceLabel` (`types.ts:144`) **permissively** counts anything
+`startsWith("window-")` (including `window-pool-*`); unpromoted pool windows are gated out
+**host-side** before being reported. The floating filter is the **opposite** — it *excludes* the
+pool prefix. Mirroring the window path would mean making `isFloatingPaneLabel` permissive **and**
+wiring floaters into the launcher-report path (which they bypass entirely today) — strictly more work
+than the rename. So the precedent informs but does not transfer; **Option A (rename) is the smaller,
+cleaner fit for floaters precisely because floaters bypass the launcher.**
+
+---
+
+## 4. Host changes (agentmux-cef)
+
+### 4.1 Re-key surface — MUST update on rename (these persist for the window's life)
+| Store | Location | Action |
+|---|---|---|
+| `HostState.browsers` (label → `BrowserHandle`) | `reducer/mod.rs:96`, `state.rs:219` | Remove old key, reinsert under new label. **Also update the duplicated `BrowserHandle.label` field.** `register_browser` rejects dup keys, so this is remove+reinsert, not insert. |
+| `AppState.window_hwnds` (label → outer HWND, Windows) | `state.rs:859` | Re-key. Feeds `label_for_hwnd` reverse-scan (`state.rs:1091`) and all floater geometry/opacity ops. A partial rename desyncs forward/reverse lookups. |
+| `AppState.window_meta` (label → `WindowMeta`) | `state.rs:641` | Re-key. **Also update the duplicated `WindowMeta.label` field.** Orphan cleanup removes by label (`window_pool.rs:1500`). |
+| `ACTIVE_FLOATER_HWNDS` static | `floating_pane.rs:78` | Register with the **new** label at `window_pool.rs:1593` (removal is by-HWND, so rename-agnostic — just register the new key). |
+
+### 4.2 Re-key only if present (usually absent at promote — created lazily later)
+- `HostState.pane_window_states` (`reducer/mod.rs:142`) — maximize/restore state; created on first
+  maximize toggle. Guard: re-key iff the old label has an entry.
+- `HostState.window_opacities` (`reducer/mod.rs:130`) — created iff opacity was set. Same guard.
+
+### 4.3 No action (ephemeral — cleared/consumed during the promote itself)
+`pane_pool.{queue, unpromoted}` (popped/removed by `PopAndPromoteFrontPanePoolWindow` *before* the
+rename), `PANE_POOL_HWND_CACHE` (`take_pane_pool_hwnd` removes it), `pending_window_creations`
+(dequeued at `on_after_created`). Confirmed not floater-keyed: `browser_panes`,
+`pending_browser_pane_creates`, `shadow_*`, tab-pool caches.
+
+### 4.4 New reducer command: `HostCommand::RelabelBrowser { old_label, new_label }`
+The rename must be a **pure reducer mutation** (single source of truth, testable) that:
+- moves the `browsers` entry old→new (error if old absent or new already present),
+- updates `BrowserHandle.label`,
+- re-keys `window_meta` (+ `WindowMeta.label`), and conditionally `pane_window_states` /
+  `window_opacities`.
+`window_hwnds` / `ACTIVE_FLOATER_HWNDS` are `AppState`/static (not `HostState`) — re-key those in
+`promote_pane_pool_window` directly, adjacent to the dispatch.
+
+### 4.5 Sequencing inside `promote_pane_pool_window` (Windows block `1527-1613`)
+1. `PopAndPromoteFrontPanePoolWindow` dispatch (old label leaves the pools; `is_pool=false`).
+2. `take_pane_pool_hwnd(&old_label)`.
+3. HWND liveness (`IsWindow`) + `SetWindowPos` / `ShowWindow`.
+4. `let new_label = format!("floating-{}", uuid_of(&old_label))`.
+5. **Re-key:** dispatch `RelabelBrowser { old_label, new_label }`; re-key `window_hwnds`.
+6. `register_floater_hwnd(new_label.clone(), outer_hwnd, parent_hwnd)`.
+7. `emit_event_to_window(state, &new_label, "pool:pane-promote", { paneId, workspaceId, windowLabel: new_label })`
+   — **must** emit under the new key: `emit_event_to_window` resolves the target via
+   `get_browser(label)` (`events.rs:91`), and after step 5 the browser lives under `new_label`.
+8. Return `new_label` so `open_floating_pane_window` reports it as `window_label` to the caller.
+9. `spawn_pane_pool_window` refill.
+
+Apply the equivalent to the **non-Windows** promote block (`window_pool.rs:105`-region /
+`floating_pane.rs:272`); it has no `window_hwnds`/HWND-cache steps but the `browsers`/`window_meta`
+re-key + payload + return-label changes are identical.
+
+---
+
+## 5. Frontend changes
+
+### 5.1 Carry the new label in the promote event
+`pool:pane-promote` payload gains `windowLabel: string` (host §4.5 step 7).
+
+### 5.2 Rewrite the renderer's URL label — the critical loose end
+`awaitPanePoolPromote` (`init/pool.ts:116-131`) currently rewrites `floatingPaneId` / `workspaceId`
+and deletes `pane-pool`, but **not** `windowLabel`. Add:
+```ts
+url.searchParams.set("windowLabel", payload.windowLabel);
+```
+Reason: multiple readers derive the renderer's own label from `?windowLabel=` (e.g.
+`browser-view.tsx:61,114,376`, `floating-pane-workspace.tsx`, `blockframe.tsx:245`, drag hooks). After
+a host re-key, every label-addressed IPC from this renderer (`browser_pane_create`,
+`set_window_rect`/`get_window_rect`, `main_window_focus`, `closeWindowByLabel`,
+`registerBackendWindow`) would target the dead `floating-pool-*` label and fail unless the URL param
+is updated. Update the event's TS type to include `windowLabel`.
+
+### 5.3 Label-source consistency (verification point, not necessarily a code change)
+Two sources of the renderer's label must agree post-rename:
+- **`getApi().getWindowLabel()`** — a host IPC call (`InstancePanel.tsx:81`), i.e. host-resolved
+  live. **Verify** the host `get_window_label` command resolves via a browser→label reverse lookup so
+  it returns the **new** label after re-key (expected, but confirm — if it caches, fix it).
+- **URL `?windowLabel=`** — fixed by §5.2.
+Audit that no reader caches the label at load in a way that survives the rename; if any does, it must
+re-read after `pool:pane-promote`.
+
+### 5.4 Counter — no change needed
+`isFloatingPaneLabel` already accepts `floating-<uuid>` and rejects `floating-pool-*`. Once the
+snapshot returns the new label, seed/reconcile counts it. **Do not** loosen the pool exclusion (warm
+unpromoted pool panes must still read 0).
+
+---
+
+## 6. Explicitly NOT affected (do not over-engineer)
+- **Launcher (agentmux-launcher):** tracks **zero** floating panes today — `windows`, `pool`,
+  `instance_registry`, `backend_window_ids`, `just_promoted_labels` never contain `floating-*`. A
+  rename touches no launcher state, and **no host→launcher rename message is needed** (none exists;
+  `Event::WorkspaceRenamed`/`TabRenamed` carry workspace/tab ids, not window labels). Do **not** add
+  launcher reporting for floaters — the snapshot path already counts them.
+- **srv (agentmux-srv):** never stores window labels (`WindowRecord`/`Window` WaveObject key on
+  `window_id`/`oid`; label-bearing IPC is discarded at `extract_version`). Zero srv impact.
+
+---
+
+## 7. Loose-ends checklist (label-immutability assumptions to satisfy)
+- [ ] `browsers` re-key is remove+reinsert (dup-key reject) and updates `BrowserHandle.label`.
+- [ ] `emit_event_to_window` for `pool:pane-promote` fires **after** the re-key, under the new label
+      (else `get_browser` misses).
+- [ ] `window_hwnds` forward + `label_for_hwnd` reverse stay consistent (re-key atomically).
+- [ ] `window_meta.label` field updated, not just the map key.
+- [ ] `pane_window_states` / `window_opacities` re-keyed **iff** an entry exists.
+- [ ] `ACTIVE_FLOATER_HWNDS` registered with the new label.
+- [ ] Renderer URL `windowLabel` rewritten (§5.2); `get_window_label` returns the new label (§5.3).
+- [ ] Non-Windows promote block updated to match (browsers/meta/payload/return-label).
+- [ ] Return value of `open_floating_pane_window` (`OpenFloatingPaneResponse.window_label`) is the new
+      label, so any caller that stored it is correct.
+
+---
+
+## 8. Test plan
+- **Unit (host reducer):** `RelabelBrowser` — moves the entry, updates the `.label` field, errors on
+  missing-old / existing-new, re-keys `window_meta` and conditionally `pane_window_states` /
+  `window_opacities`; leaves unrelated labels untouched.
+- **Unit (frontend):** `awaitPanePoolPromote` rewrites `windowLabel` from the payload; the
+  `pool:pane-promote` type includes it.
+- **Manual (Windows, the reported repro):** open a floating pane (hits the pool fast path) → status-bar
+  InstancePanel counts **1** floating pane (after reconcile); open a second → **2**; close → decrements;
+  a warm, un-opened pool pane still counts **0**.
+- **Manual regression:** after promotion, exercise the floater's label-addressed paths — move/resize,
+  maximize toggle, focus, redock, close — confirm none break (they'd break if any store or the URL
+  label were left stale). This is the real risk surface.
+
+---
+
+## 9. Risks / caveats
+- **Partial re-key = dangling reference.** The whole risk is missing one keyed-by-label store; §4 +
+  §7 enumerate them. The `emit`-after-re-key ordering (§4.5 step 7) is the subtlest.
+- **Renderer label desync** (§5.2/5.3) is the highest-impact loose end: get it wrong and the floater's
+  IPC silently targets a dead label. Cover it in the manual regression.
+- **This needs the app running to fully verify** — the unit tests prove the re-key mechanics, but the
+  renderer-label consistency and the count are runtime properties. Treat like other runtime-gated
+  changes: verify in a live instance before merge, don't rely on bots alone.
+- Scope discipline: resist the temptation to "also fix" the snapshot/reconcile timing lag or to wire
+  floaters into launcher reporting — both are out of scope; the rename alone fixes the reported bug.
+
+---
+
+## 10. Sources
+- Host: `commands/floating_pane.rs:100,130,219,272`, `commands/window_pool.rs:1517,1527-1613,1593,1600`,
+  `commands/window/meta.rs:102-127`, `state.rs:219,641,859,1091`, `reducer/mod.rs:96,130,142`,
+  `commands/events.rs:91`, `reducer/pane_pool.rs:63-77`.
+- Frontend: `store/launcher-event/types.ts:144-158`, `store/launcher-event-reducer.ts:69-115,187-229,297`,
+  `store/init/pool.ts:107-143`, `statusbar/InstancePanel.tsx:81,576`, `block/blockframe.tsx:245`,
+  `view/browser/browser-view.tsx:61,114,376`.
+- Precedent: window-pool `promote_pool_window` (`window_pool.rs:654,829-859`), `isInstanceLabel`
+  (`types.ts:144`).
+- Investigation: this session's full label-lifecycle map (host/launcher/srv/frontend).

--- a/frontend/app/init/pool.ts
+++ b/frontend/app/init/pool.ts
@@ -113,7 +113,7 @@ export async function awaitPanePoolPromote(): Promise<void> {
         let unsub: (() => void) | undefined;
         const cleanup = () => { unsub?.(); };
 
-        unsub = await listenEvent<{ paneId: string; workspaceId: string }>(
+        unsub = await listenEvent<{ paneId: string; workspaceId: string; windowLabel?: string }>(
             "pool:pane-promote",
             (payload) => {
                 cleanup();
@@ -125,6 +125,16 @@ export async function awaitPanePoolPromote(): Promise<void> {
                 // for a pane tear-off, but guard defensively.
                 if (payload.workspaceId) {
                     url.searchParams.set("workspaceId", payload.workspaceId);
+                }
+                // The host renames floating-pool-<uuid> → floating-<uuid> on
+                // promotion (SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30). Adopt
+                // the new label so every ?windowLabel=-derived reader and
+                // label-addressed IPC from this renderer targets the host's
+                // current browser key — otherwise the renderer keeps addressing
+                // the dead pool label. Guarded: only the Windows promote path
+                // carries `windowLabel` today.
+                if (payload.windowLabel) {
+                    url.searchParams.set("windowLabel", payload.windowLabel);
                 }
                 url.searchParams.delete("pane-pool");
                 window.history.replaceState({}, "", url.toString());


### PR DESCRIPTION
## ⚠️ Do NOT merge until runtime-verified on Windows
The highest-risk piece (the promoted floater's renderer label consistency) is a **runtime** property. See "Verification" below.

## Bug
On Windows, a user floating pane opened via the pane-pool fast path keeps its warm-pool label `floating-pool-<uuid>` after promotion, so the status-bar InstancePanel counter (`isFloatingPaneLabel`, which excludes `floating-pool-*`) reports **0 floating panes** while one is visible. Cosmetic; pre-existing (not a regression).

## Fix — Option A (rename on promotion)
Full scoping in `SPEC_FLOATING_PANE_POOL_RELABEL_2026_06_30.md`. On promotion, rename `floating-pool-<uuid>` → `floating-<uuid>` so the pane is counted like any cold-path floater. (The count is fed by the `list_window_instances` snapshot, which already returns promoted panes — just under the excluded label — so the rename alone is sufficient.)

- **New pure reducer command** `HostCommand::RelabelBrowser` (`browsers::handle_relabel_browser`): re-keys `browsers` (+ the duplicated `BrowserHandle.label`) and, when present, `window_opacities` / `pane_window_states`; errors on missing-old / existing-new. Added to the Debug impl + `is_quit_relevant` exclusion.
- **`promote_pane_pool_window` (Windows)**: re-keys the AppState maps `window_hwnds` / `window_meta` under lock, then registers the floater hook and emits `pool:pane-promote` **under the new label** (the emit resolves via `get_browser`, so it must run after the re-key), and returns the new label.
- **`pool:pane-promote` payload** now carries `windowLabel`; the renderer's `awaitPanePoolPromote` rewrites `?windowLabel=` so every label-addressed IPC targets the host's current key — the subtlest loose end.

## Scope
- **Windows path only** (the repro + where it's runtime-verifiable). Non-Windows promote is annotated as a follow-up.
- **Launcher / srv untouched** — neither stores floater labels (verified).
- **Counter unchanged** — already accepts `floating-*`, rejects `floating-pool-*` (warm pool panes still read 0).

## Verification (required before merge)
- `cargo check -p agentmux-cef` ✅ clean; `tsc --noEmit` ✅ clean (no errors in `init/pool.ts`).
- No reducer unit test for `RelabelBrowser` — cef::Browser can't be constructed in unit tests, so the browser-registry arms (register/unregister/relabel) are runtime-verified by design.
- **Manual (Windows), pending:** open a floating pane → InstancePanel counts 1 (after reconcile); open a 2nd → 2; close → decrements; a warm un-opened pool pane still reads 0. **Then** exercise the promoted floater — move / resize / maximize / focus / redock / close — to confirm no label-addressed IPC broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)