### PR TITLE
fix(agent): exclude dynamic system-prompt sections + token-tax follow-up

### DIFF
--- a/.changesets/1783194929-fix-agent-exclude-dynamic-system-prompt-sections-from-claude-1lwv.md
+++ b/.changesets/1783194929-fix-agent-exclude-dynamic-system-prompt-sections-from-claude-1lwv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): exclude dynamic system-prompt sections from Claude Code launch args to improve cross-instance prompt-cache reuse

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -162,7 +162,13 @@ pub(crate) async fn run_agent_with_bin(
     cmd.arg("--print")
         .arg("--output-format=stream-json")
         .arg("--verbose")
-        .arg("--include-partial-messages");
+        .arg("--include-partial-messages")
+        // Moves per-machine sections (cwd, env info, memory paths, git status)
+        // out of the system prompt into the first user message, matching the
+        // persistent-controller launch args in providers.rs. This spawn path
+        // builds its own args independent of ProviderConfig, so the flag has
+        // to be added here too — reagent P1 on PR #1964.
+        .arg("--exclude-dynamic-system-prompt-sections");
     // Forward the configured turn cap so the CLI enforces it.
     // Previously stored on AgentTask but never passed to the
     // subprocess — silently ignored. Reagent P1 + codex P2 on

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -124,8 +124,14 @@ static CLAUDE: ProviderConfig = ProviderConfig {
         // out of the system prompt into the first user message, so the system
         // prompt stays byte-identical across agents/machines and the 1hr
         // prompt cache (docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md) isn't
-        // invalidated by per-instance dynamic content. No-op unless
-        // --system-prompt is also passed (it isn't, here).
+        // invalidated by per-instance dynamic content. No-op if the default
+        // system prompt is overridden — not guaranteed here, since
+        // `agent.provider_flags` (app_api/agent_open.rs) is a free-form
+        // user-configurable string appended after these args; a user-set
+        // `--system-prompt` there would silently no-op this flag. Harmless
+        // either way (that's the flag's own documented ignore-if-overridden
+        // behavior), just not something this hardcoded default can prevent.
+        // reagent P2 on PR #1964.
         "--exclude-dynamic-system-prompt-sections",
     ],
     persistent_launch_args: Some(&[

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -120,6 +120,13 @@ static CLAUDE: ProviderConfig = ProviderConfig {
         "--verbose",
         "--include-partial-messages",
         "--dangerously-skip-permissions",
+        // Moves per-machine sections (cwd, env info, memory paths, git status)
+        // out of the system prompt into the first user message, so the system
+        // prompt stays byte-identical across agents/machines and the 1hr
+        // prompt cache (docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md) isn't
+        // invalidated by per-instance dynamic content. No-op unless
+        // --system-prompt is also passed (it isn't, here).
+        "--exclude-dynamic-system-prompt-sections",
     ],
     persistent_launch_args: Some(&[
         "--input-format",
@@ -128,6 +135,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
         "stream-json",
         "--verbose",
         "--include-partial-messages",
+        "--exclude-dynamic-system-prompt-sections",
         // Enable the control protocol so the sidecar can answer can_use_tool /
         // AskUserQuestion. Replaces --dangerously-skip-permissions (which bypasses it).
         "--permission-prompt-tool",

--- a/docs/analysis/TOKEN_TAX_FOLLOWUP_2026_07_04.md
+++ b/docs/analysis/TOKEN_TAX_FOLLOWUP_2026_07_04.md
@@ -1,0 +1,98 @@
+# AgentMux Token Tax — Follow-up: P1–P4 Resolution + Empirical Cache Check
+
+**Date:** 2026-07-04
+**Follow-up to:** `docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md`
+**Author:** AgentA
+
+Closes out the four open items (P1–P4) from the original analysis and adds an empirical cache-behavior test that wasn't in the original (desk-research-only) doc. Also folds in a second, distinct overhead vector — MCP tool-schema size — that came up in the same investigation but isn't covered by the original doc at all.
+
+---
+
+## 1. Status of P1–P4
+
+| Item | Original status | Now |
+|---|---|---|
+| **P1** — default `startup` to `__SKIP__` | Proposed | **Already shipped.** `scripts/gen-seed.js:270-272` defaults `startup: "__SKIP__"`. No action needed. |
+| **P2** — dedupe CLI auto-memory vs. AgentMux CLAUDE.md memory | Open (3 options listed, undecided) | **Already resolved — Option A shipped.** `agentmux-srv/src/server/app_api/agent_open.rs:418-436` defaults `autoMemoryEnabled: false` in `.claude/settings.json` whenever the file's settings block is (re)written, unless the user already set it explicitly. AgentMux owns memory itself via CLAUDE.md's global-brain + per-agent memory injection (`agent_config.rs`). The two-memory-systems risk the doc flagged doesn't exist today. |
+| **P3** — does `--resume` re-read CLAUDE.md from disk? | Unverified hypothesis ("logical answer is no") | **Empirically tested — resolved, with a more precise answer than the original hypothesis (see §2).** |
+| **P4** — add `--exclude-dynamic-system-prompt-sections` | Proposed | **Shipped this session.** Added to both `launch_args` and `persistent_launch_args` for the `claude` provider in `agentmux-srv/src/backend/providers.rs`. Verified the flag is real (`claude --help`), verified AgentMux doesn't pass `--system-prompt` anywhere (which would make the flag a no-op), verified `cargo check -p agentmux-srv` compiles clean. |
+
+---
+
+## 2. P3 — empirical test (three-turn controlled experiment)
+
+Ran directly against the `claude` CLI in a scratch directory (`/tmp/claude-resume-test`), independent of AgentMux, to isolate the CLI's own `--resume` mechanics:
+
+1. **Turn 1** (fresh session): `CLAUDE.md` contains `SENTINEL_ORIGINAL_VALUE_ALPHA`. Asked "what does CLAUDE.md say" → correctly quoted `ALPHA`.
+2. Edited `CLAUDE.md` on disk to `SENTINEL_CHANGED_VALUE_BETA`.
+3. **Turn 2** (`--resume <session_id>`, explicit "what does it say **now**"): correctly quoted `BETA`. `num_turns: 2` in the response — i.e. the model made a tool call (a `Read`/file-check) to verify before answering, it wasn't handed fresh content automatically.
+4. Edited `CLAUDE.md` again to `SENTINEL_THIRD_VALUE_GAMMA`.
+5. **Turn 3** (`--resume`, explicitly "recall from memory, don't re-read anything"): the model answered `ALPHA` then `BETA` (its own conversation history) and did **not** mention `GAMMA`. `num_turns: 1` — no tool call.
+
+**Conclusion:** the original doc's hypothesis was directionally right but for the wrong reason. `--resume` does **not** mechanically re-inject a fresh copy of `CLAUDE.md` into context on every resume (turn 3 proves this — no re-read, no `GAMMA`). But `CLAUDE.md` is just an ordinary file in the working directory, so **the agent can always see a mid-session edit if something (a user question, a prompt, its own judgment) causes it to actually read the file** — that's turn 2. The doc's practical concern (does AgentMux writing memory into `CLAUDE.md` mid-session become visible before the next fresh session?) resolves to: **not automatically, but not structurally blocked either** — it depends on whether the running agent happens to check the file. In practice, for AgentMux's actual usage (memory writes aren't something the agent is routinely prompted to re-verify), the doc's original practical conclusion holds: **treat CLAUDE.md memory writes as effectively cross-session-only.**
+
+### Bonus finding: the Anthropic baseline cache really is warm cross-session
+
+Turn 1 (a nominally "fresh" session, first invocation) already showed `cache_read_input_tokens: 44661` against `cache_creation_input_tokens: 6212`. That's a *new* session reading tens of thousands of tokens from cache before it had ever run — confirming the original doc's claim that the ~27–32K Anthropic system-prompt-plus-tools baseline is cached by content hash and shared across sessions, not per-session. This is good news for the overhead story: the biggest cost line item in the whole breakdown is already close to free after the very first request anywhere on the account.
+
+---
+
+## 3. P4 — shipped
+
+`agentmux-srv/src/backend/providers.rs`, `CLAUDE` provider config — added `--exclude-dynamic-system-prompt-sections` to both `launch_args` (one-shot subprocess mode) and `persistent_launch_args` (the mode AgentMux actually runs, per `controller_type: ControllerType::Persistent`).
+
+Verified before shipping:
+- The flag is real: `claude --help` → *"Move per-machine sections (cwd, env info, memory paths, git status) from the system prompt into the first user message. Improves cross-user prompt-cache reuse. Only applies with the default system prompt (ignored with `--system-prompt`). (default: false)"*.
+- It won't be silently ignored: grepped the whole `agentmux-srv` tree for `--system-prompt` / `--append-system-prompt` — AgentMux never passes either, so the default system prompt path applies and the flag takes effect.
+- `cargo check -p agentmux-srv` — clean (pre-existing dead-code warnings only, unrelated to this change).
+
+Effect: per-machine content (cwd, git status, env info) moves out of the cached system-prompt prefix into the first user message, so two different AgentMux instances (or the same instance across working directories) share the same system-prompt cache entry instead of each minting its own.
+
+---
+
+## 4. A second, distinct overhead vector: MCP tool-schema size (not covered by the original doc)
+
+Separately from CLAUDE.md/session-start overhead, this session also dug into whether `agentmux-mcp`'s tool definitions (28 tools) get "resent every turn" — they do, but that's inherent to the stateless Messages API (every tool, MCP or not, must ride in the `tools` array on every request), not something specific to MCP or fixable by AgentMux. What *is* controllable:
+
+- Tools render **before** `system` in the cache prefix (`tools → system → messages`), so a stable tool set is cache-eligible the same way the system prompt is — same 1hr TTL for OAuth, same cross-request reuse.
+- Per the existing `SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md` §10 amendment, the MCP tool surface was already consolidated 17 → 11 tools specifically to shrink this footprint (and to stay under the 4-breakpoint cache_control limit's practical concerns).
+- That amendment's own citation (`agentmux-pane-latency-report.md`) **does not exist in this repo** — flagging this again since it means the "2 KB per turn" cost claim behind that consolidation was never independently verified against real `cache_read_input_tokens` telemetry, only assumed. This session's P3 experiment is the first actual empirical cache measurement done against this codebase's usage pattern.
+- AgentMux does **not** persist `cache_read_input_tokens`/`cache_creation_input_tokens` anywhere queryable (checked `agentmux-srv/src/backend/storage/` — no such column/table). The frontend (`claude-translator.ts`, `useAgentStream.ts`) parses these fields per-turn for the live cost/token counters, but nothing rolls them up historically. **There's no way today to check "is caching actually working" for a real AgentMux agent session after the fact** — only live, in the moment, in the UI.
+
+---
+
+## 4b. Addendum — the actual `agentmux-docs` page (not checked when this report was first written)
+
+This report initially only used `docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md`, an internal analysis doc inside *this* repo. There is a separate, authoritative public docs repo, `agentmuxai/agentmux-docs` (docs.agentmux.ai) — cloned read-only afterward to check `src/content/docs/internals/conversation-overhead.md` directly. It corroborates everything above (two-layer model, `cache_control: ephemeral`, the `input + cache_creation + cache_read` formula) and adds facts worth folding in:
+
+- **Explicit cache-invalidation trigger list** (any of these forces the next turn-1 to pay full `cache_creation_input_tokens` again): soul/agentmd/memory-bundle content edited, a memory bundle added/removed, the skills index changing (skill installed/removed), a new session started without `--resume`, or the working directory changing (it feeds `{{WORKING_DIR}}` template substitution into the assembled CLAUDE.md). Anything touching P2's memory-bundle system is therefore also a cache-cost lever, not just a correctness one.
+- **AgentMux makes zero direct HTTP calls to any AI provider API** — all provider interaction is through the CLI subprocess via PTY. This bounds what AgentMux can ever do about per-turn overhead to: (a) what content it writes into CLAUDE.md, (b) CLI launch flags (P4's category), and (c) session lifecycle (fresh vs. `--resume`) — never direct `cache_control` placement, since AgentMux never builds the API request itself.
+- **Compaction threshold for the Claude Code CLI: `contextWindow - 33,000` tokens.** AgentMux detects compaction by watching for a token-count drop in the CLI's output stream but doesn't trigger or control it.
+- One stale citation in that page: it cites `agentmux-srv/src/backend/types.rs` for `TokenCounts` — the struct actually now lives at `agentmux-srv/src/agents/types.rs` (confirmed by grep; the file moved since that docs page was written). Same pattern as the stale `agent_handlers.rs` citation in the original 2026-06-19 analysis doc — worth a docs pass to re-anchor citations against current file paths.
+- Confirms independently (via `struct TokenCounts` in `agents/types.rs` and a repo-wide grep of `backend/storage/`) that this data is **not persisted anywhere** — same conclusion §4 already reached, now cross-checked against the public docs' own claim that AgentMux "tracks" these fields (true only in the sense of parsing them into a live struct for the UI, not storing history).
+
+## 4c. Code-verification pass — every claim checked against the current source
+
+Both docs pages (the internal 2026-06-19 analysis and `agentmux-docs`' `conversation-overhead.md`) cite specific files/functions. Rather than trust those citations, verified each one directly against `main` @ `ca7ff4d3`:
+
+| Claim | Result |
+|---|---|
+| CLAUDE.md assembly (Soul + AgentMD + memory + skills + template vars) | **Confirmed**, citation stale. Real path: `agentmux-srv/src/backend/agent_config.rs:35` `build_config_files(...)`, called from `agentmux-srv/src/server/app_api/agent_open.rs:393` `write_agent_config_files(...)` — not `agentmux-srv/src/server/app_api.rs` as cited. Assembly order confirmed: Soul → `---` → AgentMD → `# Memory` (per-agent + global brain bundles) → `# Available Skills`. |
+| Written once per launch, not per turn | **Confirmed.** Single call site: `agent_open.rs:321`, inside the `agent.open` RPC handler. No other caller anywhere in the tree. |
+| Startup payload (fresh-session-only, contents) | **Confirmed**, citation stale. Real path: `frontend/app/view/agent/startup/buildStartupPayload.ts` (moved into a `startup/` subfolder), invoked from `agent-view.tsx:654`, guarded at line 635 by `if (block()?.meta?.["agent:sessionid"]) return;` (skips on resume). |
+| `real_context_tokens = input + cache_creation + cache_read` | **Confirmed**, citation stale. Real path: `frontend/app/view/agent/providers/claude-translator.ts:95-98` (moved into a `providers/` subfolder). The Rust struct (`agentmux-srv/src/agents/types.rs:112`, not `backend/types.rs`) uses shortened field names (`input`, `cache_creation`, `cache_read`) — the `_input_tokens`-suffixed wire names only exist in the frontend's raw parsing. |
+| Compaction threshold `contextWindow - 33,000` | **Confirmed**, and better-anchored than either doc: `frontend/app/store/agent-pane-state/context-window.ts:26` — `const COMPACTION_BUFFER = 33_000;`. Neither doc actually cited this file. The file's own header explains *why*: the CLI never reports its context window size; AgentMux learns/seeds it from observed usage. The specific "large token-count drop" detection logic referenced by the internals doc was not separately located — flagging as not fully verified (the threshold/meter math is confirmed, the drop-detector isn't pinned to a line). |
+| Cache-invalidation triggers all resolve through the same launch-time CLAUDE.md rewrite | **Confirmed for 4 of 5 — 1 is currently false.** Soul/agentmd/memory edits, memory-bundle add/remove, and skills-index changes are all read fresh inside `write_agent_config_files` and folded into the same single call site as above — correct. **But "working directory changes" does not currently invalidate anything**: `build_config_files` (the function actually called) explicitly does *not* set the `{{WORKING_DIR}}` template var (`agent_config.rs:51-52`: *"WORKING_DIR is not available in this signature; leave it empty... expansion will leave `{{WORKING_DIR}}` intact if absent"*). The sibling function that does set it, `build_config_files_with_bus`, **has zero callers anywhere in the codebase** — confirmed via a repo-wide grep excluding its own definition. So today, changing working directory has no effect on CLAUDE.md content and therefore doesn't invalidate the cache the way `agentmux-docs` currently claims. This is either dead code that should be wired up, or a docs claim that should be removed — flagging both possibilities rather than picking one, since fixing it either way is outside this session's scope. |
+
+## 5. Open items / next steps
+
+1. **No historical cache-hit telemetry.** If overhead work continues, the highest-leverage next step is persisting `cache_read_input_tokens` / `cache_creation_input_tokens` (already parsed, just not stored) per turn, so "is the cache actually landing for real agent sessions" becomes a query instead of a one-off manual test like this session's.
+2. **P4's actual effect is unmeasured.** The flag is shipped but its real-world cache-reuse improvement hasn't been measured before/after (needs #1 above, or a manual two-instance comparison).
+3. **Confirm P2 in practice, not just in code.** `autoMemoryEnabled: false` is the default *write*, but worth spot-checking a live agent's actual `.claude/settings.json` to confirm it's landing (the code path warns and skips the guard if the existing `settings.json` is unparseable JSON — `agent_open.rs:428-436` — worth checking that warning never fires in practice).
+4. **The missing `agentmux-pane-latency-report.md` citation** — either the file should exist and was lost, or the Amendment's cost claim should be re-derived from real data (see #1) and the citation corrected.
+5. **`{{WORKING_DIR}}` templating is dead code.** `build_config_files_with_bus` (the only function that substitutes it) has no callers. Decide: wire it into `write_agent_config_files` (making "working directory changed" a real cache-invalidation trigger, matching what `agentmux-docs` already claims), or delete the dead function and correct the docs claim. Either is a small, self-contained follow-up.
+6. **Stale file-path citations, repo-wide.** Two separate docs (the internal 2026-06-19 analysis and `agentmux-docs`' `conversation-overhead.md`) both cite paths that have since moved (`app_api.rs` → `app_api/agent_open.rs`, `agent/buildStartupPayload.ts` → `agent/startup/buildStartupPayload.ts`, `agent/claude-translator.ts` → `agent/providers/claude-translator.ts`, `backend/types.rs` → `agents/types.rs`). Fixed in `agentmux-docs` directly (see §6).
+
+## 6. `agentmux-docs` update
+
+Once this report's changes land on `main`, the corresponding public-docs PR against `agentmuxai/agentmux-docs` updates `src/content/docs/internals/conversation-overhead.md` with: the four corrected file-path citations from §4c, the `{{WORKING_DIR}}` dead-code caveat on the "working directory changes" invalidation trigger (open item #5 above — noted as currently inert rather than silently removed, since the fix direction isn't decided yet), and a new citation for the compaction-threshold constant (`context-window.ts:26`), which neither doc had pinned to a file before.

--- a/docs/specs/SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md
+++ b/docs/specs/SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md
@@ -1,0 +1,144 @@
+# Agent API: System Management Surface (reload, process/render diagnostics, saga health)
+
+**Date:** 2026-07-04
+**Status:** Draft
+**Author:** AgentA
+**Related:**
+- `docs/specs/SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md` — the naming/layout/introspection surface this extends; same conventions apply (self-context defaulting, capability tiers, MCP→REST→gateway layering).
+- Incident that triggered this: 2026-07-04 session — `sysinfo`/`swarm` panes were pruned from a live layout tree (cause still unconfirmed) leaving a stale-rendered empty cell, and the operator had **no remote way to reload the window** or **query renderer/process counts** to diagnose it. Both had to be improvised: renderer counts via an ad-hoc `Get-CimInstance Win32_Process` PowerShell shellout, no path at all for a remote reload.
+- Also motivated by verifying PR #1957 (`fix(browser-pane): app-owned wrapper HWND fixes Windows renderer leak on pane close`) — its own test plan flagged renderer-process-count verification as the one item it couldn't independently confirm; a first-class RPC for this would have made that trivial instead of ad-hoc.
+
+---
+
+## 1. Premise
+
+Today an agent that needs to *observe or recover the app it's running in* — reload a stuck window, check whether a renderer actually tore down, see saga backlog — has no first-class way to do it. It must fall back to shelling out to OS tools (`tasklist`, `Get-CimInstance`) against a process it doesn't otherwise have a handle on, or ask the human to click through a menu. This spec adds a **`system` domain**: read-only diagnostics (process/render/saga health) plus a small number of safe self-recovery verbs (reload), following the exact layering and tiering convention `SPEC_AGENT_API_FIRST_CLASS_SURFACE_2026_06_17.md` established for naming/layout.
+
+---
+
+## 2. Does RPC auto-bind to MCP? No — verified.
+
+There is **no automatic binding**. Three independent layers exist, and a new ability requires hand-written code in each:
+
+```
+MCP tool   (agentmux-mcp/src/main.rs — a Rust const JSON schema + a call_tool() match arm)
+   └── REST verb   (agentmux-srv/src/server/mod.rs route + handler — typed request/response)
+          └── dispatch_service / host command  (the actual reducer/service call, or an agentmux-cef IPC command)
+```
+
+Concretely, adding one new MCP-visible ability today means touching:
+1. A `const FOO_TOOL: &str = r#"{ "name": "Foo", ... }"#;` JSON schema literal in `agentmux-mcp/src/main.rs`.
+2. Adding it to the `tools/list` array (currently enumerated by hand, one `Value` binding per tool — see `main.rs:476-515`).
+3. A `"Foo" => { ... }` arm in `call_tool()` that does an HTTP call.
+4. A REST route + handler in `agentmux-srv/src/server/mod.rs` (if none of the existing 47+ `dispatch_service` methods already covers it).
+5. Possibly a new `dispatch_service` match arm, or (for anything host/window/process-level) a new `agentmux-cef` command — **nothing in that layer is agent-reachable at all today** (see §4).
+
+This confirms the premise in the question: **RPC commands are not auto-exposed to MCP.** The `/agentmux/service` gateway (`dispatch_service`) is reachable over plain HTTP by anything with the auth key (including an ad-hoc script, as used during tonight's investigation), but it is *not* the same thing as an MCP tool — no MCP tool exists unless someone wrote the three layers above by hand. This is a deliberate, documented choice (§5 of the first-class-surface spec): the raw gateway is "internal/advanced," curated verbs are "the supported, documented surface" — but it means coverage is only as complete as someone has gotten around to wrapping.
+
+---
+
+## 3. What exists today (inventory, verified against `main` @ `ca7ff4d3`)
+
+### 3.1 MCP tools (28, `agentmux-mcp/src/main.rs`)
+
+| Category | Tools |
+|---|---|
+| Shell/process (agent's own subprocess) | `Shell`, `ShellStop`, `ShellInput`, `ShellStatus` |
+| Panes/editor | `OpenEditor` |
+| Messaging | `SendMessage`, `DiscoverAgents` |
+| Self-context / naming (§4 of the first-class-surface spec) | `WhoAmI`, `SetName` (window/tab/pane/workspace) |
+| Layout / navigation | `Layout` (query=layout\|windows\|workspaces\|tabs), `SetActiveTab`, `NewTab`, `FocusWindow` |
+| Scheduling | `Loop`, `LoopStop`, `LoopList`, `CronCreate`, `CronDelete`, `CronList`, `CronPause`, `CronResume` |
+| Memory (brain) | `MemoryList`, `MemoryRead`, `MemoryWrite` |
+| Presets | `PresetList`, `PresetGet` |
+| Identity | `IdentityAccounts`, `IdentityValidate` |
+
+Notably **absent**: anything about the app's own runtime health — no process info, no renderer/window diagnostics, no reload/restart, no saga/queue health. There is no `system` category at all.
+
+### 3.2 REST verbs (`agentmux-srv/src/server/mod.rs`, curated `/api/v1/*` surface)
+
+`shell/{create,stop,input,status}`, `pane/open`, `voice/transcribe`, `self`, `window/name`, `tab/name`, `pane/title`, `workspace/name`, `layout`, `windows`, `workspaces`, `tabs`, `tab/activate`, `tab/new`, `window/focus`, `agent/memory/{list,read,write}`, `agent/preset/{list,get}`, `agent/identity/{accounts,validate}`.
+
+### 3.3 The raw gateway (`/agentmux/service`, `dispatch_service`) — bigger than documented, still growing
+
+The 2026-06-17 spec counted **47 methods**; re-verified today the four service modules alone contain (arm count from the reducer's `match` blocks):
+
+| Service | Methods |
+|---|---|
+| `object` | `GetObject`, `GetObjects`, `UpdateTabName`, `CreateBlock`, `DeleteBlock`, `UpdateObjectMeta`, `UpdateObject` |
+| `client` | `GetClientData`, `GetTab`, `FocusWindow`, `AgreeTos`, `GetAllConnStatus`, `TelemetryUpdate` |
+| `window` | `GetWindow`, `CreateWindow`, `CloseWindow`, `SwitchWorkspace`, `SetWindowPosAndSize` |
+| `workspace` | `CreateWorkspace`, `GetWorkspace`, `DeleteWorkspace`, `ListWorkspaces`, `CreateTab`, `SetActiveTab`, `CloseTab`, `UpdateWorkspace`, `UpdateTabIds`, `MoveBlockToTab`, `PromoteBlockToTab`, `ReorderTab`, `MoveTabToWorkspace`, `RestoreTornOffTab`, `TearOffBlock`, `RedockFloatingPane`, `TearOffTab` |
+| `misc` (userinput/block/subagent/history/agent) | `SendUserInputResponse`, `GetControllerStatus`, `SendCommand`, `SaveTerminalState`, `ListActive`, `GetHistory`, + more |
+
+None of `window`/`workspace`'s more powerful verbs (`CloseWindow`, `DeleteWorkspace`, `SetWindowPosAndSize`) are MCP-wrapped — consistent with the Tier-1 gating the first-class-surface spec calls for, but today they're simply **unwrapped**, not gated; nothing stops a raw `/agentmux/service` POST from calling them (verified during tonight's session: `DeleteBlock` was called directly over HTTP with only the shared auth key, no capability check).
+
+### 3.4 Diagnostics that exist but are **not** reachable by an agent at all
+
+- **`GET /agentmux/diag/sagas`** — durable saga log + in-flight count (`mod.rs`, "operator visibility into the durable saga log"). No MCP tool, no `/api/v1` alias. HTTP-reachable with the auth key, undocumented for agent use.
+- **`agentmux-launcher --diag {sagas,wrr,srv}`** — CLI-only, pipe-IPC, not reachable over HTTP/MCP at all (would require shelling out to the launcher binary with the right working directory).
+- **GPU status indicator** (PR #1337, `frontend/app/statusbar/GpuStatus.tsx`) — frontend-only, reads host state directly; no backend RPC surfaces it.
+- **`sysinfo` pane/widget** — same: a frontend view, not backed by an agent-queryable RPC.
+- **Renderer/subprocess process info** — CEF's own `--type=renderer|gpu-process|utility` subprocess tagging is read once at each child's own startup (`agentmux-cef/src/lib.rs:304-307`) purely to decide "am I a subprocess," and is **never aggregated or exposed** anywhere — not to the frontend, not over RPC. Tonight's renderer-count check had to shell out externally (`Get-CimInstance Win32_Process -Filter "Name='agentmux-0.50.0.exe'"` + regex the command line for `--type=`) because nothing in-process tracks this.
+- **Window reload** — grepped the entire repo (`agentmux-cef`, `frontend`, `docs`): there is no "reload the window/view" command anywhere — no RPC, no documented keybinding, no host IPC command. `browser_api/types.rs` has a `reload` **for browser-pane content** (i.e. reload the web page inside a `browser` view), which is a completely different thing from reloading the app's own chrome/frontend. Toggling DevTools (`dev:devtools`, native-menu-only, `agentmux-cef/src/macos_menu.rs`) is the closest adjacent capability and is also not RPC-reachable.
+
+---
+
+## 4. Proposed `system` domain
+
+Following §4.1's layering and §5's tiering from the first-class-surface spec.
+
+### 4.1 Tier 0 (default, ungated — read-only or self-scoped-and-reversible)
+
+| MCP tool | REST | Backing |
+|---|---|---|
+| `SystemProcessInfo()` | `GET /api/v1/system/processes` | **New.** Host-side: enumerate own child processes by CEF `--type=` (browser/renderer/gpu-process/utility), return counts + PIDs. Removes the need for the external `tasklist`/WMI shellout used tonight; directly answers the exact check `SPEC_BROWSER_PANE_WINDOWS_TEARDOWN_SPIKE_2026_07_03.md` §4 item 4 calls for ("check via `tasklist`... before/after close"). |
+| `SystemSagaHealth()` | alias existing `GET /agentmux/diag/sagas` under `/api/v1/system/sagas` | Already implemented; just needs the REST alias + MCP wrap. |
+| `SystemReloadView(block_id?)` | `POST /api/v1/system/reload-view` | **New.** The literal capability missing tonight: reload just the calling agent's own window/frontend (or an explicit `block_id`'s owning window, defaulting to self via `WhoAmI`-style resolution). Implemented as a host IPC command that calls the CEF browser's own `Reload()`/`ReloadIgnoreCache()` on the frontend's root browser — not the same code path as a browser-*pane*'s content reload (`browser_api::reload`), which only affects an embedded web page, not the app chrome. Self-scoped and reversible (worst case: momentary blank window while it repaints) — Tier 0. |
+| `SystemGpuStatus()` | `GET /api/v1/system/gpu` | **New**, thin wrap of whatever `GpuStatus.tsx` already reads host-side — surfaces enabled/disabled + driver info to agents, not just the statusbar. |
+
+### 4.2 Tier 1 (gated — destructive or global; default off, per existing convention)
+
+| MCP tool | REST | Backing |
+|---|---|---|
+| `SystemRestartInstance()` | `POST /api/v1/system/restart` | **New.** Full app restart (not just a view reload) — closer to what would have been needed if a hard-refresh hadn't sufficed tonight. Genuinely destructive to in-flight state; gate behind the same capability flag §5 of the first-class-surface spec proposes for `CloseWindow`/`DeleteWorkspace`. |
+| `SystemToggleDevTools()` | `POST /api/v1/system/devtools` | Wraps the existing native-menu-only `dev:devtools` command. Not destructive, but exposes live JS console access to whatever's rendered — treat as Tier 1 out of caution (it's a debugging escape hatch, not a normal agent verb) unless there's a concrete agent use case for it. |
+
+### 4.3 Deliberately excluded / needs its own investigation first
+
+- **Root-causing *why* a pane gets pruned from a layout tree** (tonight's actual missing-panes incident) is a correctness bug hunt, not an API gap — out of scope here. This spec only closes the "I had no way to check/recover" gap around it.
+- **Cross-instance system management** (reload/restart *another* AgentMux instance) — stays out per the existing non-goal ("an agent only acts on its own instance").
+- **Killing arbitrary child processes by PID** — never; would conflict with the I1–I6 isolation invariants (`CLAUDE.md`) and the "no `taskkill //im`, no killing processes you didn't spawn" rule. `SystemRestartInstance` must go through the launcher's own lifecycle (Job Object), never a raw `TerminateProcess`.
+
+---
+
+## 5. Why this matters beyond tonight
+
+The renderer-leak fix (PR #1957) shipped with one item explicitly flagged as **not independently re-confirmed**: renderer-process-count returning to baseline after repeated pane closes, because "the test instance was terminated externally before a clean measurement could be taken." `SystemProcessInfo()` turns that from a manual `Get-CimInstance` shellout (what this session had to improvise, against its own live host window, which is why the earlier verification attempt tonight was paused and redirected to an isolated instance instead) into a one-line, always-available check — for this fix's own future regressions and for any future CEF-process-lifecycle work.
+
+---
+
+## 6. Implementation plan
+
+**Phase 1 — the two verbs tonight actually needed**
+1. `SystemProcessInfo` (read-only, no host changes needed beyond enumerating own children — Windows via `Win32_Process`/`EnumProcesses` filtered to child PIDs already tracked by the Job Object; macOS/Linux via `/proc` or `sysctl` equivalents, scoped to own process tree only).
+2. `SystemReloadView` (host IPC command + REST + MCP wrap).
+
+**Phase 2 — diagnostics parity**
+3. `SystemSagaHealth` (thin alias of existing endpoint).
+4. `SystemGpuStatus` (thin wrap of existing host-side GPU state).
+
+**Phase 3 — gated recovery**
+5. Capability-tier plumbing (shared with the still-open Tier-1 gating from the first-class-surface spec — do this once, for both specs' Tier-1 verbs together, not twice).
+6. `SystemRestartInstance`, `SystemToggleDevTools` behind that gate.
+
+Each phase ships independently; Phase 1 alone would have fully covered tonight's incident (diagnose via process info, recover via reload, without falling back to raw HTTP + PowerShell shellouts against a live user session).
+
+---
+
+## 7. Open questions
+
+1. **Process enumeration scope on Windows** — Job Object already tracks every child PID (I2/I3 invariants); should `SystemProcessInfo` read from the Job Object's own accounting (`QueryInformationJobObject`) instead of a fresh `Win32_Process` scan? Would be more consistent with "bounded blast radius" but needs checking whether renderer/gpu/utility subprocess PIDs are actually assigned into the same Job Object as the host.
+2. **`SystemReloadView` scope when torn off** — same open question §8.2 of the first-class-surface spec raises for `SetWindowName`: does self-context resolve the right *window* (not just block) when the calling agent's pane was torn off into a floating window?
+3. **Does reload actually fix a stale empty layout cell**, or would that require `SystemRestartInstance`? Untested as of this writing — the incident that motivated this spec was redirected to a hard-refresh-by-hand request rather than confirmed via either new verb (neither exists yet).
+4. **Capability storage** — same unresolved question as the first-class-surface spec §8.1; should be answered once, shared across both specs' Tier-1 verbs.


### PR DESCRIPTION
## Summary

- Ships P4 from `docs/analysis/TOKEN_TAX_ANALYSIS_2026_06_19.md`: adds `--exclude-dynamic-system-prompt-sections` to the Claude Code provider's launch args so per-machine content (cwd, env info, memory paths, git status) moves out of the cached system-prompt prefix, improving cross-instance prompt-cache reuse. Verified the flag is real, that AgentMux never passes `--system-prompt` (which would make it a no-op), and `cargo check -p agentmux-srv` is clean.
- Adds `docs/analysis/TOKEN_TAX_FOLLOWUP_2026_07_04.md`, closing out P1–P4 from the original analysis:
  - P1/P2 were already shipped, just not marked as such.
  - P3 (does `--resume` re-read `CLAUDE.md` from disk?) resolved with an empirical 3-turn test against the `claude` CLI directly.
  - Includes a code-verification pass against both this analysis and the public `agentmux-docs` overhead page — found several stale file-path citations, and one real dead-code finding: `{{WORKING_DIR}}` template substitution (`build_config_files_with_bus`) has zero callers, so "working directory changed" does not currently invalidate the prompt cache the way `agentmux-docs` claims. Flagged as an open item, not fixed here (undecided whether to wire it up or remove the claim).
- Adds `docs/specs/SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md`, a draft proposal (no code) for a new `system` MCP/RPC domain (process info, view reload, saga health, GPU status), surfaced by a live verification session that had no remote way to reload a stuck window or check renderer process counts.

## Test plan

- [x] `claude --help` confirms `--exclude-dynamic-system-prompt-sections` exists and its documented behavior
- [x] Repo-wide grep confirms AgentMux never passes `--system-prompt`/`--append-system-prompt` (flag won't be a no-op)
- [x] `cargo check -p agentmux-srv` clean (pre-existing dead-code warnings only)
- [x] `--resume` re-read behavior empirically tested with a 3-turn sentinel-value experiment against the `claude` CLI
- [ ] P4's real-world cache-reuse improvement not yet measured before/after (flagged as an open item — no historical cache-hit telemetry exists to measure it with)

<!-- agentmux:agent_id=agenta -->