### PR TITLE
fix(layout): SPEC_864 Phase 3 — layout seeders route through the reducer

### DIFF
--- a/.changesets/1783277218-fix-layout-spec-864-phase-3-layout-seeders-route-through-the-lvbd.md
+++ b/.changesets/1783277218-fix-layout-spec-864-phase-3-layout-seeders-route-through-the-lvbd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): SPEC_864 Phase 3 — layout seeders route through the reducer (CreateWindow three-pane, tear-off/promote/redock/floating single-leaf)

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -187,7 +187,28 @@ pub(crate) fn write_default_three_pane_layout(
     swarm_block_id: &str,
 ) -> Result<(), StoreError> {
     let tab = store.must_get::<Tab>(tab_id)?;
+    let (rootnode, focused_node_id, leaforder) =
+        default_three_pane_tree(agent_block_id, sysinfo_block_id, swarm_block_id);
+    let mut layout = store.must_get::<LayoutState>(&tab.layoutstate)?;
+    layout.rootnode = Some(rootnode);
+    layout.focusednodeid = focused_node_id;
+    layout.leaforder = Some(leaforder);
+    layout.pendingbackendactions = None;
+    store.update(&mut layout)?;
+    Ok(())
+}
 
+/// Pure builder for the default 3-pane tree (`agent | [sysinfo / swarm]`).
+/// Returns `(rootnode, focused_node_id, leaforder)`. Shared by the
+/// pre-bootstrap store-direct writer above (first launch — reducer not
+/// hydrated yet) and the post-bootstrap reducer-routed CreateWindow seed
+/// (SPEC_864 Phase 3, `seed_layout_via_reducer`), so the layout shape can
+/// never drift between the two paths.
+pub(crate) fn default_three_pane_tree(
+    agent_block_id: &str,
+    sysinfo_block_id: &str,
+    swarm_block_id: &str,
+) -> (LayoutNode, String, Vec<LeafOrderEntry>) {
     // Node IDs for each tree position. Leaves get their own node IDs distinct
     // from the block IDs they wrap.
     let agent_node_id = Uuid::new_v4().to_string();
@@ -249,17 +270,12 @@ pub(crate) fn write_default_three_pane_layout(
         ..Default::default()
     };
 
-    let mut layout = store.must_get::<LayoutState>(&tab.layoutstate)?;
-    layout.rootnode = Some(rootnode);
-    layout.focusednodeid = agent_node_id.clone();
-    layout.leaforder = Some(vec![
-        LeafOrderEntry { nodeid: agent_node_id, blockid: agent_block_id.to_string() },
+    let leaforder = vec![
+        LeafOrderEntry { nodeid: agent_node_id.clone(), blockid: agent_block_id.to_string() },
         LeafOrderEntry { nodeid: sysinfo_node_id, blockid: sysinfo_block_id.to_string() },
         LeafOrderEntry { nodeid: swarm_node_id, blockid: swarm_block_id.to_string() },
-    ]);
-    layout.pendingbackendactions = None;
-    store.update(&mut layout)?;
-    Ok(())
+    ];
+    (rootnode, agent_node_id, leaforder)
 }
 
 /// Get the singleton client record.

