### PR TITLE
fix(memory): pagefile hygiene — B.1-B.3 leak fixes + pool refill guard

### DIFF
--- a/.changesets/1783063556-fix-scripts-resolve-task-via-pathext-instead-of-hardcoded-ex-2dyj.md
+++ b/.changesets/1783063556-fix-scripts-resolve-task-via-pathext-instead-of-hardcoded-ex-2dyj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(scripts): resolve task via PATHEXT instead of hardcoded .exe extension in agent bridge scripts

--- a/.changesets/1783068338-fix-memory-pagefile-hygiene-fixes-wps-persist-map-pruning-bo-6ax8.md
+++ b/.changesets/1783068338-fix-memory-pagefile-hygiene-fixes-wps-persist-map-pruning-bo-6ax8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(memory): pagefile hygiene fixes — WPS persist_map pruning, bounded WS egress, SubagentWatcher capping, pool refill guard under commit pressure

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -249,6 +249,21 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
         return;
     }
 
+    // Commit-pressure guard (SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02
+    // §B.5(b)) — refuse to grow the warm pool while commit is tight. This is
+    // refill-suppression only: it never destroys an already-queued pool
+    // window (that needs its own saga-aware design, tracked in #1936),
+    // it just stops the pool from re-filling back to POOL_TARGET_SIZE
+    // every time a window is promoted while the system is under pressure.
+    if crate::memory_pressure::current_level() != crate::memory_pressure::PressureLevel::Normal {
+        tracing::debug!(
+            target: "dnd:tearoff:pool",
+            level = crate::memory_pressure::current_level().as_str(),
+            "[pool] spawn skipped — commit pressure"
+        );
+        return;
+    }
+
     // PR #6 H.7 — refuse pool refill while any pane is mid-close. Pool
     // windows are CEF top-levels just like user-visible ones; the v146
     // deadlock fires regardless of whether the new window is on-screen.
