### PR TITLE
feat(agent): providers.models RPC + live model-catalog overlay

### DIFF
--- a/.changesets/1783039588-feat-agent-providers-models-rpc-catalog-overlay.md
+++ b/.changesets/1783039588-feat-agent-providers-models-rpc-catalog-overlay.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): `providers.models` RPC + live model-catalog overlay for the strip drop-up

--- a/.changesets/1783039588-feat-agent-providers-models-rpc-catalog-overlay.md
+++ b/.changesets/1783039588-feat-agent-providers-models-rpc-catalog-overlay.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(agent): `providers.models` RPC + live model-catalog overlay for the strip drop-up

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -14,6 +14,7 @@ mod reactive;
 pub(crate) mod service;
 mod shell_handlers;
 mod tool_handlers;
+mod providers_handlers;
 mod voice;
 pub(crate) mod wave_obj_bridge;
 mod websocket;

--- a/agentmux-srv/src/server/providers_handlers.rs
+++ b/agentmux-srv/src/server/providers_handlers.rs
@@ -56,9 +56,12 @@ pub fn register_providers_handlers(engine: &Arc<WshRpcEngine>, _state: &AppState
                 }
 
                 // Account-GLOBAL shared creds dir (version/channel-independent).
+                // If data paths can't be resolved (CI / unusual env), stay
+                // best-effort per the module contract: empty list → FE keeps its
+                // static catalog, rather than erroring the RPC.
                 let paths = match agentmux_common::DataPaths::from_env() {
                     Some(p) => p,
-                    None => return Err("DataPaths::from_env() failed".to_string()),
+                    None => return empty_result(),
                 };
                 let dir = paths.provider_auth_dir(provider.auth_dir_name);
                 let token = match read_oauth_access_token(&dir) {

--- a/agentmux-srv/src/server/providers_handlers.rs
+++ b/agentmux-srv/src/server/providers_handlers.rs
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! RPC: `providers.models` — authoritative model catalog for a provider,
+//! fetched from the Anthropic Models API with the account-global OAuth token.
+//!
+//! Best-effort by design: any missing token (e.g. macOS Keychain), expiry, or
+//! network failure returns an empty `models` list, and the frontend keeps its
+//! bundled static catalog. Only Claude has an authoritative Models API today;
+//! other providers return empty. See `backend/model_catalog.rs` and
+//! `docs/specs/SPEC_MODEL_CATALOG_REFRESH_2026_07_02.md`.
+
+use std::sync::Arc;
+
+use crate::backend::model_catalog::{fetch_model_catalog, read_oauth_access_token, CatalogModel};
+use crate::backend::providers::get_provider;
+use crate::backend::rpc::engine::WshRpcEngine;
+
+use super::AppState;
+
+#[derive(serde::Deserialize)]
+struct ProvidersModelsParams {
+    provider_id: String,
+}
+
+#[derive(serde::Serialize)]
+struct ProvidersModelsResult {
+    /// `CatalogModel` serializes to `{ id, display_name }`.
+    models: Vec<CatalogModel>,
+}
+
+fn empty_result() -> Result<Option<serde_json::Value>, String> {
+    serde_json::to_value(ProvidersModelsResult { models: vec![] })
+        .map(Some)
+        .map_err(|e| format!("serialize: {e}"))
+}
+
+pub fn register_providers_handlers(engine: &Arc<WshRpcEngine>, _state: &AppState) {
+    // providers.models → authoritative model list for a provider (Claude only
+    // today). Reads the account-global OAuth token and hits GET /v1/models.
+    engine.register_handler(
+        "providers.models",
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let params: ProvidersModelsParams = serde_json::from_value(data)
+                    .map_err(|e| format!("providers.models: {e}"))?;
+
+                // Only Claude exposes an authoritative Models API; others fall
+                // back to the frontend's static catalog.
+                let provider = match get_provider(&params.provider_id) {
+                    Some(p) => p,
+                    None => return Err(format!("unknown provider: {}", params.provider_id)),
+                };
+                if provider.id != "claude" {
+                    return empty_result();
+                }
+
+                // Account-GLOBAL shared creds dir (version/channel-independent).
+                let paths = match agentmux_common::DataPaths::from_env() {
+                    Some(p) => p,
+                    None => return Err("DataPaths::from_env() failed".to_string()),
+                };
+                let dir = paths.provider_auth_dir(provider.auth_dir_name);
+                let token = match read_oauth_access_token(&dir) {
+                    Some(t) => t,
+                    // No token here (logged out, or macOS Keychain) → empty →
+                    // frontend keeps its static fallback.
+                    None => return empty_result(),
+                };
+
+                let models = fetch_model_catalog(&token).await.unwrap_or_default();
+                serde_json::to_value(ProvidersModelsResult { models })
+                    .map(Some)
+                    .map_err(|e| format!("serialize: {e}"))
+            })
+        }),
+    );
+}

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -898,6 +898,9 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     // Tool store handlers (gettoolstatus, installtool)
     super::tool_handlers::register_tool_handlers(engine, &state);
 
