### PR TITLE
feat(ambient): unified gateway for background model calls

### DIFF
--- a/.changesets/1783092345-feat-ambient-unified-gateway-for-background-model-calls-acti-y5d5.md
+++ b/.changesets/1783092345-feat-ambient-unified-gateway-for-background-model-calls-acti-y5d5.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(ambient): unified gateway for background model calls (activity-summary coalescing, cancellation, token accounting)

--- a/agentmux-srv/src/agents/translator/claude.rs
+++ b/agentmux-srv/src/agents/translator/claude.rs
@@ -265,7 +265,7 @@ fn handle_result(t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<AgentEve
     });
 }
 
-fn parse_usage(usage: Option<&Value>) -> TokenCounts {
+pub(crate) fn parse_usage(usage: Option<&Value>) -> TokenCounts {
     let Some(usage) = usage.and_then(|v| v.as_object()) else {
         return TokenCounts::default();
     };

--- a/agentmux-srv/src/ambient/mod.rs
+++ b/agentmux-srv/src/ambient/mod.rs
@@ -1,0 +1,237 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Ambient Model Call (AMC) gateway — the single mandatory path for every
+//! non-user-driven ("ambient") model call in the backend: cheap, background
+//! LLM calls that augment the UX (e.g. summarizing what an agent is doing
+//! for the pane header / Swarm tree) rather than answering a user's own
+//! turn. See `docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md`.
+//!
+//! Every ambient call is keyed by `(entity_id, purpose)` and carries a
+//! caller-supplied generation (monotonic per entity — e.g. a turn counter).
+//! The gateway:
+//!   - cancels a lower-generation in-flight call for the same key the moment
+//!     a higher-generation one is admitted (real subprocess cancellation via
+//!     the returned `CancellationToken`, not just a discard-on-arrival check)
+//!   - rejects a request whose generation is not strictly greater than the
+//!     highest one already admitted for that key (stale-on-arrival — the
+//!     caller does no work at all, not even a discarded one)
+//!
+//! This does NOT track token usage itself — callers record usage through the
+//! normal per-call-site accounting path (tagged by purpose), same as any
+//! other RPC result. The gateway's job is coalescing/cancellation only.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use tokio_util::sync::CancellationToken;
+
+/// Identifies one class of ambient call for a specific entity, e.g.
+/// `(block_id, "activity_summary")`. `purpose` is a short stable string —
+/// also suitable for tagging cost/usage dashboards by call category.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AmbientCallKey {
+    pub entity_id: String,
+    pub purpose: &'static str,
+}
+
+impl AmbientCallKey {
+    pub fn new(entity_id: impl Into<String>, purpose: &'static str) -> Self {
+        Self { entity_id: entity_id.into(), purpose }
+    }
+}
+
+struct InFlight {
+    generation: u64,
+    cancel: CancellationToken,
+}
+
+#[derive(Default)]
+struct GatewayState {
+    inflight: HashMap<AmbientCallKey, InFlight>,
+}
+
+pub struct AmbientGateway {
+    state: Mutex<GatewayState>,
+}
+
+static GATEWAY: OnceLock<AmbientGateway> = OnceLock::new();
+
+/// The process-wide ambient-call gateway singleton.
+pub fn gateway() -> &'static AmbientGateway {
+    GATEWAY.get_or_init(|| AmbientGateway { state: Mutex::new(GatewayState::default()) })
+}
+
+/// Outcome of admitting a request for a key at a given generation.
+pub enum Admission<'a> {
+    /// This is the newest request seen for the key — proceed. Holding the
+    /// guard for the duration of the call gives access to its cancellation
+    /// token; dropping the guard (end of scope, any return path) clears the
+    /// in-flight entry unless a newer request has already replaced it.
+    Proceed(AmbientCallGuard<'a>),
+    /// A request at this generation-or-newer is already in flight, or has
+    /// already completed, for this key — do no work at all.
+    StaleOnArrival,
+}
+
+impl AmbientGateway {
+    /// Admit a request for `key` at `generation`. If an older in-flight
+    /// request exists for the same key, it is cancelled (its cancellation
+    /// token is triggered — the caller holding that token is responsible
+    /// for actually killing its subprocess). If `generation` is not
+    /// strictly greater than the generation already recorded for this key,
+    /// returns `StaleOnArrival` without mutating any state.
+    pub fn admit(&self, key: AmbientCallKey, generation: u64) -> Admission<'_> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(existing) = state.inflight.get(&key) {
+            if generation <= existing.generation {
+                return Admission::StaleOnArrival;
+            }
+            existing.cancel.cancel();
+        }
+        let cancel = CancellationToken::new();
+        state.inflight.insert(
+            key.clone(),
+            InFlight { generation, cancel: cancel.clone() },
+        );
+        Admission::Proceed(AmbientCallGuard {
+            gateway: self,
+            key,
+            generation,
+            cancel,
+        })
+    }
+}
+
+/// Held for the duration of one admitted ambient call.
+pub struct AmbientCallGuard<'a> {
+    gateway: &'a AmbientGateway,
+    key: AmbientCallKey,
+    generation: u64,
+    cancel: CancellationToken,
+}
+
+impl AmbientCallGuard<'_> {
+    /// Cancellation token for this call. Race it against the subprocess
+    /// (`tokio::select!`) and kill the child if it fires — a newer request
+    /// for the same key has superseded this one.
+    pub fn cancellation(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+}
+
+impl Drop for AmbientCallGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.gateway.state.lock().unwrap();
+        // Only clear if we're still the entry of record — a newer request
+        // may have already replaced it (and its own guard owns the clear).
+        if let Some(entry) = state.inflight.get(&self.key) {
+            if entry.generation == self.generation {
+                state.inflight.remove(&self.key);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(id: &str) -> AmbientCallKey {
+        AmbientCallKey::new(id, "activity_summary")
+    }
+
+    #[test]
+    fn first_request_is_admitted() {
+        let gw = AmbientGateway { state: Mutex::new(GatewayState::default()) };
+        match gw.admit(key("block-1"), 1) {
+            Admission::Proceed(_) => {}
+            Admission::StaleOnArrival => panic!("first request should be admitted"),
+        };
+    }
+
+    #[test]
+    fn older_or_equal_generation_is_stale_on_arrival() {
+        let gw = AmbientGateway { state: Mutex::new(GatewayState::default()) };
+        let _guard = match gw.admit(key("block-1"), 5) {
+            Admission::Proceed(g) => g,
+            Admission::StaleOnArrival => panic!("gen 5 should be admitted"),
+        };
+        match gw.admit(key("block-1"), 5) {
+            Admission::StaleOnArrival => {}
+            Admission::Proceed(_) => panic!("equal generation must be rejected"),
+        }
+        match gw.admit(key("block-1"), 3) {
+            Admission::StaleOnArrival => {}
+            Admission::Proceed(_) => panic!("older generation must be rejected"),
+        };
+    }
+
+    #[test]
+    fn newer_generation_cancels_the_older_inflight_request() {
+        let gw = AmbientGateway { state: Mutex::new(GatewayState::default()) };
+        let guard1 = match gw.admit(key("block-1"), 1) {
+            Admission::Proceed(g) => g,
+            Admission::StaleOnArrival => panic!("gen 1 should be admitted"),
+        };
+        let cancel1 = guard1.cancellation();
+        assert!(!cancel1.is_cancelled());
+
+        let _guard2 = match gw.admit(key("block-1"), 2) {
+            Admission::Proceed(g) => g,
+            Admission::StaleOnArrival => panic!("gen 2 should be admitted"),
+        };
+        assert!(cancel1.is_cancelled(), "admitting gen 2 must cancel gen 1's token");
+    }
+
+    #[test]
+    fn different_keys_do_not_interfere() {
+        let gw = AmbientGateway { state: Mutex::new(GatewayState::default()) };
+        let guard1 = match gw.admit(key("block-1"), 1) {
+            Admission::Proceed(g) => g,
+            Admission::StaleOnArrival => panic!("block-1 gen 1 should be admitted"),
+        };
+        match gw.admit(key("block-2"), 1) {
+            Admission::Proceed(_) => {}
+            Admission::StaleOnArrival => panic!("block-2 gen 1 should be admitted independently"),
+        }
+        assert!(!guard1.cancellation().is_cancelled(), "unrelated key must not cancel block-1");
+    }
+
+    #[test]
+    fn dropping_the_guard_clears_the_slot_for_a_later_retry_at_the_same_generation() {
+        let gw = AmbientGateway { state: Mutex::new(GatewayState::default()) };
+        {
+            let _guard = match gw.admit(key("block-1"), 1) {
+                Admission::Proceed(g) => g,
+                Admission::StaleOnArrival => panic!("gen 1 should be admitted"),
+            };
+        } // guard dropped here — slot cleared
+        match gw.admit(key("block-1"), 1) {
+            Admission::Proceed(_) => {}
+            Admission::StaleOnArrival => {
+                panic!("gen 1 should be admittable again once the prior call finished")
+            }
+        };
+    }
+
+    #[test]
+    fn stale_guard_dropping_does_not_clear_a_newer_inflight_entry() {
+        let gw = AmbientGateway { state: Mutex::new(GatewayState::default()) };
+        let guard1 = match gw.admit(key("block-1"), 1) {
+            Admission::Proceed(g) => g,
+            Admission::StaleOnArrival => panic!("gen 1 should be admitted"),
+        };
+        let _guard2 = match gw.admit(key("block-1"), 2) {
+            Admission::Proceed(g) => g,
+            Admission::StaleOnArrival => panic!("gen 2 should be admitted"),
+        };
+        drop(guard1); // superseded guard drops — must NOT clear gen 2's slot
+        match gw.admit(key("block-1"), 2) {
+            Admission::StaleOnArrival => {}
+            Admission::Proceed(_) => {
+                panic!("gen 2 is still in flight; dropping the stale gen-1 guard must not clear it")
+            }
+        };
+    }
+}

--- a/agentmux-srv/src/backend/osc_extractor.rs
+++ b/agentmux-srv/src/backend/osc_extractor.rs
@@ -6,7 +6,7 @@
 //! Parses OSC 0 and OSC 2 sequences from PTY output and normalises
 //! Claude Code window-title payloads into bare conversation-topic strings.
 //! Used by the agent-pane PTY read loop to surface the session topic as
-//! `term:activity` block metadata without leaking raw escape bytes into
+//! `term:osc_title` block metadata without leaking raw escape bytes into
 //! the FileStore.
 //!
 //! Design notes:

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -327,7 +327,8 @@ pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";
 pub const COMMAND_SESSION_RESTORE: &str = "session:restore";
 pub const COMMAND_SESSION_EXPORT: &str = "session:export";
 
-// Per-turn live activity summary (Haiku-powered, writes term:activity)
+// Per-turn live activity summary (Haiku-powered, writes term:ambient_summary;
+// routed through the Ambient Model Call gateway, crate::ambient)
 pub const COMMAND_SESSION_ACTIVITY_SUMMARY: &str = "session:activity_summary";
 
 // Option E (PR 1 of 2) — agent-anchored session zones.

--- a/agentmux-srv/src/backend/rpc_types/session.rs
+++ b/agentmux-srv/src/backend/rpc_types/session.rs
@@ -7,22 +7,35 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::agents::TokenCounts;
+
 // ---- Session activity summary types ----
 
-/// Request for session:activity_summary — generate a per-turn live summary via Haiku.
+/// Request for session:activity_summary — generate a per-turn live summary via
+/// Haiku, routed through the Ambient Model Call gateway (`crate::ambient`).
+/// See docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CommandActivitySummaryData {
     pub block_id: String,
     /// Target word count, derived from pane width. Defaults to 7.
     pub word_target: Option<u32>,
+    /// Caller's monotonic turn counter for this block (bumped on every new
+    /// turn). Used by the ambient gateway to cancel a stale in-flight call
+    /// for the same block and reject a request that arrives out of order.
+    pub generation: u64,
 }
 
