### PR TITLE
fix(scripts): resolve task via PATHEXT instead of hardcoded .exe extension

### DIFF
--- a/.changesets/1783063556-fix-scripts-resolve-task-via-pathext-instead-of-hardcoded-ex-2dyj.md
+++ b/.changesets/1783063556-fix-scripts-resolve-task-via-pathext-instead-of-hardcoded-ex-2dyj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(scripts): resolve task via PATHEXT instead of hardcoded .exe extension in agent bridge scripts

--- a/scripts/dev-agent.cmd
+++ b/scripts/dev-agent.cmd
@@ -34,8 +34,11 @@ set "GIT_BIN=C:\Program Files\Git\bin"
 set "GIT_USR=C:\Program Files\Git\usr\bin"
 set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
 
-:: Call task.exe by explicit extension (Gap A fix — no bash lookup needed here).
-:: task is installed as task.exe (via go install / WinGet), not task.cmd.
+:: Call bare `task` (no extension) — this .cmd wrapper itself runs under cmd.exe
+:: (Gap A only applies to bash resolving .cmd files, not to us), so PATHEXT
+:: resolution finds task.exe (go install / WinGet) OR task.cmd (npm global
+:: install) transparently. Do NOT hardcode an extension — which one exists
+:: depends on how `task` was installed on the machine.
 :: Merge stderr into stdout so shell viewers don't color build progress red
 :: (cargo writes all output to stderr, not stdout).
-task.exe dev %* 2>&1
+task dev %* 2>&1

--- a/scripts/package-agent.cmd
+++ b/scripts/package-agent.cmd
@@ -1,0 +1,15 @@
+@echo off
+:: Bridge script for agent / MCP-Shell invocation of `task package` on Windows.
+:: Same Gap A + Gap B fixes as dev-agent.cmd — see that file for full explanation.
+
+cd /d "%~dp0.."
+
+set "GIT_BIN=C:\Program Files\Git\bin"
+set "GIT_USR=C:\Program Files\Git\usr\bin"
+set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
+
+:: Call bare `task` — PATHEXT resolves task.exe or task.cmd depending on how
+:: it was installed on the machine (see dev-agent.cmd for the full rationale).
+:: Merge stderr into stdout so shell viewers don't color build progress red
+:: (cargo writes all output to stderr, not stdout).
+task package %* 2>&1


### PR DESCRIPTION
## Summary

- `dev-agent.cmd` / `package-agent.cmd` hardcoded `task.exe`, assuming `task` was installed via `go install` / WinGet. On machines where `task` was installed via npm (go-task's npm wrapper), the binary is `task.cmd`, not `task.exe` — calling `task.exe` fails immediately with "not recognized as an internal or external command" (exit 1, <100ms).
- Since these `.cmd` wrapper scripts already run under `cmd.exe` (that's what fixes the bash-can't-resolve-.cmd-files gap — no bash lookup needed to invoke the wrapper itself), calling bare `task` lets `cmd.exe`'s `PATHEXT` resolve to whichever extension actually exists, instead of assuming one specific install method.
- Also adds `package-agent.cmd`, the `task package` counterpart to the existing `task dev` bridge script, for portable-build invocation from an agent's MCP Shell.

## Test plan

- [x] `cmd /C scripts\package-agent.cmd --help` now resolves and runs `task` (previously: `'task.exe' is not recognized as an internal or external command`)
- [x] Confirmed via `mcp__agentmux__Shell` — build now actually compiles (npm/frontend steps observed running) instead of failing in <100ms

<!-- agentmux:agent_id=lzop -->