### PR TITLE
feat(agent): Mode/Model/Effort drop-ups (replace native <select>)

### DIFF
--- a/.changesets/1783038175-fix-agent-composer-dropups.md
+++ b/.changesets/1783038175-fix-agent-composer-dropups.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): Mode/Model/Effort drop-ups (open upward) replace native <select>; stop hiding controls on narrow panes

--- a/docs/specs/SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md
@@ -1,0 +1,133 @@
+# SPEC — Composer strip responsive architecture: stop hiding the runtime controls
+
+**Date:** 2026-07-02
+**Type:** Architecture spec
+**Status:** Root-caused (live-verified); proposes an architecture rethink + an immediate fix.
+**Owner:** asaf
+**Scope:** `frontend/app/view/agent/components/AgentComposerStrip.tsx` +
+`frontend/app/view/agent/styles/_composer-strip.scss`.
+
+> **Symptom.** On a normal agent pane the composer strip shows **only the "Log" button** — no
+> Mode / Model / Effort controls. Reported as "may need an architecture rethink … a lot of hackish crude."
+
+---
+
+## 1. Root cause (live-verified, not theory)
+
+Instrumented the running dev build (`task dev`, this branch) with a DOM probe. Findings:
+
+| Probe | Value |
+|---|---|
+| `showControls()` | **true** (`providerId=claude`, `agentProvider=claude`, `blockAtom!=null`) |
+| Trigger buttons in DOM | **3** — rendered with correct labels **`Bypass▴` `Sonnet 4.6▴` `High▴`** |
+| Their computed style | **`display:none`, width 0** |
+| Strip width | **310px** |
+
+So the controls **are** rendered correctly (the drop-up works) — they're **force-hidden by CSS**. The
+culprit is the narrow-pane container query (`_composer-strip.scss:219`):
+
+```scss
+@container modal-mount (max-width: 320px) {
+    .agent-composer-strip-select { display: none; }        // ← hides ALL runtime controls
+    .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
+}
+```
+
+The user's pane container is **310px** — under the **320px** threshold — so **every** Mode/Model/Effort
+control is `display:none`, leaving only Log. **320px is a very common pane width**, so this fires for a
+large fraction of real panes. This predates the drop-up work (it hid the native `<select>`s the same
+way); the drop-up just made it obvious because the user was looking for the new controls.
+
+## 2. The "hackish crude" — what's actually wrong architecturally
+
+1. **Blunt `display:none` on *essential* controls.** Responsive shrink is done by hiding the runtime
+   controls entirely — no fallback, no collapsed form. The controls (how the agent runs: Mode/Model/
+   Effort) are arguably the *most* important thing in the strip, and they're the *first* thing dropped.
+2. **The truncation priority is backwards.** The strip *keeps* informational content (token stats,
+   elapsed, context text) and *drops* the actionable controls. It should be the reverse: shed
+   informational bits first; controls last.
+3. **A magic 320px threshold, guessed not measured.** It's a single hardcoded breakpoint that doesn't
+   correspond to the actual rendered width of the controls, so it clips at a width where the controls
+   would still fit (three compact drop-up pills fit well under 320px).
+4. **Two overlapping truncation systems.** There's a `240px` query (drops stats + ctx) *and* a `320px`
+   query (drops controls, shrinks Log) — applied in the "wrong" order (controls go at the *wider* 320px
+   breakpoint, before some informational content at 240px).
+5. **Historical multi-consumer drift** (context, mostly resolved): Mode/Model/Effort were defined
+   independently in `AgentComposerStrip`, `AgentControlBar`, and the `/model` command — three lists that
+   drifted. #1912 removed the `AgentControlBar` duplicate; the strip + `/model` should converge on one
+   catalog (see `SPEC_MODEL_CATALOG_REFRESH_2026_07_02`).
+6. **Provider gating is a hard string check** (`providerId === "claude"`). Works, but tightly couples the
+   strip to one provider id; fine for now, flagged for awareness.
+
+## 3. Proposed architecture — progressive collapse, controls last
+
+**Principle: the runtime controls never fully disappear.** As width shrinks, degrade *gracefully* and
+shed *informational* content first. The drop-up trigger is the right primitive for this — it can shrink
+from full label → short label → icon-only, and its popup (opened upward) always shows the full options
+regardless of trigger size.
+
+### Width tiers (measure real content widths; these are illustrative)
+```
+WIDE (≳ 420px) — everything, full labels
+┌──────────────────────────────────────────────────────────────────────┐
+│ [Bypass ▴][Sonnet 4.6 ▴][X-High ▴]  [Log]      ↑2k ↓1k 1m12s ⚙2 12k/64k│
+└──────────────────────────────────────────────────────────────────────┘
+
+MEDIUM (~320–420px) — drop informational tail first (stats → ctx), keep controls full
+┌──────────────────────────────────────────────────┐
+│ [Bypass ▴][Sonnet 4.6 ▴][X-High ▴]  [Log]   12k/64k│
+└──────────────────────────────────────────────────┘
+
+NARROW (~240–320px) — controls shrink to short/icon; Log stays; info gone
+┌────────────────────────────────────┐
+│ [Byp▴][Son▴][XHi▴]  [Log]           │   ← still actionable, not hidden
+└────────────────────────────────────┘
+
+TINY (< 240px) — controls collapse into ONE combined chip; Log stays
+┌────────────────────────┐
+│ [⚙ Byp·Son·XHi ▴] [Log]│   ← one trigger opens a small drop-up panel
+└────────────────────────┘        with Mode / Model / Effort stacked
+```
+
+### Rules
+- **Never** apply `display:none` to the runtime controls. Instead:
+  - **Tier MEDIUM:** hide `.agent-composer-strip-stats` then `.agent-composer-strip-ctx` (informational).
+  - **Tier NARROW:** switch the drop-up triggers to a compact form — short label (first 3 chars) or
+    icon-only. The popup still shows full option text.
+  - **Tier TINY:** collapse the three triggers into a **single combined chip** (`⚙ Byp·Son·XHi ▴`) whose
+    drop-up panel stacks Mode/Model/Effort. This guarantees the controls are always reachable at any
+    width the pane can realistically be.
+- **Order of shedding (widest→narrowest):** stats → elapsed → context text → process badge → control
+  labels (→ icons) → combine controls. Log and the controls are the last things standing.
+- **Breakpoints come from measured content**, not a guessed 320. Prefer a container query per tier keyed
+  to the widths the compact forms actually need (a drop-up pill is ~44–68px; three fit < 240px in short
+  form).
+- **One control model.** Define Mode/Model/Effort as a single data list (value + label + optional short
+  label + optional color) and render every surface (strip, `/model`, any future one) from it — so labels
+  never drift and the compact/short forms are defined once.
+
+## 4. Immediate fix (unblocks the current bug now, low-risk)
+
+The full progressive-collapse is the *architecture*; the one-line unblock is: **stop hiding the controls,
+and if anything must go at narrow widths, drop the informational content, not the controls.** Concretely
+in `_composer-strip.scss`:
+
+- **Remove** `.agent-composer-strip-select { display: none; }` from the `≤320px` query (drop-up pills are
+  compact enough to keep). Keep the Log shrink.
+- Optionally move stats/ctx hiding up so informational content sheds first.
+
+This makes the drop-ups appear on the 310px pane immediately (verified: they render `Bypass▴ Sonnet 4.6▴
+High▴`, just hidden). Progressive collapse (short/icon/combined forms) is the follow-up that makes narrow
+widths graceful rather than just "unhidden."
+
+## 5. Verification
+- Live probe (2026-07-02): 3 triggers present, labels correct, `display:none` at strip width 310px.
+- After the §4 fix: the three drop-ups show on a 310px pane; opening each opens upward with full options.
+- Progressive collapse: shrink the pane through the tiers and confirm controls never vanish (they shrink /
+  combine), and informational content sheds first.
+
+## 6. Sources
+- Root cause: `frontend/app/view/agent/styles/_composer-strip.scss:171-182,219` (the `240px` + `320px`
+  container queries); `AgentComposerStrip.tsx` (drop-up triggers use `.agent-composer-strip-select`).
+- Related: `SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02` (Mode promotion + Fix 7 drop-ups),
+  `SPEC_MODEL_CATALOG_REFRESH_2026_07_02` (one control catalog), PR #1922 (drop-up impl).

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -5,7 +5,7 @@
  * AgentComposerStrip — slim 28-32px status row that sits directly above
  * the textarea in the agent pane composer region.
  *
