### PR TITLE
chore: release v0.49.12

### DIFF
--- a/.changesets/1751338000-feat-toolchain-check-latest-versions-c3d1.md
+++ b/.changesets/1751338000-feat-toolchain-check-latest-versions-c3d1.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(toolchain): Check latest versions button — fetch latest npm versions for provider CLIs

--- a/.changesets/1782825787-fix-editor-restore-preview-source-toggle-remove-split-screen-gvyv.md
+++ b/.changesets/1782825787-fix-editor-restore-preview-source-toggle-remove-split-screen-gvyv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): restore preview/source toggle, remove split-screen default

--- a/.changesets/1782842618-feat-mcp-shellinput-shellstatus-phase-3b-k8m2.md
+++ b/.changesets/1782842618-feat-mcp-shellinput-shellstatus-phase-3b-k8m2.md
@@ -1,6 +1,0 @@
----
-type: minor
----
-feat(mcp): ShellInput + ShellStatus — Phase 3b of persistent shell
-
-Agents can now write to a running shell's stdin (`ShellInput(shell_id, text)`) to answer interactive prompts like `Terminate batch job (Y/N)?`, and query whether a shell is still running with its exit code and line count (`ShellStatus(shell_id)`). Closes item 2 (Phase 3b) in the long-running shell tracking issue.

--- a/.changesets/1782861210-feat-ui-expand-tab-palette-to-14-colors-add-reusable-colorsw-8dc8.md
+++ b/.changesets/1782861210-feat-ui-expand-tab-palette-to-14-colors-add-reusable-colorsw-8dc8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ui): expand tab palette to 14 colors, add reusable ColorSwatchPalette, and show visual pane color panel on all pane header right-clicks

--- a/.changesets/1782861450-fix-browser-pane-unsubclass-hwnds-on-pane-close-to-prevent-f-xm6x.md
+++ b/.changesets/1782861450-fix-browser-pane-unsubclass-hwnds-on-pane-close-to-prevent-f-xm6x.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): unsubclass HWNDs on pane close to prevent focus storm after switching to external browser

--- a/.changesets/1782874440-fix-floating-pane-relabel-promoted-pane-pool-windows-floatin-6x2q.md
+++ b/.changesets/1782874440-fix-floating-pane-relabel-promoted-pane-pool-windows-floatin-6x2q.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): relabel promoted pane-pool windows floating-pool-* -> floating-* so the status bar counts them (Windows)

--- a/.changesets/1782900000-feat-jekt-security-markers-sensitive-tier-detection.md
+++ b/.changesets/1782900000-feat-jekt-security-markers-sensitive-tier-detection.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): JEKT markers, JektTier enum, sensitive-tier detection, and CLAUDE.md security rules

--- a/.changesets/1782901221-refactor-srv-split-agent-handlers-into-submodules-2x5z.md
+++ b/.changesets/1782901221-refactor-srv-split-agent-handlers-into-submodules-2x5z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): split agent_handlers into submodules

--- a/.changesets/1782902034-refactor-srv-split-app-api-into-submodules-oc1t.md
+++ b/.changesets/1782902034-refactor-srv-split-app-api-into-submodules-oc1t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): split app_api into submodules

--- a/.changesets/1782924586-feat-srv-persist-the-7-granular-layout-events-via-the-reduce-2kbh.md
+++ b/.changesets/1782924586-feat-srv-persist-the-7-granular-layout-events-via-the-reduce-2kbh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): persist the 7 granular layout events via the reducer→subscriber path (carry resulting tree; no algebra re-run)

--- a/.changesets/1782937319-feat-pane-color-swatch-submenu.md
+++ b/.changesets/1782937319-feat-pane-color-swatch-submenu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(pane): add "Pane Color" context-menu submenu with inline color swatches

--- a/.changesets/1782937681-fix-flyoutmenu-open-over-native-panes.md
+++ b/.changesets/1782937681-fix-flyoutmenu-open-over-native-panes.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(menu): open hamburger, "More" widget dropdown, flyout menus, and popovers in place over browser/webview panes instead of floating to the window edge

--- a/.changesets/1782938765-refactor-srv-extract-store-rs-inline-tests-to-submodule-efys.md
+++ b/.changesets/1782938765-refactor-srv-extract-store-rs-inline-tests-to-submodule-efys.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): extract store.rs inline tests to submodule

--- a/.changesets/1782939074-refactor-srv-split-rpc-types-into-domain-submodules-u5jo.md
+++ b/.changesets/1782939074-refactor-srv-split-rpc-types-into-domain-submodules-u5jo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): split rpc_types into domain submodules

--- a/.changesets/1782953967-refactor-srv-split-service-into-concern-submodules-bxdr.md
+++ b/.changesets/1782953967-refactor-srv-split-service-into-concern-submodules-bxdr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): split service into concern submodules

