### PR TITLE
fix(muxbus): cloud_subscriber sends periodic WS ping to survive API Gateway idle timeout

### DIFF
--- a/.changesets/1783109150-fix-muxbus-cloud-subscriber-sends-periodic-ws-ping-to-surviv-1k70.md
+++ b/.changesets/1783109150-fix-muxbus-cloud-subscriber-sends-periodic-ws-ping-to-surviv-1k70.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): cloud_subscriber sends periodic WS ping to survive API Gateway idle timeout

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -34,6 +34,11 @@ const MUXBUS_WS_URL: &str = "wss://muxbus.agentmux.ai/ws";
 const MUXBUS_REST_URL: &str = "https://muxbus.agentmux.ai";
 const RECONNECT_DELAY_SECS: u64 = 5;
 const MAX_RECONNECT_DELAY_SECS: u64 = 60;
+// AWS API Gateway WebSocket APIs enforce a 10-minute idle timeout with no
+// server-initiated keepalive of their own — the connection is dropped on
+// silence in both directions. Ping well under that so a quiet connection
+// (no inject_available traffic) survives indefinitely.
+const CLIENT_PING_INTERVAL_SECS: u64 = 240;
 
 // ── Wire protocol ─────────────────────────────────────────────────────────────
 
@@ -287,8 +292,19 @@ async fn connect_and_run(
         .await
         .map_err(|e| format!("send subscribe: {e}"))?;
 
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(CLIENT_PING_INTERVAL_SECS));
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ping_interval.tick().await; // first tick fires immediately — consume it, we just connected
+
     loop {
         tokio::select! {
+            // Keepalive — see CLIENT_PING_INTERVAL_SECS.
+            _ = ping_interval.tick() => {
+                if let Err(e) = write.send(Message::Ping(Vec::new().into())).await {
+                    return Err(format!("send ping: {e}"));
+                }
+            }
+
             // Incoming WebSocket message from cloud
             msg = read.next() => {
                 match msg {


### PR DESCRIPTION
## Context

Resolves open question #2 from `muxbus/PLAN_WEBSOCKET_RELAY_REDESIGN_2026_07_03.md` (agentmux-cloud repo) — the plan to fix muxbus's real-time push transport, which currently never completes a WS handshake at all (separate, already-diagnosed infra bug: the relay is wired to a bare Lambda Function URL that can't do WebSocket).

## Finding

`cloud_subscriber.rs` already replies correctly to server-initiated WS pings (`Message::Ping` → `Message::Pong`, line ~312), but never sends its own ping and has no application-level heartbeat. The planned relay redesign targets AWS API Gateway WebSocket API, which enforces a **10-minute idle timeout with no server-side keepalive of its own** — silence in both directions drops the connection. Once the server side is fixed, a quiet connection (no `inject_available` traffic) would still get silently dropped every ~10 minutes without this fix.

## Fix

Add a `tokio::time::interval`-driven `Message::Ping` every 4 minutes (comfortably under the 10-minute window) inside the existing `select!` loop in `connect_and_run`.

## Notes
- No behavior change today — the WS handshake to `muxbus.agentmux.ai` currently never succeeds (server-side bug, tracked separately), so this ping never fires in production yet. Purely preparatory for when the relay redesign ships.
- `cargo check -p agentmux-srv` passes clean, no new warnings.

<!-- agentmux:agent_id=agentx -->