### PR TITLE
feat(agent): single 'Agent setup' icon + unified tabbed modal (Phase 3 slice 1)

### DIFF
--- a/.changesets/1783037038-feat-agent-consolidate-pane-header-to-a-single-agent-setup-i-a2yv.md
+++ b/.changesets/1783037038-feat-agent-consolidate-pane-header-to-a-single-agent-setup-i-a2yv.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): consolidate pane header to a single Agent setup icon + unified modal

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -18,9 +18,11 @@ import { AgentCreateFromTemplateModalPanel } from "@/app/view/agent/components/A
 import { BrowserAuthModalPanel } from "@/app/view/browser/components/BrowserAuthModal";
 import { AgentIdentityModalPanel } from "@/app/view/agent/components/AgentIdentityModal";
 import { AgentNativeMemoryModal } from "@/app/view/agent/components/AgentNativeMemoryModal";
+import { AgentSetupModal } from "@/app/view/agent/components/AgentSetupModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
 import "@/app/view/agent/components/AgentIdentityModal.scss";
+import "@/app/view/agent/components/AgentSetupModal.scss";
 import "@/app/view/browser/components/BrowserAuthModal.scss";
 
 import type { ModalLayerApi, ModalLayerRequest } from "./modal-layer";
@@ -45,6 +47,8 @@ export function requestLabel(req: ModalLayerRequest): string {
             return `Identity — ${req.agent.name}`;
         case "agent-memory":
             return `Memory — ${req.agentName}`;
+        case "agent-setup":
+            return "Agent setup";
     }
 }
 
