### PR TITLE
fix(muxbus): claim injections before local delivery to prevent cross-channel duplicates

### DIFF
--- a/.changesets/1783132884-fix-muxbus-claim-injections-before-local-delivery-to-prevent-t7pp.md
+++ b/.changesets/1783132884-fix-muxbus-claim-injections-before-local-delivery-to-prevent-t7pp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): claim injections before local delivery to prevent cross-channel duplicates

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -400,6 +400,11 @@ async fn handle_server_msg(
                 message: String,
                 priority: Option<String>,
             }
+            #[derive(Deserialize)]
+            struct AckResp {
+                acknowledged: Vec<String>,
+                delivered_at: String,
+            }
 
             let handler = get_global_handler();
             for agent_id in &registered {
@@ -439,8 +444,56 @@ async fn handle_server_msg(
                     }
                 };
 
-                let mut ack_ids: Vec<String> = Vec::new();
+                if body.injections.is_empty() {
+                    continue;
+                }
+
+                // Claim BEFORE delivering, not after: this is what prevents
+                // double-delivery when the same agent_id is concurrently
+                // registered by another AgentMux channel on this host (an
+                // intentionally-supported "two seats" workflow — see
+                // docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md).
+                // /reactive/ack now performs an atomic pending->delivered
+                // transition server-side; only injection ids that come back
+                // in `acknowledged` were actually won by this call and get
+                // delivered locally below. A previous version of this code
+                // delivered first and only acked successes afterward, which
+                // let two concurrent pollers both deliver the same injection.
+                let all_ids: Vec<String> = body.injections.iter().map(|inj| inj.id.clone()).collect();
+                let ack_url = format!("{}/reactive/ack", MUXBUS_REST_URL);
+                let claim_resp = match http
+                    .post(&ack_url)
+                    .header("Authorization", format!("Bearer {}", token))
+                    .header("X-Agent-ID", agent_id)
+                    .json(&serde_json::json!({ "injection_ids": all_ids }))
+                    .send()
+                    .await
+                {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::warn!(agent_id = %agent_id, error = %e, "cloud_subscriber: claim request failed");
+                        continue; // nothing claimed — retried on the next wake/poll
+                    }
+                };
+                let claimed: AckResp = match claim_resp.json().await {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "cloud_subscriber: parse claim response failed");
+                        continue;
+                    }
+                };
+                let delivered_at = claimed.delivered_at;
+                let claimed_ids: std::collections::HashSet<String> =
+                    claimed.acknowledged.into_iter().collect();
+
                 for inj in &body.injections {
+                    if !claimed_ids.contains(&inj.id) {
+                        // Another concurrent poller (this account's other
+                        // channel/seat) already won this claim — expected
+                        // under the "two seats" workflow, not an error.
+                        continue;
+                    }
+
                     let req = InjectionRequest {
                         target_agent: agent_id.clone(),
                         message: inj.message.clone(),
@@ -458,22 +511,24 @@ async fn handle_server_msg(
                         success = delivery.success,
                         "cloud_subscriber: delivered injection"
                     );
-                    // Only ACK successfully delivered injections — failed deliveries stay
-                    // in the queue so the cloud can retry (e.g. rate-limited or agent not ready).
-                    if delivery.success {
-                        ack_ids.push(inj.id.clone());
-                    }
-                }
 
-                if !ack_ids.is_empty() {
-                    let ack_url = format!("{}/reactive/ack", MUXBUS_REST_URL);
-                    let _ = http
-                        .post(&ack_url)
-                        .header("Authorization", format!("Bearer {}", token))
-                        .header("X-Agent-ID", agent_id)
-                        .json(&serde_json::json!({ "injection_ids": ack_ids }))
-                        .send()
-                        .await;
+                    if !delivery.success {
+                        // We hold the claim but local delivery failed (e.g.
+                        // agent not ready) — release it back to pending so
+                        // it's retried, instead of silently dropping it now
+                        // that claiming already marked it "delivered".
+                        let release_url = format!("{}/reactive/release", MUXBUS_REST_URL);
+                        let _ = http
+                            .post(&release_url)
+                            .header("Authorization", format!("Bearer {}", token))
+                            .header("X-Agent-ID", agent_id)
+                            .json(&serde_json::json!({
+                                "injection_id": inj.id,
+                                "delivered_at": delivered_at,
+                            }))
+                            .send()
+                            .await;
+                    }
                 }
             }
         }

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -495,7 +495,26 @@ async fn handle_server_msg(
                 let claimed: AckResp = match claim_resp.json().await {
                     Ok(b) => b,
                     Err(e) => {
-                        tracing::warn!(error = %e, "cloud_subscriber: parse claim response failed");
+                        // The server processed the claim (status was 2xx) before this
+                        // body failed to parse — some subset of `all_ids` may now be
+                        // flipped to "delivered" server-side with no local delivery
+                        // and no way for us to release them, since we don't know
+                        // which ids succeeded or their delivered_at stamp (required
+                        // by /reactive/release). We deliberately do NOT guess (e.g.
+                        // via /reactive/status) and release whatever looks delivered:
+                        // some of `all_ids` may have been legitimately claimed and
+                        // delivered by a *different* concurrent poller (another
+                        // channel/seat racing for the same agent_id), and blindly
+                        // releasing those would reintroduce the exact duplicate-
+                        // delivery bug this change exists to fix. Logging every
+                        // affected id loudly is the safe tradeoff: rare silent
+                        // message loss here, never a resurrected duplicate.
+                        tracing::error!(
+                            agent_id = %agent_id,
+                            injection_ids = ?all_ids,
+                            error = %e,
+                            "cloud_subscriber: parse claim response failed — these injections may be claimed server-side with no local delivery and cannot be safely auto-recovered"
+                        );
                         continue;
                     }
                 };

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -8,7 +8,12 @@
 //!   1. Opens wss://muxbus-ws.agentmux.ai with the bearer token.
 //!   2. Listens for { type: "inject_available" } broadcast wake signals (zero metadata).
 //!   3. On each signal, polls REST GET /reactive/pending/:id for every locally-registered agent.
-//!   4. Delivers via ReactiveHandler; ACKs successful deliveries via REST POST /reactive/ack.
+//!   4. Claims all pending injections via REST POST /reactive/ack (atomic
+//!      pending->delivered transition server-side) *before* delivering — only
+//!      ids this call actually won the claim on get delivered via
+//!      ReactiveHandler. A claimed injection that fails local delivery is
+//!      released back to pending via REST POST /reactive/release so it's
+//!      retried, rather than silently dropped.
 //!   5. Reconnects with exponential back-off on any disconnect.
 //!
 //! The server broadcasts to ALL connected sidecars on every injection, so a subscriber
@@ -475,6 +480,18 @@ async fn handle_server_msg(
                         continue; // nothing claimed — retried on the next wake/poll
                     }
                 };
