### PR TITLE
fix(layout): floating-pane redock lands at the ghost's exact rect

### DIFF
--- a/.changesets/1783245822-fix-layout-floating-pane-redock-lands-at-the-ghost-s-exact-r-qvr3.md
+++ b/.changesets/1783245822-fix-layout-floating-pane-redock-lands-at-the-ghost-s-exact-r-qvr3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): floating-pane redock lands at the ghost's exact rect — size fraction carved from target, siblings untouched

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -277,6 +277,14 @@ pub struct LayoutActionData {
     pub blockid: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nodesize: Option<u32>,
+    /// Split-only: the new node's desired size as a fraction (0.0-1.0) of the
+    /// TARGET node's current size, e.g. 0.5 for a 50/50 inner-direction drop,
+    /// 0.2 for an outer-direction drop (matches the ghost's `leaf/5` band).
+    /// The frontend applies this against the target's live `size` at split
+    /// time (`layoutTree.ts:splitHorizontal/splitVertical`), which the
+    /// backend cannot see. Takes precedence over `nodesize` when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nodesizefraction: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub indexarr: Option<Vec<i32>>,
     #[serde(default)]

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -222,6 +222,7 @@ pub fn tear_off_block(
         actionid: Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
         nodesize: None,
+        nodesizefraction: None,
         indexarr: None,
         focused: false,
         magnified: false,

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -293,6 +293,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             actionid: uuid::Uuid::new_v4().to_string(),
                             blockid: block_id.clone(),
                             nodesize: None,
+                            nodesizefraction: None,
                             indexarr: None,
                             focused: true,
                             magnified: false,

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -137,6 +137,7 @@ pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<Pan
                 actionid: uuid::Uuid::new_v4().to_string(),
                 blockid: block_id.clone(),
                 nodesize: None,
+                nodesizefraction: None,
                 indexarr: None,
                 focused,
                 magnified: false,

--- a/agentmux-srv/src/server/service/layout_helpers.rs
+++ b/agentmux-srv/src/server/service/layout_helpers.rs
@@ -79,6 +79,7 @@ pub(super) fn queue_target_layout_insert(
         actionid: uuid::Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
         nodesize: None,
+        nodesizefraction: None,
         indexarr: None,
         focused: true,
         magnified: false,
@@ -91,7 +92,7 @@ pub(super) fn queue_target_layout_insert(
     Ok(())
 }
 
-/// Phase 4b — enqueue a directional split action on the TARGET tab's
+/// Phase 4b/4c — enqueue a directional split action on the TARGET tab's
 /// `LayoutState.pendingbackendactions` so the redocked block lands in
 /// the exact slot the ghost overlay previewed.
 ///
@@ -102,10 +103,13 @@ pub(super) fn queue_target_layout_insert(
 /// * 1/5 (Right/OuterRight)→ `SplitHorizontal`, position `after`
 /// * 8   (Center)          → falls through to `InsertNode` (handled by caller)
 ///
-/// Outer directions use `nodesize = Some(3)` so the new node occupies ≈23%
-/// (3 / 13) — the nearest representable integer to the ghost's `height/5`
-/// (20%) when the target node is at DefaultNodeSize (10).
-/// Inner directions use `nodesize = None` (DefaultNodeSize = 10 → 50/50).
+/// Phase 4c: rather than an absolute `nodesize` guess (which was only correct
+/// when the target happened to be at `DefaultNodeSize`), this sends
+/// `nodesizefraction` — the new node's share of the target's CURRENT size —
+/// which the frontend applies against the target's live size at split time
+/// (`layoutTree.ts`). Inner directions use 0.5 (50/50, matching the ghost's
+/// half-leaf); outer directions use 0.2 (matching the ghost's exact `leaf/5`
+/// band — see `ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md`).
 pub(super) fn queue_target_layout_split(
     store: &Store,
     target_tab_id: &str,
@@ -113,17 +117,17 @@ pub(super) fn queue_target_layout_split(
     target_block_id: &str,
     dir: u8,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Inner directions (Top=0,Right=1,Bottom=2,Left=3): new node at
-    // DefaultNodeSize (10) → 50/50 split, matching the ghost's half-leaf.
-    // Outer directions (4-7): nodesize=3 → ≈23% (3/13), close to the
-    // ghost's 20% (1/5). The exact ratio depends on the target node's
-    // current flex size which isn't available server-side; 3 is a
-    // reasonable integer approximation when the target is at DefaultNodeSize.
-    let (actiontype, position, nodesize): (&str, &str, Option<u32>) = match dir {
-        0 | 4 => ("splitvertical",   "before", if dir >= 4 { Some(3) } else { None }),
-        2 | 6 => ("splitvertical",   "after",  if dir >= 4 { Some(3) } else { None }),
-        3 | 7 => ("splithorizontal", "before", if dir >= 4 { Some(3) } else { None }),
-        1 | 5 => ("splithorizontal", "after",  if dir >= 4 { Some(3) } else { None }),
+    const INNER_FRACTION: f64 = 0.5;
+    const OUTER_FRACTION: f64 = 0.2;
+    let (actiontype, position, nodesizefraction): (&str, &str, f64) = match dir {
+        0 => ("splitvertical",   "before", INNER_FRACTION),
+        4 => ("splitvertical",   "before", OUTER_FRACTION),
+        2 => ("splitvertical",   "after",  INNER_FRACTION),
+        6 => ("splitvertical",   "after",  OUTER_FRACTION),
+        3 => ("splithorizontal", "before", INNER_FRACTION),
+        7 => ("splithorizontal", "before", OUTER_FRACTION),
+        1 => ("splithorizontal", "after",  INNER_FRACTION),
+        5 => ("splithorizontal", "after",  OUTER_FRACTION),
         // Center (8) or unknown — caller should use queue_target_layout_insert.
         _ => return queue_target_layout_insert(store, target_tab_id, block_id),
     };
@@ -134,7 +138,8 @@ pub(super) fn queue_target_layout_split(
         actiontype: actiontype.to_string(),
         actionid: uuid::Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
-        nodesize,
+        nodesize: None,
+        nodesizefraction: Some(nodesizefraction),
         indexarr: None,
         focused: true,
         magnified: false,
@@ -165,6 +170,7 @@ pub(super) fn queue_source_layout_delete(
         actionid: uuid::Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
         nodesize: None,
+        nodesizefraction: None,
         indexarr: None,
         focused: false,
         magnified: false,
@@ -175,4 +181,76 @@ pub(super) fn queue_source_layout_delete(
     source_layout.pendingbackendactions = Some(actions);
     store.update(&mut source_layout)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::tests::test_state;
+
+    fn seeded_tab_id(state: &crate::server::AppState) -> String {
+        state
+            .wstore
+            .get_all::<Tab>()
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("seeded tab")
+            .oid
+    }
+
+    fn last_action(state: &crate::server::AppState, tab_id: &str) -> LayoutActionData {
+        let tab = state.wstore.must_get::<Tab>(tab_id).unwrap();
+        let layout = state.wstore.must_get::<LayoutState>(&tab.layoutstate).unwrap();
+        layout
+            .pendingbackendactions
+            .unwrap_or_default()
+            .last()
+            .expect("an action was queued")
+            .clone()
+    }
+
+    #[test]
+    fn queue_target_layout_split_maps_every_direction_to_an_exact_fraction() {
+        // Phase 4c: every non-Center direction must carry `nodesizefraction`
+        // (not the old hardcoded-integer `nodesize` guess) so the frontend
+        // can derive an exact size from the target's live size. See
+        // ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md.
+        let state = test_state();
+        let tab_id = seeded_tab_id(&state);
+
+        let cases: &[(u8, &str, &str, f64)] = &[
+            (0, "splitvertical", "before", 0.5),
+            (4, "splitvertical", "before", 0.2),
+            (2, "splitvertical", "after", 0.5),
+            (6, "splitvertical", "after", 0.2),
+            (3, "splithorizontal", "before", 0.5),
+            (7, "splithorizontal", "before", 0.2),
+            (1, "splithorizontal", "after", 0.5),
+            (5, "splithorizontal", "after", 0.2),
+        ];
+
+        for &(dir, expected_type, expected_pos, expected_fraction) in cases {
+            queue_target_layout_split(&state.wstore, &tab_id, "new-block", "target-block", dir).unwrap();
+            let action = last_action(&state, &tab_id);
+            assert_eq!(action.actiontype, expected_type, "dir={dir}");
+            assert_eq!(action.position, expected_pos, "dir={dir}");
+            assert_eq!(action.nodesizefraction, Some(expected_fraction), "dir={dir}");
+            assert_eq!(action.nodesize, None, "dir={dir}: absolute nodesize is no longer used for splits");
+            assert_eq!(action.targetblockid, "target-block");
+        }
+    }
+
+    #[test]
+    fn queue_target_layout_split_falls_back_to_insert_for_center_and_unknown_dirs() {
+        let state = test_state();
+        let tab_id = seeded_tab_id(&state);
+
+        for dir in [8u8, 200u8] {
+            queue_target_layout_split(&state.wstore, &tab_id, "new-block", "target-block", dir).unwrap();
+            let action = last_action(&state, &tab_id);
+            assert_eq!(action.actiontype, "insert", "dir={dir}");
+            assert_eq!(action.nodesizefraction, None, "dir={dir}");
+        }
+    }
 }

--- a/docs/analysis/ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md
+++ b/docs/analysis/ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md
@@ -1,0 +1,293 @@
+# ANALYSIS: Floating Pane Ghost-to-Landing Disconnect
+
+**Date:** 2026-07-04
+**Status:** Root causes confirmed by direct file inspection (see citations). Builds on and
+supersedes the sizing portion of `ANALYSIS_FLOATING_PANE_REDOCK_SIZE_2026_06_23.md`, whose
+Phase 4b fix is now shipped. This document identifies what Phase 4b did **not** fix, plus a
+mechanical failure mode never previously documented.
+
+**Update (2026-07-04, same day):** Fix Direction A and B below (Phase 4c) have been
+implemented and are covered by tests on both sides:
+- Backend: `agentmux-srv/src/backend/obj.rs` (`LayoutActionData.nodesizefraction`),
+  `agentmux-srv/src/server/service/layout_helpers.rs` (`queue_target_layout_split` now sends
+  an exact 0.5/0.2 fraction instead of the old `None`/`Some(3)` guess) —
+  `cargo test -p agentmux-srv layout_helpers` passes (2 new tests covering all 8 directions'
+  fraction/actiontype/position mapping, plus the Center/unknown fallback).
+- Frontend: `frontend/layout/lib/types.ts` (`sizeFraction` on both split actions),
+  `frontend/layout/lib/layoutPersistence.ts` (threads `action.nodesizefraction` through),
+  `frontend/layout/lib/layoutTree.ts` (`applySizeFraction` — a single helper applied
+  uniformly to both the wrap and splice branches, computed from the target's live
+  `.size` at split time, run *before* the wrap branch's group-node construction so the
+  group still inherits the target's correct pre-split footprint) — `vitest run` passes
+  (full suite: 105 files / 1585 tests, including 4 new tests exercising the splice
+  no-dilution case, the outer-fraction case, the wrap-branch footprint-preservation case,
+  and an end-to-end non-default-target-size case).
+- Implementation detail worth noting: the originally-sketched Fix B pseudocode below
+  (independently computing `newNode.size` via the Fix A formula, then separately
+  "carving" from `targetNode.size`) does not actually conserve the parent's pool — the
+  shipped fix unifies both into one calculation (`applySizeFraction`) so `newNode.size +
+  targetNode.size` after the split exactly equals `targetNode.size` before it, for both
+  branches. See that function's doc comment in `layoutTree.ts` for the corrected math.
+
+---
+
+## Problem (as reported)
+
+Dragging a floating pane onto a docked layout shows a ghost overlay that previews an exact
+sub-rect of the hovered leaf. When the pane is dropped:
+
+1. The pane does not land at the rect the ghost showed — proportions are visibly off.
+2. **Other, unrelated panes resize** to make room, even though the ghost never touched them.
+3. The overall experience feels like the ghost and the landing are two disconnected systems
+   rather than the ghost "becoming" the pane.
+
+Goal: make the landing geometry deterministically equal to the last-shown ghost rect, with no
+side effects on panes outside that rect — i.e., the ghost visually *is* a preview of the final
+pane, not a rough hint.
+
+---
+
+## What Phase 4b already fixed (confirmed still in place)
+
+`ANALYSIS_FLOATING_PANE_REDOCK_SIZE_2026_06_23.md` diagnosed that the ghost's `DropDirection`
+was computed only in the target window's renderer and never reached the backend — the block
+always landed via a generic `InsertNode` at `DefaultNodeSize` regardless of which zone was
+highlighted. That gap is closed:
+
+- `frontend/app-init.ts:263-270` — after computing `dir` and the hovered leaf's `blockId`, the
+  target renderer pushes `{ window_label, block_id, dir }` to the CEF host via
+  `set_floating_redock_target`.
+- `agentmux-cef/src/commands/window/motion.rs` — hosts a `floating_redock_ghost` map keyed by
+  window label (per the 06-23 doc's "push-then-store" design).
+- `frontend/app/workspace/floating-pane-workspace.tsx:512-519` — the floater queries
+  `get_floating_redock_target` at drop time and threads `target_block_id` + `direction` into
+  `RedockFloatingPane`.
+- `agentmux-srv/src/server/service/layout_helpers.rs:109-148` (`queue_target_layout_split`) —
+  now routes to `SplitHorizontal`/`SplitVertical` (not generic insert) for all 8 non-Center
+  directions, so the block lands **adjacent to the correct target leaf, on the correct axis,
+  on the correct side.** This part of the disconnect — landing next to the wrong pane, or as a
+  same-axis sibling appended at the end — is resolved.
+
+What remains is **size**, and a second, previously undocumented mechanism.
+
+---
+
+## Root cause 1 (known, still open): server-side size is a hardcoded guess
+
+`agentmux-srv/src/server/service/layout_helpers.rs:105-129`:
+
+```rust
+// Outer directions use `nodesize = Some(3)` so the new node occupies ≈23%
+// (3 / 13) — the nearest representable integer to the ghost's `height/5`
+// (20%) when the target node is at DefaultNodeSize (10).
+// Inner directions use `nodesize = None` (DefaultNodeSize = 10 → 50/50).
+let (actiontype, position, nodesize): (&str, &str, Option<u32>) = match dir {
+    0 | 4 => ("splitvertical",   "before", if dir >= 4 { Some(3) } else { None }),
+    ...
+```
+
+The comment is explicit: this is only correct **when the target leaf is at exactly
+`DefaultNodeSize` (10)**. The ghost's rect (`app-init.ts:150-174`, `rectForDirection`) is always
+computed from the target leaf's *live* `getBoundingClientRect()` — i.e. it reflects the leaf's
+**actual current size**, including any prior user resize or any parent with more than the
+default two children. The backend has no way to know that size (`layout_helpers.rs:118-121`:
+*"the exact ratio depends on the target node's current flex size which isn't available
+server-side"*) — so any leaf that isn't at the pristine default 50/50 gets a landing ratio that
+doesn't match what the ghost showed. This reproduces most visibly on:
+- A leaf that the user has manually resized before the drop.
+- A leaf that is one of 3+ siblings in a row/column (its rendered fraction is not 50%, but the
+  server still assumes it is).
+
+**This part of the disconnect is a known limitation, not a bug** — the doc that introduced it
+already flagged the approximation as temporary. It is not fixable in Rust without either (a)
+the backend maintaining a shadow copy of the frontend's live layout tree (rejected in the 06-23
+doc's design — see `layout_helpers.rs:56-66`'s comment on why layout state is frontend-owned),
+or (b) moving the size computation to where the real size already lives — see Fix Direction A.
+
+---
+
+## Root cause 2 (new): the *splice* code path resizes uninvolved siblings — this is not a bug, it's what `size` means
+
+This is the mechanical explanation for "other panes must resize," and it is independent of the
+size-accuracy problem above — it would happen even if the backend sent a perfectly accurate
+size.
+
+### The rendering model treats `size` as a shared-pool flex ratio
+
+`frontend/layout/lib/layoutGeometry.ts`, `updateTreeHelper()`:
+
+```ts
+// line 139-140
+const totalChildrenSize = node.children.reduce((acc, child) => acc + getNodeSize(child), 0);
+const pixelToSizeRatio = totalChildrenSize / nodePixels;
+// line 150-151
+width: nodeIsRow ? childSize / pixelToSizeRatio : nodeRect.width,
+height: nodeIsRow ? nodeRect.height : childSize / pixelToSizeRatio,
+```
+
+Every child's *rendered pixel size* is its own `size` divided by a ratio computed from **all**
+sibling sizes combined. `size` is not a percentage of a slot; it's a flex-grow-style share of a
+shared pool. Adding any sibling with nonzero `size` to a children array necessarily shrinks
+every other sibling in that array, proportionally, by construction.
+
+### The split code has two branches, and only one of them exposes this pool to sibling panes
+
+`frontend/layout/lib/layoutTree.ts`, `splitHorizontal()` (lines 462-502, `splitVertical` mirrors
+it at 506-544):
+
+```ts
+const parent = findParent(layoutState.rootNode, targetNodeId);
+if (parent && parent.flexDirection === FlexDirection.Row) {
+    const insertIndex = position === "before" ? index : index + 1;
+    parent.children.splice(insertIndex, 0, newNode);          // ← SPLICE branch
+} else {
+    const groupNode = newLayoutNode(FlexDirection.Row, targetNode.size, [targetNode], undefined);
+    groupNode.children = position === "before" ? [newNode, targetNode] : [targetNode, newNode];
+    parent.children[index] = groupNode;                        // ← WRAP branch
+}
+```
+
+- **Wrap branch** (split axis ≠ parent's existing flex axis — e.g. splitting Top/Bottom on a
+  leaf that lives in a horizontal row): the target is replaced *in place* by a brand-new
+  2-child group node, and that group is given `targetNode.size` — i.e. it takes over exactly
+  the pixel footprint the target used to occupy in the outer parent. **No other sibling in the
+  outer parent is touched.** Inside the new group, only `targetNode` and `newNode` share the
+  pool — so only Root Cause 1 (wrong ratio) applies here, not sibling resize.
+
+- **Splice branch** (split axis == parent's existing flex axis — e.g. splitting Left/Right on a
+  leaf that is one of several panes already in a row): `newNode` is spliced directly into the
+  **same children array as every other sibling in that row**, unrelated ones included.
+  `pixelToSizeRatio` is then recomputed over the enlarged pool (§ above), so **every sibling in
+  that row shrinks**, not just the target — exactly the "other panes must resize" symptom the
+  user is describing. This is unavoidable under the current model whenever the ghost's
+  direction matches the parent's existing axis, which is precisely the common case for a row or
+  column of 2+ panes (Left/Right in a row, Top/Bottom in a column) — arguably the *majority* of
+  real redock drops.
+
+Neither branch touches `targetNode.size` (confirmed: no assignment to `targetNode.size` appears
+in either function) — the target's own size is never reduced to "make room"; room is manufactured
+by diluting the shared pool instead. That is the structural reason the landing feels
+disconnected from a ghost that only ever highlighted a sub-rect of one leaf: the ghost implies
+"carve this rect out of the target," but the implementation instead does "add a new claim to
+everyone's shared pool."
+
+---
+
+## Why the fix belongs in the frontend, not the backend
+
+`agentmux-srv/src/server/service/layout_helpers.rs:118-121` says the target's current size
+"isn't available server-side" — true, but the frontend handler that actually *applies* the
+split already has it, unused:
+
+`frontend/layout/lib/layoutPersistence.ts`, `handleBackendAction()`, `SplitHorizontal` case
+(lines 215-242, `SplitVertical` mirrors at 243-270):
+
+```ts
+case LayoutTreeActionType.SplitHorizontal: {
+    const targetNode = model?.getNodeByBlockId(action.targetblockid);   // ← real, current size is right here
+    ...
+    const newNode = newLayoutNode(undefined, action.nodesize, undefined, {  // ← but only action.nodesize (backend's guess) is used
+        blockId: action.blockid,
+    });
+    const splitAction: LayoutTreeSplitHorizontalAction = {
+        type: LayoutTreeActionType.SplitHorizontal,
+        targetNodeId: targetNode.id,
+        newNode: newNode,
+        position: action.position,
+    };
+    model.treeReducer(splitAction, false);
+```
+
+`targetNode` (with its live `.size`) is resolved on line 216/244 and then discarded for sizing
+purposes — `action.nodesize` (the backend's `None`/`Some(3)` approximation) is used instead of
+`targetNode.size`. This is the same asymmetry as Root Cause 1, but it also implies the fix
+location: **this handler, not the Rust backend, is where an accurate size can be computed**,
+because this is the one place in the whole pipeline that has simultaneous access to (a) the
+direction the ghost computed and (b) the target's real, current `size`.
+
+---
+
+## Recommended fix direction ("ghost becomes the pane")
+
+Two independent changes, addressing Root Cause 1 and Root Cause 2 respectively. Both are
+frontend-only (no backend/IPC schema change required beyond optionally simplifying what the
+backend sends).
+
+### A. Compute exact size from `targetNode.size`, in `handleBackendAction`, not in Rust
+
+Replace the backend's absolute `nodesize` guess with a **target-relative fraction** the ghost
+already encodes as a constant (`app-init.ts:150-174`: inner = 0.5, outer = 0.2 of the leaf).
+Send that fraction (or just the direction, since the frontend already maps direction → fraction
+for the ghost rect) instead of an absolute integer, and derive the new node's size in
+`layoutPersistence.ts` as:
+
+```
+desiredFraction = 0.5 for inner directions, 0.2 for outer directions   // matches rectForDirection exactly
+newNode.size = desiredFraction * targetNode.size / (1 - desiredFraction)
+```
+
+This guarantees `newNode.size / (targetNode.size + newNode.size) === desiredFraction` for
+*any* current `targetNode.size`, not just the default — closing Root Cause 1 exactly, using data
+that already exists on the client. (`nodesize` in `LayoutActionData` would need to become a
+float or the fraction sent as a separate field — `agentmux-srv`'s `LayoutActionData.nodesize`
+is currently `Option<u32>`; either widen it or add `nodesizefraction: Option<f64>` and prefer it
+when present.)
+
+### B. Make the splice branch carve from the target instead of diluting the pool
+
+In the splice branch of `splitHorizontal`/`splitVertical` (`layoutTree.ts:471-479` /
+`515-523`), reduce `targetNode.size` by the portion being handed to `newNode` instead of leaving
+it untouched:
+
+```ts
+if (parent && parent.flexDirection === FlexDirection.Row) {
+    const carved = newNode.size ?? DefaultNodeSize;
+    targetNode.size = Math.max(targetNode.size - carved, MIN_NODE_SIZE);
+    parent.children.splice(insertIndex, 0, newNode);
+}
+```
+
+Combined with Fix A (`newNode.size` already computed as an exact fraction of `targetNode.size`),
+this makes `totalChildrenSize` for the row/column **unchanged** before and after the splice —
+`pixelToSizeRatio` stays the same, so **every sibling other than the target keeps its exact
+current pixel size**. Only the target's slot visually splits into the ghost's two sub-rects.
+This is what turns "ghost previews a sub-rect, landing dilutes everyone" into "ghost previews a
+sub-rect, landing carves exactly that sub-rect out of the target and nothing else moves" — i.e.
+the ghost rect and the final rendered rect become the same rect, by construction, for both the
+splice and wrap branches.
+
+### Suggested validation
+
+- Unit test `updateTreeHelper`/`layoutTree` pair: given a 3-pane row (sizes e.g. `[10, 10, 10]`),
+  simulate a `Right` (inner, 0.5) split on the middle pane → assert the two *other* panes' pixel
+  width is unchanged after the split, and the middle pane's original footprint is now occupied by
+  two panes at exactly 50/50.
+  the same test with `OuterLeft` (outer, 0.2) → assert new pane occupies exactly 20% of the
+  target's original footprint and outer siblings are untouched.
+- Manual repro: resize a pane to a non-default size, then redock a floater onto it from each of
+  the 9 zones; the landing rect should pixel-match the last ghost rect shown before release.
+
+---
+
+## Files referenced (all read directly, not inferred)
+
+| File | Role |
+|---|---|
+| `frontend/app-init.ts:113-273` | Ghost geometry + push-then-store hand-off (Phase 4b, already shipped) |
+| `frontend/app/workspace/floating-pane-workspace.tsx:491-577, 889-1006` | Drop-time ghost query + `RedockFloatingPane` call |
+| `agentmux-srv/src/server/service/layout_helpers.rs:94-148` | Server-side direction→split-action mapping + hardcoded `nodesize` approximation (Root Cause 1) |
+| `frontend/layout/lib/layoutPersistence.ts:105-274` | Frontend action handler — has `targetNode` with live size, currently unused for sizing (fix location for A) |
+| `frontend/layout/lib/layoutTree.ts:462-544` | `splitHorizontal`/`splitVertical` — wrap vs. splice branches (Root Cause 2, fix location for B) |
+| `frontend/layout/lib/layoutGeometry.ts:88-197` | `updateTreeHelper` — the shared-pool flex-ratio rendering model that makes splice-branch dilution mechanical, not incidental |
+| `frontend/layout/lib/layoutNode.ts:16-34` | `newLayoutNode` — confirms `size` defaults to flat `DefaultNodeSize=10` when omitted |
+
+## Related prior docs
+
+| Path | Relevance |
+|---|---|
+| `docs/analysis/ANALYSIS_FLOATING_PANE_REDOCK_SIZE_2026_06_23.md` | Diagnosed the process-boundary direction-loss gap and designed the push-then-store fix this doc confirms is shipped; flagged (but did not solve) the size-approximation gap this doc addresses as Root Cause 1. |
+| `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` | Broader tear-off/redock/browser-pane architecture reference; predates Phase 4b. |
+| `docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md` | Original Phase 4 spec (ghost + cross-window highlight goal). |
+| `docs/specs/SPEC_FLOATING_PANE_REDOCK_PHASE_4A_SCOPING_2026-05-27.md` | MVP scoping that deferred direction-aware landing to "Phase 4b" (now shipped; size accuracy still open — this doc's Root Cause 1/2). |
+| `docs/specs/SPEC_FLOATING_PANE_DND_RETHINK_2026_06_22.md` | Argues point-fixes on this subsystem keep recurring; this doc's Fix B (carve-from-target) is a structural rather than symptomatic change, in that spirit. |
+| `docs/specs/SPEC_PANE_COLOR_PANEL_TOPLEVEL_2026_07_01.md` | Checked — unrelated (pane-header color popover anchoring, not drag/dock). |

--- a/frontend/layout/lib/layoutPersistence.ts
+++ b/frontend/layout/lib/layoutPersistence.ts
@@ -236,6 +236,7 @@ async function handleBackendAction(model: LayoutModel, action: LayoutActionData)
                 targetNodeId: targetNode.id,
                 newNode: newNode,
                 position: action.position,
+                sizeFraction: action.nodesizefraction,
             };
             model.treeReducer(splitAction, false);
             break;
@@ -264,6 +265,7 @@ async function handleBackendAction(model: LayoutModel, action: LayoutActionData)
                 targetNodeId: targetNode.id,
                 newNode: newNode,
                 position: action.position,
+                sizeFraction: action.nodesizefraction,
             };
             model.treeReducer(splitAction, false);
             break;

--- a/frontend/layout/lib/layoutTree.ts
+++ b/frontend/layout/lib/layoutTree.ts
@@ -27,6 +27,7 @@ import {
     LayoutTreeResizeNodeAction,
     LayoutTreeState,
     LayoutTreeSwapNodeAction,
+    LayoutNode,
     MoveOperation,
 } from "./types";
 
@@ -457,15 +458,40 @@ export function replaceNode(layoutState: LayoutTreeState, action: LayoutTreeRepl
     
 }
 
+// Carve newNode's size out of targetNode's CURRENT size, split proportionally
+// by `sizeFraction` (e.g. 0.5 for a 50/50 inner-direction drop, 0.2 for an
+// outer-direction drop's leaf/5 band). Returns the target's size as it was
+// BEFORE this mutation, which the wrap branch needs (it re-parents the
+// target's original footprint into a new group).
+//
+// The point of mutating targetNode.size (rather than just sizing newNode,
+// as an earlier version of this fix did) is the splice branch: newNode joins
+// the SAME children array as any other siblings there, and every sibling's
+// rendered pixel size depends on the parent's total pool
+// (`layoutGeometry.ts:updateTreeHelper`'s pixelToSizeRatio). Carving from the
+// target keeps that pool constant, so unrelated siblings are pixel-for-pixel
+// unaffected by the split — only the target's own slot divides into the
+// ghost's two sub-rects. See ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md.
+function applySizeFraction(targetNode: LayoutNode, newNode: LayoutNode, sizeFraction: number | undefined): number {
+    const originalSize = targetNode.size;
+    if (sizeFraction != null) {
+        const fraction = Math.min(Math.max(sizeFraction, 0.05), 0.95);
+        newNode.size = fraction * originalSize;
+        targetNode.size = (1 - fraction) * originalSize;
+    }
+    return originalSize;
+}
+
 // ─── SPLIT HORIZONTAL ─────────────────────────────────────────────────────────────
 
 export function splitHorizontal(layoutState: LayoutTreeState, action: LayoutTreeSplitHorizontalAction) {
-    const { targetNodeId, newNode, position } = action;
+    const { targetNodeId, newNode, position, sizeFraction } = action;
     const targetNode = findNode(layoutState.rootNode, targetNodeId);
     if (!targetNode) {
         console.error("splitHorizontal: Target node not found", targetNodeId);
         return;
     }
+    const originalTargetSize = applySizeFraction(targetNode, newNode, sizeFraction);
 
     const parent = findParent(layoutState.rootNode, targetNodeId);
     if (parent && parent.flexDirection === FlexDirection.Row) {
@@ -481,7 +507,9 @@ export function splitHorizontal(layoutState: LayoutTreeState, action: LayoutTree
         // Otherwise, if no parent or parent's flexDirection is not Row, we need to wrap
         // Create a new group node with horizontal layout.
         // IMPORTANT: pass an initial children array so the new node is valid.
-        const groupNode = newLayoutNode(FlexDirection.Row, targetNode.size, [targetNode], undefined);
+        // Use the target's PRE-split size so the group inherits the exact
+        // footprint the target used to occupy in the outer parent.
+        const groupNode = newLayoutNode(FlexDirection.Row, originalTargetSize, [targetNode], undefined);
         // Now decide the ordering based on the "position"
         groupNode.children = position === "before" ? [newNode, targetNode] : [targetNode, newNode];
         if (parent) {
@@ -498,18 +526,19 @@ export function splitHorizontal(layoutState: LayoutTreeState, action: LayoutTree
     if (action.focused) {
         layoutState.focusedNodeId = newNode.id;
     }
-    
+
 }
 
 // ─── SPLIT VERTICAL ─────────────────────────────────────────────────────────────
 
 export function splitVertical(layoutState: LayoutTreeState, action: LayoutTreeSplitVerticalAction) {
-    const { targetNodeId, newNode, position } = action;
+    const { targetNodeId, newNode, position, sizeFraction } = action;
     const targetNode = findNode(layoutState.rootNode, targetNodeId);
     if (!targetNode) {
         console.error("splitVertical: Target node not found", targetNodeId);
         return;
     }
+    const originalTargetSize = applySizeFraction(targetNode, newNode, sizeFraction);
 
     const parent = findParent(layoutState.rootNode, targetNodeId);
     if (parent && parent.flexDirection === FlexDirection.Column) {
@@ -524,7 +553,9 @@ export function splitVertical(layoutState: LayoutTreeState, action: LayoutTreeSp
     } else {
         // Wrap target node in a new vertical group.
         // Create group node with an initial children array so that validation passes.
-        const groupNode = newLayoutNode(FlexDirection.Column, targetNode.size, [targetNode], undefined);
+        // Use the target's PRE-split size so the group inherits the exact
+        // footprint the target used to occupy in the outer parent.
+        const groupNode = newLayoutNode(FlexDirection.Column, originalTargetSize, [targetNode], undefined);
         groupNode.children = position === "before" ? [newNode, targetNode] : [targetNode, newNode];
         if (parent) {
             const index = parent.children.findIndex((child) => child.id === targetNodeId);
@@ -540,5 +571,5 @@ export function splitVertical(layoutState: LayoutTreeState, action: LayoutTreeSp
     if (action.focused) {
         layoutState.focusedNodeId = newNode.id;
     }
-    
+
 }

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -148,6 +148,13 @@ export interface LayoutTreeSplitHorizontalAction extends LayoutTreeAction {
     newNode: LayoutNode;
     position: "before" | "after";
     focused?: boolean;
+    // The new node's size as a fraction (0-1) of the target node's CURRENT
+    // size at split time. When present, both the new node's size and the
+    // target's remaining size are derived from this fraction (instead of
+    // `newNode.size` as an absolute value), so the split carves the new
+    // node out of the target rather than diluting the shared flex pool of
+    // any other siblings. See ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md.
+    sizeFraction?: number;
 }
 
 export interface LayoutTreeSplitVerticalAction extends LayoutTreeAction {
@@ -156,6 +163,7 @@ export interface LayoutTreeSplitVerticalAction extends LayoutTreeAction {
     newNode: LayoutNode;
     position: "before" | "after";
     focused?: boolean;
+    sizeFraction?: number;
 }
 
 export interface ResizeNodeOperation {

--- a/frontend/layout/tests/layoutPersistence.test.ts
+++ b/frontend/layout/tests/layoutPersistence.test.ts
@@ -236,6 +236,36 @@ describe("processPendingBackendActions — Phase 4b Split routes", () => {
         expect(root.children![0].size).toBe(3);
     });
 
+    it("SplitHorizontal with nodesizefraction — sizes derive from the target's CURRENT size, not a default", async () => {
+        // ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md Root Cause 1:
+        // a target that isn't at DefaultNodeSize (e.g. user-resized) must still land
+        // at the ghost's exact ratio. Simulate a resized target (size 20, not 10).
+        const model = createLayoutModel();
+        const target = insertBlock(model, "existing");
+        target.size = 20;
+
+        setPendingActions(model, [{
+            actiontype: LayoutTreeActionType.SplitHorizontal,
+            actionid: "action-h-fraction",
+            blockid: "new-block",
+            targetblockid: "existing",
+            position: "before",
+            nodesize: undefined,
+            nodesizefraction: 0.2,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+        }]);
+
+        await processPendingBackendActions(model);
+
+        const root = model.treeState.rootNode!;
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].data?.blockId).toBe("new-block");
+        expect(root.children![0].size).toBe(4); // 0.2 * 20
+        expect(root.children![1].size).toBe(16); // 20 - 4
+    });
+
     it("SplitHorizontal logs error and no-ops when targetblockid not found", async () => {
         const model = createLayoutModel();
         insertBlock(model, "existing");

--- a/frontend/layout/tests/layoutTree.test.ts
+++ b/frontend/layout/tests/layoutTree.test.ts
@@ -463,3 +463,78 @@ test("splitHorizontal - missing target is a no-op (logs error)", () => {
     });
     assert(JSON.stringify(treeState) === before);
 });
+
+// ── splitHorizontal / splitVertical — sizeFraction (ghost-landing fix) ───────
+// See ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md.
+
+test("splitHorizontal - sizeFraction splice branch conserves unrelated siblings' size", () => {
+    // Row of 3 siblings, split the MIDDLE one horizontally (matches parent's
+    // own axis, so this exercises the splice branch, not the wrap branch).
+    const c1 = newLayoutNode(undefined, 10, undefined, { blockId: "c1" });
+    const c2 = newLayoutNode(undefined, 10, undefined, { blockId: "c2" });
+    const c3 = newLayoutNode(undefined, 10, undefined, { blockId: "c3" });
+    const root = newLayoutNode(FlexDirection.Row, undefined, [c1, c2, c3]);
+    const treeState = newLayoutTreeState(root);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+
+    splitHorizontal(treeState, {
+        type: LayoutTreeActionType.SplitHorizontal,
+        targetNodeId: c2.id,
+        newNode,
+        position: "after",
+        sizeFraction: 0.5,
+    });
+
+    // Unrelated siblings keep their exact original size — no dilution.
+    assert(c1.size === 10, "c1 untouched");
+    assert(c3.size === 10, "c3 untouched");
+    // The target's original 10 is carved 50/50 with the new node.
+    assert(c2.size === 5, "target carved to half its original size");
+    assert(newNode.size === 5, "new node gets the other half");
+    assert(
+        treeState.rootNode.children!.map((c) => c.data?.blockId).join(",") === "c1,c2,new,c3",
+        "new node lands directly after target, siblings otherwise untouched"
+    );
+});
+
+test("splitHorizontal - sizeFraction splice branch honors an outer-direction (0.2) fraction", () => {
+    const c1 = newLayoutNode(undefined, 10, undefined, { blockId: "c1" });
+    const c2 = newLayoutNode(undefined, 10, undefined, { blockId: "c2" });
+    const root = newLayoutNode(FlexDirection.Row, undefined, [c1, c2]);
+    const treeState = newLayoutTreeState(root);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+
+    splitHorizontal(treeState, {
+        type: LayoutTreeActionType.SplitHorizontal,
+        targetNodeId: c2.id,
+        newNode,
+        position: "before",
+        sizeFraction: 0.2,
+    });
+
+    assert(c1.size === 10, "c1 untouched");
+    assert(c2.size === 8, "target keeps 80% of its original size");
+    assert(newNode.size === 2, "new node gets 20% of the target's original size");
+});
+
+test("splitVertical - sizeFraction wrap branch preserves the target's footprint in the outer parent", () => {
+    // Target has a non-default size (as if the user had resized it) to prove
+    // the ratio is computed from the target's CURRENT size, not a hardcoded
+    // default — the group must inherit the target's PRE-split size exactly.
+    const leaf = newLayoutNode(undefined, 40, undefined, { blockId: "only" });
+    const treeState = newLayoutTreeState(leaf);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+
+    splitVertical(treeState, {
+        type: LayoutTreeActionType.SplitVertical,
+        targetNodeId: leaf.id,
+        newNode,
+        position: "after",
+        sizeFraction: 0.2,
+    });
+
+    assert(treeState.rootNode.flexDirection === FlexDirection.Column, "root wrapped in Column");
+    assert(treeState.rootNode.size === 40, "wrapping group inherits target's pre-split footprint");
+    assert(leaf.size === 32, "target keeps 80% of its original 40");
+    assert(newNode.size === 8, "new node gets 20% of the target's original 40");
+});

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1132,6 +1132,7 @@ declare global {
         actionid: string;
         blockid: string;
         nodesize?: number;
+        nodesizefraction?: number;
         indexarr?: number[];
         focused: boolean;
         magnified: boolean;


### PR DESCRIPTION
## Summary

Phase 4c of the ghost/landing work (follow-up to Phase 4b, #1666-era): the drop now lands at exactly the rect the ghost previewed, and unrelated sibling panes no longer resize.

**Root causes** (full analysis in `docs/analysis/ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md`):
1. `queue_target_layout_split` hardcoded the new node's size (`None` → 50/50, `Some(3)` → ~23%) — only correct when the target leaf happened to be at `DefaultNodeSize`. The ghost, by contrast, is always computed from the leaf's live rect.
2. `splitHorizontal`/`splitVertical`'s splice branch inserts the new node into the parent's shared flex pool without reducing the target's size — `pixelToSizeRatio` then shrinks **every** sibling in that row/column, not just the target.

**Fix:**
- Backend sends `nodesizefraction` (0.5 inner / 0.2 outer — matching the ghost's exact geometry) instead of an absolute size guess (`layout_helpers.rs`).
- New `applySizeFraction` helper in `layoutTree.ts` carves the new node's share out of the **target's live size** at split time, so `newNode.size + targetNode.size` after == `targetNode.size` before — the parent's pool is conserved and siblings keep their exact pixel size, for both the splice and wrap branches.

## Tests
- 2 new Rust tests: all 8 directions' fraction/actiontype/position mapping + Center/unknown fallback (`cargo test -p agentmux-srv layout_helpers`)
- 4 new frontend tests: splice no-dilution (3-pane row), outer-fraction ratio, wrap-branch footprint preservation, end-to-end non-default-target-size via `processPendingBackendActions`
- Full suites green: `npx vitest run` (1585 tests), `cargo check --workspace`, `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agent2 -->