### PR TITLE
feat(host): SPEC_PILLAR1_STEP2 Slice A Phase 2 — wire per-window opacity write-through + crash-restart read-back

### DIFF
--- a/.changesets/1783384293-feat-host-spec-pillar1-step2-phase-2-wire-per-window-opacity-twu6.md
+++ b/.changesets/1783384293-feat-host-spec-pillar1-step2-phase-2-wire-per-window-opacity-twu6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP2 Phase 2 — wire per-window opacity write-through + crash-restart read-back

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -149,3 +149,163 @@ pub(crate) fn backend_close_window(web_endpoint: &str, auth_key: &str, window_id
         }
     }
 }
+
+/// Parse "http://host:port" / "https://host:port" into a `SocketAddr`, or
+/// `None` (logged) if it doesn't parse. Shared by the two SPEC_PILLAR1_STEP2
+/// helpers below — factored out rather than duplicating
+/// `backend_close_window`'s inline parse.
+fn parse_web_endpoint(web_endpoint: &str, caller: &str) -> Option<std::net::SocketAddr> {
+    let addr_str = web_endpoint
+        .trim_start_matches("http://")
+        .trim_start_matches("https://");
+    match addr_str.parse() {
+        Ok(a) => Some(a),
+        Err(e) => {
+            tracing::warn!("[{caller}] cannot parse endpoint '{}': {}", web_endpoint, e);
+            None
+        }
+    }
+}
+
+/// SPEC_PILLAR1_STEP2 Slice A Phase 2 — write-through the host's per-window
+/// opacity to srv's `Window.opacity` so a crashed/restarted host can restore
+/// it (via `backend_get_window_opacity` below). Fire-and-forget, same shape
+/// as `backend_close_window`: raw TCP, no async runtime needed, always
+/// called from its own background thread (see `set_window_opacity` in
+/// `commands/window/transparency.rs`) so a slow/failed srv round-trip never
+/// stalls the opacity change the user is actively making. Failures are
+/// logged, not surfaced — a missed write-through only affects crash
+/// recovery, not the live opacity the user just set (which already applied
+/// via the local Win32/AppKit/X11 side-effect before this is even called).
+///
+/// `opacity: None` sends a real JSON `null` — srv's `SetWindowOpacity` RPC
+/// treats that as an explicit clear (`Window.opacity = None`), distinct
+/// from `Some(1.0)` ("set to fully opaque"). Mirrors the reducer's own
+/// `WindowOpacityApplied`/`WindowOpacityCleared` distinction (the caller in
+/// `transparency.rs` maps `Cleared` to `None`, not `Some(1.0)`).
+pub(crate) fn backend_set_window_opacity(web_endpoint: &str, auth_key: &str, window_id: &str, opacity: Option<f32>) {
+    use std::io::Write;
+
+    let Some(addr) = parse_web_endpoint(web_endpoint, "backend_set_window_opacity") else {
+        return;
+    };
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "SetWindowOpacity",
+        "args": [window_id, opacity],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    match std::net::TcpStream::connect_timeout(&addr, timeout) {
+        Ok(mut stream) => {
+            stream.set_write_timeout(Some(timeout)).ok();
+            stream.set_read_timeout(Some(timeout)).ok();
+            if let Err(e) = stream.write_all(request.as_bytes()) {
+                tracing::warn!(
+                    window_id = %window_id,
+                    error = %e,
+                    "[backend_set_window_opacity] write failed — opacity mirror not persisted"
+                );
+                return;
+            }
+            // Drain the response so the connection closes cleanly; only the
+            // status line matters here (best-effort, unlike
+            // backend_close_window this isn't gating a user-visible retry).
+            use std::io::Read;
+            let mut resp = String::new();
+            let _ = stream.read_to_string(&mut resp);
+            let first_line = resp.lines().next().unwrap_or("(empty)");
+            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
+                tracing::warn!(
+                    window_id = %window_id,
+                    response = %first_line,
+                    "[backend_set_window_opacity] SetWindowOpacity did not succeed — opacity mirror not persisted"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                window_id = %window_id,
+                addr = %addr,
+                error = %e,
+                "[backend_set_window_opacity] connect failed — opacity mirror not persisted"
+            );
+        }
+    }
+}
+
+/// SPEC_PILLAR1_STEP2 Slice A Phase 2 — read back the last-persisted opacity
+/// for `window_id` from srv (the crash-recovery path: the host's in-memory
+/// `window_opacities` map is empty on a fresh process, so a restart falls
+/// back to this instead of defaulting to fully opaque). Blocking — callers
+/// run it via `tokio::task::spawn_blocking` (see `get_window_opacity` in
+/// `commands/window/transparency.rs`), not inline on an async task, since
+/// this does a real network round-trip.
+///
+/// Returns `None` on any failure (parse/connect/non-200/missing field) —
+/// the caller's existing `unwrap_or(1.0)` fallback covers all of those
+/// identically, so there's no need to distinguish "srv has no value" from
+/// "couldn't reach srv" here.
+pub(crate) fn backend_get_window_opacity(web_endpoint: &str, auth_key: &str, window_id: &str) -> Option<f32> {
+    use std::io::Write;
+
+    let addr = parse_web_endpoint(web_endpoint, "backend_get_window_opacity")?;
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "GetWindow",
+        "args": [window_id],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_opacity] connect failed"))
+        .ok()?;
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_opacity] write failed"))
+        .ok()?;
+
+    use std::io::Read;
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok()?;
+
+    // Split the raw HTTP/1.1 response into headers and body on the blank
+    // line (matches the request format written above — no chunked
+    // encoding involved, srv's axum response is a single JSON payload).
+    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
+    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    parsed.get("data")?.get("opacity")?.as_f64().map(|o| o as f32)
+}

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -65,6 +65,9 @@ pub(crate) use wndproc::install_main_window_floater_cascade_hook;
 // `on_before_close`'s backend cleanup (which never fires for parked
 // pool-window browsers).
 pub(crate) use helpers::backend_close_window;
