### PR TITLE
chore: release v0.50.2

### DIFF
--- a/.changesets/1783156315-feat-agent-ghost-text-next-prompt-suggestion-via-the-ambient-3vcb.md
+++ b/.changesets/1783156315-feat-agent-ghost-text-next-prompt-suggestion-via-the-ambient-3vcb.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): ghost-text next-prompt suggestion via the Ambient Model Call gateway

--- a/.changesets/1783198154-fix-agent-clear-stale-next-prompt-ghost-text-on-session-end-nu35.md
+++ b/.changesets/1783198154-fix-agent-clear-stale-next-prompt-ghost-text-on-session-end-nu35.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): clear stale next-prompt ghost text on session end

--- a/.changesets/1783201574-fix-toolchain-unify-docker-toolchain-capability-detection-ac-w8l7.md
+++ b/.changesets/1783201574-fix-toolchain-unify-docker-toolchain-capability-detection-ac-w8l7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(toolchain): unify Docker/toolchain capability detection across the app

--- a/.changesets/1783245822-fix-layout-floating-pane-redock-lands-at-the-ghost-s-exact-r-qvr3.md
+++ b/.changesets/1783245822-fix-layout-floating-pane-redock-lands-at-the-ghost-s-exact-r-qvr3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): floating-pane redock lands at the ghost's exact rect — size fraction carved from target, siblings untouched

--- a/.changesets/1783247011-wip-window-instrument-close-cascade-browser-teardown-attempt-y50t.md
+++ b/.changesets/1783247011-wip-window-instrument-close-cascade-browser-teardown-attempt-y50t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): instrument the window-close cascade and isolate the CEF 148 browser-parking break point (rounds 2-5 evidence trail behind the pool-demote fix)

--- a/.changesets/1783247349-fix-layout-updateobject-routes-layout-pushes-through-the-red-hjid.md
+++ b/.changesets/1783247349-fix-layout-updateobject-routes-layout-pushes-through-the-red-hjid.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): UpdateObject routes layout pushes through the reducer as a single LayoutSetTree (SPEC_864 Phase 2)

--- a/.changesets/1783269391-fix-window-pool-demote-on-close-recycle-promoted-pool-window-3drr.md
+++ b/.changesets/1783269391-fix-window-pool-demote-on-close-recycle-promoted-pool-window-3drr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): pool-demote on close — recycle promoted pool windows instead of leaking renderers; fix backend_close_window 401 (query-param auth removed 2026-05-11)

--- a/.changesets/1783277218-fix-layout-spec-864-phase-3-layout-seeders-route-through-the-lvbd.md
+++ b/.changesets/1783277218-fix-layout-spec-864-phase-3-layout-seeders-route-through-the-lvbd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): SPEC_864 Phase 3 — layout seeders route through the reducer (CreateWindow three-pane, tear-off/promote/redock/floating single-leaf)

--- a/.changesets/1783285419-fix-layout-spec-864-site-6-delete-block-layout-prune-routes--60qa.md
+++ b/.changesets/1783285419-fix-layout-spec-864-site-6-delete-block-layout-prune-routes--60qa.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): SPEC_864 site 6 — delete_block layout prune routes through the reducer

--- a/.changesets/1783286794-fix-tabs-tighten-tab-inner-right-padding-so-the-close-button-6wi5.md
+++ b/.changesets/1783286794-fix-tabs-tighten-tab-inner-right-padding-so-the-close-button-6wi5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): tighten tab-inner right padding so the close button sits closer to the edge

--- a/.changesets/1783303965-fix-agent-smooth-the-running-completed-tool-preview-transiti-1f8w.md
+++ b/.changesets/1783303965-fix-agent-smooth-the-running-completed-tool-preview-transiti-1f8w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): smooth the running -> completed tool-preview transition (fade-in summary elements, FLIP height transition on panel body)

--- a/.changesets/1783308848-feat-swarm-track-workflow-tool-runs-in-subagent-watcher-9vw3.md
+++ b/.changesets/1783308848-feat-swarm-track-workflow-tool-runs-in-subagent-watcher-9vw3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): track workflow tool runs in subagent_watcher

