### PR TITLE
fix(layout): SPEC_864 Phase 4 — pendingbackendactions queue writers through the reducer

### DIFF
--- a/.changesets/1783309236-fix-layout-spec-864-phase-4-route-pendingbackendactions-queu-oosg.md
+++ b/.changesets/1783309236-fix-layout-spec-864-phase-4-route-pendingbackendactions-queu-oosg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): SPEC_864 Phase 4 — route pendingbackendactions queue writers through the reducer

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -611,6 +611,16 @@ pub enum Command {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         slices: Option<crate::LayoutClientSlices>,
     },
+    /// SPEC_864 Phase 4 — append actions to a tab's
+    /// `pendingbackendactions` queue through the reducer. `actions` is a
+    /// JSON array of `LayoutActionData` objects (raw-value pass-through;
+    /// the reducer does not model the queue — see
+    /// `Event::LayoutBackendActionsQueued`).
+    LayoutQueueBackendActions {
+        tab_id: String,
+        actions: serde_json::Value,
+        correlation_id: String,
+    },
 
     /// Phase D.3 — request an `Event::EventList` reply containing the
     /// events the launcher has emitted with version > `since`. Used
@@ -1591,6 +1601,23 @@ pub enum Event {
         correlation_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         slices: Option<crate::LayoutClientSlices>,
+        version: u64,
+    },
+
+    /// SPEC_864 Phase 4 — actions appended to a tab's
+    /// `pendingbackendactions` queue through the reducer (the
+    /// backend→frontend "please mutate your layout tree" channel).
+    /// `actions` is a JSON array of `LayoutActionData` objects, carried
+    /// as a raw value the same way `LayoutClientSlices` carries the
+    /// queue: the reducer does NOT model the queue in `TabRecord`
+    /// (pass-through), and the persist subscriber APPENDS these to the
+    /// existing `LayoutState.pendingbackendactions` (append semantics —
+    /// unlike the slices REPLACE semantics of a frontend push, which is
+    /// how the frontend acks/clears the queue).
+    LayoutBackendActionsQueued {
+        tab_id: String,
+        actions: serde_json::Value,
+        correlation_id: String,
         version: u64,
     },
 

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -304,6 +304,7 @@ fn event_version(e: &Event) -> u64 {
         | Event::LayoutSplitHorizontalApplied { version, .. }
         | Event::LayoutSplitVerticalApplied { version, .. }
         | Event::LayoutCleared { version, .. }
+        | Event::LayoutBackendActionsQueued { version, .. }
         | Event::LayoutTreeReplaced { version, .. }
         | Event::WindowMetaUpdated { version, .. } => *version,
     }

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -988,6 +988,7 @@ async fn enforce_register_first(
         | Command::LayoutInsertNodeAtIndex { .. }
         | Command::LayoutDeleteNode { .. }
         | Command::LayoutDeleteNodeByBlock { .. }
+        | Command::LayoutQueueBackendActions { .. }
         | Command::LayoutMoveNode { .. }
         | Command::LayoutSwapNodes { .. }
         | Command::LayoutResizeNodes { .. }

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -529,6 +529,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         | Command::LayoutInsertNodeAtIndex { .. }
         | Command::LayoutDeleteNode { .. }
         | Command::LayoutDeleteNodeByBlock { .. }
+        | Command::LayoutQueueBackendActions { .. }
         | Command::LayoutMoveNode { .. }
         | Command::LayoutSwapNodes { .. }
         | Command::LayoutResizeNodes { .. }

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -222,6 +222,7 @@ fn extract_version(e: &Event) -> u64 {
         | Event::LayoutSplitHorizontalApplied { version, .. }
         | Event::LayoutSplitVerticalApplied { version, .. }
         | Event::LayoutCleared { version, .. }
+        | Event::LayoutBackendActionsQueued { version, .. }
         | Event::LayoutTreeReplaced { version, .. }
         | Event::WindowMetaUpdated { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -305,7 +305,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::LayoutSplitHorizontalApplied { version, .. }
         | Event::LayoutSplitVerticalApplied { version, .. }
         | Event::LayoutCleared { version, .. }
-        | Event::LayoutTreeReplaced { version, .. } => *version,
+        | Event::LayoutBackendActionsQueued { version, .. }
+            | Event::LayoutTreeReplaced { version, .. } => *version,
     }
 }
 

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -360,6 +360,16 @@ pub(crate) fn apply_event_to_wstore(
                 None => Ok(()),
             }
         }
+        // SPEC_864 Phase 4 — APPEND to the pending queue (unlike the
+        // slices path above, which REPLACEs it: pushing a slice without
+        // processed actions is how the frontend ACKS the queue; the
+        // backend enqueues by appending). Idempotent under the
+        // double-apply contract (sync from the dispatch helper, again
+        // from broadcast) by deduping on `actionid` — every writer
+        // stamps a fresh UUID per action.
+        Event::LayoutBackendActionsQueued { tab_id, actions, .. } => {
+            apply_layout_backend_actions_queued(wstore, tab_id, actions)
+        }
         // All other event variants are not domain-state mutations
         // (lifecycle, errors, snapshots). The subscriber ignores them.
         _ => Ok(()),
