### PR TITLE
fix(launcher): macOS build break from #1907 (splash_mac crate-root call)

### DIFF
--- a/.changesets/1782993804-fix-launcher-qualify-forward-open-new-window-or-log-path-in--tbnw.md
+++ b/.changesets/1782993804-fix-launcher-qualify-forward-open-new-window-or-log-path-in--tbnw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): qualify forward_open_new_window_or_log path in splash_mac (macOS build break from #1907)

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -213,7 +213,7 @@ unsafe extern "C" fn should_handle_reopen(
     match REOPEN_TARGET.get() {
         Some((data_dir, dir_hash)) => {
             crate::log("reopen-hook:fired proc=launcher — forwarding open_new_window");
-            crate::forward_open_new_window_or_log(data_dir, dir_hash);
+            crate::second_instance::forward_open_new_window_or_log(data_dir, dir_hash);
         }
         // Reopen fired before the socket was bound (host still starting): the
         // first window is already on its way, so do nothing (SPEC §6.4).


### PR DESCRIPTION
One-line fix: #1907 moved `forward_open_new_window_or_log` from `main.rs` into `second_instance`; macOS-only `splash_mac.rs:216` still called `crate::forward_open_new_window_or_log` → `cargo check` fails on macOS (E0425). Qualified the path per the compiler's suggestion.

This is the **second** macOS-only compile break from a modularization refactor today — #1891 broke `ui_tasks/platform_macos.rs` the same way (fixed in #1895). No CI compiles the macOS-gated modules. Suggested follow-up: a `cargo check` gate on a macOS runner (or `--target aarch64-apple-darwin` cross-check) for PRs touching `agentmux-cef`/`agentmux-launcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)