### PR TITLE
chore(muxbus): add dev-mode env file so task dev has a MuxBus client ID

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,15 @@
+# MuxBus Cloud Auth (dev)
+# Same values as .env.production — there is one MuxBus Cognito user pool /
+# desktop client shared by dev and prod builds (see muxbus-cognito.ts: the
+# desktop client's callbackUrls include both the packaged-app and local-dev
+# redirect URIs). Vite's dev server runs in mode "development" and does not
+# load .env.production, so without this file VITE_MUXBUS_CLIENT_ID is empty
+# in `task dev`, isConfigured() is false, and the whole MuxBus Cloud row in
+# HostPopover.tsx / AgentMuxConnectPanel.tsx stays hidden — not a bug, just
+# missing dev config.
+#
+# VITE_MUXBUS_CLIENT_ID is a public PKCE client ID — safe to commit (see
+# .env.production for provenance / how to re-derive it from the CDK stack).
+
+VITE_MUXBUS_COGNITO_DOMAIN=https://auth.muxbus.agentmux.ai
+VITE_MUXBUS_CLIENT_ID=26odoigu6a7r8ecdmj5egvnc3b


### PR DESCRIPTION
## Summary

Follow-up to #1938 (the Windows sign-in fix). While verifying that fix via
`task dev`, found that MuxBus Cloud sign-in never appeared in dev mode at all
— separate issue from #1938, pre-existing dev-tooling gap, not a regression.

`task dev` runs plain `vite` with no `--mode` flag, so Vite defaults to mode
`development` and only loads `.env` / `.env.development` — never
`.env.production`. The repo only ever shipped `frontend/.env.production`, so
under `task dev`, `VITE_MUXBUS_CLIENT_ID` was always empty,
`isConfigured()` was `false`, and the whole MuxBus Cloud row in
`HostPopover.tsx` / `AgentMuxConnectPanel.tsx` silently disappeared (no error,
just missing) — every time, for everyone, regardless of #1938.

Portable/production builds were never affected: `task build:frontend` runs
`vite build --mode production`, which does load `.env.production`.

## Change

Add `frontend/.env.development` with the same public, safe-to-commit PKCE
client ID already in `.env.production` (same MuxBus Cognito user pool /
desktop client serves both dev and prod — see `muxbus-cognito.ts`'s
`callbackUrls`, which already include the local-dev redirect URI alongside
the packaged-app one).

No changeset — dev-only tooling config, doesn't change shipped app behavior.

## Test plan

- [x] Ran a fresh `task dev` build with this file present — MuxBus Cloud row
      appears in the statusbar popover, "Sign in" opens the real Cognito
      hosted-UI page (via #1938's fix), completed a real login successfully.

<!-- agentmux:agent_id=agent3 -->