### PR TITLE
fix(tabs): move the close button closer to the tab's right edge

### DIFF
--- a/.changesets/1783286794-fix-tabs-tighten-tab-inner-right-padding-so-the-close-button-6wi5.md
+++ b/.changesets/1783286794-fix-tabs-tighten-tab-inner-right-padding-so-the-close-button-6wi5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): tighten tab-inner right padding so the close button sits closer to the edge

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -42,7 +42,7 @@
         display: flex;
         align-items: center;
         gap: var(--space-1);
-        padding: 0 10px;
+        padding: 0 1px 0 10px;
         height: 100%;
         white-space: nowrap;
         border-radius: 0;


### PR DESCRIPTION
## Summary
- `.tab-inner`'s symmetric `10px` padding left visible dead space between the close button and the tab's actual right edge.
- Tabs are content-width (`width: auto`), so nudging the button itself via `margin` doesn't change its distance from the edge — it just grows the tab by the same amount (verified this the wrong way first). The real fix is `.tab-inner`'s right-side padding, reduced to `1px`.
- Manually verified live in a running `task dev` build, iterated on the exact value with the user until it looked right.

## Test plan
- [x] `npx stylelint frontend/app/tab/tab.scss` — clean
- [x] Manual, live in `task dev`: confirmed the close button sits close to the tab's right edge, no clipping/overlap

<!-- agentmux:agent_id=agent3 -->