### PR TITLE
chore: release v0.50.1

### DIFF
--- a/.changesets/1783088326-fix-ci-winget-create-no-longer-ships-a-linux-binary-use-wind-gagx.md
+++ b/.changesets/1783088326-fix-ci-winget-create-no-longer-ships-a-linux-binary-use-wind-gagx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): winget-create no longer ships a Linux binary, use windows-latest

--- a/.changesets/1783128641-fix-agent-pane-contain-scroll-chaining-in-nested-tool-previe-n0ug.md
+++ b/.changesets/1783128641-fix-agent-pane-contain-scroll-chaining-in-nested-tool-previe-n0ug.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): contain scroll chaining in nested tool-preview boxes

--- a/.changesets/1783130177-fix-browser-pane-app-owned-wrapper-hwnd-fixes-windows-render-vo50.md
+++ b/.changesets/1783130177-fix-browser-pane-app-owned-wrapper-hwnd-fixes-windows-render-vo50.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): app-owned wrapper HWND fixes Windows renderer leak on pane close

--- a/.changesets/1783132884-fix-muxbus-claim-injections-before-local-delivery-to-prevent-t7pp.md
+++ b/.changesets/1783132884-fix-muxbus-claim-injections-before-local-delivery-to-prevent-t7pp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): claim injections before local delivery to prevent cross-channel duplicates

--- a/.changesets/1783156414-feat-armory-bound-to-agent-flag-on-mcp-list-skill-list-state-bg0r.md
+++ b/.changesets/1783156414-feat-armory-bound-to-agent-flag-on-mcp-list-skill-list-state-bg0r.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): bound_to_agent flag on mcp.list/skill.list — stateful bind/unbind toggle

--- a/.changesets/1783179787-fix-agent-pane-tool-preview-scroll-dead-zone-at-overscroll-b-rk0q.md
+++ b/.changesets/1783179787-fix-agent-pane-tool-preview-scroll-dead-zone-at-overscroll-b-rk0q.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): tool-preview scroll dead-zone at overscroll boundary

--- a/.changesets/1783194929-fix-agent-exclude-dynamic-system-prompt-sections-from-claude-1lwv.md
+++ b/.changesets/1783194929-fix-agent-exclude-dynamic-system-prompt-sections-from-claude-1lwv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): exclude dynamic system-prompt sections from Claude Code launch args to improve cross-instance prompt-cache reuse

--- a/.changesets/1783199340-fix-window-retry-backend-window-id-lookup-on-close-so-window-7qjh.md
+++ b/.changesets/1783199340-fix-window-retry-backend-window-id-lookup-on-close-so-window-7qjh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): retry backend_window_id lookup on close so window.CloseWindow reliably reaches srv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.50.0"
+version = "0.50.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,17 @@
 # AgentMux Version History
 
+## 0.50.1 — 2026-07-05
+
+- fix(ci): winget-create no longer ships a Linux binary, use windows-latest
+- fix(agent-pane): contain scroll chaining in nested tool-preview boxes
+- fix(browser-pane): app-owned wrapper HWND fixes Windows renderer leak on pane close
+- fix(muxbus): claim injections before local delivery to prevent cross-channel duplicates
+- feat(armory): bound_to_agent flag on mcp.list/skill.list — stateful bind/unbind toggle
+- fix(agent-pane): tool-preview scroll dead-zone at overscroll boundary
+- fix(agent): exclude dynamic system-prompt sections from Claude Code launch args to improve cross-instance prompt-cache reuse
+- fix(window): retry backend_window_id lookup on close so window.CloseWindow reliably reaches srv
+
+
 ## 0.50.0 — 2026-07-03
 
 - feat(cef): report CEF dlopen + cef_init sub-stages to splash telemetry

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -11,7 +11,6 @@
 - fix(agent): exclude dynamic system-prompt sections from Claude Code launch args to improve cross-instance prompt-cache reuse
 - fix(window): retry backend_window_id lookup on close so window.CloseWindow reliably reaches srv
 
-
 ## 0.50.0 — 2026-07-03
 
 - feat(cef): report CEF dlopen + cef_init sub-stages to splash telemetry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.50.0",
+      "version": "0.50.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -196,7 +196,7 @@ PKG_V="$(node -p "require('./package.json').version" 2>/dev/null || echo '<unrea
 [[ "$PKG_V" == "$NEW_VERSION" ]] || \
     INCONSISTENCIES+=("package.json version=$PKG_V")
 
-CARGO_V="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"$/\1/p}' Cargo.toml | head -1)"
+CARGO_V="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"$/\1/p;}' Cargo.toml | head -1)"
 [[ "$CARGO_V" == "$NEW_VERSION" ]] || \
     INCONSISTENCIES+=("Cargo.toml [workspace.package].version=$CARGO_V")
 

--- a/scripts/verify-release-consistency.sh
+++ b/scripts/verify-release-consistency.sh
@@ -47,7 +47,7 @@ log() { (( QUIET )) && return; echo "$*"; }
 
 # ── Read every location ───────────────────────────────────────────────
 PKG_V="$(node -p "require('./package.json').version" 2>/dev/null || echo '<unreadable>')"
-CARGO_V="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"$/\1/p}' Cargo.toml | head -1)"
+CARGO_V="$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version *= *"\(.*\)"$/\1/p;}' Cargo.toml | head -1)"
 PL_V="$(node -p "require('./package-lock.json').version" 2>/dev/null || echo '<unreadable>')"
 CL_V="$(sed -n '/^name = "agentmux-cef"$/{n;s/^version = "\(.*\)"$/\1/p;q}' Cargo.lock)"
 VH_V="$(awk '/^## /{print $2; exit}' VERSION_HISTORY.md)"


### PR DESCRIPTION
Consumes 8 pending changesets, **forced patch bump** (`task release:patch`) overriding the auto-detected minor (one changeset — armory `bound_to_agent` flag — is feat-typed):

- fix(ci): winget-create no longer ships a Linux binary, use windows-latest
- fix(agent-pane): contain scroll chaining in nested tool-preview boxes
- fix(browser-pane): app-owned wrapper HWND fixes Windows renderer leak on pane close
- fix(muxbus): claim injections before local delivery to prevent cross-channel duplicates
- feat(armory): bound_to_agent flag on mcp.list/skill.list — stateful bind/unbind toggle
- fix(agent-pane): tool-preview scroll dead-zone at overscroll boundary
- fix(agent): exclude dynamic system-prompt sections from Claude Code launch args to improve cross-instance prompt-cache reuse
- fix(window): retry backend_window_id lookup on close so window.CloseWindow reliably reaches srv

All 5 version locations agree at **0.50.1**.

Also includes a small fix to `scripts/release.sh` + `scripts/verify-release-consistency.sh`: the Cargo.toml version-extraction `sed` used `p}` with no separator before the closing brace — valid under GNU sed, rejected by macOS's BSD sed (`bad flag in substitute command: '}'`). This was blocking `task release:patch`'s own consistency guard from completing on macOS; added the missing `;`.

## Test plan
- [x] `task release:patch` completes cleanly, all 5 version locations verified to agree at 0.50.1
- [ ] CI release workflow