### PR TITLE
docs: clarify the intent-flip is not required for the disposable host (weak vs strong single-writer)

### DIFF
--- a/docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md
+++ b/docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md
@@ -137,6 +137,25 @@ host's existing `shadow_*` fields are the reference pattern (read-only projectio
 This demotion = Pillar 2 Stage 3 (demote `orphan_reconcile` + WRR to pure executors) + Pillar 1 (host
 topology becomes a projection).
 
+## 7b. Clarification (2026-07-02) — the intent-flip is NOT on Pillar 1's critical path
+Two goals were traveling together and must be separated:
+
+- **Disposable host (Pillar 1)** needs srv to be a **coherent single source of truth** for layout, so a
+  reprojecting host reads consistent state (not a raced/stale tree). That is satisfied by the **WEAK
+  single-writer**: retire the wcore-direct write path and route the frontend's full-tree push through the
+  reducer (`LayoutSetTree` carrying the computed tree), so the reducer's in-memory `TabRecord` stays
+  authoritative and matches `db_layout`. The frontend keeps **computing** the tree; there is **one write
+  path**. That is *all* Pillar 1 requires.
+- **Strong reducer-authority** (the intent-flip: frontend sends **intents**, the layout *algebra* lives in
+  srv/the durable tier) additionally moves the **logic** out of the disposable renderer. This is
+  architectural purity — valuable, and earlier decided "critical, not optional" (§7a spirit) — but it is
+  **above-and-beyond disposability, not on its critical path.**
+
+**Implication:** for the disposable-host goal, prefer the **weak cutover** (UpdateObject→`LayoutSetTree`,
+delete wcore-direct + `heal_layout`) — smaller, lower-risk, finishes #864's *coherence* requirement and
+unblocks Pillar 1. The full intent-flip (strong) can follow later, or be skipped, if only disposability
+matters. Pick per priority: **disposability → weak cutover; architectural purity → intent-flip.**
+
 ## 8. Next steps — see §"Best next steps" in the closing discussion / `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR` §6.
 Sequence: **Pillar 2 (wire `reconcile_quit`)** → **Pillar 3 (admission control)** → **Pillar 1 (host
 reproject)** → saga collapse + persistence pay-down (#864, agents Phase 3b/3c). Add the missing E2E

--- a/docs/specs/SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md
+++ b/docs/specs/SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md
@@ -22,6 +22,12 @@ while two writers race one `db_layout` row. This must land before Pillar 1.
 
 ---
 
+> **Scope note (2026-07-02):** for **Pillar 1 (disposable host)** the minimum is the **weak cutover** —
+> retire wcore-direct and route the frontend's full-tree push through `LayoutSetTree` (the frontend keeps
+> *computing* the tree) so there is ONE coherent writer of `db_layout`. The strong reducer-authority /
+> intent-flip (`SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT`) is a separate, above-and-beyond goal, not a Pillar-1
+> blocker. See `DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE` §7b.
+
 ## 0. TL;DR
 
 The layout tree is already persisted in srv (`db_layout`), so it survives host death. The problem

--- a/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
+++ b/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
@@ -13,6 +13,12 @@
 
 ---
 
+> **Scope note (2026-07-02):** the layout prerequisite (#864 / Q3 below) is satisfied by the **weak
+> single-writer** — retire wcore-direct and route the frontend's full-tree push through the reducer
+> (`LayoutSetTree`) so the reducer's in-memory state is the coherent source reproject reads. The full
+> **strong reducer-authority / intent-flip is NOT required for Pillar 1** (it moves layout *logic* into srv —
+> architectural purity, a separate goal). See `DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE` §7b.
+
 ## 0. TL;DR
 
 Pillar 1 is, in the literature's terms, making the host a **crash-only, microrebootable,

--- a/docs/specs/SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md
+++ b/docs/specs/SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT_2026_06_30.md
@@ -17,6 +17,14 @@ becomes Phase 1 here; this spec is the committed end-goal)
 
 ---
 
+> **Scope note (2026-07-02):** this strong-authority work (frontend sends *intents*; layout algebra in srv)
+> is **NOT strictly required for the disposable host (Pillar 1)**. Pillar 1 needs only a *coherent single
+> writer* for `db_layout`, which the **weak cutover** achieves — route the frontend's full-tree push through
+> `LayoutSetTree` + retire wcore-direct (see `SPEC_864_LAYOUT_SINGLE_WRITER` and
+> `DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE` §7b). This spec is the architectural-purity target (moving
+> layout *logic* out of the disposable renderer); pursue it above-and-beyond disposability, not as a Pillar-1
+> blocker.
+
 ## 0. TL;DR — the decision and the surprise
 
 **Decision (asaf, 2026-06-30):** reducer-as-authority is **critical, not optional**. Weak authority