--- a/.changesets/1782954204-feat-muxbus-point-desktop-sign-in-at-branded-auth-muxbus-age-c052.md
+++ b/.changesets/1782954204-feat-muxbus-point-desktop-sign-in-at-branded-auth-muxbus-age-c052.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(muxbus): point desktop sign-in at branded auth.muxbus.agentmux.ai

--- a/.changesets/1782954470-fix-browser-tearoff-black-screen.md
+++ b/.changesets/1782954470-fix-browser-tearoff-black-screen.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): fix black screen when tearing a browser off into a floating pane (cross-window AlreadyLive race)

--- a/.changesets/1782954594-feat-srv-v1-standalone-mcp-server-and-skill-primitives-trust-nzro.md
+++ b/.changesets/1782954594-feat-srv-v1-standalone-mcp-server-and-skill-primitives-trust-nzro.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): v1 standalone MCP Server and Skill primitives (Trust Center)

--- a/.changesets/1782955411-refactor-cef-split-ui-tasks-into-category-submodules-1ddg.md
+++ b/.changesets/1782955411-refactor-cef-split-ui-tasks-into-category-submodules-1ddg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(cef): split ui_tasks into category submodules

--- a/.changesets/1782956072-feat-macos-window-transparency-opacity-via-nswindow-alphaval-h2me.md
+++ b/.changesets/1782956072-feat-macos-window-transparency-opacity-via-nswindow-alphaval-h2me.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(macos): window transparency/opacity via NSWindow alphaValue (Windows parity)

--- a/.changesets/1782956392-refactor-frontend-split-rpc-api-into-domain-modules-lo5p.md
+++ b/.changesets/1782956392-refactor-frontend-split-rpc-api-into-domain-modules-lo5p.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(frontend): split rpc-api into domain modules

--- a/.changesets/1782956857-fix-test-acknowledge-mcp-skill-backend-only-handlers-in-rpc--v91n.md
+++ b/.changesets/1782956857-fix-test-acknowledge-mcp-skill-backend-only-handlers-in-rpc--v91n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(test): acknowledge mcp/skill backend-only handlers in rpc contract baseline

--- a/.changesets/1782957522-refactor-frontend-extract-hooks-from-agent-view-if7v.md
+++ b/.changesets/1782957522-refactor-frontend-extract-hooks-from-agent-view-if7v.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(frontend): extract hooks from agent-view

--- a/.changesets/1782957850-chore-providers-pin-claude-code-cli-to-2-1-198-latest-fjju.md
+++ b/.changesets/1782957850-chore-providers-pin-claude-code-cli-to-2-1-198-latest-fjju.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(providers): pin Claude Code CLI to 2.1.198 (latest)

--- a/.changesets/1782957992-fix-agent-log-log-button-expands-collapses-the-full-entries--fuxp.md
+++ b/.changesets/1782957992-fix-agent-log-log-button-expands-collapses-the-full-entries--fuxp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-log): Log button expands/collapses the full entries directly (remove middle collapse layer)

--- a/.changesets/1782958384-feat-agent-versioned-model-labels-in-the-composer-dropdowns--1tu6.md
+++ b/.changesets/1782958384-feat-agent-versioned-model-labels-in-the-composer-dropdowns--1tu6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): versioned model labels in the composer dropdowns, sourced from the provider registry

--- a/.changesets/1782972226-refactor-srv-split-agent-session-into-submodules-aclb.md
+++ b/.changesets/1782972226-refactor-srv-split-agent-session-into-submodules-aclb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): split agent_session into submodules

--- a/.changesets/1782973032-refactor-cef-split-client-mod-rs-into-submodules-7308.md
+++ b/.changesets/1782973032-refactor-cef-split-client-mod-rs-into-submodules-7308.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(cef): split client/mod.rs into submodules

--- a/.changesets/1782973254-feat-linux-window-transparency-opacity-via-net-wm-window-opa-0uf1.md
+++ b/.changesets/1782973254-feat-linux-window-transparency-opacity-via-net-wm-window-opa-0uf1.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(linux): window transparency/opacity via _NET_WM_WINDOW_OPACITY (Windows/macOS parity)

--- a/.changesets/1782973832-refactor-srv-split-shell-controller-into-submodules-8ksv.md
+++ b/.changesets/1782973832-refactor-srv-split-shell-controller-into-submodules-8ksv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): split shell controller into submodules

--- a/.changesets/1782974746-refactor-launcher-extract-main-rs-logic-into-sibling-modules-d0a3.md
+++ b/.changesets/1782974746-refactor-launcher-extract-main-rs-logic-into-sibling-modules-d0a3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(launcher): extract main.rs logic into sibling modules

