### PR TITLE
feat(srv): v1 standalone MCP Server and Skill primitives (Trust Center)

### DIFF
--- a/.changesets/1782954594-feat-srv-v1-standalone-mcp-server-and-skill-primitives-trust-nzro.md
+++ b/.changesets/1782954594-feat-srv-v1-standalone-mcp-server-and-skill-primitives-trust-nzro.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(srv): v1 standalone MCP Server and Skill primitives (Trust Center)

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -308,10 +308,15 @@ pub fn build_mcp_config(
 
 /// Build `.mcp.json` from standalone McpServer ref rows (v1 composable model).
 ///
-/// Always injects the synthetic "agentmux" entry. For each server row the
-/// `config` field is a JSON object that becomes the server value directly —
-/// callers store the full server object (including `"type"`) in that field.
-/// Falls back to `build_mcp_config` with the blob if `servers` is empty.
+/// Layering (later wins on key collision, except the reserved `agentmux` key):
+///   1. synthetic `agentmux` entry (always injected)
+///   2. `user_mcp_blob`'s `mcpServers` — the legacy per-agent blob, merged when
+///      the caller passes it (used so a global-only ref set never wipes a
+///      legacy agent's user servers)
+///   3. `servers` ref rows (the agent's own bound servers + globals)
+/// For each ref row the `config` field is a JSON object used as the server
+/// value directly. Falls back to `build_mcp_config` when there are no ref rows
+/// and no blob.
 pub fn build_mcp_config_from_refs(
     servers: &[crate::backend::storage::McpServer],
     user_mcp_blob: Option<&str>,
@@ -339,6 +344,27 @@ pub fn build_mcp_config_from_refs(
     let mut mcp_servers = serde_json::Map::new();
     mcp_servers.insert("agentmux".to_string(), agentmux_server);
 
+    // Layer 2: merge the legacy user blob's servers (skip the reserved key).
+    if let Some(raw) = user_mcp_blob {
+        match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Object(user_obj)) => {
+                if let Some(Value::Object(user_servers)) = user_obj.get("mcpServers") {
+                    for (k, v) in user_servers {
+                        if k == "agentmux" {
+                            continue;
+                        }
+                        mcp_servers.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(_) => {
+                tracing::error!("agent_config: invalid MCP JSON in legacy blob; skipping blob merge");
+            }
+        }
+    }
+
+    // Layer 3: ref rows (own + global) overlay the blob.
     for server in servers {
         if server.name == "agentmux" {
             continue; // synthetic entry wins; user cannot override the key

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -306,6 +306,89 @@ pub fn build_mcp_config(
     }
 }
 
+/// Build `.mcp.json` from standalone McpServer ref rows (v1 composable model).
+///
+/// Always injects the synthetic "agentmux" entry. For each server row the
+/// `config` field is a JSON object that becomes the server value directly —
+/// callers store the full server object (including `"type"`) in that field.
+/// Falls back to `build_mcp_config` with the blob if `servers` is empty.
+pub fn build_mcp_config_from_refs(
+    servers: &[crate::backend::storage::McpServer],
+    user_mcp_blob: Option<&str>,
+    agent_slug: &str,
+    agent_bus_id: &str,
+) -> Option<String> {
+    if servers.is_empty() {
+        return build_mcp_config(user_mcp_blob, agent_slug, agent_bus_id);
+    }
+
+    let mut env_map = serde_json::Map::new();
+    if !agent_slug.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(agent_slug));
+    }
+    if !agent_bus_id.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_BUS_ID".to_string(), json!(agent_bus_id));
+    }
+    let agentmux_server = json!({
+        "type": "stdio",
+        "command": "agentmux-mcp",
+        "args": [],
+        "env": Value::Object(env_map),
+    });
+
+    let mut mcp_servers = serde_json::Map::new();
+    mcp_servers.insert("agentmux".to_string(), agentmux_server);
+
+    for server in servers {
+        if server.name == "agentmux" {
+            continue; // synthetic entry wins; user cannot override the key
+        }
+        match serde_json::from_str::<Value>(&server.config) {
+            Ok(cfg) => {
+                mcp_servers.insert(server.name.clone(), cfg);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    id = %server.id,
+                    name = %server.name,
+                    error = %e,
+                    "agent_config: invalid JSON in mcp_server.config; skipping entry"
+                );
+            }
+        }
+    }
+
+    let result = json!({ "mcpServers": Value::Object(mcp_servers) });
+    match serde_json::to_string_pretty(&result) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::error!("agent_config: failed to serialize ref-based MCP config: {e}");
+            None
+        }
+    }
+}
+
+/// Convert standalone Skill records into the AgentSkill shape expected by
+/// `build_config_files`. Used when the v1 ref tables are non-empty.
+pub fn skills_to_agent_skills(
+    skills: &[crate::backend::storage::Skill],
+    agent_id: &str,
+) -> Vec<crate::backend::storage::AgentSkill> {
+    skills
+        .iter()
+        .map(|s| crate::backend::storage::AgentSkill {
+            id: s.id.clone(),
+            agent_id: agent_id.to_string(),
+            name: s.name.clone(),
+            trigger: s.trigger.clone(),
+            skill_type: s.skill_type.clone(),
+            description: s.description.clone(),
+            content: s.content.clone(),
+            created_at: s.created_at,
+        })
+        .collect()
+}
+
 /// Build `.claude/settings.json` content with the auto-injected
 /// PreToolUse Bash hook (under the `"hooks"` key) that redirects
 /// Bash invocations into the streaming wrapper

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -298,6 +298,22 @@ pub const COMMAND_MEMORY_LIST: &str = "memory.list";
 pub const COMMAND_MEMORY_READ: &str = "memory.read";
 pub const COMMAND_MEMORY_WRITE: &str = "memory.write";
 
