### PR TITLE
fix(agent-pane): eliminate double scrollbar and scroll dead-zone in tool previews

### DIFF
--- a/.changesets/1783179787-fix-agent-pane-tool-preview-scroll-dead-zone-at-overscroll-b-rk0q.md
+++ b/.changesets/1783179787-fix-agent-pane-tool-preview-scroll-dead-zone-at-overscroll-b-rk0q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): tool-preview scroll dead-zone at overscroll boundary

--- a/docs/specs/SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md
+++ b/docs/specs/SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md
@@ -1,7 +1,9 @@
 # Spec: Scroll Chaining for Nested Tool-Preview Regions
 
 **Date:** 2026-07-03
-**Status:** proposed
+**Status:** Phase 1 shipped (d190dff7 / #1956) and found insufficient by live
+reproduction on 2026-07-04; Phase 2 implemented same day. See "Addendum"
+at the bottom.
 **Related:** `docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md` (owns
 `AgentDocumentVirtualList.handleScroll` — this spec must not fight its stick-to-bottom
 gating), `frontend/app/view/agent/components/ToolBlock.tsx` (existing Ctrl+wheel zoom
@@ -184,3 +186,49 @@ unnecessary given CEF's fixed, modern Chromium.
 - Confirm stick-to-bottom (new streaming output auto-scrolls) and scroll-driven
   tool-collapse (per the companion spec) still behave correctly when scrolling the outer
   pane directly.
+
+## Addendum (2026-07-04): Phase 1 was insufficient — this was a dead zone, not a jerk
+
+A same-day double-scrollbar fix (`frontend/app/view/agent/styles/_document-nodes.scss`)
+removed the `max-height`/`overflow-y` from the ~8 secondary nested boxes this spec
+targeted (they shouldn't have been independently scrollable in the first place — that was
+the actual cause of the double-scrollbar bug). That left exactly one tool-preview scroll
+container per tool block: `.agent-tool-overlay-log`.
+
+Reproducing against that single container (live, via CDP `Input.dispatchMouseEvent` against
+the running dev build, scripted wheel ticks with `scrollTop` logged after each) showed Phase
+1 does not deliver the handoff this spec describes. Once `.agent-tool-overlay-log` hit
+either scroll boundary, **further wheel ticks did nothing at all** — `.agent-document`'s
+`scrollTop` stayed frozen through 10+ additional ticks in both directions. Not a jerk, a
+dead zone.
+
+**Why Phase 1's premise was wrong:** `overscroll-behavior: contain` does exactly what MDN
+says — it stops the browser's native scroll chain from reaching the ancestor once the
+container's own range is exhausted. That's an isolation primitive, not a handoff primitive.
+The "smooth handoff, no dead zone, no jump" behavior this spec's Problem section asks for is
+actually what `overscroll-behavior: auto` (the pre-existing default) already does — chaining
+to the ancestor is the *default* browser behavior once a container is exhausted. What Phase
+1 actually changed was trading the old jerk/bounce feel of that default chaining for a hard
+stop, not implementing a cleaner version of chaining.
+
+**Fix:** implemented this spec's own Phase 2 (previously deferred, "only if Phase 1 proves
+insufficient in practice" — it did). `ToolOverlayLog.tsx` now attaches a non-passive `wheel`
+listener to `.agent-tool-overlay-log`: when the box is at a scroll boundary in the wheel's
+direction, it manually forwards the same `deltaY` to `.agent-document.scrollTop` and calls
+`preventDefault()`. This is a deliberate manual relay, not "let the event bubble" — bubbling
+doesn't help here, since `contain` blocks the browser's own scroll-chaining regardless of
+whether a JS listener calls `preventDefault()`; only directly mutating the ancestor's
+`scrollTop` produces the handoff. `overscroll-behavior: contain` stays in place — it still
+suppresses the native bounce/rubber-band, and the JS supplies the intentional handoff in its
+place.
+
+Only `.agent-tool-overlay-log` needed this — the ~8 secondary boxes are no longer
+independent scroll containers post-double-scrollbar-fix, so there's nothing nested left to
+hand off from at that level. `.agent-document`'s own `overscroll-behavior: contain` (stopping
+the chain from reaching the OS level) is untouched and unaffected, since the fix mutates
+`scrollTop` directly rather than relying on native chaining.
+
+Verified live the same way as the initial repro: synthetic markup matching the real
+(post-fix) DOM shape injected into the running dev window, wheel ticks driven via CDP in
+both directions, `scrollTop` asserted after each tick. Confirmed the outer pane now picks up
+immediately and smoothly at both the top and bottom boundary, with no dead zone.

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -102,6 +102,39 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         stickToBottom = dist < 40;
     };
 
