### PR TITLE
fix(browser-pane): macOS click on pane body now selects the pane

### DIFF
--- a/.changesets/1783447818-fix-browser-pane-macos-linux-click-on-pane-body-now-selects--jh4e.md
+++ b/.changesets/1783447818-fix-browser-pane-macos-linux-click-on-pane-body-now-selects--jh4e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): macOS/Linux click on pane body now selects the pane

--- a/.changesets/1783447818-fix-browser-pane-macos-linux-click-on-pane-body-now-selects--jh4e.md
+++ b/.changesets/1783447818-fix-browser-pane-macos-linux-click-on-pane-body-now-selects--jh4e.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-fix(browser-pane): macOS/Linux click on pane body now selects the pane
+fix(browser-pane): macOS click on pane body now selects the pane (Linux still open)

--- a/.changesets/1783448218-fix-window-nudge-macos-hamburger-button-2px-up-for-optical-a-g2fs.md
+++ b/.changesets/1783448218-fix-window-nudge-macos-hamburger-button-2px-up-for-optical-a-g2fs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): nudge macOS hamburger button 2px up for optical alignment

--- a/agentmux-cef/src/ui_tasks/pane_geometry.rs
+++ b/agentmux-cef/src/ui_tasks/pane_geometry.rs
@@ -625,6 +625,26 @@ wrap_task! {
                                         }
                                     }
                                 }
+                                // Register the pane's OWN overlay window (not
+                                // task_main_win above) → block_id, so the
+                                // sendEvent: swizzle's `is_overlay` branch can
+                                // resolve which pane a direct click on its body
+                                // belongs to and emit `browser-pane-clicked`
+                                // (click-to-select — see PANE_OVERLAY_WIN_TO_BLOCK
+                                // doc comment in platform_macos.rs).
+                                if !task_overlay_win.is_null() {
+                                    if let Some(block_id) = self.label
+                                        .strip_prefix("browser-pane-")
+                                        .and_then(|rest| rest.rfind('-').map(|dash| rest[..dash].to_string()))
+                                    {
+                                        if let Ok(mut om) = crate::ui_tasks::PANE_OVERLAY_WIN_TO_BLOCK.try_lock() {
+                                            om.insert(
+                                                task_overlay_win as usize,
+                                                (self.label.clone(), block_id, Arc::downgrade(&self.state)),
+                                            );
+                                        }
+                                    }
+                                }
                                 crate::ui_tasks::PANE_LOCAL_W.store(
                                     task_dip_w, std::sync::atomic::Ordering::SeqCst);
                                 tracing::info!(

--- a/agentmux-cef/src/ui_tasks/platform_macos.rs
+++ b/agentmux-cef/src/ui_tasks/platform_macos.rs
@@ -57,6 +57,25 @@ pub(crate) static ORIG_RWHVC_SHOULD_IGNORE: std::sync::atomic::AtomicUsize =
 #[cfg(target_os = "macos")]
 pub(crate) static PANE_LOCAL_W: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
 
+// Overlay NSWindow* (the pane's OWN window — not the main window key used by
+// PANE_WIN_TO_HOST/PANE_LABEL_TO_WIN above) → (pane label, block_id, weak
+// AppState). Populated alongside those two maps by SetPaneBoundsViewsTask.
+// Read by swizzled_nsapp_send_event's `is_overlay` branch to detect a click
+// landing directly on a pane's rendered body and emit `browser-pane-clicked`
+// — the click-to-select signal every in-DOM pane gets for free via ordinary
+// click bubbling to blockframe.tsx (see block/block.tsx::handleBlockClick),
+// but a browser pane's content is a separate native BrowserView layered on
+// top, so no DOM click ever fires for it. Mirrors the Windows
+// WM_LBUTTONDOWN → browser-pane-clicked path in browser_pane/hwnd.rs; this
+// is the macOS/Linux equivalent (see
+// docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md).
+#[cfg(target_os = "macos")]
+pub(crate) static PANE_OVERLAY_WIN_TO_BLOCK: std::sync::LazyLock<
+    std::sync::Mutex<
+        std::collections::HashMap<usize, (String, String, std::sync::Weak<crate::state::AppState>)>,
+    >,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
 /// Swizzled NSWindow::isMainWindow — returns YES only for the tagged pane overlay.
 /// All other NativeWidgetMacNSWindow instances (pool windows, etc.) call through
 /// to the original implementation and return their real value.
@@ -167,6 +186,12 @@ pub(crate) fn clear_pane_swizzle_statics(pane_label: &str) {
                 MAIN_RWHVC_PTR.store(0, Relaxed);
             }
         }