@@ -1337,6 +1352,15 @@ pub fn spawn_pane_pool_window(state: &Arc<AppState>) {
     // instead of None. The early-return guard that blocked spawning on Windows
     // was not removed in that PR; removing it here enables the pool on Windows.
     if state.is_quitting() {
+        return;
+    }
+    // Commit-pressure guard — see the matching comment in spawn_pool_window.
+    if crate::memory_pressure::current_level() != crate::memory_pressure::PressureLevel::Normal {
+        tracing::debug!(
+            target: "pool:pane",
+            level = crate::memory_pressure::current_level().as_str(),
+            "[pane-pool] spawn skipped — commit pressure"
+        );
         return;
     }
     if state.any_browser_pane_closing() {

--- a/agentmux-cef/src/memory_pressure.rs
+++ b/agentmux-cef/src/memory_pressure.rs
@@ -11,10 +11,15 @@
 //! renderer purge, the low-memory banner — later PRs) and any operator tooling
 //! can read a single, stable signal instead of re-deriving thresholds.
 //!
-//! This PR is **detection + observability only**: a structured `mem_pressure`
-//! log line on every transition and a published `PRESSURE_LEVEL` atom. It
-//! deliberately takes **no** action on renderers, windows, or the pool — those
-//! responses need runtime verification and land in their own slices.
+//! Originally detection + observability only: a structured `mem_pressure` log
+//! line on every transition and a published `PRESSURE_LEVEL` atom, with no
+//! action taken on renderers, windows, or the pool. The first proactive
+//! shedding response now reads it: `commands/window_pool.rs`'s
+//! `spawn_pool_window` / `spawn_pane_pool_window` refuse to grow the warm
+//! pool while pressure is non-Normal (issue #1936 /
+//! `docs/specs/SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02.md`
+//! §B.5(b)) — refill suppression only, not active eviction of an
+//! already-warm pool window (that needs its own saga-aware design).
 //!
 //! The classifier is pure and unit-tested; hysteresis prevents banner/log flap
 //! when commit oscillates around a threshold (the same anti-flap discipline the
@@ -64,10 +69,11 @@ impl PressureLevel {
 /// responses + tooling. `Normal` until the first sample.
 static PRESSURE_LEVEL: AtomicU8 = AtomicU8::new(PressureLevel::Normal as u8);
 
-/// The current debounced pressure level (last published by the tracker). The
-/// proactive-shedding responses (warm-pool drain, CDP purge, banner — later
-/// PRs) read this; unused in this detection-only slice.
-#[allow(dead_code)]
+/// The current debounced pressure level (last published by the tracker).
+/// Read by proactive-shedding responses — currently the warm-pool refill
+/// guard (`commands/window_pool.rs::spawn_pool_window` /
+/// `spawn_pane_pool_window`) — and available for future CDP purge / banner
+/// consumers.
 pub fn current_level() -> PressureLevel {
     PressureLevel::from_u8(PRESSURE_LEVEL.load(Ordering::Relaxed))
 }

--- a/agentmux-srv/src/backend/eventbus.rs
+++ b/agentmux-srv/src/backend/eventbus.rs
@@ -29,12 +29,27 @@ pub enum Lane {
     Background,
 }
 
+/// Egress channel capacities. Bounded (not unbounded) so a stalled/hidden-
+/// renderer WS consumer can't grow sidecar commit without limit — a healthy
+/// connection drains far below these depths; hitting the cap is itself the
+/// signal that the consumer isn't keeping up. See
+/// docs/specs/SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02.md §B.2.
+///
+/// Priority carries terminal echo + interactive events, which must not be
+/// silently dropped in normal operation — sized generously so legitimate
+/// bursts (e.g. `cat` of a large file) never hit the cap.
+const PRIORITY_LANE_CAPACITY: usize = 8192;
+/// Background carries droppable perf telemetry (sysinfo ~1/s, per-block
+/// stats) already coalesced-to-latest by the receive loop — a healthy
+/// consumer never queues more than a couple of entries.
+const BACKGROUND_LANE_CAPACITY: usize = 256;
+
 /// The pair of receivers handed to a WebSocket connection on registration.
 /// Terminal echo + interactive events arrive on `priority`; perf telemetry on
 /// `background`.
 pub struct WsReceivers {
-    pub priority: tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
-    pub background: tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
+    pub priority: tokio::sync::mpsc::Receiver<serde_json::Value>,
+    pub background: tokio::sync::mpsc::Receiver<serde_json::Value>,
 }
 
 // ---- Types ----
@@ -50,15 +65,15 @@ pub struct WSEventType {
 
 struct WindowWatchData {
     /// Interactive lane: terminal echo, RPC-routed wave events, obj updates.
-    priority: tokio::sync::mpsc::UnboundedSender<serde_json::Value>,
+    priority: tokio::sync::mpsc::Sender<serde_json::Value>,
     /// Background lane: droppable perf telemetry (sysinfo, blockstats).
-    background: tokio::sync::mpsc::UnboundedSender<serde_json::Value>,
+    background: tokio::sync::mpsc::Sender<serde_json::Value>,
     #[allow(dead_code)]
     tab_id: String,
 }
 
 impl WindowWatchData {
-    fn sender(&self, lane: Lane) -> &tokio::sync::mpsc::UnboundedSender<serde_json::Value> {
+    fn sender(&self, lane: Lane) -> &tokio::sync::mpsc::Sender<serde_json::Value> {
         match lane {
             Lane::Priority => &self.priority,
             Lane::Background => &self.background,
@@ -81,8 +96,8 @@ impl EventBus {
     /// Register a WebSocket connection for receiving events.
     /// Returns the priority + background receiver pair for the connection.
     pub fn register_ws(&self, conn_id: &str, tab_id: &str) -> WsReceivers {
-        let (priority_tx, priority_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (background_tx, background_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (priority_tx, priority_rx) = tokio::sync::mpsc::channel(PRIORITY_LANE_CAPACITY);
+        let (background_tx, background_rx) = tokio::sync::mpsc::channel(BACKGROUND_LANE_CAPACITY);
         let mut watches = self.watches.lock().unwrap();
         watches.insert(
             conn_id.to_string(),
@@ -148,9 +163,7 @@ impl EventBus {
         };
         let watches = self.watches.lock().unwrap();
         if let Some(watch) = watches.get(conn_id) {
-            if watch.sender(lane).send(data).is_err() {
-                tracing::warn!("failed to send event to conn {}", conn_id);
-            }
+            Self::try_send_lane(conn_id, watch.sender(lane), data);
         }
     }
 
@@ -170,7 +183,28 @@ impl EventBus {
         };
         let watches = self.watches.lock().unwrap();
         for (conn_id, watch) in watches.iter() {
-            if watch.sender(lane).send(data.clone()).is_err() {
+            Self::try_send_lane(conn_id, watch.sender(lane), data.clone());
+        }
+    }
+
+    /// Non-blocking send with distinct logging for a genuinely-full lane
+    /// (stalled/hidden-renderer consumer — see `PRIORITY_LANE_CAPACITY` /
+    /// `BACKGROUND_LANE_CAPACITY`) vs. a closed one (connection already
+    /// gone). Never blocks the caller — callers hold the `watches` lock.
+    fn try_send_lane(
+        conn_id: &str,
+        sender: &tokio::sync::mpsc::Sender<serde_json::Value>,
+        data: serde_json::Value,
+    ) {
+        match sender.try_send(data) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    "ws egress lane full for conn {} — consumer stalled, dropping event",
+                    conn_id
+                );
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 tracing::warn!("failed to send event to conn {}", conn_id);
             }
         }
@@ -189,7 +223,7 @@ impl EventBus {
         let watches = self.watches.lock().unwrap();
         for watch in watches.values() {
             if watch.tab_id == tab_id {
-                let _ = watch.sender(Lane::Priority).send(data.clone());
+                let _ = watch.sender(Lane::Priority).try_send(data.clone());
             }
         }
     }
@@ -326,6 +360,36 @@ mod tests {
         bus.send_to_conn_lane("conn-1", &event, Lane::Priority);
         assert!(rx.background.try_recv().is_err()); // nothing on background
         assert!(rx.priority.try_recv().is_ok()); // interactive on priority
+    }
+
+    #[test]
+    fn test_stalled_consumer_drops_instead_of_growing_unbounded() {
+        // A consumer that never drains must not let the channel grow past its
+        // bound — this is the memory-safety property B.2 exists for. Fill the
+        // background lane (small capacity) past its cap without ever calling
+        // recv(), then drain and count: the received count must be bounded
+        // by the channel capacity, proving excess sends were dropped
+        // (try_send Full) rather than queued without limit.
+        let bus = EventBus::new();
+        let mut rx = bus.register_ws("conn-1", "tab-1"); // never drained during the flood
+        let event = WSEventType {
+            eventtype: WS_EVENT_RPC.to_string(),
+            oref: String::new(),
+            data: None,
+        };
+        let sent = BACKGROUND_LANE_CAPACITY * 4;
+        for _ in 0..sent {
+            bus.send_to_conn_lane("conn-1", &event, Lane::Background);
+        }
+        let mut received = 0;
+        while rx.background.try_recv().is_ok() {
+            received += 1;
+        }
+        assert!(
+            received <= BACKGROUND_LANE_CAPACITY,
+            "received {received} events from a lane capped at {BACKGROUND_LANE_CAPACITY} — sends were not bounded"
+        );
+        assert!(received < sent, "no events were dropped despite flooding well past capacity");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/eventbus.rs
+++ b/agentmux-srv/src/backend/eventbus.rs
@@ -221,9 +221,9 @@ impl EventBus {
             }
         };
         let watches = self.watches.lock().unwrap();
-        for watch in watches.values() {
+        for (conn_id, watch) in watches.iter() {
             if watch.tab_id == tab_id {
-                let _ = watch.sender(Lane::Priority).try_send(data.clone());
+                Self::try_send_lane(conn_id, watch.sender(Lane::Priority), data.clone());
             }
         }
     }

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -83,26 +83,33 @@ impl ShellSessionRegistry {
 
     // Full registration called by the runner after spawning the child.
     // stdin_tx is None when capture_stdin is false (stdin is /dev/null).
+    // Returns shell_ids evicted by the prune pass — the caller (which holds
+    // the Broker, unlike this registry) purges their `shell:<id>` persisted
+    // WaveEvent history so the broker's persist_map key set stays bounded
+    // in step with this registry's own MAX_EXITED_STATUS cap.
     fn register_full(
         &self,
         shell_id: String,
         stop_tx: oneshot::Sender<()>,
         stdin_tx: Option<mpsc::UnboundedSender<String>>,
         status: Arc<Mutex<ShellStatusInfo>>,
-    ) {
+    ) -> Vec<String> {
         self.shells.lock().insert(shell_id.clone(), ShellEntry { stop_tx, stdin_tx });
         self.status_map.lock().insert(shell_id.clone(), status);
         self.status_order.lock().push_back(shell_id);
         // Bound retained exited statuses; every spawn is a natural prune trigger.
-        self.prune_exited_statuses();
+        self.prune_exited_statuses()
     }
 
     /// Evict oldest EXITED status entries beyond `MAX_EXITED_STATUS`. Running
     /// shells are always retained (their status is read live via ShellStatus).
     /// Also drops any order-queue ids whose status entry is already gone.
-    fn prune_exited_statuses(&self) {
+    /// Returns the shell_ids actually evicted (status entry removed) so the
+    /// caller can purge their broker-side persisted history too.
+    fn prune_exited_statuses(&self) -> Vec<String> {
         let mut map = self.status_map.lock();
         let mut order = self.status_order.lock();
+        let mut evicted = Vec::new();
         let mut exited = map
             .values()
             .filter(|arc| !arc.lock().running)
@@ -116,6 +123,7 @@ impl ShellSessionRegistry {
                     map.remove(&id);
                     order.remove(i);
                     exited -= 1;
+                    evicted.push(id);
                 }
                 // Still running → keep in place, advance.
                 Some(_) => i += 1,
@@ -125,6 +133,7 @@ impl ShellSessionRegistry {
                 }
             }
         }
+        evicted
     }
 
     /// Request stop of a running shell. Returns false if unknown or already exited.
@@ -340,12 +349,15 @@ impl ShellNodeRunner {
 
         let status_arc = Arc::new(Mutex::new(ShellStatusInfo { running: true, exit_code: None, line_count: 0 }));
         let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
-        self.registry.register_full(
+        let evicted = self.registry.register_full(
             shell_id.clone(),
             cancel_tx,
             stdin_tx,
             Arc::clone(&status_arc),
         );
+        for evicted_id in evicted {
+            broker.purge_scope(&format!("shell:{evicted_id}"));
+        }
         let kill_task = tokio::spawn(async move {
             match cancel_rx.await {
                 Ok(()) => {

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -71,6 +71,14 @@ struct SessionWatch {
     subagents: HashMap<String, SubagentState>,
 }
 
+/// Cap on `SubagentState.events` — without it, a long-running subagent (or a
+/// long-lived srv process accumulating many subagents) grows this Vec
+/// unboundedly; `info.event_count` still tracks the true total separately
+/// (mirrors `wps.rs`'s `arr_total_adds` vs. capped `PersistEventWrap.events`).
+/// `get_history`'s `limit` is a request ceiling, not a guarantee — this is
+/// the hard ceiling on what's retained to serve it from.
+const MAX_SUBAGENT_EVENTS: usize = 2048;
+
 struct SubagentState {
     info: SubagentInfo,
     file_offset: u64,
@@ -254,14 +262,39 @@ impl SubagentWatcher {
     ///
     /// Without this, `watched_agents` was push-only: every distinct agent that
     /// ever ran leaked one OS watch handle + channel + idle task for the rest of
-    /// the process lifetime, even after its pane/agent was deleted. (Session
-    /// records in `sessions` are plain data, not handles, and are left as-is.)
+    /// the process lifetime, even after its pane/agent was deleted.
+    ///
+    /// Also prunes `sessions`: every subagent whose `info.parent_agent` is
+    /// this agent (across all sessions — subagents are keyed by session_id,
+    /// not by parent), and any session left with no subagents afterward.
+    /// The parent agent is gone, so nothing can query this data again — it
+    /// was previously left as plain data forever, growing `sessions` by one
+    /// entry set per distinct agent that ever ran a subagent.
     pub fn unwatch_agent(&self, agent_id: &str) {
         let mut watched = self.watched_agents.lock().unwrap();
         let before = watched.len();
         watched.retain(|w| w.agent_id != agent_id);
         if watched.len() != before {
             tracing::info!(agent = %agent_id, "stopped watching subagent dir");
+        }
+        drop(watched);
+
+        let mut sessions = self.sessions.lock().unwrap();
+        let mut pruned_subagents = 0usize;
+        sessions.retain(|_session_id, session| {
+            let before = session.subagents.len();
+            session
+                .subagents
+                .retain(|_agent_id, state| state.info.parent_agent != agent_id);
+            pruned_subagents += before - session.subagents.len();
+            !session.subagents.is_empty()
+        });
+        if pruned_subagents > 0 {
+            tracing::debug!(
+                agent = %agent_id,
+                pruned_subagents,
+                "pruned subagent session state for unwatched agent"
+            );
         }
     }
 
@@ -417,6 +450,12 @@ impl SubagentWatcher {
                 state.info.event_count += 1;
                 state.info.last_event_at = event.timestamp;
                 state.events.push(event.clone());
+            }
+            // Trim to the cap, oldest-first — event_count above already
+            // recorded the true cumulative total before this truncation.
+            if state.events.len() > MAX_SUBAGENT_EVENTS {
+                let excess = state.events.len() - MAX_SUBAGENT_EVENTS;
+                state.events.drain(..excess);
             }
 
             // Check last event for result type (completion)
@@ -740,4 +779,105 @@ pub fn derive_claude_config_dir(agent_id: &str) -> Option<PathBuf> {
         .join(".config")
         .join(format!("claude-{}", agent_id.to_lowercase()));
     Some(config_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_watcher() -> SubagentWatcher {
+        SubagentWatcher::new(Arc::new(EventBus::new()))
+    }
+
+    fn fixture_state(parent_agent: &str, agent_id: &str, session_id: &str) -> SubagentState {
+        SubagentState {
+            info: SubagentInfo {
+                agent_id: agent_id.to_string(),
+                slug: String::new(),
+                jsonl_path: String::new(),
+                parent_agent: parent_agent.to_string(),
+                parent_block_id: String::new(),
+                session_id: session_id.to_string(),
+                last_event_at: 0,
+                status: SubagentStatus::Active,
+                event_count: 0,
+                model: None,
+            },
+            file_offset: 0,
+            events: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn unwatch_agent_prunes_only_matching_parent_subagents() {
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            // Two sessions; session "s1" has subagents from two different
+            // parents, session "s2" has a subagent from a third parent.
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            s1.subagents.insert("sub-a".to_string(), fixture_state("parent-1", "sub-a", "s1"));
+            s1.subagents.insert("sub-b".to_string(), fixture_state("parent-2", "sub-b", "s1"));
+            sessions.insert("s1".to_string(), s1);
+
+            let mut s2 = SessionWatch { subagents: HashMap::new() };
+            s2.subagents.insert("sub-c".to_string(), fixture_state("parent-1", "sub-c", "s2"));
+            sessions.insert("s2".to_string(), s2);
+        }
+
+        watcher.unwatch_agent("parent-1");
+
+        let sessions = watcher.sessions.lock().unwrap();
+        // s1: parent-1's subagent gone, parent-2's remains.
+        let s1 = sessions.get("s1").expect("s1 still has parent-2's subagent, should not be dropped");
+        assert!(!s1.subagents.contains_key("sub-a"));
+        assert!(s1.subagents.contains_key("sub-b"));
+        // s2: its only subagent belonged to parent-1, so the whole session
+        // entry is pruned (not left behind as an empty HashMap).
+        assert!(!sessions.contains_key("s2"), "session left with zero subagents must be removed, not left empty");
+    }
+
+    #[test]
+    fn unwatch_agent_on_unknown_agent_is_noop() {
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            s1.subagents.insert("sub-a".to_string(), fixture_state("parent-1", "sub-a", "s1"));
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        watcher.unwatch_agent("never-watched");
+
+        let sessions = watcher.sessions.lock().unwrap();
+        assert!(sessions.get("s1").unwrap().subagents.contains_key("sub-a"));
+    }
+
+    #[test]
+    fn subagent_events_are_capped_at_max() {
+        let mut state = fixture_state("parent-1", "sub-a", "s1");
+        // Simulate what process_jsonl_change's push+trim loop does, without
+        // going through real JSONL files.
+        for i in 0..(MAX_SUBAGENT_EVENTS + 100) {
+            state.info.event_count += 1;
+            state.events.push(SubagentEvent {
+                agent_id: "sub-a".to_string(),
+                event_type: SubagentEventType::Text { content: i.to_string() },
+                timestamp: i as u64,
+            });
+        }
+        if state.events.len() > MAX_SUBAGENT_EVENTS {
+            let excess = state.events.len() - MAX_SUBAGENT_EVENTS;
+            state.events.drain(..excess);
+        }
+
+        assert_eq!(state.events.len(), MAX_SUBAGENT_EVENTS);
+        // event_count kept the true cumulative total despite truncation.
+        assert_eq!(state.info.event_count, MAX_SUBAGENT_EVENTS + 100);
+        // Oldest events were dropped — the retained window is the newest ones.
+        let SubagentEventType::Text { content } = &state.events[0].event_type else {
+            panic!("expected Text event");
+        };
+        assert_eq!(content, "100"); // first 100 (0..100) were trimmed away
+    }
 }

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -309,6 +309,19 @@ impl Broker {
         inner.replayed.retain(|(r, _, _)| r != route_id);
     }
 
+    /// Purge all persisted history for a scope (e.g. `block:<id>` or
+    /// `shell:<id>`), regardless of event name. Call when the underlying
+    /// block/shell is deleted — `persist_map`'s key set is otherwise never
+    /// pruned (each key's event Vec is capped, but the map only grows over
+    /// a session's cumulative block/shell count). Also drops matching
+    /// `replayed` entries so a stale scope can't linger across route
+    /// reconnects.
+    pub fn purge_scope(&self, scope: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.persist_map.retain(|k, _| k.scope != scope);
+        inner.replayed.retain(|(_, _, s)| s != scope);
+    }
+
     fn unsubscribe_nolock(inner: &mut BrokerInner, route_id: &str, event_name: &str) {
         let bs = match inner.sub_map.get_mut(event_name) {
             Some(bs) => bs,
@@ -908,6 +921,55 @@ mod tests {
         // Read scoped history
         let scoped = broker.read_event_history(EVENT_SYS_INFO, "cpu", 2);
         assert_eq!(scoped.len(), 2);
+    }
+
+    #[test]
+    fn test_purge_scope_removes_only_matching_scope() {
+        let broker = Broker::new();
+
+        // Two different event names persisted under the same scope
+        // (block:abc), plus one persisted under a different scope
+        // (block:xyz) that must survive the purge.
+        broker.publish(WaveEvent {
+            event: "install_progress".to_string(),
+            scopes: vec!["block:abc".to_string()],
+            sender: String::new(),
+            persist: 5,
+            data: Some(serde_json::json!("a")),
+        });
+        broker.publish(WaveEvent {
+            event: EVENT_BLOCK_ACTIVITY.to_string(),
+            scopes: vec!["block:abc".to_string()],
+            sender: String::new(),
+            persist: 5,
+            data: Some(serde_json::json!("b")),
+        });
+        broker.publish(WaveEvent {
+            event: "install_progress".to_string(),
+            scopes: vec!["block:xyz".to_string()],
+            sender: String::new(),
+            persist: 5,
+            data: Some(serde_json::json!("c")),
+        });
+
+        assert_eq!(broker.read_event_history("install_progress", "block:abc", 10).len(), 1);
+        assert_eq!(broker.read_event_history(EVENT_BLOCK_ACTIVITY, "block:abc", 10).len(), 1);
+        assert_eq!(broker.read_event_history("install_progress", "block:xyz", 10).len(), 1);
+
+        broker.purge_scope("block:abc");
+
+        // Both event names under the purged scope are gone...
+        assert_eq!(broker.read_event_history("install_progress", "block:abc", 10).len(), 0);
+        assert_eq!(broker.read_event_history(EVENT_BLOCK_ACTIVITY, "block:abc", 10).len(), 0);
+        // ...but the other scope is untouched.
+        assert_eq!(broker.read_event_history("install_progress", "block:xyz", 10).len(), 1);
+    }
+
+    #[test]
+    fn test_purge_scope_on_unknown_scope_is_noop() {
+        // Purging a scope with no persisted entries must not panic.
+        let broker = Broker::new();
+        broker.purge_scope("block:never-existed");
     }
 
     #[test]

--- a/agentmux-srv/src/sagas/delete_block.rs
+++ b/agentmux-srv/src/sagas/delete_block.rs
@@ -125,6 +125,11 @@ pub async fn run(
             state.srv_state.lock().await.blocks.contains_key(&block_id);
         if !block_still_in_reducer {
             crate::backend::blockcontroller::delete_controller(&block_id);
+            // WPS persist_map is keyed by (event, scope) and its key set is
+            // never otherwise pruned — a deleted block's persisted history
+            // (install_progress, block:activity, ...) would linger for the
+            // life of the process. Purge it alongside the controller kill.
+            state.broker.purge_scope(&format!("block:{}", block_id));
         }
     }
     emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -309,7 +309,7 @@ fn background_event_key(event: &serde_json::Value) -> String {
 /// order in the returned Vec is first-seen (stable across coalescing rounds).
 fn coalesce_background(
     first: serde_json::Value,
-    rx: &mut tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
+    rx: &mut tokio::sync::mpsc::Receiver<serde_json::Value>,
 ) -> Vec<serde_json::Value> {
     let mut order: Vec<String> = Vec::new();
     let mut map: std::collections::HashMap<String, serde_json::Value> = std::collections::HashMap::new();

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -205,9 +205,15 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
             //
             // Tradeoff of `biased;`: a SUSTAINED priority-lane flood (e.g.
             // `! yes` pumping terminal output continuously) keeps the priority
-            // branches ready, so this lane is starved and its unbounded receiver
-            // accumulates sysinfo/blockstats until the flood pauses, then
-            // flushes as a stale burst. Acceptable for now because telemetry
+            // branches ready, so this lane is starved and events queue here
+            // until the flood pauses, then flush as a stale burst. As of B.2
+            // (SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02) this is a
+            // bounded `mpsc::channel(BACKGROUND_LANE_CAPACITY)` with
+            // `try_send` drop-on-full semantics (see eventbus.rs), not an
+            // unbounded receiver — a starvation period long enough to fill
+            // all 256 slots drops each new event as it arrives (the queued
+            // events already in the channel are unaffected) rather than
+            // growing commit without limit. Acceptable for now because telemetry
             // ingress is low-rate (sysinfo ~1/s) and a flood also saturates the
             // socket writes — during which the priority lanes do drain, so this
             // lane gets serviced — making true never-empty starvation the rare

--- a/scripts/dev-agent.cmd
+++ b/scripts/dev-agent.cmd
@@ -34,8 +34,11 @@ set "GIT_BIN=C:\Program Files\Git\bin"
 set "GIT_USR=C:\Program Files\Git\usr\bin"
 set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
 
-:: Call task.exe by explicit extension (Gap A fix — no bash lookup needed here).
-:: task is installed as task.exe (via go install / WinGet), not task.cmd.
+:: Call bare `task` (no extension) — this .cmd wrapper itself runs under cmd.exe
+:: (Gap A only applies to bash resolving .cmd files, not to us), so PATHEXT
+:: resolution finds task.exe (go install / WinGet) OR task.cmd (npm global
+:: install) transparently. Do NOT hardcode an extension — which one exists
+:: depends on how `task` was installed on the machine.
 :: Merge stderr into stdout so shell viewers don't color build progress red
 :: (cargo writes all output to stderr, not stdout).
-task.exe dev %* 2>&1
+task dev %* 2>&1

--- a/scripts/package-agent.cmd
+++ b/scripts/package-agent.cmd
@@ -1,0 +1,15 @@
+@echo off
+:: Bridge script for agent / MCP-Shell invocation of `task package` on Windows.
+:: Same Gap A + Gap B fixes as dev-agent.cmd — see that file for full explanation.
+
+cd /d "%~dp0.."
+
+set "GIT_BIN=C:\Program Files\Git\bin"
+set "GIT_USR=C:\Program Files\Git\usr\bin"
+set "PATH=%GIT_BIN%;%GIT_USR%;%PATH%"
+
+:: Call bare `task` — PATHEXT resolves task.exe or task.cmd depending on how
+:: it was installed on the machine (see dev-agent.cmd for the full rationale).
+:: Merge stderr into stdout so shell viewers don't color build progress red
+:: (cargo writes all output to stderr, not stdout).
+task package %* 2>&1


### PR DESCRIPTION
## Summary

Four bounded, additive fixes from the "safe wins first" slice of the renderer/pagefile commit-charge leak (#1936, see `docs/specs/SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02.md` §B). The riskier primary fix (Windows browser-pane `close_browser` cascade) is deliberately deferred to its own design spike — none of these touch that fragile HWND-cascade code.

- **B.1** — `Broker::purge_scope` prunes WPS `persist_map` by scope on block delete (`DeleteBlock` saga) and shell exit-eviction (piggybacks on the existing `MAX_EXITED_STATUS` cap in `ShellSessionRegistry`, so the broker's key set stays bounded in step with an eviction policy that already exists rather than inventing a new one).
- **B.2** — WS egress channels (`eventbus.rs`) converted from unbounded to bounded `mpsc::channel` + `try_send`. Priority lane (terminal echo — must not silently drop in normal operation) gets a generous 8192 depth; background lane (droppable telemetry, already coalesced-to-latest) gets 256. A stalled/hidden-renderer consumer now drops with a warning instead of growing commit forever.
- **B.3** — `SubagentWatcher`: per-subagent `events` Vec capped at 2048 (ring-style; `event_count` keeps the true cumulative total separately), and `unwatch_agent` now prunes every subagent session record for that parent across all sessions (previously left as plain data forever, per its own doc comment).
- **Pool refill guard** — `spawn_pool_window`/`spawn_pane_pool_window` refuse to grow the warm pool while `memory_pressure::current_level()` is non-Normal. Refill suppression only, not active eviction of an already-warm window — `memory_pressure.rs`'s doc comment already anticipated this exact consumer ("later PRs") but had none until now.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv wps::` — 16 passed (2 new: `test_purge_scope_removes_only_matching_scope`, `test_purge_scope_on_unknown_scope_is_noop`)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv eventbus::` — 7 passed (1 new: `test_stalled_consumer_drops_instead_of_growing_unbounded`)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv subagent_watcher::` — 3 passed, all new (`unwatch_agent_prunes_only_matching_parent_subagents`, `unwatch_agent_on_unknown_agent_is_noop`, `subagent_events_are_capped_at_max`)
- [x] `cargo test --release -p agentmux-cef --lib memory_pressure::` — 5 passed (pre-existing, unaffected)
- [x] `cargo check -p agentmux-srv` and `cargo check --release -p agentmux-cef` both clean (no new warnings)

<!-- agentmux:agent_id=lzop -->