-/// Response from session:activity_summary. The backend also writes `term:activity` to block meta.
+/// Response from session:activity_summary. The backend also writes
+/// `term:ambient_summary` to block meta. `tokens` is `None` when the request
+/// was rejected as stale-on-arrival or the underlying call failed/was
+/// cancelled — callers should only record usage when it's `Some`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ActivitySummaryResult {
     pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<TokenCounts>,
 }
 
 // ---- Session archival types ----

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -54,7 +54,7 @@ pub const EVENT_SHELL_NODE_CREATE: &str = "shell_node_create";
 pub const EVENT_SHELL_CHUNK: &str = "shell_chunk";
 /// Fired by the agent-pane PTY read loop when an OSC 0/2 window-title sequence
 /// from Claude Code is extracted. Carries the normalised conversation-topic string
-/// so the frontend can surface it as a `term:activity` tab label.
+/// so the frontend can surface it as a `term:osc_title` tab label.
 /// Payload: `{ "blockId": "...", "activity": "auth refactor" }`.
 pub const EVENT_BLOCK_ACTIVITY: &str = "block:activity";
 
@@ -509,7 +509,7 @@ pub fn publish_install_progress(broker: &Broker, block_id: &str, message: &str) 
 /// Publish a Claude Code OSC window-title activity string to the frontend
 /// for a given agent-pane block. Frontend subscribes to `block:activity`
 /// events scoped to `block:{block_id}` and writes the payload to
-/// `term:activity` block metadata, which the tab label reads.
+/// `term:osc_title` block metadata, which the tab label reads.
 pub fn publish_block_activity(broker: &Broker, block_id: &str, activity: &str) {
     let scope = format!("block:{}", block_id);
     broker.publish(WaveEvent {

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod agents;
+mod ambient;
 mod backend;
 mod config;
 mod event_log;

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -106,6 +106,14 @@ fn register_session_export_handler(engine: &Arc<WshRpcEngine>, state: &AppState)
     );
 }
 
+/// Ambient-call purpose tag for the per-turn activity summary. Also usable
+/// as the token-usage/cost-dashboard category for this call site.
+const AMBIENT_PURPOSE_ACTIVITY_SUMMARY: &str = "activity_summary";
+
+fn empty_summary_result() -> serde_json::Value {
+    serde_json::to_value(&ActivitySummaryResult { summary: String::new(), tokens: None }).unwrap()
+}
+
 fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let filestore = state.filestore.clone();
@@ -118,6 +126,22 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
             Box::pin(async move {
                 let cmd: CommandActivitySummaryData = serde_json::from_value(data)
                     .map_err(|e| format!("session:activity_summary: {e}"))?;
+
+                // Admit through the Ambient Model Call gateway BEFORE doing any
+                // work: a stale (superseded) request does zero FileStore reads
+                // or prompt building, not just skips the CLI spawn. See
+                // docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md.
+                let key = crate::ambient::AmbientCallKey::new(
+                    cmd.block_id.clone(),
+                    AMBIENT_PURPOSE_ACTIVITY_SUMMARY,
+                );
+                let guard = match crate::ambient::gateway().admit(key, cmd.generation) {
+                    crate::ambient::Admission::Proceed(guard) => guard,
+                    crate::ambient::Admission::StaleOnArrival => {
+                        return Ok(Some(empty_summary_result()));
+                    }
+                };
+                let cancel = guard.cancellation();
 
                 let word_target = cmd.word_target.unwrap_or(7).max(3).min(20);
 
@@ -153,24 +177,18 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
                 let window: Vec<&str> = all_lines[start..].iter().map(|s| s.as_str()).collect();
 
                 if window.is_empty() {
-                    return Ok(Some(serde_json::to_value(&ActivitySummaryResult {
-                        summary: String::new(),
-                    }).unwrap()));
+                    return Ok(Some(empty_summary_result()));
                 }
 
                 let extracted = extract_digest_text(&window);
                 if extracted.is_empty() {
-                    return Ok(Some(serde_json::to_value(&ActivitySummaryResult {
-                        summary: String::new(),
-                    }).unwrap()));
+                    return Ok(Some(empty_summary_result()));
                 }
 
                 let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
                 if cli_path.is_empty() {
                     tracing::debug!(block_id = %cmd.block_id, "session:activity_summary: no CLI path in meta");
-                    return Ok(Some(serde_json::to_value(&ActivitySummaryResult {
-                        summary: String::new(),
-                    }).unwrap()));
+                    return Ok(Some(empty_summary_result()));
                 }
 
                 let prompt = format!(
@@ -179,27 +197,47 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
                      Recent activity:\n\n{extracted}"
                 );
 
-                let summary = invoke_cli_for_activity(&cli_path, &prompt, &block.meta).await
-                    .unwrap_or_else(|e| {
-                        tracing::debug!(block_id = %cmd.block_id, error = %e, "session:activity_summary: CLI failed");
-                        String::new()
-                    });
+                let (summary, tokens) =
+                    invoke_cli_for_activity(&cli_path, &prompt, &block.meta, cancel).await
+                        .unwrap_or_else(|e| {
+                            tracing::debug!(block_id = %cmd.block_id, error = %e, "session:activity_summary: CLI failed or was superseded");
+                            (String::new(), None)
+                        });
 
-                // The frontend writes `term:activity` after receiving this response so it
-                // can discard results from turns that were superseded before they returned.
-                Ok(Some(serde_json::to_value(&ActivitySummaryResult { summary }).unwrap()))
+                // guard is held until here so the in-flight entry stays
+                // registered (and cancellable by a newer request) for the
+                // full duration of the CLI call.
+                drop(guard);
+
+                // The frontend writes `term:ambient_summary` after receiving this
+                // response so it can discard results from turns that were
+                // superseded before they returned (belt-and-suspenders on top of
+                // the gateway's own cancellation).
+                Ok(Some(serde_json::to_value(&ActivitySummaryResult { summary, tokens }).unwrap()))
             })
         }),
     );
 }
 
