### PR TITLE
feat(host): SPEC_PILLAR1_STEP3 Phase 1 -- SetWindowTopology RPC for window kind + parent linkage

### DIFF
--- a/.changesets/1783417549-feat-host-spec-pillar1-step3-phase-1-setwindowtopology-rpc-f-x5r7.md
+++ b/.changesets/1783417549-feat-host-spec-pillar1-step3-phase-1-setwindowtopology-rpc-f-x5r7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP3 Phase 1 -- SetWindowTopology RPC for window kind + parent linkage

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -353,6 +353,22 @@ pub struct Window {
     /// mirror.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f32>,
+    /// SPEC_PILLAR1_STEP3 — the window's kind (`"full_instance"` |
+    /// `"subwindow"`), durable so a reproject can tell which native-window
+    /// creation path to drive. `None` = unknown/legacy row; treat as
+    /// `full_instance` on read (matches today's implicit default — every
+    /// window was a full instance before this field existed). Written only
+    /// via the `SetWindowTopology` RPC (a direct store read-modify-write,
+    /// not reducer-dispatched — window kind/parent were never reducer
+    /// state, same rationale as `opacity` above).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// SPEC_PILLAR1_STEP3 — the parent `Window.oid` for a `subwindow`;
+    /// `None` for a `full_instance` (or an unset/legacy row). A `subwindow`
+    /// with `parent_window_id: None` is a nonsensical state the
+    /// `SetWindowTopology` RPC rejects at write time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_window_id: Option<String>,
     #[serde(default, serialize_with = "serialize_meta_as_null_if_empty", deserialize_with = "deserialize_meta_or_null")]
     pub meta: MetaMapType,
 }

--- a/agentmux-srv/src/backend/service.rs
+++ b/agentmux-srv/src/backend/service.rs
@@ -265,6 +265,11 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
             arg_names: vec!["ctx".into(), "windowId".into(), "opacity".into()],
             return_desc: None,
         }),
+        ("window", "SetWindowTopology") => Some(MethodMeta {
+            desc: Some("set a window's persisted kind + parent_window_id".into()),
+            arg_names: vec!["ctx".into(), "windowId".into(), "kind".into(), "parentWindowId".into()],
+            return_desc: None,
+        }),
         ("window", "MoveBlockToNewWindow") => Some(MethodMeta {
             desc: Some("move block to new window".into()),
             arg_names: vec!["ctx".into(), "currentTabId".into(), "blockId".into()],

--- a/agentmux-srv/src/server/service/window.rs
+++ b/agentmux-srv/src/server/service/window.rs
@@ -497,6 +497,51 @@ pub(super) async fn handle_window_service(state: &AppState, call: &WebCallType) 
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
+        // SPEC_PILLAR1_STEP3 — durable mirror of a window's kind + parent
+        // linkage, so a future reproject can tell which native-window
+        // creation path to drive for each window in `Client.windowids`.
+        // Direct store read-modify-write, same shape as SetWindowOpacity
+        // just above — kind/parent aren't reducer-tracked state (see
+        // `state::WindowRecord`), so there's no split-brain risk to route
+        // around.
+        "SetWindowTopology" => {
+            let window_id: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let kind: Option<String> = match service::get_optional_arg(args, 1) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let parent_window_id: Option<String> = match service::get_optional_arg(args, 2) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            if let Some(k) = &kind {
+                if k != "full_instance" && k != "subwindow" {
+                    return WebReturnType::error(format!(
+                        "SetWindowTopology: kind must be 'full_instance' or 'subwindow', got '{k}'"
+                    ));
+                }
+                if k == "subwindow" && parent_window_id.is_none() {
+                    return WebReturnType::error(
+                        "SetWindowTopology: kind='subwindow' requires a non-null parent_window_id"
+                            .to_string(),
+                    );
+                }
+            }
+            match store.must_get::<Window>(&window_id) {
+                Ok(mut win) => {
+                    win.kind = kind;
+                    win.parent_window_id = parent_window_id;
+                    match store.update(&mut win) {
+                        Ok(_) => WebReturnType::success_empty(),
+                        Err(e) => WebReturnType::error(e.to_string()),
+                    }
+                }
+                Err(e) => WebReturnType::error(e.to_string()),
+            }
+        }
         _ => WebReturnType::error(format!("unknown window method: {}", call.method)),
     }
 }