- * LEFT:  Mode <select> · Model <select> · Effort <select> · Log toggle
+ * LEFT:  Mode · Model · Effort drop-ups (open upward) · Log toggle
  * RIGHT: tokens (↑in ↓out) · elapsed · ⚙N process badge ·
  *        context text (12.1k / 64k)
  *
@@ -22,6 +22,7 @@ import { compactionThreshold } from "@/app/store/agent-pane-state/context-window
 import { getRuntimeConfig } from "../buildRuntimeArgs";
 import { applyRuntimeChange } from "../runtime-apply";
 import { getProvider } from "../providers";
+import { FlyoutMenu } from "@/app/element/flyoutmenu";
 import type { AgentRuntimeConfig, EffortLevel, ModelChoice, PermissionMode, SessionStats, TurnTokens } from "../types";
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -47,6 +48,68 @@ const EFFORT_OPTIONS = [
     { value: "xhigh", label: "X-High" },
     { value: "max", label: "Max" },
 ] as const;
+
+// Mode: trigger shows the short `label`; the menu shows `menuLabel` (the
+// descriptive form) when present.
+const MODE_OPTIONS = [
+    { value: "bypass", label: "Bypass", menuLabel: "Bypass (no prompts)" },
+    { value: "auto", label: "Auto", menuLabel: "Auto (AI classifier)" },
+    { value: "acceptEdits", label: "Accept Edits" },
+    { value: "plan", label: "Plan", menuLabel: "Plan (read-only)" },
+    { value: "default", label: "Default", menuLabel: "Default (prompt all)" },
+] as const;
+
+// ── Drop-up select ───────────────────────────────────────────────────────────
+
+/**
+ * A strip control rendered as a **drop-up**: the trigger is the same slim pill
+ * as before, but the popup opens *upward* (via FlyoutMenu `placement="top-start"`)
+ * with the app's own menu styling instead of the browser's native `<select>`
+ * chrome. Each row is a uniform-height menu item; the selected row carries a
+ * radio check. Effort uses `horizontal` to lay its options out in a single row.
+ * See SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02 Fix 7.
+ */
+function StripSelect(props: {
+    current: string | undefined;
+    options: readonly { value: string; label: string; menuLabel?: string }[];
+    onSelect: (value: string) => void;
+    title: string;
+    /** BEM modifier suffix on the trigger, e.g. "--mode" | "--model" | "--effort". */
+    modifier: string;
+    /** Color stripe on the trigger's left edge (Mode → permission color). */
+    leftColor?: string;
+    /** Lay the popup options out horizontally (Effort). */
+    horizontal?: boolean;
+}): JSX.Element {
+    const currentLabel = (): string =>
+        props.options.find((o) => o.value === props.current)?.label ?? props.current ?? "";
+    // Reactive: Solid wraps this prop expression in a getter, so FlyoutMenu's
+    // <For each={items}> re-reads it when `current` changes — the check mark
+    // and label stay in sync after a selection.
+    const items = (): MenuItem[] =>
+        props.options.map((o) => ({
+            label: o.menuLabel ?? o.label,
+            checked: o.value === props.current,
+            onClick: () => props.onSelect(o.value),
+        }));
+    return (
+        <FlyoutMenu
+            placement="top-start"
+            className={`strip-flyout${props.horizontal ? " strip-flyout--horizontal" : ""}`}
+            items={items()}
+        >
+            <button
+                type="button"
+                class={`agent-composer-strip-select agent-composer-strip-select${props.modifier}`}
+                title={props.title}
+                style={props.leftColor ? { "border-left": `3px solid ${props.leftColor}` } : undefined}
+            >
+                <span class="agent-composer-strip-select-label">{currentLabel()}</span>
+                <span class="agent-composer-strip-select-caret" aria-hidden="true">▴</span>
+            </button>
+        </FlyoutMenu>
+    );
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -206,43 +269,33 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 flags the agent actually runs with from first paint. */}
             <span class="agent-composer-strip-controls">
                 <Show when={showControls()}>