-/// Invoke the Claude CLI with Haiku model for a lightweight per-turn activity summary.
-/// Uses `--model claude-haiku-4-5-20251001` and a 15s timeout.
+/// Invoke the Claude CLI with Haiku model for a lightweight per-turn activity
+/// summary. Uses `--model claude-haiku-4-5-20251001` and a 15s timeout.
+///
+/// `cancel` is this call's Ambient Model Call gateway cancellation token — if
+/// a newer request for the same `(block_id, "activity_summary")` key is
+/// admitted while this one is still running, `cancel` fires and the child
+/// process is killed immediately rather than left to run to completion (and
+/// keep burning tokens) only to have its result discarded on arrival.
+///
+/// Returns the summary text plus token usage parsed from the CLI's `result`
+/// stream-json line (same `usage` shape the main turn pipeline parses —
+/// see `agents::translator::claude::parse_usage`), so ambient calls are
+/// never silently excluded from token accounting.
 pub(super) async fn invoke_cli_for_activity(
     cli_path: &str,
     prompt: &str,
     meta: &obj::MetaMapType,
-) -> Result<String, String> {
+    cancel: tokio_util::sync::CancellationToken,
+) -> Result<(String, Option<crate::agents::TokenCounts>), String> {
     let auth_env: std::collections::HashMap<String, String> = match meta.get("cmd:env") {
         Some(serde_json::Value::Object(obj_map)) => obj_map
             .iter()
@@ -227,35 +265,63 @@ pub(super) async fn invoke_cli_for_activity(
             .map_err(|e| format!("activity CLI stdin shutdown: {e}"))?;
     }
 
-    let output = tokio::time::timeout(
-        std::time::Duration::from_secs(15),
-        child.wait_with_output(),
-    )
-    .await
-    .map_err(|_| "activity CLI timed out after 15s".to_string())?
-    .map_err(|e| format!("activity CLI wait: {e}"))?;
+    // `child.wait()` only borrows (unlike `wait_with_output()`, which
+    // consumes `child` by value and would make the cancel branch's
+    // `child.kill()` below impossible). Drain stdout concurrently via a
+    // separate task — same rationale `wait_with_output()` itself uses
+    // internally — so a chatty response can't fill the OS pipe buffer and
+    // deadlock the child waiting to write while nothing is reading.
+    let mut stdout_pipe = child.stdout.take()
+        .ok_or_else(|| "activity CLI: no stdout pipe".to_string())?;
+    let stdout_task = tokio::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buf).await;
+        buf
+    });
 