+    }
+    // PANE_OVERLAY_WIN_TO_BLOCK is keyed by the pane's OWN overlay window
+    // pointer (unrelated to win_ptr/PANE_WIN_TO_HOST above, which key by the
+    // main window) — always independently evict this pane's entry by label.
+    if let Ok(mut m) = PANE_OVERLAY_WIN_TO_BLOCK.try_lock() {
+        m.retain(|_, (label, _, _)| label != pane_label);
     }
 }
 #[cfg(not(target_os = "macos"))]
@@ -346,6 +371,31 @@ pub(crate) extern "C" fn swizzled_nsapp_send_event(
                         }
                         dispatch_fn(rwhvc, sel_m, event);
                         return;
+                    }
+                } else if ev_type == 1 {
+                    // A click landed directly on a pane's own overlay window —
+                    // the pane-body click that (unlike every in-DOM pane) never
+                    // produces a DOM click for blockframe.tsx's selection
+                    // handler to bubble-catch. Tap it here and emit
+                    // `browser-pane-clicked` so the frontend selects/borders
+                    // the pane exactly as the header-click path already does
+                    // (browser-model.ts → refocusNode). This does NOT return —
+                    // dispatch continues via the original sendEvent: call
+                    // below/at function end, unchanged from before this tap
+                    // existed.
+                    let win_usize = win as usize;
+                    let hit = PANE_OVERLAY_WIN_TO_BLOCK
+                        .try_lock()
+                        .ok()
+                        .and_then(|m| m.get(&win_usize).cloned());
+                    if let Some((_, block_id, weak_state)) = hit {
+                        if let Some(state) = weak_state.upgrade() {
+                            crate::events::emit_event_from_state(
+                                &state,
+                                "browser-pane-clicked",
+                                &serde_json::json!({ "block_id": block_id }),
+                            );
+                        }
                     }
                 }
             }

--- a/agentmux-cef/src/ui_tasks/platform_macos.rs
+++ b/agentmux-cef/src/ui_tasks/platform_macos.rs
@@ -67,8 +67,8 @@ pub(crate) static PANE_LOCAL_W: std::sync::atomic::AtomicI32 = std::sync::atomic
 // but a browser pane's content is a separate native BrowserView layered on
 // top, so no DOM click ever fires for it. Mirrors the Windows
 // WM_LBUTTONDOWN → browser-pane-clicked path in browser_pane/hwnd.rs; this
-// is the macOS/Linux equivalent (see
-// docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md).
+// is the macOS equivalent — Linux still has no click-to-select for browser
+// pane bodies, see docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md.
 #[cfg(target_os = "macos")]
 pub(crate) static PANE_OVERLAY_WIN_TO_BLOCK: std::sync::LazyLock<
     std::sync::Mutex<

