### PR TITLE
feat(agent): brain-spinner loading overlay covers blank pane-mount and history-replay window

### DIFF
--- a/.changesets/1783390062-feat-agent-brain-spinner-loading-overlay-covers-blank-pane-m-60k7.md
+++ b/.changesets/1783390062-feat-agent-brain-spinner-loading-overlay-covers-blank-pane-m-60k7.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): brain-spinner loading overlay covers blank pane-mount and history-replay window

--- a/docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md
+++ b/docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md
@@ -1,0 +1,179 @@
+# Report: agent pane blank-load period + brain-logo loading indicator
+
+**Status:** Investigation complete — no code changed. Written to inform a
+design before implementation.
+**Author:** AgentX
+**Date:** 2026-07-04
+
+## Ask
+
+When an agent pane with a lot of content is loading, it's blank for a bit
+before the transcript appears. Show the existing pulsating brain logo
+immediately when the pane mounts, then fade it out once the UI has actually
+painted.
+
+## Where the blank period actually comes from
+
+There are two independent causes, and they stack for content-heavy panes.
+
+### 1. `block.tsx` renders literally nothing until the pane object resolves
+
+`frontend/app/block/block.tsx:299` — the `ready` memo:
+```ts
+const ready = createMemo(() => !loading() && !isBlank(props.nodeModel.blockId) && blockData() != null && viewModel() != null);
+```
+Until this flips true, `<Show when={ready()}>` (around line 308) renders
+**nothing at all** — no fallback. Once `ready()` is true, the view component
+loads behind a `<Suspense fallback={<CenteredDiv>Loading...</CenteredDiv>}>`
+(lines 128 and 263) — plain text, no spinner, no brand.
+
+This is stage-one blank: waiting on the block's WaveObject metadata +
+`makeViewModel()`. Usually fast, but it's still a zero-indicator window today.
+
+### 2. Content-heavy history replay is a single synchronous blocking parse
+
+`frontend/app/view/agent/hooks/useHistoryPagination.ts`, `onMount` (~line 181):
+- Dispatches `InitStart` immediately, then asynchronously tries a v2 snapshot
+  restore, falling back to v1, falling back to raw NDJSON replay.
+- `RESTORE_WINDOW_LINES = 5_000` (line 116) — on restore, up to 5000 trailing
+  NDJSON lines are fetched and parsed via `parseHistoryLines()`
+  (`frontend/app/view/agent/parseHistoryLines.ts`, 77 lines) — a **pure,
+  synchronous, non-yielding** loop: per line, `JSON.parse` → `translator
+  .translate()` → `parser.parseLine()`, building a `DocumentNode[]`.
+- The result is bulk-dispatched in one `batch(...)` call (lines 286/348/410),
+  which drives the reducer + `AgentDocumentVirtualList`
+  (`frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx`) to
+  mount/measure the initially-visible rows.
+
+`docs/specs/SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` already measured
+this exact path for tab-switching and found the dominant cost (500-600ms for
+heavy sessions) is **browser-side layout/paint of the resulting DOM tree**,
+not any single JS function — markdown memoization, virtualizer
+`measureElement`, and partition recompute were each profiled and ruled out as
+the bottleneck. So "a lot of content" → more NDJSON lines parsed synchronously
+in step 2, and more DOM nodes for the browser to lay out in step 3 — both
+scale with conversation size, matching the report exactly.
+
+### The existing reveal-gate doesn't cover this case
+
+AgentMux already has a hide-until-settled mechanism for a *similar* problem —
+`frontend/app/store/tab-reveal.ts` + `frontend/app/workspace/workspace.tsx` —
+used for whole-**tab** switches: `holdRevealGate()` hides the active tab
+(`visibility:hidden; opacity:0`) before an async tab operation, and
+`scheduleRevealLift()` (a `PerformanceObserver` watching for Long Tasks, with
+an 80ms settle window and an 800ms hard cap) reveals it with a 120ms
+opacity fade once things quiet down.
+
+Confirmed via grep: `holdRevealGate`/`scheduleRevealLift` have **no other
+callers**. They only fire from `createTab()` and `setActiveTab()` in
+`frontend/app/store/global.ts`. **Opening a new agent pane inside an
+already-visible tab — split, view-swap, swarm sub-agent click, tear-off
+landing — has no gating and no indicator at all.** This is very likely the
+specific scenario behind the report: not "switching tabs is blank" (already
+gated), but "a new/growing pane inside a tab I'm already looking at is
+blank."
+
+`docs/specs/SPEC_TAB_CONTENT_REVEAL_GATE.md` (the reveal gate's original
+spec, issue #774) explicitly lists both "fade-in transition on reveal" and
+"per-block skeletons" as **out of scope**, filed for later. This is that
+later.
+
+## The brain logo: exists, but not as a reusable component
+
+`index.html` (lines 20-61, 82-130) has the pulsating brain today — as
+**static inline SVG + CSS baked into the HTML shell**, not a SolidJS
+component:
+```css
+#startup-loading svg {
+    width: 96px; height: 96px; opacity: 0.9;
+    animation: startup-pulse 1.8s ease-in-out infinite;
+}
+@keyframes startup-pulse {
+    0%, 100% { opacity: 0.9; transform: scale(1) translateZ(0); }
+    50%       { opacity: 0.65; transform: scale(0.97) translateZ(0); }
+}
+```
+Same SVG is also saved standalone at
+`frontend/logos/agentmux-logo-brain-alternate.svg`.
+
+`frontend/app/init/startup-splash.ts` controls it:
+`fadeOutStartupSplash()` adds a `.fading` class, waits for `transitionend`
+(or a 320ms timeout), then **permanently removes the DOM node**. It's called
+from `tab-reveal.ts`'s `liftGate()` — every tab-reveal gate lift calls it, but
+it's a no-op after the very first call (element already gone).
+
+**Net: the asset is real and already shipped, but it's wired as a
+non-reusable, one-shot, singleton overlay.** To use it per-pane, the SVG +
+`@keyframes startup-pulse` need to become an actual component (something like
+`<BrainSpinner/>`) — not a second call into `startup-splash.ts`, which cannot
+be re-armed.
+
+## A clean, already-existing hook point for "fade out now"
+
+`frontend/app/view/agent/state.ts:87,179` — `initPhaseAtom`, a
+`SignalPair<InitPhase>` initialized to `{ kind: "InitPending" }`, flipped to
+`InitReady` (success) or `InitFailed` (error) once the initial history load
+resolves.
+
+`useHistoryPagination.ts:74` — `onHistoryReady?: () => void`, already fired
+exactly once (lines 319, 360, 393, 427, 445) the moment history load
+finishes, success **or** failure (fail-open). Today it's consumed only to
+gate the new-message enter animation ("history rows shouldn't animate on
+open/restore").
+
+This is the fade-out trigger, already built and already firing at the right
+moment — currently unused for any visual loading-state purpose.
+
+## What would actually need to be built
+
+1. **Extract the brain into a real component** (SVG + `startup-pulse`
+   keyframes) — `frontend/app/element/` seems like the natural home, matching
+   where other small reusable visual elements live.
+2. **A per-pane (not global-singleton) show/fade signal.** The existing
+   `tabSwitching` signal in `tab-reveal.ts` is a single module-level boolean,
+   not keyed by block/pane id — it can't represent "this specific pane is
+   still settling" independent of others. Needs either a small
+   `Map<blockId, boolean>`-backed variant, or a signal instantiated per pane
+   instance (e.g. owned by the agent view's own model, alongside
+   `initPhaseAtom`).
+3. **Wire it into `block.tsx` around the `ready` memo (line 299) and the
+   `Suspense` fallback (lines 128/263)** — that's the true "nothing rendered
+   yet" window, before the agent view (and therefore `initPhaseAtom`) even
+   exists. The brain needs to show from pane-mount, not from
+   agent-view-mount, to cover stage-one blank too.
+4. **Fade out on `InitReady`/`InitFailed`** (i.e. on `onHistoryReady` firing),
+   mirroring the existing `opacity 120-200ms ease-out` idiom already used at
+   both the tab-reveal and startup-splash layers — same visual language, new
+   scope.
+5. **Respect `prefersReducedMotion()`** (already imported/used in
+   `workspace.tsx`) — skip the animation/transition, show/hide instantly.
+6. Decide whether this should show unconditionally on every pane mount, or
+   only kick in past some minimum delay (e.g. don't flash the brain for a
+   pane that resolves in 50ms) — the tab-reveal gate's `SETTLE_MS`/
+   `MAX_GATE_MS` pattern (80ms / 800ms) is a reasonable template: show the
+   brain only if settling takes longer than a short grace period, so fast
+   panes don't flicker a logo in and immediately out.
+
+## Prior art / related specs (for context, not yet implemented against)
+
+- `docs/specs/SPEC_TAB_CONTENT_REVEAL_GATE.md` — origin of the tab-level gate;
+  explicitly scoped out fade-in and per-block skeletons.
+- `docs/specs/SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` — measured the
+  same 500-600ms paint cost this report describes, proposed (but per that
+  doc, did not confirm shipped) lazy tool-block hydration and a snapshot
+  pre-warm, either of which would reduce how long the brain needs to stay
+  visible rather than just covering for it.
+- No spec, issue, or PR proposes using the brain logo as a per-pane loading
+  indicator specifically — this is new scope, not a revival of an abandoned
+  attempt.
+
+## Suggested next step
+
+Small, scoped implementation: extract `<BrainSpinner/>`, add a per-pane
+show/fade signal gated on `ready` (block.tsx) union `initPhaseAtom !==
+"InitReady"/"InitFailed"` (agent view), fade out on whichever resolves last.
+Should not require touching `useHistoryPagination.ts`'s parse/dispatch logic
+itself — this is a visual cover for the existing cost, not a fix to the cost.
+Reducing the 500-600ms paint cost itself (lazy tool-block hydration, snapshot
+pre-warm) is a separate, larger effort already scoped in
+`SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` and out of scope here.

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/app/block/blocktypes";
 import { getBlockViewClass } from "@/app/block/block-registry";
 import { invokeCommand } from "@/app/platform/ipc";
+import { BrainSpinner } from "@/app/element/BrainSpinner";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
 import { NodeModel, useDebouncedNodeInnerRect } from "@/layout/index";
@@ -125,7 +126,7 @@ function BlockSubBlock({ nodeModel, viewModel }: FullSubBlockProps): JSX.Element
         <Show when={blockData()}>
             <div class={clsx("block-content", { "block-no-padding": noPadding })} ref={(el) => { contentRef.current = el; }}>
                 <ErrorBoundary>
-                    <Suspense fallback={<CenteredDiv>Loading...</CenteredDiv>}>{viewElem()}</Suspense>
+                    <Suspense fallback={<BrainSpinner />}>{viewElem()}</Suspense>
                 </ErrorBoundary>
             </div>
         </Show>
@@ -260,7 +261,7 @@ function BlockFull({ nodeModel, viewModel }: FullBlockProps): JSX.Element {
                 style={blockContentStyle()}
             >
                 <ErrorBoundary>
-                    <Suspense fallback={<CenteredDiv>Loading...</CenteredDiv>}>{viewElem()}</Suspense>
+                    <Suspense fallback={<BrainSpinner />}>{viewElem()}</Suspense>
                 </ErrorBoundary>
             </div>
         </BlockFrame>
@@ -306,7 +307,7 @@ function Block(props: BlockProps): JSX.Element {
     // graph, which may be half-flushed.
     const viewTypeStr = createMemo(() => blockData()?.meta?.view);
     return (
-        <Show when={ready()}>
+        <Show when={ready()} fallback={<BrainSpinner />}>
             <BlockErrorBoundary
                 blockId={props.nodeModel.blockId}
                 viewType={viewTypeStr()}
@@ -348,7 +349,10 @@ function SubBlock(props: SubBlockProps): JSX.Element {
 
     const viewTypeStr = createMemo(() => blockData()?.meta?.view);
     return (
-        <Show when={!loading() && !isBlank(props.nodeModel.blockId) && blockData() != null && viewModel()}>
+        <Show
+            when={!loading() && !isBlank(props.nodeModel.blockId) && blockData() != null && viewModel()}
+            fallback={<BrainSpinner />}
+        >
             <BlockErrorBoundary
                 blockId={props.nodeModel.blockId}
                 viewType={viewTypeStr()}

--- a/frontend/app/element/BrainSpinner.scss
+++ b/frontend/app/element/BrainSpinner.scss
@@ -28,8 +28,20 @@
         pointer-events: none;
     }
 
-    &.is-reduced-motion svg {
-        animation: none;
+    // Instant show/hide, no animation — matches this codebase's established
+    // reduced-motion pattern for the analogous tab-reveal fade
+    // (workspace.tsx sets transition:"none" when prefersReducedMotion() is
+    // true). Must override BOTH the pulse keyframe and the fade transition;
+    // an earlier version of this rule only disabled the pulse, leaving the
+    // opacity fade still animated under prefers-reduced-motion.
+    &.is-reduced-motion {
+        svg {
+            animation: none;
+        }
+
+        &.is-fading {
+            transition: none;
+        }
     }
 }
 

--- a/frontend/app/element/BrainSpinner.scss
+++ b/frontend/app/element/BrainSpinner.scss
@@ -1,0 +1,39 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Same pulse timing/easing as index.html's #startup-loading — keep them in
+// sync if either changes, they're meant to read as the same brand moment.
+
+.brain-spinner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    svg {
+        width: 64px;
+        height: 64px;
+        opacity: 0.9;
+        animation: brain-spinner-pulse 1.8s ease-in-out infinite;
+        // See index.html's #startup-loading svg comment: without a dedicated
+        // GPU layer, Chromium re-rasterizes this large multi-gradient vector
+        // every animation frame, which reads as a flicker instead of a pulse.
+        will-change: transform, opacity;
+    }
+
+    &.is-fading {
+        opacity: 0;
+        transition: opacity 200ms ease-out;
+        pointer-events: none;
+    }
+
+    &.is-reduced-motion svg {
+        animation: none;
+    }
+}
+
+@keyframes brain-spinner-pulse {
+    0%, 100% { opacity: 0.9; transform: scale(1) translateZ(0); }
+    50%       { opacity: 0.65; transform: scale(0.97) translateZ(0); }
+}

--- a/frontend/app/element/BrainSpinner.tsx
+++ b/frontend/app/element/BrainSpinner.tsx
@@ -1,0 +1,40 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BrainSpinner — the pulsating AgentMux brain mark as a reusable loading
+ * indicator. The same asset/animation as the startup splash
+ * (index.html's #startup-loading, frontend/app/init/startup-splash.ts), but
+ * that one is a single-shot, non-reusable singleton overlay tied to one DOM
+ * id — this component can be mounted per-pane instead, any number of times,
+ * each fading independently via the `fading` prop.
+ *
+ * See docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md.
+ */
+
+import { atoms } from "@/store/global";
+import type { JSX } from "solid-js";
+import brainSvg from "@/app/asset/logo-brain.svg?raw";
+import "./BrainSpinner.scss";
+
+interface BrainSpinnerProps {
+    /** Set true to cross-fade the spinner out. Caller owns unmounting it
+     *  after the transition ends (e.g. via a short timeout matching the CSS
+     *  duration) — this component only handles the visual fade. */
+    fading?: boolean;
+    class?: string;
+}
+
+export const BrainSpinner = (props: BrainSpinnerProps): JSX.Element => {
+    const reducedMotion = atoms.prefersReducedMotionAtom;
+
+    return (
+        <div
+            class={`brain-spinner${props.fading ? " is-fading" : ""}${reducedMotion() ? " is-reduced-motion" : ""}${props.class ? ` ${props.class}` : ""}`}
+            aria-hidden="true"
+            innerHTML={brainSvg}
+        />
+    );
+};
+
+BrainSpinner.displayName = "BrainSpinner";

--- a/frontend/app/util/settle-detector.ts
+++ b/frontend/app/util/settle-detector.ts
@@ -1,0 +1,92 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * scheduleOnSettle — call `onSettled` once the main thread has gone quiet
+ * (no Long Tasks) for `settleMs`, or `maxMs` has elapsed, whichever comes
+ * first. Same detection algorithm as `frontend/app/store/tab-reveal.ts`'s
+ * `scheduleRevealLift` (issue #774,
+ * `docs/specs/SPEC_TAB_CONTENT_REVEAL_GATE.md`), factored out so a caller
+ * can run its own independent instance — tab-reveal.ts's version is
+ * module-level singleton state (one gate, keyed to nothing), which is right
+ * for "the current tab switch" but wrong for "N agent panes each waiting on
+ * their own settle," since concurrent callers would clobber each other's
+ * detector.
+ *
+ * A flat `setTimeout` is the wrong tool here: the cost this is meant to
+ * cover (virtualizer measureElement, markdown render, ResizeObserver
+ * fan-out — see SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md) happens
+ * *after* the triggering dispatch and scales with content size, so a fixed
+ * delay either fires too early for heavy sessions (revealing unpainted
+ * content) or wastes time on light ones. Watching for actual Long-Task
+ * quiet adapts to both.
+ *
+ * Returns a cancel function — call it if the caller unmounts/disposes
+ * before settling (e.g. the pane closes mid-load).
+ */
+export function scheduleOnSettle(
+    onSettled: () => void,
+    opts?: { settleMs?: number; maxMs?: number },
+): () => void {
+    const settleMs = opts?.settleMs ?? 80;
+    const maxMs = opts?.maxMs ?? 800;
+    const startedAt = performance.now();
+    let lastBusyAt = startedAt;
+    let cancelled = false;
+    let observer: PerformanceObserver | null = null;
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const cancel = (): void => {
+        cancelled = true;
+        observer?.disconnect();
+        observer = null;
+        if (fallbackTimer !== null) {
+            clearTimeout(fallbackTimer);
+            fallbackTimer = null;
+        }
+    };
+
+    const fallbackToHardCap = (): void => {
+        // No longtask data available (no PerformanceObserver, or the
+        // "longtask" entry type isn't supported — historically Safari) —
+        // wait the full maxMs budget rather than settleMs, since without
+        // longtask signal there's no way to detect the real settle moment.
+        fallbackTimer = setTimeout(() => {
+            fallbackTimer = null;
+            if (!cancelled) onSettled();
+        }, maxMs);
+    };
+
+    if (typeof PerformanceObserver === "undefined") {
+        fallbackToHardCap();
+        return cancel;
+    }
+
+    try {
+        observer = new PerformanceObserver((entries) => {
+            for (const e of entries.getEntries()) {
+                if (e.duration > 50) lastBusyAt = performance.now();
+            }
+        });
+        observer.observe({ entryTypes: ["longtask"] });
+    } catch {
+        fallbackToHardCap();
+        return cancel;
+    }
+
+    const tick = (): void => {
+        if (cancelled) return;
+        const now = performance.now();
+        const settledSinceLastBusy = now - lastBusyAt >= settleMs;
+        const hardCapHit = now - startedAt >= maxMs;
+        if (settledSinceLastBusy || hardCapHit) {
+            cancel();
+            onSettled();
+            return;
+        }
+        requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+
+    return cancel;
+}

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -31,6 +31,7 @@
 @use "styles/responsive";
 @use "styles/decision-panel";
 @use "styles/shell-node";
+@use "styles/loading-overlay";
 
 .agent-view {
     container-type: inline-size;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -72,6 +72,7 @@ import { ResizableDetailsDrawer } from "./components/ResizableDetailsDrawer";
 import { PendingMessagesPanel } from "./components/PendingMessagesPanel";
 import { AgentPicker, useAgentDefinitions } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
+import { BrainSpinner } from "@/app/element/BrainSpinner";
 import { SlashCommandPicker } from "./components/SlashCommandPicker";
 import { SlashHelpPanel } from "./components/SlashHelpPanel";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -344,12 +345,28 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // that lives inside AgentDocumentView. This drives the enter-animation
     // gate on the streaming buffer.
     let historyReadyFn: (() => void) | undefined;
+    // Brain-spinner loading overlay (see
+    // docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md):
+    // shown from mount, cross-fades out once the initial history load
+    // resolves (success or failure — same fail-open behavior as
+    // onHistoryReady itself) so a content-heavy pane never sits blank while
+    // it replays. `showLoadingOverlay` unmounts the overlay entirely once the
+    // fade transition has had time to finish, instead of leaving an
+    // invisible-but-present pointer-events:none div forever.
+    const [historyLoaded, setHistoryLoaded] = createSignal(false);
+    const [showLoadingOverlay, setShowLoadingOverlay] = createSignal(true);
+    let loadingOverlayTimeout: ReturnType<typeof setTimeout> | undefined;
+    onCleanup(() => clearTimeout(loadingOverlayTimeout));
     const history = useHistoryPagination({
         blockId: model.blockId,
         model: paneModel,
         outputFormat,
         definitionId: agentId,
-        onHistoryReady: () => historyReadyFn?.(),
+        onHistoryReady: () => {
+            historyReadyFn?.();
+            setHistoryLoaded(true);
+            loadingOverlayTimeout = setTimeout(() => setShowLoadingOverlay(false), 260);
+        },
         // Schema v2: apply DocumentState + pane overlay after NDJSON replay.
         onSnapshotOverlay: ({ documentState, detailsOpen }) => {
             const [, setDocState] = agentAtoms().documentStateAtom;
@@ -799,6 +816,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             onContextMenu={handleContextMenu}
             tabIndex={-1}
         >
+            {/* Loading overlay — covers the pane from mount until the initial
+                history load resolves, so a content-heavy pane never sits
+                blank while it replays. See
+                docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md. */}
+            <Show when={showLoadingOverlay()}>
+                <div class="agent-pane-loading-overlay">
+                    <BrainSpinner fading={historyLoaded()} />
+                </div>
+            </Show>
             {/* Gradient progress bar — 2px, pinned position:absolute top:0.
                 Animated shimmer while working, hidden at rest. Colors derived
                 from --accent-color via color-mix() so it adapts to all themes.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -73,6 +73,7 @@ import { PendingMessagesPanel } from "./components/PendingMessagesPanel";
 import { AgentPicker, useAgentDefinitions } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { BrainSpinner } from "@/app/element/BrainSpinner";
+import { scheduleOnSettle } from "@/app/util/settle-detector";
 import { SlashCommandPicker } from "./components/SlashCommandPicker";
 import { SlashHelpPanel } from "./components/SlashHelpPanel";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -347,16 +348,29 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     let historyReadyFn: (() => void) | undefined;
     // Brain-spinner loading overlay (see
     // docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md):
-    // shown from mount, cross-fades out once the initial history load
-    // resolves (success or failure — same fail-open behavior as
-    // onHistoryReady itself) so a content-heavy pane never sits blank while
-    // it replays. `showLoadingOverlay` unmounts the overlay entirely once the
-    // fade transition has had time to finish, instead of leaving an
-    // invisible-but-present pointer-events:none div forever.
+    // shown from mount, cross-fades out once real content has actually
+    // painted, so a content-heavy pane never sits blank while it replays.
+    //
+    // `onHistoryReady` fires right after the NDJSON parse/dispatch — BEFORE
+    // the resulting DOM's layout/paint, which is the dominant cost for heavy
+    // sessions (500-600ms, see SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md).
+    // Starting the fade there (or after any flat delay) would make the
+    // overlay disappear before painting finishes for exactly the
+    // content-heavy case this exists to cover — reproducing the blank
+    // window instead of fixing it. `scheduleOnSettle` (same Long-Task-quiet
+    // detector `tab-reveal.ts` uses for the analogous tab-switch case) waits
+    // for the main thread to actually go quiet post-dispatch before the
+    // fade starts. `showLoadingOverlay` then unmounts the overlay entirely
+    // once the fade transition has had time to finish, instead of leaving
+    // an invisible-but-present pointer-events:none div forever.
     const [historyLoaded, setHistoryLoaded] = createSignal(false);
     const [showLoadingOverlay, setShowLoadingOverlay] = createSignal(true);
-    let loadingOverlayTimeout: ReturnType<typeof setTimeout> | undefined;
-    onCleanup(() => clearTimeout(loadingOverlayTimeout));
+    let cancelSettleWait: (() => void) | undefined;
+    let loadingOverlayFadeTimeout: ReturnType<typeof setTimeout> | undefined;
+    onCleanup(() => {
+        cancelSettleWait?.();
+        clearTimeout(loadingOverlayFadeTimeout);
+    });
     const history = useHistoryPagination({
         blockId: model.blockId,
         model: paneModel,
@@ -364,8 +378,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         definitionId: agentId,
         onHistoryReady: () => {
             historyReadyFn?.();
-            setHistoryLoaded(true);
-            loadingOverlayTimeout = setTimeout(() => setShowLoadingOverlay(false), 260);
+            cancelSettleWait = scheduleOnSettle(() => {
+                setHistoryLoaded(true);
+                loadingOverlayFadeTimeout = setTimeout(() => setShowLoadingOverlay(false), 220);
+            });
         },
         // Schema v2: apply DocumentState + pane overlay after NDJSON replay.
         onSnapshotOverlay: ({ documentState, detailsOpen }) => {

--- a/frontend/app/view/agent/styles/_loading-overlay.scss
+++ b/frontend/app/view/agent/styles/_loading-overlay.scss
@@ -1,0 +1,22 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Brain-spinner loading overlay — covers the pane from mount until initial
+// history load resolves. See
+// docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md.
+// Wrapped in .agent-view so the cascade chain matches the pre-split file
+// (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24), same convention as
+// _auth-overlay.scss.
+.agent-view {
+    .agent-pane-loading-overlay {
+        position: absolute;
+        inset: 0;
+        background: var(--main-bg-color);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        // Same tier as the auth overlay — needs to cover the whole pane
+        // (progress bar, search, document, composer) while loading.
+        z-index: var(--zindex-elem-modal);
+    }
+}


### PR DESCRIPTION
## Problem

Panes with a lot of content sat blank for a bit while loading. Full investigation in [`docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md`](docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md) (included in this PR). Short version: two stacked causes —
1. `block.tsx`'s `ready` memo renders **nothing** until the block object + viewModel resolve; its `Suspense` fallback was plain "Loading..." text.
2. Once the agent view mounts, `useHistoryPagination` synchronously parses up to 5000 NDJSON history lines and bulk-dispatches them, driving a DOM build whose paint cost scales with conversation size — previously measured at 500-600ms for heavy sessions (`SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md`), attributed to browser-side layout/paint, not a single fixable JS function.

The existing tab-switch reveal gate (`tab-reveal.ts` + `workspace.tsx`) already hides this window — but only for whole-tab switches. Opening a new pane inside an already-visible tab (split, view-swap, swarm click, tear-off landing) has **no gating at all**, which is almost certainly the scenario being reported.

## Fix

- **New `frontend/app/element/BrainSpinner.tsx`** — the same pulsating brain mark/animation used by the startup splash, extracted into a reusable component. The original (`index.html` + `startup-splash.ts`) is a one-shot singleton tied to one DOM id and can't be re-armed per pane; this reuses the same already-imported raw SVG asset (`@/app/asset/logo-brain.svg?raw` — the one `ProviderLogo.tsx` already uses for the "agentmux"/"muxcode" provider mark) and mirrors the same keyframes/timing.
- **`block.tsx`**: both `Suspense` fallbacks and the `ready`-gate fallbacks now show `<BrainSpinner/>` instead of rendering nothing / plain text — covers stage-one blank for every pane type, not just agent panes.
- **`agent-view.tsx`**: a pane-local overlay shows `<BrainSpinner/>` from mount, cross-fades out (200ms, matching the existing startup-splash/tab-reveal opacity idiom) once `useHistoryPagination`'s existing `onHistoryReady` callback fires — already dispatched exactly once on load success **or** failure (fail-open, unchanged). Respects `prefersReducedMotionAtom` (instant show/hide, no animation).

**Not in scope**: reducing the underlying paint cost itself (lazy tool-block hydration, snapshot pre-warm) — that's separate, larger scope already tracked in `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md`. This PR is a visual cover for the existing cost, not a fix to the cost.

## Verification
- `tsc --noEmit`: clean.
- Ran `task dev` end-to-end (`dev:main`, v0.50.3) for ~10 minutes — no new errors in `muxlog` beyond pre-existing startup noise (Shiki highlight warnings, etc.), confirming no crash/exception from the new code paths.
- **Could not visually confirm the fade timing/appearance myself** — no screenshot/UI-automation tool available in this environment. Flagging explicitly rather than claiming full visual verification; would appreciate a manual look before/after merge.

<!-- agentmux:agent_id=agentx -->