### PR TITLE
fix(agent): reconcile TurnPhase from backend truth at pane mount

### DIFF
--- a/.changesets/1783417480-fix-ambient-cap-concurrent-haiku-spawns-across-the-two-pull--sna1.md
+++ b/.changesets/1783417480-fix-ambient-cap-concurrent-haiku-spawns-across-the-two-pull--sna1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ambient): cap concurrent Haiku spawns across the two pull RPCs

--- a/.changesets/1783433373-fix-agent-reconcile-turnphase-from-backend-truth-at-pane-mou-e7ef.md
+++ b/.changesets/1783433373-fix-agent-reconcile-turnphase-from-backend-truth-at-pane-mou-e7ef.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): reconcile TurnPhase from backend truth at pane mount

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -127,6 +127,7 @@ impl AcpController {
             shellprocexitcode: inner.proc_exit_code,
             spawn_ts_ms: None,
             is_agent_pane: true,
+            turn_active: self.health_monitor.is_active_turn(),
         }
     }
 
@@ -426,6 +427,7 @@ impl AcpController {
                             shellprocexitcode: -1,
                             spawn_ts_ms: None,
                             is_agent_pane: true,
+                            turn_active: false,
                         };
                         super::publish_controller_status(broker, &status);
                     }
@@ -454,6 +456,7 @@ impl AcpController {
                             shellprocexitcode: exit_code,
                             spawn_ts_ms: None,
                             is_agent_pane: true,
+                            turn_active: false,
                         };
                         super::publish_controller_status(broker, &status);
                     }

--- a/agentmux-srv/src/backend/blockcontroller/health.rs
+++ b/agentmux-srv/src/backend/blockcontroller/health.rs
@@ -181,6 +181,28 @@ impl HealthMonitor {
         self.evaluate_and_transition();
     }
 
