### PR TITLE
feat(agent): ghost-text next-prompt suggestion via the Ambient Model Call gateway

### DIFF
--- a/.changesets/1783156315-feat-agent-ghost-text-next-prompt-suggestion-via-the-ambient-3vcb.md
+++ b/.changesets/1783156315-feat-agent-ghost-text-next-prompt-suggestion-via-the-ambient-3vcb.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): ghost-text next-prompt suggestion via the Ambient Model Call gateway

--- a/.changesets/1783198154-fix-agent-clear-stale-next-prompt-ghost-text-on-session-end-nu35.md
+++ b/.changesets/1783198154-fix-agent-clear-stale-next-prompt-ghost-text-on-session-end-nu35.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): clear stale next-prompt ghost text on session end

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -352,6 +352,11 @@ pub const COMMAND_SESSION_EXPORT: &str = "session:export";
 // routed through the Ambient Model Call gateway, crate::ambient)
 pub const COMMAND_SESSION_ACTIVITY_SUMMARY: &str = "session:activity_summary";
 
+// Per-turn ghost-text next-prompt suggestion (Haiku-powered, writes
+// term:next_prompt_suggestion; routed through the Ambient Model Call gateway,
+// crate::ambient). See docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md.
+pub const COMMAND_SESSION_NEXT_PROMPT_SUGGESTION: &str = "session:next_prompt_suggestion";
+
 // Option E (PR 1 of 2) — agent-anchored session zones.
 // A session zone is bound to the *agent definition* (`definition_id`),
 // not the identity bundle. Every block of the same agent reads/writes

--- a/agentmux-srv/src/backend/rpc_types/session.rs
+++ b/agentmux-srv/src/backend/rpc_types/session.rs
@@ -38,6 +38,32 @@ pub struct ActivitySummaryResult {
     pub tokens: Option<TokenCounts>,
 }
 
+// ---- Ghost-text next-prompt suggestion types ----
+
+/// Request for session:next_prompt_suggestion — predict a plausible next
+/// user message via Haiku, routed through the Ambient Model Call gateway
+/// (same shape as CommandActivitySummaryData). See
+/// docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandNextPromptSuggestionData {
+    pub block_id: String,
+    /// Caller's generation for this block — see CommandActivitySummaryData's
+    /// doc comment for the wall-clock-vs-remount rationale (identical here).
+    pub generation: u64,
+}
+
+/// Response from session:next_prompt_suggestion. The backend also writes
+/// `term:next_prompt_suggestion` to block meta. `tokens` is `None` under the
+/// same conditions as ActivitySummaryResult.tokens.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct NextPromptSuggestionResult {
+    pub suggestion: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<TokenCounts>,
+}
+
 // ---- Session archival types ----
 
 /// Request for session:archive — compress and archive a session's FileStore output.

--- a/agentmux-srv/src/backend/rpc_types/session.rs
+++ b/agentmux-srv/src/backend/rpc_types/session.rs
@@ -53,9 +53,12 @@ pub struct CommandNextPromptSuggestionData {
     pub generation: u64,
 }
 
-/// Response from session:next_prompt_suggestion. The backend also writes
-/// `term:next_prompt_suggestion` to block meta. `tokens` is `None` under the
-/// same conditions as ActivitySummaryResult.tokens.
+/// Response from session:next_prompt_suggestion. The FRONTEND writes
+/// `term:next_prompt_suggestion` to block meta after receiving this response
+/// (useNextPromptSuggestion.ts) — the handler itself never touches block
+/// meta, same as session:activity_summary's handler (see the inline comment
+/// at its call site in `register_session_activity_summary`). `tokens` is
+/// `None` under the same conditions as ActivitySummaryResult.tokens.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct NextPromptSuggestionResult {

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_session_activity_summary(engine, state);
+    register_session_next_prompt_suggestion(engine, state);
     register_session_archive_handler(engine, state);
     register_session_restore_handler(engine, state);
     register_session_export_handler(engine, state);
@@ -150,40 +151,9 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
                     .map_err(|e| format!("session:activity_summary: {e}"))?
                     .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
 
