### PR TITLE
docs: retain CLAUDE.md decision (reverses proposal 3.4)

### DIFF
--- a/docs/specs/EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md
+++ b/docs/specs/EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md
@@ -26,9 +26,11 @@ The merged proposal (product-owner decision) **retires "preset"** and separates 
 | **Account** | The provider login + credential the agent runs as (OAuth/key, per-account config dir). "Identity" is just a *derived view* over an agent's bound accounts — **not** a stored object. | at pane open (env injection: `GH_TOKEN`, `ANTHROPIC_API_KEY`, …) |
 | **Memory** | Persistent learned knowledge (the native memory store). "The brain" is a nickname, not the canonical term. | recalled at startup |
 | **MCP Server** | An external tool/connection surface (URL/stdio + which tools). Broken out of preset. | connects at startup; tools on demand |
-| **Skill** | An on-demand instruction/knowledge module (a folder). Broken out of preset. **All instructional/behavioral content lives here** — there is no always-on instruction blob. | only when invoked |
-| **Brief** | **The first message** injected when a pane opens — the startup/kickoff payload. That is *all* it is; not standing instructions. | as the first user message |
+| **Skill** | An on-demand instruction/knowledge module (a folder), loaded when invoked. Broken out of preset. Complements — does **not** replace — the standing instructions in `CLAUDE.md` (see the standing-instructions note below). | only when invoked |
+| **Brief** | **The first message** injected when a pane opens — the startup/kickoff payload. It is *additive to* `CLAUDE.md`, not a replacement for standing instructions. | as the first user message |
 | **Bundle** | The optional **named collection** — references (not copies of) the primitives above, so you can apply a whole set in one step and share it. Replaces "preset". | resolves to its referenced primitives |
+
+> **Standing instructions stay in `CLAUDE.md` (product decision, 2026-07-02).** The Claude CLI natively auto-loads `CLAUDE.md` from the working dir as its always-on project instructions; AgentMux assembles it from `soul` + `agentmd` + `memory` + skills index (`agent_config.rs:28`). We are **retaining** it — an earlier proposal draft (§3.4) floated retiring it, but that would break standing-instruction delivery for Claude agents. So `soul`/`agentmd` stay in `CLAUDE.md`; Brief and Skills are additive, not replacements. (Other CLIs get their own native file — `AGENTS.md`, `GEMINI.md`, etc.)
 
 **The key mental shift:** an agent binds primitives **directly** (any number of MCP servers + skills, one Brief, ≤1 Account per provider, a Memory). A **Bundle** is *sugar* — a saved, shareable set of those bindings — **not** a required wrapper. Effective config = direct bindings ∪ included Bundles, with a direct binding overriding the same item from a Bundle.
 
