### PR TITLE
feat(host): SPEC_PILLAR1_STEP2 Slice B — floating-pane placement write-through

### DIFF
--- a/.changesets/1783388737-feat-host-spec-pillar1-step2-slice-b-floating-pane-placement-9aec.md
+++ b/.changesets/1783388737-feat-host-spec-pillar1-step2-slice-b-floating-pane-placement-9aec.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP2 Slice B — floating-pane placement write-through to srv

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -309,3 +309,80 @@ pub(crate) fn backend_get_window_opacity(web_endpoint: &str, auth_key: &str, win
     }
     parsed.get("data")?.get("opacity")?.as_f64().map(|o| o as f32)
 }
+
+/// SPEC_PILLAR1_STEP2 Slice B Phase 4 — write-through a floating pane's
+/// OS-window placement to its block's `meta` map, via the existing generic
+/// `object.UpdateObjectMeta` RPC (Phase E.5.3 — `Command::UpdateBlockMeta`
+/// already does a shallow merge against `block.meta`, so no new srv-side RPC
+/// was needed for this phase, unlike opacity's Phase 1). `meta_patch` is
+/// merged as-is — pass only the keys that changed (e.g. omit
+/// `pane:floating_normal_rect` on a restore that only changes placement).
+///
+/// Fire-and-forget, same shape as `backend_set_window_opacity`: raw TCP, no
+/// async runtime needed, called from `toggle_floating_maximize`
+/// (`commands/window/chrome.rs`) off the calling thread so a slow/failed srv
+/// round-trip never stalls the maximize/restore the user is actively
+/// triggering. No debounce (unlike opacity): this fires once per button
+/// click, not once per drag tick, so there's no burst to collapse.
+pub(crate) fn backend_update_block_meta(web_endpoint: &str, auth_key: &str, block_id: &str, meta_patch: serde_json::Value) {
+    use std::io::Write;
+
+    let Some(addr) = parse_web_endpoint(web_endpoint, "backend_update_block_meta") else {
+        return;
+    };
+
+    let oref = format!("block:{block_id}");
+    let body = serde_json::json!({
+        "service": "object",
+        "method": "UpdateObjectMeta",
+        "args": [oref, meta_patch],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    match std::net::TcpStream::connect_timeout(&addr, timeout) {
+        Ok(mut stream) => {
+            stream.set_write_timeout(Some(timeout)).ok();
+            stream.set_read_timeout(Some(timeout)).ok();
+            if let Err(e) = stream.write_all(request.as_bytes()) {
+                tracing::warn!(
+                    block_id = %block_id,
+                    error = %e,
+                    "[backend_update_block_meta] write failed — floating-pane placement not persisted"
+                );
+                return;
+            }
+            use std::io::Read;
+            let mut resp = String::new();
+            let _ = stream.read_to_string(&mut resp);
+            let first_line = resp.lines().next().unwrap_or("(empty)");
+            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
+                tracing::warn!(
+                    block_id = %block_id,
+                    response = %first_line,
+                    "[backend_update_block_meta] UpdateObjectMeta did not succeed — floating-pane placement not persisted"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                block_id = %block_id,
+                addr = %addr,
+                error = %e,
+                "[backend_update_block_meta] connect failed — floating-pane placement not persisted"
+            );
+        }
+    }
+}

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -68,6 +68,9 @@ pub(crate) use helpers::backend_close_window;
 // SPEC_PILLAR1_STEP2 Slice A Phase 2 — durable opacity mirror write-through
 // / read-back, used by `commands/window/transparency.rs`.
 pub(crate) use helpers::{backend_get_window_opacity, backend_set_window_opacity};
+// SPEC_PILLAR1_STEP2 Slice B Phase 4 — floating-pane placement write-through,
+// used by `commands/window/chrome.rs`.
+pub(crate) use helpers::backend_update_block_meta;
 pub(crate) use lifecycle::{
     retry_backend_window_id_lookup, BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
     BACKEND_WINDOW_ID_RETRY_DELAY,

--- a/agentmux-cef/src/commands/window/chrome.rs
+++ b/agentmux-cef/src/commands/window/chrome.rs
@@ -102,6 +102,13 @@ pub fn toggle_floating_maximize(
         .and_then(|v| v.as_str())
         .ok_or_else(|| "toggle_floating_maximize: label is required".to_string())?
         .to_string();
+    // SPEC_PILLAR1_STEP2 Slice B Phase 4 — the frontend caller
+    // (`FloatingMaximizeButton` in `blockframe.tsx`) already has
+    // `nodeModel.blockId` in scope and passes it alongside `label`. Optional
+    // for back-compat (older/mismatched builds): the srv write-through below
+    // is silently skipped when absent, same as opacity's missing-
+    // `backend_window_id` skip.
+    let block_id = args.get("block_id").and_then(|v| v.as_str()).map(|s| s.to_string());
 
     // Read the floater's CURRENT (pre-toggle) screen rect so the reducer can
     // stash it as the restore target. Win32 physical pixels — the same space
@@ -213,5 +220,39 @@ pub fn toggle_floating_maximize(
         crate::state::WindowPlacement::Maximized => "maximized",
         _ => "normal",
     };
+
+    // SPEC_PILLAR1_STEP2 Slice B Phase 4 — write-through to the block's
+    // durable `meta` mirror (added in Phase 3 via the existing generic
+    // `UpdateObjectMeta` RPC — no new srv code needed). Fire-and-forget on a
+    // background thread, mirroring `set_window_opacity`'s write-through: a
+    // slow/failed srv round-trip must never stall the maximize/restore the
+    // user is actively triggering.
+    //
+    // Rect to persist: on Maximize (`current_rect`, the pre-toggle rect the
+    // reducer just stashed as `last_known_normal_rect`) or on Restore
+    // (`restore_rect`, the rect the reducer just handed back and the Win32
+    // side-effect above just applied) — both describe "where the floater
+    // sits/should sit when Normal", matching `pane:floating_normal_rect`'s
+    // meaning. Omitted from the patch (not written as null) when unavailable
+    // (e.g. `GetWindowRect` failed) — a partial merge leaves any
+    // previously-persisted rect untouched rather than clearing it.
+    if let Some(block_id) = block_id {
+        let rect_to_persist = match placement {
+            crate::state::WindowPlacement::Maximized => current_rect,
+            _ => restore_rect,
+        };
+        let mut meta_patch = serde_json::json!({ "pane:floating_placement": placement_str });
+        if let Some(r) = rect_to_persist {
+            meta_patch["pane:floating_normal_rect"] = serde_json::json!({
+                "left": r.left, "top": r.top, "right": r.right, "bottom": r.bottom,
+            });
+        }
+        let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+        let auth_key = state.auth_key.lock().clone();
+        std::thread::spawn(move || {
+            crate::client::backend_update_block_meta(&web_endpoint, &auth_key, &block_id, meta_patch);
+        });
+    }
+
     Ok(serde_json::json!({ "placement": placement_str }))
 }

--- a/docs/specs/SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md
+++ b/docs/specs/SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_PERSISTENCE_2026_07_06.md
@@ -150,12 +150,27 @@ moves tabs), and delete (block removed, meta goes with it). Inventing a parallel
 object keyed by the host's ephemeral label would need its own lifecycle-matching logic for zero
 benefit over reusing the block's.
 
-**Host write-through:**
-- `chrome.rs::toggle_floating_maximize`: after capturing/restoring `current_rect` /
-  `last_known_normal_rect`, resolve the **block_id** displayed in this floating window (the host must
-  already know this to route input/render — check `PaneWindowState` or the window-label→block-id
-  registry used elsewhere in `floating_pane.rs`) and fire `ObjectService.UpdateObjectMeta` (or the
-  block-metadata equivalent) with the two keys above.
+**Host write-through — block_id resolution, verified (no longer an open question):**
+- `PaneWindowState` (`agentmux-cef/src/state.rs:207-213`) has no `block_id` field — only `placement`
+  and `last_known_normal_rect`. Confirmed no reverse label→block_id registry exists anywhere in
+  `agentmux-cef` either; the only block-keyed map (`HostState.browser_panes`) goes block_id→label, not
+  the other way, and resolving label→block_id from it would require an unenforced 1:1 linear scan.
+- **The caller already has `block_id` in scope and doesn't need a host-side lookup at all.**
+  `toggle_floating_maximize` (`chrome.rs:96-104`) is invoked from `FloatingMaximizeButton`
+  (`frontend/app/block/blockframe.tsx:201-211`), itself rendered from `EndIcons`
+  (`blockframe.tsx:282`) — which already holds `props.nodeModel.blockId` in scope two lines earlier
+  (used for the mic button, `blockframe.tsx:255`). **Design change from the original draft:** thread
+  `block_id` through as a new IPC arg (`invokeCommand("toggle_floating_maximize", { label, block_id })`)
+  rather than having `chrome.rs` resolve it host-side. This is strictly simpler than adding a registry
+  and avoids the 1:1-assumption fragility a lookup table would carry.
+- With `block_id` supplied by the caller, `chrome.rs::toggle_floating_maximize` fires
+  `ObjectService.UpdateObjectMeta` (or the block-metadata equivalent — confirm exact RPC name at Phase 3)
+  with the two keys above, after capturing/restoring `current_rect`/`last_known_normal_rect`.
+- **Creation-time resolution also verified:** `OpenFloatingPaneArgs.pane_id` (`floating_pane.rs:38`) is
+  supplied by the frontend when the floating window is first created — likely already the block_id
+  under a different field name, but this equivalence needs a one-time confirmation against the
+  block/pane ID scheme (`agentmux-srv/src/server/app_api/pane.rs`) before Phase 4, not assumed. If
+  `pane_id` ≠ `block_id`, `OpenFloatingPaneArgs` needs a new field for the read-back path.
 - **Read-back on floating-pane re-open:** when `open_floating_pane_window` creates the native window
   for a block, read `block.meta["pane:floating_normal_rect"]`/`["pane:floating_placement"]` (if present)
   to restore geometry instead of falling back to the caller-supplied default width/height. This is
@@ -176,15 +191,34 @@ fallback on init. **App-running verification required** (per the design doc's Q2
 anything touching host↔srv write-through) — set an opacity, kill the host process (not graceful quit),
 relaunch, confirm the window restores the opacity from srv rather than defaulting to opaque.
 
-**Phase 3 (Slice B) — floating-pane placement, srv side.** Confirm the exact RPC that already supports
-arbitrary block-meta patches (or add one if `UpdateObjectMeta` doesn't cover it), unit tests for the
-meta round-trip.
+**Phase 3 (Slice B) — floating-pane placement, srv side. Done — no new code needed.** Confirmed
+`UpdateObjectMeta` (`agentmux-srv/src/server/service/object.rs:291-389`) already routes `OTYPE_BLOCK`
+through `Command::UpdateBlockMeta` → the reducer → `apply_block_meta_updated`/`merge_meta_patch`
+(`persist_subscriber.rs:1013-1025,1168+`), a generic shallow merge over arbitrary `block.meta` keys
+(including `null`-to-delete section-clear semantics). This already fully supports writing
+`pane:floating_normal_rect`/`pane:floating_placement` — no srv-side PR needed for this phase.
 
-**Phase 4 (Slice B) — floating-pane placement, host wiring.** `chrome.rs` write-through on
-maximize/restore; `open_floating_pane_window` read-back on creation. **App-running verification
-required**: open a floating pane, resize+move it to a non-default rect, maximize then restore (to
-populate `last_known_normal_rect` through the existing trigger), kill the host, relaunch, redock or
-re-open the floating pane, confirm it reopens at the persisted rect.
+**Phase 4 (Slice B) — floating-pane placement, host wiring. Write-through done; read-back deferred
+(see below).**
+- `chrome.rs::toggle_floating_maximize` now accepts an optional `block_id` in its IPC args (threaded
+  through from `FloatingMaximizeButton` in `blockframe.tsx`, which already has `nodeModel.blockId` in
+  scope — see the resolved §2.B design). After the reducer dispatch and Win32 geometry side-effect, it
+  fires `client::backend_update_block_meta` (fire-and-forget, mirrors `backend_set_window_opacity`'s
+  shape, no debounce needed since this is a button click, not a continuous drag) with
+  `pane:floating_placement` always, and `pane:floating_normal_rect` when a rect is available (the
+  pre-toggle `current_rect` on maximize, the reducer-returned `restore_rect` on restore).
+- **`open_floating_pane_window` read-back on creation — deliberately NOT implemented in this phase.**
+  Verified via `frontend/app/workspace/floating-pane-workspace.tsx:9-11`'s own doc comment: "The
+  floating window's backend state is a normal workspace+tab+block (created by `TearOffBlock` in the
+  source window)" — i.e. `OpenFloatingPaneArgs.pane_id` (`floating_pane.rs:38`) IS the block_id, and a
+  *new* block is created by `TearOffBlock` on every single tear-off. That means
+  `block.meta["pane:floating_normal_rect"]` can never be present the first time
+  `open_floating_pane_window` runs for a given block — there is no call site today where a floater is
+  recreated for a block that was PREVIOUSLY floating (redock removes the floating block entirely; a
+  fresh tear-off always makes a fresh block). Wiring a read-back now would be dead code with no live
+  trigger, not a verifiable feature — it only becomes meaningful once crash-reproject (Step 4 of the
+  Pillar 1 sequence, explicitly out of scope per §5) actually recreates floating windows for
+  surviving blocks after a restart. Revisit this read-back as part of Step 4, not here.
 
 Each phase independently shippable + testable, mirroring #864's approach. Do not gate Phase 1/3 on
 Phase 2/4 landing — the srv-side plumbing is valid and testable on its own.
@@ -198,12 +232,10 @@ Phase 2/4 landing — the srv-side plumbing is valid and testable on its own.
   control — an RPC round-trip must be async/non-blocking, matching the existing
   `report_backend_window_id_registered` pattern (send-and-forget over the launcher-ipc channel, not a
   synchronous wait).
-- **Floating-pane block-id resolution needs verification, not assumption.** §2.B assumes the host can
-  resolve "which block is this floating window showing" from existing state — confirm the exact field
-  before implementing Phase 4 (likely already tracked for input-routing purposes; grep
-  `floating_pane.rs`/`window_pool.rs` for the label→block_id mapping used by drag/redock).
-  This spec explicitly does NOT verify that mapping — flagged as the one open question for whoever
-  implements Slice B.
+- **Floating-pane block-id resolution — resolved, see §2.B.** No label→block_id registry exists
+  host-side; the fix is threading `block_id` through as a new IPC arg from the frontend caller (which
+  already has it), not a host-side lookup. One remaining sub-item before Phase 4: confirm
+  `OpenFloatingPaneArgs.pane_id` (`floating_pane.rs:38`) is actually the block_id (or add a field if not).
 - **This spec does not implement `ReportNormalRect`/`ReportOSPlacementChange`** (continuous drag/resize
   tracking). Only the existing maximize-button trigger gets write-through. A floating pane resized by
   dragging its edge (not via the maximize button) will NOT have its new size persisted until/unless
@@ -240,8 +272,24 @@ Phase 2/4 landing — the srv-side plumbing is valid and testable on its own.
    `window.api.getWindowOpacity('main')` on the fresh process returned `0.7`, not the 1.0 default).
    Also verified the clear path: `setWindowOpacity('main', 1.0)` → srv's `Window.opacity` field became
    fully absent (`None`, matching `WindowOpacityCleared`, not `Some(1.0)`).
-4. ⬜ Slice B — not started.
-5. ⬜ Slice B — not started.
+4. ✅ Floating-pane placement (`pane:floating_placement`/`pane:floating_normal_rect`) persists to the
+   block's `meta` map through the existing generic `UpdateObjectMeta` RPC (Phase 3 needed no new srv
+   code — verified the generic shallow-merge mechanism already covers this) and the Phase 4 host
+   write-through in `chrome.rs::toggle_floating_maximize`. Compiles clean (`cargo check -p agentmux-cef`,
+   `cargo test -p agentmux-cef` — 159 passed), `tsc --noEmit` clean on the frontend change.
+   **Verified live** on an isolated instance: created a real floating pane via `open_floating_pane_window`
+   (block `596df4fc-…`, 500×400 at (300,300)), called `toggle_floating_maximize` with the new `block_id`
+   arg — srv's `GetObject` showed `meta.pane:floating_placement:"maximized"` and
+   `pane:floating_normal_rect:{left:300,top:300,right:800,bottom:700}` (`version: 2`). Toggled again
+   (restore) — `placement` flipped to `"normal"`, rect unchanged, `version: 3`. Killed the outer
+   `agentmux.exe` (not graceful quit) and relaunched against the same channel — `GetObject` on the same
+   block still returned `placement:"normal"`, the same rect, `version: 3` unchanged — confirms the
+   write-through survives a host crash (expected, since it bypasses host memory entirely, unlike
+   opacity's `HostState.window_opacities` mirror).
+5. ⬜ Read-back on floating-pane re-open — deliberately deferred, not a gap in this phase. See §3
+   Phase 4: no call site exists today where `open_floating_pane_window` runs for a block that already
+   has persisted placement meta (every tear-off creates a fresh block). Belongs to Step 4
+   (crash-reproject), not this spec.
 6. ✅ Both write-through paths (Phase 2) are `std::thread::spawn`/`spawn_blocking`, off the calling
    thread — no stall observed live.
 

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -198,13 +198,15 @@ function OptMagnifyButton(props: { magnified: boolean; toggleMagnify: () => void
  *  expect a maximize button to toggle), which keeps the button stateless —
  *  the reducer is the single source of truth for placement, not a mirrored
  *  frontend signal that can drift. */
-function FloatingMaximizeButton(props: { label: string }): JSX.Element {
+function FloatingMaximizeButton(props: { label: string; blockId: string }): JSX.Element {
     const decl: IconButtonDecl = {
         elemtype: "iconbutton",
         icon: "window-maximize",
         title: "Maximize",
         click: () => {
-            invokeCommand("toggle_floating_maximize", { label: props.label }).catch(console.error);
+            invokeCommand("toggle_floating_maximize", { label: props.label, block_id: props.blockId }).catch(
+                console.error
+            );
         },
     };
     return <IconButton decl={decl} className="block-frame-magnify" />;
@@ -279,7 +281,7 @@ function EndIcons(props: {
                         disabled={magnifyDisabled()}
                     />
                 }>
-                    <FloatingMaximizeButton label={floatingLabel()!} />
+                    <FloatingMaximizeButton label={floatingLabel()!} blockId={props.nodeModel.blockId} />
                 </Show>
             }>
                 <IconButton decl={{


### PR DESCRIPTION
## Summary
- Completes Slice B of SPEC_PILLAR1_STEP2 (the second Q1-category host-only topology fact — floating-pane placement — alongside Slice A's per-window opacity from #1982/#1985).
- **Phase 3 (srv side): no new code needed.** Confirmed the existing generic `UpdateObjectMeta` RPC already routes `block.meta` patches through the reducer's shallow-merge path (`Command::UpdateBlockMeta` → `apply_block_meta_updated`/`merge_meta_patch`), which fully covers writing `pane:floating_placement`/`pane:floating_normal_rect`.
- **Phase 4 (host wiring):** `toggle_floating_maximize` now accepts an optional `block_id` IPC arg (threaded from `FloatingMaximizeButton` in `blockframe.tsx`, which already has `nodeModel.blockId` in scope) and fires a fire-and-forget write-through (`client::backend_update_block_meta`, mirroring `backend_set_window_opacity`'s shape) with the placement + rect on maximize/restore.
- **Read-back on floating-pane re-open deliberately deferred** — `TearOffBlock` creates a fresh block on every tear-off, so there's no live call site today where `open_floating_pane_window` would ever see persisted meta for its block. This becomes meaningful once crash-reproject (Step 4 of the Pillar 1 sequence) actually recreates floating windows for surviving blocks — tracked in the spec, not implemented here.

## Test plan
- [x] `cargo check -p agentmux-cef` clean
- [x] `cargo test -p agentmux-cef` — 159 passed
- [x] `tsc --noEmit` clean on the frontend change
- [x] Live-verified on an isolated portable build: created a real floating pane via `open_floating_pane_window`, toggled maximize (srv `GetObject` showed `pane:floating_placement:"maximized"`, `pane:floating_normal_rect:{left:300,top:300,right:800,bottom:700}`), toggled restore (`placement` → `"normal"`, rect unchanged), killed the host process (not graceful quit) and relaunched — confirmed the placement/rect survived the crash-restart

<!-- agentmux:agent_id=agenta -->