### PR TITLE
feat(agent): Esc delivers a queued message immediately, mirroring Claude Code CLI

### DIFF
--- a/.changesets/1783389028-feat-agent-esc-delivers-a-queued-message-immediately-mirrori-ksiy.md
+++ b/.changesets/1783389028-feat-agent-esc-delivers-a-queued-message-immediately-mirrori-ksiy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): Esc delivers a queued message immediately, mirroring Claude Code CLI

--- a/docs/specs/SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md
+++ b/docs/specs/SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md
@@ -1,0 +1,80 @@
+# SPEC — Escape delivers a queued message immediately (mimic Claude CLI's interrupt-and-steer)
+
+**Date:** 2026-07-06
+**Author:** Agent2
+**Status:** Draft
+**Scope:** `frontend/app/view/agent/components/AgentFooter.tsx`, `frontend/app/view/agent/hooks/useAgentCommands.ts`, `frontend/app/view/agent/agent-view.tsx`; a Tier 2 follow-on may touch `agentmux-srv/src/backend/blockcontroller/persistent.rs`.
+**Related (must-read first):**
+`docs/specs/SPEC_INJECT_AT_TOOL_BOUNDARY_2026_06_16.md` (the empirical proof this spec leans on — mid-turn stdin steering for persistent Claude Code is proven, with a reusable probe-script methodology this spec follows for its own open question),
+`docs/analysis/ANALYSIS_AGENT_INPUT_LIFECYCLE_RATELIMIT_SENDNOW_2026_07_06.md` (Issue 3 — the "Send now" button this spec's design replaces),
+`docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md` (the immediately-preceding PR — this spec is a direct continuation of that thread, not a new investigation),
+`docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md` (the existing control-protocol demultiplexer in `persistent.rs` this spec's Tier 2 would extend, if it turns out to be needed).
+
+---
+
+## 1. Summary
+
+The user asked to mimic real Claude Code CLI's queued-message behavior: type a message while the agent is busy, it queues; it's delivered automatically at the agent's next natural breakpoint (already implemented — see §2); **but if it's still queued and the user presses Escape, the CLI delivers it right then, telling the agent "stop what you're doing and consider this now."**
+
+The investigation below turned up something better than expected: **the "deliver right now" half of this is already fully supported by existing, already-proven backend plumbing.** `persistent.rs`'s `send_message()` — the exact call the frontend's normal send path already uses — writes directly to the CLI's live stdin **unconditionally**, whether the agent is busy or idle (§3.1). The only reason a queued message doesn't already arrive immediately today is that the **frontend chooses to hold it** in `heldQueue` and wait for a tool-boundary/idle signal before calling that same function (§2). So "Escape delivers the queued message now" is a **small, backend-risk-free frontend change**: skip the wait, call the existing delivery path immediately.
+
+The other half — **does it also silence the agent's current output right away**, the way it visually appears to in the real interactive CLI — is genuinely unverified in this codebase. The one empirical probe that exists (`SPEC_INJECT_AT_TOOL_BOUNDARY`'s `steer-probe.py`) proved steering happens at the **next inference boundary** (right after an in-flight tool's result lands), not instantaneously mid-generation. Whether AgentMux's stream-json protocol usage exposes anything stronger than that is an open question this spec proposes to answer with a new probe, mirroring the existing one, **before** committing to any backend work for it.
+
+## 2. Where we are today
+
+**The "queues, then auto-delivers at the next breakpoint" half already exists and already works correctly** — this was not part of the investigation, it's confirmed-working prior art:
+- `sendMessage()` (`frontend/app/view/agent/hooks/useAgentCommands.ts`, ~264-388): while a turn is in flight, the message is dispatched as `PendingMessageQueued{enqueuedWhileBusy:true}` and pushed onto `heldQueue` (~184) instead of being delivered yet.
+- An auto-flush `createEffect` in `agent-view.tsx` (~624-640) watches `currentToolAtom` and `turnPhaseAtom.kind`, calling `commands.flushHeldMessages()` as soon as a new tool call starts **or** the turn becomes idle/done.
+- `flushHeldMessages()` (~462-480) drains `heldQueue` FIFO via `deliverToBackend()` (~397-454), which calls the `agentinput` RPC.
+
+**The `agentinput` RPC, for a persistent controller, already writes to live stdin regardless of busy state — no idle-gate exists.** Traced precisely:
+- `agentmux-srv/src/server/agent_handlers/input.rs` (~236-269): the `agentinput` handler, when the block's controller downcasts to `PersistentSubprocessController`, unconditionally calls `persistent_ctrl.send_message(cmd.message, config)`.
+- `persistent.rs:292-306` (`send_message`): spawns the process only `if !self.is_running()`; otherwise it **just writes the message to the live `stdin_tx` immediately** — there is no check anywhere for "is a turn currently in progress." This is the **exact mechanism** `SPEC_INJECT_AT_TOOL_BOUNDARY`'s probe proved causes Claude to steer.
+
+**So today, the only thing preventing a queued message from landing mid-turn is that the frontend hasn't called `deliverToBackend` yet** — it's sitting in `heldQueue`, waiting for the auto-flush effect's watched conditions (new tool start / turn idle). The backend has been ready for this the whole time.
+
+**Escape today** (`AgentFooter.tsx:682-704`): on an empty composer, calls `props.onStopAgent` → `commands.stopAgent()` (`useAgentCommands.ts:502-531`) → `RequestStop` + `ControllerInputCommand({signame:"SIGINT"})`. It never inspects `heldQueue` (already exported and available via `commands.hasHeldMessages()`, `useAgentCommands.ts:494`, but unused by the Escape path).
+
+**Why today's Escape is destructive for exactly the case this spec targets:** for a persistent controller, `send_input` with `SIGINT`/`SIGTERM` (`persistent.rs:988-1010`) calls `stop_process(true)`, which kills the subprocess outright (`persistent.rs:942-954`, via `kill_tx`) — only `session_id` survives, for the *next spawned process* to `--resume`. If a message were sitting in `heldQueue` when Escape fires today, this is what happens: kill the whole CLI process → wait for `Done` → the auto-flush effect fires → `flushHeldMessages` delivers the queued text as a **brand-new turn on a freshly `--resume`'d process** — not a steer of the still-live one. Slower and more destructive than necessary, and unrelated to the interrupt itself (no "here's why I stopped you" framing at all).
+
+## 3. Proposed design — two tiers
+
+### Tier 1 (this PR): deliver the queued message immediately, no interrupt signal at all
+
+When Escape is pressed on an empty composer:
+- **If `commands.hasHeldMessages()` is true:** call `commands.flushHeldMessages()` (or a small wrapper) immediately — **do not** call `stopAgent()`/send any signal. This delivers the queued text via the exact same `send_message()` write-to-live-stdin path the auto-flush effect already uses, just without waiting for the tool-boundary/idle trigger. For persistent Claude, this steers the live process per the proven `SPEC_INJECT_AT_TOOL_BOUNDARY` mechanism — consumed at the CLI's next inference step (after the in-flight tool's result, if one is running).
+- **If `hasHeldMessages()` is false:** unchanged — `stopAgent()` (today's SIGINT/kill behavior). Nothing to steer, so "stop the agent" is the only reasonable meaning of Escape on an empty box with nothing queued.
+
+This single branch is the entire Tier 1 change. No reducer changes, no new RPC, no backend touch — `flushHeldMessages`/`hasHeldMessages` are already exported from `useAgentCommands`'s return object (`useAgentCommands.ts:111,537`); the only wiring needed is at the `agent-view.tsx:1113` call site that currently passes `onStopAgent={commands.stopAgent}` directly to `AgentFooter`.
+
+This also fully replaces "Send now" (Issue 3 of the motivating analysis) with something strictly better: instead of a separate button that killed the agent as an indirect way to hurry the queue along, the **same Escape key** the user already presses to interrupt now does the right thing contextually — steers if something's queued, interrupts if not. The "Send now" button, its `showSendNow`/`onSendImmediately` wiring, and `isInterruptibleTurn` can be deleted exactly as already scoped in the prior analysis, with no replacement affordance needed — Escape *is* the affordance now, matching the real CLI.
+
+**One-shot providers** (codex/gemini/qwen/kimi — no live stdin, per `SPEC_INJECT_AT_TOOL_BOUNDARY` §5): `flushHeldMessages` already degrades correctly for these today (delivers as the next turn once the current one exits) — Tier 1 doesn't change their behavior, it only changes *when the frontend decides to call* the delivery path, and for one-shot providers that decision already can't take effect any sooner than the current turn's exit regardless. No special-casing needed.
+
+### Tier 2 (needs empirical validation first): also silence the agent's current output right away
+
+The open question: does the real interactive Claude CLI's Escape *only* deliver the next message sooner (same next-inference-boundary timing `SPEC_INJECT_AT_TOOL_BOUNDARY` already proved), or does it *also* immediately truncate whatever the model is currently streaming/whatever tool is in flight — a genuine interrupt, not just an early steer? The existing probe only tested injection during an in-flight **tool call** (four `sleep 4`s); it did not test injection during **plain streaming text** with no tool running, which is the scenario closest to what a literal "stops mid-sentence" experience would require.
+
+This is unverified, not assumed. Before any backend work:
+1. **Extend `docs/specs/evidence/steer-probe.py`** (or write a sibling probe) with a case that forces Claude to stream a long plain-text answer (no tool call), inject a second stdin message partway through, and capture whether the CLI (a) keeps streaming the original response to its natural end before addressing the new message, or (b) stops early. This mirrors exactly how `SPEC_INJECT_AT_TOOL_BOUNDARY` §4 resolved its own open questions — captured bytes, not speculation.
+2. **If the CLI's stream-json control protocol exposes an actual interrupt/cancel control-request** (distinct from `can_use_tool`, the only control-request type this codebase currently demultiplexes, `persistent.rs:458-489`), capture its exact wire shape from real traffic before writing any Rust to send it — do not guess the JSON shape.
+3. **If no such mechanism exists**, the honest answer is that "immediate visual silence mid-stream" isn't achievable for stream-json-driven Claude without killing the process (which is what today's Escape already does, just without the steering benefit) — in which case Tier 1's "steer at the next natural boundary, don't kill" is the correct final behavior, and the user-facing difference from real interactive Claude CLI (which may rely on true terminal-level Ctrl-C handling not exposed over stream-json) would be a documented, accepted gap rather than something to force via a destructive workaround.
+
+**Recommendation: ship Tier 1 alone first.** It's a 5-10 line frontend change reusing fully-proven backend plumbing, it already fixes the reported UX gap for the common case (queued message delivered at the next real breakpoint instead of waiting for full idle or requiring a destructive kill), and it cleanly retires "Send now." Tier 2 is a genuine unknown that deserves its own empirical pass and should not block Tier 1.
+
+## 4. What NOT to do
+
+- **Do not** make Escape-with-queued-message also send `SIGINT`/`stopAgent()` alongside the delivery. Killing the process the delivery just wrote into defeats the entire point (destroys the live session `send_message()` targeted) and would silently regress Tier 1 back to today's kill-then-`--resume` behavior.
+- **Do not** invent a wire-level "interrupt" control-request shape for Tier 2 without capturing real bytes first (same discipline `SPEC_INJECT_AT_TOOL_BOUNDARY` used) — guessing a JSON shape the CLI doesn't actually understand is worse than not shipping Tier 2 at all.
+- **Do not** thread `pendingContent`/`Interrupting.reason` changes through the `TurnPhase` reducer for this — Tier 1 needs no new reducer state; the queued text already lives in `heldQueue`/`PendingMessage`, which is exactly what needs to be delivered, unchanged.
+
+## 5. Tests
+
+- `useAgentCommands.test.ts` (or a new focused test): Escape-equivalent call with `heldQueue` non-empty calls `flushHeldMessages` and does NOT call `stopAgent`/dispatch `RequestStop`.
+- Escape-equivalent call with `heldQueue` empty: unchanged existing behavior (`stopAgent()` fires).
+- Regression: `flushHeldMessages` still drains FIFO in order when called via this new immediate path, same as via the existing auto-flush effect.
+- Tier 2 (only once/if pursued): a probe-script-backed integration test asserting the observed truncation behavior, gated on whatever the probe actually finds — not written speculatively ahead of the probe.
+
+## 6. Why this is worth doing (and why it's a natural continuation, not a new thread)
+
+This is the direct completion of the "Send now" removal that the unified-failure-reducer PR deliberately left out of scope (`ANALYSIS_AGENT_INPUT_LIFECYCLE_RATELIMIT_SENDNOW_2026_07_06.md` Issue 3) — same investigation thread, same composer/queue subsystem, same session. It also closes a gap the *other* recent spec (`SPEC_INJECT_AT_TOOL_BOUNDARY`) left explicitly unaddressed: that spec proved mid-turn steering works and proposed wiring it into the passive auto-flush path, but never considered a user-initiated "delivered right now" gesture riding the same already-proven mechanism. Tier 1 here is small precisely because it's standing on already-verified work from both threads rather than starting fresh.

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -335,28 +335,6 @@ export function workingFromPhase(phase: TurnPhase): boolean {
 }
 
 /**
- * Selector — `true` iff there is an in-flight turn that SIGINT can
- * interrupt. Same shape as {@link workingFromPhase}, but **excludes
- * `Submitting`** — during Submitting the would-be turn is itself
- * sitting in the pending queue waiting for `agent-message-accepted`,
- * so there is no CLI process to interrupt yet.
- *
- * Used by the "Send now" affordance (`PendingMessagesPanel`), which
- * is meaningful only when the queue genuinely sits behind a running
- * turn. Gating that button on the broader `workingFromPhase` caused
- * a brief flash on every send: the freshly-typed message was in
- * `pendingMessages` for ~50–200 ms while the phase sat in `Submitting`,
- * lighting the button before `agent-message-accepted` cleared the
- * queue. Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
- *
- * Returns true ⇔ `phase.kind ∈ {Streaming, Interrupting}`.
- */
-export function isInterruptibleTurn(phase: TurnPhase): boolean {
-    const k = phase.kind;
-    return k === "Streaming" || k === "Interrupting";
-}
-
-/**
  * Selector — `true` iff the pane is in the `Disconnected` phase. PR F:
  * drives the {@link AgentDisconnectedBanner} visibility, replacing any
  * ad-hoc "streaming.active === false but turn was active" checks. Pure

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -29,7 +29,7 @@ import {
     unregisterPane as unregisterLayoutPane,
     type LayoutView,
 } from "@/app/store/agent-pane-layout-store";
-import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
+import { workingFromPhase } from "@/app/store/agent-pane-state/types";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { getRecentDispatches } from "@/app/store/command-source";
@@ -554,15 +554,32 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // promotion and agent-message-accepted. See ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
         const wasAlreadyWorking = workingFromPhase(paneSnapshot(model.blockId)?.turnPhase ?? { kind: "Idle" });
         // Only start a NEW turn when the agent is idle. Dispatching TurnStart
-        // while a turn is already running regresses Streaming → Submitting, which
-        // hides the "Send now" affordance (isInterruptibleTurn is false during
-        // Submitting) until the next stream event — the "panel shows up a couple
-        // seconds late" bug. A queued-while-busy message rides the running turn;
-        // the queue-drain (agent-message-accepted) re-enters Submitting if needed.
+        // while a turn is already running regresses Streaming → Submitting,
+        // which would flicker the busy indicator back to its "Submitting"
+        // look for no reason. A queued-while-busy message rides the running
+        // turn; the queue-drain (agent-message-accepted) re-enters Submitting
+        // if needed.
         if (!wasAlreadyWorking) {
             dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
         }
         return commands.sendMessage(message, wasAlreadyWorking);
+    };
+
+    // Esc on an empty composer. Mirrors Claude Code CLI: if a message is
+    // already queued behind a running turn, deliver it to the live agent
+    // right now instead of waiting for the next tool-boundary/idle
+    // auto-flush — "stop and consider this now." Must NOT also call
+    // stopAgent(): killing the process here would destroy the very live
+    // session the delivery just wrote into (persistent controllers only
+    // steer while the process stays alive). Only fall back to stopAgent()
+    // (SIGINT) when there's nothing queued to steer with.
+    // See SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md.
+    const handleEscapeOnEmptyComposer = (): void => {
+        if (commands.hasHeldMessages()) {
+            void commands.flushHeldMessages();
+            return;
+        }
+        commands.stopAgent();
     };
 
     // Failure-recovery accessory row (per-error-class actions + 5s auto-retry
@@ -926,26 +943,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 typed message lands next to the live conversation it's
                 queued against. Previously lived below the activity log;
                 repositioning per SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.
-                "Send now" lives inside the queue header (right side)
-                so it sits adjacent to the messages it accelerates. */}
-            <PendingMessagesPanel
-                pendingMessages={pendingMessagesAtom[0]}
-                showSendNow={() =>
-                    // "Send now" appears only when there is an in-flight
-                    // turn that SIGINT can actually interrupt — i.e.
-                    // Streaming / Interrupting. `Submitting` is excluded
-                    // because the message in the queue during Submitting
-                    // IS the would-be turn; there is no CLI process to
-                    // stop yet. Gating on the broader `workingFromPhase`
-                    // caused a brief flash on every send.
-                    // Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
-                    isInterruptibleTurn(agentAtoms().turnPhaseAtom[0]()) &&
-                    pendingMessagesAtom[0]().some((m) => m.enqueuedWhileBusy)
-                }
-                onSendImmediately={() => {
-                    commands.stopAgent();
-                }}
-            />
+                No "Send now" affordance — Esc on an empty composer delivers
+                a queued message immediately instead (mirrors Claude Code
+                CLI). See SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md. */}
+            <PendingMessagesPanel pendingMessages={pendingMessagesAtom[0]} />
 
             {/* PR F — Disconnected banner. Visible when the stream
                 tore down while a turn was in flight (kind=Disconnected).
@@ -1110,7 +1111,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onTyping={() => {
                         scrollToBottomFn?.();
                     }}
-                    onStopAgent={commands.stopAgent}
+                    onStopAgent={handleEscapeOnEmptyComposer}
                     onRecallLatestQueued={commands.recallLatestHeld}
                     getCompletions={commands.completions}
                     viewModel={model}

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -188,10 +188,16 @@ interface AgentFooterProps {
      */
     onTyping?: () => void;
     /**
-     * Called on Esc when the textarea is empty (or whitespace only). The
-     * parent sends SIGINT to the agent CLI process — equivalent to Ctrl+C
-     * in a terminal. With text in the textarea, Esc clears instead.
-     * See SPEC_AGENT_PANE_FOLLOWUPS item #9.
+     * Called on Esc when the textarea is empty (or whitespace only). With
+     * text in the textarea, Esc clears instead. See SPEC_AGENT_PANE_FOLLOWUPS
+     * item #9.
+     *
+     * The parent decides what Esc actually does, mirroring Claude Code CLI:
+     * if a message is already queued (sitting behind a running turn), Esc
+     * delivers it to the live agent right now instead of waiting for the
+     * next natural breakpoint — "stop and consider this now." Only when
+     * nothing is queued does it fall back to sending SIGINT (equivalent to
+     * Ctrl+C in a terminal). See SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md.
      */
     onStopAgent?: () => void;
     /**
@@ -706,9 +712,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
 
     return (
         <div class="agent-footer">
-            {/* "Send now" now renders inside PendingMessagesPanel (right
-                of the queue header) so it sits next to the messages it
-                accelerates, not above the composer. */}
             <div class="agent-input-container">
                 <Show when={autocompletePrefix() !== null && completions().length > 0}>
                     <SlashAutocomplete