@@ -87,12 +89,13 @@ From `SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md`:
 
 So the single-icon **Agent setup** pane is the **Phase 3 UI outcome**: the pane already opens the account surface (as "identity"); Phase 3 unifies it with Memory (and the other primitives) behind one modal and makes the data model match. Implementation note for Phase 3: in `agent-model.ts` `endIconButtons`, replace the two-button array with a single `id-card` button whose `click` opens the unified modal; retire `_openMemoryModal` / `_openIdentityModal` in favor of one `_openAgentSetupModal` (or reuse the Armory's tabbed manager scoped to the agent).
 
-## 7. Open product decisions this depends on (proposal §9)
+## 7. Product decisions (proposal §9)
 
-Phase 3 (hence the icon relabel) is gated on:
-1. **Derived-Identity UX** — drop the "Identities" tab entirely, or keep a read-only derived view for one release?
+**Resolved (2026-07-02):**
+1. ✅ **Derived-Identity UX** — the pane consolidates to one `id-card` "Agent setup" icon (§4); "Identities" folds in as the **Accounts** tab; identity stays a derived view.
+3. ✅ **Static `memory` blob & 4. `soul`/`agentmd`** — **`CLAUDE.md` is RETAINED.** The Claude CLI natively loads it as standing instructions; `soul`/`agentmd`/`memory` stay in `CLAUDE.md`. Brief (first message) and Skills (on-demand) are *additive*, not replacements. This reverses the proposal's §3.4 "retire CLAUDE.md" stance.
+
+**Still open:**
 2. **Policy primitive** — hooks + `.claude/settings.json` permissions: a distinct 7th primitive, or folded in? (Affects whether the pane/Armory grows another surface.)
-3. **Static `memory` blob** (in today's CLAUDE.md) → merge into Brief vs. native Memory.
-4. **`soul`/`agentmd` → Skills** — retire the always-on CLAUDE.md instruction blob (proposal's stance) as part of this, or separately.
 
-Answering these unblocks the pane's transition to the clean **Memory + Accounts** (+ optional Bundle) surface.
+The Policy question is the only remaining gate on Phase 3's full shape; the pane's transition to the single **Agent setup** icon can proceed regardless.

--- a/docs/specs/EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md
+++ b/docs/specs/EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md
@@ -95,7 +95,6 @@ So the single-icon **Agent setup** pane is the **Phase 3 UI outcome**: the pane 
 1. ✅ **Derived-Identity UX** — the pane consolidates to one `id-card` "Agent setup" icon (§4); "Identities" folds in as the **Accounts** tab; identity stays a derived view.
 3. ✅ **Static `memory` blob & 4. `soul`/`agentmd`** — **`CLAUDE.md` is RETAINED.** The Claude CLI natively loads it as standing instructions; `soul`/`agentmd`/`memory` stay in `CLAUDE.md`. Brief (first message) and Skills (on-demand) are *additive*, not replacements. This reverses the proposal's §3.4 "retire CLAUDE.md" stance.
 
-**Still open:**
-2. **Policy primitive** — hooks + `.claude/settings.json` permissions: a distinct 7th primitive, or folded in? (Affects whether the pane/Armory grows another surface.)
+2. ✅ **Policy primitive** — hooks + `.claude/settings.json` permissions **will be a distinct 7th primitive** (a trust decision, like Accounts/MCP — deserves first-class review), **but deferred to a later phase.** Phase 3 leaves hooks/permissions writing exactly as today; Policy is broken out separately.
 
-The Policy question is the only remaining gate on Phase 3's full shape; the pane's transition to the single **Agent setup** icon can proceed regardless.
+**All §9 decisions are resolved.** Phase 3 is fully specced and unblocked: Account-direct resolver + identity-bundle collapse + backfill + the single **Agent setup** icon. Policy and the storage `_bundles` rename (Phase 4) follow after.

--- a/docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md
+++ b/docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md
@@ -90,7 +90,19 @@ Implementation:
 
 **Phase 3 deliverable:** one PR (resolver + backfill + UI derived-view). Heaviest behavior change — needs the identity/keychain reconciliation tracked in **issue #1624** ("Reconcile per-agent keychain with the live identity-bundle system") to land compatibly; coordinate.
 
-**Open product decision (proposal §9.4/§9.6):** confirm the derived-Identity UX and whether a **Policy** primitive (hooks + `.claude/settings.json` permissions) is introduced here or deferred. Flag, don't assume.
+**Open product decision (proposal §9.6):** whether a **Policy** primitive (hooks + `.claude/settings.json` permissions) is introduced here or deferred. Flag, don't assume.
+
+### 3.4 RESOLVED product decisions (2026-07-02)
+
+These override the corresponding open items in `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md`:
+
+- **§9.1 / derived-Identity UX — RESOLVED:** the agent-pane header consolidates to a **single `id-card` icon** opening a unified per-agent management modal (see §3.2b); the standalone "Identities" concept folds in as the **Accounts** tab. "Identity" remains a derived view only.
+- **§3.4 / §9.7 — retire the always-on `CLAUDE.md`? — RESOLVED: NO. Retain `CLAUDE.md`.**
+  - **Why:** the Claude CLI **natively auto-loads `CLAUDE.md`** from the agent working directory as its standing project instructions. AgentMux already assembles it from `soul` + `agentmd` + `memory` + skills index (`agentmux-srv/src/backend/agent_config.rs:28,55-96`). Retiring it would break standing-instruction delivery for Claude agents — there is no equivalent always-on channel.
+  - **Therefore:** `soul` / `agentmd` / the static `memory` blob **stay in `CLAUDE.md`** (do NOT migrate them into Skills-only). The always-on instruction blob is kept.
+  - **Brief** stays defined as *the first message* (kickoff payload), but it is **additive to `CLAUDE.md`**, not a replacement for standing instructions. **Skills** remain on-demand modules, but they are **not** the sole home for instructional content — `CLAUDE.md` remains the standing-instruction home.
+  - **Impact on this refactor:** none of the Phase 2–4 storage/naming work depends on retiring `CLAUDE.md`; this decision simply removes the "migrate soul/agentmd → Skills / retire CLAUDE.md" strand from the composable-model rollout. The `agent_config.rs` CLAUDE.md assembly stays as-is.
+  - **Note:** `CLAUDE.md` is Claude-specific; other CLIs use their own native context files (e.g. `AGENTS.md`, `GEMINI.md`). "Retain CLAUDE.md" generalizes to "keep writing each provider's native standing-instruction file."
 
 ---
 

--- a/docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md
+++ b/docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md
@@ -90,8 +90,6 @@ Implementation:
 
 **Phase 3 deliverable:** one PR (resolver + backfill + UI derived-view). Heaviest behavior change — needs the identity/keychain reconciliation tracked in **issue #1624** ("Reconcile per-agent keychain with the live identity-bundle system") to land compatibly; coordinate.
 
-**Open product decision (proposal §9.6):** whether a **Policy** primitive (hooks + `.claude/settings.json` permissions) is introduced here or deferred. Flag, don't assume.
-
 ### 3.4 RESOLVED product decisions (2026-07-02)
 
 These override the corresponding open items in `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md`:
@@ -103,6 +101,12 @@ These override the corresponding open items in `PROPOSAL_COMPOSABLE_AGENT_MODEL_
   - **Brief** stays defined as *the first message* (kickoff payload), but it is **additive to `CLAUDE.md`**, not a replacement for standing instructions. **Skills** remain on-demand modules, but they are **not** the sole home for instructional content — `CLAUDE.md` remains the standing-instruction home.
   - **Impact on this refactor:** none of the Phase 2–4 storage/naming work depends on retiring `CLAUDE.md`; this decision simply removes the "migrate soul/agentmd → Skills / retire CLAUDE.md" strand from the composable-model rollout. The `agent_config.rs` CLAUDE.md assembly stays as-is.
   - **Note:** `CLAUDE.md` is Claude-specific; other CLIs use their own native context files (e.g. `AGENTS.md`, `GEMINI.md`). "Retain CLAUDE.md" generalizes to "keep writing each provider's native standing-instruction file."
+- **§9.6 / Policy primitive — RESOLVED: YES, it's a distinct 7th primitive — but DEFERRED to a follow-on phase (call it Phase 5), NOT part of Phase 3.**
+  - **Why first-class:** hooks + `.claude/settings.json` permissions are a *trust decision* (allow/deny tool rules, hook execution) — the same class as Accounts and MCP servers. The model's thesis is that security-sensitive config gets explicit review, not burial in agent config. So Policy earns first-class, reviewable, shareable status in the target model, surfaced in the Armory + the per-agent setup modal.
+  - **Why deferred:** it has zero dependency on Phase 3's resolver/identity work, and Phase 3 is already the heaviest phase. Bundling Policy in would expand scope and risk for no sequencing benefit.
+  - **Therefore Phase 3 leaves hooks + `.claude/settings.json` writing EXACTLY as today** (no behavior change). Policy is broken out later: a `db`-backed Policy primitive + Armory surface, referenced by Bundles/agents like the other primitives, with an ownership/global guard (§6). Track as a follow-up; not gating Phase 3.
+
+**Phase 3 is now fully specced and unblocked** — all §9 decisions resolved (Policy explicitly deferred).
 
 ---
 


### PR DESCRIPTION
## Summary
Records the product decision (2026-07-02): **retain `CLAUDE.md`** as the agent's always-on standing-instruction file, reversing the composable-model proposal's §3.4/§9.7 "retire the always-on CLAUDE.md" stance.

**Why:** the Claude CLI natively auto-loads `CLAUDE.md` from the working dir as project instructions; AgentMux already assembles it from `soul` + `agentmd` + `memory` + skills index (`agentmux-srv/src/backend/agent_config.rs:28,55-96`). Retiring it would break standing-instruction delivery for Claude agents — there's no equivalent always-on channel.

- `soul`/`agentmd`/`memory` stay in `CLAUDE.md` (not migrated to Skills-only)
- **Brief** (first message) and **Skills** (on-demand) are additive, not replacements
- Generalizes to "keep writing each provider's native standing-instruction file" (`AGENTS.md`, `GEMINI.md`, …)
- Also marks the derived-Identity / single-icon decisions resolved; only the **Policy primitive** question remains open for Phase 3

Docs only — updates SPEC_PRESET_TO_BUNDLE_REFACTOR §3.4 and the explainer §2/§7.

<!-- agentmux:agent_id=agent1 -->