### PR TITLE
feat(linux): window transparency/opacity via _NET_WM_WINDOW_OPACITY (Windows/macOS parity)

### DIFF
--- a/.changesets/1782973254-feat-linux-window-transparency-opacity-via-net-wm-window-opa-0uf1.md
+++ b/.changesets/1782973254-feat-linux-window-transparency-opacity-via-net-wm-window-opa-0uf1.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(linux): window transparency/opacity via _NET_WM_WINDOW_OPACITY (Windows/macOS parity)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "whoami",
  "windows-sys 0.59.0",
  "winres",
+ "x11rb",
 ]
 
 [[package]]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -111,6 +111,10 @@ libc = "0.2"
 # the host already bundles libvulkan.so.1. See app.rs `has_hardware_vulkan` and
 # docs/specs/SPEC_LINUX_GPU_BACKEND_PRECEDENCE_2026_06_13.md.
 ash = "0.38"
+# EWMH `_NET_WM_WINDOW_OPACITY` for Track 1 uniform window alpha
+# (SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01, Linux arm). Same crate the
+# launcher's splash already uses.
+x11rb = "0.13"
 
 [dev-dependencies]
 # Property tests for the shadow projection (master spec §8.14

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -572,20 +572,68 @@ unsafe fn ensure_macos_native_window_buttons(nsview: *mut std::ffi::c_void) {
 // CefApp + BrowserProcessHandler
 // ---------------------------------------------------------------------------
 
+/// The ozone platform this process appended to the command line (Linux).
+/// Unset when nothing was appended (pure X11 session → Chromium's X11
+/// default). Read by `ui_tasks::SetWindowAlphaTask` to decide whether
+/// `window_handle()` is an X11 XID that `_NET_WM_WINDOW_OPACITY` can target.
+#[cfg(target_os = "linux")]
+pub static SELECTED_OZONE_PLATFORM: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
 /// Read `window:transparent` from the user's settings.json before CefInitialize.
 /// Gates the transparent-compositing command-line flags so non-transparent
 /// windows don't pay the LCD-text and opacity-flash penalties. Returns false
 /// if the file is absent or the key is missing (default = opaque).
 fn read_window_transparent_setting() -> bool {
-    fn inner() -> Option<bool> {
-        let config_dir = std::env::var_os("AGENTMUX_CONFIG_DIR")
-            .map(std::path::PathBuf::from)
-            .or_else(|| agentmux_common::DataPaths::from_env().map(|p| p.config_dir))?;
-        let text = std::fs::read_to_string(config_dir.join("settings.json")).ok()?;
-        let v: serde_json::Value = serde_json::from_str(&text).ok()?;
-        v.get("window:transparent").and_then(|v| v.as_bool())
+    // Candidate locations for the LIVE settings.json, in priority order —
+    // mirrors srv's `config_watcher_fs::resolve_settings_dir()` (the file the
+    // settings UI actually edits), then legacy/per-instance fallbacks:
+    //   1. $AGENTMUX_SETTINGS_DIR/settings.json (explicit override)
+    //   2. $AGENTMUX_CONFIG_HOME/../../settings.json (channels-root shared
+    //      file — the modern location, e.g. ~/.agentmux/channels/settings.json)
+    //   3. $AGENTMUX_CONFIG_DIR/settings.json (per-instance config dir)
+    //   4. ~/.agentmux/channels/settings.json
+    //   5. ~/.agentmux/settings.json (legacy)
+    // First file that exists wins. The old code checked ONLY (3), which is
+    // empty in every real deployment — so `window:transparent` silently read
+    // `false` for everyone on Linux/macOS.
+    fn candidates() -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        if let Some(d) = std::env::var_os("AGENTMUX_SETTINGS_DIR").filter(|s| !s.is_empty()) {
+            out.push(std::path::PathBuf::from(d).join("settings.json"));
+        }
+        if let Some(d) = std::env::var_os("AGENTMUX_CONFIG_HOME").filter(|s| !s.is_empty()) {
+            let p = std::path::PathBuf::from(d);
+            if let Some(root) = p.parent().and_then(|p| p.parent()) {
+                out.push(root.join("settings.json"));
+            }
+        }
+        if let Some(d) = std::env::var_os("AGENTMUX_CONFIG_DIR").filter(|s| !s.is_empty()) {
+            out.push(std::path::PathBuf::from(d).join("settings.json"));
+        } else if let Some(p) = agentmux_common::DataPaths::from_env().map(|p| p.config_dir) {
+            out.push(p.join("settings.json"));
+        }
+        if let Some(home) = dirs::home_dir() {
+            out.push(home.join(".agentmux").join("channels").join("settings.json"));
+            out.push(home.join(".agentmux").join("settings.json"));
+        }
+        out
     }
-    inner().unwrap_or(false)
+    for path in candidates() {
+        if !path.exists() {
+            continue;
+        }
+        // settings.json is JSONC (comments + trailing commas) — a strict
+        // serde_json parse fails on the shipped template. Use the same
+        // lenient reader the settings command path uses.
+        let map = crate::commands::platform::read_settings_jsonc(&path);
+        if let Some(v) = map.get("window:transparent").and_then(|v| v.as_bool()) {
+            tracing::info!("window:transparent={} (from {})", v, path.display());
+            return v;
+        }
+        // File exists but has no (uncommented) key → default false, but keep
+        // scanning lower-priority locations in case an older file has it.
+    }
+    false
 }
 
 wrap_app! {
@@ -725,12 +773,31 @@ wrap_app! {
                         let on_wayland = std::env::var("WAYLAND_DISPLAY")
                             .map(|s| !s.is_empty())
                             .unwrap_or(false);
-                        on_wayland.then(|| "wayland".to_string())
+                        if !on_wayland {
+                            return None;
+                        }
+                        // Track 1 window transparency (uniform whole-window
+                        // alpha, SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01) is
+                        // delivered via the EWMH `_NET_WM_WINDOW_OPACITY` X11
+                        // property — native Wayland has no equivalent protocol
+                        // Chromium supports. Route transparent windows through
+                        // XWayland (the universal default until CEF 148) so the
+                        // property applies; opaque users keep native Wayland.
+                        // An explicit AGENTMUX_OZONE_PLATFORM still wins above.
+                        if read_window_transparent_setting() {
+                            tracing::info!(
+                                "window:transparent=true → ozone-platform=x11 (XWayland) for _NET_WM_WINDOW_OPACITY"
+                            );
+                            Some("x11".to_string())
+                        } else {
+                            Some("wayland".to_string())
+                        }
                     });
                     if let Some(platform) = ozone {
                         let oz_key = CefString::from("ozone-platform");
                         let oz_val = CefString::from(platform.as_str());
                         cmd.append_switch_with_value(Some(&oz_key), Some(&oz_val));
+                        let _ = crate::app::SELECTED_OZONE_PLATFORM.set(platform);
                     }
 
                     // Linux sandbox: use kernel namespace isolation instead of the setuid

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1133,7 +1133,7 @@ fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
 
 // --- Settings helpers (ported from src-tauri/src/commands/platform.rs) ---
 
-fn read_settings_jsonc(path: &std::path::Path) -> serde_json::Map<String, serde_json::Value> {
+pub(crate) fn read_settings_jsonc(path: &std::path::Path) -> serde_json::Map<String, serde_json::Value> {
     if !path.exists() {
         return serde_json::Map::new();
     }

--- a/agentmux-cef/src/commands/window/transparency.rs
+++ b/agentmux-cef/src/commands/window/transparency.rs
@@ -18,8 +18,9 @@
 //             (Win32 window-style ops are safe from any thread).
 //   macOS   — [NSWindow setAlphaValue:], via ui_tasks::post_set_window_alpha
 //             (AppKit → must run on the UI thread).
-//   Linux   — not yet implemented (needs _NET_WM_WINDOW_OPACITY; owned by the
-//             Linux track of SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01).
+//   Linux   — EWMH _NET_WM_WINDOW_OPACITY (X11/XWayland — the default ozone),
+//             via ui_tasks::post_set_window_alpha (CEF Views handle → must run
+//             on the UI thread). Native-Wayland ozone: no protocol, no-op.
 
 use std::sync::Arc;
 
@@ -76,11 +77,17 @@ pub fn set_window_transparency(state: &Arc<AppState>, args: &serde_json::Value) 
         crate::ui_tasks::post_set_window_alpha(state, &label, alpha);
     }
 
+    // Linux — Track 1 (SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01): EWMH
+    // _NET_WM_WINDOW_OPACITY, the X11/XWayland analogue of the Win32 layered
+    // window and NSWindow.alphaValue arms above. Native-Wayland ozone has no
+    // uniform-alpha protocol; the UI task warns and no-ops there.
+    #[cfg(target_os = "linux")]
+    {
+        let alpha = if transparent { opacity.clamp(0.0, 1.0) } else { 1.0 };
+        crate::ui_tasks::post_set_window_alpha(state, &label, alpha);
+    }
+
     let _ = state;
-    // Linux — still a no-op here: uniform alpha needs _NET_WM_WINDOW_OPACITY
-    // (X11/XWayland); owned by the Linux track of the same spec.
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    let _ = (transparent, opacity);
 
     Ok(serde_json::Value::Null)
 }
@@ -181,6 +188,22 @@ pub fn set_window_opacity(
     // windows semi-transparent after restore). Applies NSWindow.alphaValue
     // on the UI thread via SetWindowAlphaTask.
     #[cfg(target_os = "macos")]
+    for ev in &out.events {
+        match ev {
+            crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity, .. } => {
+                crate::ui_tasks::post_set_window_alpha(state, ev_label, *ev_opacity as f64);
+            }
+            crate::reducer::HostEvent::WindowOpacityCleared { label: ev_label, .. } => {
+                crate::ui_tasks::post_set_window_alpha(state, ev_label, 1.0);
+            }
+            _ => {}
+        }
+    }
+
+    // Linux mirror — same reducer events, same both-arms requirement
+    // (reagent P1 on #868). Applies _NET_WM_WINDOW_OPACITY on the UI thread
+    // via SetWindowAlphaTask.
+    #[cfg(target_os = "linux")]
     for ev in &out.events {
         match ev {
             crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity, .. } => {

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -334,6 +334,88 @@ unsafe fn macos_set_window_alpha_by_number(wnum: isize, alpha: f64) -> bool {
     true
 }
 
+// ── Window alpha (Linux/X11 uniform whole-window opacity) ────────────────
+// Track 1 of SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01, Linux arm: the EWMH
+// analogue of Win32 LWA_ALPHA / NSWindow.alphaValue. The compositor (Mutter,
+// KWin, picom, xfwm4) fades the finished window over the desktop — including
+// under XWayland, which is AgentMux's default ozone platform. Post-render:
+// needs no CEF/renderer cooperation. Native-Wayland ozone has no equivalent
+// protocol; there we log once and no-op (per-pixel Track 2 is the only route).
+
+#[cfg(target_os = "linux")]
+wrap_task! {
+    pub struct SetWindowAlphaTask {
+        state: Arc<AppState>,
+        label: String,
+        alpha: f64,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // browser_view.window() returns None post-load on Linux (same
+            // CEF behaviour that broke GetWindowPositionTask — see the
+            // state.windows fallback there). state.windows is populated at
+            // on_window_created and stays valid for the window's lifetime.
+            let window = get_window_on_ui(&self.state, &self.label)
+                .or_else(|| self.state.windows.lock().get(&self.label).cloned());
+            let Some(window) = window else {
+                tracing::warn!(label = %self.label, "[opacity] SetWindowAlphaTask: no window for label");
+                return;
+            };
+            // Under ozone-x11 `window_handle()` is the X11 Window XID. Under
+            // native Wayland it is not an XID and there is no uniform-alpha
+            // protocol at all — the host routes `window:transparent=true`
+            // sessions through XWayland (app.rs ozone selection), so this
+            // guard only fires on an explicit AGENTMUX_OZONE_PLATFORM=wayland
+            // override or when opacity is requested with transparency off.
+            if crate::app::SELECTED_OZONE_PLATFORM.get().map(String::as_str) == Some("wayland") {
+                tracing::warn!("[opacity] uniform window alpha unsupported on native Wayland (no protocol); set window:transparent=true (XWayland) or use per-pixel transparency");
+                return;
+            }
+            let xid = window.window_handle() as u32;
+            if xid == 0 {
+                tracing::warn!(label = %self.label, "[opacity] SetWindowAlphaTask: null X11 window handle");
+                return;
+            }
+            match x11_set_window_opacity(xid, self.alpha) {
+                Ok(()) => tracing::info!(label = %self.label, alpha = self.alpha, "[opacity] applied _NET_WM_WINDOW_OPACITY"),
+                Err(e) => tracing::warn!(label = %self.label, "[opacity] X11 property set failed: {e}"),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn post_set_window_alpha(state: &Arc<AppState>, label: &str, alpha: f64) {
+    let mut task = SetWindowAlphaTask::new(state.clone(), label.to_string(), alpha);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
+/// Set (or clear, when alpha >= 1.0) the EWMH `_NET_WM_WINDOW_OPACITY`
+/// CARDINAL/32 property on the toplevel client window. Value is
+/// alpha × 0xFFFFFFFF. Modern compositors read it from the client window.
+#[cfg(target_os = "linux")]
+fn x11_set_window_opacity(xid: u32, alpha: f64) -> Result<(), Box<dyn std::error::Error>> {
+    use x11rb::connection::Connection;
+    use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _, PropMode};
+    use x11rb::wrapper::ConnectionExt as _;
+
+    let (conn, _screen) = x11rb::connect(None)?;
+    let atom = conn
+        .intern_atom(false, b"_NET_WM_WINDOW_OPACITY")?
+        .reply()?
+        .atom;
+    if alpha >= 1.0 {
+        conn.delete_property(xid, atom)?.check()?;
+    } else {
+        let value = (alpha.clamp(0.0, 1.0) * u32::MAX as f64) as u32;
+        conn.change_property32(PropMode::REPLACE, xid, atom, AtomEnum::CARDINAL, &[value])?
+            .check()?;
+    }
+    conn.flush()?;
+    Ok(())
+}
+
 // ── Move window ───────────────────────────────────────────────────────────
 
 wrap_task! {

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -396,24 +396,72 @@ pub fn post_set_window_alpha(state: &Arc<AppState>, label: &str, alpha: f64) {
 /// alpha × 0xFFFFFFFF. Modern compositors read it from the client window.
 #[cfg(target_os = "linux")]
 fn x11_set_window_opacity(xid: u32, alpha: f64) -> Result<(), Box<dyn std::error::Error>> {
+    use std::cell::RefCell;
     use x11rb::connection::Connection;
-    use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _, PropMode};
+    use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, PropMode};
+    use x11rb::rust_connection::RustConnection;
     use x11rb::wrapper::ConnectionExt as _;
 
-    let (conn, _screen) = x11rb::connect(None)?;
-    let atom = conn
-        .intern_atom(false, b"_NET_WM_WINDOW_OPACITY")?
-        .reply()?
-        .atom;
-    if alpha >= 1.0 {
-        conn.delete_property(xid, atom)?.check()?;
-    } else {
-        let value = (alpha.clamp(0.0, 1.0) * u32::MAX as f64) as u32;
-        conn.change_property32(PropMode::REPLACE, xid, atom, AtomEnum::CARDINAL, &[value])?
-            .check()?;
+    // One connection + interned atom, cached per thread — this only ever runs
+    // on the CEF UI thread (SetWindowAlphaTask), so thread_local needs no
+    // locking. Avoids a fresh socket + intern_atom round-trip per event when
+    // the user drags the opacity slider (reagent P1 on #1905). On an X error
+    // the cache is dropped and we reconnect once — covers an XWayland restart
+    // without reintroducing per-event churn on the happy path.
+    thread_local! {
+        static X11_OPACITY_CONN: RefCell<Option<(RustConnection, Atom)>> =
+            const { RefCell::new(None) };
     }
-    conn.flush()?;
-    Ok(())
+
+    fn connect() -> Result<(RustConnection, Atom), Box<dyn std::error::Error>> {
+        let (conn, _screen) = x11rb::connect(None)?;
+        let atom = conn
+            .intern_atom(false, b"_NET_WM_WINDOW_OPACITY")?
+            .reply()?
+            .atom;
+        Ok((conn, atom))
+    }
+
+    fn apply(
+        conn: &RustConnection,
+        atom: Atom,
+        xid: u32,
+        alpha: f64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if alpha >= 1.0 {
+            conn.delete_property(xid, atom)?.check()?;
+        } else {
+            let value = (alpha.clamp(0.0, 1.0) * u32::MAX as f64) as u32;
+            conn.change_property32(PropMode::REPLACE, xid, atom, AtomEnum::CARDINAL, &[value])?
+                .check()?;
+        }
+        conn.flush()?;
+        Ok(())
+    }
+
+    X11_OPACITY_CONN.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(connect()?);
+        }
+        let (conn, atom) = slot.as_ref().expect("slot populated above");
+        match apply(conn, *atom, xid, alpha) {
+            Ok(()) => Ok(()),
+            Err(_) => {
+                // Cached connection may be dead — retry once on a fresh one,
+                // and only re-cache it if the retry succeeds (a persistent
+                // error like BadWindow shouldn't evict a healthy connection
+                // slot with a doomed one… nor cache anything at all).
+                *slot = None;
+                let (fresh_conn, fresh_atom) = connect()?;
+                let out = apply(&fresh_conn, fresh_atom, xid, alpha);
+                if out.is_ok() {
+                    *slot = Some((fresh_conn, fresh_atom));
+                }
+                out
+            }
+        }
+    })
 }
 
 // ── Move window ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Linux arm of **Track 1** (`SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01`) — uniform whole-window alpha over the desktop, the same user-visible behavior Windows (`WS_EX_LAYERED`) and macOS (#1895) already ship. Executes `docs/plans/PLAN_LINUX_TRANSPARENCY_AGENTU_2026_07_01.md` Task L1, plus two latent-bug fixes the plan didn't anticipate (both were preventing ANY transparency setting from having an effect on Linux):

1. **EWMH `_NET_WM_WINDOW_OPACITY` UI task** (`ui_tasks/window.rs`) + arms in `set_window_transparency` / `set_window_opacity` mirroring the macOS ones exactly (both `Applied` and `Cleared` events — reagent P1 on #868). Includes the `state.windows` fallback because `browser_view.window()` returns `None` post-load on Linux (the #1823 lesson).
2. **`read_window_transparent_setting` never actually read the setting**: strict `serde_json` parse of a JSONC file (comments + trailing commas) + wrong location (per-instance `AGENTMUX_CONFIG_DIR`, empty everywhere; live settings sit at the channels root). Now uses the lenient `read_settings_jsonc` + srv's `resolve_settings_dir` path cascade. Windows/macOS Track 1 was unaffected because it applies via runtime IPC — but this read gates the Track 2 per-pixel CEF flags on every platform, so those were silently off for everyone too.
3. **Ozone routing**: main now auto-selects native Wayland (CEF 148), which has no uniform-alpha protocol. `window:transparent=true` → `ozone-platform=x11` (XWayland) so the EWMH property applies; opaque users keep native Wayland; explicit `AGENTMUX_OZONE_PLATFORM` still wins. Chosen platform recorded in `SELECTED_OZONE_PLATFORM` for a useful no-op warning under forced native Wayland.

## Verification (live, GNOME/Mutter, XWayland)

- Host log: `window:transparent=true (from ~/.agentmux/channels/settings.json)` → `ozone-platform=x11 (XWayland)` → `[opacity] applied _NET_WM_WINDOW_OPACITY alpha=0.7`
- Eyes (user-confirmed): whole window fades over the desktop; the Settings opacity slider drives it live
- `window:transparent=false` → property deleted (alpha ≥ 1.0 path), fully opaque
- Native-Wayland override → clean warn + no-op, no crash

## Known follow-up (not in this PR)

The first `set_window_transparency` IPC at startup can arrive with `opacity=1` before the settings tick settles — window starts fully opaque until the next settings change. Tracked separately.

Sibling: macOS #1895 · CEF per-pixel track: agentmuxai/cef#4 (Linux libcef `148.0.20-3` released)

<!-- agentmux:agent_id= -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)