### PR TITLE
docs(build): fix stale React/Vite references — app is SolidJS

### DIFF
--- a/.changesets/1783449619-docs-build-fix-stale-react-vite-references-app-is-solidjs-0mol.md
+++ b/.changesets/1783449619-docs-build-fix-stale-react-vite-references-app-is-solidjs-0mol.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(build): fix stale React/Vite references, app is SolidJS

--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ These instructions cover setting up dependencies and building AgentMux from sour
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| **Node.js** | v22 LTS | Frontend build (React/Vite) |
+| **Node.js** | v22 LTS | Frontend build (SolidJS/Vite) |
 | **Rust** | 1.77+ | Backend (agentmux-srv) + Host (agentmux-cef) |
 | **Task** | Latest | Build orchestration |
 
@@ -123,7 +123,7 @@ task dev
 ```
 
 Features:
-- Frontend hot reload (React HMR via Vite)
+- Frontend hot reload (Solid Refresh via Vite)
 - Auto-rebuild on Rust changes
 - DevTools available (Ctrl+Shift+I)
 


### PR DESCRIPTION
## Summary
- ARCH-015 (trivial, doc-drift) from the 2026-07-07 architecture-analyst report: `BUILD.md`'s prerequisite table said "Frontend build (React/Vite)" and dev-mode notes said "React HMR via Vite", but the app is SolidJS (`solid-js` dependency, `vite-plugin-solid` for HMR) — already correctly stated in README and CONTRIBUTING. Updated both lines to match.

## Test plan
- [ ] Docs-only change, no build/runtime impact — just a read-through for accuracy

<!-- agentmux:agent_id=agent3 -->