### PR TITLE
chore: release v0.50.0

### DIFF
--- a/.changesets/1783068648-feat-cef-report-cef-dlopen-cef-init-sub-stages-to-splash-tel-bkzr.md
+++ b/.changesets/1783068648-feat-cef-report-cef-dlopen-cef-init-sub-stages-to-splash-tel-bkzr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(cef): report CEF dlopen + cef_init sub-stages to splash telemetry

--- a/.changesets/1783090820-feat-agent-headless-term-sub-block-spike-for-the-shell-drawe-gb6q.md
+++ b/.changesets/1783090820-feat-agent-headless-term-sub-block-spike-for-the-shell-drawe-gb6q.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): headless term sub-block spike for the Shell drawer (createsubblock/deletesubblock RPCs)

--- a/.changesets/1783092345-feat-ambient-unified-gateway-for-background-model-calls-acti-y5d5.md
+++ b/.changesets/1783092345-feat-ambient-unified-gateway-for-background-model-calls-acti-y5d5.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(ambient): unified gateway for background model calls (activity-summary coalescing, cancellation, token accounting)

--- a/.changesets/1783112030-fix-muxbus-cloud-subscriber-connects-to-dedicated-wss-muxbus-p9md.md
+++ b/.changesets/1783112030-fix-muxbus-cloud-subscriber-connects-to-dedicated-wss-muxbus-p9md.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): cloud_subscriber connects to dedicated wss://muxbus-ws.agentmux.ai domain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.49.14"
+version = "0.50.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.49.14"
+version = "0.50.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.49.14"
+version = "0.50.0"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.49.14"
+version = "0.50.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.49.14"
+version = "0.50.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.49.14"
+version = "0.50.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.49.14"
+version = "0.50.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.50.0 — 2026-07-03
+
+- feat(cef): report CEF dlopen + cef_init sub-stages to splash telemetry
+- feat(agent): headless term sub-block spike for the Shell drawer (createsubblock/deletesubblock RPCs)
+- feat(ambient): unified gateway for background model calls (activity-summary coalescing, cancellation, token accounting)
+- fix(muxbus): cloud_subscriber connects to dedicated wss://muxbus-ws.agentmux.ai domain
+
+
 ## 0.49.14 — 2026-07-03
 
 - docs: correct CLAUDE.md stale claim about macOS/Linux dev-mode launcher bypass

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.49.14",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.49.14",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.49.14",
+  "version": "0.50.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes 4 pending changesets (minor bump, highest-typed change wins):
- feat(cef): report cef_dlopen/cef_init sub-stages to splash telemetry
- feat(agent): headless term sub-block spike for the Shell drawer
- feat: ambient unified gateway for background model calls
- fix(muxbus): cloud_subscriber connects to dedicated wss://muxbus-ws.agentmux.ai domain

The muxbus changeset is the one this release exists for — it ships the corrected WebSocket relay URL (`wss://muxbus-ws.agentmux.ai`) to real users for the first time. v0.49.13/v0.49.14 merged but were never tagged, so no build has shipped since v0.49.12; this consumes everything queued since then.

All 5 version locations agree at 0.50.0.

<!-- agentmux:agent_id=agentx -->