### PR TITLE
chore: release v0.50.3

### DIFF
--- a/.changesets/1783333377-feat-tabs-active-tab-s-custom-color-traces-the-tab-strip-s-b-05dk.md
+++ b/.changesets/1783333377-feat-tabs-active-tab-s-custom-color-traces-the-tab-strip-s-b-05dk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tabs): active tab's custom color traces the tab strip's boundary line

--- a/.changesets/1783362496-fix-layout-spec-864-phase-5-delete-the-heal-layout-reorder-r-egt2.md
+++ b/.changesets/1783362496-fix-layout-spec-864-phase-5-delete-the-heal-layout-reorder-r-egt2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): SPEC_864 Phase 5 — delete the heal_layout/reorder-relaxation backstops now that no Path-B writer remains

--- a/.changesets/1783377095-feat-srv-spec-pillar1-step2-setwindowopacity-rpc-durable-per-q39e.md
+++ b/.changesets/1783377095-feat-srv-spec-pillar1-step2-setwindowopacity-rpc-durable-per-q39e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): SPEC_PILLAR1_STEP2 — SetWindowOpacity RPC, durable per-window opacity mirror

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.50.2"
+version = "0.50.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,12 @@
 # AgentMux Version History
 
+## 0.50.3 — 2026-07-06
+
+- feat(tabs): active tab's custom color traces the tab strip's boundary line
+- fix(layout): SPEC_864 Phase 5 — delete the heal_layout/reorder-relaxation backstops now that no Path-B writer remains
+- feat(srv): SPEC_PILLAR1_STEP2 — SetWindowOpacity RPC, durable per-window opacity mirror
+
+
 ## 0.50.2 — 2026-07-06
 
 - feat(agent): ghost-text next-prompt suggestion via the Ambient Model Call gateway

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.50.2",
+      "version": "0.50.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release PR consuming 3 pending changesets, all `patch` — no override needed this time.

## Version bump
0.50.2 → 0.50.3, verified consistent across all 5 tracked locations (VERSION_HISTORY.md, package.json, Cargo.toml, Cargo.lock, package-lock.json).

## Changelog
- feat(tabs): active tab's custom color traces the tab strip's boundary line
- fix(layout): SPEC_864 Phase 5 — delete the heal_layout/reorder-relaxation backstops now that no Path-B writer remains
- feat(srv): SPEC_PILLAR1_STEP2 — SetWindowOpacity RPC, durable per-window opacity mirror

<!-- agentmux:agent_id=agenta -->