--- a/frontend/app/view/agent/components/PendingMessagesPanel.tsx
+++ b/frontend/app/view/agent/components/PendingMessagesPanel.tsx
@@ -20,6 +20,11 @@
  * See docs/analysis/ANALYSIS_IDLE_SEND_RACE_2026_06_11.md.
  *
  * See AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md.
+ *
+ * No "Send now" button — Esc on an empty composer delivers the queue to the
+ * live agent immediately instead (mirrors Claude Code CLI's "stop and
+ * consider this now" gesture). See
+ * docs/specs/SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md.
  */
 
 import { For, Show, createMemo, type Accessor, type JSX } from "solid-js";
@@ -27,12 +32,6 @@ import type { PendingMessage } from "../state";
 
 interface PendingMessagesPanelProps {
     pendingMessages: Accessor<PendingMessage[]>;
-    /** True when the user should be offered a "Send now" shortcut —
-     *  typically: a turn is running AND the queue is non-empty. */
-    showSendNow?: Accessor<boolean>;
-    /** Fires when the user clicks "Send now". Caller is expected to
-     *  SIGINT the running turn so the queued messages drain. */
-    onSendImmediately?: () => void;
 }
 
 export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => {
@@ -48,21 +47,10 @@ export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Elem
                 <div class="agent-pending-header">
                     <span class="agent-spinner-dot" />
                     <span class="agent-pending-header-text">
-                        Queued — sends at the agent's next step; ↑ to edit (
+                        Queued — sends at the agent's next step; ↑ to edit, Esc to send now (
                         {queuedMessages().length}
                         {queuedMessages().length === 1 ? " message" : " messages"})
                     </span>
-                    <Show when={props.showSendNow?.()}>
-                        <button
-                            type="button"
-                            class="agent-send-immediately-btn"
-                            onClick={() => props.onSendImmediately?.()}
-                            title="Stop the current turn and process the queue now"
-                        >
-                            <span class="agent-send-immediately-icon">⏭</span>
-                            <span>Send now</span>
-                        </button>
-                    </Show>
                 </div>
                 <For each={queuedMessages()}>
                     {(msg) => (

--- a/frontend/app/view/agent/state.test.ts
+++ b/frontend/app/view/agent/state.test.ts
@@ -6,7 +6,7 @@ import {
     createAgentAtoms,
     type AgentAtoms,
 } from "./state";
-import { isInterruptibleTurn, workingFromPhase } from "@/app/store/agent-pane-state/types";
+import { workingFromPhase } from "@/app/store/agent-pane-state/types";
 
 let atoms: AgentAtoms;
 
@@ -86,57 +86,6 @@ describe("createAgentAtoms", () => {
             reason: "stream-unsubscribed",
         });
         expect(workingFromPhase(getPhase())).toBe(false);
-    });
-
-    // ── isInterruptibleTurn — "Send now" affordance gating ──────────────
-    // The pending-queue "Send now" button is meaningful only when a CLI
-    // process is in flight that SIGINT can interrupt — i.e. Streaming or
-    // Interrupting. `Submitting` is excluded because the message itself
-    // is the would-be turn, still waiting for `agent-message-accepted`.
-    // Gating on `workingFromPhase` caused a brief flash on every send.
-    // Spec: docs/analysis/ANALYSIS_SEND_NOW_FLASH_2026_05_28.md.
-    test("isInterruptibleTurn = false for Idle / Submitting / Done / Disconnected", () => {
-        const [getPhase, setPhase] = atoms.turnPhaseAtom;
-
-        expect(getPhase().kind).toBe("Idle");
-        expect(isInterruptibleTurn(getPhase())).toBe(false);
-
-        setPhase({ kind: "Submitting", submittedAt: 1, pendingContent: "" });
-        expect(isInterruptibleTurn(getPhase())).toBe(false);
-
-        setPhase({ kind: "Done", outcome: "completed", finishedAt: 1 });
-        expect(isInterruptibleTurn(getPhase())).toBe(false);
-
-        setPhase({
-            kind: "Disconnected",
-            lastKind: "Streaming",
-            lastConnectedAt: 1,
-            reason: "stream-unsubscribed",
-        });
-        expect(isInterruptibleTurn(getPhase())).toBe(false);
-    });
-
-    test("isInterruptibleTurn = true for Streaming / Interrupting", () => {
-        const [getPhase, setPhase] = atoms.turnPhaseAtom;
-
-        setPhase({
-            kind: "Streaming",
-            bufferSize: 0,
-            toolsActive: 0,
-            lastEventMs: 1,
-        });
-        expect(isInterruptibleTurn(getPhase())).toBe(true);
-
-        setPhase({ kind: "Interrupting", reason: "user", sigintSentAt: 1 });
-        expect(isInterruptibleTurn(getPhase())).toBe(true);
-    });
-
-    test("isInterruptibleTurn excludes the Submitting case that workingFromPhase includes", () => {
-        const submitting = { kind: "Submitting", submittedAt: 1, pendingContent: "" } as const;
-        // The exact divergence point: this is why the Send-now flash
-        // existed and why a separate predicate was needed.
-        expect(workingFromPhase(submitting)).toBe(true);
-        expect(isInterruptibleTurn(submitting)).toBe(false);
     });
 
     test("Interrupting phase drives the 'Stopping…' label", () => {

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -40,45 +40,12 @@
             letter-spacing: 0.5px;
             opacity: 0.9;
 
-            // Let the text take the middle and the "Send now" button
-            // float flush right. Per user feedback: button lives inside
-            // the queue block, on the right of its header row.
             .agent-pending-header-text {
                 flex: 1;
                 min-width: 0;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
-            }
-        }
-
-        // "Send now" — sits on the right of the queue header. Appears
-        // only when a turn is running AND something is queued. Clicking
-        // fires SIGINT; the backend's queue drains the oldest pending
-        // message as soon as the killed process exits.
-        .agent-send-immediately-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: var(--space-1);
-            padding: var(--space-0-5) var(--space-2);
-            background: color-mix(in srgb, var(--accent-color) 20%, transparent);
-            border: 1px solid var(--accent-color);
-            border-radius: 0;
-            color: var(--accent-color);
-            font-family: inherit;
-            font-size: 10px;
-            font-weight: 500;
-            text-transform: none;
-            letter-spacing: 0;
-            cursor: default;
-            transition: background 80ms ease;
-            flex-shrink: 0;
-            &:hover {
-                background: color-mix(in srgb, var(--accent-color) 30%, transparent);
-            }
-            .agent-send-immediately-icon {
-                font-size: 12px;
-                line-height: 1;
             }
         }
 


### PR DESCRIPTION
## Summary
Implements Tier 1 of `docs/specs/SPEC_AGENT_ESCAPE_STEER_QUEUED_MESSAGE_2026_07_06.md` and closes out Issue 3 ("Send now" removal) of `docs/analysis/ANALYSIS_AGENT_INPUT_LIFECYCLE_RATELIMIT_SENDNOW_2026_07_06.md`, which the unified-failure-reducer PR (#1987) deliberately left out of scope.

- **Esc on an empty composer now checks `hasHeldMessages()` first**: if a message is already queued behind a running turn, it's delivered to the live agent right now via the existing `flushHeldMessages()`/`agentinput` path — instead of waiting for the next tool-boundary/idle auto-flush. This mirrors Claude Code CLI's "stop and consider this now" gesture. Falls back to today's `stopAgent()` (SIGINT) only when nothing is queued.
- **No backend changes needed.** `persistent.rs`'s `send_message()` already writes to the CLI's live stdin unconditionally — busy or idle — which is the exact mechanism `SPEC_INJECT_AT_TOOL_BOUNDARY_2026_06_16.md` already proved causes real mid-turn steering. The only thing preventing immediate delivery today was the frontend's own choice to hold the message and wait; `hasHeldMessages()`/`flushHeldMessages()` were already exported from `useAgentCommands` and simply unused by the Escape path.
- **Deliberately does NOT also send SIGINT** alongside the delivery — killing the process would destroy the very live session the delivery just wrote into.
- **Removes "Send now" entirely** as the direct replacement: `PendingMessagesPanel`'s `showSendNow`/`onSendImmediately` props, the `isInterruptibleTurn` selector (`types.ts`) and its dedicated tests (`state.test.ts`), and the button's SCSS. Esc is now the sole affordance, matching the real CLI — no separate button needed.

**Left explicitly out of scope (Tier 2, spec'd separately):** whether this should also truncate in-progress streaming output immediately, vs. steering at the next natural tool boundary (all today's evidence — the existing `steer-probe.py` — proves the latter). That's an open, empirically unverified question the spec proposes to answer with a new probe before any protocol-level work, not assumed here.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent frontend/app/store` — 1241/1241 passing (3 fewer than before this PR, expected: the deleted `isInterruptibleTurn` tests)
- Note: `agent-view.tsx`'s inline Escape-handling logic isn't independently unit-tested, consistent with this file's existing convention (no dedicated test file for its inline handlers today); the underlying primitives it calls (`hasHeldMessages`/`flushHeldMessages`/`stopAgent`) are unchanged.

<!-- agentmux:agent_id=agent2 -->