### PR TITLE
fix(agent-log): one-toggle Log — remove the middle collapse layer

### DIFF
--- a/.changesets/1782957992-fix-agent-log-log-button-expands-collapses-the-full-entries--fuxp.md
+++ b/.changesets/1782957992-fix-agent-log-log-button-expands-collapses-the-full-entries--fuxp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-log): Log button expands/collapses the full entries directly (remove middle collapse layer)

--- a/frontend/app/view/agent/components/ActivityLogPanel.tsx
+++ b/frontend/app/view/agent/components/ActivityLogPanel.tsx
@@ -48,7 +48,7 @@ export const ActivityLogPanel = (props: ActivityLogPanelProps): JSX.Element => {
     return (
         <Show when={props.entries().length > 0}>
             <div
-                class="agent-activity-log agent-activity-log--open"
+                class="agent-activity-log"
                 classList={{
                     "agent-activity-log--has-error": lastLevel() === "error",
                     "agent-activity-log--has-warn": lastLevel() === "warn",

--- a/frontend/app/view/agent/components/ActivityLogPanel.tsx
+++ b/frontend/app/view/agent/components/ActivityLogPanel.tsx
@@ -2,19 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * ActivityLogPanel — collapsible log panel docked above the composer.
- * Shows the per-pane activity log (launch flow, subprocess lifecycle,
- * slash command outcomes, errors). Collapsed by default; a one-line
- * summary (most recent entry + total count) is shown in the header.
- * Auto-expands when new entries arrive, unless the user has explicitly
- * collapsed it — in that case it stays closed until the user reopens it.
+ * ActivityLogPanel — the per-pane activity log docked above the composer
+ * (launch flow, subprocess lifecycle, slash command outcomes, errors).
  *
- * Replaces the old `.agent-status-log` block that lived at the top of
- * the conversation scroll area and grew unbounded over the session —
- * see `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
+ * This panel is mounted ONLY while the composer's details region is open —
+ * i.e. the "Log" button in `AgentComposerStrip` is the single expand/collapse
+ * toggle for the whole list. So the panel renders its full entries list
+ * DIRECTLY: there is no second header toggle / one-line-summary layer.
+ * (The redundant middle collapse level was removed per
+ * SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02 Part C.) The only remaining
+ * collapse is per-entry: clicking a row toggles truncated ↔ full text.
+ *
+ * Replaces the old `.agent-status-log` block that lived at the top of the
+ * conversation scroll area and grew unbounded — see
+ * `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { For, Show, createEffect, createMemo, createSignal, type Accessor, type JSX } from "solid-js";
+import { For, Show, createSignal, type Accessor, type JSX } from "solid-js";
 import type { LogLine } from "../types";
 
 interface ActivityLogPanelProps {
@@ -22,28 +26,15 @@ interface ActivityLogPanelProps {
 }
 
 export const ActivityLogPanel = (props: ActivityLogPanelProps): JSX.Element => {
-    const [isOpen, setIsOpen] = createSignal(false);
+    // Per-entry expand (truncated ↔ full text) — the sole collapse level here.
     const [expandedIds, setExpandedIds] = createSignal<Set<string>>(new Set());
-    // True after the user explicitly clicks to close — suppresses auto-expand
-    // until they reopen the panel themselves, preventing non-bang log entries
-    // (subprocess lifecycle, slash outcomes) from fighting the user's intent.
-    let userCollapsed = false;
 
-    // Auto-expand when new entries arrive, but only if the user hasn't
-    // explicitly collapsed the panel since the last open.
-    let prevLength = props.entries().length;
-    createEffect(() => {
-        const len = props.entries().length;
-        if (len > prevLength && !userCollapsed) {
-            setIsOpen(true);
-        }
-        prevLength = len;
-    });
-
-    const mostRecent = createMemo(() => {
+    // Latest entry's level drives the container error/warn accent (the rows
+    // also carry their own per-line level styling).
+    const lastLevel = (): LogLine["level"] | undefined => {
         const list = props.entries();
-        return list.length > 0 ? list[list.length - 1] : null;
-    });
+        return list.length > 0 ? list[list.length - 1].level : undefined;
+    };
 
     const toggleExpanded = (id: string) => {
         setExpandedIds((prev) => {
@@ -57,65 +48,36 @@ export const ActivityLogPanel = (props: ActivityLogPanelProps): JSX.Element => {
     return (
         <Show when={props.entries().length > 0}>
             <div
-                class="agent-activity-log"
+                class="agent-activity-log agent-activity-log--open"
                 classList={{
-                    "agent-activity-log--open": isOpen(),
-                    "agent-activity-log--has-error": mostRecent()?.level === "error",
-                    "agent-activity-log--has-warn": mostRecent()?.level === "warn",
+                    "agent-activity-log--has-error": lastLevel() === "error",
+                    "agent-activity-log--has-warn": lastLevel() === "warn",
                 }}
             >
-                <button
-                    type="button"
-                    class="agent-activity-log-header"
-                    onClick={() => {
-                        const next = !isOpen();
-                        userCollapsed = !next; // track explicit close to suppress auto-expand
-                        setIsOpen(next);
-                    }}
-                    title={isOpen() ? "Collapse shell log" : "Expand shell log"}
-                    aria-expanded={isOpen()}
-                >
-                    <span class="agent-activity-log-chevron">{isOpen() ? "⌄" : "›"}</span>
-                    <Show when={!isOpen() && mostRecent()}>
-                        {(entry) => (
-                            <span class="agent-activity-log-preview">
-                                <span class="agent-status-tag">[{entry().tag}]</span>
-                                <span class="agent-activity-log-preview-text">{entry().text}</span>
-                            </span>
-                        )}
-                    </Show>
-                    <span class="agent-activity-log-count">
-                        {props.entries().length}
-                        {props.entries().length === 1 ? " entry" : " entries"}
-                    </span>
-                </button>
-                <Show when={isOpen()}>
-                    <div class="agent-activity-log-body">
-                        <For each={props.entries()}>
-                            {(line) => {
-                                const isExpanded = () => expandedIds().has(line.id);
-                                return (
-                                    <div
-                                        class="agent-status-line agent-status-line--toggle"
-                                        classList={{
-                                            "agent-status-line--error": line.level === "error",
-                                            "agent-status-line--warn": line.level === "warn",
-                                            "agent-status-line--expanded": isExpanded(),
-                                        }}
-                                        // Click toggles full/truncated text — the
-                                        // expand affordance the removed hover strip
-                                        // used to provide.
-                                        onClick={() => toggleExpanded(line.id)}
-                                    >
-                                        <span class="agent-status-line-text">
-                                            <span class="agent-status-tag">[{line.tag}]</span> {line.text}
-                                        </span>
-                                    </div>
-                                );
-                            }}
-                        </For>
-                    </div>
-                </Show>
+                <div class="agent-activity-log-body">
+                    <For each={props.entries()}>
+                        {(line) => {
+                            const isExpanded = () => expandedIds().has(line.id);
+                            return (
+                                <div
+                                    class="agent-status-line agent-status-line--toggle"
+                                    classList={{
+                                        "agent-status-line--error": line.level === "error",
+                                        "agent-status-line--warn": line.level === "warn",
+                                        "agent-status-line--expanded": isExpanded(),
+                                    }}
+                                    // Click toggles full/truncated text — the
+                                    // per-entry expand affordance.
+                                    onClick={() => toggleExpanded(line.id)}
+                                >
+                                    <span class="agent-status-line-text">
+                                        <span class="agent-status-tag">[{line.tag}]</span> {line.text}
+                                    </span>
+                                </div>
+                            );
+                        }}
+                    </For>
+                </div>
             </div>
         </Show>
     );

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -5,13 +5,15 @@
 // the pre-split file (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
 .agent-view {
     // === Activity log panel ===
-    // Collapsible log of per-session diagnostic entries (launch flow,
-    // subprocess lifecycle, slash-command outcomes, errors). Docked
-    // above the composer. Replaces the old always-visible
-    // `.agent-status-log` block that lived at the top of the
-    // conversation. Auto-opens when a new error arrives; otherwise
-    // default-collapsed with a one-line preview of the most recent entry.
-    // See `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
+    // Log of per-session diagnostic entries (launch flow, subprocess
+    // lifecycle, slash-command outcomes, errors). Docked above the
+    // composer and mounted only while the "Log" button is toggled on —
+    // that button is the sole show/hide control, so the panel renders its
+    // full entries list directly (no internal collapse layer). The only
+    // per-entry collapse is click-to-expand truncated ↔ full text.
+    // Replaces the old always-visible `.agent-status-log` block that lived
+    // at the top of the conversation. See
+    // `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
     .agent-activity-log {
         border-top: 1px solid var(--border-color);
         font-family: var(--fixed-font);

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -20,76 +20,20 @@
         user-select: text;
         flex-shrink: 0;
 
-        &--has-error .agent-activity-log-header {
-            color: var(--error-color);
+        // Latest-entry accent. The header (which used to carry this tint)
+        // was removed with the middle collapse layer, so accent the panel's
+        // own top border instead.
+        &--has-error {
+            border-top-color: var(--error-color);
         }
-        &--has-warn .agent-activity-log-header {
-            color: var(--warning-color);
-        }
-
-        .agent-activity-log-header {
-            display: flex;
-            align-items: center;
-            gap: var(--space-1-5);
-            width: 100%;
-            padding: var(--space-0-5) var(--space-1-5);
-            background: transparent;
-            border: none;
-            color: var(--secondary-text-color);
-            font: inherit;
-            text-align: left;
-            cursor: default;
-            transition: background 80ms ease;
-
-            &:hover {
-                background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
-            }
-        }
-
-        .agent-activity-log-chevron {
-            display: inline-block;
-            width: 10px;
-            text-align: center;
-            opacity: 0.7;
-        }
-
-        .agent-activity-log-label {
-            font-size: 10px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            opacity: 0.8;
-            flex-shrink: 0;
-        }
-
-        .agent-activity-log-preview {
-            flex: 1;
-            min-width: 0;
-            display: inline-flex;
-            align-items: center;
-            gap: var(--space-1);
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            opacity: 0.65;
-        }
-
-        .agent-activity-log-preview-text {
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        .agent-activity-log-count {
-            font-size: 10px;
-            opacity: 0.5;
-            flex-shrink: 0;
-            font-variant-numeric: tabular-nums;
+        &--has-warn {
+            border-top-color: var(--warning-color);
         }
 
         .agent-activity-log-body {
             max-height: 30vh;
             overflow-y: auto;
             padding: var(--space-0-5) var(--space-1) var(--space-1);
-            border-top: 1px solid var(--border-color);
         }
     }
 


### PR DESCRIPTION
The activity log had **three** collapse levels: the **Log** button (opens the composer details region) → `ActivityLogPanel`'s own header toggle (one-line summary ↔ full list) → per-entry row expand. The middle level is redundant — after clicking "Log" you had to click the panel header *again* to see any entries.

**Removes the middle level.** `ActivityLogPanel` now renders its full entries list directly (it's mounted only while the details region is open, so the **Log button is the single expand/collapse**). Dropped the internal `isOpen`, the auto-expand effect, `userCollapsed`, the most-recent memo, and the header button + one-line preview. Kept the Log button (L1) and **per-entry expand** (L3, truncated ↔ full text).

Part C of `SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02`. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)