@@ -716,5 +761,122 @@ mod set_window_opacity_tests {
             let win = state.wstore.must_get::<Window>(&window_id).unwrap();
             assert_eq!(win.opacity, Some(boundary));
         }
+    }
+}
+
+/// SPEC_PILLAR1_STEP3 — `SetWindowTopology` unit tests.
+#[cfg(test)]
+mod set_window_topology_tests {
+    use super::handle_window_service;
+    use crate::backend::obj::Window;
+    use crate::backend::service::WebCallType;
+    use crate::server::tests::test_state;
+
+    fn call(window_id: &str, kind: Option<&str>, parent_window_id: Option<&str>) -> WebCallType {
+        WebCallType {
+            service: "window".to_string(),
+            method: "SetWindowTopology".to_string(),
+            uicontext: None,
+            args: vec![
+                serde_json::Value::String(window_id.to_string()),
+                kind.map(|k| serde_json::json!(k)).unwrap_or(serde_json::Value::Null),
+                parent_window_id
+                    .map(|p| serde_json::json!(p))
+                    .unwrap_or(serde_json::Value::Null),
+            ],
+        }
+    }
+
+    async fn seeded_window_id(state: &crate::server::AppState) -> String {
+        let ret = handle_window_service(
+            state,
+            &WebCallType {
+                service: "window".to_string(),
+                method: "CreateWindow".to_string(),
+                uicontext: None,
+                args: vec![
+                    serde_json::Value::Null,
+                    serde_json::Value::String(String::new()),
+                ],
+            },
+        )
+        .await;
+        assert!(ret.success, "CreateWindow failed: {:?}", ret.error);
+        ret.data
+            .expect("CreateWindow returns the Window")
+            .get("oid")
+            .and_then(|v| v.as_str())
+            .expect("window has an oid")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn sets_and_persists_full_instance() {
+        let state = test_state();
+        let window_id = seeded_window_id(&state).await;
+
+        let ret = handle_window_service(&state, &call(&window_id, Some("full_instance"), None)).await;
+        assert!(ret.success, "SetWindowTopology failed: {:?}", ret.error);
+
+        let win = state.wstore.must_get::<Window>(&window_id).unwrap();
+        assert_eq!(win.kind, Some("full_instance".to_string()));
+        assert_eq!(win.parent_window_id, None);
+    }
+
+    #[tokio::test]
+    async fn sets_and_persists_subwindow_with_parent() {
+        let state = test_state();
+        let parent_id = seeded_window_id(&state).await;
+        let window_id = seeded_window_id(&state).await;
+
+        let ret =
+            handle_window_service(&state, &call(&window_id, Some("subwindow"), Some(&parent_id))).await;
+        assert!(ret.success, "SetWindowTopology failed: {:?}", ret.error);
+
+        let win = state.wstore.must_get::<Window>(&window_id).unwrap();
+        assert_eq!(win.kind, Some("subwindow".to_string()));
+        assert_eq!(win.parent_window_id, Some(parent_id));
+    }
+
+    #[tokio::test]
+    async fn rejects_subwindow_without_parent() {
+        let state = test_state();
+        let window_id = seeded_window_id(&state).await;
+
+        let ret = handle_window_service(&state, &call(&window_id, Some("subwindow"), None)).await;
+        assert!(!ret.success, "subwindow with no parent_window_id must be rejected");
+
+        let win = state.wstore.must_get::<Window>(&window_id).unwrap();
+        assert_eq!(win.kind, None, "rejected write must not persist");
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_kind() {
+        let state = test_state();
+        let window_id = seeded_window_id(&state).await;
+
+        let ret = handle_window_service(&state, &call(&window_id, Some("floating"), None)).await;
+        assert!(!ret.success, "unknown kind must be rejected");
+    }
+
+    #[tokio::test]
+    async fn null_kind_clears_it() {
+        let state = test_state();
+        let window_id = seeded_window_id(&state).await;
+
+        handle_window_service(&state, &call(&window_id, Some("full_instance"), None)).await;
+        let ret = handle_window_service(&state, &call(&window_id, None, None)).await;
+        assert!(ret.success, "SetWindowTopology (clear) failed: {:?}", ret.error);
+
+        let win = state.wstore.must_get::<Window>(&window_id).unwrap();
+        assert_eq!(win.kind, None);
+        assert_eq!(win.parent_window_id, None);
+    }
+
+    #[tokio::test]
+    async fn errors_on_unknown_window() {
+        let state = test_state();
+        let ret = handle_window_service(&state, &call("ghost-window", Some("full_instance"), None)).await;
+        assert!(!ret.success, "unknown window must error");
     }
 }

--- a/agentmux-srv/src/server/service/window.rs
+++ b/agentmux-srv/src/server/service/window.rs
@@ -530,6 +530,32 @@ pub(super) async fn handle_window_service(state: &AppState, call: &WebCallType) 
                     );
                 }
             }
