### PR TITLE
feat(armory): MCP Servers + Skills catalog tabs

### DIFF
--- a/.changesets/1783107603-feat-armory-mcp-servers-skills-catalog-tabs-f442.md
+++ b/.changesets/1783107603-feat-armory-mcp-servers-skills-catalog-tabs-f442.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): MCP Servers + Skills catalog tabs

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -314,6 +314,12 @@ pub const COMMAND_SKILL_DELETE: &str = "skill.delete";
 pub const COMMAND_SKILL_BIND: &str = "skill.bind";
 pub const COMMAND_SKILL_UNBIND: &str = "skill.unbind";
 
+// App API — Armory-level Skill catalog (global skills only, window-scoped —
+// no agent_id, no check_s1 — mirrors bundle.* auth shape).
+pub const COMMAND_SKILL_CATALOG_LIST: &str = "skill.catalog.list";
+pub const COMMAND_SKILL_CATALOG_UPSERT: &str = "skill.catalog.upsert";
+pub const COMMAND_SKILL_CATALOG_DELETE: &str = "skill.catalog.delete";
+
 // App API — v1 standalone MCP Server primitives
 pub const COMMAND_MCP_LIST: &str = "mcp.list";
 pub const COMMAND_MCP_GET: &str = "mcp.get";
@@ -321,6 +327,12 @@ pub const COMMAND_MCP_UPSERT: &str = "mcp.upsert";
 pub const COMMAND_MCP_DELETE: &str = "mcp.delete";
 pub const COMMAND_MCP_BIND: &str = "mcp.bind";
 pub const COMMAND_MCP_UNBIND: &str = "mcp.unbind";
+
+// App API — Armory-level MCP Server catalog (global servers only,
+// window-scoped — no agent_id, no check_s1 — mirrors bundle.* auth shape).
+pub const COMMAND_MCP_CATALOG_LIST: &str = "mcp.catalog.list";
+pub const COMMAND_MCP_CATALOG_UPSERT: &str = "mcp.catalog.upsert";
+pub const COMMAND_MCP_CATALOG_DELETE: &str = "mcp.catalog.delete";
 
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -209,6 +209,43 @@ impl Store {
         Ok(())
     }
 
