### PR TITLE
feat(ui): restore Theme and Opacity submenus in hamburger menu

### DIFF
--- a/.changesets/1782997612-feat-ui-restore-theme-and-opacity-submenus-in-hamburger-menu-2yeq.md
+++ b/.changesets/1782997612-feat-ui-restore-theme-and-opacity-submenus-in-hamburger-menu-2yeq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(ui): restore Theme and Opacity submenus in hamburger menu

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -12,11 +12,14 @@
 // Every menu action resolves to a module-level store/RPC primitive, so the
 // component is fully self-contained (no TabBar state coupling).
 
-import { createTab, getApi, openOrFocusPaneByView } from "@/store/global";
+import { createTab, getApi, openOrFocusPaneByView, settingsAtom } from "@/store/global";
 import { FlyoutMenu } from "@/app/element/flyoutmenu";
 import { fireAndForget } from "@/util/util";
 import { openModal } from "@/app/store/modalmodel";
 import { CommandPaletteModal } from "@/app/modals/command-palette";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { THEME_OPTIONS } from "@/app/menu/base-menus";
 import { isMacOS } from "@/util/platformutil";
 import { createMemo, type JSX } from "solid-js";
 import "./hamburger-menu.scss";
@@ -35,6 +38,45 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
         const mac = isMacOS();
         const kbd = (m: string, w: string) => (mac ? m : w);
 
+        const settings = settingsAtom() ?? ({} as any);
+
+        const currentTheme = (settings["window:theme"] as string) || "default";
+        const themeSubItems: MenuItem[] = THEME_OPTIONS.map((opt) => ({
+            label: opt.label,
+            checked: currentTheme === opt.id,
+            onClick: () => {
+                fireAndForget(() =>
+                    RpcApi.SetConfigCommand(TabRpcClient, { "window:theme": opt.id } as any),
+                );
+            },
+        }));
+
+        const rawOpacity = (settings["window:opacity"] as number) ?? 0.8;
+        const isTransparent = (settings["window:transparent"] as boolean) ?? false;
+        const effectiveOpacity = isTransparent ? rawOpacity : 1.0;
+        const opacityStep = Math.round(effectiveOpacity * 20) / 20;
+        const opacitySubItems: MenuItem[] = [];
+        for (let pct = 100; pct >= 35; pct -= 5) {
+            const value = pct / 100;
+            opacitySubItems.push({
+                label: `${pct}%`,
+                checked: Math.abs(value - opacityStep) < 0.001,
+                onClick: () => {
+                    fireAndForget(() =>
+                        value < 1.0
+                            ? RpcApi.SetConfigCommand(TabRpcClient, {
+                                  "window:opacity": value,
+                                  "window:transparent": true,
+                              } as any)
+                            : RpcApi.SetConfigCommand(TabRpcClient, {
+                                  "window:opacity": 1.0,
+                                  "window:transparent": false,
+                              } as any),
+                    );
+                },
+            });
+        }
+
         return [
             {
                 label: "New Tab",
@@ -48,6 +90,17 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
                 icon: "window-restore",
                 shortcut: kbd("⌘⇧N", "Ctrl+Shift+N"),
                 onClick: () => getApi().openNewWindow().catch(console.error),
+            },
+            { label: "", divider: true },
+            {
+                label: "Theme",
+                icon: "palette",
+                subItems: themeSubItems,
+            },
+            {
+                label: "Opacity",
+                icon: "circle-half-stroke",
+                subItems: opacitySubItems,
             },
             { label: "", divider: true },
             {


### PR DESCRIPTION
## Summary
Restores the **Theme** and **Opacity** submenus to the hamburger (≡) menu. They were intentionally moved into the Settings pane's Appearance section in #1792 (commit `88fe22f7`); this brings the quick-access submenus back to the hamburger per user request.

- Re-adds the theme submenu (from `THEME_OPTIONS`) and the opacity submenu (100%→35% in 5% steps), placed between "New Window" and "Settings".
- Both write the same config keys as before (`window:theme`, `window:opacity`, `window:transparent`) via `RpcApi.SetConfigCommand`.
- Verbatim restore of the removed code; all supporting infra (`THEME_OPTIONS`, `settingsAtom`, `SetConfigCommand`, `--window-opacity` wiring) is unchanged on main.

## Note
The Settings pane's Appearance section (added in #1792) still exists and writes the same keys, so Theme/Opacity are now reachable from **both** the hamburger submenus and the Settings pane. Both paths write identical config; this is intentional (quick access + full pane). If a single source of truth is preferred, say the word and I'll gate one.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Hamburger ≡ → Theme shows all themes with the active one checked; selecting applies it
- [ ] Hamburger ≡ → Opacity shows 35–100%; selecting sets opacity + toggles transparency

<!-- agentmux:agent_id=agent1 -->