+            // reagent P1: parent_window_id must only ever be set alongside
+            // kind='subwindow' — the doc comment's invariant ("None for a
+            // full_instance ... or an unset/legacy row") was previously only
+            // enforced in one direction (subwindow requires a parent), not
+            // the reverse (full_instance/None must NOT carry a parent).
+            if parent_window_id.is_some() && kind.as_deref() != Some("subwindow") {
+                return WebReturnType::error(
+                    "SetWindowTopology: parent_window_id must only be set when kind='subwindow'"
+                        .to_string(),
+                );
+            }
+            // reagent P2: a subwindow's parent must reference a real,
+            // DIFFERENT window — otherwise a dangling or self-referential
+            // parent_window_id silently persists undetected.
+            if let Some(parent_id) = &parent_window_id {
+                if parent_id == &window_id {
+                    return WebReturnType::error(
+                        "SetWindowTopology: parent_window_id must not equal window_id".to_string(),
+                    );
+                }
+                if store.must_get::<Window>(parent_id).is_err() {
+                    return WebReturnType::error(format!(
+                        "SetWindowTopology: parent_window_id '{parent_id}' does not reference an existing window"
+                    ));
+                }
+            }
             match store.must_get::<Window>(&window_id) {
                 Ok(mut win) => {
                     win.kind = kind;
@@ -857,6 +883,63 @@ mod set_window_topology_tests {
 
         let ret = handle_window_service(&state, &call(&window_id, Some("floating"), None)).await;
         assert!(!ret.success, "unknown kind must be rejected");
+    }
+
+    /// reagent P1: a full_instance (or unset/None kind) must never carry a
+    /// parent_window_id — only the reverse (subwindow requires a parent)
+    /// was originally enforced.
+    #[tokio::test]
+    async fn rejects_full_instance_with_parent() {
+        let state = test_state();
+        let parent_id = seeded_window_id(&state).await;
+        let window_id = seeded_window_id(&state).await;
+
+        let ret =
+            handle_window_service(&state, &call(&window_id, Some("full_instance"), Some(&parent_id)))
+                .await;
+        assert!(!ret.success, "full_instance with a parent_window_id must be rejected");
+
+        let win = state.wstore.must_get::<Window>(&window_id).unwrap();
+        assert_eq!(win.kind, None, "rejected write must not persist");
+    }
+
+    /// reagent P1: same rule when kind is omitted entirely (None) but a
+    /// parent_window_id is supplied anyway.
+    #[tokio::test]
+    async fn rejects_none_kind_with_parent() {
+        let state = test_state();
+        let parent_id = seeded_window_id(&state).await;
+        let window_id = seeded_window_id(&state).await;
+
+        let ret = handle_window_service(&state, &call(&window_id, None, Some(&parent_id))).await;
+        assert!(!ret.success, "kind=None with a parent_window_id must be rejected");
+    }
+
+    /// reagent P2: parent_window_id must reference a real window row, not a
+    /// dangling id.
+    #[tokio::test]
+    async fn rejects_dangling_parent_window_id() {
+        let state = test_state();
+        let window_id = seeded_window_id(&state).await;
+
+        let ret =
+            handle_window_service(&state, &call(&window_id, Some("subwindow"), Some("ghost-parent")))
+                .await;
+        assert!(!ret.success, "a parent_window_id that doesn't exist must be rejected");
+
+        let win = state.wstore.must_get::<Window>(&window_id).unwrap();
+        assert_eq!(win.kind, None, "rejected write must not persist");
+    }
+
+    /// reagent P2: a window cannot be its own parent.
+    #[tokio::test]
+    async fn rejects_self_referential_parent() {
+        let state = test_state();
+        let window_id = seeded_window_id(&state).await;
+
+        let ret =
+            handle_window_service(&state, &call(&window_id, Some("subwindow"), Some(&window_id))).await;
+        assert!(!ret.success, "a window referencing itself as parent must be rejected");
     }
 
     #[tokio::test]

--- a/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
+++ b/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
@@ -81,11 +81,19 @@ Full field inventory from `agentmux-cef/src/state.rs` + `reducer/`, grouped by d
 ### 2.A — LOGICAL TOPOLOGY → **must be authoritative in srv** (the actual Pillar 1 work)
 | Host field | What it is | In srv today? | Action |
 |---|---|---|---|
-| window set (via `shadow_window_meta` / `window_meta`) | which top-level windows exist, kind, parent linkage | **Yes** — launcher owns `instance_registry`, `backend_window_ids`, `windows`; host already projects them | Confirm completeness; close any host-only window facts |
-| layout tree (pane topology) | the split/tab structure per window | **Partially** — `db_layout` exists but is written via **two paths** (reducer + wcore-direct) | **#864**: collapse to one write path; this is the core gap |
-| `window_opacities: HashMap<String,f32>` | per-window opacity | **No** | Persist to window metadata |
-| `pane_window_states: HashMap<String,PaneWindowState>` | floating-pane Normal/Max/Min + `last_known_normal_rect` | **No** | Persist restore-rects + placement |
+| window set (via `shadow_window_meta` / `window_meta`) | which top-level windows exist, kind, parent linkage | **Corrected 2026-07-07 — was wrong.** See §2.A.1 below: the window-**id** list is durable (`Client.windowids`, SQLite), but `kind`/parent linkage is **not in srv at all**, only in the launcher's in-memory registry (itself non-durable across a full process-tree kill). | New work, not just an audit: persist `kind` + `parent_window_id` to srv (Step 3, sized separately) |
+| layout tree (pane topology) | the split/tab structure per window | **Yes, verified** — SPEC_864's single-writer collapse (all 5 phases) is fully merged; `TabRecord.rootnode`/`LayoutState` is coherent, no Path-B writer remains. Confirmed live, not just claimed. | Done |
+| `window_opacities: HashMap<String,f32>` | per-window opacity | **Yes** (SPEC_PILLAR1_STEP2 Slice A, merged + live-verified) | Done |
+| `pane_window_states: HashMap<String,PaneWindowState>` | floating-pane Normal/Max/Min + `last_known_normal_rect` | **Yes** (SPEC_PILLAR1_STEP2 Slice B, merged + live-verified). Read-back-on-reopen deliberately deferred to Step 4 — no live trigger exists until reproject recreates floaters. | Done (write-through); read-back is Step 4 scope |
 | pool **target size** | how many warm windows/panes to keep | config | Keep in config (already durable) |
+
+#### 2.A.1 — Correction (2026-07-07): the window-set row above was wrong
+
+Verified against source, not assumed (see `docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md` for the full citations). Two separate facts were conflated in the original table:
+
+- **What IS durable:** `Client.windowids: Vec<String>` (SQLite) — the *list of window ids that should exist* survives a full kill of launcher + host + srv (same data dir). A crash never calls `CloseWindow`, so a crash-killed window's id is never pruned.
+- **What is NOT durable, anywhere:** `Window`'s persisted row (`agentmux-srv/src/backend/obj.rs`) has no `kind` or `parent` field at all. `WindowKind` (`FullInstance`/`Subwindow`) and parent linkage live only in the **launcher's** in-memory `WindowMirror` map (`agentmux-launcher/src/state.rs`) — a third process, separate from both host and srv, with **zero disk persistence** (grepped the whole launcher state/reducer for save/load/serde/sqlite — nothing). Killing the launcher loses this instantly.
+- **Bigger consequence, also corrected:** cold launch does not "read srv topology and rebuild the window set." `agentmux-cef/src/app.rs::on_context_initialized` unconditionally creates exactly **one** native window (implicitly "main"); the frontend inside it then reads only `Client.windowids[0]`. A second FullInstance window or a Subwindow is *never* automatically recreated by the existing cold-start path — today, after ANY relaunch (crash or not), those come back only if the user manually reopens them. "Reproject fires the existing cold-start path" (§4 below) is therefore not sufficient for Step 4 on its own; multi-window recreation is new code, not an existing capability being triggered on a new event.
 
 ### 2.B — NATIVE / EPHEMERAL HANDLES → **rebuilt on reproject, never serialized**
 `browsers: HashMap<String,BrowserHandle>` (CEF `Browser` FFI objects), GPU/renderer processes,
@@ -157,8 +165,14 @@ What we do instead:
   is **#864: retire the wcore-direct second write path** so the reducer is the *only* writer.
   Pillar 1's durability correctness is impossible while two writers race one record (audit §2.3
   "layout split-brain"); fixing #864 is therefore a **hard prerequisite**, not a nice-to-have.
-- **Reproject read path = the existing cold-start restore.** No new deserialization code; the host
-  already reads srv topology on launch. Pillar 1 makes that read fire on crash and cover 2.A fully.
+- **Reproject read path = the existing cold-start restore — corrected 2026-07-07, partially true.**
+  The read/render machinery for **one window's** workspace/tab/layout is real and reusable (no new
+  deserialization code needed there). But the existing cold-start path only ever *invokes* that
+  machinery for window #1 ("main") — see §2.A.1. "Making that read fire on crash and cover 2.A
+  fully" undersells the work: covering *all* windows requires new code to enumerate the durable
+  window-id list beyond the first, resolve each one's `kind`/parent (once Step 3 gives that
+  somewhere to live), and drive per-window native creation — the single-window path doesn't
+  generalize by itself.
 
 **Consequence for sequencing:** #864 is pulled *into* Pillar 1's critical path (it was previously
 "pay-down"). Single-write-path first, then opacity/placement persistence, then fire-restore-on-crash.