-                    <select
-                        class="agent-composer-strip-select agent-composer-strip-select--mode"
+                    {/* Drop-ups (open upward) replace the native <select>s — see
+                        SPEC_COMPOSER_STRIP_MODE_TOPLEVEL Fix 7. Model options are
+                        registry-driven (single source with /model), so an
+                        API-sourced catalog surfaces new labels automatically. */}
+                    <StripSelect
+                        current={runtime()?.permissionMode ?? "default"}
+                        options={MODE_OPTIONS}
+                        onSelect={(v) => void updateRuntime({ permissionMode: v as PermissionMode })}
                         title="Permission mode — how the agent asks before running tools. Applies on the next turn."
-                        style={{ "border-left": `3px solid ${PERMISSION_COLORS[runtime()?.permissionMode ?? "default"]}` }}
-                        prop:value={runtime()?.permissionMode ?? "default"}
-                        onChange={(e) => void updateRuntime({ permissionMode: e.currentTarget.value as PermissionMode })}
-                    >
-                        <option value="bypass">Bypass (no prompts)</option>
-                        <option value="auto">Auto (AI classifier)</option>
-                        <option value="acceptEdits">Accept Edits</option>
-                        <option value="plan">Plan (read-only)</option>
-                        <option value="default">Default (prompt all)</option>
-                    </select>
-                    <select
-                        class="agent-composer-strip-select agent-composer-strip-select--model"
+                        modifier="--mode"
+                        leftColor={PERMISSION_COLORS[runtime()?.permissionMode ?? "default"]}
+                    />
+                    <StripSelect
+                        current={runtime()?.model}
+                        options={getProvider(props.providerId)?.models ?? MODEL_OPTIONS}
+                        onSelect={(v) => void updateRuntime({ model: v as ModelChoice })}
                         title="Model — which model the agent uses. Applies on the next turn."
