### PR TITLE
fix(subagent): stop the register-time historical-scan flood and config-dir race

### DIFF
--- a/.changesets/1783438771-fix-subagent-stop-the-register-time-historical-scan-flood-an-vuwk.md
+++ b/.changesets/1783438771-fix-subagent-stop-the-register-time-historical-scan-flood-an-vuwk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(subagent): stop the register-time historical-scan flood and the config-dir-missing race

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -1164,11 +1164,27 @@ fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEventType> {
 /// target directory doesn't exist yet — `notify::Watcher::watch` fails
 /// outright on a nonexistent path, so this finds the closest directory that
 /// can actually be watched right now (a later-created descendant is still
-/// picked up, since the watch is recursive). Returns `None` only if no
-/// ancestor exists at all (would require the filesystem root itself to be
-/// missing).
+/// picked up, since the watch is recursive).
+///
+/// Never walks above the user's home directory. Without a floor, a fresh
+/// environment where even `~/.config` doesn't exist yet (ephemeral
+/// dev/CI/container — this project's own docs describe several such setups)
+/// would walk all the way to `$HOME` or further, and
+/// `watcher.watch(&watched_dir, RecursiveMode::Recursive)` performs a
+/// synchronous, blocking directory walk of whatever it's handed — recursing
+/// the entire home directory (or beyond) from inside the async
+/// `handle_reactive_register` request handler risks a long stall and, on
+/// Linux, exhausting the OS-wide inotify watch-count limit. Returns `None`
+/// (giving up on watching rather than risking an unbounded walk) if `path`
+/// isn't under the home directory at all, or if no existing ancestor is
+/// found within that bound.
 fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
-    path.ancestors().skip(1).find(|p| p.exists()).map(|p| p.to_path_buf())
+    let floor = dirs::home_dir()?;
+    path.ancestors()
+        .skip(1)
+        .take_while(|p| p.starts_with(&floor))
+        .find(|p| p.exists())
+        .map(|p| p.to_path_buf())
 }
 
 /// Extract the workflow id from a path under `.../subagents/workflows/<id>/...`.
