### PR TITLE
fix(layout): SPEC_864 site #6 — delete_block layout prune routes through the reducer

### DIFF
--- a/.changesets/1783285419-fix-layout-spec-864-site-6-delete-block-layout-prune-routes--60qa.md
+++ b/.changesets/1783285419-fix-layout-spec-864-site-6-delete-block-layout-prune-routes--60qa.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): SPEC_864 site 6 — delete_block layout prune routes through the reducer

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -527,6 +527,18 @@ pub enum Command {
         node_id: String,
         correlation_id: String,
     },
+    /// Remove the node holding `block_id`; collapse empty parents.
+    /// SPEC_864 site #6 — the block→node resolution happens in the
+    /// reducer arm (the reducer owns the tree), so callers that only
+    /// know a block id (the `delete_block` saga) don't need tree
+    /// access. Resolving to no node is a silent idempotent no-op:
+    /// blocks may legitimately have no layout node (already pruned by
+    /// a frontend push, or never laid out).
+    LayoutDeleteNodeByBlock {
+        tab_id: String,
+        block_id: String,
+        correlation_id: String,
+    },
     /// Reparent a node to a new parent at the given child index.
     LayoutMoveNode {
         tab_id: String,
@@ -1467,6 +1479,24 @@ pub enum Event {
     LayoutNodeDeleted {
         tab_id: String,
         node_id: String,
+        /// The reducer's resulting tree (post-delete, post-collapse) for
+        /// the persist subscriber to write to `db_layout` — single-writer,
+        /// no algebra re-run (SPEC_STRONG_REDUCER_AUTHORITY_LAYOUT /
+        /// SPEC_864 site #6). Unlike the other structural events, a delete
+        /// CAN legitimately empty the tree (root-orphan case) — `None`
+        /// alone is ambiguous with a version-skewed pre-change sender, so
+        /// `tree_cleared` below disambiguates. `#[serde(default)]` for
+        /// forward-compat.
+        #[serde(default)]
+        new_tree: Option<crate::LayoutNode>,
+        /// True when the delete legitimately emptied the tree (the deleted
+        /// node WAS the root). The persist subscriber clears `db_layout`'s
+        /// rootnode only when `new_tree.is_none() && tree_cleared` — a bare
+        /// `None` (old sender / replayed pre-change JSON) is ignored rather
+        /// than erasing the persisted layout (same skew concern as codex
+        /// P2 on #1883). `#[serde(default)]` = false for old JSON.
+        #[serde(default)]
+        tree_cleared: bool,
         /// True if the deleted node was the focused one (subscribers may
         /// need to refocus).
         was_focused: bool,

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -987,6 +987,7 @@ async fn enforce_register_first(
         Command::LayoutInsertNode { .. }
         | Command::LayoutInsertNodeAtIndex { .. }
         | Command::LayoutDeleteNode { .. }
+        | Command::LayoutDeleteNodeByBlock { .. }
         | Command::LayoutMoveNode { .. }
         | Command::LayoutSwapNodes { .. }
         | Command::LayoutResizeNodes { .. }

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -528,6 +528,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::LayoutInsertNode { .. }
         | Command::LayoutInsertNodeAtIndex { .. }
         | Command::LayoutDeleteNode { .. }
+        | Command::LayoutDeleteNodeByBlock { .. }
         | Command::LayoutMoveNode { .. }
         | Command::LayoutSwapNodes { .. }
         | Command::LayoutResizeNodes { .. }

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -132,6 +132,27 @@ pub fn find_node_by_id_mut<'a>(tree: &'a mut LayoutNode, id: &str) -> Option<&'a
     None
 }
 
+/// Find the id of the (first) leaf node whose `data.block_id` matches
+/// `block_id`. SPEC_864 site #6 — lets `LayoutDeleteNodeByBlock` resolve a
+/// block to its layout node inside the reducer arm (the reducer owns the
+/// tree; callers like the `delete_block` saga only know the block id).
+/// Blocks appear at most once in a well-formed tree; first match wins.
+pub fn find_node_id_by_block(tree: &LayoutNode, block_id: &str) -> Option<String> {
+    if tree
+        .data
+        .as_ref()
+        .is_some_and(|d| d.block_id == block_id)
+    {
+        return Some(tree.id.clone());
+    }
+    for child in &tree.children {
+        if let Some(found) = find_node_id_by_block(child, block_id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
 // ── Insert-location heuristic ──────────────────────────────────────────────
 
 /// Candidate for insertion location, collected during tree traversal.

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -32,7 +32,18 @@ pub fn create_block(
     Ok(block)
 }
 
-/// Delete a block from its parent tab and prune it from the layout tree.
+/// Delete a block's rows: remove it from its parent tab's `blockids` and
+/// delete the Block row.
+///
+/// SPEC_864 site #6 — the layout-tree prune that used to live here
+/// (wcore-direct `LayoutState` write, the last Path-B writer on the
+/// block-delete path) moved to the reducer: the `delete_block` saga
+/// dispatches `LayoutDeleteNodeByBlock` as its Step 2, and the persist
+/// subscriber writes the reducer's resulting tree from the
+/// `LayoutNodeDeleted{new_tree, tree_cleared}` event. This fn is row-ops
+/// only, keeping `db_layout` single-writer. (`prune_block_from_layout`
+/// below stays — `heal_layout`'s orphan sweep still uses it until Phase 5
+/// deletes the backstops.)
 pub fn delete_block(
     store: &Store,
     tab_id: &str,
@@ -42,22 +53,6 @@ pub fn delete_block(
     tab.blockids.retain(|id| id != block_id);
     store.update(&mut tab)?;
     store.delete::<Block>(block_id)?;
-
-    // Prune the deleted block's node from the layout tree so it doesn't
-    // leave a blank pane. The frontend also removes the node, but if the
-    // frontend update races with the delete or is lost, the orphaned node
-    // persists in the database.
-    if !tab.layoutstate.is_empty() {
-        if let Ok(Some(mut layout)) = store.get::<LayoutState>(&tab.layoutstate) {
-            tracing::info!(
-                block_id = %block_id,
-                layout_id = %tab.layoutstate,
-                "pruning deleted block from layout tree"
-            );
-            prune_block_from_layout(&mut layout, block_id);
-            let _ = store.update(&mut layout);
-        }
-    }
     Ok(())
 }
 

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -302,11 +302,12 @@ pub(crate) fn apply_event_to_wstore(
         // LayoutSetTree (the Layout* arms are still dormant per
         // reducer.rs §"4 of 11"); they land the persistence path that
         // the UpdateObject→LayoutSetTree reroute (next phase) needs.
-        // Insert/Delete are deliberately NOT here yet — their events
-        // carry op params, not the resulting tree, so persisting them
-        // would require re-running the algebra in the subscriber (a new
-        // divergence surface). That is resolved in a later phase by
-        // having those events carry the reducer's resulting tree.
+        // Insert is deliberately NOT here yet — its event carries op
+        // params, not the resulting tree, so persisting it would require
+        // re-running the algebra in the subscriber (a new divergence
+        // surface). Delete WAS in the same boat until SPEC_864 site #6
+        // gave `LayoutNodeDeleted` a `new_tree` (+ `tree_cleared`) and its
+        // own arm below; Insert follows when a production caller needs it.
         Event::LayoutCleared { tab_id, .. } => apply_layout_cleared(wstore, tab_id),
         Event::LayoutTreeReplaced {
             tab_id,
@@ -314,6 +315,26 @@ pub(crate) fn apply_event_to_wstore(
             slices,
             ..
         } => apply_layout_tree_replaced(wstore, tab_id, new_tree, slices.as_ref()),
+        // SPEC_864 site #6 — LayoutNodeDeleted gets its own arm (not the
+        // group below) because a delete is the one structural op that can
+        // legitimately EMPTY the tree (root-orphan case). `tree_cleared`
+        // disambiguates a real root-delete clear from a version-skewed
+        // sender's absent `new_tree`, which must be ignored rather than
+        // applied as an erase (same skew concern as the group below).
+        // Leaforder handling follows the granular-arm convention: untouched
+        // for a non-empty tree (frontend-recomputed geometry cache, not
+        // read on reproject), cleared with everything else on a real
+        // empty-tree clear (apply_layout_tree_replaced's clears path).
+        Event::LayoutNodeDeleted {
+            tab_id,
+            new_tree,
+            tree_cleared,
+            ..
+        } => match (new_tree.is_some(), tree_cleared) {
+            (true, _) => apply_layout_tree_replaced(wstore, tab_id, new_tree, None),
+            (false, true) => apply_layout_tree_replaced(wstore, tab_id, &None, None),
+            (false, false) => Ok(()),
+        },
         // The 7 granular structural arms each carry the reducer's resulting
         // tree in `new_tree` (post-op, post-balance), so persistence is the
         // same rootnode write as LayoutTreeReplaced — no algebra re-run in the
@@ -1514,6 +1535,107 @@ mod tests {
             .rootnode
             .expect("tree preserved, not cleared by a None granular event");
         assert_eq!(root.id, "keep");
+    }
+
+    // ── SPEC_864 site #6 — LayoutNodeDeleted persistence ────────────────────
+
+    #[test]
+    fn layout_node_deleted_persists_new_tree() {
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutNodeDeleted {
+                tab_id: tab.clone(),
+                node_id: "gone".into(),
+                new_tree: Some(leaf("survivor", "bs")),
+                tree_cleared: false,
+                was_focused: false,
+                was_magnified: false,
+                correlation_id: "c".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let root = layout_of(&s, &tab)
+            .rootnode
+            .expect("delete event persisted the resulting tree");
+        assert_eq!(root.id, "survivor");
+    }
+
+    #[test]
+    fn layout_node_deleted_none_without_cleared_is_ignored() {
+        // A version-skewed LayoutNodeDeleted (pre-site-#6 JSON: no
+        // new_tree, tree_cleared defaults false) must NOT erase the
+        // persisted layout — same skew rule as the granular group.
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("keep", "bk")),
+                correlation_id: "seed".into(),
+                slices: None,
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::LayoutNodeDeleted {
+                tab_id: tab.clone(),
+                node_id: "x".into(),
+                new_tree: None,
+                tree_cleared: false, // skewed sender — not a real clear
+                was_focused: false,
+                was_magnified: false,
+                correlation_id: "c".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let root = layout_of(&s, &tab)
+            .rootnode
+            .expect("tree preserved — skewed delete event must not clear");
+        assert_eq!(root.id, "keep");
+    }
+
+    #[test]
+    fn layout_node_deleted_tree_cleared_erases_tree() {
+        // Root-orphan delete: new_tree=None + tree_cleared=true is a REAL
+        // clear (the deleted node was the root) and must wipe rootnode.
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutTreeReplaced {
+                tab_id: tab.clone(),
+                new_tree: Some(leaf("doomed-root", "bd")),
+                correlation_id: "seed".into(),
+                slices: None,
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::LayoutNodeDeleted {
+                tab_id: tab.clone(),
+                node_id: "doomed-root".into(),
+                new_tree: None,
+                tree_cleared: true,
+                was_focused: true,
+                was_magnified: false,
+                correlation_id: "c".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        assert!(
+            layout_of(&s, &tab).rootnode.is_none(),
+            "tree_cleared delete must wipe the persisted tree"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -120,6 +120,13 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             node_id,
             correlation_id,
         } => layout::handle_layout_delete_node(state, tab_id, node_id, correlation_id),
+        // SPEC_864 site #6 — block→node resolution in the arm; silent
+        // no-op when the block has no layout node (see the handler doc).
+        Command::LayoutDeleteNodeByBlock {
+            tab_id,
+            block_id,
+            correlation_id,
+        } => layout::handle_layout_delete_node_by_block(state, tab_id, block_id, correlation_id),
         // Phase 3 — the remaining 7 layout-tree arms. Each resolves the
         // tab, calls the existing pure fn in `backend::layout`, runs
         // `balance_node` (matching the frontend's post-action normalize),
@@ -3300,6 +3307,109 @@ mod tests {
             state.tabs[&tab_id].rootnode.is_none(),
             "root deletion must wipe the tree"
         );
+    }
+
+    // ── SPEC_864 site #6 — LayoutDeleteNodeByBlock + new_tree carriage ──────
+
+    #[test]
+    fn layout_delete_node_by_block_resolves_and_carries_new_tree() {
+        let (mut state, tab_id) = fresh_tab();
+        let mut root = leaf_node("group", "");
+        root.data = None;
+        root.children = vec![
+            leaf_node("a", "b1"),
+            leaf_node("b", "b2"),
+            leaf_node("c", "b3"),
+        ];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(root);
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNodeByBlock {
+                tab_id: tab_id.clone(),
+                block_id: "b2".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::LayoutNodeDeleted {
+                node_id,
+                new_tree,
+                tree_cleared,
+                ..
+            } => {
+                assert_eq!(node_id, "b", "must resolve block b2 to node b");
+                assert!(!*tree_cleared, "non-root delete must not claim a clear");
+                let tree = new_tree.as_ref().expect("non-root delete keeps a tree");
+                assert!(
+                    crate::backend::layout::find_node_id_by_block(tree, "b2").is_none(),
+                    "deleted block must be gone from the event's tree"
+                );
+                assert!(
+                    crate::backend::layout::find_node_id_by_block(tree, "b1").is_some(),
+                    "sibling blocks must survive"
+                );
+                // The event's tree IS the reducer's post-delete tree — the
+                // single-writer contract the persist subscriber relies on.
+                assert_eq!(Some(tree), state.tabs[&tab_id].rootnode.as_ref());
+            }
+            other => panic!("expected LayoutNodeDeleted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn layout_delete_node_by_block_unknown_block_is_silent_noop() {
+        // Every delete_block saga run dispatches this command; a block
+        // with no layout node (frontend already pruned, never laid out,
+        // empty tab) must be a silent no-op — no Event::Error, no
+        // version churn, tree untouched.
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("only", "b1"));
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNodeByBlock {
+                tab_id: tab_id.clone(),
+                block_id: "not-in-tree".into(),
+                correlation_id: String::new(),
+            },
+            &ctx(1),
+        );
+        assert!(events.is_empty(), "unresolved block must be a silent no-op");
+        assert_eq!(state.tabs[&tab_id].rootnode.as_ref().unwrap().id, "only");
+    }
+
+    #[test]
+    fn layout_delete_node_by_block_root_orphan_sets_tree_cleared() {
+        // Deleting the last block empties the tree — the one structural
+        // op where new_tree=None is legitimate. tree_cleared=true is what
+        // lets the persist subscriber distinguish this from a
+        // version-skewed sender's absent field.
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("solo", "b1"));
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNodeByBlock {
+                tab_id: tab_id.clone(),
+                block_id: "b1".into(),
+                correlation_id: String::new(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::LayoutNodeDeleted {
+                new_tree,
+                tree_cleared,
+                ..
+            } => {
+                assert!(new_tree.is_none());
+                assert!(*tree_cleared, "root-orphan delete must mark the clear as real");
+            }
+            other => panic!("expected LayoutNodeDeleted, got {:?}", other),
+        }
+        assert!(state.tabs[&tab_id].rootnode.is_none());
     }
 
     #[test]

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -321,15 +321,53 @@ pub(super) fn handle_layout_delete_node(
         tab.magnified_node_id = String::new();
     }
 
+    // SPEC_864 site #6 — carry the resulting tree so the persist
+    // subscriber can write db_layout without re-running the algebra
+    // (same single-writer shape as the 7 structural arms). A delete is
+    // the one structural op that can legitimately EMPTY the tree
+    // (root-orphan case), so `tree_cleared` disambiguates a real clear
+    // from a version-skewed sender's absent field.
+    let new_tree = tab.rootnode.clone();
+    let tree_cleared = new_tree.is_none();
     let v = state.bump_version();
     vec![Event::LayoutNodeDeleted {
         tab_id,
         node_id,
+        new_tree,
+        tree_cleared,
         was_focused,
         was_magnified,
         correlation_id,
         version: v,
     }]
+}
+
+/// SPEC_864 site #6 — delete the layout node holding `block_id`.
+/// Resolution happens here because the reducer owns the tree; the
+/// caller (the `delete_block` saga) only knows the block id.
+///
+/// Unresolved block → silent idempotent no-op (empty event vec), NOT an
+/// error: every `delete_block` saga run dispatches this, and a block
+/// may legitimately have no layout node (the frontend's own delete
+/// flow already pushed a pruned tree via `LayoutSetTree`, the block
+/// was floating/never laid out, or the tab tree is empty).
+pub(super) fn handle_layout_delete_node_by_block(
+    state: &mut State,
+    tab_id: String,
+    block_id: String,
+    correlation_id: String,
+) -> Vec<Event> {
+    let node_id = match state
+        .tabs
+        .get(&tab_id)
+        .and_then(|tab| tab.rootnode.as_ref())
+        .and_then(|root| crate::backend::layout::find_node_id_by_block(root, &block_id))
+    {
+        Some(id) => id,
+        // Unknown tab, empty tree, or block not in the tree — no-op.
+        None => return Vec::new(),
+    };
+    handle_layout_delete_node(state, tab_id, node_id, correlation_id)
 }
 
 // ── Phase 3 — remaining structural arms ─────────────────────────────────────

--- a/agentmux-srv/src/sagas/delete_block.rs
+++ b/agentmux-srv/src/sagas/delete_block.rs
@@ -143,7 +143,8 @@ async fn run_inner(
 ) -> Result<Value, String> {
     // Step 1: dispatch DeleteBlock through the reducer. The persist
     // subscriber sees the BlockDeleted event and runs
-    // `wcore::delete_block` (SQLite delete + layout prune).
+    // `wcore::delete_block` (SQLite row deletes; the layout prune moved
+    // to Step 2 — SPEC_864 site #6).
     if let Err(reason) = ctx
         .dispatch(Command::DeleteBlock {
             tab_id: tab_id.clone(),
@@ -162,6 +163,36 @@ async fn run_inner(
             reason
         );
         return Err(format!("DeleteBlock: {}", reason));
+    }
+
+    // Step 2 (SPEC_864 site #6): prune the deleted block's layout node
+    // through the reducer — the single writer of db_layout — instead of
+    // the retired wcore-direct prune the persist subscriber used to run.
+    // The reducer resolves block→node itself (it owns the tree) and
+    // silently no-ops when the block has no node (frontend already
+    // pushed a pruned tree, block never laid out, empty tab). The
+    // resulting `LayoutNodeDeleted{new_tree, tree_cleared}` event is
+    // what the subscriber persists.
+    //
+    // Best-effort, mirroring the old wcore prune's `let _ =
+    // store.update(&mut layout)`: a prune failure must not fail the
+    // block deletion itself (the block + controller are already gone);
+    // an orphaned node is exactly what the frontend's own delete-push
+    // and (until Phase 5) `heal_layout` converge away.
+    if let Err(reason) = ctx
+        .dispatch(Command::LayoutDeleteNodeByBlock {
+            tab_id: tab_id.clone(),
+            block_id: block_id.clone(),
+            correlation_id: String::new(),
+        })
+        .await
+    {
+        tracing::warn!(
+            tab_id = %tab_id,
+            block_id = %block_id,
+            "[saga] LayoutDeleteNodeByBlock dispatch failed (best-effort; layout node may orphan until frontend push / heal): {}",
+            reason
+        );
     }
 
     Ok(json!({
@@ -265,6 +296,78 @@ mod tests {
 
         // SQLite: block gone.
         assert!(state.wstore.get::<Block>(&block_id).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn saga_prunes_layout_through_reducer_coherently() {
+        // SPEC_864 site #6 — the layout prune is Step 2 of this saga
+        // (Command::LayoutDeleteNodeByBlock), not the retired
+        // wcore-direct write in the persist subscriber. Invariant:
+        // after the saga, the reducer's TabRecord tree and
+        // db_layout's rootnode agree (single-writer coherence), and a
+        // single-block tree ends genuinely empty on both sides.
+        let (state, _ws_id, tab_id, block_id) = seed().await;
+
+        // Seed a layout tree holding the block, reducer-routed +
+        // persisted (same LayoutSetTree path the frontend push uses).
+        let tree = agentmux_common::LayoutNode {
+            id: "n-solo".into(),
+            data: Some(agentmux_common::LayoutNodeData {
+                block_id: block_id.clone(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: Some(tree),
+                correlation_id: String::new(),
+                slices: None,
+            },
+        )
+        .await;
+        // Sanity: reducer + SQLite both hold the seeded tree.
+        {
+            let s = state.srv_state.lock().await;
+            assert!(s.tabs[&tab_id].rootnode.is_some());
+        }
+        let layout_id = state
+            .wstore
+            .get::<crate::backend::obj::Tab>(&tab_id)
+            .unwrap()
+            .unwrap()
+            .layoutstate;
+        assert!(state
+            .wstore
+            .get::<crate::backend::obj::LayoutState>(&layout_id)
+            .unwrap()
+            .unwrap()
+            .rootnode
+            .is_some());
+
+        run(&state, tab_id.clone(), block_id.clone()).await.unwrap();
+
+        // Reducer tree: pruned to empty (block was the sole leaf).
+        {
+            let s = state.srv_state.lock().await;
+            assert!(
+                s.tabs[&tab_id].rootnode.is_none(),
+                "reducer tree must be pruned by the saga's Step-2 dispatch"
+            );
+        }
+        // db_layout: matches the reducer (tree_cleared persisted the wipe).
+        assert!(
+            state
+                .wstore
+                .get::<crate::backend::obj::LayoutState>(&layout_id)
+                .unwrap()
+                .unwrap()
+                .rootnode
+                .is_none(),
+            "db_layout must agree with the reducer post-saga (single-writer coherence)"
+        );
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/sagas/integration_tests.rs
+++ b/agentmux-srv/src/sagas/integration_tests.rs
@@ -257,7 +257,11 @@ async fn delete_block_happy_path_removes_block_across_all_surfaces() {
         .find(|s| s.name == "delete_block")
         .expect("delete_block saga not in snapshot");
     assert_eq!(del.state, "completed");
-    assert_eq!(del.step_count, 1);
+    // SPEC_864 site #6 — the saga now dispatches two steps: DeleteBlock
+    // (row deletes) + LayoutDeleteNodeByBlock (reducer-routed layout
+    // prune). The durable log records both dispatches even when the
+    // second no-ops (block not in any layout tree, as here).
+    assert_eq!(del.step_count, 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Continues the SPEC_864 weak-cutover roadmap per `docs/handoff/HANDOFF_864_AUTHORITY_AND_WINDOW_LIFECYCLE_2026_07_05.md` §5.1 (picking up from #1970 Phase 2 / #1971 Phase 3). Retires the last wcore-direct `db_layout` writer on the block-delete path: the layout prune inside `wcore::delete_block`, invoked from the persist subscriber's `apply_block_deleted` (a subscriber must not dispatch commands — so the prune moves to the saga as a dispatch, not into the subscriber).

- **`Command::LayoutDeleteNodeByBlock`** (new): block→node resolution happens **in the reducer arm** — the reducer owns the tree; the `delete_block` saga only knows the block id. Unresolved block = silent idempotent no-op (every saga run dispatches this; blocks may legitimately have no layout node — frontend already pushed a pruned tree, floating/never laid out, empty tab). The handoff suggested reusing `find_node_by_block`; that fn turned out not to exist — added `find_node_id_by_block` to `backend/layout`.
- **`Event::LayoutNodeDeleted` gains `new_tree` + `tree_cleared`** — the change the subscriber's own comment anticipated ("resolved in a later phase by having those events carry the reducer's resulting tree"). Unlike the 7 structural arms, a delete CAN legitimately empty the tree (root-orphan case), so `tree_cleared` disambiguates a real clear from a version-skewed sender's absent `new_tree` (same skew rule as codex P2 on #1883 — a bare `None` is ignored, never applied as an erase).
- **Persist subscriber**: dedicated `LayoutNodeDeleted` arm — `Some(tree)` persists via `apply_layout_tree_replaced` (tree-only, granular-arm convention); `None`+`tree_cleared` clears; `None` alone ignored.
- **`sagas::delete_block` Step 2**: dispatches `LayoutDeleteNodeByBlock` after `DeleteBlock`, best-effort (a prune failure must not fail the block deletion — the block+controller are already gone; an orphan converges via the frontend's own delete-push and, until Phase 5, `heal_layout`). Saga log records 2 steps now; integration test updated accordingly.
- **`wcore::delete_block`**: row-ops only. `prune_block_from_layout` deliberately stays — `heal_layout`'s orphan sweep uses it until Phase 5 deletes the backstops.
- **Bonus fix**: the reducer's in-memory `TabRecord` used to keep the deleted block's layout node forever (`handle_delete_block` never touched `rootnode`; only SQLite got pruned) — a live reducer↔SQLite divergence, now gone since the prune goes through the reducer first.

## Test plan

- [x] 3 new reducer tests: resolve + `new_tree` carriage (incl. event-tree == reducer-tree single-writer invariant), unresolved-block silent no-op, root-orphan `tree_cleared`
- [x] 3 new persist-subscriber tests: persists tree / ignores skewed `None` / `tree_cleared` erases
- [x] 1 new saga test: post-saga coherence (reducer `TabRecord.rootnode` == `db_layout.rootnode`, both empty for a sole-block tree)
- [x] Full `agentmux-srv` suite: **1314 passed / 0 failed** (`--test-threads=1`)
- [x] `cargo check --workspace --tests` clean (launcher's two exhaustive Command matches extended)

Roadmap next (separate PRs): Phase 4 (`pendingbackendactions` queue writers), Phase 5 (backstop deletion + DoD).

<!-- agentmux:agent_id=agenta -->