### PR TITLE
feat(subagent): brain-spinner loading overlay + targeted info lookup

### DIFF
--- a/.changesets/1783433910-feat-subagent-brain-spinner-loading-overlay-targeted-info-lo-pgbf.md
+++ b/.changesets/1783433910-feat-subagent-brain-spinner-loading-overlay-targeted-info-lo-pgbf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(subagent): brain-spinner loading overlay + targeted info lookup

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -403,6 +403,21 @@ impl SubagentWatcher {
         Vec::new()
     }
 
+    /// Get info for a single subagent (sync — safe to call from RPC dispatch).
+    /// Targeted counterpart of `list_active()` — a subagent pane reopened
+    /// after its `subagent:spawned` event already fired needs its info once,
+    /// at mount; scanning + cloning every active subagent across every
+    /// session for that is wasteful when the caller already knows the id.
+    pub fn get_info(&self, agent_id: &str) -> Option<SubagentInfo> {
+        let sessions = self.sessions.lock().unwrap();
+        for session in sessions.values() {
+            if let Some(state) = session.subagents.get(agent_id) {
+                return Some(state.info.clone());
+            }
+        }
+        None
+    }
+
     // ── Internal methods ──────────────────────────────────────────────────
 
     /// Scan for existing subagent JSONL files in a projects directory.
@@ -1234,6 +1249,24 @@ mod tests {
         // s2: its only subagent belonged to parent-1, so the whole session
         // entry is pruned (not left behind as an empty HashMap).
         assert!(!sessions.contains_key("s2"), "session left with zero subagents must be removed, not left empty");
+    }
+
+    #[test]
+    fn get_info_finds_a_subagent_by_id_without_scanning_the_full_list() {
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            s1.subagents.insert("sub-a".to_string(), fixture_state("parent-1", "sub-a", "s1"));
+            s1.subagents.insert("sub-b".to_string(), fixture_state("parent-1", "sub-b", "s1"));
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        let found = watcher.get_info("sub-b").expect("sub-b should be found");
+        assert_eq!(found.agent_id, "sub-b");
+        assert_eq!(found.parent_agent, "parent-1");
+
+        assert!(watcher.get_info("never-spawned").is_none());
     }
 
     #[test]

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -61,6 +61,14 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
             let history = state.subagent_watcher.get_history(&agent_id, limit);
             WebReturnType::success(serde_json::to_value(&history).unwrap_or_default())
         }
