### PR TITLE
refactor(host): SPEC_PILLAR2 Stage 2 (partial) — wire on_before_close through reconcile_quit

### DIFF
--- a/.changesets/1783393908-refactor-host-spec-pillar2-stage-2-partial-wire-on-before-cl-v2sk.md
+++ b/.changesets/1783393908-refactor-host-spec-pillar2-stage-2-partial-wire-on-before-cl-v2sk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(host): SPEC_PILLAR2 Stage 2 (partial) — wire on_before_close through reconcile_quit

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -542,10 +542,19 @@ impl AgentMuxHandler {
             })
             .map(|(k, _)| k.clone());
         dlog(&format!("label found: {:?}", label));
+        // Pillar 2 Stage 2 (SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md §3.2/§4#3)
+        // — `UnregisterBrowser` is quit-relevant, so `reducer::update` already
+        // computed `reconcile_quit` under the same lock and surfaced its
+        // verdict here. Capture it now (state.browsers doesn't change again
+        // before the gate below reads it) instead of re-deriving
+        // `count_live_user_windows() == 0` locally — `reconcile_quit` is the
+        // single decision authority; this handler is now just an executor.
+        let mut request_drain: Option<crate::state::QuitReason> = None;
         if let Some(ref lbl) = label {
-            self.state.host_dispatch(
+            let unregister_dispatch = self.state.host_dispatch(
                 crate::reducer::HostCommand::UnregisterBrowser { label: lbl.clone() },
             );
+            request_drain = unregister_dispatch.request_drain;
             let remaining = self.state.host_state.lock().browsers.len();
             tracing::info!(
                 "Unregistered browser: label={} (remaining: {})",
@@ -795,7 +804,14 @@ impl AgentMuxHandler {
             // browser-pane-* only. window-pool-* labels (promoted)
             // are tracked windows and need their cleanup events.
             if !lbl.starts_with("browser-pane-") {
-                let was_last = user_browser_count == 0 && !self.is_browser_pane;
+                // Pillar 2 Stage 2 — mirrors the actual cascade gate below
+                // (`request_drain.is_some()`), not the raw `user_browser_count`
+                // reading, so this report and the real decision can't drift
+                // apart. `request_drain` is strictly more conservative than
+                // `user_browser_count == 0` alone (it's also `None` while a
+                // user window-creation is in flight, or once already
+                // draining) — see reconcile_quit's should_begin_drain.
+                let was_last = request_drain.is_some() && !self.is_browser_pane;
                 crate::launcher_ipc::report_pool_drain_decision(lbl.clone(), was_last);
             }
         }
@@ -824,108 +840,17 @@ impl AgentMuxHandler {
         // Windows path. macOS uses NSWindow.performClose:; Linux
         // uses X11 WM_DELETE_WINDOW. Same async-close-cascade
         // semantics on all platforms; only the OS API differs.
-        if user_browser_count == 0 && !self.is_browser_pane {
-            // PR #5 H.5 — flip QuitState Running → Draining via reducer.
-            // Mirrors the pre-PR Phase B.9.3 drain flag: spawn_pool_window
-            // checks `quit_state != Running` (in the reducer's spawn arm)
-            // and skips refill on every subsequent on_pool_window_destroyed
-            // → no new pool browsers added → browsers map can actually
-            // drain. BeginDrain is idempotent — safe if a duplicate
-            // last-close fires.
-            self.state.host_dispatch(
-                crate::reducer::HostCommand::BeginDrain {
-                    reason: crate::state::QuitReason::LastWindowClosed,
-                },
-            );
-            tracing::warn!(target: "wrr", "[wrr] quit_state=Draining (drain mode)");
-
-            // Phase H.2.b — reducer-aware iteration with fallback + drift logging.
-            // Collect ALL background-only browsers: tab pool (window-pool-*)
-            // AND pane pool (floating-pool-*). Both live in browser_list
-            // (created via CreateWindowTask which clones the main top-level
-            // client). Omitting pane pool windows here means browser_list
-            // never empties on macOS/Linux (init_pane_pool spawns one at
-            // startup), so Stage 2's is_empty() gate never fires and the
-            // host hangs on every quit.
-            let pool_browsers: Vec<cef::Browser> = self
-                .state
-                .list_browsers()
-                .into_iter()
-                .filter(|(label, _)| {
-                    label.starts_with("window-pool-") || label.starts_with("floating-pool-")
-                })
-                .map(|(_, b)| b)
-                .collect();
-            tracing::warn!(
-                target: "wrr",
-                "[wrr] stage 1: user_count==0; closing {} pool browser(s) (tab+pane)",
-                pool_browsers.len()
-            );
-
-            // Windows path: prefer Win32 PostMessage(WM_CLOSE) —
-            // bypasses CEF's task queue (proven reliable; smoke
-            // v0.33.500+). When window_handle() returns null
-            // (early/late lifecycle), fall through to the
-            // post_task path so the close still happens — without
-            // the fallback, self.browser_list never empties and
-            // Stage 2 never fires. (codex #601 P1.)
-            #[cfg(target_os = "windows")]
-            {
-                use windows_sys::Win32::Foundation::HWND;
-                use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
-                for (i, mut b) in pool_browsers.into_iter().enumerate() {
-                    let hwnd_opt = b.host().and_then(|h| {
-                        let wh = h.window_handle();
-                        if wh.0.is_null() {
-                            None
-                        } else {
-                            Some(wh.0 as HWND)
-                        }
-                    });
-                    if let Some(hwnd) = hwnd_opt {
-                        let ok = unsafe { PostMessageW(hwnd, WM_CLOSE, 0, 0) };
-                        tracing::debug!(
-                            target: "wrr-trace",
-                            "[trace] stage1[{}] PostMessage(hwnd={:p}, WM_CLOSE) ok={}",
-                            i, hwnd, ok != 0
-                        );
-                    } else {
-                        // Fallback: defer close_browser via UI task.
-                        // Same path as non-Windows so the cascade
-                        // still drains.
-                        let mut task = ClosePoolBrowserTask::new(b);
-                        let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
-                        tracing::warn!(
-                            target: "wrr",
-                            "[wrr] stage1[{}] hwnd=null; fell back to post_task(close_browser) posted={}",
-                            i, posted != 0
-                        );
-                    }
-                }
-            }
-
-            // Non-Windows path: defer `close_browser` to the UI
-            // thread via `cef::post_task`. Calling close_browser
-            // inline from inside another browser's on_before_close
-            // hangs the UI thread (CEF re-entrance, smoke
-            // v0.33.497 confirmed on Windows; same constraint on
-            // macOS / Linux per CEF docs). Windows prefers
-            // PostMessage(WM_CLOSE) as the primary path (bypasses
-            // CEF's task queue, which proved unreliable in
-            // late-teardown windows — see
-            // `docs/retro/b9-3-quit-thread-analysis.md`).
-            // (reagent #601 P1.)
-            #[cfg(not(target_os = "windows"))]
-            {
-                for (i, b) in pool_browsers.into_iter().enumerate() {
-                    let mut task = ClosePoolBrowserTask::new(b);
-                    let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
-                    tracing::debug!(
-                        target: "wrr-trace",
-                        "[trace] stage1[{}] post_task(close_browser) posted={}",
-                        i, posted != 0
-                    );
-                }
+        // Pillar 2 Stage 2 — the decision ("should we drain?") now comes
+        // solely from `reconcile_quit` (via the `request_drain` captured
+        // above from the `UnregisterBrowser` dispatch); this handler only
+        // executes it. `!self.is_browser_pane` stays as a belt-and-suspenders
+        // guard (a browser-pane close should never drive top-level app-quit
+        // logic), though in practice `request_drain` is already `None` for a
+        // pane close — `count_live_user_windows` only counts
+        // `BrowserKind::TopLevel{is_pool:false}`, never panes.
+        if !self.is_browser_pane {
+            if let Some(reason) = request_drain {
+                self.begin_drain_and_cascade(reason);
             }
         }
 
@@ -1030,6 +955,123 @@ impl AgentMuxHandler {
             "[trace] on_before_close EXIT label={:?} self.browser_list.len()={}",
             label, self.browser_list.len()
         );
+    }
+
+    /// Pillar 2 Stage 2 (SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md §3.2) —
+    /// the Stage-1 drain-and-cascade executor, extracted verbatim from what
+    /// used to be `on_before_close`'s inline `user_browser_count == 0` block
+    /// so it's callable from any UI-thread CEF callback that observes
+    /// `reconcile_quit`'s decision via `DispatchOutput.request_drain` — not
+    /// just the close-edge that happened to trigger it this time. This is
+    /// the "action" half of the decision/action split (`reducer/quit.rs:49-54`):
+    /// callers must have already confirmed `request_drain.is_some()` (the
+    /// DECISION) before calling this (the ACTION) — this function does not
+    /// re-check anything, it just executes.
+    ///
+    /// Only flips `QuitState` and closes the (already-hidden) pool browsers.
+    /// Never calls `quit_message_loop()` — that stays Stage 2, gated
+    /// separately on `self.browser_list.is_empty()` in `on_before_close`,
+    /// since calling it from inside another browser's `on_before_close`
+    /// deadlocks the UI thread (confirmed v0.33.498).
+    pub(crate) fn begin_drain_and_cascade(&self, reason: crate::state::QuitReason) {
+        // PR #5 H.5 — flip QuitState Running → Draining via reducer.
+        // Mirrors the pre-PR Phase B.9.3 drain flag: spawn_pool_window
+        // checks `quit_state != Running` (in the reducer's spawn arm)
+        // and skips refill on every subsequent on_pool_window_destroyed
+        // → no new pool browsers added → browsers map can actually
+        // drain. BeginDrain is idempotent — safe if a duplicate
+        // last-close (or a later reconcile) fires.
+        self.state.host_dispatch(crate::reducer::HostCommand::BeginDrain { reason });
+        tracing::warn!(target: "wrr", "[wrr] quit_state=Draining (drain mode)");
+
+        // Phase H.2.b — reducer-aware iteration with fallback + drift logging.
+        // Collect ALL background-only browsers: tab pool (window-pool-*)
+        // AND pane pool (floating-pool-*). Both live in browser_list
+        // (created via CreateWindowTask which clones the main top-level
+        // client). Omitting pane pool windows here means browser_list
+        // never empties on macOS/Linux (init_pane_pool spawns one at
+        // startup), so Stage 2's is_empty() gate never fires and the
+        // host hangs on every quit.
+        let pool_browsers: Vec<cef::Browser> = self
+            .state
+            .list_browsers()
+            .into_iter()
+            .filter(|(label, _)| {
+                label.starts_with("window-pool-") || label.starts_with("floating-pool-")
+            })
+            .map(|(_, b)| b)
+            .collect();
+        tracing::warn!(
+            target: "wrr",
+            "[wrr] stage 1: draining; closing {} pool browser(s) (tab+pane)",
+            pool_browsers.len()
+        );
+
+        // Windows path: prefer Win32 PostMessage(WM_CLOSE) —
+        // bypasses CEF's task queue (proven reliable; smoke
+        // v0.33.500+). When window_handle() returns null
+        // (early/late lifecycle), fall through to the
+        // post_task path so the close still happens — without
+        // the fallback, self.browser_list never empties and
+        // Stage 2 never fires. (codex #601 P1.)
+        #[cfg(target_os = "windows")]
+        {
+            use windows_sys::Win32::Foundation::HWND;
+            use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+            for (i, mut b) in pool_browsers.into_iter().enumerate() {
+                let hwnd_opt = b.host().and_then(|h| {
+                    let wh = h.window_handle();
+                    if wh.0.is_null() {
+                        None
+                    } else {
+                        Some(wh.0 as HWND)
+                    }
+                });
+                if let Some(hwnd) = hwnd_opt {
+                    let ok = unsafe { PostMessageW(hwnd, WM_CLOSE, 0, 0) };
+                    tracing::debug!(
+                        target: "wrr-trace",
+                        "[trace] stage1[{}] PostMessage(hwnd={:p}, WM_CLOSE) ok={}",
+                        i, hwnd, ok != 0
+                    );
+                } else {
+                    // Fallback: defer close_browser via UI task.
+                    // Same path as non-Windows so the cascade
+                    // still drains.
+                    let mut task = ClosePoolBrowserTask::new(b);
+                    let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
+                    tracing::warn!(
+                        target: "wrr",
+                        "[wrr] stage1[{}] hwnd=null; fell back to post_task(close_browser) posted={}",
+                        i, posted != 0
+                    );
+                }
+            }
+        }
+
+        // Non-Windows path: defer `close_browser` to the UI
+        // thread via `cef::post_task`. Calling close_browser
+        // inline from inside another browser's on_before_close
+        // hangs the UI thread (CEF re-entrance, smoke
+        // v0.33.497 confirmed on Windows; same constraint on
+        // macOS / Linux per CEF docs). Windows prefers
+        // PostMessage(WM_CLOSE) as the primary path (bypasses
+        // CEF's task queue, which proved unreliable in
+        // late-teardown windows — see
+        // `docs/retro/b9-3-quit-thread-analysis.md`).
+        // (reagent #601 P1.)
+        #[cfg(not(target_os = "windows"))]
+        {
+            for (i, b) in pool_browsers.into_iter().enumerate() {
+                let mut task = ClosePoolBrowserTask::new(b);
+                let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
+                tracing::debug!(
+                    target: "wrr-trace",
+                    "[trace] stage1[{}] post_task(close_browser) posted={}",
+                    i, posted != 0
+                );
+            }
+        }
     }
 }
 

--- a/agentmux-cef/src/reducer/quit.rs
+++ b/agentmux-cef/src/reducer/quit.rs
@@ -57,10 +57,26 @@ pub(super) fn handle_confirm_drained(state: &mut HostState) -> DispatchOutput {
 // `reducer::update` now calls `reconcile_quit` after every quit-relevant command
 // (gated by `is_quit_relevant`) and surfaces the result via
 // `DispatchOutput::request_drain`. The decision is computed here, under the
-// host-state lock, as a pure read. The UI-thread executor that consumes
-// `request_drain` and runs the Stage-1 close cascade is wired in Stage 2; until
-// then the legacy edge-triggered gate in `client::on_before_close` still drives
-// the actual drain, so Stage 1 is behavior-neutral.
+// host-state lock, as a pure read.
+//
+// WIRED, PARTIALLY (Pillar 2, Stage 2 — same spec, §3.2/§4#3):
+// `client::on_before_close` now consumes `request_drain` (from the
+// `UnregisterBrowser` dispatch it already makes) and calls the extracted
+// `AgentMuxHandler::begin_drain_and_cascade` executor instead of re-deriving
+// `count_live_user_windows() == 0` itself — the close-edge path is now a pure
+// executor of this module's decision, not a second decision-maker.
+//
+// NOT YET WIRED: the spec's other "settling" call sites — the pool
+// spawn/promote/destroy completion callbacks in `commands/window_pool.rs`
+// (`PopAndPromoteFrontPoolWindow`/`PanePoolWindow*`/etc.) — still discard their
+// `DispatchOutput.request_drain`. This means the actual regression the spec
+// exists to fix (a concurrent pool refill keeping the close-time count
+// non-zero, with nothing re-evaluating once the refill settles) is NOT yet
+// closed — only the common, non-racing close path is now single-authority.
+// `wrr::win_event::maybe_quit_on_last_user_window` and
+// `commands::orphan_reconcile`'s independent `begin_drain` predicate (§3.3)
+// are also untouched. See the spec's §3.2 "correctness obligation" and §7
+// rollout for the remaining steps.
 
 /// Background PENDING-CREATION labels — warm-pool tab refills (`window-pool-`),
 /// browser-pane children (`browser-pane-`), and floating panes (`floating-`, the

--- a/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
+++ b/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
@@ -112,15 +112,36 @@ returns once not `Running` (`quit.rs:15`), and `BeginDrain` is documented idempo
 (`client/mod.rs:1090`).
 
 ### 3.3 Result: the three decision sites become executors
-- **`client::on_before_close`** — keep the `UnregisterBrowser` dispatch; **delete the inline
-  `count_live_user_windows()==0` gate + inline `BeginDrain`** (lines ~1084-1097). The post-dispatch
-  hook now fires `reconcile_quit` after the `UnregisterBrowser` it just dispatched. The Stage-1 body
-  moves into `begin_drain_and_cascade`.
-- **`wrr::win_event::maybe_quit_on_last_user_window`** — remove as a *decision*; if it still needs to
-  exist for OS-event reasons, it calls the same reconcile path, never its own count.
-- **`commands::orphan_reconcile`** — its `plan.begin_drain` computation (`orphan_reconcile.rs:189,345`)
-  is now redundant with `reconcile_quit`; have it call the shared executor instead of duplicating the
-  drain-safety predicate. (Keep its *close-plan* execution; drop its independent drain *decision*.)
+- **`client::on_before_close`** — ✅ **DONE** (Stage 2, first slice). Keeps the `UnregisterBrowser`
+  dispatch, now captures its `DispatchOutput.request_drain` instead of re-deriving
+  `count_live_user_windows() == 0` locally; the Stage-1 body was extracted verbatim into
+  `AgentMuxHandler::begin_drain_and_cascade(reason)`, called only when `request_drain.is_some()`.
+  Live-verified (isolated instance, debug tracing): a promoted secondary window closing while main
+  stays open correctly fires `on_before_close` with `request_drain: None` (main still counts) and no
+  cascade; closing the last window in a normal two-window session exits the whole process tree
+  cleanly within 1 second, no deadlock, no orphan (`tasklist` confirmed clean afterward).
+- **`wrr::win_event::maybe_quit_on_last_user_window`** — ⚠️ **NOT DONE — bigger gap than this section
+  assumed.** Live-verified (2026-07-07) that on Windows, closing the **main window does not fire
+  `on_before_close` at all** (confirmed via `RUST_LOG="info,wrr-trace=debug"`: closing "main" produced
+  zero `on_before_close ENTER` trace lines for the "main" label itself — only WRR's
+  `[wrr] all user windows hidden/closed ... quitting message loop` fired, followed by CEF's own
+  shutdown cascade closing the *other* remaining browsers, whose `on_before_close` fired only as a
+  side effect of `quit_message_loop()` already having been called). This means, for the single most
+  common quit scenario — the user closes the main window — `HostState.browsers` never learns "main"
+  is gone (no `UnregisterBrowser` dispatch ever fires for it), so `reconcile_quit`'s
+  `count_live_user_windows()` would keep reporting `main` as live even after the OS says otherwise.
+  **"Have WRR call the same reconcile path instead of its own count" (as originally written above) is
+  not achievable as a simple swap** — `reconcile_quit` has no way to know main closed unless something
+  tells the reducer. Closing this gap needs WRR's OS-hook to itself report the main-window-gone
+  transition into the reducer (a new command/event, or reusing `UnregisterBrowser` off the OS
+  signal instead of the CEF signal) *before* trusting `reconcile_quit`'s count — a real design task,
+  not part of this rollout's original scope. Tracked as a separate follow-up; `quit_message_loop()`
+  called directly from WRR, bypassing `QuitState` entirely, is unchanged for now.
+- **`commands::orphan_reconcile`** — not started. Its `plan.begin_drain` computation
+  (`orphan_reconcile.rs:189,345`) is still independent of `reconcile_quit`; per the research done
+  2026-07-07 it also carries a "Race B" (`freshly_promoted`) guard with no `HostState` equivalent —
+  merging it away needs either a new `HostState` field or a two-phase "sanitize state.browsers, then
+  trust reconcile_quit" design, not a direct swap either.
 
 ## 4. Exact code changes
 
@@ -165,15 +186,33 @@ The retro (§7.4) notes **zero E2E coverage** for "close last window ⇒ tree ex
   skip it).
 
 ## 7. Rollout
-1. Land #1 (un-dead-code) + #2 (reducer hook + `request_drain`) + tests #5.1/#5.2 — pure, no behavior
+1. ✅ Land #1 (un-dead-code) + #2 (reducer hook + `request_drain`) + tests #5.1/#5.2 — pure, no behavior
    change yet (hook computed but executor still the old inline path).
-2. Land #3 (extract executor, delete inline gate, wire `request_drain`).
-3. Land #4/#5 (demote orphan_reconcile + WRR; E2E test).
-4. Verify against the retro's reproduction (#1647/#1650/#1676 scenarios) and the orphan-log signature
-   (drain marker now always present).
+2. ✅ **Partially landed 2026-07-07.** Land #3 (extract executor, delete inline gate, wire
+   `request_drain`) — done for `on_before_close`. Live-verified: single-window close and sequential
+   multi-window close both exit cleanly with no deadlock/orphan. **However**, live verification also
+   found `on_before_close` never fires for the main window's close on Windows at all (§3.3) — so this
+   step alone does not yet close the actual race the spec exists to fix; it only makes the
+   already-firing call sites (secondary/pool window closes) single-authority instead of duplicating
+   the decision.
+3. ⬜ Land #4/#5 (demote orphan_reconcile + WRR; E2E test) — **not started; scope now understood to be
+   larger than originally written.** Wiring WRR needs a new mechanism for the reducer to learn the main
+   window closed (§3.3), and demoting `orphan_reconcile` needs to either add a `HostState` field for its
+   "Race B" (`freshly_promoted`) guard or keep it as an upstream state-sanitize step — neither is a
+   simple call-the-shared-executor swap. Re-scope before starting.
+4. ⬜ Verify against the retro's reproduction (#1647/#1650/#1676 scenarios) and the orphan-log signature
+   (drain marker now always present) — blocked on #3 above, since those scenarios are exactly the
+   main-window/pool-refill race that step 2's landing doesn't reach.
 
 ## 8. Definition of done
 - `reconcile_quit` is the only place "should we drain?" is decided; the other sites are executors.
-- The race regression test fails on `main` (pre-wire) and passes after.
-- Closing the last window always exits the process tree (E2E green); no orphan host logs.
+  **Partial:** true for `on_before_close`'s two verified scenarios; not yet true for WRR or
+  `orphan_reconcile`.
+- The race regression test fails on `main` (pre-wire) and passes after. **Not written yet** — needs
+  step 3 above to be meaningful (the current landing doesn't touch the actual racing path).
+- Closing the last window always exits the process tree (E2E green); no orphan host logs. **Verified
+  manually** for the two-window and one-window cases (2026-07-07); no automated E2E test yet.
 - Net deletion of duplicated drain-decision code in `on_before_close` / `orphan_reconcile` / `wrr`.
+  **Done for `on_before_close`** (the inline `count_live_user_windows()==0` + `BeginDrain` block was
+  deleted, replaced by consuming `request_drain`); `orphan_reconcile` and `wrr` still duplicate the
+  decision.


### PR DESCRIPTION
## Summary
- Wires `client::on_before_close` to consume `reconcile_quit`'s verdict (surfaced via `DispatchOutput.request_drain`, already computed since Stage 1 landed) instead of re-deriving its own `count_live_user_windows() == 0` gate — matches `SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md` §3.2/§4#3.
- Extracts the Stage-1 close-pool-browsers cascade into `AgentMuxHandler::begin_drain_and_cascade(reason)`, a pure executor callable from any UI-thread CEF callback that observes a drain request — currently only `on_before_close`, verbatim behavior preserved (same PostMessage/post_task platform branches).
- Net deletion of the duplicated drain-decision logic in `on_before_close` (the inline `user_browser_count == 0` gate is gone; `was_last`'s reporting now mirrors the same `request_drain` the cascade gates on, so they can't drift apart).

## Honest scope — this is a partial landing, not the full spec
Live-verifying this surfaced something the spec didn't anticipate: **on Windows, closing the main window never fires `on_before_close` at all.** Confirmed via `RUST_LOG="info,wrr-trace=debug"` — closing "main" produced zero `on_before_close` trace lines for that label; the actual quit was driven entirely by `wrr::win_event::maybe_quit_on_last_user_window`'s independent OS-level `EnumWindows` visibility scan, which calls `quit_message_loop()` directly and bypasses `reconcile_quit`/`BeginDrain`/`QuitState` completely. The other remaining browsers' `on_before_close` fired only as a side effect of CEF's own shutdown cascade, after the fact.

This means the spec's §3.3 suggestion ("have WRR call the same reconcile path instead of its own count") is not a simple swap — `reconcile_quit` has no way to know the main window closed unless something tells the reducer, and nothing does today. Closing that gap needs a real design task (teaching the reducer about the OS-level close signal), which I've flagged as a separate follow-up rather than scope-creep this PR. `docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md` is updated with this finding (§3.3, §7, §8) so whoever picks up the WRR/`orphan_reconcile` follow-up isn't relitigating it.

## Test plan
- [x] `cargo check -p agentmux-cef` clean
- [x] `cargo test -p agentmux-cef` — 159 passed
- [x] Live-verified on an isolated portable build: single-window close exits the whole process tree cleanly within 1 second (no deadlock, no orphan — confirmed via `tasklist` after)
- [x] Live-verified sequential multi-window close: closing a secondary window while main stays open correctly does NOT quit (`request_drain: None`, main still counted); closing main after exits cleanly, same as above
- [x] Confirmed via debug tracing that `on_before_close`'s new gate fires correctly (`request_drain` observed `None` when a window remains, and the cascade never double-fires)

<!-- agentmux:agent_id=agenta -->