### PR TITLE
feat(host): SPEC_PILLAR1_STEP4 Phase 1 -- request the launcher's live window snapshot on connect

### DIFF
--- a/.changesets/1783448715-feat-host-spec-pillar1-step4-phase-1-request-the-launcher-s--cfch.md
+++ b/.changesets/1783448715-feat-host-spec-pillar1-step4-phase-1-request-the-launcher-s--cfch.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP4 Phase 1 -- request the launcher's live window snapshot on connect

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -170,6 +170,12 @@ pub async fn connect_to_launcher(
     if COMMAND_TX.set(tx).is_err() {
         tracing::warn!("[launcher-ipc] COMMAND_TX already set — connect_to_launcher called twice");
     }
+    // SPEC_PILLAR1_STEP4 Phase 1 — request the launcher's live window
+    // snapshot on every connect (cold start AND a post-crash respawn look
+    // identical here; see the spec for why no separate "is this a restart"
+    // signal is needed). Phase 1 is observe-only: the reader task logs what
+    // this would drive but doesn't recreate anything yet.
+    request_snapshot();
     let writer_for_drain = Arc::clone(&writer);
     tokio::spawn(async move {
         while let Some(cmd) = rx.recv().await {
@@ -390,6 +396,9 @@ pub async fn connect_to_launcher(
     if COMMAND_TX.set(tx).is_err() {
         tracing::warn!("[launcher-ipc] COMMAND_TX already set — connect_to_launcher called twice");
     }
+    // SPEC_PILLAR1_STEP4 Phase 1 — see the Windows variant's identical call
+    // for the rationale.
+    request_snapshot();
     let writer_for_drain = Arc::clone(&writer);
     tokio::spawn(async move {
         while let Some(cmd) = rx.recv().await {
@@ -664,6 +673,27 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             );
             crate::commands::orphan_reconcile::reconcile_and_drain(state);
         }
+        // SPEC_PILLAR1_STEP4 Phase 1 — observe-only. Logs what a reproject
+        // pass would drive (window count/kind/parent) but doesn't create
+        // anything yet; that's Phase 2. Deliberately returns before the
+        // generic broadcast below: this is a large, host-internal
+        // request/response payload, not a typed delta the frontend's
+        // launcher-event reducer expects — forwarding it would be either
+        // dead weight or a mis-parse, and Phase 1's whole point is zero
+        // externally-visible behavior change.
+        Event::Snapshot { version, windows, .. } => {
+            tracing::info!(
+                target: "reproject",
+                version,
+                window_count = windows.len(),
+                windows = ?windows
+                    .iter()
+                    .map(|w| (w.label.as_str(), w.kind, w.parent_label.as_deref(), w.last_rect))
+                    .collect::<Vec<_>>(),
+                "[reproject] launcher snapshot received"
+            );
+            return;
+        }
         _ => {}
     }
 
@@ -695,6 +725,21 @@ pub fn report_window_opened(
     };
     if let Err(e) = tx.send(cmd) {
         tracing::warn!("[launcher-ipc] report_window_opened: channel closed ({})", e);
+    }
+}
+
+/// SPEC_PILLAR1_STEP4 Phase 1 — request the launcher's live window
+/// snapshot (`Event::Snapshot`, handled in `apply_event_to_shadow` below).
+/// Called once, right after `COMMAND_TX` is published, from both platform
+/// variants of `connect_to_launcher`. No-op if the launcher pipe isn't
+/// connected (`task dev` mode), same semantics as every other `report_*`
+/// helper here.
+fn request_snapshot() {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    if let Err(e) = tx.send(Command::GetSnapshot) {
+        tracing::warn!("[launcher-ipc] request_snapshot: channel closed ({})", e);
     }
 }
 

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -215,11 +215,20 @@ gating a larger piece of work.
 
 ## 3. Phased plan
 
-**Phase 1 — wire the launcher snapshot fetch (fast path), no window recreation yet.** On host
-startup, send `Command::GetSnapshot`, log what it would drive (window count, kinds, parents) but
-don't act yet. Pure plumbing + observability; zero behavior change. Unit-testable on the launcher
-side (`handle_get_snapshot` already has coverage per its doc comment); host-side needs new tests for
-the request/response round trip.
+**Phase 1 — wire the launcher snapshot fetch (fast path), no window recreation yet. ✅ Done,
+live-verified.** `request_snapshot()` sends `Command::GetSnapshot` right after `COMMAND_TX` is
+published in both platform variants of `connect_to_launcher`
+(`agentmux-cef/src/launcher_ipc.rs`); the resulting `Event::Snapshot` is logged (window count,
+label/kind/parent/last_rect per window) and deliberately **not** broadcast to renderers (it's a
+large host-internal payload, not a typed delta the frontend expects — broadcasting it would violate
+Phase 1's zero-behavior-change goal). Live-verified on an isolated instance: opened a subwindow,
+killed the inner host process only (launcher survives), and the respawned host's snapshot request
+came back with `window_count=2`, correctly showing `("main", FullInstance, None, None)` and
+`("window-...", Subwindow, Some("main"), Some(Rect{...}))` — kind, parent, AND `last_rect` all
+correctly reflected from the launcher's live memory, with zero srv query involved. 159 existing unit
+tests unaffected (no test regressions); no new unit tests added for the request/response round trip
+itself since Phase 1's own log line was the live-verification signal — revisit if Phase 2 needs a
+more structured (non-string-log) handoff.
 
 **Phase 2 — per-window recreation from the fast-path snapshot.** Make `open_window_with_kind`
 `pub(crate)`, add the explicit-rect parameter, implement the enumeration + parent-before-child
@@ -293,7 +302,7 @@ session established.
 
 ## 6. Definition of done
 
-1. ⬜ `Command::GetSnapshot` is sent by the host on every launcher connection; the response is parsed
+1. ✅ `Command::GetSnapshot` is sent by the host on every launcher connection; the response is parsed
    and logged (Phase 1).
 2. ⬜ Killing the inner host process only (launcher survives) and confirming a multi-window session
    (including a subwindow) fully reprojects with correct kind/parent/content and approximately


### PR DESCRIPTION
## Summary

Pillar 1 Step 4, Phase 1 -- pure plumbing + observability, zero behavior change. On every launcher connection (cold start and post-crash respawn look identical by design -- no new "is this a restart" signal needed, per the spec), the host now sends `Command::GetSnapshot` right after publishing `COMMAND_TX`. The response (`Event::Snapshot`) is logged (window count, label/kind/parent/last_rect per window) via a new `[reproject]` log target, and deliberately does **not** reach the generic renderer broadcast -- it's a large host-internal payload, not a typed delta the frontend's launcher-event reducer expects.

This wires up `Command::GetSnapshot`/`handle_get_snapshot`, which existed fully built and tested on the launcher side but had **zero call sites in `agentmux-cef`** until now (confirmed via grep during the design spec's research pass -- #2012).

## Test plan (spec's Phase 1 DoD, live on an isolated instance)
- [x] `cargo check -p agentmux-cef` clean, `cargo test -p agentmux-cef` -- 159 passed, no regressions
- [x] Opened a subwindow, killed the **inner host process only** (launcher survives) to trigger the launcher's supervised respawn
- [x] The respawned host's `GetSnapshot` request came back with `window_count=2`, showing `("main", FullInstance, None, None)` and `("window-...", Subwindow, Some("main"), Some(Rect{...}))` -- kind, parent, **and `last_rect`** (which srv never persists) all correctly sourced from the launcher's live memory, zero srv query involved
- [x] Cold-start snapshot correctly empty (`window_count=0`) -- confirms the idempotent-by-construction design

<!-- agentmux:agent_id=agenta -->