### PR TITLE
fix(toolchain): unify Docker/toolchain capability detection across the app

### DIFF
--- a/.changesets/1783201574-fix-toolchain-unify-docker-toolchain-capability-detection-ac-w8l7.md
+++ b/.changesets/1783201574-fix-toolchain-unify-docker-toolchain-capability-detection-ac-w8l7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(toolchain): unify Docker/toolchain capability detection across the app

--- a/agentmux-srv/src/backend/container.rs
+++ b/agentmux-srv/src/backend/container.rs
@@ -487,6 +487,96 @@ impl ContainerManager {
     }
 }
 
+/// State of the container-runtime slot held by [`ContainerRuntimeHandle`].
+enum RuntimeSlot {
+    /// Test/no-docker-expected fixtures — `get()` never attempts a real
+    /// connect, always reports unavailable.
+    Disabled,
+    /// No manager yet: never connected, or the last connect attempt
+    /// failed. `get()` retries `ContainerManager::connect()` on every
+    /// call while in this state.
+    Empty,
+    Connected(ContainerManager),
+}
+
+/// Self-healing holder for the container runtime connection.
+///
+/// A plain `Option<ContainerManager>` fixed at process boot means a Docker
+/// daemon that starts (or a socket/named-pipe that appears) AFTER AgentMux
+/// launched is never picked up without an app restart — every consumer
+/// (the availability probe AND the actual container-launch code paths)
+/// would see a permanent `None`. This type retries on demand instead, so
+/// "start Docker Desktop while AgentMux is already running" is picked up
+/// within one call, everywhere `container_manager` is read.
+///
+/// See docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+pub struct ContainerRuntimeHandle {
+    slot: tokio::sync::RwLock<RuntimeSlot>,
+}
+
+impl ContainerRuntimeHandle {
+    /// Boot-time constructor. Attempts one connect (same as the prior
+    /// behavior) but never permanently gives up on failure — a failed
+    /// attempt leaves the slot `Empty` so `get()`/`is_available()` retry
+    /// later instead of staying stuck for the process lifetime.
+    pub fn connect_at_startup() -> Self {
+        let slot = match ContainerManager::connect() {
+            Ok(mgr) => RuntimeSlot::Connected(mgr),
+            Err(_) => RuntimeSlot::Empty,
+        };
+        Self { slot: tokio::sync::RwLock::new(slot) }
+    }
+
+    /// Test-only constructor: permanently reports unavailable and never
+    /// attempts a real connect, keeping host-only unit tests hermetic and
+    /// deterministic regardless of whether the test box has Docker.
+    pub fn disabled() -> Self {
+        Self { slot: tokio::sync::RwLock::new(RuntimeSlot::Disabled) }
+    }
+
+    /// Returns a connected manager, retrying `ContainerManager::connect()`
+    /// if the slot is currently `Empty`. Cheap on the happy path (a
+    /// read-lock plus a cheap `Arc`-backed clone); only takes the write
+    /// lock and re-dials when we don't already have a manager.
+    pub async fn get(&self) -> Option<ContainerManager> {
+        {
+            let slot = self.slot.read().await;
+            match &*slot {
+                RuntimeSlot::Connected(mgr) => return Some(mgr.clone()),
+                RuntimeSlot::Disabled => return None,
+                RuntimeSlot::Empty => {}
+            }
+        }
+        let mut slot = self.slot.write().await;
+        // Re-check under the write lock — another caller may have already
+        // connected between our read-unlock and this write-lock.
+        if let RuntimeSlot::Connected(mgr) = &*slot {
+            return Some(mgr.clone());
+        }
+        if matches!(&*slot, RuntimeSlot::Disabled) {
+            return None;
+        }
+        match ContainerManager::connect() {
+            Ok(mgr) => {
+                *slot = RuntimeSlot::Connected(mgr.clone());
+                Some(mgr)
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// True iff a manager is available AND its daemon answers a live ping
+    /// right now. Never trusts a cached `Connected` slot alone — the
+    /// daemon can go down again after a successful connect, and
+    /// `check_available` is a real `docker.ping()`, not a cached flag.
+    pub async fn is_available(&self) -> bool {
+        match self.get().await {
+            Some(mgr) => mgr.check_available().await.is_ok(),
+            None => false,
+        }
+    }
+}
+
 /// Derive the stable container name for an agent from its slug.
 /// Format: `agentmux-<slug>`. Deterministic so restarts reuse the same container.
 pub fn container_name_for_slug(slug: &str) -> String {

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -972,25 +972,26 @@ async fn main() {
         ),
         install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
         container_manager: {
-            match crate::backend::container::ContainerManager::connect() {
-                Ok(mgr) => {
-                    // Ping is async — spawn a task; the manager is still exposed
-                    // so container agents can start even before the ping resolves.
-                    let mgr = std::sync::Arc::new(mgr);
-                    let mgr_check = mgr.clone();
-                    tokio::spawn(async move {
-                        match mgr_check.check_available().await {
-                            Ok(()) => tracing::info!("Docker daemon available — container agent panes enabled"),
-                            Err(e) => tracing::warn!(error = %e, "Docker daemon not reachable; container agent panes will fail to start"),
-                        }
-                    });
-                    Some(mgr)
+            // Self-healing: unlike a plain `Option<ContainerManager>` fixed at
+            // boot, `ContainerRuntimeHandle` retries the connect on demand, so
+            // a daemon that starts after this point is picked up by later
+            // calls without an app restart. See
+            // docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+            let handle = std::sync::Arc::new(
+                crate::backend::container::ContainerRuntimeHandle::connect_at_startup(),
+            );
+            let handle_check = handle.clone();
+            tokio::spawn(async move {
+                if handle_check.is_available().await {
+                    tracing::info!("Docker daemon available — container agent panes enabled");
+                } else {
+                    tracing::warn!(
+                        "Docker daemon not reachable at startup; container agent panes will \
+                         become available automatically once Docker is running"
+                    );
                 }
-                Err(e) => {
-                    tracing::warn!(error = %e, "Docker not available; container agent panes disabled");
-                    None
-                }
-            }
+            });
+            handle
         },
         shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
         cron_scheduler: crate::backend::cron::CronScheduler::new(

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -246,23 +246,21 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
     // containerruntimeavailable → does the Docker DAEMON answer a ping
     // right now? Returns `{ available: bool }`. The create-from-template
-    // modal uses this to gate/default the container runtime. Distinct
-    // from `resolvecli docker`, which only confirms the CLI binary is on
-    // PATH — that false-positives when Docker is installed but the daemon
-    // is stopped, steering users into a container agent that can't start
-    // (codex P1 on #1576). `None` manager (Docker absent at startup) →
-    // false; `Some` → live `check_available()` ping so a daemon that
-    // came up or went down since launch is reflected.
+    // modal (via the frontend's shared toolchain-capabilities store) uses
+    // this to gate/default the container runtime. Distinct from
+    // `resolvecli docker`, which only confirms the CLI binary is on PATH —
+    // that false-positives when Docker is installed but the daemon is
+    // stopped, steering users into a container agent that can't start
+    // (codex P1 on #1576). `ContainerRuntimeHandle::is_available()` retries
+    // the connection on demand, so a daemon that came up or went down
+    // since launch is reflected without an app restart.
     let container_manager_cra = state.container_manager.clone();
     engine.register_handler(
         COMMAND_CONTAINER_RUNTIME_AVAILABLE,
         Box::new(move |_data, _ctx| {
             let cm = container_manager_cra.clone();
             Box::pin(async move {
-                let available = match cm {
-                    Some(mgr) => mgr.check_available().await.is_ok(),
-                    None => false,
-                };
+                let available = cm.is_available().await;
                 Ok(Some(serde_json::json!({ "available": available })))
             })
         }),

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -289,7 +289,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                         &block.meta, "agentMode", "host",
                     );
                     if agent_mode == "container" {
-                        let cm = container_manager.as_deref()
+                        let cm = container_manager.get().await
                             .ok_or_else(|| "Docker not available on this host; cannot start container agent".to_string())?;
                         let container_image = {
                             let img = crate::backend::obj::meta_get_string(&block.meta, "agent:container_image", "");

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -349,7 +349,7 @@ mod recent_sessions_tests {
             saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
             auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
             install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
-            container_manager: None,
+            container_manager: Arc::new(crate::backend::container::ContainerRuntimeHandle::disabled()),
             shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
             cron_scheduler: crate::backend::cron::CronScheduler::new(
                 None,
@@ -647,7 +647,7 @@ mod recent_sessions_tests {
             saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
             auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
             install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
-            container_manager: None,
+            container_manager: Arc::new(crate::backend::container::ContainerRuntimeHandle::disabled()),
             shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
             cron_scheduler: crate::backend::cron::CronScheduler::new(
                 None,

--- a/agentmux-srv/src/server/app_api/agent_io.rs
+++ b/agentmux-srv/src/server/app_api/agent_io.rs
@@ -220,7 +220,7 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // secrets in argv). Host agent branch: regular CLI subprocess.
                     let agent_mode = obj::meta_get_string(&block.meta, "agentMode", "host");
                     if agent_mode == "container" {
-                        let cm = container_manager.as_deref()
+                        let cm = container_manager.get().await
                             .ok_or_else(|| "Docker not available on this host; cannot start container agent".to_string())?;
                         let container_image = {
                             let img = obj::meta_get_string(&block.meta, "agent:container_image", "");

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -151,10 +151,13 @@ pub struct AppState {
     /// an install mid-flight.
     /// See `SPEC_AGENT_INSTALL_STAGE_2026_05_17.md` §9.
     pub install_sessions: std::sync::Arc<crate::server::install_handlers::InstallSessionRegistry>,
-    /// Docker container manager for container-type agent panes (Phase 2).
-    /// `None` when Docker is not available on this host — container agents
-    /// will refuse to start rather than crashing the server.
-    pub container_manager: Option<std::sync::Arc<crate::backend::container::ContainerManager>>,
+    /// Docker container runtime handle for container-type agent panes
+    /// (Phase 2). Self-healing — `.get()`/`.is_available()` retry the
+    /// Docker connection on demand rather than being fixed at process
+    /// boot, so a daemon that starts after AgentMux launched is picked up
+    /// without an app restart. See `ContainerRuntimeHandle` and
+    /// docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+    pub container_manager: std::sync::Arc<crate::backend::container::ContainerRuntimeHandle>,
     /// Phase 3 — per-shell stop handles so `ShellStop` (MCP tool) and the UI
     /// stop button can tree-kill a running persistent shell node. See
     /// `docs/specs/SPEC_PERSISTENT_SHELL_PHASE3_STOP_2026_06_14.md`.

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -83,7 +83,7 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // ── Container agents ─────────────────────────────────────────
                 if agent_mode == "container" {
-                    let cm = cm_opt.as_deref().ok_or_else(|| {
+                    let cm = cm_opt.get().await.ok_or_else(|| {
                         "shellexec: Docker not available on this host; \
                          cannot exec in container agent".to_string()
                     })?;

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -73,7 +73,7 @@ pub(crate) fn test_state() -> AppState {
         saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
         auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
         install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
-        container_manager: None,
+        container_manager: Arc::new(crate::backend::container::ContainerRuntimeHandle::disabled()),
         shell_sessions: crate::backend::shell_node::ShellSessionRegistry::new(),
         cron_scheduler: crate::backend::cron::CronScheduler::new(
             None,

--- a/docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md
+++ b/docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md
@@ -37,7 +37,7 @@ See PR for the full diff and `frontend/app/store/toolchain-capabilities.test.ts`
 
 - `cargo check`/`cargo test -p agentmux-srv` — 1296 passed, including the container module's existing unit tests.
 - `npx tsc --noEmit` and the full `vitest` suite — 1590 passed across 106 files, including the new store's tests and the existing `AgentCreateFromTemplateModal.test.tsx`/`AgentLaunchModal.integration.test.tsx` suites (updated to route their Docker mocks through the shared store).
-- Manual, live: stopped Docker Desktop, confirmed the Toolchain widget and the create-agent modal agreed ("not detected" in both). Started Docker Desktop with AgentMux still running — both flipped to available within the store's poll interval, with no manual refresh and no AgentMux restart. Launched an actual container-mode agent afterward to confirm the reconnected manager was visible to the real launch path, not just the status probe.
+- **Not yet live-tested end-to-end** in a running dev instance (stop/start Docker Desktop while `task dev` is up, confirm the Toolchain widget and create-agent modal agree throughout, then launch an actual container-mode agent to confirm the reconnected manager reaches the real launch path, not just the status probe). The automated coverage above exercises the dispatch logic, caching, de-dup, and polling lifecycle directly, but the live cross-view-agreement scenario this fix targets should still get a manual pass before/shortly after merge.
 
 ## Explicit follow-ups (found during this investigation, not fixed here)
 

--- a/docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md
+++ b/docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md
@@ -1,0 +1,51 @@
+# Retro: Docker "installed" signal disagreed across the app
+
+**Date:** 2026-07-04
+**Severity:** Medium (confusing UX, no data loss; workaround was to restart AgentMux, which wasn't even guaranteed to help)
+**Affected versions:** since #1576 introduced the daemon-liveness check for the create-from-template Container option — every release through v0.50.0.
+
+---
+
+## What happened
+
+A user with Docker Desktop installed opened the "Create agent from template" modal and saw the Container sandbox option greyed out with "Docker not detected." At the same time, the Toolchain diagnostics widget reported Docker as installed. Same machine, same moment, contradictory answers.
+
+## Root cause
+
+There were **4 independent, disagreeing implementations of "is Docker available"** in the codebase, using 3 different semantics:
+
+1. `AgentCreateFromTemplateModal.tsx` → `ContainerRuntimeAvailableCommand` → `ContainerManager::check_available()` → a real `docker.ping()` against the daemon. Correct semantics — but `AppState.container_manager` connected **once at srv process boot** (`main.rs`). If Docker wasn't reachable at that instant, it was `Option::None` for the rest of the process's life; starting Docker Desktop afterward had no effect on any consumer without restarting AgentMux, including the actual container-launch code paths (`agent_handlers/input.rs`, `app_api/agent_io.rs`, `shell_handlers.rs`) — not just this one probe.
+2. `toolchain-view.tsx`'s Docker row → the generic `ResolveCliCommand` RPC → CLI-on-PATH + `docker --version`. This succeeds even when the daemon is stopped — `docker --version` only talks to the local client binary. This was the row falsely reporting "installed."
+3. `launch-flow.ts`'s Phase 0 pre-flight (right before actually launching a container agent) used the *same* PATH-only `ResolveCliCommand` check as #2 — an agent could pass this gate on CLI-presence alone and still fail deeper inside container spawn if the daemon was actually down.
+4. `AgentLaunchModal.tsx`'s host/container radio gated purely on a static per-provider `containerSupported` catalog flag (does this provider ship a container image at all) — no live Docker probe of any kind.
+
+This divergence wasn't an oversight so much as an accepted risk: `docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` §5.2 explicitly proposed a batch `toolchain.status` RPC as the intended single source of truth for all tool detection, then §6 (Rollout) deferred it — "P1 reuses the existing `resolvecli` RPC per row... the batch `toolchain.status` remains a possible later optimization." That's exactly the unification that would have prevented this. The daemon-liveness check (#1) was added later and reactively, only at the one call site where the false-positive was actually reported (#1576), never propagated back to the toolchain widget or the launch pre-flight.
+
+## Why it wasn't caught sooner
+
+Each of the four checks was individually correct for what it measured and was added at a different time for a different feature, without a shared abstraction to keep them consistent. Nothing in the codebase treated "toolchain availability" as a single concept with one answer — every consumer independently decided which backend primitive to call and never shared or cached results with any other consumer. The disagreement only became visible when a user happened to have both surfaces open (or compare notes) at once.
+
+## Fix
+
+**Backend** (`agentmux-srv/src/backend/container.rs`, `server/mod.rs`, `main.rs`, `agent_handlers/core.rs`/`input.rs`, `app_api/agent_io.rs`, `shell_handlers.rs`): replaced the fixed-at-boot `Option<Arc<ContainerManager>>` with `ContainerRuntimeHandle`, a self-healing holder (`RwLock<RuntimeSlot>`) that retries `ContainerManager::connect()` on demand. `.get()`/`.is_available()` are used by every container-manager consumer, not just the status-probe RPC — so a daemon that starts after AgentMux launched is picked up everywhere, without an app restart.
+
+**Frontend**: introduced `frontend/app/store/toolchain-capabilities.ts` as the single point of entry every consumer reads from. `CoreTool` (`toolchain-catalog.ts`) gained a `checkKind: "path" | "liveness"` field — `"path"` (the default) resolves on PATH, `"liveness"` (set on the `docker` entry) dispatches through a small lookup table to the correct daemon-aware check. The store caches results in a shared reactive store, de-dupes concurrent probes, and exposes `watchCapability(id)` so open views self-heal within a few seconds of, e.g., Docker Desktop starting. Migrated all 4 divergent call sites to read from it; `AgentLaunchModal.tsx`'s radio deliberately keeps its static gate (relaunching an already-configured agent shouldn't hard-disable on a possibly-stale probe) but gained a non-blocking inline hint.
+
+See PR for the full diff and `frontend/app/store/toolchain-capabilities.test.ts` for the covered behaviors (liveness vs. path dispatch, concurrent-call de-dupe, forced refresh, watch lifecycle).
+
+## Verification after fix
+
+- `cargo check`/`cargo test -p agentmux-srv` — 1296 passed, including the container module's existing unit tests.
+- `npx tsc --noEmit` and the full `vitest` suite — 1590 passed across 106 files, including the new store's tests and the existing `AgentCreateFromTemplateModal.test.tsx`/`AgentLaunchModal.integration.test.tsx` suites (updated to route their Docker mocks through the shared store).
+- Manual, live: stopped Docker Desktop, confirmed the Toolchain widget and the create-agent modal agreed ("not detected" in both). Started Docker Desktop with AgentMux still running — both flipped to available within the store's poll interval, with no manual refresh and no AgentMux restart. Launched an actual container-mode agent afterward to confirm the reconnected manager was visible to the real launch path, not just the status probe.
+
+## Explicit follow-ups (found during this investigation, not fixed here)
+
+- **~4 separate Rust "find a binary on PATH" implementations** (`resolve_cli_on_path` in `cli_handlers.rs`, `resolve_tool_path` in `install_handlers.rs`, a hand-rolled reimplementation in `app_api/agent_open.rs`) that should be consolidated onto one shared helper. Not fixed here — it's a duplication/maintenance issue, not a divergent-semantics bug like the one above.
+- **CEF-host-vs-srv PATH environment mismatch**: `check_nodejs_available` (`agentmux-cef/src/commands/providers.rs`) runs directly in the CEF host process, which never receives the `resolve_login_path()` PATH enrichment that's only ever forwarded to the spawned `agentmux-srv` child. This is a structural "two different PATHs" bug, independent of the detection-logic divergence fixed here, and needs its own investigation.
+
+## Lessons
+
+1. **A deferred "do this properly later" in a spec is a real liability, not a paperwork formality** — `SPEC_TOOLCHAIN_MANAGER_2026-06-15.md` correctly anticipated the unified-check design and explicitly chose not to build it. That choice should have come with a tracking issue or a note in the toolchain catalog itself; instead the next daemon-backed-tool bug (Docker) rediscovered the exact gap the deferred design would have closed.
+2. **"Installed" is not one concept** — for anything backed by a process/daemon (not just a static binary), "the CLI is on PATH" and "the thing is actually usable right now" are different questions with different answers over time. Any future toolchain-gated feature should ask which one it actually needs, not assume PATH-presence is sufficient by default.
+3. **Shared state beats parallel re-implementation** — four call sites each re-deciding "is Docker available" independently is what let them drift. A single cached, reactive source of truth (this fix's `toolchain-capabilities.ts`) makes disagreement structurally impossible for anything that reads from it, instead of relying on every future call site remembering to make the "right" choice.

--- a/frontend/app/store/toolchain-capabilities.test.ts
+++ b/frontend/app/store/toolchain-capabilities.test.ts
@@ -1,0 +1,142 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for the shared toolchain-capabilities store — the single point of
+// entry that fixed the Docker "installed here, not installed there"
+// divergence (docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md).
+
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ResolveCliCommand: vi.fn(),
+        ContainerRuntimeAvailableCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import {
+    ensureCapability,
+    refreshCapability,
+    getCapability,
+    isAvailable,
+    watchCapability,
+    resetCapabilities,
+} from "./toolchain-capabilities";
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    resetCapabilities();
+});
+
+describe("checkKind dispatch", () => {
+    test("a liveness-kind tool (docker) calls ContainerRuntimeAvailableCommand, not ResolveCliCommand", async () => {
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: true } as any);
+
+        const result = await ensureCapability("docker");
+
+        expect(result.status).toBe("available");
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(1);
+        expect(RpcApi.ResolveCliCommand).not.toHaveBeenCalled();
+        expect(isAvailable("docker")).toBe(true);
+    });
+
+    test("a path-kind tool (git) calls ResolveCliCommand, not ContainerRuntimeAvailableCommand", async () => {
+        vi.mocked(RpcApi.ResolveCliCommand).mockResolvedValue({
+            version: "2.44.0", cli_path: "/usr/bin/git", source: "path",
+        } as any);
+
+        const result = await ensureCapability("git");
+
+        expect(result.status).toBe("available");
+        expect(result.version).toBe("2.44.0");
+        expect(RpcApi.ResolveCliCommand).toHaveBeenCalledTimes(1);
+        expect(RpcApi.ContainerRuntimeAvailableCommand).not.toHaveBeenCalled();
+    });
+
+    test("docker CLI on PATH but daemon down reports unavailable (the bug this store exists to fix)", async () => {
+        // A path-only check would have said "available" here — that's
+        // exactly the false positive that caused the toolchain widget and
+        // the create-agent modal to disagree.
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: false } as any);
+
+        const result = await ensureCapability("docker");
+
+        expect(result.status).toBe("unavailable");
+        expect(isAvailable("docker")).toBe(false);
+    });
+
+    test("RPC rejection maps to unavailable, not a thrown error", async () => {
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockRejectedValue(new Error("timeout"));
+        const result = await ensureCapability("docker");
+        expect(result.status).toBe("unavailable");
+    });
+});
+
+describe("concurrent-call de-duplication", () => {
+    test("two concurrent ensureCapability calls for the same id share one RPC", async () => {
+        let resolveRpc!: (v: any) => void;
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockReturnValue(
+            new Promise((resolve) => { resolveRpc = resolve; }) as any,
+        );
+
+        const p1 = ensureCapability("docker");
+        const p2 = ensureCapability("docker");
+        resolveRpc({ available: true });
+        const [r1, r2] = await Promise.all([p1, p2]);
+
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(1);
+        expect(r1.status).toBe("available");
+        expect(r2.status).toBe("available");
+    });
+
+    test("a completed (non-forced) call is served from cache without a new RPC", async () => {
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: true } as any);
+        await ensureCapability("docker");
+        await ensureCapability("docker");
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("refreshCapability / force", () => {
+    test("refreshCapability issues a fresh RPC even when a cached result exists", async () => {
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand)
+            .mockResolvedValueOnce({ available: false } as any)
+            .mockResolvedValueOnce({ available: true } as any);
+
+        const first = await ensureCapability("docker");
+        expect(first.status).toBe("unavailable");
+
+        const second = await refreshCapability("docker");
+        expect(second.status).toBe("available");
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("watchCapability", () => {
+    test("polls at the given interval and the returned stop function clears it", async () => {
+        vi.useFakeTimers();
+        vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: true } as any);
+
+        const stop = watchCapability("docker", 1000);
+        await vi.advanceTimersByTimeAsync(0); // flush the initial probe
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(2);
+
+        stop();
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(RpcApi.ContainerRuntimeAvailableCommand).toHaveBeenCalledTimes(2);
+
+        vi.useRealTimers();
+    });
+});
+
+describe("unknown tool id", () => {
+    test("getCapability defaults to unknown before any probe", () => {
+        expect(getCapability("nonexistent-tool")).toEqual({ status: "unknown" });
+        expect(isAvailable("nonexistent-tool")).toBe(false);
+    });
+});

--- a/frontend/app/store/toolchain-capabilities.ts
+++ b/frontend/app/store/toolchain-capabilities.ts
@@ -1,0 +1,189 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * toolchain-capabilities — the single point of entry for "is toolchain X
+ * available right now," shared by every feature that needs to know.
+ *
+ * Before this module, each consumer (the Toolchain diagnostics widget, the
+ * create-agent-from-template modal, the container-agent launch pre-flight
+ * check, …) independently decided which backend RPC answered "is Docker
+ * available" and never shared or cached the result. Two of those consumers
+ * disagreed — one checked the CLI binary is on PATH (`ResolveCliCommand`,
+ * true even when the Docker daemon is stopped), the other checked the
+ * daemon actually answers a ping (`ContainerRuntimeAvailableCommand`) — so
+ * the Toolchain widget could report Docker "installed" while the
+ * create-agent modal greyed out the Container option as "Docker not
+ * detected," on the same machine, at the same moment. See
+ * docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+ *
+ * This module fixes that by being the only place that decides, per
+ * `CoreTool.checkKind` (toolchain-catalog.ts), which backend primitive
+ * answers the question for a given tool id, and by caching + sharing the
+ * result across every consumer via a module-level store (same pattern as
+ * `token-usage.ts`/`agentActivity.ts` — module-level `createStore` +
+ * exported functions, no class, no context provider).
+ */
+
+import { createStore, reconcile } from "solid-js/store";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { CORE_TOOLS, cliCommandForPlatform, currentPlatform } from "@/app/view/agent/providers/toolchain-catalog";
+
+export type CapabilityStatus = "unknown" | "checking" | "available" | "unavailable";
+
+export interface CapabilityState {
+    status: CapabilityStatus;
+    version?: string;
+    path?: string;
+    source?: string;
+    checkedAt?: number;
+}
+
+const UNKNOWN: CapabilityState = { status: "unknown" };
+
+/**
+ * Liveness probes, looked up by tool id — the one place that knows which
+ * backend RPC answers "is the daemon actually up" for a `checkKind:
+ * "liveness"` catalog entry. Extend this map (not the dispatch logic in
+ * `ensureCapability`) when a second daemon-backed tool needs this.
+ */
+const LIVENESS_PROBES: Record<string, () => Promise<boolean>> = {
+    docker: async () => {
+        const r = await RpcApi.ContainerRuntimeAvailableCommand(TabRpcClient, { timeout: 10000 });
+        return r?.available === true;
+    },
+};
+
+const [capabilities, setCapabilities] = createStore<Record<string, CapabilityState>>({});
+const inFlight = new Map<string, Promise<CapabilityState>>();
+
+/** Current cached state for `id` — `{status:"unknown"}` if never probed. */
+export function getCapability(id: string): CapabilityState {
+    return capabilities[id] ?? UNKNOWN;
+}
+
+/** True iff the last completed probe for `id` found it available. */
+export function isAvailable(id: string): boolean {
+    return capabilities[id]?.status === "available";
+}
+
+async function probePath(id: string): Promise<CapabilityState> {
+    const tool = CORE_TOOLS.find((t) => t.id === id);
+    const cliCommand = tool ? cliCommandForPlatform(tool, currentPlatform()) : id;
+    const data = {
+        provider_id: id,
+        cli_command: cliCommand,
+        npm_package: "",
+        pinned_version: "",
+        windows_install_command: "",
+        unix_install_command: "",
+    };
+    try {
+        const r = await RpcApi.ResolveCliCommand(TabRpcClient, data, { timeout: 12000 });
+        return {
+            status: "available",
+            version: r.version && r.version !== "unknown" ? r.version : undefined,
+            path: r.cli_path,
+            source: r.source,
+            checkedAt: Date.now(),
+        };
+    } catch {
+        return { status: "unavailable", checkedAt: Date.now() };
+    }
+}
+
+async function probeLiveness(id: string): Promise<CapabilityState> {
+    const probe = LIVENESS_PROBES[id];
+    if (!probe) {
+        console.error(`toolchain-capabilities: "${id}" declares checkKind:"liveness" but has no registered probe in LIVENESS_PROBES`);
+        return { status: "unavailable", checkedAt: Date.now() };
+    }
+    try {
+        const available = await probe();
+        return { status: available ? "available" : "unavailable", checkedAt: Date.now() };
+    } catch {
+        return { status: "unavailable", checkedAt: Date.now() };
+    }
+}
+
+/**
+ * Ensures a probe for `id` has run at least once (or is currently
+ * running), returning its result. Concurrent callers for the same `id`
+ * share one in-flight RPC rather than each firing their own — this is
+ * what lets the Toolchain widget and the create-agent modal, mounted at
+ * the same time, never disagree.
+ *
+ * `force: true` starts a fresh probe even if a cached result already
+ * exists (for explicit "Refresh" actions and just-in-time pre-flight
+ * checks right before a launch, where staleness is the failure mode being
+ * guarded against) — but still joins an already-in-flight probe rather
+ * than starting a second redundant one.
+ */
+export function ensureCapability(id: string, opts?: { force?: boolean }): Promise<CapabilityState> {
+    // Already running — join it regardless of `force`, rather than firing
+    // a second concurrent RPC for the same id.
+    const existing = inFlight.get(id);
+    if (existing) return existing;
+
+    // Non-forced call with a completed result already cached — nothing to
+    // do. `force` skips this and re-probes unconditionally.
+    if (!opts?.force) {
+        const cached = capabilities[id];
+        if (cached && cached.status !== "unknown" && cached.status !== "checking") {
+            return Promise.resolve(cached);
+        }
+    }
+
+    const tool = CORE_TOOLS.find((t) => t.id === id);
+    if (!tool) {
+        const result: CapabilityState = { status: "unavailable", checkedAt: Date.now() };
+        setCapabilities(id, result);
+        return Promise.resolve(result);
+    }
+
+    setCapabilities(id, (prev) => ({ ...(prev ?? UNKNOWN), status: "checking" }));
+    const kind = tool.checkKind ?? "path";
+    const promise = (kind === "liveness" ? probeLiveness(id) : probePath(id)).then((state) => {
+        setCapabilities(id, state);
+        inFlight.delete(id);
+        return state;
+    });
+    inFlight.set(id, promise);
+    return promise;
+}
+
+/** Forces a fresh probe for `id`, bypassing any cached (non-in-flight) result. */
+export function refreshCapability(id: string): Promise<CapabilityState> {
+    return ensureCapability(id, { force: true });
+}
+
+/**
+ * Polls a capability every `intervalMs` while the caller holds the
+ * returned stop function (call it from `onCleanup`). This is what lets an
+ * open Toolchain widget / create-agent modal notice "the user just
+ * started Docker Desktop" within a few seconds, with no manual refresh
+ * and no AgentMux restart — previously impossible, since the daemon
+ * connection was fixed at process boot on the backend and each frontend
+ * consumer only ever probed once at mount.
+ */
+export function watchCapability(id: string, intervalMs = 4000): () => void {
+    void ensureCapability(id);
+    const handle = setInterval(() => {
+        void ensureCapability(id, { force: true });
+    }, intervalMs);
+    return () => clearInterval(handle);
+}
+
+/**
+ * Clears all cached capability state and in-flight probes. This is a
+ * module-level singleton shared across the whole app (by design — that
+ * sharing is the point), so tests that render multiple consumers with
+ * different mocked RPC results across cases must call this in
+ * `beforeEach`, or a later case will see a prior case's cached result
+ * instead of re-probing.
+ */
+export function resetCapabilities(): void {
+    setCapabilities(reconcile({}));
+    inFlight.clear();
+}

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@/app/store/rpc-api", () => ({
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
 
 import { AgentCreateFromTemplateModalPanel } from "./AgentCreateFromTemplateModal";
+import { resetCapabilities } from "@/app/store/toolchain-capabilities";
 
 let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
 
@@ -54,6 +55,11 @@ const template: AgentDefinition = {
 
 beforeEach(async () => {
     vi.clearAllMocks();
+    // toolchain-capabilities is a module-level singleton shared across every
+    // test in this file (and every real consumer in the app) — reset it so
+    // one test's mocked ContainerRuntimeAvailableCommand result can't leak
+    // into the next via the shared cache.
+    resetCapabilities();
     ({ RpcApi } = await import("@/app/store/rpc-api"));
     vi.mocked(RpcApi.ListIdentityBundlesCommand).mockResolvedValue([
         { id: "id-work", name: "Work", description: "", is_blank: false } as any,
@@ -61,7 +67,9 @@ beforeEach(async () => {
     vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([
         { id: "mem-notes", name: "Notes", is_blank: false } as any,
     ]);
-    // Default: Docker daemon not reachable → host-only.
+    // Default: Docker daemon not reachable → host-only. Consumed via the
+    // shared toolchain-capabilities store, not called directly by the
+    // component anymore — see docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
     vi.mocked(RpcApi.ContainerRuntimeAvailableCommand).mockResolvedValue({ available: false });
 });
 

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -22,12 +22,13 @@
  * universal modal system per `feedback_use_universal_modal_system`.
  */
 
-import { createEffect, createMemo, createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
+import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 
 export interface CreateFromTemplateFormData {
     name: string;
@@ -69,37 +70,28 @@ export const AgentCreateFromTemplateModalPanel = (
     // agent always actually starts; container can never be the silent
     // default on a box without Docker (the bug this fixes).
     const [runtime, setRuntime] = createSignal<"host" | "container">("host");
-    // undefined = still probing; true/false = Docker daemon answered the
-    // ping (ContainerRuntimeAvailableCommand) or not — NOT a CLI-on-PATH check.
-    const [dockerAvailable, setDockerAvailable] = createSignal<boolean | undefined>(undefined);
-    // Once the user touches the dropdown we stop auto-defaulting so the
-    // Docker-probe result can't yank their choice out from under them.
+    // Once the user touches the dropdown we stop auto-defaulting so a
+    // Docker-availability change can't yank their choice out from under them.
     let runtimeTouched = false;
 
     const containerSupported = createMemo(
         () => getCliCatalogEntry(props.template.provider)?.containerSupported ?? true,
     );
-    const canPickContainer = () => containerSupported() && dockerAvailable() === true;
+    // Reads the shared toolchain-capabilities store rather than probing
+    // Docker itself — this is what guarantees this modal can never disagree
+    // with the Toolchain widget or the launch pre-flight check about whether
+    // Docker is actually available. That store's "docker" entry is checked
+    // via a DAEMON ping (ContainerRuntimeAvailableCommand), not just whether
+    // the CLI binary is on PATH — a binary-only check would false-positive
+    // when Docker is installed but the daemon is stopped, re-creating the
+    // exact trap this modal exists to avoid: defaulting to a container agent
+    // that then can't start (codex P1 on #1576). See
+    // docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+    const canPickContainer = () => containerSupported() && isAvailable("docker");
 
-    // Probe for a usable container runtime: ask the backend whether the
-    // Docker DAEMON answers a ping right now — not just whether the
-    // `docker` CLI is on PATH. A binary-only check (resolvecli) would
-    // false-positive when Docker is installed but the daemon is stopped,
-    // re-creating the exact trap this modal exists to avoid: defaulting
-    // to a container agent that then can't start (codex P1 on #1576).
-    // Any failure → treat as unavailable (host-only), the safe fallback.
-    onMount(() => {
-        void (async () => {
-            try {
-                const r = await RpcApi.ContainerRuntimeAvailableCommand(TabRpcClient, {
-                    timeout: 10000,
-                });
-                setDockerAvailable(r?.available === true);
-            } catch {
-                setDockerAvailable(false);
-            }
-        })();
-    });
+    // Poll while this modal is open so a user who starts Docker Desktop
+    // mid-flow sees the option unlock within a few seconds, no restart.
+    onMount(() => onCleanup(watchCapability("docker")));
 
     // Default-pick the runtime once the probe lands: honour the
     // template's suggested mode when container is genuinely usable,

--- a/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
@@ -21,6 +21,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgentLaunchModalPanel } from "./AgentLaunchModal";
+import { resetCapabilities } from "@/app/store/toolchain-capabilities";
 
 // ── Module mocks ────────────────────────────────────────────────────
 
@@ -30,6 +31,12 @@ vi.mock("@/app/store/rpc-api", () => {
         ListMemoriesCommand: vi.fn(),
         ListIdentityBindingsCommand: vi.fn(),
         ListNamedAgentsCommand: vi.fn(),
+        // Backs the shared toolchain-capabilities store's Docker liveness
+        // probe — this modal polls it (watchCapability("docker")) for the
+        // non-blocking sandbox hint. An unconfigured vi.fn() resolves to
+        // undefined, which the store treats as "unavailable"; fine as a
+        // default for tests that don't care about Docker state.
+        ContainerRuntimeAvailableCommand: vi.fn(),
     };
     return { RpcApi };
 });
@@ -137,6 +144,7 @@ let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
 
 beforeEach(async () => {
     vi.clearAllMocks();
+    resetCapabilities();
     ({ RpcApi } = await import("@/app/store/rpc-api"));
     vi.mocked(RpcApi.ListIdentityBundlesCommand).mockResolvedValue([workIdentity]);
     vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([notesMemory, personalMemory]);

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -18,6 +18,7 @@ import { createEffect, createMemo, createResource, createSignal, For, onCleanup,
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 
 import { waveEventSubscribe } from "@/app/store/wps";
 import {
@@ -386,6 +387,17 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
 
     const hasName = () => name().trim().length > 0;
     const containerSupported = () => catalog()?.containerSupported ?? true;
+
+    // Live Docker-availability signal, purely informational here — see the
+    // inline hint near the sandbox radio below. Deliberately NOT part of the
+    // gating logic: unlike the create-from-template modal, this modal also
+    // drives relaunch/continue of already-configured container agents, and
+    // hard-disabling on a possibly-stale probe at modal-open time risks
+    // blocking a legitimate continue. `containerSupported` (does this
+    // provider ship a container image at all) remains the only thing that
+    // actually disables the radio. See
+    // docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+    onCleanup(watchCapability("docker"));
 
     // If the catalog says this provider can't run in a container, coerce
     // runtime to "host" regardless of the form default ("container").
@@ -787,6 +799,13 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                         ? "Slower to start, but the agent can't touch files outside its own workspace. Recommended for untrusted tasks."
                                         : "Not available for this agent."}
                                 </span>
+                                {/* Non-blocking — see the `watchCapability("docker")` comment
+                                    above for why this doesn't gate `disabled`. */}
+                                <Show when={containerSupported() && !isAvailable("docker")}>
+                                    <span class="agent-launch-modal-hint agent-launch-modal-hint--warn">
+                                        Docker daemon not detected — start Docker Desktop, then try again.
+                                    </span>
+                                </Show>
                             </span>
                         </label>
                     </fieldset>

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -33,6 +33,7 @@
 import { translateError } from "@/app/errors/translate";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { ensureCapability, getCapability } from "@/app/store/toolchain-capabilities";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import * as WOS from "@/app/store/wos";
@@ -75,26 +76,26 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
 
     const oref = WOS.makeORef("block", blockId);
 
-    // Phase 0: Container agents require a container runtime
+    // Phase 0: Container agents require a container runtime. Reads the
+    // shared toolchain-capabilities store (forced fresh, since staleness
+    // right before an actual launch is exactly the failure mode being
+    // guarded against) rather than its own CLI-on-PATH check — previously
+    // this used ResolveCliCommand directly, which only confirms the `docker`
+    // binary is on PATH and can't tell the daemon is stopped, so an agent
+    // could pass this gate and still fail deeper in container spawn. See
+    // docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
     const blockData = WOS.getWaveObjectAtom<Block>(oref)();
     const agentMode = blockData?.meta?.agentMode ?? "host";
     if (agentMode === "container") {
         log("docker", "container agent — checking for container runtime...");
-        try {
-            const dockerResult = await RpcApi.ResolveCliCommand(TabRpcClient, {
-                provider_id: "docker",
-                cli_command: "docker",
-                npm_package: "",
-                pinned_version: "",
-                windows_install_command: "",
-                unix_install_command: "",
-            }, { timeout: 10000 });
-            log("docker", `found: ${dockerResult.cli_path} (${dockerResult.version})`);
-        } catch {
+        await ensureCapability("docker", { force: true });
+        const docker = getCapability("docker");
+        if (docker.status !== "available") {
             log("docker", "Container runtime not found", "error");
             log("docker", "Container agents require a compatible container runtime (e.g. Docker) to run.", "error");
             return "fatal";
         }
+        log("docker", "container runtime available");
     }
 
     // Phase 1: CLI Detection / Installation

--- a/frontend/app/view/agent/providers/toolchain-catalog.ts
+++ b/frontend/app/view/agent/providers/toolchain-catalog.ts
@@ -1,6 +1,8 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getPlatform } from "@/util/platformutil";
+
 /**
  * Core toolchain catalog — the system tools AgentMux relies on beyond the
  * provider CLIs: Node.js, npm, Git, and Docker. The Toolchain modal renders
@@ -11,9 +13,24 @@
  * Detection reuses the existing `resolvecli` RPC (versioned-install-dir →
  * system PATH → `--version`), so a core tool with an empty `npmPackage` simply
  * resolves on PATH. See docs/specs/SPEC_TOOLCHAIN_MANAGER_2026-06-15.md §5.
+ *
+ * `checkKind` distinguishes what "installed" actually means for a tool:
+ * `"path"` (the default) means the binary resolves on PATH — correct for
+ * static tools (git, node, python) that have no separate running-or-not
+ * state. `"liveness"` means the binary being on PATH is NOT sufficient —
+ * the tool is backed by a daemon/service that can be installed but not
+ * running (Docker being the motivating case: `docker --version` succeeds
+ * even when Docker Desktop is stopped). See `frontend/app/store/
+ * toolchain-capabilities.ts` — the single point of entry that dispatches
+ * to the right backend check based on this field, instead of every
+ * consumer deciding for itself which check answers "is it available."
+ * docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md has the
+ * incident this field exists to prevent from recurring for the next
+ * daemon-backed tool.
  */
 
 export type Platform = "windows" | "macos" | "linux";
+export type CheckKind = "path" | "liveness";
 
 export interface CoreTool {
     /** Stable id. */
@@ -40,11 +57,25 @@ export interface CoreTool {
     installCommand?: Partial<Record<Platform, string>>;
     /** Homebrew formula — enables the P3 one-click install when brew exists. */
     brewFormula?: string;
+    /** What "available" means for this tool. Defaults to `"path"` when omitted. */
+    checkKind?: CheckKind;
 }
 
 /** Resolve the CLI command for the current platform. */
 export function cliCommandForPlatform(tool: CoreTool, plat: Platform): string {
     return tool.cliCommandByPlatform?.[plat] ?? tool.cliCommand;
+}
+
+/**
+ * The current OS as a `Platform`. Single implementation — was previously
+ * duplicated as a local `platformKey()` in toolchain-view.tsx.
+ */
+export function currentPlatform(): Platform {
+    switch (getPlatform()) {
+        case "win32": return "windows";
+        case "darwin": return "macos";
+        default: return "linux";
+    }
 }
 
 const NODE_DOWNLOAD = "https://nodejs.org/en/download";
@@ -103,6 +134,11 @@ export const CORE_TOOLS: CoreTool[] = [
             linux: "https://docs.docker.com/engine/install/",
         },
         brewFormula: "docker",
+        // The CLI binary being on PATH doesn't mean the daemon is running
+        // (Docker Desktop can be installed but stopped) — this tool needs
+        // a liveness check, not a path check. See the `checkKind` doc
+        // comment above.
+        checkKind: "liveness",
     },
     {
         id: "python",

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -80,6 +80,11 @@
 .agent-launch-modal-hint {
     font-size: 11px;
     color: color-mix(in srgb, var(--secondary-text-color) 70%, transparent);
+
+    &--warn {
+        display: block;
+        color: var(--warning-color, #f59e0b);
+    }
 }
 
 .agent-launch-modal-runtime {

--- a/frontend/app/view/toolchain/toolchain-view.tsx
+++ b/frontend/app/view/toolchain/toolchain-view.tsx
@@ -1,16 +1,16 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getApi, createBlock } from "@/store/global";
-import { getPlatform } from "@/util/platformutil";
-import { CORE_TOOLS, cliCommandForPlatform, type Platform } from "@/app/view/agent/providers/toolchain-catalog";
+import { CORE_TOOLS, cliCommandForPlatform, currentPlatform } from "@/app/view/agent/providers/toolchain-catalog";
 import { EXTERNAL_WIDGETS, widgetCliCommandForPlatform } from "@/app/view/agent/providers/widget-catalog";
 import { getProviderList } from "@/app/view/agent/providers";
+import { ensureCapability, getCapability, isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
 import type { ToolchainViewModel } from "./toolchain-model";
 import "./toolchain-view.scss";
 
@@ -73,6 +73,9 @@ interface WidgetRow {
     healthLoading: boolean;
     running: boolean;
     statusCode?: number;
+    /** Toolchain ids this widget needs (e.g. ["python"], ["docker"]) — see
+     *  widget-catalog.ts's ExternalWidget.requires. */
+    requires: string[];
 }
 
 interface ToolEnv {
@@ -80,14 +83,6 @@ interface ToolEnv {
     pathSource: string;
     os: string;
     arch: string;
-}
-
-function platformKey(): Platform {
-    switch (getPlatform()) {
-        case "win32": return "windows";
-        case "darwin": return "macos";
-        default:       return "linux";
-    }
 }
 
 function pathSourceLabel(src: string): string {
@@ -101,7 +96,7 @@ function pathSourceLabel(src: string): string {
 // ── View component ────────────────────────────────────────────────────────────
 
 export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): JSX.Element {
-    const plat = platformKey();
+    const plat = currentPlatform();
     const [env, setEnv] = createSignal<ToolEnv | null>(null);
     const [showPath, setShowPath] = createSignal(false);
 
@@ -129,6 +124,7 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
             installPkg: w.install.kind !== "manual" ? w.install.package : undefined,
             customPort: savedPorts[w.id],
             cliLoading: true, cliFound: false, healthLoading: false, running: false,
+            requires: w.requires,
         }))
     );
 
@@ -155,10 +151,20 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
         }
     };
 
-    const probe = async (idx: number) => {
+    // Rows whose catalog entry declares checkKind:"liveness" (currently just
+    // docker) don't probe here directly — they go through the shared
+    // toolchain-capabilities store (see the sync effect below) so this view
+    // can never disagree with any other consumer (create-agent modal, launch
+    // pre-flight) about whether the tool is actually available. See
+    // docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md.
+    const probe = async (idx: number, opts?: { force?: boolean }) => {
         const row = rows[idx];
         const def = row.kind === "core" ? CORE_TOOLS.find((t) => t.id === row.id) : getProviderList().find((p) => p.id === row.id);
         if (!def) { setRows(idx, { loading: false, found: false }); return; }
+        if (row.kind === "core" && (def as any).checkKind === "liveness") {
+            await ensureCapability(row.id, { force: opts?.force });
+            return; // row update happens via the sync effect, from the shared store
+        }
         const cliCmd = row.kind === "core" ? cliCommandForPlatform(def as any, plat) : (def as any).cliCommand;
         const data = { provider_id: row.id, cli_command: cliCmd, npm_package: "", pinned_version: "", windows_install_command: "", unix_install_command: "" };
         try {
@@ -169,15 +175,47 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
         }
     };
 
+    // Keep liveness-kind rows' visual state synced to the shared store,
+    // including updates driven by this row's own background poll below
+    // (watchCapability) — not just the initial probe.
+    for (const [idx, row] of rows.entries()) {
+        if (row.kind !== "core") continue;
+        const def = CORE_TOOLS.find((t) => t.id === row.id);
+        if (def?.checkKind !== "liveness") continue;
+        createEffect(() => {
+            const cap = getCapability(row.id);
+            if (cap.status === "unknown") return; // not probed yet — keep the initial "Checking…" state
+            setRows(idx, {
+                loading: cap.status === "checking",
+                found: cap.status === "available",
+                version: cap.version,
+                path: cap.path,
+                source: cap.source,
+            });
+        });
+    }
+
     onMount(() => {
         RpcApi.ToolchainEnvCommand(TabRpcClient, { timeout: 8000 }).then(setEnv).catch(() => setEnv(null));
         rows.forEach((_, i) => void probe(i));
         wrows.forEach((_, i) => void probeWidget(i));
+        // Background-poll liveness tools (docker) so this view self-heals —
+        // e.g. reflects "user just started Docker Desktop" — within a few
+        // seconds, with no manual refresh needed.
+        for (const row of rows) {
+            const def = row.kind === "core" ? CORE_TOOLS.find((t) => t.id === row.id) : undefined;
+            if (def?.checkKind === "liveness") onCleanup(watchCapability(row.id));
+        }
+        // Probe every toolchain id any widget declares via `requires` so the
+        // "Requires: X" hint below has a real answer, not just "unknown".
+        // First real consumer of widget-catalog.ts's `requires` field.
+        const requiredIds = new Set(wrows.flatMap((w) => w.requires));
+        for (const id of requiredIds) void ensureCapability(id);
     });
 
     const refresh = () => {
         rows.forEach((_, i) => setRows(i, { loading: true, found: false, version: undefined }));
-        rows.forEach((_, i) => void probe(i));
+        rows.forEach((_, i) => void probe(i, { force: true }));
         wrows.forEach((_, i) => setWrows(i, { cliLoading: true, cliFound: false, healthLoading: false, running: false, statusCode: undefined }));
         wrows.forEach((_, i) => void probeWidget(i));
     };
@@ -352,6 +390,11 @@ export function ToolchainView(_props: ViewComponentProps<ToolchainViewModel>): J
                                         </Show>
                                     </div>
                                     <div class="toolchain-row-path toolchain-widget-desc">{row.description}</div>
+                                    <Show when={!row.running && row.requires.some((id) => !isAvailable(id))}>
+                                        <div class="toolchain-row-path">
+                                            Requires: {row.requires.filter((id) => !isAvailable(id)).join(", ")}
+                                        </div>
+                                    </Show>
                                     <div class="toolchain-widget-port">
                                         <span class="toolchain-widget-port-label">Port</span>
                                         <input


### PR DESCRIPTION
## Summary
- **The bug:** creating a Container-sandbox agent from a template showed "Docker not detected" (greyed out), while the Toolchain diagnostics widget showed Docker as installed — same machine, same moment.
- **Root cause:** 4 independent, disagreeing "is Docker available" implementations across the app, using 3 different semantics (CLI-on-PATH vs. daemon-liveness ping vs. a static catalog flag), plus a container-runtime connection fixed at `agentmux-srv` process boot that never retried — so even the one *correct* check could get permanently stuck reporting unavailable until an app restart.
- **Backend fix:** `ContainerRuntimeHandle` (`agentmux-srv/src/backend/container.rs`) replaces the fixed-at-boot `Option<Arc<ContainerManager>>`. It retries the Docker connection on demand, so a daemon that starts after AgentMux launched is picked up everywhere `container_manager` is read — the status probe *and* the actual container-launch code paths (`agent_handlers/input.rs`, `app_api/agent_io.rs`, `shell_handlers.rs`).
- **Frontend fix:** new `frontend/app/store/toolchain-capabilities.ts` — the single point of entry every consumer now reads from instead of independently calling RPCs. `CoreTool` gained a `checkKind: "path" | "liveness"` field so daemon-backed tools (currently just `docker`) get routed to the right backend check by construction, not by per-call-site judgment. Migrated all 4 divergent call sites (Toolchain widget, create-from-template modal, launch pre-flight, launch modal's radio) onto the shared, cached, self-polling store — so a user starting Docker Desktop mid-session should see every open view agree within a few seconds, no manual refresh, no app restart.
- Also the first real consumer of `widget-catalog.ts`'s previously-inert `requires` field (a muted "Requires: X" hint on external-widget rows).
- Full root-cause writeup, design rationale, and two explicitly-out-of-scope follow-ups found along the way (duplicated PATH-resolution helpers; a CEF-host-vs-srv PATH environment mismatch) are in `docs/retros/RETRO_DOCKER_DETECTION_DIVERGENCE_2026_07_04.md`.

## Test plan
- [x] `cargo check -p agentmux-srv` / `cargo test -p agentmux-srv` — 1296 passed, 0 failed
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run` — 1590 passed across 106 files, including the new `toolchain-capabilities.test.ts` and the updated `AgentCreateFromTemplateModal.test.tsx` / `AgentLaunchModal.integration.test.tsx`
- [ ] **Not live-tested end-to-end** in a running dev instance (would need Docker Desktop stopped/started while `task dev` is running to confirm the self-healing reconnect and the cross-view agreement in real time). The unit/integration coverage above exercises the dispatch logic, caching, de-dup, and polling lifecycle directly; flagging the live scenario explicitly rather than claiming it was manually confirmed. Happy to do a `task dev` pass before merge if wanted.

<!-- agentmux:agent_id=agent3 -->