--- a/docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md
@@ -1,0 +1,79 @@
+# SPEC — Browser pane: clicking the body selects the pane (macOS/Linux)
+
+**Date:** 2026-07-07
+**Type:** Bug fix
+**Status:** Implemented, pending manual click smoke test
+**Scope:** `agentmux-cef` (`ui_tasks/platform_macos.rs`, `ui_tasks/pane_geometry.rs`)
+
+## Problem
+
+Clicking a normal (in-DOM) pane's body selects it — the thin `block-focused`
+border appears — because the click is a real DOM event that bubbles up to
+`blockframe.tsx`'s outer wrapper (`onClick={props.blockModel?.onClick}` →
+`handleBlockClick` in `block/block.tsx` → `nodeModel.focusNode()`).
+
+A **browser pane** doesn't work this way: per
+`docs/specs/SPEC_NATIVE_BROWSER_PANE_2026_04_17.md`, its content is a second,
+sibling `CefBrowserView` layered on top of the main window's DOM via CEF's
+Views `AddOverlayView`, not an iframe. Once a page is loaded, the pixels and
+input for that page belong to a separate native Chromium instance — a click
+there never becomes a DOM `click`/`mousedown` event, so it can't bubble to
+`blockframe.tsx` and the pane never selects. Only clicking the pane's header
+(real DOM) worked.
+
+Windows already has a fix: `agentmux-cef/src/browser_pane/hwnd.rs` subclasses
+the pane's HWND and emits `browser-pane-clicked` (with `block_id`) directly
+from `WM_LBUTTONDOWN`. `agentmux-cef/src/browser_pane/callbacks.rs`'s
+`#[cfg(not(target_os = "windows"))]` branch explicitly notes this subclass
+"doesn't exist" on macOS/Linux — that gap is what this fix closes for macOS.
+
+## Root cause confirmation
+
+Verified directly against the running app's server log and by reading
+`ui_tasks/platform_macos.rs` — no existing code path emitted a select signal
+for a click landing on the overlay's own `NativeWidgetMacNSWindow`.
+
+## Fix
+
+Rather than adding new native hooking machinery, this reuses the
+`swizzled_nsapp_send_event` `-[NSApplication sendEvent:]` swizzle that's
+already installed while any pane is open (originally for keyboard-focus
+routing — see the swizzle's own doc comment). That function already
+classifies every intercepted mouse event by whether its window is the pane's
+own overlay (`is_overlay`) or the main window; the `is_overlay == true` branch
+previously just fell through to the original `sendEvent:` unmodified.
+
+Added:
+
+- `PANE_OVERLAY_WIN_TO_BLOCK` (`platform_macos.rs`): a new static map, keyed
+  by the pane's own overlay `NSWindow*` (distinct from `PANE_WIN_TO_HOST` /
+  `PANE_LABEL_TO_WIN`, which key by the *main* window), storing
+  `(pane label, block_id, Weak<AppState>)`.
+- Populated in `SetPaneBoundsViewsTask::execute` (`pane_geometry.rs`), at the
+  same point `PANE_WIN_TO_HOST`/`PANE_LABEL_TO_WIN` are populated, using the
+  already-resolved `task_overlay_win` pointer and `block_id` parsed from the
+  pane label (same `browser-pane-<uuid>-<seq>` parsing as
+  `callbacks.rs::resolve_pane_block_id`).
+- Cleaned up in `clear_pane_swizzle_statics` by pane label, alongside the
+  existing `PANE_LABEL_TO_WIN` cleanup.
+- In `swizzled_nsapp_send_event`'s `is_overlay` branch: on `ev_type == 1`
+  (leftMouseDown), look up the event's window in `PANE_OVERLAY_WIN_TO_BLOCK`
+  and, if found, emit `browser-pane-clicked` with that `block_id` — the same
+  event Windows emits, consumed unchanged by the existing frontend path
+  (`browser-model.ts` → reducer → `refocusNode` → `layoutModel.focusNode`).
+  This is a non-invasive tap: it does not `return` early, so the event still
+  falls through to the original `sendEvent:` exactly as before this change —
+  only an additional event emission was added.
+
+No frontend changes were needed; the consumer side already existed for the
+Windows path and is provider-agnostic.
+
+## Verification
+
+- `cargo check -p agentmux-cef` passes clean, no new warnings.
+- **Not yet manually click-tested** — this changes core native mouse dispatch
+  for the whole app while any browser pane is open, so it needs a human to
+  actually click a loaded browser pane's body and confirm (a) the pane
+  border/selection now appears, and (b) no regression to normal in-pane
+  interaction (scrolling, form input, right-click context menu, dragging)
+  that the surrounding swizzle logic already handles.

--- a/docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md
+++ b/docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md
@@ -1,9 +1,17 @@
-# SPEC — Browser pane: clicking the body selects the pane (macOS/Linux)
+# SPEC — Browser pane: clicking the body selects the pane (macOS)
 
 **Date:** 2026-07-07
 **Type:** Bug fix