--- a/agentmux-srv/src/server/app_api/pane.rs
+++ b/agentmux-srv/src/server/app_api/pane.rs
@@ -108,7 +108,7 @@ pub(super) async fn open_pane_floating(
 
     // Make the moved block the new tab's single root node so it renders.
     if let Err(e) =
-        crate::server::service::setup_torn_off_block_layout(wstore, &new_tab_id, &block_id)
+        crate::server::service::setup_torn_off_block_layout(state, &new_tab_id, &block_id).await
     {
         tracing::warn!(
             new_tab = %new_tab_id,

--- a/agentmux-srv/src/server/service/layout_helpers.rs
+++ b/agentmux-srv/src/server/service/layout_helpers.rs
@@ -11,9 +11,11 @@ use crate::backend::storage::store::Store;
 
 /// Phase E.5.5 — set up the layout tree for a tab that just received
 /// its first block via the TearOffBlock saga. Called from the
-/// TearOffBlock / RedockFloatingPane / PromoteBlockToTab handlers and the
-/// floating `pane.open` path after the saga's reducer-state portion
-/// (CreateTab + MoveBlock) completes.
+/// TearOffBlock / PromoteBlockToTab handlers and the floating
+/// `pane.open` path after the saga's reducer-state portion
+/// (CreateTab + MoveBlock) completes. (NOT RedockFloatingPane — that
+/// redocks into an EXISTING tab and goes through
+/// `queue_target_layout_insert`/`_split` instead; reagent P2 on #1971.)
 ///
 /// SPEC_864 Phase 3 — reducer-routed: dispatches `LayoutSetTree` via
 /// `seed_layout_via_reducer` (single writer of `db_layout`; the reducer's

--- a/agentmux-srv/src/server/service/layout_helpers.rs
+++ b/agentmux-srv/src/server/service/layout_helpers.rs
@@ -11,25 +11,25 @@ use crate::backend::storage::store::Store;
 
 /// Phase E.5.5 — set up the layout tree for a tab that just received
 /// its first block via the TearOffBlock saga. Called from the
-/// TearOffBlock RPC handler after the saga's reducer-state portion
-/// (CreateTab + MoveBlock) completes. Mirrors the layout-rootnode
-/// + leaforder construction that `wcore::tear_off_block` previously
-/// embedded in its single function.
+/// TearOffBlock / RedockFloatingPane / PromoteBlockToTab handlers and the
+/// floating `pane.open` path after the saga's reducer-state portion
+/// (CreateTab + MoveBlock) completes.
 ///
-/// Layout state migration is E.4 — until then layout writes are
-/// wcore-direct and not reducer-routed. Best-effort: a failure here
-/// leaves the new tab with the moved block but a malformed layout;
+/// SPEC_864 Phase 3 — reducer-routed: dispatches `LayoutSetTree` via
+/// `seed_layout_via_reducer` (single writer of `db_layout`; the reducer's
+/// `TabRecord.rootnode` stays authoritative) instead of the retired
+/// wcore-direct `rootnode`/`leaforder` write. Every caller runs post-saga,
+/// so the tab is always reducer-known. Best-effort at the call sites: a
+/// failure leaves the new tab with the moved block but a malformed layout;
 /// the user-visible symptom is an empty render in the new window.
-pub(crate) fn setup_torn_off_block_layout(
-    store: &Store,
+pub(crate) async fn setup_torn_off_block_layout(
+    state: &super::super::AppState,
     new_tab_id: &str,
     block_id: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let new_tab = store.must_get::<Tab>(new_tab_id)?;
-    let mut layout = store.must_get::<LayoutState>(&new_tab.layoutstate)?;
+) -> Result<(), String> {
     let node_id = uuid::Uuid::new_v4().to_string();
     // Phase E.4.B Phase 2 — construct typed LayoutNode (was inline JSON).
-    layout.rootnode = Some(LayoutNode {
+    let rootnode = LayoutNode {
         id: node_id.clone(),
         flex_direction: FlexDirection::Row,
         size: 1.0,
@@ -39,13 +39,21 @@ pub(crate) fn setup_torn_off_block_layout(
             ..Default::default()
         }),
         ..Default::default()
-    });
-    layout.leaforder = Some(vec![LeafOrderEntry {
+    };
+    let leaforder = vec![LeafOrderEntry {
         nodeid: node_id,
         blockid: block_id.to_string(),
-    }]);
-    store.update(&mut layout)?;
-    Ok(())
+    }];
+    // Focused id stays empty — the legacy writer never set it for a
+    // torn-off tab; the frontend focuses on load.
+    super::reducer_helpers::seed_layout_via_reducer(
+        state,
+        new_tab_id,
+        rootnode,
+        String::new(),
+        leaforder,
+    )
+    .await
 }
 
 /// Floating-pane re-dock — enqueue an "insert" action on the TARGET

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use introspect::{
 };
 pub(crate) use layout_helpers::setup_torn_off_block_layout;
 pub(crate) use object_helpers::{schedule_agent_zoom_mirror, update_object_meta};
-pub(crate) use reducer_helpers::{dispatch_to_reducer, publish_events};
+pub(crate) use reducer_helpers::{dispatch_to_reducer, publish_events, seed_layout_via_reducer};
 
 pub(super) async fn handle_service(
     State(state): State<AppState>,

--- a/agentmux-srv/src/server/service/reducer_helpers.rs
+++ b/agentmux-srv/src/server/service/reducer_helpers.rs
@@ -61,6 +61,100 @@ pub(crate) async fn compensate_via_reducer(
     }
 }
 
+/// SPEC_864 Phase 3 — single-writer layout seeding. Dispatch a
+/// `LayoutSetTree` (tree + focus + leaforder as client slices) and persist
+/// it inside ONE hold of the reducer mutex, so persist order equals
+/// dispatch order — the same contract as `UpdateObject`'s Phase-2 route in
+/// `object.rs`. Replaces the wcore-direct seeders
+/// (`write_default_three_pane_layout` post-bootstrap caller,
+/// `setup_torn_off_block_layout`): the reducer's `TabRecord.rootnode` is
+/// authoritative, and the persist subscriber is the sole `db_layout`
+/// writer on this path.
+///
+/// On SQLite apply failure the reducer is rolled back to an empty tree
+/// (the seed target is a fresh tab whose row was empty) inside the same
+/// lock hold. Publishes events on success. Requires the tab to be known
+/// to the reducer — true for every caller (all run after reducer-routed
+/// CreateTab / sagas); the pre-bootstrap first-launch seed
+/// (`ensure_initial_data` → `seed_default_layout`) deliberately stays
+/// store-direct because the reducer isn't hydrated yet (spec site #3).
+pub(crate) async fn seed_layout_via_reducer(
+    state: &AppState,
+    tab_id: &str,
+    new_tree: agentmux_common::LayoutNode,
+    focused_node_id: String,
+    leaforder: Vec<crate::backend::obj::LeafOrderEntry>,
+) -> Result<(), String> {
+    let store = &state.wstore;
+    let slices = agentmux_common::LayoutClientSlices {
+        leaforder: serde_json::to_value(&leaforder).ok(),
+        focused_node_id,
+        magnified_node_id: String::new(),
+        // Fresh-tab seed: REPLACE semantics clear any stale queue.
+        pending_backend_actions: None,
+    };
+    let cmd = agentmux_common::ipc::Command::LayoutSetTree {
+        tab_id: tab_id.to_string(),
+        new_tree: Some(new_tree),
+        correlation_id: String::new(),
+        slices: Some(slices),
+    };
+
+    let mut apply_err: Option<String> = None;
+    let events = {
+        let mut s = state.srv_state.lock().await;
+        let ctx = crate::reducer::Ctx {
+            now_rfc3339: chrono::Utc::now().to_rfc3339(),
+            conn_id: 0,
+            registered_pid: None,
+        };
+        let events = crate::reducer::update(&mut s, cmd, &ctx);
+        let has_error = events
+            .iter()
+            .any(|e| matches!(e, agentmux_common::ipc::Event::Error { .. }));
+        if !has_error {
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    apply_err = Some(e.to_string());
+                    break;
+                }
+            }
+            if apply_err.is_some() {
+                // Roll the reducer back to the empty pre-seed tree inside
+                // the same lock hold; best-effort SQLite mirror.
+                let rollback = agentmux_common::ipc::Command::LayoutSetTree {
+                    tab_id: tab_id.to_string(),
+                    new_tree: None,
+                    correlation_id: String::new(),
+                    slices: Some(agentmux_common::LayoutClientSlices::default()),
+                };
+                let rb_events = crate::reducer::update(&mut s, rollback, &ctx);
+                for ev in &rb_events {
+                    if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                        tracing::warn!(
+                            error = %e,
+                            "seed_layout_via_reducer: rollback SQLite mirror failed"
+                        );
+                    }
+                }
+            }
+        }
+        events
+    };
+
+    if let Some(err_msg) = events.iter().find_map(|e| match e {
+        agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+        _ => None,
+    }) {
+        return Err(err_msg);
+    }
+    if let Some(err) = apply_err {
+        return Err(format!("layout seed SQLite write failed: {}", err));
+    }
+    publish_events(state, &events);
+    Ok(())
+}
+
 /// Existence check used by `DeleteWorkspace` to decide whether to
 /// run the wcore delete path. Propagates `StoreError` so the caller
 /// can surface real I/O / corruption failures instead of