-                // Read the last 32 KB of agent output from FileStore. EVENT_BLOCK_FILE
-                // events have persist: 0 so the ring buffer is always empty — FileStore
-                // is the only reliable source. We tail-read to avoid loading multi-MB
-                // output files on every turn; 32 KB comfortably covers 30 stream-json lines.
-                const TAIL_BYTES: i64 = 32 * 1024;
-                let all_lines: Vec<String> = match filestore.stat(&cmd.block_id, "output") {
-                    Ok(Some(ref wf)) if wf.size > 0 => {
-                        let tail_offset = (wf.size - TAIL_BYTES).max(0);
-                        match filestore.read_at(&cmd.block_id, "output", tail_offset, TAIL_BYTES) {
-                            Ok((_, bytes)) => {
-                                let text = String::from_utf8_lossy(&bytes);
-                                text.lines()
-                                    .filter(|l| !l.trim().is_empty())
-                                    .map(|l| l.to_string())
-                                    .collect()
-                            }
-                            _ => Vec::new(),
-                        }
-                    }
-                    _ => Vec::new(),
+                let Some(extracted) = read_recent_activity_digest(&filestore, &cmd.block_id) else {
+                    return Ok(Some(empty_summary_result()));
                 };
-
-                let n = all_lines.len();
-                let start = n.saturating_sub(30);
-                let window: Vec<&str> = all_lines[start..].iter().map(|s| s.as_str()).collect();
-
-                if window.is_empty() {
-                    return Ok(Some(empty_summary_result()));
-                }
-
-                let extracted = extract_digest_text(&window);
-                if extracted.is_empty() {
-                    return Ok(Some(empty_summary_result()));
-                }
 
                 let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
                 if cli_path.is_empty() {
@@ -198,7 +168,7 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
                 );
 
                 let (summary, tokens) =
-                    invoke_cli_for_activity(&cli_path, &prompt, &block.meta, cancel).await
+                    invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await
                         .unwrap_or_else(|e| {
                             tracing::debug!(block_id = %cmd.block_id, error = %e, "session:activity_summary: CLI failed or was superseded");
                             (String::new(), None)
@@ -219,20 +189,147 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
     );
 }
 
-/// Invoke the Claude CLI with Haiku model for a lightweight per-turn activity
-/// summary. Uses `--model claude-haiku-4-5-20251001` and a 15s timeout.
+/// Ambient-call purpose tag for the ghost-text next-prompt suggestion. See
+/// docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md.
+const AMBIENT_PURPOSE_NEXT_PROMPT_SUGGESTION: &str = "next_prompt_suggestion";
+
+fn empty_suggestion_result() -> serde_json::Value {
+    serde_json::to_value(&NextPromptSuggestionResult { suggestion: String::new(), tokens: None }).unwrap()
+}
+
+fn register_session_next_prompt_suggestion(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let filestore = state.filestore.clone();
+
+    engine.register_handler(
+        COMMAND_SESSION_NEXT_PROMPT_SUGGESTION,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            Box::pin(async move {
+                let cmd: CommandNextPromptSuggestionData = serde_json::from_value(data)
+                    .map_err(|e| format!("session:next_prompt_suggestion: {e}"))?;
+
+                // Same admission discipline as activity_summary — see that
+                // handler's comment. Ghost text has a sharper failure mode
+                // than the read-only summary (a stale suggestion can put
+                // words in the user's mouth), so admitting before any work
+                // matters just as much here.
+                let key = crate::ambient::AmbientCallKey::new(
+                    cmd.block_id.clone(),
+                    AMBIENT_PURPOSE_NEXT_PROMPT_SUGGESTION,
+                );
+                let guard = match crate::ambient::gateway().admit(key, cmd.generation) {
+                    crate::ambient::Admission::Proceed(guard) => guard,
+                    crate::ambient::Admission::StaleOnArrival => {
+                        return Ok(Some(empty_suggestion_result()));
+                    }
+                };
+                let cancel = guard.cancellation();
+
+                let block: Block = wstore
+                    .get(&cmd.block_id)
+                    .map_err(|e| format!("session:next_prompt_suggestion: {e}"))?
+                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
+
+                let Some(extracted) = read_recent_activity_digest(&filestore, &cmd.block_id) else {
+                    return Ok(Some(empty_suggestion_result()));
+                };
+
+                let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
+                if cli_path.is_empty() {
+                    tracing::debug!(block_id = %cmd.block_id, "session:next_prompt_suggestion: no CLI path in meta");
+                    return Ok(Some(empty_suggestion_result()));
+                }
+
+                let prompt = format!(
+                    "Based on this recent activity, predict ONE short, natural next \
+                     message the user might send to continue the conversation. \
+                     Respond with just that message and nothing else — no quotes, \
+                     no explanation, no preamble. If nothing plausible comes to mind, \
+                     respond with an empty string.\n\n\
+                     Recent activity:\n\n{extracted}"
+                );
+
+                let (suggestion, tokens) =
+                    invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await
+                        .unwrap_or_else(|e| {
+                            tracing::debug!(block_id = %cmd.block_id, error = %e, "session:next_prompt_suggestion: CLI failed or was superseded");
+                            (String::new(), None)
+                        });
+
+                // guard is held until here — same rationale as activity_summary.
+                drop(guard);
+
+                Ok(Some(serde_json::to_value(&NextPromptSuggestionResult { suggestion, tokens }).unwrap()))
+            })
+        }),
+    );
+}
+
+/// Read the last 32 KB of a block's FileStore output, take the most recent
+/// ~30 non-empty lines, and extract digest text from them (`extract_digest_text`).
+/// Shared by both ambient call sites (activity_summary, next_prompt_suggestion)
+/// so their tail-read window stays identical. Returns `None` when there's
+/// nothing usable — callers should return an empty ambient result in that
+/// case without invoking the CLI.
+///
+/// EVENT_BLOCK_FILE events have persist: 0 so the ring buffer is always
+/// empty — FileStore is the only reliable source. Tail-reading avoids
+/// loading multi-MB output files on every turn; 32 KB comfortably covers
+/// 30 stream-json lines.
+fn read_recent_activity_digest(
+    filestore: &crate::backend::storage::filestore::FileStore,
+    block_id: &str,
+) -> Option<String> {
+    const TAIL_BYTES: i64 = 32 * 1024;
+    let all_lines: Vec<String> = match filestore.stat(block_id, "output") {
+        Ok(Some(ref wf)) if wf.size > 0 => {
+            let tail_offset = (wf.size - TAIL_BYTES).max(0);
+            match filestore.read_at(block_id, "output", tail_offset, TAIL_BYTES) {
+                Ok((_, bytes)) => {
+                    let text = String::from_utf8_lossy(&bytes);
+                    text.lines()
+                        .filter(|l| !l.trim().is_empty())
+                        .map(|l| l.to_string())
+                        .collect()
+                }
+                _ => Vec::new(),
+            }
+        }
+        _ => Vec::new(),
+    };
+
+    let n = all_lines.len();
+    let start = n.saturating_sub(30);
+    let window: Vec<&str> = all_lines[start..].iter().map(|s| s.as_str()).collect();
+    if window.is_empty() {
+        return None;
+    }
+
+    let extracted = extract_digest_text(&window);
+    if extracted.is_empty() {
+        return None;
+    }
+    Some(extracted)
+}
+
+/// Invoke the Claude CLI with Haiku model for a lightweight ambient call
+/// (activity summary, ghost-text next-prompt suggestion, or any future
+/// purpose routed through the Ambient Model Call gateway). Uses
+/// `--model claude-haiku-4-5-20251001` and a 15s timeout.
 ///
 /// `cancel` is this call's Ambient Model Call gateway cancellation token — if
-/// a newer request for the same `(block_id, "activity_summary")` key is
-/// admitted while this one is still running, `cancel` fires and the child
-/// process is killed immediately rather than left to run to completion (and
-/// keep burning tokens) only to have its result discarded on arrival.
+/// a newer request for the same `(block_id, purpose)` key is admitted while
+/// this one is still running, `cancel` fires and the child process is killed
+/// immediately rather than left to run to completion (and keep burning
+/// tokens) only to have its result discarded on arrival.
 ///
-/// Returns the summary text plus token usage parsed from the CLI's `result`
+/// Returns the response text plus token usage parsed from the CLI's `result`
 /// stream-json line (same `usage` shape the main turn pipeline parses —
 /// see `agents::translator::claude::parse_usage`), so ambient calls are
 /// never silently excluded from token accounting.
