### PR TITLE
fix(layout): UpdateObject routes layout pushes through LayoutSetTree — SPEC_864 Phase 2 (weak single-writer cutover)

### DIFF
--- a/.changesets/1783247349-fix-layout-updateobject-routes-layout-pushes-through-the-red-hjid.md
+++ b/.changesets/1783247349-fix-layout-updateobject-routes-layout-pushes-through-the-red-hjid.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): UpdateObject routes layout pushes through the reducer as a single LayoutSetTree (SPEC_864 Phase 2)

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -585,10 +585,19 @@ pub enum Command {
     },
     /// Bulk-replace the tree. Used during Phase 7a writer migration and
     /// for tear-off where the whole subtree changes atomically.
+    ///
+    /// SPEC_864 Phase 2 — when the command originates from the frontend's
+    /// full-row `UpdateObject` push, `slices` carries the remaining
+    /// frontend-owned `LayoutState` columns (leaforder / focus / magnify /
+    /// pendingbackendactions) with REPLACE semantics, so the single
+    /// dispatch fully supersedes the legacy `update_raw` whole-row write.
+    /// `slices: None` (tree-only callers) leaves those columns untouched.
     LayoutSetTree {
         tab_id: String,
         new_tree: Option<crate::LayoutNode>,
         correlation_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        slices: Option<crate::LayoutClientSlices>,
     },
 
     /// Phase D.3 — request an `Event::EventList` reply containing the
@@ -1542,10 +1551,16 @@ pub enum Event {
         correlation_id: String,
         version: u64,
     },
+    /// SPEC_864 Phase 2 — `slices` mirrors the command's field: when
+    /// present, the persist subscriber also writes leaforder / focus /
+    /// magnify / pendingbackendactions (REPLACE semantics). `None` =
+    /// tree-only replace; those columns stay untouched.
     LayoutTreeReplaced {
         tab_id: String,
         new_tree: Option<crate::LayoutNode>,
         correlation_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        slices: Option<crate::LayoutClientSlices>,
         version: u64,
     },
 

--- a/agentmux-common/src/layout_types.rs
+++ b/agentmux-common/src/layout_types.rs
@@ -94,6 +94,38 @@ where
 
 // ── Command helper types ────────────────────────────────────────────────────
 
+/// SPEC_864 Phase 2 — the frontend-owned `LayoutState` slices carried by a
+/// full-row-replace push (the `UpdateObject`→`LayoutSetTree` route). The
+/// reducer applies `focused_node_id`/`magnified_node_id` to its `TabRecord`;
+/// `leaforder` and `pending_backend_actions` are opaque pass-through JSON the
+/// persist subscriber writes verbatim (no algebra re-run in the subscriber —
+/// that would be a new divergence surface).
+///
+/// Semantics are REPLACE, mirroring the legacy `update_raw` whole-row write
+/// this route retires: an absent/`null` `leaforder` or
+/// `pending_backend_actions` CLEARS the persisted column (pushing the row
+/// without processed actions is how the frontend acks its backend-action
+/// queue); an empty `focused_node_id`/`magnified_node_id` clears focus/
+/// magnify. A `LayoutSetTree` with `slices: None` (granular/tree-only
+/// callers) leaves all four columns untouched.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct LayoutClientSlices {
+    /// Frontend-recomputed geometry cache (`getLeafOrder`). Not read on
+    /// reproject; persisted only for legacy readers. `None` = clear.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leaforder: Option<serde_json::Value>,
+    /// Focused layout-node id; empty = clear.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub focused_node_id: String,
+    /// Magnified layout-node id; empty = clear.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub magnified_node_id: String,
+    /// The backend→frontend action queue as the client sees it after
+    /// processing. `None` = clear (the ack path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_backend_actions: Option<serde_json::Value>,
+}
+
 /// A single resize operation: target node + new flex size (0–100 relative units).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResizeOp {

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -15,7 +15,9 @@ pub mod toolchain_path;
 pub use cli::make_cli_cmd;
 pub use data_paths::DataPaths;
 pub use errors::{AgentMuxError, AmxCode};
