### PR TITLE
feat(host): SPEC_PILLAR1_STEP3 Phase 2 -- wire SetWindowTopology into window creation

### DIFF
--- a/.changesets/1783438502-feat-host-spec-pillar1-step3-phase-2-wire-setwindowtopology--ze46.md
+++ b/.changesets/1783438502-feat-host-spec-pillar1-step3-phase-2-wire-setwindowtopology--ze46.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP3 Phase 2 -- wire SetWindowTopology into window creation

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -248,6 +248,86 @@ pub(crate) fn backend_set_window_opacity(web_endpoint: &str, auth_key: &str, win
     }
 }
 
+/// SPEC_PILLAR1_STEP3 Phase 2 — write-through a window's `kind` +
+/// `parent_window_id` to srv, so a future reproject can tell which
+/// native-window creation path to drive for each window. Fire-and-forget,
+/// same shape as `backend_set_window_opacity`: raw TCP, called from its own
+/// background thread (see `register_backend_window` in
+/// `commands/window/meta.rs`) so a slow/failed srv round-trip never stalls
+/// the registration the frontend is actively completing.
+///
+/// `parent_window_id` must already be resolved to a srv `Window.oid` by the
+/// caller — `WindowMeta.parent_instance_id` (the host-side source of this
+/// value) is a window LABEL, not a srv id; the caller resolves it via
+/// `AppState::backend_window_id` before calling this.
+pub(crate) fn backend_set_window_topology(
+    web_endpoint: &str,
+    auth_key: &str,
+    window_id: &str,
+    kind: &str,
+    parent_window_id: Option<&str>,
+) {
+    use std::io::Write;
+
+    let Some(addr) = parse_web_endpoint(web_endpoint, "backend_set_window_topology") else {
+        return;
+    };
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "SetWindowTopology",
+        "args": [window_id, kind, parent_window_id],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    match std::net::TcpStream::connect_timeout(&addr, timeout) {
+        Ok(mut stream) => {
+            stream.set_write_timeout(Some(timeout)).ok();
+            stream.set_read_timeout(Some(timeout)).ok();
+            if let Err(e) = stream.write_all(request.as_bytes()) {
+                tracing::warn!(
+                    window_id = %window_id,
+                    error = %e,
+                    "[backend_set_window_topology] write failed — topology mirror not persisted"
+                );
+                return;
+            }
+            use std::io::Read;
+            let mut resp = String::new();
+            let _ = stream.read_to_string(&mut resp);
+            let first_line = resp.lines().next().unwrap_or("(empty)");
+            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
+                tracing::warn!(
+                    window_id = %window_id,
+                    response = %first_line,
+                    "[backend_set_window_topology] SetWindowTopology did not succeed — topology mirror not persisted"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                window_id = %window_id,
+                addr = %addr,
+                error = %e,
+                "[backend_set_window_topology] connect failed — topology mirror not persisted"
+            );
+        }
+    }
+}
+
 /// SPEC_PILLAR1_STEP2 Slice A Phase 2 — read back the last-persisted opacity
 /// for `window_id` from srv (the crash-recovery path: the host's in-memory
 /// `window_opacities` map is empty on a fresh process, so a restart falls

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -71,6 +71,9 @@ pub(crate) use helpers::{backend_get_window_opacity, backend_set_window_opacity}
 // SPEC_PILLAR1_STEP2 Slice B Phase 4 — floating-pane placement write-through,
 // used by `commands/window/chrome.rs`.
 pub(crate) use helpers::backend_update_block_meta;
