### PR TITLE
feat(swarm): push periodic Haiku activity summaries per agent

### DIFF
--- a/.changesets/1783309517-feat-swarm-push-periodic-haiku-activity-summaries-per-agent-ar8e.md
+++ b/.changesets/1783309517-feat-swarm-push-periodic-haiku-activity-summaries-per-agent-ar8e.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): push periodic Haiku activity summaries per agent

--- a/agentmux-srv/src/backend/reactive/activity_watcher.rs
+++ b/agentmux-srv/src/backend/reactive/activity_watcher.rs
@@ -11,10 +11,18 @@
 //!   - skipped entirely for agents whose controller isn't `STATUS_RUNNING`
 //!     (an idle/stopped pane costs nothing)
 //!   - skipped when the block's `output` FileStore size hasn't changed since
-//!     the last summary (nothing new happened; no point re-summarizing)
+//!     the last *successful* summary (nothing new happened; no point
+//!     re-summarizing) — a failed/empty attempt does not mark the size as
+//!     seen, so the next tick retries rather than being permanently
+//!     suppressed until the output happens to grow again
+//!   - skipped when a summarization for that block is already in flight
+//!     (guards against a slow call still running when the next tick fires)
 //!   - capped at `MAX_CONCURRENT_SUMMARIES` simultaneous Haiku CLI spawns
+//!   - per-block bookkeeping is pruned each tick against the current
+//!     registration list, so a disconnected/unregistered agent's entry
+//!     doesn't linger for the rest of the process's lifetime
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -45,9 +53,20 @@ pub const EVENT_AGENT_SUMMARY: &str = "agent:summary";
 pub async fn run_agent_summary_loop(wstore: Arc<Store>, filestore: Arc<FileStore>, broker: Arc<Broker>) {
     let mut ticker = interval(Duration::from_secs(SWEEP_INTERVAL_SECS));
     let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_SUMMARIES));
-    // block_id -> last output size we summarized at, so idle agents (no new
-    // output since last sweep) are skipped instead of re-billed every tick.
+    // block_id -> last output size we *successfully* summarized at, so idle
+    // agents (no new output since the last summary) are skipped instead of
+    // re-billed every tick. An entry is only written after a non-empty
+    // summary comes back (see the spawned task below) — a transient failure
+    // (CLI error, missing `cmd` in meta, missing block) leaves no entry, so
+    // the next tick retries instead of being permanently suppressed until
+    // the output size happens to change again.
     let last_seen_size: Arc<Mutex<HashMap<String, i64>>> = Arc::new(Mutex::new(HashMap::new()));
+    // block_ids with a summarization currently in flight, so a slow call
+    // (up to the 15s CLI timeout) doesn't get double-dispatched by the next
+    // 20s tick before last_seen_size has a chance to reflect its result.
+    // Self-cleaning: every insert below has a matching remove once that same
+    // spawned task's call resolves, on every exit path.
+    let in_flight: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
 
     // Shared generation counter for the Ambient Model Call gateway — only
     // needs to strictly increase per (block_id, purpose) key over time, so