-pub use layout_types::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
+pub use layout_types::{
+    FlexDirection, LayoutClientSlices, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition,
+};
 pub use runtime_mode::{is_dev_build_exe, is_dev_self, RuntimeMode};
 pub use toolchain_path::{
     enrich_current_process_path, looks_like_launchd_default, resolve_login_path, EnrichedPath,

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -270,7 +270,7 @@ pub struct StickerType {
 
 // ---- LayoutActionData / LeafOrderEntry ----
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LayoutActionData {
     pub actiontype: String,
     pub actionid: String,
@@ -299,7 +299,7 @@ pub struct LayoutActionData {
     pub position: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LeafOrderEntry {
     pub nodeid: String,
     pub blockid: String,

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -1690,6 +1690,7 @@ mod tests {
                 actionid: "a1".into(),
                 blockid: "b-new".into(),
                 nodesize: None,
+                nodesizefraction: None,
                 indexarr: None,
                 focused: true,
                 magnified: false,

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -41,7 +41,10 @@ use std::sync::Arc;
 use agentmux_common::ipc::Event;
 use tokio::sync::{broadcast, Mutex};
 
-use crate::backend::obj::{Block, Client, LayoutState as PersistedLayoutState, Tab, Window, Workspace};
+use crate::backend::obj::{
+    Block, Client, LayoutActionData, LayoutState as PersistedLayoutState, LeafOrderEntry, Tab,
+    Window, Workspace,
+};
 use crate::backend::storage::store::Store;
 use crate::backend::wcore;
 use crate::state::State;
@@ -306,8 +309,11 @@ pub(crate) fn apply_event_to_wstore(
         // having those events carry the reducer's resulting tree.
         Event::LayoutCleared { tab_id, .. } => apply_layout_cleared(wstore, tab_id),
         Event::LayoutTreeReplaced {
-            tab_id, new_tree, ..
-        } => apply_layout_tree_replaced(wstore, tab_id, new_tree),
+            tab_id,
+            new_tree,
+            slices,
+            ..
+        } => apply_layout_tree_replaced(wstore, tab_id, new_tree, slices.as_ref()),
         // The 7 granular structural arms each carry the reducer's resulting
         // tree in `new_tree` (post-op, post-balance), so persistence is the
         // same rootnode write as LayoutTreeReplaced — no algebra re-run in the
@@ -328,7 +334,8 @@ pub(crate) fn apply_event_to_wstore(
             // `None` as an intentional empty-tree clear and ERASE the
             // persisted layout (codex P2 on #1883). Persist only a real tree.
             match new_tree {
-                Some(_) => apply_layout_tree_replaced(wstore, tab_id, new_tree),
+                // Granular events carry no client slices — tree-only write.
+                Some(_) => apply_layout_tree_replaced(wstore, tab_id, new_tree, None),
                 None => Ok(()),
             }
         }
@@ -796,17 +803,23 @@ fn apply_layout_cleared(
 /// empty, also clear the focus/magnify ids (and leaforder) so they don't
 /// dangle at nodes that no longer exist.
 ///
-/// When a tree IS present, `leaforder` is intentionally left untouched:
-/// it is a frontend-recomputed geometry cache (`getLeafOrder` in
-/// `layoutGeometry.ts`, sorted by render `treeKey`) and is NOT read on
-/// reproject — `persist::bootstrap_state_from_wstore` reads
-/// rootnode/focus/magnify only. The next phase extends LayoutSetTree to
-/// carry the frontend's leaforder when the UpdateObject push routes
-/// through it. Idempotent: no-op (no version bump) when nothing changes.
+/// SPEC_864 Phase 2 — when the event carries `slices` (the
+/// `UpdateObject`→`LayoutSetTree` full-row push), the frontend-owned
+/// columns are REPLACED to mirror the legacy `update_raw` whole-row write
+/// this route retires: leaforder / pendingbackendactions are written
+/// verbatim (absent = clear — pushing without processed actions is how
+/// the frontend acks its queue); focus/magnify strings overwrite (empty =
+/// clear). `slices: None` (granular events, tree-only callers) leaves
+/// those columns untouched — leaforder is a frontend-recomputed geometry
+/// cache (`getLeafOrder` in `layoutGeometry.ts`) and is NOT read on
+/// reproject (`persist::bootstrap_state_from_wstore` reads
+/// rootnode/focus/magnify only). Idempotent: no-op (no version bump)
+/// when nothing changes.
 fn apply_layout_tree_replaced(
     wstore: &Store,
     tab_id: &str,
     new_tree: &Option<agentmux_common::LayoutNode>,
+    slices: Option<&agentmux_common::LayoutClientSlices>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let Some(tab) = wstore.get::<Tab>(tab_id)? else {
         return Ok(());
@@ -818,23 +831,53 @@ fn apply_layout_tree_replaced(
         return Ok(());
     };
     let clears = new_tree.is_none();
-    // Idempotent short-circuit: skip the write (and version bump) when the
-    // tree already matches and, for the empty-tree case, focus/magnify/
-    // leaforder are already cleared.
+
+    // Compute the candidate values for every column this event owns, then
+    // write once only if something actually changed (idempotency contract:
+    // a double-apply — sync from the RPC handler, again from broadcast —
+    // must not churn the version).
+    let new_focused = match (slices, clears) {
+        (_, true) => String::new(),
+        (Some(s), false) => s.focused_node_id.clone(),
+        (None, false) => layout.focusednodeid.clone(),
+    };
+    let new_magnified = match (slices, clears) {
+        (_, true) => String::new(),
+        (Some(s), false) => s.magnified_node_id.clone(),
+        (None, false) => layout.magnifiednodeid.clone(),
+    };
+    let new_leaforder: Option<Vec<LeafOrderEntry>> = match (slices, clears) {
+        (_, true) => None,
+        (Some(s), false) => match &s.leaforder {
+            Some(v) if !v.is_null() => Some(serde_json::from_value(v.clone())?),
+            _ => None,
+        },
+        (None, false) => layout.leaforder.clone(),
+    };
+    let new_pending: Option<Vec<LayoutActionData>> = match slices {
+        // The pending queue is frontend-acked state, not tree geometry —
+        // an empty-tree push still replaces it (unlike focus/leaforder,
+        // which dangle without a tree).
+        Some(s) => match &s.pending_backend_actions {
+            Some(v) if !v.is_null() => Some(serde_json::from_value(v.clone())?),
+            _ => None,
+        },
+        None => layout.pendingbackendactions.clone(),
+    };
+
     let already = layout.rootnode == *new_tree
-        && (!clears
-            || (layout.focusednodeid.is_empty()
-                && layout.magnifiednodeid.is_empty()
-                && layout.leaforder.is_none()));
+        && layout.focusednodeid == new_focused
+        && layout.magnifiednodeid == new_magnified
+        && layout.leaforder == new_leaforder
+        && layout.pendingbackendactions == new_pending;
     if already {
         return Ok(());
     }
     layout.rootnode = new_tree.clone();
-    if clears {
-        layout.focusednodeid = String::new();
-        layout.magnifiednodeid = String::new();
-        layout.leaforder = None;
-    }
+    layout.focusednodeid = new_focused;
+    layout.magnifiednodeid = new_magnified;
+    layout.leaforder = new_leaforder;
+    layout.pendingbackendactions = new_pending;
     wstore.update(&mut layout)?;
     Ok(())
 }
@@ -1398,6 +1441,7 @@ mod tests {
                 tab_id: tab.clone(),
                 new_tree: Some(leaf("n1", "b1")),
                 correlation_id: "c1".into(),
+                slices: None,
                 version: 3,
             },
             &s,
@@ -1447,6 +1491,7 @@ mod tests {
                 tab_id: tab.clone(),
                 new_tree: Some(leaf("keep", "bk")),
                 correlation_id: "seed".into(),
+                slices: None,
                 version: 2,
             },
             &s,
@@ -1480,6 +1525,7 @@ mod tests {
                 tab_id: tab.clone(),
                 new_tree: Some(leaf("n1", "b1")),
                 correlation_id: "c".into(),
+                slices: None,
                 version: 3,
             },
             &s,
@@ -1528,6 +1574,7 @@ mod tests {
                 tab_id: tab.clone(),
                 new_tree: Some(leaf("n1", "b1")),
                 correlation_id: "c".into(),
+                slices: None,
                 version: 3,
             },
             &s,
@@ -1547,6 +1594,7 @@ mod tests {
                 tab_id: tab.clone(),
                 new_tree: None,
                 correlation_id: "c".into(),
+                slices: None,
                 version: 5,
             },
             &s,
@@ -1566,6 +1614,7 @@ mod tests {
             tab_id: tab.clone(),
             new_tree: Some(leaf("n1", "b1")),
             correlation_id: "c".into(),
+            slices: None,
             version: 3,
         };
         apply_event_to_wstore(&ev, &s).unwrap();
@@ -1573,6 +1622,150 @@ mod tests {
         apply_event_to_wstore(&ev, &s).unwrap();
         let v2 = layout_of(&s, &tab).version;
         assert_eq!(v1, v2, "idempotent re-apply must not bump version");
+    }
+
+    // ── SPEC_864 Phase 2 — client slices on LayoutTreeReplaced ─────────
+
+    fn slices(
+        leaforder: Option<serde_json::Value>,
+        focused: &str,
+        magnified: &str,
+        pending: Option<serde_json::Value>,
+    ) -> agentmux_common::LayoutClientSlices {
+        agentmux_common::LayoutClientSlices {
+            leaforder,
+            focused_node_id: focused.into(),
+            magnified_node_id: magnified.into(),
+            pending_backend_actions: pending,
+        }
+    }
+
+    #[test]
+    fn layout_tree_replaced_with_slices_writes_full_row() {
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n1", "b1")),
+                correlation_id: "c".into(),
+                slices: Some(slices(
+                    Some(serde_json::json!([{ "nodeid": "n1", "blockid": "b1" }])),
+                    "n1",
+                    "n1",
+                    None,
+                )),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let layout = layout_of(&s, &tab);
+        assert_eq!(layout.rootnode.unwrap().id, "n1");
+        assert_eq!(layout.focusednodeid, "n1");
+        assert_eq!(layout.magnifiednodeid, "n1");
+        let lo = layout.leaforder.expect("leaforder written");
+        assert_eq!(lo.len(), 1);
+        assert_eq!(lo[0].nodeid, "n1");
+        assert_eq!(lo[0].blockid, "b1");
+    }
+
+    #[test]
+    fn layout_tree_replaced_slices_ack_clears_pending_actions() {
+        // Pushing the row without pendingbackendactions is how the frontend
+        // acks its processed backend-action queue — the slice-carrying write
+        // must CLEAR the column, not leave it (else actions re-apply on the
+        // next reload).
+        let s = store();
+        let tab = ws_tab(&s);
+        // Seed a pending action directly (as queue_target_layout_* would).
+        {
+            let t = s.get::<Tab>(&tab).unwrap().unwrap();
+            let mut layout = s
+                .get::<PersistedLayoutState>(&t.layoutstate)
+                .unwrap()
+                .unwrap();
+            layout.pendingbackendactions = Some(vec![LayoutActionData {
+                actiontype: "insert".into(),
+                actionid: "a1".into(),
+                blockid: "b-new".into(),
+                nodesize: None,
+                indexarr: None,
+                focused: true,
+                magnified: false,
+                ephemeral: false,
+                targetblockid: String::new(),
+                position: String::new(),
+            }]);
+            s.update(&mut layout).unwrap();
+        }
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n1", "b1")),
+                correlation_id: "c".into(),
+                slices: Some(slices(None, "n1", "", None)),
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        assert!(
+            layout_of(&s, &tab).pendingbackendactions.is_none(),
+            "slice write with absent pending queue must clear the column (ack path)"
+        );
+    }
+
+    #[test]
+    fn layout_tree_replaced_without_slices_leaves_client_columns_untouched() {
+        // Tree-only events (granular arms, dormant callers) must not clobber
+        // focus/magnify/leaforder/pending — only a slice-carrying full-row
+        // push owns those columns.
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n1", "b1")),
+                correlation_id: "seed".into(),
+                slices: Some(slices(
+                    Some(serde_json::json!([{ "nodeid": "n1", "blockid": "b1" }])),
+                    "n1",
+                    "",
+                    Some(serde_json::json!([{
+                        "actiontype": "insert",
+                        "actionid": "a1",
+                        "blockid": "b2",
+                        "focused": false,
+                        "magnified": false,
+                        "ephemeral": false,
+                    }])),
+                )),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        // Now a tree-only replace (slices: None) with a different tree.
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("n2", "b2")),
+                correlation_id: "c".into(),
+                slices: None,
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        let layout = layout_of(&s, &tab);
+        assert_eq!(layout.rootnode.unwrap().id, "n2", "tree replaced");
+        assert_eq!(layout.focusednodeid, "n1", "focus untouched");
+        assert!(layout.leaforder.is_some(), "leaforder untouched");
+        assert!(
+            layout.pendingbackendactions.is_some(),
+            "pending queue untouched by tree-only write"
+        );
     }
 
     #[test]
@@ -1592,6 +1785,7 @@ mod tests {
                 tab_id: "ghost".into(),
                 new_tree: Some(leaf("n", "b")),
                 correlation_id: "c".into(),
+                slices: None,
                 version: 1,
             },
             &s,

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -83,12 +83,10 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::SetMagnifiedNode { tab_id, node_id } => {
             layout::handle_set_magnified_node(state, tab_id, node_id)
         }
-        // Phase E.4.B Phase 5 — layout tree mutation arms. Currently
-        // dormant scaffolding (no production callers; Phase 7 migrates
-        // the wcore-direct writers to dispatch through these). 4 of 11
-        // arms shipped in this PR; remaining 7 (insert_at_index, move,
-        // swap, resize, replace, split_horizontal, split_vertical) are
-        // structurally identical and follow in subsequent PRs.
+        // Phase E.4.B Phase 5 — layout tree mutation arms. All 11 arms are
+        // wired. First production dispatcher: the `UpdateObject`→
+        // `LayoutSetTree` reroute (SPEC_864 Phase 2, `object.rs`); the
+        // remaining wcore-direct writers migrate in SPEC_864 Phases 3–5.
         Command::LayoutClear {
             tab_id,
             correlation_id,
@@ -97,7 +95,8 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             tab_id,
             new_tree,
             correlation_id,
-        } => layout::handle_layout_set_tree(state, tab_id, new_tree, correlation_id),
+            slices,
+        } => layout::handle_layout_set_tree(state, tab_id, new_tree, correlation_id, slices),
         Command::LayoutInsertNode {
             tab_id,
             node,
@@ -2535,6 +2534,7 @@ mod tests {
                 tab_id: tab_id.clone(),
                 new_tree: new_tree.clone(),
                 correlation_id: "corr-set".into(),
+                slices: None,
             },
             &ctx(1),
         );
@@ -2554,10 +2554,70 @@ mod tests {
                 tab_id: tab_id.clone(),
                 new_tree: None,
                 correlation_id: "corr".into(),
+                slices: None,
             },
             &ctx(1),
         );
         assert!(state.tabs[&tab_id].rootnode.is_none());
+    }
+
+    /// SPEC_864 Phase 2 — a slice-carrying full-row push applies focus/
+    /// magnify to the TabRecord (empty = clear) and echoes the slices on
+    /// the emitted event for the persist subscriber.
+    #[test]
+    fn layout_set_tree_with_slices_applies_focus_magnify() {
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "stale".into();
+
+        let events = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: Some(leaf_node("n1", "b1")),
+                correlation_id: "corr".into(),
+                slices: Some(agentmux_common::LayoutClientSlices {
+                    leaforder: None,
+                    focused_node_id: "n1".into(),
+                    magnified_node_id: String::new(),
+                    pending_backend_actions: None,
+                }),
+            },
+            &ctx(1),
+        );
+
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "n1");
+        assert!(
+            state.tabs[&tab_id].magnified_node_id.is_empty(),
+            "empty slice value clears stale magnify"
+        );
+        assert!(matches!(
+            &events[0],
+            Event::LayoutTreeReplaced { slices: Some(_), .. }
+        ));
+    }
+
+    /// Empty-tree contract wins over slices: wiping the tree clears focus/
+    /// magnify even if the (skewed) push carried non-empty ids.
+    #[test]
+    fn layout_set_tree_none_tree_overrides_slice_focus() {
+        let (mut state, tab_id) = fresh_tab();
+        let _ = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: None,
+                correlation_id: "corr".into(),
+                slices: Some(agentmux_common::LayoutClientSlices {
+                    leaforder: None,
+                    focused_node_id: "dangling".into(),
+                    magnified_node_id: "dangling".into(),
+                    pending_backend_actions: None,
+                }),
+            },
+            &ctx(1),
+        );
+        assert!(state.tabs[&tab_id].focused_node_id.is_empty());
+        assert!(state.tabs[&tab_id].magnified_node_id.is_empty());
     }
 
     #[test]
