### PR TITLE
fix(muxbus): quote Windows browser-open URL so cmd.exe doesn't truncate it at the first &

### DIFF
--- a/.changesets/1783064614-fix-muxbus-quote-windows-browser-open-url-so-cmd-exe-doesn-t-titf.md
+++ b/.changesets/1783064614-fix-muxbus-quote-windows-browser-open-url-so-cmd-exe-doesn-t-titf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): quote Windows browser-open URL so cmd.exe doesn't truncate it at the first &

--- a/agentmux-srv/src/identity/oauth_client.rs
+++ b/agentmux-srv/src/identity/oauth_client.rs
@@ -270,6 +270,7 @@ pub fn resolve_client(
 // ── Flow execution ──────────────────────────────────────────────────────────
 
 use crate::backend::storage::store::{IdentityAccount, SecretRef, Store};
+use crate::util::open_browser;
 
 fn http() -> &'static reqwest::Client {
     static C: OnceLock<reqwest::Client> = OnceLock::new();
@@ -280,21 +281,6 @@ fn http() -> &'static reqwest::Client {
             .build()
             .expect("reqwest client build failed")
     })
-}
-
-fn open_browser(url: &str) {
-    #[cfg(target_os = "windows")]
-    {
-        let _ = std::process::Command::new("cmd").args(["/C", "start", "", url]).spawn();
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let _ = std::process::Command::new("open").arg(url).spawn();
-    }
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    {
-        let _ = std::process::Command::new("xdg-open").arg(url).spawn();
-    }
 }
 
 /// Tokens returned by an exchange. Stored as a keychain JSON blob — never the

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -18,6 +18,7 @@ mod state;
 mod drone;
 mod messaging;
 mod muxbus;
+mod util;
 #[cfg(windows)]
 mod crash_monitor;
 

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -19,6 +19,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpSocket;
 
 use crate::backend::storage::muxbus::MuxBusCredentials;
+use crate::util::open_browser;
 
 pub const LOGIN_TIMEOUT_SECS: u64 = 300;
 
@@ -346,19 +347,3 @@ fn extract_jwt_claims(token: &str) -> (String, String) {
     (email, sub)
 }
 
-fn open_browser(url: &str) {
-    #[cfg(target_os = "windows")]
-    {
-        let _ = std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .spawn();
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let _ = std::process::Command::new("open").arg(url).spawn();
-    }
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    {
-        let _ = std::process::Command::new("xdg-open").arg(url).spawn();
-    }
-}

--- a/agentmux-srv/src/util.rs
+++ b/agentmux-srv/src/util.rs
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Small OS-level helpers shared across backend modules.
+
+/// Open `url` in the user's default browser.
+///
+/// On Windows this shells out via `cmd /C start`. `cmd.exe` re-parses its
+/// trailing argument as a batch command line, where `&`, `|`, `^`, `<`, `>`
+/// are operators outside of quotes — an OAuth authorize URL is full of
+/// unencoded `&` between query params, so passing it bare truncates the URL
+/// at the first `&` and silently drops every parameter after it (client_id,
+/// redirect_uri, scope, ...). Wrapping the URL in its own quoted argument via
+/// `raw_arg` keeps `cmd.exe` in quoted mode for the whole string, so those
+/// characters are never seen as operators. `raw_arg` (not `arg`) is required
+/// here: `Command::arg` would apply MSVCRT-style quote escaping, which
+/// `cmd.exe`'s simpler quote-toggle parser does not understand and would
+/// re-break out of the quoted region.
+pub fn open_browser(url: &str) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        let _ = std::process::Command::new("cmd")
+            .arg("/C")
+            .raw_arg(format!("start \"\" \"{url}\""))
+            .spawn();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open").arg(url).spawn();
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use std::os::windows::process::CommandExt;
+
+    // Regresses the truncation bug this module fixes: cmd.exe splits an
+    // unquoted `&` into a new command, so an OAuth URL's query params after
+    // the first `&` never reached the browser. Runs the same quoted `raw_arg`
+    // construction as `open_browser`, swapping `start` for `echo` so the
+    // output is inspectable, and asserts the URL survives intact.
+    #[test]
+    fn quoted_url_survives_cmd_ampersand_splitting() {
+        let url = "https://example.com/oauth2/authorize?response_type=code&client_id=abc&redirect_uri=http://127.0.0.1:9379/callback&scope=openid";
+
+        let output = std::process::Command::new("cmd")
+            .arg("/C")
+            .raw_arg(format!("echo \"{url}\""))
+            .output()
+            .expect("failed to run cmd.exe");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(url),
+            "URL was truncated by cmd.exe's `&` splitting: {stdout}"
+        );
+    }
+
+    // Sanity check that the bug is real: the old unquoted invocation truncates
+    // at the first `&`.
+    #[test]
+    fn unquoted_url_is_truncated_by_cmd_ampersand_splitting() {
+        let url = "https://example.com/oauth2/authorize?response_type=code&client_id=abc";
+
+        let output = std::process::Command::new("cmd")
+            .args(["/C", "echo", url])
+            .output()
+            .expect("failed to run cmd.exe");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains(url),
+            "expected truncation, got intact URL: {stdout}"
+        );
+        assert!(stdout.contains("response_type=code"));
+    }
+}

