### PR TITLE
fix(test): unbreak rpc contract baseline for mcp/skill backend-only handlers

### DIFF
--- a/.changesets/1782956857-fix-test-acknowledge-mcp-skill-backend-only-handlers-in-rpc--v91n.md
+++ b/.changesets/1782956857-fix-test-acknowledge-mcp-skill-backend-only-handlers-in-rpc--v91n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(test): acknowledge mcp/skill backend-only handlers in rpc contract baseline

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -276,7 +276,12 @@ const KNOWN_DECLARED_UNREGISTERED = [
     "wslstatus",
 ];
 
-/** Backend registers these handlers, but rpc-api.ts has no method. */
+/**
+ * Backend registers these handlers, but rpc-api.ts has no method.
+ * Note: the `mcp.*` / `skill.*` entries are the standalone MCP Server + Skill
+ * primitives (Trust Center) — intentionally backend-only for now; frontend
+ * bindings land when the UI is wired. Shrink this baseline as they get bound.
+ */
 const KNOWN_REGISTERED_UNDECLARED = [
     "agent.define",
     "agent.list",
@@ -293,6 +298,12 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "identity.account.validate",
     "identity.self.accounts",
     "identity.self.unlink",
+    "mcp.bind",
+    "mcp.delete",
+    "mcp.get",
+    "mcp.list",
+    "mcp.unbind",
+    "mcp.upsert",
     "memory.list",
     "memory.read",
     "memory.write",
@@ -302,6 +313,12 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "preset.list",
     "preset.self.get",
     "preset.upsert",
+    "skill.bind",
+    "skill.delete",
+    "skill.get",
+    "skill.list",
+    "skill.unbind",
+    "skill.upsert",
     "slow",
 ];
 


### PR DESCRIPTION
## Summary
Main's `vitest` check is currently red: the recently-merged standalone MCP Server + Skill primitives (PR #1877) register 12 new backend handlers (`mcp.*` ×6, `skill.*` ×6) that have no frontend binding yet, but the `rpc-contract` test's `KNOWN_REGISTERED_UNDECLARED` baseline was not updated. This blocks CI on **every** open PR.

This adds the 12 handlers to the baseline (they are intentionally backend-only for now — frontend bindings land when the UI is wired) and documents why. Baseline still "may only shrink" going forward.

## Test plan
- [x] `npx vitest run test/contract/rpc-contract.test.ts` — 4/4 pass (was 3/4)
- [x] Verified the failure reproduces on clean `main` (pre-existing, not from any refactor)

<!-- agentmux:agent_id=agent1 -->