--- a/.changesets/1782993804-fix-launcher-qualify-forward-open-new-window-or-log-path-in--tbnw.md
+++ b/.changesets/1782993804-fix-launcher-qualify-forward-open-new-window-or-log-path-in--tbnw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher): qualify forward_open_new_window_or_log path in splash_mac (macOS build break from #1907)

--- a/.changesets/1782997612-feat-ui-restore-theme-and-opacity-submenus-in-hamburger-menu-2yeq.md
+++ b/.changesets/1782997612-feat-ui-restore-theme-and-opacity-submenus-in-hamburger-menu-2yeq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(ui): restore Theme and Opacity submenus in hamburger menu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.11"
+version = "0.49.12"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.11"
+version = "0.49.12"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.11"
+version = "0.49.12"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.11"
+version = "0.49.12"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.11"
+version = "0.49.12"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.11"
+version = "0.49.12"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.11"
+version = "0.49.12"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,42 @@
 # AgentMux Version History
 
+## 0.49.12 — 2026-07-02
+
+- feat(toolchain): Check latest versions button — fetch latest npm versions for provider CLIs
+- fix(editor): restore preview/source toggle, remove split-screen default
+- feat(mcp): ShellInput + ShellStatus — Phase 3b of persistent shell
+- feat(ui): expand tab palette to 14 colors, add reusable ColorSwatchPalette, and show visual pane color panel on all pane header right-clicks
+- fix(browser-pane): unsubclass HWNDs on pane close to prevent focus storm after switching to external browser
+- fix(floating-pane): relabel promoted pane-pool windows floating-pool-* -> floating-* so the status bar counts them (Windows)
+- feat(jekt): JEKT markers, JektTier enum, sensitive-tier detection, and CLAUDE.md security rules
+- refactor(srv): split agent_handlers into submodules
+- refactor(srv): split app_api into submodules
+- feat(srv): persist the 7 granular layout events via the reducer→subscriber path (carry resulting tree; no algebra re-run)
+- feat(pane): add "Pane Color" context-menu submenu with inline color swatches
+- fix(menu): open hamburger, "More" widget dropdown, flyout menus, and popovers in place over browser/webview panes instead of floating to the window edge
+- refactor(srv): extract store.rs inline tests to submodule
+- refactor(srv): split rpc_types into domain submodules
+- refactor(srv): split service into concern submodules
+- feat(muxbus): point desktop sign-in at branded auth.muxbus.agentmux.ai
+- fix(browser-pane): fix black screen when tearing a browser off into a floating pane (cross-window AlreadyLive race)
+- feat(srv): v1 standalone MCP Server and Skill primitives (Trust Center)
+- refactor(cef): split ui_tasks into category submodules
+- feat(macos): window transparency/opacity via NSWindow alphaValue (Windows parity)
+- refactor(frontend): split rpc-api into domain modules
+- fix(test): acknowledge mcp/skill backend-only handlers in rpc contract baseline
+- refactor(frontend): extract hooks from agent-view
+- chore(providers): pin Claude Code CLI to 2.1.198 (latest)
+- fix(agent-log): Log button expands/collapses the full entries directly (remove middle collapse layer)
+- feat(agent): versioned model labels in the composer dropdowns, sourced from the provider registry
+- refactor(srv): split agent_session into submodules
+- refactor(cef): split client/mod.rs into submodules
+- feat(linux): window transparency/opacity via _NET_WM_WINDOW_OPACITY (Windows/macOS parity)
+- refactor(srv): split shell controller into submodules
+- refactor(launcher): extract main.rs logic into sibling modules
+- fix(launcher): qualify forward_open_new_window_or_log path in splash_mac (macOS build break from #1907)
+- feat(ui): restore Theme and Opacity submenus in hamburger menu
+
+
 ## 0.49.11 — 2026-07-02
 
 - chore(providers): pin Claude Code CLI to 2.1.198 (latest)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.11",
+  "version": "0.49.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.11",
+      "version": "0.49.12",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.11",
+  "version": "0.49.12",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Forced **patch** release (`task release -- --as patch`) — `0.49.11 → 0.49.12` — consuming all pending changesets.

All five version locations agree at 0.49.12 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY head), verified by the release script's post-bump check.

Notable changes shipping in this release:
- feat(srv): v1 standalone MCP Server & Skill primitives (Trust Center)
- feat(muxbus): branded `auth.muxbus.agentmux.ai` desktop sign-in
- feat(jekt): structured JEKT security markers + sensitive-tier detection
- refactor(srv): split `app_api` / `agent_handlers` / `rpc_types` into submodules
- assorted pane/editor/browser/floating-window fixes

Note: some queued changesets were `minor`-level (feat); per the `--as patch` override they ship under this patch version, as intended.

<!-- agentmux:agent_id=agentx -->