### PR TITLE
fix(muxbus): cloud_subscriber connects to dedicated wss://muxbus-ws.agentmux.ai domain

### DIFF
--- a/.changesets/1783112030-fix-muxbus-cloud-subscriber-connects-to-dedicated-wss-muxbus-p9md.md
+++ b/.changesets/1783112030-fix-muxbus-cloud-subscriber-connects-to-dedicated-wss-muxbus-p9md.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): cloud_subscriber connects to dedicated wss://muxbus-ws.agentmux.ai domain

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Cloud push subscription — replaces per-agent polling with a single
-//! sidecar-level WebSocket to muxbus.agentmux.ai.
+//! sidecar-level WebSocket to muxbus-ws.agentmux.ai.
 //!
 //! When MUXBUS_TOKEN is present, the subscriber:
-//!   1. Opens wss://muxbus.agentmux.ai/ws with the bearer token.
+//!   1. Opens wss://muxbus-ws.agentmux.ai with the bearer token.
 //!   2. Listens for { type: "inject_available" } broadcast wake signals (zero metadata).
 //!   3. On each signal, polls REST GET /reactive/pending/:id for every locally-registered agent.
 //!   4. Delivers via ReactiveHandler; ACKs successful deliveries via REST POST /reactive/ack.

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -32,12 +32,12 @@ use crate::backend::storage::store::Store;
 
 // Dedicated custom domain on the API Gateway WebSocket API (apigatewayv2
 // DomainName + ApiMapping), not a path under muxbus.agentmux.ai's CloudFront
-// distribution — see agentmux-cloud's
-// muxbus/PLAN_WEBSOCKET_RELAY_REDESIGN_2026_07_03.md for why (a CloudFront
-// path behavior would have forwarded this client's literal /ws request path
-// prefixed by originPath, landing at /{stage}/ws on the origin — but the WS
-// handshake endpoint only exists at exactly /{stage}). No path suffix here:
-// the domain root maps directly to the API's default stage.
+// distribution. A CloudFront path behavior would have forwarded this
+// client's literal /ws request path prefixed by originPath, landing at
+// /{stage}/ws on the origin — but the WS handshake endpoint only exists at
+// exactly /{stage}. No path suffix here: the domain root maps directly to
+// the API's default stage. Full design/history in the agentmux-cloud repo's
+// muxbus/ directory (search for the WebSocket relay redesign writeup).
 const MUXBUS_WS_URL: &str = "wss://muxbus-ws.agentmux.ai";
 const MUXBUS_REST_URL: &str = "https://muxbus.agentmux.ai";
 const RECONNECT_DELAY_SECS: u64 = 5;

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -30,7 +30,15 @@ use crate::backend::reactive::handler::get_global_handler;
 use crate::backend::reactive::types::InjectionRequest;
 use crate::backend::storage::store::Store;
 
-const MUXBUS_WS_URL: &str = "wss://muxbus.agentmux.ai/ws";
+// Dedicated custom domain on the API Gateway WebSocket API (apigatewayv2
+// DomainName + ApiMapping), not a path under muxbus.agentmux.ai's CloudFront
+// distribution — see agentmux-cloud's
+// muxbus/PLAN_WEBSOCKET_RELAY_REDESIGN_2026_07_03.md for why (a CloudFront
+// path behavior would have forwarded this client's literal /ws request path
+// prefixed by originPath, landing at /{stage}/ws on the origin — but the WS
+// handshake endpoint only exists at exactly /{stage}). No path suffix here:
+// the domain root maps directly to the API's default stage.
+const MUXBUS_WS_URL: &str = "wss://muxbus-ws.agentmux.ai";
 const MUXBUS_REST_URL: &str = "https://muxbus.agentmux.ai";
 const RECONNECT_DELAY_SECS: u64 = 5;
 const MAX_RECONNECT_DELAY_SECS: u64 = 60;


### PR DESCRIPTION
## Context

Companion to [agentmuxai/agentmux-cloud#22](https://github.com/agentmuxai/agentmux-cloud/pull/22) (the API Gateway WebSocket relay). That PR's original design fronted the relay with a CloudFront `/ws*` path behavior under the existing `muxbus.agentmux.ai` distribution, but review caught a real bug (reagent P0): CloudFront forwards the viewer's literal request path (`/ws`) prefixed by `originPath` (`/{stage}`), landing origin requests at `/{stage}/ws` — but the WS API's handshake endpoint only exists at exactly `/{stage}`. That combination was never actually tested (the plan doc's verification spike only tested a root/default CloudFront behavior).

## Fix

agentmux-cloud#22 was redesigned to give the WebSocket API its **own dedicated custom domain** (`apigatewayv2.DomainName` + `ApiMapping`) instead of a CloudFront path behavior — matching this org's own established pattern for API Gateway custom domains, and sidestepping the path-math risk entirely. No CloudFront involved in the WS path at all now.

This requires updating `MUXBUS_WS_URL` here: `wss://muxbus.agentmux.ai/ws` → `wss://muxbus-ws.agentmux.ai` (no path suffix — the domain root maps directly to the API's default stage).

## Notes
- `MUXBUS_REST_URL` (`https://muxbus.agentmux.ai`) is unaffected — REST paths still go through the existing CloudFront distribution unchanged.
- Still inert in production today — the relay redesign itself is in review.
- `cargo check -p agentmux-srv` passes clean, no new warnings.

<!-- agentmux:agent_id=agentx -->