### PR TITLE
chore: release v0.49.14

### DIFF
--- a/.changesets/1783044456-docs-correct-claude-md-stale-claim-about-macos-linux-dev-mod-q1dz.md
+++ b/.changesets/1783044456-docs-correct-claude-md-stale-claim-about-macos-linux-dev-mod-q1dz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: correct CLAUDE.md stale claim about macOS/Linux dev-mode launcher bypass

--- a/.changesets/1783044933-feat-launcher-instrument-host-spawn-latency-as-a-startup-sta-besx.md
+++ b/.changesets/1783044933-feat-launcher-instrument-host-spawn-latency-as-a-startup-sta-besx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(launcher): instrument host-spawn latency as a startup stage (unix + windows)

--- a/.changesets/1783061882-perf-launcher-overlap-saga-recovery-ipc-server-setup-with-sr-c06i.md
+++ b/.changesets/1783061882-perf-launcher-overlap-saga-recovery-ipc-server-setup-with-sr-c06i.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-perf(launcher): overlap saga recovery/IPC-server setup with srv spawn

--- a/.changesets/1783062549-feat-launcher-macos-splash-shows-live-startup-stage-load-tim-e9fw.md
+++ b/.changesets/1783062549-feat-launcher-macos-splash-shows-live-startup-stage-load-tim-e9fw.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(launcher): macOS splash shows live startup-stage load times

--- a/.changesets/1783062817-docs-correct-launch-speed-audit-finding-close-out-spec-statu-3fic.md
+++ b/.changesets/1783062817-docs-correct-launch-speed-audit-finding-close-out-spec-statu-3fic.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: correct launch-speed audit finding, close out spec status

--- a/.changesets/1783063200-fix-armory-distinct-vault-icon-trust-center-comment-sweep-ic3x.md
+++ b/.changesets/1783063200-fix-armory-distinct-vault-icon-trust-center-comment-sweep-ic3x.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): distinct vault icon + Trust Center comment sweep

--- a/.changesets/1783063556-fix-scripts-resolve-task-via-pathext-instead-of-hardcoded-ex-2dyj.md
+++ b/.changesets/1783063556-fix-scripts-resolve-task-via-pathext-instead-of-hardcoded-ex-2dyj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(scripts): resolve task via PATHEXT instead of hardcoded .exe extension in agent bridge scripts

--- a/.changesets/1783064614-fix-muxbus-quote-windows-browser-open-url-so-cmd-exe-doesn-t-titf.md
+++ b/.changesets/1783064614-fix-muxbus-quote-windows-browser-open-url-so-cmd-exe-doesn-t-titf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): quote Windows browser-open URL so cmd.exe doesn't truncate it at the first &

--- a/.changesets/1783068338-fix-memory-pagefile-hygiene-fixes-wps-persist-map-pruning-bo-6ax8.md
+++ b/.changesets/1783068338-fix-memory-pagefile-hygiene-fixes-wps-persist-map-pruning-bo-6ax8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(memory): pagefile hygiene fixes — WPS persist_map pruning, bounded WS egress, SubagentWatcher capping, pool refill guard under commit pressure

--- a/.changesets/1783090047-feat-armory-mcp-ts-skill-ts-rpc-api-bindings-for-the-standal-m1j8.md
+++ b/.changesets/1783090047-feat-armory-mcp-ts-skill-ts-rpc-api-bindings-for-the-standal-m1j8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): mcp.ts/skill.ts rpc-api bindings for the standalone MCP Server + Skill primitives

--- a/.changesets/1783090366-feat-armory-mcp-servers-skills-tabs-in-the-agent-setup-modal-jeyb.md
+++ b/.changesets/1783090366-feat-armory-mcp-servers-skills-tabs-in-the-agent-setup-modal-jeyb.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): MCP Servers + Skills tabs in the Agent setup modal

--- a/.changesets/1783107603-feat-armory-mcp-servers-skills-catalog-tabs-f442.md
+++ b/.changesets/1783107603-feat-armory-mcp-servers-skills-catalog-tabs-f442.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): MCP Servers + Skills catalog tabs