@@ -2654,6 +2714,7 @@ mod tests {
                 tab_id: tab_id.clone(),
                 new_tree: None,
                 correlation_id: "corr".into(),
+                slices: None,
             },
             &ctx(1),
         );
@@ -2676,6 +2737,7 @@ mod tests {
                 tab_id: tab_id.clone(),
                 new_tree: Some(leaf_node("n", "b")),
                 correlation_id: "corr".into(),
+                slices: None,
             },
             &ctx(1),
         );

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -88,6 +88,7 @@ pub(super) fn handle_layout_set_tree(
     tab_id: String,
     new_tree: Option<agentmux_common::LayoutNode>,
     correlation_id: String,
+    slices: Option<agentmux_common::LayoutClientSlices>,
 ) -> Vec<Event> {
     let Some(tab) = state.tabs.get_mut(&tab_id) else {
         let v = state.bump_version();
@@ -99,6 +100,14 @@ pub(super) fn handle_layout_set_tree(
         }];
     };
     tab.rootnode = new_tree.clone();
+    // SPEC_864 Phase 2 — a full-row push carries focus/magnify in `slices`
+    // (REPLACE semantics; empty string = clear). leaforder /
+    // pending_backend_actions are not modeled in TabRecord — they ride the
+    // event through to the persist subscriber untouched.
+    if let Some(s) = &slices {
+        tab.focused_node_id = s.focused_node_id.clone();
+        tab.magnified_node_id = s.magnified_node_id.clone();
+    }
     // when the tree is wiped, focused/
     // magnified ids would point at non-existent nodes. Match
     // `handle_layout_clear`'s contract for the empty-tree case.