-**Status:** Implemented, pending manual click smoke test
-**Scope:** `agentmux-cef` (`ui_tasks/platform_macos.rs`, `ui_tasks/pane_geometry.rs`)
+**Status:** Implemented for macOS and manually confirmed; Linux still open (see Scope)
+**Scope:** `agentmux-cef` (`ui_tasks/platform_macos.rs`, `ui_tasks/pane_geometry.rs`) —
+macOS only. The new `PANE_OVERLAY_WIN_TO_BLOCK` map, the registration in
+`SetPaneBoundsViewsTask`, and the `sendEvent:` swizzle tap are all
+`#[cfg(target_os = "macos")]`; Linux's branch of `SetPaneBoundsViewsTask`
+(`pane_geometry.rs`, the `#[cfg(not(target_os = "macos"))]` early-return path)
+never reaches this registration code, so **Linux gets no fix from this
+change** — it needs its own native click-detection mechanism (GTK/X11 or
+Wayland have neither an HWND-style subclass nor an AppKit-style `sendEvent:`
+swizzle to reuse), tracked as follow-up work, not implemented here.
 
 ## Problem
 
@@ -25,7 +33,8 @@ Windows already has a fix: `agentmux-cef/src/browser_pane/hwnd.rs` subclasses
 the pane's HWND and emits `browser-pane-clicked` (with `block_id`) directly
 from `WM_LBUTTONDOWN`. `agentmux-cef/src/browser_pane/callbacks.rs`'s
 `#[cfg(not(target_os = "windows"))]` branch explicitly notes this subclass
-"doesn't exist" on macOS/Linux — that gap is what this fix closes for macOS.
+"doesn't exist" on macOS/Linux — that gap is what this fix closes for macOS
+only (Linux remains open, see Scope above).
 
 ## Root cause confirmation
 

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -48,5 +48,8 @@
     &--right {
         margin-left: 4px;
         margin-right: 8px;
+        // 2px optical alignment nudge vs. the other title-bar icons.
+        position: relative;
+        top: -2px;
     }
 }


### PR DESCRIPTION
## Summary
- **macOS only.** Browser panes render as a separate native `CefBrowserView` layered on top of the DOM (`SPEC_NATIVE_BROWSER_PANE_2026_04_17`), not an iframe — so a click on loaded page content never becomes a DOM event and can't bubble to `blockframe.tsx`'s selection handler the way every other pane's body click does. Only clicking the pane header (real DOM) selected it.
- Windows already emits `browser-pane-clicked` from a `WM_LBUTTONDOWN` HWND subclass (`browser_pane/hwnd.rs`); macOS/Linux had no equivalent — `browser_pane/callbacks.rs` explicitly noted the gap. This PR closes it for **macOS only** (all new code is `#[cfg(target_os = "macos")]`) — Linux still has no fix, tracked as follow-up (Linux has neither an HWND-style subclass nor an AppKit `sendEvent:` swizzle to reuse, so it needs its own mechanism).
- Reuses the `-[NSApplication sendEvent:]` swizzle already installed while a pane is open (`ui_tasks/platform_macos.rs`, originally for keyboard-focus routing) and taps its existing `is_overlay` branch: a `leftMouseDown` landing on the pane's own overlay window now resolves the `block_id` via a new `PANE_OVERLAY_WIN_TO_BLOCK` map and emits `browser-pane-clicked`, reusing the same frontend consumer path Windows already has (`browser-model.ts` → reducer → `refocusNode`). No frontend changes needed for this part.
- Non-invasive tap: doesn't intercept dispatch, only adds an emission alongside the existing fallthrough to the original `sendEvent:`.
- See `docs/specs/SPEC_BROWSER_PANE_CLICK_TO_SELECT_2026_07_07.md` for the full writeup.
- Also bundled: a small macOS-only cosmetic fix — nudges the `.hamburger-btn--right` (macOS title-bar hamburger) 2px up for optical alignment with the other title-bar icons (`window/hamburger-menu.scss`).

## Test plan
- [x] `cargo check -p agentmux-cef` passes clean, no new warnings
- [x] Manual smoke test in `task dev`: clicked a loaded browser pane's body — pane now selects/borders correctly, confirmed by the user
- [x] Manual smoke test: hamburger button 2px-up nudge confirmed by the user via hot reload