+// SPEC_PILLAR1_STEP2 Slice A Phase 2 — durable opacity mirror write-through
+// / read-back, used by `commands/window/transparency.rs`.
+pub(crate) use helpers::{backend_get_window_opacity, backend_set_window_opacity};
 pub(crate) use lifecycle::{
     retry_backend_window_id_lookup, BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
     BACKEND_WINDOW_ID_RETRY_DELAY,

--- a/agentmux-cef/src/commands/window/transparency.rs
+++ b/agentmux-cef/src/commands/window/transparency.rs
@@ -216,6 +216,47 @@ pub fn set_window_opacity(
         }
     }
 
+    // SPEC_PILLAR1_STEP2 Slice A Phase 2 — write-through to srv's durable
+    // `Window.opacity` mirror (added in Phase 1, #1982) so a crashed/
+    // restarted host can restore it instead of defaulting to fully opaque
+    // (`get_window_opacity` below reads it back). Platform-agnostic:
+    // `out.events` is the same regardless of which cfg-gated block above
+    // ran, so this fires once per call, not once per platform.
+    //
+    // Best-effort and off this thread entirely (`std::thread::spawn`,
+    // matching `backend_close_window`'s established pattern for
+    // host→srv calls) — a slow or failed srv write must never delay the
+    // opacity change the user is actively making, which already applied
+    // via the local Win32/AppKit/X11 side-effect above. Silently skipped
+    // when the label has no registered `backend_window_id` (e.g. a
+    // pre-promote pool window, or a floating pane — see
+    // SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md §1.B,
+    // floating panes have no srv `Window` row to write to at all).
+    for ev in &out.events {
+        let resolved = match ev {
+            crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity, .. } => {
+                Some((ev_label.clone(), Some(*ev_opacity)))
+            }
+            crate::reducer::HostEvent::WindowOpacityCleared { label: ev_label, .. } => {
+                Some((ev_label.clone(), None))
+            }
+            _ => None,
+        };
+        let Some((ev_label, ev_opacity)) = resolved else { continue };
+        let Some(window_id) = state.backend_window_id(&ev_label) else {
+            tracing::debug!(
+                label = %ev_label,
+                "[opacity] set_window_opacity: no backend_window_id — skipping srv write-through"
+            );
+            continue;
+        };
+        let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+        let auth_key = state.auth_key.lock().clone();
+        std::thread::spawn(move || {
+            crate::client::backend_set_window_opacity(&web_endpoint, &auth_key, &window_id, ev_opacity);
+        });
+    }
+
     let _ = out;
     Ok(serde_json::Value::Null)
 }
