### PR TITLE
ci: run cargo check --tests + test on every PR; unbreak reactive tests

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,78 @@
+name: CI (PR) — compile tests + run
+
+# The nightly (ci-nightly-build.yml) compiles + tests all three platforms, but
+# only on a `schedule` — so a broken TEST build or a stale test assertion merges
+# UNNOTICED until the next 07:00 UTC run. That is how both #1823 (a Windows-only
+# `cfg` break in agentmux-cef) and #1876 (JEKT `InjectionRequest` gained fields
+# its `reactive/tests.rs` constructors never got, plus 3 tests left asserting the
+# pre-JEKT message format) reached `main`: the release build workflows are
+# manual `workflow_dispatch` and never compile `#[cfg(test)]` code, and reviewers
+# (incl. reagent) read diffs — they do not compile or run the suite. Nothing ran
+# on the PR.
+#
+# This runs the same compile-and-test on EVERY PR, so the gate is at merge time.
+#
+# Scope: `cargo check --workspace --tests` compiles `#[cfg(test)]` code too — the
+# exact step that catches a missing-field / cfg-gated test break — then
+# `cargo test --workspace` catches stale-assertion breaks. Windows is the
+# REQUIRED leg (primary platform; catches cfg-gated breaks); ubuntu is
+# non-blocking (continue-on-error) until greened. Standard GitHub-hosted runners
+# only (free on public repos).
+#
+# NOTE: adding this workflow makes the checks RUN on PRs; to ENFORCE them, add
+# "check --tests + test (windows-latest)" and "vitest" as required status checks
+# in branch protection.
+#
+# --test-threads=1 mirrors the nightly (process-shared in-memory FileStore + a
+# focus-flag global flake under parallel runs; serial is deterministic).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rust:
+    name: check --tests + test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'windows-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      # cef-dll-sys builds CEF's C wrapper with CMake + Ninja (runs in build.rs,
+      # so `cargo check` triggers it too).
+      - name: Install Ninja (Windows — CMake ships with VS)
+        if: matrix.os == 'windows-latest'
+        run: choco install ninja -y
+      - name: Install build deps (Linux — CEF + launcher Wayland/GTK)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake libwayland-dev libxkbcommon-dev libgtk-3-dev
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Compiles the WHOLE workspace including `#[cfg(test)]` code — the gate that
+      # would have caught #1823 (Windows cfg) and #1876 (missing fields).
+      - name: cargo check --workspace --tests
+        run: cargo check --workspace --tests
+
+      # Catches stale-assertion breaks (e.g. #1876's pre-JEKT expectations).
+      - name: cargo test --workspace
+        run: cargo test --workspace -- --test-threads=1
+
+  frontend:
+    name: vitest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - name: vitest run
+        run: npx vitest run

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -257,6 +257,8 @@ fn test_handler_inject_no_sender() {
         request_id: None,
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     assert!(!resp.success);
@@ -274,6 +276,8 @@ fn test_handler_inject_agent_not_found() {
         request_id: None,
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     assert!(!resp.success);
@@ -307,6 +311,8 @@ async fn test_handler_inject_success() {
         request_id: Some("req-1".to_string()),
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     assert!(resp.success);
@@ -320,7 +326,14 @@ async fn test_handler_inject_success() {
     // the assertions in this synchronous-only test body.
     assert_eq!(calls.len(), 2);
     assert_eq!(calls[0], ("block1".to_string(), b"\r".to_vec()));
-    assert_eq!(calls[1], ("block1".to_string(), b"hello\r".to_vec()));
+    // The message is now wrapped in a JEKT marker block (#1876); the block
+    // carries a timestamp so assert structurally, not by exact bytes.
+    assert_eq!(calls[1].0, "block1");
+    let payload = String::from_utf8_lossy(&calls[1].1);
+    assert!(payload.contains("[JEKT:"), "JEKT open marker present");
+    assert!(payload.contains("[/JEKT]"), "JEKT close marker present");
+    assert!(payload.contains("hello"), "message payload present");
+    assert!(payload.ends_with('\r'), "trailing CR submits the message");
 }
 
 // Controller-aware delivery (SPEC_AGENT_CONTROL_PROTOCOL §6 / Phase 3).
@@ -359,14 +372,20 @@ fn test_handler_inject_structured_delivery_skips_pty() {
         request_id: Some("req-1".to_string()),
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     assert!(resp.success);
     assert_eq!(resp.block_id.as_deref(), Some("block1"));
-    // Structured channel got the message; PTY got nothing.
-    assert_eq!(
-        *msg_calls.lock().unwrap(),
-        vec![("block1".to_string(), "hello".to_string())]
+    // Structured channel got the (JEKT-wrapped, #1876) message; PTY got
+    // nothing. The wrap carries a timestamp, so assert structurally.
+    let msgs = msg_calls.lock().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].0, "block1");
+    assert!(
+        msgs[0].1.contains("[JEKT:") && msgs[0].1.contains("hello"),
+        "structured channel got the JEKT-wrapped message"
     );
     assert!(pty_calls.lock().unwrap().is_empty());
 }
@@ -396,6 +415,8 @@ async fn test_handler_inject_pty_fallback() {
         request_id: Some("req-1".to_string()),
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     assert!(resp.success);
@@ -403,7 +424,14 @@ async fn test_handler_inject_pty_fallback() {
     let calls = pty_calls.lock().unwrap();
     assert_eq!(calls.len(), 2);
     assert_eq!(calls[0], ("block1".to_string(), b"\r".to_vec()));
-    assert_eq!(calls[1], ("block1".to_string(), b"hello\r".to_vec()));
+    // The message is now wrapped in a JEKT marker block (#1876); the block
+    // carries a timestamp so assert structurally, not by exact bytes.
+    assert_eq!(calls[1].0, "block1");
+    let payload = String::from_utf8_lossy(&calls[1].1);
+    assert!(payload.contains("[JEKT:"), "JEKT open marker present");
+    assert!(payload.contains("[/JEKT]"), "JEKT close marker present");
+    assert!(payload.contains("hello"), "message payload present");
+    assert!(payload.ends_with('\r'), "trailing CR submits the message");
 }
 
 // A structured controller that fails to accept the message must surface the error
@@ -433,6 +461,8 @@ fn test_handler_inject_structured_failure_no_pty_fallback() {
         request_id: Some("req-1".to_string()),
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     assert!(!resp.success);
@@ -456,6 +486,8 @@ fn test_handler_audit_log() {
         request_id: Some("req-1".to_string()),
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     });
 
     let log = handler.get_audit_log(10);
@@ -580,6 +612,8 @@ fn test_injection_request_serde() {
         request_id: Some("req-123".to_string()),
         priority: None,
         wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
     };
 
     let json = serde_json::to_string(&req).unwrap();

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -384,8 +384,10 @@ fn test_handler_inject_structured_delivery_skips_pty() {
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].0, "block1");
     assert!(
-        msgs[0].1.contains("[JEKT:") && msgs[0].1.contains("hello"),
-        "structured channel got the JEKT-wrapped message"
+        msgs[0].1.contains("[JEKT:")
+            && msgs[0].1.contains("[/JEKT]")
+            && msgs[0].1.contains("hello"),
+        "structured channel got the JEKT-wrapped message (open + close markers + payload)"
     );
     assert!(pty_calls.lock().unwrap().is_empty());
 }


### PR DESCRIPTION
## Why
**Main's srv test suite is currently broken, and nothing on a PR would ever tell you.** Traced the mechanism:

- `build-linux.yml` / `build-macos.yml` are **manual `workflow_dispatch`** and build **release** (never compile `#[cfg(test)]` code).
- The only `cargo test` is **`ci-nightly-build.yml`** — a **07:00 UTC cron**, i.e. *post-merge*.
- Reviewers (incl. reagent) read diffs; they don't compile or run the suite.

So **no build or test runs on any PR.** That's how **#1823** (a Windows-only `cfg` break in `agentmux-cef`) and **#1876** (jekt) both merged broken — #1876 left `reactive/tests.rs` with `InjectionRequest` constructors missing the new `jekt_tier`/`delivery_tier` fields (test binary won't compile) **and** 3 tests asserting the pre-JEKT message format (runtime failures). It sat on main until caught locally.

## What

**1. `.github/workflows/ci-pr.yml`** — runs on `pull_request` + `push:main`:
- `cargo check --workspace --tests` (compiles `#[cfg(test)]` code — the step that catches a missing-field/cfg break) → `cargo test --workspace` → `vitest`.
- **Windows required**, ubuntu non-blocking. Mirrors the nightly's toolchain/deps/cache.
- These two breaks would **both** have been blocked at PR time.

**2. Unbreak #1876's reactive tests** so the suite is green under the new CI:
- add `jekt_tier: None` / `delivery_tier: None` to the 8 `InjectionRequest` test constructors (compile),
- update the 3 delivery tests to assert the JEKT-wrapped output **structurally** (`[JEKT:` / `[/JEKT]` markers + payload + trailing CR) — the wrap carries a timestamp, so exact-byte assertions are impossible. Treats #1876's reviewed-and-merged JEKT wrapping as the intended behavior.

## Verified
- `cargo test -p agentmux-srv` → **1264 passed, 0 failed** (reactive suite 48/0).

## Note
Adding the workflow makes the checks **run**; to **enforce** them, add `check --tests + test (windows-latest)` and `vitest` as required status checks in branch protection.

Refs #1864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)