+                if claim_resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+                    // Token expired during session — reconnect to refresh.
+                    return Err("reconnect:token_expired".to_string());
+                }
+                if !claim_resp.status().is_success() {
+                    tracing::warn!(
+                        status = %claim_resp.status(),
+                        agent_id = %agent_id,
+                        "cloud_subscriber: claim request non-2xx"
+                    );
+                    continue; // nothing claimed — retried on the next wake/poll
+                }
                 let claimed: AckResp = match claim_resp.json().await {
                     Ok(b) => b,
                     Err(e) => {
@@ -518,7 +535,7 @@ async fn handle_server_msg(
                         // it's retried, instead of silently dropping it now
                         // that claiming already marked it "delivered".
                         let release_url = format!("{}/reactive/release", MUXBUS_REST_URL);
-                        let _ = http
+                        match http
                             .post(&release_url)
                             .header("Authorization", format!("Bearer {}", token))
                             .header("X-Agent-ID", agent_id)
@@ -527,7 +544,29 @@ async fn handle_server_msg(
                                 "delivered_at": delivered_at,
                             }))
                             .send()
-                            .await;
+                            .await
+                        {
+                            Ok(r) if r.status().is_success() => {}
+                            Ok(r) => {
+                                // Claim is stranded as "delivered" with no local
+                                // delivery and no retry until this is visible —
+                                // log loudly rather than discarding silently.
+                                tracing::warn!(
+                                    injection_id = %inj.id,
+                                    agent_id = %agent_id,
+                                    status = %r.status(),
+                                    "cloud_subscriber: release request non-2xx — injection stranded as delivered, message lost"
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    injection_id = %inj.id,
+                                    agent_id = %agent_id,
+                                    error = %e,
+                                    "cloud_subscriber: release request failed — injection stranded as delivered, message lost"
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md
+++ b/docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md
@@ -1,0 +1,167 @@
+# Plan: muxbus cross-channel duplicate delivery
+
+**Status:** Draft — investigation complete, not yet implemented. Written for
+review before touching either repo.
+**Author:** AgentX
+**Date:** 2026-07-04
+**Related:** #1916 (MuxBus cross-channel *local* delivery — the mirror-image
+problem; same root cause, opposite symptom).
+
+## Problem
+
+Two different AgentMux channels (e.g. a dev build and a portable build, or two
+different versions) running on the same host, each with an agent named
+`agent_id`, can cause muxbus to **silently deliver the same jekt twice** — once
+into each channel's local pane — because nothing arbitrates that name across
+channels.
+
+### Why this is possible, not hypothetical
+
+- `agent_id` is a free-text string set at launch (`AGENTMUX_AGENT_ID`),
+  validated only for *format* (`sanitize.rs:124-131` — ASCII
+  alphanumeric/`_`/`-`, ≤64 chars). There is no uniqueness check anywhere:
+  `Handler::register_agent` (`agentmux-srv/src/backend/reactive/handler.rs:102-142`)
+  is a per-process in-memory `HashMap` that can't see other channels' agents,
+  and `db_agent_definitions`' only `UNIQUE INDEX` is on `slug`, not `name`
+  (`migrations.rs:143-171`).
+- The product **intentionally sanctions** running two live sessions of the
+  same-named agent at once — `SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md`
+  §9: *"Two running instances of same name — Allowed... Users do this rarely
+  but it's a real workflow."*
+- muxbus credentials are **global across channels** (PR #1750,
+  `~/.agentmux/shared/store.db`), so both channels' `cloud_subscriber`
+  connects under the identical account.
+
+### The actual failure sequence
+
+1. Channel A and Channel B both have an agent named `agentx` locally active.
+   Both call `cloud_subscriber::add_agent("agentx")`
+   (`server/agent_handlers/input.rs:411-412`) on their own independent WS
+   connection.
+2. A jekt arrives for `agentx`. The server broadcasts a zero-metadata
+   `{type:"inject_available"}` wake to **every** connected socket on the
+   account — there is no per-agent or per-connection routing
+   (`index.ts:70-72`: *"routing is broadcast, not per-agent"*).
+3. Both A and B poll `GET /reactive/pending/agentx`. This is a plain DynamoDB
+   `Query` with no claim/lock (`store.ts:213-225`) — both get the same pending
+   injection.
+4. Both locally deliver it (`cloud_subscriber.rs:443-466`,
+   `handler.inject_message`).
+5. Both call `POST /reactive/ack`. `acknowledgeInjections` (`store.ts:232-252`)
+   does an **unconditional** `PutCommand` setting `status: "delivered"` — no
+   already-delivered guard, so the second ack just silently overwrites the
+   same field. Neither side sees an error.
+
+Net effect: the sender's one message reaches two panes, with no signal to
+either side that this happened.
+
+### Severity / how urgent is this
+
+- **Not a billing problem** — `GET /reactive/pending` and `POST /reactive/ack`
+  have no `consumeQuota` call anywhere (confirmed via full grep of
+  `quota.ts`/`index.ts`); only `jekt_messages` (send) and `drone_runs`
+  (inject) are metered.
+- **Not triggered by ordinary channel sprawl.** Issue #1916's own worked
+  example ("15+ per-channel `agents/` registries") is explicitly *stale disk
+  residue* — a collided entry's `pid` was dead and `updated_at` was ~6 weeks
+  old. Old, non-running channel directories accumulating on disk (a
+  documented, separately-tracked cleanup gap — see `CLAUDE.md`'s "Data
+  isolation is per-BUILD" section) do **not** trigger this bug.
+- The bug requires the narrower, deliberate condition: the *same agent name*
+  concurrently live in 2+ channels, **and** a jekt landing in that overlap
+  window. Given "two seats of the same name" is described as rare in its own
+  spec, this is real but not a five-alarm fire — worth fixing, not worth a
+  hotfix.
+
+## Relationship to #1916
+
+Both problems trace to the same gap: nothing arbitrates `agent_id` identity
+across channels on one host.
+
+- **#1916 (delivery miss):** Tier-2 local file registry is siloed per-channel
+  (invariant I6), so a message to an agent in a *different* channel can't find
+  it at all. Proposed fix: a host-global registry at
+  `~/.agentmux/shared/reactive-agents/{agent_id}.json`, explicitly scoped to
+  Tiers 2/3 (same-host local delivery) — cloud/Tier 4 called out as
+  unchanged/out of scope.
+- **This doc (delivery duplicate):** Tier 4 (cloud) has the opposite problem —
+  it has *no* channel scoping at all, so the same name active in two channels
+  gets the *same* cloud-originated message delivered to *both*.
+
+A single shared concept could address both: if #1916's host-global registry
+tracked *which channel(s)* currently have a given `agent_id` locally active,
+the cloud-delivery race in this doc could be resolved by making the
+claim/delivery atomic per *(agent_id)* regardless of which channel's
+`cloud_subscriber` gets there first — the registry itself doesn't need to
+pick a "winner" channel, only the claim step does. **Recommend implementing
+whichever of these ships first with the other in mind** — they likely share
+a migration/design review, even if the actual code changes land separately
+(one is agentmux-only, this one spans agentmux + agentmux-cloud).
+
+## Proposed fix: move the claim before delivery, not after
+
+The core bug is a protocol ordering problem: today the flow is
+**poll → deliver locally → ack**. Ack currently means "mark read," not
+"claim." Two pollers can both pass the poll step before either acks, so both
+deliver.
+
+Fix: make the **claim atomic and come first**, so only one sidecar ever
+proceeds to local delivery.
+
+### Server-side (`agentmux-cloud`, `muxbus/server/src/store.ts` + `index.ts`)
+
+- Change `acknowledgeInjections` (or add a new endpoint, TBD during design) to
+  perform a **conditional** DynamoDB update:
+  ```
+  ConditionExpression: "status = :pending"
+  ExpressionAttributeValues: { ":pending": "pending" }
+  ```
+  on the existing `status` field, atomically flipping it to `"delivered"`
+  only if it was still `"pending"`.
+- On `ConditionalCheckFailedException`, return a clear "already claimed"
+  signal (e.g. `409 Conflict` or `{claimed: false}` in the response body) —
+  today's ack has no failure mode to signal at all.
+- This must happen **before** the sidecar delivers locally, not after — i.e.
+  the call sequence changes from "poll, deliver, ack" to "poll, claim
+  (attempt), deliver only if claim succeeded."
+
+### Client-side (`agentmux`, `agentmux-srv/src/muxbus/cloud_subscriber.rs`)
+
+- Restructure `handle_server_msg`'s `InjectAvailable` handling
+  (`cloud_subscriber.rs:443-466` area): for each pending injection returned by
+  poll, call the claim step *before* `handler.inject_message(req)`. Only
+  deliver locally if the claim succeeded; skip silently (this is the expected,
+  correct outcome when another seat won the race) if it didn't.
+- No change needed to the "two seats" capability itself — both seats can
+  still run concurrently; only the *message delivery* becomes exactly-once
+  across them, delivered to whichever seat's poll happens to win. That's
+  correct from the sender's perspective (the message reached "the agent"),
+  even though which physical pane it landed in is arbitrary.
+
+## Scope / non-goals
+
+- **Not** trying to prevent or warn about same-name agents across channels —
+  that's an intentional product capability, don't fight it.
+- **Not** trying to pick an authoritative "primary" channel for a given
+  agent name — the atomic-claim approach makes that unnecessary; whichever
+  seat polls first legitimately wins, no arbitration needed.
+- **Not** addressing #1916's local Tier-2/3 delivery-miss gap — cross-reference
+  only, separate implementation.
+
+## Open questions
+
+1. Should the claim step be a change to `POST /reactive/ack`'s semantics
+   (breaking: existing callers currently expect ack to always succeed), or a
+   new endpoint (e.g. `POST /reactive/claim`) called before delivery, with
+   `/reactive/ack` staying as a separate "mark fully processed" step after
+   successful local delivery? Leaning toward a new endpoint to avoid changing
+   existing ack semantics for callers that don't need claim ordering (e.g. the
+   TS `muxbus-client` package's poll loop, which may have different
+   correctness requirements).
+2. Does the GitHub PR-review consumer (`consumers/github/handler.ts`) ever
+   poll on behalf of an agent name that could collide across channels, or is
+   its delivery path exclusively `POST /reactive/inject` (write-only, not
+   subject to this race)? If write-only, no client-side change needed there.
+3. Worth a regression test that spins up two local `MessageStore` instances
+   (or two poll calls in quick succession) against the same injection to
+   confirm exactly-once claim semantics before shipping.


### PR DESCRIPTION
## Problem

When the same `agent_id` is concurrently registered by two different AgentMux channels on one host (an intentionally-supported "two seats" workflow — `SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md`), both channels' `cloud_subscriber` connections poll the same pending injection and both deliver it locally before either acks — the ack step happened *after* delivery, purely as a "mark read" step, so nothing prevented both from delivering. Full investigation + design: [`docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md`](docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md) (included in this PR).

## Fix

Companion to [agentmuxai/agentmux-cloud#23](https://github.com/agentmuxai/agentmux-cloud/pull/23), which made `/reactive/ack` an atomic conditional claim (`pending`→`delivered`) instead of an unconditional overwrite, and added `POST /reactive/release` as the failure-path counterpart.

This PR is what actually changes the *call order* — restructures `InjectAvailable` handling:

**Before:** poll → deliver all → ack only the ones that delivered successfully
**After:** poll → **claim all** (via `/reactive/ack`, now atomic) → deliver only the ones this call actually won the claim on → release back to pending any claimed-but-locally-failed delivery

- If another channel's poller already won the claim for a given injection id, this sidecar simply skips it (not logged as an error — expected under the "two seats" workflow).
- Injections claimed here but that fail local delivery (e.g. target agent not ready) get released via `/reactive/release`, preserving today's retry-on-failure behavior instead of silently dropping them now that claiming marks them delivered immediately.

## Notes
- `cargo check -p agentmux-srv` passes clean, no new warnings.
- No behavior change for the common case (single channel, no collision) — same poll → deliver flow, just with an atomic claim step that's a no-op contention-wise when there's only one poller.

<!-- agentmux:agent_id=agentx -->