+    /// Atomically marks a turn active and reports whether one was already in
+    /// flight (the pre-call value) — a single lock acquisition, unlike
+    /// calling `is_active_turn()` then `set_active_turn(true)` separately.
+    /// That two-step form is a check-then-act race: `send_message` (user
+    /// input) and `send_user_message` (muxbus delivery) can run concurrently
+    /// on the same block, and both reading `false` before either writes
+    /// `true` lets both decide to spawn a watchdog — the exact duplicate the
+    /// "only re-arm when resuming from idle" logic exists to prevent.
+    pub fn mark_turn_active_returning_was_active(&self) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        let was_active = inner.active_turn;
+        inner.active_turn = true;
+        let now = Instant::now();
+        inner.last_output_ts = now;
+        inner.last_meaningful_ts = now;
+        inner.errors.reset();
+        inner.exit_code = None;
+        drop(inner);
+        self.evaluate_and_transition();
+        was_active
+    }
+
     /// Called when the subprocess exits.
     pub fn set_exited(&self, exit_code: i32) {
         let mut inner = self.inner.lock().unwrap();
@@ -501,5 +523,42 @@ mod tests {
             let inner = monitor.inner.lock().unwrap();
             assert_eq!(inner.current_health, AgentHealth::Dead);
         }
+    }
+
+    #[test]
+    fn mark_turn_active_returning_was_active_reports_the_pre_call_value() {
+        let monitor = HealthMonitor::new("test-block".to_string(), None);
+        assert!(!monitor.is_active_turn());
+
+        // First call: was idle before this call.
+        let was_active = monitor.mark_turn_active_returning_was_active();
+        assert!(!was_active, "first call should report idle-before-call");
+        assert!(monitor.is_active_turn(), "turn is now active");
+
+        // Second call while already active: reports true (already in flight).
+        let was_active_again = monitor.mark_turn_active_returning_was_active();
+        assert!(was_active_again, "second call should report already-active");
+        assert!(monitor.is_active_turn());
+    }
+
+    /// Regression test for the exact race reagent flagged on PR #2005: a
+    /// naive `is_active_turn()` read followed by a separate
+    /// `set_active_turn(true)` write lets two concurrent callers (send_message
+    /// vs. send_user_message on the same block) both observe `false` before
+    /// either writes `true`, so both decide to spawn a watchdog.
+    /// `mark_turn_active_returning_was_active` closes that window by holding
+    /// the lock across both the read and the write — this test simulates the
+    /// interleaving directly (no real concurrency needed to prove the
+    /// invariant: exactly one of N concurrent-in-spirit calls sees "was
+    /// idle").
+    #[test]
+    fn mark_turn_active_is_atomic_across_repeated_calls() {
+        let monitor = HealthMonitor::new("test-block".to_string(), None);
+        let results: Vec<bool> = (0..5).map(|_| monitor.mark_turn_active_returning_was_active()).collect();
+        // Exactly the first call observes "was idle" (false); every
+        // subsequent call — however tightly interleaved a real concurrent
+        // caller might be — observes "already active" (true), because each
+        // read-and-write pair is indivisible under the lock.
+        assert_eq!(results, vec![false, true, true, true, true]);
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -157,6 +157,18 @@ pub struct BlockControllerRuntimeStatus {
     /// True if this pane is running an agent CLI (e.g. claude, codex, gemini, kimi, openclaw, pi).
     #[serde(default, skip_serializing_if = "is_false")]
     pub is_agent_pane: bool,
+    /// True if a turn is currently in flight (message sent, no terminating
+    /// `"result"` event observed yet). For `PersistentSubprocessController`
+    /// this is the only signal that distinguishes "actively generating a
+    /// turn" from "process alive, idle between turns" — `shellprocstatus`
+    /// stays `"running"` for the whole process lifetime either way. Backed
+    /// by `HealthMonitor.active_turn` (see `blockcontroller/health.rs`).
+    /// Frontend seeds `TurnPhase` from this at mount instead of always
+    /// defaulting to `Idle` — see
+    /// docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+    /// Finding 1.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub turn_active: bool,
 }
 
 // ---- Controller trait ----

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -307,12 +307,19 @@ impl PersistentSubprocessController {
         // re-arming here, but only when actually resuming from idle: a
         // mid-turn steering send (`send_user_message`) already has one
         // running, so re-spawning on every call would leak duplicate
-        // watchdog tasks.
-        let was_active = self.health_monitor.is_active_turn();
-        self.health_monitor.set_active_turn(true);
+        // watchdog tasks. `mark_turn_active_returning_was_active` reads and
+        // flips the flag under one lock — a separate is_active_turn() +
+        // set_active_turn(true) would race a concurrent send_user_message
+        // (muxbus delivery) on the same block, letting both observe `false`
+        // and both spawn a watchdog.
+        let was_active = self.health_monitor.mark_turn_active_returning_was_active();
         if !was_active {
             core::spawn_health_watchdog(&self.health_monitor);
         }
+        // Publish the turn_active flip so the Swarm view's live
+        // ControllerStatus subscription picks it up immediately instead of
+        // waiting for the next unrelated status change (or process exit).
+        self.publish_status();
 
         // Format as stream-json user message
         let json_msg = serde_json::json!({
@@ -358,12 +365,14 @@ impl PersistentSubprocessController {
     pub fn send_user_message(&self, message: String) -> Result<(), String> {
         // Whether the process was busy or idle, delivering this message
         // (re)starts an active turn — see the comment in `send_message`,
-        // including the watchdog re-arm-only-if-was-idle rationale.
-        let was_active = self.health_monitor.is_active_turn();
-        self.health_monitor.set_active_turn(true);
+        // including the watchdog re-arm-only-if-was-idle rationale and why
+        // this must be the atomic read-and-set (send_message and
+        // send_user_message can race on the same block).
+        let was_active = self.health_monitor.mark_turn_active_returning_was_active();
         if !was_active {
             core::spawn_health_watchdog(&self.health_monitor);
         }
+        self.publish_status();
 
         let json_msg = serde_json::json!({
             "type": "user",
@@ -811,6 +820,28 @@ impl PersistentSubprocessController {
                     // see `send_message`'s matching `set_active_turn(true)`.
                     if parsed.get("type").and_then(|v| v.as_str()) == Some("result") {
                         health_read.set_active_turn(false);
+                        // Publish the flip so the Swarm view's live
+                        // ControllerStatus subscription reflects "turn
+                        // ended" immediately instead of only on the next
+                        // unrelated status change (or process exit) — see
+                        // send_message's matching publish_status() call for
+                        // the turn-start side of this pair.
+                        if let Some(ref broker) = broker_read {
+                            let status = {
+                                let locked = inner_read.lock().unwrap();
+                                BlockControllerRuntimeStatus {
+                                    blockid: block_id_read.clone(),
+                                    version: locked.status_version,
+                                    shellprocstatus: locked.proc_status.clone(),
+                                    shellprocconnname: "local".to_string(),
+                                    shellprocexitcode: locked.proc_exit_code,
+                                    spawn_ts_ms: None,
+                                    is_agent_pane: true,
+                                    turn_active: false,
+                                }
+                            };
+                            super::publish_controller_status(broker, &status);
+                        }
                     }
                     if let Some(sid) = parsed.get(&session_id_field).and_then(|v| v.as_str()) {
                         let sid_string = sid.to_string();

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -248,6 +248,7 @@ impl PersistentSubprocessController {
             shellprocexitcode: inner.proc_exit_code,
             spawn_ts_ms: None,
             is_agent_pane: true,
+            turn_active: self.health_monitor.is_active_turn(),
         }
     }
 
@@ -294,6 +295,24 @@ impl PersistentSubprocessController {
         if !self.is_running() {
             self.spawn_process(config.clone())?;
         }
+        // spawn_process already marks a fresh process's first turn active
+        // (and starts its watchdog); for an already-running process (the
+        // common case — every turn after the first) this is the only place
+        // that re-marks the turn active, since the persistent process never
+        // exits between turns. Without this, `turn_active` would go stale
+        // after turn 1 and never distinguish "generating" from "idle between
+        // turns" again. The watchdog spawned per-turn (`spawn_health_watchdog`
+        // exits as soon as `is_active_turn()` goes false — see
+        // `core::spawn_health_watchdog`'s doc comment) also needs
+        // re-arming here, but only when actually resuming from idle: a
+        // mid-turn steering send (`send_user_message`) already has one
+        // running, so re-spawning on every call would leak duplicate
+        // watchdog tasks.
+        let was_active = self.health_monitor.is_active_turn();
+        self.health_monitor.set_active_turn(true);
+        if !was_active {
+            core::spawn_health_watchdog(&self.health_monitor);
+        }
 
         // Format as stream-json user message
         let json_msg = serde_json::json!({
@@ -337,6 +356,15 @@ impl PersistentSubprocessController {
     /// the message land mid-turn (steering) instead of waiting for idle.
     /// Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md §6 (Phase 3).
     pub fn send_user_message(&self, message: String) -> Result<(), String> {
+        // Whether the process was busy or idle, delivering this message
+        // (re)starts an active turn — see the comment in `send_message`,
+        // including the watchdog re-arm-only-if-was-idle rationale.
+        let was_active = self.health_monitor.is_active_turn();
+        self.health_monitor.set_active_turn(true);
+        if !was_active {
+            core::spawn_health_watchdog(&self.health_monitor);
+        }
+
         let json_msg = serde_json::json!({
             "type": "user",
             "message": {
@@ -777,6 +805,13 @@ impl PersistentSubprocessController {
                     }
                     let (meaningful, _error) = classify_output_line(&parsed);
                     health_read.record_output(meaningful);
+                    // Claude's turn-ending marker. Persistent mode never exits
+                    // between turns, so this is the only place `turn_active`
+                    // can go back to false without waiting for process exit —
+                    // see `send_message`'s matching `set_active_turn(true)`.
+                    if parsed.get("type").and_then(|v| v.as_str()) == Some("result") {
+                        health_read.set_active_turn(false);
+                    }
                     if let Some(sid) = parsed.get(&session_id_field).and_then(|v| v.as_str()) {
                         let sid_string = sid.to_string();
                         let already_captured = inner_read.lock().unwrap().session_id.is_some();
@@ -881,6 +916,7 @@ impl PersistentSubprocessController {
                             shellprocexitcode: exit_code,
                             spawn_ts_ms: None,
                             is_agent_pane: true,
+                            turn_active: false,
                         };
                         super::publish_controller_status(broker, &status);
                     }
@@ -1101,6 +1137,34 @@ mod send_input_tests {
         assert!(
             err.contains("does not accept raw input"),
             "raw input should be rejected, got {err:?}"
+        );
+    }
+
+    // `turn_active` on the runtime status snapshot must track the health
+    // monitor's active-turn flag directly — this is the signal the frontend
+    // seeds TurnPhase from at mount instead of always defaulting to Idle
+    // (see docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+    // Finding 1). Exercised here via the health monitor directly rather than
+    // send_message()/the stdout reader, which both require a real spawned
+    // process.
+    #[test]
+    fn status_snapshot_turn_active_tracks_health_monitor() {
+        let c = controller();
+        assert!(
+            !c.get_status_snapshot().turn_active,
+            "freshly constructed controller has no turn in flight"
+        );
+
+        c.health_monitor.set_active_turn(true);
+        assert!(
+            c.get_status_snapshot().turn_active,
+            "turn_active must flip true once the health monitor marks a turn active"
+        );
+
+        c.health_monitor.set_active_turn(false);
+        assert!(
+            !c.get_status_snapshot().turn_active,
+            "turn_active must flip back false once the turn ends"
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/shell/controller.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/controller.rs
@@ -168,6 +168,12 @@ impl ShellController {
             shellprocexitcode: inner.proc_exit_code,
             spawn_ts_ms: inner.spawn_ts_ms,
             is_agent_pane: inner.is_agent_pane,
+            // The shell/PTY controller has no NDJSON-derived health monitor
+            // (no structured turn-end marker to key off, unlike
+            // persistent.rs/acp.rs) — leave unset rather than guess. Mount
+            // reconciliation falls back to today's Idle default for these
+            // panes, same as before this field existed.
+            turn_active: false,
         }
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -751,6 +751,7 @@ impl Controller for ShellController {
                         shellprocexitcode: inner.proc_exit_code,
                         spawn_ts_ms: inner.spawn_ts_ms,
                         is_agent_pane: inner.is_agent_pane,
+                        turn_active: false,
                     }
                 };
                 super::super::publish_controller_status(broker, &status);

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -207,6 +207,7 @@ impl SubprocessController {
             shellprocexitcode: inner.proc_exit_code,
             spawn_ts_ms: None,
             is_agent_pane: false,
+            turn_active: self.health_monitor.is_active_turn(),
         }
     }
 
@@ -834,6 +835,7 @@ impl SubprocessController {
                         shellprocexitcode: inner.proc_exit_code,
                         spawn_ts_ms: None,
                         is_agent_pane: false,
+                        turn_active: false,
                     }
                 };
                 super::publish_controller_status(broker, &status);
@@ -1038,6 +1040,7 @@ impl SubprocessController {
                                 shellprocexitcode: inner.proc_exit_code,
                                 spawn_ts_ms: None,
                                 is_agent_pane: false,
+                                turn_active: false,
                             }
                         };
                         super::publish_controller_status(b, &status);
@@ -1088,6 +1091,9 @@ impl SubprocessController {
                         shellprocexitcode: inner.proc_exit_code,
                         spawn_ts_ms: None,
                         is_agent_pane: false,
+                        // Published just before set_active_turn(true) below —
+                        // accurate at the moment this snapshot is built.
+                        turn_active: false,
                     }
                 };
                 super::publish_controller_status(b, &status);
@@ -1260,6 +1266,7 @@ impl SubprocessController {
                         shellprocexitcode: inner.proc_exit_code,
                         spawn_ts_ms: None,
                         is_agent_pane: false,
+                        turn_active: false,
                     }
                 };
                 super::publish_controller_status(b, &status);

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -107,6 +107,23 @@ fn register_session_export_handler(engine: &Arc<WshRpcEngine>, state: &AppState)
     );
 }
 
+/// Max simultaneous Haiku CLI spawns across the two user-turn-triggered pull
+/// RPCs (`session:activity_summary`, `session:next_prompt_suggestion`). The
+/// Ambient Model Call gateway's `admit()` only dedupes/cancels *per key*
+/// (per block+purpose) — with no cap across different blocks, many panes
+/// finishing a turn around the same moment could each spawn their own Haiku
+/// subprocess unbounded. Mirrors `activity_watcher.rs`'s
+/// `MAX_CONCURRENT_SUMMARIES` cap on the separate pushed-summary sweep, but
+/// kept as its own semaphore rather than shared with that one: a burst of
+/// background sweep summaries should not queue behind, or block, a live
+/// user-facing pane-header/ghost-text request, and vice versa.
+const MAX_CONCURRENT_PULL_CALLS: usize = 2;
+
+fn pull_call_semaphore() -> &'static tokio::sync::Semaphore {
+    static SEM: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
+    SEM.get_or_init(|| tokio::sync::Semaphore::new(MAX_CONCURRENT_PULL_CALLS))
+}
+
 /// Ambient-call purpose tag for the per-turn activity summary. Also usable
 /// as the token-usage/cost-dashboard category for this call site.
 const AMBIENT_PURPOSE_ACTIVITY_SUMMARY: &str = "activity_summary";
@@ -200,6 +217,20 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
                 };
                 let cancel = guard.cancellation();
 
+                // Cap concurrent Haiku spawns across all blocks — see
+                // MAX_CONCURRENT_PULL_CALLS. Raced against cancellation so a
+                // request superseded while queued for a permit never spawns
+                // the CLI at all.
+                let permit = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => None,
+                    permit = pull_call_semaphore().acquire() => permit.ok(),
+                };
+                let Some(_permit) = permit else {
+                    drop(guard);
+                    return Ok(Some(empty_summary_result()));
+                };
+
                 let word_target = cmd.word_target.unwrap_or(7).max(3).min(20);
 
                 let block: Block = wstore
@@ -282,6 +313,19 @@ fn register_session_next_prompt_suggestion(engine: &Arc<WshRpcEngine>, state: &A
                     }
                 };
                 let cancel = guard.cancellation();
+
+                // Same cross-block concurrency cap as activity_summary — the
+                // two pull RPCs share MAX_CONCURRENT_PULL_CALLS so neither
+                // alone can flood the machine with Haiku subprocesses.
+                let permit = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => None,
+                    permit = pull_call_semaphore().acquire() => permit.ok(),
+                };
+                let Some(_permit) = permit else {
+                    drop(guard);
+                    return Ok(Some(empty_suggestion_result()));
+                };
 
                 let block: Block = wstore
                     .get(&cmd.block_id)
@@ -562,4 +606,29 @@ pub(super) fn extract_digest_text(lines: &[&str]) -> String {
     }
 
     parts.join("\n")
+}
+
+#[cfg(test)]
+mod pull_call_semaphore_tests {
+    use super::*;
+
+    /// The two pull RPCs share one process-wide cap: once
+    /// MAX_CONCURRENT_PULL_CALLS permits are held, a further non-blocking
+    /// acquire must fail rather than let a third Haiku CLI spawn through.
+    #[tokio::test]
+    async fn caps_at_max_concurrent_pull_calls() {
+        let sem = pull_call_semaphore();
+        let mut held = Vec::new();
+        for _ in 0..MAX_CONCURRENT_PULL_CALLS {
+            held.push(sem.try_acquire().expect("permit within the cap should be available"));
+        }
+        assert!(
+            sem.try_acquire().is_err(),
+            "a permit beyond MAX_CONCURRENT_PULL_CALLS must not be granted"
+        );
+
+        // Releasing one frees a slot for the next caller.
+        held.pop();
+        assert!(sem.try_acquire().is_ok(), "releasing a permit must free a slot");
+    }
 }

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -70,6 +70,39 @@ describe("agent-pane-state reducer", () => {
         });
     });
 
+    describe("ReconcileTurnActive (mount-time reconciliation)", () => {
+        it("promotes a fresh Idle pane to Streaming when the backend reports a turn in flight", () => {
+            const start = mk();
+            expect(start.turnPhase.kind).toBe("Idle");
+            const r = update(start, { type: "ReconcileTurnActive", at: 100, active: true });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events[0]).toMatchObject({ type: "turn-active-reconciled-at-mount" });
+        });
+
+        it("active: false is a no-op — Idle is already correct", () => {
+            const start = mk();
+            const r = update(start, { type: "ReconcileTurnActive", at: 100, active: false });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+
+        it("does not override a phase a real event already produced", () => {
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnPhase.kind).toBe("Submitting");
+            const r = update(s1, { type: "ReconcileTurnActive", at: 120, active: true });
+            expect(r.state).toBe(s1);
+            expect(r.events).toEqual([]);
+        });
+
+        it("does not require the stream to be subscribed yet (unlike TurnStart)", () => {
+            const start = mk();
+            expect(start.lastEventMs).toBe(null);
+            const r = update(start, { type: "ReconcileTurnActive", at: 100, active: true });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+        });
+    });
+
     describe("Turn lifecycle invariants", () => {
         it("TurnStart while stream unsubscribed is suppressed", () => {
             const start = mk();

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -342,6 +342,32 @@ export function update(
             };
         }
 
+        case "ReconcileTurnActive": {
+            // Only ever promotes the mount-default Idle — never overrides a
+            // phase a real stream/user event already produced. A `false`
+            // active flag is a no-op: Idle is already correct. Deliberately
+            // does NOT gate on `state.lastEventMs` the way TurnStart /
+            // StreamFlushObserved do — this seed is meant to cover exactly
+            // the window before the live stream has necessarily subscribed
+            // yet, which is the gap this command exists to close. See the
+            // type's doc comment in types.ts.
+            if (!command.active || state.turnPhase.kind !== "Idle") {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    turnPhase: {
+                        kind: "Streaming",
+                        bufferSize: 0,
+                        toolsActive: 0,
+                        lastEventMs: command.at,
+                    },
+                },
+                events: [{ type: "turn-active-reconciled-at-mount" }],
+            };
+        }
+
         case "TurnStart": {
             // Invariant 1: can't start a turn without a subscribed
             // stream. PR G: `state.lastEventMs !== null` replaces the

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -378,6 +378,22 @@ export type AgentPaneCommand =
     | { type: "StreamWatchdogTick"; nowMs: number }
 
     /**
+     * Mount-time reconciliation: `BlockControllerRuntimeStatus.turn_active`
+     * (backend-verified, from the health monitor wired to the NDJSON
+     * stream — see `agentmux-srv/src/backend/blockcontroller/health.rs`)
+     * fetched once via `GetControllerStatus` during the launch flow's
+     * Phase 3. `registerPane()` always seeds `turnPhase: Idle` regardless
+     * of whether the agent is actually mid-turn; this command corrects
+     * that ONLY IF still `Idle` when it arrives — it never overrides a
+     * phase a real stream/user event already produced (TurnStart,
+     * StreamFlushObserved, etc. always win if they got there first). A
+     * `false` active flag is a no-op: `Idle` is already the right state
+     * and there is nothing to correct. See
+     * docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+     * Finding 1.
+     */
+    | { type: "ReconcileTurnActive"; at: number; active: boolean }
+    /**
      * User pressed send — turn becomes active. Also clears stale
      * sessionStats from the previous turn.
      */
@@ -535,6 +551,13 @@ export type AgentPaneEvent =
           thresholdMs: number;
       }
     | { type: "turn-started"; at: number }
+    /**
+     * `ReconcileTurnActive` promoted the mount-default `Idle` to
+     * `Streaming` because the backend reported a turn already in flight.
+     * Surfaced for diagnostics — distinguishes this from a normal
+     * user-initiated `turn-started`.
+     */
+    | { type: "turn-active-reconciled-at-mount" }
     | {
           /**
            * A turn finished and the phase transitioned to `Done`. Since

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -456,6 +456,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         },
         onReady: () => onReadyFn?.(),
         getInitialTermSize: () => computeTermSizeFromEl(rootRef),
+        // Mount-time TurnPhase reconciliation — see
+        // docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+        // Finding 1. dispatchPaneIfRegistered (not dispatchPane) because
+        // this can resolve before registerPane() has run for a pane still
+        // mid-mount.
+        onControllerStatus: (rts) => {
+            dispatchPaneIfRegistered(
+                model.blockId,
+                { type: "ReconcileTurnActive", at: Date.now(), active: !!rts.turn_active },
+                "system",
+            );
+        },
     });
 
     onMount(() => {

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -62,6 +62,15 @@ export interface LaunchFlowOptions {
      * docs/analysis/AGENT_PANE_PTY_RESIZE_RACE_2026_06_16.md.
      */
     getInitialTermSize?: () => { rows: number; cols: number } | undefined;
+    /**
+     * Called once Phase 3's `GetControllerStatus` resolves, with the raw
+     * runtime status — previously this result was only ever logged. Used
+     * to seed `TurnPhase` from `rts.turn_active` at mount instead of the
+     * hardcoded `Idle` default. See
+     * docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+     * Finding 1.
+     */
+    onControllerStatus?: (rts: BlockControllerRuntimeStatus) => void;
 }
 
 export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
@@ -307,6 +316,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         const rts = await BlockService.GetControllerStatus(blockId);
         const status = rts?.shellprocstatus ?? "init";
         log("controller", `status: ${status}`);
+        if (rts) opts.onControllerStatus?.(rts);
         if (status === "init") {
             log("agent", "ready — type a message below to start");
         } else if (status === "done") {

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -55,6 +55,8 @@ export interface UseAgentControllerStatusOptions {
      * yet). Forwarded to the launch flow to seed the PTY size at spawn.
      */
     getInitialTermSize?: () => { rows: number; cols: number } | undefined;
+    /** Forwarded to the launch flow — see `LaunchFlowOptions.onControllerStatus`. */
+    onControllerStatus?: (rts: BlockControllerRuntimeStatus) => void;
 }
 
 export interface UseAgentControllerStatus {
@@ -148,6 +150,7 @@ export function useAgentControllerStatus(
                 authEnv,
                 onLoginSuccess: opts.onLoginSuccess,
                 getInitialTermSize: opts.getInitialTermSize,
+                onControllerStatus: opts.onControllerStatus,
             });
             if (result === "success") {
                 setAgentReady(true);

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -36,6 +36,31 @@ export interface AgentTreeNode {
     subagents: ActiveSubagent[];
 }
 
+// ── Status derivation ────────────────────────────────────────────────────
+
+/**
+ * `turn_active` is turn-precise (backed by the health monitor wired to the
+ * NDJSON stream) but only meaningful for persistent/ACP agent controllers —
+ * `is_agent_pane` is the discriminator, since `turn_active: false` and "this
+ * controller never populates turn_active" are indistinguishable on the wire
+ * (the Rust struct omits `false` fields — `skip_serializing_if = "is_false"`).
+ * For `is_agent_pane` panes, trust `turn_active` alone: `shellprocstatus`
+ * stays `"running"` for a persistent agent's entire process lifetime,
+ * idle-between-turns included, so OR-ing it back in would misrepresent an
+ * idle agent as "working" again — the exact bug this field exists to fix.
+ * For everything else (shell/PTY panes with no turn concept), fall back to
+ * `shellprocstatus` as before. See
+ * docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md Finding 1.
+ */
+function derivedRunningStatus(
+    isAgentPane: boolean | undefined,
+    turnActive: boolean | undefined,
+    shellprocstatus: string | undefined,
+): "running" | "idle" {
+    if (isAgentPane) return turnActive ? "running" : "idle";
+    return shellprocstatus === "running" ? "running" : "idle";
+}
+
 // ── ViewModel ────────────────────────────────────────────────────────────
 
 export class SwarmViewModel implements ViewModel {
@@ -174,7 +199,7 @@ export class SwarmViewModel implements ViewModel {
             // Fetch current status — don't assume idle for already-running agents.
             void BlockService.GetControllerStatus(blockId)
                 .then((rts) => {
-                    const status = rts?.shellprocstatus === "running" ? "running" : "idle";
+                    const status = derivedRunningStatus(rts?.is_agent_pane, rts?.turn_active, rts?.shellprocstatus);
                     this.setAgentStatuses((prev) => {
                         const m = new Map(prev);
                         m.set(blockId, status);
@@ -188,8 +213,8 @@ export class SwarmViewModel implements ViewModel {
                 eventType: WpsEvent.ControllerStatus,
                 scope,
                 handler: (ev) => {
-                    const proc = (ev as any)?.data?.shellprocstatus as string | undefined;
-                    const next: "running" | "idle" = proc === "running" ? "running" : "idle";
+                    const data = (ev as any)?.data;
+                    const next = derivedRunningStatus(data?.is_agent_pane, data?.turn_active, data?.shellprocstatus);
                     this.setAgentStatuses((prev) => {
                         const m = new Map(prev);
                         m.set(blockId, next);

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -160,7 +160,7 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
 
 type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected" | "unknown";
 
-function phaseToDisplayStatus(blockId: string, _fallback: "running" | "idle"): AgentDisplayStatus {
+function phaseToDisplayStatus(blockId: string, fallback: "running" | "idle"): AgentDisplayStatus {
     const phaseAccessor = getBlockTurnPhase(blockId);
     // A block only has a registered TurnPhase while its pane is mounted in
     // THIS renderer (registerActivity() in agentActivity.ts runs from the
@@ -170,7 +170,16 @@ function phaseToDisplayStatus(blockId: string, _fallback: "running" | "idle"): A
     // here. Conflating the two used to render active agents as flatly
     // "idle" ("nothing in progress" when something clearly was) — see
     // docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §1.4/§3.5.
-    if (!phaseAccessor) return "unknown";
+    //
+    // `fallback` is `node.agentStatus` — backend-verified via
+    // `GetControllerStatus`/`ControllerStatus` (swarm-model.ts's
+    // `derivedRunningStatus`), independent of whether this renderer has a
+    // mounted pane for the block. For agent panes it's turn-precise (keyed
+    // off `turn_active`, not raw process-alive `shellprocstatus` — see
+    // docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+    // Finding 1), so it's safe to trust here instead of falling through to
+    // "unknown" for an unmounted/background agent.
+    if (!phaseAccessor) return fallback === "running" ? "working" : "idle";
     const phase = phaseAccessor();
     switch (phase.kind) {
         case "Submitting":    return "working";

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -73,6 +73,11 @@ declare global {
         shellprocexitcode: number;
         spawn_ts_ms?: number;
         is_agent_pane?: boolean;
+        // True if a turn is in flight (message sent, no terminating "result"
+        // event observed yet). Only meaningful for persistent/ACP agent
+        // controllers with a health monitor wired to the NDJSON stream —
+        // absent/false for shell/PTY-backed panes, which have no such signal.
+        turn_active?: boolean;
     };
 
     // agents.failure.AgentFailure — payload of the `agentfailure` wave event


### PR DESCRIPTION
## Summary

`registerPane()` unconditionally seeds every (re)mounted pane's `TurnPhase` to `Idle`, regardless of whether the underlying agent process is actually mid-turn. The launch flow already fetches `GetControllerStatus` at mount, but the result was only ever logged — and for persistent-mode agents (Claude's default), `shellprocstatus` stays `"running"` for the *entire process lifetime*, so it couldn't have seeded an accurate phase even if wired up. There was no backend signal precise enough to distinguish "actively generating a turn" from "idle between turns."

**Backend** (`agentmux-srv/src/backend/blockcontroller/`):
- `HealthMonitor.active_turn` was only ever marked active once, at initial process spawn, for `PersistentSubprocessController` — never turn-scoped past turn 1. `send_message()`/`send_user_message()` now mark it active on every turn; the stdout reader marks it inactive on Claude's `"result"` turn-end event.
- The per-turn health watchdog (stall/dead detection) is re-armed only when actually resuming from idle, so mid-turn steering sends don't leak duplicate watchdog tasks.
- Added `BlockControllerRuntimeStatus.turn_active`, backed by `is_active_turn()`. Populated accurately for `persistent.rs`/`acp.rs` (real health-monitor signal); `subprocess.rs`/`shell/*.rs` have no such signal and report `false`, matching today's existing default — no behavior change for those.

**Frontend**:
- New `ReconcileTurnActive` reducer command promotes a mount-default `Idle` phase to `Streaming` when `turn_active` is true. Deliberately not gated on `lastEventMs` the way `TurnStart` is — it exists specifically to cover the window before the live stream has necessarily subscribed. Never overrides a phase a real stream/user event already produced.
- `swarm-model.ts`'s `agentStatus` now derives from `turn_active` (turn-precise) instead of raw `shellprocstatus` (process-alive only — this previously misrepresented an idle-between-turns agent as "working", the exact bug PR #1947 fixed by having `phaseToDisplayStatus` ignore the signal entirely). With the signal now accurate, `phaseToDisplayStatus` consumes it as a fallback for unmounted/background agents instead of returning `"unknown"`.

Finding 1 (the architecture-decision finding) of `docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md` — Findings 2 and 3 shipped separately in #2002 and #2003.

## Test plan
- [x] `cargo test -p agentmux-srv blockcontroller` — 85 passed, including a new `status_snapshot_turn_active_tracks_health_monitor` test
- [x] `cargo build -p agentmux-srv` — clean
- [x] `npx vitest run` across `agent-pane-state`, `view/agent`, `view/swarm` — 795 passed, including 4 new `ReconcileTurnActive` reducer tests
- [x] `tsc --noEmit` — clean
- [ ] Manual: reopen a pane whose agent is genuinely mid-turn (e.g. a long-running task) and confirm it shows working/streaming immediately instead of flashing Idle first; reopen a Swarm-tracked but unmounted agent and confirm its status chip reflects real turn state instead of "unknown"

<!-- agentmux:agent_id=agentx -->