### PR TITLE
feat(launcher): instrument host-spawn latency as a startup stage

### DIFF
--- a/.changesets/1783044933-feat-launcher-instrument-host-spawn-latency-as-a-startup-sta-besx.md
+++ b/.changesets/1783044933-feat-launcher-instrument-host-spawn-latency-as-a-startup-sta-besx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launcher): instrument host-spawn latency as a startup stage (unix + windows)

--- a/agentmux-launcher/src/supervisor/unix.rs
+++ b/agentmux-launcher/src/supervisor/unix.rs
@@ -326,9 +326,35 @@ pub(crate) async fn run_unix(
             std::ffi::OsString::from(host_runtime),
         ));
     }
+    // "host" stage currently covers process-spawn latency only (begin →
+    // spawn_host_unix returning a live Child), not full first-paint — the
+    // signal for "host painted its first frame" (AGENTMUX_SPLASH_READY_FILE)
+    // is written by the host process itself and consumed exclusively by the
+    // splash's own poll loop (splash_mac.rs / splash_linux); having the
+    // supervisor also poll/remove that file risks a race with the splash's
+    // consumer. Extending this stage to span to first-paint is a follow-up
+    // once a race-safe signal exists (see SPEC_MACOS_LAUNCH_SPEED_AND_
+    // SPLASH_TELEMETRY_2026_07_02.md §B.7). Spawn latency is still a real,
+    // independently useful number.
+    startup_sink.stage_begin("host", "Host startup");
+    let host_spawn_t = std::time::Instant::now();
     let mut host_child = match spawn_host_unix(real_exe, args, &srv_result, &host_env, false) {
-        Some(c) => c,
+        Some(c) => {
+            startup_sink.stage_end(
+                "host",
+                host_spawn_t.elapsed().as_millis() as u64,
+                startup_events::StartupStatus::Ok,
+                None,
+            );
+            c
+        }
         None => {
+            startup_sink.stage_end(
+                "host",
+                host_spawn_t.elapsed().as_millis() as u64,
+                startup_events::StartupStatus::Error,
+                Some("spawn failed".to_string()),
+            );
             log("FATAL: could not start CEF host — terminating");
             eprintln!("Failed to launch AgentMux.");
             terminate_child_gracefully(&srv_child);

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -393,6 +393,17 @@ pub(crate) async fn run_windows(
     // Prevents two running releases from overwriting each other's port
     // file (codex P1 on #1227).
     host_env.push(("AGENTMUX_IPC_HASH", std::ffi::OsString::from(&dir_hash)));
+    // "host" stage covers process-spawn latency (begin → spawn_host_supervised
+    // returning a live Child), including the suspend → job-assign → resume
+    // dance (see resume_main_thread's Toolhelp32 snapshot walk in
+    // host_spawn.rs) — not full first-paint. The first-paint signal
+    // (splash_event_name) is consumed exclusively by the splash's own wait;
+    // having the supervisor also wait on it risks double-signaling semantics
+    // on the named event. Extending this stage to span to first-paint is a
+    // follow-up once a race-safe signal exists (see SPEC_MACOS_LAUNCH_SPEED_
+    // AND_SPLASH_TELEMETRY_2026_07_02.md §B.7). Mirrors unix.rs's "host" stage.
+    startup_sink.stage_begin("host", "Host startup");
+    let host_spawn_t = std::time::Instant::now();
     let mut host_child = match spawn_host_supervised(
         real_exe,
         args,
@@ -404,8 +415,22 @@ pub(crate) async fn run_windows(
         splash_event_name.as_deref(),
         false,
     ) {
-        Some(c) => c,
+        Some(c) => {
+            startup_sink.stage_end(
+                "host",
+                host_spawn_t.elapsed().as_millis() as u64,
+                startup_events::StartupStatus::Ok,
+                None,
+            );
+            c
+        }
         None => {
+            startup_sink.stage_end(
+                "host",
+                host_spawn_t.elapsed().as_millis() as u64,
+                startup_events::StartupStatus::Error,
+                Some("spawn failed".to_string()),
+            );
             // First-launch failure is fatal. Happy path: drop(job) →
             // KILL_ON_JOB_CLOSE reaps srv. Degraded path (J0 absent):
             // kill srv explicitly or it orphans (kill_on_drop is false).


### PR DESCRIPTION
## Summary
- Adds a `"host"` `StartupEvent` stage bracketing `spawn_host_unix` (`unix.rs`) and `spawn_host_supervised` (`windows.rs`), mirroring the existing `"saga"`/`"backend"` stage pattern (`startup_events.rs`). On Windows this also captures the suspend → job-assign → resume dance.
- **Deliberately scoped to spawn latency, not full spawn-to-first-paint.** The first-paint signal (`AGENTMUX_SPLASH_READY_FILE` / the Windows named event) is currently consumed exclusively by the splash's own poll loop — having the supervisor also observe/consume it risks a race with that consumer (double-remove on the ready-file, or double-signal semantics on the named event). Extending `"host"` to span all the way to first-paint is flagged as a follow-up in the spec once a race-safe signal exists (e.g. an explicit IPC report from the host, or a shared `tokio::sync::Notify`), rather than risk a platform-specific timing bug I can't fully verify (Windows changes here were reviewed carefully against the existing pattern but not cross-compiled — see Test plan).
- Second PR in the `SPEC_MACOS_LAUNCH_SPEED_AND_SPLASH_TELEMETRY_2026_07_02.md` implementation stack (after #1930). Cross-platform benefit now (Windows/Linux splashes already consume `StartupEvent`s and will show this stage); it's also the direct prerequisite for #1930's macOS splash work.

## Test plan
- [x] `cargo build -p agentmux-launcher` (macOS) — clean, no new warnings
- [x] `cargo test -p agentmux-launcher` — 199/199 passing
- [x] Windows: attempted `cargo check --target x86_64-pc-windows-msvc` — blocked by missing MSVC C toolchain in this environment (libsqlite3-sys build script needs a real `cc`), so I could not get a machine-verified Windows build. The `windows.rs` change is a small, mechanical mirror of the exact `stage_begin`/`stage_end` pattern already compiling in the same file (`"saga"` stage, lines 257-282) — same types, same call shape, no new imports. Flagging explicitly rather than claiming Windows-verified.
- [ ] Manual: run on Windows/Linux and confirm the splash's stage panel now shows a "Host startup" row with a plausible duration

<!-- agentmux:agent_id=agento -->