### PR TITLE
feat(armory): MCP Servers + Skills tabs in the Agent setup modal

### DIFF
--- a/.changesets/1783090047-feat-armory-mcp-ts-skill-ts-rpc-api-bindings-for-the-standal-m1j8.md
+++ b/.changesets/1783090047-feat-armory-mcp-ts-skill-ts-rpc-api-bindings-for-the-standal-m1j8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(armory): mcp.ts/skill.ts rpc-api bindings for the standalone MCP Server + Skill primitives

--- a/.changesets/1783090366-feat-armory-mcp-servers-skills-tabs-in-the-agent-setup-modal-jeyb.md
+++ b/.changesets/1783090366-feat-armory-mcp-servers-skills-tabs-in-the-agent-setup-modal-jeyb.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): MCP Servers + Skills tabs in the Agent setup modal

--- a/frontend/app/store/rpc-api/index.ts
+++ b/frontend/app/store/rpc-api/index.ts
@@ -15,9 +15,11 @@ import { AgentApi } from "./agent";
 import { BlockApi } from "./block";
 import { FileApi } from "./file";
 import { IdentityApi } from "./identity";
+import { McpApi } from "./mcp";
 import { MemoryApi } from "./memory";
 import { MiscApi } from "./misc";
 import { SessionApi } from "./session";
+import { SkillApi } from "./skill";
 import { WorkspaceApi } from "./workspace";
 
 export type { OAuthFlowStatus } from "./types";