+// SPEC_PILLAR1_STEP3 Phase 2 — window kind/parent-linkage write-through,
+// used by `commands/window/meta.rs::register_backend_window`.
+pub(crate) use helpers::backend_set_window_topology;
 pub(crate) use lifecycle::{
     retry_backend_window_id_lookup, BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
     BACKEND_WINDOW_ID_RETRY_DELAY,

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -179,7 +179,7 @@ pub fn get_instance_number(state: &Arc<AppState>, args: &serde_json::Value) -> s
 /// Register the backend window ID for a window label.
 /// Called by the frontend after it has initialized its backend Window object.
 /// Used by `on_before_close` to notify the backend when a secondary window closes.
-pub fn register_backend_window(_state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
+pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     let window_id = args.get("window_id").and_then(|v| v.as_str()).unwrap_or("");
     tracing::info!(label = %label, window_id = %window_id, "[window] register_backend_window received");
@@ -210,10 +210,65 @@ pub fn register_backend_window(_state: &Arc<AppState>, args: &serde_json::Value)
         // without this it is always `None` on macOS/Linux and redock silently
         // fails. See docs/analysis/REPORT_MACOS_FLOATING_PANE_REDOCK_2026_05_30.md.
         #[cfg(not(target_os = "windows"))]
-        _state
+        state
             .shadow_backend_window_ids
             .lock()
             .insert(label.to_string(), window_id.to_string());
+
+        // SPEC_PILLAR1_STEP3 Phase 2 — write-through this window's kind +
+        // parent linkage to srv now that its concrete window_id is known.
+        // This is the first point in the window's life where the host has
+        // both facts at once: `WindowMeta` (kind/parent_instance_id) was
+        // populated at creation time (`on_after_created`, from the
+        // pre-create handoff — see the module doc above), and `window_id`
+        // just arrived as this call's argument. The frontend never learns
+        // its own window's kind, so this write-through is host-only.
+        if let Some(meta) = state.window_meta(label) {
+            let kind_str = match meta.kind {
+                crate::state::WindowKind::FullInstance => "full_instance",
+                crate::state::WindowKind::Subwindow => "subwindow",
+            };
+            // `parent_instance_id` is a window LABEL (see `WindowMeta`'s doc
+            // comment), not a srv window_id — resolve it through the same
+            // label→window_id lookup the opacity/floating-placement
+            // write-throughs already use. A `Subwindow` whose parent hasn't
+            // registered its own window_id yet (a narrow creation-order
+            // race) is skipped rather than written with a wrong/missing
+            // parent — the same class of bounded gap SPEC_PILLAR1_STEP2
+            // already accepted for its own write-throughs.
+            let parent_window_id: Option<String> = match &meta.parent_instance_id {
+                Some(parent_label) => match state.backend_window_id(parent_label) {
+                    Some(id) => Some(id),
+                    None => {
+                        tracing::debug!(
+                            label = %label,
+                            parent_label = %parent_label,
+                            "[window-topology] parent's backend_window_id not yet known — skipping topology write-through"
+                        );
+                        return serde_json::Value::Null;
+                    }
+                },
+                None => None,
+            };
+            let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+            let auth_key = state.auth_key.lock().clone();
+            let window_id_owned = window_id.to_string();
+            let kind_owned = kind_str.to_string();
+            std::thread::spawn(move || {
+                crate::client::backend_set_window_topology(
+                    &web_endpoint,
+                    &auth_key,
+                    &window_id_owned,
+                    &kind_owned,
+                    parent_window_id.as_deref(),
+                );
+            });
+        } else {
+            tracing::debug!(
+                label = %label,
+                "[window-topology] no WindowMeta for label — skipping topology write-through (e.g. pool/browser-pane label)"
+            );
+        }
     } else {
         tracing::warn!(label = %label, "[window] register_backend_window called with empty window_id — skipped");
     }

--- a/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
+++ b/docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md
@@ -198,10 +198,10 @@ independent of Pillar 1 and can land anytime.
 2. ✅ **Persist the two host-only topology facts** to srv: per-window opacity, floating-pane
    placement + `last_known_normal_rect`. **Done, merged, live-verified (SPEC_PILLAR1_STEP2 Slices
    A + B).**
-3. ⬜ **Persist window `kind` + parent linkage to srv** — corrected scope (2026-07-07): this is
-   **not** an "audit + close small gaps" step as originally written. `kind`/parent have no srv
-   representation at all today (§2.A.1). Sized as its own spec:
-   `docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md`.
+3. ✅ **Persist window `kind` + parent linkage to srv** — corrected scope (2026-07-07): this was
+   **not** an "audit + close small gaps" step as originally written. `kind`/parent had no srv
+   representation at all before this (§2.A.1). Sized as its own spec, both phases done, merged,
+   live-verified: `docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md`.
 4. ⬜ **Fire the cold-start restore path on crash** (mid-session reproject) + the "Restoring session…"
    overlay; ensure in-flight (2.C) work is **re-derived from topology, not resumed**. **Corrected
    scope (2026-07-07):** this needs genuinely new multi-window recreation code (§2.A.1) — the

--- a/docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP3_WINDOW_TOPOLOGY_2026_07_07.md
@@ -80,9 +80,16 @@ implementation, not guessed here:
    `commands/window/creation.rs`'s call sites) and call the new RPC directly after
    `WindowService.CreateWindow` resolves in `initHostNewWindow()` (`frontend/app-init.ts:421-493`).
 
-Candidate 1 is likely cleaner (the host already has the truth without inventing a new frontend
-signal), but requires confirming the `register_backend_window` timing actually gives the host a
-reliable "this window_id is now real in srv" hook — verify at implementation time.
+**Resolved (2026-07-07, Phase 2 implementation): Candidate 1.** `register_backend_window`
+(`agentmux-cef/src/commands/window/meta.rs`) is exactly the right hook — it fires once per window
+with that window's concrete srv `window_id`, and the host already has `WindowMeta{kind,
+parent_instance_id}` for the label at that point (populated at creation time). One nuance found
+during implementation: `WindowMeta.parent_instance_id` is a window **label**, not a srv id — it must
+be resolved to the parent's `window_id` via `AppState::backend_window_id(parent_label)` before
+writing srv's `parent_window_id` field (the same label→id lookup the opacity/floating-placement
+write-throughs already use). If the parent hasn't registered its own `window_id` yet (a narrow
+creation-order race — in practice a subwindow's parent is always already open, so this is
+theoretical), the write-through is skipped for that call rather than persisting a wrong value.
 
 **Reproject read-back (Step 4's dependency, not this spec's job):** once persisted, a future
 reproject pass can `GetWindow` each id from `Client.windowids[1..]`, read `kind`/`parent_window_id`,
@@ -91,17 +98,20 @@ somewhere; consuming it is Step 4.
 
 ## 3. Phased plan
 
-**Phase 1 — srv side.** Add `Window.kind`/`parent_window_id` fields + `SetWindowTopology` RPC arm
-(direct store read-modify-write, mirroring `service/window.rs`'s `SetWindowOpacity`). Validate
-`kind` against the known enum values (reject anything else, matching opacity's range validation
-pattern). Unit tests: round-trip persists, unknown window errors, `subwindow` requires a
-non-empty `parent_window_id` (reject `subwindow` + `None` parent — a nonsensical state). Behavior-
-neutral — nothing calls it yet.
+**Phase 1 — srv side. ✅ Done, merged (PR #2004).** Added `Window.kind`/`parent_window_id` fields +
+`SetWindowTopology` RPC arm (direct store read-modify-write, mirroring `service/window.rs`'s
+`SetWindowOpacity`). Validates `kind` against the known enum, rejects `subwindow` without a
+`parent_window_id`, and (added during reagent review) rejects a `parent_window_id` set alongside
+any kind other than `subwindow`, a dangling `parent_window_id` (doesn't reference a real window), or
+a self-referential one. 10 unit tests, behavior-neutral at merge (nothing called it yet).
 
-**Phase 2 — host/frontend wiring.** Resolve the write-through call site (§2's open question) and
-wire it. **App-running verification required**, same bar as SPEC_PILLAR1_STEP2: open a subwindow,
-confirm `GetWindow` on its id shows `kind: "subwindow"` and the correct `parent_window_id`; open a
-second FullInstance window, confirm `kind: "full_instance"`, `parent_window_id: null`.
+**Phase 2 — host/frontend wiring. ✅ Done.** Wired via `register_backend_window` (Candidate 1
+above). **Live-verified** on an isolated instance: `main` → `kind: "full_instance"`, no
+`parent_window_id`; a second full window opened via `openNewWindow()` → `kind: "full_instance"`, no
+`parent_window_id`; a subwindow opened via `open_subwindow {parent_instance_id: "main"}` →
+`kind: "subwindow"`, `parent_window_id` == main's own srv `oid` (correctly resolved from the label,
+not the literal string `"main"`) — confirmed via direct `GetWindow` RPC calls against srv, not just
+host-side logging.
 
 Each phase independently shippable, matching every other Pillar 1 spec's phasing discipline.
 
@@ -127,11 +137,11 @@ Each phase independently shippable, matching every other Pillar 1 spec's phasing
 
 ## 6. Definition of done
 
-1. ⬜ `Window.kind`/`parent_window_id` persist through `SetWindowTopology`, unit-tested.
-2. ⬜ Opening a subwindow live-verifiably persists `kind: "subwindow"` + the correct parent id to
+1. ✅ `Window.kind`/`parent_window_id` persist through `SetWindowTopology`, unit-tested (10 tests).
+2. ✅ Opening a subwindow live-verifiably persists `kind: "subwindow"` + the correct parent id to
    srv (checked via `GetWindow`, same isolated-instance methodology as every other Pillar 1 spec
    this session).
-3. ⬜ Opening a second full window live-verifiably persists `kind: "full_instance"`,
+3. ✅ Opening a second full window live-verifiably persists `kind: "full_instance"`,
    `parent_window_id: null`.
 
 ## 7. Sources


### PR DESCRIPTION
## Summary

Pillar 1 Step 3, Phase 2 -- resolves the open design question left from Phase 1 (#2004): the frontend never learns its own window's `kind` at all (`is_main_window` is a pure `label == "main"` string check), so the write-through fires host-side instead, hooked into `register_backend_window` -- the point where the host learns a label's concrete srv `window_id`, and already has `WindowMeta{kind, parent_instance_id}` for that label from creation time.

**Nuance found during implementation:** `WindowMeta.parent_instance_id` is a window **label** (e.g. `"main"`), not a srv `window_id` -- it's resolved via `AppState::backend_window_id(parent_label)` before writing srv's `parent_window_id` field, the same label->id lookup the opacity/floating-placement write-throughs already use. A parent whose own `window_id` isn't registered yet (a narrow, in-practice-theoretical creation-order race, since a subwindow's parent is always already open) is skipped rather than persisting a wrong value.

Adds `backend_set_window_topology` (`client/helpers.rs`), mirroring `backend_set_window_opacity`'s fire-and-forget shape exactly.

## Test plan (spec's DoD, live on an isolated instance)
- [x] `cargo check -p agentmux-cef` clean, `cargo test -p agentmux-cef` -- 159 passed
- [x] `main` -> `GetWindow` shows `kind: "full_instance"`, no `parent_window_id`
- [x] A second full window (`openNewWindow()`) -> `kind: "full_instance"`, no `parent_window_id`
- [x] A subwindow (`open_subwindow {parent_instance_id: "main"}`) -> `kind: "subwindow"`, `parent_window_id` == main's own srv `oid` -- confirmed it's the resolved id, not the literal string `"main"`
- [x] All three confirmed via direct `GetWindow` RPC calls against srv, not just host-side logging

<!-- agentmux:agent_id=agenta -->