### PR TITLE
docs: large-tier modularization specs

### DIFF
--- a/docs/specs/SPEC_LARGE_TIER_MODULARIZATION_INDEX_2026_07_02.md
+++ b/docs/specs/SPEC_LARGE_TIER_MODULARIZATION_INDEX_2026_07_02.md
@@ -1,0 +1,36 @@
+# Large-Tier Modularization — Index & Sequencing
+
+**Date:** 2026-07-02
+**Context:** Follow-on to the critical-tier run (PRs #1880, #1881, #1887, #1888, #1889, #1891, #1893, #1897 — all merged). Those cleared every file >3,000 lines except the four below plus the already-done set. This batch targets the "Large" (1,500–3,000) tier's top offenders.
+
+## The four targets
+
+| File | Lines | Spec | Risk | Notes |
+|------|-------|------|------|-------|
+| `agentmux-srv/src/backend/agent_session.rs` | 2,801 | [agent_session](SPEC_MODULARIZE_AGENT_SESSION_2026_07_02.md) | **Low** | No trait impls, no platform cfg. Do first. |
+| `agentmux-cef/src/client/mod.rs` | 2,377 | [cef_client](SPEC_MODULARIZE_CEF_CLIENT_2026_07_02.md) | **Medium** | Inherent impls split cleanly; watch struct field visibility. |
+| `agentmux-srv/src/backend/blockcontroller/shell.rs` | 2,394 | [shell](SPEC_MODULARIZE_SHELL_2026_07_02.md) | **Medium** | Trait impl must stay whole; extract helper bodies only. Platform cfg + hot PTY path. |
+| `agentmux-launcher/src/main.rs` | 2,264 | [launcher_main](SPEC_MODULARIZE_LAUNCHER_MAIN_2026_07_02.md) | **High** | Touches isolation invariants I1–I6. Pure move; explicit invariant statement in PR body; consider 2-PR split. |
+
+## Recommended order
+
+1. **agent_session.rs** (Low) — warm up, prove the pattern on a clean file.
+2. **cef_client** (Medium) — isolated to `client/`, no invariant surface.
+3. **shell.rs** (Medium) — trait-impl care; keep `impl Controller` intact.
+4. **launcher/main.rs** (High) — last, most careful; invariant gate.
+
+## Shared rules (from the critical-tier run's lessons)
+
+- **Sequential only.** The agent workdir shares ONE git checkout (no worktree isolation) — run one branch-mutating agent at a time. Parallel branch work collided last time (see memory `shared-worktree-agent-collision`).
+- **Agent1 identity for all git/gh:** prefix with `GH_TOKEN=<agent1 PAT>`; NEVER `gh auth login`.
+- **No `#![allow(unused_imports)]`** — reagent flags leftover unused imports (P2 on #1880). Trim via `cargo check` output.
+- **Inline-test symbol visibility** — when moving `#[cfg(test)] mod tests` to a `tests.rs`, ensure symbols it reaches via `use super::*` are re-exported or `pub(crate)`. reagent caught this as a P1 on #1880 (RecentSessionRow).
+- **Preserve every `#[cfg]` guard byte-for-byte.** We compile-verify Windows locally; CI covers ubuntu/mac.
+- **Changeset per PR:** `task changeset -- patch "refactor(...): ..."`. No version-file bumps.
+- **PR body:** include `<!-- agentmux:agent_id=agent1 -->`. For launcher, add the explicit I1–I6 "no lifecycle/naming logic changed, only relocated" statement.
+
+## Verification gate (every PR)
+
+- `cargo check` + `cargo check --tests` (or `-p <crate>`) clean, zero new warnings
+- Relevant `cargo test <module>` passes
+- reagent review; expect only import/comment nits on a clean pure-reorg

--- a/docs/specs/SPEC_MODULARIZE_AGENT_SESSION_2026_07_02.md
+++ b/docs/specs/SPEC_MODULARIZE_AGENT_SESSION_2026_07_02.md
@@ -1,0 +1,60 @@
+# Spec: Modularize `agent_session.rs`
+
+**Date:** 2026-07-02
+**File:** `agentmux-srv/src/backend/agent_session.rs` (2,801 lines)
+**Type:** Pure reorganization — zero logic changes, zero public API changes
+**Tier:** Large (follow-on to the critical-tier modularization run, PRs #1880–#1897)
+
+---
+
+## Current state
+
+- **2,801 lines total:** ~1,477 impl + ~1,322 inline `#[cfg(test)] mod tests`
+- **No `impl` blocks / no trait impls** — all functions are module-level (simplifies the split)
+- Callers across the crate use fully-qualified `crate::backend::agent_session::*` paths, so a `mod.rs` with `pub use` re-exports preserves every call site unchanged
+
+## Public API surface (must remain re-exported from `mod.rs`)
+
+Consumed by: `shell.rs`, `persistent.rs`, `transcript_backfill.rs`, `server/…/session.rs` (RPC), `instance.rs`, `app_api/mod.rs`, `main.rs`, `migrations/m0002_block_zones_v1.rs`, `migrations/m0003_template_sessions_v1.rs`.
+
+Constants: `SNAPSHOT_FILE`, `OUTPUT_FILE`, `MIGRATION_MARKER_V1`, `TEMPLATE_PROMOTE_MARKER_V1`
+Zone naming: `is_valid_definition_id`, `agent_current_zone`, `agent_archive_zone`, `validate_and_current`
+Global store: `set_global_transcript_store`, `global_transcript_store`, `agent_zone_for_block_meta`
+Session IO: `write_session_state`, `read_session_state`, `append_session_output`, `read_snapshot_from`, `normalize_snapshot_for_global`, `heal_global_snapshot_source_block_ids`
+Archive: `archive_session`, `archive_global_current`, `clear_local_current_zone`, `clear_global_current_zone`, `list_archives`, `read_archive_preview`, `ArchiveSummary`
+Migrations: `migrate_block_zones_v1`, `MigrationStats`, `migrate_promote_template_sessions_v1`, `TemplatePromoteStats`
+
+Private (keep module-private): `now_ms`, `move_zone`, `CopyAction`, `ensure_file`, `write_zone_file`, `read_snapshot_bytes`, `collapse_preview`.
+
+## Proposed layout
+
+```
+src/backend/agent_session/
+├── mod.rs               (~40 lines: pub use re-exports + module decls)
+├── zone_naming.rs       (~130: validation + zone-name builders)
+├── global_store.rs      (~50: cross-channel transcript singleton + block-meta resolution)
+├── session_io.rs        (~270: read/write/append snapshot state + normalization + heal)
+├── archive.rs           (~380: archive lifecycle, browsing, previews, ArchiveSummary)
+├── helpers.rs           (~180: FileStore I/O wrappers)
+├── migrations/
+│   ├── mod.rs           (re-export both migrations + marker consts)
+│   ├── v1_blocks.rs     (~180: migrate_block_zones_v1, MigrationStats)
+│   └── v1_templates.rs  (~480: migrate_promote_template_sessions_v1, TemplatePromoteStats, move_zone, CopyAction)
+└── tests.rs             (~1,322: the existing #[cfg(test)] mod tests, moved via `#[cfg(test)] mod tests;`)
+```
+
+`tests.rs` uses `use super::*;` (child of `agent_session`) so it resolves exactly as the inline module did — same pattern proven in store.rs (#1887).
+
+## Execution notes
+
+- mod.rs `pub use self::<submod>::{...}` for every public item listed above — verify no external file's import breaks.
+- Each submodule declares its own `use` imports; do NOT add `#![allow(unused_imports)]` (reagent flagged this in #1880 — trim via `cargo check` output).
+- The test module references migration internals via `use super::*` — since tests move to `agent_session/tests.rs` (a child of the parent `agent_session` module, NOT of the `migrations` submodule), any migration symbols the tests touch must be reachable from `agent_session::` — re-export them (they already are, per the public list) or add `pub(crate)` where a test uses a currently-private helper. Run `cargo test --lib backend::agent_session` (or `cargo test agent_session`) and fix breakages before pushing.
+
+## Verification gate
+
+- `cargo check` + `cargo check --tests` clean, zero new warnings
+- `cargo test agent_session` — all tests pass (was passing before)
+- reagent review; pure-reorg, so expect only import/comment nits
+
+## Risk: **Low.** No trait impls, no platform cfg, callers use qualified paths. Main risk is test-module symbol visibility after the move — covered above.

--- a/docs/specs/SPEC_MODULARIZE_CEF_CLIENT_2026_07_02.md
+++ b/docs/specs/SPEC_MODULARIZE_CEF_CLIENT_2026_07_02.md
@@ -1,0 +1,66 @@
+# Spec: Modularize `agentmux-cef/src/client/mod.rs`
+
+**Date:** 2026-07-02
+**File:** `agentmux-cef/src/client/mod.rs` (2,377 lines)
+**Type:** Pure reorganization — zero logic changes, zero public API changes
+**Tier:** Large
+
+---
+
+## Current state
+
+- **2,377 lines:** ~2,273 impl + 104 inline tests (5 tests)
+- **Already partially modularized** — `client/` also contains `handlers.rs` (507, CEF trait wrappers), `helpers.rs` (106), `wndproc.rs` (489, Windows-only). This spec finishes the job by breaking up `mod.rs` itself.
+- The handler logic lives in **inherent `impl AgentMuxHandler { ... }` blocks** grouped by CEF concern. **Multiple inherent impl blocks across files ARE allowed in Rust** — so unlike shell.rs, the methods can be distributed cleanly.
+- Platform code: Windows blocks scattered in `on_after_created` (icon/taskbar/focus hooks, SetWindowTextW, splash event, HWND cache) + macOS/Linux splash signals. `wndproc.rs` already isolates the bulk of Windows subclassing. Compile-verify Windows locally; CI covers ubuntu/mac.
+
+## Public API surface (must remain re-exported from `mod.rs`)
+
+Consumed by: `app.rs` (`use crate::client::*`), `creation.rs`, `window_pool.rs`, `floating_pane.rs`, `commands/window/meta.rs`.
+
+- `AgentMuxClient` (re-exported from `handlers.rs` — unchanged)
+- `AgentMuxHandler` (pub struct, core state)
+- `dlog` (pub fn)
+- `helpers::{js_string_literal, html_escape, backend_close_window}` (pub(crate), unchanged)
+- `wndproc::install_main_window_floater_cascade_hook` (Windows, unchanged)
+- `ClosePoolBrowserTask`
+
+## Proposed layout
+
+Keep `handlers.rs`, `helpers.rs`, `wndproc.rs` **unchanged**. Split `mod.rs` into:
+
+```
+agentmux-cef/src/client/
+├── mod.rs            (~450: AgentMuxHandler struct def, constructors, window_label_for,
+│                      ClosePoolBrowserTask, constants, dlog, mod decls + pub use re-exports)
+├── lifecycle.rs      (~900: impl AgentMuxHandler { on_after_created, do_close,
+│                      on_before_close, on_before_popup } — window/pool/cascade/quit-gate)
+├── display.rs        (~126: impl AgentMuxHandler { on_title_change, on_favicon_urlchange })
+├── navigation.rs     (~299: impl AgentMuxHandler { on_loading_state_change, on_load_end,
+│                      on_load_error } — IPC injection, error pages, splash signals)
+├── crash_recovery.rs (~520: impl AgentMuxHandler { on_render_process_terminated,
+│                      on_auth_credentials } — crash/memory budgets, auth registry)
+├── recovery_pages.rs (~190: free fns crash_loop_terminal_page, memory_paused_page,
+│                      url_on_origin, record_memory_pause, recovery_navigation_url)
+├── handlers.rs       (unchanged — CEF trait wrappers)
+├── helpers.rs        (unchanged)
+├── wndproc.rs        (unchanged — Windows only)
+└── tests.rs          (the 104-line #[cfg(test)] block, or keep inline in the file
+                       whose functions it exercises — recovery_pages tests → recovery_pages.rs)
+```
+
+## Execution notes
+
+- Each new file adds `impl AgentMuxHandler { ... }` with just its methods — legal since inherent impls compose across files within a crate. The struct definition + fields stay in `mod.rs`; **all fields the moved methods touch must be reachable** — if any field is currently private-to-module and a method in another file uses it, fields on a struct defined in `mod.rs` are visible to sibling submodules only if `pub(crate)`/`pub(super)` OR if the impl is in the same module. **Key rule:** methods in `lifecycle.rs` etc. can access private fields of `AgentMuxHandler` ONLY if those files are child modules of the module that defines the struct — which they are (all under `client`), BUT Rust field privacy is module-scoped: a struct defined in `client::mod` has fields private to `client` module itself, and child modules (`client::lifecycle`) can access them via `pub(super)` visibility or if fields are `pub(crate)`. **Verify with `cargo check`;** if field-access errors appear, mark the relevant fields `pub(crate)` (they're on a crate-internal struct, so this is safe and non-breaking).
+- The 5 tests mostly cover recovery pages / memory budgets / URL matching — move them next to the code they test (`recovery_pages.rs`, `crash_recovery.rs`) so `use super::*` resolves.
+- Preserve every `#[cfg(target_os = ...)]` guard exactly.
+- No `#![allow(unused_imports)]`; trim per file.
+
+## Verification gate
+
+- `cargo check -p agentmux-cef` clean on Windows, zero new warnings
+- The 5 unit tests pass
+- Manual re-read of moved `#[cfg]` blocks
+- reagent review
+
+## Risk: **Medium.** Cleaner than shell.rs (inherent impls split freely), but watch struct field visibility across the new child modules — bump fields to `pub(crate)` if `cargo check` complains (safe on a crate-internal type).

--- a/docs/specs/SPEC_MODULARIZE_LAUNCHER_MAIN_2026_07_02.md
+++ b/docs/specs/SPEC_MODULARIZE_LAUNCHER_MAIN_2026_07_02.md
@@ -1,0 +1,68 @@
+# Spec: Modularize `agentmux-launcher/src/main.rs`
+
+**Date:** 2026-07-02
+**File:** `agentmux-launcher/src/main.rs` (2,264 lines)
+**Type:** Pure reorganization — zero logic changes, zero behavior changes
+**Tier:** Large — **HIGHEST RISK of the four** (touches isolation invariants I1–I6)
+
+---
+
+## Current state
+
+- **2,264 lines, 0 inline tests, 21 top-level functions + 1 enum**
+- ~37 platform `#[cfg]` blocks (windows / macos / linux / not(windows) / not(macos) / any(...))
+- 15 sibling modules already exist (`config`, `data_dir`, `diag`, `event_log`, `hash`, `host_pipe`, `ipc/`, `mem_supervisor`, `reducer`, `saga`, `splash*`, `srv_spawner`, `state`, `wrr`) — this split ADDS to that pattern, moving logic out of `main.rs`.
+
+## Isolation invariants — MANDATORY reviewer gate (per CLAUDE.md I1–I6)
+
+Any moved function touching these must be reviewed to confirm the move changes nothing:
+
+| Invariant | Functions | APIs |
+|-----------|-----------|------|
+| I1 pipe uniqueness | `hash::data_dir_hash16`, `ipc::pipe_name`/`srv_pipe_name` | hash → namespace key |
+| I2 no global lifecycle handles | `create_job_object` (unnamed job), `srv_spawner::assign_pid_to_job` | `CreateJobObjectW`, `AssignProcessToJobObject` |
+| I3 bounded blast radius | `spawn_host_supervised`, job drop/cleanup | `KILL_ON_JOB_CLOSE` |
+| I4 forward-only contact | `forward_open_new_window` | HTTP POST to existing host (side-effect-free) |
+| I5 keyed shared OS objects | `pipe_name(&dir_hash)`, `splash::spawn_splash(&dir_hash)` | pipe/event names embed `dir_hash` |
+| I6 data isolation | `paths.data_dir` (channel+version keyed) | env forwarding |
+
+**Because this is a PURE MOVE, the invariants are preserved by construction — no naming, no handle lifetime, no forwarding logic changes. The spec requires the PR description to explicitly state "no `CreateJobObjectW`/`AssignProcessToJobObject`/`OpenProcess`/`TerminateProcess`/pipe-naming logic was modified, only relocated" so reagent's I1–I6 gate can confirm at a glance.**
+
+## Must stay in `main.rs`
+
+- `fn main()` — entry point + runtime construction
+- `suppress_os_crash_dialogs()` — must run before runtime
+- `async fn launcher_main()` — top-level orchestrator (may shrink, but stays at crate root as the flow spine)
+
+## Proposed new sibling modules
+
+```
+src/
+├── main.rs              (~150 lines: main() + launcher_main() orchestration + mod decls)
+├── job_object.rs        (JobHandle, create_job_object — Windows; I2/I3)
+├── host_spawn.rs        (spawn_host_supervised + resume_main_thread [win], spawn_host_unix + terminate_child_gracefully [unix]; I2/I3)
+├── second_instance.rs   (ForwardError, forward_open_new_window[_or_log], bind_socket_with_recovery [unix]; I1/I4/I5)
+├── supervisor/
+│   ├── mod.rs
+│   ├── windows.rs       (run_windows loop — ~600 lines)
+│   └── unix.rs          (run_unix loop + next_signal — ~550 lines)
+├── binary_resolution.rs (find_cef_binary)
+└── logging.rs           (log, dirs_fallback_home)
+```
+
+## Execution notes
+
+- Do this in **one PR** but keep the diff a clean move: each extracted function keeps its exact body + `#[cfg]` guards; `main.rs` gains `mod` decls and the call sites become `job_object::create_job_object(...)`, `supervisor::run_windows(...)`, etc.
+- Extracted functions that `main.rs`/`launcher_main` call must be `pub(crate)`.
+- Preserve every platform guard exactly. Windows and Unix supervisor loops go to separate files under `supervisor/`, each fully `#[cfg]`-gated.
+- No `#![allow(unused_imports)]`; trim imports per file via `cargo check`.
+- **Suggest splitting into two PRs if the diff is unreviewable:** PR-A = the low-invariant extractions (`binary_resolution`, `logging`, `host_spawn` non-job parts, `supervisor`); PR-B = the I1–I6-touching bits (`job_object`, `second_instance`). This lets reagent's invariant gate focus on a small surface. Author's call based on diff size.
+
+## Verification gate
+
+- `cargo check -p agentmux-launcher` clean on Windows, zero new warnings
+- Manual re-read of every I1–I6 touchpoint confirming byte-identical logic
+- CI ubuntu run covers the Unix supervisor/socket paths
+- reagent review with explicit I1–I6 confirmation in the PR body
+
+## Risk: **High** (invariant-sensitive). Mitigation: pure move, explicit invariant statement in PR body, optional two-PR split isolating the I1–I6 surface. No logic edits under any circumstances — if a move seems to *require* a logic tweak, STOP and leave that function in `main.rs`.

--- a/docs/specs/SPEC_MODULARIZE_SHELL_2026_07_02.md
+++ b/docs/specs/SPEC_MODULARIZE_SHELL_2026_07_02.md
@@ -1,0 +1,62 @@
+# Spec: Modularize `blockcontroller/shell.rs`
+
+**Date:** 2026-07-02
+**File:** `agentmux-srv/src/backend/blockcontroller/shell.rs` (2,394 lines)
+**Type:** Pure reorganization — zero logic changes, zero public API changes
+**Tier:** Large
+
+---
+
+## Current state
+
+- **2,394 lines:** ~1,620 impl + ~769 inline `#[cfg(test)] mod tests` (30+ tests)
+- Contains **`impl Controller for ShellController`** — a large trait impl (~855 lines, lines 362–1217) which is the main complication vs the flat files split earlier
+- **Platform-conditional code:** Unix-only signal delivery (`libc::kill`, SIGTERM→SIGKILL), Windows-only shell detection (`detect_local_shell_path_windows`), plus runtime `cfg!(windows)` branches for shell wrapper + PATH separator. We can only compile-verify Windows locally — CI covers ubuntu.
+
+## Public API surface (must remain re-exported from `shell/mod.rs`)
+
+Consumed by: `blockcontroller/mod.rs` (resync), `acp.rs`, `persistent.rs`, `subprocess.rs`, `watchdog.rs`, `agent_handlers/input.rs`, `blockfile.rs`, `app_api/mod.rs`.
+
+- `ShellController` (struct) — instantiated in `resync_controller()`
+- `handle_append_block_file()` — acp, persistent, subprocess, input
+- `persist_to_blockfile_silent()` — persistent, subprocess
+- `resolve_global_output_zone()` — acp, persistent, subprocess
+- `rebuild_output_idx()`, `OUTPUT_IDX_HEADER_LEN` — blockfile, app_api
+- `ConnFactory` (type alias) — test mocking
+- `extract_agent_events()` — if referenced externally; else keep private
+
+Keep private: `ShellControllerInner`.
+
+## Proposed layout
+
+```
+blockcontroller/shell/
+├── mod.rs             (re-exports + module decls)
+├── controller.rs      (ShellController + ShellControllerInner struct defs; ConnFactory alias)
+├── lifecycle.rs       (impl Controller: start/stop/get_runtime_status wiring + status mgmt + meta helpers)
+├── pty.rs             (pty_size_from_rt_opts + platform shell detection w/ its #[cfg] guards)
+├── spawn.rs           (command building, env/PATH setup — the ~200-line block from start())
+├── io_tasks.rs        (the read / input / wait async task closures)
+├── file_ops.rs        (handle_append_block_file, persist_to_blockfile_silent, mirror_append_to_global, resolve_global_output_zone)
+├── indexing.rs        (rebuild_output_idx, OUTPUT_IDX_HEADER_LEN)
+├── translation.rs     (extract_agent_events, accumulate_and_translate)
+└── tests.rs           (the 769-line #[cfg(test)] mod tests)
+```
+
+## Execution notes — HIGHER RISK than the flat splits
+
+- **The trait impl must stay one `impl Controller for ShellController` block.** Rust does not allow splitting one inherent/trait impl across files by simply moving methods. Two viable approaches:
+  1. **Keep `impl Controller` whole in `lifecycle.rs`**, and move the big *free-function* helpers (spawn command-builder, io task bodies, file_ops, indexing, translation) into sibling modules that `lifecycle.rs` calls. The `start()` method body then calls `spawn::build_command(...)`, `io_tasks::spawn_read_loop(...)`, etc. This is the recommended approach — extract the helper bodies, keep the trait impl as the orchestrator.
+  2. If any helper is currently an inherent method (`impl ShellController { fn ... }`), it can move to its own `impl ShellController` block in another file (multiple inherent impl blocks ARE allowed across files in the same crate).
+- Preserve every `#[cfg(unix)]` / `#[cfg(windows)]` / `#[cfg(not(windows))]` guard exactly. Do not change which platform compiles which code.
+- Each submodule gets its own `use` imports; no `#![allow(unused_imports)]`.
+- Because a trait impl calls into moved free functions, those functions must be `pub(super)` or `pub(crate)` as needed.
+
+## Verification gate
+
+- `cargo check` + `cargo check --tests` clean on Windows, zero new warnings
+- `cargo test shell` (or `cargo test blockcontroller::shell`) — all 30+ tests pass
+- Manual re-read of every moved `#[cfg]`-guarded block to confirm guard integrity (CI ubuntu run covers Unix compile)
+- reagent review
+
+## Risk: **Medium.** Trait-impl boundary + platform cfg + hot-path PTY code. Do approach (1): keep `impl Controller` intact, extract helper bodies only. Verify tests pass before pushing.


### PR DESCRIPTION
## Summary
Adds execution specs for the next modularization batch (the "Large" tier, 1,500–3,000 line files) — follow-on to the merged critical-tier run (#1880–#1897).

- `SPEC_LARGE_TIER_MODULARIZATION_INDEX` — overview, sequencing, shared rules/lessons
- `SPEC_MODULARIZE_AGENT_SESSION` (2,801, low risk)
- `SPEC_MODULARIZE_CEF_CLIENT` (2,377, medium)
- `SPEC_MODULARIZE_SHELL` (2,394, medium — trait-impl care)
- `SPEC_MODULARIZE_LAUNCHER_MAIN` (2,264, high — touches isolation invariants I1–I6)

Each spec has the real file structure, exact public API surface with callers, a concrete submodule layout, and per-file risk callouts. Docs only.

<!-- agentmux:agent_id=agent1 -->