### PR TITLE
chore: release v0.51.0

### DIFF
--- a/.changesets/1783384293-feat-host-spec-pillar1-step2-phase-2-wire-per-window-opacity-twu6.md
+++ b/.changesets/1783384293-feat-host-spec-pillar1-step2-phase-2-wire-per-window-opacity-twu6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP2 Phase 2 — wire per-window opacity write-through + crash-restart read-back

--- a/.changesets/1783384860-fix-ui-suppress-the-focus-ring-when-a-pane-is-alone-in-its-t-q3zq.md
+++ b/.changesets/1783384860-fix-ui-suppress-the-focus-ring-when-a-pane-is-alone-in-its-t-q3zq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): suppress the focus ring when a pane is alone in its tab

--- a/.changesets/1783385426-fix-agent-unify-failure-state-into-the-pane-reducer-fix-stuc-neuu.md
+++ b/.changesets/1783385426-fix-agent-unify-failure-state-into-the-pane-reducer-fix-stuc-neuu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): unify failure state into the pane reducer, fix stuck-Waiting and false-positive rate-limit label

--- a/.changesets/1783387832-fix-tabs-active-tab-color-line-now-starts-at-the-selected-ta-3vz9.md
+++ b/.changesets/1783387832-fix-tabs-active-tab-color-line-now-starts-at-the-selected-ta-3vz9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): active-tab color line now starts at the selected tab's left edge

--- a/.changesets/1783388737-feat-host-spec-pillar1-step2-slice-b-floating-pane-placement-9aec.md
+++ b/.changesets/1783388737-feat-host-spec-pillar1-step2-slice-b-floating-pane-placement-9aec.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP2 Slice B — floating-pane placement write-through to srv

--- a/.changesets/1783389028-feat-agent-esc-delivers-a-queued-message-immediately-mirrori-ksiy.md
+++ b/.changesets/1783389028-feat-agent-esc-delivers-a-queued-message-immediately-mirrori-ksiy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): Esc delivers a queued message immediately, mirroring Claude Code CLI

--- a/.changesets/1783389431-fix-agent-remove-non-functional-tool-overlay-action-bar-open-xs88.md
+++ b/.changesets/1783389431-fix-agent-remove-non-functional-tool-overlay-action-bar-open-xs88.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove non-functional tool overlay action bar (open-in-pane/window, new-agent-here)

--- a/.changesets/1783390062-feat-agent-brain-spinner-loading-overlay-covers-blank-pane-m-60k7.md
+++ b/.changesets/1783390062-feat-agent-brain-spinner-loading-overlay-covers-blank-pane-m-60k7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): brain-spinner loading overlay covers blank pane-mount and history-replay window

--- a/.changesets/1783393908-refactor-host-spec-pillar2-stage-2-partial-wire-on-before-cl-v2sk.md
+++ b/.changesets/1783393908-refactor-host-spec-pillar2-stage-2-partial-wire-on-before-cl-v2sk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(host): SPEC_PILLAR2 Stage 2 (partial) — wire on_before_close through reconcile_quit

--- a/.changesets/1783410019-fix-model-catalog-fall-back-to-claude-code-oauth-token-on-ma-3qm1.md
+++ b/.changesets/1783410019-fix-model-catalog-fall-back-to-claude-code-oauth-token-on-ma-3qm1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(model-catalog): fall back to CLAUDE_CODE_OAUTH_TOKEN on macOS

--- a/.changesets/1783411229-feat-agent-right-arrow-also-accepts-the-ghost-text-next-prom-tvo2.md
+++ b/.changesets/1783411229-feat-agent-right-arrow-also-accepts-the-ghost-text-next-prom-tvo2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): Right Arrow also accepts the ghost-text next-prompt suggestion

--- a/.changesets/1783413586-fix-browser-pane-marshal-wrapper-destroy-to-the-cef-ui-threa-h1zj.md
+++ b/.changesets/1783413586-fix-browser-pane-marshal-wrapper-destroy-to-the-cef-ui-threa-h1zj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): marshal wrapper destroy to the CEF UI thread — closes the per-close renderer leak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.50.3"
+version = "0.51.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.50.3"
+version = "0.51.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,21 @@
 # AgentMux Version History
 
+## 0.51.0 — 2026-07-07
+
+- feat(host): SPEC_PILLAR1_STEP2 Phase 2 — wire per-window opacity write-through + crash-restart read-back
+- fix(ui): suppress the focus ring when a pane is alone in its tab
+- fix(agent): unify failure state into the pane reducer, fix stuck-Waiting and false-positive rate-limit label
+- fix(tabs): active-tab color line now starts at the selected tab's left edge
+- feat(host): SPEC_PILLAR1_STEP2 Slice B — floating-pane placement write-through to srv
+- feat(agent): Esc delivers a queued message immediately, mirroring Claude Code CLI
+- fix(agent): remove non-functional tool overlay action bar (open-in-pane/window, new-agent-here)
+- feat(agent): brain-spinner loading overlay covers blank pane-mount and history-replay window
+- refactor(host): SPEC_PILLAR2 Stage 2 (partial) — wire on_before_close through reconcile_quit
+- fix(model-catalog): fall back to CLAUDE_CODE_OAUTH_TOKEN on macOS
+- feat(agent): Right Arrow also accepts the ghost-text next-prompt suggestion
+- fix(browser-pane): marshal wrapper destroy to the CEF UI thread — closes the per-close renderer leak
+
+
 ## 0.50.3 — 2026-07-06
 
 - feat(tabs): active tab's custom color traces the tab strip's boundary line

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.50.3",
+  "version": "0.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.50.3",
+      "version": "0.51.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.50.3",
+  "version": "0.51.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming 12 pending changesets, minor bump (0.50.3 → 0.51.0).

### Changes in this release
- feat(host): SPEC_PILLAR1_STEP2 Phase 2 — wire per-window opacity write-through + crash-restart read-back
- fix(ui): suppress the focus ring when a pane is alone in its tab
- fix(agent): unify failure state into the pane reducer, fix stuck-Waiting and false-positive rate-limit label
- fix(tabs): active-tab color line now starts at the selected tab's left edge
- feat(host): SPEC_PILLAR1_STEP2 Slice B — floating-pane placement write-through to srv
- feat(agent): Esc delivers a queued message immediately, mirroring Claude Code CLI
- fix(agent): remove non-functional tool overlay action bar (open-in-pane/window, new-agent-here)
- feat(agent): brain-spinner loading overlay covers blank pane-mount and history-replay window
- refactor(host): SPEC_PILLAR2 Stage 2 (partial) — wire on_before_close through reconcile_quit
- fix(model-catalog): fall back to CLAUDE_CODE_OAUTH_TOKEN on macOS
- feat(agent): Right Arrow also accepts the ghost-text next-prompt suggestion
- **fix(browser-pane): marshal wrapper destroy to the CEF UI thread — closes the per-close renderer leak** (every browser-pane close since the feature existed leaked a full renderer process; likely a major contributor to the pagefile/commit-charge growth investigation)

### Version consistency invariant
All 5 locations verified to agree at `0.51.0`: `VERSION_HISTORY.md`, `package.json`, `Cargo.toml [workspace.package]`, `Cargo.lock` (agentmux-cef member), `package-lock.json`.

## Test plan
- [x] `task release` completed cleanly, all 12 changesets consumed
- [x] 5-location version invariant manually verified (`grep` each file)
- [x] No changesets remain except `.changesets/README.md`

<!-- agentmux:agent_id=agenta -->