@@ -294,6 +298,21 @@ export function renderRequest(
                         agentId={req.agentId}
                         agentName={req.agentName}
                         workingDirectory={req.workingDirectory}
+                        onClose={api.close}
+                    />
+                ),
+            };
+        case "agent-setup":
+            return {
+                label: requestLabel(req),
+                panel: (
+                    <AgentSetupModal
+                        agent={req.agent}
+                        agentId={req.agentId}
+                        agentName={req.agentName}
+                        workingDirectory={req.workingDirectory}
+                        blockId={req.blockId}
+                        initialTab={req.initialTab}
                         onClose={api.close}
                     />
                 ),

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -24,7 +24,8 @@ export type ModalLayerRequest =
     | CreateFromTemplateRequest
     | BrowserAuthRequest
     | AgentIdentityRequest
-    | AgentMemoryRequest;
+    | AgentMemoryRequest
+    | AgentSetupRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -278,9 +279,11 @@ export interface BrowserAuthRequest {
 }
 
 /**
- * Agent pane identity modal — opened by the id-card icon in the agent
- * pane header. Replaces the cog → Identity tab flow with a pane-scoped
- * modal. Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md.
+ * Agent pane identity modal — formerly opened by the id-card icon in the
+ * agent pane header. Superseded by agent-setup (the unified tabbed modal
+ * now hosts this panel as the "Accounts" tab); kept for the dispatch case
+ * and any future direct callers. Spec:
+ * SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md.
  */
 export interface AgentIdentityRequest {
     kind: "agent-identity";
@@ -291,10 +294,11 @@ export interface AgentIdentityRequest {
 }
 
 /**
- * Agent pane memory modal — opened by the brain icon in the agent
- * pane header. Shows the native memory folder for the agent.
- * Phase 1: placeholder UI. Phase 3 adds the full file browser + editor.
- * Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md.
+ * Agent pane memory modal — formerly opened by the brain icon in the
+ * agent pane header. Shows the native memory folder for the agent.
+ * Superseded by agent-setup (the unified tabbed modal now hosts this
+ * panel as the "Memory" tab); kept for the dispatch case and any future
+ * direct callers. Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md.
  */
 export interface AgentMemoryRequest {
     kind: "agent-memory";
@@ -302,6 +306,31 @@ export interface AgentMemoryRequest {
     agentName: string;
     /** Agent's working directory — used to compute the memory folder path. */
     workingDirectory: string;
+}
+
+/**
+ * Agent setup modal — opened by the single id-card icon in the agent
+ * pane header. Unified tabbed container hosting the former Identity
+ * ("Accounts") + native Memory surfaces as tabs; supersedes the separate
+ * agent-identity / agent-memory icons. Structured so future primitives
+ * (MCP Servers · Skills · Briefs · Bundle) slot in as additional tabs.
+ * Spec: SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md §3.2b.
+ */
+export interface AgentSetupRequest {
+    kind: "agent-setup";
+    /** Agent definition to show/edit accounts for (Accounts tab). May be
+     *  null for quick-launch panes with no loadable definition — the
+     *  Accounts tab renders its own empty state in that case. */
+    agent: AgentDefinition | null;
+    /** Provider/definition id — used by the Memory tab. */
+    agentId: string;
+    agentName: string;
+    /** Agent's working directory — used to compute the memory folder path. */
+    workingDirectory: string;
+    /** Block id of the pane — used to construct the IdentityViewModel. */
+    blockId: string;
+    /** Which tab to open on. Defaults to "accounts". */
+    initialTab?: "accounts" | "memory";
 }
 
 // ── Context API ──────────────────────────────────────────────────────────────

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -7,7 +7,7 @@ import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { atoms, getApi, WOS } from "@/app/store/global";
-import { createSignalAtom, SignalAtom } from "@/util/util";
+import { SignalAtom } from "@/util/util";
 import { AgentViewWrapper } from "./agent-view";
 import { buildAgentPaneIcon } from "./components/AgentPaneIcon";
 import { PROVIDERS, resolveProviderAlias } from "./providers";
@@ -30,18 +30,12 @@ export class AgentViewModel implements ViewModel {
     endIconButtons: () => IconButtonDecl[];
     nodejsError: string | null = null;
 
-    // Callbacks wired by AgentPresentationView on mount so the title-bar
-    // buttons can open pane-scoped modals without holding a SolidJS context
-    // in the model. Replaced the _setOverlayTab / _lastOverlayTab pattern.
-    _openIdentityModal: (() => void) | null = null;
-    _openMemoryModal: (() => void) | null = null;
-    // SolidJS signal updated by a createEffect in agent-view.tsx so
-    // endIconButtons reactively hides the id-card button for quick-launch
-    // panes (where agentId is a provider key, not a definition UUID, and
-    // no AgentDefinition loads). A plain () => boolean mutation would not
-    // create a reactive dependency — BlockFrame would evaluate
-    // endIconButtons once with () => false and never re-run (codex P1 #1587).
-    _agentDefLoaded: SignalAtom<boolean> = createSignalAtom(false);
+    // Callback wired by AgentPresentationView on mount so the title-bar
+    // button can open the pane-scoped Agent-setup modal without holding a
+    // SolidJS context in the model. Replaced the former separate
+    // _openIdentityModal / _openMemoryModal pair (Phase 3 slice 1 — one
+    // "Agent setup" icon opens a unified tabbed modal).
+    _openAgentSetupModal: (() => void) | null = null;
 
     // Voice-input target ref. AgentFooter populates this on mount with a
     // textarea-backed handle (and clears it on unmount). The exposed
@@ -133,31 +127,25 @@ export class AgentViewModel implements ViewModel {
             await RpcApi.SetMetaCommand(TabRpcClient, { oref, meta: { agentName: name.trim() } });
         };
 
-        // Pane-frame header buttons: when an agent is loaded show brain + id-card.
-        // Hidden when no agent is loaded (picker screen).
-        // id-card is further gated on _hasAgentDef() — quick-launch panes
-        // (where agentId is a provider key, not a definition UUID) don't have
-        // a loadable AgentDefinition so identity assignment is not available.
+        // Pane-frame header button: a single "Agent setup" (id-card) icon
+        // when an agent is loaded — opens the unified tabbed modal
+        // (Accounts + Memory). Hidden when no agent is loaded (picker
+        // screen). Always shown when agentId exists: quick-launch panes
+        // (where agentId is a provider key, not a definition UUID) still
+        // get the button — the Accounts tab renders its own empty state
+        // for panes without a loadable AgentDefinition, and the Memory
+        // tab needs no definition.
         this.endIconButtons = () => {
             const agentId = this.blockAtom()?.meta?.["agentId"];
             if (!agentId) return [];
-            const buttons: IconButtonDecl[] = [
+            return [
                 {
                     elemtype: "iconbutton",
-                    icon: "brain",
-                    title: "Agent memory",
-                    click: () => { this._openMemoryModal?.(); },
+                    icon: "id-card",
+                    title: "Agent setup",
+                    click: () => { this._openAgentSetupModal?.(); },
                 },
             ];
-            if (this._agentDefLoaded()) {
-                buttons.push({
-                    elemtype: "iconbutton",
-                    icon: "id-card",
-                    title: "Agent identity",
-                    click: () => { this._openIdentityModal?.(); },
-                });
-            }
-            return buttons;
         };
     }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -135,26 +135,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const agentDefinitions = useAgentDefinitions();
     const currentAgent = createMemo(() => agentDefinitions().find((a) => a.id === agentId));
 
-    // Wire pane-scoped modal callbacks into the model so the title-bar icon
-    // buttons (brain / id-card) can open modals without holding a SolidJS
-    // context in the model. Mirrors the former _setOverlayTab pattern.
+    // Wire the pane-scoped modal callback into the model so the single
+    // title-bar "Agent setup" (id-card) icon can open the unified tabbed
+    // modal (Accounts + Memory) without holding a SolidJS context in the
+    // model. Mirrors the former _setOverlayTab pattern; supersedes the
+    // separate _openIdentityModal / _openMemoryModal callbacks.
     const modalLayer = useModalLayer();
-    // Drive model._agentDefLoaded via a createEffect so endIconButtons
-    // has a proper SolidJS reactive dependency on the async definition
-    // list. A plain function-mutation (_hasAgentDef = () => ...) would
-    // not create a tracking subscription — BlockFrame evaluates
-    // endIconButtons once with the default () => false and the id-card
-    // button never appears without a reactive signal atom.
-    createEffect(() => {
-        model._agentDefLoaded._set(currentAgent() != null);
-    });
     onMount(() => {
-        model._openIdentityModal = () => {
-            const agent = currentAgent();
-            if (!agent) return;
-            modalLayer.open({ kind: "agent-identity", agent, blockId: model.blockId });
-        };
-        model._openMemoryModal = () => {
+        model._openAgentSetupModal = () => {
             // Prefer cmd:cwd (actual launch cwd, set by launchAgentDefinition)
             // over AgentDefinition.working_directory, which is often empty or a
             // stale default for template-launched and continuation agents.
@@ -163,18 +151,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 (block?.meta?.["cmd:cwd"] as string) ||
                 currentAgent()?.working_directory ||
                 "";
+            const agent = currentAgent() ?? null;
             modalLayer.open({
-                kind: "agent-memory",
+                kind: "agent-setup",
+                agent,
                 agentId,
                 agentName: agentName(),
                 workingDirectory,
+                blockId: model.blockId,
+                // No loadable definition (quick-launch pane) → default to
+                // the Memory tab, which needs no AgentDefinition; the
+                // Accounts tab still renders its own empty state.
+                initialTab: agent ? "accounts" : "memory",
             });
         };
     });
     onCleanup(() => {
-        model._openIdentityModal = null;
-        model._openMemoryModal = null;
-        model._agentDefLoaded._set(false);
+        model._openAgentSetupModal = null;
     });
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// AgentSetupModal — unified tabbed container hosting the Accounts (identity)
+// and Memory (native memory) panels. The inner panels keep their own styling
+// (_identity-panel.scss / AgentNativeMemoryModal.scss); this file only styles
+// the top tab bar + panel wrapper.
+
+.agent-setup-modal {
+    display: flex;
+    flex-direction: column;
+    min-width: 480px;
+    max-width: 720px;
+}
+
+.agent-setup-modal-tabs {
+    display: flex;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-4) 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.agent-setup-modal-tab {
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--secondary-text-color);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: default;
+
+    &:hover:not(.is-active) {
+        color: var(--main-text-color);
+    }
+
+    &.is-active {
+        color: var(--main-text-color);
+        border-bottom-color: var(--accent-color);
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--shadow-focus-ring);
+    }
+}
+
+.agent-setup-modal-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.agent-setup-modal-empty {
+    padding: var(--space-6) var(--space-5);
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: 1.5;
+}

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -9,8 +9,14 @@
 .agent-setup-modal {
     display: flex;
     flex-direction: column;
-    min-width: 480px;
-    max-width: 720px;
+    // One fixed size for the whole modal so the frame doesn't resize between
+    // tabs. Sized to fit the widest/tallest embedded panel (the Memory panel,
+    // which is 780×520 in its standalone form) plus the tab bar.
+    width: 780px;
+    max-width: 92vw;
+    height: 560px;
+    max-height: 85vh;
+    min-width: 0;
 }
 
 .agent-setup-modal-tabs {
@@ -48,7 +54,23 @@
 .agent-setup-modal-panel {
     display: flex;
     flex-direction: column;
+    flex: 1;
     min-height: 0;
+    overflow: hidden;
+
+    // Neutralize the embedded panels' standalone-modal sizing so each tab fills
+    // the shared panel area at one consistent size — no horizontal overflow past
+    // the 780px frame, and no height jump when switching tabs (the Memory panel
+    // otherwise forces its own 780×520; the Accounts body is auto-height).
+    .agent-memory-modal,
+    .agent-identity-modal-body {
+        width: 100%;
+        height: 100%;
+        max-width: none;
+        max-height: none;
+        min-width: 0;
+        box-sizing: border-box;
+    }
 }
 
 .agent-setup-modal-empty {

--- a/frontend/app/view/agent/components/AgentSetupModal.tsx
+++ b/frontend/app/view/agent/components/AgentSetupModal.tsx
@@ -1,0 +1,109 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentSetupModal — unified tabbed container for per-agent setup surfaces,
+ * opened by the single "Agent setup" (id-card) icon in the agent pane
+ * header. Consolidates the former two icons (identity + native memory)
+ * into one modal with tabs:
+ *   - Accounts — the former Identity panel (AgentIdentityModalPanel).
+ *   - Memory   — the native-memory browser (AgentNativeMemoryModal).
+ *
+ * The tab list is a data array so future primitives slot in trivially.
+ * Behavior-preserving: the two hosted panels are reused as-is; only the
+ * entry point (one icon + tabs) changed.
+ *
+ * Spec: SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md §3.2b +
+ *       EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md §4.
+ */
+
+import { createSignal, For, Show, type JSX } from "solid-js";
+import { AgentIdentityModalPanel } from "./AgentIdentityModal";
+import { AgentNativeMemoryModal } from "./AgentNativeMemoryModal";
+import "./AgentSetupModal.scss";
+
+type SetupTabId = "accounts" | "memory";
+
+interface AgentSetupModalProps {
+    /** Agent definition for the Accounts tab. Null for quick-launch panes
+     *  with no loadable definition — the Accounts tab shows an empty state. */
+    agent: AgentDefinition | null;
+    agentId: string;
+    agentName: string;
+    workingDirectory: string;
+    blockId: string;
+    initialTab?: SetupTabId;
+    onClose: () => void;
+}
+
+interface SetupTabDef {
+    id: SetupTabId;
+    label: string;
+}
+
+export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
+    // Data-driven tab list — future primitives (Phase 3+): MCP Servers ·
+    // Skills · Briefs · Bundle slot in here as additional entries plus a
+    // render branch below. Do NOT build those managers yet.
+    const tabs: SetupTabDef[] = [
+        { id: "accounts", label: "Accounts" },
+        { id: "memory", label: "Memory" },
+    ];
+
+    const [activeTab, setActiveTab] = createSignal<SetupTabId>(props.initialTab ?? "accounts");
+
+    return (
+        <div class="agent-setup-modal">
+            <div class="agent-setup-modal-tabs" role="tablist">
+                <For each={tabs}>
+                    {(tab) => (
+                        <button
+                            class="agent-setup-modal-tab"
+                            classList={{ "is-active": activeTab() === tab.id }}
+                            role="tab"
+                            aria-selected={activeTab() === tab.id}
+                            onClick={() => setActiveTab(tab.id)}
+                        >
+                            {tab.label}
+                        </button>
+                    )}
+                </For>
+            </div>
+
+            <div class="agent-setup-modal-panel">
+                <Show when={activeTab() === "accounts"}>
+                    <Show
+                        when={props.agent}
+                        fallback={
+                            <div class="agent-setup-modal-empty">
+                                Account assignment is unavailable for this pane — it isn't
+                                backed by a saved agent definition.
+                            </div>
+                        }
+                    >
+                        {(agent) => (
+                            <AgentIdentityModalPanel
+                                agent={agent()}
+                                blockId={props.blockId}
+                                onClose={props.onClose}
+                            />
+                        )}
+                    </Show>
+                </Show>
+
+                <Show when={activeTab() === "memory"}>
+                    <AgentNativeMemoryModal
+                        agentId={props.agentId}
+                        agentName={props.agentName}
+                        workingDirectory={props.workingDirectory}
+                        onClose={props.onClose}
+                    />
+                </Show>
+
+                {/* Future primitives (Phase 3+): MCP Servers · Skills · Briefs · Bundle */}
+            </div>
+        </div>
+    );
+};
+
+AgentSetupModal.displayName = "AgentSetupModal";


### PR DESCRIPTION
## Summary
Phase 3, slice 1 (frontend-only, no auth/resolver/data change) of the composable-agent-model rollout. Consolidates the agent pane's two title-bar icons (`brain`/Memory + `id-card`/Identity) into a **single `id-card` "Agent setup" icon** that opens a **unified tabbed modal**: **Accounts** (the former Identity panel) + **Memory**. Structured so MCP / Skills / Briefs / Bundle tabs slot in later.

Per SPEC_PRESET_TO_BUNDLE_REFACTOR §3.2b + the composable-model explainer §4 (product-owner decision).

- New `agent-setup` modal kind hosting the existing identity + native-memory panels as tabs
- Pane header: two buttons -> one `id-card` "Agent setup" button
- Behavior-preserving: same two surfaces, now one entry point; "Identity" presented as "Accounts"
- No backend / RPC / resolver / data changes

## Test plan
- [x] `tsc --noEmit` clean (only 3 pre-existing AgentComposerStrip errors, unrelated)
- [x] full `vitest` suite green (1576 passed)
- [x] build passes
- [ ] pane shows one 'Agent setup' icon; modal opens with Accounts + Memory tabs

<!-- agentmux:agent_id=agent1 -->