### PR TITLE
fix(agent): composer strip near input now shows real session totals

### DIFF
--- a/.changesets/1782997838-fix-agent-compute-real-running-totals-for-composer-strip-ins-mx7z.md
+++ b/.changesets/1782997838-fix-agent-compute-real-running-totals-for-composer-strip-ins-mx7z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): compute real running totals for composer strip instead of reusing per-query stats

--- a/docs/specs/SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md
+++ b/docs/specs/SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md
@@ -1,0 +1,152 @@
+# SPEC: Agent Pane Session Cost/Token Totals
+
+**Date:** 2026-07-02
+**Status:** Proposed
+**Area:** Agent pane (frontend)
+**Severity:** P2 — misleading UI, no data loss
+
+---
+
+## Problem
+
+The agent pane's composer strip (`AgentComposerStrip`, the slim status row directly
+above the textarea) is documented as showing "final session totals" next to the token
+count and elapsed time. In practice it shows the exact same number as the per-turn
+"Worked" delimiter row (`AgentWorkingRow`, rendered once below the transcript) —
+i.e. the cost/tokens for the single most-recently-completed query, not a running
+total across every query sent in the pane's lifetime.
+
+User-visible symptom: after sending several queries in one pane, the number shown
+"near the input" never grows past what a single query cost — it should be the sum
+across all queries in the session, resetting only when the pane/session resets.
+
+---
+
+## Root Cause
+
+There is exactly one piece of state involved, `AgentPaneState.sessionStats`
+(`frontend/app/store/agent-pane-state/types.ts:167`), and it is *correctly*
+per-turn:
+
+- `TurnStart` nulls it (`reducer.ts:382`).
+- `TurnEnd` overwrites it with `mergeStats(command.stats, state.turnTokens)`
+  (`reducer.ts:409,451`) — the merge combines the just-finished turn's CLI
+  `result` stats with that turn's live token signal. It never reads or adds to
+  the *previous* `sessionStats` value.
+
+Both consumers bind to the identical projected atom:
+
+- `AgentWorkingRow` (`frontend/app/view/agent/components/AgentFooter.tsx:66-141`),
+  wired at `frontend/app/view/agent/agent-view.tsx:822-828` via
+  `sessionStats={agentAtoms().sessionStatsAtom[0]()}`.
+- `AgentComposerStrip` (`frontend/app/view/agent/components/AgentComposerStrip.tsx:97-160`),
+  wired at `agent-view.tsx:984-985` via the same
+  `sessionStats={agentAtoms().sessionStatsAtom[0]()}`.
+
+Since only one such value exists in the whole pane, and both components read it by
+reference, they trivially always match. No cumulative accumulator was ever built —
+the composer strip's doc comment ("Final session totals") was aspirational, not
+implemented. (A genuine cross-turn accumulator does exist —
+`frontend/app/store/token-usage.ts` — but it feeds the global status-bar token
+popover, not this pane-local composer strip, and it is keyed by provider/service,
+not by pane.)
+
+---
+
+## Fix
+
+Add a second, genuinely-cumulative field to `AgentPaneState` — `sessionTotals` —
+that sums each completed turn's stats into a running total for the pane's
+lifetime. Leave `sessionStats` (and `AgentWorkingRow`, which correctly shows
+per-turn data) untouched. Point `AgentComposerStrip` at the new field instead.
+
+### 1. State shape
+
+`frontend/app/store/agent-pane-state/types.ts`
+
+- Add `sessionTotals: SessionStats | null` to `AgentPaneState`, reusing the
+  existing `SessionStats` shape (`cost_usd`, `duration_ms`, `num_turns`,
+  `input_tokens`, `output_tokens`) since the composer strip only ever reads
+  those fields.
+- Initialize to `null` in `initialState()`.
+
+### 2. Reducer accumulation
+
+`frontend/app/store/agent-pane-state/reducer.ts`
+
+- Add an `accumulateStats(totals, merged)` helper next to `mergeStats`: returns
+  a new `SessionStats` summing `cost_usd`, `duration_ms`, `input_tokens`,
+  `output_tokens` (treat missing fields as `0`) and `num_turns` (fallback `1`
+  per completed turn when the CLI didn't report one), seeded from `totals ??
+  { }` when this is the pane's first completed turn.
+- In the `TurnEnd` arm, after computing `merged` (the existing per-turn value),
+  also compute `sessionTotals: accumulateStats(state.sessionTotals, merged)`
+  and include it in the returned state alongside the existing `sessionStats:
+  merged`.
+- Reset `sessionTotals: null` on `TurnReset` (session wipe) alongside the
+  existing `sessionStats: null` reset (`reducer.ts:476`) — a wiped session
+  has no history to total.
+- `TurnStart` does **not** touch `sessionTotals` (unlike `sessionStats`,
+  which intentionally nulls per turn) — totals persist across turns by
+  design.
+
+### 3. Atom + projection wiring
+
+`frontend/app/view/agent/state.ts`
+
+- Add `sessionTotalsAtom: SignalPair<SessionStats | null>`, initialized to
+  `createSignal<SessionStats | null>(null)`, mirroring `sessionStatsAtom`.
+
+`frontend/app/store/agent-pane-state-store.ts`
+
+- Add `sessionTotals: (next: SessionStats | null) => void` to
+  `AgentPaneProjections`.
+- Add the corresponding `proj("sessionTotals", prev.sessionTotals,
+  slot.state.sessionTotals, slot.proj.sessionTotals);` line beside the
+  existing `sessionStats` line (~line 190) in `dispatch()`.
+
+`frontend/app/view/agent/agent-view.tsx`
+
+- Register the new projection: `sessionTotals: a.sessionTotalsAtom[1]` in the
+  `projections` object passed to `registerAgentPane` (~line 214, beside the
+  existing `sessionStats` entry).
+- Rewire `AgentComposerStrip`'s `sessionStats` prop (~line 984-985) to read
+  `agentAtoms().sessionTotalsAtom[0]()` instead of `sessionStatsAtom[0]()`.
+  Leave the `AgentWorkingRow` usage (~line 827) unchanged — it is correctly
+  per-turn today.
+
+### 4. Component prop rename (clarity)
+
+`frontend/app/view/agent/components/AgentComposerStrip.tsx`
+
+- Rename the `sessionStats` prop to `sessionTotals: SessionStats | null` and
+  update its doc comment to accurately describe cumulative totals (no
+  behavior change beyond the name — the prop type is unchanged since both
+  reuse `SessionStats`). Update the one call site in `agent-view.tsx`
+  accordingly.
+
+---
+
+## Non-goals
+
+- No change to `AgentWorkingRow` / per-turn `sessionStats` — that display is
+  already correct (resets to the just-finished turn's own numbers, not a
+  running total).
+- No change to `frontend/app/store/token-usage.ts` (the global status-bar
+  accumulator) — it's a separate, already-working mechanism at a different
+  scope (cross-pane, per-provider) and out of scope here.
+- No backend changes — `AgentEvent::Cost` already carries correct per-run
+  data; this is purely a frontend aggregation gap.
+
+---
+
+## Verification
+
+1. Open an agent pane, send three queries in sequence.
+2. After each query completes, confirm the "Worked" row (below the
+   transcript) shows only that query's own cost/tokens/duration (should NOT
+   equal the running sum).
+3. Confirm the composer strip (above the input) shows the cumulative sum of
+   all completed queries so far, growing after each one.
+4. Trigger a session reset (`TurnReset`) and confirm both values clear to
+   null/empty.

--- a/frontend/app/store/agent-pane-model.test.ts
+++ b/frontend/app/store/agent-pane-model.test.ts
@@ -39,6 +39,7 @@ function noopProjections(): AgentPaneProjections {
     return {
         streaming: () => {},
         sessionStats: () => {},
+        sessionTotals: () => {},
         currentTool: () => {},
         turnTokens: () => {},
         pending: () => {},

--- a/frontend/app/store/agent-pane-registration.test.ts
+++ b/frontend/app/store/agent-pane-registration.test.ts
@@ -43,6 +43,7 @@ function noopProjections(): AgentPaneProjections {
     return {
         streaming: () => {},
         sessionStats: () => {},
+        sessionTotals: () => {},
         currentTool: () => {},
         turnTokens: () => {},
         pending: () => {},

--- a/frontend/app/store/agent-pane-state-store.test.ts
+++ b/frontend/app/store/agent-pane-state-store.test.ts
@@ -36,6 +36,7 @@ function noopProj(): AgentPaneProjections {
     return {
         streaming: () => {},
         sessionStats: () => {},
+        sessionTotals: () => {},
         currentTool: () => {},
         turnTokens: () => {},
         pending: () => {},

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -41,6 +41,8 @@ import { type CommandSource, recordDispatch } from "./command-source";
 export interface AgentPaneProjections {
     streaming: (next: StreamingState) => void;
     sessionStats: (next: SessionStats | null) => void;
+    /** Cumulative session totals — see SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md. */
+    sessionTotals: (next: SessionStats | null) => void;
     currentTool: (next: string | null) => void;
     turnTokens: (next: TurnTokens | null) => void;
     pending: (next: PendingMessage[]) => void;
@@ -188,6 +190,7 @@ export function dispatch(
     };
     proj("streaming", prev.streaming, slot.state.streaming, slot.proj.streaming);
     proj("sessionStats", prev.sessionStats, slot.state.sessionStats, slot.proj.sessionStats);
+    proj("sessionTotals", prev.sessionTotals, slot.state.sessionTotals, slot.proj.sessionTotals);
     proj("currentTool", prev.currentTool, slot.state.currentTool, slot.proj.currentTool);
     proj("turnTokens", prev.turnTokens, slot.state.turnTokens, slot.proj.turnTokens);
     proj("contextTokens",

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -150,6 +150,45 @@ describe("agent-pane-state reducer", () => {
             expect(r.state.sessionStats).toMatchObject({ input_tokens: 70000, output_tokens: 512 });
         });
 
+        // SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md — sessionTotals must
+        // accumulate across turns while sessionStats (per-turn) resets.
+        it("TurnEnd accumulates sessionTotals across multiple turns, unlike per-turn sessionStats", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, {
+                type: "TurnEnd",
+                stats: { input_tokens: 100, output_tokens: 50, cost_usd: 0.01 } as any,
+            }).state;
+            expect(s2.sessionStats).toMatchObject({ input_tokens: 100, output_tokens: 50, cost_usd: 0.01 });
+            expect(s2.sessionTotals).toMatchObject({
+                input_tokens: 100,
+                output_tokens: 50,
+                cost_usd: 0.01,
+                num_turns: 1,
+            });
+
+            // Second query in the same pane — per-turn stats reset on
+            // TurnStart and are replaced (not summed) on TurnEnd, but
+            // sessionTotals must add on top of the first turn's totals.
+            const s3 = update(s2, { type: "TurnStart", at: 200 }).state;
+            expect(s3.sessionStats).toBe(null);
+            expect(s3.sessionTotals).toMatchObject({ input_tokens: 100, output_tokens: 50, cost_usd: 0.01 });
+
+            const s4 = update(s3, {
+                type: "TurnEnd",
+                stats: { input_tokens: 30, output_tokens: 20, cost_usd: 0.002 } as any,
+            }).state;
+            // Per-turn: only reflects this second query.
+            expect(s4.sessionStats).toMatchObject({ input_tokens: 30, output_tokens: 20, cost_usd: 0.002 });
+            // Running total: sum of both queries.
+            expect(s4.sessionTotals).toMatchObject({
+                input_tokens: 130,
+                output_tokens: 70,
+                cost_usd: expect.closeTo(0.012, 10),
+                num_turns: 2,
+            });
+        });
+
         it("TurnReset clears turn-scoped state but keeps subscription + pending", () => {
             const s0 = ready(100);
             const s1 = update(s0, {
@@ -167,6 +206,19 @@ describe("agent-pane-state reducer", () => {
             expect(r.state.pending).toHaveLength(1); // preserved
             expect(r.state.currentTool).toBe(null);
             expect(r.state.turnPhase.kind).toBe("Idle");
+        });
+
+        it("TurnReset clears accumulated sessionTotals (session wipe)", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, {
+                type: "TurnEnd",
+                stats: { input_tokens: 100, output_tokens: 50, cost_usd: 0.01 } as any,
+            }).state;
+            expect(s2.sessionTotals).not.toBeNull();
+            const r = update(s2, { type: "TurnReset" });
+            expect(r.state.sessionStats).toBe(null);
+            expect(r.state.sessionTotals).toBe(null);
         });
     });
 

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -449,6 +449,7 @@ export function update(
                 state: {
                     ...state,
                     sessionStats: merged,
+                    sessionTotals: accumulateStats(state.sessionTotals, merged),
                     currentTool: null,
                     currentToolArg: null,
                     turnTokens: null,
@@ -474,6 +475,7 @@ export function update(
                 state: {
                     ...state,
                     sessionStats: null,
+                    sessionTotals: null,
                     currentTool: null,
                     currentToolArg: null,
                     turnTokens: null,
@@ -927,4 +929,25 @@ function mergeStats(
         return { input_tokens: tokens.input, output_tokens: tokens.output };
     }
     return null;
+}
+
+/**
+ * Sum a just-completed turn's merged stats into the pane's running total.
+ * Unlike mergeStats (which replaces sessionStats per turn), this adds —
+ * missing numeric fields are treated as 0, num_turns falls back to 1 per
+ * completed turn so a CLI that omits it still counts as one query.
+ * See SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md.
+ */
+function accumulateStats(
+    totals: AgentPaneState["sessionTotals"],
+    merged: AgentPaneState["sessionStats"],
+): AgentPaneState["sessionTotals"] {
+    if (!merged) return totals;
+    return {
+        cost_usd: (totals?.cost_usd ?? 0) + (merged.cost_usd ?? 0),
+        duration_ms: (totals?.duration_ms ?? 0) + (merged.duration_ms ?? 0),
+        input_tokens: (totals?.input_tokens ?? 0) + (merged.input_tokens ?? 0),
+        output_tokens: (totals?.output_tokens ?? 0) + (merged.output_tokens ?? 0),
+        num_turns: (totals?.num_turns ?? 0) + (merged.num_turns ?? 1),
+    };
 }

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -165,6 +165,14 @@ export type TurnPhase =
 export interface AgentPaneState {
     streaming: StreamingState;
     sessionStats: SessionStats | null;
+    /**
+     * Cumulative cost/tokens/duration across every completed turn in this
+     * pane's lifetime — unlike `sessionStats` (which is replaced, not
+     * accumulated, on each TurnEnd), this sums into the previous value.
+     * Feeds the composer-strip "totals" display near the input. Cleared
+     * only on TurnReset. See SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md.
+     */
+    sessionTotals: SessionStats | null;
     currentTool: string | null;
     /** First significant argument of the active tool (file path, command, etc.).
      *  Cleared alongside currentTool on ToolEnd / TurnEnd / TurnReset. */
@@ -238,6 +246,7 @@ export interface AgentPaneState {
 export const initialState = (agentId: string): AgentPaneState => ({
     streaming: { agentId, bufferSize: 0, lastEventTime: 0 },
     sessionStats: null,
+    sessionTotals: null,
     currentTool: null,
     currentToolArg: null,
     turnTokens: null,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -212,6 +212,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             projections: {
                 streaming: a.streamingStateAtom[1],
                 sessionStats: a.sessionStatsAtom[1],
+                sessionTotals: a.sessionTotalsAtom[1],
                 currentTool: a.currentToolAtom[1],
                 turnTokens: a.turnTokensAtom[1],
                 contextTokens: a.contextTokensAtom[1],
@@ -981,7 +982,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     status.isLoading()
                     || workingFromPhase(agentAtoms().turnPhaseAtom[0]())
                 }
-                sessionStats={agentAtoms().sessionStatsAtom[0]()}
+                sessionTotals={agentAtoms().sessionTotalsAtom[0]()}
                 turnTokens={agentAtoms().turnTokensAtom[0]()}
                 processCount={processCount()}
                 onProcessBadgeClick={() => {

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -97,8 +97,12 @@ function contextTitle(tokens: number, contextWindow: number | undefined): string
 interface AgentComposerStripProps {
     /** True while a turn is in flight. */
     loading?: boolean;
-    /** Final session totals; non-null after the first TurnEnd. */
-    sessionStats?: SessionStats | null;
+    /**
+     * Cumulative cost/tokens/duration across every completed turn in this
+     * pane's lifetime; non-null after the first TurnEnd. Sums, rather than
+     * replaces, on each turn — see SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md.
+     */
+    sessionTotals?: SessionStats | null;
     /** Live tokens for the in-flight turn. */
     turnTokens?: TurnTokens | null;
     /** Count of OS processes tracked for this agent block. */
@@ -147,8 +151,8 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
         if (props.loading) {
             if (props.turnTokens) parts.push(fmtTokens(props.turnTokens));
             parts.push(fmtElapsed(elapsedMs()));
-        } else if (props.sessionStats) {
-            const s = props.sessionStats;
+        } else if (props.sessionTotals) {
+            const s = props.sessionTotals;
             if (s.input_tokens != null || s.output_tokens != null) {
                 parts.push(fmtTokens({ input: s.input_tokens ?? 0, output: s.output_tokens ?? 0 }));
             }

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -53,6 +53,12 @@ export interface AgentAtoms {
      */
     streamingStateAtom: SignalPair<StreamingState>;
     sessionStatsAtom: SignalPair<SessionStats | null>;
+    /**
+     * Cumulative cost/tokens/duration across every completed turn this
+     * pane's lifetime — feeds the composer-strip totals display. See
+     * SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md.
+     */
+    sessionTotalsAtom: SignalPair<SessionStats | null>;
     currentToolAtom: SignalPair<string | null>;
     turnTokensAtom: SignalPair<TurnTokens | null>;
     /**
@@ -154,6 +160,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
             lastEventTime: 0,
         }),
         sessionStatsAtom: createSignal<SessionStats | null>(null),
+        sessionTotalsAtom: createSignal<SessionStats | null>(null),
         currentToolAtom: createSignal<string | null>(null),
         turnTokensAtom: createSignal<TurnTokens | null>(null),
         contextTokensAtom: createSignal<number | null>(null),


### PR DESCRIPTION
## Summary
- The composer strip above the textarea was documented as "final session totals" but bound to the same per-turn `sessionStats` atom as the per-query "Worked" row below the transcript, so both always showed the same (latest-query-only) numbers instead of a running sum across the session.
- Adds a genuine `sessionTotals` accumulator to `AgentPaneState` that sums cost/tokens/duration on every `TurnEnd` (persists across `TurnStart`, clears only on `TurnReset`), and points the composer strip at it. The per-turn `AgentWorkingRow` display is unchanged — it was already correct.
- See `docs/specs/SPEC_AGENT_SESSION_COST_TOTALS_2026_07_02.md` for the full root-cause writeup and design.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx vitest run` on the touched suites (`agent-pane-state/reducer.test.ts`, `agent-pane-state-store.test.ts`, `agent-pane-registration.test.ts`, `agent-pane-model.test.ts`, `view/agent/state.test.ts`) — 192/192 passing, including 2 new tests covering cross-turn accumulation and reset-on-`TurnReset`
- [ ] Manual: send several queries in an agent pane; confirm the "Worked" row per query stays scoped to that query while the composer-strip total near the input grows across queries and resets on session wipe