### PR TITLE
fix(ci): winget-create no longer ships a Linux binary, use windows-latest

### DIFF
--- a/.changesets/1783088326-fix-ci-winget-create-no-longer-ships-a-linux-binary-use-wind-gagx.md
+++ b/.changesets/1783088326-fix-ci-winget-create-no-longer-ships-a-linux-binary-use-wind-gagx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): winget-create no longer ships a Linux binary, use windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,18 +483,20 @@ jobs:
   winget:
     name: Submit WinGet update
     needs: [verify, publish]
-    runs-on: ubuntu-latest
+    # microsoft/winget-create's release no longer ships a Linux binary (only
+    # wingetcreate.exe) — mirrors the ms-store job's runner below.
+    runs-on: windows-latest
     continue-on-error: true
     env:
       VERSION: ${{ needs.verify.outputs.version }}
     steps:
       - name: Install wingetcreate
+        shell: pwsh
         run: |
-          curl -fsSL -o wingetcreate \
-            "https://github.com/microsoft/winget-create/releases/latest/download/wingetcreate-linux"
-          chmod +x wingetcreate
+          Invoke-WebRequest -Uri "https://github.com/microsoft/winget-create/releases/latest/download/wingetcreate.exe" -OutFile wingetcreate.exe
 
       - name: Submit WinGet manifest PR
+        shell: bash
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -511,7 +513,7 @@ jobs:
             exit 1
           fi
           echo "WinGet installer URL: $INSTALLER_URL"
-          ./wingetcreate update AgentMux.AgentMux \
+          ./wingetcreate.exe update AgentMux.AgentMux \
             --version "${VERSION}" \
             --urls "$INSTALLER_URL" \
             --submit \


### PR DESCRIPTION
## Problem

The `winget` job in `release.yml` failed on v0.49.12:
```
curl: (22) The requested URL returned error: 404
```

`microsoft/winget-create`'s latest release (v1.12.8.0) only publishes `wingetcreate.exe` — the `wingetcreate-linux` asset this job downloads no longer exists.

## Fix

Switch the job to `windows-latest` (matching the `ms-store` job's runner one below it) and download `wingetcreate.exe` directly via `Invoke-WebRequest`.

## Notes
- `continue-on-error: true` is unchanged — this job was always non-blocking, this just makes it actually succeed instead of silently 404ing.
- No secret/permission changes.

## Test plan
- [ ] Next tagged release: confirm the `winget` job succeeds and opens a WinGet manifest PR.

<!-- agentmux:agent_id=agentx -->