@@ -225,20 +266,42 @@ pub fn set_window_opacity(
 /// Reads from `HostState.window_opacities` — reflects the last value applied
 /// via `set_window_opacity`, not the Win32 layer. Used by the frontend to
 /// restore opacity on window init without an extra IPC round-trip.
-pub fn get_window_opacity(
+///
+/// SPEC_PILLAR1_STEP2 Slice A Phase 2 — a miss here means either "never set"
+/// OR "fresh process after a crash/restart" (`window_opacities` starts
+/// empty every launch). Falls back to srv's durable `Window.opacity` mirror
+/// via `backend_get_window_opacity` in the latter case — the actual
+/// reproject payoff of Phase 1's write-through. `async` (unlike the sibling
+/// handlers in this file) so the blocking network read runs on tokio's
+/// blocking-thread pool (`spawn_blocking`) rather than the async worker
+/// thread handling this IPC request.
+pub async fn get_window_opacity(
     state: &Arc<AppState>,
     args: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let label = args
         .get("label")
         .and_then(|v| v.as_str())
-        .unwrap_or("main");
-    let opacity = state
-        .host_state
-        .lock()
-        .window_opacities
-        .get(label)
-        .copied()
-        .unwrap_or(1.0);
+        .unwrap_or("main")
+        .to_string();
+    let host_memory = state.host_state.lock().window_opacities.get(&label).copied();
+    if let Some(opacity) = host_memory {
+        return Ok(serde_json::json!(opacity));
+    }
+
+    let opacity = match state.backend_window_id(&label) {
+        Some(window_id) => {
+            let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+            let auth_key = state.auth_key.lock().clone();
+            tokio::task::spawn_blocking(move || {
+                crate::client::backend_get_window_opacity(&web_endpoint, &auth_key, &window_id)
+            })
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or(1.0)
+        }
+        None => 1.0,
+    };
     Ok(serde_json::json!(opacity))
 }

--- a/agentmux-cef/src/commands/window/transparency.rs
+++ b/agentmux-cef/src/commands/window/transparency.rs
@@ -22,12 +22,58 @@
 //             via ui_tasks::post_set_window_alpha (CEF Views handle → must run
 //             on the UI thread). Native-Wayland ozone: no protocol, no-op.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::state::AppState;
 
 #[cfg(target_os = "windows")]
 use super::lifecycle::find_all_own_windows;
+
+/// SPEC_PILLAR1_STEP2 Slice A Phase 2 (reagent P1 on #1985) — trailing-edge
+/// debounce for the srv opacity write-through, keyed by window label.
+///
+/// The frontend's opacity slider calls `set_window_opacity` on every
+/// `onInput` tick with no debounce of its own — a drag can fire dozens of
+/// calls/sec. The naive approach (spawn a thread + TCP connection per call)
+/// lets those writes race each other: srv's `SetWindowOpacity` RPC does an
+/// unconditional `store.update` with no sequencing, so out-of-order network
+/// delivery could persist a stale mid-drag value instead of the final one
+/// — silently defeating the crash-restart correctness this phase exists
+/// for. A generation counter per label fixes this without touching the
+/// frontend or adding a CAS/version check to the Phase 1 RPC (out of
+/// scope for this phase): each call bumps its label's generation, then
+/// its spawned writer sleeps `OPACITY_WRITE_DEBOUNCE_MS` and only actually
+/// writes if no newer call has superseded it in the meantime. A burst
+/// collapses to exactly one outbound write — the final settled value —
+/// while deliberate, slowly-spaced changes (deliberate clicks, not a drag)
+/// each still get their own write once they clear the window.
+const OPACITY_WRITE_DEBOUNCE_MS: u64 = 400;
+
+fn opacity_write_generations() -> &'static Mutex<HashMap<String, u64>> {
+    static MAP: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    MAP.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Bump and return the new generation for `label`.
+fn next_opacity_write_generation(label: &str) -> u64 {
+    let mut m = opacity_write_generations()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let gen = m.entry(label.to_string()).or_insert(0);
+    *gen += 1;
+    *gen
+}
+
+/// True if `generation` is still the latest recorded generation for
+/// `label` — i.e. no newer `set_window_opacity` call for this label has
+/// happened since this one was scheduled.
+fn is_current_opacity_write_generation(label: &str, generation: u64) -> bool {
+    let m = opacity_write_generations()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    m.get(label).copied() == Some(generation)
+}
 
 /// Set window transparency/blur effects for a single window.
 ///
@@ -223,13 +269,14 @@ pub fn set_window_opacity(
     // `out.events` is the same regardless of which cfg-gated block above
     // ran, so this fires once per call, not once per platform.
     //
-    // Best-effort and off this thread entirely (`std::thread::spawn`,
-    // matching `backend_close_window`'s established pattern for
-    // host→srv calls) — a slow or failed srv write must never delay the
-    // opacity change the user is actively making, which already applied
-    // via the local Win32/AppKit/X11 side-effect above. Silently skipped
-    // when the label has no registered `backend_window_id` (e.g. a
-    // pre-promote pool window, or a floating pane — see
+    // Debounced per label (see `next_opacity_write_generation` above,
+    // reagent P1 on #1985) so a rapid burst — e.g. a slider drag, which
+    // the frontend fires on every `onInput` tick with no debounce of its
+    // own — collapses to exactly one outbound write of the final settled
+    // value, instead of one thread + TCP connection per tick racing to
+    // persist whichever happens to land last over the network. Silently
+    // skipped when the label has no registered `backend_window_id` (e.g.
+    // a pre-promote pool window, or a floating pane — see
     // SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md §1.B,
     // floating panes have no srv `Window` row to write to at all).
     for ev in &out.events {
@@ -250,9 +297,17 @@ pub fn set_window_opacity(
             );
             continue;
         };
+        let generation = next_opacity_write_generation(&ev_label);
         let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
         let auth_key = state.auth_key.lock().clone();
+        let debounce_label = ev_label.clone();
         std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(OPACITY_WRITE_DEBOUNCE_MS));
+            if !is_current_opacity_write_generation(&debounce_label, generation) {
+                // A newer call for this label superseded us during the
+                // sleep — this value is stale, don't persist it.
+                return;
+            }
             crate::client::backend_set_window_opacity(&web_endpoint, &auth_key, &window_id, ev_opacity);
         });
     }
