### PR TITLE
fix(muxbus): cloud_subscriber keepalive uses app-level ping, not WS-protocol ping

### DIFF
--- a/.changesets/1783111298-fix-muxbus-cloud-subscriber-keepalive-uses-app-level-ping-no-rfe1.md
+++ b/.changesets/1783111298-fix-muxbus-cloud-subscriber-keepalive-uses-app-level-ping-no-rfe1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): cloud_subscriber keepalive uses app-level ping, not WS-protocol ping

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -37,7 +37,11 @@ const MAX_RECONNECT_DELAY_SECS: u64 = 60;
 // AWS API Gateway WebSocket APIs enforce a 10-minute idle timeout with no
 // server-initiated keepalive of their own — the connection is dropped on
 // silence in both directions. Ping well under that so a quiet connection
-// (no inject_available traffic) survives indefinitely.
+// (no inject_available traffic) survives indefinitely. The ping is an
+// app-level ClientMsg::Ping frame, not a WS-protocol-level Message::Ping —
+// API Gateway does not reliably relay raw protocol ping/pong control frames,
+// so a normal data frame is what actually keeps the connection alive in
+// production (see ClientMsg::Ping's doc comment).
 const CLIENT_PING_INTERVAL_SECS: u64 = 240;
 
 // ── Wire protocol ─────────────────────────────────────────────────────────────
@@ -51,6 +55,11 @@ enum ClientMsg {
     #[serde(rename = "subscribe:remove")]
     SubscribeRemove { agents: Vec<String> },
     // Ack removed — ACK is sent via REST POST /reactive/ack, not WS
+    // App-level keepalive — see CLIENT_PING_INTERVAL_SECS. AWS API Gateway
+    // WebSocket APIs (the production transport) do not reliably relay raw
+    // WS-protocol Ping/Pong control frames, so the keepalive must be a normal
+    // data frame the server's $default route can see and reply to.
+    Ping,
 }
 
 #[derive(Deserialize)]
@@ -300,7 +309,9 @@ async fn connect_and_run(
         tokio::select! {
             // Keepalive — see CLIENT_PING_INTERVAL_SECS.
             _ = ping_interval.tick() => {
-                if let Err(e) = write.send(Message::Ping(Vec::new().into())).await {
+                let ping_msg = serde_json::to_string(&ClientMsg::Ping)
+                    .map_err(|e| format!("serialize ping: {e}"))?;
+                if let Err(e) = write.send(Message::Text(ping_msg.into())).await {
                     return Err(format!("send ping: {e}"));
                 }
             }


### PR DESCRIPTION
## Context

Follow-up correction to #1951 (merged). While implementing the actual API Gateway WebSocket relay in `agentmux-cloud` (see [muxbus/PLAN_WEBSOCKET_RELAY_REDESIGN_2026_07_03.md](https://github.com/agentmuxai/agentmux-cloud/blob/main/muxbus/PLAN_WEBSOCKET_RELAY_REDESIGN_2026_07_03.md)), it turned out AWS API Gateway WebSocket APIs do **not** reliably relay raw WS-protocol `Ping`/`Pong` control frames to a Lambda's `$default` route — AWS's documented guidance is to use an application-level message for keepalives instead. #1951's raw `Message::Ping` would likely not reliably keep the connection alive once the real relay ships.

## Fix

- Add `ClientMsg::Ping` — a normal `{"type":"ping"}` data frame, sent the same way as the existing `Subscribe`/`SubscribeAdd` messages.
- Send that (not `Message::Ping`) on the existing `CLIENT_PING_INTERVAL_SECS` timer.
- The server's `$default` route replies `{"type":"pong"}`, which this client already deserializes into `ServerMsg::Pong` (was already a clean no-op match arm — no server-response-handling changes needed).

## Notes
- Still inert in production today — the WS handshake doesn't succeed yet (companion infra PR in `agentmux-cloud` is in review).
- `cargo check -p agentmux-srv` passes clean, no new warnings.

<!-- agentmux:agent_id=agentx -->