-    if !output.status.success() {
-        return Err(format!("activity CLI exited with status {}", output.status));
+    let status = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            let _ = child.kill().await;
+            return Err("cancelled: superseded by a newer activity-summary request".to_string());
+        }
+        result = tokio::time::timeout(std::time::Duration::from_secs(15), child.wait()) => {
+            result.map_err(|_| "activity CLI timed out after 15s".to_string())?
+                .map_err(|e| format!("activity CLI wait: {e}"))?
+        }
+    };
+
+    if !status.success() {
+        return Err(format!("activity CLI exited with status {status}"));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout_bytes = stdout_task.await
+        .map_err(|e| format!("activity CLI stdout reader task: {e}"))?;
+    let stdout = String::from_utf8_lossy(&stdout_bytes);
     let mut last_text = String::new();
+    let mut tokens: Option<crate::agents::TokenCounts> = None;
     for line in stdout.lines() {
         let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else { continue };
-        if val.get("type").and_then(|v| v.as_str()) == Some("assistant") {
-            if let Some(content) = val.get("message")
-                .and_then(|m| m.get("content"))
-                .and_then(|c| c.as_array())
-            {
-                for block in content {
-                    if block.get("type").and_then(|v| v.as_str()) == Some("text") {
-                        if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
-                            last_text = text.trim().to_string();
+        match val.get("type").and_then(|v| v.as_str()) {
+            Some("assistant") => {
+                if let Some(content) = val.get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                {
+                    for block in content {
+                        if block.get("type").and_then(|v| v.as_str()) == Some("text") {
+                            if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                last_text = text.trim().to_string();
+                            }
                         }
                     }
                 }
             }
+            Some("result") => {
+                tokens = Some(crate::agents::translator::claude::parse_usage(val.get("usage")));
+            }
+            _ => {}
         }
     }
 
@@ -263,7 +329,7 @@ pub(super) async fn invoke_cli_for_activity(
         return Err("no text in activity CLI response".to_string());
     }
 
-    Ok(last_text)
+    Ok((last_text, tokens))
 }
 
 /// Extract meaningful text from raw stream-json lines for digest summarization.

--- a/docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md
+++ b/docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md
@@ -1,0 +1,342 @@
+# SPEC: A Unified Framework for Ambient (Non-User-Driven) Model Calls
+
+**Date:** 2026-07-03
+**Status:** Draft — proposal, not yet implemented
+**Related:** `agentmux-srv/src/server/app_api/session.rs`, `frontend/app/view/agent/hooks/useAgentActivitySummary.ts`,
+`frontend/app/view/agent/hooks/useBlockActivity.ts`, `frontend/app/view/swarm/`, `frontend/app/store/token-usage.ts`,
+`docs/specs/SPEC_AGENT_OSC_TITLE_ACTIVITY_2026_06_18.md`, `specs/SPEC_AGENT_PANE_HEADER_NAME_PRECEDENCE_2026_06_29.md`,
+`docs/retro/retro-haiku-activity-pane-header-2026-06-24.md`
+
+---
+
+## 0. TL;DR
+
+Today there is exactly one "ambient" LLM call in the codebase — a Haiku call that
+summarizes what an agent is doing, once per completed turn, feeding both the pane
+header text and the Swarm tree (`invoke_cli_for_activity`, `session.rs:198-267`).
+It has no debounce, no in-flight guard, no cancellation, and its tokens are
+silently discarded — they never reach the app's total-tokens display. It shares
+a single meta key (`term:activity`) with a second, unrelated, LLM-free writer
+(OSC terminal-title sequences), with no ownership or precedence protocol between
+them. The combination produces the two symptoms reported: calls firing too often
+and overlapping, and panes/Swarm nodes reading as idle/blank when the agent is
+actually active.
+
+This spec proposes an **Ambient Model Call (AMC) framework**: a single mandatory
+gateway that every present and future non-user-driven model call must go through,
+built on three well-established patterns from outside this codebase — single-flight
+request coalescing, generation/epoch-based cancellation and staleness rejection,
+and mandatory-gateway cost accounting. It is a point of leverage: because Haiku is
+"almost always" the model for this class of call today (per the user), centralizing
+now is cheap and prevents the next five ad-hoc call sites from repeating the same
+mistakes.
+
+---
+
+## 1. Current state (mapped 2026-07-03)
+
+### 1.1 The one real LLM call site
+
+- Trigger: `frontend/app/view/agent/hooks/useAgentActivitySummary.ts:42-71` — on
+  `TurnPhase.kind === "Done"`, calls `RpcApi.AgentActivitySummaryCommand` (20s
+  frontend timeout, no retry).
+- Backend: `agentmux-srv/src/server/app_api/session.rs:109`
+  (`register_session_activity_summary`) tail-reads the last 32KB of the block's
+  FileStore output, builds a summarize prompt, and `invoke_cli_for_activity`
+  (`session.rs:198-267`) spawns the CLI with `--model claude-haiku-4-5-20251001`,
+  15s timeout.
+- Result is written to block meta key `"term:activity"`.
+- Consumers: `frontend/app/view/agent/agent-model.ts:106-122` (`viewText()`, the
+  pane header text) and `frontend/app/view/swarm/swarm-model.ts:221-222`
+  (`AgentTreeNode.activitySummary`, the Swarm tree).
+
+This is a **singleton pattern** — grepping for `haiku` and for
+`invoke_cli_for_activity`-shaped code across `agentmux-srv/src/agents/`,
+`.../server/`, `.../backend/`, and frontend hooks turns up no other ambient LLM
+call anywhere in the repo. `agents/failure.rs`'s `classify()` (CLI exit-code/stderr
+taxonomy) looks superficially similar but is pure Rust, no subprocess, no model.
+A prior "session digest" feature was removed; only its text-extraction helper
+(`extract_digest_text`, `session.rs:272`) survives, reused by the activity-summary
+handler itself.
+
+**Implication:** there is no legacy fan-out to migrate yet. This is the ideal moment
+to build the framework — one call site to move, and every future one built on top
+of it instead of copied from it.
+
+### 1.2 Bug 1 — tokens silently discarded
+
+`invoke_cli_for_activity` parses the Haiku subprocess's stream-json stdout only for
+`type == "assistant"` text blocks; it never reads the `result`/usage event, and
+`ActivitySummaryResult` has no token-count field to carry it back
+(`session.rs:242-266`). The app's total-tokens counter
+(`frontend/app/store/token-usage.ts`'s `recordTurn()`) is fed exclusively by
+`frontend/app/view/agent/useAgentStream.ts:426-444` from the *main* agent turn's
+`session_end` event. The Haiku subprocess is a real, billed API call that never
+touches this counter — a structural under-count, not a display lag.
+
+### 1.3 Bug 2 — two uncoordinated writers to one meta key
+
+`term:activity` has two independent writers with no merge/precedence protocol
+(last-write-wins via plain `UpdateObjectMeta`):
+
+1. `frontend/app/view/agent/hooks/useBlockActivity.ts:39-83` — subscribes to a
+   `block:activity` WPS event sourced from **OSC 0 terminal-title escape
+   sequences** the CLI itself emits (parsed by
+   `agentmux-srv/src/backend/osc_extractor.rs`, a pure state machine, no LLM, no
+   subprocess — see `docs/specs/SPEC_AGENT_OSC_TITLE_ACTIVITY_2026_06_18.md`).
+   300ms debounced. Cleared only on `ControllerStatus === "done"`.
+2. `useAgentActivitySummary.ts:54-66` — the Haiku writer (§1.1). No debounce, no
+   in-flight guard (two 15-20s Haiku calls from quick successive turns can run
+   concurrently), and — per its own comment at line 15 — `term:activity` is
+   **never cleared on a new turn**, so a stale prior-turn summary can sit
+   indefinitely if the newer RPC errors silently (its `.catch()` swallows all
+   failures, lines 67-69).
+
+`specs/SPEC_AGENT_PANE_HEADER_NAME_PRECEDENCE_2026_06_29.md:108` explicitly treats
+`term:activity`'s generation/ownership as out of scope — this gap has been
+noted, not fixed, before.
+
+### 1.4 Bug 3 — Swarm renders "idle"/blank for actually-active agents
+
+`frontend/app/view/swarm/swarm-view.tsx:163-167` (`phaseToDisplayStatus`):
+`if (!phaseAccessor) return "idle";` — if a block's `TurnPhase` was never
+registered in the *current renderer's* registry
+(`frontend/app/store/agentActivity.ts:55-57`, populated only by `registerActivity()`
+from a *mounted* agent-pane component), the status defaults to `"idle"`
+regardless of actual backend state. A subagent running in an unmounted pane,
+a background tab, or another workspace has no registry entry — it reads as idle.
+Combined with a null `activitySummary` (§1.3, `swarm-view.tsx:231`
+`<Show when={node.activitySummary}>` renders nothing), this is the concrete
+mechanism behind "clearly something is in progress but the UI shows nothing."
+
+---
+
+## 2. Prior art
+
+Four groups of patterns, all directly applicable and already load-bearing in
+mainstream systems facing the same shape of problem (frequent, cheap,
+non-user-initiated background calls updating live UI state):
+
+**Request coalescing / single-flight.** Go's `singleflight.Do(key, fn)`: concurrent
+callers with the same key share one in-flight execution rather than issuing
+duplicate work; no persistent cache, pure concurrent dedup.
+([nickyt.co](https://www.nickyt.co/blog/gos-singleflight-package-and-why-its-awesome-for-concurrent-requests-4122/))
+RxJS `switchMap`: unsubscribes (truly cancels) the previous inner call the
+instant a new trigger arrives — the standard pattern for "only the latest
+matters," explicitly contrasted with `mergeMap` for calls with side effects.
+([learnrxjs.io](https://www.learnrxjs.io/learn-rxjs/operators/transformation/switchmap))
+Cloudflare calls the server-side version "request collapsing," framed around
+avoiding thundering-herd duplicate work.
+([stanza.dev](https://www.stanza.dev/courses/redis-caching/advanced-caching/redis-caching-request-coalescing))
+
+**Cancellation-on-stale-context.** `AbortController` paired with a monotonic
+generation/epoch counter — `abort()` only *signals* cancellation, it doesn't
+guarantee the work stops, so the receiver independently compares the counter
+value captured at request time against the current counter at resolution time
+and discards on mismatch even if the abort signal didn't land.
+([dev.to](https://dev.to/bdestrempes/a-practical-guide-to-the-abortcontroller-api-5420))
+Fencing tokens generalize this: the *receiver*, not the caller, is the
+authority that rejects stale writes.
+([levelup.gitconnected.com](https://levelup.gitconnected.com/beyond-the-lock-why-fencing-tokens-are-essential-5be0857d5a6a))
+TanStack Query's own bug history shows *ignoring* a stale response is not
+enough — a documented failure mode where a stale result still satisfied a
+newer query; the fix was active discard (`removeQueries`), not passive
+staleness. ([github.com/TanStack/query#6953](https://github.com/TanStack/query/discussions/6953))
+
+**Mandatory-gateway cost accounting.** OpenTelemetry's GenAI semantic
+conventions define vendor-neutral `gen_ai.*` span attributes
+(`gen_ai.usage.input_tokens`/`output_tokens`, `gen_ai.operation.name`) so any
+call site — user-facing or background — emits a comparable, taggable record.
+([github.com/open-telemetry/semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai))
+LLM gateways (LiteLLM/Langfuse/Helicone) tag calls with free-form
+`tags`/`metadata` (e.g. `purpose=background-summary`) filterable in a
+dashboard. ([docs.litellm.ai](https://docs.litellm.ai/docs/observability/helicone_integration))
+The structural fix industry converges on once a codebase has more than one LLM
+call site: route **all** calls through one internal client that owns
+credentials, so no new call site can physically bypass logging/accounting —
+this is the direct answer to "how do we make sure Haiku tokens are never
+silently discarded again."
+([red-gate.com](https://www.red-gate.com/simple-talk/ai/the-llm-layer-youre-probably-missing-llm-gateway-pattern-explained/))
+
+**Binding async results to UI entity lifecycle.** The reusable synthesis across
+the above: an entity-scoped generation counter, used simultaneously as the
+single-flight coalescing key, the cancellation scope, and the write-time
+staleness check — "if current entity generation ≠ response generation, discard."
+
+---
+
+## 3. Proposed design: the Ambient Model Call (AMC) framework
+
+### 3.1 Scope and one hard rule
+
+**Every current and future non-user-driven model call in the backend must be
+issued through the AMC gateway. No other code path may spawn a model
+subprocess for augmentation/summarization purposes.** This is the structural
+guarantee that makes under-counted tokens (§1.2) and uncoordinated concurrent
+calls (§1.3) impossible by construction rather than by convention.
+
+This does **not** apply to the main user-driven agent turn pipeline
+(`useAgentStream.ts` / the primary CLI invocation) — that path already has its
+own token accounting and is not "ambient."
+
+### 3.2 Core primitives
+
+**Entity + purpose key.** Every AMC request is keyed by
+`(entity_id, purpose)` — e.g. `(block_id, "activity_summary")`. `entity_id` is
+whatever the caller is augmenting (today: a block; the key shape generalizes to
+panes, workspaces, or non-block entities later). `purpose` is a short stable
+string used for both single-flight coalescing and cost-dashboard tagging
+(mirroring the LiteLLM/Langfuse `purpose=` tag pattern, §2).
+
+**Generation counter per entity.** Each entity carries a monotonically
+increasing generation, bumped whenever its underlying state advances to a new
+"round" (for blocks: a new turn starting). A request captures
+`(entity_id, generation)` at issue time. On resolution, the AMC gateway itself
+— not the caller — checks the entity's *current* generation against the
+request's captured generation; a mismatch means **discard**, never write.  This
+is the fencing-token pattern (§2): the authority to reject stale results lives
+at the write boundary, not scattered across every call site's own ad hoc check
+(unlike today's `useAgentActivitySummary.ts` turn-ID check, which is a
+caller-side filter only).
+
+**Single-flight per `(entity_id, purpose)`.** Before issuing a subprocess, the
+gateway checks for an in-flight request with the same key. If found: either
+attach to its result (dedup) or drop the new trigger (latest-wins), per
+purpose-level policy — activity summaries want latest-wins (a fresher turn
+supersedes a summary of an older one), so a new trigger for a key with an
+in-flight request **cancels** the old one rather than queuing behind it
+(`switchMap` semantics, §2), rather than the current "let two Haiku calls run
+concurrently" behavior.
+
+**Real cancellation, not just discard-on-arrival.** When a new trigger
+supersedes an in-flight request for the same key, the gateway actively kills
+the subprocess (Rust: hold a `tokio::process::Child` handle + generation guard,
+`child.kill()` on supersession) rather than letting it run to completion and
+discarding the result — this also stops burning tokens on a call whose answer
+is already known to be moot, which a pure "check on arrival" design does not.
+
+**Debounce / minimum interval.** Per-purpose configurable minimum spacing
+between calls for the same entity (default: no more than one activity-summary
+call per N seconds per block, independent of how many turns complete in that
+window) — directly answers "these calls are too often." `useBlockActivity.ts`'s
+existing 300ms debounce is the right shape; the gateway makes it a first-class,
+uniformly-applied primitive rather than a pattern reimplemented ad hoc per call
+site.
+
+**Mandatory accounting.** Every AMC call, success or failure, records
+`(purpose, model, input_tokens, output_tokens)` through the same counter the
+main-turn pipeline uses (`token-usage.ts`'s `recordTurn`-equivalent), tagged
+distinctly (e.g. a new `"ambient"` service bucket, or `purpose`-qualified
+buckets like `"ambient:activity_summary"`) so the total-tokens view can show
+ambient vs. user-driven cost as a breakdown, not just a merged number. Because
+issuing an ambient model call and recording its usage happen inside the same
+gateway function, no call site can add a ninth ambient feature next year that
+silently repeats §1.2.
+
+### 3.3 Sketch (illustrative, not final API)
+
+```rust
+// agentmux-srv/src/ambient/mod.rs (new)
+pub struct AmbientCallKey {
+    entity_id: String,   // e.g. block id
+    purpose: &'static str, // e.g. "activity_summary"
+}
+
+pub struct AmbientCallRequest {
+    key: AmbientCallKey,
+    generation: u64,      // caller's snapshot of entity generation
+    model: &'static str,  // defaults to the configured ambient model (Haiku today)
+    prompt: String,
+    policy: SupersedePolicy, // Cancel | Dedup | Queue(n)
+}
+
+// Gateway owns: in-flight table keyed by AmbientCallKey, per-entity generation
+// store, debounce timers, and the ONLY code path allowed to spawn an ambient
+// model subprocess. Returns None if superseded/cancelled before completion.
+pub async fn call(req: AmbientCallRequest) -> Option<AmbientCallResult>;
+```
+
+```ts
+// frontend/app/hooks/useAmbientModelCall.ts (new, generalizes useAgentActivitySummary.ts)
+// Callers pass (entityId, purpose, generation) instead of hand-rolling their
+// own turn-id staleness check; the hook itself no longer decides whether to
+// fire — it just declares "this entity, this generation, wants this purpose
+// refreshed," and the backend gateway owns coalescing/cancellation/debounce.
+```
+
+### 3.4 Fixing the shared-key problem (§1.3)
+
+Split `term:activity` into two explicitly-owned keys instead of one
+contested one:
+
+- `term:osc_title` — the free, LLM-less CLI-emitted title (current
+  `useBlockActivity.ts` writer). Infrequent, essentially free; always safe to
+  show if present.
+- `term:ambient_summary` — the AMC-gateway-owned Haiku summary, generation-
+  stamped, cleared/superseded automatically by the gateway's generation check.
+
+Precedence at render time (`agent-model.ts:viewText()`, `swarm-model.ts`):
+prefer `term:ambient_summary` if present and its generation matches the
+entity's current generation; else fall back to `term:osc_title`; else show
+nothing. This replaces last-write-wins with an explicit, generation-aware
+precedence rule — directly closing §1.3.
+
+### 3.5 Fixing the Swarm idle-vs-unknown gap (§1.4)
+
+Adjacent to AMC proper but part of the same "don't lose the binding" mandate
+the user named explicitly: `phaseToDisplayStatus`'s
+`if (!phaseAccessor) return "idle"` should distinguish "confirmed idle" from
+"no registry entry for this block in this renderer" (return e.g.
+`"unknown"`/`"untracked"` and render it distinctly, not as a false idle). The
+deeper fix is widening `agentActivity.ts`'s registry so a tracked block reports
+real phase regardless of which window/workspace renders it, rather than only
+those with a currently-mounted pane component — but that is a larger, separate
+change; the minimal fix (stop conflating "unknown" with "idle") should ship
+regardless.
+
+---
+
+## 4. Migration plan
+
+1. Build the AMC gateway (`agentmux-srv/src/ambient/`) with the primitives in
+   §3.2, initially supporting exactly one purpose: `activity_summary`.
+2. Port `register_session_activity_summary` / `invoke_cli_for_activity`
+   (`session.rs:109-267`) to call through the gateway instead of spawning the
+   CLI directly. Delete the direct-spawn code once ported.
+3. Add per-entity generation to blocks (bumped on new-turn-start — likely
+   already adjacent to wherever `activeTurnId` is set today, per
+   `useAgentActivitySummary.ts:59`).
+4. Split `term:activity` → `term:osc_title` / `term:ambient_summary` (§3.4);
+   update `agent-model.ts:viewText()` and `swarm-model.ts` precedence.
+5. Wire ambient token usage into `token-usage.ts` as a distinct bucket;
+   surface an ambient-vs-user breakdown in `TokenUsageIndicator.tsx`.
+6. Fix `phaseToDisplayStatus`'s idle/unknown conflation (§3.5), independently
+   shippable.
+7. Any future ambient call (pane-title generation for a *new* purpose,
+   speculative next-step suggestions, etc.) is required to go through the
+   gateway from day one — no direct subprocess spawns for augmentation
+   purposes anywhere else in the codebase.
+
+## 5. Non-goals
+
+- Not proposing a general-purpose LLM gateway for **user-driven** turns — that
+  pipeline (`useAgentStream.ts`) already has its own accounting and lifecycle;
+  AMC is scoped to non-user-initiated calls only.
+- Not solving cross-window/cross-workspace activity registry visibility in
+  this spec (§3.5's deeper fix) — flagged as a follow-up, not blocking.
+- Not picking a different model than Haiku for ambient calls — out of scope;
+  the framework is model-agnostic (the `model` field in §3.3's sketch), Haiku
+  simply remains the default today.
+
+## 6. Open questions
+
+- Should `SupersedePolicy` (cancel vs. dedup vs. queue) be a per-purpose
+  constant, or configurable at the call site? Leaning per-purpose constant to
+  keep the gateway's behavior predictable and auditable.
+- Where should the per-entity generation counter live — colocated with
+  existing block/turn state (`activeTurnId`) or a new dedicated store? Leaning
+  colocated, to avoid a second source of truth for "which turn is this."
+- Rate limiting / global ambient-call budget (e.g. cap ambient calls per
+  minute across the whole app) is mentioned as desirable by the user's framing
+  ("calls fire too often") but not designed in detail here — likely a simple
+  token-bucket in front of the gateway, deferred to implementation.

--- a/frontend/app/store/activitySummary.test.ts
+++ b/frontend/app/store/activitySummary.test.ts
@@ -1,0 +1,34 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { assert, describe, test } from "vitest";
+import { readActivitySummary } from "./activitySummary";
+
+describe("readActivitySummary", () => {
+    test("prefers term:ambient_summary over term:osc_title when both present", () => {
+        assert.equal(
+            readActivitySummary({ "term:ambient_summary": "fixing auth bug", "term:osc_title": "claude - auth" }),
+            "fixing auth bug",
+        );
+    });
+
+    test("falls back to term:osc_title when term:ambient_summary is absent", () => {
+        assert.equal(readActivitySummary({ "term:osc_title": "claude - auth refactor" }), "claude - auth refactor");
+    });
+
+    test("falls back to term:osc_title when term:ambient_summary is empty", () => {
+        assert.equal(
+            readActivitySummary({ "term:ambient_summary": "", "term:osc_title": "claude - auth refactor" }),
+            "claude - auth refactor",
+        );
+    });
+
+    test("returns undefined when neither key is present", () => {
+        assert.equal(readActivitySummary({}), undefined);
+        assert.equal(readActivitySummary(undefined), undefined);
+    });
+
+    test("returns undefined when both keys are empty strings", () => {
+        assert.equal(readActivitySummary({ "term:ambient_summary": "", "term:osc_title": "" }), undefined);
+    });
+});

--- a/frontend/app/store/activitySummary.ts
+++ b/frontend/app/store/activitySummary.ts
@@ -1,0 +1,25 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared precedence rule for an agent pane's "what's it doing" label.
+ *
+ * Two independent sources write to a block's meta:
+ *   - `term:ambient_summary` — Haiku-derived, per-turn paraphrase (Ambient
+ *     Model Call gateway; see useAgentActivitySummary.ts).
+ *   - `term:osc_title` — free, CLI-emitted OSC window-title topic, no LLM
+ *     call of our own (see useBlockActivity.ts / termosc.ts).
+ *
+ * These used to share one meta key (`term:activity`) with no ownership
+ * protocol — last write won, regardless of which source was actually more
+ * current. This is the single place both readers (agent-model.ts,
+ * swarm-model.ts) resolve precedence, so it can't drift between them again.
+ * See docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §3.4.
+ */
+export function readActivitySummary(meta: Record<string, unknown> | undefined): string | undefined {
+    const ambient = meta?.["term:ambient_summary"] as string | undefined;
+    if (ambient && ambient.length > 0) return ambient;
+    const oscTitle = meta?.["term:osc_title"] as string | undefined;
+    if (oscTitle && oscTitle.length > 0) return oscTitle;
+    return undefined;
+}

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -14,6 +14,7 @@ import { PROVIDERS, resolveProviderAlias } from "./providers";
 import { Logger } from "@/util/logger";
 import { buildInstanceSlug } from "./defaults/instance-slug";
 import type { LaunchOverrides } from "./components/AgentLaunchModal";
+import { readActivitySummary } from "@/app/store/activitySummary";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -56,14 +57,15 @@ export class AgentViewModel implements ViewModel {
         this.blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
         this.viewComponent = AgentViewWrapper as any;
 
-        // Flash signal: set true briefly when term:activity changes to a new
-        // non-empty value. Compare to previous so unrelated meta writes (status,
-        // agentName, etc.) during an active turn don't trigger spurious flashes.
+        // Flash signal: set true briefly when the activity summary changes to a
+        // new non-empty value. Compare to previous so unrelated meta writes
+        // (status, agentName, etc.) during an active turn don't trigger
+        // spurious flashes.
         const [activityFlash, setActivityFlash] = createSignal(false);
         let flashTimer: ReturnType<typeof setTimeout> | undefined;
         let prevActivity: string | undefined;
         createEffect(() => {
-            const activity = this.blockAtom()?.meta?.["term:activity"] as string | undefined;
+            const activity = readActivitySummary(this.blockAtom()?.meta);
             if (activity && activity !== prevActivity) {
                 clearTimeout(flashTimer);
                 setActivityFlash(true);
@@ -106,10 +108,11 @@ export class AgentViewModel implements ViewModel {
         this.viewText = (): HeaderElem[] => {
             const elems: HeaderElem[] = [];
 
-            // Per-turn live mini-summary from useAgentActivitySummary (Haiku on
-            // every turn completion). Persists across turns; flashes briefly when
-            // a new summary lands.
-            const activity = this.blockAtom()?.meta?.["term:activity"] as string | undefined;
+            // Per-turn live mini-summary — prefers the Haiku-derived
+            // term:ambient_summary (useAgentActivitySummary.ts), falling back to
+            // the free CLI-emitted term:osc_title (useBlockActivity.ts). Persists
+            // across turns; flashes briefly when a new summary lands.
+            const activity = readActivitySummary(this.blockAtom()?.meta);
             if (activity && activity.length > 0) {
                 elems.push({
                     elemtype: "text",

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -404,11 +404,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     useControllerStatusEvents({ blockId: model.blockId, log });
 
     // Subscribe to Claude Code OSC window-title extractions and write them
-    // to term:activity block metadata for the tab label.
+    // to term:osc_title block metadata (free fallback signal — see
+    // readActivitySummary()'s precedence in agent-model.ts).
     useBlockActivity({ blockId: model.blockId });
 
-    // Haiku-powered live mini-summary: generates a fresh phrase in the pane header
-    // on every completed agent turn, replacing the non-functional OSC path.
+    // Haiku-powered live mini-summary: generates a fresh phrase in
+    // term:ambient_summary on every completed agent turn, preferred over
+    // the OSC title above when both are present. Routed through the
+    // backend's Ambient Model Call gateway — see
+    // docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md.
     useAgentActivitySummary({
         blockId: model.blockId,
         turnPhase: agentAtoms().turnPhaseAtom[0],

--- a/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
+++ b/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
@@ -15,12 +15,20 @@
  * panes can accommodate up to 12.
  *
  * This call is routed through the backend's Ambient Model Call gateway
- * (`crate::ambient`): the turn counter sent as `generation` lets the gateway
- * cancel a still-running Haiku call from a superseded turn (killing the
- * subprocess, not just discarding its result) and reject an out-of-order
- * request before any work happens. The `activeTurnId !== myTurnId` check
- * below is belt-and-suspenders on top of that — the gateway is the primary
- * guard now, this is a second, independent check at the write boundary.
+ * (`crate::ambient`), keyed by block_id: the gateway persists its
+ * per-block generation state across pane remounts (tab-switch), but this
+ * hook's own state does not (a fresh `activeTurnId` starts at 0 on every
+ * mount — confirmed by useBlockActivity.ts's own comment on remount
+ * behavior). Sending the local counter as `generation` would mean a remount
+ * right after a high-generation turn could send a *lower* number than the
+ * gateway already has recorded for this block, getting rejected as
+ * stale-on-arrival for up to 15s (until the still-in-flight prior call's
+ * guard drops) even though it's a legitimately new request. `Date.now()` is
+ * used for the wire `generation` instead — always increasing regardless of
+ * remounts, since real time never goes backwards for this purpose. The
+ * local `activeTurnId !== myTurnId` check below is unaffected by this (it's
+ * scoped to a single mount's closures) and remains a second, independent
+ * guard at the write boundary on top of the gateway's own cancellation.
  *
  * The summary is never cleared on our own — it persists across turns so the
  * header always shows the last known activity. It's cleared elsewhere
@@ -45,9 +53,9 @@ export interface UseAgentActivitySummaryOptions {
 export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): void {
     const { blockId, turnPhase, getRootWidth } = opts;
 
-    // Monotonically increasing turn ID. Bumped on every Submitting transition;
-    // sent to the backend as `generation` (ambient-gateway cancellation key)
-    // and re-checked locally when the response lands.
+    // Monotonically increasing turn ID, scoped to this mount. Bumped on every
+    // Submitting transition and re-checked locally when the response lands
+    // (NOT sent to the backend — see the module doc comment above for why).
     let activeTurnId = 0;
 
     createEffect(on(turnPhase, (phase) => {
@@ -64,7 +72,7 @@ export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): v
 
             RpcApi.AgentActivitySummaryCommand(
                 TabRpcClient,
-                { block_id: blockId, word_target: wordTarget, generation: myTurnId },
+                { block_id: blockId, word_target: wordTarget, generation: Date.now() },
                 { timeout: 20_000 },
             ).then((result) => {
                 if (activeTurnId !== myTurnId) return; // superseded by a newer turn

--- a/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
+++ b/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
@@ -6,15 +6,25 @@
  *
  * On every completed agent turn, sends recent session output to
  * claude-haiku-4-5-20251001 and asks for a short phrase (~word_target words)
- * describing what was just done. The result is written to the `term:activity`
- * block meta key, which agent-model.ts surfaces in the pane header.
+ * describing what was just done. The result is written to the
+ * `term:ambient_summary` block meta key, which agent-model.ts and
+ * swarm-model.ts read (preferring it over the free `term:osc_title` signal —
+ * see docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §3.4).
  *
  * Word target is derived from pane width so narrow panes get ~5 words and wide
  * panes can accommodate up to 12.
  *
- * The summary is never cleared — it persists across turns so the header always
- * shows the last known activity. A turn counter ensures a slow Haiku response
- * from a superseded turn cannot overwrite a newer summary.
+ * This call is routed through the backend's Ambient Model Call gateway
+ * (`crate::ambient`): the turn counter sent as `generation` lets the gateway
+ * cancel a still-running Haiku call from a superseded turn (killing the
+ * subprocess, not just discarding its result) and reject an out-of-order
+ * request before any work happens. The `activeTurnId !== myTurnId` check
+ * below is belt-and-suspenders on top of that — the gateway is the primary
+ * guard now, this is a second, independent check at the write boundary.
+ *
+ * The summary is never cleared on our own — it persists across turns so the
+ * header always shows the last known activity. It's cleared elsewhere
+ * (useBlockActivity.ts) when the underlying session ends.
  */
 
 import { createEffect, on, type Accessor } from "solid-js";
@@ -23,6 +33,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { makeORef } from "@/app/store/wos";
 import { ObjectService } from "@/app/store/services";
 import { fireAndForget } from "@/util/util";
+import { recordTurn } from "@/app/store/token-usage";
 import type { TurnPhase } from "@/app/store/agent-pane-state/types";
 
 export interface UseAgentActivitySummaryOptions {
@@ -34,9 +45,9 @@ export interface UseAgentActivitySummaryOptions {
 export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): void {
     const { blockId, turnPhase, getRootWidth } = opts;
 
-    // Monotonically increasing turn ID. Bumped on every Submitting transition so
-    // any in-flight Haiku response from a prior turn can detect it is stale and
-    // skip the meta write.
+    // Monotonically increasing turn ID. Bumped on every Submitting transition;
+    // sent to the backend as `generation` (ambient-gateway cancellation key)
+    // and re-checked locally when the response lands.
     let activeTurnId = 0;
 
     createEffect(on(turnPhase, (phase) => {
@@ -53,14 +64,17 @@ export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): v
 
             RpcApi.AgentActivitySummaryCommand(
                 TabRpcClient,
-                { block_id: blockId, word_target: wordTarget },
+                { block_id: blockId, word_target: wordTarget, generation: myTurnId },
                 { timeout: 20_000 },
             ).then((result) => {
                 if (activeTurnId !== myTurnId) return; // superseded by a newer turn
+                if (result.tokens) {
+                    recordTurn("ambient:activity_summary", result.tokens);
+                }
                 if (result.summary) {
                     fireAndForget(() =>
                         ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
-                            "term:activity": result.summary,
+                            "term:ambient_summary": result.summary,
                         } as any)
                     );
                 }

--- a/frontend/app/view/agent/hooks/useBlockActivity.ts
+++ b/frontend/app/view/agent/hooks/useBlockActivity.ts
@@ -3,18 +3,22 @@
 
 /**
  * useBlockActivity — subscribes to `block:activity` WPS events and writes
- * the payload to `term:activity` block metadata so the agent-pane tab
+ * the payload to `term:osc_title` block metadata so the agent-pane tab
  * label shows the Claude Code session topic.
  *
  * The backend emits `block:activity` when it extracts an OSC 0/2
  * window-title sequence from the agent PTY stream (osc_extractor.rs).
  * The topic is a session-level LLM-derived label (e.g. "auth refactor"),
- * not a per-tool-call status — it updates infrequently.
+ * not a per-tool-call status — it updates infrequently, and unlike
+ * useAgentActivitySummary.ts this is free (no LLM call of our own; the CLI
+ * emits the title itself). Owns a distinct meta key from the Haiku-derived
+ * `term:ambient_summary` — the two used to share `term:activity` with no
+ * ownership protocol, which is what agent-model.ts / swarm-model.ts's
+ * precedence logic now resolves. See
+ * docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §3.4 and
+ * docs/specs/SPEC_AGENT_OSC_TITLE_ACTIVITY_2026_06_18.md.
  *
- * Reuses the existing `term:activity` metadata key so no new tab-bar
- * plumbing is needed — terminal panes write the same key via termosc.ts.
- *
- * See: docs/specs/SPEC_AGENT_OSC_TITLE_ACTIVITY_2026_06_18.md
+ * Terminal panes write the same key via termosc.ts.
  */
 
 import { onCleanup, onMount } from "solid-js";
@@ -31,7 +35,8 @@ export interface UseBlockActivityOptions {
 function clearActivity(blockId: string): void {
     fireAndForget(() =>
         ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
-            "term:activity": null,
+            "term:osc_title": null,
+            "term:ambient_summary": null,
         } as any)
     );
 }
@@ -50,19 +55,20 @@ export function useBlockActivity(opts: UseBlockActivityOptions): void {
                 debounceTimer = setTimeout(() => {
                     fireAndForget(() =>
                         ObjectService.UpdateObjectMeta(makeORef("block", opts.blockId), {
-                            "term:activity": activity,
+                            "term:osc_title": activity,
                         } as any)
                     );
                 }, 300);
             },
         });
 
-        // Clear on session end (process exit) so a subsequent session in the
-        // same pane starts without a stale topic. term:activity is persisted in
-        // the block store and survives tab-switch remounts, so we must NOT clear
-        // in onCleanup — doing so would blank the label every time the pane
-        // remounts (tab switch), and Claude Code only emits OSC titles once per
-        // session so no new event would restore it.
+        // Clear both term:osc_title and term:ambient_summary on session end
+        // (process exit) so a subsequent session in the same pane starts
+        // without a stale topic/summary from the finished one. These keys
+        // are persisted in the block store and survive tab-switch remounts,
+        // so we must NOT clear in onCleanup — doing so would blank the label
+        // every time the pane remounts (tab switch), and Claude Code only
+        // emits OSC titles once per session so no new event would restore it.
         const unsubStatus = waveEventSubscribe({
             eventType: WpsEvent.ControllerStatus,
             scope: makeORef("block", opts.blockId),

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -120,9 +120,10 @@ export class SwarmViewModel implements ViewModel {
         });
         if (unsubReactiveUnreg) this.unsubs.push(unsubReactiveUnreg);
 
-        // Block:activity meta changes (term:activity) — force re-read of block meta.
-        // The block atom in WOS updates reactively, so the memo in the view
-        // already reacts; no explicit handler needed here beyond the WOS atom.
+        // term:osc_title / term:ambient_summary meta changes — force re-read
+        // of block meta. The block atom in WOS updates reactively, so the
+        // memo in the view already reacts; no explicit handler needed here
+        // beyond the WOS atom.
     }
 
     loadAll = async (): Promise<void> => {

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -9,6 +9,7 @@ import { WpsEvent } from "@/app/store/wps-events";
 import { WOS } from "@/app/store/global";
 import { callBackendService } from "@/store/wos";
 import { BlockService } from "@/app/store/services";
+import { readActivitySummary } from "@/app/store/activitySummary";
 import { createSignal, type Accessor, type Setter } from "solid-js";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -218,8 +219,7 @@ export class SwarmViewModel implements ViewModel {
                 "Agent";
             const agentProvider =
                 (block?.meta?.["agentProvider"] as string | undefined)?.trim() || null;
-            const activitySummary =
-                (block?.meta?.["term:activity"] as string | undefined)?.trim() || null;
+            const activitySummary = readActivitySummary(block?.meta)?.trim() || null;
             const rawCtx = block?.meta?.["term:ctx-tokens"];
             const contextTokens = typeof rawCtx === "number" ? rawCtx : null;
             const agentStatus = statuses.get(blockId) ?? "idle";

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -227,6 +227,14 @@
         background: var(--secondary-text-color);
         opacity: 0.25;
     }
+    // Distinct from --idle: this block has no registered TurnPhase in this
+    // renderer (unmounted pane / other workspace) — we genuinely don't know
+    // its state, so it must not look like a confirmed-idle solid dot.
+    &--unknown {
+        background: transparent;
+        border: 1px solid var(--secondary-text-color);
+        opacity: 0.5;
+    }
 }
 
 @keyframes swarm-pulse {

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -158,13 +158,19 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
 
 // ── Status derived from TurnPhase ────────────────────────────────────────
 
-type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected";
+type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected" | "unknown";
 
 function phaseToDisplayStatus(blockId: string, _fallback: "running" | "idle"): AgentDisplayStatus {
     const phaseAccessor = getBlockTurnPhase(blockId);
-    // shellprocstatus "running" only means the process is alive, not that it's
-    // doing LLM work. Without a registered TurnPhase, default to idle.
-    if (!phaseAccessor) return "idle";
+    // A block only has a registered TurnPhase while its pane is mounted in
+    // THIS renderer (registerActivity() in agentActivity.ts runs from the
+    // mounted agent-pane component). A subagent running in an unmounted
+    // pane, a background tab, or another workspace has no entry here — that
+    // does NOT mean it's idle, it means we have no visibility into it from
+    // here. Conflating the two used to render active agents as flatly
+    // "idle" ("nothing in progress" when something clearly was) — see
+    // docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §1.4/§3.5.
+    if (!phaseAccessor) return "unknown";
     const phase = phaseAccessor();
     switch (phase.kind) {
         case "Submitting":    return "working";
@@ -278,6 +284,7 @@ const STATUS_LABEL: Record<AgentDisplayStatus, string> = {
     idle:         "idle",
     error:        "error",
     disconnected: "offline",
+    unknown:      "unknown",
 };
 
 function AgentStatusChip({ status }: { status: AgentDisplayStatus }): JSX.Element {

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -188,7 +188,7 @@ class TermViewModel implements ViewModel {
             }
             if (!isCmd) {
                 const blockMeta = this.blockAtom()?.meta;
-                const activity = blockMeta?.["term:activity"] as string | undefined;
+                const activity = blockMeta?.["term:osc_title"] as string | undefined;
                 if (activity && activity.length > 0) {
                     rtn.push({
                         elemtype: "text",

--- a/frontend/app/view/term/termosc.ts
+++ b/frontend/app/view/term/termosc.ts
@@ -164,7 +164,7 @@ export function handleOscTitleCommand(data: string, blockId: string, loaded: boo
         titleUpdateDebounceMap.delete(blockId);
         fireAndForget(async () => {
             await services.ObjectService.UpdateObjectMeta(WOS.makeORef("block", blockId), {
-                "term:activity": activity,
+                "term:osc_title": activity,
             } as any);
         });
     }, TITLE_UPDATE_DEBOUNCE_MS);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2223,11 +2223,18 @@ declare global {
     type CommandActivitySummaryData = {
         block_id: string;
         word_target?: number;
+        // Caller's monotonic turn counter for this block. The ambient-call
+        // gateway uses it to cancel a stale in-flight request for the same
+        // block and reject a request that arrives out of order.
+        generation: number;
     };
 
     // wshrpc.ActivitySummaryResult
     type ActivitySummaryResult = {
         summary: string;
+        // Absent when the request was rejected as stale-on-arrival or the
+        // underlying call failed/was cancelled.
+        tokens?: TokenCounts;
     };
 
     // wshrpc.CommandSessionArchiveData


### PR DESCRIPTION
## Summary

Implements the Ambient Model Call (AMC) framework proposed in
`docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md` — a single
mandatory path for non-user-driven ("ambient") model calls, starting with the
per-turn Haiku activity summary that drives the pane header and Swarm tree
(the only such call site in the repo today, per the spec's investigation).

## Root causes fixed

- **Tokens silently discarded.** `invoke_cli_for_activity` never parsed the
  CLI's `result` usage event, so every Haiku call was a real, billed API call
  invisible to the app's total-tokens display. Now parsed via
  `agents::translator::claude::parse_usage` (bumped `pub(crate)` for reuse)
  and returned to the frontend, which records it into `token-usage.ts` under
  a distinct `"ambient:activity_summary"` bucket.
- **Two uncoordinated writers on one meta key.** `term:activity` was shared
  by the free OSC-title signal (CLI-emitted terminal title, no LLM) and the
  Haiku summary, with no ownership/precedence protocol — last write won.
  Split into `term:osc_title` (`useBlockActivity.ts`, `termosc.ts`) and
  `term:ambient_summary` (`useAgentActivitySummary.ts`), with a shared
  `readActivitySummary()` precedence helper (prefer `ambient_summary`, fall
  back to `osc_title`) used by `agent-model.ts` and `swarm-model.ts`.
- **Calls fired too often / overlapped.** The new `agentmux-srv/src/ambient`
  gateway coalesces by `(block_id, purpose)`, cancelling a lower-generation
  in-flight subprocess (a real kill via `tokio_util::sync::CancellationToken`,
  not just a discard-on-arrival check) the instant a newer turn is admitted,
  and rejecting stale requests before any FileStore read or prompt build. The
  frontend's turn-id check is now defense-in-depth on top of this, not the
  only guard.
- **Swarm showing "idle" for actually-active agents.** `phaseToDisplayStatus`
  defaulted an unregistered block (no `TurnPhase` in this renderer — e.g. a
  subagent in an unmounted pane or another workspace) straight to `"idle"`.
  Added a distinct `"unknown"` status (hollow dot, not solid) so
  untracked-here is never conflated with confirmed-idle — likely the "clearly
  something is in progress but Swarm shows nothing" symptom.

## Non-goals (per spec)

- Cross-window/cross-workspace activity-registry visibility (the deeper fix
  behind the idle/unknown gap) — flagged as a follow-up, not blocking.
- No change to macOS/Linux browser-opening or unrelated OAuth flows.

## Test plan

- [x] 6 new `ambient::tests::*` unit tests (admission, staleness rejection,
      cancellation-on-supersede, per-key isolation, guard-drop slot release)
- [x] 5 new `readActivitySummary` precedence tests
- [x] Full backend suite: 1285 passed, 0 failed
- [x] Full frontend suite: 1581 passed (105 files), 0 failed
- [x] `tsc --noEmit` clean
- [x] `cargo check` clean, no new warnings

<!-- agentmux:agent_id=agent3 -->