--- a/docs/analysis/ANALYSIS_MUXBUS_WINDOWS_SIGNIN_URL_TRUNCATION_2026_07_03.md
+++ b/docs/analysis/ANALYSIS_MUXBUS_WINDOWS_SIGNIN_URL_TRUNCATION_2026_07_03.md
@@ -1,0 +1,163 @@
+# ANALYSIS: MuxBus Cloud sign-in fails on Windows — OAuth URL truncated by `cmd /C start`
+
+**Date:** 2026-07-03
+**Status:** Root-caused, fix implemented (see `agent3/muxbus-windows-open-browser`)
+**Scope:** `agentmux-srv/src/muxbus/pkce.rs`, `agentmux-srv/src/identity/oauth_client.rs`
+**Trigger:** Clicking "Connect with AgentMux" (Armory → Accounts, the per-agent identity
+panel, or the statusbar HostPopover — all three share `AgentMuxConnectPanel.tsx`'s
+`useMuxBusStatus().connect()`) opens a browser tab that lands on
+`https://auth.muxbus.agentmux.ai/error?error=Required+parameters+missing` instead of
+the Cognito hosted-UI login page.
+
+---
+
+## 0. TL;DR
+
+**Bug:** On Windows, `open_browser()` shells out via `cmd /C start "" <url>` with the
+URL passed as a bare (unquoted) argument. `cmd.exe`'s `/C` mode re-parses its entire
+trailing argument as a batch command line, where `&` is an unescaped command
+separator. An OAuth authorize URL is built entirely from `&`-joined query params
+(`?response_type=code&client_id=...&redirect_uri=...&scope=...`), so `cmd.exe` splits
+it at the *first* `&` and only ever launches the browser with
+`.../oauth2/authorize?response_type=code` — every parameter after that (`client_id`,
+`redirect_uri`, `scope`, PKCE challenge, `state`) is silently dropped.
+
+Cognito receives a request with no `client_id`, which is indistinguishable (from its
+error handling) from a request with an empty `client_id`, and returns its generic
+`error=Required+parameters+missing` page. This reproduces the user's exact symptom
+byte-for-byte (confirmed by hitting the live endpoint directly — see §2).
+
+**Blast radius:** every Windows install, both browser-based OAuth flows in the repo:
+- `muxbus/pkce.rs` — AgentMux Cloud sign-in (MuxBus PKCE).
+- `identity/oauth_client.rs` — the generic Armory service-OAuth flow (Google/Microsoft
+  code-flow providers), currently gated behind unprovisioned client IDs
+  (`client_id: None` — see the module's own "Scaffold status" doc-comment) but would
+  hit the identical failure the moment a provider is activated.
+
+This is **not** a deploy-timing issue. The branded `auth.muxbus.agentmux.ai` Cognito
+domain (agentmux-cloud PR #21) is live and correctly configured — confirmed directly
+against the endpoint (§2). The desktop-side flip to that domain (agentmux PR #1882,
+shipped in v0.49.12) is unrelated to this bug; the same truncation would happen
+against the legacy `muxbus-auth.auth.us-east-1.amazoncognito.com` prefix domain too,
+since the bug is in how the URL reaches the browser, not which domain it points at.
+
+**Fix:** quote the URL as a single `raw_arg` token so `cmd.exe` stays in quoted mode
+for the whole string (§3). Deduplicated the two copies of `open_browser()` into
+`agentmux-srv/src/util.rs`.
+
+---
+
+## 1. Where the two flows call the vulnerable code
+
+`frontend/app/view/accounts/AgentMuxConnectPanel.tsx` is the single shared
+implementation for AgentMux Cloud connect, rendered from three places:
+- `MuxBusConnectSection` — per-agent identity panel (`AgentIdentityPanel.tsx`)
+- `AgentMuxConnectPanel` — Armory → Accounts gallery tile (`accounts-manager.tsx`)
+- `frontend/app/statusbar/HostPopover.tsx` — the statusbar popover ("status panel")
+
+All three call the same `useMuxBusStatus().connect()`, which RPCs `muxbus.login` →
+`agentmux-srv/src/server/muxbus_handlers.rs` → `crate::muxbus::pkce::run_pkce_login()`
+→ `open_browser(&auth_url)` (`pkce.rs:85`, prior to this fix). The frontend's
+`isConfigured()` gate only checks that a build-time `client_id` string is non-empty —
+it has no visibility into what actually reaches the browser, so it cannot catch this
+class of bug.
+
+`agentmux-srv/src/identity/oauth_client.rs` had a byte-for-byte identical
+`open_browser()` (same `cmd /C start "" <url>` pattern) for the generic Armory
+service-OAuth flow.
+
+---
+
+## 2. Confirming the exact failure against the live endpoint
+
+Hitting `https://auth.muxbus.agentmux.ai/oauth2/authorize` directly (this machine,
+2026-07-03) shows the domain is live and genuinely Cognito (real
+`x-amz-cognito-request-id` response headers, not a CloudFront placeholder):
+
+| Request | Response `Location` |
+|---|---|
+| Full valid query string, garbage `client_id=test` | `.../error?error=invalid_request&client_id=test` |
+| `client_id` param entirely absent | `.../error?error=Required+parameters+missing` (no `client_id` echoed) |
+| `client_id=` (present, empty) | `.../error?error=Required+parameters+missing` (no `client_id` echoed) |
+| Only `?response_type=code` (everything after the first `&` dropped) | `.../error?error=Required+parameters+missing` |
+
+The last row is the exact URL the user saw, and it's exactly what `cmd.exe` produces
+when handed the real `auth_url` unquoted — reproduced directly against `cmd.exe` on
+this machine:
+
+```
+$ cmd.exe //C "echo a&echo b&echo c"
+a
+b
+c
+```
+
+i.e. `cmd /C "<string>"` treats each unescaped `&` as a command separator, executing
+`echo a`, `echo b`, `echo c` as three independent commands. Applied to
+`start "" https://.../authorize?response_type=code&client_id=...&...`, only
+`start "" https://.../authorize?response_type=code` ever runs; `client_id=...`,
+`redirect_uri=...`, etc. get interpreted as (failing) commands of their own and never
+reach the browser.
+
+Quoting suppresses this:
+
+```
+$ cmd.exe //C "echo \"https://x/?a=1&b=2\""
+\"https://x/?a=1&b=2\"
+```
+
+The whole string survives as one token when wrapped in quotes cmd.exe itself
+recognizes (confirmed empirically before writing the fix, and locked in as an
+automated test — see §3).
+
+---
+
+## 3. The fix
+
+`agentmux-srv/src/util.rs` (new — previously duplicated verbatim in `pkce.rs` and
+`oauth_client.rs`):
+
+```rust
+pub fn open_browser(url: &str) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        let _ = std::process::Command::new("cmd")
+            .arg("/C")
+            .raw_arg(format!("start \"\" \"{url}\""))
+            .spawn();
+    }
+    // macos / other unchanged
+}
+```
+
+`raw_arg` (not `arg`) is required: `Command::arg` would apply the MSVCRT-style
+quote-escaping Rust normally uses for Windows argv, which `cmd.exe`'s own (much
+simpler, escaping-unaware) quote-toggle parser does not understand — a naively
+`format!("\"{url}\"")`-wrapped value passed through `.arg()` gets re-escaped by Rust
+and would break out of the quoted region again. `raw_arg` hands `cmd.exe` the exact
+bytes it should parse, matching its actual quoting model.
+
+Two regression tests added in `util.rs` (`cfg(all(test, target_os = "windows"))`, run
+by the existing `windows-latest` CI job):
+- `unquoted_url_is_truncated_by_cmd_ampersand_splitting` — pins the *old*
+  broken behavior so the bug can't silently reappear unnoticed in a refactor.
+- `quoted_url_survives_cmd_ampersand_splitting` — proves the fix: the same
+  `raw_arg` construction used by `open_browser`, run through real `cmd.exe`, and
+  asserts the full URL (with embedded `&`) survives as one token.
+
+Both pass locally against real `cmd.exe` on this machine, and existing `muxbus::*`
+and `identity::oauth_client::*` test suites remain green (11/11).
+
+---
+
+## 4. Non-goals / out of scope
+
+- Did not touch the agentmux-cloud Cognito/CDK side — it's confirmed working correctly
+  (§2) and PR #21's deploy notes were followed correctly by whoever ran `cdk deploy`.
+- Did not change macOS/Linux `open_browser` — `open` (macOS) and `xdg-open` (Linux) are
+  passed the URL as a single argv element via `Command::arg`, which does not go through
+  a secondary shell re-parse, so they were never affected.
+- Left `identity/oauth_client.rs`'s per-provider OAuth flow otherwise untouched — it's
+  still scaffold-gated (`client_id: None`) and unreachable from the UI today; this fix
+  just ensures it doesn't inherit the same bug the moment a provider is activated.


### PR DESCRIPTION
## Summary

Root-caused and fixed a bug that breaks AgentMux Cloud sign-in (and any
future Armory service-OAuth flow) on every Windows install: `open_browser()`
shelled out via `cmd /C start "" <url>` with the URL passed bare. `cmd.exe`'s
`/C` mode re-parses its trailing argument as a batch command line, where
unescaped `&` is a command separator — every OAuth authorize URL here is
`&`-joined query params, so `cmd.exe` only ever launched the browser with the
URL truncated at the first `&`, silently dropping `client_id`, `redirect_uri`,
`scope`, the PKCE challenge, and `state`. Cognito then returns its generic
`error=Required+parameters+missing` page — reproduced byte-for-byte against
the live `auth.muxbus.agentmux.ai` endpoint (full writeup, including the
live-endpoint probe table and the `cmd.exe` repro, in
`docs/analysis/ANALYSIS_MUXBUS_WINDOWS_SIGNIN_URL_TRUNCATION_2026_07_03.md`).

This is not a deploy-timing issue — the branded Cognito domain
(agentmux-cloud #21) is live and correctly configured. The bug is purely in
how the URL reaches the browser on Windows.

## Changes

- Quote the URL as a single `raw_arg` token so `cmd.exe` stays in quoted mode
  for the whole string. `raw_arg` (not `arg`) is required: `Command::arg`
  applies MSVCRT-style quote escaping that `cmd.exe`'s simpler quote-toggle
  parser doesn't understand, which would break the quoting again.
- Deduplicated the identical `open_browser()` that existed independently in
  both `muxbus/pkce.rs` and `identity/oauth_client.rs` into a shared
  `agentmux-srv/src/util.rs`, so this class of bug can't diverge between the
  two OAuth flows again.
- Added two regression tests (`cfg(target_os = "windows")`, run by the
  existing `windows-latest` CI job) that exercise real `cmd.exe`: one pins the
  old truncation behavior, one proves the fix keeps the URL intact.

## Test plan

- [x] `cargo check` clean, no new warnings
- [x] New `util::tests::*` pass against real `cmd.exe` on this machine
- [x] Existing `muxbus::*` (4) and `identity::oauth_client::*` (7) suites still green
- [x] `cargo fmt --check` clean for all touched files

<!-- agentmux:agent_id=agent3 -->