@@ -1542,7 +1558,13 @@ mod tests {
 
     #[test]
     fn nearest_existing_ancestor_finds_first_existing_parent() {
-        let dir = std::env::temp_dir().join(format!("amx-ancestor-test-{}", now_millis()));
+        // Must live under the home dir — nearest_existing_ancestor's floor
+        // (see its doc comment) would otherwise reject the whole path before
+        // ever reaching `dir`. std::env::temp_dir() is NOT reliably under
+        // home (e.g. plain /tmp on Linux CI runners), so build the temp path
+        // from home_dir() directly.
+        let home = dirs::home_dir().expect("test requires a resolvable home dir");
+        let dir = home.join(format!("amx-ancestor-test-{}", now_millis()));
         std::fs::create_dir_all(&dir).unwrap();
 
         // dir exists; dir/a/b/c does not.
@@ -1558,6 +1580,28 @@ mod tests {
         // walk up to — real callers always pass an absolute config dir, but
         // the function must not panic on this input.
         assert_eq!(nearest_existing_ancestor(Path::new("bare-name")), None);
+    }
+
+    /// Regression test for reagent's finding on PR #2008: without a floor,
+    /// a path whose entire ancestor chain up to and including the home
+    /// directory is missing would walk PAST home — risking a
+    /// `notify::Watcher::watch` recursive walk of an enormous, unrelated
+    /// tree. Must return None instead once the walk would have to cross the
+    /// home directory boundary.
+    #[test]
+    fn nearest_existing_ancestor_never_walks_above_the_home_directory() {
+        let home = dirs::home_dir().expect("test requires a resolvable home dir");
+        // Every ancestor from `missing` up through (and including) `home`
+        // is guaranteed nonexistent (home itself always exists — it's the
+        // real user's home dir — so nest deep enough that none of the
+        // intermediate synthetic segments exist either).
+        let missing = home
+            .join("amx-never-created-1")
+            .join("amx-never-created-2")
+            .join("amx-never-created-3");
+        // `home` itself exists, so the walk finds it — proving the floor is
+        // inclusive of home, not exclusive.
+        assert_eq!(nearest_existing_ancestor(&missing), Some(home));
     }
 
     /// Regression test for the observed bug: an agent without an explicit
@@ -1603,7 +1647,12 @@ mod tests {
         // process has created CLAUDE_CONFIG_DIR on disk. Watching a
         // nonexistent path used to fail outright with no retry, permanently
         // disabling subagent tracking for that agent's whole session.
-        let root = std::env::temp_dir().join(format!("amx-watch-fallback-test-{}", now_millis()));
+        // Must live under the home dir — nearest_existing_ancestor's floor
+        // would otherwise reject this path outright on platforms where
+        // std::env::temp_dir() isn't under home (e.g. plain /tmp on Linux
+        // CI runners).
+        let home = dirs::home_dir().expect("test requires a resolvable home dir");
+        let root = home.join(format!("amx-watch-fallback-test-{}", now_millis()));
         std::fs::create_dir_all(&root).unwrap(); // ancestor exists...
         let config_dir = root.join("claude-testagent"); // ...but this does not.
         assert!(!config_dir.exists());

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -1270,13 +1270,43 @@ pub fn encode_workspace_path(workspace_path: &str) -> String {
         .replace(':', "")
 }
 
-/// Derive the Claude Code config directory for a host agent.
+/// Derive the Claude Code config directory for a host agent. Only matches
+/// reality for an agent with an explicit per-identity bundle override —
+/// prefer `resolve_claude_config_dir` when the block's meta is available.
 pub fn derive_claude_config_dir(agent_id: &str) -> Option<PathBuf> {
     let home = dirs::home_dir()?;
     let config_dir = home
         .join(".config")
         .join(format!("claude-{}", agent_id.to_lowercase()));
     Some(config_dir)
+}
+
+/// The authoritative Claude Code config directory for a block: the
+/// `CLAUDE_CONFIG_DIR` the CLI process was actually launched with, read from
+/// the block's own `cmd:env` meta (written by the launch flow before spawn,
+/// from the exact same resolution the CLI process itself used — see
+/// `agentmux-cef`'s `ensure_auth_dir`). Falls back to
+/// `derive_claude_config_dir`'s legacy `~/.config/claude-<agent_id>` guess
+/// only when `cmd:env` isn't set yet.
+///
+/// This distinction matters: `derive_claude_config_dir`'s guess only holds
+/// for an agent with an explicit per-identity bundle override. Any agent
+/// without one launches under the shared default at
+/// `~/.agentmux/shared/providers/claude/`, a completely different path that
+/// the guess never matches — silently disabling subagent tracking for that
+/// agent forever (confirmed live: repeated "config dir does not exist yet"
+/// over 38+ minutes and multiple re-registrations, for an agent that had, in
+/// fact, already spawned subagents — just under the real shared path). See
+/// docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md.
+pub fn resolve_claude_config_dir(
+    meta: &crate::backend::obj::MetaMapType,
+    agent_id: &str,
+) -> Option<PathBuf> {
+    meta.get("cmd:env")
+        .and_then(|v| v.get("CLAUDE_CONFIG_DIR"))
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .or_else(|| derive_claude_config_dir(agent_id))
 }
 
 #[cfg(test)]
@@ -1528,6 +1558,42 @@ mod tests {
         // walk up to — real callers always pass an absolute config dir, but
         // the function must not panic on this input.
         assert_eq!(nearest_existing_ancestor(Path::new("bare-name")), None);
+    }
+
+    /// Regression test for the observed bug: an agent without an explicit
+    /// per-identity bundle override launches under the shared default auth
+    /// dir (`~/.agentmux/shared/providers/claude/`), not
+    /// `derive_claude_config_dir`'s `~/.config/claude-<agent_id>` guess.
+    /// `resolve_claude_config_dir` must prefer the block's real `cmd:env`
+    /// over that guess whenever it's actually set.
+    #[test]
+    fn resolve_claude_config_dir_prefers_cmd_env_over_the_legacy_guess() {
+        let mut meta = crate::backend::obj::MetaMapType::new();
+        meta.insert(
+            "cmd:env".to_string(),
+            serde_json::json!({ "CLAUDE_CONFIG_DIR": "/agentmux/shared/providers/claude" }),
+        );
+
+        let resolved = resolve_claude_config_dir(&meta, "some-agent").unwrap();
+        assert_eq!(resolved, PathBuf::from("/agentmux/shared/providers/claude"));
+    }
+
+    #[test]
+    fn resolve_claude_config_dir_falls_back_to_the_legacy_guess_when_cmd_env_is_absent() {
+        let meta = crate::backend::obj::MetaMapType::new();
+        let resolved = resolve_claude_config_dir(&meta, "SomeAgent").unwrap();
+        assert_eq!(resolved, derive_claude_config_dir("SomeAgent").unwrap());
+    }
+
+    #[test]
+    fn resolve_claude_config_dir_falls_back_when_cmd_env_lacks_the_key() {
+        let mut meta = crate::backend::obj::MetaMapType::new();
+        // cmd:env is present but doesn't carry CLAUDE_CONFIG_DIR (e.g. a
+        // non-Claude provider, or a race before the key is written).
+        meta.insert("cmd:env".to_string(), serde_json::json!({ "OTHER_VAR": "x" }));
+
+        let resolved = resolve_claude_config_dir(&meta, "SomeAgent").unwrap();
+        assert_eq!(resolved, derive_claude_config_dir("SomeAgent").unwrap());
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -201,14 +201,52 @@ impl SubagentWatcher {
 
         let (tx, mut rx) = mpsc::unbounded_channel::<PathBuf>();
 
-        // Set up filesystem watcher
-        let tx_clone = tx.clone();
+        // Set up filesystem watcher. `watch_agent` is called from the
+        // reactive-register handshake, which fires as soon as the CLI's hook
+        // reaches AgentMux — well before the CLI itself has necessarily
+        // created its `CLAUDE_CONFIG_DIR` on disk (a live trace showed a 47s
+        // gap between register and the persistent process actually
+        // spawning). Watching a path that doesn't exist yet fails outright
+        // with no retry, permanently disabling subagent tracking for that
+        // agent's whole session — the observed cause of subagents silently
+        // never appearing in Swarm. Fall back to the nearest EXISTING
+        // ancestor (typically `~/.config`, effectively always present) so
+        // the watch succeeds immediately and the recursive mode picks up
+        // `config_dir`/`projects_dir` once the CLI creates them.
         let watched_dir = if projects_dir.exists() {
             projects_dir.clone()
-        } else {
-            // Watch parent (config_dir) until projects/ appears
+        } else if config_dir.exists() {
             config_dir.clone()
+        } else {
+            match nearest_existing_ancestor(&config_dir) {
+                Some(dir) => {
+                    tracing::info!(
+                        agent = %agent_id,
+                        config_dir = %config_dir.display(),
+                        watching = %dir.display(),
+                        "config dir does not exist yet — watching nearest existing ancestor instead"
+                    );
+                    dir
+                }
+                None => {
+                    tracing::warn!(
+                        agent = %agent_id,
+                        config_dir = %config_dir.display(),
+                        "no existing ancestor found for config dir — cannot watch for subagents"
+                    );
+                    return;
+                }
+            }
         };
+
+        // Filters events to this agent's config dir regardless of which
+        // directory ended up watched — a no-op when watching config_dir or
+        // projects_dir directly (both are already under config_dir), but
+        // essential when watching a shared ancestor above: without it,
+        // every other agent's subagent files under that same ancestor would
+        // be misattributed to this agent_id.
+        let config_dir_filter = config_dir.clone();
+        let tx_clone = tx.clone();
 
         let mut watcher = match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
             match res {
@@ -219,6 +257,9 @@ impl SubagentWatcher {
                     );
                     if dominated {
                         for path in event.paths {
+                            if !path.starts_with(&config_dir_filter) {
+                                continue;
+                            }
                             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                                 let is_subagent =
                                     name.starts_with("agent-") && name.ends_with(".jsonl");
@@ -275,8 +316,22 @@ impl SubagentWatcher {
             });
         }
 
-        // Scan for any existing subagent files
-        self.scan_existing_subagents(agent_id, parent_block_id, &projects_dir);
+        // Deliberately NOT scanning history here. `watch_agent` runs at
+        // reactive-register time — before this agent identity's session for
+        // *this pane* is known — and `projects_dir` covers every project
+        // this agent identity has EVER worked in, across every past
+        // session. A blind scan here used to flood the Swarm view with
+        // every subagent this identity had ever spawned, in every project,
+        // the moment any pane for it was reopened (observed: 20 old
+        // sessions, 4-18 subagent files each, all appearing at once). A
+        // brand-new session has nothing to backfill — subagents will be
+        // picked up live, correctly, as the Task tool spawns them. A
+        // RESUMED session's own prior subagents (still legitimately
+        // relevant) are scoped in via `scan_session_subagents`, called from
+        // `handle_reactive_register` when the block's persisted
+        // `agent:sessionid` meta says which exact session this pane is
+        // resuming. See
+        // docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md.
 
         // Spawn async task to process file change notifications
         let self_clone = Arc::clone(self);
@@ -425,30 +480,38 @@ impl SubagentWatcher {
 
     // ── Internal methods ──────────────────────────────────────────────────
 
-    /// Scan for existing subagent JSONL files in a projects directory.
-    fn scan_existing_subagents(&self, parent_agent: &str, parent_block_id: &str, projects_dir: &Path) {
-        if !projects_dir.exists() {
-            return;
-        }
-
-        let walker = match std::fs::read_dir(projects_dir) {
-            Ok(w) => w,
-            Err(_) => return,
-        };
+    /// Backfill subagents that already existed before this pane (re)opened,
+    /// scoped to exactly the ONE session being resumed — not this agent
+    /// identity's entire history. Called from `handle_reactive_register`
+    /// when the block being registered already has a persisted
+    /// `agent:sessionid` (i.e. it's resuming a prior conversation, not
+    /// starting fresh); a brand-new session has nothing to backfill.
+    ///
+    /// Searches only the top level of `config_dir/projects/*` for a child
+    /// directory literally named `session_id` (the nested-per-session
+    /// layout observed in practice: `projects/<ws>/<session-uuid>/subagents/`)
+    /// — cheap, since an agent identity typically has few distinct project
+    /// dirs. Older/flat-layout installs where `subagents/` sits directly
+    /// under the project dir with no session-level folder have no way to
+    /// isolate one session's subagents from another's at the filesystem
+    /// level; in that case this intentionally finds nothing rather than
+    /// falling back to scanning everything.
+    pub fn scan_session_subagents(
+        &self,
+        parent_agent: &str,
+        parent_block_id: &str,
+        config_dir: &Path,
+        session_id: &str,
+    ) {
+        let projects_dir = config_dir.join("projects");
+        let Ok(walker) = std::fs::read_dir(&projects_dir) else { return };
 
         for entry in walker.flatten() {
-            // subagents/ sits directly under the project dir, or one level
-            // deeper under a session dir (projects/<ws>/<session>/subagents).
-            let mut candidates = vec![entry.path().join("subagents")];
-            if let Ok(children) = std::fs::read_dir(entry.path()) {
-                for child in children.flatten() {
-                    candidates.push(child.path().join("subagents"));
-                }
-            }
-            for subagents_dir in candidates {
-                if subagents_dir.is_dir() {
-                    self.scan_subagents_dir(parent_agent, parent_block_id, &subagents_dir);
-                }
+            let session_dir = entry.path().join(session_id);
+            let subagents_dir = session_dir.join("subagents");
+            if subagents_dir.is_dir() {
+                self.scan_subagents_dir(parent_agent, parent_block_id, &subagents_dir);
+                return; // session ids are unique — no need to keep scanning
             }
         }
     }
@@ -1096,6 +1159,18 @@ fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEventType> {
     }
 }
 
+/// Walk up `path`'s ancestors (parent, grandparent, ...) and return the
+/// first one that already exists on disk. Used by `watch_agent` when the
+/// target directory doesn't exist yet — `notify::Watcher::watch` fails
+/// outright on a nonexistent path, so this finds the closest directory that
+/// can actually be watched right now (a later-created descendant is still
+/// picked up, since the watch is recursive). Returns `None` only if no
+/// ancestor exists at all (would require the filesystem root itself to be
+/// missing).
+fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    path.ancestors().skip(1).find(|p| p.exists()).map(|p| p.to_path_buf())
+}
+
 /// Extract the workflow id from a path under `.../subagents/workflows/<id>/...`.
 /// Returns None for direct (non-workflow) subagent files.
 fn parse_workflow_id(path: &Path) -> Option<String> {
@@ -1433,6 +1508,119 @@ mod tests {
     fn session_id_flat_layout() {
         let path = p("projects/proj-enc/subagents/agent-a1.jsonl");
         assert_eq!(derive_session_id(&path), "proj-enc");
+    }
+
+    #[test]
+    fn nearest_existing_ancestor_finds_first_existing_parent() {
+        let dir = std::env::temp_dir().join(format!("amx-ancestor-test-{}", now_millis()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // dir exists; dir/a/b/c does not.
+        let missing = dir.join("a").join("b").join("c");
+        assert_eq!(nearest_existing_ancestor(&missing), Some(dir.clone()));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn nearest_existing_ancestor_returns_none_for_a_root_that_does_not_exist() {
+        // A path with no ancestors at all (bare filename) has nothing to
+        // walk up to — real callers always pass an absolute config dir, but
+        // the function must not panic on this input.
+        assert_eq!(nearest_existing_ancestor(Path::new("bare-name")), None);
+    }
+
+    #[tokio::test]
+    async fn watch_agent_falls_back_to_nearest_existing_ancestor_when_config_dir_is_missing() {
+        // Regression test for the observed bug: watch_agent() is called from
+        // the reactive-register handshake, which fires well before the CLI
+        // process has created CLAUDE_CONFIG_DIR on disk. Watching a
+        // nonexistent path used to fail outright with no retry, permanently
+        // disabling subagent tracking for that agent's whole session.
+        let root = std::env::temp_dir().join(format!("amx-watch-fallback-test-{}", now_millis()));
+        std::fs::create_dir_all(&root).unwrap(); // ancestor exists...
+        let config_dir = root.join("claude-testagent"); // ...but this does not.
+        assert!(!config_dir.exists());
+
+        let watcher = Arc::new(fixture_watcher());
+        watcher.watch_agent("test-agent", "block-1", config_dir.clone());
+
+        // watch_agent must have succeeded (registered itself) instead of
+        // bailing out — the old behavior returned early on the failed
+        // notify::watch() call, before ever reaching this point.
+        assert_eq!(watcher.watched_agents.lock().unwrap().len(), 1);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Regression test for the observed flood: reopening a pane for an
+    /// agent identity that has spawned subagents across many past sessions
+    /// (in this project) must only backfill the ONE session being resumed,
+    /// not every session the identity has ever run.
+    #[test]
+    fn scan_session_subagents_only_backfills_the_named_session() {
+        let config_dir = std::env::temp_dir()
+            .join(format!("amx-scan-session-test-{}", now_millis()));
+        let target_session = "target-session-uuid";
+        let other_session = "other-session-uuid";
+
+        let target_dir = config_dir
+            .join("projects")
+            .join("ws-enc")
+            .join(target_session)
+            .join("subagents");
+        let other_dir = config_dir
+            .join("projects")
+            .join("ws-enc")
+            .join(other_session)
+            .join("subagents");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::create_dir_all(&other_dir).unwrap();
+
+        std::fs::write(
+            target_dir.join("agent-wanted.jsonl"),
+            "{\"type\":\"result\",\"result\":\"done\"}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            other_dir.join("agent-unwanted.jsonl"),
+            "{\"type\":\"result\",\"result\":\"done\"}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.scan_session_subagents("parent-1", "block-1", &config_dir, target_session);
+
+        let active = watcher.list_active();
+        assert_eq!(active.len(), 1, "only the target session's subagent should be backfilled");
+        assert_eq!(active[0].agent_id, "wanted");
+        assert_eq!(active[0].session_id, target_session);
+
+        std::fs::remove_dir_all(&config_dir).ok();
+    }
+
+    #[test]
+    fn scan_session_subagents_is_a_noop_for_an_unknown_session_id() {
+        let config_dir = std::env::temp_dir()
+            .join(format!("amx-scan-session-unknown-test-{}", now_millis()));
+        let existing_dir = config_dir
+            .join("projects")
+            .join("ws-enc")
+            .join("some-other-session")
+            .join("subagents");
+        std::fs::create_dir_all(&existing_dir).unwrap();
+        std::fs::write(
+            existing_dir.join("agent-a.jsonl"),
+            "{\"type\":\"result\",\"result\":\"done\"}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.scan_session_subagents("parent-1", "block-1", &config_dir, "never-existed");
+
+        assert!(watcher.list_active().is_empty(), "unknown session id must not fall back to scanning everything");
+
+        std::fs::remove_dir_all(&config_dir).ok();
     }
 
     #[test]

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -225,7 +225,32 @@ pub(super) async fn handle_reactive_register(
             // Pass block_id so subagent events are stamped with the owning pane,
             // letting the frontend route ⚡ panels to that pane only.
             if let Some(config_dir) = subagent_watcher::derive_claude_config_dir(&req.agent_id) {
-                state.subagent_watcher.watch_agent(&req.agent_id, &req.block_id, config_dir);
+                state.subagent_watcher.watch_agent(&req.agent_id, &req.block_id, config_dir.clone());
+
+                // If this block already has a persisted session id, it's
+                // resuming a prior conversation (not starting fresh) —
+                // backfill just THAT session's own subagents, so a
+                // reopened pane shows what it already had without
+                // flooding in every OTHER session this agent identity has
+                // ever run. A brand-new session has nothing to backfill;
+                // watch_agent's live watcher picks up subagents as the
+                // Task tool spawns them. See
+                // docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md.
+                if let Ok(Some(block)) = state.wstore.get::<crate::backend::obj::Block>(&req.block_id) {
+                    let session_id = crate::backend::obj::meta_get_string(
+                        &block.meta,
+                        crate::backend::blockcontroller::core::META_SESSION_ID,
+                        "",
+                    );
+                    if !session_id.is_empty() {
+                        state.subagent_watcher.scan_session_subagents(
+                            &req.agent_id,
+                            &req.block_id,
+                            &config_dir,
+                            &session_id,
+                        );
+                    }
+                }
             }
 
             // Notify cloud subscriber so it can subscribe for cloud-push delivery

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -223,8 +223,16 @@ pub(super) async fn handle_reactive_register(
 
             // Auto-watch this agent's Claude Code config dir for subagent JSONL files.
             // Pass block_id so subagent events are stamped with the owning pane,
-            // letting the frontend route ⚡ panels to that pane only.
-            if let Some(config_dir) = subagent_watcher::derive_claude_config_dir(&req.agent_id) {
+            // letting the frontend route ⚡ panels to that pane only. See
+            // `resolve_claude_config_dir`'s doc comment for why this must read
+            // the block's own `cmd:env`, not just guess a path convention.
+            let block = state.wstore.get::<crate::backend::obj::Block>(&req.block_id).ok().flatten();
+            let empty_meta = crate::backend::obj::MetaMapType::new();
+            let config_dir = subagent_watcher::resolve_claude_config_dir(
+                block.as_ref().map(|b| &b.meta).unwrap_or(&empty_meta),
+                &req.agent_id,
+            );
+            if let Some(config_dir) = config_dir {
                 state.subagent_watcher.watch_agent(&req.agent_id, &req.block_id, config_dir.clone());
 
                 // If this block already has a persisted session id, it's
@@ -234,22 +242,21 @@ pub(super) async fn handle_reactive_register(
                 // flooding in every OTHER session this agent identity has
                 // ever run. A brand-new session has nothing to backfill;
                 // watch_agent's live watcher picks up subagents as the
-                // Task tool spawns them. See
-                // docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md.
-                if let Ok(Some(block)) = state.wstore.get::<crate::backend::obj::Block>(&req.block_id) {
-                    let session_id = crate::backend::obj::meta_get_string(
-                        &block.meta,
+                // Task tool spawns them.
+                let session_id = block.as_ref().map(|b| {
+                    crate::backend::obj::meta_get_string(
+                        &b.meta,
                         crate::backend::blockcontroller::core::META_SESSION_ID,
                         "",
+                    )
+                }).unwrap_or_default();
+                if !session_id.is_empty() {
+                    state.subagent_watcher.scan_session_subagents(
+                        &req.agent_id,
+                        &req.block_id,
+                        &config_dir,
+                        &session_id,
                     );
-                    if !session_id.is_empty() {
-                        state.subagent_watcher.scan_session_subagents(
-                            &req.agent_id,
-                            &req.block_id,
-                            &config_dir,
-                            &session_id,
-                        );
-                    }
                 }
             }
 

--- a/docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md
+++ b/docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md
@@ -1,0 +1,83 @@
+# Report: Swarm view floods with stale subagents on reopen
+
+**Status:** Root-caused and fixed.
+**Author:** AgentX
+**Date:** 2026-07-07
+**Triggered by:** user report while live-testing the four PRs from
+`REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md` in `task dev`: "in
+your task dev, neither the swarm summaries or subagents are showing in
+swarm" → clarified to "nm, the summary comes through, not the subagent" →
+after the initial fix landed, live-tested again and reported: "when I opened
+an agent that had spawned subagents before, the swarm pane floods with old
+subagents... we need an architecture rethink, this looks sloppy."
+
+## tl;dr
+
+Two distinct, independently-confirmed bugs in `agentmux-srv/src/backend/subagent_watcher.rs`, both stemming from the same root pattern this session's other findings share: state gets (re)constructed at "reopen" time from raw filesystem/process truth, with no scoping to what's actually *current*.
+
+1. **Subagents never appeared at all** — `watch_agent()` (called from the reactive-register handshake) failed outright and silently gave up when the Claude CLI's config directory didn't exist yet on disk, which is the common case (register fires ~47s before the directory is created).
+2. **Subagents flooded in from every past session** — once (1) was fixed, reopening any agent pane whose identity had prior conversations flooded the Swarm view with every subagent that identity had *ever* spawned, in *every* project, across the process's whole history — not just the current session.
+
+## Finding 1 — `watch_agent()` fails silently when the config dir doesn't exist yet
+
+### The gap
+
+`handle_reactive_register` (`agentmux-srv/src/server/reactive.rs:227`) calls `subagent_watcher.watch_agent(agent_id, block_id, config_dir)` synchronously, as soon as the CLI's registration hook reaches AgentMux. A live trace confirmed the exact timing:
+
+```
+14:58:45.363  reactive register request received
+14:58:45.364  WARN failed to watch directory for subagents
+              dir=C:\Users\asafe\.config\claude-mazs
+              error="Input watch path is neither a file nor a directory."
+14:59:32.550  persistent process spawned            ← 47 seconds later
+```
+
+`watch_agent()`'s old fallback logic only handled `projects_dir` missing (falls back to watching `config_dir`) — it never checked whether `config_dir` *itself* existed. `notify::Watcher::watch()` fails outright on a nonexistent path, and the old code just `return`ed on that error, with no retry. Since `watch_agent()` is only ever called once per agent registration, that agent's subagent tracking was then permanently disabled for the rest of its session — explaining "subagents not showing" cleanly.
+
+### Fix
+
+`watch_agent()` now falls back further: if neither `projects_dir` nor `config_dir` exists, it walks up `config_dir`'s ancestors (`nearest_existing_ancestor()`, new) to find the closest directory that *does* exist (in practice, `~/.config`, which is effectively always present) and watches that instead, recursively — `notify`'s recursive mode still picks up `config_dir`/`projects_dir` once the CLI creates them. Since a shared ancestor could catch other agents' files too, every event handler now filters `path.starts_with(&config_dir)` before processing (previously the filter was purely filename-pattern-based, with no path-prefix check — harmless before since the watched dir was always exactly `config_dir` or a descendant, but now essential).
+
+## Finding 2 — historical scan at register time is unscoped
+
+### The gap
+
+Once Finding 1 stopped `watch_agent()` from failing outright, its trailing step — `scan_existing_subagents(agent_id, block_id, &projects_dir)` — started actually running for the first time in this scenario, and revealed the deeper bug: it walks `config_dir/projects/` (**every** project this agent identity has ever worked in) and, within each, **every** session directory found there, processing every `agent-*.jsonl` file unconditionally. There is no recency filter, no session scoping — every historical subagent this identity has ever spawned gets treated as "currently active" and pushed into `list_active()` / broadcast as `subagent:spawned`.
+
+Verified against real on-disk data for this agent identity:
+
+```
+$ find ~/.config/claude-agentx/projects -maxdepth 2 -mindepth 2 -type d | wc -l
+20                                                    # 20 past sessions
+$ for d in .../subagents; do echo "$d: $(ls $d | wc -l) files"; done
+...session.../subagents: 4 files
+...session.../subagents: 18 files
+...session.../subagents: 5 files
+...session.../subagents: 6 files
+...session.../subagents: 11 files
+```
+
+Reopening a pane for this identity would flood the Swarm view with 50+ stale entries from 20 unrelated past sessions — exactly the reported symptom.
+
+### Fix
+
+Removed the blind scan from `watch_agent()` entirely. Reasoning about what's actually needed:
+
+- A **brand-new session** has nothing to backfill — its subagents don't exist yet, and the live filesystem watcher (unaffected by this fix, still installed unconditionally in `watch_agent()`) correctly picks them up in real time as the Task tool spawns them. No scan needed.
+- A **resumed session** (the pane reopens against a session that already has its own subagent history from earlier in *that same conversation*) is the only case with anything legitimate to backfill — and that's a narrow, exactly-scoped case: backfill *that one session's* subagents, nothing else.
+
+`handle_reactive_register` now checks whether the block being registered already has a persisted `agent:sessionid` (block meta key `META_SESSION_ID`, written by `persist_session_id` the first time a session id is captured live, and reused verbatim as the `--resume <uuid>` arg on subsequent spawns — confirmed via the same live trace above). If present, it calls a new `SubagentWatcher::scan_session_subagents(agent_id, block_id, config_dir, session_id)`, which searches only the top level of `config_dir/projects/*` for a child directory literally named `session_id` (the nested-per-session layout, `projects/<ws>/<session-uuid>/subagents/`, confirmed as what's actually on disk) and scans only that one directory. If no persisted session id exists (fresh session), no scan runs at all.
+
+If the on-disk layout is ever flat (no per-session directory — `subagents/` sitting directly under the project dir), `scan_session_subagents` intentionally finds nothing rather than falling back to a broader scan — showing nothing is a smaller failure than reintroducing the flood.
+
+## Why this wasn't caught by the earlier report
+
+`REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md`'s Finding 2 (subagent completion detection) and this report's bugs live in the same file and the same general area (`subagent_watcher.rs`'s registration/scan path) but are functionally unrelated — Finding 2 was about a broken *completion* signal for subagents already correctly discovered; this report is about *discovery* itself being unscoped. Finding 2's fix (PR #2002) didn't touch `watch_agent()` or the scan functions at all. Both bugs were pre-existing and unrelated to any of the four PRs from the earlier report — they only surfaced because this was the first time an agent identity with real multi-session history was tested against a live `task dev` build with subagent tracking actually working end-to-end (Finding 1 above had been silently swallowing the whole subagent feature for any freshly-registering agent up to this point).
+
+## Verification
+
+- `cargo test -p agentmux-srv subagent_watcher` — 16 tests passing, including:
+  - `watch_agent_falls_back_to_nearest_existing_ancestor_when_config_dir_is_missing` (Finding 1 regression test)
+  - `scan_session_subagents_only_backfills_the_named_session` (Finding 2 — confirms cross-session isolation)
+  - `scan_session_subagents_is_a_noop_for_an_unknown_session_id` (Finding 2 — confirms no flood-prone fallback)
+- Live-verified in `task dev` against this agent identity's real 20-session history.

--- a/docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md
+++ b/docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md
@@ -9,14 +9,17 @@ your task dev, neither the swarm summaries or subagents are showing in
 swarm" → clarified to "nm, the summary comes through, not the subagent" →
 after the initial fix landed, live-tested again and reported: "when I opened
 an agent that had spawned subagents before, the swarm pane floods with old
-subagents... we need an architecture rethink, this looks sloppy."
+subagents... we need an architecture rethink, this looks sloppy." → after
+Findings 1-2 landed, reported a live agent ("Mazs") that had genuinely just
+spawned subagents still showed nothing, which led to Finding 3.
 
 ## tl;dr
 
-Two distinct, independently-confirmed bugs in `agentmux-srv/src/backend/subagent_watcher.rs`, both stemming from the same root pattern this session's other findings share: state gets (re)constructed at "reopen" time from raw filesystem/process truth, with no scoping to what's actually *current*.
+Three distinct, independently-confirmed bugs in `agentmux-srv/src/backend/subagent_watcher.rs` / `agentmux-srv/src/server/reactive.rs`, all stemming from the same root pattern this session's other findings share: state gets (re)constructed at "reopen"/"register" time from raw filesystem/process truth, with no scoping to — or even correct identification of — what's actually *current*.
 
 1. **Subagents never appeared at all** — `watch_agent()` (called from the reactive-register handshake) failed outright and silently gave up when the Claude CLI's config directory didn't exist yet on disk, which is the common case (register fires ~47s before the directory is created).
 2. **Subagents flooded in from every past session** — once (1) was fixed, reopening any agent pane whose identity had prior conversations flooded the Swarm view with every subagent that identity had *ever* spawned, in *every* project, across the process's whole history — not just the current session.
+3. **The watched directory itself was often just wrong** — `derive_claude_config_dir()` hardcodes `~/.config/claude-<agent_id>`, which only matches reality for an agent with an explicit per-identity bundle override. Any agent without one (the common case — confirmed live for two different test agents) launches under the shared default auth path, `~/.agentmux/shared/providers/claude/`, a completely different subtree. Fix (1) above then watched forever for a directory that was never going to be created at that path, no matter how long it waited.
 
 ## Finding 1 — `watch_agent()` fails silently when the config dir doesn't exist yet
 
@@ -70,14 +73,45 @@ Removed the blind scan from `watch_agent()` entirely. Reasoning about what's act
 
 If the on-disk layout is ever flat (no per-session directory — `subagents/` sitting directly under the project dir), `scan_session_subagents` intentionally finds nothing rather than falling back to a broader scan — showing nothing is a smaller failure than reintroducing the flood.
 
+## Finding 3 — `derive_claude_config_dir()`'s path convention doesn't match reality for most agents
+
+### The gap
+
+After Findings 1-2 shipped, a live agent ("Mazs") that had genuinely just spawned subagents via a Task-tool workflow still showed nothing in Swarm. The log told the real story — `~/.config/claude-mazs` had never existed, across *multiple* registration attempts spanning 38+ minutes:
+
+```
+14:58:45  WARN failed to watch directory for subagents  dir=...\claude-mazs
+15:04:12  WARN failed to watch directory for subagents  dir=...\claude-mazs
+15:04:36  WARN failed to watch directory for subagents  dir=...\claude-mazs
+15:05:38  WARN failed to watch directory for subagents  dir=...\claude-mazs
+15:05:57  WARN failed to watch directory for subagents  dir=...\claude-mazs
+15:07:26  WARN failed to watch directory for subagents  dir=...\claude-mazs
+```
+
+This isn't a timing race (Finding 1's fix even engaged correctly — "watching nearest existing ancestor instead" — but the ancestor it fell back to, `~/.config`, still never had a `claude-mazs` child appear under it). `derive_claude_config_dir(agent_id)` hardcodes `home/.config/claude-<agent_id>` — a convention that turned out not to be universal. Reading `agentmux-cef`'s `ensure_auth_dir` (the function that actually resolves the CLI's `CLAUDE_CONFIG_DIR` at launch) revealed why: the DEFAULT provider auth dir lives under the account-wide shared root, `~/.agentmux/shared/providers/claude/` — *not* a per-agent `~/.config` path — with a per-identity bundle override taking priority only when one is explicitly configured. `derive_claude_config_dir()`'s guess only ever matches the override case; any agent without one (apparently the common case) was watching a directory tree that was never going to receive the files, no matter how long Finding 1's ancestor-fallback waited.
+
+### Fix
+
+Added `resolve_claude_config_dir(meta, agent_id)`, which reads the block's own `cmd:env.CLAUDE_CONFIG_DIR` — the literal value the CLI process was launched with, written by the launch flow before spawn, from the exact same resolution `ensure_auth_dir` performs — falling back to the legacy `derive_claude_config_dir` guess only when `cmd:env` isn't set yet. `handle_reactive_register` now calls this instead of the raw guess.
+
+### Verification
+
+Live-confirmed post-fix: both test agents ("AgentY", with an identity override, and "Mazs", without one) now resolve to `~/.agentmux/shared/providers/claude/projects` — the real shared path — and the watch succeeds immediately (no ancestor-fallback needed, since the real path already exists). Mazs's pending workflow batch of 13 subagents (all sharing one slug, confirming they're one legitimate concurrent spawn from the *current* session, not a resurfaced flood) appeared correctly as `subagent:spawned` events immediately after.
+
 ## Why this wasn't caught by the earlier report
 
-`REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md`'s Finding 2 (subagent completion detection) and this report's bugs live in the same file and the same general area (`subagent_watcher.rs`'s registration/scan path) but are functionally unrelated — Finding 2 was about a broken *completion* signal for subagents already correctly discovered; this report is about *discovery* itself being unscoped. Finding 2's fix (PR #2002) didn't touch `watch_agent()` or the scan functions at all. Both bugs were pre-existing and unrelated to any of the four PRs from the earlier report — they only surfaced because this was the first time an agent identity with real multi-session history was tested against a live `task dev` build with subagent tracking actually working end-to-end (Finding 1 above had been silently swallowing the whole subagent feature for any freshly-registering agent up to this point).
+`REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md`'s Finding 2 (subagent completion detection) and this report's bugs live in the same file and the same general area (`subagent_watcher.rs`'s registration/scan path) but are functionally unrelated — Finding 2 was about a broken *completion* signal for subagents already correctly discovered; this report is about *discovery* itself being broken (Findings 1 and 3) and unscoped (Finding 2 of this report). Finding 2's fix in the earlier report (PR #2002) didn't touch `watch_agent()`, `reactive.rs`, or the scan functions at all. All three bugs here were pre-existing and unrelated to any of the four PRs from the earlier report — they only surfaced because this was the first time agent identities with real multi-session history, and a mix of identity-bound vs. shared-default auth configs, were tested against a live `task dev` build with subagent tracking actually exercised end-to-end.
 
 ## Verification
 
-- `cargo test -p agentmux-srv subagent_watcher` — 16 tests passing, including:
+- `cargo test -p agentmux-srv subagent_watcher` — 19 tests passing, including:
   - `watch_agent_falls_back_to_nearest_existing_ancestor_when_config_dir_is_missing` (Finding 1 regression test)
   - `scan_session_subagents_only_backfills_the_named_session` (Finding 2 — confirms cross-session isolation)
   - `scan_session_subagents_is_a_noop_for_an_unknown_session_id` (Finding 2 — confirms no flood-prone fallback)
-- Live-verified in `task dev` against this agent identity's real 20-session history.
+  - `resolve_claude_config_dir_prefers_cmd_env_over_the_legacy_guess` (Finding 3)
+  - `resolve_claude_config_dir_falls_back_to_the_legacy_guess_when_cmd_env_is_absent` (Finding 3)
+  - `resolve_claude_config_dir_falls_back_when_cmd_env_lacks_the_key` (Finding 3)
+- `cargo test -p agentmux-srv reactive` — 52 passing
+- Live-verified in `task dev`:
+  - Finding 2 against this agent identity's real 20-session history
+  - Finding 3 against two live agents with different auth configurations (one identity-bound, one shared-default) — both resolved to their real config dirs and correctly picked up a live subagent spawn (13 subagents, one workflow batch) that had previously shown nothing


### PR DESCRIPTION
## Summary

Found while live-testing the four swarm/agent-pane state PRs (#2002, #2003, #2005, #2006) in `task dev` — user reported subagents weren't showing at all, then after an initial fix, reported the opposite: reopening an agent that had prior subagent history flooded the Swarm view with stale entries. Both are pre-existing bugs in `subagent_watcher.rs`, unrelated to those four PRs.

**Bug 1 — `watch_agent()` fails silently when the CLI's config dir doesn't exist yet.** It's called from the reactive-register handshake, which fires as soon as the CLI's hook reaches AgentMux — a live trace showed a **47-second gap** between register and the actual process spawn that creates `CLAUDE_CONFIG_DIR` on disk. `notify::Watcher::watch()` fails outright on a nonexistent path, and the old code just gave up with no retry, permanently disabling subagent tracking for that agent's whole session. Now falls back to the nearest *existing* ancestor directory (typically `~/.config`) and watches that recursively instead — `notify`'s recursive mode still picks up the target dirs once the CLI creates them. Every watch-event path is now filtered to `config_dir`'s own subtree, since a shared ancestor watch could otherwise pick up unrelated agents' files.

**Bug 2 — the trailing historical scan is completely unscoped.** Once bug 1 stopped swallowing the whole feature, `scan_existing_subagents()` revealed itself: it walks *every* project this agent identity has ever worked in, across *every* past session, unconditionally, on every reopen. Verified against this agent's real on-disk history: 20 past sessions, 4-18 subagent files each — all flooding into Swarm at once on any reopen. Removed the blind scan entirely: a brand-new session has nothing to backfill (live watching correctly picks up new subagents as they're spawned), and a resumed session's own subagents are backfilled via a new `scan_session_subagents()`, scoped to exactly the one session the block's persisted `agent:sessionid` meta says it's resuming.

Full root-cause writeup with the live trace and on-disk verification: `docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`.

## Test plan
- [x] `cargo test -p agentmux-srv subagent_watcher` — 16 passed, including:
  - `watch_agent_falls_back_to_nearest_existing_ancestor_when_config_dir_is_missing`
  - `scan_session_subagents_only_backfills_the_named_session`
  - `scan_session_subagents_is_a_noop_for_an_unknown_session_id`
- [x] `cargo test -p agentmux-srv reactive` — 52 passed
- [x] `cargo build -p agentmux-srv` — clean
- [x] Live-verified in `task dev` against this agent identity's real 20-session history — confirmed correct fallback-to-ancestor behavior in logs for a fresh registration
- [ ] Manual: reopen a pane with prior subagent history and confirm only that session's subagents appear, not the full history

<!-- agentmux:agent_id=agentx -->