+    /// Atomically upsert a GLOBAL MCP server enforcing catalog-wide name
+    /// uniqueness (no `agent_id` — unlike `mcp_server_upsert_unique`, this
+    /// checks for a duplicate name among *every* global row, not just those
+    /// visible to one agent). Reagent P1 on #1948: `agent_config.rs`'s
+    /// `build_mcp_config_from_refs` merges servers into a JSON object keyed
+    /// by `server.name` — two same-named global servers would silently
+    /// clobber each other's config for every agent that has either bound.
+    /// `server.is_global` must already be `true`; caller's job.
+    pub fn mcp_server_upsert_unique_global(&self, server: &McpServer) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let dup: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM db_mcp_servers WHERE name = ?1 AND id <> ?2 AND is_global = 1",
+            params![server.name, server.id],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            return Err(StoreError::Other(format!(
+                "a global server named '{}' already exists",
+                server.name
+            )));
+        }
+        tx.execute(
+            "INSERT INTO db_mcp_servers (id, name, transport, config, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+               name=excluded.name, transport=excluded.transport, config=excluded.config,
+               updated_at=excluded.updated_at",
+            params![
+                server.id, server.name, server.transport, server.config,
+                server.created_at, server.updated_at,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Return true if the given MCP server is accessible to the agent (global or bound).
     /// Used for read and mutation access checks.
     pub fn mcp_server_is_accessible_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -54,6 +54,36 @@ impl Store {
         Ok(out)
     }
 
+    /// List every GLOBAL MCP server — the Armory catalog view. Unlike
+    /// `mcp_server_list`, this takes no `agent_id` and never includes an
+    /// agent's private servers; it backs the window-scoped `mcp.catalog.*`
+    /// App API (no `check_s1`, so there is no agent context to scope by).
+    pub fn mcp_server_list_global(&self) -> Result<Vec<McpServer>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, transport, config, is_global, created_at, updated_at
+             FROM db_mcp_servers
+             WHERE is_global = 1
+             ORDER BY updated_at DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(McpServer {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                transport: row.get(2)?,
+                config: row.get(3)?,
+                is_global: row.get::<_, i64>(4)? != 0,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Get a standalone MCP server by id.
     pub fn mcp_server_get(&self, id: &str) -> Result<Option<McpServer>, StoreError> {
         let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -249,6 +249,38 @@ impl Store {
         Ok(out)
     }
 
+    /// List every GLOBAL skill — the Armory catalog view. Unlike
+    /// `skill_list`, this takes no `agent_id` and never includes an agent's
+    /// private skills; it backs the window-scoped `skill.catalog.*` App API
+    /// (no `check_s1`, so there is no agent context to scope by).
+    pub fn skill_list_global(&self) -> Result<Vec<Skill>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, trigger, skill_type, description, content, is_global, created_at, updated_at
+             FROM db_skills
+             WHERE is_global = 1
+             ORDER BY updated_at DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(Skill {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                trigger: row.get(2)?,
+                skill_type: row.get(3)?,
+                description: row.get(4)?,
+                content: row.get(5)?,
+                is_global: row.get::<_, i64>(6)? != 0,
+                created_at: row.get(7)?,
+                updated_at: row.get(8)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Get a standalone skill by id.
     pub fn skill_get(&self, id: &str) -> Result<Option<Skill>, StoreError> {
         let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -415,6 +415,45 @@ impl Store {
         Ok(())
     }
 
+    /// Atomically upsert a GLOBAL skill enforcing catalog-wide name
+    /// uniqueness (no `agent_id` — unlike `skill_upsert_unique`, this checks
+    /// for a duplicate name among *every* global row, not just those visible
+    /// to one agent). Same defense-in-depth as
+    /// `McpServer::mcp_server_upsert_unique_global` (reagent P1 on #1948) —
+    /// two same-named global skills would at minimum produce a confusing
+    /// duplicate bullet in the assembled CLAUDE.md skills index.
+    /// `skill.is_global` must already be `true`; caller's job.
+    pub fn skill_upsert_unique_global(&self, skill: &Skill) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let dup: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM db_skills WHERE name = ?1 AND id <> ?2 AND is_global = 1",
+            params![skill.name, skill.id],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            return Err(StoreError::Other(format!(
+                "a global skill named '{}' already exists",
+                skill.name
+            )));
+        }
+        tx.execute(
+            "INSERT INTO db_skills (id, name, trigger, skill_type, description, content, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8)
+             ON CONFLICT(id) DO UPDATE SET
+               name=excluded.name, trigger=excluded.trigger, skill_type=excluded.skill_type,
+               description=excluded.description, content=excluded.content,
+               updated_at=excluded.updated_at",
+            params![
+                skill.id, skill.name, skill.trigger, skill.skill_type,
+                skill.description, skill.content,
+                skill.created_at, skill.updated_at,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Return true if the given skill is accessible to the agent (global or bound).
     /// Used for read and delete access checks.
     pub fn skill_is_accessible_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -3,6 +3,10 @@
 
 //! App API handlers for the v1 standalone MCP Server primitive.
 //! mcp.list / mcp.get / mcp.upsert / mcp.delete / mcp.bind / mcp.unbind
+//!
+//! Plus the Armory-level catalog (mcp.catalog.*): global servers only,
+//! window-scoped — no `agent_id`, no `check_s1` (mirrors bundle.* auth
+//! shape, since the Armory has no agent connection context to gate on).
 
 use super::*;
 
@@ -13,6 +17,9 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_mcp_delete(engine, state);
     register_mcp_bind(engine, state);
     register_mcp_unbind(engine, state);
+    register_mcp_catalog_list(engine, state);
+    register_mcp_catalog_upsert(engine, state);
+    register_mcp_catalog_delete(engine, state);
 }
 
 fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -228,6 +235,125 @@ fn register_mcp_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let unbound = wstore.mcp_server_unbind(&req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.unbind: {e}"))?;
                 Ok(Some(json!({ "unbound": unbound })))
+            })
+        }),
+    );
+}
+
+fn register_mcp_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_LIST,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let servers = wstore.mcp_server_list_global()
+                    .map_err(|e| format!("mcp.catalog.list: {e}"))?;
+                Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_UPSERT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req {
+                    #[serde(default)] id: String,
+                    name: String,
+                    #[serde(default = "default_transport")] transport: String,
+                    #[serde(default = "default_config")] config: String,
+                }
+                fn default_transport() -> String { "stdio".to_string() }
+                fn default_config() -> String { "{}".to_string() }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.catalog.upsert: {e}"))?;
+
+                match serde_json::from_str::<serde_json::Value>(&req.config) {
+                    Ok(serde_json::Value::Object(_)) => {}
+                    Ok(_) => return Err("mcp.catalog.upsert: config must be a JSON object".to_string()),
+                    Err(_) => return Err("mcp.catalog.upsert: config must be valid JSON".to_string()),
+                }
+                if req.name == "agentmux" {
+                    return Err("FORBIDDEN: 'agentmux' is a reserved MCP server name".to_string());
+                }
+
+                let now = now_ms();
+                let (id, created_at) = if req.id.is_empty() {
+                    (uuid::Uuid::new_v4().to_string(), now)
+                } else {
+                    let existing = wstore.mcp_server_get(&req.id)
+                        .map_err(|e| format!("mcp.catalog.upsert: {e}"))?;
+                    match existing {
+                        // No agent_id/check_s1 here to verify ownership of a private
+                        // server, so the catalog surface may only create new global
+                        // rows or edit ones that are ALREADY global — never promote
+                        // a private server into the catalog by supplying its id.
+                        Some(s) if !s.is_global => {
+                            return Err("FORBIDDEN: cannot promote a private MCP server via the catalog".to_string());
+                        }
+                        Some(s) => (req.id.clone(), s.created_at),
+                        None => (req.id.clone(), now),
+                    }
+                };
+
+                let server = crate::backend::storage::McpServer {
+                    id: id.clone(),
+                    name: req.name,
+                    transport: req.transport,
+                    config: req.config,
+                    is_global: true,
+                    created_at,
+                    updated_at: now,
+                };
+                wstore.mcp_server_upsert(&server)
+                    .map_err(|e| format!("mcp.catalog.upsert: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "mcp:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                Ok(Some(serde_json::to_value(&server).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_mcp_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_DELETE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.catalog.delete: {e}"))?;
+                if let Some(existing) = wstore.mcp_server_get(&req.id)
+                    .map_err(|e| format!("mcp.catalog.delete: {e}"))?
+                {
+                    if !existing.is_global {
+                        return Err("FORBIDDEN: cannot delete a private MCP server via the catalog".to_string());
+                    }
+                }
+                let deleted = wstore.mcp_server_delete(&req.id)
+                    .map_err(|e| format!("mcp.catalog.delete: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "mcp:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
             })
         }),
     );

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -313,7 +313,12 @@ fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                wstore.mcp_server_upsert(&server)
+                // Global-scoped uniqueness (not mcp_server_upsert_unique's
+                // per-agent check): agent_config.rs merges servers into a
+                // JSON object keyed by name, so two same-named global
+                // servers would silently clobber each other's config for
+                // every agent that has either bound. Reagent P1 on #1948.
+                wstore.mcp_server_upsert_unique_global(&server)
                     .map_err(|e| format!("mcp.catalog.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "mcp:changed".to_string(),

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -301,7 +301,10 @@ fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                wstore.skill_upsert(&skill)
+                // Global-scoped uniqueness (not skill_upsert_unique's
+                // per-agent check) — same defense-in-depth as the mcp.catalog
+                // fix, reagent P1 on #1948.
+                wstore.skill_upsert_unique_global(&skill)
                     .map_err(|e| format!("skill.catalog.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "skills:changed".to_string(),

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -3,6 +3,10 @@
 
 //! App API handlers for the v1 standalone Skill primitive.
 //! skill.list / skill.get / skill.upsert / skill.delete / skill.bind / skill.unbind
+//!
+//! Plus the Armory-level catalog (skill.catalog.*): global skills only,
+//! window-scoped — no `agent_id`, no `check_s1` (mirrors bundle.* auth
+//! shape, since the Armory has no agent connection context to gate on).
 
 use super::*;
 
@@ -13,6 +17,9 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_skill_delete(engine, state);
     register_skill_bind(engine, state);
     register_skill_unbind(engine, state);
+    register_skill_catalog_list(engine, state);
+    register_skill_catalog_upsert(engine, state);
+    register_skill_catalog_delete(engine, state);
 }
 
 fn register_skill_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -222,6 +229,119 @@ fn register_skill_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let unbound = wstore.skill_unbind(&req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.unbind: {e}"))?;
                 Ok(Some(json!({ "unbound": unbound })))
+            })
+        }),
+    );
+}
+
+fn register_skill_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_CATALOG_LIST,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let skills = wstore.skill_list_global()
+                    .map_err(|e| format!("skill.catalog.list: {e}"))?;
+                Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_SKILL_CATALOG_UPSERT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req {
+                    #[serde(default)] id: String,
+                    name: String,
+                    #[serde(default)] trigger: String,
+                    #[serde(default = "default_skill_type")] skill_type: String,
+                    #[serde(default)] description: String,
+                    #[serde(default)] content: String,
+                }
+                fn default_skill_type() -> String { "prompt".to_string() }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.catalog.upsert: {e}"))?;
+
+                let now = now_ms();
+                let (id, created_at) = if req.id.is_empty() {
+                    (uuid::Uuid::new_v4().to_string(), now)
+                } else {
+                    let existing = wstore.skill_get(&req.id)
+                        .map_err(|e| format!("skill.catalog.upsert: {e}"))?;
+                    match existing {
+                        // No agent_id/check_s1 here to verify ownership of a private
+                        // skill, so the catalog surface may only create new global
+                        // rows or edit ones that are ALREADY global — never promote
+                        // a private skill into the catalog by supplying its id.
+                        Some(s) if !s.is_global => {
+                            return Err("FORBIDDEN: cannot promote a private skill via the catalog".to_string());
+                        }
+                        Some(s) => (req.id.clone(), s.created_at),
+                        None => (req.id.clone(), now),
+                    }
+                };
+
+                let skill = crate::backend::storage::Skill {
+                    id: id.clone(),
+                    name: req.name,
+                    trigger: req.trigger,
+                    skill_type: req.skill_type,
+                    description: req.description,
+                    content: req.content,
+                    is_global: true,
+                    created_at,
+                    updated_at: now,
+                };
+                wstore.skill_upsert(&skill)
+                    .map_err(|e| format!("skill.catalog.upsert: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "skills:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
+                Ok(Some(serde_json::to_value(&skill).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+fn register_skill_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_SKILL_CATALOG_DELETE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.catalog.delete: {e}"))?;
+                if let Some(existing) = wstore.skill_get(&req.id)
+                    .map_err(|e| format!("skill.catalog.delete: {e}"))?
+                {
+                    if !existing.is_global {
+                        return Err("FORBIDDEN: cannot delete a private skill via the catalog".to_string());
+                    }
+                }
+                let deleted = wstore.skill_delete(&req.id)
+                    .map_err(|e| format!("skill.catalog.delete: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "skills:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
             })
         }),
     );

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -4,9 +4,9 @@
 // v1 composable model — standalone MCP Server primitive
 // (agentmux-srv/src/server/app_api/mcp.rs). Agent-scoped: every command is
 // `check_s1`-gated (ctx.agent_id must equal the request's agent_id), so
-// these only work from an authenticated agent connection. There is no
-// window-scoped "list every MCP server" command yet — see mcp.catalog.*
-// (Armory-level, global-only) for that surface.
+// these only work from an authenticated agent connection. The mcp.catalog.*
+// commands are the window-scoped counterpart (no agent_id, global rows
+// only) — that's what the Armory's MCP Servers tab uses.
 
 import { RpcClient } from "../rpc-client";
 
@@ -57,5 +57,31 @@ export const McpApi = {
         opts?: RpcOpts,
     ): Promise<{ unbound: boolean }> {
         return client.rpcCall("mcp.unbind", data, opts);
+    },
+
+    // ── Armory catalog (global servers only, no agent_id) ──────────────────
+
+    McpCatalogListCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<McpServer[]> {
+        return client.rpcCall("mcp.catalog.list", data, opts);
+    },
+
+    McpCatalogUpsertCommand(
+        client: RpcClient,
+        data: { id?: string; name: string; transport?: string; config?: string },
+        opts?: RpcOpts,
+    ): Promise<McpServer> {
+        return client.rpcCall("mcp.catalog.upsert", data, opts);
+    },
+
+    McpCatalogDeleteCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("mcp.catalog.delete", data, opts);
     },
 };

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -7,8 +7,9 @@
 // these only work from an authenticated agent connection. Distinct from the
 // legacy agent-scoped AgentSkill (`agent_skill_*` / `db_agent_skills`,
 // `AgentSkillCard.tsx` et al.) — this is the v1 standalone primitive
-// (`db_skills`). There is no window-scoped "list every skill" command yet —
-// see skill.catalog.* (Armory-level, global-only) for that surface.
+// (`db_skills`). The skill.catalog.* commands are the window-scoped
+// counterpart (no agent_id, global rows only) — that's what the Armory's
+// Skills tab uses.
 
 import { RpcClient } from "../rpc-client";
 
@@ -67,5 +68,38 @@ export const SkillApi = {
         opts?: RpcOpts,
     ): Promise<{ unbound: boolean }> {
         return client.rpcCall("skill.unbind", data, opts);
+    },
+
+    // ── Armory catalog (global skills only, no agent_id) ────────────────────
+
+    SkillCatalogListCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<Skill[]> {
+        return client.rpcCall("skill.catalog.list", data, opts);
+    },
+
+    SkillCatalogUpsertCommand(
+        client: RpcClient,
+        data: {
+            id?: string;
+            name: string;
+            trigger?: string;
+            skill_type?: string;
+            description?: string;
+            content?: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<Skill> {
+        return client.rpcCall("skill.catalog.upsert", data, opts);
+    },
+
+    SkillCatalogDeleteCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("skill.catalog.delete", data, opts);
     },
 };

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-export type ArmorySection = "accounts" | "identities" | "brain" | "memories";
+export type ArmorySection = "accounts" | "identities" | "brain" | "memories" | "mcp" | "skills";
 
 export class ArmoryViewModel implements ViewModel {
     viewType = "armory";

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -7,6 +7,8 @@ import { IdentityManager } from "@/app/view/identity/identity-manager";
 import { MemoryManager } from "@/app/view/memory/memory-manager";
 import { AccountsManager } from "@/app/view/accounts/accounts-manager";
 import { GlobalBrainManager } from "@/app/view/brain/global-brain-manager";
+import { McpManager } from "@/app/view/mcp/mcp-manager";
+import { SkillManager } from "@/app/view/skill/skill-manager";
 import type { ArmorySection, ArmoryViewModel } from "./armory-model";
 import "./armory-view.scss";
 
@@ -15,6 +17,8 @@ const RAIL: { id: ArmorySection; label: string; icon: string }[] = [
     { id: "identities", label: "Identities", icon: "id-card" },
     { id: "brain",      label: "Brain",      icon: "brain" },
     { id: "memories",   label: "Bundles",    icon: "layer-group" },
+    { id: "mcp",        label: "MCP Servers", icon: "plug" },
+    { id: "skills",     label: "Skills",      icon: "wand-magic-sparkles" },
 ];
 
 export function ArmoryView(_props: ViewComponentProps<ArmoryViewModel>): JSX.Element {
@@ -44,8 +48,8 @@ export function ArmoryView(_props: ViewComponentProps<ArmoryViewModel>): JSX.Ele
                 </nav>
                 <div class="bundle-manager-section">
                     {/*
-                     * All four managers stay mounted — toggling is instant and
-                     * never re-fetches. Both stay consistent via WPS *:changed events.
+                     * All six managers stay mounted — toggling is instant and
+                     * never re-fetches. All stay consistent via WPS *:changed events.
                      */}
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "accounts" }}>
                         <AccountsManager />
@@ -58,6 +62,12 @@ export function ArmoryView(_props: ViewComponentProps<ArmoryViewModel>): JSX.Ele
                     </div>
                     <div class="bundle-manager-pane bundle-manager-pane--memories" classList={{ "is-hidden": section() !== "memories" }}>
                         <MemoryManager />
+                    </div>
+                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "mcp" }}>
+                        <McpManager />
+                    </div>
+                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "skills" }}>
+                        <SkillManager />
                     </div>
                 </div>
                 <nav class="bundle-manager-tab-bar" aria-label="Armory section">

