### PR TITLE
feat(armory): mcp.ts/skill.ts rpc-api bindings for standalone MCP/Skill primitives

### DIFF
--- a/.changesets/1783090047-feat-armory-mcp-ts-skill-ts-rpc-api-bindings-for-the-standal-m1j8.md
+++ b/.changesets/1783090047-feat-armory-mcp-ts-skill-ts-rpc-api-bindings-for-the-standal-m1j8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(armory): mcp.ts/skill.ts rpc-api bindings for the standalone MCP Server + Skill primitives

--- a/frontend/app/store/rpc-api/index.ts
+++ b/frontend/app/store/rpc-api/index.ts
@@ -15,9 +15,11 @@ import { AgentApi } from "./agent";
 import { BlockApi } from "./block";
 import { FileApi } from "./file";
 import { IdentityApi } from "./identity";
+import { McpApi } from "./mcp";
 import { MemoryApi } from "./memory";
 import { MiscApi } from "./misc";
 import { SessionApi } from "./session";
+import { SkillApi } from "./skill";
 import { WorkspaceApi } from "./workspace";
 
 export type { OAuthFlowStatus } from "./types";
@@ -32,4 +34,6 @@ export const RpcApi = {
     ...IdentityApi,
     ...MemoryApi,
     ...SessionApi,
+    ...McpApi,
+    ...SkillApi,
 };

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -23,7 +23,7 @@ export const McpApi = {
         client: RpcClient,
         data: { agent_id: string; id: string },
         opts?: RpcOpts,
-    ): Promise<McpServer> {
+    ): Promise<McpServer | null> {
         return client.rpcCall("mcp.get", data, opts);
     },
 

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -1,0 +1,61 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// v1 composable model — standalone MCP Server primitive
+// (agentmux-srv/src/server/app_api/mcp.rs). Agent-scoped: every command is
+// `check_s1`-gated (ctx.agent_id must equal the request's agent_id), so
+// these only work from an authenticated agent connection. There is no
+// window-scoped "list every MCP server" command yet — see mcp.catalog.*
+// (Armory-level, global-only) for that surface.
+
+import { RpcClient } from "../rpc-client";
+
+export const McpApi = {
+    McpListCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer[]> {
+        return client.rpcCall("mcp.list", data, opts);
+    },
+
+    McpGetCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer> {
+        return client.rpcCall("mcp.get", data, opts);
+    },
+
+    McpUpsertCommand(
+        client: RpcClient,
+        data: { agent_id: string; id?: string; name: string; transport?: string; config?: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer> {
+        return client.rpcCall("mcp.upsert", data, opts);
+    },
+
+    McpDeleteCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("mcp.delete", data, opts);
+    },
+
+    McpBindCommand(
+        client: RpcClient,
+        data: { agent_id: string; mcp_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ bound: boolean }> {
+        return client.rpcCall("mcp.bind", data, opts);
+    },
+
+    McpUnbindCommand(
+        client: RpcClient,
+        data: { agent_id: string; mcp_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("mcp.unbind", data, opts);
+    },
+};

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -25,7 +25,7 @@ export const SkillApi = {
         client: RpcClient,
         data: { agent_id: string; id: string },
         opts?: RpcOpts,
-    ): Promise<Skill> {
+    ): Promise<Skill | null> {
         return client.rpcCall("skill.get", data, opts);
     },
 

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -1,0 +1,71 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// v1 composable model — standalone Skill primitive
+// (agentmux-srv/src/server/app_api/skill.rs). Agent-scoped: every command is
+// `check_s1`-gated (ctx.agent_id must equal the request's agent_id), so
+// these only work from an authenticated agent connection. Distinct from the
+// legacy agent-scoped AgentSkill (`agent_skill_*` / `db_agent_skills`,
+// `AgentSkillCard.tsx` et al.) — this is the v1 standalone primitive
+// (`db_skills`). There is no window-scoped "list every skill" command yet —
+// see skill.catalog.* (Armory-level, global-only) for that surface.
+
+import { RpcClient } from "../rpc-client";
+
+export const SkillApi = {
+    SkillListCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<Skill[]> {
+        return client.rpcCall("skill.list", data, opts);
+    },
+
+    SkillGetCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<Skill> {
+        return client.rpcCall("skill.get", data, opts);
+    },
+
+    SkillUpsertCommand(
+        client: RpcClient,
+        data: {
+            agent_id: string;
+            id?: string;
+            name: string;
+            trigger?: string;
+            skill_type?: string;
+            description?: string;
+            content?: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<Skill> {
+        return client.rpcCall("skill.upsert", data, opts);
+    },
+
+    SkillDeleteCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("skill.delete", data, opts);
+    },
+
+    SkillBindCommand(
+        client: RpcClient,
+        data: { agent_id: string; skill_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ bound: boolean }> {
+        return client.rpcCall("skill.bind", data, opts);
+    },
+
+    SkillUnbindCommand(
+        client: RpcClient,
+        data: { agent_id: string; skill_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("skill.unbind", data, opts);
+    },
+};

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -389,6 +389,39 @@ declare global {
         updated_at: number;
     };
 
+    // ── v1 composable model — standalone MCP Server + Skill primitives ─────
+    // Mirrors agentmux-srv/src/backend/storage/mcp_servers.rs::McpServer and
+    // skills.rs::Skill (the v1 struct, not the legacy agent-scoped AgentSkill).
+
+    /** A standalone MCP Server primitive. `config` is a JSON-encoded object
+     *  (command/args/env for stdio; url/headers for sse) merged into
+     *  `.mcp.json` at agent launch. Global servers (`is_global`) are visible
+     *  to every agent and cannot be mutated/deleted by agent-scoped RPCs. */
+    type McpServer = {
+        id: string;
+        name: string;
+        transport: string; // "stdio" | "sse"
+        config: string;
+        is_global: boolean;
+        created_at: number;
+        updated_at: number;
+    };
+
+    /** A standalone Skill primitive — an on-demand instruction/knowledge
+     *  module, loaded when invoked. Global skills (`is_global`) are visible
+     *  to every agent and cannot be mutated/deleted by agent-scoped RPCs. */
+    type Skill = {
+        id: string;
+        name: string;
+        trigger: string;
+        skill_type: string; // "prompt" | ...
+        description: string;
+        content: string;
+        is_global: boolean;
+        created_at: number;
+        updated_at: number;
+    };
+
     /** Drone pane (issue #753 Phase 1). Mirrors the Rust types in
      *  agentmux-srv/src/drone/types.rs. */
     type DroneDefinition = {

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -286,9 +286,6 @@ const KNOWN_DECLARED_UNREGISTERED = [
 
 /**
  * Backend registers these handlers, but rpc-api.ts has no method.
- * Note: the `mcp.*` / `skill.*` entries are the standalone MCP Server + Skill
- * primitives (Trust Center) — intentionally backend-only for now; frontend
- * bindings land when the UI is wired. Shrink this baseline as they get bound.
  */
 const KNOWN_REGISTERED_UNDECLARED = [
     "agent.define",
@@ -311,12 +308,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "identity.account.validate",
     "identity.self.accounts",
     "identity.self.unlink",
-    "mcp.bind",
-    "mcp.delete",
-    "mcp.get",
-    "mcp.list",
-    "mcp.unbind",
-    "mcp.upsert",
     "memory.list",
     "memory.read",
     "memory.write",
@@ -326,12 +317,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "preset.list",
     "preset.self.get",
     "preset.upsert",
-    "skill.bind",
-    "skill.delete",
-    "skill.get",
-    "skill.list",
-    "skill.unbind",
-    "skill.upsert",
     "slow",
 ];
 


### PR DESCRIPTION
## Summary
- Phase 1 (#1877) made MCP Server + Skill first-class backend primitives (`mcp.*`/`skill.*` App API) but left them entirely backend-only — no frontend binding existed.
- Adds `frontend/app/store/rpc-api/mcp.ts` and `skill.ts` (agent-scoped CRUD, matching the `check_s1`-gated backend RPC shape), registers both in `rpc-api/index.ts`, and adds `McpServer`/`Skill` types to `gotypes.d.ts` mirroring the Rust structs 1:1.
- Shrinks `test/contract/rpc-contract.test.ts`'s `KNOWN_REGISTERED_UNDECLARED` baseline by the 12 `mcp.*`/`skill.*` entries now that they're declared.

This is PR A1 of a 7-PR plan to close the gap flagged when a user noticed a fresh Armory instance has no MCP Servers/Skills tab (see `AgentSetupModal.tsx`'s `// Future primitives (Phase 3+): MCP Servers · Skills · Briefs · Bundle` marker). Pure plumbing — no UI changes yet; sets up the next PR (MCP/Skills tabs in the Agent-setup modal).

## Test plan
- [x] `npx vitest run test/contract/rpc-contract.test.ts` — 4/4 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Reviewer: confirm `mcp.ts`/`skill.ts` request/response shapes match `agentmux-srv/src/server/app_api/mcp.rs` / `skill.rs` exactly (no runtime call sites yet to exercise these — that lands in the next PR)

<!-- agentmux:agent_id=agent1 -->