### PR TITLE
fix(browser-pane): fix black floating pane on tear-off (cross-window AlreadyLive race)

### DIFF
--- a/.changesets/1782954470-fix-browser-tearoff-black-screen.md
+++ b/.changesets/1782954470-fix-browser-tearoff-black-screen.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): fix black screen when tearing a browser off into a floating pane (cross-window AlreadyLive race)

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -269,6 +269,30 @@ impl BrowserPaneManager {
                 }
                 Ok(())
             }
+            RegisterResult::AlreadyLiveElsewhere(label) => {
+                // Cross-window move (tear-off / redock): the block is Live in a
+                // DIFFERENT window. The reducer stashed our pending create;
+                // close the old pane now. Its close-completion (CompleteBrowserPaneClose
+                // / DrainBrowserPaneByLabel) drains the entry and replays the
+                // stashed create as `Fresh` in the requested window — so the
+                // browser reappears in the new (floating) window instead of the
+                // requested window rendering black. See
+                // ANALYSIS_BROWSER_PANE_REDOCK_BLACK_TYPING_LOCK_2026_06_15 §2.
+                tracing::info!(
+                    block_id,
+                    old_label = %label,
+                    requested_window = %window_label,
+                    rect = ?(rect.x, rect.y, rect.width, rect.height),
+                    "browser pane create is a cross-window move — closing old pane; reducer will replay create in requested window"
+                );
+                crate::browser_pane::trace::pane_trace(
+                    block_id,
+                    "create-cross-window-move",
+                    &format!("old_label={label} requested_win={window_label}"),
+                );
+                self.close(block_id, state);
+                Ok(())
+            }
             RegisterResult::Closing => {
                 // Old CEF Browser mid-teardown — don't overwrite (its
                 // on_before_close → DrainBrowserPaneByLabel would evict the NEW

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -425,6 +425,38 @@ async fn route_command(
         }
         "browser_pane_close" => {
             let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            // Window-aware close (tear-off / redock race fix). During a
+            // cross-window move the pane is closed in the old window and
+            // re-created in the new one (see browser_panes::create's
+            // AlreadyLiveElsewhere arm). The OLD window's browser-view then
+            // unmounts and fires this close — but by now the pane's entry
+            // points at the NEW window. Honoring that stale close would destroy
+            // the just-moved pane, leaving the new window black. So: if the
+            // caller passed its window_label and it no longer matches the pane's
+            // current window, ignore the close. Frontends that don't send
+            // window_label keep the old unconditional behavior.
+            let requesting_window = args
+                .get("window_label")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if !requesting_window.is_empty() {
+                if let Some(current) = state.browser_pane_window_label(block_id) {
+                    if current != requesting_window {
+                        tracing::info!(
+                            block_id,
+                            requesting_window,
+                            current_window = %current,
+                            "[browser_pane_close] ignoring stale close from a window that no longer owns the pane (moved via tear-off/redock)"
+                        );
+                        crate::browser_pane::trace::pane_trace(
+                            block_id,
+                            "close-ignored-stale-window",
+                            &format!("from={requesting_window} current={current}"),
+                        );
+                        return Ok(serde_json::json!(true));
+                    }
+                }
+            }
             // Cancel any pending HTTP-auth callbacks parked for this
             // pane before tearing it down. Without this, closing a
             // pane mid-auth-prompt leaks the CEF AuthCallback refcount

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -222,6 +222,13 @@ pub enum RegisterResult {
     /// Entry already existed and is `Live`; caller should re-navigate the
     /// existing browser at `label`.
     AlreadyLive(String),
+    /// Entry already existed, is `Live`, but in a DIFFERENT window than the
+    /// create request targets (tear-off / redock). Carries the existing
+    /// `label`. The reducer has stashed the pending create; the caller must
+    /// `close()` the old pane — its close-completion replays the stashed
+    /// create as `Fresh` in the requested window. Re-navigating in place (the
+    /// `AlreadyLive` behavior) would leave the requested window black.
+    AlreadyLiveElsewhere(String),
     /// Entry exists and is `Closing`; caller must reject the re-create
     /// because the old browser's `on_before_close` will drain the entry,
     /// and overwriting now would lose the new entry instead of the old.

--- a/agentmux-cef/src/reducer/panes.rs
+++ b/agentmux-cef/src/reducer/panes.rs
@@ -75,10 +75,12 @@ pub(super) fn handle_enqueue_browser_pane_close(state: &mut HostState, block_id:
 /// PR #5 — sole pane registration entry point. Replaces
 /// `pane::lifecycle::PaneStateMachine::try_register_live`.
 ///
-/// - Live entry exists → `AlreadyLive(label)`
-/// - Closing entry exists → `Closing`
-/// - No entry → generate label, insert Live, `Fresh(label)` + emit
-///   `BrowserPaneCreateRequested`
+/// - Live entry exists, create targets the SAME window → `AlreadyLive(label)`
+/// - Live entry exists, create targets a DIFFERENT window (tear-off / redock)
+///   → `AlreadyLiveElsewhere(label)` and stash the pending create for replay
+/// - Closing entry exists → `Closing` (stash pending for replay on close)
+/// - No entry → generate label, insert Live (recording the window), `Fresh(label)`
+///   + emit `BrowserPaneCreateRequested`
 pub(super) fn handle_try_register_browser_pane_live(
     state: &mut HostState,
     block_id: String,

--- a/agentmux-cef/src/reducer/panes.rs
+++ b/agentmux-cef/src/reducer/panes.rs
@@ -29,6 +29,8 @@ pub(super) fn handle_enqueue_browser_pane_create(
             block_id: block_id.clone(),
             label: label.clone(),
             lifecycle: BrowserPaneLifecycle::Live,
+            // Legacy path (no production caller); window unknown here.
+            window_label: String::new(),
         },
     );
     let v = state.bump_version();
@@ -89,17 +91,42 @@ pub(super) fn handle_try_register_browser_pane_live(
         );
     }
     if let Some(entry) = state.browser_panes.get(&block_id) {
-        let result = match entry.lifecycle {
-            BrowserPaneLifecycle::Live => RegisterResult::AlreadyLive(entry.label.clone()),
-            BrowserPaneLifecycle::Closing { .. } => RegisterResult::Closing,
+        // Snapshot what we need, then drop the `entry` borrow so the
+        // `pending_browser_pane_creates` mutation below is sound (NLL).
+        let existing_label = entry.label.clone();
+        let existing_window = entry.window_label.clone();
+        let is_closing = matches!(entry.lifecycle, BrowserPaneLifecycle::Closing { .. });
+
+        let result = if is_closing {
+            RegisterResult::Closing
+        } else {
+            // Live entry. If the create targets a DIFFERENT window than the one
+            // the pane currently lives in, this is a cross-window move (tear-off
+            // or redock). Re-navigating the existing browser in place
+            // (`AlreadyLive`) would leave the requested window black — the smoking
+            // gun from ANALYSIS_BROWSER_PANE_REDOCK_BLACK_TYPING_LOCK_2026_06_15.
+            // Instead, stash the pending create and tell the caller to close the
+            // old pane; its close-completion replays the create as `Fresh` in the
+            // requested window. Same-window re-nav keeps the `AlreadyLive` path.
+            match pending.as_ref().map(|p| p.window_label.as_str()) {
+                Some(requested) if requested != existing_window => {
+                    RegisterResult::AlreadyLiveElsewhere(existing_label)
+                }
+                _ => RegisterResult::AlreadyLive(existing_label),
+            }
         };
-        // Closing: stash the pending create (if the caller supplied one) so the
-        // close-completion arm (`CompleteBrowserPaneClose`/`DrainBrowserPaneByLabel`)
-        // can replay it. Done HERE, under the same host_state lock that just
-        // observed `Closing`, so the stash is atomic with that observation —
-        // no TOCTOU with a separate map (reagent P1 on #1168). The `entry`
-        // borrow ended with the match above, so this mutation is sound.
-        if matches!(result, RegisterResult::Closing) {
+
+        // Stash the pending create so a close-completion arm
+        // (`CompleteBrowserPaneClose` / `DrainBrowserPaneByLabel`) can replay it —
+        // for BOTH `Closing` (old teardown already in flight) and
+        // `AlreadyLiveElsewhere` (caller will close the old pane next). Done HERE,
+        // under the same host_state lock that just observed the state, so the
+        // stash is atomic with that observation — no TOCTOU with a separate map
+        // (reagent P1 on #1168). The `entry` borrow ended above, so this is sound.
+        if matches!(
+            result,
+            RegisterResult::Closing | RegisterResult::AlreadyLiveElsewhere(_)
+        ) {
             if let Some(p) = pending {
                 state.pending_browser_pane_creates.insert(block_id.clone(), p);
             }
@@ -110,12 +137,19 @@ pub(super) fn handle_try_register_browser_pane_live(
         };
     }
     let label = super::next_browser_pane_label(&block_id);
+    // Record the window this pane is created in, so a later cross-window create
+    // (tear-off / redock) can be detected in the match above.
+    let window_label = pending
+        .as_ref()
+        .map(|p| p.window_label.clone())
+        .unwrap_or_default();
     state.browser_panes.insert(
         block_id.clone(),
         BrowserPaneEntry {
             block_id: block_id.clone(),
             label: label.clone(),
             lifecycle: BrowserPaneLifecycle::Live,
+            window_label,
         },
     );
     let v = state.bump_version();

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -242,6 +242,75 @@ fn try_register_browser_pane_live_already_live_returns_existing_label() {
     assert!(out.events.is_empty(), "no event for AlreadyLive — caller just navigates");
 }
 
+fn pending_in(window: &str) -> crate::state::PendingBrowserPaneCreate {
+    crate::state::PendingBrowserPaneCreate {
+        url: "https://agentmux.ai".into(),
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+        window_label: window.into(),
+    }
+}
+
+#[test]
+fn try_register_same_window_relive_returns_already_live() {
+    // A re-create targeting the SAME window the pane already lives in is a
+    // genuine re-navigation — keep the AlreadyLive path, no pending stash.
+    let mut state = HostState::default();
+    let first = match update(
+        &mut state,
+        HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into(), pending: Some(pending_in("main")) },
+    ).browser_pane_register_result
+    {
+        Some(RegisterResult::Fresh(l)) => l,
+        _ => unreachable!(),
+    };
+    assert_eq!(state.browser_panes["b1"].window_label, "main");
+    let out = update(
+        &mut state,
+        HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into(), pending: Some(pending_in("main")) },
+    );
+    match out.browser_pane_register_result {
+        Some(RegisterResult::AlreadyLive(l)) => assert_eq!(l, first),
+        other => panic!("expected AlreadyLive, got {:?}", other),
+    }
+    assert!(!state.pending_browser_pane_creates.contains_key("b1"), "same-window re-nav must not stash a pending create");
+}
+
+#[test]
+fn try_register_cross_window_returns_already_live_elsewhere_and_stashes() {
+    // A create targeting a DIFFERENT window (tear-off / redock) must NOT
+    // re-navigate in place — it returns AlreadyLiveElsewhere and stashes the
+    // pending create so the caller's close-completion replays it in the new
+    // window. This is the black-screen fix.
+    let mut state = HostState::default();
+    let first = match update(
+        &mut state,
+        HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into(), pending: Some(pending_in("main")) },
+    ).browser_pane_register_result
+    {
+        Some(RegisterResult::Fresh(l)) => l,
+        _ => unreachable!(),
+    };
+    let out = update(
+        &mut state,
+        HostCommand::TryRegisterBrowserPaneLive {
+            block_id: "b1".into(),
+            pending: Some(pending_in("floating-abc")),
+        },
+    );
+    match out.browser_pane_register_result {
+        Some(RegisterResult::AlreadyLiveElsewhere(l)) => assert_eq!(l, first),
+        other => panic!("expected AlreadyLiveElsewhere, got {:?}", other),
+    }
+    // Pending create was stashed, targeting the new window, for replay on close.
+    let stashed = state.pending_browser_pane_creates.get("b1").expect("pending create must be stashed");
+    assert_eq!(stashed.window_label, "floating-abc");
+    // The old entry is still Live (caller will close it next).
+    assert!(matches!(state.browser_panes["b1"].lifecycle, BrowserPaneLifecycle::Live));
+}
+
 #[test]
 fn try_register_browser_pane_live_closing_returns_closing() {
     let mut state = HostState::default();

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1162,6 +1162,20 @@ impl AppState {
             .map(|e| e.label.clone())
     }
 
+    /// The window a pane currently lives in (`main`, `floating-<uuid>`, …),
+    /// or `None` if there is no entry. Used to make `browser_pane_close`
+    /// window-aware: a close from a window that no longer owns the pane (e.g.
+    /// the source window's view unmounting after a tear-off moved the pane to a
+    /// floating window) must be ignored, else it destroys the pane that just
+    /// moved. Returns the label regardless of Live/Closing.
+    pub fn browser_pane_window_label(&self, block_id: &str) -> Option<String> {
+        self.host_state
+            .lock()
+            .browser_panes
+            .get(block_id)
+            .map(|e| e.window_label.clone())
+    }
+
     /// Snapshot of all `Live` pane labels. Used by `defocus_all` etc.
     pub fn live_browser_pane_labels(&self) -> Vec<String> {
         self.host_state

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -146,6 +146,13 @@ pub struct BrowserPaneEntry {
     pub block_id: String,
     pub label: String,
     pub lifecycle: BrowserPaneLifecycle,
+    /// The window this pane was created in (`main`, `floating-<uuid>`, …).
+    /// Used to detect a cross-window move (tear-off / redock): a create
+    /// request whose `window_label` differs from this must NOT be served by
+    /// re-navigating the existing browser in the OLD window (that leaves the
+    /// requested window black). See the `AlreadyLiveElsewhere` handling in
+    /// `reducer/panes.rs` + `browser_panes.rs`.
+    pub window_label: String,
 }
 
 // ── Pane window-placement state (pane-state reducer, Phase 0) ─────────────

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -397,7 +397,14 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
         // that haven't reached the backend yet get no-op'd there instead of
         // racing a mid-destruction HWND. See SPEC_BROWSER_PANE_LIFECYCLE.md §5.
         if (paneCreated()) {
-            invokeCommand("browser_pane_close", { block_id: model.blockId }).catch(() => {});
+            // Pass window_label so the host can ignore a stale close from a
+            // window that no longer owns the pane. On tear-off/redock the pane
+            // moves to another window and is recreated there; this old
+            // component then unmounts and fires this close — without the label,
+            // the host (which keys close on block_id) would destroy the moved
+            // pane and black out the new window. See browser_pane_close in
+            // ipc.rs + the AlreadyLiveElsewhere fix.
+            invokeCommand("browser_pane_close", { block_id: model.blockId, window_label: windowLabel }).catch(() => {});
         }
         resizeObserver?.disconnect();
         if (positionInterval) {


### PR DESCRIPTION
## Summary

Tearing a browser (or Slack/webview) pane off into a floating pane rendered **black**. Two window-blindness bugs in the browser-pane lifecycle combine to cause it; this PR fixes both.

## Root cause (two halves)

Browser-pane create **and** close were keyed only on `block_id`, ignoring **which window** the pane lives in.

1. **Create half** — on tear-off, the create for the new floating window races ahead of the old pane's close, so the reducer still sees the entry `Live` and returns `AlreadyLive`. The host then just re-navigates the existing browser (still parented to the *old* window) and never creates a pane in the requested floating window → black. (Smoking gun: `browser pane create hit AlreadyLive — re-navigating existing browser (NOT creating in requested window)`; documented in `ANALYSIS_BROWSER_PANE_REDOCK_BLACK_TYPING_LOCK_2026_06_15.md §2`.)

2. **Close half** — once the create half creates the pane in the floating window, the **old window's** browser-view unmounts and fires `browser_pane_close(block_id)`. Being window-blind, that close destroys the just-moved pane ~330ms later → black again. (Confirmed in host log: `vm=<old> dispose → view-unmount → close → BrowserUnregistered`.)

## Fix

Track the pane's window on the reducer entry and make **both** create and close window-aware:

- `state.rs` — `BrowserPaneEntry` gains `window_label`; `browser_pane_window_label(block_id)` accessor.
- `reducer/mod.rs` — new `RegisterResult::AlreadyLiveElsewhere(label)`.
- `reducer/panes.rs` — a `Live` entry whose window differs from the create's target returns `AlreadyLiveElsewhere` and **stashes** the pending create; the `Fresh` insert records the window. Same-window re-creates keep `AlreadyLive` (re-navigate).
- `browser_panes.rs` — the `AlreadyLiveElsewhere` arm **closes the old pane**; its close-completion replays the stashed create as `Fresh` in the requested window (reusing the existing `Closing` defer/replay machinery).
- `ipc.rs` + `browser-view.tsx` — `browser_pane_close` now carries the caller's `window_label`; the host **ignores the close if the pane's current window no longer matches** the caller (a stale close from a window that no longer owns the pane). Internal host-initiated close (the move) bypasses the check.

## Tests

`reducer/tests.rs`:
- `try_register_same_window_relive_returns_already_live` — same-window re-nav stays `AlreadyLive`, no stash.
- `try_register_cross_window_returns_already_live_elsewhere_and_stashes` — cross-window returns `AlreadyLiveElsewhere` + stashes the pending create targeting the new window.

## Verification

Verified live in a dev build: tearing off a browser now moves it into the floating window and it stays/renders (log shows `create-cross-window-move` immediately followed by a suppressed `close-ignored-stale-window`). Reducer tests pass locally; CI runs the full suite.

## Known follow-up (out of scope)

A **multi-window dock** (docking a floating browser into a *second top-level window*) still has an intermittent **create-vs-create race**: both windows briefly issue creates and the move bounces between them, occasionally aborting the load (`ERR_ABORTED`) → black on retry-sensitive timing. The deterministic fix (gate the host pane move on the `RedockFloating`/`TearOffBlock` saga's authoritative target window) is tracked in `SPEC_BROWSER_PANE_CROSS_WINDOW_MOVE_DETERMINISM_2026_07_02.md` and will be a separate PR. This PR is a clear net improvement (simple tear-off fixed, most docks fixed).

<!-- agentmux:agent_id=agent2 -->