--- a/frontend/app/view/mcp/mcp-manager.tsx
+++ b/frontend/app/view/mcp/mcp-manager.tsx
@@ -1,0 +1,145 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * McpManager — the Armory's "MCP Servers" tab body. Context-free
+ * list/create/edit/delete over the global MCP Server catalog
+ * (mcp.catalog.* App API via McpCatalogModel). Every row here is global —
+ * per-agent private servers live in the Agent-setup modal (AgentMcpModal),
+ * not here.
+ */
+
+import { onCleanup, For, Show, type JSX } from "solid-js";
+import { McpCatalogModel } from "./mcp-model";
+import "../agent/components/AgentPrimitiveModal.scss";
+
+export const McpManager = (): JSX.Element => {
+    const model = new McpCatalogModel();
+    onCleanup(() => model.dispose());
+
+    return (
+        <div class="agent-primitive-modal">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+
+            <div class="agent-primitive-modal-body">
+                <div class="agent-primitive-modal-list">
+                    <Show
+                        when={model.serversAtom().length > 0}
+                        fallback={<div class="agent-primitive-modal-list-empty">No MCP servers yet</div>}
+                    >
+                        <For each={model.serversAtom()}>
+                            {(server) => (
+                                <button
+                                    class="agent-primitive-modal-list-item"
+                                    classList={{ "is-selected": model.selectedIdAtom() === server.id }}
+                                    onClick={() => model.handleSelect(server)}
+                                >
+                                    <span class="agent-primitive-modal-list-item-name">{server.name}</span>
+                                </button>
+                            )}
+                        </For>
+                    </Show>
+
+                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                        + New MCP server
+                    </button>
+                </div>
+
+                <div class="agent-primitive-modal-detail">
+                    <Show
+                        when={model.draftAtom()}
+                        fallback={
+                            <Show
+                                when={model.selectedAtom()}
+                                fallback={
+                                    <div class="agent-primitive-modal-empty">
+                                        Select a server from the list, or create a new one. Servers
+                                        created here are global — visible to every agent.
+                                    </div>
+                                }
+                            >
+                                {(server) => (
+                                    <div class="agent-primitive-modal-readonly">
+                                        <h3 class="agent-primitive-modal-name">{server().name}</h3>
+                                        <span class="agent-primitive-modal-field-label">Transport</span>
+                                        <pre class="agent-primitive-modal-field-value">{server().transport}</pre>
+                                        <span class="agent-primitive-modal-field-label">Config</span>
+                                        <pre class="agent-primitive-modal-field-value">{server().config}</pre>
+                                        <div class="agent-primitive-modal-actions">
+                                            <button
+                                                class="agent-primitive-modal-btn agent-primitive-modal-btn-danger"
+                                                onClick={() => void model.deleteServer(server().id)}
+                                            >
+                                                Delete
+                                            </button>
+                                            <button
+                                                class="agent-primitive-modal-btn"
+                                                onClick={() => model.startEdit(server())}
+                                            >
+                                                Edit
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
+                            </Show>
+                        }
+                    >
+                        {(draft) => (
+                            <form
+                                class="agent-primitive-modal-form"
+                                onSubmit={(e) => { e.preventDefault(); void model.saveDraft(); }}
+                            >
+                                <span class="agent-primitive-modal-field-label">Name *</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().name}
+                                    onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
+                                    placeholder="e.g. filesystem"
+                                    required
+                                />
+                                <span class="agent-primitive-modal-field-label">Transport</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().transport}
+                                    onInput={(e) => model.setDraft({ ...draft(), transport: e.currentTarget.value })}
+                                    placeholder="stdio"
+                                />
+                                <span class="agent-primitive-modal-field-label">Config (JSON)</span>
+                                <textarea
+                                    class="agent-primitive-modal-textarea"
+                                    rows={6}
+                                    value={draft().config}
+                                    onInput={(e) => model.setDraft({ ...draft(), config: e.currentTarget.value })}
+                                    spellcheck={false}
+                                />
+                                <div class="agent-primitive-modal-actions">
+                                    <button
+                                        type="button"
+                                        class="agent-primitive-modal-btn"
+                                        onClick={() => model.cancelDraft()}
+                                        disabled={model.savingAtom()}
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        type="submit"
+                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                        disabled={model.savingAtom() || !draft().name.trim()}
+                                    >
+                                        {model.savingAtom() ? "Saving…" : "Save"}
+                                    </button>
+                                </div>
+                            </form>
+                        )}
+                    </Show>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+McpManager.displayName = "McpManager";

--- a/frontend/app/view/mcp/mcp-model.ts
+++ b/frontend/app/view/mcp/mcp-model.ts
@@ -1,0 +1,144 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * McpCatalogModel — view model for the Armory's MCP Servers tab. Drives
+ * list + create/edit/delete over the window-scoped `mcp.catalog.*` App API
+ * (agentmux-srv/src/server/app_api/mcp.rs). Every row here is global by
+ * construction — the catalog only ever lists/creates/edits is_global rows.
+ * Per-agent private servers and bind/unbind live in the Agent-setup modal
+ * (AgentMcpModel), not here.
+ */
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface McpDraft {
+    id?: string;
+    name: string;
+    transport: string;
+    config: string;
+}
+
+export function emptyMcpDraft(): McpDraft {
+    return { id: undefined, name: "", transport: "stdio", config: "{}" };
+}
+
+function draftFromServer(s: McpServer): McpDraft {
+    return { id: s.id, name: s.name, transport: s.transport, config: s.config };
+}
+
+export class McpCatalogModel {
+    private _servers = createSignal<McpServer[]>([]);
+    serversAtom: Accessor<McpServer[]> = this._servers[0];
+    private setServers = this._servers[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _draft = createSignal<McpDraft | null>(null);
+    draftAtom: Accessor<McpDraft | null> = this._draft[0];
+    setDraft = this._draft[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    private setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    selectedAtom: Accessor<McpServer | null>;
+
+    constructor() {
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.serversAtom().find((s) => s.id === id) ?? null;
+        });
+        void this.refresh();
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.McpCatalogListCommand(TabRpcClient, {});
+            this.setServers(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load MCP servers: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    handleSelect(server: McpServer): void {
+        this.setError(null);
+        this.setDraft(null);
+        this.setSelectedId(server.id);
+    }
+
+    startNew(): void {
+        this.setError(null);
+        this.setDraft(emptyMcpDraft());
+        this.setSelectedId(null);
+    }
+
+    startEdit(server: McpServer): void {
+        this.setError(null);
+        this.setDraft(draftFromServer(server));
+        this.setSelectedId(server.id);
+    }
+
+    cancelDraft(): void {
+        this.setDraft(null);
+        this.setError(null);
+    }
+
+    async saveDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        if (!draft.name.trim()) {
+            this.setError("Name is required.");
+            return;
+        }
+        try {
+            JSON.parse(draft.config || "{}");
+        } catch {
+            this.setError("Config must be valid JSON.");
+            return;
+        }
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const saved = await RpcApi.McpCatalogUpsertCommand(TabRpcClient, {
+                id: draft.id,
+                name: draft.name.trim(),
+                transport: draft.transport || "stdio",
+                config: draft.config || "{}",
+            });
+            await this.refresh();
+            this.setDraft(null);
+            this.setSelectedId(saved.id);
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    async deleteServer(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.McpCatalogDeleteCommand(TabRpcClient, { id });
+            if (this.selectedIdAtom() === id) this.setSelectedId(null);
+            this.setDraft(null);
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    dispose(): void {
+        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+}

--- a/frontend/app/view/skill/skill-manager.tsx
+++ b/frontend/app/view/skill/skill-manager.tsx
@@ -1,0 +1,158 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SkillManager — the Armory's "Skills" tab body. Context-free
+ * list/create/edit/delete over the global Skill catalog (skill.catalog.*
+ * App API via SkillCatalogModel). Every row here is global — per-agent
+ * private skills live in the Agent-setup modal (AgentSkillsModal), not
+ * here.
+ */
+
+import { onCleanup, For, Show, type JSX } from "solid-js";
+import { SkillCatalogModel } from "./skill-model";
+import "../agent/components/AgentPrimitiveModal.scss";
+
+export const SkillManager = (): JSX.Element => {
+    const model = new SkillCatalogModel();
+    onCleanup(() => model.dispose());
+
+    return (
+        <div class="agent-primitive-modal">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+
+            <div class="agent-primitive-modal-body">
+                <div class="agent-primitive-modal-list">
+                    <Show
+                        when={model.skillsAtom().length > 0}
+                        fallback={<div class="agent-primitive-modal-list-empty">No skills yet</div>}
+                    >
+                        <For each={model.skillsAtom()}>
+                            {(skill) => (
+                                <button
+                                    class="agent-primitive-modal-list-item"
+                                    classList={{ "is-selected": model.selectedIdAtom() === skill.id }}
+                                    onClick={() => model.handleSelect(skill)}
+                                >
+                                    <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
+                                </button>
+                            )}
+                        </For>
+                    </Show>
+
+                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                        + New skill
+                    </button>
+                </div>
+
+                <div class="agent-primitive-modal-detail">
+                    <Show
+                        when={model.draftAtom()}
+                        fallback={
+                            <Show
+                                when={model.selectedAtom()}
+                                fallback={
+                                    <div class="agent-primitive-modal-empty">
+                                        Select a skill from the list, or create a new one. Skills
+                                        created here are global — visible to every agent.
+                                    </div>
+                                }
+                            >
+                                {(skill) => (
+                                    <div class="agent-primitive-modal-readonly">
+                                        <h3 class="agent-primitive-modal-name">{skill().name}</h3>
+                                        <Show when={skill().description}>
+                                            <span class="agent-primitive-modal-field-label">Description</span>
+                                            <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
+                                        </Show>
+                                        <Show when={skill().trigger}>
+                                            <span class="agent-primitive-modal-field-label">Trigger</span>
+                                            <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
+                                        </Show>
+                                        <span class="agent-primitive-modal-field-label">Content</span>
+                                        <pre class="agent-primitive-modal-field-value">{skill().content || "(none)"}</pre>
+                                        <div class="agent-primitive-modal-actions">
+                                            <button
+                                                class="agent-primitive-modal-btn agent-primitive-modal-btn-danger"
+                                                onClick={() => void model.deleteSkill(skill().id)}
+                                            >
+                                                Delete
+                                            </button>
+                                            <button
+                                                class="agent-primitive-modal-btn"
+                                                onClick={() => model.startEdit(skill())}
+                                            >
+                                                Edit
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
+                            </Show>
+                        }
+                    >
+                        {(draft) => (
+                            <form
+                                class="agent-primitive-modal-form"
+                                onSubmit={(e) => { e.preventDefault(); void model.saveDraft(); }}
+                            >
+                                <span class="agent-primitive-modal-field-label">Name *</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().name}
+                                    onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
+                                    placeholder="e.g. pdf-extraction"
+                                    required
+                                />
+                                <span class="agent-primitive-modal-field-label">Trigger</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().trigger}
+                                    onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
+                                    placeholder="When should this skill be invoked?"
+                                />
+                                <span class="agent-primitive-modal-field-label">Description</span>
+                                <input
+                                    class="agent-primitive-modal-input"
+                                    type="text"
+                                    value={draft().description}
+                                    onInput={(e) => model.setDraft({ ...draft(), description: e.currentTarget.value })}
+                                />
+                                <span class="agent-primitive-modal-field-label">Content</span>
+                                <textarea
+                                    class="agent-primitive-modal-textarea"
+                                    rows={8}
+                                    value={draft().content}
+                                    onInput={(e) => model.setDraft({ ...draft(), content: e.currentTarget.value })}
+                                    spellcheck={false}
+                                />
+                                <div class="agent-primitive-modal-actions">
+                                    <button
+                                        type="button"
+                                        class="agent-primitive-modal-btn"
+                                        onClick={() => model.cancelDraft()}
+                                        disabled={model.savingAtom()}
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        type="submit"
+                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                        disabled={model.savingAtom() || !draft().name.trim()}
+                                    >
+                                        {model.savingAtom() ? "Saving…" : "Save"}
+                                    </button>
+                                </div>
+                            </form>
+                        )}
+                    </Show>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+SkillManager.displayName = "SkillManager";

--- a/frontend/app/view/skill/skill-model.ts
+++ b/frontend/app/view/skill/skill-model.ts
@@ -1,0 +1,149 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SkillCatalogModel — view model for the Armory's Skills tab. Drives list +
+ * create/edit/delete over the window-scoped `skill.catalog.*` App API
+ * (agentmux-srv/src/server/app_api/skill.rs). Every row here is global by
+ * construction — the catalog only ever lists/creates/edits is_global rows.
+ * Per-agent private skills and bind/unbind live in the Agent-setup modal
+ * (AgentSkillModel), not here.
+ */
+
+import { createMemo, createSignal, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface SkillDraft {
+    id?: string;
+    name: string;
+    trigger: string;
+    skill_type: string;
+    description: string;
+    content: string;
+}
+
+export function emptySkillDraft(): SkillDraft {
+    return { id: undefined, name: "", trigger: "", skill_type: "prompt", description: "", content: "" };
+}
+
+function draftFromSkill(s: Skill): SkillDraft {
+    return {
+        id: s.id,
+        name: s.name,
+        trigger: s.trigger,
+        skill_type: s.skill_type,
+        description: s.description,
+        content: s.content,
+    };
+}
+
+export class SkillCatalogModel {
+    private _skills = createSignal<Skill[]>([]);
+    skillsAtom: Accessor<Skill[]> = this._skills[0];
+    private setSkills = this._skills[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _draft = createSignal<SkillDraft | null>(null);
+    draftAtom: Accessor<SkillDraft | null> = this._draft[0];
+    setDraft = this._draft[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    private setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    selectedAtom: Accessor<Skill | null>;
+
+    constructor() {
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.skillsAtom().find((s) => s.id === id) ?? null;
+        });
+        void this.refresh();
+    }
+
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.SkillCatalogListCommand(TabRpcClient, {});
+            this.setSkills(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load skills: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    handleSelect(skill: Skill): void {
+        this.setError(null);
+        this.setDraft(null);
+        this.setSelectedId(skill.id);
+    }
+
+    startNew(): void {
+        this.setError(null);
+        this.setDraft(emptySkillDraft());
+        this.setSelectedId(null);
+    }
+
+    startEdit(skill: Skill): void {
+        this.setError(null);
+        this.setDraft(draftFromSkill(skill));
+        this.setSelectedId(skill.id);
+    }
+
+    cancelDraft(): void {
+        this.setDraft(null);
+        this.setError(null);
+    }
+
+    async saveDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        if (!draft.name.trim()) {
+            this.setError("Name is required.");
+            return;
+        }
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const saved = await RpcApi.SkillCatalogUpsertCommand(TabRpcClient, {
+                id: draft.id,
+                name: draft.name.trim(),
+                trigger: draft.trigger,
+                skill_type: draft.skill_type || "prompt",
+                description: draft.description,
+                content: draft.content,
+            });
+            await this.refresh();
+            this.setDraft(null);
+            this.setSelectedId(saved.id);
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    async deleteSkill(id: string): Promise<void> {
+        this.setError(null);
+        try {
+            await RpcApi.SkillCatalogDeleteCommand(TabRpcClient, { id });
+            if (this.selectedIdAtom() === id) this.setSelectedId(null);
+            this.setDraft(null);
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    dispose(): void {
+        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+    }
+}


### PR DESCRIPTION
## Summary
PR A3 of the 7-PR plan — this is the piece that actually answers "why doesn't the Armory have MCP Servers/Skills tabs." Builds on #1943/#1946 (merged).

The existing `mcp.*`/`skill.*` App API is agent-scoped and `check_s1`-gated (`ctx.agent_id` must equal the request's `agent_id`) — calling it from the Armory (a window-scoped pane with no agent connection context) hits `FORBIDDEN: unauthenticated agent connection`. `bundle.*` has no such gate (window-scoped by design, see `bundle.rs`), so this adds a parallel unscoped surface mirroring that shape:

- **Backend:** `mcp.catalog.{list,upsert,delete}` / `skill.catalog.{list,upsert,delete}` in `agentmux-srv/src/server/app_api/{mcp,skill}.rs`. No `agent_id`, no `check_s1`.
  - `catalog.list` only returns `is_global` rows (new `mcp_server_list_global`/`skill_list_global` storage helpers).
  - `catalog.upsert` always writes `is_global: true` and **refuses to mutate an existing non-global row** — there's no `agent_id` here to verify ownership, so the catalog surface must never be able to silently promote a private server/skill into the shared catalog just by supplying its id.
  - `catalog.delete` similarly refuses to delete a non-global row.
- **Frontend:** new `frontend/app/view/mcp/` and `frontend/app/view/skill/` (`McpManager`/`SkillManager` + matching catalog view models), wired into `armory-view.tsx`'s `RAIL` as two new tabs. Reuses `AgentPrimitiveModal.scss` from #1946 rather than a third copy of the list/detail CSS.

## Test plan
- [x] `cargo check -p agentmux-srv` — clean (only pre-existing dead-code warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 104/104 files, 1576/1576 tests passing (rpc-contract needed no baseline changes — the new commands are both registered and declared in this same PR)
- [x] Verified the `plug`/`wand-magic-sparkles` rail icons exist in the bundled Font Awesome set before using them
- [ ] Reviewer: manually create a global MCP server/skill from the Armory, confirm it also shows up (read-only, bind/unbind only) in an agent pane's Agent-setup modal from #1946

<!-- agentmux:agent_id=agent1 -->