--- a/.changesets/1783108870-feat-identity-launch-flow-writes-direct-account-links-alongs-8els.md
+++ b/.changesets/1783108870-feat-identity-launch-flow-writes-direct-account-links-alongs-8els.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(identity): launch flow writes direct account links alongside the bundle pick

--- a/.changesets/1783109150-fix-muxbus-cloud-subscriber-sends-periodic-ws-ping-to-surviv-1k70.md
+++ b/.changesets/1783109150-fix-muxbus-cloud-subscriber-sends-periodic-ws-ping-to-surviv-1k70.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): cloud_subscriber sends periodic WS ping to survive API Gateway idle timeout

--- a/.changesets/1783109985-fix-identity-re-run-direct-link-backfill-to-catch-the-m0013--nuat.md
+++ b/.changesets/1783109985-fix-identity-re-run-direct-link-backfill-to-catch-the-m0013--nuat.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): re-run direct-link backfill to catch the m0013-to-write-through gap

--- a/.changesets/1783111298-fix-muxbus-cloud-subscriber-keepalive-uses-app-level-ping-no-rfe1.md
+++ b/.changesets/1783111298-fix-muxbus-cloud-subscriber-keepalive-uses-app-level-ping-no-rfe1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): cloud_subscriber keepalive uses app-level ping, not WS-protocol ping

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.13"
+version = "0.49.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.13"
+version = "0.49.14"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.13"
+version = "0.49.14"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.13"
+version = "0.49.14"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.13"
+version = "0.49.14"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.13"
+version = "0.49.14"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.13"
+version = "0.49.14"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,25 @@
 # AgentMux Version History
 
+## 0.49.14 — 2026-07-03
+
+- docs: correct CLAUDE.md stale claim about macOS/Linux dev-mode launcher bypass
+- feat(launcher): instrument host-spawn latency as a startup stage (unix + windows)
+- perf(launcher): overlap saga recovery/IPC-server setup with srv spawn
+- feat(launcher): macOS splash shows live startup-stage load times
+- docs: correct launch-speed audit finding, close out spec status
+- fix(armory): distinct vault icon + Trust Center comment sweep
+- fix(scripts): resolve task via PATHEXT instead of hardcoded .exe extension in agent bridge scripts
+- fix(muxbus): quote Windows browser-open URL so cmd.exe doesn't truncate it at the first &
+- fix(memory): pagefile hygiene fixes — WPS persist_map pruning, bounded WS egress, SubagentWatcher capping, pool refill guard under commit pressure
+- feat(armory): mcp.ts/skill.ts rpc-api bindings for the standalone MCP Server + Skill primitives
+- feat(armory): MCP Servers + Skills tabs in the Agent setup modal
+- feat(armory): MCP Servers + Skills catalog tabs
+- feat(identity): launch flow writes direct account links alongside the bundle pick
+- fix(muxbus): cloud_subscriber sends periodic WS ping to survive API Gateway idle timeout
+- fix(identity): re-run direct-link backfill to catch the m0013-to-write-through gap
+- fix(muxbus): cloud_subscriber keepalive uses app-level ping, not WS-protocol ping
+
+
 ## 0.49.13 — 2026-07-02
 
 - fix(agent): promote Mode to composer strip, un-nest Controls from Log, style Session buttons

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.13",
+  "version": "0.49.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.13",
+      "version": "0.49.14",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.13",
+  "version": "0.49.14",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR consuming all 16 pending changesets — forced patch bump (`task release -- --as patch`) even though some queued changes are minor-level, per user request.

`0.49.13` → `0.49.14`. All 5 release-consistency-invariant locations agree (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`).

Includes this session's Track A (MCP Servers + Skills surfacing in the Agent-setup modal and Armory) and the first two Track B PRs (launch-flow direct-link write-through + backfill migration), plus several other agents' merged changesets (launcher startup instrumentation, muxbus keepalive fixes, memory hygiene fixes, etc.) — see `VERSION_HISTORY.md`'s new `0.49.14` section for the full list.

## Test plan
- [x] `task release -- --as patch` completed cleanly, reported all 5 version locations in agreement
- [x] Verified `VERSION_HISTORY.md`'s new section lists all 16 consumed changesets
- [x] No manual edits beyond what the release script generated

<!-- agentmux:agent_id=agent1 -->