--- a/.changesets/1783309236-fix-layout-spec-864-phase-4-route-pendingbackendactions-queu-oosg.md
+++ b/.changesets/1783309236-fix-layout-spec-864-phase-4-route-pendingbackendactions-queu-oosg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): SPEC_864 Phase 4 — route pendingbackendactions queue writers through the reducer

--- a/.changesets/1783309517-feat-swarm-push-periodic-haiku-activity-summaries-per-agent-ar8e.md
+++ b/.changesets/1783309517-feat-swarm-push-periodic-haiku-activity-summaries-per-agent-ar8e.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): push periodic Haiku activity summaries per agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.50.1"
+version = "0.50.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,23 @@
 # AgentMux Version History
 
+## 0.50.2 — 2026-07-06
+
+- feat(agent): ghost-text next-prompt suggestion via the Ambient Model Call gateway
+- fix(agent): clear stale next-prompt ghost text on session end
+- fix(toolchain): unify Docker/toolchain capability detection across the app
+- fix(layout): floating-pane redock lands at the ghost's exact rect — size fraction carved from target, siblings untouched
+- fix(window): instrument the window-close cascade and isolate the CEF 148 browser-parking break point (rounds 2-5 evidence trail behind the pool-demote fix)
+- fix(layout): UpdateObject routes layout pushes through the reducer as a single LayoutSetTree (SPEC_864 Phase 2)
+- fix(window): pool-demote on close — recycle promoted pool windows instead of leaking renderers; fix backend_close_window 401 (query-param auth removed 2026-05-11)
+- fix(layout): SPEC_864 Phase 3 — layout seeders route through the reducer (CreateWindow three-pane, tear-off/promote/redock/floating single-leaf)
+- fix(layout): SPEC_864 site 6 — delete_block layout prune routes through the reducer
+- fix(tabs): tighten tab-inner right padding so the close button sits closer to the edge
+- fix(agent): smooth the running -> completed tool-preview transition (fade-in summary elements, FLIP height transition on panel body)
+- feat(swarm): track workflow tool runs in subagent_watcher
+- fix(layout): SPEC_864 Phase 4 — route pendingbackendactions queue writers through the reducer
+- feat(swarm): push periodic Haiku activity summaries per agent
+
+
 ## 0.50.1 — 2026-07-05
 
 - fix(ci): winget-create no longer ships a Linux binary, use windows-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.50.1",
+      "version": "0.50.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release PR consuming 14 pending changesets. Bump type **forced to patch** via `task release -- --as patch` (explicit request), overriding the computed `minor` (one queued changeset — the ghost-text next-prompt suggestion feature — is `type: minor`). The release script printed its standard warning about shipping a minor-level change under a patch version; that's intentional here, not an error.

## Version bump
0.50.1 → 0.50.2, verified consistent across all 5 tracked locations (VERSION_HISTORY.md, package.json, Cargo.toml, Cargo.lock, package-lock.json).

## Changelog
- feat(agent): ghost-text next-prompt suggestion via the Ambient Model Call gateway
- fix(agent): clear stale next-prompt ghost text on session end
- fix(toolchain): unify Docker/toolchain capability detection across the app
- fix(layout): floating-pane redock lands at the ghost's exact rect — size fraction carved from target, siblings untouched
- fix(window): instrument the window-close cascade and isolate the CEF 148 browser-parking break point (rounds 2-5 evidence trail behind the pool-demote fix)
- fix(layout): UpdateObject routes layout pushes through the reducer as a single LayoutSetTree (SPEC_864 Phase 2)
- fix(window): pool-demote on close — recycle promoted pool windows instead of leaking renderers; fix backend_close_window 401 (query-param auth removed 2026-05-11)
- fix(layout): SPEC_864 Phase 3 — layout seeders route through the reducer (CreateWindow three-pane, tear-off/promote/redock/floating single-leaf)
- fix(layout): SPEC_864 site 6 — delete_block layout prune routes through the reducer
- fix(tabs): tighten tab-inner right padding so the close button sits closer to the edge
- fix(agent): smooth the running → completed tool-preview transition (fade-in summary elements, FLIP height transition on panel body)
- feat(swarm): track workflow tool runs in subagent_watcher
- fix(layout): SPEC_864 Phase 4 — route pendingbackendactions queue writers through the reducer
- feat(swarm): push periodic Haiku activity summaries per agent

<!-- agentmux:agent_id=agenta -->