### PR TITLE
fix(armory): distinct icon + finish Trust Center comment sweep

### DIFF
--- a/.changesets/1783063200-fix-armory-distinct-vault-icon-trust-center-comment-sweep-ic3x.md
+++ b/.changesets/1783063200-fix-armory-distinct-vault-icon-trust-center-comment-sweep-ic3x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): distinct vault icon + Trust Center comment sweep

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -37,7 +37,7 @@ parking_lot = "0.12"
 notify = "7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 # OS-native secret storage (macOS Keychain / Windows Credential Manager /
-# Linux Secret Service) for Trust Center API keys. See
+# Linux Secret Service) for Armory API keys. See
 # specs/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
 keyring = "2"
 # Zero plaintext secret buffers on drop.

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -208,7 +208,7 @@
     "defwidget@armory": {
         "display:order": 21,
         "display:pinned": false,
-        "icon": "shield-halved",
+        "icon": "vault",
         "label": "Armory",
         "description": "Manage accounts, identities, brain, and presets",
         "blockdef": {

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,6 +1,6 @@
 # MuxBus Cloud Auth
 # VITE_MUXBUS_COGNITO_DOMAIN and VITE_MUXBUS_CLIENT_ID enable the AgentMux
-# Cloud sign-in button in Trust Center → Accounts → AgentMux.
+# Cloud sign-in button in Armory → Accounts → AgentMux.
 #
 # VITE_MUXBUS_COGNITO_DOMAIN is the branded Cognito custom domain (muxbus-cognito.ts):
 #   prod env → auth.muxbus.agentmux.ai

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Trust Center Accounts gallery — brand tiles + per-tile connected count +
+// Armory Accounts gallery — brand tiles + per-tile connected count +
 // the OAuth/Key chooser. SPEC_TRUST_CENTER_2026_06_15.md §3.
 
 .accounts-gallery {

--- a/frontend/app/view/accounts/oauth-connect.scss
+++ b/frontend/app/view/accounts/oauth-connect.scss
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Trust Center service-OAuth connect panel (Accounts form).
+// Armory service-OAuth connect panel (Accounts form).
 // Reuses identity-view form primitives (.identity-input, .identity-btn,
 // .identity-form-field/-label, .identity-key-actions); only the OAuth-specific
 // bits live here. Spec: specs/SPEC_TRUST_CENTER_2026_06_15.md §4.2.

--- a/frontend/app/view/agent/components/PaneRow.scss
+++ b/frontend/app/view/agent/components/PaneRow.scss
@@ -95,7 +95,7 @@
 }
 
 // Labelled / primary / disabled action buttons — the failure-recovery row uses
-// text buttons (Retry now, Login Again, Trust Center) rather than bare glyphs.
+// text buttons (Retry now, Login Again, Armory) rather than bare glyphs.
 .pane-row-action {
     gap: var(--space-0-5);
 

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -8,7 +8,7 @@ export class ArmoryViewModel implements ViewModel {
     blockId: string;
     nodeModel: BlockNodeModel;
 
-    viewIcon = () => "shield-halved";
+    viewIcon = () => "vault";
     viewName = () => "Armory";
     // wired in armory.tsx to avoid circular import
     declare viewComponent: ViewComponent<ArmoryViewModel>;

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Styles for the Trust Center "Brain" tab (GlobalBrainManager). Renders
+// Styles for the Armory "Brain" tab (GlobalBrainManager). Renders
 // inside the bundle-manager pane, which provides the scroll container.
 
 .global-brain {

--- a/frontend/app/view/identity/styles/_form-overlay.scss
+++ b/frontend/app/view/identity/styles/_form-overlay.scss
@@ -117,7 +117,7 @@
     justify-content: flex-end;
 }
 
-// ── Trust Center secure-key lifecycle (SPEC_TRUST_CENTER §5) ──
+// ── Armory secure-key lifecycle (SPEC_TRUST_CENTER §5) ──
 
 .identity-key-egress-note {
     font-size: 11px;

--- a/frontend/app/window/hamburger-menu.tsx
+++ b/frontend/app/window/hamburger-menu.tsx
@@ -116,7 +116,7 @@ export function HamburgerMenu(props: HamburgerMenuProps): JSX.Element {
             },
             {
                 label: "Armory",
-                icon: "shield-halved",
+                icon: "vault",
                 onClick: () => fireAndForget(() => openOrFocusPaneByView("armory")),
             },
             {


### PR DESCRIPTION
## Summary
- Armory reused Warden's `shield-halved` icon, making the two rail widgets look identical. Switched Armory to `vault` (one of the alternatives already called out in `docs/specs/SPEC_RENAME_TRUST_CENTER_TO_ARMORY_2026_07_02.md` §F), updated in `widgets.json`, `armory-model.ts`, and `hamburger-menu.tsx`.
- Finished the §G comment sweep from the same rename spec: 7 leftover "Trust Center" comments in accounts/brain/identity/agent view dirs, `Cargo.toml`, and `frontend/.env.production` now say "Armory". Historical spec filenames/bodies (`SPEC_TRUST_CENTER_*`) are left untouched, and the `block.tsx` view-dispatch shim comment (which correctly describes the rename event itself) is unchanged.

## Test plan
- [x] `widgets.json` validated as well-formed JSON
- [x] Confirmed no remaining `shield-halved` reference under Armory (Warden's own icon usage is untouched)
- [x] Confirmed no remaining `Trust Center` string outside historical spec docs and the intentional block.tsx shim comment

<!-- agentmux:agent_id=agent3 -->