+    // Provider model catalog (providers.models → authoritative /v1/models list)
+    super::providers_handlers::register_providers_handlers(engine, &state);
+
     // eventreadhistory → read persisted event history from the WPS broker
     let broker_history = state.broker.clone();
     engine.register_handler(

--- a/docs/specs/SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md
+++ b/docs/specs/SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md
@@ -64,7 +64,8 @@ same cadence as the curated model metadata already is.
 ## 2. Goals / non-goals
 
 **Goals**
-1. The Effort drop-up shows **only levels valid for the currently-selected model**.
+1. The Effort control is a **titled, pitted spectrum slider** (faster → smarter) that
+   exposes **only levels valid for the currently-selected model** and locks onto one.
 2. `--effort` is emitted **iff** the model supports effort — replacing the `!== "haiku"`
    special case with data-driven gating (Sonnet 4.5 is also unsupported today and slips
    through).
@@ -166,23 +167,49 @@ export function resolveEffortCapability(providerId: string, modelValue: string):
 export function clampEffort(providerId: string, modelValue: string, desired: EffortLevel): EffortLevel | null;
 ```
 
-### 4.1 UI — Effort drop-up (`AgentComposerStrip.tsx`)
+### 4.1 UI — Effort **spectrum slider** (pitted), not a menu
 
-`EFFORT_OPTIONS` becomes derived, not static:
+Effort is an **ordinal** scale (`low < medium < high < xhigh < max`), unlike Mode/Model
+which are categorical. So its expanded panel is a **detented ("pitted") slider** that
+snaps + locks to one level, with a title and endpoint framing — it communicates the
+ordering and lets you step a notch faster than picking from a list. Mode/Model keep their
+drop-ups.
 
-```tsx
-const effortOptions = createMemo(() => {
-    const cap = resolveEffortCapability(props.providerId ?? "", runtime()?.model ?? "");
-    return EFFORT_OPTIONS_ALL.filter((o) => cap.allowed.includes(o.value as EffortLevel));
-});
+**Trigger** (collapsed, in the strip): unchanged shape — a compact pill showing the current
+level and the up-caret, e.g. `high ▴`. Clicking opens the panel below.
+
+**Expanded panel** (the flyout, `placement="top-start"`):
+
+```
+┌───────────────────────────────┐
+│ Effort                        │   ← panel title
+│                               │
+│ faster  ●──●──◉──●──●  smarter│   ← pitted spectrum; ◉ = locked thumb (current)
+│         low md high xh max    │   (per-level ticks; labels shown on hover/active)
+└───────────────────────────────┘
 ```
 
-- If `cap.allowed` is empty (model doesn't support effort, e.g. Haiku): **hide the Effort
-  drop-up entirely** (render nothing) rather than an empty menu. This is cleaner than a
-  disabled trigger and needs no new `MenuItem` field.
-- **Why filter, not grey-out:** the global `MenuItem` type (`custom.d.ts:405`) has no
-  `disabled`/`enabled` field, so a disabled row would require extending `MenuItem` +
-  FlyoutMenu render. Filtering needs neither. Greying-out is deferred to §7 (optional).
+- **Pits = the valid levels.** The thumb **snaps to the nearest detent on release and
+  locks** (no in-between values); ←/→ step one pit; the active pit's label shows inline,
+  others on hover.
+- **Endpoints frame the scale:** left = **faster** (`low`), right = **smarter** (`max`).
+  These are fixed captions, not selectable — they orient the user on what the axis means.
+- **Per-model capability shrinks the track** (this replaces the earlier "filter the menu"
+  idea — same data, better fit for a slider):
+  - Levels above `maxLevel` render as **disabled/greyed pits** past a hard stop, so the
+    thumb cannot land on them, e.g. a `max`-incapable model:
+    ```
+    faster  ●──●──◉──●──╳  smarter     (max pit disabled — thumb stops at xhigh)
+    ```
+  - If the model supports **no** effort (Haiku): **hide the whole Effort control**
+    (trigger + panel). A slider with one pit is meaningless.
+
+**Component:** new `EffortSpectrum` (SolidJS) rendered inside the flyout. Back it with a
+native `<input type="range" min=0 max=allowed.length-1 step=1>` for free snapping +
+keyboard + a11y, with the pits/track/labels styled over it (`_composer-strip.scss`). The
+index maps into `cap.allowed` (already ordered), so a shrunk track is just a shorter range.
+`onChange` → `updateRuntime({ effort: cap.allowed[idx] })`. No `MenuItem`/FlyoutMenu change
+needed (the panel hosts a custom body, not menu rows).
 
 ### 4.2 `/effort` slash command (`commands/global/runtime.ts`)
 

--- a/docs/specs/SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md
+++ b/docs/specs/SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md
@@ -1,0 +1,308 @@
+<!--
+Copyright 2026, AgentMux Corp.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# SPEC — Per-model effort-capability validation for the composer strip
+
+**Date:** 2026-07-02
+**Author:** AgentA
+**Status:** Proposed
+**Depends on:** #1926 (model-catalog overlay) — this stacks on top.
+**Source of truth for the matrix:** `docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md §1`
+
+---
+
+## 1. Problem
+
+The composer-strip **Effort** drop-up offers a fixed set of five levels for **every**
+model, but the levels a model actually accepts differ per model — and sending an
+unsupported one **400s the turn**. Today nothing validates this beyond a single
+hardcoded string check.
+
+### 1.1 Current state (evidence)
+
+| Concern | Where | Behavior |
+|---|---|---|
+| Effort list is static + universal | `AgentComposerStrip.tsx:44` (`EFFORT_OPTIONS`) | `Low/Med/High/XHigh/Max` rendered identically for every model; no per-model filtering. |
+| `/effort` slash command likewise | `commands/global/runtime.ts:105-109` (`effortChoices`) | Same five choices, unconditional. |
+| Only guard that exists | `buildRuntimeArgs.ts:110` | `if ((!providerId || providerId === "claude") && config.model !== "haiku") args.push("--effort", …)` — a single literal `!== "haiku"`. |
+| Effort type | `types.ts:626` | `type EffortLevel = "low" \| "medium" \| "high" \| "xhigh" \| "max"` |
+| Default | `types.ts:641` | `effort: "high"` |
+
+### 1.2 The real matrix (from the authoritative doc §1)
+
+- Effort **works on**: Fable 5, Opus 4.5–4.8, Sonnet 4.6.
+- Effort **400s on**: **Haiku 4.5** and **Sonnet 4.5** (and older Sonnets).
+- `max` is **narrower still** — valid only on **Fable 5, Opus 4.6+, Sonnet 4.6**; **not** Haiku, **not** older Sonnets.
+
+So two independent facts must be modeled per model: **(a) does it accept `--effort` at
+all**, and **(b) what is its highest valid level** (`max` vs `xhigh`).
+
+### 1.3 Why the catalog can't supply this
+
+`GET /v1/models` returns only `{ id, display_name, type, created }` — **no
+effort/reasoning capability field**. Unlike the model *labels* (which #1926 refreshes
+from the API), effort validity has **no authoritative machine-readable source**. It must
+be a **curated capability map**, seeded from the doc above and updated on CLI pin bumps —
+same cadence as the curated model metadata already is.
+
+### 1.4 Interaction with #1926 (important)
+
+#1926's overlay changes model **values** for families the curated list doesn't cover
+(e.g. Fable → concrete id `claude-fable-5`) and keeps curated families on their aliases
+(`opus`/`sonnet`/`haiku`). Two consequences:
+
+- The existing `config.model !== "haiku"` guard still fires for the curated haiku entry
+  (value stays `"haiku"`) — good, but it is **capability-blind**: a string match, not data.
+- Auto-appended families (Fable today) have **no effort metadata**, so the resolver needs
+  a **safe default** for unknown models (see §4.4). Fable *does* support effort incl.
+  `max`, but the mechanism must not assume that for the *next* unknown family.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+1. The Effort drop-up shows **only levels valid for the currently-selected model**.
+2. `--effort` is emitted **iff** the model supports effort — replacing the `!== "haiku"`
+   special case with data-driven gating (Sonnet 4.5 is also unsupported today and slips
+   through).
+3. The `/effort` slash command offers the same validated subset.
+4. Switching to a model that doesn't support the current effort **clamps** the effort to a
+   valid value instead of carrying an invalid one into the next turn.
+5. New families auto-appended by the catalog get **safe, non-crashing defaults**.
+
+**Non-goals**
+- Generalizing effort to Codex/Gemini (`model_reasoning_effort` / `thinking_level`). The
+  doc §11.5 tracks that; this spec is Claude-only to stay scoped. The data model below is
+  shaped so it *can* extend there later.
+- Fetching effort capability from any API (there is none — §1.3).
+- Changing the effort **default** (`high`) or the model default. Out of scope.
+
+---
+
+## 3. Capability data model
+
+Add optional effort metadata to `ProviderModel` (`providers/index.ts:36`). Optional so
+non-Claude providers and auto-appended models are unaffected.
+
+```ts
+export interface ProviderModel {
+    value: string;
+    label: string;
+    default?: boolean;
+    description?: string;
+    aliases?: string[];
+    /**
+     * Reasoning-effort capability. Omitted → provider default applies
+     * (see resolveEffortCapability). `supported: false` means the model 400s on
+     * any `--effort` (Haiku 4.5, Sonnet 4.5). `maxLevel` caps the offered levels
+     * (e.g. "xhigh" for models where `max` 400s). Source of truth:
+     * docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md §1.
+     */
+    effort?: {
+        supported: boolean;
+        /** Highest valid level; levels above it are hidden. Default "max". */
+        maxLevel?: EffortLevel;
+    };
+}
+```
+
+Curated Claude entries (`providers/index.ts:196-200`) become:
+
+```ts
+models: [
+    { value: "opus",   label: "Opus 4.8",   description: "…", aliases: ["claude-opus"],
+      effort: { supported: true, maxLevel: "max" } },
+    { value: "sonnet", label: "Sonnet 4.6", default: true, description: "…", aliases: ["claude-sonnet"],
+      effort: { supported: true, maxLevel: "max" } },
+    { value: "haiku",  label: "Haiku 4.5",  description: "…", aliases: ["claude-haiku"],
+      effort: { supported: false } },
+],
+```
+
+> Note: the curated `sonnet` alias resolves to the *current* Sonnet (4.6), which supports
+> `max`. The doc's "Sonnet 4.5 400s" caveat only matters if a concrete older Sonnet ever
+> becomes selectable; the alias insulates us. The generic default (§4.4) covers that case
+> anyway.
+
+### 3.1 Ordering of `EffortLevel`
+
+Introduce a single canonical rank so "levels above `maxLevel`" is well-defined and reused
+by clamping:
+
+```ts
+export const EFFORT_ORDER: EffortLevel[] = ["low", "medium", "high", "xhigh", "max"];
+```
+
+Place next to `EffortLevel` in `types.ts` so both the UI and `buildRuntimeArgs` import one
+source.
+
+---
+
+## 4. Resolver — the single decision point
+
+One pure function that every consumer calls. Lives in a new
+`frontend/app/view/agent/agent-effort.ts` (mirrors the existing `agent-model.ts`).
+
+```ts
+import { EffortLevel, EFFORT_ORDER } from "./types";
+import { getProvider, ProviderModel } from "./providers";
+
+export interface EffortCapability {
+    supported: boolean;
+    /** The allowed levels, in order, for this model (subset of EFFORT_ORDER). */
+    allowed: EffortLevel[];
+}
+
+/** Effort capability for (providerId, modelValue). Data-driven; safe defaults
+ *  for unknown models (§4.4). */
+export function resolveEffortCapability(providerId: string, modelValue: string): EffortCapability;
+
+/** Clamp a desired effort to the nearest valid level for a model — highest
+ *  allowed level ≤ desired, else the model's lowest allowed. Returns null when
+ *  the model supports no effort at all. */
+export function clampEffort(providerId: string, modelValue: string, desired: EffortLevel): EffortLevel | null;
+```
+
+### 4.1 UI — Effort drop-up (`AgentComposerStrip.tsx`)
+
+`EFFORT_OPTIONS` becomes derived, not static:
+
+```tsx
+const effortOptions = createMemo(() => {
+    const cap = resolveEffortCapability(props.providerId ?? "", runtime()?.model ?? "");
+    return EFFORT_OPTIONS_ALL.filter((o) => cap.allowed.includes(o.value as EffortLevel));
+});
+```
+
+- If `cap.allowed` is empty (model doesn't support effort, e.g. Haiku): **hide the Effort
+  drop-up entirely** (render nothing) rather than an empty menu. This is cleaner than a
+  disabled trigger and needs no new `MenuItem` field.
+- **Why filter, not grey-out:** the global `MenuItem` type (`custom.d.ts:405`) has no
+  `disabled`/`enabled` field, so a disabled row would require extending `MenuItem` +
+  FlyoutMenu render. Filtering needs neither. Greying-out is deferred to §7 (optional).
+
+### 4.2 `/effort` slash command (`commands/global/runtime.ts`)
+
+`effortChoices` filters the same way, reading the block's current model:
+
+```ts
+function effortChoices(ctx: SlashCommandContext): SlashChoice[] {
+    const meta = ctx.block()?.meta;
+    const cfg = getRuntimeConfig(meta);
+    const cap = resolveEffortCapability(providerOf(meta), cfg.model);
+    return ALL_EFFORT_CHOICES.filter((c) => cap.allowed.includes(c.value as EffortLevel));
+}
+```
+
+If the model supports no effort, `/effort` returns zero choices and the command surfaces a
+"model X does not support reasoning effort" message rather than silently accepting one.
+
+### 4.3 `buildRuntimeArgs.ts` — data-driven gate
+
+Replace the `!== "haiku"` literal (`:110`) with the resolver + clamp:
+
+```ts
+if (!providerId || providerId === "claude") {
+    const eff = clampEffort(providerId ?? "claude", config.model, config.effort);
+    if (eff) args.push("--effort", eff);   // null → model supports no effort → omit
+}
+```
+
+This is the safety net: even if the UI leaks an invalid value (stale meta, race with a
+model switch), the arg builder clamps or drops it, so **no turn 400s on effort**.
+
+### 4.4 Safe default for unknown models (§1.4)
+
+`resolveEffortCapability` when the model has no `effort` metadata (auto-appended families,
+or an id the curated list doesn't recognize):
+
+- **Claude provider, unknown model → `supported: true, allowed = [low..xhigh]`** (omit
+  `max`). Rationale: every current Claude model accepts `low..high`; `xhigh` is the coding
+  default; `max` is the *only* level with a genuinely narrow support set, so excluding it
+  by default is the conservative choice that won't 400. Fable (which *does* support `max`)
+  can be promoted to `maxLevel: "max"` via a one-line curated `effort` entry keyed on the
+  `claude-fable` family when we choose to — but it works safely without it.
+- **Non-Claude provider → `supported: false`** (matches today; effort is Claude-only).
+
+This makes the whole system **fail-safe**: a brand-new family the catalog surfaces gets a
+non-crashing effort set with zero code changes, and can be tuned later.
+
+### 4.5 Clamp on model switch (Goal 4)
+
+When the user changes **model** (`updateRuntime({ model })` in `AgentComposerStrip.tsx`,
+and the `/model` command), run `clampEffort(provider, newModel, currentEffort)` and, if it
+differs from the stored effort, patch effort in the **same** runtime update. Example:
+Haiku selected while effort was `max` → effort clamped to `null`→ dropped; switch to Opus
+→ effort restored from default (`high`) if it was previously dropped. Keep the rule simple:
+persist the *user-intended* effort, but never send an invalid one (the arg builder is the
+final guard, §4.3).
+
+> Decision needed (§8-Q1): do we (a) silently clamp, or (b) clamp + a one-line toast
+> ("Haiku doesn't support effort — reasoning level hidden")? Recommend (b) for the strip's
+> first occurrence per pane, silent thereafter.
+
+---
+
+## 5. Files touched
+
+| File | Change |
+|---|---|
+| `frontend/app/view/agent/types.ts` | Add `EFFORT_ORDER`; keep `EffortLevel`. |
+| `frontend/app/view/agent/providers/index.ts` | Add `effort?` to `ProviderModel`; populate curated Claude entries. |
+| `frontend/app/view/agent/agent-effort.ts` | **New** — `resolveEffortCapability`, `clampEffort`, defaults. |
+| `frontend/app/view/agent/components/AgentComposerStrip.tsx` | Derive `effortOptions`; hide drop-up when empty; clamp on model switch. |
+| `frontend/app/view/agent/commands/global/runtime.ts` | `effortChoices` filters; `/effort` on unsupported model messages. |
+| `frontend/app/view/agent/buildRuntimeArgs.ts` | Replace `!== "haiku"` with `clampEffort`. |
+| `docs/providers/PROVIDER_MODELS_EFFORT_SETTINGS_2026-06.md` | Cross-link this spec as the implementation of §11.3. |
+
+No backend/Rust changes. No `providers.models` RPC change. No `MenuItem`/FlyoutMenu change
+(unless §7 is taken).
+
+---
+
+## 6. Testing
+
+- **Unit (`agent-effort.test.ts`)**: `resolveEffortCapability`/`clampEffort` for
+  opus (max allowed), sonnet (max), haiku (unsupported → empty), unknown-claude
+  (low..xhigh), non-claude (unsupported); clamp cases (`max`→`xhigh` when capped, `max`→
+  dropped on haiku, in-range unchanged).
+- **`buildRuntimeArgs.test.ts`**: extend — no `--effort` for haiku (existing, now
+  data-driven); `--effort` present for opus/sonnet; `max` clamped to `xhigh` for a
+  capped model; effort dropped for a non-claude provider.
+- **Contract/UI**: strip renders 5 levels for opus, ≤4 for a capped model, hides Effort for
+  haiku; `/effort` choice count matches.
+
+---
+
+## 7. Optional enhancement — grey-out instead of hide
+
+If product prefers showing invalid levels greyed (discoverability) over hiding them:
+add `enabled?: boolean` (or reuse the existing `visible?`) to the global `MenuItem`
+(`custom.d.ts:405`) and have `FlyoutMenu` render a non-clickable dimmed row. Then
+`StripSelect` passes `enabled: cap.allowed.includes(o.value)`. Larger blast radius
+(touches the shared menu component) — **not** in the base implementation; filtering (§4.1)
+ships first.
+
+---
+
+## 8. Open decisions
+
+- **Q1 — clamp UX:** silent vs one-time toast on effort clamp/hide (§4.5). *Recommend:
+  toast once per pane, then silent.*
+- **Q2 — Fable `max`:** ship Fable via the §4.4 safe default (`low..xhigh`, no `max`), or
+  add a curated `claude-fable` effort entry granting `max` now? *Recommend: safe default
+  first (correct, never 400s), promote to `max` in a follow-up once verified live.*
+- **Q3 — hide vs disable:** filtering (hide) is the base plan (§4.1); grey-out is §7.
+  *Recommend: hide.*
+
+---
+
+## 9. Rollout
+
+Single PR, stacked on #1926. No migration (metadata is additive; missing `effort` →
+safe default). Reversible by dropping the `effort` fields (resolver falls back to
+defaults). Verify with `cargo` untouched, `tsc --noEmit`, the new unit tests, and the
+`rpc-contract` test (unaffected — no RPC surface change).

--- a/docs/specs/SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md
+++ b/docs/specs/SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md
@@ -24,7 +24,7 @@ hardcoded string check.
 
 | Concern | Where | Behavior |
 |---|---|---|
-| Effort list is static + universal | `AgentComposerStrip.tsx:44` (`EFFORT_OPTIONS`) | `Low/Med/High/XHigh/Max` rendered identically for every model; no per-model filtering. |
+| Effort list is static + universal | `AgentComposerStrip.tsx:44` (`EFFORT_OPTIONS`) | `low/medium/high/xhigh/max` rendered identically for every model; no per-model filtering. |
 | `/effort` slash command likewise | `commands/global/runtime.ts:105-109` (`effortChoices`) | Same five choices, unconditional. |
 | Only guard that exists | `buildRuntimeArgs.ts:110` | `if ((!providerId || providerId === "claude") && config.model !== "haiku") args.push("--effort", …)` — a single literal `!== "haiku"`. |
 | Effort type | `types.ts:626` | `type EffortLevel = "low" \| "medium" \| "high" \| "xhigh" \| "max"` |

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -51,6 +51,7 @@ import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
 import { fireAndForget } from "@/util/util";
+import { setProviderModels } from "@/app/view/agent/providers";
 import { scheduleRevealLift } from "@/store/tab-reveal";
 import { installLauncherEventBridge } from "@/util/launcher-events";
 import { installSrvEventBridge } from "@/util/srv-events";
@@ -1018,6 +1019,19 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     // See docs/specs/SPEC_SOUND_NOTIFICATIONS_2026_06_05.md.
     const { installSoundService } = await import("@/app/notification/sound");
     installSoundService();
+
+    // Refresh the Claude model catalog from the authoritative /v1/models list
+    // (backend `providers.models`, account OAuth token). Fire-and-forget: the
+    // model drop-up shows the curated static list until this resolves, then
+    // re-renders with fresh labels (Sonnet 5, …) + any new families (Fable).
+    // Best-effort — returns [] with no token (logged out / macOS Keychain).
+    fireAndForget(async () => {
+        const res = await RpcApi.ProvidersModelsCommand(TabRpcClient, { provider_id: "claude" });
+        setProviderModels(
+            "claude",
+            (res?.models ?? []).map((m) => ({ value: m.id, label: m.display_name })),
+        );
+    });
 
     tlog("TOTAL initWave", t0);
 

--- a/frontend/app/store/rpc-api/misc.ts
+++ b/frontend/app/store/rpc-api/misc.ts
@@ -41,6 +41,18 @@ export const MiscApi = {
         return client.rpcCall("notify", data, opts);
     },
 
+    // command "providers.models" [call] — authoritative model catalog for a
+    // provider, fetched server-side from the Anthropic Models API with the
+    // account OAuth token. Returns [] (never throws for the model list) when
+    // the token is absent/expired; the frontend then keeps its static catalog.
+    ProvidersModelsCommand(
+        client: RpcClient,
+        data: { provider_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ models: Array<{ id: string; display_name: string }> }> {
+        return client.rpcCall("providers.models", data, opts);
+    },
+
     RecordTEventCommand(client: RpcClient, data: TEvent, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("recordtevent", data, opts);
     },

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -102,11 +102,11 @@ function effortChoices(ctx: SlashCommandContext): SlashChoice[] {
         aliases,
     });
     return [
-        make("low", "Low", "Minimal reasoning effort", "low"),
-        make("medium", "Medium", "Balanced reasoning effort", "medium", ["med"]),
-        make("high", "High", "High reasoning effort", "high"),
-        make("xhigh", "XHigh", "Best for coding/agentic (Claude Code default)", "xhigh", ["extra-high", "x-high"]),
-        make("max", "Max", "Maximum reasoning effort", "max"),
+        make("low", "low", "Minimal reasoning effort", "low"),
+        make("medium", "medium", "Balanced reasoning effort", "medium", ["med"]),
+        make("high", "high", "High reasoning effort", "high"),
+        make("xhigh", "xhigh", "Best for coding/agentic (Claude Code default)", "xhigh", ["extra-high", "x-high"]),
+        make("max", "max", "Maximum reasoning effort", "max"),
     ];
 }
 

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -105,7 +105,7 @@ function effortChoices(ctx: SlashCommandContext): SlashChoice[] {
         make("low", "Low", "Minimal reasoning effort", "low"),
         make("medium", "Medium", "Balanced reasoning effort", "medium", ["med"]),
         make("high", "High", "High reasoning effort", "high"),
-        make("xhigh", "X-High", "Best for coding/agentic (Claude Code default)", "xhigh", ["extra-high"]),
+        make("xhigh", "XHigh", "Best for coding/agentic (Claude Code default)", "xhigh", ["extra-high", "x-high"]),
         make("max", "Max", "Maximum reasoning effort", "max"),
     ];
 }

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -42,11 +42,11 @@ const MODEL_OPTIONS = [
 ] as const;
 
 const EFFORT_OPTIONS = [
-    { value: "low", label: "Low" },
-    { value: "medium", label: "Med" },
-    { value: "high", label: "High" },
-    { value: "xhigh", label: "XHigh" },
-    { value: "max", label: "Max" },
+    { value: "low", label: "low" },
+    { value: "medium", label: "medium" },
+    { value: "high", label: "high" },
+    { value: "xhigh", label: "xhigh" },
+    { value: "max", label: "max" },
 ] as const;
 
 // Mode: trigger shows the short `label`; the menu shows `menuLabel` (the

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -45,7 +45,7 @@ const EFFORT_OPTIONS = [
     { value: "low", label: "Low" },
     { value: "medium", label: "Med" },
     { value: "high", label: "High" },
-    { value: "xhigh", label: "X-High" },
+    { value: "xhigh", label: "XHigh" },
     { value: "max", label: "Max" },
 ] as const;
 

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -608,5 +608,8 @@ export function getProvider(id: string): ProviderDefinition | undefined {
 }
 
 export function getProviderList(): ProviderDefinition[] {
-    return Object.values(PROVIDERS);
+    // Route through getProvider so list consumers that read `.models` see the
+    // same API-sourced overlay (refreshed labels / new families) as callers of
+    // getProvider(), not the raw static list.
+    return Object.keys(PROVIDERS).map((id) => getProvider(id)!);
 }

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -1,6 +1,8 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createSignal } from "solid-js";
+
 /**
  * A system tool the provider's CLI needs at runtime — beyond Node
  * itself, which is checked separately by `check_nodejs_available`.
@@ -504,8 +506,105 @@ export function resolveProviderAlias(id: string): string {
     return PROVIDER_ALIASES[id] ?? id;
 }
 
+// ── API-sourced model catalog overlay ───────────────────────────────────────
+//
+// The static `models` above are hand-curated and their version labels drift
+// ("Sonnet 4.6" → "Sonnet 5" …). `providers.models` (backend) reads the
+// authoritative list from the Anthropic Models API; `setProviderModels` folds
+// it in. Signal-backed so a strip that rendered before the fetch resolved
+// re-renders when the catalog lands (see app-init.ts).
+const [modelOverlay, setModelOverlay] = createSignal<Record<string, ProviderModel[]>>({});
+
+/** Numeric version tokens of a model id, e.g. "claude-sonnet-5" → [5],
+ *  "claude-opus-4-8" → [4,8]. Order-independent "which is newest" key. */
+function versionTuple(id: string): number[] {
+    return (id.match(/\d+/g) ?? []).map((n) => parseInt(n, 10));
+}
+
+/** Element-wise version compare; missing positions count as 0 so [5] > [3,5]. */
+function cmpVersion(a: number[], b: number[]): number {
+    const n = Math.max(a.length, b.length);
+    for (let i = 0; i < n; i++) {
+        const d = (a[i] ?? 0) - (b[i] ?? 0);
+        if (d !== 0) return d;
+    }
+    return 0;
+}
+
+/** The highest-versioned model in a group — robust to API ordering, so a newly
+ *  shipped Sonnet 5.x / 6 wins over the prior version automatically. */
+function pickNewest(models: ProviderModel[]): ProviderModel {
+    return models.reduce((best, m) =>
+        cmpVersion(versionTuple(m.value), versionTuple(best.value)) > 0 ? m : best,
+    );
+}
+
+/** Family key for an id the curated list doesn't cover — its alphabetic tokens
+ *  minus the "claude" prefix, e.g. "claude-fable-5" → "fable". Groups versions
+ *  of a genuinely new family so we surface one (newest) entry for it. */
+function familyKey(id: string): string {
+    const alpha = id.split("-").filter((t) => /^[a-z]+$/i.test(t) && t.toLowerCase() !== "claude");
+    return alpha.join("-").toLowerCase() || id.toLowerCase();
+}
+
+/** Drop the redundant "Claude " prefix so API labels match the curated style
+ *  ("Claude Sonnet 5" → "Sonnet 5"). */
+function cleanLabel(label: string): string {
+    return label.replace(/^claude\s+/i, "").trim();
+}
+
+/**
+ * Fold the authoritative catalog into a provider's model list. Behavior-
+ * preserving by design:
+ *  - Curated family entries (opus/sonnet/haiku) keep their short `value` (which
+ *    `--model` resolves to the current version), `default` marker, `aliases`,
+ *    and `description`; only their **label** is refreshed to the newest matching
+ *    API model. This is what turns "Sonnet 4.6" into "Sonnet 5" without changing
+ *    what `--model` receives or breaking `models.find(m => m.default)`.
+ *  - Families the curated list doesn't cover (Fable today, any future family)
+ *    are appended automatically, one newest entry each, using the concrete API
+ *    id as `value` (always a valid `--model` target). No family is hardcoded.
+ * Empty input (no token / macOS Keychain / offline) is a no-op → static list.
+ */
+export function setProviderModels(id: string, apiModels: ProviderModel[]): void {
+    if (apiModels.length === 0) return;
+    const canonical = resolveProviderAlias(id);
+    const base = PROVIDERS[id] ?? PROVIDERS[canonical];
+    if (!base) return;
+
+    const consumed = new Set<string>();
+
+    // 1. Refresh curated family labels from the newest API model in that family.
+    const curated = base.models.map((m) => {
+        const family = m.value.toLowerCase();
+        const matches = apiModels.filter((a) => a.value.toLowerCase().includes(family));
+        if (matches.length === 0) return m;
+        matches.forEach((a) => consumed.add(a.value)); // don't re-surface as an "extra"
+        return { ...m, label: cleanLabel(pickNewest(matches).label) };
+    });
+
+    // 2. Surface families the curated list misses (grouped, newest per family).
+    const byFamily = new Map<string, ProviderModel[]>();
+    for (const a of apiModels) {
+        if (consumed.has(a.value)) continue;
+        const key = familyKey(a.value);
+        const group = byFamily.get(key) ?? [];
+        group.push(a);
+        byFamily.set(key, group);
+    }
+    const extras = [...byFamily.values()].map((group) => {
+        const newest = pickNewest(group);
+        return { value: newest.value, label: cleanLabel(newest.label) } satisfies ProviderModel;
+    });
+
+    setModelOverlay((prev) => ({ ...prev, [canonical]: [...curated, ...extras] }));
+}
+
 export function getProvider(id: string): ProviderDefinition | undefined {
-    return PROVIDERS[id] ?? PROVIDERS[resolveProviderAlias(id)];
+    const base = PROVIDERS[id] ?? PROVIDERS[resolveProviderAlias(id)];
+    if (!base) return undefined;
+    const overlay = modelOverlay()[resolveProviderAlias(base.id)];
+    return overlay ? { ...base, models: overlay } : base;
 }
 
 export function getProviderList(): ProviderDefinition[] {


### PR DESCRIPTION
## What

End-to-end wiring so the composer-strip **Model** drop-up shows the authoritative Claude model list from `GET /v1/models` instead of hand-curated labels that drift each release ("Sonnet 4.6" → "Sonnet 5" …). Builds on the fetch layer merged in #1923.

## Backend
- **New `providers.models` RPC** (`server/providers_handlers.rs`): resolves the account-global OAuth token via `DataPaths::provider_auth_dir("claude")` and calls the existing `fetch_model_catalog()`. Best-effort — returns `{models:[]}` when there is no token (logged out / macOS Keychain), so the frontend keeps its static list. Non-Claude providers return empty. Registered next to the tool-store handlers.

## Frontend
- `rpc-api/misc.ts`: `ProvidersModelsCommand` binding. Identical command string on both sides keeps the `rpc-contract` baseline green.
- `providers/index.ts`: signal-backed model **overlay**. `setProviderModels` folds the catalog in, **behavior-preserving**:
  - curated family entries (`opus`/`sonnet`/`haiku`) keep their short `value` (which `--model` resolves to the current version), the `default` marker, `aliases`, and `description`; only the **label** is refreshed to the newest matching model. Version-tuple comparison means **Sonnet 5 → 5.x → 6 auto-wins** regardless of API ordering.
  - families the curated list does not cover (**Fable** today, any future family) are appended automatically, newest per family, using the concrete id as `value`. **No family is hardcoded.**
- `app-init.ts`: one-time fire-and-forget fetch after render; the drop-up shows the static list until it resolves, then re-renders with fresh labels.

## Why this shape
The static Claude entries intentionally use family aliases (`sonnet`) as `--model` values so the CLI resolves to the current version, and `sonnet` carries `default: true` that `DEFAULT_RUNTIME_CONFIG` readers depend on. A naive full replace with concrete API ids would break both. The overlay refreshes only what drifts (labels) and adds only what is genuinely new (families).

## Verification
- `cargo check -p agentmux-srv` — clean (pre-existing warnings only)
- `tsc --noEmit -p tsconfig.json` — exit 0
- `vitest run test/contract/rpc-contract.test.ts` — 4/4 pass (command present in both `registered` and `declared`; baseline diffs unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)