### PR TITLE
chore: bump version to 0.49.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.10"
+version = "0.49.11"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.10"
+version = "0.49.11"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.10"
+version = "0.49.11"
 dependencies = [
  "dirs",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.10"
+version = "0.49.11"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.10"
+version = "0.49.11"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.10"
+version = "0.49.11"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.10"
+version = "0.49.11"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,11 @@
 # AgentMux Version History
 
+## 0.49.11 — 2026-07-02
+
+- chore(providers): pin Claude Code CLI to 2.1.198 (latest)
+- feat(agent): versioned, registry-driven model dropdowns (Opus 4.8 / Sonnet 4.6 / Haiku 4.5), sourced from the provider registry
+- fix(agent-log): one-toggle Log — remove the middle collapse layer
+
 ## 0.49.10 — 2026-06-30
 
 - fix(agent-pane): watchdog recovers a stalled rate-limited turn past retryAfterMs + liveness window

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.10",
+  "version": "0.49.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.10",
+      "version": "0.49.11",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.10",
+  "version": "0.49.11",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Patch bump 0.49.10 → 0.49.11 for a portable build.

Rolls up the just-merged agent model/log work:
- #1898 — pin Claude Code CLI to 2.1.198 (latest)
- #1900 — versioned, registry-driven model dropdowns (Opus 4.8 / Sonnet 4.6 / Haiku 4.5)
- #1899 — one-toggle Log (removed the middle collapse layer)

`bump verify` clean (package.json + Cargo.toml both 0.49.11; package-lock + Cargo.lock synced). VERSION_HISTORY.md updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)