### PR TITLE
feat(muxbus): point desktop sign-in at branded auth.muxbus.agentmux.ai

### DIFF
--- a/.changesets/1782954204-feat-muxbus-point-desktop-sign-in-at-branded-auth-muxbus-age-c052.md
+++ b/.changesets/1782954204-feat-muxbus-point-desktop-sign-in-at-branded-auth-muxbus-age-c052.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(muxbus): point desktop sign-in at branded auth.muxbus.agentmux.ai

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -2,8 +2,10 @@
 # VITE_MUXBUS_COGNITO_DOMAIN and VITE_MUXBUS_CLIENT_ID enable the AgentMux
 # Cloud sign-in button in Trust Center → Accounts → AgentMux.
 #
-# VITE_MUXBUS_COGNITO_DOMAIN is deterministic from CDK (muxbus-cognito.ts):
-#   prod env → muxbus-auth.auth.us-east-1.amazoncognito.com
+# VITE_MUXBUS_COGNITO_DOMAIN is the branded Cognito custom domain (muxbus-cognito.ts):
+#   prod env → auth.muxbus.agentmux.ai
+# The legacy amazoncognito.com prefix domain stays live for already-installed
+# builds; new builds point at the branded host.
 #
 # VITE_MUXBUS_CLIENT_ID comes from the CDK stack output "DesktopClientId".
 # It is a public PKCE client ID — safe to commit once obtained.
@@ -20,5 +22,5 @@
 #   /muxbus/google-client-id
 #   /muxbus/google-client-secret
 
-VITE_MUXBUS_COGNITO_DOMAIN=https://muxbus-auth.auth.us-east-1.amazoncognito.com
+VITE_MUXBUS_COGNITO_DOMAIN=https://auth.muxbus.agentmux.ai
 VITE_MUXBUS_CLIENT_ID=26odoigu6a7r8ecdmj5egvnc3b


### PR DESCRIPTION
## Summary

Flips the desktop MuxBus sign-in (`VITE_MUXBUS_COGNITO_DOMAIN`) from the raw `muxbus-auth.auth.us-east-1.amazoncognito.com` to the branded **`https://auth.muxbus.agentmux.ai`** — the status-chip login now shows the clean host instead of the amazoncognito.com URL.

Pairs with infra **agentmuxai/agentmux-cloud#21**, which provisions the Cognito custom domain (new ACM cert + Route53 alias) **alongside** the existing prefix domain. The client ID is unchanged (same pool, same PKCE desktop client).

## Safe to build once infra is live

The custom domain is deployed additively — the legacy prefix domain stays live, so:
- **Already-installed builds** (prefix host baked in) keep logging in.
- **New builds from this branch** use the branded host.

Build/merge this **after** the agentmux-cloud deploy finishes provisioning the custom domain's CloudFront distribution (~15–20 min) and `auth.muxbus.agentmux.ai` serves the hosted UI. Until then a new build would point at a not-yet-live host (the prefix host remains the working fallback).

## Verification (before you build)
```
curl -sI https://auth.muxbus.agentmux.ai/oauth2/authorize \
  ?response_type=code\&client_id=26odoigu6a7r8ecdmj5egvnc3b\&redirect_uri=http://127.0.0.1:9379/callback
# expect 200/302 from the Cognito hosted UI
```

<!-- agentmux:agent_id=agentx -->