### PR TITLE
fix(agent): smooth the running -> completed tool-preview transition

### DIFF
--- a/.changesets/1783303965-fix-agent-smooth-the-running-completed-tool-preview-transiti-1f8w.md
+++ b/.changesets/1783303965-fix-agent-smooth-the-running-completed-tool-preview-transiti-1f8w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): smooth the running -> completed tool-preview transition (fade-in summary elements, FLIP height transition on panel body)

--- a/docs/analysis/ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md
+++ b/docs/analysis/ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md
@@ -1,0 +1,195 @@
+# ANALYSIS: Tool preview "jerk" on running → completed transition
+
+**Date:** 2026-07-05
+**Status:** Root causes confirmed by direct file inspection (see citations). Not previously
+documented — `SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md` describes a different, already-fixed
+bug (native scroll-chaining dead zone / double-scrollbar); its own addendum explicitly says "Not a
+jerk, a dead zone" — that "jerk" refers to browser scroll-bounce feel, not this layout reflow.
+
+---
+
+## Problem (as reported)
+
+In the Agent pane, when a running tool call finishes, the tool-call preview visibly jerks — an
+abrupt layout shift rather than a smooth transition — because the DOM shape rendered for the
+`running` state differs from the DOM shape rendered for the terminal (`success`/`failed`/etc.)
+state, and nothing bridges the two.
+
+---
+
+## Root cause: one state update flips two independent DOM shapes at once, and neither is transitioned
+
+The `running`→terminal transition is driven by a single object replacement,
+`mergeReplacement()` (`frontend/app/store/agent-document/reducer.ts:659-679`). When a
+`tool_result` arrives, the parser's replacement node is merged with the existing node's live-log
+buffer, and — critically — `log.open` is force-cleared to `false` in the same merge whenever the
+new status is terminal:
+
+```ts
+const terminal =
+    replacement.status === "success" ||
+    replacement.status === "failed" ||
+    replacement.status === "denied";
+const mergedLog: ToolStreamingLog = {
+    chunks: existingLog.chunks,
+    open: terminal ? false : existingLog.open,   // line 676
+};
+```
+
+So on the *same* render tick, `status` leaves `"running"` **and** `log.open` flips `true → false`.
+Two independent pieces of UI key off exactly these two signals, and both change shape at once:
+
+### A. Summary row — content swap, not a style change (`ToolBlock.tsx:256-322`)
+
+- `resultPill()` (lines 177-229) explicitly returns `null` while `status === "running"` (line
+  179: `if (s === "running" || s === "pending_approval" || !props.node.result) return null;`).
+  So the result-pill `<span>` (lines 262-266) is **absent** while running and **appears** the
+  instant status leaves running.
+- The live-tail/elapsed-ticker block is gated on `props.node.log?.open === true` (line 274). It
+  renders either the last stdout/stderr line (`.agent-tool-live-tail`, lines 286-294) or an
+  `<ToolElapsedTicker>` (lines 296-301) while running, and is **removed entirely** the instant
+  `log.open` flips false — the exact same tick the result pill appears.
+- The status icon (`statusIcon()`, line 236, backed by the `STATUS_ICON` map) also swaps glyph
+  in that tick.
+
+Net effect: one flex row (`.agent-tool-summary`) loses one child (`.agent-tool-live-tail`) and
+gains another (`.agent-tool-result-pill`) simultaneously, with no transition on either —
+confirmed by `frontend/app/view/agent/styles/_document-nodes.scss`: the live-tail rule (around
+line 219-241) and the result-pill rule (around line 424-442) carry no `transition` property, and
+grepping the whole file for `transition` turns up only an unrelated hover rule (line 142) and the
+panel collapse/expand transition (lines 297-307, see below — doesn't apply here).
+
+### B. Panel body — two structurally different component trees swapped, not a style/height change (`ToolOverlayLog.tsx:90, 198-220`)
+
+```tsx
+const isStreaming = () => props.node.log?.open === true;   // line 90
+...
+<Switch>
+    <Match when={isStreaming() && hasChunks()}>
+        <ChunkList chunks={chunks()} />                      // raw streamed log lines
+    </Match>
+    <Match when={!isStreaming() && hasResult()}>
+        <ToolOverlayResult node={props.node} />               // DiffViewer / BashOutputViewer / etc.
+    </Match>
+    ...
+</Switch>
+```
+
+`isStreaming()` flips false in the same tick `result` is populated, so Solid's `<Switch>`
+unmounts `ChunkList` and mounts `ToolOverlayResult` — a **different component**, per-tool
+(`DiffViewer`, `BashOutputViewer`, `HighlightedCode`, etc.). The doc comment right above this
+block (lines 187-196) confirms this was deliberately built as an exclusive `<Switch>` (rather
+than a `<Show>` cascade) specifically to fix a *different* bug — a reconciler crash from
+`ToolOverlayResult` appearing in two sibling `<Show>` branches during this exact transition. That
+fix made the transition crash-safe; it did not make it visually smooth. `ChunkList` (raw log
+lines) and `ToolOverlayResult` (e.g. a syntax-highlighted diff) can have very different natural
+heights, and the container, `.agent-tool-overlay-log` (`_tool-overlay-portal.scss:34-68`), has
+**no transition at all** on any property — confirmed by grep: zero `transition` hits in that
+file. The outer `.agent-tool-panel` *does* have a 120ms transition
+(`_document-nodes.scss:297-307`, on `max-height/padding/margin/opacity/content-visibility`), but
+that only covers the hidden↔flow collapse/expand toggle — the panel stays in `flow` the entire
+time here, so that transition never engages; it's the content *inside* the still-open panel that
+jumps.
+
+### C. Secondary contributor for non-success terminal states (`ToolBlockOverlay.tsx:49-63`)
+
+```tsx
+<div class="agent-tool-overlay-header" style={{
+    display: props.node.status === "running" || props.node.status === "success" ? "none" : "",
+}}>
+```
+
+The overlay header is suppressed for both `running` and `success`, so a plain successful Bash
+call doesn't add/remove this row. But any tool terminating as `failed`/`denied`/`canceled`/
+`pending_approval` shows this header for the first time on that same tick — another whole row
+appearing with no transition (and `display` toggled via inline `style`, which CSS transitions
+cannot animate as written regardless).
+
+---
+
+## Why this hasn't been caught by the scroll-chaining work
+
+`SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md` / PR #1963 fixed a *different* problem in the
+same file (`ToolOverlayLog.tsx`) — double scrollbars and a wheel-scroll dead zone at the box's
+scroll boundary. Its own addendum explicitly disambiguates: "Not a jerk, a dead zone." That
+"jerk" language describes native browser scroll-chaining bounce, unrelated to the DOM-reflow jerk
+here. No spec or analysis doc anywhere under `docs/specs/` or `docs/analysis/` mentions this
+running→completed rendering jerk; the closest related docs
+(`PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`,
+`ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`,
+`SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md`, `SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md`) are all
+about *when* the panel opens/closes or *what* it streams, not the internal-content-swap-while-open
+case.
+
+---
+
+## Why "universalize the form" is the right framing
+
+The user's instinct — make the running-state and completed-state DOM shapes closer so there's
+less to jerk over — is correct, but a pure CSS transition cannot fully solve part B: `ChunkList`
+and `ToolOverlayResult` are genuinely different components with different natural content, so
+there's no single element whose properties can be eased between them. Two complementary
+directions:
+
+### A viable fix shape (not yet implemented — for discussion before any code changes)
+
+1. **Summary row (A):** stop keying the live-tail/elapsed-ticker's *presence* directly off
+   `log.open`, and stop keying the result-pill's presence directly off `status !== "running"`.
+   Instead, keep both elements mounted with a shared fixed-height wrapper and cross-fade via
+   `opacity`/`transform` (absolute-position both, transition opacity), so the row's box stays a
+   constant height across the swap and only the content cross-fades. This is a bounded, purely
+   CSS/markup change in `ToolBlock.tsx:256-322` and `_document-nodes.scss`.
+2. **Panel body (B):** this is the harder one, since `ChunkList` and `ToolOverlayResult` are
+   different trees with different intrinsic sizes. Two candidate approaches:
+   - **Height-only transition**: measure the outgoing tree's height before unmount (already have
+     `scrollRef` in `ToolOverlayLog.tsx`), set an explicit `height` on `.agent-tool-overlay-log`
+     equal to that measurement, swap the `<Switch>` branch, then transition `height` to `auto`
+     (or the new measured height) over ~120-150ms matching the existing panel-collapse easing at
+     `_document-nodes.scss:297-307`. This is the standard "FLIP"-style approach for swapping
+     differently-sized subtrees and needs no new abstraction — `ToolOverlayLog.tsx` already does
+     manual RAF-based DOM measurement for the auto-scroll-to-bottom logic (lines 164-185), so the
+     pattern is already present in this file.
+   - **Narrow the gap instead of bridging it**: when a tool streamed chunks and is now terminal
+     with a structured result, consider keeping `ChunkList`'s last N lines visible *underneath* or
+     *behind* `ToolOverlayResult` very briefly with a cross-fade, rather than an instant swap —
+     more visual work, likely overkill for what's fundamentally a small-tool-call preview.
+   - The height-measure-then-transition approach is recommended: it directly targets the box that
+     currently has zero transition (`.agent-tool-overlay-log`), reuses an existing measurement
+     pattern in the same file, and doesn't require touching the `<Switch>`'s crash-safety
+     properties (must stay exclusive per the existing comment at lines 187-196).
+3. **Header row (C):** same cross-fade/reserved-space treatment as (A), lower priority since it
+   only affects non-success terminations.
+
+### Scope/complexity note
+
+Implementing (2)'s height-measure-then-transition needs care around the existing
+`content-visibility: hidden` interaction (`ToolOverlayLog.tsx:138-162` already documents a
+subtlety here — measuring a hidden subtree forces synchronous layout and emits console warnings)
+and around the auto-scroll-to-bottom effect (lines 164-185) — a height transition mid-flight
+would fight that RAF-based scrollTop assignment if not sequenced correctly (transition should
+likely be skipped/instant when the panel isn't visible, matching the existing `panelHidden` guard
+at line 180).
+
+---
+
+## Files referenced (all read directly, not inferred)
+
+| File | Role |
+|---|---|
+| `frontend/app/store/agent-document/reducer.ts:659-679` | `mergeReplacement` — the single state update that couples `status` and `log.open`, root cause of both A and B firing on the same tick |
+| `frontend/app/view/agent/components/ToolBlock.tsx:177-322` | Summary row — `resultPill()` (177-229), live-tail/elapsed-ticker (267-303), status icon (236), the flex row that gains/loses children (256-322) |
+| `frontend/app/view/agent/components/ToolOverlayLog.tsx:90, 187-220` | `isStreaming()` gate + the exclusive `<Switch>` that swaps `ChunkList` ↔ `ToolOverlayResult`; comment at 187-196 explains its crash-safety history |
+| `frontend/app/view/agent/components/ToolBlockOverlay.tsx:49-63` | Overlay header `display` toggle — secondary contributor for non-success terminations |
+| `frontend/app/view/agent/styles/_document-nodes.scss:142, 219-241, 297-307, 424-442` | `.agent-tool-block` hover transition (142, unrelated); live-tail rule (219-241, no transition); panel hidden↔flow transition (297-307, doesn't cover this case); result-pill rule (424-442, no transition) |
+| `frontend/app/view/agent/styles/_tool-overlay-portal.scss:34-68` | `.agent-tool-overlay-log` — the panel-body container; zero `transition` declarations anywhere in this file |
+
+## Related docs (checked, confirmed unrelated or tangential)
+
+| Path | Relevance |
+|---|---|
+| `docs/specs/SPEC_TOOL_PREVIEW_SCROLL_CHAINING_2026_07_03.md` (PR #1963) | Different bug (scroll dead zone / double scrollbar) in the same file; explicitly disclaims being this "jerk" |
+| `docs/specs/PLAN_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md`, `docs/analysis/ANALYSIS_TOOL_BLOCK_SCROLL_DRIVEN_COLLAPSE_2026_06_16.md` | About *when* the panel auto-collapses on scroll, not content swaps while open |
+| `docs/specs/SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md` | About *when* the panel auto-expands |
+| `docs/specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md` | About what the live log streams, predates the terminal-state pill/switch design |
+
+No prior doc addresses this issue — it appears genuinely unreported until now.

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -151,4 +151,58 @@ describe("ToolBlock — panel mode", () => {
         const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
         expect(panel.style.maxHeight).toBe("");
     });
+
+    // ── Result-pill one-shot fade-in (reagent P2 on PR #1975) ────────────
+    // The fade-in must be a one-shot class added by a `ref` callback at
+    // genuine mount time, NOT a persistent CSS `animation:` on the
+    // selector — the pill's `display` also toggles via an unrelated
+    // `@container` width breakpoint (_responsive.scss), and a persistent
+    // animation would replay on every resize across that breakpoint even
+    // for an already-completed, unrelated tool call.
+    describe("result-pill one-shot fade-in", () => {
+        const withResult: ToolNode = {
+            ...baseTool,
+            result: { exitCode: 0 } as any,
+        };
+
+        it("adds the one-shot class on mount and removes it after animationend", async () => {
+            const { container } = render(() => (
+                <ToolBlock node={withResult} pinned={false} onTogglePin={() => {}} />
+            ));
+            const pill = container.querySelector(".agent-tool-result-pill") as HTMLElement;
+            expect(pill).not.toBeNull();
+
+            // The class is added a microtask after mount — deferred past
+            // Solid's own dynamic `class={...}` effect, which sets
+            // `className` wholesale and would otherwise clobber a
+            // classList mutation made synchronously in the ref (see
+            // `fadeInOnMount`'s doc comment in ToolBlock.tsx).
+            await Promise.resolve();
+            expect(pill.classList.contains("agent-tool-fade-in-once")).toBe(true);
+
+            pill.dispatchEvent(new Event("animationend"));
+            expect(pill.classList.contains("agent-tool-fade-in-once")).toBe(false);
+        });
+
+        it("does not re-add the class on an unrelated re-render (only a genuine remount)", async () => {
+            // Regression guard for the actual bug: re-rendering with the
+            // SAME resultPill (simulating a resize-driven display toggle,
+            // not a real remount) must not re-add the one-shot class,
+            // since the ref callback only fires on genuine DOM insertion.
+            const [node, setNode] = createSignal<ToolNode>(withResult);
+            const { container } = render(() => <ToolBlock node={node()} pinned={false} onTogglePin={() => {}} />);
+            const pill = container.querySelector(".agent-tool-result-pill") as HTMLElement;
+            await Promise.resolve();
+            pill.dispatchEvent(new Event("animationend"));
+            expect(pill.classList.contains("agent-tool-fade-in-once")).toBe(false);
+
+            // Same status/result, just a new object reference (mirrors an
+            // unrelated parent re-render) — the pill is NOT unmounted by
+            // Solid (same <Show> branch stays true), so the ref never
+            // re-fires and the class must stay off.
+            setNode({ ...withResult });
+            await Promise.resolve();
+            expect(pill.classList.contains("agent-tool-fade-in-once")).toBe(false);
+        });
+    });
 });

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -41,6 +41,34 @@ import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
 import { ToolBlockOverlay } from "./ToolBlockOverlay";
 
