### PR TITLE
chore: release v0.49.13

### DIFF
--- a/.changesets/1782997789-fix-agent-composer-strip-mode-toplevel.md
+++ b/.changesets/1782997789-fix-agent-composer-strip-mode-toplevel.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): promote Mode to composer strip, un-nest Controls from Log, style Session buttons

--- a/.changesets/1782997838-fix-agent-compute-real-running-totals-for-composer-strip-ins-mx7z.md
+++ b/.changesets/1782997838-fix-agent-compute-real-running-totals-for-composer-strip-ins-mx7z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): compute real running totals for composer strip instead of reusing per-query stats

--- a/.changesets/1782998810-fix-read-preview-markdown-and-zoom.md
+++ b/.changesets/1782998810-fix-read-preview-markdown-and-zoom.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): render markdown in Read-tool preview; zoom the preview body (not the filepath) and route filename/pane zoom by hover

--- a/.changesets/1782999624-feat-ui-rename-trust-center-to-armory-4h33.md
+++ b/.changesets/1782999624-feat-ui-rename-trust-center-to-armory-4h33.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ui): rename Trust Center to Armory

--- a/.changesets/1783001123-feat-armory-rename-preset-to-bundle-app-api-ui-phase-2-87p1.md
+++ b/.changesets/1783001123-feat-armory-rename-preset-to-bundle-app-api-ui-phase-2-87p1.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): rename Preset to Bundle (App API + UI, phase 2)

--- a/.changesets/1783037038-feat-agent-consolidate-pane-header-to-a-single-agent-setup-i-a2yv.md
+++ b/.changesets/1783037038-feat-agent-consolidate-pane-header-to-a-single-agent-setup-i-a2yv.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): consolidate pane header to a single Agent setup icon + unified modal

--- a/.changesets/1783038175-fix-agent-composer-dropups.md
+++ b/.changesets/1783038175-fix-agent-composer-dropups.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): Mode/Model/Effort drop-ups (open upward) replace native <select>; stop hiding controls on narrow panes

--- a/.changesets/1783038288-feat-srv-model-catalog.md
+++ b/.changesets/1783038288-feat-srv-model-catalog.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): model catalog fetch layer (GET /v1/models via OAuth) — foundation for API-sourced model dropdown

--- a/.changesets/1783039588-feat-agent-providers-models-rpc-catalog-overlay.md
+++ b/.changesets/1783039588-feat-agent-providers-models-rpc-catalog-overlay.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): `providers.models` RPC + live model-catalog overlay for the strip drop-up

--- a/.changesets/1783040229-feat-identity-revive-direct-agent-account-bindings-additive--zwe5.md
+++ b/.changesets/1783040229-feat-identity-revive-direct-agent-account-bindings-additive--zwe5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(identity): revive direct agent-account bindings (additive, dual-read + backfill)

--- a/.changesets/1783042066-docs-remove-legacy-workflow-lineage-docs.md
+++ b/.changesets/1783042066-docs-remove-legacy-workflow-lineage-docs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: remove legacy pre-Drone "Workflows" lineage specs; free the term for Claude's workflows feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.12"
+version = "0.49.13"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.12"
+version = "0.49.13"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.12"
+version = "0.49.13"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.12"
+version = "0.49.13"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.12"
+version = "0.49.13"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.12"
+version = "0.49.13"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.12"
+version = "0.49.13"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.49.13 — 2026-07-02
+
+- fix(agent): promote Mode to composer strip, un-nest Controls from Log, style Session buttons
+- fix(agent): compute real running totals for composer strip instead of reusing per-query stats
+- fix(agent): render markdown in Read-tool preview; zoom the preview body (not the filepath) and route filename/pane zoom by hover
+- feat(ui): rename Trust Center to Armory
+- feat(armory): rename Preset to Bundle (App API + UI, phase 2)
+- feat(agent): consolidate pane header to a single Agent setup icon + unified modal
+- fix(agent): Mode/Model/Effort drop-ups (open upward) replace native <select>; stop hiding controls on narrow panes
+- feat(srv): model catalog fetch layer (GET /v1/models via OAuth) — foundation for API-sourced model dropdown
+- feat(agent): `providers.models` RPC + live model-catalog overlay for the strip drop-up
+- feat(identity): revive direct agent-account bindings (additive, dual-read + backfill)
+- docs: remove legacy pre-Drone "Workflows" lineage specs; free the term for Claude's workflows feature
+
+
 ## 0.49.12 — 2026-07-02
 
 - feat(toolchain): Check latest versions button — fetch latest npm versions for provider CLIs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.12",
+  "version": "0.49.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.12",
+      "version": "0.49.13",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.12",
+  "version": "0.49.13",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Patch release **v0.49.13** (0.49.12 → 0.49.13), consuming 11 pending changesets.

**Bump override:** forced `--as patch` per request. The queued changesets include `feat`-level entries (computed bump = minor); those minor changes ship under this patch version by explicit override (the changesets contract logs a loud warning for a lower-than-requested bump).

Notable changes rolled up:
- feat(ui): rename Trust Center → **Armory**
- feat(armory): rename Preset → **Bundle** (App API + UI, phase 2)
- feat(agent): single **Agent setup** icon + unified modal
- feat(identity): additive direct agent↔account bindings (dual-read + backfill)
- feat(srv): model catalog fetch layer + providers/models RPC overlay
- feat(agent): Mode/Model/Effort drop-ups
- fixes: composer strip mode, running totals, preview markdown/zoom, composer dropups
- docs: remove legacy workflow lineage docs

**Release invariant:** all 5 version locations (`package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`, `VERSION_HISTORY.md` head) agree at 0.49.13.

<!-- agentmux:agent_id=agent1 -->