@@ -60,7 +79,16 @@ pub async fn run_agent_summary_loop(wstore: Arc<Store>, filestore: Arc<FileStore
         ticker.tick().await;
         tick += 1;
 
-        for agent in get_global_handler().list_agents() {
+        let agents = get_global_handler().list_agents();
+
+        // Drop last_seen_size entries for agents that unregistered/disconnected
+        // since the last sweep, so this map stays bounded by the current agent
+        // count instead of growing for every block_id ever seen in the
+        // process's lifetime.
+        let registered: HashSet<String> = agents.iter().map(|a| a.block_id.clone()).collect();
+        last_seen_size.lock().unwrap().retain(|block_id, _| registered.contains(block_id));
+
+        for agent in agents {
             let block_id = agent.block_id.clone();
 
             let status = match get_block_controller_status(&block_id) {
@@ -75,28 +103,41 @@ pub async fn run_agent_summary_loop(wstore: Arc<Store>, filestore: Arc<FileStore
                 Ok(Some(wf)) => wf.size,
                 _ => continue,
             };
-            {
-                let mut seen = last_seen_size.lock().unwrap();
-                if seen.get(&block_id) == Some(&current_size) {
-                    continue; // no new output since the last summary — skip
-                }
-                seen.insert(block_id.clone(), current_size);
+            if last_seen_size.lock().unwrap().get(&block_id) == Some(&current_size) {
+                continue; // already summarized this exact output size — skip
+            }
+            if !in_flight.lock().unwrap().insert(block_id.clone()) {
+                continue; // a summarization for this block is already running
             }
 
             let wstore = wstore.clone();
             let filestore = filestore.clone();
             let broker = broker.clone();
             let semaphore = semaphore.clone();
+            let last_seen_size = last_seen_size.clone();
+            let in_flight = in_flight.clone();
             let agent_id = agent.agent_id.clone();
 
             tokio::spawn(async move {
-                let Ok(_permit) = semaphore.acquire().await else { return };
-
-                let Some((summary, _tokens)) = crate::server::app_api::session::generate_pushed_activity_summary(
-                    &wstore, &filestore, &block_id, tick, WORD_TARGET,
-                ).await else {
+                let Ok(_permit) = semaphore.acquire().await else {
+                    in_flight.lock().unwrap().remove(&block_id);
                     return;
                 };
+
+                let result = crate::server::app_api::session::generate_pushed_activity_summary(
+                    &wstore, &filestore, &block_id, tick, WORD_TARGET,
+                ).await;
+
+                in_flight.lock().unwrap().remove(&block_id);
+
+                let Some((summary, _tokens)) = result else {
+                    // Leave last_seen_size untouched so a future tick retries
+                    // this block — whether the failure was transient (CLI
+                    // hiccup, stale-on-arrival via the Ambient Model Call
+                    // gateway) or persistent (no CLI path in meta yet).
+                    return;
+                };
+                last_seen_size.lock().unwrap().insert(block_id.clone(), current_size);
 
                 let ts = SystemTime::now()
                     .duration_since(UNIX_EPOCH)

--- a/agentmux-srv/src/backend/reactive/activity_watcher.rs
+++ b/agentmux-srv/src/backend/reactive/activity_watcher.rs
@@ -1,0 +1,121 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pushed per-agent activity summaries: periodically runs the same
+//! Haiku-powered digest used by `session:activity_summary` for every
+//! registered reactive agent that is actively running, and publishes the
+//! result as an `agent:summary` WaveEvent — so panes (the swarm feed, in
+//! particular) can show a live one-liner without polling.
+//!
+//! Cost controls:
+//!   - skipped entirely for agents whose controller isn't `STATUS_RUNNING`
+//!     (an idle/stopped pane costs nothing)
+//!   - skipped when the block's `output` FileStore size hasn't changed since
+//!     the last summary (nothing new happened; no point re-summarizing)
+//!   - capped at `MAX_CONCURRENT_SUMMARIES` simultaneous Haiku CLI spawns
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::Semaphore;
+use tokio::time::interval;
+
+use crate::backend::blockcontroller::{get_block_controller_status, STATUS_RUNNING};
+use crate::backend::storage::filestore::FileStore;
+use crate::backend::storage::store::Store;
+use crate::backend::wps::{Broker, WaveEvent};
+
+use super::get_global_handler;
+
+/// How often to sweep registered agents for a fresh summary.
+const SWEEP_INTERVAL_SECS: u64 = 20;
+
+/// Max simultaneous Haiku CLI spawns across all agents.
+const MAX_CONCURRENT_SUMMARIES: usize = 2;
+
+/// Word budget for the pushed summary (a bit tighter than the pull RPC's
+/// default, since this renders in a narrow swarm-tree row rather than a
+/// pane title).
+const WORD_TARGET: u32 = 12;
+
+pub const EVENT_AGENT_SUMMARY: &str = "agent:summary";
+
+/// Run the pushed-summary sweep loop. Never returns.
+pub async fn run_agent_summary_loop(wstore: Arc<Store>, filestore: Arc<FileStore>, broker: Arc<Broker>) {
+    let mut ticker = interval(Duration::from_secs(SWEEP_INTERVAL_SECS));
+    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_SUMMARIES));
+    // block_id -> last output size we summarized at, so idle agents (no new
+    // output since last sweep) are skipped instead of re-billed every tick.
+    let last_seen_size: Arc<Mutex<HashMap<String, i64>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    // Shared generation counter for the Ambient Model Call gateway — only
+    // needs to strictly increase per (block_id, purpose) key over time, so
+    // one counter incremented once per tick and reused across every block
+    // checked in that tick is sufficient (different block_ids are different
+    // gateway keys and never interact).
+    let mut tick: u64 = 0;
+
+    loop {
+        ticker.tick().await;
+        tick += 1;
+
+        for agent in get_global_handler().list_agents() {
+            let block_id = agent.block_id.clone();
+
+            let status = match get_block_controller_status(&block_id) {
+                Some(s) => s,
+                None => continue,
+            };
+            if status.shellprocstatus != STATUS_RUNNING || !status.is_agent_pane {
+                continue;
+            }
+
+            let current_size = match filestore.stat(&block_id, "output") {
+                Ok(Some(wf)) => wf.size,
+                _ => continue,
+            };
+            {
+                let mut seen = last_seen_size.lock().unwrap();
+                if seen.get(&block_id) == Some(&current_size) {
+                    continue; // no new output since the last summary — skip
+                }
+                seen.insert(block_id.clone(), current_size);
+            }
+
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            let broker = broker.clone();
+            let semaphore = semaphore.clone();
+            let agent_id = agent.agent_id.clone();
+
+            tokio::spawn(async move {
+                let Ok(_permit) = semaphore.acquire().await else { return };
+
+                let Some((summary, _tokens)) = crate::server::app_api::session::generate_pushed_activity_summary(
+                    &wstore, &filestore, &block_id, tick, WORD_TARGET,
+                ).await else {
+                    return;
+                };
+
+                let ts = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+
+                broker.publish(WaveEvent {
+                    event: EVENT_AGENT_SUMMARY.to_string(),
+                    scopes: vec![format!("block:{}", block_id)],
+                    sender: String::new(),
+                    persist: 0,
+                    data: Some(serde_json::json!({
+                        "agentId": agent_id,
+                        "blockId": block_id,
+                        "summary": summary,
+                        "ts": ts,
+                    })),
+                });
+            });
+        }
+    }
+}

--- a/agentmux-srv/src/backend/reactive/activity_watcher.rs
+++ b/agentmux-srv/src/backend/reactive/activity_watcher.rs
@@ -7,6 +7,12 @@
 //! result as an `agent:summary` WaveEvent — so panes (the swarm feed, in
 //! particular) can show a live one-liner without polling.
 //!
+//! Each call goes through `app_api::session::generate_pushed_activity_summary`,
+//! which routes it through the Ambient Model Call gateway (`crate::ambient`)
+//! under its own purpose tag — distinct from the pull RPC's, so a periodic
+//! background summary never contends with a live, user-facing pane-header
+//! request for the same block.
+//!
 //! Cost controls:
 //!   - skipped entirely for agents whose controller isn't `STATUS_RUNNING`
 //!     (an idle/stopped pane costs nothing)
@@ -42,9 +48,11 @@ const SWEEP_INTERVAL_SECS: u64 = 20;
 /// Max simultaneous Haiku CLI spawns across all agents.
 const MAX_CONCURRENT_SUMMARIES: usize = 2;
 
-/// Word budget for the pushed summary (a bit tighter than the pull RPC's
-/// default, since this renders in a narrow swarm-tree row rather than a
-/// pane title).
+/// Word budget for the pushed summary. Matches the frontend's dynamic cap
+/// for `session:activity_summary` (`useAgentActivitySummary.ts`), not that
+/// RPC's own bare default of 7 (`app_api/session.rs`'s `unwrap_or(7)`) — the
+/// pull path's effective width varies with pane size, so 12 is the closest
+/// fixed stand-in for a swarm-tree row rather than a claim of being tighter.
 const WORD_TARGET: u32 = 12;
 
 pub const EVENT_AGENT_SUMMARY: &str = "agent:summary";

--- a/agentmux-srv/src/backend/reactive/mod.rs
+++ b/agentmux-srv/src/backend/reactive/mod.rs
@@ -8,6 +8,7 @@
 //! rate limiting, message sanitization, audit logging, and cross-host
 //! polling via AgentMux cloud service.
 
+pub mod activity_watcher;
 pub mod handler;
 pub mod poller;
 pub mod registry;

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -685,6 +685,18 @@ async fn main() {
         backend::blockcontroller::watchdog::run_watchdog_loop(watchdog_config).await;
     });
 
+    // Push a live Haiku activity summary per registered agent (swarm feed) —
+    // reads reactive::get_global_handler() as its registry, so it needs no
+    // AppState and can start before AppState is built (matches sysinfo/watchdog above).
+    let activity_wstore = Arc::clone(&wstore);
+    let activity_filestore = Arc::clone(&filestore);
+    let activity_broker = broker.clone();
+    tokio::spawn(async move {
+        backend::reactive::activity_watcher::run_agent_summary_loop(
+            activity_wstore, activity_filestore, activity_broker,
+        ).await;
+    });
+
     // Reactive handler (global singleton) + poller
     let reactive_handler = reactive::get_global_handler();
     reactive_handler.set_input_sender(Arc::new(|block_id: &str, data: &[u8]| {

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -30,7 +30,7 @@ mod agent_io;
 mod agent_define;
 mod pane;
 mod blockfile;
-mod session;
+pub(crate) mod session;
 mod identity;
 mod bundle;
 mod memory;

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -111,8 +111,64 @@ fn register_session_export_handler(engine: &Arc<WshRpcEngine>, state: &AppState)
 /// as the token-usage/cost-dashboard category for this call site.
 const AMBIENT_PURPOSE_ACTIVITY_SUMMARY: &str = "activity_summary";
 
+/// Purpose tag for the background/pushed activity summary (the swarm-feed
+/// sweep in `backend::reactive::activity_watcher`) — distinct from
+/// `AMBIENT_PURPOSE_ACTIVITY_SUMMARY` so the two never contend for the same
+/// Ambient Model Call gateway slot. A periodic background summary should not
+/// cancel, or be cancelled by, a live user-facing pane-header request for
+/// the same block.
+const AMBIENT_PURPOSE_ACTIVITY_SUMMARY_PUSHED: &str = "activity_summary_pushed";
+
 fn empty_summary_result() -> serde_json::Value {
     serde_json::to_value(&ActivitySummaryResult { summary: String::new(), tokens: None }).unwrap()
+}
+
+/// Pushed counterpart of `register_session_activity_summary`'s handler body —
+/// callable directly (no RPC envelope) by the background sweep in
+/// `backend::reactive::activity_watcher`. Goes through the same Ambient
+/// Model Call gateway (admission, cancellation-of-superseded, token
+/// accounting) under the distinct `_PUSHED` purpose above.
+///
+/// `generation` only needs to strictly increase across successive calls for
+/// the *same* `block_id` — the sweep loop's tick counter is sufficient; it
+/// doesn't need to correlate with the pull path's per-turn generation.
+///
+/// Returns `None` when there's nothing to summarize yet, the block/CLI path
+/// isn't resolvable, this call was superseded, or the CLI failed — the
+/// caller treats all of these as "no summary this tick."
+pub(crate) async fn generate_pushed_activity_summary(
+    wstore: &Store,
+    filestore: &crate::backend::storage::filestore::FileStore,
+    block_id: &str,
+    generation: u64,
+    word_target: u32,
+) -> Option<(String, Option<crate::agents::TokenCounts>)> {
+    let word_target = word_target.max(3).min(20);
+
+    let key = crate::ambient::AmbientCallKey::new(block_id, AMBIENT_PURPOSE_ACTIVITY_SUMMARY_PUSHED);
+    let guard = match crate::ambient::gateway().admit(key, generation) {
+        crate::ambient::Admission::Proceed(guard) => guard,
+        crate::ambient::Admission::StaleOnArrival => return None,
+    };
+    let cancel = guard.cancellation();
+
+    let block: Block = wstore.get(block_id).ok().flatten()?;
+    let extracted = read_recent_activity_digest(filestore, block_id)?;
+
+    let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
+    if cli_path.is_empty() {
+        return None;
+    }
+
+    let prompt = format!(
+        "Summarize in {word_target} words or fewer what is currently being worked on. \
+         Use a short terse phrase with no quotes or punctuation.\n\n\
+         Recent activity:\n\n{extracted}"
+    );
+
+    let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
+    drop(guard);
+    result.filter(|(summary, _)| !summary.is_empty())
 }
 
 fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppState) {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -3,7 +3,7 @@
 
 pub(crate) mod cli_handlers;
 mod files;
-mod app_api;
+pub(crate) mod app_api;
 mod agent_handlers;
 mod editor_handlers;
 mod identity_handlers;

--- a/docs/analysis/ANALYSIS_AGENT_ZOOM_PERSISTENCE_BUG_2026_06_25.md
+++ b/docs/analysis/ANALYSIS_AGENT_ZOOM_PERSISTENCE_BUG_2026_06_25.md
@@ -1,0 +1,196 @@
+# Bug Report — Agent Pane Zoom Persistence Not Working
+
+**Date:** 2026-06-25
+**Status:** Root cause confirmed, fix identified
+**Area:** Agent pane / per-agent zoom storage
+
+---
+
+## Summary
+
+Two PRs shipped zoom persistence (#1700, #1754) yet reopening an agent always
+resets to 1.0×. The save path silently does nothing because the frontend's zoom
+write goes through the WebSocket `setmeta` handler, which calls `update_object_meta`
+directly — the function that **only writes the block row and returns**. The zoom
+mirror that copies `term:zoom` → `ui:zoom` lives exclusively in the HTTP
+`UpdateObjectMeta` handler and is never reached.
+
+---
+
+## The Two PRs and What They Claimed to Fix
+
+### PR #1700 — `feat(agent): persist per-agent zoom across pane close/reopen`
+
+Added the full save/restore plumbing:
+
+- **Restore on open** (`app_api.rs:341-349`): `agent.open` reads `ui:zoom` from
+  the per-agent content store and seeds the new block's `term:zoom`.
+- **Save on change** (`service.rs:605-622`): the `UpdateObjectMeta` HTTP handler
+  calls `schedule_agent_zoom_mirror` whenever a block's `term:zoom` key changes.
+- **Debounce** (`service.rs:2831-2871`): `schedule_agent_zoom_mirror` waits 300ms
+  and coalesces bursts into a single `agent_content_set("ui:zoom", ...)`.
+
+### PR #1754 — `fix(zoom): persist zoom for cross-channel agents via global registry`
+
+Fixed a secondary issue where `agent_content_set` failed with an FK error for
+cross-channel agents not present in `db_agent_definitions`. Added a separate path
+through `registry_def_update_content_field` for those agents.
+
+Neither PR noticed that the frontend never exercises the HTTP `UpdateObjectMeta`
+handler for zoom writes.
+
+---
+
+## Root Cause
+
+### Two independent paths for `SetMeta` — only one has the mirror
+
+There are two server-side handlers that mutate object metadata:
+
+| Path | Handler | Trigger | Has zoom mirror? |
+|------|---------|---------|-----------------|
+| HTTP (legacy wave protocol) | `"UpdateObjectMeta"` in `service.rs:537` | registered in `mod.rs:703,770` | **YES** (`service.rs:605-622`) |
+| WebSocket (wshrpc/wshnet) | `"setmeta"` in `websocket.rs:565` | registered in WebSocket engine | **NO** |
+
+### The frontend uses the WebSocket path
+
+`zoom.win32.ts` (and `.darwin.ts`, `.linux.ts`) call:
+
+```typescript
+// zoom.win32.ts:76-80
+fireAndForget(() =>
+    RpcApi.SetMetaCommand(TabRpcClient, {
+        oref: WOS.makeORef("block", blockId),
+        meta: { "term:zoom": metaValue },
+    })
+);
+```
+
+`RpcApi.SetMetaCommand` → `client.rpcCall("setmeta", ...)` → WebSocket.
+
+The WebSocket `setmeta` handler (`websocket.rs:565-601`) does:
+
+```rust
+update_object_meta(&wstore, &oref_str, &cmd.meta)?;
+// broadcast WaveObjUpdate
+// return Ok(None)
+```
+
+`update_object_meta` (`service.rs:2777-2826`) writes the block row and returns.
+There is no zoom mirror call anywhere in this path.
+
+### What the zoom mirror call looks like in the HTTP path (never reached)
+
+```rust
+// service.rs:605-622 — inside the "UpdateObjectMeta" HTTP handler
+if oref.otype == OTYPE_BLOCK && meta_update.contains_key("term:zoom") {
+    if let Ok(block) = store.must_get::<Block>(&oref.oid) {
+        let agent_id = block.meta.get("agentId")
+            .and_then(|v| v.as_str()).unwrap_or("").to_string();
+        if !agent_id.is_empty() {
+            let zoom = meta_update.get("term:zoom").and_then(|v| v.as_f64());
+            schedule_agent_zoom_mirror(store.clone(), agent_id, zoom);
+        }
+    }
+}
+```
+
+This code is correct and complete. It just never runs.
+
+---
+
+## Full Call Chain (Current, Broken)
+
+```
+User: Ctrl+Wheel on agent pane
+  ↓
+zoomBlockIn/Out  (zoom.win32.ts)
+  ↓
+setBlockZoom  (zoom.win32.ts:67-82)
+  ↓
+RpcApi.SetMetaCommand(TabRpcClient, { oref: "block:<id>", meta: { "term:zoom": 1.3 } })
+  ↓
+WebSocket rpcCall("setmeta", ...)
+  ↓
+websocket.rs:565 — setmeta handler
+  ↓
+update_object_meta(&wstore, "block:<id>", { "term:zoom": 1.3 })
+  ↓
+[writes block row, returns — NO ZOOM MIRROR]
+  ↓
+broadcast WaveObjUpdate → frontend sees new zoom, renders correctly
+
+--- pane closes ---
+
+block deleted → term:zoom gone
+agent_content "ui:zoom" row: never written ← BUG
+
+--- agent.open ---
+
+app_api.rs:346: agent_content_get(agent.id, "ui:zoom") → None
+term:zoom not seeded → new block defaults to 1.0
+```
+
+---
+
+## Why It Went Unnoticed
+
+The restore half (`app_api.rs:341-349`) and debounce/mirror infrastructure
+(`schedule_agent_zoom_mirror`) were built and unit-tested in isolation. The
+integration test that would catch it — "zoom, close, reopen, assert zoom
+restored" — was not written. Because the block-level `term:zoom` persists within
+a session (the block exists until the pane is closed), the feature appears to
+work during a session; the break only surfaces on the close→reopen cycle.
+
+PR #1754 then fixed a secondary failure in the cross-channel write path — a real
+bug, but one that can only be triggered after the primary mirror is actually
+called, which it never is.
+
+---
+
+## Fix
+
+Add the zoom mirror call to the WebSocket `setmeta` handler
+(`agentmux-srv/src/server/websocket.rs`), immediately after the
+`update_object_meta` call:
+
+```rust
+// websocket.rs — inside the "setmeta" async handler, after update_object_meta:
+
+// Per-agent zoom persistence: mirror term:zoom → ui:zoom (same logic as
+// the UpdateObjectMeta HTTP handler in service.rs).
+let oref_parsed = crate::backend::ORef::parse(&oref_str)
+    .map_err(|e| e.to_string())?;
+if oref_parsed.otype == "block" && cmd.meta.contains_key("term:zoom") {
+    if let Ok(block) = wstore.must_get::<Block>(&oref_parsed.oid) {
+        let agent_id = block.meta.get("agentId")
+            .and_then(|v| v.as_str()).unwrap_or("").to_string();
+        if !agent_id.is_empty() {
+            let zoom = cmd.meta.get("term:zoom").and_then(|v| v.as_f64());
+            crate::server::service::schedule_agent_zoom_mirror(
+                wstore.clone(), agent_id, zoom,
+            );
+        }
+    }
+}
+```
+
+`schedule_agent_zoom_mirror` is already `pub(crate)` accessible. The WebSocket
+handler is async so `tokio::spawn` inside the function works fine.
+
+Alternatively, move the mirror logic into `update_object_meta` itself — but that
+function is synchronous and takes `&Store` (not `Arc<Store>`), so spawning would
+require an API change. The handler-level fix is lower risk.
+
+---
+
+## Affected Files
+
+| File | Role |
+|------|------|
+| `agentmux-srv/src/server/websocket.rs:565` | `setmeta` handler — where fix goes |
+| `agentmux-srv/src/server/service.rs:537-622` | `UpdateObjectMeta` HTTP handler — has the mirror, but never called by frontend |
+| `agentmux-srv/src/server/service.rs:2831-2871` | `schedule_agent_zoom_mirror` — correct, unused |
+| `agentmux-srv/src/server/app_api.rs:341-349` | Restore on `agent.open` — correct, would work once mirror is fixed |
+| `agentmux-srv/src/backend/storage/content.rs` | `agent_content_get/set` — correct |
+| `frontend/app/store/zoom.win32.ts:67-82` | `setBlockZoom` — uses WebSocket, correct |

--- a/docs/analysis/ANALYSIS_MIGRATE_STDOUT_HANG_2026_06_26.md
+++ b/docs/analysis/ANALYSIS_MIGRATE_STDOUT_HANG_2026_06_26.md
@@ -1,0 +1,139 @@
+# Analysis: Migrate Subprocess Stdout Hang — Splash Stuck at "Migrations"
+
+**Date:** 2026-06-26  
+**Version affected:** 0.49.4 (first observed; likely present in prior versions)  
+**PR:** #1797 (`fix/migrate-stdout-hang`)  
+**Status:** Fixed
+
+---
+
+## Symptom
+
+After launching the 0.49.4 portable build, the splash screen showed "Migrations" as the active stage for 44+ seconds (and indefinitely thereafter). The app never progressed to "Backend startup" or first paint.
+
+---
+
+## Root Cause
+
+`run_migrate` in `agentmux-launcher/src/srv_spawner.rs` reads the migrate subprocess's stdout in an inline loop until EOF:
+
+```rust
+while let Ok(Some(line)) = reader.next_line().await {
+    // parse migration JSON events...
+}
+// then: child.wait().await
+```
+
+The migrate subprocess (`agentmux-srv --migrate`) emits all its events — including the final `{"event":"complete"}` — then **stalls in Tokio runtime shutdown** instead of exiting. The shutdown stall is caused by the crash-monitor task:
+
+1. On startup, the srv binary installs a VEH crash handler and spawns a `--crash-monitor` subprocess (confirmed as pid 190372, `agentmux-srv-0.49.4-windows.x64.exe --crash-monitor`)
+2. The crash monitor holds an async handle (likely `WaitForSingleObject` or a named-pipe connection via `monitor.sock`) that never resolves
+3. Tokio's graceful runtime shutdown waits for all tasks to complete — this task never does
+4. The migrate subprocess is therefore **permanently alive** after printing "complete"
+5. With the process alive, its stdout pipe stays open — **EOF never arrives**
+6. The launcher's `reader.next_line().await` blocks forever waiting for the next line
+7. `stage_end("migrations")` is never called → splash stays on "Migrations"
+8. `spawn_srv` is never called → no backend → no app
+
+---
+
+## Evidence Trail
+
+| Observation | Implication |
+|---|---|
+| `[migrate] {"event":"complete","applied":4,"skipped":9}` appears in launcher log at `[1782456947]` | Migrate subprocess emitted complete event — migrations succeeded |
+| `[1782456947]` is the LAST 0.49.4 entry in launcher log | Launcher never advanced past `run_migrate` |
+| `[ipc] srv pipe path = ...` (logged immediately after `run_migrate`) is absent | Code never reached line 1671 in `main.rs` |
+| `agentmux.exe` pid 275300 alive at 17MB | Launcher process did not exit |
+| `agentmux-srv-0.49.4-windows.x64.exe` pid 190372 alive at 11MB | Crash monitor still running |
+| `Get-CimInstance` on pid 190372: `CommandLine = ... --crash-monitor` | Confirmed crash monitor, not migrate subprocess |
+| No other `agentmux-srv-0.49.4` in process list | Migrate subprocess already exited OR is hidden |
+| All db files timestamped `Jun 25 23:55` (migrations moment) | No db activity since migrations — srv never started |
+| `launcher-sagas.db-wal` at 41KB | Launcher progressed far enough to write saga data |
+
+The crash monitor (pid 190372) staying alive 12+ minutes after migrations completed is the key signal: the crash monitor only exits when the process it monitors exits. Since the crash monitor is still alive, the migrate subprocess is still alive (or was alive very recently), confirming the hang is in the migrate process's shutdown.
+
+---
+
+## Fix
+
+**`agentmux-launcher/src/srv_spawner.rs`**
+
+### 1. Break on `Complete`
+
+```rust
+Some(MigrationLine::Complete { applied: a, skipped: s }) => {
+    applied = a;
+    skipped = s;
+    migration_complete = true;
+    break; // Don't wait for EOF — kill below.
+}
+```
+
+Stop reading stdout as soon as the complete event arrives. The subprocess may still be running, but we have everything we need.
+
+### 2. Force-kill before wait
+
+```rust
+// If we got a complete event, kill the migrate process so we don't hang
+// on wait() if its Tokio runtime shutdown stalls.
+if migration_complete {
+    let _ = child.start_kill();
+}
+
+let status = child.wait().await...;
+```
+
+`start_kill()` sends `TerminateProcess` on Windows. The process exits within milliseconds. `wait()` returns immediately.
+
+### 3. Treat stdout signal as authoritative
+
+```rust
+if migration_complete || status.success() {
+    // success path
+}
+```
+
+A force-killed process returns a non-zero exit code. Since we killed it ourselves after seeing the success signal, we use `migration_complete` as the authoritative indicator. `status.success()` is only the tiebreaker for the case where the process exited naturally before we could kill it.
+
+---
+
+## Why This Was Silent Before
+
+The crash monitor interaction is not new — it exists in prior versions. However, the hang may have been masked in earlier builds by:
+
+- Faster SQLite shutdown timing on less-loaded databases (newly migrated db has more WAL to checkpoint)
+- The `dedup_identity_accounts` migration deleting **100 rows** — a large write that creates substantial WAL entries, potentially extending the SQLite teardown that keeps the srv binary's I/O threads alive longer
+- Previous migration runs on established databases applying 0 migrations (skipped all), meaning the srv in migrate mode exited very quickly with minimal cleanup
+
+The first time 0.49.4 ran against an existing database, all 4 pending migrations applied (including the 100-row deletion), and the subsequent shutdown took long enough to trigger the hang reliably.
+
+---
+
+## Related Gaps (from Splash Telemetry Audit)
+
+This hang exposed a deeper architectural gap in the splash telemetry: there is no per-stage timeout. The spec (§9) mandates a `⚠` prefix on the running clock after 10 seconds, but this is not implemented. Had the warning been present, the user would have seen the stage flag at 10s, making the hang immediately diagnosable without log access.
+
+Recommended follow-up:
+1. Add `⚠` prefix to running stages after 10 seconds (spec §9)
+2. Add a hard timeout to `run_migrate`'s `child.wait()` as a second defense (e.g., 60s with force-kill and error)
+3. Investigate whether the crash monitor subprocess should be suppressed in `--migrate` mode — a crash during a migration run needs a dump, but the monitor's async shutdown cost is now a known startup hazard
+
+---
+
+## Timeline
+
+| Time (UTC) | Event |
+|---|---|
+| 06:55:46 | 0.49.4 launcher started (pid 275300) |
+| 06:55:46 | IPC server, saga coordinator initialized |
+| 06:55:46 | Migrate subprocess spawned |
+| 06:55:47 | All 4 migrations complete (total ~50ms) |
+| 06:55:47 | `{"event":"complete"}` emitted — LAST launcher log entry for 0.49.4 |
+| 06:55:47+ | Migrate subprocess stalls on Tokio shutdown |
+| 06:55:47+ | Crash monitor (pid 190372) remains alive watching migrate process |
+| 06:55:47+ | `run_migrate` stdout loop blocks waiting for EOF |
+| ~07:08+ | User reports hang; diagnosis begins |
+| ~07:10 | Root cause identified via process list + command-line inspection |
+| ~07:12 | Fix implemented and compiled |
+| ~07:14 | PR #1797 opened |

--- a/docs/analysis/ANALYSIS_MSSTORE_AUTH_OPTIONS_2026_06_30.md
+++ b/docs/analysis/ANALYSIS_MSSTORE_AUTH_OPTIONS_2026_06_30.md
@@ -1,0 +1,101 @@
+# MS Store CI Auth — Research Findings
+**Date:** 2026-06-30
+**Question:** Can msstore CLI authenticate in CI without Entra admin access / using a personal Microsoft account?
+
+---
+
+## Bottom line
+
+**Entra is required — but you don't need the Azure portal.**
+Partner Center has a built-in path to create a free Entra tenant without ever touching `portal.azure.com` or `entra.microsoft.com`.
+
+---
+
+## Key confirmed findings
+
+### 1. msstore CLI CI mode requires a service principal — no MSA path
+
+The `msstore reconfigure` command (the CI-mode auth setup) takes only:
+```
+--tenantId   --sellerId   --clientId   --clientSecret
+```
+(or `--certificateThumbprint` / `--certificateFilePath` variants)
+
+There is no `--token`, `--apiKey`, or personal-account parameter. The CLI overview page (updated June 2026) explicitly warns:
+
+> "When signing in, don't use your MSA! The Microsoft Store Developer CLI requires you to use your Microsoft Entra ID credentials."
+
+**Confirmed by:** msstore CLI docs, Store Submission API docs, multiple GitHub issues (msstore-cli #4, #25). No credible contradicting source found.
+
+### 2. The 401 on entra.microsoft.com is expected for personal MSA holders
+
+Personal Microsoft accounts (`@outlook.com`, `@hotmail.com`) are used to *register* as Windows developers in Partner Center — but they don't automatically give you admin access to an Entra tenant. The tenant ID `4687dc46-1fd2-45e9-9411-ab7a7ad55df5` exists but you're not its admin, hence the 401.
+
+### 3. The fix: create the Entra tenant FROM Partner Center — no Azure portal needed
+
+Partner Center has its own tenant creation wizard that bypasses the 401:
+
+**Partner Center → Account settings → Tenants → Associate Azure AD → Create a brand new Azure AD tenant**
+
+This creates a free Entra tenant scoped to your Partner Center account. No Azure subscription, no `portal.azure.com` access needed.
+
+After creating the tenant, the app registration can also be done from within Partner Center:
+
+**Partner Center → Account settings → Users → Azure AD applications → Add an Azure AD application**
+
+This generates a Client ID + lets you create a Client Secret without going to Entra directly.
+
+### 4. Required role is Manager, not Global Admin
+
+Some Microsoft docs mention "global admin" — those apply to the CSP Partner Center SDK (cloud reseller API), not the Windows Store Submission API. For msstore CLI the required Partner Center role is **Manager**, which is set when you add the Azure AD application to your account.
+
+### 5. No alternative to Entra for CI
+
+No documented workaround exists. A June 2024 Microsoft identity platform breaking change explicitly tightened this by requiring all app registrations to exist within a directory tenant, eliminating the last "tenantless" MSA path.
+
+---
+
+## Recommended setup path (avoids Azure portal entirely)
+
+1. **Partner Center → Account settings → Tenants → Create new Azure AD tenant**
+   - Name it (e.g. `agentmux`) — this gives you a new `MSSTORE_TENANT_ID`
+
+2. **Partner Center → Account settings → Users → Azure AD applications → Add**
+   - Create new application (e.g. `AgentMux CI`)
+   - Assign **Manager** role
+   - Copy the **Client ID** → `MSSTORE_CLIENT_ID`
+   - Generate a new key (client secret) → `MSSTORE_CLIENT_SECRET`
+   - The Tenant ID is from step 1 → `MSSTORE_TENANT_ID`
+
+3. **Profile/Seller ID** is already known: `15588cde-ee0a-4471-a7e9-d5828d87ada6` → `MSSTORE_SELLER_ID`
+
+4. **Store App ID** (`MSSTORE_APP_ID`): Partner Center → Apps & games → AgentMux → App identity → Store ID (format `9NXXXXXXX`)
+
+---
+
+## Why automated MS Store submission is deferred
+
+After exhausting all available paths (2026-06-30):
+
+| Path | Outcome |
+|---|---|
+| Partner Center → Tenants → Create new Azure AD tenant | Blocked — requires work/school account at sign-in |
+| `entra.microsoft.com` | 401 — tenant `4687dc46-...` exists but Microsoft is the admin, not the account holder |
+| Microsoft 365 Developer Program sandbox | Rejected — account doesn't meet activity threshold |
+| Azure free account tenant creation | Blocked — Microsoft now requires a **paid Entra P1/P2 license** to create new Workforce tenants. Free accounts, trial subscriptions, and verified Azure free accounts are all explicitly blocked. Error: "Customers must own a paid license to create Microsoft Entra Workforce tenant." Introduced after Microsoft's security team flagged free tenant creation as a fraud vector (2024). |
+
+**Decision:** Defer automated Store submission. The MSIX ships with every GH Release; manual upload via Partner Center is the interim process. Revisit when release cadence justifies an Entra P1 license (~$6/user/month).
+
+The `ms-store` job remains in `release.yml` with `continue-on-error: true` — it will activate automatically once secrets are added.
+
+---
+
+## What we already have
+
+| Secret | Value | Source |
+|---|---|---|
+| `MSSTORE_SELLER_ID` | `15588cde-ee0a-4471-a7e9-d5828d87ada6` | Partner Center profile |
+| `MSSTORE_TENANT_ID` | pending new tenant creation | Partner Center wizard |
+| `MSSTORE_CLIENT_ID` | pending app registration | Partner Center Users page |
+| `MSSTORE_CLIENT_SECRET` | pending app registration | Partner Center Users page |
+| `MSSTORE_APP_ID` | pending | Partner Center → App identity |

--- a/docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md
+++ b/docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md
@@ -1,0 +1,136 @@
+# SPEC: Swarm Live Feed — backend code bindings
+
+**Date:** 2026-07-05
+**Status:** Draft (PR-1 scope partially implemented in working tree, see §6)
+**Owner:** camper
+**Companion spec:** `SPEC_SWARM_LIVE_FEED_UI_2026_07_05.md`
+
+## Goal
+
+Give the frontend everything it needs to render a real-time swarm feed:
+per-agent subagent activity (exists), **workflow run grouping + progress**
+(new), and **pushed haiku summaries** of what each agent is doing (new).
+
+## What exists (verified 2026-07-05)
+
+- `backend/subagent_watcher.rs` — watches `<claude-config>/projects/**` for
+  `agent-*.jsonl` (notify crate, recursive, 200ms debounce, incremental
+  offset reads). Emits `subagent:spawned` / `subagent:activity` (with parsed
+  `SubagentEventType::{Text,ToolUse,ToolResult,Progress}`) /
+  `subagent:completed` directly on the EventBus as `eventrecv`.
+  RPC: `subagent.ListActive`, `subagent.GetHistory`, `subagent.WatchAgent`.
+  Auto-wired per reactive agent registration (`server/reactive.rs`).
+- **No workflow tracking.** Old `db_workflow_*` tables are dead (Drone is the
+  DAG successor). Workflow tool runs exist only as files:
+  `projects/<ws>/<session>/subagents/workflows/wf_<runid>/agent-<n>.jsonl`
+  plus a `journal.jsonl` per run. Verified journal format (live run):
+  one JSON object per line, `{"type":"started","key","agentId"}` and
+  `{"type":"result","key","agentId","result":{...}}`.
+- Haiku summarizer exists but is pull-only: `server/app_api.rs`
+  `session:activity_summary` RPC — tail-reads last 32KB of the block's
+  `output` FileStore, prompts `claude-haiku-4-5-20251001` (15s timeout),
+  returns a ≤N-word summary. Frontend stores it in block meta `term:activity`.
+- Event transport: WPS `Broker` → `EventBusBridge` → two-lane WebSocket.
+  The subagent watcher bypasses the Broker and broadcasts on EventBus
+  directly.
+
+## Design
+
+### 1. Workflow grouping in subagent_watcher
+
+- `SubagentInfo.workflow_id: Option<String>` — parsed from the JSONL path:
+  a `subagents/workflows/<id>/` segment ⇒ `Some(id)`. The recursive watch
+  already delivers these files; no new watcher.
+- Session-id derivation walks ancestors to the dir containing `subagents/`
+  (workflow members are nested two levels deeper than direct subagents, so
+  the old fixed-depth `parent().parent()` derivation breaks on them).
+- Watch `journal.jsonl` inside each `wf_*` dir. Tally `started` / `result`
+  records incrementally (offset-based, same pattern as agent files):
+  `agents_total = max(journal started, member files seen)`,
+  `agents_done = max(journal results, members completed)` — either source
+  can lag the other.
+- Startup scan extended: `subagents/` may sit directly under the project dir
+  or one level deeper under a session dir; also descend into
+  `subagents/workflows/<wf>/` for member files + journal.
+
+### 2. New/changed events (EventBus `eventrecv`, same envelope as today)
+
+- `workflow:updated` — `{workflowId, parentAgent, parentBlockId, sessionId,
+  agentsTotal, agentsDone, status}`; emitted on member spawn/completion and
+  journal changes.
+- `subagent:spawned` / `subagent:activity` / `subagent:completed` payloads
+  gain `workflowId` (null for direct subagents).
+- `status` semantics: `running` until counts-complete AND 60s quiet. There
+  is no timer — the flip happens lazily at the next event or
+  `ListWorkflows` read. Frontend treats it as advisory (it can render
+  "n/n done" from counts regardless).
+
+### 3. New RPC
+
+- `subagent.ListWorkflows` → `Vec<WorkflowInfo>` sorted by recency, for
+  backfill when the swarm pane opens.
+
+```rust
+pub struct WorkflowInfo {
+    pub workflow_id: String,
+    pub parent_agent: String,
+    pub parent_block_id: String,
+    pub session_id: String,
+    pub agents_total: usize,
+    pub agents_done: usize,
+    pub status: WorkflowStatus, // running | completed
+    pub last_event_at: u64,
+}
+```
+
+### 4. Pushed haiku summaries (PR-2, not yet implemented)
+
+Reuse the existing `session:activity_summary` machinery, but push:
+
+- srv task: for every registered reactive agent whose controller status is
+  `working`, run the existing digest+haiku path every 20s. Skip when the
+  output FileStore offset is unchanged since the last summary (idle agents
+  burn zero tokens).
+- Publish `agent:summary` WaveEvent `{agentId, blockId, summary, ts}` on
+  scope `block:<id>` via the Broker (normal WPS path, not the EventBus
+  bypass).
+- Guardrails: one in-flight haiku call per agent, global concurrency 2,
+  15s timeout (existing), word_target 12.
+- Out of scope: changing the summarizer model (currently pinned
+  `claude-haiku-4-5-20251001`; verify against the live model list if
+  touched).
+
+### 5. Testing
+
+- Unit: path parsing (`parse_workflow_id`, `derive_session_id`), journal
+  incremental counting (`read_journal_counts`).
+- Integration: fake `wf_*/agent-1.jsonl` + `journal.jsonl` tree → assert
+  `workflow:updated` counters and `ListWorkflows` output.
+- Manual: run a real Workflow tool invocation, open swarm pane, watch
+  grouping + counters live.
+
+### 6. Implementation status (working tree, not committed)
+
+PR-1 scope is implemented and passing in the local working tree:
+- `subagent_watcher.rs`: `workflow_id` field, path helpers, journal watch +
+  incremental counts, `WorkflowInfo`/`WorkflowStatus`, workflow aggregate
+  state + `workflow:updated` broadcast, extended startup scan, 7 unit tests
+  (all green; `cargo check` clean).
+- `service.rs`: `subagent.ListWorkflows` dispatch.
+
+Remaining for PR-1: integration test. PR-2 (pushed summaries) not started.
+
+## Phases / PRs
+
+1. **PR-1 (srv):** workflow grouping + `workflow:updated` + `ListWorkflows`.
+2. **PR-2 (srv):** pushed `agent:summary` (periodic haiku, offset-gated).
+
+Each PR reviewed by reagent, merged only on approval.
+
+## Open questions
+
+1. Haiku push cadence 20s ok? (~3 haiku calls/min/active agent, tiny prompt.)
+   Alternative: only on turn-phase transitions.
+2. Should workflow nodes carry the phase titles from the script's
+   `meta.phases` (requires locating + parsing the script file) or counts
+   only? Counts-only for v1.

--- a/docs/specs/SPEC_SWARM_LIVE_FEED_UI_2026_07_05.md
+++ b/docs/specs/SPEC_SWARM_LIVE_FEED_UI_2026_07_05.md
@@ -1,0 +1,144 @@
+# SPEC: Swarm Live Feed — UI
+
+**Date:** 2026-07-05
+**Status:** Draft
+**Owner:** camper
+**Companion spec:** `SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md`
+
+## Goal
+
+Upgrade the swarm pane into a real-time feed of everything each agent is
+doing:
+
+```
+▸ Camper                                   [working]
+    "verifying release pipeline artifacts"          ← haiku summary, live
+    ▸ workflows/deep-research (wf_d1f80d9f)  63/84 agents done
+        ▸ verify:vicky-ward-quote            [active]
+        ▾ search:journalists                 [completed]
+            │ Searching for Vanity Fair 2003 profile…
+            │ ⚙ WebSearch {"query": "..."}
+            │ ✓ 12 results (2.1 KB)
+    ▾ Explore: map frontend UI               [completed]
+        │ …live stream as simple text…
+```
+
+- Row 1 per agent: name + status chip (exists today in the swarm pane).
+- Row 2: **haiku summary** — live one-liner of what the agent is working on.
+- Children: **subagents and workflows, collapsed by default**. Workflow
+  nodes group their member agents and show `done/total` progress.
+- Expanding a subagent shows its **live event stream as simple text**.
+- The whole tree is **virtualized** — large swarms (10 agents × workflows ×
+  16 concurrent members × hundreds of stream lines) must scroll smoothly.
+
+## What exists (verified 2026-07-05)
+
+- `view/swarm/{swarm-view.tsx,swarm-model.ts}` — 2-level tree (AgentRow →
+  SubagentRow), always expanded, no inline stream. Subscribes to
+  `subagent:spawned/completed`, `agent:process-added/exited`, scoped
+  `ControllerStatus`. Clicking a subagent opens the separate subagent pane.
+- `view/subagent/` — separate pane streaming one subagent's events.
+- **Agent-pane virtualization** (`view/agent/virtualization/`):
+  `AgentDocumentVirtualList` — custom virtualizer (absolute positioning,
+  per-row ResizeObserver measurement, scroll anchoring in `anchor.ts`,
+  height estimation in `renderers.ts`, layout math in the
+  `agent-pane-layout` store) plus a non-virtualized trailing streaming
+  buffer. This is the infra to reuse. `@tanstack/solid-virtual` is
+  installed but unused — do not adopt it.
+- Realtime: `waveEventSubscribe` in `store/wps.ts`; canonical usage pattern
+  in `swarm-model.ts` (subscribe in ctor, unsubs array, `dispose()`).
+- Design system: tokens in `frontend/app/theme.scss`; stylelint forbids raw
+  hex, `!important`, and non-token z-index.
+
+## Design
+
+### 1. Row model — flatten, then virtualize
+
+The tree is state + a flattening selector; the DOM is one virtualized flat
+list. Avoids nested scrolling and makes row count the only perf variable.
+
+```ts
+type SwarmRow =
+  | { kind: "agent";    id: string; node: AgentTreeNode }
+  | { kind: "summary";  id: string; agentId: string; text: string }
+  | { kind: "workflow"; id: string; wf: WorkflowNode; depth: 1 }
+  | { kind: "subagent"; id: string; sa: SubagentNode; depth: 1 | 2 }
+  | { kind: "stream";   id: string; line: StreamLine; depth: 2 | 3 };
+```
+
+`swarm-model.ts` additions:
+- `workflowsByAgent: Map<agentId, WorkflowNode[]>` — from
+  `subagent.ListWorkflows` backfill + `workflow:updated` events.
+- `subagentsByParent: Map<workflowId | agentId, SubagentNode[]>` — existing
+  subagent atoms re-keyed; a subagent with `workflowId` parents to its
+  workflow node, else to its agent.
+- `summaries: Map<agentId, string>` — from `agent:summary` events, seeded
+  from block meta `term:activity`.
+- `expanded: Set<rowId>` — collapse state. Defaults: workflows and
+  subagents collapsed; agent sections expanded (summary row always shows).
+- `streams: Map<subagentId, StreamLine[]>` — ring buffer, cap 500 lines
+  (older lines drop; full history remains in the subagent pane).
+- `flattenTree(): SwarmRow[]` — memo; only expanded nodes contribute rows.
+
+### 2. Row rendering
+
+- **agent** — name + status chip (existing `AgentStatusChip`), chevron.
+- **summary** — caption size, secondary color, italic; empty until first
+  `agent:summary` arrives.
+- **workflow** — `workflows/<name-or-id>` + `done/total agents` counter +
+  advisory status dot; chevron.
+- **subagent** — slug + status (existing SubagentRow visuals), chevron;
+  click still opens the full subagent pane (unchanged).
+- **stream** — monospace caption, single line, CSS-truncated with title
+  tooltip:
+  - `text` → first 200 chars
+  - `tool_use` → `⚙ <name> <input_summary>`
+  - `tool_result` → `✓ <preview>` / `✗ <preview>` when is_error
+  - `progress` → `… <output>`
+
+Stream backfill on expand: `subagent.GetHistory(agentId, 200)`, then live
+append from `subagent:activity`.
+
+### 3. Virtualization — reuse the agent pane's infra
+
+We already built and hardened a virtualizer for the agent document; the
+swarm feed is a strictly simpler instance of the same problem (append-heavy
+list, bottom pinning, mixed row heights).
+
+- Extract the core (positioning, ResizeObserver measurement, scroll
+  anchoring) into a shared module under `frontend/app/element/` — or
+  parametrize `AgentDocumentVirtualList` over a row renderer — so the agent
+  doc and swarm tree consume one implementation. The streaming-buffer
+  partition is disabled for swarm: stream rows are single-line and cheap.
+- Height estimates by kind (agent 28, summary 20, workflow 24, subagent 24,
+  stream 18 px) feed the existing estimator.
+- Follow-output: reuse the anchor pattern — pinned to bottom of an expanded
+  stream while at bottom; no viewport jump otherwise.
+- `@tanstack/solid-virtual`: candidate for dep removal in a separate
+  cleanup PR.
+
+### 4. Styling
+
+Tokens only: `--space-*`, `--text-caption` for summary/stream rows,
+`--color-*`/`--*-color` from theme.scss (no raw hex), `--z-*` for any
+overlay, no `!important`. Indentation via `--space-*` multiples of depth.
+
+## Phases / PRs
+
+1. **PR-3 (frontend):** swarm tree rework — flatten + collapse/expand +
+   summary row + workflow nodes + inline streams, using the extracted
+   virtualizer.
+2. **PR-4 (polish):** follow-output pinning, ring-buffer tuning, perf probe
+   on a synthetic 10-agent × 3-workflow swarm (reuse
+   `virtualization/perf-probe.ts`).
+
+Each PR reviewed by reagent, merged only on approval.
+
+## Open questions
+
+1. Ring buffer 500 lines/subagent — enough?
+2. Should collapse state persist across pane reloads (block meta) or reset?
+   v1: reset.
+3. Virtualizer extraction vs parametrization — decide in PR-3 after reading
+   `AgentDocumentVirtualList` closely; extraction preferred if the diff to
+   the agent pane stays mechanical.

--- a/reports/epstein_firsthand_accounts_2026_07_05.md
+++ b/reports/epstein_firsthand_accounts_2026_07_05.md
@@ -1,0 +1,167 @@
+# People Who Met Jeffrey Epstein: Verified First-Person Accounts
+
+**Compiled:** 2026-07-05
+**Method:** Multi-agent deep research — 5 search angles, 22 sources fetched, 103 candidate claims extracted, 25 claims independently adversarial-verified (3-vote panel, need 2/3 confirm), merged into 9 distinct eyewitness narratives. 0 refuted, 0 unverified.
+
+## Summary
+
+First-person accounts of meeting Jeffrey Epstein exist across every category this research covered — journalists, scientists/academics, victims giving sworn testimony, business associates, and socialites. Journalists James B. Stewart (*New York Times*) and Vicky Ward (*Vanity Fair*) supplied direct quoted recollections of Epstein boasting about dirt on powerful people, defending sex with teenage girls as a "cultural aberration," and obsessively probing what Ward knew "on the girls." Sworn court testimony from Johanna Sjoberg and estate manager Rinaldo Rizzo (unsealed *Giuffre v. Maxwell* depositions, January 2024) gives paragraph-length victim and witness accounts of the "massage" operation, the Prince Andrew puppet-photo incident, and a terrified 15-year-old's confiscated passport. Social and intellectual-world accounts come from publicist Peggy Siegal, Edge Foundation founder John Brockman, Steven Pinker, Lisa Randall, and Leon Botstein, with Sarah Kellen's abuse account issued via a spokesperson. Together they show a consistent pattern: Epstein used wealth-signaling, name-dropping, and information-gathering to penetrate elite circles while surrounding himself with underage girls "almost in plain sight."
+
+---
+
+## 1. James B. Stewart (journalist, *New York Times*)
+
+**Relationship:** Interviewed Epstein in person for ~90 minutes at his Manhattan mansion, August 16, 2018, on background (an agreement Stewart deemed lapsed after Epstein's death).
+
+> "Almost exactly a year ago, on August 16th, 2018, I visited Jeffrey Epstein at his cavernous Manhattan mansion... Epstein claimed to know potentially damaging or embarrassing information about many rich, famous and powerful people, including their supposed sexual proclivities and recreational drug use... [and] told me that criminalizing sex with teenage girls was a cultural aberration and that at times in history it was perfectly acceptable."
+
+**Source:** James B. Stewart, "The Day Jeffrey Epstein Told Me He Had Dirt on Powerful People," *The New York Times*, Aug 12, 2019. https://www.nytimes.com/2019/08/12/business/jeffrey-epstein-interview.html (corroborated by CJR: https://www.cjr.org/podcast/jeffrey-epstein-james-stewart-background-suicide-new-york-times.php)
+
+**Confidence:** High. Single-witness recollection of an unrecorded conversation, but recounted by a Pulitzer-winning reporter in the paper of record; no source disputes date, location, duration, or content.
+
+---
+
+## 2. Vicky Ward (journalist, *Vanity Fair*)
+
+**Relationship:** Profiled Epstein for *Vanity Fair* (published March 2003); met him in person for an off-the-record tea at his Upper East Side townhouse during her 2002–03 reporting.
+
+> [After the tea, a female assistant called to say] "Jeffrey wanted me to tell you that you looked so pretty."
+
+> [In repeated phone calls, Epstein asked] "What do you have on the girls?" — "over and over again," per her contemporaneous notes.
+
+> [Ward alleges editor Graydon Carter cut her on-the-record allegations from a Phoenix mother and two daughters, one aged 16, telling her Epstein was] "sensitive about the young women."
+
+**Source:** Vicky Ward, "I Tried to Warn You About Sleazy Billionaire Jeffrey Epstein in 2003," 2015, republished at https://vickyward.com/article/i-tried-to-warn-you-about-sleazy-billionaire-jeffrey-epstein-in-2003/ (also https://www.thedailybeast.com/i-tried-to-warn-you-about-sleazy-billionaire-jeffrey-epstein-in-2003/); NPR corroboration of the Farmer family's on-record 2002 account: https://www.npr.org/2019/08/22/753337520/why-the-media-didnt-pay-much-attention-to-jeffrey-epstein
+
+**Confidence:** High for the quotes themselves. Note: Graydon Carter disputes Ward's account of *why* the material was cut (he says it fell below a "legal threshold," not that he was protecting Epstein), and a 2022 *New Yorker* piece challenged aspects of Ward's broader reporting — her account should be read as her account, not settled fact.
+
+### 2a. Vicky Ward, retrospective (NPR, July 2025)
+
+> "[Epstein] claimed that he was a financial adviser for billionaires, and yet there was no footprint of him trading in the markets... The math has never added up" [regarding his townhouse, island, ranch, Paris apartment, and jet].
+
+> [Epstein hosted politicians and very rich men while] "surrounded by beautiful women, many of whom were underage minors, almost in plain sight."
+
+**Source:** "Investigative journalist Vicky Ward reviews 'Just Who Jeffrey Epstein Was,'" NPR Morning Edition, July 28, 2025. https://www.npr.org/2025/07/28/nx-s1-5479843/investigative-journalist-vicky-ward-reviews-just-who-jeffrey-epstein-was
+
+**Confidence:** Medium — single interview transcript; one constituent claim (about the birthday-album messages) passed verification 2-1 rather than unanimously, and some phrasing ("island") was slightly less hedged than Ward's own wording ("may have visited").
+
+---
+
+## 3. Johanna Sjoberg (victim/witness, sworn deposition)
+
+**Relationship:** Recruited by Ghislaine Maxwell in 2001 from Palm Beach Atlantic College to work at the Epstein/Maxwell Palm Beach house; gave sworn deposition testimony unsealed in *Giuffre v. Maxwell*, January 2024.
+
+> "I remember him being in a bathrobe... I remember thinking this guy is very smart" [describing her first meeting with Epstein].
+
+> [Maxwell phoned to reprimand her after a massage:] "You came here and didn't finish your job and I had to finish it for you."
+
+> [Describing the New York mansion incident, a photo was taken of her with an ITV *Spitting Image* puppet caricature of Prince Andrew while Andrew put his hand on her breast, with Virginia Giuffre, Epstein, and Maxwell present.]
+
+**Source:** Unsealed deposition, *Giuffre v. Maxwell*, 1:15-cv-07433-LAP (S.D.N.Y.), Doc. 1320-12 and related exhibits, released Jan 3–4, 2024. https://uploads.guim.co.uk/2024/01/04/Final_Epstein_documents.pdf ; https://storage.courtlistener.com/recap/gov.uscourts.nysd.447706/gov.uscourts.nysd.447706.1320.12.pdf ; corroborated by CBC: https://www.cbc.ca/news/world/jeffrey-epstein-court-documents-unsealed-1.7072375
+
+**Confidence:** High — verified directly against the primary court record. Sworn testimony under oath. Maxwell and Prince Andrew dispute the underlying conduct, not that Sjoberg gave this testimony. (Minor correction: Sjoberg described the puppet as from "the BBC" — it was actually an ITV *Spitting Image* prop.)
+
+---
+
+## 4. Rinaldo Rizzo (estate manager, sworn deposition)
+
+**Relationship:** Estate manager for the Dubin family, friends of Epstein and Maxwell; gave sworn deposition testimony in the same unsealed case.
+
+> [A terrified 15-year-old girl told Rizzo and his wife that on Epstein's island she was asked for sex and refused, that Sarah Kellen took her passport and phone and gave them to Ghislaine Maxwell, and that she was threatened by Epstein and Maxwell not to talk about it.]
+
+**Source:** Unsealed deposition, *Giuffre v. Maxwell*, 1320-series exhibits. https://uploads.guim.co.uk/2024/01/04/Final_Epstein_documents.pdf ; https://rollcall.com/factbase/epstein/file?id=giuffre-v-maxwell-115-cv-07433-sdny-2015-1320-26
+
+**Confidence:** High for the deposition itself; the island events are Rizzo's secondhand relay of what the girl told him (firsthand as to that conversation). The Dubin family disputes the underlying events, not that Rizzo testified to this.
+
+---
+
+## 5. Peggy Siegal (Hollywood publicist)
+
+**Relationship:** Knew Epstein for roughly 12 years and acted as one of his social "guarantors," bringing him into elite social/media circles.
+
+> [Epstein introduced himself by name-dropping mutual friends and] "made it clear that he had numerous houses and a jet" [to get onto her screening-invitation list.]
+
+> "I instantly knew that he collected information to use against you... There was a sense of danger. It was like a warning bell."
+
+> "I totally jeopardized my relationship with all these important people — they did not know who he was" [referring to elite guests — Katie Couric, George Stephanopoulos, Chelsea Handler, Woody Allen — she brought to his post-conviction dinners.]
+
+**Source:** *New York* magazine interview, summarized/quoted by *The Hollywood Reporter*, March 2026. https://www.hollywoodreporter.com/news/general-news/hollywood-publicist-peggy-siegal-jeffrey-epstein-new-york-interview-1236522678/
+
+**Confidence:** Medium. Secondary coverage of a primary interview; Siegal is a self-interested narrator with prior inconsistent statements (she previously denied taking Epstein's money, though DOJ emails show contact continuing until April 2019). The "instant" sense of danger was described as forming during an early phone call, not strictly at an in-person meeting.
+
+---
+
+## 6. John Brockman (Edge Foundation founder/literary agent)
+
+**Relationship:** Epstein was the dominant financial patron of Brockman's Edge Foundation; the two interacted at Edge's "billionaires' dinners" and elsewhere over roughly 15 years.
+
+> [Brockman, in a 2013 email to Evgeny Morozov, described Epstein as a] "billionaire who owns Victoria's Secret plus a modelling agency" with "a beautiful young assistant from Belarus," adding "He also got into trouble and spent a year in jail in Florida."
+
+> [In another passage, describing a visit to Epstein's Manhattan townhouse, Brockman recounted finding Epstein and a British man receiving foot massages from young Russian women — a man Brockman later realized was Prince Andrew.]
+
+Foundations associated with Epstein gave $638,000 of the roughly $857,000 Edge received in total donations between 2001 and 2017 — his last gift ($30,000) came in 2015, after which the annual "billionaires' dinner" ended. Epstein was photographed at the 1999 and 2000 dinners and attended Edge events as late as 2011, three years after his 2008 conviction. In 2002, Brockman, Steven Pinker, Richard Dawkins, and Daniel Dennett were photographed together on Epstein's jet en route to TED.
+
+**Source:** BuzzFeed News, "How Jeffrey Epstein Bankrolled the Exclusive Edge Foundation and Reaped the Benefits." https://www.buzzfeednews.com/article/peteraldhous/jeffrey-epstein-john-brockman-edge-foundation ; Evgeny Morozov, "Jeffrey Epstein's Intellectual Enabler," *The New Republic*. https://newrepublic.com/article/154826/jeffrey-epsteins-intellectual-enabler
+
+**Confidence:** High. Donation figures verified against IRS 990 filings; Brockman's emails published verbatim by Morozov; jet photo and dinner attendance corroborated by 2002 *New York Times* reporting and confirmed by Pinker and Dennett themselves. Brockman declined to comment rather than disputing the account. (Note: Epstein did not actually own Victoria's Secret — that was Leslie Wexner — so this line reports Brockman's own words, not established fact.)
+
+---
+
+## 7. Sarah Kellen (former Epstein/Maxwell assistant) — statement via spokesperson
+
+**Relationship:** Assistant to Epstein and Maxwell, appears in photos from Edge Foundation events; her own status (victim vs. facilitator) is contested in other litigation.
+
+> [Via representative Tracy Schmaler: Kellen] "had just turned 22 when she was recruited by Jeffrey Epstein and Ghislaine Maxwell," and Epstein "began to sexually abuse her, and this abuse went on for years"; she "continues to struggle with the trauma."
+
+**Source:** BuzzFeed News, Sept 26, 2019. https://www.buzzfeednews.com/article/peteraldhous/jeffrey-epstein-john-brockman-edge-foundation
+
+**Confidence:** Medium. This is a third-person statement issued via a spokesperson rather than a direct first-person quote from Kellen, and her victim status is disputed by other litigants who describe her as a facilitator. The existence and content of the published statement itself is not in dispute.
+
+---
+
+## 8. Academics: Steven Pinker, Lisa Randall, Leon Botstein
+
+**Steven Pinker** (Harvard psychologist) — flew on Epstein's jet in 2002:
+
+> "I immediately disliked Epstein and thought he was a dilettante and a smartass."
+
+> [On providing linguistic assistance to Alan Dershowitz, later used in Epstein's legal defense:] "I was doing a professional courtesy to a colleague—it's routine. If I knew at the time what we know now, I would not have agreed."
+
+**Source:** *Scientific American*, "Why Did Jeffrey Epstein Cultivate Famous Scientists?", Jan 2026. https://www.scientificamerican.com/article/why-did-jeffrey-epstein-cultivate-famous-scientists/
+
+**Lisa Randall** (Harvard physicist) — visited Epstein's island in 2014 per DOJ-released flight manifests:
+
+> "I am appalled by the full extent of allegations against him and deeply regret maintaining contact."
+
+**Source:** *Times Higher Education*, "'He Was Surrounded by Smart People': Academics on the Epstein Files." https://www.timeshighereducation.com/news/he-was-surrounded-smart-people-academics-epstein-files (DOJ flight manifest, Nov 30, 2014, St. Thomas to Boston)
+
+**Leon Botstein** (president, Bard College) — exchanged emails with Epstein, one 2013 message closing "Miss you":
+
+> [His contact with Epstein was] "always and only for the sole purpose of soliciting donations for the college."
+
+**Source:** *Times Higher Education*, *The Chronicle of Higher Education*, and *New York Times* coverage. https://www.timeshighereducation.com/news/he-was-surrounded-smart-people-academics-epstein-files ; https://www.thecrimson.com/article/2026/2/1/lisa-randall-epstein-ties/
+
+**Confidence:** High overall. Important caveat on Botstein: a subsequent WilmerHale investigation for Bard's board concluded he "minimized and was not fully accurate" about the relationship (which included $150,000 in consulting fees and a $56,000 watch), and he later announced his retirement — his quote is genuine and citable, but was later shown incomplete by the further investigation. Randall's statement is brief, not paragraph-length.
+
+---
+
+## Caveats (from the research run)
+
+- Several accounts are single-witness recollections of unrecorded private conversations (Stewart's interview, Ward's tea and phone calls, Siegal's interview) — accurately attributed, but Epstein's exact words are inherently unverifiable beyond the speaker's own account.
+- Ward's broader narrative is contested (Graydon Carter's account of the 2003 edit differs; a 2022 *New Yorker* piece challenged aspects of her reporting).
+- Siegal and Botstein are self-interested narrators whose statements were later shown incomplete by further reporting/investigation.
+- The Kellen statement came via a spokesperson, not directly from her, and her victim/facilitator status is contested elsewhere in the litigation.
+- Sjoberg's and Rizzo's testimony is sworn but the underlying conduct is denied by Maxwell, Prince Andrew, and the Dubin family (not the fact that this testimony was given).
+- Two minor factual wrinkles inside otherwise-accurate quotes: the Sjoberg puppet was ITV's *Spitting Image*, not the BBC; Brockman's description of Epstein as owning Victoria's Secret was factually wrong (that was Wexner) — reported here as Brockman's belief, not fact.
+- Several sources (Siegal interview, Pinker/*Scientific American*, Botstein coverage, DOJ file releases) date from Jan–Mar 2026; follow-on reporting may add or revise details.
+
+## Open questions / gaps for a follow-up pass
+
+1. Victims' own public trial testimony ("Jane," "Carolyn," Annie Farmer at the 2021 Maxwell trial, Virginia Giuffre's own published accounts) was underrepresented in the final verified set — a follow-up pass on trial transcripts and victim memoirs would round out the victim-voice category directly (rather than via depositions of third-party witnesses).
+2. What do the full WSJ-reported 50th-birthday-album letters (released by House Oversight, Sept 2025) contain in first-person terms from named associates, and who has confirmed or disputed authorship?
+3. Beyond Pinker, Randall, Dennett, and Botstein — which other scientists/academics named in the 2026 DOJ file releases (e.g., Joichi Ito, Reid Hoffman on the 2014 manifest) have given quotable first-person accounts?
+4. Did business associates from Epstein's Bear Stearns/Towers Financial era, or Leslie Wexner himself, give paragraph-length first-person accounts on the record?
+
+---
+
+*Research stats: 5 search angles → 22 sources fetched → 103 candidate claims extracted → 25 independently verified (3-vote adversarial panel) → merged into the 9 accounts above. 0 refuted, 0 left unverified.*

--- a/reports/epstein_infographic_2026_07_05.html
+++ b/reports/epstein_infographic_2026_07_05.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Jeffrey Epstein — Verified First-Person Accounts</title>
+<style>
+  :root {
+    --surface-1:      #fcfcfb;
+    --page-plane:     #f9f9f7;
+    --text-primary:   #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted:     #898781;
+    --gridline:       #e1e0d9;
+    --border:         rgba(11,11,11,0.10);
+
+    --cat-journalist: #2a78d6; /* blue   — slot 1 */
+    --cat-scientific: #1baf7a; /* aqua   — slot 2 */
+    --cat-social:     #4a3aa7; /* violet — slot 5 */
+    --cat-testimony:  #e34948; /* red    — slot 6 */
+
+    --status-good:    #0ca30c;
+    --status-warning: #fab219;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --surface-1:      #1a1a19;
+      --page-plane:     #0d0d0d;
+      --text-primary:   #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted:     #898781;
+      --gridline:       #2c2c2a;
+      --border:         rgba(255,255,255,0.10);
+
+      --cat-journalist: #3987e5;
+      --cat-scientific: #199e70;
+      --cat-social:     #9085e9;
+      --cat-testimony:  #e66767;
+
+      --status-good:    #0ca30c;
+      --status-warning: #fab219;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--page-plane);
+    color: var(--text-primary);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.5;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 48px 24px 80px; }
+
+  /* ── Header ───────────────────────────────────────────── */
+  header { margin-bottom: 40px; }
+  header h1 { font-size: 32px; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; }
+  header p.dek { font-size: 16px; color: var(--text-secondary); max-width: 640px; margin: 0; }
+  header p.meta { font-size: 13px; color: var(--text-muted); margin: 12px 0 0; }
+
+  /* ── KPI row ──────────────────────────────────────────── */
+  .kpi-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--gridline); border: 1px solid var(--gridline); border-radius: 6px; overflow: hidden; margin-bottom: 44px; }
+  .kpi-tile { background: var(--surface-1); padding: 20px 16px; }
+  .kpi-tile .value { font-size: 30px; font-weight: 600; line-height: 1.1; }
+  .kpi-tile .label { font-size: 12.5px; color: var(--text-secondary); margin-top: 4px; }
+
+  /* ── Category pill ───────────────────────────────────── */
+  .pill { display: inline-flex; align-items: center; font-size: 11.5px; font-weight: 600; padding: 3px 9px; border-radius: 100px; letter-spacing: 0.02em; text-transform: uppercase; }
+  .pill.journalist { background: var(--cat-journalist); color: #fff; }
+  .pill.scientific { background: var(--cat-scientific); color: #0b0b0b; }
+  .pill.social     { background: var(--cat-social);     color: #fff; }
+  .pill.testimony  { background: var(--cat-testimony);  color: #fff; }
+
+  /* ── Confidence badge ─────────────────────────────────── */
+  .badge { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 600; color: var(--text-primary); }
+  .badge svg { width: 14px; height: 14px; flex: none; }
+  .badge.high .dot   { color: var(--status-good); }
+  .badge.medium .dot { color: var(--status-warning); }
+
+  /* ── Cards ────────────────────────────────────────────── */
+  section.accounts { display: flex; flex-direction: column; gap: 20px; }
+  .card { background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px; padding: 24px 28px; }
+  .card-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 12px; margin-bottom: 4px; }
+  .card-head h2 { font-size: 19px; font-weight: 700; margin: 0; }
+  .card-head .role { font-size: 13.5px; color: var(--text-secondary); }
+  .card-head .spacer { flex: 1 1 auto; }
+  .card .claims-note { font-size: 12px; color: var(--text-muted); margin: 2px 0 14px; }
+
+  .quote-group { margin-bottom: 14px; }
+  .quote-group:last-of-type { margin-bottom: 0; }
+  .quote-group .sub-label { font-size: 12px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.03em; margin: 0 0 6px; }
+  blockquote {
+    margin: 0 0 8px; padding: 4px 0 4px 16px;
+    border-left: 3px solid; font-size: 15px; color: var(--text-primary);
+  }
+  .card.journalist blockquote, .quote-group.journalist blockquote { border-color: var(--cat-journalist); }
+  .card.scientific blockquote, .quote-group.scientific blockquote { border-color: var(--cat-scientific); }
+  .card.social blockquote     { border-color: var(--cat-social); }
+  .card.testimony blockquote  { border-color: var(--cat-testimony); }
+
+  .evidence { font-size: 13.5px; color: var(--text-secondary); margin: 10px 0 10px; }
+  .evidence strong { color: var(--text-primary); font-weight: 600; }
+
+  .citations { display: flex; flex-wrap: wrap; gap: 6px 14px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--gridline); }
+  .citations a { font-size: 12.5px; color: var(--text-secondary); text-decoration: underline; text-decoration-color: var(--gridline); text-underline-offset: 2px; }
+  .citations a:hover { color: var(--text-primary); }
+
+  /* ── Footer / caveats ─────────────────────────────────── */
+  .footnote { margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--gridline); }
+  .footnote h3 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-muted); margin: 0 0 10px; }
+  .footnote ul { margin: 0 0 24px; padding-left: 18px; font-size: 13.5px; color: var(--text-secondary); }
+  .footnote li { margin-bottom: 6px; }
+  .footnote .methodology { font-size: 12.5px; color: var(--text-muted); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <h1>People Who Met Jeffrey Epstein</h1>
+    <p class="dek">Paragraph-length, directly quoted first-person accounts — journalists, sworn victim/witness testimony, scientists, and social contacts — each independently adversarial-verified against primary sources.</p>
+    <p class="meta">Compiled 2026-07-05 · Multi-agent deep research, 3-vote adversarial verification per claim</p>
+  </header>
+
+  <div class="kpi-row">
+    <div class="kpi-tile"><div class="value">25</div><div class="label">Verified claims</div></div>
+    <div class="kpi-tile"><div class="value">9</div><div class="label">Distinct accounts</div></div>
+    <div class="kpi-tile"><div class="value">22</div><div class="label">Sources fetched</div></div>
+    <div class="kpi-tile"><div class="value">0</div><div class="label">Refuted / unverified</div></div>
+  </div>
+
+  <section class="accounts">
+
+    <!-- 1. James B. Stewart -->
+    <article class="card journalist">
+      <div class="card-head">
+        <span class="pill journalist">Journalist</span>
+        <h2>James B. Stewart</h2>
+        <span class="role">Columnist, The New York Times</span>
+        <span class="spacer"></span>
+        <span class="badge high"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><path d="M5 8.2l2 2 4-4.4" stroke="#fff" stroke-width="1.4" fill="none"/></svg>High confidence</span>
+      </div>
+      <p class="claims-note">90-minute in-person interview at Epstein's Manhattan mansion, Aug 16, 2018 · 4 claims merged</p>
+      <blockquote>&ldquo;Almost exactly a year ago, on August 16th, 2018, I visited Jeffrey Epstein at his cavernous Manhattan mansion&hellip; Epstein claimed to know potentially damaging or embarrassing information about many rich, famous and powerful people, including their supposed sexual proclivities and recreational drug use&hellip; [and] told me that criminalizing sex with teenage girls was a cultural aberration and that at times in history it was perfectly acceptable.&rdquo;</blockquote>
+      <p class="evidence"><strong>Evidence:</strong> Single-witness recollection of an unrecorded conversation, recounted by a Pulitzer-winning reporter in the paper of record. No source disputes date, location, duration, or content.</p>
+      <div class="citations">
+        <a href="https://www.nytimes.com/2019/08/12/business/jeffrey-epstein-interview.html" target="_blank" rel="noopener">NYT, "The Day Jeffrey Epstein Told Me He Had Dirt on Powerful People," Aug 12, 2019</a>
+        <a href="https://www.cjr.org/podcast/jeffrey-epstein-james-stewart-background-suicide-new-york-times.php" target="_blank" rel="noopener">CJR (corroboration)</a>
+      </div>
+    </article>
+
+    <!-- 2. Vicky Ward -->
+    <article class="card journalist">
+      <div class="card-head">
+        <span class="pill journalist">Journalist</span>
+        <h2>Vicky Ward</h2>
+        <span class="role">Contributor, Vanity Fair</span>
+      </div>
+
+      <div class="quote-group journalist">
+        <p class="sub-label">2002–03 reporting <span class="badge high" style="margin-left:8px"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><path d="M5 8.2l2 2 4-4.4" stroke="#fff" stroke-width="1.4" fill="none"/></svg>High confidence</span> · 3 claims merged</p>
+        <blockquote>&ldquo;Jeffrey wanted me to tell you that you looked so pretty&rdquo; — relayed by a female assistant after an off-the-record tea at Epstein's Upper East Side townhouse.</blockquote>
+        <blockquote>In repeated phone calls, Epstein asked &ldquo;What do you have on the girls?&rdquo; — &ldquo;over and over again,&rdquo; per Ward's contemporaneous notes.</blockquote>
+        <blockquote>Ward alleges editor Graydon Carter cut on-the-record allegations from a Phoenix mother and two daughters (one aged 16), telling her Epstein was &ldquo;sensitive about the young women.&rdquo;</blockquote>
+      </div>
+
+      <div class="quote-group journalist">
+        <p class="sub-label">2025 retrospective (NPR) <span class="badge medium" style="margin-left:8px"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><rect x="5" y="7.2" width="6" height="1.6" fill="#0b0b0b"/></svg>Medium confidence</span> · 2 claims merged</p>
+        <blockquote>&ldquo;[Epstein] claimed that he was a financial adviser for billionaires, and yet there was no footprint of him trading in the markets&hellip; The math has never added up.&rdquo;</blockquote>
+        <blockquote>Epstein hosted politicians and rich men while &ldquo;surrounded by beautiful women, many of whom were underage minors, almost in plain sight.&rdquo;</blockquote>
+      </div>
+
+      <p class="evidence"><strong>Evidence:</strong> Quotes verified verbatim against Ward's own essay and the NPR transcript; NPR independently confirmed the Farmer family spoke on record in 2002. Graydon Carter disputes Ward's account of <em>why</em> material was cut (he cites a "legal threshold"); a 2022 New Yorker piece challenged aspects of her broader reporting — her account should be read as her account.</p>
+      <div class="citations">
+        <a href="https://vickyward.com/article/i-tried-to-warn-you-about-sleazy-billionaire-jeffrey-epstein-in-2003/" target="_blank" rel="noopener">vickyward.com, 2015 essay</a>
+        <a href="https://www.thedailybeast.com/i-tried-to-warn-you-about-sleazy-billionaire-jeffrey-epstein-in-2003/" target="_blank" rel="noopener">The Daily Beast</a>
+        <a href="https://www.npr.org/2019/08/22/753337520/why-the-media-didnt-pay-much-attention-to-jeffrey-epstein" target="_blank" rel="noopener">NPR, 2019 (Farmer family corroboration)</a>
+        <a href="https://www.npr.org/2025/07/28/nx-s1-5479843/investigative-journalist-vicky-ward-reviews-just-who-jeffrey-epstein-was" target="_blank" rel="noopener">NPR Morning Edition, Jul 28, 2025</a>
+      </div>
+    </article>
+
+    <!-- 3. Johanna Sjoberg -->
+    <article class="card testimony">
+      <div class="card-head">
+        <span class="pill testimony">Sworn testimony</span>
+        <h2>Johanna Sjoberg</h2>
+        <span class="role">Recruited by Ghislaine Maxwell, 2001</span>
+        <span class="spacer"></span>
+        <span class="badge high"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><path d="M5 8.2l2 2 4-4.4" stroke="#fff" stroke-width="1.4" fill="none"/></svg>High confidence</span>
+      </div>
+      <p class="claims-note">Deposition, Giuffre v. Maxwell, unsealed Jan 2024 · 3 claims merged</p>
+      <blockquote>&ldquo;I remember him being in a bathrobe&hellip; I remember thinking this guy is very smart&rdquo; — describing her first meeting with Epstein.</blockquote>
+      <blockquote>Maxwell phoned to reprimand her after a massage: &ldquo;You came here and didn't finish your job and I had to finish it for you.&rdquo;</blockquote>
+      <blockquote>A photo was taken of Sjoberg with a puppet caricature of Prince Andrew while Andrew put his hand on her breast, with Virginia Giuffre, Epstein, and Maxwell present.</blockquote>
+      <p class="evidence"><strong>Evidence:</strong> Verified directly against the primary court record (1:15-cv-07433-LAP, Doc. 1320-12 and exhibits). Sworn testimony under oath. Maxwell and Prince Andrew dispute the underlying conduct, not that Sjoberg gave this testimony. <em>Minor correction: the puppet was ITV's Spitting Image, not the BBC as Sjoberg described it.</em></p>
+      <div class="citations">
+        <a href="https://uploads.guim.co.uk/2024/01/04/Final_Epstein_documents.pdf" target="_blank" rel="noopener">Unsealed court filing (PDF)</a>
+        <a href="https://storage.courtlistener.com/recap/gov.uscourts.nysd.447706/gov.uscourts.nysd.447706.1320.12.pdf" target="_blank" rel="noopener">CourtListener, Doc. 1320-12</a>
+        <a href="https://www.cbc.ca/news/world/jeffrey-epstein-court-documents-unsealed-1.7072375" target="_blank" rel="noopener">CBC (corroboration)</a>
+      </div>
+    </article>
+
+    <!-- 4. Rinaldo Rizzo -->
+    <article class="card testimony">
+      <div class="card-head">
+        <span class="pill testimony">Sworn testimony</span>
+        <h2>Rinaldo Rizzo</h2>
+        <span class="role">Estate manager for the Dubin family</span>
+        <span class="spacer"></span>
+        <span class="badge high"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><path d="M5 8.2l2 2 4-4.4" stroke="#fff" stroke-width="1.4" fill="none"/></svg>High confidence</span>
+      </div>
+      <p class="claims-note">Deposition, Giuffre v. Maxwell 1320-series</p>
+      <blockquote>Rizzo testified that a terrified 15-year-old girl told him and his wife that on Epstein's island she was asked for sex and refused; that Sarah Kellen took her passport and phone and gave them to Ghislaine Maxwell; and that she was threatened by Epstein and Maxwell not to talk about it.</blockquote>
+      <p class="evidence"><strong>Evidence:</strong> Sworn deposition; firsthand as to the conversation, secondhand as to the island events (relaying what the girl told him). The Dubin family disputes the underlying events, not that Rizzo gave this testimony.</p>
+      <div class="citations">
+        <a href="https://uploads.guim.co.uk/2024/01/04/Final_Epstein_documents.pdf" target="_blank" rel="noopener">Unsealed court filing (PDF)</a>
+        <a href="https://rollcall.com/factbase/epstein/file?id=giuffre-v-maxwell-115-cv-07433-sdny-2015-1320-26" target="_blank" rel="noopener">Roll Call Factbase</a>
+      </div>
+    </article>
+
+    <!-- 5. Peggy Siegal -->
+    <article class="card social">
+      <div class="card-head">
+        <span class="pill social">Social circle</span>
+        <h2>Peggy Siegal</h2>
+        <span class="role">Hollywood publicist, ~12-year acquaintance</span>
+        <span class="spacer"></span>
+        <span class="badge medium"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><rect x="5" y="7.2" width="6" height="1.6" fill="#0b0b0b"/></svg>Medium confidence</span>
+      </div>
+      <p class="claims-note">New York magazine interview, reported by THR, Mar 2026 · 3 claims merged</p>
+      <blockquote>Epstein introduced himself by name-dropping mutual friends and made clear he had &ldquo;numerous houses and a jet&rdquo; to get onto her screening-invitation list.</blockquote>
+      <blockquote>&ldquo;I instantly knew that he collected information to use against you&hellip; There was a sense of danger. It was like a warning bell.&rdquo;</blockquote>
+      <blockquote>&ldquo;I totally jeopardized my relationship with all these important people — they did not know who he was,&rdquo; referring to guests she brought to his post-conviction dinners.</blockquote>
+      <p class="evidence"><strong>Evidence:</strong> Secondary coverage of a primary interview. Siegal is a self-interested narrator with prior inconsistent statements — she previously denied taking Epstein's money, though DOJ emails show contact continuing until April 2019.</p>
+      <div class="citations">
+        <a href="https://www.hollywoodreporter.com/news/general-news/hollywood-publicist-peggy-siegal-jeffrey-epstein-new-york-interview-1236522678/" target="_blank" rel="noopener">The Hollywood Reporter, Mar 2026</a>
+      </div>
+    </article>
+
+    <!-- 6. John Brockman -->
+    <article class="card scientific">
+      <div class="card-head">
+        <span class="pill scientific">Academic &amp; scientific circle</span>
+        <h2>John Brockman</h2>
+        <span class="role">Founder, Edge Foundation</span>
+        <span class="spacer"></span>
+        <span class="badge high"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><path d="M5 8.2l2 2 4-4.4" stroke="#0b0b0b" stroke-width="1.4" fill="none"/></svg>High confidence</span>
+      </div>
+      <p class="claims-note">2013 emails to Evgeny Morozov, published 2019 · 3 claims merged</p>
+      <blockquote>Describing Epstein as a &ldquo;billionaire who owns Victoria's Secret plus a modelling agency&rdquo; with &ldquo;a beautiful young assistant from Belarus,&rdquo; adding &ldquo;He also got into trouble and spent a year in jail in Florida.&rdquo;</blockquote>
+      <blockquote>Recounting a visit to Epstein's townhouse where he found Epstein and a British man receiving foot massages from young Russian women — a man Brockman later realized was Prince Andrew.</blockquote>
+      <p class="evidence"><strong>Evidence:</strong> Epstein-linked foundations gave $638,000 of Edge's ~$857,000 in total donations (2001–2017), verified against IRS 990 filings. Emails published verbatim; jet photo and dinner attendance corroborated by 2002 NYT reporting and confirmed by Pinker and Dennett. Brockman declined comment rather than disputing. <em>Note: Epstein did not actually own Victoria's Secret (that was Leslie Wexner) — this reports Brockman's belief, not fact.</em></p>
+      <div class="citations">
+        <a href="https://www.buzzfeednews.com/article/peteraldhous/jeffrey-epstein-john-brockman-edge-foundation" target="_blank" rel="noopener">BuzzFeed News</a>
+        <a href="https://newrepublic.com/article/154826/jeffrey-epsteins-intellectual-enabler" target="_blank" rel="noopener">The New Republic (Morozov)</a>
+      </div>
+    </article>
+
+    <!-- 7. Sarah Kellen -->
+    <article class="card testimony">
+      <div class="card-head">
+        <span class="pill testimony">Statement via spokesperson</span>
+        <h2>Sarah Kellen</h2>
+        <span class="role">Former Epstein/Maxwell assistant</span>
+        <span class="spacer"></span>
+        <span class="badge medium"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><rect x="5" y="7.2" width="6" height="1.6" fill="#0b0b0b"/></svg>Medium confidence</span>
+      </div>
+      <p class="claims-note">Statement issued via representative Tracy Schmaler, 2019</p>
+      <blockquote>Kellen &ldquo;had just turned 22 when she was recruited by Jeffrey Epstein and Ghislaine Maxwell,&rdquo; after which Epstein &ldquo;began to sexually abuse her, and this abuse went on for years&rdquo;; she &ldquo;continues to struggle with the trauma.&rdquo;</blockquote>
+      <p class="evidence"><strong>Evidence:</strong> Third-person statement issued via a spokesperson, not a direct first-person quote. Kellen's victim/facilitator status is contested by other litigants who describe her as a facilitator; the existence and content of the published statement itself is not in dispute.</p>
+      <div class="citations">
+        <a href="https://www.buzzfeednews.com/article/peteraldhous/jeffrey-epstein-john-brockman-edge-foundation" target="_blank" rel="noopener">BuzzFeed News, Sep 26, 2019</a>
+      </div>
+    </article>
+
+    <!-- 8. Academics -->
+    <article class="card scientific">
+      <div class="card-head">
+        <span class="pill scientific">Academic &amp; scientific circle</span>
+        <h2>Steven Pinker, Lisa Randall &amp; Leon Botstein</h2>
+        <span class="role">Harvard psychologist · Harvard physicist · President, Bard College</span>
+        <span class="spacer"></span>
+        <span class="badge high"><svg class="dot" viewBox="0 0 16 16" fill="currentColor"><circle cx="8" cy="8" r="7"/><path d="M5 8.2l2 2 4-4.4" stroke="#0b0b0b" stroke-width="1.4" fill="none"/></svg>High confidence</span>
+      </div>
+      <p class="claims-note">4 claims merged</p>
+
+      <div class="quote-group scientific">
+        <p class="sub-label">Steven Pinker — flew on Epstein's jet, 2002</p>
+        <blockquote>&ldquo;I immediately disliked Epstein and thought he was a dilettante and a smartass.&rdquo;</blockquote>
+        <blockquote>On providing linguistic help later used in Epstein's legal defense: &ldquo;I was doing a professional courtesy to a colleague—it's routine. If I knew at the time what we know now, I would not have agreed.&rdquo;</blockquote>
+      </div>
+      <div class="quote-group scientific">
+        <p class="sub-label">Lisa Randall — visited Epstein's island, 2014</p>
+        <blockquote>&ldquo;I am appalled by the full extent of allegations against him and deeply regret maintaining contact.&rdquo;</blockquote>
+      </div>
+      <div class="quote-group scientific">
+        <p class="sub-label">Leon Botstein — email correspondent</p>
+        <blockquote>His contact with Epstein was &ldquo;always and only for the sole purpose of soliciting donations for the college.&rdquo;</blockquote>
+      </div>
+
+      <p class="evidence"><strong>Evidence:</strong> Verified verbatim across Scientific American, Times Higher Education, and the Harvard Crimson; Randall's 2014 trip is documented in a DOJ-released flight manifest. <em>Caveat on Botstein: a subsequent WilmerHale investigation for Bard's board concluded he "minimized and was not fully accurate" about the relationship ($150,000 in consulting fees, a $56,000 watch), and he later announced retirement — his quote is genuine but was shown incomplete by further investigation.</em></p>
+      <div class="citations">
+        <a href="https://www.scientificamerican.com/article/why-did-jeffrey-epstein-cultivate-famous-scientists/" target="_blank" rel="noopener">Scientific American, Jan 2026</a>
+        <a href="https://www.timeshighereducation.com/news/he-was-surrounded-smart-people-academics-epstein-files" target="_blank" rel="noopener">Times Higher Education</a>
+        <a href="https://www.thecrimson.com/article/2026/2/1/lisa-randall-epstein-ties/" target="_blank" rel="noopener">Harvard Crimson, Feb 1, 2026</a>
+      </div>
+    </article>
+
+  </section>
+
+  <div class="footnote">
+    <h3>Caveats</h3>
+    <ul>
+      <li>Several accounts are single-witness recollections of unrecorded private conversations (Stewart, Ward, Siegal) — accurately attributed, but the exact words are inherently unverifiable beyond the speaker's own account.</li>
+      <li>Ward's broader narrative is contested: Graydon Carter disputes her account of the 2003 edit, and a 2022 New Yorker piece challenged aspects of her reporting.</li>
+      <li>Siegal and Botstein are self-interested narrators whose statements were later shown incomplete by further reporting or investigation.</li>
+      <li>The Kellen statement came via a spokesperson, not directly from her, and her victim/facilitator status is contested elsewhere in the litigation.</li>
+      <li>Sworn testimony (Sjoberg, Rizzo) is denied as to underlying conduct by Maxwell, Prince Andrew, and the Dubin family — not the fact that the testimony was given.</li>
+      <li>Two minor factual wrinkles inside otherwise-accurate quotes: the Sjoberg puppet was ITV's Spitting Image, not the BBC; Brockman's description of Epstein owning Victoria's Secret was factually wrong (that was Wexner).</li>
+    </ul>
+    <p class="methodology">Methodology: 5 search angles → 22 sources fetched → 103 candidate claims extracted → 25 independently verified via 3-vote adversarial panel (need 2/3 to confirm) → merged into the 9 accounts above. 0 claims refuted, 0 left unverified. Full source report: <code>reports/epstein_firsthand_accounts_2026_07_05.md</code></p>
+  </div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

PR-2 of the swarm live-feed work (spec kept local — `docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md`). Independent of PR-1 (#1976). Pushes a live one-line activity summary per agent instead of requiring the frontend to poll.

- Extracted `generate_activity_summary()` out of the `session:activity_summary` RPC handler so both the existing pull path and this new push loop share the same tail-read + digest + Haiku-CLI logic — no behavior change to the existing RPC.
- New `backend/reactive/activity_watcher.rs::run_agent_summary_loop()`: sweeps every registered reactive agent every 20s, gated on controller status (`STATUS_RUNNING && is_agent_pane`) and skipped when the block's output size is unchanged since the last summary (idle agents cost nothing). Capped at 2 concurrent Haiku CLI spawns via a semaphore.
- Publishes `agent:summary` on scope `block:<id>` via the normal `Broker::publish` path (not the subagent-watcher's EventBus bypass).
- `server::app_api` module made `pub(crate)` so the new loop (under `backend::reactive`) can reach the shared summarizer.
- Wired into `main.rs` alongside the existing sysinfo/watchdog background spawns.

## Test plan
- [x] `cargo check -p agentmux-srv` clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1263/1263 passing (no regressions)
- [ ] Manual: leave an agent pane running, confirm `agent:summary` events arrive on `block:<id>` roughly every 20s while the pane is active, and stop while idle

<!-- agentmux:agent_id=camper -->