### PR TITLE
fix(window): nudge macOS hamburger button 3px up for optical alignment

### DIFF
--- a/.changesets/1783464473-fix-window-nudge-macos-hamburger-button-3px-up-for-optical-a-x37c.md
+++ b/.changesets/1783464473-fix-window-nudge-macos-hamburger-button-3px-up-for-optical-a-x37c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): nudge macOS hamburger button 3px up for optical alignment

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -48,8 +48,8 @@
     &--right {
         margin-left: 4px;
         margin-right: 8px;
-        // 2px optical alignment nudge vs. the other title-bar icons.
+        // 3px optical alignment nudge vs. the other title-bar icons.
         position: relative;
-        top: -2px;
+        top: -3px;
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up to the 2px nudge in #2013 — after more live smoke testing in `task dev`, one more pixel reads better for optical alignment with the other macOS title-bar icons.
- `frontend/app/window/hamburger-menu.scss`: `.hamburger-btn--right { top: -2px }` → `top: -3px`.

## Test plan
- [x] Manual smoke test: confirmed by the user via hot reload in `task dev`