### PR TITLE
chore(providers): pin Claude Code CLI to 2.1.198 (latest)

### DIFF
--- a/.changesets/1782957850-chore-providers-pin-claude-code-cli-to-2-1-198-latest-fjju.md
+++ b/.changesets/1782957850-chore-providers-pin-claude-code-cli-to-2-1-198-latest-fjju.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(providers): pin Claude Code CLI to 2.1.198 (latest)

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -143,7 +143,8 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &["CLAUDECODE"],
     npm_package: "@anthropic-ai/claude-code",
-    pinned_version: "2.1.185",
+    // Keep in sync with frontend/app/view/agent/providers/index.ts `pinnedVersion`.
+    pinned_version: "2.1.198",
     icon: "sparkles",
     docs_url: "https://docs.anthropic.com/claude-code",
 };

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -153,7 +153,8 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // stays alive for the paste. See docs / run_cli_login_pty.
         requiresLoginTty: true,
         npmPackage: "@anthropic-ai/claude-code",
-        pinnedVersion: "2.1.185",
+        // Keep in sync with agentmux-srv/src/backend/providers.rs `pinned_version`.
+        pinnedVersion: "2.1.198",
         docsUrl: "https://docs.anthropic.com/claude-code",
         windowsInstallCommand: "irm https://claude.ai/install.ps1 | iex",
         unixInstallCommand: "curl -fsSL https://claude.ai/install.sh | bash",


### PR DESCRIPTION
Bumps the Claude provider install pin **2.1.185 → 2.1.198** (current npm `latest`) in the two hand-synced registries (`agentmux-srv/src/backend/providers.rs`, `frontend/app/view/agent/providers/index.ts`), with a cross-reference comment on each so a future bump updates both.

Part A of `SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02`. (Follow-ups in that spec: a sync-guard/test and an installed-vs-pinned drift indicator — not in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)