-pub(super) async fn invoke_cli_for_activity(
+pub(super) async fn invoke_ambient_haiku_call(
     cli_path: &str,
     prompt: &str,
     meta: &obj::MetaMapType,

--- a/docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md
+++ b/docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md
@@ -1,0 +1,245 @@
+# SPEC: Ghost-Text Next-Prompt Suggestion — a Second Ambient Model Call Gateway Bind Point
+
+**Date:** 2026-07-03
+**Status:** Draft — investigation complete, design proposed, not yet implemented
+**Related:** `agentmux-srv/src/ambient/mod.rs`, `agentmux-srv/src/server/app_api/session.rs`,
+`frontend/app/view/agent/hooks/useAgentActivitySummary.ts`,
+`frontend/app/view/agent/components/AgentFooter.tsx`,
+`docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md`
+
+---
+
+## 0. TL;DR
+
+Claude Code CLI has a real, shipping "ghost text" feature: after a turn
+finishes, the interactive TUI shows a dimmed, predicted **next user prompt**
+in the empty input box (e.g. "Try running the tests"), accept it with Tab,
+or ignore it and type your own message. Internally it's a `prompt_suggestion`
+stream-json event with schema `{ type: "prompt_suggestion", suggestion:
+string, uuid: string, session_id: string }` (confirmed by inspecting the
+installed CLI binary directly, §1).
+
+**The critical finding: this native mechanism is unreachable from AgentMux.**
+It is unconditionally suppressed whenever Claude Code runs non-interactively
+(`-p`/`--print`) — which is how AgentMux spawns every agent CLI, with no
+exception. Confirmed empirically (§2): even with the CLI's own enabling env
+var set, a real `-p --output-format stream-json --verbose` invocation never
+emits a `prompt_suggestion` event.
+
+So AgentMux cannot "turn on" Claude's ghost text — it has to build its own
+equivalent. That turns out to be exactly what the Ambient Model Call (AMC)
+framework (`docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md`) is
+for: a second ambient call, `next_prompt_suggestion`, built the same shape as
+the existing `activity_summary` one — triggered on `Done`, gated through the
+AMC gateway for coalescing/cancellation, tagged for token accounting — whose
+result is rendered as real ghost text in the composer (§4), a genuinely new
+UI surface, not the existing static placeholder text (§3).
+
+---
+
+## 1. What Claude Code's native feature actually is (ground truth)
+
+Investigated by inspecting the installed CLI binary (`claude` v2.1.112,
+`/c/Users/asafe/.local/bin/claude`) directly for the literal strings its
+compiled bundle contains — not blog posts, which turned out to be
+unreliable for this (§1.3).
+
+### 1.1 Wire schema
+
+A Zod-style schema literal found in the bundle:
+
+```
+h.object({ type: h.literal("prompt_suggestion"), suggestion: h.string(),
+           uuid: D5(), session_id: h.string() })
+```
+
+i.e. the stream-json event shape is:
+
+```json
+{ "type": "prompt_suggestion", "suggestion": "...", "uuid": "...", "session_id": "..." }
+```
+
+A nearby doc string: `"Predicted next user prompt, emitted as..."` — this
+predicts the **user's** likely next message, not a preview of what Claude
+would say next. "Ghost text" here means: an editable, acceptable suggestion
+for what *you* might type next, shown once Claude's own turn is fully done.
+
+### 1.2 Gating — four independent suppression checks
+
+Found in sequence in the bundle (each an early-return that disables the
+feature, source-tagged for telemetry):
+
+| Check | Source tag | Meaning |
+|---|---|---|
+| `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION` env var | `"env"` | explicit env opt-out |
+| A GrowthBook remote feature flag | `"growthbook"` | staged rollout — explains inconsistent reports across users/versions online |
+| **Non-interactive session** (`-p`/print mode) | `"non_interactive"` | **unconditional** — see §2 |
+| Running as a "swarm teammate" (Claude Code's own internal multi-agent concept — unrelated to AgentMux's "Swarm" pane; naming collision, not a technical one) | `"swarm_teammate"` | suppressed for sub-agent/teammate sessions |
+| (only past all the above) `promptSuggestionEnabled !== false` | `"setting"` | final local settings.json toggle |
+
+The GitHub issue that prompted this investigation
+([anthropics/claude-code#34211](https://github.com/anthropics/claude-code/issues/34211))
+reported the feature "silently disappeared" and that its old settings key
+(`showSuggestedNextSteps`) is now a dead key in the compiled CLI — confirmed:
+that exact string has **zero** occurrences in the current binary, while
+`prompt_suggestion` / `promptSuggestionEnabled` have ~50. The feature was
+renamed/reworked, not removed — but remains gated by the checks above,
+independent of that renaming.
+
+### 1.3 A note on research quality
+
+Initial web search results included several SEO "Claude cheat codes" blog
+posts confidently describing a `--prompt-suggestions` CLI flag. That flag
+**does not exist** — confirmed by running the real installed CLI:
+
+```
+$ claude --prompt-suggestions -p "say hi"
+error: unknown option '--prompt-suggestions'
+```
+
+The only reliable sources were (a) the GitHub issue, a first-party bug
+report referencing real compiled-output symbol names, and (b) directly
+grepping the installed binary. Anthropic's own docs page on interactive mode
+corroborates the *existence* of post-response suggestions but not the
+fabricated flag. Lesson for future ghost-text-adjacent research: verify
+CLI-flag claims against `--help` / the real binary before trusting them.
+
+---
+
+## 2. Empirical proof it's unreachable in AgentMux's spawn mode
+
+AgentMux always drives Claude Code via `-p --output-format stream-json
+--verbose` (see `agentmux-srv/src/server/app_api/session.rs`'s
+`invoke_cli_for_activity`, and the main turn pipeline in
+`agents/translator/claude.rs`) — never as an interactive TTY session.
+
+Direct test, with the CLI's own enabling env var explicitly set:
+
+```
+$ CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=1 claude -p "What is 2+2? Answer in one word." \
+    --output-format stream-json --verbose
+```
+
+Event types observed in the output: `system`, `assistant`, `message`, `text`,
+`rate_limit_event`, `result`. **No `prompt_suggestion` event, ever** —
+confirming the `"non_interactive"` gate (§1.2) has no override; the env var
+only clears the *first* of four sequential checks, and non-interactive mode
+is checked independently and unconditionally.
+
+**Conclusion: there is no flag, env var, or setting combination that makes
+Claude Code emit `prompt_suggestion` in `-p` mode.** AgentMux must generate
+this signal itself if it wants the UX.
+
+---
+
+## 3. What AgentMux has today (and why it isn't this feature)
+
+`frontend/app/view/agent/components/AgentFooter.tsx`'s composer already has
+something informally called "ghost text" in its own comments (line ~316),
+but it's the textarea's static HTML `placeholder` — a constant string
+("Send message to Claude...", or "Speak to Claude..." while voice input is
+listening), not a dynamic, per-turn, model-generated suggestion. It's a
+different, much simpler mechanism than what this spec proposes, and the two
+are compatible: the new suggestion can simply *become* the placeholder text
+when present (§4.2), no conflict.
+
+---
+
+## 4. Proposed design: `next_prompt_suggestion`, a second AMC purpose
+
+### 4.1 Backend — mirrors `activity_summary` exactly
+
+New RPC, `session:next_prompt_suggestion`, structurally identical to
+`session:activity_summary` (`session.rs`):
+
+- Same trigger: `TurnPhase.kind === "Done"`.
+- Same gateway usage: `ambient::gateway().admit(AmbientCallKey::new(block_id,
+  "next_prompt_suggestion"), generation)` — coalesced, cancelled-on-supersede,
+  rejected-stale-on-arrival, exactly like activity_summary's admission.
+- Same CLI-invocation shape: spawn Claude with `-p --output-format
+  stream-json --model claude-haiku-4-5-20251001`, prompt built from the
+  recent conversation tail, asking it to predict a plausible, short next
+  user message (e.g. "Summarize the last N turns; suggest one short, natural
+  next thing the user might ask, as a single sentence with no quotes").
+- Same token capture: parse the `result` event's `usage` via the existing
+  `agents::translator::claude::parse_usage`, tag as
+  `"ambient:next_prompt_suggestion"` in `token-usage.ts` (a new, distinct
+  bucket — same pattern as `"ambient:activity_summary"`).
+- New meta key: `term:next_prompt_suggestion`, generation-stamped the same
+  way `term:ambient_summary` is (§4.3 covers why this matters more here, not
+  less).
+
+This is a clean second consumer of the AMC gateway with zero changes needed
+to `agentmux-srv/src/ambient/mod.rs` itself — the gateway was built
+key-and-purpose-generic from the start (`docs/specs/
+SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md` §3.2), so this is the
+validation that it actually generalizes past its first (only) caller.
+
+### 4.2 Frontend — real ghost text in the composer
+
+Unlike the activity summary (read-only pane-header/Swarm text), this
+suggestion is **interactive**:
+
+- Rendered as dimmed text in the composer textarea, shown only when the
+  textarea is empty (matching Claude's own UX — a suggestion, not an
+  overlay on text the user is actively typing) and the current turn is
+  `Done`.
+- **Tab accepts** the suggestion into the real input (matching Claude Code's
+  own terminal UX exactly, so users familiar with the CLI get a consistent
+  mental model). Any other keystroke dismisses it — normal typing takes over
+  immediately, no different from typing over a placeholder.
+- Precedence over the existing static placeholder (§3): show
+  `term:next_prompt_suggestion` if present and current-generation; else the
+  existing static placeholder text. Same "prefer the richer ambient signal,
+  fall back to the free one" shape as `readActivitySummary()`'s precedence
+  for `term:ambient_summary` / `term:osc_title` — worth implementing as a
+  sibling helper (e.g. `readNextPromptSuggestion()`) in
+  `frontend/app/store/activitySummary.ts` or a co-located new file, for the
+  same reason: one place owning precedence so it can't drift.
+
+### 4.3 Binding-lifecycle discipline — the sharpest edge of this feature
+
+The user's original framing ("the framework's responsibility is keeping
+track of these bindings so they don't get lost") matters *more* here than
+for the read-only activity summary, because a wrong ghost-text binding isn't
+just a stale label — it can put words in the user's mouth:
+
+- **Must clear the instant a new turn starts** (`Submitting`), not persist
+  like `term:ambient_summary` does. A suggestion from turn N is meaningless
+  (and actively misleading) once turn N+1 has begun — showing "you might
+  want to ask about tests" while the agent is mid-way through a *different*,
+  already-in-progress turn is a real correctness bug, not a cosmetic one.
+- **Must clear the instant the user starts typing their own message** —
+  independent of turn phase. If the suggestion RPC (1-3s round trip) resolves
+  *after* the user has already started typing, the write must be dropped
+  entirely (check "is the composer still empty" at write time, not just "is
+  this still the current generation").
+- **Must never partially apply** — if accepted via Tab, the full suggestion
+  text goes in atomically; there's no "accept word by word" mode to design
+  for (unlike Copilot-style completions), which keeps the write-and-accept
+  path simple.
+- Reuses the AMC gateway's existing generation-cancellation for the
+  *backend* half of this (killing a stale in-flight subprocess) — the
+  *frontend* half (checking "is the composer still empty") is new and
+  specific to this feature; the gateway's generation guard alone is not
+  sufficient here the way it is for the read-only activity summary.
+
+---
+
+## 5. Open questions
+
+1. ~~Predict the next user prompt vs. predict the next agent action~~ —
+   **decided: next user prompt**, matching Claude Code's own semantic
+   (§1.1). Agent-action prediction (a Swarm-oriented, AgentMux-specific
+   idea) is out of scope for this spec — a distinct future idea, not a
+   variant of this one.
+2. **Should this be opt-in?** Unlike activity_summary (which only writes a
+   header label), this is a second Haiku call *and* a UI feature that puts
+   suggested text in front of every user after every turn. Worth a
+   settings toggle (mirroring Claude Code's own `promptSuggestionEnabled`)
+   rather than always-on, given the added per-turn cost.
+3. **Prompt design** — how many turns of context, what word/length target,
+   whether to bias toward actionable next steps (Claude's own docs mention
+   things like "run the tests") vs. open-ended continuations. Needs
+   iteration once a first version is running, not fully specifiable up
+   front.

--- a/frontend/app/store/rpc-api/session.ts
+++ b/frontend/app/store/rpc-api/session.ts
@@ -34,6 +34,10 @@ export const SessionApi = {
         return client.rpcCall("session:activity_summary", data, opts);
     },
 
+    NextPromptSuggestionCommand(client: RpcClient, data: CommandNextPromptSuggestionData, opts?: RpcOpts): Promise<NextPromptSuggestionResult> {
+        return client.rpcCall("session:next_prompt_suggestion", data, opts);
+    },
+
     SessionArchiveCommand(client: RpcClient, data: CommandSessionArchiveData, opts?: RpcOpts): Promise<SessionArchiveResult> {
         return client.rpcCall("session:archive", data, opts);
     },

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -47,6 +47,7 @@ import { useSubagentEvents } from "./hooks/useSubagentEvents";
 import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
 import { useBlockActivity } from "./hooks/useBlockActivity";
 import { useAgentActivitySummary } from "./hooks/useAgentActivitySummary";
+import { useNextPromptSuggestion } from "./hooks/useNextPromptSuggestion";
 import { useAgentCommands } from "./hooks/useAgentCommands";
 import { useAgentFailure } from "./hooks/useAgentFailure";
 import { PaneRow } from "./components/PaneRow";
@@ -449,6 +450,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         blockId: model.blockId,
         turnPhase: agentAtoms().turnPhaseAtom[0],
         getRootWidth: () => rootRef?.offsetWidth,
+    });
+
+    // Ghost-text next-prompt suggestion (composer). Populated by AgentFooter
+    // via its isComposerEmptyRef prop below. Defaults to "empty" if the
+    // footer hasn't mounted yet — matches the common case (no suggestion
+    // exists yet either, since one only appears after a completed turn).
+    let composerIsEmptyFn: (() => boolean) | null = null;
+    useNextPromptSuggestion({
+        blockId: model.blockId,
+        turnPhase: agentAtoms().turnPhaseAtom[0],
+        isComposerEmpty: () => composerIsEmptyFn?.() ?? true,
     });
 
     // Subagent event subscriptions. See hooks/useSubagentEvents.ts.
@@ -1098,6 +1110,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onRecallLatestQueued={commands.recallLatestHeld}
                     getCompletions={commands.completions}
                     viewModel={model}
+                    isComposerEmptyRef={(fn) => { composerIsEmptyFn = fn; }}
                 />
             </div>
             {/* AgentActionBar (Add / Import / Export) lives in the

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -401,6 +401,13 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // frame collapses to one callback; even rapid typing costs ~1 callback
     // per 16ms. Flag is per-component-instance (captured in closure).
     let typingScrollPending = false;
+    // Tracks the box's emptiness immediately BEFORE the current edit, for
+    // the ghost-text clear check below. Updated at the end of every
+    // handleInput call to hold for the next one. Seeded `true` (safe
+    // default: even if wrong for a mount with restored draft text, ghost
+    // text is only ever shown for an empty composer, so there's nothing to
+    // dismiss in that case anyway).
+    let boxWasEmpty = true;
     const handleInput = () => {
         // A manual edit exits history navigation — the next ArrowUp starts
         // again from the newest sent message. (Programmatic recall writes the
@@ -410,12 +417,17 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // body P95 < 5 ms. The mark span ends BEFORE the RAF enqueue so
         // we measure only the synchronous handler cost.
         markStart("agent-keystroke");
-        // First character typed into a previously-empty box dismisses any
-        // pending ghost-text suggestion — it must not silently reappear if
-        // the user later deletes back to empty. Length===1 check keeps this
-        // O(1) on every other keystroke (no-op past the first character).
-        // See docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md §4.3.
-        if (textareaRef?.value.length === 1) {
+        // The first edit into a previously-empty box dismisses any pending
+        // ghost-text suggestion — it must not silently reappear if the user
+        // later deletes back to empty. Checks the box's PRE-edit emptiness
+        // (boxWasEmpty) rather than the post-edit length: a `value.length
+        // === 1` check only catches a single typed keystroke and misses
+        // paste or voice-transcript inserts, which dispatch the same
+        // `input` event but can write multiple characters into an empty
+        // box at once (reagentx review on #1961). See
+        // docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md §4.3.
+        const newValue = textareaRef?.value ?? "";
+        if (boxWasEmpty && newValue.length > 0) {
             const vm = props.viewModel;
             if (vm?.blockAtom()?.meta?.["term:next_prompt_suggestion"]) {
                 fireAndForget(() =>
@@ -425,6 +437,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 );
             }
         }
+        boxWasEmpty = newValue.length === 0;
         updateAutocomplete();
         setIsBangCmd(textareaRef?.value.startsWith("!") ?? false);
         const cb = props.onTyping;

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -374,9 +374,27 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         }
     };
 
+    // Tracks the box's emptiness immediately BEFORE the current edit — used
+    // by the ghost-text clear check in handleInput below (SPEC_AMBIENT_GHOST_
+    // TEXT_NEXT_PROMPT_2026_07_03.md §4.3). Every programmatic write to
+    // textareaRef.value MUST go through writeComposerValue (never assign
+    // `.value` directly) so this stays in sync — none of these writers
+    // dispatch a real `input` event, so handleInput never sees them, and a
+    // stale flag either misses clearing a real stale suggestion or
+    // re-triggers the clear check on an edit that isn't actually the first
+    // one from empty. Seeded `true` (safe default: even if wrong for a mount
+    // with restored draft text, ghost text is only ever shown for an empty
+    // composer, so there's nothing to dismiss in that case anyway).
+    let boxWasEmpty = true;
+    const writeComposerValue = (text: string): void => {
+        if (!textareaRef) return;
+        textareaRef.value = text;
+        boxWasEmpty = text.length === 0;
+    };
+
     const acceptCompletion = (cmd: SlashCommand): void => {
         if (!textareaRef) return;
-        textareaRef.value = `/${cmd.name} `;
+        writeComposerValue(`/${cmd.name} `);
         setAutocompletePrefix(null);
         setIsBangCmd(false);
         textareaRef.focus();
@@ -390,7 +408,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // it never trips the history-cursor reset in handleInput.
     const setComposerValue = (text: string): void => {
         if (!textareaRef) return;
-        textareaRef.value = text;
+        writeComposerValue(text);
         textareaRef.setSelectionRange(text.length, text.length);
         setIsBangCmd(text.startsWith("!"));
         updateAutocomplete();
@@ -401,13 +419,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // frame collapses to one callback; even rapid typing costs ~1 callback
     // per 16ms. Flag is per-component-instance (captured in closure).
     let typingScrollPending = false;
-    // Tracks the box's emptiness immediately BEFORE the current edit, for
-    // the ghost-text clear check below. Updated at the end of every
-    // handleInput call to hold for the next one. Seeded `true` (safe
-    // default: even if wrong for a mount with restored draft text, ghost
-    // text is only ever shown for an empty composer, so there's nothing to
-    // dismiss in that case anyway).
-    let boxWasEmpty = true;
     const handleInput = () => {
         // A manual edit exits history navigation — the next ArrowUp starts
         // again from the newest sent message. (Programmatic recall writes the
@@ -541,7 +552,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             }
             histPos = sentHistory.length;
             histDraft = "";
-            textareaRef.value = "";
+            writeComposerValue("");
             setAutocompletePrefix(null);
             setIsBangCmd(false);
             // Scroll the new user message into view. SolidJS flushes the
@@ -675,7 +686,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             if (!textareaRef) return;
             if (textareaRef.value.trim().length > 0) {
                 e.preventDefault();
-                textareaRef.value = "";
+                writeComposerValue("");
                 setIsBangCmd(false);
                 // Clearing exits history navigation — park the cursor at the
                 // newest message so the next ArrowUp doesn't skip an entry.

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -9,6 +9,9 @@ import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type 
 import { useTick } from "@/app/hook/useTick";
 import { getVoiceSession, type PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { markEnd, markStart } from "@/perf";
+import { makeORef } from "@/app/store/wos";
+import { ObjectService } from "@/app/store/services";
+import { fireAndForget } from "@/util/util";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
@@ -209,9 +212,19 @@ interface AgentFooterProps {
      * AgentViewModel — used to register a textarea-backed
      * PaneVoiceHandle so the frame-header mic button can write
      * transcripts into the composer. Optional so tests / older
-     * callers that haven't been updated still type-check.
+     * callers that haven't been updated still type-check. Also read for
+     * the ghost-text next-prompt suggestion (term:next_prompt_suggestion —
+     * see docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md).
      */
     viewModel?: AgentViewModel;
+    /**
+     * Exposes an `isEmpty()` check on the (uncontrolled) textarea up to the
+     * parent, called once on mount. useNextPromptSuggestion.ts needs this at
+     * RPC-response time (which happens outside this component) to avoid
+     * writing a suggestion after the user has already started typing — see
+     * that hook's doc comment, guard 2.
+     */
+    isComposerEmptyRef?: (fn: () => boolean) => void;
 }
 
 /**
@@ -313,15 +326,21 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         return props.getCompletions(p);
     });
 
-    // Composer ghost text. While voice is listening AND this pane owns the
-    // session, switch to "Speak to <agent>…" so it's obvious transcription is
-    // live and routed here (the mic button also shows a red recording ring).
-    // Otherwise the normal "Send message to <agent>…" prompt. Reactive: reads
-    // the voice singleton's SignalAtoms so it flips the instant the mic toggles
-    // or retargets to another pane.
+    // Composer placeholder text, in precedence order:
+    //   1. Ghost-text next-prompt suggestion (term:next_prompt_suggestion) —
+    //      Haiku-predicted next message, accept with Tab (see handleKeyDown
+    //      below). Only meaningful while the box is empty, which is exactly
+    //      when a native `placeholder` attribute renders anyway.
+    //   2. "Speak to <agent>…" while voice is listening AND this pane owns
+    //      the session, so it's obvious transcription is live and routed here.
+    //   3. The default "Send message to <agent>…" prompt.
+    // Reactive: reads the block meta atom + the voice singleton's SignalAtoms
+    // so it flips the instant either changes.
     const voice = getVoiceSession();
     const placeholder = createMemo(() => {
         const vm = props.viewModel;
+        const suggestion = vm?.blockAtom()?.meta?.["term:next_prompt_suggestion"] as string | undefined;
+        if (suggestion) return suggestion;
         const listeningHere =
             !!vm && voice.isListening() && voice.currentTargetId() === vm.blockId;
         return listeningHere
@@ -391,6 +410,21 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // body P95 < 5 ms. The mark span ends BEFORE the RAF enqueue so
         // we measure only the synchronous handler cost.
         markStart("agent-keystroke");
+        // First character typed into a previously-empty box dismisses any
+        // pending ghost-text suggestion — it must not silently reappear if
+        // the user later deletes back to empty. Length===1 check keeps this
+        // O(1) on every other keystroke (no-op past the first character).
+        // See docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md §4.3.
+        if (textareaRef?.value.length === 1) {
+            const vm = props.viewModel;
+            if (vm?.blockAtom()?.meta?.["term:next_prompt_suggestion"]) {
+                fireAndForget(() =>
+                    ObjectService.UpdateObjectMeta(makeORef("block", vm.blockId), {
+                        "term:next_prompt_suggestion": null,
+                    } as any)
+                );
+            }
+        }
         updateAutocomplete();
         setIsBangCmd(textareaRef?.value.startsWith("!") ?? false);
         const cb = props.onTyping;
@@ -413,6 +447,14 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         });
         markEnd("agent-keystroke", "scheduled");
     };
+
+    // Expose an isEmpty() check on this uncontrolled textarea up to the
+    // parent — useNextPromptSuggestion.ts needs it at RPC-response time
+    // (outside this component) to avoid writing a stale ghost-text
+    // suggestion after the user already started typing.
+    onMount(() => {
+        props.isComposerEmptyRef?.(() => (textareaRef?.value.length ?? 0) === 0);
+    });
 
     // ── Voice input handle ───────────────────────────────────────────
     // Registers a textarea-backed PaneVoiceHandle on the AgentViewModel
@@ -506,6 +548,26 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // events without setting `isComposing`. Both checks are
         // load-bearing. See SPEC_INPUT_RESPONSIVENESS §6.2.
         if (e.isComposing || e.keyCode === 229) return;
+        // Ghost-text next-prompt suggestion: Tab accepts it into the real
+        // input, matching Claude Code CLI's own terminal UX (see
+        // docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md).
+        // Only reachable when the textarea is empty, which is also the only
+        // state the slash-autocomplete branch below can't be in (it requires
+        // a `/prefix`) — the two Tab handlers never compete.
+        if (e.key === "Tab" && textareaRef && textareaRef.value.length === 0) {
+            const vm = props.viewModel;
+            const suggestion = vm?.blockAtom()?.meta?.["term:next_prompt_suggestion"] as string | undefined;
+            if (suggestion) {
+                e.preventDefault();
+                setComposerValue(suggestion);
+                fireAndForget(() =>
+                    ObjectService.UpdateObjectMeta(makeORef("block", vm!.blockId), {
+                        "term:next_prompt_suggestion": null,
+                    } as any)
+                );
+                return;
+            }
+        }
         // Autocomplete keys take precedence when the dropdown is open
         // and has at least one match. Tab/Enter accept the selection;
         // arrows navigate; Esc dismisses without affecting text.

--- a/frontend/app/view/agent/hooks/useBlockActivity.ts
+++ b/frontend/app/view/agent/hooks/useBlockActivity.ts
@@ -19,6 +19,16 @@
  * docs/specs/SPEC_AGENT_OSC_TITLE_ACTIVITY_2026_06_18.md.
  *
  * Terminal panes write the same key via termosc.ts.
+ *
+ * This is also the one place that reacts to session end (`shellprocstatus
+ * === "done"`), so `clearActivity` doubles as the session-end clear point
+ * for `term:next_prompt_suggestion` (useNextPromptSuggestion.ts) too —
+ * without it, a ghost-text suggestion from a finished session would persist
+ * into a brand-new session started in the same pane and render as the
+ * composer placeholder before any new turn completes. That key gets its own
+ * mid-session clears (new turn start, superseded turn) from
+ * useNextPromptSuggestion.ts directly; this hook only owns the
+ * session-boundary case, matching term:osc_title/term:ambient_summary.
  */
 
 import { onCleanup, onMount } from "solid-js";
@@ -37,6 +47,7 @@ function clearActivity(blockId: string): void {
         ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
             "term:osc_title": null,
             "term:ambient_summary": null,
+            "term:next_prompt_suggestion": null,
         } as any)
     );
 }
@@ -62,13 +73,15 @@ export function useBlockActivity(opts: UseBlockActivityOptions): void {
             },
         });
 