+// App API — v1 standalone Skill primitives
+pub const COMMAND_SKILL_LIST: &str = "skill.list";
+pub const COMMAND_SKILL_GET: &str = "skill.get";
+pub const COMMAND_SKILL_UPSERT: &str = "skill.upsert";
+pub const COMMAND_SKILL_DELETE: &str = "skill.delete";
+pub const COMMAND_SKILL_BIND: &str = "skill.bind";
+pub const COMMAND_SKILL_UNBIND: &str = "skill.unbind";
+
+// App API — v1 standalone MCP Server primitives
+pub const COMMAND_MCP_LIST: &str = "mcp.list";
+pub const COMMAND_MCP_GET: &str = "mcp.get";
+pub const COMMAND_MCP_UPSERT: &str = "mcp.upsert";
+pub const COMMAND_MCP_DELETE: &str = "mcp.delete";
+pub const COMMAND_MCP_BIND: &str = "mcp.bind";
+pub const COMMAND_MCP_UNBIND: &str = "mcp.unbind";
+
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";
 pub const COMMAND_SESSION_RESTORE: &str = "session:restore";

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -1,0 +1,164 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standalone MCP Server primitives (v1 composable model).
+//!
+//! Agents reference servers via db_agent_mcp_ref. The `config` field stores
+//! the full server object JSON (command/args/env for stdio; url/headers for
+//! SSE) that gets merged into `.mcp.json` at agent launch.
+
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use super::error::StoreError;
+use super::store::Store;
+
+/// A standalone MCP Server primitive (v1 composable model).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServer {
+    pub id: String,
+    pub name: String,
+    pub transport: String,
+    pub config: String,
+    pub is_global: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl Store {
+    /// List all MCP servers visible to an agent: own (referenced) + global.
+    pub fn mcp_server_list(&self, agent_id: &str) -> Result<Vec<McpServer>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, transport, config, is_global, created_at, updated_at
+             FROM db_mcp_servers
+             WHERE is_global = 1
+                OR id IN (SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?1)
+             ORDER BY is_global DESC, updated_at DESC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(McpServer {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                transport: row.get(2)?,
+                config: row.get(3)?,
+                is_global: row.get::<_, i64>(4)? != 0,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Get a standalone MCP server by id.
+    pub fn mcp_server_get(&self, id: &str) -> Result<Option<McpServer>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let result = conn.query_row(
+            "SELECT id, name, transport, config, is_global, created_at, updated_at
+             FROM db_mcp_servers WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(McpServer {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    transport: row.get(2)?,
+                    config: row.get(3)?,
+                    is_global: row.get::<_, i64>(4)? != 0,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                })
+            },
+        );
+        match result {
+            Ok(s) => Ok(Some(s)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(StoreError::Sqlite(e)),
+        }
+    }
+
+    /// Upsert a standalone MCP server. Caller must have stripped is_global escalation.
+    pub fn mcp_server_upsert(&self, server: &McpServer) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_mcp_servers (id, name, transport, config, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(id) DO UPDATE SET
+               name=excluded.name, transport=excluded.transport, config=excluded.config,
+               updated_at=excluded.updated_at",
+            params![
+                server.id,
+                server.name,
+                server.transport,
+                server.config,
+                if server.is_global { 1i64 } else { 0i64 },
+                server.created_at,
+                server.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a standalone MCP server and purge ref rows. Returns true if deleted.
+    pub fn mcp_server_delete(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM db_agent_mcp_ref WHERE mcp_id = ?1", params![id])?;
+        let rows = conn.execute("DELETE FROM db_mcp_servers WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+
+    /// Bind an MCP server to an agent (insert ref row). Idempotent.
+    pub fn mcp_server_bind(&self, agent_id: &str, mcp_id: &str) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES (?1, ?2)",
+            params![agent_id, mcp_id],
+        )?;
+        Ok(())
+    }
+
+    /// Unbind an MCP server from an agent. Returns true if a row was removed.
+    pub fn mcp_server_unbind(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM db_agent_mcp_ref WHERE agent_id = ?1 AND mcp_id = ?2",
+            params![agent_id, mcp_id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// List MCP servers referenced by an agent (for config generation).
+    pub fn mcp_server_list_for_config(&self, agent_id: &str) -> Result<Vec<McpServer>, StoreError> {
+        self.mcp_server_list(agent_id)
+    }
+
+    /// Return true if the given MCP server is accessible to the agent (global or bound).
+    /// Used for read and mutation access checks.
+    pub fn mcp_server_is_accessible_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM db_mcp_servers
+             WHERE id = ?1 AND (is_global = 1 OR id IN (
+               SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?2
+             ))",
+            rusqlite::params![mcp_id, agent_id],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Return true if the agent has a direct ref binding to this MCP server.
+    /// Used for delete access — an agent may only delete servers it directly bound.
+    pub fn mcp_server_is_bound_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM db_agent_mcp_ref WHERE agent_id = ?1 AND mcp_id = ?2",
+            rusqlite::params![agent_id, mcp_id],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+}

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -130,11 +130,6 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// List MCP servers referenced by an agent (for config generation).
-    pub fn mcp_server_list_for_config(&self, agent_id: &str) -> Result<Vec<McpServer>, StoreError> {
-        self.mcp_server_list(agent_id)
-    }
-
     /// Return true if the given MCP server is accessible to the agent (global or bound).
     /// Used for read and mutation access checks.
     pub fn mcp_server_is_accessible_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -130,6 +130,55 @@ impl Store {
         Ok(rows > 0)
     }
 
+    /// Atomically upsert an MCP server enforcing per-agent name uniqueness, and
+    /// (when `bind_new`) bind it — all in one transaction so concurrent
+    /// `mcp.upsert` calls for the same name can't both pass a check and insert
+    /// duplicate-named bindings. Returns an error if another server visible to
+    /// the agent (bound or global) already uses the name.
+    pub fn mcp_server_upsert_unique(
+        &self,
+        agent_id: &str,
+        server: &McpServer,
+        bind_new: bool,
+    ) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let dup: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM db_mcp_servers
+             WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
+               SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?3
+             ))",
+            params![server.name, server.id, agent_id],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            return Err(StoreError::Other(format!(
+                "server name '{}' already bound to this agent",
+                server.name
+            )));
+        }
+        tx.execute(
+            "INSERT INTO db_mcp_servers (id, name, transport, config, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(id) DO UPDATE SET
+               name=excluded.name, transport=excluded.transport, config=excluded.config,
+               updated_at=excluded.updated_at",
+            params![
+                server.id, server.name, server.transport, server.config,
+                if server.is_global { 1i64 } else { 0i64 },
+                server.created_at, server.updated_at,
+            ],
+        )?;
+        if bind_new {
+            tx.execute(
+                "INSERT OR IGNORE INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES (?1, ?2)",
+                params![agent_id, server.id],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Return true if the given MCP server is accessible to the agent (global or bound).
     /// Used for read and mutation access checks.
     pub fn mcp_server_is_accessible_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -51,7 +51,10 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 2;
 ///   v9 — db_memory_bundles.sort_order: explicit ordering for the Trust
 ///        Center global brain (controls CLAUDE.md injection order). Existing
 ///        rows default to 0; the Brain tab assigns positions via reorder.
-pub const OBJECT_SCHEMA_VERSION: i64 = 9;
+///   v10 — db_skills, db_mcp_servers, db_agent_skills_ref, db_agent_mcp_ref:
+///        standalone MCP Server and Skill primitives with per-agent ref tables
+///        (v1 composable model, SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md).
+pub const OBJECT_SCHEMA_VERSION: i64 = 10;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -396,6 +399,47 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         CREATE INDEX IF NOT EXISTS idx_drone_runs_status
             ON db_drone_runs(status);
 
+        -- v10: Standalone skill and MCP server primitives (composable model).
+        CREATE TABLE IF NOT EXISTS db_skills (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            trigger     TEXT NOT NULL DEFAULT '',
+            skill_type  TEXT NOT NULL DEFAULT 'prompt',
+            description TEXT NOT NULL DEFAULT '',
+            content     TEXT NOT NULL DEFAULT '',
+            is_global   INTEGER NOT NULL DEFAULT 0,
+            created_at  INTEGER NOT NULL DEFAULT 0,
+            updated_at  INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_skills_is_global ON db_skills(is_global);
+
+        CREATE TABLE IF NOT EXISTS db_mcp_servers (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            transport   TEXT NOT NULL DEFAULT 'stdio',
+            config      TEXT NOT NULL DEFAULT '{}',
+            is_global   INTEGER NOT NULL DEFAULT 0,
+            created_at  INTEGER NOT NULL DEFAULT 0,
+            updated_at  INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_mcp_servers_is_global ON db_mcp_servers(is_global);
+
+        CREATE TABLE IF NOT EXISTS db_agent_skills_ref (
+            agent_id TEXT NOT NULL,
+            skill_id TEXT NOT NULL,
+            PRIMARY KEY (agent_id, skill_id),
+            FOREIGN KEY (agent_id) REFERENCES db_agent_definitions(id) ON DELETE CASCADE,
+            FOREIGN KEY (skill_id) REFERENCES db_skills(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS db_agent_mcp_ref (
+            agent_id TEXT NOT NULL,
+            mcp_id   TEXT NOT NULL,
+            PRIMARY KEY (agent_id, mcp_id),
+            FOREIGN KEY (agent_id) REFERENCES db_agent_definitions(id) ON DELETE CASCADE,
+            FOREIGN KEY (mcp_id)   REFERENCES db_mcp_servers(id) ON DELETE CASCADE
+        );
+
         -- v7: MuxBus cloud connectivity — global singleton PKCE token store.
         CREATE TABLE IF NOT EXISTS db_muxbus_credentials (
             id             TEXT PRIMARY KEY DEFAULT 'global',
@@ -432,6 +476,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
     //     populates them on first container spawn.
     // v7: create db_muxbus_credentials if it doesn't exist yet (existing DBs
     //     won't have it since it's a new table, not an added column).
+    // v10: standalone skill + MCP server tables (new tables, handled via
+    //     CREATE TABLE IF NOT EXISTS in the flat batch above; no ALTER needed).
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS db_muxbus_credentials (
             id             TEXT PRIMARY KEY DEFAULT 'global',

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod filestore;
 pub mod history;
 pub mod identities;
+pub mod mcp_servers;
 pub mod memory_bundles;
 pub mod migrations;
 pub mod muxbus;
@@ -29,5 +30,6 @@ pub use error::StoreError;
 #[allow(unused_imports)]
 pub use history::AgentHistory;
 pub use identities::{AgentIdentityLink, Identity, IdentityAccount, IdentityBinding, SecretRef};
+pub use mcp_servers::McpServer;
 pub use memory_bundles::{format_global_brain_block, Memory};
-pub use skills::AgentSkill;
+pub use skills::{AgentSkill, Skill};

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -170,7 +170,7 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// Delete a skill by id. Returns true if a row was deleted.
+    /// Delete a legacy skill by id. Returns true if a row was deleted.
     pub fn agent_skill_delete(&self, id: &str) -> Result<bool, StoreError> {
         let (rows, agent_id) = {
             let conn = self.conn.lock().unwrap();
@@ -196,5 +196,170 @@ impl Store {
             }
         }
         Ok(rows > 0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// v1 standalone Skill primitive
+// ---------------------------------------------------------------------------
+
+/// Standalone skill primitive (v1 composable model).
+/// Not bound to a specific agent at rest — agents reference via db_agent_skills_ref.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Skill {
+    pub id: String,
+    pub name: String,
+    pub trigger: String,
+    pub skill_type: String,
+    pub description: String,
+    pub content: String,
+    pub is_global: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl Store {
+    /// List all skills visible to an agent: own (referenced) + global.
+    pub fn skill_list(&self, agent_id: &str) -> Result<Vec<Skill>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, trigger, skill_type, description, content, is_global, created_at, updated_at
+             FROM db_skills
+             WHERE is_global = 1
+                OR id IN (SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?1)
+             ORDER BY is_global DESC, updated_at DESC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(Skill {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                trigger: row.get(2)?,
+                skill_type: row.get(3)?,
+                description: row.get(4)?,
+                content: row.get(5)?,
+                is_global: row.get::<_, i64>(6)? != 0,
+                created_at: row.get(7)?,
+                updated_at: row.get(8)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Get a standalone skill by id.
+    pub fn skill_get(&self, id: &str) -> Result<Option<Skill>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let result = conn.query_row(
+            "SELECT id, name, trigger, skill_type, description, content, is_global, created_at, updated_at
+             FROM db_skills WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(Skill {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    trigger: row.get(2)?,
+                    skill_type: row.get(3)?,
+                    description: row.get(4)?,
+                    content: row.get(5)?,
+                    is_global: row.get::<_, i64>(6)? != 0,
+                    created_at: row.get(7)?,
+                    updated_at: row.get(8)?,
+                })
+            },
+        );
+        match result {
+            Ok(s) => Ok(Some(s)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(StoreError::Sqlite(e)),
+        }
+    }
+
+    /// Upsert a standalone skill. Caller must have already stripped is_global escalation.
+    pub fn skill_upsert(&self, skill: &Skill) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_skills (id, name, trigger, skill_type, description, content, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(id) DO UPDATE SET
+               name=excluded.name, trigger=excluded.trigger, skill_type=excluded.skill_type,
+               description=excluded.description, content=excluded.content,
+               updated_at=excluded.updated_at",
+            params![
+                skill.id,
+                skill.name,
+                skill.trigger,
+                skill.skill_type,
+                skill.description,
+                skill.content,
+                if skill.is_global { 1i64 } else { 0i64 },
+                skill.created_at,
+                skill.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a standalone skill and purge its ref rows. Returns true if deleted.
+    pub fn skill_delete(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        // Purge ref rows explicitly (FK cascades may be off on some builds).
+        conn.execute("DELETE FROM db_agent_skills_ref WHERE skill_id = ?1", params![id])?;
+        let rows = conn.execute("DELETE FROM db_skills WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+
+    /// Bind a skill to an agent (insert ref row). Idempotent.
+    pub fn skill_bind(&self, agent_id: &str, skill_id: &str) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO db_agent_skills_ref (agent_id, skill_id) VALUES (?1, ?2)",
+            params![agent_id, skill_id],
+        )?;
+        Ok(())
+    }
+
+    /// Unbind a skill from an agent. Returns true if a row was removed.
+    pub fn skill_unbind(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM db_agent_skills_ref WHERE agent_id = ?1 AND skill_id = ?2",
+            params![agent_id, skill_id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// List skills for config generation (own refs + globals, same as skill_list).
+    pub fn skill_list_for_config(&self, agent_id: &str) -> Result<Vec<Skill>, StoreError> {
+        self.skill_list(agent_id)
+    }
+
+    /// Return true if the given skill is accessible to the agent (global or bound).
+    /// Used for read and delete access checks.
+    pub fn skill_is_accessible_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM db_skills
+             WHERE id = ?1 AND (is_global = 1 OR id IN (
+               SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?2
+             ))",
+            rusqlite::params![skill_id, agent_id],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Return true if the agent has a direct ref binding to this skill (for delete/mutation).
+    /// Global skills are excluded — use the is_global guard separately.
+    pub fn skill_is_bound_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM db_agent_skills_ref WHERE agent_id = ?1 AND skill_id = ?2",
+            rusqlite::params![agent_id, skill_id],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
     }
 }

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -331,11 +331,6 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// List skills for config generation (own refs + globals, same as skill_list).
-    pub fn skill_list_for_config(&self, agent_id: &str) -> Result<Vec<Skill>, StoreError> {
-        self.skill_list(agent_id)
-    }
-
     /// Return true if the given skill is accessible to the agent (global or bound).
     /// Used for read and delete access checks.
     pub fn skill_is_accessible_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -331,6 +331,58 @@ impl Store {
         Ok(rows > 0)
     }
 
+    /// Atomically upsert a skill enforcing per-agent name uniqueness, and (when
+    /// `bind_new`) bind it to the agent — all in one transaction so concurrent
+    /// `skill.upsert` calls for the same name can't both pass a separate check
+    /// and insert duplicates (the check+write is not split across lock releases).
+    /// Returns `NameConflict` if another skill visible to the agent (bound or
+    /// global) already uses the name.
+    pub fn skill_upsert_unique(
+        &self,
+        agent_id: &str,
+        skill: &Skill,
+        bind_new: bool,
+    ) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let dup: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM db_skills
+             WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
+               SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?3
+             ))",
+            params![skill.name, skill.id, agent_id],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            return Err(StoreError::Other(format!(
+                "skill name '{}' already bound to this agent",
+                skill.name
+            )));
+        }
+        tx.execute(
+            "INSERT INTO db_skills (id, name, trigger, skill_type, description, content, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(id) DO UPDATE SET
+               name=excluded.name, trigger=excluded.trigger, skill_type=excluded.skill_type,
+               description=excluded.description, content=excluded.content,
+               updated_at=excluded.updated_at",
+            params![
+                skill.id, skill.name, skill.trigger, skill.skill_type,
+                skill.description, skill.content,
+                if skill.is_global { 1i64 } else { 0i64 },
+                skill.created_at, skill.updated_at,
+            ],
+        )?;
+        if bind_new {
+            tx.execute(
+                "INSERT OR IGNORE INTO db_agent_skills_ref (agent_id, skill_id) VALUES (?1, ?2)",
+                params![agent_id, skill.id],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Return true if the given skill is accessible to the agent (global or bound).
     /// Used for read and delete access checks.
     pub fn skill_is_accessible_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -452,13 +452,44 @@ pub(super) fn write_agent_config_files(
             .or_insert(global_block);
     }
 
-    let config_files = crate::backend::agent_config::build_config_files(
+    // v1: prefer standalone skill refs over legacy db_agent_skills when present.
+    let standalone_skills = wstore.skill_list_for_config(&agent.id).unwrap_or_default();
+    let effective_skills: Vec<crate::backend::storage::AgentSkill> = if !standalone_skills.is_empty() {
+        crate::backend::agent_config::skills_to_agent_skills(&standalone_skills, &agent.id)
+    } else {
+        skills
+    };
+
+    let mut config_files = crate::backend::agent_config::build_config_files(
         &content_map,
-        &skills,
+        &effective_skills,
         &agent.name,
         &agent.id,
         agent_slug,
     );
+
+    // v1: if standalone MCP server refs exist, replace .mcp.json with the
+    // ref-built version (always keeps the synthetic "agentmux" entry). Falls
+    // back to the legacy blob path when no refs are bound.
+    let standalone_mcp = wstore.mcp_server_list_for_config(&agent.id).unwrap_or_default();
+    if !standalone_mcp.is_empty() {
+        let mcp_blob = content_map.get("mcp").map(|s| s.as_str());
+        if let Some(mcp_json) = crate::backend::agent_config::build_mcp_config_from_refs(
+            &standalone_mcp,
+            mcp_blob,
+            agent_slug,
+            &agent.agent_bus_id,
+        ) {
+            if let Some(pos) = config_files.iter().position(|f| f.filename == ".mcp.json") {
+                config_files[pos].content = mcp_json;
+            } else {
+                config_files.push(crate::backend::agent_config::AgentConfigFile {
+                    filename: ".mcp.json".to_string(),
+                    content: mcp_json,
+                });
+            }
+        }
+    }
 
     // Expand ~ in work_dir
     let expanded_dir = if work_dir.starts_with("~/") || work_dir == "~" {

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -452,12 +452,22 @@ pub(super) fn write_agent_config_files(
             .or_insert(global_block);
     }
 
-    // v1: prefer standalone skill refs over legacy db_agent_skills when present.
-    let standalone_skills = wstore.skill_list_for_config(&agent.id).unwrap_or_default();
-    let effective_skills: Vec<crate::backend::storage::AgentSkill> = if !standalone_skills.is_empty() {
-        crate::backend::agent_config::skills_to_agent_skills(&standalone_skills, &agent.id)
+    // v1 skills: globals are always injected; the agent's OWN ref-bound skills
+    // are authoritative when present, otherwise fall back to legacy
+    // db_agent_skills. The fallback decision is gated on *own* refs only — NOT
+    // the global-inclusive list — so adding a global skill never discards a
+    // legacy-only agent's skills.
+    let visible_skills = wstore.skill_list(&agent.id).unwrap_or_default(); // own refs + globals
+    let has_own_skill_refs = visible_skills.iter().any(|s| !s.is_global);
+    let effective_skills: Vec<crate::backend::storage::AgentSkill> = if has_own_skill_refs {
+        // Ref-based path: own bound + globals (the full visible list).
+        crate::backend::agent_config::skills_to_agent_skills(&visible_skills, &agent.id)
     } else {
-        skills
+        // Legacy path: keep legacy skills, then inject globals on top.
+        // `visible_skills` here contains only globals (no own refs).
+        let mut merged = skills;
+        merged.extend(crate::backend::agent_config::skills_to_agent_skills(&visible_skills, &agent.id));
+        merged
     };
 
     let mut config_files = crate::backend::agent_config::build_config_files(
@@ -468,15 +478,21 @@ pub(super) fn write_agent_config_files(
         agent_slug,
     );
 
-    // v1: if standalone MCP server refs exist, replace .mcp.json with the
-    // ref-built version (always keeps the synthetic "agentmux" entry). Falls
-    // back to the legacy blob path when no refs are bound.
-    let standalone_mcp = wstore.mcp_server_list_for_config(&agent.id).unwrap_or_default();
-    if !standalone_mcp.is_empty() {
-        let mcp_blob = content_map.get("mcp").map(|s| s.as_str());
+    // v1 MCP: same rule. Globals + synthetic "agentmux" are always emitted; the
+    // legacy blob's user servers are merged in ONLY when the agent has no own
+    // ref-bound servers (so a global server never wipes a legacy-only agent's
+    // .mcp.json). When the agent has own refs, those are authoritative.
+    let visible_mcp = wstore.mcp_server_list(&agent.id).unwrap_or_default(); // own refs + globals
+    let has_own_mcp_refs = visible_mcp.iter().any(|s| !s.is_global);
+    if !visible_mcp.is_empty() {
+        let blob_for_merge = if has_own_mcp_refs {
+            None
+        } else {
+            content_map.get("mcp").map(|s| s.as_str())
+        };
         if let Some(mcp_json) = crate::backend::agent_config::build_mcp_config_from_refs(
-            &standalone_mcp,
-            mcp_blob,
+            &visible_mcp,
+            blob_for_merge,
             agent_slug,
             &agent.agent_bus_id,
         ) {

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -115,17 +115,6 @@ fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                 };
 
-                // Reject a duplicate name already bound to this agent (excluding
-                // the row being updated, so a rename-to-self is allowed).
-                let bound = wstore.mcp_server_list(&req.agent_id)
-                    .map_err(|e| format!("mcp.upsert: {e}"))?;
-                if bound.iter().any(|s| s.name == req.name && s.id != id) {
-                    return Err(format!(
-                        "mcp.upsert: server name '{}' already bound to this agent",
-                        req.name
-                    ));
-                }
-
                 let server = crate::backend::storage::McpServer {
                     id: id.clone(),
                     name: req.name,
@@ -135,12 +124,10 @@ fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                wstore.mcp_server_upsert(&server)
+                // Atomic: name-uniqueness check + upsert + (bind on create) in one
+                // transaction, so concurrent same-name upserts can't both pass.
+                wstore.mcp_server_upsert_unique(&req.agent_id, &server, req.id.is_empty())
                     .map_err(|e| format!("mcp.upsert: {e}"))?;
-                if req.id.is_empty() {
-                    wstore.mcp_server_bind(&req.agent_id, &id)
-                        .map_err(|e| format!("mcp.upsert: bind: {e}"))?;
-                }
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "mcp:changed".to_string(),
                     scopes: vec![], sender: String::new(), persist: 0, data: None,

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -1,0 +1,247 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! App API handlers for the v1 standalone MCP Server primitive.
+//! mcp.list / mcp.get / mcp.upsert / mcp.delete / mcp.bind / mcp.unbind
+
+use super::*;
+
+pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    register_mcp_list(engine, state);
+    register_mcp_get(engine, state);
+    register_mcp_upsert(engine, state);
+    register_mcp_delete(engine, state);
+    register_mcp_bind(engine, state);
+    register_mcp_unbind(engine, state);
+}
+
+fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_LIST,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.list: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                let servers = wstore.mcp_server_list(&req.agent_id)
+                    .map_err(|e| format!("mcp.list: {e}"))?;
+                Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_mcp_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_GET,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.get: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                if !wstore.mcp_server_is_accessible_to(&req.agent_id, &req.id)
+                    .map_err(|e| format!("mcp.get: {e}"))?
+                {
+                    return Err("FORBIDDEN: MCP server not accessible to this agent".to_string());
+                }
+                let server = wstore.mcp_server_get(&req.id)
+                    .map_err(|e| format!("mcp.get: {e}"))?;
+                Ok(Some(serde_json::to_value(&server).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_MCP_UPSERT,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req {
+                    agent_id: String,
+                    #[serde(default)] id: String,
+                    name: String,
+                    #[serde(default = "default_transport")] transport: String,
+                    #[serde(default = "default_config")] config: String,
+                }
+                fn default_transport() -> String { "stdio".to_string() }
+                fn default_config() -> String { "{}".to_string() }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.upsert: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+
+                match serde_json::from_str::<serde_json::Value>(&req.config) {
+                    Ok(serde_json::Value::Object(_)) => {}
+                    Ok(_) => return Err("mcp.upsert: config must be a JSON object".to_string()),
+                    Err(_) => return Err("mcp.upsert: config must be valid JSON".to_string()),
+                }
+                if req.name == "agentmux" {
+                    return Err("FORBIDDEN: 'agentmux' is a reserved MCP server name".to_string());
+                }
+
+                let now = now_ms();
+                // created_at is preserved across updates (ON CONFLICT keeps the
+                // original), so the returned struct never reports a timestamp the
+                // DB won't persist. New rows default to `now`.
+                let (id, created_at) = if req.id.is_empty() {
+                    (uuid::Uuid::new_v4().to_string(), now)
+                } else {
+                    if !wstore.mcp_server_is_bound_to(&req.agent_id, &req.id)
+                        .map_err(|e| format!("mcp.upsert: {e}"))?
+                    {
+                        return Err("FORBIDDEN: MCP server not bound to this agent".to_string());
+                    }
+                    let existing = wstore.mcp_server_get(&req.id)
+                        .map_err(|e| format!("mcp.upsert: {e}"))?;
+                    match existing {
+                        Some(s) if s.is_global => {
+                            return Err("FORBIDDEN: cannot mutate a global MCP server".to_string());
+                        }
+                        Some(s) => (req.id.clone(), s.created_at),
+                        None => (req.id.clone(), now),
+                    }
+                };
+
+                // Reject a duplicate name already bound to this agent (excluding
+                // the row being updated, so a rename-to-self is allowed).
+                let bound = wstore.mcp_server_list(&req.agent_id)
+                    .map_err(|e| format!("mcp.upsert: {e}"))?;
+                if bound.iter().any(|s| s.name == req.name && s.id != id) {
+                    return Err(format!(
+                        "mcp.upsert: server name '{}' already bound to this agent",
+                        req.name
+                    ));
+                }
+
+                let server = crate::backend::storage::McpServer {
+                    id: id.clone(),
+                    name: req.name,
+                    transport: req.transport,
+                    config: req.config,
+                    is_global: false,
+                    created_at,
+                    updated_at: now,
+                };
+                wstore.mcp_server_upsert(&server)
+                    .map_err(|e| format!("mcp.upsert: {e}"))?;
+                if req.id.is_empty() {
+                    wstore.mcp_server_bind(&req.agent_id, &id)
+                        .map_err(|e| format!("mcp.upsert: bind: {e}"))?;
+                }
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "mcp:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                Ok(Some(serde_json::to_value(&server).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_mcp_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_MCP_DELETE,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.delete: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                if !wstore.mcp_server_is_bound_to(&req.agent_id, &req.id)
+                    .map_err(|e| format!("mcp.delete: {e}"))?
+                {
+                    return Err("FORBIDDEN: MCP server not bound to this agent".to_string());
+                }
+                if let Some(existing) = wstore.mcp_server_get(&req.id)
+                    .map_err(|e| format!("mcp.delete: {e}"))?
+                {
+                    if existing.is_global {
+                        return Err("FORBIDDEN: cannot delete a global MCP server".to_string());
+                    }
+                }
+                let deleted = wstore.mcp_server_delete(&req.id)
+                    .map_err(|e| format!("mcp.delete: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "mcp:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+}
+
+fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_BIND,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, mcp_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.bind: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                // Only global servers (or ones already bound) may be bound, so an
+                // agent can't escalate to read another agent's server config.
+                match wstore.mcp_server_get(&req.mcp_id)
+                    .map_err(|e| format!("mcp.bind: {e}"))?
+                {
+                    None => return Err("mcp.bind: MCP server not found".to_string()),
+                    Some(s) if !s.is_global => {
+                        if !wstore.mcp_server_is_bound_to(&req.agent_id, &req.mcp_id)
+                            .map_err(|e| format!("mcp.bind: {e}"))?
+                        {
+                            return Err("FORBIDDEN: can only bind global MCP servers".to_string());
+                        }
+                    }
+                    Some(_) => {}
+                }
+                wstore.mcp_server_bind(&req.agent_id, &req.mcp_id)
+                    .map_err(|e| format!("mcp.bind: {e}"))?;
+                Ok(Some(json!({ "bound": true })))
+            })
+        }),
+    );
+}
+
+fn register_mcp_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_UNBIND,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, mcp_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.unbind: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                let unbound = wstore.mcp_server_unbind(&req.agent_id, &req.mcp_id)
+                    .map_err(|e| format!("mcp.unbind: {e}"))?;
+                Ok(Some(json!({ "unbound": unbound })))
+            })
+        }),
+    );
+}

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -34,6 +34,8 @@ mod session;
 mod identity;
 mod preset;
 mod memory;
+mod skill;
+mod mcp;
 
 /// Register all App API handlers on the RPC engine.
 pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -46,6 +48,8 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     identity::register(engine, state);
     preset::register(engine, state);
     memory::register(engine, state);
+    skill::register(engine, state);
+    mcp::register(engine, state);
 }
 
 /// Core `pane.open` logic, shared by the WebSocket RPC handler
@@ -793,6 +797,14 @@ pub(super) fn check_s1(ctx: &RpcContext, req_agent_id: &str) -> Result<(), Strin
         return Err("FORBIDDEN: agent_id mismatch".to_string());
     }
     Ok(())
+}
+
+/// Current unix time in milliseconds (0 if the clock is before the epoch).
+pub(super) fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 /// Parse + validate a saved per-agent `ui:zoom` content blob for seeding a new

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -107,18 +107,6 @@ fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                 };
 
-                // Reject a duplicate name already bound to this agent (mirrors
-                // mcp.upsert). Excludes the row being updated so a no-op rename
-                // to itself is allowed.
-                let bound = wstore.skill_list(&req.agent_id)
-                    .map_err(|e| format!("skill.upsert: {e}"))?;
-                if bound.iter().any(|s| s.name == req.name && s.id != id) {
-                    return Err(format!(
-                        "skill.upsert: skill name '{}' already bound to this agent",
-                        req.name
-                    ));
-                }
-
                 let skill = crate::backend::storage::Skill {
                     id: id.clone(),
                     name: req.name,
@@ -130,11 +118,10 @@ fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                wstore.skill_upsert(&skill).map_err(|e| format!("skill.upsert: {e}"))?;
-                if req.id.is_empty() {
-                    wstore.skill_bind(&req.agent_id, &id)
-                        .map_err(|e| format!("skill.upsert: bind: {e}"))?;
-                }
+                // Atomic: name-uniqueness check + upsert + (bind on create) in one
+                // transaction, so concurrent same-name upserts can't both pass.
+                wstore.skill_upsert_unique(&req.agent_id, &skill, req.id.is_empty())
+                    .map_err(|e| format!("skill.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "skills:changed".to_string(),
                     scopes: vec![], sender: String::new(), persist: 0, data: None,

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -1,0 +1,241 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! App API handlers for the v1 standalone Skill primitive.
+//! skill.list / skill.get / skill.upsert / skill.delete / skill.bind / skill.unbind
+
+use super::*;
+
+pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    register_skill_list(engine, state);
+    register_skill_get(engine, state);
+    register_skill_upsert(engine, state);
+    register_skill_delete(engine, state);
+    register_skill_bind(engine, state);
+    register_skill_unbind(engine, state);
+}
+
+fn register_skill_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_LIST,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.list: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                let skills = wstore.skill_list(&req.agent_id)
+                    .map_err(|e| format!("skill.list: {e}"))?;
+                Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_skill_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_GET,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.get: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                if !wstore.skill_is_accessible_to(&req.agent_id, &req.id)
+                    .map_err(|e| format!("skill.get: {e}"))?
+                {
+                    return Err("FORBIDDEN: skill not accessible to this agent".to_string());
+                }
+                let skill = wstore.skill_get(&req.id)
+                    .map_err(|e| format!("skill.get: {e}"))?;
+                Ok(Some(serde_json::to_value(&skill).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_SKILL_UPSERT,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req {
+                    agent_id: String,
+                    #[serde(default)] id: String,
+                    name: String,
+                    #[serde(default)] trigger: String,
+                    #[serde(default = "default_skill_type")] skill_type: String,
+                    #[serde(default)] description: String,
+                    #[serde(default)] content: String,
+                }
+                fn default_skill_type() -> String { "prompt".to_string() }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.upsert: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+
+                let now = now_ms();
+                // created_at is preserved across updates so the response never
+                // reports a timestamp the DB won't persist (ON CONFLICT keeps
+                // the original). For a new row it defaults to `now`.
+                let (id, created_at) = if req.id.is_empty() {
+                    (uuid::Uuid::new_v4().to_string(), now)
+                } else {
+                    if !wstore.skill_is_bound_to(&req.agent_id, &req.id)
+                        .map_err(|e| format!("skill.upsert: {e}"))?
+                    {
+                        return Err("FORBIDDEN: skill not bound to this agent".to_string());
+                    }
+                    let existing = wstore.skill_get(&req.id)
+                        .map_err(|e| format!("skill.upsert: {e}"))?;
+                    match existing {
+                        Some(s) if s.is_global => {
+                            return Err("FORBIDDEN: cannot mutate a global skill".to_string());
+                        }
+                        Some(s) => (req.id.clone(), s.created_at),
+                        None => (req.id.clone(), now),
+                    }
+                };
+
+                // Reject a duplicate name already bound to this agent (mirrors
+                // mcp.upsert). Excludes the row being updated so a no-op rename
+                // to itself is allowed.
+                let bound = wstore.skill_list(&req.agent_id)
+                    .map_err(|e| format!("skill.upsert: {e}"))?;
+                if bound.iter().any(|s| s.name == req.name && s.id != id) {
+                    return Err(format!(
+                        "skill.upsert: skill name '{}' already bound to this agent",
+                        req.name
+                    ));
+                }
+
+                let skill = crate::backend::storage::Skill {
+                    id: id.clone(),
+                    name: req.name,
+                    trigger: req.trigger,
+                    skill_type: req.skill_type,
+                    description: req.description,
+                    content: req.content,
+                    is_global: false,
+                    created_at,
+                    updated_at: now,
+                };
+                wstore.skill_upsert(&skill).map_err(|e| format!("skill.upsert: {e}"))?;
+                if req.id.is_empty() {
+                    wstore.skill_bind(&req.agent_id, &id)
+                        .map_err(|e| format!("skill.upsert: bind: {e}"))?;
+                }
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "skills:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                Ok(Some(serde_json::to_value(&skill).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_skill_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_SKILL_DELETE,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.delete: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                if !wstore.skill_is_bound_to(&req.agent_id, &req.id)
+                    .map_err(|e| format!("skill.delete: {e}"))?
+                {
+                    return Err("FORBIDDEN: skill not bound to this agent".to_string());
+                }
+                if let Some(existing) = wstore.skill_get(&req.id)
+                    .map_err(|e| format!("skill.delete: {e}"))?
+                {
+                    if existing.is_global {
+                        return Err("FORBIDDEN: cannot delete a global skill".to_string());
+                    }
+                }
+                let deleted = wstore.skill_delete(&req.id)
+                    .map_err(|e| format!("skill.delete: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "skills:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+}
+
+fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_BIND,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, skill_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.bind: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                // Only global skills (or ones already bound) may be bound, so an
+                // agent can't bootstrap read access to another agent's private skill.
+                match wstore.skill_get(&req.skill_id)
+                    .map_err(|e| format!("skill.bind: {e}"))?
+                {
+                    None => return Err("skill.bind: skill not found".to_string()),
+                    Some(s) if !s.is_global => {
+                        if !wstore.skill_is_bound_to(&req.agent_id, &req.skill_id)
+                            .map_err(|e| format!("skill.bind: {e}"))?
+                        {
+                            return Err("FORBIDDEN: can only bind global skills".to_string());
+                        }
+                    }
+                    Some(_) => {}
+                }
+                wstore.skill_bind(&req.agent_id, &req.skill_id)
+                    .map_err(|e| format!("skill.bind: {e}"))?;
+                Ok(Some(json!({ "bound": true })))
+            })
+        }),
+    );
+}
+
+fn register_skill_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_UNBIND,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, skill_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.unbind: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                let unbound = wstore.skill_unbind(&req.agent_id, &req.skill_id)
+                    .map_err(|e| format!("skill.unbind: {e}"))?;
+                Ok(Some(json!({ "unbound": unbound })))
+            })
+        }),
+    );
+}


### PR DESCRIPTION
## Summary

Implements [SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md](specs/SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md) in full. Skills and MCP Servers are now first-class Trust Center primitives — standalone rows an agent can create, and global rows an operator can inject into every agent.

### Storage (schema v10)

- **`db_skills`** — standalone Skill rows: `name`, `trigger`, `skill_type`, `description`, `content`, `is_global`
- **`db_mcp_servers`** — standalone MCP Server rows: `name`, `transport`, `config` (JSON object), `is_global`
- **`db_agent_skills_ref`** / **`db_agent_mcp_ref`** — per-agent binding tables (many-to-many)
- `OBJECT_SCHEMA_VERSION` bumped **9 → 10**; additive (CREATE TABLE IF NOT EXISTS), no data loss on existing DBs

### App API — 12 new handlers (all S1-guarded)

| Namespace | Handlers |
|-----------|---------|
| `skill.*` | `skill.list`, `skill.get`, `skill.upsert`, `skill.delete`, `skill.bind`, `skill.unbind` |
| `mcp.*` | `mcp.list`, `mcp.get`, `mcp.upsert`, `mcp.delete`, `mcp.bind`, `mcp.unbind` |

Security guards (mirrors preset.* pattern):
- **S4a**: `is_global = false` always stripped from caller input
- Global rows cannot be mutated or deleted by agents
- `mcp.upsert` rejects the reserved name `"agentmux"` (synthetic entry) and duplicate names already bound to the agent
- `skill.upsert` / `mcp.upsert` auto-bind the new row to the requesting agent on create

### Config generation

- **`build_mcp_config_from_refs`** in `agent_config.rs`: builds `.mcp.json` from `McpServer` ref rows; always injects the synthetic `"agentmux"` entry; falls back to blob path if no refs exist
- **`skills_to_agent_skills`**: adapts standalone `Skill` rows to `AgentSkill` for the existing `build_config_files` call
- **`write_agent_config_files`** updated: prefers ref-based skills/MCP when refs are non-empty, falls back to legacy `db_agent_skills` / `AgentContent("mcp")` blob — zero regression on existing agents

## Test plan

- [ ] Fresh DB: `OBJECT_SCHEMA_VERSION` reads 10; all four new tables exist
- [ ] `skill.upsert` → creates row + ref; `skill.list` returns it; `skill.delete` removes row + ref
- [ ] `mcp.upsert` rejects `name="agentmux"` with FORBIDDEN; accepts valid names
- [ ] `mcp.upsert` duplicate name for same agent → rejected
- [ ] Agent with MCP refs: `.mcp.json` at launch contains ref rows + synthetic `"agentmux"` entry
- [ ] Agent with no refs: falls back to legacy blob path (no regression)
- [ ] Global skill/MCP: not mutable or deletable by non-operator agent

<!-- agentmux:agent_id=agentx -->