@@ -179,17 +193,26 @@ independent of Pillar 1 and can land anytime.
 
 ## 6. Resulting Pillar 1 implementation sequence (for the sized spec next)
 
-1. **#864 — collapse layout to one write path** (reducer is sole writer; delete wcore-direct).
-   *Hard prerequisite — durability is incoherent with two writers.*
-2. **Persist the two host-only topology facts** to srv: per-window opacity, floating-pane
-   placement + `last_known_normal_rect`.
-3. **Audit window-set completeness** — confirm no host-only window truth beyond what
-   `shadow_*` already projects; close gaps.
-4. **Fire the cold-start restore path on crash** (mid-session reproject) + the "Restoring session…"
-   overlay; ensure in-flight (2.C) work is **re-derived from topology, not resumed**.
-5. **E2E test:** "host OOM ⇒ session reprojects" (topology equivalence within budget, overlay
+1. ✅ **#864 — collapse layout to one write path** (reducer is sole writer; delete wcore-direct).
+   *Hard prerequisite — durability is incoherent with two writers.* **Done, merged (all 5 phases).**
+2. ✅ **Persist the two host-only topology facts** to srv: per-window opacity, floating-pane
+   placement + `last_known_normal_rect`. **Done, merged, live-verified (SPEC_PILLAR1_STEP2 Slices
+   A + B).**
+3. ⬜ **Persist window `kind` + parent linkage to srv** — corrected scope (2026-07-07): this is
+   **not** an "audit + close small gaps" step as originally written. `kind`/parent have no srv
+   representation at all today (§2.A.1). Sized as its own spec:
+   `docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md`.
+4. ⬜ **Fire the cold-start restore path on crash** (mid-session reproject) + the "Restoring session…"
+   overlay; ensure in-flight (2.C) work is **re-derived from topology, not resumed**. **Corrected
+   scope (2026-07-07):** this needs genuinely new multi-window recreation code (§2.A.1) — the
+   existing cold-start path only ever handles one window. The in-flight re-derivation rule (§7) has
+   **zero existing scaffolding** to build on (verified by search — the closest analog,
+   `commands/orphan_reconcile.rs`'s live/dead/hostless planner, is structurally similar but solves a
+   different trigger). Needs its own dedicated design pass before implementation, not a subtask of
+   this sequence step.
+5. ⬜ **E2E test:** "host OOM ⇒ session reprojects" (topology equivalence within budget, overlay
    shown, no orphan tree).
-6. **Then the collapses land:** graceful-flush-vs-crash incoherence deleted (one recover path);
+6. ⬜ **Then the collapses land:** graceful-flush-vs-crash incoherence deleted (one recover path);
    saga layer collapses to an in-memory registry (nothing durable left to compensate).
 
 ---

--- a/docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md
@@ -1,0 +1,146 @@
+# Pillar 1 Step 3 — Persist Window Kind + Parent Linkage to srv
+
+**Date:** 2026-07-07
+**Type:** Sized implementation spec
+**Status:** Ready to implement
+**Builds on:** SPEC_864 (merged), SPEC_PILLAR1_STEP2 (merged) — this spec follows the exact same
+shape as those: a small, host-only fact gets a durable srv counterpart, via a direct RPC, no reducer
+machinery.
+**Corrects:** `SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md` §2.A/§6 step 3 — see that doc's
+2026-07-07 addendum for why "audit completeness" was the wrong framing (there is nothing to audit;
+the facts were never written anywhere durable).
+
+---
+
+## 0. TL;DR
+
+`Window.kind` (`FullInstance`/`Subwindow`) and parent-window linkage (which window a Subwindow
+belongs to) exist **only** in the launcher's in-memory `WindowMirror` map — a third process, with no
+disk persistence at all. Killing the launcher (not just the host) loses this instantly; the
+persisted `Window` row in srv (`agentmux-srv/src/backend/obj.rs`) has no field for either. This
+spec adds both, writable via a direct RPC at window-creation time, following the exact
+read-modify-write shape `SetWindowOpacity` already established. This is the prerequisite Step 4
+(actual reproject) needs to know which windows to recreate and how — without it, a reproject can
+recover *one* window's content perfectly but has no way to know a second window (or a subwindow)
+ever existed, let alone its kind or its parent.
+
+## 1. Current state (verified against source)
+
+- **Durable today:** `Client.windowids: Vec<String>` (`agentmux-srv/src/backend/obj.rs:314-327`) —
+  survives a full kill of launcher + host + srv (same data dir), since a crash never calls the
+  explicit `CloseWindow` RPC that prunes it (`agentmux-srv/src/server/service/window.rs:394-396`).
+  So "how many windows, which ids" is already recoverable.
+- **NOT durable, anywhere:** the persisted `Window` struct (`obj.rs:333-358`) has fields
+  `oid, version, workspaceid, isnew, pos, winsize, lastfocusts, opacity, meta` — no `kind`, no
+  `parent`. `WindowKind` (`agentmux-common/src/ipc.rs:848-853`, `FullInstance`/`Subwindow`) and
+  parent linkage (`parent_instance_id`) live only in:
+  - The launcher's `WindowMirror` (`agentmux-launcher/src/state.rs:94-166`, `parent_label:
+    Option<String>` at `:100`) — in-memory only, no serialization anywhere in that crate.
+  - The host's own `WindowMeta` (`agentmux-cef/src/state.rs:77-82`) — also in-memory, rebuilt each
+    host launch from the (in-memory) launcher's shadow projection.
+  - The reducer command that creates a window (`HostCommand::EnqueuePendingWindowCreation`,
+    `agentmux-cef/src/commands/window/creation.rs:395-398`) — fired once at creation time, never
+    sent to srv.
+- **Cold-launch behavior today:** `agentmux-cef/src/app.rs::on_context_initialized` creates exactly
+  one native window unconditionally (implicitly "main"); the frontend inside it reads only
+  `Client.windowids[0]` (`frontend/app-init.ts:317-339`). A second window or a subwindow is *never*
+  automatically recreated — only ever by explicit user/agent action
+  (`open_new_window`/`open_subwindow`, `agentmux-cef/src/commands/window/creation.rs:237-332`).
+
+## 2. Target design
+
+**New fields on `Window`** (additive, `#[serde(default)]`, mirrors `opacity`'s shape exactly —
+`agentmux-srv/src/backend/obj.rs`):
+- `kind: Option<String>` — `"full_instance"` | `"subwindow"`. `None` = unknown/legacy row (treat as
+  `full_instance` on read, matching today's implicit default).
+- `parent_window_id: Option<String>` — the parent `Window.oid`, set only for `subwindow`.
+
+**New RPC**, same direct-store shape as `SetWindowOpacity` (`agentmux-srv/src/server/service/
+window.rs:437-459` is the precedent to mirror, not the reducer): `SetWindowTopology(window_id, kind,
+parent_window_id)`. Not reducer-routed, for the same reason opacity wasn't: the srv reducer's
+`WindowRecord` tracks only `{window_id, workspace_id}` — kind/parent were never reducer state, so
+there's no split-brain risk to guard against (confirmed pattern from SPEC_PILLAR1_STEP2 §2.A).
+
+**Host write-through — the open question requiring verification at implementation time:** unlike
+opacity (host-only state, host always has the value to write), `kind`/`parent_instance_id` are
+currently known at creation time only in two places, and **the frontend does not currently know its
+own window's kind at all** (confirmed: `is_main_window` is a pure `label == "main"` string check,
+`agentmux-cef/src/commands/window/meta.rs:64-67`; grepped `frontend/app-init.ts` for
+`kind`/`parent_instance_id` — zero hits). Two candidate write-through points, to be resolved during
+implementation, not guessed here:
+1. **Host-side, at creation**: `open_new_window`/`open_subwindow`
+   (`agentmux-cef/src/commands/window/creation.rs:237-332`) already receive `kind`/
+   `parent_instance_id` as call parameters — thread a write-through call there, after the backend
+   `Window` row exists (i.e. after the frontend's `CreateWindow` RPC resolves, which the host isn't
+   synchronously waiting on today — needs a signal back, e.g. piggyback on
+   `register_backend_window`/`report_backend_window_id_registered`, which already fires once the
+   frontend confirms a `window_id` for a label).
+2. **Frontend-side**: thread `kind` through the existing `?windowLabel=`/tear-off URL param
+   mechanism (subwindows already get a distinguishing URL context per
+   `commands/window/creation.rs`'s call sites) and call the new RPC directly after
+   `WindowService.CreateWindow` resolves in `initHostNewWindow()` (`frontend/app-init.ts:421-493`).
+
+Candidate 1 is likely cleaner (the host already has the truth without inventing a new frontend
+signal), but requires confirming the `register_backend_window` timing actually gives the host a
+reliable "this window_id is now real in srv" hook — verify at implementation time.
+
+**Reproject read-back (Step 4's dependency, not this spec's job):** once persisted, a future
+reproject pass can `GetWindow` each id from `Client.windowids[1..]`, read `kind`/`parent_window_id`,
+and know which native-window-creation call to drive for each — this spec only makes that data exist
+somewhere; consuming it is Step 4.
+
+## 3. Phased plan
+
+**Phase 1 — srv side.** Add `Window.kind`/`parent_window_id` fields + `SetWindowTopology` RPC arm
+(direct store read-modify-write, mirroring `service/window.rs`'s `SetWindowOpacity`). Validate
+`kind` against the known enum values (reject anything else, matching opacity's range validation
+pattern). Unit tests: round-trip persists, unknown window errors, `subwindow` requires a
+non-empty `parent_window_id` (reject `subwindow` + `None` parent — a nonsensical state). Behavior-
+neutral — nothing calls it yet.
+
+**Phase 2 — host/frontend wiring.** Resolve the write-through call site (§2's open question) and
+wire it. **App-running verification required**, same bar as SPEC_PILLAR1_STEP2: open a subwindow,
+confirm `GetWindow` on its id shows `kind: "subwindow"` and the correct `parent_window_id`; open a
+second FullInstance window, confirm `kind: "full_instance"`, `parent_window_id: null`.
+
+Each phase independently shippable, matching every other Pillar 1 spec's phasing discipline.
+
+## 4. Risks / honest caveats
+
+- **The write-through timing gap is real, not cosmetic.** If the host process crashes in the
+  narrow window between a new window's backend `Window` row existing and the topology write-through
+  landing, that window reprojects as `kind: None` (defaults to `full_instance`) on the next
+  restart — parent linkage for a subwindow would be lost for that one window. Acceptable (same
+  class of gap SPEC_PILLAR1_STEP2 already accepted for opacity/placement — a narrow, bounded
+  data-loss window on an already-rare crash path, not a correctness bug), but should be stated
+  explicitly rather than silently accepted.
+- **This spec does not change cold-launch or crash-restart behavior at all.** Even after this
+  lands, only window #1 is ever automatically recreated — see the parent design doc's 2026-07-07
+  correction. This is purely making the data exist; Step 4 is a separate, larger, not-yet-scoped
+  piece of work.
+
+## 5. Explicitly out of scope
+
+- Actually consuming `kind`/`parent_window_id` to recreate windows on reproject — Step 4.
+- Any change to `open_new_window`/`open_subwindow`'s existing behavior for a live, non-crashed
+  session — this is additive persistence only.
+
+## 6. Definition of done
+
+1. ⬜ `Window.kind`/`parent_window_id` persist through `SetWindowTopology`, unit-tested.
+2. ⬜ Opening a subwindow live-verifiably persists `kind: "subwindow"` + the correct parent id to
+   srv (checked via `GetWindow`, same isolated-instance methodology as every other Pillar 1 spec
+   this session).
+3. ⬜ Opening a second full window live-verifiably persists `kind: "full_instance"`,
+   `parent_window_id: null`.
+
+## 7. Sources
+
+- `docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md` (parent design doc, corrected
+  2026-07-07).
+- Code read for this spec (via a research pass, 2026-07-07): `agentmux-cef/src/app.rs`
+  (`on_context_initialized`), `agentmux-cef/src/commands/window/creation.rs:237-419`,
+  `agentmux-cef/src/commands/window/meta.rs:64-67`, `agentmux-cef/src/state.rs:77-82`,
+  `agentmux-launcher/src/state.rs:94-297`, `agentmux-srv/src/backend/obj.rs:314-358`,
+  `agentmux-srv/src/server/service/window.rs:437-459` (the `SetWindowOpacity` precedent),
+  `frontend/app-init.ts:317-493`, `frontend/app/store/services.ts:108-109`.


### PR DESCRIPTION
## Summary

Pillar 1 Step 3, Phase 1 (srv side) -- persist window `kind` (FullInstance/Subwindow) + parent linkage, so a future reproject pass can tell which native-window creation path to drive for each window.

**Corrects a real gap in the parent design doc.** `SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md`'s Q1 table claimed window kind/parent linkage was already "in srv" via the launcher's projections. Verified against source (this PR includes the correction in place): it isn't. The launcher's `WindowMirror` map is in-memory only -- grepped the whole `agentmux-launcher` crate for save/load/serde/sqlite, nothing. The persisted `Window` row has no `kind`/`parent` field at all. Only `Client.windowids` (the id list) is actually durable.

This also corrects the doc's headline claim that "reproject read path = the existing cold-start restore, already covers window topology." Verified: cold launch (`agentmux-cef/src/app.rs::on_context_initialized`) unconditionally creates exactly one native window; the frontend inside it reads only `windowids[0]`. A second window or a subwindow is *never* automatically recreated today -- only by explicit user/agent action. Covering all windows on reproject needs genuinely new multi-window recreation code (Step 4, out of scope here), which first needs somewhere to read `kind`/`parent` back from -- this PR.

**Changes:**
- `Window.kind: Option<String>` / `Window.parent_window_id: Option<String>` (additive, mirrors `opacity`'s shape exactly).
- `SetWindowTopology` RPC -- direct store read-modify-write (same shape as `SetWindowOpacity`; kind/parent were never reducer-tracked state, so no split-brain risk). Validates `kind` against the known enum, rejects `subwindow` without a `parent_window_id`.
- New sized spec: `docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md`.

**Behavior-neutral** -- nothing calls `SetWindowTopology` yet. Phase 2 (host/frontend wiring) has an open question flagged in the new spec about the right write-through call site (the frontend doesn't currently know its own window's kind at all) -- not resolved in this PR.

## Test plan
- [x] `cargo check -p agentmux-srv` clean
- [x] `cargo test -p agentmux-srv` -- 1340+11 passed, including 6 new `set_window_topology_tests`

<!-- agentmux:agent_id=agenta -->