### PR TITLE
feat(agent): Right Arrow also accepts the ghost-text next-prompt suggestion

### DIFF
--- a/.changesets/1783411229-feat-agent-right-arrow-also-accepts-the-ghost-text-next-prom-tvo2.md
+++ b/.changesets/1783411229-feat-agent-right-arrow-also-accepts-the-ghost-text-next-prom-tvo2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): Right Arrow also accepts the ghost-text next-prompt suggestion

--- a/docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md
+++ b/docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md
@@ -186,8 +186,18 @@ suggestion is **interactive**:
   `Done`.
 - **Tab accepts** the suggestion into the real input (matching Claude Code's
   own terminal UX exactly, so users familiar with the CLI get a consistent
-  mental model). Any other keystroke dismisses it — normal typing takes over
-  immediately, no different from typing over a placeholder.
+  mental model). **Right Arrow also accepts it** — verified 2026-07-07 by
+  inspecting the Claude Code CLI binary directly (`strings` + grep for every
+  `name==="rightArrow"`/`name==="right"` key check): the real CLI has no
+  right-arrow path anywhere near the prompt-suggestion logic, only `tab`. So
+  this is a deliberate AgentMux-only addition layered on top of the CLI-parity
+  baseline — the fish-shell/zsh-autosuggestions/Copilot convention of
+  accepting an inline suggestion with the "keep going right" key, so the user
+  can Right-Arrow-then-Enter without reaching for Tab. Safe to add: with the
+  textarea empty (the only state the suggestion renders in) there's no cursor
+  to move, so Right Arrow is otherwise a no-op there. Any other keystroke
+  dismisses it — normal typing takes over immediately, no different from
+  typing over a placeholder.
 - Precedence over the existing static placeholder (§3): show
   `term:next_prompt_suggestion` if present and current-generation; else the
   existing static placeholder text. Same "prefer the richer ambient signal,

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -581,10 +581,17 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // Ghost-text next-prompt suggestion: Tab accepts it into the real
         // input, matching Claude Code CLI's own terminal UX (see
         // docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md).
+        // Right Arrow is a deliberate AgentMux addition on top of that
+        // parity baseline — not something Claude Code's own CLI does — for
+        // the fish-shell/zsh-autosuggestions/Copilot-style convenience of
+        // accepting an inline suggestion with the "continue typing right"
+        // key, letting the user just press Enter after. Safe to claim here:
+        // with the textarea empty there's no cursor to move, so Right Arrow
+        // is otherwise a no-op in this state.
         // Only reachable when the textarea is empty, which is also the only
         // state the slash-autocomplete branch below can't be in (it requires
-        // a `/prefix`) — the two Tab handlers never compete.
-        if (e.key === "Tab" && textareaRef && textareaRef.value.length === 0) {
+        // a `/prefix`) — these handlers never compete with it.
+        if ((e.key === "Tab" || e.key === "ArrowRight") && textareaRef && textareaRef.value.length === 0) {
             const vm = props.viewModel;
             const suggestion = vm?.blockAtom()?.meta?.["term:next_prompt_suggestion"] as string | undefined;
             if (suggestion) {


### PR DESCRIPTION
## Summary
- The agent-pane ghost-text next-prompt suggestion (`term:next_prompt_suggestion`, SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03) currently only accepts via Tab, matching Claude Code CLI's own terminal UX exactly.
- Adds Right Arrow as an additional accept key — a deliberate AgentMux-only convenience, not CLI parity. Verified by inspecting the Claude Code CLI binary directly (`strings` + grep for every `name==="rightArrow"`/`name==="right"` key check): the real CLI has no right-arrow path near its prompt-suggestion logic, only `tab`. This follows the fish-shell/zsh-autosuggestions/GitHub Copilot convention instead — accept an inline suggestion with the "keep going right" key, then Enter to send.
- Safe: the suggestion only renders when the textarea is empty, and in that state Right Arrow has no cursor to move, so there's no collision with normal cursor navigation.
- Updated the spec doc to document this as a deliberate deviation from strict CLI parity, with the verification method.

## Test plan
- [ ] Manual: with an empty composer showing a ghost-text suggestion, press Right Arrow — the suggestion fills the input (same as Tab), cursor lands at the end, Enter sends it.
- [ ] Manual: confirm Right Arrow with a non-empty composer (normal cursor movement) is unaffected.