@@ -111,6 +120,7 @@ pub(super) fn handle_layout_set_tree(
         tab_id,
         new_tree,
         correlation_id,
+        slices,
         version: v,
     }]
 }

--- a/agentmux-srv/src/server/service/object.rs
+++ b/agentmux-srv/src/server/service/object.rs
@@ -482,16 +482,6 @@ async fn update_layout_via_reducer(
         .unwrap_or_default()
         .to_string();
 
-    // Snapshot the current row for the rollback path before anything
-    // mutates. (A racing push between this read and the locked section
-    // below only affects which row the FAILURE path restores; the success
-    // path never reads old_row.)
-    let old_row = match store.get::<LayoutState>(&oid) {
-        Ok(Some(row)) => row,
-        Ok(None) => return WebReturnType::error(format!("UpdateObject: layout not found: {}", oid)),
-        Err(e) => return WebReturnType::error(format!("UpdateObject: {}", e)),
-    };
-
     let get_str = |key: &str| -> String {
         wave_obj_value
             .get(key)
@@ -514,62 +504,91 @@ async fn update_layout_via_reducer(
         correlation_id: String::new(),
         slices: Some(slices),
     };
-    let rollback_cmd = agentmux_common::ipc::Command::LayoutSetTree {
-        tab_id,
-        new_tree: old_row.rootnode.clone(),
-        correlation_id: String::new(),
-        slices: Some(agentmux_common::LayoutClientSlices {
-            leaforder: old_row
-                .leaforder
-                .as_ref()
-                .and_then(|v| serde_json::to_value(v).ok()),
-            focused_node_id: old_row.focusednodeid.clone(),
-            magnified_node_id: old_row.magnifiednodeid.clone(),
-            pending_backend_actions: old_row
-                .pendingbackendactions
-                .as_ref()
-                .and_then(|v| serde_json::to_value(v).ok()),
-        }),
-    };
 
-    // ── single critical section: dispatch + persist (+ rollback) ──
+    // ── single critical section: snapshot + dispatch + persist (+ rollback) ──
     let mut apply_err: Option<String> = None;
+    let mut early_err: Option<String> = None;
     let events = {
         let mut s = state.srv_state.lock().await;
-        let ctx = crate::reducer::Ctx {
-            now_rfc3339: chrono::Utc::now().to_rfc3339(),
-            conn_id: 0,
-            registered_pid: None,
-        };
-        let events = crate::reducer::update(&mut s, cmd, &ctx);
-        let has_error = events
-            .iter()
-            .any(|e| matches!(e, agentmux_common::ipc::Event::Error { .. }));
-        if !has_error {
-            for ev in &events {
-                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
-                    apply_err = Some(e.to_string());
-                    break;
-                }
+        // Snapshot the current row for the rollback path INSIDE the
+        // critical section (reagent P1 #1970, review 4): a pre-lock
+        // snapshot could be overtaken by a concurrent push committing
+        // between the read and this lock acquisition — a subsequent
+        // rollback would then restore the STALE snapshot, clobbering the
+        // concurrently-committed newer state in both TabRecord and
+        // db_layout. Read under the lock, immediately before the forward
+        // dispatch, no interleaving is possible.
+        let old_row = match store.get::<LayoutState>(&oid) {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                early_err = Some(format!("UpdateObject: layout not found: {}", oid));
+                LayoutState::default()
             }
-            if apply_err.is_some() {
-                // Roll the reducer back to the pre-push row inside the
-                // same lock hold so no concurrent dispatch can observe
-                // the divergent state; best-effort mirror to SQLite.
-                let rb_events = crate::reducer::update(&mut s, rollback_cmd, &ctx);
-                for ev in &rb_events {
+            Err(e) => {
+                early_err = Some(format!("UpdateObject: {}", e));
+                LayoutState::default()
+            }
+        };
+        if early_err.is_some() {
+            Vec::new()
+        } else {
+            let ctx = crate::reducer::Ctx {
+                now_rfc3339: chrono::Utc::now().to_rfc3339(),
+                conn_id: 0,
+                registered_pid: None,
+            };
+            let events = crate::reducer::update(&mut s, cmd, &ctx);
+            let has_error = events
+                .iter()
+                .any(|e| matches!(e, agentmux_common::ipc::Event::Error { .. }));
+            if !has_error {
+                for ev in &events {
                     if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
-                        tracing::warn!(
-                            error = %e,
-                            "UpdateObject: layout rollback SQLite mirror failed"
-                        );
+                        apply_err = Some(e.to_string());
+                        break;
+                    }
+                }
+                if apply_err.is_some() {
+                    // Roll the reducer back to the pre-push row inside the
+                    // same lock hold so no concurrent dispatch can observe
+                    // the divergent state; best-effort mirror to SQLite.
+                    let rollback_cmd = agentmux_common::ipc::Command::LayoutSetTree {
+                        tab_id,
+                        new_tree: old_row.rootnode.clone(),
+                        correlation_id: String::new(),
+                        slices: Some(agentmux_common::LayoutClientSlices {
+                            leaforder: old_row
+                                .leaforder
+                                .as_ref()
+                                .and_then(|v| serde_json::to_value(v).ok()),
+                            focused_node_id: old_row.focusednodeid.clone(),
+                            magnified_node_id: old_row.magnifiednodeid.clone(),
+                            pending_backend_actions: old_row
+                                .pendingbackendactions
+                                .as_ref()
+                                .and_then(|v| serde_json::to_value(v).ok()),
+                        }),
+                    };
+                    let rb_events = crate::reducer::update(&mut s, rollback_cmd, &ctx);
+                    for ev in &rb_events {
+                        if let Err(e) =
+                            crate::persist_subscriber::apply_event_to_wstore(ev, store)
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                "UpdateObject: layout rollback SQLite mirror failed"
+                            );
+                        }
                     }
                 }
             }
+            events
         }
-        events
     };
 
+    if let Some(err) = early_err {
+        return WebReturnType::error(err);
+    }
     if let Some(err_msg) = events.iter().find_map(|e| match e {
         agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
         _ => None,

--- a/agentmux-srv/src/server/service/object.rs
+++ b/agentmux-srv/src/server/service/object.rs
@@ -181,74 +181,59 @@ pub(super) async fn handle_object_service(state: &AppState, call: &WebCallType) 
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            // Phase E.4 (Option A) — when a LayoutState update lands,
-            // route the focused/magnified slice through the srv reducer
-            // so its canonical state matches what the frontend just
-            // pushed and the persist subscriber emits the new
-            // FocusedNodeChanged / MagnifiedNodeChanged events for E.6
-            // dispatcher consumption. The remaining LayoutState fields
-            // (rootnode/leaforder/pendingbackendactions) keep the
-            // wcore-direct write below per the deferred Option B
-            // decision in `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`.
+            // SPEC_864 Phase 2 — an OTYPE_LAYOUT push routes through the
+            // reducer as a single `LayoutSetTree` (tree + client slices),
+            // replacing the legacy `update_raw` whole-row write PLUS the
+            // separate SetFocusedNode/SetMagnifiedNode dispatches (the
+            // "double-write": two SQLite writes, two version bumps, per
+            // push, with `TabRecord.rootnode` left a stale shadow). One
+            // dispatch → one persist-subscriber write → one version bump,
+            // and the reducer's in-memory tree stays authoritative.
             //
-            // (codex P2 PR #632) Capture the slice now but DO NOT
-            // dispatch yet — reducer + subscriber updates must happen
-            // ONLY AFTER update_object succeeds. Otherwise an
-            // UpdateObject failure would leave reducer state and
-            // FocusedNodeChanged/MagnifiedNodeChanged events fired for
-            // a request that returned an error, breaking failure
-            // atomicity.
-            let layout_slice: Option<(String, String, String)> = if wave_obj_value
-                .get("otype")
-                .and_then(|v| v.as_str())
-                == Some(OTYPE_LAYOUT)
-            {
-                wave_obj_value
-                    .get("oid")
-                    .and_then(|v| v.as_str())
-                    .and_then(|layout_oid| find_tab_for_layout(store, layout_oid))
-                    .map(|tab_id| {
-                        let new_focused = wave_obj_value
-                            .get("focusednodeid")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        let new_magnified = wave_obj_value
-                            .get("magnifiednodeid")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        (tab_id, new_focused, new_magnified)
-                    })
-            } else {
-                None
-            };
+            // Fallback: an unowned layout row (no tab references it) or a
+            // rootnode that fails typed deserialization takes the legacy
+            // wcore-direct path below, loudly — never silently drop a push.
+            if wave_obj_value.get("otype").and_then(|v| v.as_str()) == Some(OTYPE_LAYOUT) {
+                let layout_route: Option<(String, Option<agentmux_common::LayoutNode>)> =
+                    match wave_obj_value
+                        .get("oid")
+                        .and_then(|v| v.as_str())
+                        .and_then(|layout_oid| find_tab_for_layout(store, layout_oid))
+                    {
+                        Some(tab_id) => match wave_obj_value.get("rootnode") {
+                            None | Some(serde_json::Value::Null) => Some((tab_id, None)),
+                            Some(v) => match serde_json::from_value(v.clone()) {
+                                Ok(tree) => Some((tab_id, Some(tree))),
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "UpdateObject: layout rootnode failed typed parse; \
+                                         falling back to legacy wcore-direct write"
+                                    );
+                                    None
+                                }
+                            },
+                        },
+                        None => {
+                            tracing::warn!(
+                                "UpdateObject: layout row not owned by any tab; \
+                                 falling back to legacy wcore-direct write"
+                            );
+                            None
+                        }
+                    };
+                if let Some((tab_id, new_tree)) = layout_route {
+                    return update_layout_via_reducer(state, wave_obj_value, tab_id, new_tree)
+                        .await;
+                }
+            }
+            // Non-layout otypes and the layout fallback: legacy wholesale
+            // row replace. (Pre-Phase-2, layout pushes also dispatched the
+            // focus/magnify slice here — that now lives inside
+            // `update_layout_via_reducer`; the degenerate fallback cases
+            // have no reducer-known tab, so there is nothing to dispatch.)
             match update_object(store, wave_obj_value) {
                 Ok((otype, oid, obj_val)) => {
-                    // DB write succeeded — now dispatch the layout
-                    // reducer updates so reducer state and persist-
-                    // subscriber events stay aligned with the
-                    // committed wstore state. (codex P2 PR #632)
-                    if let Some((tab_id, new_focused, new_magnified)) = layout_slice {
-                        let focus_events = dispatch_to_reducer(
-                            state,
-                            agentmux_common::ipc::Command::SetFocusedNode {
-                                tab_id: tab_id.clone(),
-                                node_id: new_focused,
-                            },
-                        )
-                        .await;
-                        publish_events(state, &focus_events);
-                        let mag_events = dispatch_to_reducer(
-                            state,
-                            agentmux_common::ipc::Command::SetMagnifiedNode {
-                                tab_id,
-                                node_id: new_magnified,
-                            },
-                        )
-                        .await;
-                        publish_events(state, &mag_events);
-                    }
                     let update = WaveObjUpdate {
                         updatetype: "update".into(),
                         otype,
@@ -420,5 +405,124 @@ pub(super) async fn handle_object_service(state: &AppState, call: &WebCallType) 
             WebReturnType::success_empty()
         }
         _ => WebReturnType::error(format!("unknown object method: {}", call.method)),
+    }
+}
+
+/// SPEC_864 Phase 2 — route a frontend `UpdateObject` layout push through
+/// the reducer as a single `LayoutSetTree` dispatch.
+///
+/// Ordering follows the CreateBlock pattern: dispatch (reducer state
+/// mutates) → apply events to wstore (the persist subscriber is the sole
+/// `db_layout` writer) → on SQLite failure, compensate by re-dispatching
+/// the pre-push row so reducer state rolls back → publish events (the
+/// wave-obj bridge re-reads the row, so publish must follow the write).
+///
+/// Not carried: `LayoutState.meta`. The legacy whole-row write persisted
+/// it incidentally, but nothing mutates layout meta (`UpdateObjectMeta`
+/// rejects OTYPE_LAYOUT and the frontend's `persistToBackend` writes only
+/// tree/focus/magnify/leaforder/pendingbackendactions), so the reducer
+/// route leaves the stored meta untouched.
+async fn update_layout_via_reducer(
+    state: &AppState,
+    wave_obj_value: serde_json::Value,
+    tab_id: String,
+    new_tree: Option<agentmux_common::LayoutNode>,
+) -> WebReturnType {
+    let store = &state.wstore;
+    let oid = wave_obj_value
+        .get("oid")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    // Snapshot the current row for compensation before anything mutates.
+    let old_row = match store.get::<LayoutState>(&oid) {
+        Ok(Some(row)) => row,
+        Ok(None) => return WebReturnType::error(format!("UpdateObject: layout not found: {}", oid)),
+        Err(e) => return WebReturnType::error(format!("UpdateObject: {}", e)),
+    };
+
+    let get_str = |key: &str| -> String {
+        wave_obj_value
+            .get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    let get_json = |key: &str| -> Option<serde_json::Value> {
+        wave_obj_value.get(key).filter(|v| !v.is_null()).cloned()
+    };
+    let slices = agentmux_common::LayoutClientSlices {
+        leaforder: get_json("leaforder"),
+        focused_node_id: get_str("focusednodeid"),
+        magnified_node_id: get_str("magnifiednodeid"),
+        pending_backend_actions: get_json("pendingbackendactions"),
+    };
+
+    let events = dispatch_to_reducer(
+        state,
+        agentmux_common::ipc::Command::LayoutSetTree {
+            tab_id: tab_id.clone(),
+            new_tree,
+            correlation_id: String::new(),
+            slices: Some(slices),
+        },
+    )
+    .await;
+    if let Some(err_msg) = events.iter().find_map(|e| match e {
+        agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+        _ => None,
+    }) {
+        return WebReturnType::error(err_msg);
+    }
+    // Convert the (non-Send) boxed error to a String before awaiting the
+    // compensation — same shape as CreateBlock's apply/compensate flow.
+    let mut apply_err: Option<String> = None;
+    for ev in &events {
+        if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+            apply_err = Some(e.to_string());
+            break;
+        }
+    }
+    if let Some(err) = apply_err {
+        // Roll the reducer back to the pre-push row so its in-memory
+        // tree doesn't diverge from the (unwritten) DB row.
+        let old_slices = agentmux_common::LayoutClientSlices {
+            leaforder: old_row
+                .leaforder
+                .as_ref()
+                .and_then(|v| serde_json::to_value(v).ok()),
+            focused_node_id: old_row.focusednodeid.clone(),
+            magnified_node_id: old_row.magnifiednodeid.clone(),
+            pending_backend_actions: old_row
+                .pendingbackendactions
+                .as_ref()
+                .and_then(|v| serde_json::to_value(v).ok()),
+        };
+        compensate_via_reducer(
+            state,
+            agentmux_common::ipc::Command::LayoutSetTree {
+                tab_id,
+                new_tree: old_row.rootnode.clone(),
+                correlation_id: String::new(),
+                slices: Some(old_slices),
+            },
+            store,
+        )
+        .await;
+        return WebReturnType::error(format!("UpdateObject: SQLite write failed: {}", err));
+    }
+    publish_events(state, &events);
+
+    // Return the committed row (fresh version) so the pusher's WOS cache
+    // stays in sync — same response shape as the legacy path.
+    match get_object_by_oref(store, &format!("{}:{}", OTYPE_LAYOUT, oid)) {
+        Ok(obj_val) => WebReturnType::success_with_updates(vec![WaveObjUpdate {
+            updatetype: "update".into(),
+            otype: OTYPE_LAYOUT.to_string(),
+            oid,
+            obj: Some(obj_val),
+        }]),
+        Err(e) => WebReturnType::error(format!("UpdateObject: re-read failed: {}", e)),
     }
 }

--- a/agentmux-srv/src/server/service/object.rs
+++ b/agentmux-srv/src/server/service/object.rs
@@ -411,11 +411,20 @@ pub(super) async fn handle_object_service(state: &AppState, call: &WebCallType) 
 /// SPEC_864 Phase 2 — route a frontend `UpdateObject` layout push through
 /// the reducer as a single `LayoutSetTree` dispatch.
 ///
-/// Ordering follows the CreateBlock pattern: dispatch (reducer state
-/// mutates) → apply events to wstore (the persist subscriber is the sole
-/// `db_layout` writer) → on SQLite failure, compensate by re-dispatching
-/// the pre-push row so reducer state rolls back → publish events (the
-/// wave-obj bridge re-reads the row, so publish must follow the write).
+/// Dispatch AND SQLite apply happen under ONE hold of the `srv_state`
+/// mutex (reagent P1 #1970): with `dispatch_to_reducer`'s usual
+/// release-before-I/O contract, two concurrent pushes for the same tab
+/// could dispatch in order A→B but persist B→A, leaving `db_layout` on
+/// the older tree while `TabRecord` (authoritative as of this route)
+/// holds the newer one — the exact coherence this route exists to
+/// guarantee, and a regression vs. the legacy single atomic `update_raw`.
+/// Holding the lock across the row UPDATE (a sub-ms local SQLite write)
+/// makes persist order equal dispatch order; the SQLite-failure rollback
+/// re-dispatch also runs inside the same hold so no interleaved dispatch
+/// can observe the un-rolled-back state. Publish happens after release
+/// (the wave-obj bridge re-reads the row, so publish must follow the
+/// write; subscribers never see events out of dispatch order because
+/// publish order still matches — see below).
 ///
 /// Not carried: `LayoutState.meta`. The legacy whole-row write persisted
 /// it incidentally, but nothing mutates layout meta (`UpdateObjectMeta`
@@ -435,7 +444,10 @@ async fn update_layout_via_reducer(
         .unwrap_or_default()
         .to_string();
 
-    // Snapshot the current row for compensation before anything mutates.
+    // Snapshot the current row for the rollback path before anything
+    // mutates. (A racing push between this read and the locked section
+    // below only affects which row the FAILURE path restores; the success
+    // path never reads old_row.)
     let old_row = match store.get::<LayoutState>(&oid) {
         Ok(Some(row)) => row,
         Ok(None) => return WebReturnType::error(format!("UpdateObject: layout not found: {}", oid)),
@@ -458,36 +470,17 @@ async fn update_layout_via_reducer(
         magnified_node_id: get_str("magnifiednodeid"),
         pending_backend_actions: get_json("pendingbackendactions"),
     };
-
-    let events = dispatch_to_reducer(
-        state,
-        agentmux_common::ipc::Command::LayoutSetTree {
-            tab_id: tab_id.clone(),
-            new_tree,
-            correlation_id: String::new(),
-            slices: Some(slices),
-        },
-    )
-    .await;
-    if let Some(err_msg) = events.iter().find_map(|e| match e {
-        agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
-        _ => None,
-    }) {
-        return WebReturnType::error(err_msg);
-    }
-    // Convert the (non-Send) boxed error to a String before awaiting the
-    // compensation — same shape as CreateBlock's apply/compensate flow.
-    let mut apply_err: Option<String> = None;
-    for ev in &events {
-        if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
-            apply_err = Some(e.to_string());
-            break;
-        }
-    }
-    if let Some(err) = apply_err {
-        // Roll the reducer back to the pre-push row so its in-memory
-        // tree doesn't diverge from the (unwritten) DB row.
-        let old_slices = agentmux_common::LayoutClientSlices {
+    let cmd = agentmux_common::ipc::Command::LayoutSetTree {
+        tab_id: tab_id.clone(),
+        new_tree,
+        correlation_id: String::new(),
+        slices: Some(slices),
+    };
+    let rollback_cmd = agentmux_common::ipc::Command::LayoutSetTree {
+        tab_id,
+        new_tree: old_row.rootnode.clone(),
+        correlation_id: String::new(),
+        slices: Some(agentmux_common::LayoutClientSlices {
             leaforder: old_row
                 .leaforder
                 .as_ref()
@@ -498,18 +491,54 @@ async fn update_layout_via_reducer(
                 .pendingbackendactions
                 .as_ref()
                 .and_then(|v| serde_json::to_value(v).ok()),
+        }),
+    };
+
+    // ── single critical section: dispatch + persist (+ rollback) ──
+    let mut apply_err: Option<String> = None;
+    let events = {
+        let mut s = state.srv_state.lock().await;
+        let ctx = crate::reducer::Ctx {
+            now_rfc3339: chrono::Utc::now().to_rfc3339(),
+            conn_id: 0,
+            registered_pid: None,
         };
-        compensate_via_reducer(
-            state,
-            agentmux_common::ipc::Command::LayoutSetTree {
-                tab_id,
-                new_tree: old_row.rootnode.clone(),
-                correlation_id: String::new(),
-                slices: Some(old_slices),
-            },
-            store,
-        )
-        .await;
+        let events = crate::reducer::update(&mut s, cmd, &ctx);
+        let has_error = events
+            .iter()
+            .any(|e| matches!(e, agentmux_common::ipc::Event::Error { .. }));
+        if !has_error {
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    apply_err = Some(e.to_string());
+                    break;
+                }
+            }
+            if apply_err.is_some() {
+                // Roll the reducer back to the pre-push row inside the
+                // same lock hold so no concurrent dispatch can observe
+                // the divergent state; best-effort mirror to SQLite.
+                let rb_events = crate::reducer::update(&mut s, rollback_cmd, &ctx);
+                for ev in &rb_events {
+                    if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                        tracing::warn!(
+                            error = %e,
+                            "UpdateObject: layout rollback SQLite mirror failed"
+                        );
+                    }
+                }
+            }
+        }
+        events
+    };
+
+    if let Some(err_msg) = events.iter().find_map(|e| match e {
+        agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+        _ => None,
+    }) {
+        return WebReturnType::error(err_msg);
+    }
+    if let Some(err) = apply_err {
         return WebReturnType::error(format!("UpdateObject: SQLite write failed: {}", err));
     }
     publish_events(state, &events);

--- a/agentmux-srv/src/server/service/object.rs
+++ b/agentmux-srv/src/server/service/object.rs
@@ -193,6 +193,12 @@ pub(super) async fn handle_object_service(state: &AppState, call: &WebCallType) 
             // Fallback: an unowned layout row (no tab references it) or a
             // rootnode that fails typed deserialization takes the legacy
             // wcore-direct path below, loudly — never silently drop a push.
+            // For an OWNED row whose rootnode failed the typed parse, the
+            // legacy path must still dispatch the focus/magnify slice to
+            // the reducer (the pre-Phase-2 Option-A behavior) so
+            // `TabRecord` focus state can't silently diverge on that
+            // branch (reagent P1 #1970, review 3).
+            let mut fallback_slice: Option<(String, String, String)> = None;
             if wave_obj_value.get("otype").and_then(|v| v.as_str()) == Some(OTYPE_LAYOUT) {
                 let layout_route: Option<(String, Option<agentmux_common::LayoutNode>)> =
                     match wave_obj_value
@@ -210,6 +216,18 @@ pub(super) async fn handle_object_service(state: &AppState, call: &WebCallType) 
                                         "UpdateObject: layout rootnode failed typed parse; \
                                          falling back to legacy wcore-direct write"
                                     );
+                                    let get_str = |key: &str| -> String {
+                                        wave_obj_value
+                                            .get(key)
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("")
+                                            .to_string()
+                                    };
+                                    fallback_slice = Some((
+                                        tab_id,
+                                        get_str("focusednodeid"),
+                                        get_str("magnifiednodeid"),
+                                    ));
                                     None
                                 }
                             },