+        ("subagent", "GetInfo") => {
+            let agent_id: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let info = state.subagent_watcher.get_info(&agent_id);
+            WebReturnType::success(serde_json::to_value(&info).unwrap_or(serde_json::Value::Null))
+        }
         // ---- HistoryService ----
         ("history", "List") => {
             let provider: Option<String> = service::get_optional_arg(args, 0).unwrap_or(None);

--- a/frontend/app/view/subagent/subagent-model.ts
+++ b/frontend/app/view/subagent/subagent-model.ts
@@ -161,12 +161,17 @@ export class SubagentViewModel implements ViewModel {
             this.setStatus("active");
         }
 
-        // Also load info
+        // Also load info — a targeted single-agent lookup, not ListActive's
+        // full scan of every active subagent across every session (wasteful
+        // fan-out that compounds when several subagent panes are open at
+        // once). Still needed even though subagent:spawned/subagent:completed
+        // event handlers populate info reactively: this pane may be
+        // reopening a subagent that already spawned before it mounted, so
+        // that event already fired and won't refire.
         try {
-            const allActive = await callBackendService("subagent", "ListActive", []);
-            const list = (allActive as SubagentInfo[]) ?? [];
-            const match = list.find((s) => s.agent_id === this.subagentId);
-            if (match) {
+            const info = await callBackendService("subagent", "GetInfo", [this.subagentId]);
+            if (info) {
+                const match = info as SubagentInfo;
                 this.setInfo(match);
                 this.setStatus(match.status);
             }

--- a/frontend/app/view/subagent/subagent-view.scss
+++ b/frontend/app/view/subagent/subagent-view.scss
@@ -11,6 +11,21 @@
     position: relative;
 }
 
+// Brain-spinner loading overlay — covers the pane from mount until
+// loadHistory resolves and the resulting DOM has painted. Same tier/pattern
+// as agent-view's _loading-overlay.scss (docs/specs/
+// REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md); the pulse/
+// fade/reduced-motion behavior itself lives in BrainSpinner.scss.
+.subagent-pane-loading-overlay {
+    position: absolute;
+    inset: 0;
+    background: var(--main-bg-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: var(--zindex-elem-modal);
+}
+
 .subagent-header {
     display: flex;
     align-items: center;

--- a/frontend/app/view/subagent/subagent-view.tsx
+++ b/frontend/app/view/subagent/subagent-view.tsx
@@ -1,9 +1,11 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createEffect, createSignal, For, Show } from "solid-js";
+import { createEffect, createSignal, onCleanup, For, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import type { SubagentViewModel, SubagentEvent, SubagentEventType } from "./subagent-model";
+import { BrainSpinner } from "@/app/element/BrainSpinner";
+import { scheduleOnSettle } from "@/app/util/settle-detector";
 import "./subagent-view.scss";
 
 export function SubagentView(props: ViewComponentProps<SubagentViewModel>): JSX.Element {
@@ -11,6 +13,40 @@ export function SubagentView(props: ViewComponentProps<SubagentViewModel>): JSX.
     const events = props.model.eventsAtom;
     const status = props.model.statusAtom;
     const autoScroll = props.model.autoScrollAtom;
+
+    // Loading overlay — mirrors agent-view.tsx's brain-spinner treatment
+    // (docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md):
+    // shown from mount, cross-fades out once loadHistory's two RPCs
+    // (GetHistory + GetInfo) have resolved AND the resulting DOM has
+    // actually painted. #1992 wired the brain-spinner treatment into
+    // block.tsx's generic stage-one fallback (before the block/viewModel
+    // resolve) and into agent-view.tsx's stage-two window, but SubagentView
+    // resolves its viewModel near-instantly — its own stage-two window
+    // (loadHistory's RPC round trip) was left showing only a static
+    // "Loading subagent activity..." text. See
+    // docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
+    // Finding 4.
+    const [historyLoaded, setHistoryLoaded] = createSignal(false);
+    const [showLoadingOverlay, setShowLoadingOverlay] = createSignal(true);
+    let cancelSettleWait: (() => void) | undefined;
+    let loadingOverlayFadeTimeout: ReturnType<typeof setTimeout> | undefined;
+    onCleanup(() => {
+        cancelSettleWait?.();
+        clearTimeout(loadingOverlayFadeTimeout);
+    });
+    // status() starts "loading" and flips to "active"/"completed" once
+    // loadHistory resolves (subagent-model.ts) — that transition is this
+    // view's equivalent of agent-view.tsx's onHistoryReady.
+    createEffect((wasLoading: boolean) => {
+        const isLoading = status() === "loading";
+        if (wasLoading && !isLoading) {
+            cancelSettleWait = scheduleOnSettle(() => {
+                setHistoryLoaded(true);
+                loadingOverlayFadeTimeout = setTimeout(() => setShowLoadingOverlay(false), 220);
+            });
+        }
+        return isLoading;
+    }, true);
 
     let scrollRef: HTMLDivElement | null = null;
 
@@ -44,6 +80,11 @@ export function SubagentView(props: ViewComponentProps<SubagentViewModel>): JSX.
 
     return (
         <div class="subagent-pane">
+            <Show when={showLoadingOverlay()}>
+                <div class="subagent-pane-loading-overlay">
+                    <BrainSpinner fading={historyLoaded()} />
+                </div>
+            </Show>
             <div class="subagent-header">
                 <div class="subagent-header-left">
                     <span class="subagent-header-icon">


### PR DESCRIPTION
## Summary

`SubagentView` (`frontend/app/view/subagent/subagent-view.tsx`) never got the brain-spinner treatment from #1992 — it renders through a wholly separate, lightweight component from `AgentPresentationView`, and its own perceptible loading window (`SubagentViewModel.loadHistory()`'s RPC round trip) showed only a static `"Loading subagent activity..."` text, no spinner, no settle-detector.

- Wired the same `BrainSpinner` + `scheduleOnSettle` pattern used in `agent-view.tsx`, keyed off `statusAtom`'s `"loading"` → `"active"`/`"completed"` transition (this view's equivalent of `onHistoryReady`).
- Also fixed the secondary finding in the same file: `loadHistory()` called `subagent.ListActive` (a full scan + clone of *every* active subagent across *every* session, just to find one by id) on every subagent pane mount — wasteful fan-out that compounds when several subagent panes are open at once. Replaced with a new targeted `subagent.GetInfo` RPC; added `SubagentWatcher::get_info()` mirroring `get_history()`'s single-lookup pattern instead of `list_active()`'s full scan.

Finding 4 of `docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md` — the last of the four findings (1-3 shipped separately in #2005, #2002, #2003).

## Test plan
- [x] `cargo test -p agentmux-srv subagent_watcher` — 12 passed, including new `get_info_finds_a_subagent_by_id_without_scanning_the_full_list` test
- [x] `cargo build -p agentmux-srv` — clean
- [x] `tsc --noEmit` — clean
- [ ] Manual: click into a subagent from the Swarm view and confirm the brain spinner appears immediately and fades once activity renders, instead of a blank/static-text window

<!-- agentmux:agent_id=agentx -->