--- a/agentmux-srv/src/server/service/window.rs
+++ b/agentmux-srv/src/server/service/window.rs
@@ -192,13 +192,26 @@ pub(super) async fn handle_window_service(state: &AppState, call: &WebCallType) 
                         }
 
                         if seeded_ids.len() == 3 {
-                            if let Err(e) = crate::backend::wcore::write_default_three_pane_layout(
-                                store,
+                            // SPEC_864 Phase 3 — post-bootstrap seed routes
+                            // through the reducer (single writer of
+                            // db_layout); the tree shape is shared with the
+                            // pre-bootstrap store-direct first-launch seed
+                            // via `default_three_pane_tree`.
+                            let (tree, focused, leaforder) =
+                                crate::backend::wcore::default_three_pane_tree(
+                                    &seeded_ids[0],
+                                    &seeded_ids[1],
+                                    &seeded_ids[2],
+                                );
+                            if let Err(e) = super::reducer_helpers::seed_layout_via_reducer(
+                                state,
                                 &new_tab_id,
-                                &seeded_ids[0],
-                                &seeded_ids[1],
-                                &seeded_ids[2],
-                            ) {
+                                tree,
+                                focused,
+                                leaforder,
+                            )
+                            .await
+                            {
                                 tracing::warn!(
                                     tab_id = %new_tab_id,
                                     error = %e,

--- a/agentmux-srv/src/server/service/workspace.rs
+++ b/agentmux-srv/src/server/service/workspace.rs
@@ -726,7 +726,7 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
             // Layout setup: rootnode + leaforder for the new tab so
             // the frontend renders the moved block correctly. Same
             // helper TearOffBlock uses.
-            if let Err(e) = setup_torn_off_block_layout(store, &new_tab_oid, &block_id) {
+            if let Err(e) = setup_torn_off_block_layout(state, &new_tab_oid, &block_id).await {
                 tracing::warn!(new_tab = %new_tab_oid, "PromoteBlockToTab: layout setup failed: {}", e);
             }
             // Source tab: queue layout-delete action.
@@ -1104,7 +1104,7 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
             // single root node so the frontend renders it. Mirrors
             // wcore::tear_off_block. Best-effort; layout migration is
             // E.4 territory and not yet reducer-routed.
-            if let Err(e) = setup_torn_off_block_layout(store, &new_tab_oid, &block_id) {
+            if let Err(e) = setup_torn_off_block_layout(state, &new_tab_oid, &block_id).await {
                 tracing::warn!(new_tab = %new_tab_oid, "TearOffBlock: layout setup failed: {} (block in tab but layout malformed)", e);
             }
             // Source tab: queue a layout-delete action so the source

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -706,6 +706,124 @@ async fn update_object_layout_parse_failure_falls_back_with_focus_dispatch() {
     );
 }
 
+/// SPEC_864 Phase 3 — the seeders route through the reducer: after
+/// `seed_layout_via_reducer` / `setup_torn_off_block_layout`, the reducer's
+/// `TabRecord.rootnode` and `db_layout.rootnode` are the same tree (single
+/// writer), and the persisted row carries focus + leaforder.
+#[tokio::test]
+async fn layout_seeders_route_through_reducer_coherently() {
+    use agentmux_common::ipc::{Command, Event};
+    use crate::backend::obj::{LayoutState, Tab};
+
+    let state = test_state();
+    let wstore = state.wstore.clone();
+    let srv_state = state.srv_state.clone();
+
+    async fn dispatch_apply(state: &AppState, cmd: Command) -> Vec<Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+    let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "ws".into() }).await;
+    let ws_id = ws_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+
+    // ── three-pane seed (the CreateWindow post-bootstrap path) ──
+    let tab_evs = dispatch_apply(
+        &state,
+        Command::CreateTab {
+            workspace_id: ws_id.clone(),
+            name: "t1".into(),
+        },
+    )
+    .await;
+    let tab1 = tab_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let (tree, focused, leaforder) =
+        crate::backend::wcore::default_three_pane_tree("b-agent", "b-sysinfo", "b-swarm");
+    crate::server::service::seed_layout_via_reducer(
+        &state, &tab1, tree, focused, leaforder,
+    )
+    .await
+    .expect("three-pane seed via reducer");
+
+    let layout_oid = wstore.get::<Tab>(&tab1).unwrap().unwrap().layoutstate;
+    let row = wstore.get::<LayoutState>(&layout_oid).unwrap().unwrap();
+    assert_eq!(row.leaforder.as_ref().unwrap().len(), 3);
+    assert!(!row.focusednodeid.is_empty(), "focus persisted");
+    {
+        let s = srv_state.lock().await;
+        let rec = s.tabs.get(&tab1).expect("reducer knows tab1");
+        assert_eq!(
+            rec.rootnode, row.rootnode,
+            "TabRecord == db_layout after three-pane seed"
+        );
+        assert_eq!(rec.focused_node_id, row.focusednodeid);
+    }
+
+    // ── single-leaf tear-off seed ──
+    let tab_evs = dispatch_apply(
+        &state,
+        Command::CreateTab {
+            workspace_id: ws_id,
+            name: "t2".into(),
+        },
+    )
+    .await;
+    let tab2 = tab_evs
+        .iter()
+        .find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+    crate::server::service::setup_torn_off_block_layout(&state, &tab2, "b-moved")
+        .await
+        .expect("tear-off seed via reducer");
+
+    let layout_oid = wstore.get::<Tab>(&tab2).unwrap().unwrap().layoutstate;
+    let row = wstore.get::<LayoutState>(&layout_oid).unwrap().unwrap();
+    let root = row.rootnode.as_ref().expect("single-leaf tree persisted");
+    assert_eq!(root.data.as_ref().unwrap().block_id, "b-moved");
+    assert_eq!(row.leaforder.as_ref().unwrap()[0].blockid, "b-moved");
+    {
+        let s = srv_state.lock().await;
+        let rec = s.tabs.get(&tab2).expect("reducer knows tab2");
+        assert_eq!(
+            rec.rootnode, row.rootnode,
+            "TabRecord == db_layout after tear-off seed"
+        );
+    }
+}
+
+/// Seeding a tab the reducer doesn't know must fail loudly (Error event),
+/// not silently write db_layout — the pre-bootstrap first-launch seed is
+/// the only sanctioned store-direct path.
+#[tokio::test]
+async fn layout_seed_unknown_tab_errors() {
+    let state = test_state();
+    let (tree, focused, leaforder) =
+        crate::backend::wcore::default_three_pane_tree("a", "b", "c");
+    let err = crate::server::service::seed_layout_via_reducer(
+        &state, "ghost-tab", tree, focused, leaforder,
+    )
+    .await
+    .expect_err("unknown tab must error");
+    assert!(err.contains("unknown tab"), "got: {err}");
+}
+
 #[test]
 fn clean_name_trims_clamps_and_rejects_empty() {
     use super::clean_name;


### PR DESCRIPTION
## Summary

Phase 3 of the weak single-writer cutover (`SPEC_864_LAYOUT_SINGLE_WRITER_2026_06_30.md` §3.3/§4, follows #1970): the layout **seeders** stop writing `db_layout` wcore-direct and dispatch through the reducer instead.

- **New `seed_layout_via_reducer`**: one `LayoutSetTree` dispatch (tree + focus + leaforder via `LayoutClientSlices`), persisted inside a single reducer-mutex hold (persist order == dispatch order — same contract as Phase 2), with empty-tree rollback on SQLite apply failure.
- **Site #2 — CreateWindow's three-pane seed** (`service/window.rs`): now reducer-routed. The tree shape is shared with the pre-bootstrap first-launch seed via a new pure `default_three_pane_tree` builder, so the two paths can't drift. The first-launch seed itself (site #3, `ensure_initial_data`) deliberately stays store-direct — the reducer isn't hydrated pre-bootstrap, exactly as the spec anticipates.
- **Site #4 — `setup_torn_off_block_layout`** (TearOffBlock / RedockFloatingPane / PromoteBlockToTab / floating `pane.open`): now async + reducer-routed; the wcore-direct `rootnode`/`leaforder` write is retired. All callers run post-saga, so the tab is always reducer-known.
- **Site #8** (`wcore::dnd::tear_off_block`): confirmed dead — zero production callers (superseded by sagas); deletion belongs to the tree-shake work.
- **Site #6** (delete_block layout prune) follows in its own PR — it needs `LayoutDeleteNode`-by-block plumbing, a different shape from the seeders.

After this lands, the remaining Path-B writers are: site #6, the `pendingbackendactions` queues (Phase 4), `object_helpers::update_raw`'s non-layout otypes (out of scope), and `heal_layout` (deleted in Phase 5).

## Tests
- `layout_seeders_route_through_reducer_coherently` — both seed shapes end with `TabRecord.rootnode == db_layout.rootnode` (the Pillar-1 coherence invariant) + persisted focus/leaforder
- `layout_seed_unknown_tab_errors` — seeding a reducer-unknown tab fails loudly instead of silently writing SQLite
- Full srv suite green: 1,307 + 4 + 7 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agent2 -->