-        // Clear both term:osc_title and term:ambient_summary on session end
-        // (process exit) so a subsequent session in the same pane starts
-        // without a stale topic/summary from the finished one. These keys
-        // are persisted in the block store and survive tab-switch remounts,
-        // so we must NOT clear in onCleanup — doing so would blank the label
-        // every time the pane remounts (tab switch), and Claude Code only
-        // emits OSC titles once per session so no new event would restore it.
+        // Clear term:osc_title, term:ambient_summary, and
+        // term:next_prompt_suggestion on session end (process exit) so a
+        // subsequent session in the same pane starts without a stale
+        // topic/summary/ghost-text-suggestion from the finished one. These
+        // keys are persisted in the block store and survive tab-switch
+        // remounts, so we must NOT clear in onCleanup — doing so would blank
+        // the label every time the pane remounts (tab switch), and Claude
+        // Code only emits OSC titles once per session so no new event would
+        // restore it.
         const unsubStatus = waveEventSubscribe({
             eventType: WpsEvent.ControllerStatus,
             scope: makeORef("block", opts.blockId),

--- a/frontend/app/view/agent/hooks/useNextPromptSuggestion.ts
+++ b/frontend/app/view/agent/hooks/useNextPromptSuggestion.ts
@@ -22,7 +22,7 @@
  *
  * Unlike the read-only activity summary (which persists across turns), a
  * stale suggestion here is a correctness bug, not a cosmetic one — it can
- * put words in the user's mouth. Three independent guards:
+ * put words in the user's mouth. Four independent guards:
  *   1. Cleared the instant a new turn starts (`Submitting`) — a suggestion
  *      from turn N is meaningless (and misleading) once turn N+1 has begun.
  *      `term:ambient_summary` deliberately persists across turns; this key
@@ -38,6 +38,13 @@
  *      *after* the user already typed something: without this check, a late
  *      response could silently overwrite whatever cleared the suggestion
  *      when typing started (see AgentFooter.tsx's handleInput).
+ *   4. Cleared on session end (process exit) — but NOT by this hook.
+ *      useBlockActivity.ts's `clearActivity` owns that transition (it
+ *      already clears `term:osc_title`/`term:ambient_summary` there) and
+ *      clears this key too, so a suggestion from a finished session can't
+ *      persist into a brand-new session started in the same pane. Don't
+ *      duplicate that listener here — one `ControllerStatus` subscription
+ *      per pane for this purpose is enough.
  */
 
 import { createEffect, on, type Accessor } from "solid-js";

--- a/frontend/app/view/agent/hooks/useNextPromptSuggestion.ts
+++ b/frontend/app/view/agent/hooks/useNextPromptSuggestion.ts
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useNextPromptSuggestion — ghost-text "predicted next user message" in the
+ * agent pane composer.
+ *
+ * Mirrors Claude Code CLI's own interactive-mode feature (a dimmed
+ * suggestion shown in the empty input box after a turn finishes, Tab
+ * accepts it): that native mechanism is unreachable from AgentMux because
+ * it's unconditionally suppressed in non-interactive (`-p`) mode, which is
+ * how AgentMux always drives the CLI. This reimplements the same UX as a
+ * second Ambient Model Call gateway purpose. See
+ * docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md.
+ *
+ * On every completed agent turn, sends recent session output to
+ * claude-haiku-4-5-20251001 and asks for a short, natural next user message.
+ * The result is written to `term:next_prompt_suggestion` block meta, which
+ * the composer reads as ghost text (dimmed, shown only while the input is
+ * empty; Tab accepts it into the real input; any other keystroke dismisses
+ * it — see AgentFooter.tsx).
+ *
+ * Unlike the read-only activity summary (which persists across turns), a
+ * stale suggestion here is a correctness bug, not a cosmetic one — it can
+ * put words in the user's mouth. Three independent guards:
+ *   1. Cleared the instant a new turn starts (`Submitting`) — a suggestion
+ *      from turn N is meaningless (and misleading) once turn N+1 has begun.
+ *      `term:ambient_summary` deliberately persists across turns; this key
+ *      deliberately does not.
+ *   2. `activeTurnId !== myTurnId` at write time — a newer turn has already
+ *      started (same belt-and-suspenders pattern as
+ *      useAgentActivitySummary.ts, on top of the backend gateway's own
+ *      cancellation).
+ *   3. `!opts.isComposerEmpty()` at write time — the user has started typing
+ *      their own message since this request was issued. Checked when the
+ *      response arrives (not just "was the composer empty when we sent the
+ *      request") specifically to close the race where the RPC resolves
+ *      *after* the user already typed something: without this check, a late
+ *      response could silently overwrite whatever cleared the suggestion
+ *      when typing started (see AgentFooter.tsx's handleInput).
+ */
+
+import { createEffect, on, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { makeORef } from "@/app/store/wos";
+import { ObjectService } from "@/app/store/services";
+import { fireAndForget } from "@/util/util";
+import { recordTurn } from "@/app/store/token-usage";
+import type { TurnPhase } from "@/app/store/agent-pane-state/types";
+
+export interface UseNextPromptSuggestionOptions {
+    blockId: string;
+    turnPhase: Accessor<TurnPhase>;
+    /** Checked at write time — see the module doc comment, guard 3. */
+    isComposerEmpty: () => boolean;
+}
+
+function clearSuggestion(blockId: string): void {
+    fireAndForget(() =>
+        ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
+            "term:next_prompt_suggestion": null,
+        } as any)
+    );
+}
+
+export function useNextPromptSuggestion(opts: UseNextPromptSuggestionOptions): void {
+    const { blockId, turnPhase, isComposerEmpty } = opts;
+
+    // Scoped to this mount — see useAgentActivitySummary.ts's doc comment for
+    // why the wire `generation` is Date.now() instead of this counter.
+    let activeTurnId = 0;
+
+    createEffect(on(turnPhase, (phase) => {
+        if (phase.kind === "Submitting") {
+            activeTurnId++;
+            clearSuggestion(blockId); // guard 1 — see module doc comment
+            return;
+        }
+
+        if (phase.kind === "Done") {
+            const myTurnId = activeTurnId;
+
+            RpcApi.NextPromptSuggestionCommand(
+                TabRpcClient,
+                { block_id: blockId, generation: Date.now() },
+                { timeout: 20_000 },
+            ).then((result) => {
+                if (activeTurnId !== myTurnId) return; // superseded by a newer turn
+                if (result.tokens) {
+                    recordTurn("ambient:next_prompt_suggestion", result.tokens);
+                }
+                if (result.suggestion && isComposerEmpty()) {
+                    fireAndForget(() =>
+                        ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
+                            "term:next_prompt_suggestion": result.suggestion,
+                        } as any)
+                    );
+                }
+            }).catch(() => {
+                // Silently ignore — no ghost text shows.
+            });
+        }
+    }));
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -2270,6 +2270,20 @@ declare global {
         tokens?: TokenCounts;
     };
 
+    // wshrpc.CommandNextPromptSuggestionData
+    type CommandNextPromptSuggestionData = {
+        block_id: string;
+        // Same generation contract as CommandActivitySummaryData.
+        generation: number;
+    };
+
+    // wshrpc.NextPromptSuggestionResult
+    type NextPromptSuggestionResult = {
+        suggestion: string;
+        // Absent under the same conditions as ActivitySummaryResult.tokens.
+        tokens?: TokenCounts;
+    };
+
     // wshrpc.CommandSessionArchiveData
     type CommandSessionArchiveData = {
         block_id: string;


### PR DESCRIPTION
## Summary

Implements `docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md`: a
second consumer of the Ambient Model Call gateway (`agentmux-srv/src/ambient`,
#1947). After a turn completes, predict a short, plausible next user message
and show it as dimmed ghost text in the empty composer — Tab accepts it.

This reimplements Claude Code CLI's own interactive-mode feature. Confirmed
by inspecting the installed CLI binary directly: a real `prompt_suggestion`
stream-json event exists, gated by four independent checks (env var,
GrowthBook remote flag, non-interactive-mode, "swarm teammate"). It's
unreachable from AgentMux because the non-interactive check unconditionally
suppresses it whenever Claude runs via `-p`/`--print` — which is how
AgentMux always drives the CLI. Verified empirically: ran the real CLI with
`-p --output-format stream-json` and its own enabling env var set — zero
`prompt_suggestion` events. (One web search result claimed a
`--prompt-suggestions` CLI flag exists; it doesn't — `claude --help` and a
live invocation both confirm that's fabricated blog content. Full writeup
in the spec.)

## Backend

- New RPC `session:next_prompt_suggestion`, structurally identical to
  `session:activity_summary` — same gateway admission/cancellation, same
  Haiku CLI invocation, same result/usage parsing.
- Renamed `invoke_cli_for_activity` → `invoke_ambient_haiku_call` and
  extracted `read_recent_activity_digest` as a shared helper — both ambient
  call sites need the identical tail-read + digest-extract + CLI-invoke
  logic now. Pure dedup, no behavior change to the existing activity-summary
  path.
- New meta key `term:next_prompt_suggestion`; tokens tagged
  `"ambient:next_prompt_suggestion"` in the total-tokens view.

## Frontend

- New hook `useNextPromptSuggestion.ts`, mirroring
  `useAgentActivitySummary.ts` but with sharper lifecycle rules — a stale
  suggestion here can put words in the user's mouth, not just show a stale
  label:
  - Cleared on every new turn start (`Submitting`), not just checked against
    the current generation — `term:ambient_summary` deliberately persists
    across turns, this key deliberately does not.
  - Checked again at write time against composer-emptiness (not just at
    request time), closing the race where the RPC resolves after the user
    already started typing.
- `AgentFooter.tsx`: composer placeholder now prefers the ghost-text
  suggestion (falls back to the existing voice/default placeholder); Tab
  accepts it into the real input (matches Claude Code's own terminal UX so
  it's a consistent mental model for users who know the CLI); first
  keystroke into a previously-empty box clears any pending suggestion so it
  can't silently reappear if the box is emptied again.

## Test plan

- [x] Full backend suite: 1296 passed, 0 failed (includes the existing
      `ambient::tests::*` — generic over purpose, so this validates the
      gateway's second real consumer for free)
- [x] Full frontend suite: 1581 passed (105 files), 0 failed
- [x] `tsc --noEmit` clean
- [x] `cargo check` clean, no new warnings
- [ ] **Not live-tested end-to-end** in a running dev instance (needs a real
      completed agent turn to trigger). Backend logic is unit-tested and
      reuses the already-verified `activity_summary` pipeline; frontend
      logic typechecks cleanly. Flagging this explicitly rather than
      claiming full manual verification — happy to do a `task dev` pass if
      wanted before merge.

<!-- agentmux:agent_id=agent3 -->