@@ -227,13 +245,33 @@ pub(super) async fn handle_object_service(state: &AppState, call: &WebCallType) 
                         .await;
                 }
             }
-            // Non-layout otypes and the layout fallback: legacy wholesale
-            // row replace. (Pre-Phase-2, layout pushes also dispatched the
-            // focus/magnify slice here — that now lives inside
-            // `update_layout_via_reducer`; the degenerate fallback cases
-            // have no reducer-known tab, so there is nothing to dispatch.)
+            // Non-layout otypes and the layout fallbacks: legacy wholesale
+            // row replace. The unowned-row fallback has no reducer-known
+            // tab, so there is nothing to dispatch; the owned-but-unparsable
+            // fallback dispatches the focus/magnify slice AFTER the write
+            // succeeds (failure-atomicity ordering per codex P2 PR #632).
             match update_object(store, wave_obj_value) {
                 Ok((otype, oid, obj_val)) => {
+                    if let Some((tab_id, new_focused, new_magnified)) = fallback_slice {
+                        let focus_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::SetFocusedNode {
+                                tab_id: tab_id.clone(),
+                                node_id: new_focused,
+                            },
+                        )
+                        .await;
+                        publish_events(state, &focus_events);
+                        let mag_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::SetMagnifiedNode {
+                                tab_id,
+                                node_id: new_magnified,
+                            },
+                        )
+                        .await;
+                        publish_events(state, &mag_events);
+                    }
                     let update = WaveObjUpdate {
                         updatetype: "update".into(),
                         otype,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -468,6 +468,149 @@ async fn self_endpoint_missing_block_id_is_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
+// ── SPEC_864 Phase 2 — UpdateObject routes layout pushes through the reducer ──
+
+/// End-to-end over the HTTP service: a frontend-style full-row layout push
+/// must (a) succeed, (b) bump `db_layout.version` exactly once (the legacy
+/// path double-wrote: update_raw + the focus/magnify subscriber write),
+/// (c) leave the reducer's `TabRecord.rootnode` equal to the persisted
+/// rootnode (the Pillar-1 coherence invariant — TabRecord was previously a
+/// passive shadow that diverged on every push), and (d) clear
+/// `pendingbackendactions` when the push omits it (the frontend's ack path).
+#[tokio::test]
+async fn update_object_layout_push_single_write_and_coherent_reducer() {
+    use agentmux_common::ipc::{Command, Event};
+    use crate::backend::obj::{LayoutActionData, LayoutState, Tab};
+
+    let state = test_state();
+    let wstore = state.wstore.clone();
+    let srv_state = state.srv_state.clone();
+
+    // Seed workspace + tab through the reducer so BOTH reducer state and
+    // wstore know the tab (mirrors production bootstrap).
+    async fn dispatch_apply(state: &AppState, cmd: Command) -> Vec<Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+    let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "ws".into() }).await;
+    let ws_id = ws_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let tab_evs = dispatch_apply(
+        &state,
+        Command::CreateTab {
+            workspace_id: ws_id,
+            name: "t".into(),
+        },
+    )
+    .await;
+    let tab_id = tab_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+
+    let tab = wstore.get::<Tab>(&tab_id).unwrap().unwrap();
+    let layout_oid = tab.layoutstate.clone();
+
+    // Seed a pending backend action (as a redock would); the push below
+    // omits pendingbackendactions — the ack must clear it.
+    {
+        let mut layout = wstore.get::<LayoutState>(&layout_oid).unwrap().unwrap();
+        layout.pendingbackendactions = Some(vec![LayoutActionData {
+            actiontype: "insert".into(),
+            actionid: "a1".into(),
+            blockid: "b-x".into(),
+            nodesize: None,
+            indexarr: None,
+            focused: false,
+            magnified: false,
+            ephemeral: false,
+            targetblockid: String::new(),
+            position: String::new(),
+        }]);
+        wstore.update(&mut layout).unwrap();
+    }
+    let version_before = wstore
+        .get::<LayoutState>(&layout_oid)
+        .unwrap()
+        .unwrap()
+        .version;
+
+    // Frontend-style full-row push (persistToBackend shape).
+    let push = serde_json::json!({
+        "service": "object",
+        "method": "UpdateObject",
+        "args": [{
+            "otype": "layout",
+            "oid": layout_oid,
+            "version": version_before,
+            "rootnode": {
+                "id": "n-root",
+                "flexDirection": "row",
+                "size": 1,
+                "data": { "blockId": "b-1" }
+            },
+            "focusednodeid": "n-root",
+            "leaforder": [{ "nodeid": "n-root", "blockid": "b-1" }]
+        }]
+    });
+    let app = build_router(state);
+    let req = Request::builder()
+        .uri("/agentmux/service")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(push.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json["success"].as_bool().unwrap_or(false),
+        "UpdateObject failed: {}",
+        json["error"]
+    );
+
+    // (b) exactly ONE version bump — the double-write is collapsed.
+    let layout = wstore.get::<LayoutState>(&layout_oid).unwrap().unwrap();
+    assert_eq!(
+        layout.version,
+        version_before + 1,
+        "layout push must produce exactly one db_layout write"
+    );
+    // Row content matches the push.
+    assert_eq!(layout.rootnode.as_ref().unwrap().id, "n-root");
+    assert_eq!(layout.focusednodeid, "n-root");
+    assert_eq!(layout.leaforder.as_ref().unwrap()[0].blockid, "b-1");
+    // (d) omitted pendingbackendactions = ack → cleared.
+    assert!(
+        layout.pendingbackendactions.is_none(),
+        "push without pendingbackendactions must clear the queue (ack)"
+    );
+
+    // (c) the coherence invariant: TabRecord.rootnode == db_layout.rootnode.
+    let s = srv_state.lock().await;
+    let rec = s.tabs.get(&tab_id).expect("reducer knows the tab");
+    assert_eq!(
+        rec.rootnode, layout.rootnode,
+        "TabRecord.rootnode must match db_layout mid-session (no stale shadow)"
+    );
+    assert_eq!(rec.focused_node_id, "n-root");
+}
+
 #[test]
 fn clean_name_trims_clamps_and_rejects_empty() {
     use super::clean_name;

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -531,6 +531,7 @@ async fn update_object_layout_push_single_write_and_coherent_reducer() {
             actionid: "a1".into(),
             blockid: "b-x".into(),
             nodesize: None,
+            nodesizefraction: None,
             indexarr: None,
             focused: false,
             magnified: false,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -612,6 +612,100 @@ async fn update_object_layout_push_single_write_and_coherent_reducer() {
     assert_eq!(rec.focused_node_id, "n-root");
 }
 
+/// Reagent P1 (#1970 review 3) — the owned-row PARSE-FAILURE fallback must
+/// keep the pre-Phase-2 Option-A behavior: legacy wholesale write PLUS the
+/// focus/magnify reducer dispatch, so `TabRecord` focus state can't
+/// silently diverge on the degenerate branch.
+#[tokio::test]
+async fn update_object_layout_parse_failure_falls_back_with_focus_dispatch() {
+    use agentmux_common::ipc::{Command, Event};
+    use crate::backend::obj::Tab;
+
+    let state = test_state();
+    let wstore = state.wstore.clone();
+    let srv_state = state.srv_state.clone();
+
+    async fn dispatch_apply(state: &AppState, cmd: Command) -> Vec<Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+    let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "ws".into() }).await;
+    let ws_id = ws_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let tab_evs = dispatch_apply(
+        &state,
+        Command::CreateTab {
+            workspace_id: ws_id,
+            name: "t".into(),
+        },
+    )
+    .await;
+    let tab_id = tab_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let layout_oid = wstore.get::<Tab>(&tab_id).unwrap().unwrap().layoutstate;
+
+    // rootnode.id must be a string — a numeric id fails the typed parse and
+    // forces the legacy fallback branch.
+    let push = serde_json::json!({
+        "service": "object",
+        "method": "UpdateObject",
+        "args": [{
+            "otype": "layout",
+            "oid": layout_oid,
+            "rootnode": { "id": 12345 },
+            "focusednodeid": "n-fallback"
+        }]
+    });
+    let app = build_router(state);
+    let req = Request::builder()
+        .uri("/agentmux/service")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(push.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json["success"].as_bool().unwrap_or(false),
+        "fallback push must still succeed: {}",
+        json["error"]
+    );
+
+    // Row was written wholesale (raw JSON survives even though typed parse failed).
+    let raw = wstore
+        .get_raw("layout", &layout_oid)
+        .unwrap()
+        .expect("row present");
+    assert_eq!(raw["focusednodeid"], "n-fallback");
+    assert_eq!(raw["rootnode"]["id"], 12345);
+
+    // The focus slice still reached the reducer (pre-Phase-2 Option-A behavior).
+    let s = srv_state.lock().await;
+    let rec = s.tabs.get(&tab_id).expect("reducer knows the tab");
+    assert_eq!(
+        rec.focused_node_id, "n-fallback",
+        "parse-failure fallback must still dispatch focus to the reducer"
+    );
+}
+
 #[test]
 fn clean_name_trims_clamps_and_rejects_empty() {
     use super::clean_name;


### PR DESCRIPTION
## Summary

**SPEC_864 Phase 2 — the load-bearing single-writer change** (per `SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md` §4 Phase 2 and the 2026-07-02 weak-cutover scope note / DISCUSSION §7b): an `OTYPE_LAYOUT` `UpdateObject` push now dispatches **one** `Command::LayoutSetTree` through the srv reducer instead of the legacy `update_raw` whole-row write + separate `SetFocusedNode`/`SetMagnifiedNode` dispatches.

- **One `db_layout` write, one version bump per push** (was two — the "double-write" at `object.rs`)
- **`TabRecord.rootnode` stays authoritative mid-session** — previously a passive shadow that diverged on the first push and stayed stale for the whole session (the Pillar-1 reproject coherence gap)
- New `LayoutClientSlices` (common) carries leaforder / focus / magnify / pendingbackendactions with REPLACE semantics — pushing without processed actions still **clears the backend-action queue** (the frontend's ack path), exactly as the wholesale row write did
- Granular/tree-only `LayoutSetTree` callers (`slices: None`) leave the client columns untouched
- Unowned layout rows and rootnode parse failures fall back to the legacy path **loudly** (`tracing::warn`); a SQLite apply failure compensates by re-dispatching the pre-push row so reducer state rolls back
- **Frontend unchanged** — wire format identical; also updates the stale "4 of 11 arms" scaffolding comment in `reducer.rs`

## Verification

**Unit/integration (all green — `cargo test --workspace`, 1,796 tests):**
- New router-level invariant test `update_object_layout_push_single_write_and_coherent_reducer`: real HTTP push → exactly one version bump, row content matches, `TabRecord.rootnode == db_layout.rootnode`, omitted pendingbackendactions clears the queue
- New reducer tests: slices apply focus/magnify (empty = clear); empty-tree contract wins over skewed slices
- New persist tests: full-row slice write, ack-clears-pending, tree-only write leaves client columns untouched

**App-running E2E (per spec §5 — this is the "sharp edge" phase):**
- `task dev` on this branch; drove `POST /api/v1/pane/open` (backend queues action → frontend processes → pushes tree via UpdateObject → **new reducer route**)
- Persisted row verified via GetObject: new pane present in rootnode, leaforder written (4 entries), `pendingbackendactions: None` (acked), version low/coherent
- **0 "falling back to legacy" warnings**; no layout errors in srv log

⚠️ Per the spec: **do not auto-merge on bot approval** — this is the highest-frequency layout writer. Suggest a human smoke of split/resize/drag + an app restart (persistence) before merge.

Unblocks: SPEC_864 Phases 3–5 (seeder/tear-off reroute, pendingbackendactions reducer-routing, `heal_layout` deletion) → Pillar 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agent2 -->