@@ -899,6 +909,51 @@ fn apply_layout_tree_replaced(
     layout.magnifiednodeid = new_magnified;
     layout.leaforder = new_leaforder;
     layout.pendingbackendactions = new_pending;
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+
+/// SPEC_864 Phase 4 — apply a `LayoutBackendActionsQueued` event:
+/// APPEND the reducer-validated actions to
+/// `LayoutState.pendingbackendactions`. The queue is a backend→frontend
+/// mailbox: the backend appends here; the frontend drains it by pushing
+/// a full slice without the processed actions (the REPLACE path in
+/// `apply_layout_tree_replaced`).
+///
+/// Idempotency: the event is applied twice on the happy path (sync in
+/// `queue_layout_actions_via_reducer`, again by the subscriber task
+/// consuming the broadcast), so actions whose `actionid` is already in
+/// the queue are skipped. Every writer stamps a fresh UUID per action;
+/// an (out-of-contract) empty `actionid` dedupes against other empties,
+/// which is the safe direction — skip rather than duplicate.
+fn apply_layout_backend_actions_queued(
+    wstore: &Store,
+    tab_id: &str,
+    actions: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if tab.layoutstate.is_empty() {
+        return Ok(());
+    }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else {
+        return Ok(());
+    };
+    let incoming: Vec<LayoutActionData> = serde_json::from_value(actions.clone())?;
+    let mut pending = layout.pendingbackendactions.take().unwrap_or_default();
+    let before = pending.len();
+    for action in incoming {
+        if !pending.iter().any(|p| p.actionid == action.actionid) {
+            pending.push(action);
+        }
+    }
+    if pending.len() == before {
+        // Every action already queued (double-apply) — no version churn.
+        layout.pendingbackendactions = Some(pending);
+        return Ok(());
+    }
+    layout.pendingbackendactions = Some(pending);
     wstore.update(&mut layout)?;
     Ok(())
 }
@@ -2279,5 +2334,86 @@ mod tests {
         .unwrap();
         let tab_after = s.get::<Tab>(&tab.oid).unwrap().unwrap();
         assert_eq!(tab_after.blockids, vec!["b2".to_string(), "b3".to_string(), "b1".to_string()]);
+    }
+
+    // ── SPEC_864 Phase 4 — pendingbackendactions APPEND semantics ──────────
+
+    fn action(id: &str, block: &str) -> LayoutActionData {
+        LayoutActionData {
+            actiontype: "insert".into(),
+            actionid: id.into(),
+            blockid: block.into(),
+            nodesize: None,
+            nodesizefraction: None,
+            indexarr: None,
+            focused: true,
+            magnified: false,
+            ephemeral: false,
+            targetblockid: String::new(),
+            position: String::new(),
+        }
+    }
+
+    #[test]
+    fn layout_backend_actions_queued_appends_not_replaces() {
+        let s = store();
+        let tab = ws_tab(&s);
+        apply_event_to_wstore(
+            &Event::LayoutBackendActionsQueued {
+                tab_id: tab.clone(),
+                actions: serde_json::to_value(vec![action("a1", "b1")]).unwrap(),
+                correlation_id: "c1".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::LayoutBackendActionsQueued {
+                tab_id: tab.clone(),
+                actions: serde_json::to_value(vec![action("a2", "b2")]).unwrap(),
+                correlation_id: "c2".into(),
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        let pending = layout_of(&s, &tab).pendingbackendactions.unwrap();
+        assert_eq!(pending.len(), 2, "second event must APPEND, not replace");
+        assert_eq!(pending[0].actionid, "a1");
+        assert_eq!(pending[1].actionid, "a2");
+    }
+
+    #[test]
+    fn layout_backend_actions_queued_dedupes_on_double_apply() {
+        // Same event applied twice (sync dispatch + broadcast redelivery)
+        // must not duplicate the queued action.
+        let s = store();
+        let tab = ws_tab(&s);
+        let ev = Event::LayoutBackendActionsQueued {
+            tab_id: tab.clone(),
+            actions: serde_json::to_value(vec![action("a1", "b1")]).unwrap(),
+            correlation_id: "c1".into(),
+            version: 3,
+        };
+        apply_event_to_wstore(&ev, &s).unwrap();
+        apply_event_to_wstore(&ev, &s).unwrap();
+        let pending = layout_of(&s, &tab).pendingbackendactions.unwrap();
+        assert_eq!(pending.len(), 1, "double-apply must not duplicate by actionid");
+    }
+
+    #[test]
+    fn layout_backend_actions_queued_silent_when_tab_missing() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::LayoutBackendActionsQueued {
+                tab_id: "ghost".into(),
+                actions: serde_json::to_value(vec![action("a1", "b1")]).unwrap(),
+                correlation_id: "c1".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
     }
 }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -127,6 +127,14 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             block_id,
             correlation_id,
         } => layout::handle_layout_delete_node_by_block(state, tab_id, block_id, correlation_id),
+        // SPEC_864 Phase 4 — queue-append pass-through (the reducer does
+        // not model pendingbackendactions in TabRecord; the persist
+        // subscriber appends to db_layout from the event).
+        Command::LayoutQueueBackendActions {
+            tab_id,
+            actions,
+            correlation_id,
+        } => layout::handle_layout_queue_backend_actions(state, tab_id, actions, correlation_id),
         // Phase 3 — the remaining 7 layout-tree arms. Each resolves the
         // tab, calls the existing pure fn in `backend::layout`, runs
         // `balance_node` (matching the frontend's post-action normalize),
@@ -364,6 +372,7 @@ mod tests {
             | Event::LayoutSplitHorizontalApplied { version, .. }
             | Event::LayoutSplitVerticalApplied { version, .. }
             | Event::LayoutCleared { version, .. }
+            | Event::LayoutBackendActionsQueued { version, .. }
             | Event::LayoutTreeReplaced { version, .. } => *version,
         }
     }
@@ -2513,6 +2522,79 @@ mod tests {
         assert!(tab.rootnode.is_none(), "rootnode wiped");
         assert_eq!(tab.focused_node_id, "");
         assert_eq!(tab.magnified_node_id, "");
+    }
+
+    #[test]
+    fn layout_queue_backend_actions_passes_through_and_emits_event() {
+        let (mut state, tab_id) = fresh_tab();
+        let actions = serde_json::json!([{
+            "actiontype": "insert",
+            "actionid": "a1",
+            "blockid": "b1",
+            "nodesize": null,
+            "nodesizefraction": null,
+            "indexarr": null,
+            "focused": true,
+            "magnified": false,
+            "ephemeral": false,
+            "targetblockid": "",
+            "position": "",
+        }]);
+        let events = update(
+            &mut state,
+            Command::LayoutQueueBackendActions {
+                tab_id: tab_id.clone(),
+                actions: actions.clone(),
+                correlation_id: "corr-q1".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::LayoutBackendActionsQueued {
+                tab_id: ev_tab_id,
+                actions: ev_actions,
+                correlation_id,
+                ..
+            } => {
+                assert_eq!(ev_tab_id, &tab_id);
+                assert_eq!(ev_actions, &actions);
+                assert_eq!(correlation_id, "corr-q1");
+            }
+            other => panic!("expected LayoutBackendActionsQueued, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn layout_queue_backend_actions_unknown_tab_emits_error() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::LayoutQueueBackendActions {
+                tab_id: "nope".into(),
+                actions: serde_json::json!([{}]),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    #[test]
+    fn layout_queue_backend_actions_empty_array_emits_error() {
+        let (mut state, tab_id) = fresh_tab();
+        let events = update(
+            &mut state,
+            Command::LayoutQueueBackendActions {
+                tab_id,
+                actions: serde_json::json!([]),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], Event::Error { .. }));
     }
 
     #[test]

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -370,6 +370,46 @@ pub(super) fn handle_layout_delete_node_by_block(
     handle_layout_delete_node(state, tab_id, node_id, correlation_id)
 }
 
+/// SPEC_864 Phase 4 — append backend actions to a tab's
+/// `pendingbackendactions` queue. The reducer does NOT model the queue
+/// in `TabRecord` (it is a transient backend→frontend mailbox the
+/// frontend drains via REPLACE-clear slices, not layout-tree state), so
+/// this arm only validates and passes the payload through; the persist
+/// subscriber APPENDs it to `LayoutState.pendingbackendactions`.
+///
+/// `actions` must be a non-empty JSON array of `LayoutActionData`
+/// objects (the type lives in `agentmux-srv::backend::obj`, not the
+/// common crate — hence the raw-value carriage).
+pub(super) fn handle_layout_queue_backend_actions(
+    state: &mut State,
+    tab_id: String,
+    actions: serde_json::Value,
+    correlation_id: String,
+) -> Vec<Event> {
+    if !state.tabs.contains_key(&tab_id) {
+        return unknown_tab(state, "LayoutQueueBackendActions", &tab_id);
+    }
+    match actions.as_array() {
+        Some(arr) if !arr.is_empty() => {}
+        _ => {
+            return op_error(
+                state,
+                format!(
+                    "LayoutQueueBackendActions: actions must be a non-empty JSON array (tab {})",
+                    tab_id
+                ),
+            )
+        }
+    }
+    let v = state.bump_version();
+    vec![Event::LayoutBackendActionsQueued {
+        tab_id,
+        actions,
+        correlation_id,
+        version: v,
+    }]
+}
+
 // ── Phase 3 — remaining structural arms ─────────────────────────────────────
 //
 // Each arm resolves the tab, calls the existing pure fn in `backend::layout`,

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -283,26 +283,31 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // The frontend's LayoutModel watches pendingbackendactions on the
                 // LayoutState and applies them via treeReducer — same mechanism
                 // used by cross-window drag-and-drop (dnd.rs).
+                // SPEC_864 Phase 4 — append through the reducer (single
+                // writer of db_layout). Best-effort like the store-direct
+                // write it replaces.
                 {
-                    let tab: Tab = wstore.must_get(&tab_id)
-                        .map_err(|e| format!("agent.open: reload tab: {e}"))?;
-                    if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
-                        let mut actions = layout.pendingbackendactions.take().unwrap_or_default();
-                        actions.push(obj::LayoutActionData {
-                            actiontype: "insert".to_string(),
-                            actionid: uuid::Uuid::new_v4().to_string(),
-                            blockid: block_id.clone(),
-                            nodesize: None,
-                            nodesizefraction: None,
-                            indexarr: None,
-                            focused: true,
-                            magnified: false,
-                            ephemeral: false,
-                            targetblockid: String::new(),
-                            position: String::new(),
-                        });
-                        layout.pendingbackendactions = Some(actions);
-                        let _ = wstore.update(&mut layout);
+                    let action = obj::LayoutActionData {
+                        actiontype: "insert".to_string(),
+                        actionid: uuid::Uuid::new_v4().to_string(),
+                        blockid: block_id.clone(),
+                        nodesize: None,
+                        nodesizefraction: None,
+                        indexarr: None,
+                        focused: true,
+                        magnified: false,
+                        ephemeral: false,
+                        targetblockid: String::new(),
+                        position: String::new(),
+                    };
+                    if let Err(e) = crate::server::service::queue_layout_actions_via_reducer(
+                        &app_state,
+                        &tab_id,
+                        vec![action],
+                    )
+                    .await
+                    {
+                        tracing::warn!("agent.open: layout action enqueue failed: {e}");
                     }
                 }
 

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -127,26 +127,31 @@ pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<Pan
     );
     let focused = cmd.focus.unwrap_or(true);
 
+    // SPEC_864 Phase 4 — append through the reducer (single writer of
+    // db_layout). Best-effort like the store-direct write it replaces:
+    // a failure leaves the block created but not laid out.
     {
-        let tab: Tab = wstore.must_get(&tab_id)
-            .map_err(|e| format!("pane.open: reload tab: {e}"))?;
-        if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
-            let mut actions = layout.pendingbackendactions.take().unwrap_or_default();
-            actions.push(obj::LayoutActionData {
-                actiontype,
-                actionid: uuid::Uuid::new_v4().to_string(),
-                blockid: block_id.clone(),
-                nodesize: None,
-                nodesizefraction: None,
-                indexarr: None,
-                focused,
-                magnified: false,
-                ephemeral: false,
-                targetblockid,
-                position,
-            });
-            layout.pendingbackendactions = Some(actions);
-            let _ = wstore.update(&mut layout);
+        let action = obj::LayoutActionData {
+            actiontype,
+            actionid: uuid::Uuid::new_v4().to_string(),
+            blockid: block_id.clone(),
+            nodesize: None,
+            nodesizefraction: None,
+            indexarr: None,
+            focused,
+            magnified: false,
+            ephemeral: false,
+            targetblockid,
+            position,
+        };
+        if let Err(e) = crate::server::service::queue_layout_actions_via_reducer(
+            state,
+            &tab_id,
+            vec![action],
+        )
+        .await
+        {
+            tracing::warn!("pane.open: layout action enqueue failed: {e}");
         }
     }
 

--- a/agentmux-srv/src/server/service/layout_helpers.rs
+++ b/agentmux-srv/src/server/service/layout_helpers.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Layout-tree + pending-action writers used by the tear-off / promote /
-//! redock handlers. Layout state migration is E.4 territory; until then these
-//! write straight to wstore. `setup_torn_off_block_layout` is re-exported
-//! crate-wide (the pane app-API uses it).
+//! redock handlers. SPEC_864 Phase 3/4 — all of them route through the
+//! reducer (`seed_layout_via_reducer` / `queue_layout_actions_via_reducer`);
+//! nothing here writes wstore directly anymore.
+//! `setup_torn_off_block_layout` is re-exported crate-wide (the pane
+//! app-API uses it).
 
 use crate::backend::obj::*;
-use crate::backend::storage::store::Store;
 
 /// Phase E.5.5 — set up the layout tree for a tab that just received
 /// its first block via the TearOffBlock saga. Called from the
@@ -74,15 +75,15 @@ pub(crate) async fn setup_torn_off_block_layout(
 /// channel for "backend wants the frontend to mutate its layout
 /// tree". Source-delete on tear-off uses the same channel via
 /// `queue_source_layout_delete`.
-pub(super) fn queue_target_layout_insert(
-    store: &Store,
+///
+/// SPEC_864 Phase 4 — appends through the reducer
+/// (`queue_layout_actions_via_reducer`), not `store.update`.
+pub(super) async fn queue_target_layout_insert(
+    state: &super::super::AppState,
     target_tab_id: &str,
     block_id: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let target_tab = store.must_get::<Tab>(target_tab_id)?;
-    let mut target_layout = store.must_get::<LayoutState>(&target_tab.layoutstate)?;
-    let mut actions = target_layout.pendingbackendactions.take().unwrap_or_default();
-    actions.push(LayoutActionData {
+) -> Result<(), String> {
+    let action = LayoutActionData {
         // Matches `LayoutTreeActionType.InsertNode = "insert"` in
         // `frontend/layout/lib/types.ts:73`.
         actiontype: "insert".to_string(),
@@ -96,10 +97,9 @@ pub(super) fn queue_target_layout_insert(
         ephemeral: false,
         targetblockid: String::new(),
         position: String::new(),
-    });
-    target_layout.pendingbackendactions = Some(actions);
-    store.update(&mut target_layout)?;
-    Ok(())
+    };
+    super::reducer_helpers::queue_layout_actions_via_reducer(state, target_tab_id, vec![action])
+        .await
 }
 
 /// Phase 4b/4c — enqueue a directional split action on the TARGET tab's
@@ -120,13 +120,13 @@ pub(super) fn queue_target_layout_insert(
 /// (`layoutTree.ts`). Inner directions use 0.5 (50/50, matching the ghost's
 /// half-leaf); outer directions use 0.2 (matching the ghost's exact `leaf/5`
 /// band — see `ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md`).
-pub(super) fn queue_target_layout_split(
-    store: &Store,
+pub(super) async fn queue_target_layout_split(
+    state: &super::super::AppState,
     target_tab_id: &str,
     block_id: &str,
     target_block_id: &str,
     dir: u8,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), String> {
     const INNER_FRACTION: f64 = 0.5;
     const OUTER_FRACTION: f64 = 0.2;
     let (actiontype, position, nodesizefraction): (&str, &str, f64) = match dir {
@@ -139,12 +139,9 @@ pub(super) fn queue_target_layout_split(
         1 => ("splithorizontal", "after",  INNER_FRACTION),
         5 => ("splithorizontal", "after",  OUTER_FRACTION),
         // Center (8) or unknown — caller should use queue_target_layout_insert.
-        _ => return queue_target_layout_insert(store, target_tab_id, block_id),
+        _ => return queue_target_layout_insert(state, target_tab_id, block_id).await,
     };
-    let target_tab = store.must_get::<Tab>(target_tab_id)?;
-    let mut target_layout = store.must_get::<LayoutState>(&target_tab.layoutstate)?;
-    let mut actions = target_layout.pendingbackendactions.take().unwrap_or_default();
-    actions.push(LayoutActionData {
+    let action = LayoutActionData {
         actiontype: actiontype.to_string(),
         actionid: uuid::Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
@@ -156,10 +153,9 @@ pub(super) fn queue_target_layout_split(
         ephemeral: false,
         targetblockid: target_block_id.to_string(),
         position: position.to_string(),
-    });
-    target_layout.pendingbackendactions = Some(actions);
-    store.update(&mut target_layout)?;
-    Ok(())
+    };
+    super::reducer_helpers::queue_layout_actions_via_reducer(state, target_tab_id, vec![action])
+        .await
 }
 
 /// Phase E.5.5 — append a layout-delete action to the source tab's
@@ -167,15 +163,12 @@ pub(super) fn queue_target_layout_split(
 /// frontend tears the moved block out of its layout tree on next
 /// poll. Mirrors the action-queueing portion of
 /// `wcore::tear_off_block`. Layout migration is E.4.
-pub(super) fn queue_source_layout_delete(
-    store: &Store,
+pub(super) async fn queue_source_layout_delete(
+    state: &super::super::AppState,
     source_tab_id: &str,
     block_id: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let source_tab = store.must_get::<Tab>(source_tab_id)?;
-    let mut source_layout = store.must_get::<LayoutState>(&source_tab.layoutstate)?;
-    let mut actions = source_layout.pendingbackendactions.take().unwrap_or_default();
-    actions.push(LayoutActionData {
+) -> Result<(), String> {
+    let action = LayoutActionData {
         actiontype: "delete".to_string(),
         actionid: uuid::Uuid::new_v4().to_string(),
         blockid: block_id.to_string(),
@@ -187,47 +180,76 @@ pub(super) fn queue_source_layout_delete(
         ephemeral: false,
         targetblockid: String::new(),
         position: String::new(),
-    });
-    source_layout.pendingbackendactions = Some(actions);
-    store.update(&mut source_layout)?;
-    Ok(())
+    };
+    super::reducer_helpers::queue_layout_actions_via_reducer(state, source_tab_id, vec![action])
+        .await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::server::tests::test_state;
+    use agentmux_common::ipc::{Command, Event};
 
-    fn seeded_tab_id(state: &crate::server::AppState) -> String {
-        state
-            .wstore
-            .get_all::<Tab>()
+    /// SPEC_864 Phase 4 — the queue helpers dispatch through the reducer,
+    /// which rejects unknown tabs, so tests must create the tab via
+    /// reducer commands (same pattern as
+    /// `layout_seeders_route_through_reducer_coherently` in server tests)
+    /// rather than reading the wcore-seeded tab.
+    async fn reducer_known_tab(state: &crate::server::AppState) -> String {
+        async fn dispatch_apply(state: &crate::server::AppState, cmd: Command) -> Vec<Event> {
+            let events = super::super::reducer_helpers::dispatch_to_reducer(state, cmd).await;
+            for ev in &events {
+                crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+            }
+            events
+        }
+        let ws_evs = dispatch_apply(state, Command::CreateWorkspace { name: "ws".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            state,
+            Command::CreateTab {
+                workspace_id: ws_id,
+                name: "t1".into(),
+            },
+        )
+        .await;
+        tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
             .unwrap()
-            .into_iter()
-            .next()
-            .expect("seeded tab")
-            .oid
+    }
+
+    fn pending_actions(state: &crate::server::AppState, tab_id: &str) -> Vec<LayoutActionData> {
+        let tab = state.wstore.must_get::<Tab>(tab_id).unwrap();
+        let layout = state.wstore.must_get::<LayoutState>(&tab.layoutstate).unwrap();
+        layout.pendingbackendactions.unwrap_or_default()
     }
 
     fn last_action(state: &crate::server::AppState, tab_id: &str) -> LayoutActionData {
-        let tab = state.wstore.must_get::<Tab>(tab_id).unwrap();
-        let layout = state.wstore.must_get::<LayoutState>(&tab.layoutstate).unwrap();
-        layout
-            .pendingbackendactions
-            .unwrap_or_default()
+        pending_actions(state, tab_id)
             .last()
             .expect("an action was queued")
             .clone()
     }
 
-    #[test]
-    fn queue_target_layout_split_maps_every_direction_to_an_exact_fraction() {
+    #[tokio::test]
+    async fn queue_target_layout_split_maps_every_direction_to_an_exact_fraction() {
         // Phase 4c: every non-Center direction must carry `nodesizefraction`
         // (not the old hardcoded-integer `nodesize` guess) so the frontend
         // can derive an exact size from the target's live size. See
         // ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md.
         let state = test_state();
-        let tab_id = seeded_tab_id(&state);
+        let tab_id = reducer_known_tab(&state).await;
 
         let cases: &[(u8, &str, &str, f64)] = &[
             (0, "splitvertical", "before", 0.5),
@@ -241,7 +263,9 @@ mod tests {
         ];
 
         for &(dir, expected_type, expected_pos, expected_fraction) in cases {
-            queue_target_layout_split(&state.wstore, &tab_id, "new-block", "target-block", dir).unwrap();
+            queue_target_layout_split(&state, &tab_id, "new-block", "target-block", dir)
+                .await
+                .unwrap();
             let action = last_action(&state, &tab_id);
             assert_eq!(action.actiontype, expected_type, "dir={dir}");
             assert_eq!(action.position, expected_pos, "dir={dir}");
@@ -249,18 +273,33 @@ mod tests {
             assert_eq!(action.nodesize, None, "dir={dir}: absolute nodesize is no longer used for splits");
             assert_eq!(action.targetblockid, "target-block");
         }
+        // 8 splits queued → 8 actions APPENDED (not replaced).
+        assert_eq!(pending_actions(&state, &tab_id).len(), cases.len());
     }
 
-    #[test]
-    fn queue_target_layout_split_falls_back_to_insert_for_center_and_unknown_dirs() {
+    #[tokio::test]
+    async fn queue_target_layout_split_falls_back_to_insert_for_center_and_unknown_dirs() {
         let state = test_state();
-        let tab_id = seeded_tab_id(&state);
+        let tab_id = reducer_known_tab(&state).await;
 
         for dir in [8u8, 200u8] {
-            queue_target_layout_split(&state.wstore, &tab_id, "new-block", "target-block", dir).unwrap();
+            queue_target_layout_split(&state, &tab_id, "new-block", "target-block", dir)
+                .await
+                .unwrap();
             let action = last_action(&state, &tab_id);
             assert_eq!(action.actiontype, "insert", "dir={dir}");
             assert_eq!(action.nodesizefraction, None, "dir={dir}");
         }
+    }
+
+    /// SPEC_864 Phase 4 — queue writers hit the reducer's unknown-tab
+    /// validation instead of silently writing wstore.
+    #[tokio::test]
+    async fn queue_helpers_error_on_reducer_unknown_tab() {
+        let state = test_state();
+        let err = queue_source_layout_delete(&state, "ghost-tab", "b1")
+            .await
+            .expect_err("unknown tab must error");
+        assert!(err.contains("unknown tab"), "got: {err}");
     }
 }

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -40,7 +40,9 @@ pub(crate) use introspect::{
 };
 pub(crate) use layout_helpers::setup_torn_off_block_layout;
 pub(crate) use object_helpers::{schedule_agent_zoom_mirror, update_object_meta};
-pub(crate) use reducer_helpers::{dispatch_to_reducer, publish_events, seed_layout_via_reducer};
+pub(crate) use reducer_helpers::{
+    dispatch_to_reducer, publish_events, queue_layout_actions_via_reducer, seed_layout_via_reducer,
+};
 
 pub(super) async fn handle_service(
     State(state): State<AppState>,

--- a/agentmux-srv/src/server/service/reducer_helpers.rs
+++ b/agentmux-srv/src/server/service/reducer_helpers.rs
@@ -155,6 +155,71 @@ pub(crate) async fn seed_layout_via_reducer(
     Ok(())
 }
 
+/// SPEC_864 Phase 4 — single-writer queue append. Dispatch a
+/// `LayoutQueueBackendActions` and persist the resulting
+/// `LayoutBackendActionsQueued` inside ONE hold of the reducer mutex
+/// (same critical-section contract as `seed_layout_via_reducer`), so a
+/// concurrent frontend ACK slice (`LayoutSetTree` REPLACE) can't
+/// interleave between dispatch and persist. Replaces the five
+/// store-direct `pendingbackendactions` writers (`layout_helpers`'
+/// insert/split/delete queuers + the two inline app_api sites).
+///
+/// No rollback arm: the reducer does not model the queue in
+/// `TabRecord` (pass-through validation only), so a SQLite apply
+/// failure leaves no reducer↔SQLite divergence to repair — just
+/// return the error.
+///
+/// `actions` must be non-empty; the reducer rejects an empty array.
+pub(crate) async fn queue_layout_actions_via_reducer(
+    state: &AppState,
+    tab_id: &str,
+    actions: Vec<crate::backend::obj::LayoutActionData>,
+) -> Result<(), String> {
+    let store = &state.wstore;
+    let actions_json = serde_json::to_value(&actions)
+        .map_err(|e| format!("queue actions serialize failed: {}", e))?;
+    let cmd = agentmux_common::ipc::Command::LayoutQueueBackendActions {
+        tab_id: tab_id.to_string(),
+        actions: actions_json,
+        correlation_id: String::new(),
+    };
+
+    let mut apply_err: Option<String> = None;
+    let events = {
+        let mut s = state.srv_state.lock().await;
+        let ctx = crate::reducer::Ctx {
+            now_rfc3339: chrono::Utc::now().to_rfc3339(),
+            conn_id: 0,
+            registered_pid: None,
+        };
+        let events = crate::reducer::update(&mut s, cmd, &ctx);
+        let has_error = events
+            .iter()
+            .any(|e| matches!(e, agentmux_common::ipc::Event::Error { .. }));
+        if !has_error {
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    apply_err = Some(e.to_string());
+                    break;
+                }
+            }
+        }
+        events
+    };
+
+    if let Some(err_msg) = events.iter().find_map(|e| match e {
+        agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+        _ => None,
+    }) {
+        return Err(err_msg);
+    }
+    if let Some(err) = apply_err {
+        return Err(format!("queue append SQLite write failed: {}", err));
+    }
+    publish_events(state, &events);
+    Ok(())
+}
+
 /// Existence check used by `DeleteWorkspace` to decide whether to
 /// run the wcore delete path. Propagates `StoreError` so the caller
 /// can surface real I/O / corruption failures instead of

--- a/agentmux-srv/src/server/service/workspace.rs
+++ b/agentmux-srv/src/server/service/workspace.rs
@@ -730,7 +730,7 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
                 tracing::warn!(new_tab = %new_tab_oid, "PromoteBlockToTab: layout setup failed: {}", e);
             }
             // Source tab: queue layout-delete action.
-            if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
+            if let Err(e) = queue_source_layout_delete(state, &source_tab_id, &block_id).await {
                 tracing::warn!(source_tab = %source_tab_id, "PromoteBlockToTab: source layout delete-action enqueue failed: {}", e);
             }
             // Set the new tab as active in the workspace via reducer.
@@ -1102,14 +1102,14 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
 
             // Layout setup for the new tab — make the moved block its
             // single root node so the frontend renders it. Mirrors
-            // wcore::tear_off_block. Best-effort; layout migration is
-            // E.4 territory and not yet reducer-routed.
+            // wcore::tear_off_block. Best-effort; reducer-routed
+            // (SPEC_864 Phase 3 seed / Phase 4 queue).
             if let Err(e) = setup_torn_off_block_layout(state, &new_tab_oid, &block_id).await {
                 tracing::warn!(new_tab = %new_tab_oid, "TearOffBlock: layout setup failed: {} (block in tab but layout malformed)", e);
             }
             // Source tab: queue a layout-delete action so the source
             // window's frontend removes the node from its tree.
-            if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
+            if let Err(e) = queue_source_layout_delete(state, &source_tab_id, &block_id).await {
                 tracing::warn!(source_tab = %source_tab_id, "TearOffBlock: source layout delete-action enqueue failed: {}", e);
             }
 
@@ -1247,9 +1247,9 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
             // retry; no visible change has propagated to the renderers yet.
             let target_layout_result = match (target_block_id.as_deref(), direction) {
                 (Some(tbid), Some(dir)) => {
-                    queue_target_layout_split(store, &target_tab_id, &block_id, tbid, dir)
+                    queue_target_layout_split(state, &target_tab_id, &block_id, tbid, dir).await
                 }
-                _ => queue_target_layout_insert(store, &target_tab_id, &block_id),
+                _ => queue_target_layout_insert(state, &target_tab_id, &block_id).await,
             };
             if let Err(e) = target_layout_result {
                 tracing::error!(
@@ -1261,7 +1261,7 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
                     "redock layout action failed: {e}"
                 ));
             }
-            if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
+            if let Err(e) = queue_source_layout_delete(state, &source_tab_id, &block_id).await {
                 tracing::error!(
                     source_tab = %source_tab_id,
                     "RedockFloatingPane: source layout delete failed — aborting broadcast: {}",
@@ -1273,14 +1273,15 @@ pub(super) async fn handle_workspace_service(state: &AppState, call: &WebCallTyp
             }
 
             let mut updates = Vec::new();
-            // Layout updates MUST come first — `append_block_to_target_layout`
-            // and `queue_source_layout_delete` write straight to wstore via
-            // `store.update`, which is NOT auto-broadcast (only the SQLite
-            // row gets a new version). Without these entries in the response,
-            // the target window's frontend never sees the new leaf and
-            // renders nothing; the source's pending delete action never
-            // gets pulled either. Both layouts are read AFTER the helpers
-            // run so we capture the fresh state.
+            // Layout updates MUST come first — the queue helpers persist
+            // via the reducer route (SPEC_864 Phase 4), whose SQLite write
+            // is NOT auto-broadcast (only the row gets a new version).
+            // Without these entries in the response, the target window's
+            // frontend never sees the new leaf and renders nothing; the
+            // source's pending delete action never gets pulled either.
+            // Both layouts are read AFTER the helpers return — the
+            // helpers persist synchronously inside the reducer lock, so
+            // the re-read always sees the appended actions.
             if let Ok(src_tab) = store.must_get::<Tab>(&source_tab_id) {
                 if let Ok(src_layout) = store.must_get::<LayoutState>(&src_tab.layoutstate) {
                     updates.push(WaveObjUpdate {


### PR DESCRIPTION
Continues the SPEC_864 single-writer rollout after site #6 (#1973) and the Phase-4 handoff in #1972 (`docs/handoff/HANDOFF_864_AUTHORITY_AND_WINDOW_LIFECYCLE_2026_07_05.md`).

## What

Routes the last direct-`store.update` writers of `LayoutState.pendingbackendactions` through the reducer, so `db_layout` stays single-writer end to end (not just the tree, the queue too).

- `agentmux-common::ipc`: `Command::LayoutQueueBackendActions` / `Event::LayoutBackendActionsQueued`. `actions` is carried as a JSON `Value` (array of `LayoutActionData`) — that type lives in `agentmux-srv::backend::obj`, not the common crate, so a raw-value pass-through avoids a cross-crate type move for a Phase-4-scoped change.
- `reducer/layout.rs::handle_layout_queue_backend_actions` — pass-through validation only (unknown tab → error, empty array → error); the reducer does not model the queue in `TabRecord` since it's a backend→frontend mailbox, not tree state.
- `persist_subscriber.rs::apply_layout_backend_actions_queued` — **APPENDs** to `pendingbackendactions` (unlike `LayoutTreeReplaced`'s slice path, which REPLACEs — that's how the frontend ACKs the queue by pushing without processed actions). Dedupes by `actionid` so the sync-dispatch-then-broadcast-redelivery double-apply doesn't duplicate a queued action.
- `reducer_helpers::queue_layout_actions_via_reducer` — mirrors `seed_layout_via_reducer`'s one-lock critical section (dispatch → apply to wstore → publish, all inside one `srv_state` lock hold). No rollback arm: the reducer holds no queue state, so a SQLite apply failure leaves nothing to unwind.
- Converted all five writer sites: `layout_helpers`'s `queue_target_layout_insert` / `queue_target_layout_split` / `queue_source_layout_delete` (now async, taking `&AppState`), the `pane.open` docked-insert path (`app_api/mod.rs`), and the `agent.open` path (`app_api/agent_open.rs`) — the latter wasn't in the original Phase-4 site count in the handoff doc; found via grep.
- Fixed the 6 non-exhaustive-match compile sites the new `Command`/`Event` variants triggered (launcher's two srv-pipe-only rejection groups + their tests, both crates' `event_log.rs` version matchers, srv's `reducer.rs` version matcher).

## Testing

- `cargo test -p agentmux-srv` — 1321 passed, 0 failed (was 1314 pre-#1973; +7 net from this PR's new reducer/persist/helper tests).
- `cargo test -p agentmux-launcher` — 199 passed, 0 failed.
- New coverage: reducer pass-through + unknown-tab + empty-array error (3 tests), persist-subscriber append-not-replace + dedupe-on-double-apply + silent-when-tab-missing (3 tests), plus the pre-existing `layout_helpers` unit tests updated from sync/`store.update` to async/reducer-routed and extended with an append-count assertion and an unknown-tab error case.

## Next

Phase 5 (delete backstops + DoD checks) per the handoff roadmap.

<!-- agentmux:agent_id=agenta -->