+/**
+ * Ref callback that plays a one-shot fade-in animation ONLY on a genuine
+ * Solid-level mount of the element (i.e. when the enclosing `<Show>`
+ * flips true because the tool's status actually changed). A persistent
+ * CSS `animation:` on the selector itself would ALSO retrigger on any
+ * unrelated `display:none` <-> visible toggle — e.g. `.agent-tool-result-
+ * pill`'s `@container` breakpoint at 600px (`_responsive.scss`) applies
+ * regardless of tool status, so resizing the pane across that width would
+ * replay the fade-in on every already-completed, unrelated tool call
+ * (reagent P2 on PR #1975). A ref only fires once, at real DOM insertion.
+ *
+ * The `classList.add` is deferred a microtask: `ref` callbacks fire at
+ * element CREATION, before Solid's own effect for this element's dynamic
+ * `class={...}` expression has run (that effect sets `el.className`
+ * wholesale, not via `classList`) — mutating classList synchronously in
+ * the ref gets immediately clobbered by that later assignment. Deferring
+ * past the current synchronous render lets Solid's class effect finish
+ * first, so this addition survives.
+ */
+function fadeInOnMount(el: HTMLElement): void {
+    queueMicrotask(() => {
+        el.classList.add("agent-tool-fade-in-once");
+        el.addEventListener("animationend", () => el.classList.remove("agent-tool-fade-in-once"), {
+            once: true,
+        });
+    });
+}
+
 function ToolElapsedTicker(props: { startMs: number }): JSX.Element {
     const tick = useTick(1000);
     const elapsed = createMemo(() => (tick(), Math.floor((Date.now() - props.startMs) / 1000)));
@@ -260,7 +288,10 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                     <span class="agent-tool-duration">({props.node.duration.toFixed(1)}s)</span>
                 </Show>
                 <Show when={resultPill() != null}>
-                    <span class={`agent-tool-result-pill pill-${resultPill()?.variant}`}>
+                    <span
+                        ref={fadeInOnMount}
+                        class={`agent-tool-result-pill pill-${resultPill()?.variant}`}
+                    >
                         {resultPill()?.label}
                     </span>
                 </Show>

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -49,7 +49,7 @@ const STATUS_LABEL: Record<ToolNode["status"], string> = {
 export const ToolBlockOverlay = (props: ToolBlockOverlayProps): JSX.Element => (
     <div class="agent-tool-overlay" data-node-id={props.node.id}>
         <div
-            class="agent-tool-overlay-header"
+            class="agent-tool-overlay-header agent-tool-summary-fade-in"
             style={{
                 display:
                     props.node.status === "running" || props.node.status === "success"

--- a/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
@@ -1,0 +1,161 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ToolOverlayLog — height-FLIP transition tests
+ * (ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md).
+ *
+ * `scrollHeight` is always 0 in jsdom (no real layout engine), so each
+ * test stubs it per-render to simulate the streaming vs. terminal content
+ * having different natural heights, then asserts the FLIP mechanics:
+ * the element is frozen at the "from" height synchronously, then eased
+ * to the "to" height on the next animation frame.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+
+import { ToolOverlayLog } from "./ToolOverlayLog";
+import type { ToolNode } from "../types";
+
+let reducedMotion = false;
+vi.mock("@/app/store/global", () => ({
+    atoms: {
+        prefersReducedMotionAtom: () => reducedMotion,
+    },
+}));
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    reducedMotion = false;
+});
+
+const streamingNode: ToolNode = {
+    type: "tool",
+    id: "tc-1",
+    tool: "Bash",
+    params: { command: "sleep 1 && echo done" },
+    status: "running",
+    collapsed: false,
+    summary: "Bash sleep 1 && echo done",
+    log: {
+        open: true,
+        chunks: [{ kind: "stdout", content: "line 1", timestamp: 1 }],
+    },
+};
+
+const terminalNode: ToolNode = {
+    ...streamingNode,
+    status: "success",
+    log: { open: false, chunks: streamingNode.log!.chunks },
+    result: { exitCode: 0, stdout: "line 1\ndone", stderr: "" } as any,
+};
+
+/** Stub `scrollHeight` on every HTMLDivElement instance for this test. */
+function stubScrollHeight(px: number) {
+    return vi.spyOn(HTMLDivElement.prototype, "scrollHeight", "get").mockReturnValue(px);
+}
+
+describe("ToolOverlayLog — height-FLIP transition", () => {
+    it("freezes at the previous height then eases to the new height on a branch change", async () => {
+        vi.useFakeTimers();
+        const heightStub = stubScrollHeight(40); // streaming-branch height
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => <ToolOverlayLog node={node()} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+
+        // Let the streaming-branch effect run and record 40px as the
+        // "last measured height" before anything transitions.
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe("");
+
+        heightStub.mockRestore();
+        stubScrollHeight(120); // terminal-branch (result view) is taller
+        setNode(terminalNode);
+
+        // Synchronously (Solid effects run synchronously with the signal
+        // write that triggers them), the element is frozen at the OLD
+        // height, and the transition is already armed — the CSS
+        // transition must be enabled BEFORE the new height is assigned on
+        // the next frame, or there's nothing for the browser to ease.
+        expect(el.style.height).toBe("40px");
+        expect(el.style.transition).toContain("height");
+
+        // Only the actual height VALUE change is deferred to the next
+        // animation frame (so the browser gets to paint the frozen "from"
+        // state first) — that's the only part fake timers need to advance.
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe("120px");
+
+        // Transition-end cleanup (jsdom doesn't run real CSS transitions,
+        // so dispatch the event manually) clears the inline overrides.
+        el.dispatchEvent(new (globalThis as any).TransitionEvent("transitionend", { propertyName: "height" }));
+        expect(el.style.height).toBe("");
+        expect(el.style.transition).toBe("");
+
+        vi.useRealTimers();
+    });
+
+    it("does not animate on initial mount", () => {
+        stubScrollHeight(40);
+        const { container } = render(() => <ToolOverlayLog node={streamingNode} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+        expect(el.style.height).toBe("");
+    });
+
+    it("does not animate when the branch is unchanged (only chunks growing)", async () => {
+        vi.useFakeTimers();
+        stubScrollHeight(40);
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => <ToolOverlayLog node={node()} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+        await vi.runOnlyPendingTimersAsync();
+
+        setNode({
+            ...streamingNode,
+            log: {
+                open: true,
+                chunks: [...streamingNode.log!.chunks, { kind: "stdout", content: "line 2", timestamp: 2 }],
+            },
+        });
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe(""); // still "streaming" branch — no FLIP
+
+        vi.useRealTimers();
+    });
+
+    it("does not animate when heights are equal", async () => {
+        vi.useFakeTimers();
+        stubScrollHeight(60);
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => <ToolOverlayLog node={node()} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+        await vi.runOnlyPendingTimersAsync();
+
+        setNode(terminalNode); // scrollHeight stub still returns 60 for both
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe("");
+
+        vi.useRealTimers();
+    });
+
+    it("does not animate when the user prefers reduced motion", async () => {
+        reducedMotion = true;
+        vi.useFakeTimers();
+        const heightStub = stubScrollHeight(40);
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => <ToolOverlayLog node={node()} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+        await vi.runOnlyPendingTimersAsync();
+
+        heightStub.mockRestore();
+        stubScrollHeight(120);
+        setNode(terminalNode);
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe(""); // branch changed + heights differ, but motion is disabled
+
+        vi.useRealTimers();
+    });
+});

--- a/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
@@ -171,6 +171,46 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         expect(el.style.height).toBe(""); // resynced silently, no FLIP
     });
 
+    it("does not animate when a different tool node swaps into the same slot", async () => {
+        // Simulates a streaming-buffer cap-advance swapping a different tool
+        // node into the same <Index> slot without ever unmounting this
+        // component (reagent P1 round 2 on #1975) — mirrors the
+        // `prevNodeId` guard `ToolBlock.tsx` already applies for the
+        // analogous slot-reuse hazard on `onHoldOpen` (PR #1317).
+        vi.useFakeTimers();
+        stubScrollHeight(40); // tc-1's "streaming" height
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => <ToolOverlayLog node={node()} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe("");
+
+        // A different node (new id) reuses this slot, already in its
+        // terminal branch, with a very different natural height.
+        const otherNode: ToolNode = {
+            ...terminalNode,
+            id: "tc-2",
+        };
+        stubScrollHeight(500);
+        setNode(otherNode);
+        await vi.runOnlyPendingTimersAsync();
+        // Must resync silently — NOT FLIP from tc-1's stale 40px baseline.
+        expect(el.style.height).toBe("");
+
+        // A genuine branch change on the NEW node (tc-2) afterwards must
+        // still be able to FLIP correctly — the reset must not poison the
+        // baseline for the node going forward. Its baseline height is now
+        // 500px (tc-2's own terminal-branch height, recorded at the swap),
+        // so this eases from 500px down to the new 120px.
+        stubScrollHeight(120);
+        setNode({ ...otherNode, log: { open: true, chunks: [{ kind: "stdout", content: "x", timestamp: 1 }] } });
+        expect(el.style.height).toBe("500px"); // frozen "from" synchronously
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe("120px"); // eased to the "to" height
+
+        vi.useRealTimers();
+    });
+
     it("does not animate when the user prefers reduced motion", async () => {
         reducedMotion = true;
         vi.useFakeTimers();

--- a/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
@@ -141,6 +141,36 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         vi.useRealTimers();
     });
 
+    it("resyncs without animating when a branch change happened entirely while the panel was hidden", async () => {
+        // A failed/denied/canceled tool auto-collapses the instant it
+        // leaves "running" (ToolBlock.tsx autoExpanded()), so the
+        // running->result branch change commonly happens while
+        // content-visibility:hidden. The first re-measurement after the
+        // panel becomes visible again (e.g. the user expands it to
+        // inspect the error) must show the final state directly, NOT
+        // FLIP from the stale pre-collapse height (reagent P1 on #1975).
+        stubScrollHeight(40);
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => (
+            <div class="agent-tool-panel agent-tool-panel--hidden">
+                <ToolOverlayLog node={node()} />
+            </div>
+        ));
+        const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+
+        setNode(terminalNode); // branch changes entirely while hidden
+        expect(el.style.height).toBe(""); // never measured/animated while hidden
+
+        stubScrollHeight(120); // the terminal branch's real (now-visible) height
+        panel.classList.remove("agent-tool-panel--hidden"); // panel becomes visible
+        // MutationObserver callbacks run as a microtask.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(el.style.height).toBe(""); // resynced silently, no FLIP
+    });
+
     it("does not animate when the user prefers reduced motion", async () => {
         reducedMotion = true;
         vi.useFakeTimers();

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -225,6 +225,15 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     // ("streaming") height to the current one instead of just showing the
     // final state (reagent P1 on PR #1975).
     let heightStale = false;
+    // Guards the same `<Index>` slot-position hazard `ToolBlock.tsx` guards
+    // via `prevNodeId` (PR #1317, `AgentDocumentVirtualList.tsx:193-194`): a
+    // streaming-buffer cap-advance can swap a different tool node into this
+    // component instance without it ever unmounting. Without this guard the
+    // outgoing node's `lastBranch`/`lastMeasuredHeight` would leak into the
+    // incoming node's first render and could spuriously satisfy
+    // `prevBranch !== b`, FLIPping from the old tool's height to the new
+    // tool's height (reagent P1 round 2 on PR #1975).
+    let lastNodeId: string = props.node.id;
 
     createEffect(() => {
         const b = branch();
@@ -232,6 +241,18 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         const hidden = panelHidden();
         const el = scrollRef;
         if (!el) return;
+
+        const nodeId = props.node.id;
+        if (nodeId !== lastNodeId) {
+            // Reset the baseline to the incoming node's own branch/height —
+            // never animate across the swap itself — so a genuine later
+            // branch change on THIS node can still FLIP correctly.
+            lastNodeId = nodeId;
+            lastBranch = b;
+            heightStale = hidden;
+            lastMeasuredHeight = hidden ? lastMeasuredHeight : el.scrollHeight;
+            return;
+        }
 
         if (hidden) {
             // Reading scrollHeight here would force a synchronous layout on

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -18,6 +18,7 @@
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 // `Show` retained for fallback ToolOverlayResult sub-tree.
 import type { ToolNode } from "../types";
+import { atoms } from "@/app/store/global";
 import { Markdown } from "@/app/element/markdown";
 import { BashOutputViewer } from "./BashOutputViewer";
 import { CompactResult } from "./CompactResult";
@@ -91,6 +92,20 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     const hasChunks = () => (props.node.log?.chunks?.length ?? 0) > 0;
     const hasResult = () => props.node.result != null;
     const chunks = () => props.node.log?.chunks ?? [];
+
+    // Mirrors the `<Switch>` branches below exactly — used only to detect
+    // when the RENDERED branch changes (for the height-FLIP effect further
+    // down), so it must stay a plain function, not a `createMemo`: see the
+    // "INLINE prop access pattern" note above `isStreaming` — memoizing
+    // anything derived from `props.node.log?.chunks` has previously broken
+    // reactivity for in-place chunk-array mutations (PR #884/#885/#886).
+    type LogBranch = "streaming" | "result" | "chunks-final" | "empty";
+    const branch = (): LogBranch => {
+        if (isStreaming() && hasChunks()) return "streaming";
+        if (!isStreaming() && hasResult()) return "result";
+        if (!isStreaming() && !hasResult() && hasChunks()) return "chunks-final";
+        return "empty";
+    };
 
     // Auto-stick to bottom while the user hasn't scrolled away. The
     // threshold is forgiving — within 40px of the bottom counts as
@@ -184,6 +199,55 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         }
     });
 
+    // FLIP-style height transition when the rendered `<Switch>` branch below
+    // changes (running -> terminal, most commonly): `ChunkList` and
+    // `ToolOverlayResult` are different component trees with different
+    // natural heights, and today they swap with zero transition — the
+    // "jerk" in ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md.
+    //
+    // `lastMeasuredHeight`/`lastBranch` hold the values captured on the
+    // PREVIOUS run of this effect — i.e. the DOM height as it stood just
+    // before whatever change triggered the CURRENT run. That's exactly the
+    // FLIP "before" state, and it's the only way to get it: Solid effects
+    // always run after the DOM has already been patched for the change
+    // that triggered them, so there is no "before" to read within the same
+    // invocation. This only works because nothing else in this component
+    // mutates `scrollRef`'s height between effect runs.
+    let lastMeasuredHeight = 0;
+    let lastBranch: LogBranch | undefined;
+    let cancelHeightFlip: (() => void) | undefined;
+
+    createEffect(() => {
+        const b = branch();
+        chunks(); // also re-measure as chunks stream in, not just on branch changes
+        const hidden = panelHidden();
+        const el = scrollRef;
+        // Reading scrollHeight on a content-visibility:hidden subtree forces
+        // a synchronous layout (same hazard as the auto-scroll effect above)
+        // — skip measuring entirely while the panel is collapsed.
+        if (!el || hidden) return;
+
+        const prevBranch = lastBranch;
+        const prevHeight = lastMeasuredHeight;
+        const newHeight = el.scrollHeight;
+
+        const shouldAnimate =
+            prevBranch !== undefined &&
+            prevBranch !== b &&
+            prevHeight > 0 &&
+            Math.abs(newHeight - prevHeight) > 1 &&
+            !atoms.prefersReducedMotionAtom();
+
+        if (shouldAnimate) {
+            cancelHeightFlip?.();
+            cancelHeightFlip = flipHeight(el, prevHeight, newHeight);
+        }
+
+        lastBranch = b;
+        lastMeasuredHeight = newHeight;
+    });
+    onCleanup(() => cancelHeightFlip?.());
+
     /**
      * Render decision — exhaustive, mutually exclusive branches via
      * `<Switch>` rather than the prior 4-way `<Show>` cascade that
@@ -219,6 +283,43 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         </div>
     );
 };
+
+const HEIGHT_FLIP_MS = 150;
+
+/**
+ * Classic FLIP height transition: freeze `el` at `fromPx` (forcing a reflow
+ * so the browser commits it before animating), then ease to `toPx`,
+ * clearing the inline style once the transition ends so the box goes back
+ * to tracking its content naturally. `overflow-y` is forced to `hidden`
+ * for the transition's duration only, so the internal scrollbar doesn't
+ * flash on/off as the height passes through intermediate values.
+ *
+ * Returns a cancel function — call it if another transition needs to start
+ * before this one finishes (the caller always cancels the previous one
+ * before starting a new one, so at most one is ever in flight per element).
+ */
+function flipHeight(el: HTMLElement, fromPx: number, toPx: number): () => void {
+    el.style.transition = "none";
+    el.style.height = `${fromPx}px`;
+    el.style.overflowY = "hidden";
+    void el.offsetHeight; // force reflow so the "from" height commits before animating
+    el.style.transition = `height ${HEIGHT_FLIP_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`;
+    const raf = requestAnimationFrame(() => {
+        el.style.height = `${toPx}px`;
+    });
+    const onEnd = (e: TransitionEvent) => {
+        if (e.target === el && e.propertyName === "height") cleanup();
+    };
+    const cleanup = () => {
+        cancelAnimationFrame(raf);
+        el.style.transition = "";
+        el.style.height = "";
+        el.style.overflowY = "";
+        el.removeEventListener("transitionend", onEnd);
+    };
+    el.addEventListener("transitionend", onEnd);
+    return cleanup;
+}
 
 type LogChunk = { kind: string; content: string; timestamp: number };
 

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -216,27 +216,47 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     let lastMeasuredHeight = 0;
     let lastBranch: LogBranch | undefined;
     let cancelHeightFlip: (() => void) | undefined;
+    // Set while the panel is (or was) content-visibility:hidden and we
+    // couldn't safely measure. A failed/denied/canceled tool auto-collapses
+    // the instant it leaves "running" (`ToolBlock.tsx` autoExpanded()), so
+    // the running->result branch change commonly happens entirely while
+    // hidden — without this flag, the first re-measurement after the user
+    // later expands the panel would FLIP from the stale pre-collapse
+    // ("streaming") height to the current one instead of just showing the
+    // final state (reagent P1 on PR #1975).
+    let heightStale = false;
 
     createEffect(() => {
         const b = branch();
         chunks(); // also re-measure as chunks stream in, not just on branch changes
         const hidden = panelHidden();
         const el = scrollRef;
-        // Reading scrollHeight on a content-visibility:hidden subtree forces
-        // a synchronous layout (same hazard as the auto-scroll effect above)
-        // — skip measuring entirely while the panel is collapsed.
-        if (!el || hidden) return;
+        if (!el) return;
+
+        if (hidden) {
+            // Reading scrollHeight here would force a synchronous layout on
+            // a content-visibility:hidden subtree (same hazard as the
+            // auto-scroll effect above). Track the logical branch (cheap,
+            // no DOM read) so a genuine change is still recorded, but mark
+            // the height stale — resolved as a silent resync, not a FLIP,
+            // the next time this runs while visible.
+            lastBranch = b;
+            heightStale = true;
+            return;
+        }
 
         const prevBranch = lastBranch;
         const prevHeight = lastMeasuredHeight;
         const newHeight = el.scrollHeight;
 
         const shouldAnimate =
+            !heightStale &&
             prevBranch !== undefined &&
             prevBranch !== b &&
             prevHeight > 0 &&
             Math.abs(newHeight - prevHeight) > 1 &&
             !atoms.prefersReducedMotionAtom();
+        heightStale = false;
 
         if (shouldAnimate) {
             cancelHeightFlip?.();

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1,12 +1,39 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+@use "../../../mixins.scss";
+
 // Document-node rendering — markdown / code / diff / bash / message
 // blocks rendered inside the agent conversation. Largest section of
 // the original `agent-view.scss` (~700 lines). Wrapped in
 // `.agent-view` so the cascade chain matches the pre-split file
 // (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
 .agent-view {
+    // Running -> terminal tool-status transition
+    // (ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md): the
+    // result pill and the live-tail/elapsed-ticker span mount/unmount
+    // instantly on the same tick a tool's status leaves "running" (they're
+    // gated by `resultPill() != null` / `log.open`, which flip together).
+    // A brief fade-in on the incoming element softens the pop; skipped
+    // entirely for reduced-motion users below.
+    @keyframes agent-tool-summary-fade-in {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    // Reusable class (as opposed to the animation applied inline on
+    // `.agent-tool-result-pill` / `.agent-tool-live-tail` below) for
+    // elements outside this file, e.g. `.agent-tool-overlay-header` in
+    // `_tool-overlay-portal.scss` — it also toggles via `display: none` <->
+    // flex rather than mount/unmount, which re-triggers a CSS animation the
+    // same way a fresh mount does.
+    .agent-tool-summary-fade-in {
+        animation: agent-tool-summary-fade-in 160ms ease-out;
+
+        @include mixins.respect-reduced-motion {
+            animation: none;
+        }
+    }
     // Shown wherever a tool-output body is render-capped
     // (SPEC_TOOL_OUTPUT_CAP_2026_05_30.md). One muted line, never silent.
     .agent-output-hidden-marker {
@@ -192,6 +219,11 @@
                 text-align: center;
                 color: var(--secondary-text-color);
                 font-size: 11px;
+                // Eases the running -> terminal color swap (warning ->
+                // success/error/etc, see the `&.success .agent-tool-status-icon`
+                // rules below) instead of an instant snap. The glyph itself
+                // still changes instantly — only its color eases.
+                transition: color 150ms ease;
             }
 
             .agent-tool-name {
@@ -229,6 +261,11 @@
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
+                animation: agent-tool-summary-fade-in 160ms ease-out;
+
+                @include mixins.respect-reduced-motion {
+                    animation: none;
+                }
 
                 // Waiting state (no stdout yet — showing elapsed timer).
                 // Dimmer than real output so it reads as "pending" rather
@@ -431,6 +468,11 @@
         flex-shrink: 0;
         white-space: nowrap;
         line-height: 1.4;
+        animation: agent-tool-summary-fade-in 160ms ease-out;
+
+        @include mixins.respect-reduced-motion {
+            animation: none;
+        }
 
         &.pill-exit-ok  { color: var(--success-color); background: color-mix(in srgb, var(--success-color) 14%, transparent); }
         &.pill-exit-err { color: var(--error-color);   background: color-mix(in srgb, var(--error-color)   14%, transparent); }

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -22,12 +22,31 @@
     }
 
     // Reusable class (as opposed to the animation applied inline on
-    // `.agent-tool-result-pill` / `.agent-tool-live-tail` below) for
-    // elements outside this file, e.g. `.agent-tool-overlay-header` in
-    // `_tool-overlay-portal.scss` — it also toggles via `display: none` <->
-    // flex rather than mount/unmount, which re-triggers a CSS animation the
-    // same way a fresh mount does.
+    // `.agent-tool-live-tail` below) for elements whose *visibility*
+    // toggle is coupled 1:1 to a genuine tool-status change — e.g.
+    // `.agent-tool-overlay-header` in `_tool-overlay-portal.scss`, which
+    // toggles `display: none` <-> flex only via `props.node.status`
+    // (`ToolBlockOverlay.tsx`), so CSS's "display:none -> visible
+    // restarts animations" behavior only ever fires on that real event.
     .agent-tool-summary-fade-in {
+        animation: agent-tool-summary-fade-in 160ms ease-out;
+
+        @include mixins.respect-reduced-motion {
+            animation: none;
+        }
+    }
+
+    // One-shot variant, added/removed by a `ref` callback
+    // (`fadeInOnMount` in `ToolBlock.tsx`) rather than living permanently
+    // on a selector. Needed wherever an element's `display` ALSO toggles
+    // for a reason unrelated to status — `.agent-tool-result-pill` below
+    // is shown/hidden by a `@container` width breakpoint
+    // (`_responsive.scss`) independent of tool status, so a persistent
+    // `animation:` on that selector would replay on every resize across
+    // 600px, even for an already-completed, unrelated tool call (reagent
+    // P2 on PR #1975). The ref only adds this class at genuine Solid
+    // mount time, so resizing never retriggers it.
+    .agent-tool-fade-in-once {
         animation: agent-tool-summary-fade-in 160ms ease-out;
 
         @include mixins.respect-reduced-motion {
@@ -468,11 +487,13 @@
         flex-shrink: 0;
         white-space: nowrap;
         line-height: 1.4;
-        animation: agent-tool-summary-fade-in 160ms ease-out;
-
-        @include mixins.respect-reduced-motion {
-            animation: none;
-        }
+        // NOT an `animation:` here — this selector's `display` also
+        // toggles on pane resize (see the `@container` rule in
+        // `_responsive.scss`), independent of tool status. The fade-in is
+        // applied via the one-shot `.agent-tool-fade-in-once` class
+        // instead (added by a `ref` callback only at genuine mount time —
+        // see `fadeInOnMount` in `ToolBlock.tsx`), so resizing never
+        // replays it (reagent P2 on PR #1975).
 
         &.pill-exit-ok  { color: var(--success-color); background: color-mix(in srgb, var(--success-color) 14%, transparent); }
         &.pill-exit-err { color: var(--error-color);   background: color-mix(in srgb, var(--error-color)   14%, transparent); }


### PR DESCRIPTION
## Summary

When a running tool call finishes, its preview jerks — an abrupt layout shift instead of a smooth transition — because the DOM shape rendered for `running` differs from the terminal-state shape, and nothing bridges the two. Full root-cause analysis: `docs/analysis/ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md`.

**Root cause:** `mergeReplacement()` (`reducer.ts`) flips `status` away from `"running"` *and* `log.open` to `false` in the same tick, so two independent pieces of UI swap DOM shape simultaneously with zero transition anywhere.

## Fix

**Summary row** (`ToolBlock.tsx` / `_document-nodes.scss`) — CSS only:
- Shared `agent-tool-summary-fade-in` keyframe applied to `.agent-tool-result-pill` (mounts the instant status leaves running) and `.agent-tool-live-tail` (unmounts the same tick) — softens the pop instead of an instant appear/disappear.
- `transition: color 150ms` on the status icon so its warning→success/error color change eases.
- Same fade-in applied to `ToolBlockOverlay`'s overlay header (shown for non-success terminal states).
- All gated behind the existing `respect-reduced-motion` mixin.

**Panel body** (`ToolOverlayLog.tsx`) — the bigger one:
- The exclusive `<Switch>` swaps `ChunkList` (streaming) ↔ `ToolOverlayResult` (terminal) — two structurally different component trees with different natural heights, currently zero transition.
- Added a FLIP-style height transition: a `branch()` accessor mirrors the `<Switch>` conditions exactly (kept as a plain function, not `createMemo`, per this file's own documented reactivity caveat around `props.node.log?.chunks`). An effect keyed off `branch()`/`chunks()` reuses its **own previous invocation's** measured height as the FLIP "before" state — the only way to get it, since Solid effects only ever see the DOM *after* it's already patched for the triggering change. Freezes the box at that height, forces a reflow, then eases to the freshly-measured new height.
- Skips entirely while the panel is `content-visibility: hidden` (same layout-forcing hazard the existing auto-scroll effect already guards against) or when `prefersReducedMotionAtom()` is set.

## Tests

5 new tests in `ToolOverlayLog.test.tsx` covering the FLIP mechanics directly (mocking `scrollHeight` per branch since jsdom has no real layout engine): freeze→ease→transitionend-cleanup, no-op on mount, no-op when the branch doesn't actually change, no-op when heights already match, no-op under reduced motion.

- `npx tsc --noEmit` — clean
- `npx stylelint` on the touched scss file — same 27 pre-existing errors as baseline (confirmed via `git stash`), zero new ones introduced
- Full frontend suite: **107 files / 1599 tests, all green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agent2 -->