@@ -304,4 +359,64 @@ pub async fn get_window_opacity(
         None => 1.0,
     };
     Ok(serde_json::json!(opacity))
+}
+
+#[cfg(test)]
+mod opacity_debounce_tests {
+    use super::{is_current_opacity_write_generation, next_opacity_write_generation};
+
+    /// Simulates a rapid burst (slider drag): only the LAST call's
+    /// generation should still be "current" once all bumps have happened
+    /// — the reagent P1 scenario this debounce exists to prevent (an
+    /// earlier, superseded call's stale value winning a network race).
+    #[test]
+    fn burst_only_the_last_generation_is_current() {
+        let label = "test-burst-only-last-wins";
+        let gens: Vec<u64> = (0..5).map(|_| next_opacity_write_generation(label)).collect();
+        for &g in &gens[..gens.len() - 1] {
+            assert!(
+                !is_current_opacity_write_generation(label, g),
+                "earlier generation {g} must be superseded after a burst"
+            );
+        }
+        assert!(
+            is_current_opacity_write_generation(label, *gens.last().unwrap()),
+            "the last generation in the burst must still be current"
+        );
+    }
+
+    /// A single, deliberate (non-burst) call must still be current —
+    /// debouncing a burst down to one write must not also drop the only
+    /// write when there's no burst to coalesce.
+    #[test]
+    fn single_call_is_current() {
+        let label = "test-single-call-is-current";
+        let g = next_opacity_write_generation(label);
+        assert!(is_current_opacity_write_generation(label, g));
+    }
+
+    /// Generations are tracked independently per label — a burst on one
+    /// window must not supersede a pending write for a different window.
+    #[test]
+    fn generations_are_independent_per_label() {
+        let a = "test-independent-label-a";
+        let b = "test-independent-label-b";
+        let ga = next_opacity_write_generation(a);
+        let gb = next_opacity_write_generation(b);
+        // A second call on `a` only supersedes `a`'s generation, not `b`'s.
+        next_opacity_write_generation(a);
+        assert!(!is_current_opacity_write_generation(a, ga));
+        assert!(is_current_opacity_write_generation(b, gb));
+    }
+
+    /// A generation that was never issued for a label (or an unknown
+    /// label entirely) must never read as current — the debounce map
+    /// only knows about labels it has actually seen.
+    #[test]
+    fn unknown_label_or_generation_is_never_current() {
+        assert!(!is_current_opacity_write_generation("test-never-seen-this-label", 1));
+        let label = "test-known-label-wrong-generation";
+        let g = next_opacity_write_generation(label);
+        assert!(!is_current_opacity_write_generation(label, g + 1));
+    }
 }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -257,7 +257,7 @@ async fn route_command(
         "reveal_in_file_explorer" => commands::platform::reveal_in_file_explorer(args),
         "set_window_transparency" => commands::window::set_window_transparency(state, args),
         "set_window_opacity" => commands::window::set_window_opacity(state, args),
-        "get_window_opacity" => commands::window::get_window_opacity(state, args),
+        "get_window_opacity" => commands::window::get_window_opacity(state, args).await,
         "start_window_drag" => commands::window::start_window_drag(state, args),
         "get_window_rect" => commands::window::get_window_rect(state, args),
         "set_window_rect" => commands::window::set_window_rect(state, args),

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -31,7 +31,7 @@
 //! passed to `spawn_splash`.  Each animation frame (~60 fps) drains the
 //! receiver and updates the stage list.  When the CEF host signals the
 //! dismiss Win32 event (from `on_load_end`), the splash freezes, holds for
-//! `AGENTMUX_SPLASH_HOLD_MS` ms (default 3000), then fades out.
+//! `AGENTMUX_SPLASH_HOLD_MS` ms (default 2000), then fades out.
 
 #![cfg(target_os = "windows")]
 
@@ -302,11 +302,11 @@ unsafe fn run_splash(
             composite(dib_pixels, 200u8, &stages, Some(total_ms), &footer);
             push_layered(hwnd, mem_dc, 255);
 
-            // Summary hold — 3 s default, shortened for very fast starts.
+            // Summary hold — 2 s default, shortened for very fast starts.
             let hold_ms = std::env::var("AGENTMUX_SPLASH_HOLD_MS")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(3000);
+                .unwrap_or(2000);
             let hold_ms = if total_ms < 500 { hold_ms.min(1000) } else { hold_ms };
             if hold_ms > 0 {
                 std::thread::sleep(std::time::Duration::from_millis(hold_ms));

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -701,7 +701,7 @@ impl Splash {
                 let hold_ms = std::env::var("AGENTMUX_SPLASH_HOLD_MS")
                     .ok()
                     .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(3000);
+                    .unwrap_or(2000);
                 let hold_ms = if total_ms < 500 { hold_ms.min(1000) } else { hold_ms };
                 hold_duration = Duration::from_millis(hold_ms);
                 changed = true; // force one final refresh showing the "total:" row

--- a/docs/specs/SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md
+++ b/docs/specs/SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md
@@ -231,14 +231,19 @@ Phase 2/4 landing — the srv-side plumbing is valid and testable on its own.
 
 ## 6. Definition of done
 
-1. `Window.opacity` persists through a real `SetWindowOpacity` RPC call, unit-tested.
-2. Setting a window's opacity in a running app persists it to srv (verified live, not just unit-tested).
-3. Killing and relaunching the host restores the last-set opacity for windows that had one (verified live).
-4. `block.meta["pane:floating_normal_rect"]`/`["pane:floating_placement"]` persist through the existing
-   generic block-meta-patch mechanism, unit-tested.
-5. Maximizing then restoring a floating pane, killing the host, and relaunching restores the pane at
-   its last-known normal rect (verified live).
-6. Neither write-through path introduces a detectable UI stall on the action that triggers it.
+1. ✅ `Window.opacity` persists through a real `SetWindowOpacity` RPC call, unit-tested (Phase 1, #1982).
+2. ✅ Setting a window's opacity in a running app persists it to srv (Phase 2 — verified live via an
+   isolated instance: `window.api.setWindowOpacity('main', 0.7)` → `GetWindow` showed
+   `opacity: 0.699999988079071` in srv).
+3. ✅ Killing and relaunching the host restores the last-set opacity for windows that had one (Phase 2 —
+   verified live: killed the host process, relaunched against the same channel,
+   `window.api.getWindowOpacity('main')` on the fresh process returned `0.7`, not the 1.0 default).
+   Also verified the clear path: `setWindowOpacity('main', 1.0)` → srv's `Window.opacity` field became
+   fully absent (`None`, matching `WindowOpacityCleared`, not `Some(1.0)`).
+4. ⬜ Slice B — not started.
+5. ⬜ Slice B — not started.
+6. ✅ Both write-through paths (Phase 2) are `std::thread::spawn`/`spawn_blocking`, off the calling
+   thread — no stall observed live.
 
 ---
 


### PR DESCRIPTION
Completes Slice A of `docs/specs/SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md` — Phase 2, wiring the host to actually use Phase 1's `SetWindowOpacity` RPC (#1982). Slice B (floating-pane placement) is a separate follow-up.

## What

- `set_window_opacity` (`agentmux-cef/src/commands/window/transparency.rs`) fires a best-effort, fire-and-forget write-through to srv after the local Win32/AppKit/X11 opacity side-effect applies, resolving the label to a real srv `window_id` via `state.backend_window_id`. `WindowOpacityCleared` sends a real JSON `null` (a genuine clear, distinct from `Some(1.0)` "set to fully opaque") — matching srv's `SetWindowOpacity` RPC semantics from Phase 1.
- `get_window_opacity` falls back to reading srv's mirror when the host's in-memory `window_opacities` map misses — which happens on every fresh process launch, i.e. the crash-recovery case this whole spec exists for. Made `async` so the network read runs via `tokio::task::spawn_blocking` rather than blocking the async task handling the IPC request.
- New host→srv HTTP helpers in `client/helpers.rs` (`backend_set_window_opacity`/`backend_get_window_opacity`). I checked first whether any reqwest/tokio-client pattern already existed for host→srv calls — it doesn't; the one precedent is `backend_close_window`'s raw-TCP HTTP/1.1 POST (used because "no async runtime or extra crate is needed" per its own comment), so I followed that shape rather than introducing a new transport.

## Testing

No unit tests added — this is Win32/AppKit/X11 + network I/O with no existing test harness in this crate for that combination (the sibling handlers in this file aren't unit-tested either). Per this program's established caution for anything touching host↔srv write-through (same reasoning as Pillar 2 Stage 2's "do not auto-merge on bot approval" rule), I verified live against an isolated built instance instead of relying on unit tests + bot approval:

- `window.api.setWindowOpacity('main', 0.7)` → srv's `GetWindow` RPC showed `opacity: 0.699999988079071` persisted.
- Killed the host process (not graceful quit), relaunched against the same channel — `window.api.getWindowOpacity('main')` on the fresh process returned `0.7`, not the 1.0 default. This is the actual payoff: a crash-restarted host recovers state a cold-start-only host would have lost.
- `window.api.setWindowOpacity('main', 1.0)` → srv's `opacity` field went fully absent (`None`), confirming the clear path is a real clear, not a stored `1.0`.
- `cargo check --workspace --tests` and `cargo test -p agentmux-cef` (155 passed, 0 failed — pre-existing suite, none touch this code path, all still pass) both clean.

## Also in this PR

An unrelated quick fix, folded in per request: reduces the post-splash summary hold from 3s to 2s — both the Windows path (`agentmux-launcher/src/splash.rs`) and the macOS path (`splash_mac.rs`, which explicitly documents itself as mirroring the Windows convention). Linux's `min_hold()` is a genuinely different mechanism (a *minimum* on-screen time before dismiss is even allowed, not a post-completion hold) with its own much-shorter default (450ms) and was left alone.

<!-- agentmux:agent_id=agenta -->