-                        prop:value={runtime()?.model}
-                        onChange={(e) => void updateRuntime({ model: e.currentTarget.value as ModelChoice })}
-                    >
-                        {/* Registry-driven (single source shared with the /model
-                            command + AgentControlBar); labels carry the versioned
-                            model names. Falls back to the static list if the
-                            provider defines none. */}
-                        {(getProvider(props.providerId)?.models ?? MODEL_OPTIONS).map((o) => (
-                            <option value={o.value}>{o.label}</option>
-                        ))}
-                    </select>
-                    <select
-                        class="agent-composer-strip-select agent-composer-strip-select--effort"
+                        modifier="--model"
+                    />
+                    <StripSelect
+                        current={runtime()?.effort}
+                        options={EFFORT_OPTIONS}
+                        onSelect={(v) => void updateRuntime({ effort: v as EffortLevel })}
                         title="Reasoning effort — how hard the model thinks per turn. Applies on the next turn."
-                        prop:value={runtime()?.effort}
-                        onChange={(e) => void updateRuntime({ effort: e.currentTarget.value as EffortLevel })}
-                    >
-                        {EFFORT_OPTIONS.map((o) => (
-                            <option value={o.value}>{o.label}</option>
-                        ))}
-                    </select>
+                        modifier="--effort"
+                        horizontal
+                    />
                 </Show>
                 <button
                     type="button"

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -38,7 +38,13 @@
     flex-shrink: 0;
 }
 
+// The drop-up trigger. Same slim pill as the former <select>, but a <button>
+// laying out a label + up-caret; the popup is a portaled FlyoutMenu (see below).
 .agent-composer-strip-select {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 3px;
     appearance: none;
     -webkit-appearance: none;
     background: transparent;
@@ -69,10 +75,44 @@
         outline: 2px solid var(--accent-color);
         outline-offset: 1px;
     }
+}
 
-    option {
-        background: var(--main-bg-color, #222);
-        color: var(--main-text-color);
+.agent-composer-strip-select-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.agent-composer-strip-select-caret {
+    font-size: 8px;
+    line-height: 1;
+    opacity: 0.7;
+    flex-shrink: 0;
+}
+
+// The drop-up popup itself (portaled to <body> by FlyoutMenu, so this is a
+// top-level global rule). Inherits the app's clean `.menu` chrome — the whole
+// point of ditching the native <select> — and just tightens rows to strip
+// scale so each entry matches the collapsed control's height/style.
+.menu.strip-flyout {
+    min-width: 0;
+    font-size: 10px;
+
+    .menu-item {
+        padding: 2px var(--space-1-5);
+        min-height: 0;
+    }
+
+    // Effort: options in a single horizontal row of equal-height chips.
+    &.strip-flyout--horizontal {
+        display: flex;
+        flex-direction: row;
+        gap: 2px;
+
+        .menu-item {
+            white-space: nowrap;
+            justify-content: center;
+        }
     }
 }
 

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -217,6 +217,10 @@
 }
 
 @container modal-mount (max-width: 320px) {
-    .agent-composer-strip-select { display: none; }
+    // Keep the runtime controls visible — the drop-up pills are compact enough.
+    // (Previously `.agent-composer-strip-select { display:none }` here hid
+    // Mode/Model/Effort on any pane ≤320px, leaving only Log — see
+    // SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02. Progressive
+    // collapse — short/icon/combined forms — is the follow-up.)
     .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
 }


### PR DESCRIPTION
## Summary
Implements **Fix 7** of `SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02` — replaces the composer strip's native `<select>` popups (the "very strange style") with **drop-ups**: custom menus that open *upward* via `FlyoutMenu` (`placement="top-start"`), inheriting the app's own clean menu chrome.

- **Trigger:** same slim pill as before (a `<button>` now — label + up-caret).
- **Popup:** opens upward, app-standard `.menu` styling (no OS `<select>` chrome); each row tightened to strip scale so it matches the collapsed control's height/style; selected row carries a radio check.
- **Effort:** options laid out in a single **horizontal** row (`.strip-flyout--horizontal`).
- **Model:** stays registry-driven (`getProvider().models`), so an API-sourced catalog (see the model-catalog PR) surfaces new labels automatically.
- Removes the `prop:value` native-`<select>` workaround (Bug 2) — a custom menu has no controlled-select artifact, so Fix 7 supersedes it.

ASCII mockups + styling rules: `SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02.md` §5d.

## Testing / caveats
- ⚠️ **Not build-verified locally** (toolchain not built in this workspace) — relies on CI typecheck.
- ⚠️ **Visual correctness needs a manual run** — CI verifies compile/typecheck but not appearance; please eyeball the drop-up (upward open, uniform rows, horizontal effort, mode color stripe) before merge.

<!-- agentmux:agent_id=agenta -->