@@ -32,4 +34,6 @@ export const RpcApi = {
     ...IdentityApi,
     ...MemoryApi,
     ...SessionApi,
+    ...McpApi,
+    ...SkillApi,
 };

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -23,7 +23,7 @@ export const McpApi = {
         client: RpcClient,
         data: { agent_id: string; id: string },
         opts?: RpcOpts,
-    ): Promise<McpServer> {
+    ): Promise<McpServer | null> {
         return client.rpcCall("mcp.get", data, opts);
     },
 

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -1,0 +1,61 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// v1 composable model — standalone MCP Server primitive
+// (agentmux-srv/src/server/app_api/mcp.rs). Agent-scoped: every command is
+// `check_s1`-gated (ctx.agent_id must equal the request's agent_id), so
+// these only work from an authenticated agent connection. There is no
+// window-scoped "list every MCP server" command yet — see mcp.catalog.*
+// (Armory-level, global-only) for that surface.
+
+import { RpcClient } from "../rpc-client";
+
+export const McpApi = {
+    McpListCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer[]> {
+        return client.rpcCall("mcp.list", data, opts);
+    },
+
+    McpGetCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer> {
+        return client.rpcCall("mcp.get", data, opts);
+    },
+
+    McpUpsertCommand(
+        client: RpcClient,
+        data: { agent_id: string; id?: string; name: string; transport?: string; config?: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer> {
+        return client.rpcCall("mcp.upsert", data, opts);
+    },
+
+    McpDeleteCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("mcp.delete", data, opts);
+    },
+
+    McpBindCommand(
+        client: RpcClient,
+        data: { agent_id: string; mcp_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ bound: boolean }> {
+        return client.rpcCall("mcp.bind", data, opts);
+    },
+
+    McpUnbindCommand(
+        client: RpcClient,
+        data: { agent_id: string; mcp_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("mcp.unbind", data, opts);
+    },
+};

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -25,7 +25,7 @@ export const SkillApi = {
         client: RpcClient,
         data: { agent_id: string; id: string },
         opts?: RpcOpts,
-    ): Promise<Skill> {
+    ): Promise<Skill | null> {
         return client.rpcCall("skill.get", data, opts);
     },
 

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -1,0 +1,71 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// v1 composable model — standalone Skill primitive
+// (agentmux-srv/src/server/app_api/skill.rs). Agent-scoped: every command is
+// `check_s1`-gated (ctx.agent_id must equal the request's agent_id), so
+// these only work from an authenticated agent connection. Distinct from the
+// legacy agent-scoped AgentSkill (`agent_skill_*` / `db_agent_skills`,
+// `AgentSkillCard.tsx` et al.) — this is the v1 standalone primitive
+// (`db_skills`). There is no window-scoped "list every skill" command yet —
+// see skill.catalog.* (Armory-level, global-only) for that surface.
+
+import { RpcClient } from "../rpc-client";
+
+export const SkillApi = {
+    SkillListCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<Skill[]> {
+        return client.rpcCall("skill.list", data, opts);
+    },
+
+    SkillGetCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<Skill> {
+        return client.rpcCall("skill.get", data, opts);
+    },
+
+    SkillUpsertCommand(
+        client: RpcClient,
+        data: {
+            agent_id: string;
+            id?: string;
+            name: string;
+            trigger?: string;
+            skill_type?: string;
+            description?: string;
+            content?: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<Skill> {
+        return client.rpcCall("skill.upsert", data, opts);
+    },
+
+    SkillDeleteCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("skill.delete", data, opts);
+    },
+
+    SkillBindCommand(
+        client: RpcClient,
+        data: { agent_id: string; skill_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ bound: boolean }> {
+        return client.rpcCall("skill.bind", data, opts);
+    },
+
+    SkillUnbindCommand(
+        client: RpcClient,
+        data: { agent_id: string; skill_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("skill.unbind", data, opts);
+    },
+};

--- a/frontend/app/view/agent/agent-mcp-model.ts
+++ b/frontend/app/view/agent/agent-mcp-model.ts
@@ -1,0 +1,183 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentMcpModel — view model for the agent pane's MCP Servers tab
+ * (part of AgentSetupModal). Drives the list + create/edit/delete/bind
+ * lifecycle over the standalone MCP Server primitive (`mcp.*` App API,
+ * agentmux-srv/src/server/app_api/mcp.rs).
+ *
+ * `mcp.list` returns both this agent's own (non-global) servers AND every
+ * global server, regardless of whether this agent is bound to it — the
+ * response carries no per-row "bound to me" flag. Own (`!is_global`) rows
+ * are always editable/deletable here; global rows are read-only (upsert/
+ * delete on a global row is backend-FORBIDDEN) and only exposed as
+ * Bind/Unbind actions, which are idempotent on the backend so the toggle
+ * works correctly even without a live bound-state indicator.
+ */
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface McpDraft {
+    id?: string;
+    name: string;
+    transport: string;
+    config: string;
+}
+
+export function emptyMcpDraft(): McpDraft {
+    return { id: undefined, name: "", transport: "stdio", config: "{}" };
+}
+
+function draftFromServer(s: McpServer): McpDraft {
+    return { id: s.id, name: s.name, transport: s.transport, config: s.config };
+}
+
+export class AgentMcpModel {
+    readonly agentId: string;
+
+    private _servers = createSignal<McpServer[]>([]);
+    serversAtom: Accessor<McpServer[]> = this._servers[0];
+    private setServers = this._servers[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _draft = createSignal<McpDraft | null>(null);
+    draftAtom: Accessor<McpDraft | null> = this._draft[0];
+    setDraft = this._draft[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    private setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    selectedAtom: Accessor<McpServer | null>;
+
+    constructor(agentId: string) {
+        this.agentId = agentId;
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.serversAtom().find((s) => s.id === id) ?? null;
+        });
+        void this.refresh();
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.McpListCommand(TabRpcClient, { agent_id: this.agentId });
+            this.setServers(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load MCP servers: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    handleSelect(server: McpServer): void {
+        this.setError(null);
+        this.setDraft(null);
+        this.setSelectedId(server.id);
+    }
+
+    startNew(): void {
+        this.setError(null);
+        this.setDraft(emptyMcpDraft());
+        this.setSelectedId(null);
+    }
+
+    startEdit(server: McpServer): void {
+        if (server.is_global) {
+            this.setError("Global MCP servers are managed in the Armory, not here.");
+            return;
+        }
+        this.setError(null);
+        this.setDraft(draftFromServer(server));
+        this.setSelectedId(server.id);
+    }
+
+    cancelDraft(): void {
+        this.setDraft(null);
+        this.setError(null);
+    }
+
+    async saveDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        if (!draft.name.trim()) {
+            this.setError("Name is required.");
+            return;
+        }
+        try {
+            JSON.parse(draft.config || "{}");
+        } catch {
+            this.setError("Config must be valid JSON.");
+            return;
+        }
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const saved = await RpcApi.McpUpsertCommand(TabRpcClient, {
+                agent_id: this.agentId,
+                id: draft.id,
+                name: draft.name.trim(),
+                transport: draft.transport || "stdio",
+                config: draft.config || "{}",
+            });
+            await this.refresh();
+            this.setDraft(null);
+            this.setSelectedId(saved.id);
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    async deleteServer(id: string): Promise<void> {
+        const target = this.serversAtom().find((s) => s.id === id);
+        if (target?.is_global) {
+            this.setError("Global MCP servers are managed in the Armory, not here.");
+            return;
+        }
+        this.setError(null);
+        try {
+            await RpcApi.McpDeleteCommand(TabRpcClient, { agent_id: this.agentId, id });
+            if (this.selectedIdAtom() === id) this.setSelectedId(null);
+            this.setDraft(null);
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    async bind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.McpBindCommand(TabRpcClient, { agent_id: this.agentId, mcp_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Bind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    async unbind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.McpUnbindCommand(TabRpcClient, { agent_id: this.agentId, mcp_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Unbind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    dispose(): void {
+        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+}

--- a/frontend/app/view/agent/agent-skill-model.ts
+++ b/frontend/app/view/agent/agent-skill-model.ts
@@ -1,0 +1,182 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentSkillModel — view model for the agent pane's Skills tab (part of
+ * AgentSetupModal). Drives the list + create/edit/delete/bind lifecycle
+ * over the standalone Skill primitive (`skill.*` App API,
+ * agentmux-srv/src/server/app_api/skill.rs). Same shape as AgentMcpModel —
+ * see its doc comment for the is_global / bound-status caveat, which
+ * applies identically here.
+ */
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface SkillDraft {
+    id?: string;
+    name: string;
+    trigger: string;
+    skill_type: string;
+    description: string;
+    content: string;
+}
+
+export function emptySkillDraft(): SkillDraft {
+    return { id: undefined, name: "", trigger: "", skill_type: "prompt", description: "", content: "" };
+}
+
+function draftFromSkill(s: Skill): SkillDraft {
+    return {
+        id: s.id,
+        name: s.name,
+        trigger: s.trigger,
+        skill_type: s.skill_type,
+        description: s.description,
+        content: s.content,
+    };
+}
+
+export class AgentSkillModel {
+    readonly agentId: string;
+
+    private _skills = createSignal<Skill[]>([]);
+    skillsAtom: Accessor<Skill[]> = this._skills[0];
+    private setSkills = this._skills[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _draft = createSignal<SkillDraft | null>(null);
+    draftAtom: Accessor<SkillDraft | null> = this._draft[0];
+    setDraft = this._draft[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    private setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    selectedAtom: Accessor<Skill | null>;
+
+    constructor(agentId: string) {
+        this.agentId = agentId;
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.skillsAtom().find((s) => s.id === id) ?? null;
+        });
+        void this.refresh();
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.SkillListCommand(TabRpcClient, { agent_id: this.agentId });
+            this.setSkills(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load skills: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    handleSelect(skill: Skill): void {
+        this.setError(null);
+        this.setDraft(null);
+        this.setSelectedId(skill.id);
+    }
+
+    startNew(): void {
+        this.setError(null);
+        this.setDraft(emptySkillDraft());
+        this.setSelectedId(null);
+    }
+
+    startEdit(skill: Skill): void {
+        if (skill.is_global) {
+            this.setError("Global skills are managed in the Armory, not here.");
+            return;
+        }
+        this.setError(null);
+        this.setDraft(draftFromSkill(skill));
+        this.setSelectedId(skill.id);
+    }
+
+    cancelDraft(): void {
+        this.setDraft(null);
+        this.setError(null);
+    }
+
+    async saveDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        if (!draft.name.trim()) {
+            this.setError("Name is required.");
+            return;
+        }
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const saved = await RpcApi.SkillUpsertCommand(TabRpcClient, {
+                agent_id: this.agentId,
+                id: draft.id,
+                name: draft.name.trim(),
+                trigger: draft.trigger,
+                skill_type: draft.skill_type || "prompt",
+                description: draft.description,
+                content: draft.content,
+            });
+            await this.refresh();
+            this.setDraft(null);
+            this.setSelectedId(saved.id);
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    async deleteSkill(id: string): Promise<void> {
+        const target = this.skillsAtom().find((s) => s.id === id);
+        if (target?.is_global) {
+            this.setError("Global skills are managed in the Armory, not here.");
+            return;
+        }
+        this.setError(null);
+        try {
+            await RpcApi.SkillDeleteCommand(TabRpcClient, { agent_id: this.agentId, id });
+            if (this.selectedIdAtom() === id) this.setSelectedId(null);
+            this.setDraft(null);
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    async bind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.SkillBindCommand(TabRpcClient, { agent_id: this.agentId, skill_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Bind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    async unbind(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.SkillUnbindCommand(TabRpcClient, { agent_id: this.agentId, skill_id: id });
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Unbind failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    dispose(): void {
+        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+}

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -1,0 +1,175 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentMcpModal — the "MCP Servers" tab body inside AgentSetupModal.
+ * List/create/edit/delete for this agent's own MCP servers, plus
+ * bind/unbind for global ones. See AgentMcpModel's doc comment for the
+ * bound-status caveat.
+ */
+
+import { onCleanup, For, Show, type JSX } from "solid-js";
+import { AgentMcpModel } from "../agent-mcp-model";
+import "./AgentPrimitiveModal.scss";
+
+interface AgentMcpModalProps {
+    agentId: string;
+}
+
+export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
+    const model = new AgentMcpModel(props.agentId);
+    onCleanup(() => model.dispose());
+
+    return (
+        <div class="agent-primitive-modal">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+
+            <div class="agent-primitive-modal-body">
+                <div class="agent-primitive-modal-list">
+                    <Show
+                        when={model.serversAtom().length > 0}
+                        fallback={<div class="agent-primitive-modal-list-empty">No MCP servers yet</div>}
+                    >
+                        <For each={model.serversAtom()}>
+                            {(server) => (
+                                <button
+                                    class="agent-primitive-modal-list-item"
+                                    classList={{ "is-selected": model.selectedIdAtom() === server.id }}
+                                    onClick={() => model.handleSelect(server)}
+                                >
+                                    <span class="agent-primitive-modal-list-item-name">{server.name}</span>
+                                    <Show when={server.is_global}>
+                                        <span class="agent-primitive-modal-list-item-badge">global</span>
+                                    </Show>
+                                </button>
+                            )}
+                        </For>
+                    </Show>
+
+                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                        + New MCP server
+                    </button>
+                </div>
+
+                <div class="agent-primitive-modal-detail">
+                    <Show
+                        when={model.draftAtom()}
+                        fallback={
+                            <Show
+                                when={model.selectedAtom()}
+                                fallback={
+                                    <div class="agent-primitive-modal-empty">
+                                        Select a server from the list, or create a new one.
+                                    </div>
+                                }
+                            >
+                                {(server) => (
+                                    <div class="agent-primitive-modal-readonly">
+                                        <h3 class="agent-primitive-modal-name">{server().name}</h3>
+                                        <Show when={server().is_global}>
+                                            <p class="agent-primitive-modal-global-note">
+                                                Global — managed in the Armory. You can bind/unbind it here.
+                                            </p>
+                                        </Show>
+                                        <span class="agent-primitive-modal-field-label">Transport</span>
+                                        <pre class="agent-primitive-modal-field-value">{server().transport}</pre>
+                                        <span class="agent-primitive-modal-field-label">Config</span>
+                                        <pre class="agent-primitive-modal-field-value">{server().config}</pre>
+                                        <div class="agent-primitive-modal-actions">
+                                            <Show
+                                                when={!server().is_global}
+                                                fallback={
+                                                    <>
+                                                        <button
+                                                            class="agent-primitive-modal-btn"
+                                                            onClick={() => void model.unbind(server().id)}
+                                                        >
+                                                            Unbind
+                                                        </button>
+                                                        <button
+                                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                                            onClick={() => void model.bind(server().id)}
+                                                        >
+                                                            Bind
+                                                        </button>
+                                                    </>
+                                                }
+                                            >
+                                                <button
+                                                    class="agent-primitive-modal-btn agent-primitive-modal-btn-danger"
+                                                    onClick={() => void model.deleteServer(server().id)}
+                                                >
+                                                    Delete
+                                                </button>
+                                                <button
+                                                    class="agent-primitive-modal-btn"
+                                                    onClick={() => model.startEdit(server())}
+                                                >
+                                                    Edit
+                                                </button>
+                                            </Show>
+                                        </div>
+                                    </div>
+                                )}
+                            </Show>
+                        }
+                    >
+                        {(draft) => (
+                            <form
+                                class="agent-primitive-modal-form"
+                                onSubmit={(e) => { e.preventDefault(); void model.saveDraft(); }}
+                            >
+                                <span class="agent-primitive-modal-field-label">Name *</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().name}
+                                    onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
+                                    placeholder="e.g. filesystem"
+                                    required
+                                />
+                                <span class="agent-primitive-modal-field-label">Transport</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().transport}
+                                    onInput={(e) => model.setDraft({ ...draft(), transport: e.currentTarget.value })}
+                                    placeholder="stdio"
+                                />
+                                <span class="agent-primitive-modal-field-label">Config (JSON)</span>
+                                <textarea
+                                    class="agent-primitive-modal-textarea"
+                                    rows={6}
+                                    value={draft().config}
+                                    onInput={(e) => model.setDraft({ ...draft(), config: e.currentTarget.value })}
+                                    spellcheck={false}
+                                />
+                                <div class="agent-primitive-modal-actions">
+                                    <button
+                                        type="button"
+                                        class="agent-primitive-modal-btn"
+                                        onClick={() => model.cancelDraft()}
+                                        disabled={model.savingAtom()}
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        type="submit"
+                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                        disabled={model.savingAtom() || !draft().name.trim()}
+                                    >
+                                        {model.savingAtom() ? "Saving…" : "Save"}
+                                    </button>
+                                </div>
+                            </form>
+                        )}
+                    </Show>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+AgentMcpModal.displayName = "AgentMcpModal";

--- a/frontend/app/view/agent/components/AgentPrimitiveModal.scss
+++ b/frontend/app/view/agent/components/AgentPrimitiveModal.scss
@@ -1,0 +1,234 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared styles for the agent-scoped primitive list/detail tabs (MCP
+// Servers, Skills) hosted inside AgentSetupModal. Same list+detail shape as
+// AgentNativeMemoryModal.scss, generalized to a form-editor detail pane
+// instead of a file browser — see AgentMcpModal.tsx / AgentSkillsModal.tsx.
+
+.agent-primitive-modal {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
+.agent-primitive-modal-error {
+    flex-shrink: 0;
+    margin-bottom: var(--space-2);
+    padding: var(--space-1-5) var(--space-2);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color) 30%, transparent);
+    color: var(--error-color);
+    font-size: var(--text-sm);
+}
+
+.agent-primitive-modal-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    border: 1px solid var(--border-color);
+}
+
+.agent-primitive-modal-list {
+    flex-shrink: 0;
+    width: 220px;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border-color);
+    overflow-y: auto;
+}
+
+.agent-primitive-modal-list-empty {
+    padding: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    font-style: italic;
+}
+
+.agent-primitive-modal-list-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    width: 100%;
+    padding: var(--space-1-5) var(--space-2);
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    font-size: var(--text-sm);
+    text-align: left;
+    cursor: default;
+
+    &:hover {
+        background: var(--hover-bg-color);
+    }
+
+    &.is-selected {
+        background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+    }
+}
+
+.agent-primitive-modal-list-item-name {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-primitive-modal-list-item-badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 1px 5px;
+    color: var(--accent-color);
+    background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+}
+
+.agent-primitive-modal-new-btn {
+    margin-top: auto;
+    padding: var(--space-1-5) var(--space-2);
+    border: none;
+    border-top: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--accent-color);
+    font-size: var(--text-sm);
+    text-align: left;
+    cursor: default;
+
+    &:hover {
+        background: var(--hover-bg-color);
+    }
+}
+
+.agent-primitive-modal-detail {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+.agent-primitive-modal-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-4);
+    text-align: center;
+    color: var(--secondary-text-color);
+    font-size: var(--text-sm);
+}
+
+.agent-primitive-modal-readonly {
+    padding: var(--space-2);
+}
+
+.agent-primitive-modal-name {
+    margin: 0 0 var(--space-1) 0;
+    font-size: var(--text-md, 14px);
+    font-weight: 600;
+    color: var(--main-text-color);
+}
+
+.agent-primitive-modal-global-note {
+    margin: 0 0 var(--space-2) 0;
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+}
+
+.agent-primitive-modal-field-label {
+    display: block;
+    margin-top: var(--space-2);
+    margin-bottom: 2px;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--secondary-text-color);
+}
+
+.agent-primitive-modal-field-value {
+    margin: 0;
+    padding: var(--space-1-5);
+    font-family: var(--fixed-font, monospace);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    background: var(--panel-bg-color);
+}
+
+.agent-primitive-modal-form {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-2);
+}
+
+.agent-primitive-modal-input,
+.agent-primitive-modal-textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: var(--space-1) var(--space-1-5);
+    border: 1px solid var(--border-color);
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    font-size: var(--text-sm);
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}
+
+.agent-primitive-modal-textarea {
+    font-family: var(--fixed-font, monospace);
+    resize: vertical;
+    min-height: 80px;
+}
+
+.agent-primitive-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+}
+
+.agent-primitive-modal-btn {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-sm);
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+
+    &.agent-primitive-modal-btn-primary {
+        background: var(--accent-color);
+        color: var(--button-text-color);
+        border-color: var(--accent-color);
+
+        &:hover:not(:disabled) {
+            opacity: 0.85;
+        }
+    }
+
+    &.agent-primitive-modal-btn-danger {
+        color: var(--error-color);
+        border-color: color-mix(in srgb, var(--error-color) 40%, transparent);
+
+        &:hover:not(:disabled) {
+            background: color-mix(in srgb, var(--error-color) 10%, transparent);
+        }
+    }
+}

--- a/frontend/app/view/agent/components/AgentSetupModal.tsx
+++ b/frontend/app/view/agent/components/AgentSetupModal.tsx
@@ -6,12 +6,14 @@
  * opened by the single "Agent setup" (id-card) icon in the agent pane
  * header. Consolidates the former two icons (identity + native memory)
  * into one modal with tabs:
- *   - Accounts — the former Identity panel (AgentIdentityModalPanel).
- *   - Memory   — the native-memory browser (AgentNativeMemoryModal).
+ *   - Accounts    — the former Identity panel (AgentIdentityModalPanel).
+ *   - Memory      — the native-memory browser (AgentNativeMemoryModal).
+ *   - MCP Servers — the standalone MCP Server primitive (AgentMcpModal).
+ *   - Skills      — the standalone Skill primitive (AgentSkillsModal).
  *
  * The tab list is a data array so future primitives slot in trivially.
- * Behavior-preserving: the two hosted panels are reused as-is; only the
- * entry point (one icon + tabs) changed.
+ * Briefs · Bundle are not wired here — Briefs has no backend primitive at
+ * all yet (tracked separately); Bundle already has its own Armory tab.
  *
  * Spec: SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md §3.2b +
  *       EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md §4.
@@ -19,10 +21,12 @@
 
 import { createSignal, For, Show, type JSX } from "solid-js";
 import { AgentIdentityModalPanel } from "./AgentIdentityModal";
+import { AgentMcpModal } from "./AgentMcpModal";
 import { AgentNativeMemoryModal } from "./AgentNativeMemoryModal";
+import { AgentSkillsModal } from "./AgentSkillsModal";
 import "./AgentSetupModal.scss";
 
-type SetupTabId = "accounts" | "memory";
+type SetupTabId = "accounts" | "memory" | "mcp" | "skills";
 
 interface AgentSetupModalProps {
     /** Agent definition for the Accounts tab. Null for quick-launch panes
@@ -42,12 +46,13 @@ interface SetupTabDef {
 }
 
 export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
-    // Data-driven tab list — future primitives (Phase 3+): MCP Servers ·
-    // Skills · Briefs · Bundle slot in here as additional entries plus a
-    // render branch below. Do NOT build those managers yet.
+    // Data-driven tab list — Briefs · Bundle slot in here later (Briefs has
+    // no backend primitive yet; Bundle has its own Armory tab already).
     const tabs: SetupTabDef[] = [
         { id: "accounts", label: "Accounts" },
         { id: "memory", label: "Memory" },
+        { id: "mcp", label: "MCP Servers" },
+        { id: "skills", label: "Skills" },
     ];
 
     const [activeTab, setActiveTab] = createSignal<SetupTabId>(props.initialTab ?? "accounts");
@@ -100,7 +105,15 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
                     />
                 </Show>
 
-                {/* Future primitives (Phase 3+): MCP Servers · Skills · Briefs · Bundle */}
+                <Show when={activeTab() === "mcp"}>
+                    <AgentMcpModal agentId={props.agentId} />
+                </Show>
+
+                <Show when={activeTab() === "skills"}>
+                    <AgentSkillsModal agentId={props.agentId} />
+                </Show>
+
+                {/* Future primitives: Briefs · Bundle */}
             </div>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -1,0 +1,190 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentSkillsModal — the "Skills" tab body inside AgentSetupModal.
+ * List/create/edit/delete for this agent's own skills, plus bind/unbind
+ * for global ones. See AgentSkillModel's doc comment for the bound-status
+ * caveat. Distinct from the legacy AgentSkillCard/AgentSkillsPanel (the
+ * agent-definition `agent_skill_*` surface) — this is the v1 standalone
+ * Skill primitive (`skill.*` / `db_skills`).
+ */
+
+import { onCleanup, For, Show, type JSX } from "solid-js";
+import { AgentSkillModel } from "../agent-skill-model";
+import "./AgentPrimitiveModal.scss";
+
+interface AgentSkillsModalProps {
+    agentId: string;
+}
+
+export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
+    const model = new AgentSkillModel(props.agentId);
+    onCleanup(() => model.dispose());
+
+    return (
+        <div class="agent-primitive-modal">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+
+            <div class="agent-primitive-modal-body">
+                <div class="agent-primitive-modal-list">
+                    <Show
+                        when={model.skillsAtom().length > 0}
+                        fallback={<div class="agent-primitive-modal-list-empty">No skills yet</div>}
+                    >
+                        <For each={model.skillsAtom()}>
+                            {(skill) => (
+                                <button
+                                    class="agent-primitive-modal-list-item"
+                                    classList={{ "is-selected": model.selectedIdAtom() === skill.id }}
+                                    onClick={() => model.handleSelect(skill)}
+                                >
+                                    <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
+                                    <Show when={skill.is_global}>
+                                        <span class="agent-primitive-modal-list-item-badge">global</span>
+                                    </Show>
+                                </button>
+                            )}
+                        </For>
+                    </Show>
+
+                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                        + New skill
+                    </button>
+                </div>
+
+                <div class="agent-primitive-modal-detail">
+                    <Show
+                        when={model.draftAtom()}
+                        fallback={
+                            <Show
+                                when={model.selectedAtom()}
+                                fallback={
+                                    <div class="agent-primitive-modal-empty">
+                                        Select a skill from the list, or create a new one.
+                                    </div>
+                                }
+                            >
+                                {(skill) => (
+                                    <div class="agent-primitive-modal-readonly">
+                                        <h3 class="agent-primitive-modal-name">{skill().name}</h3>
+                                        <Show when={skill().is_global}>
+                                            <p class="agent-primitive-modal-global-note">
+                                                Global — managed in the Armory. You can bind/unbind it here.
+                                            </p>
+                                        </Show>
+                                        <Show when={skill().description}>
+                                            <span class="agent-primitive-modal-field-label">Description</span>
+                                            <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
+                                        </Show>
+                                        <Show when={skill().trigger}>
+                                            <span class="agent-primitive-modal-field-label">Trigger</span>
+                                            <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
+                                        </Show>
+                                        <span class="agent-primitive-modal-field-label">Content</span>
+                                        <pre class="agent-primitive-modal-field-value">{skill().content || "(none)"}</pre>
+                                        <div class="agent-primitive-modal-actions">
+                                            <Show
+                                                when={!skill().is_global}
+                                                fallback={
+                                                    <>
+                                                        <button
+                                                            class="agent-primitive-modal-btn"
+                                                            onClick={() => void model.unbind(skill().id)}
+                                                        >
+                                                            Unbind
+                                                        </button>
+                                                        <button
+                                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                                            onClick={() => void model.bind(skill().id)}
+                                                        >
+                                                            Bind
+                                                        </button>
+                                                    </>
+                                                }
+                                            >
+                                                <button
+                                                    class="agent-primitive-modal-btn agent-primitive-modal-btn-danger"
+                                                    onClick={() => void model.deleteSkill(skill().id)}
+                                                >
+                                                    Delete
+                                                </button>
+                                                <button
+                                                    class="agent-primitive-modal-btn"
+                                                    onClick={() => model.startEdit(skill())}
+                                                >
+                                                    Edit
+                                                </button>
+                                            </Show>
+                                        </div>
+                                    </div>
+                                )}
+                            </Show>
+                        }
+                    >
+                        {(draft) => (
+                            <form
+                                class="agent-primitive-modal-form"
+                                onSubmit={(e) => { e.preventDefault(); void model.saveDraft(); }}
+                            >
+                                <span class="agent-primitive-modal-field-label">Name *</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().name}
+                                    onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
+                                    placeholder="e.g. pdf-extraction"
+                                    required
+                                />
+                                <span class="agent-primitive-modal-field-label">Trigger</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().trigger}
+                                    onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
+                                    placeholder="When should this skill be invoked?"
+                                />
+                                <span class="agent-primitive-modal-field-label">Description</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().description}
+                                    onInput={(e) => model.setDraft({ ...draft(), description: e.currentTarget.value })}
+                                />
+                                <span class="agent-primitive-modal-field-label">Content</span>
+                                <textarea
+                                    class="agent-primitive-modal-textarea"
+                                    rows={8}
+                                    value={draft().content}
+                                    onInput={(e) => model.setDraft({ ...draft(), content: e.currentTarget.value })}
+                                    spellcheck={false}
+                                />
+                                <div class="agent-primitive-modal-actions">
+                                    <button
+                                        type="button"
+                                        class="agent-primitive-modal-btn"
+                                        onClick={() => model.cancelDraft()}
+                                        disabled={model.savingAtom()}
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        type="submit"
+                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                        disabled={model.savingAtom() || !draft().name.trim()}
+                                    >
+                                        {model.savingAtom() ? "Saving…" : "Save"}
+                                    </button>
+                                </div>
+                            </form>
+                        )}
+                    </Show>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+AgentSkillsModal.displayName = "AgentSkillsModal";

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -389,6 +389,39 @@ declare global {
         updated_at: number;
     };
 
+    // ── v1 composable model — standalone MCP Server + Skill primitives ─────
+    // Mirrors agentmux-srv/src/backend/storage/mcp_servers.rs::McpServer and
+    // skills.rs::Skill (the v1 struct, not the legacy agent-scoped AgentSkill).
+
+    /** A standalone MCP Server primitive. `config` is a JSON-encoded object
+     *  (command/args/env for stdio; url/headers for sse) merged into
+     *  `.mcp.json` at agent launch. Global servers (`is_global`) are visible
+     *  to every agent and cannot be mutated/deleted by agent-scoped RPCs. */
+    type McpServer = {
+        id: string;
+        name: string;
+        transport: string; // "stdio" | "sse"
+        config: string;
+        is_global: boolean;
+        created_at: number;
+        updated_at: number;
+    };
+
+    /** A standalone Skill primitive — an on-demand instruction/knowledge
+     *  module, loaded when invoked. Global skills (`is_global`) are visible
+     *  to every agent and cannot be mutated/deleted by agent-scoped RPCs. */
+    type Skill = {
+        id: string;
+        name: string;
+        trigger: string;
+        skill_type: string; // "prompt" | ...
+        description: string;
+        content: string;
+        is_global: boolean;
+        created_at: number;
+        updated_at: number;
+    };
+
     /** Drone pane (issue #753 Phase 1). Mirrors the Rust types in
      *  agentmux-srv/src/drone/types.rs. */
     type DroneDefinition = {

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -286,9 +286,6 @@ const KNOWN_DECLARED_UNREGISTERED = [
 
 /**
  * Backend registers these handlers, but rpc-api.ts has no method.
- * Note: the `mcp.*` / `skill.*` entries are the standalone MCP Server + Skill
- * primitives (Trust Center) — intentionally backend-only for now; frontend
- * bindings land when the UI is wired. Shrink this baseline as they get bound.
  */
 const KNOWN_REGISTERED_UNDECLARED = [
     "agent.define",
@@ -311,12 +308,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "identity.account.validate",
     "identity.self.accounts",
     "identity.self.unlink",
-    "mcp.bind",
-    "mcp.delete",
-    "mcp.get",
-    "mcp.list",
-    "mcp.unbind",
-    "mcp.upsert",
     "memory.list",
     "memory.read",
     "memory.write",
@@ -326,12 +317,6 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "preset.list",
     "preset.self.get",
     "preset.upsert",
-    "skill.bind",
-    "skill.delete",
-    "skill.get",
-    "skill.list",
-    "skill.unbind",
-    "skill.upsert",
     "slow",
 ];
 


### PR DESCRIPTION
## Summary
Re-opened as a fresh PR targeting `main` — the original (#1944) was stacked on #1943's branch and got auto-closed by GitHub when that branch was deleted on merge (my mistake, sequencing the branch deletion before retargeting). Same commits, now based directly on `main` (which already has #1943's mcp.ts/skill.ts bindings merged in).

PR A2 of the 7-PR plan closing the gap where a fresh Armory instance shows no MCP Servers/Skills surface.

- Fills the `AgentSetupModal.tsx` `// Future primitives (Phase 3+): MCP Servers · Skills · Briefs · Bundle` TODO with **MCP Servers** and **Skills** tabs.
- New `AgentMcpModal.tsx`/`AgentSkillsModal.tsx` + matching view models (`agent-mcp-model.ts`/`agent-skill-model.ts`), following the existing `AgentNativeMemoryModal`/`memory-manager.tsx` list/detail CRUD pattern.
- Agent-scoped (matches the `check_s1`-gated backend RPC shape): own (non-global) entries are fully editable/deletable; global entries — which will be managed from the upcoming Armory catalog tabs (PR A3) — are read-only here, exposed only as Bind/Unbind.
- **Known limitation, not a bug:** `mcp.list`/`skill.list` carry no per-row "bound to me" flag, so Bind/Unbind render as idempotent toggles rather than a stateful switch.
- Includes the reagent P1 fix from #1943 (`McpGetCommand`/`SkillGetCommand` return `T | null`).

Original review on #1944: **APPROVED** (LGTM), all CI green, before the auto-close.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 104/104 files, 1576/1576 tests passing
- [ ] Reviewer: manually open an agent pane → Agent setup → MCP Servers / Skills tabs, create/edit/delete an entry, confirm round-trip

<!-- agentmux:agent_id=agent1 -->