--- a/docs/status/STATUS_LIFECYCLE_OOM_REFACTOR_2026_06_30.md
+++ b/docs/status/STATUS_LIFECYCLE_OOM_REFACTOR_2026_06_30.md
@@ -10,10 +10,16 @@ projections. See `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` and
 ---
 
 > **Update 2026-07-02:** the srv-side single-writer machinery is complete (persist arms, `balance_node`,
-> 7 reducer arms, granular-event persistence all merged) and PR-time CI is in place. The remaining work is
-> all behavior-changing + app-running/E2E-gated: the **frontend `UpdateObject`→intents flip** (finishes #864
-> → unblocks Pillar 1), **Pillar 2 Stage 2**, then **Pillar 1** proper. Sections §3–§7 below are historical
-> (they predate this arc); the table above and this note are current.
+> 7 reducer arms, granular-event persistence all merged) and PR-time CI is in place.
+>
+> **Scope clarification (see DISCUSSION §7b):** the **frontend intent-flip is NOT strictly required for the
+> disposable host.** Pillar 1 needs only a **coherent single writer** for `db_layout` — the **weak cutover**
+> (retire wcore-direct; route the frontend's full-tree push through the reducer via `LayoutSetTree`; delete
+> `heal_layout`) suffices and is smaller/lower-risk. The full **intent-flip** (strong reducer-authority —
+> frontend sends intents, algebra in srv) is a *separate* architectural-purity goal, above-and-beyond
+> disposability. Choose per priority: **disposability → weak cutover; purity → intent-flip.** Then:
+> **Pillar 2 Stage 2**, then **Pillar 1** proper — all behavior-changing + app-running/E2E-gated.
+> Sections §3–§7 below are historical (predate this arc); the table above and this note are current.
 
 ## 1. Where we are (one-glance)
 
@@ -24,7 +30,7 @@ projections. See `SPEC_ARCHITECTURE_HEALTH_AND_REFACTOR_2026_06_29.md` and
 | **Pillar 2 — single lifecycle authority** | 🟡 Stage 1 merged (#1850); Stage 2 designed, blocked on runtime verification; Stage 3 pending |
 | Pillar 3 — commit-aware admission control | ✅ Merged (#1853); follow-ons (queue-and-drain, per-agent cap, badge) pending |
 | Pillar 1 — host reproject | 🟡 Q1–Q4 resolved (`SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30`); blocked on #864 |
-| #864 — layout single writer (Pillar 1 prereq) | 🟡 **srv-side single-writer machinery COMPLETE** (below); remaining = frontend intent-flip + wcore-direct retirement (the behavior-changing collapse) |
+| #864 — layout single writer (Pillar 1 prereq) | 🟡 srv-side machinery COMPLETE (below); remaining for Pillar 1 = **weak cutover** (route `UpdateObject`→`LayoutSetTree`, retire wcore-direct + `heal_layout`). Full intent-flip (strong) is separate/optional (DISCUSSION §7b). |
 | **Strong reducer-authority (layout)** | 🟡 srv side merged: persist arms (#1862), `balance_node` (#1866), 7 reducer arms (#1868), granular-event persistence (#1883). Reducer now **authors + normalizes + persists every layout op** — still **behavior-neutral** (no prod dispatcher; wcore-direct still the writer). Remaining: **Phase-4 frontend `UpdateObject`→intents flip** (E2E-gated) → delete backstops (`heal_layout`). |
 | PR-time CI + test-build unbreak | ✅ Merged (#1885) — `ci-pr.yml` runs `check --tests` + `test` + vitest on PRs (root-caused #1823/#1876 breaks: no PR CI). **TODO(owner):** add as *required* status checks in branch protection to actually gate. |
 | Saga collapse + persistence paydown | ⬜ After Pillars 1–3 |


### PR DESCRIPTION
Docs-only. Records a scope clarification reached in discussion: **the frontend intent-flip / strong reducer-authority is NOT strictly required for the disposable host (Pillar 1).**

- **Pillar 1** needs only a *coherent single writer* for `db_layout` → the **weak cutover** (retire wcore-direct; route the frontend's full-tree push through the reducer via `LayoutSetTree`; delete `heal_layout`). Frontend keeps computing the tree; one write path; reproject reads consistent state.
- **Strong reducer-authority** (intent-flip) additionally moves layout *logic* out of the disposable renderer — architectural purity, above-and-beyond disposability.

Choose per priority: **disposability → weak cutover; purity → intent-flip.**

Updated: `DISCUSSION …` §7b (new), `STATUS …` (update note + #864 row), and scope notes on the three specs (`SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT`, `SPEC_PILLAR1_HOST_REPROJECT_DESIGN`, `SPEC_864_LAYOUT_SINGLE_WRITER`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)