+    // Scroll-chaining handoff to the outer pane (SPEC_TOOL_PREVIEW_SCROLL_
+    // CHAINING_2026_07_03.md Phase 2). This box carries `overscroll-behavior:
+    // contain` (_tool-overlay-portal.scss) so the browser's native chaining —
+    // which would otherwise hand excess wheel delta to `.agent-document` once
+    // this box hits its scroll limit — never fires; `contain` blocks that
+    // relay unconditionally, regardless of any JS listener. Verified live via
+    // CDP: with only the CSS (Phase 1), reaching either boundary of this box
+    // hard-dead-ends further wheel ticks — `.agent-document`'s scrollTop never
+    // moves. So the handoff has to be done by hand: once this box can't
+    // consume more scroll in the wheel's direction, forward the same delta to
+    // the outer pane directly (not "let it bubble" — bubbling the event
+    // doesn't help, `contain` isn't an event-propagation setting).
+    onMount(() => {
+        const el = scrollRef;
+        if (!el) return;
+        const onWheel = (e: WheelEvent) => {
+            // Ctrl+wheel is the preview font-zoom gesture (ToolBlock.tsx) —
+            // leave it alone.
+            if (e.ctrlKey) return;
+            const atTop = el.scrollTop <= 0;
+            const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+            const scrollingUp = e.deltaY < 0;
+            const scrollingDown = e.deltaY > 0;
+            if (!((atTop && scrollingUp) || (atBottom && scrollingDown))) return;
+            const outerPane = el.closest<HTMLElement>(".agent-document");
+            if (!outerPane) return;
+            e.preventDefault();
+            outerPane.scrollTop += e.deltaY;
+        };
+        el.addEventListener("wheel", onWheel, { passive: false });
+        onCleanup(() => el.removeEventListener("wheel", onWheel));
+    });
+
     // Track whether the overlay panel is collapsed (content-visibility: hidden).
     // Accessing layout-forcing properties (scrollHeight, scrollTop) on an element
     // inside a content-visibility:hidden subtree forces a synchronous subtree

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -630,11 +630,12 @@
         }
 
         .agent-bash-output {
+            // No max-height/overflow here — the enclosing
+            // `.agent-tool-overlay-log` is the single scroll container
+            // (bounded by `.agent-tool-panel`'s 50vh). A second inner
+            // scrollbar here produced the double-scrollbar bug.
             padding: 3px var(--space-1-5);
             margin: 0;
-            max-height: 400px;
-            overflow-y: auto;
-            overscroll-behavior: contain;
 
             &.has-error {
                 border-left: 2px solid var(--error-color);
@@ -1114,12 +1115,11 @@
         }
 
         .agent-tool-read-content {
+            // No max-height/overflow here — see .agent-bash-output above;
+            // the overlay-log is the single scroll container.
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
             border-radius: 0;
-            max-height: 400px;
-            overflow-y: auto;
-            overscroll-behavior: contain;
             margin: 0;
             // Shiki <pre> override: ensure our bg wins
             &[style*="background"] {
@@ -1172,24 +1172,20 @@
             border: 1px solid var(--border-color);
             padding: var(--space-1) var(--space-1-5);
             border-radius: 0;
-            max-height: 400px;
-            overflow-y: auto;
-            overscroll-behavior: contain;
             margin: 0;
             font-size: 11px;
         }
     }
 
     // === Generic Tool ===
+    // No max-height/overflow on any of these — see .agent-bash-output
+    // above; the overlay-log is the single scroll container.
     .agent-tool-generic,
     .agent-tool-task-info {
         background: var(--main-bg-color);
         border: 1px solid var(--border-color);
         padding: var(--space-1) var(--space-1-5);
         border-radius: 0;
-        max-height: 400px;
-        overflow-y: auto;
-        overscroll-behavior: contain;
         margin: 0;
         font-size: 11px;
     }
@@ -1227,13 +1223,11 @@
         }
 
         .agent-tool-compact-json {
+            // No max-height/overflow here — see .agent-bash-output above.
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
             padding: var(--space-1) var(--space-1-5);
             border-radius: 0;
-            max-height: 400px;
-            overflow-y: auto;
-            overscroll-behavior: contain;
             margin: var(--space-1) 0 0 0;
             font-size: 11px;
             white-space: pre-wrap;
@@ -1245,10 +1239,10 @@
 // Record table (RecordTable.tsx) — a top-level array of flat records renders as
 // a table instead of a JSON blob (unknown-tool path).
 .agent-tool-record-table {
+    // No max-height/overflow here — the enclosing `.agent-tool-overlay-log`
+    // is the single scroll container (bounded by `.agent-tool-panel`'s
+    // 50vh). A second inner scrollbar here produced the double-scrollbar bug.
     margin: var(--space-1) 0 0 0;
-    max-height: 400px;
-    overflow: auto;
-    overscroll-behavior: contain;
 
     table {
         border-collapse: collapse;
@@ -1285,13 +1279,11 @@
 // Web-search result cards (SearchResults.tsx) — replaces the JSON blob for
 // WebSearch-shaped results. Each card opens its URL in the system browser.
 .agent-tool-search-results {
+    // No max-height/overflow here — see .agent-tool-record-table above.
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
     margin: var(--space-1) 0 0 0;
-    max-height: 480px;
-    overflow-y: auto;
-    overscroll-behavior: contain;
 
     .agent-search-header {
         display: flex;
@@ -1476,13 +1468,11 @@
     }
 
     .agent-fetch-content {
+        // No max-height/overflow here — see .agent-tool-record-table above.
         white-space: pre-wrap;
         word-break: break-word;
         font-size: 11px;
         line-height: 1.5;
-        max-height: calc(100vh - 240px);
-        overflow-y: auto;
-        overscroll-behavior: contain;
         padding: var(--space-0-5);
         border-radius: var(--border-radius-sm);
         background: var(--secondary-bg-color);
@@ -1545,14 +1535,12 @@
 // capped panel rendering AnsiLine rows. Replaces the JSON blob for results that
 // carry a terminal string body (stdout/output/content).
 .agent-terminal-output {
+    // No max-height/overflow here — see .agent-tool-record-table above.
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     border-radius: 0;
     padding: var(--space-1) var(--space-1-5);
     margin: var(--space-1) 0 0 0;
-    max-height: 400px;
-    overflow-y: auto;
-    overscroll-behavior: contain;
     font-family: var(--fixed-font, monospace);
     font-size: 11px;
     line-height: 1.45;


### PR DESCRIPTION
## Summary
- Tool-preview boxes (bash output, read content, compact JSON, record table, search results, fetch content, terminal output) each had their own `max-height`/`overflow-y`, nested inside the already-scrollable `.agent-tool-overlay-log` — producing a visible double scrollbar. Removed the redundant inner overflow so the overlay-log is the single scroll container per tool block.
- That fix also fully exposed a pre-existing bug from #1956's scroll-chaining work: `overscroll-behavior: contain` isolates a container from its ancestor rather than handing off to it, so once a preview hit its scroll boundary, further wheel input dead-ended instead of continuing into the outer pane (confirmed both directions). Implemented that spec's own deferred Phase 2: `ToolOverlayLog` now manually forwards wheel delta to `.agent-document` at the boundary.
- Both the original bug and the fix were reproduced/verified live via CDP wheel-event injection against a running `task dev` build (not just visually — asserted `scrollTop` transitions tick-by-tick). See the addendum in `docs/specs/SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md` for the full trace and root-cause writeup.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] Live repro: injected the real tool-preview DOM shape into a running dev window, drove real wheel events via CDP `Input.dispatchMouseEvent`, confirmed the pre-fix dead zone (outer `scrollTop` frozen through 10+ ticks past either boundary) and the post-fix handoff (outer `scrollTop` moves immediately and smoothly at both boundaries)
- [ ] Manual: open a real tool call with a long output (Bash/Read/Grep) in the app, confirm single scrollbar and smooth scroll handoff at top/bottom

<!-- agentmux:agent_id=agent3 -->