### PR TITLE
feat(armory): bound_to_agent flag on mcp.list/skill.list — stateful bind/unbind toggle

### DIFF
--- a/.changesets/1783156414-feat-armory-bound-to-agent-flag-on-mcp-list-skill-list-state-bg0r.md
+++ b/.changesets/1783156414-feat-armory-bound-to-agent-flag-on-mcp-list-skill-list-state-bg0r.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): bound_to_agent flag on mcp.list/skill.list — stateful bind/unbind toggle

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -25,26 +25,44 @@ pub struct McpServer {
     pub updated_at: i64,
 }
 
+/// `mcp_server_list`'s response shape: the server plus whether the requesting
+/// agent specifically holds a `db_agent_mcp_ref` row for it. A global server
+/// is always visible to every agent (see the query below), but `is_global`
+/// alone can't tell the UI whether *this* agent has bound it — without
+/// `bound_to_agent`, bind/unbind in the per-agent modal has no way to render
+/// as a stateful toggle (see docs/specs, "bound to me" gap tracked in #1960).
+#[derive(Debug, Clone, Serialize)]
+pub struct McpServerListItem {
+    #[serde(flatten)]
+    pub server: McpServer,
+    pub bound_to_agent: bool,
+}
+
 impl Store {
-    /// List all MCP servers visible to an agent: own (referenced) + global.
-    pub fn mcp_server_list(&self, agent_id: &str) -> Result<Vec<McpServer>, StoreError> {
+    /// List all MCP servers visible to an agent: own (referenced) + global,
+    /// each annotated with whether this specific agent holds the bind ref.
+    pub fn mcp_server_list(&self, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, name, transport, config, is_global, created_at, updated_at
-             FROM db_mcp_servers
-             WHERE is_global = 1
-                OR id IN (SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?1)
-             ORDER BY is_global DESC, updated_at DESC",
+            "SELECT s.id, s.name, s.transport, s.config, s.is_global, s.created_at, s.updated_at,
+                    EXISTS(SELECT 1 FROM db_agent_mcp_ref r WHERE r.mcp_id = s.id AND r.agent_id = ?1) AS bound_to_agent
+             FROM db_mcp_servers s
+             WHERE s.is_global = 1
+                OR s.id IN (SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?1)
+             ORDER BY s.is_global DESC, s.updated_at DESC",
         )?;
         let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(McpServer {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                transport: row.get(2)?,
-                config: row.get(3)?,
-                is_global: row.get::<_, i64>(4)? != 0,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
+            Ok(McpServerListItem {
+                server: McpServer {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    transport: row.get(2)?,
+                    config: row.get(3)?,
+                    is_global: row.get::<_, i64>(4)? != 0,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                },
+                bound_to_agent: row.get::<_, i64>(7)? != 0,
             })
         })?;
         let mut out = Vec::new();

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -218,28 +218,44 @@ pub struct Skill {
     pub updated_at: i64,
 }
 
+/// `skill_list`'s response shape: the skill plus whether the requesting agent
+/// specifically holds a `db_agent_skills_ref` row for it. Mirrors
+/// `McpServerListItem` — see its doc comment for why `is_global` alone isn't
+/// enough to render bind/unbind as a stateful toggle (tracked in #1960).
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillListItem {
+    #[serde(flatten)]
+    pub skill: Skill,
+    pub bound_to_agent: bool,
+}
+
 impl Store {
-    /// List all skills visible to an agent: own (referenced) + global.
-    pub fn skill_list(&self, agent_id: &str) -> Result<Vec<Skill>, StoreError> {
+    /// List all skills visible to an agent: own (referenced) + global, each
+    /// annotated with whether this specific agent holds the bind ref.
+    pub fn skill_list(&self, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, name, trigger, skill_type, description, content, is_global, created_at, updated_at
-             FROM db_skills
-             WHERE is_global = 1
-                OR id IN (SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?1)
-             ORDER BY is_global DESC, updated_at DESC",
+            "SELECT s.id, s.name, s.trigger, s.skill_type, s.description, s.content, s.is_global, s.created_at, s.updated_at,
+                    EXISTS(SELECT 1 FROM db_agent_skills_ref r WHERE r.skill_id = s.id AND r.agent_id = ?1) AS bound_to_agent
+             FROM db_skills s
+             WHERE s.is_global = 1
+                OR s.id IN (SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?1)
+             ORDER BY s.is_global DESC, s.updated_at DESC",
         )?;
         let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(Skill {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                trigger: row.get(2)?,
-                skill_type: row.get(3)?,
-                description: row.get(4)?,
-                content: row.get(5)?,
-                is_global: row.get::<_, i64>(6)? != 0,
-                created_at: row.get(7)?,
-                updated_at: row.get(8)?,
+            Ok(SkillListItem {
+                skill: Skill {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    trigger: row.get(2)?,
+                    skill_type: row.get(3)?,
+                    description: row.get(4)?,
+                    content: row.get(5)?,
+                    is_global: row.get::<_, i64>(6)? != 0,
+                    created_at: row.get(7)?,
+                    updated_at: row.get(8)?,
+                },
+                bound_to_agent: row.get::<_, i64>(9)? != 0,
             })
         })?;
         let mut out = Vec::new();

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -457,7 +457,14 @@ pub(super) fn write_agent_config_files(
     // db_agent_skills. The fallback decision is gated on *own* refs only — NOT
     // the global-inclusive list — so adding a global skill never discards a
     // legacy-only agent's skills.
-    let visible_skills = wstore.skill_list(&agent.id).unwrap_or_default(); // own refs + globals
+    // skill_list now returns each skill wrapped with a per-agent bound_to_agent
+    // flag (for the App API's "bound to me" indicator, tracked in #1960) —
+    // this config-generation path doesn't need it, so unwrap immediately.
+    let visible_skills: Vec<crate::backend::storage::Skill> = wstore.skill_list(&agent.id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|item| item.skill)
+        .collect(); // own refs + globals
     let has_own_skill_refs = visible_skills.iter().any(|s| !s.is_global);
     let effective_skills: Vec<crate::backend::storage::AgentSkill> = if has_own_skill_refs {
         // Ref-based path: own bound + globals (the full visible list).
@@ -482,7 +489,12 @@ pub(super) fn write_agent_config_files(
     // legacy blob's user servers are merged in ONLY when the agent has no own
     // ref-bound servers (so a global server never wipes a legacy-only agent's
     // .mcp.json). When the agent has own refs, those are authoritative.
-    let visible_mcp = wstore.mcp_server_list(&agent.id).unwrap_or_default(); // own refs + globals
+    // Same unwrap as visible_skills above — this path doesn't need bound_to_agent.
+    let visible_mcp: Vec<crate::backend::storage::McpServer> = wstore.mcp_server_list(&agent.id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|item| item.server)
+        .collect(); // own refs + globals
     let has_own_mcp_refs = visible_mcp.iter().any(|s| !s.is_global);
     if !visible_mcp.is_empty() {
         let blob_for_merge = if has_own_mcp_refs {

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -15,7 +15,7 @@ export const McpApi = {
         client: RpcClient,
         data: { agent_id: string },
         opts?: RpcOpts,
-    ): Promise<McpServer[]> {
+    ): Promise<McpServerListItem[]> {
         return client.rpcCall("mcp.list", data, opts);
     },
 

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -18,7 +18,7 @@ export const SkillApi = {
         client: RpcClient,
         data: { agent_id: string },
         opts?: RpcOpts,
-    ): Promise<Skill[]> {
+    ): Promise<SkillListItem[]> {
         return client.rpcCall("skill.list", data, opts);
     },
 

--- a/frontend/app/view/agent/agent-mcp-model.ts
+++ b/frontend/app/view/agent/agent-mcp-model.ts
@@ -8,12 +8,12 @@
  * agentmux-srv/src/server/app_api/mcp.rs).
  *
  * `mcp.list` returns both this agent's own (non-global) servers AND every
- * global server, regardless of whether this agent is bound to it — the
- * response carries no per-row "bound to me" flag. Own (`!is_global`) rows
- * are always editable/deletable here; global rows are read-only (upsert/
- * delete on a global row is backend-FORBIDDEN) and only exposed as
- * Bind/Unbind actions, which are idempotent on the backend so the toggle
- * works correctly even without a live bound-state indicator.
+ * global server, each annotated with `bound_to_agent` — whether *this*
+ * agent specifically holds the bind ref (own rows are always true; a global
+ * row may or may not be). Own (`!is_global`) rows are always editable/
+ * deletable here; global rows are read-only (upsert/delete on a global row
+ * is backend-FORBIDDEN) and only exposed as a Bind/Unbind toggle driven by
+ * `bound_to_agent`.
  */
 
 import { createMemo, createSignal, type Accessor } from "solid-js";
@@ -38,8 +38,8 @@ function draftFromServer(s: McpServer): McpDraft {
 export class AgentMcpModel {
     readonly agentId: string;
 
-    private _servers = createSignal<McpServer[]>([]);
-    serversAtom: Accessor<McpServer[]> = this._servers[0];
+    private _servers = createSignal<McpServerListItem[]>([]);
+    serversAtom: Accessor<McpServerListItem[]> = this._servers[0];
     private setServers = this._servers[1];
 
     private _selectedId = createSignal<string | null>(null);
@@ -58,7 +58,7 @@ export class AgentMcpModel {
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
-    selectedAtom: Accessor<McpServer | null>;
+    selectedAtom: Accessor<McpServerListItem | null>;
 
     constructor(agentId: string) {
         this.agentId = agentId;
@@ -80,7 +80,7 @@ export class AgentMcpModel {
         }
     }
 
-    handleSelect(server: McpServer): void {
+    handleSelect(server: McpServerListItem): void {
         this.setError(null);
         this.setDraft(null);
         this.setSelectedId(server.id);
@@ -92,7 +92,7 @@ export class AgentMcpModel {
         this.setSelectedId(null);
     }
 
-    startEdit(server: McpServer): void {
+    startEdit(server: McpServerListItem): void {
         if (server.is_global) {
             this.setError("Global MCP servers are managed in the Armory, not here.");
             return;

--- a/frontend/app/view/agent/agent-skill-model.ts
+++ b/frontend/app/view/agent/agent-skill-model.ts
@@ -6,8 +6,8 @@
  * AgentSetupModal). Drives the list + create/edit/delete/bind lifecycle
  * over the standalone Skill primitive (`skill.*` App API,
  * agentmux-srv/src/server/app_api/skill.rs). Same shape as AgentMcpModel —
- * see its doc comment for the is_global / bound-status caveat, which
- * applies identically here.
+ * see its doc comment for the is_global / bound_to_agent details, which
+ * apply identically here.
  */
 
 import { createMemo, createSignal, type Accessor } from "solid-js";
@@ -41,8 +41,8 @@ function draftFromSkill(s: Skill): SkillDraft {
 export class AgentSkillModel {
     readonly agentId: string;
 
-    private _skills = createSignal<Skill[]>([]);
-    skillsAtom: Accessor<Skill[]> = this._skills[0];
+    private _skills = createSignal<SkillListItem[]>([]);
+    skillsAtom: Accessor<SkillListItem[]> = this._skills[0];
     private setSkills = this._skills[1];
 
     private _selectedId = createSignal<string | null>(null);
@@ -61,7 +61,7 @@ export class AgentSkillModel {
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
-    selectedAtom: Accessor<Skill | null>;
+    selectedAtom: Accessor<SkillListItem | null>;
 
     constructor(agentId: string) {
         this.agentId = agentId;
@@ -83,7 +83,7 @@ export class AgentSkillModel {
         }
     }
 
-    handleSelect(skill: Skill): void {
+    handleSelect(skill: SkillListItem): void {
         this.setError(null);
         this.setDraft(null);
         this.setSelectedId(skill.id);
@@ -95,7 +95,7 @@ export class AgentSkillModel {
         this.setSelectedId(null);
     }
 
-    startEdit(skill: Skill): void {
+    startEdit(skill: SkillListItem): void {
         if (skill.is_global) {
             this.setError("Global skills are managed in the Armory, not here.");
             return;

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -3,9 +3,9 @@
 
 /**
  * AgentMcpModal — the "MCP Servers" tab body inside AgentSetupModal.
- * List/create/edit/delete for this agent's own MCP servers, plus
- * bind/unbind for global ones. See AgentMcpModel's doc comment for the
- * bound-status caveat.
+ * List/create/edit/delete for this agent's own MCP servers, plus a
+ * bound-state-aware Bind/Unbind toggle for global ones (driven by
+ * `bound_to_agent` — see AgentMcpModel's doc comment).
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
@@ -42,6 +42,12 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                                     <span class="agent-primitive-modal-list-item-name">{server.name}</span>
                                     <Show when={server.is_global}>
                                         <span class="agent-primitive-modal-list-item-badge">global</span>
+                                        <span
+                                            class="agent-primitive-modal-list-item-badge"
+                                            classList={{ "is-bound": server.bound_to_agent }}
+                                        >
+                                            {server.bound_to_agent ? "bound" : "not bound"}
+                                        </span>
                                     </Show>
                                 </button>
                             )}
@@ -81,20 +87,24 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                                             <Show
                                                 when={!server().is_global}
                                                 fallback={
-                                                    <>
+                                                    <Show
+                                                        when={server().bound_to_agent}
+                                                        fallback={
+                                                            <button
+                                                                class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                                                onClick={() => void model.bind(server().id)}
+                                                            >
+                                                                Bind
+                                                            </button>
+                                                        }
+                                                    >
                                                         <button
                                                             class="agent-primitive-modal-btn"
                                                             onClick={() => void model.unbind(server().id)}
                                                         >
                                                             Unbind
                                                         </button>
-                                                        <button
-                                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                                            onClick={() => void model.bind(server().id)}
-                                                        >
-                                                            Bind
-                                                        </button>
-                                                    </>
+                                                    </Show>
                                                 }
                                             >
                                                 <button

--- a/frontend/app/view/agent/components/AgentPrimitiveModal.scss
+++ b/frontend/app/view/agent/components/AgentPrimitiveModal.scss
@@ -86,6 +86,11 @@
     padding: 1px 5px;
     color: var(--accent-color);
     background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+
+    &.is-bound {
+        color: var(--success-color);
+        background: color-mix(in srgb, var(--success-color) 12%, transparent);
+    }
 }
 
 .agent-primitive-modal-new-btn {

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -3,11 +3,12 @@
 
 /**
  * AgentSkillsModal — the "Skills" tab body inside AgentSetupModal.
- * List/create/edit/delete for this agent's own skills, plus bind/unbind
- * for global ones. See AgentSkillModel's doc comment for the bound-status
- * caveat. Distinct from the legacy AgentSkillCard/AgentSkillsPanel (the
- * agent-definition `agent_skill_*` surface) — this is the v1 standalone
- * Skill primitive (`skill.*` / `db_skills`).
+ * List/create/edit/delete for this agent's own skills, plus a
+ * bound-state-aware Bind/Unbind toggle for global ones (driven by
+ * `bound_to_agent` — see AgentSkillModel's doc comment). Distinct from the
+ * legacy AgentSkillCard/AgentSkillsPanel (the agent-definition
+ * `agent_skill_*` surface) — this is the v1 standalone Skill primitive
+ * (`skill.*` / `db_skills`).
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
@@ -44,6 +45,12 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                     <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
                                     <Show when={skill.is_global}>
                                         <span class="agent-primitive-modal-list-item-badge">global</span>
+                                        <span
+                                            class="agent-primitive-modal-list-item-badge"
+                                            classList={{ "is-bound": skill.bound_to_agent }}
+                                        >
+                                            {skill.bound_to_agent ? "bound" : "not bound"}
+                                        </span>
                                     </Show>
                                 </button>
                             )}
@@ -89,20 +96,24 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                             <Show
                                                 when={!skill().is_global}
                                                 fallback={
-                                                    <>
+                                                    <Show
+                                                        when={skill().bound_to_agent}
+                                                        fallback={
+                                                            <button
+                                                                class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                                                onClick={() => void model.bind(skill().id)}
+                                                            >
+                                                                Bind
+                                                            </button>
+                                                        }
+                                                    >
                                                         <button
                                                             class="agent-primitive-modal-btn"
                                                             onClick={() => void model.unbind(skill().id)}
                                                         >
                                                             Unbind
                                                         </button>
-                                                        <button
-                                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                                            onClick={() => void model.bind(skill().id)}
-                                                        >
-                                                            Bind
-                                                        </button>
-                                                    </>
+                                                    </Show>
                                                 }
                                             >
                                                 <button

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -422,6 +422,15 @@ declare global {
         updated_at: number;
     };
 
+    /** `mcp.list`'s response shape: an McpServer plus whether the requesting
+     *  agent specifically holds the bind ref (as opposed to just being able
+     *  to see it because it's global). Only `mcp.list` (agent-scoped) carries
+     *  this — `mcp.get`/`mcp.upsert`/`mcp.catalog.list` return bare McpServer. */
+    type McpServerListItem = McpServer & { bound_to_agent: boolean };
+
+    /** `skill.list`'s response shape — see McpServerListItem. */
+    type SkillListItem = Skill & { bound_to_agent: boolean };
+
     /** Drone pane (issue #753 Phase 1). Mirrors the Rust types in
      *  agentmux-srv/src/drone/types.rs. */
     type DroneDefinition = {


### PR DESCRIPTION
## Context

Picks up item 1 of #1960 (\"Armory MCP Servers/Skills catalog UI: PRs A4–A7 of the 7-PR plan were never filed\") — the \"bound to me\" gap flagged as a known limitation in #1946 and never revisited.

## Problem

`mcp.list`/`skill.list` return every server/skill visible to an agent (global OR own ref) with no per-row indicator of whether *this specific agent* holds the bind ref. The per-agent setup modal's Bind/Unbind buttons (`AgentMcpModal.tsx`/`AgentSkillsModal.tsx`) rendered as blind idempotent toggles — always showing **both** buttons regardless of actual bind state, since the backend response gave the UI nothing to distinguish "bound" from "just globally visible."

## Fix

- **Storage**: `mcp_server_list`/`skill_list` now return `McpServerListItem`/`SkillListItem` — the server/skill flattened with a computed `bound_to_agent: bool` (`EXISTS(...)` against `db_agent_mcp_ref`/`db_agent_skills_ref` for the requesting `agent_id`). Only these two agent-scoped list queries change; `mcp.get`/`mcp.upsert`/`mcp.catalog.list` (and skill equivalents) are untouched — no agent context to compute the flag against, and the Armory catalog itself doesn't need it.
- `agent_open.rs`'s config-generation path unwraps to the plain `McpServer`/`Skill` immediately (doesn't need the new flag).
- **Frontend**: new `McpServerListItem`/`SkillListItem` types, updated `RpcApi` return types, and both per-agent modals now render bind/unbind as an actual stateful toggle — **Bind** when not bound, **Unbind** when bound — plus a bound/not-bound badge in the list view.

## Verification
- `cargo check -p agentmux-srv`: clean.
- `tsc --noEmit`: clean.
- Manually traced the SQL for both the global-and-bound and global-but-not-bound cases (the `EXISTS` subquery correctly returns 0/1 either way).

## Not in scope (tracked in #1960)
- "Used by N agents" count on Armory catalog rows.
- Bind-to-agent action from the catalog itself.
- Deep-linking between agent config and the catalog.

<!-- agentmux:agent_id=agentx -->