### PR TITLE
Pillar 1 Step 4 Phase 3: slow-path srv reproject fallback

### DIFF
--- a/.changesets/1783470744-feat-host-spec-pillar1-step4-phase-3-slow-path-srv-reproject-3g29.md
+++ b/.changesets/1783470744-feat-host-spec-pillar1-step4-phase-3-slow-path-srv-reproject-3g29.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP4 Phase 3 - slow-path srv reproject fallback

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -390,6 +390,121 @@ pub(crate) fn backend_get_window_opacity(web_endpoint: &str, auth_key: &str, win
     parsed.get("data")?.get("opacity")?.as_f64().map(|o| o as f32)
 }
 
+/// SPEC_PILLAR1_STEP4 Phase 3 — slow-path reproject: read srv's durable
+/// `Client.windowids` (the single source of window identity that survives
+/// even a full process-tree kill, unlike the launcher's in-memory snapshot).
+/// Same raw-TCP/blocking shape as `backend_get_window_opacity` — callers
+/// MUST invoke this off the UI thread (`reproject_from_srv` spawns a
+/// `std::thread`, mirroring `register_backend_window`'s write-through).
+pub(crate) fn backend_get_client_window_ids(web_endpoint: &str, auth_key: &str) -> Option<Vec<String>> {
+    use std::io::Write;
+
+    let addr = parse_web_endpoint(web_endpoint, "backend_get_client_window_ids")?;
+
+    let body = serde_json::json!({
+        "service": "client",
+        "method": "GetClientData",
+        "args": [],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|e| tracing::warn!(error = %e, "[backend_get_client_window_ids] connect failed"))
+        .ok()?;
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| tracing::warn!(error = %e, "[backend_get_client_window_ids] write failed"))
+        .ok()?;
+
+    use std::io::Read;
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok()?;
+
+    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
+    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let ids = parsed.get("data")?.get("windowids")?.as_array()?;
+    Some(
+        ids.iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+    )
+}
+
+/// SPEC_PILLAR1_STEP4 Phase 3 — read one window's persisted `kind` /
+/// `parent_window_id` (Step 3's fields) for the slow-path reproject driver.
+/// Same shape/thread contract as `backend_get_client_window_ids` above.
+pub(crate) fn backend_get_window_topology(
+    web_endpoint: &str,
+    auth_key: &str,
+    window_id: &str,
+) -> Option<(Option<String>, Option<String>)> {
+    use std::io::Write;
+
+    let addr = parse_web_endpoint(web_endpoint, "backend_get_window_topology")?;
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "GetWindow",
+        "args": [window_id],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_topology] connect failed"))
+        .ok()?;
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_topology] write failed"))
+        .ok()?;
+
+    use std::io::Read;
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok()?;
+
+    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
+    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let data = parsed.get("data")?;
+    let kind = data.get("kind").and_then(|v| v.as_str()).map(str::to_string);
+    let parent_window_id = data.get("parent_window_id").and_then(|v| v.as_str()).map(str::to_string);
+    Some((kind, parent_window_id))
+}
+
 /// SPEC_PILLAR1_STEP2 Slice B Phase 4 — write-through a floating pane's
 /// OS-window placement to its block's `meta` map, via the existing generic
 /// `object.UpdateObjectMeta` RPC (Phase E.5.3 — `Command::UpdateBlockMeta`

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -403,12 +403,16 @@ impl AgentMuxHandler {
             // SPEC_PILLAR1_STEP4 Phase 3 — this is also the decision point
             // for fast-vs-slow path: if no fast-path snapshot has arrived by
             // the time "main" registers (no launcher connected, or the
-            // launcher's own snapshot response hasn't landed yet), fall back
-            // to srv's durable `Client.windowids`. `reprojected` (decided
-            // under this SAME lock acquisition) ensures exactly one of
-            // {replay the stash, try the slow path} runs — see that field's
-            // doc comment for why a late-arriving fast-path snapshot must
-            // not double-create on top of an already-run slow path.
+            // launcher's own snapshot response hasn't landed yet), the slow
+            // path should run — but not from here. `reproject_from_srv`
+            // needs "main"'s own confirmed srv `window_id`, which isn't
+            // known yet at this point (native browser creation happens well
+            // before the frontend loads and calls `register_backend_window`
+            // — see `pending_slow_path`'s doc comment for why an earlier
+            // version's `windowids[0]` positional guess was wrong). So this
+            // only sets `pending_slow_path`; `register_backend_window`
+            // (`commands/window/meta.rs`) is what actually triggers it, once
+            // it has that id in hand.
             //
             // A stash existing is NOT the same as the fast path having
             // anything useful: `Event::Snapshot` always stashes SOMETHING
@@ -421,7 +425,6 @@ impl AgentMuxHandler {
             // with `window_count=0`, which a naive `stashed.is_some()` check
             // wrongly treated as "fast path succeeded," permanently
             // suppressing the slow path.
-            let mut try_slow_path = false;
             let stashed = {
                 let mut gate = self.state.ui_thread_gate.lock();
                 gate.ready = true;
@@ -432,8 +435,7 @@ impl AgentMuxHandler {
                 if has_extra {
                     gate.reprojected = true;
                 } else if !gate.reprojected {
-                    gate.reprojected = true;
-                    try_slow_path = true;
+                    gate.pending_slow_path = true;
                 }
                 stashed
             };
@@ -444,13 +446,6 @@ impl AgentMuxHandler {
                     "[reproject] replaying stashed snapshot now that \"main\" has registered"
                 );
                 crate::commands::window::reproject_from_snapshot(&self.state, &windows);
-            }
-            if try_slow_path {
-                tracing::info!(
-                    target: "reproject",
-                    "[reproject] no fast-path data available — falling back to srv (slow path)"
-                );
-                crate::commands::window::reproject_from_srv(&self.state);
             }
         } else if label.starts_with("window-pool-") {
             crate::commands::window_pool::register_pool_window(&self.state, &label);

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -425,21 +425,16 @@ impl AgentMuxHandler {
             // with `window_count=0`, which a naive `stashed.is_some()` check
             // wrongly treated as "fast path succeeded," permanently
             // suppressing the slow path.
-            let stashed = {
+            let (action, stashed) = {
                 let mut gate = self.state.ui_thread_gate.lock();
-                gate.ready = true;
                 let stashed = gate.stashed.take();
                 let has_extra = stashed
                     .as_ref()
                     .is_some_and(|windows| windows.iter().any(|w| w.label != "main"));
-                if has_extra {
-                    gate.reprojected = true;
-                } else if !gate.reprojected {
-                    gate.pending_slow_path = true;
-                }
-                stashed
+                (gate.on_main_ready(has_extra), stashed)
             };
-            if let Some(windows) = stashed {
+            if action == crate::state::MainReadyAction::ReplayFastPath {
+                let windows = stashed.unwrap_or_default();
                 tracing::info!(
                     target: "reproject",
                     window_count = windows.len(),

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -399,10 +399,43 @@ impl AgentMuxHandler {
             // under the SAME lock acquisition the launcher-ipc reader task
             // uses to check-then-stash — this is what closes the TOCTOU
             // reagent's review caught in the first version of this fix.
+            //
+            // SPEC_PILLAR1_STEP4 Phase 3 — this is also the decision point
+            // for fast-vs-slow path: if no fast-path snapshot has arrived by
+            // the time "main" registers (no launcher connected, or the
+            // launcher's own snapshot response hasn't landed yet), fall back
+            // to srv's durable `Client.windowids`. `reprojected` (decided
+            // under this SAME lock acquisition) ensures exactly one of
+            // {replay the stash, try the slow path} runs — see that field's
+            // doc comment for why a late-arriving fast-path snapshot must
+            // not double-create on top of an already-run slow path.
+            //
+            // A stash existing is NOT the same as the fast path having
+            // anything useful: `Event::Snapshot` always stashes SOMETHING
+            // when it arrives before `ready` (even an empty list, or a list
+            // containing only a stale `"main"` entry — the launcher-ipc arm
+            // doesn't pre-filter). `has_extra` is what actually distinguishes
+            // "fast path found real data" from "otherwise" per the spec's
+            // §2.1 step 3-4 — checked live: a fresh launcher (full
+            // process-tree kill) sends a real, non-stale `Event::Snapshot`
+            // with `window_count=0`, which a naive `stashed.is_some()` check
+            // wrongly treated as "fast path succeeded," permanently
+            // suppressing the slow path.
+            let mut try_slow_path = false;
             let stashed = {
                 let mut gate = self.state.ui_thread_gate.lock();
                 gate.ready = true;
-                gate.stashed.take()
+                let stashed = gate.stashed.take();
+                let has_extra = stashed
+                    .as_ref()
+                    .is_some_and(|windows| windows.iter().any(|w| w.label != "main"));
+                if has_extra {
+                    gate.reprojected = true;
+                } else if !gate.reprojected {
+                    gate.reprojected = true;
+                    try_slow_path = true;
+                }
+                stashed
             };
             if let Some(windows) = stashed {
                 tracing::info!(
@@ -411,6 +444,13 @@ impl AgentMuxHandler {
                     "[reproject] replaying stashed snapshot now that \"main\" has registered"
                 );
                 crate::commands::window::reproject_from_snapshot(&self.state, &windows);
+            }
+            if try_slow_path {
+                tracing::info!(
+                    target: "reproject",
+                    "[reproject] no fast-path data available — falling back to srv (slow path)"
+                );
+                crate::commands::window::reproject_from_srv(&self.state);
             }
         } else if label.starts_with("window-pool-") {
             crate::commands::window_pool::register_pool_window(&self.state, &label);

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -74,6 +74,9 @@ pub(crate) use helpers::backend_update_block_meta;
 // SPEC_PILLAR1_STEP3 Phase 2 — window kind/parent-linkage write-through,
 // used by `commands/window/meta.rs::register_backend_window`.
 pub(crate) use helpers::backend_set_window_topology;
+// SPEC_PILLAR1_STEP4 Phase 3 — slow-path reproject reads, used by
+// `commands/window/creation.rs::reproject_from_srv`.
+pub(crate) use helpers::{backend_get_client_window_ids, backend_get_window_topology};
 pub(crate) use lifecycle::{
     retry_backend_window_id_lookup, BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
     BACKEND_WINDOW_ID_RETRY_DELAY,

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -552,18 +552,25 @@ pub(crate) fn reproject_from_snapshot(
 }
 
 /// SPEC_PILLAR1_STEP4 Phase 3 — the slow-path reproject driver. Called once
-/// per process life from `client::lifecycle`'s `"main"` registration branch,
-/// only when no fast-path (launcher-snapshot) data was available by that
-/// point — e.g. a full process-tree kill (launcher died too, so it has no
-/// in-memory history either) or `task dev` standalone mode (no launcher at
-/// all). Reads srv's durable `Client.windowids` + each window's `kind`/
+/// per process life from `commands/window/meta.rs::register_backend_window`'s
+/// `"main"` branch, only when no fast-path (launcher-snapshot) data was
+/// available — e.g. a full process-tree kill (launcher died too, so it has
+/// no in-memory history either) or `task dev` standalone mode (no launcher
+/// at all). Reads srv's durable `Client.windowids` + each window's `kind`/
 /// `parent_window_id` (SPEC_PILLAR1_STEP3) instead.
 ///
-/// `windowids[0]` is skipped deliberately, not arbitrarily: it's the same
-/// entry the frontend's own per-window bootstrap (`frontend/app-init.ts`)
-/// already reads to resolve `"main"`'s own content, so recreating it here
-/// would double-create a second root window. Every remaining id becomes an
-/// extra top-level window.
+/// `main_window_id` is `"main"`'s own confirmed srv `window_id`, passed in
+/// by the caller — NOT derived positionally from `Client.windowids[0]`.
+/// reagent (P0, PR #2017, 2026-07-08) caught that the earlier design did
+/// exactly that, on the assumption index 0 was reliably `"main"`; it isn't —
+/// `focus_window` (`agentmux-srv/.../wcore/window.rs:164`) reorders
+/// `Client.windowids` to put the last-focused window at index 0 on every
+/// focus change, so index 0 is "whichever window the user looked at last,"
+/// not a stable identity. Filtering `main_window_id` out BY VALUE (wherever
+/// it appears in the list, or not at all) is correct regardless of
+/// reordering; the caller has it with certainty because this only runs from
+/// `register_backend_window`'s own `"main"` branch, i.e. after `"main"`
+/// itself resolved and confirmed that id.
 ///
 /// No `last_rect` is available this way — Step 2/3 never persisted window
 /// position/size (see the spec's §4 risk) — so every recreated window lands
@@ -573,17 +580,16 @@ pub(crate) fn reproject_from_snapshot(
 /// Does its network I/O on a spawned thread, never the calling (UI) thread —
 /// `backend_get_client_window_ids`/`backend_get_window_topology` are
 /// blocking calls (same raw-TCP shape as every other `backend_*` read/write
-/// helper in this codebase), and this is called directly from
-/// `on_after_created`. By the time this runs, `ui_thread_gate.ready` is
-/// already true (this IS "main"'s registration), so `open_window_with_kind`
-/// posting from this background thread is safe — the same
-/// already-verified-safe pattern as any pool-window creation posted after
-/// `"main"` registers.
+/// helper in this codebase). By the time this runs, `ui_thread_gate.ready`
+/// is already true (this fires well after "main"'s own registration), so
+/// `open_window_with_kind` posting from this background thread is safe —
+/// the same already-verified-safe pattern as any pool-window creation
+/// posted after `"main"` registers.
 ///
 /// Converges on the exact same per-window recreation code
 /// (`reproject_from_snapshot`) the fast path uses, per the parent design
 /// doc's "both tiers converge on the same per-window recreation code path."
-pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
+pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) {
     let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
     let auth_key = state.auth_key.lock().clone();
     let state = state.clone();
@@ -592,7 +598,16 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
             tracing::warn!(target: "reproject", "[reproject] slow path: could not read Client.windowids from srv");
             return;
         };
-        if window_ids.len() <= 1 {
+
+        // reagent P1 (PR #2017) — `reproject_from_snapshot`'s `label_remap` is
+        // seeded only with the string `"main"` → `"main"` (the host's own
+        // stable label for it), not srv's UUID for it. A subwindow whose
+        // persisted `parent_window_id` equals `main_window_id` must be
+        // translated to the `"main"` sentinel here — otherwise the remap
+        // lookup finds nothing and the subwindow is silently skipped as if
+        // its parent were missing.
+        let extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
+        if extra_ids.is_empty() {
             tracing::debug!(
                 target: "reproject",
                 window_count = window_ids.len(),
@@ -601,16 +616,8 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
             return;
         }
 
-        // reagent P1 (PR #2017) — `reproject_from_snapshot`'s `label_remap` is
-        // seeded only with the string `"main"` → `"main"` (the host's own
-        // stable label for it), not srv's UUID for it. A subwindow whose
-        // persisted `parent_window_id` equals `windowids[0]` (main's srv
-        // window_id) must be translated to the `"main"` sentinel here —
-        // otherwise the remap lookup finds nothing and the subwindow is
-        // silently skipped as if its parent were missing.
-        let main_srv_id = &window_ids[0];
         let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
-        for window_id in window_ids.iter().skip(1) {
+        for window_id in extra_ids {
             let Some((kind, parent_window_id)) = crate::client::backend_get_window_topology(&web_endpoint, &auth_key, window_id) else {
                 tracing::warn!(target: "reproject", window_id = %window_id, "[reproject] slow path: GetWindow failed — skipping this window");
                 continue;
@@ -628,7 +635,7 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
                 }
             };
             let parent_label = parent_window_id.map(|pid| {
-                if &pid == main_srv_id {
+                if pid == main_window_id {
                     "main".to_string()
                 } else {
                     pid

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -601,6 +601,14 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
             return;
         }
 
+        // reagent P1 (PR #2017) — `reproject_from_snapshot`'s `label_remap` is
+        // seeded only with the string `"main"` → `"main"` (the host's own
+        // stable label for it), not srv's UUID for it. A subwindow whose
+        // persisted `parent_window_id` equals `windowids[0]` (main's srv
+        // window_id) must be translated to the `"main"` sentinel here —
+        // otherwise the remap lookup finds nothing and the subwindow is
+        // silently skipped as if its parent were missing.
+        let main_srv_id = &window_ids[0];
         let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
         for window_id in window_ids.iter().skip(1) {
             let Some((kind, parent_window_id)) = crate::client::backend_get_window_topology(&web_endpoint, &auth_key, window_id) else {
@@ -619,10 +627,17 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
                     agentmux_common::ipc::WindowKind::FullInstance
                 }
             };
+            let parent_label = parent_window_id.map(|pid| {
+                if &pid == main_srv_id {
+                    "main".to_string()
+                } else {
+                    pid
+                }
+            });
             snapshots.push(agentmux_common::ipc::WindowSnapshot {
                 label: window_id.clone(),
                 kind,
-                parent_label: parent_window_id,
+                parent_label,
                 hwnd: None,
                 visible: true,
                 iconic: false,

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -551,6 +551,94 @@ pub(crate) fn reproject_from_snapshot(
     );
 }
 
+/// SPEC_PILLAR1_STEP4 Phase 3 — the slow-path reproject driver. Called once
+/// per process life from `client::lifecycle`'s `"main"` registration branch,
+/// only when no fast-path (launcher-snapshot) data was available by that
+/// point — e.g. a full process-tree kill (launcher died too, so it has no
+/// in-memory history either) or `task dev` standalone mode (no launcher at
+/// all). Reads srv's durable `Client.windowids` + each window's `kind`/
+/// `parent_window_id` (SPEC_PILLAR1_STEP3) instead.
+///
+/// `windowids[0]` is skipped deliberately, not arbitrarily: it's the same
+/// entry the frontend's own per-window bootstrap (`frontend/app-init.ts`)
+/// already reads to resolve `"main"`'s own content, so recreating it here
+/// would double-create a second root window. Every remaining id becomes an
+/// extra top-level window.
+///
+/// No `last_rect` is available this way — Step 2/3 never persisted window
+/// position/size (see the spec's §4 risk) — so every recreated window lands
+/// at `open_window_with_kind`'s default offset placement, not where the
+/// user left it. Kind/parent/content are still fully correct.
+///
+/// Does its network I/O on a spawned thread, never the calling (UI) thread —
+/// `backend_get_client_window_ids`/`backend_get_window_topology` are
+/// blocking calls (same raw-TCP shape as every other `backend_*` read/write
+/// helper in this codebase), and this is called directly from
+/// `on_after_created`. By the time this runs, `ui_thread_gate.ready` is
+/// already true (this IS "main"'s registration), so `open_window_with_kind`
+/// posting from this background thread is safe — the same
+/// already-verified-safe pattern as any pool-window creation posted after
+/// `"main"` registers.
+///
+/// Converges on the exact same per-window recreation code
+/// (`reproject_from_snapshot`) the fast path uses, per the parent design
+/// doc's "both tiers converge on the same per-window recreation code path."
+pub(crate) fn reproject_from_srv(state: &Arc<AppState>) {
+    let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+    let auth_key = state.auth_key.lock().clone();
+    let state = state.clone();
+    std::thread::spawn(move || {
+        let Some(window_ids) = crate::client::backend_get_client_window_ids(&web_endpoint, &auth_key) else {
+            tracing::warn!(target: "reproject", "[reproject] slow path: could not read Client.windowids from srv");
+            return;
+        };
+        if window_ids.len() <= 1 {
+            tracing::debug!(
+                target: "reproject",
+                window_count = window_ids.len(),
+                "[reproject] slow path: nothing beyond main to recreate"
+            );
+            return;
+        }
+
+        let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
+        for window_id in window_ids.iter().skip(1) {
+            let Some((kind, parent_window_id)) = crate::client::backend_get_window_topology(&web_endpoint, &auth_key, window_id) else {
+                tracing::warn!(target: "reproject", window_id = %window_id, "[reproject] slow path: GetWindow failed — skipping this window");
+                continue;
+            };
+            let kind = match kind.as_deref() {
+                Some("subwindow") => agentmux_common::ipc::WindowKind::Subwindow,
+                Some("full_instance") => agentmux_common::ipc::WindowKind::FullInstance,
+                Some(other) => {
+                    tracing::warn!(target: "reproject", window_id = %window_id, kind = %other, "[reproject] slow path: unrecognized persisted kind — defaulting to FullInstance");
+                    agentmux_common::ipc::WindowKind::FullInstance
+                }
+                None => {
+                    tracing::warn!(target: "reproject", window_id = %window_id, "[reproject] slow path: no persisted kind (pre-Step-3 window row?) — defaulting to FullInstance");
+                    agentmux_common::ipc::WindowKind::FullInstance
+                }
+            };
+            snapshots.push(agentmux_common::ipc::WindowSnapshot {
+                label: window_id.clone(),
+                kind,
+                parent_label: parent_window_id,
+                hwnd: None,
+                visible: true,
+                iconic: false,
+                last_rect: None,
+                foregrounded_since_open: true,
+            });
+        }
+        tracing::info!(
+            target: "reproject",
+            window_count = snapshots.len(),
+            "[reproject] slow path: recreating windows from srv"
+        );
+        reproject_from_snapshot(&state, &snapshots);
+    });
+}
+
 fn percent_encode(s: &str) -> String {
     let mut out = String::with_capacity(s.len() * 3 / 2);
     for byte in s.bytes() {

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -269,6 +269,40 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
                 "[window-topology] no WindowMeta for label — skipping topology write-through (e.g. pool/browser-pane label)"
             );
         }
+
+        // SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P0, PR #2017,
+        // 2026-07-08) — this is the trigger point for the slow-path
+        // reproject, not "main"'s native browser registration
+        // (`on_after_created`). `reproject_from_srv` needs "main"'s own
+        // confirmed srv `window_id` to know which `Client.windowids` entry
+        // to exclude/treat as the parent-linkage sentinel — that's exactly
+        // this call's `window_id` argument, known with certainty here
+        // (unlike the original design's `windowids[0]` positional guess,
+        // which reagent correctly flagged as broken by `focus_window`
+        // reordering — see `ui_thread_gate.pending_slow_path`'s doc
+        // comment). Check-and-clear under the gate's lock so this and a
+        // late-arriving fast-path snapshot (`launcher_ipc.rs`'s
+        // `Event::Snapshot` arm) can't both fire.
+        if label == "main" {
+            let should_run_slow_path = {
+                let mut gate = state.ui_thread_gate.lock();
+                if gate.pending_slow_path && !gate.reprojected {
+                    gate.pending_slow_path = false;
+                    gate.reprojected = true;
+                    true
+                } else {
+                    false
+                }
+            };
+            if should_run_slow_path {
+                tracing::info!(
+                    target: "reproject",
+                    main_window_id = %window_id,
+                    "[reproject] \"main\"'s own backend window ID is now known — running the slow path"
+                );
+                crate::commands::window::reproject_from_srv(state, window_id.to_string());
+            }
+        }
     } else {
         tracing::warn!(label = %label, "[window] register_backend_window called with empty window_id — skipped");
     }

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -284,16 +284,7 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
         // late-arriving fast-path snapshot (`launcher_ipc.rs`'s
         // `Event::Snapshot` arm) can't both fire.
         if label == "main" {
-            let should_run_slow_path = {
-                let mut gate = state.ui_thread_gate.lock();
-                if gate.pending_slow_path && !gate.reprojected {
-                    gate.pending_slow_path = false;
-                    gate.reprojected = true;
-                    true
-                } else {
-                    false
-                }
-            };
+            let should_run_slow_path = state.ui_thread_gate.lock().on_main_backend_window_registered();
             if should_run_slow_path {
                 tracing::info!(
                     target: "reproject",

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -707,21 +707,36 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // that field's doc comment for the TOCTOU this closes.
             let mut gate = state.ui_thread_gate.lock();
             if gate.ready {
-                // SPEC_PILLAR1_STEP4 Phase 3 — reagent P2 (PR #2017,
-                // 2026-07-08): `gate.ready` only ever becomes true inside
-                // `client/lifecycle.rs`'s `"main"` registration block, which
-                // — under this SAME lock — always sets `gate.reprojected =
-                // true` too (both its branches do, whether it replayed a
-                // stash or fell back to the slow path). So any snapshot
-                // observed here with `ready == true` is, by construction, a
-                // late arrival after that decision already ran; there is no
-                // `ready && !reprojected` state to branch on, so this is a
-                // plain skip, not a conditional.
+                if gate.reprojected {
+                    // Fast path already ran (this is a genuine dupe/late
+                    // arrival), or the slow path already fired from
+                    // `register_backend_window`. Either way, something
+                    // already created the windows — skip.
+                    drop(gate);
+                    tracing::info!(
+                        target: "reproject",
+                        "[reproject] snapshot arrived after reproject already ran — skipping"
+                    );
+                    return;
+                }
+                // SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P0, PR #2017,
+                // 2026-07-08) — `ready == true && !reprojected` means
+                // `"main"` registered with nothing useful to replay and set
+                // `pending_slow_path`, which is still waiting on
+                // `register_backend_window` to fire. A real fast-path
+                // snapshot arriving in that window is strictly better data
+                // (has `last_rect`, no srv round-trip) than the slow path
+                // would produce, so it wins: cancel the pending slow path
+                // and use this instead.
+                gate.reprojected = true;
+                gate.pending_slow_path = false;
                 drop(gate);
                 tracing::info!(
                     target: "reproject",
-                    "[reproject] snapshot arrived after \"main\" already decided fast-vs-slow path — skipping"
+                    window_count = windows.len(),
+                    "[reproject] fast-path snapshot arrived while slow path was pending — using it instead"
                 );
+                crate::commands::window::reproject_from_snapshot(state, windows);
                 return;
             } else {
                 tracing::info!(

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -702,48 +702,39 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // bookkeeping call still succeeds. Stash and let `"main"`'s own
             // registration (proof the UI thread is alive) drain and replay.
             //
-            // The check and the stash happen under ONE lock acquisition
+            // The decision and the stash happen under ONE lock acquisition
             // (`ui_thread_gate`), not a load-then-separate-lock pair — see
-            // that field's doc comment for the TOCTOU this closes.
-            let mut gate = state.ui_thread_gate.lock();
-            if gate.ready {
-                if gate.reprojected {
-                    // Fast path already ran (this is a genuine dupe/late
-                    // arrival), or the slow path already fired from
-                    // `register_backend_window`. Either way, something
-                    // already created the windows — skip.
-                    drop(gate);
+            // `UiThreadGate::on_snapshot`'s doc comment for the TOCTOU this
+            // closes, and for what each outcome means.
+            let action = {
+                let mut gate = state.ui_thread_gate.lock();
+                let action = gate.on_snapshot();
+                if action == crate::state::SnapshotAction::Stash {
+                    gate.stashed = Some(windows.clone());
+                }
+                action
+            };
+            match action {
+                crate::state::SnapshotAction::Stash => {
+                    tracing::info!(
+                        target: "reproject",
+                        "[reproject] UI thread not ready yet — stashing snapshot for replay after \"main\" registers"
+                    );
+                }
+                crate::state::SnapshotAction::RunFastPath => {
+                    tracing::info!(
+                        target: "reproject",
+                        window_count = windows.len(),
+                        "[reproject] fast-path snapshot arrived while slow path was pending — using it instead"
+                    );
+                    crate::commands::window::reproject_from_snapshot(state, windows);
+                }
+                crate::state::SnapshotAction::Skip => {
                     tracing::info!(
                         target: "reproject",
                         "[reproject] snapshot arrived after reproject already ran — skipping"
                     );
-                    return;
                 }
-                // SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P0, PR #2017,
-                // 2026-07-08) — `ready == true && !reprojected` means
-                // `"main"` registered with nothing useful to replay and set
-                // `pending_slow_path`, which is still waiting on
-                // `register_backend_window` to fire. A real fast-path
-                // snapshot arriving in that window is strictly better data
-                // (has `last_rect`, no srv round-trip) than the slow path
-                // would produce, so it wins: cancel the pending slow path
-                // and use this instead.
-                gate.reprojected = true;
-                gate.pending_slow_path = false;
-                drop(gate);
-                tracing::info!(
-                    target: "reproject",
-                    window_count = windows.len(),
-                    "[reproject] fast-path snapshot arrived while slow path was pending — using it instead"
-                );
-                crate::commands::window::reproject_from_snapshot(state, windows);
-                return;
-            } else {
-                tracing::info!(
-                    target: "reproject",
-                    "[reproject] UI thread not ready yet — stashing snapshot for replay after \"main\" registers"
-                );
-                gate.stashed = Some(windows.clone());
             }
             return;
         }

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -707,22 +707,22 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // that field's doc comment for the TOCTOU this closes.
             let mut gate = state.ui_thread_gate.lock();
             if gate.ready {
-                // SPEC_PILLAR1_STEP4 Phase 3 — `"main"`'s registration may
-                // have already given up waiting for this snapshot and
-                // fallen back to the slow (srv) path. `reprojected` ensures
-                // whichever path runs first is the only one that actually
-                // creates windows.
-                if gate.reprojected {
-                    drop(gate);
-                    tracing::info!(
-                        target: "reproject",
-                        "[reproject] snapshot arrived after the slow path already ran — skipping fast-path reproject"
-                    );
-                    return;
-                }
-                gate.reprojected = true;
+                // SPEC_PILLAR1_STEP4 Phase 3 — reagent P2 (PR #2017,
+                // 2026-07-08): `gate.ready` only ever becomes true inside
+                // `client/lifecycle.rs`'s `"main"` registration block, which
+                // — under this SAME lock — always sets `gate.reprojected =
+                // true` too (both its branches do, whether it replayed a
+                // stash or fell back to the slow path). So any snapshot
+                // observed here with `ready == true` is, by construction, a
+                // late arrival after that decision already ran; there is no
+                // `ready && !reprojected` state to branch on, so this is a
+                // plain skip, not a conditional.
                 drop(gate);
-                crate::commands::window::reproject_from_snapshot(state, windows);
+                tracing::info!(
+                    target: "reproject",
+                    "[reproject] snapshot arrived after \"main\" already decided fast-vs-slow path — skipping"
+                );
+                return;
             } else {
                 tracing::info!(
                     target: "reproject",

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -707,6 +707,20 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // that field's doc comment for the TOCTOU this closes.
             let mut gate = state.ui_thread_gate.lock();
             if gate.ready {
+                // SPEC_PILLAR1_STEP4 Phase 3 — `"main"`'s registration may
+                // have already given up waiting for this snapshot and
+                // fallen back to the slow (srv) path. `reprojected` ensures
+                // whichever path runs first is the only one that actually
+                // creates windows.
+                if gate.reprojected {
+                    drop(gate);
+                    tracing::info!(
+                        target: "reproject",
+                        "[reproject] snapshot arrived after the slow path already ran — skipping fast-path reproject"
+                    );
+                    return;
+                }
+                gate.reprojected = true;
                 drop(gate);
                 crate::commands::window::reproject_from_snapshot(state, windows);
             } else {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -907,6 +907,13 @@ pub struct AppState {
 pub struct UiThreadGate {
     pub ready: bool,
     pub stashed: Option<Vec<agentmux_common::ipc::WindowSnapshot>>,
+    /// SPEC_PILLAR1_STEP4 Phase 3 — set true the moment EITHER reproject
+    /// path (fast, from the launcher's snapshot; or slow, from srv) has
+    /// been triggered, so only one of them ever actually creates windows.
+    /// Without this, a fast-path snapshot arriving unusually late (after
+    /// `"main"`'s registration already decided to fall back to the slow
+    /// path) would run a second, redundant reproject on top of the first.
+    pub reprojected: bool,
 }
 
 impl Default for AppState {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -932,6 +932,186 @@ pub struct UiThreadGate {
     pub pending_slow_path: bool,
 }
 
+/// What the caller of `UiThreadGate::on_main_ready` should do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MainReadyAction {
+    /// A real fast-path snapshot was stashed — replay it now.
+    ReplayFastPath,
+    /// Nothing useful was stashed — the caller should await the slow path
+    /// (triggered later, elsewhere, once `"main"`'s srv id is known).
+    AwaitSlowPath,
+    /// Something already reprojected (shouldn't normally happen — `"main"`
+    /// only registers once — kept as a defensive no-op, not a panic).
+    Noop,
+}
+
+/// What the caller of `UiThreadGate::on_snapshot` should do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotAction {
+    /// UI thread isn't ready yet — stash the snapshot for later replay.
+    Stash,
+    /// Run the fast path now with this snapshot's data.
+    RunFastPath,
+    /// Something already reprojected — ignore this snapshot.
+    Skip,
+}
+
+impl UiThreadGate {
+    /// SPEC_PILLAR1_STEP4 Phase 3 — reagent P2 (PR #2017, 2026-07-08): this
+    /// state machine has had three real bugs found across three review
+    /// rounds (a TOCTOU, a "stash exists" vs "stash has data" conflation,
+    /// and a positional-vs-value identity bug), each only caught by manual
+    /// live-kill verification. Extracted into pure, directly unit-testable
+    /// methods so future edits have more than that to lean on. Callers
+    /// (`client/lifecycle.rs`, `launcher_ipc.rs`, `commands/window/meta.rs`)
+    /// still own all I/O (taking the stash's data, actually calling
+    /// `reproject_from_snapshot`/`reproject_from_srv`) — these methods only
+    /// decide, they never act.
+    ///
+    /// Called once, when `"main"` registers. `has_extra` = does the
+    /// (already-taken) stash contain anything beyond `"main"` itself? A
+    /// stash existing is NOT the same as it having anything useful — see
+    /// the call site for why that distinction mattered.
+    pub fn on_main_ready(&mut self, has_extra: bool) -> MainReadyAction {
+        self.ready = true;
+        if has_extra {
+            self.reprojected = true;
+            MainReadyAction::ReplayFastPath
+        } else if !self.reprojected {
+            self.pending_slow_path = true;
+            MainReadyAction::AwaitSlowPath
+        } else {
+            MainReadyAction::Noop
+        }
+    }
+
+    /// Called whenever an `Event::Snapshot` arrives from the launcher.
+    pub fn on_snapshot(&mut self) -> SnapshotAction {
+        if !self.ready {
+            SnapshotAction::Stash
+        } else if self.reprojected {
+            SnapshotAction::Skip
+        } else {
+            // ready && !reprojected: a slow path is pending but hasn't
+            // fired yet. Real fast-path data is strictly better (has
+            // `last_rect`, no srv round-trip) — it wins the race.
+            self.reprojected = true;
+            self.pending_slow_path = false;
+            SnapshotAction::RunFastPath
+        }
+    }
+
+    /// Called from `register_backend_window`'s `"main"` branch, once
+    /// `"main"`'s own confirmed srv `window_id` is known. Returns whether
+    /// the caller should now run the slow path.
+    pub fn on_main_backend_window_registered(&mut self) -> bool {
+        if self.pending_slow_path && !self.reprojected {
+            self.pending_slow_path = false;
+            self.reprojected = true;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod ui_thread_gate_tests {
+    use super::*;
+
+    #[test]
+    fn main_ready_with_extra_replays_fast_path_and_sets_reprojected() {
+        let mut gate = UiThreadGate::default();
+        let action = gate.on_main_ready(true);
+        assert_eq!(action, MainReadyAction::ReplayFastPath);
+        assert!(gate.ready);
+        assert!(gate.reprojected);
+        assert!(!gate.pending_slow_path);
+    }
+
+    #[test]
+    fn main_ready_without_extra_awaits_slow_path() {
+        let mut gate = UiThreadGate::default();
+        let action = gate.on_main_ready(false);
+        assert_eq!(action, MainReadyAction::AwaitSlowPath);
+        assert!(gate.ready);
+        assert!(!gate.reprojected);
+        assert!(gate.pending_slow_path);
+    }
+
+    #[test]
+    fn main_ready_is_noop_if_already_reprojected() {
+        // Defensive case — shouldn't happen in practice ("main" registers
+        // once) but must not double-trigger if it somehow did.
+        let mut gate = UiThreadGate::default();
+        gate.reprojected = true;
+        let action = gate.on_main_ready(false);
+        assert_eq!(action, MainReadyAction::Noop);
+        assert!(!gate.pending_slow_path);
+    }
+
+    #[test]
+    fn snapshot_before_ready_stashes() {
+        let mut gate = UiThreadGate::default();
+        assert_eq!(gate.on_snapshot(), SnapshotAction::Stash);
+        assert!(!gate.reprojected);
+    }
+
+    #[test]
+    fn snapshot_after_ready_with_pending_slow_path_wins_and_cancels_it() {
+        let mut gate = UiThreadGate::default();
+        gate.on_main_ready(false); // ready=true, pending_slow_path=true
+        assert!(gate.pending_slow_path);
+        let action = gate.on_snapshot();
+        assert_eq!(action, SnapshotAction::RunFastPath);
+        assert!(gate.reprojected);
+        assert!(!gate.pending_slow_path);
+    }
+
+    #[test]
+    fn snapshot_after_reprojected_is_skipped() {
+        let mut gate = UiThreadGate::default();
+        gate.on_main_ready(true); // reprojected=true immediately
+        let action = gate.on_snapshot();
+        assert_eq!(action, SnapshotAction::Skip);
+    }
+
+    #[test]
+    fn slow_path_runs_when_pending_and_not_yet_reprojected() {
+        let mut gate = UiThreadGate::default();
+        gate.on_main_ready(false); // pending_slow_path=true
+        assert!(gate.on_main_backend_window_registered());
+        assert!(gate.reprojected);
+        assert!(!gate.pending_slow_path);
+    }
+
+    #[test]
+    fn slow_path_does_not_run_twice() {
+        let mut gate = UiThreadGate::default();
+        gate.on_main_ready(false);
+        assert!(gate.on_main_backend_window_registered());
+        // Second call (e.g. a duplicate register_backend_window) must not
+        // re-trigger the slow path.
+        assert!(!gate.on_main_backend_window_registered());
+    }
+
+    #[test]
+    fn slow_path_does_not_run_if_fast_path_already_won() {
+        let mut gate = UiThreadGate::default();
+        gate.on_main_ready(false); // pending_slow_path=true
+        gate.on_snapshot(); // fast path wins, cancels pending_slow_path
+        assert!(!gate.on_main_backend_window_registered());
+    }
+
+    #[test]
+    fn slow_path_does_not_run_if_never_pending() {
+        // Fast path had data from the start — pending_slow_path was never set.
+        let mut gate = UiThreadGate::default();
+        gate.on_main_ready(true);
+        assert!(!gate.on_main_backend_window_registered());
+    }
+}
+
 impl Default for AppState {
     fn default() -> Self {
         Self {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -909,11 +909,27 @@ pub struct UiThreadGate {
     pub stashed: Option<Vec<agentmux_common::ipc::WindowSnapshot>>,
     /// SPEC_PILLAR1_STEP4 Phase 3 — set true the moment EITHER reproject
     /// path (fast, from the launcher's snapshot; or slow, from srv) has
-    /// been triggered, so only one of them ever actually creates windows.
-    /// Without this, a fast-path snapshot arriving unusually late (after
-    /// `"main"`'s registration already decided to fall back to the slow
-    /// path) would run a second, redundant reproject on top of the first.
+    /// actually been triggered, so only one of them ever creates windows.
+    /// Without this, a fast-path snapshot arriving late (after the slow
+    /// path already ran, or vice versa) would run a second, redundant
+    /// reproject on top of the first.
     pub reprojected: bool,
+    /// SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P0, PR #2017,
+    /// 2026-07-08) — set true by `"main"`'s registration when no fast-path
+    /// stash was available, meaning the slow path SHOULD run but can't yet:
+    /// `reproject_from_srv` needs `"main"`'s own confirmed srv `window_id`
+    /// to know which entry in `Client.windowids` to exclude/treat as the
+    /// parent-linkage sentinel, and that isn't known until `"main"`'s own
+    /// `register_backend_window` call lands (well after native browser
+    /// creation — the frontend has to load and bootstrap first). The
+    /// original design used `windowids[0]` as a stand-in, positionally —
+    /// reagent caught that `windowids` gets reordered by `focus_window`
+    /// (`agentmux-srv/.../wcore/window.rs:164`) to put the last-focused
+    /// window at index 0, which is not reliably `"main"`. Consumed (cleared)
+    /// by whichever of {`register_backend_window`'s `"main"` branch, a
+    /// late-arriving real fast-path snapshot} runs first — see both call
+    /// sites' comments for why exactly one of them wins.
+    pub pending_slow_path: bool,
 }
 
 impl Default for AppState {

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -319,6 +319,33 @@ through a full process-tree kill + fresh relaunch: the reproject log now shows
 `kind=Subwindow parent_label=Some("main")` and `skipped=0`, and the subwindow appears as a real CDP
 target with a valid `windowId`.
 
+**Addendum 2026-07-08, round 2 (reagent review, PR #2017) — `windowids[0]` is not a stable "main"
+identity.** reagent's third pass found a deeper problem than a translation bug: `Client.windowids`
+gets reordered by `focus_window` (`agentmux-srv/.../wcore/window.rs:164`) to put the *last-focused*
+window at index 0 on every focus change — it's "whichever window the user looked at last," not a
+persistent identity for `"main"`. The prior fix (translate `windowids[0]`'s UUID to `"main"`) was
+therefore built on a false premise: whenever the last-focused window before a crash wasn't the
+original main (the common case with 2+ windows open), the slow path would skip the wrong entry,
+spuriously duplicate main as an extra top-level window, and mistranslate parent-label lookups.
+
+Redesigned rather than patched: `reproject_from_srv` no longer guesses main's srv identity
+positionally. It's now called from `commands/window/meta.rs::register_backend_window`'s `"main"`
+branch instead of `on_after_created` — the point where `"main"`'s own confirmed `window_id` is known
+with certainty (the frontend has already resolved and possibly created it via its own bootstrap,
+`frontend/app-init.ts`'s `initHostWave`). That confirmed id is filtered out of `Client.windowids` **by
+value**, not position, so reordering can't matter. `UiThreadGate` gained `pending_slow_path: bool`:
+`"main"`'s registration (`on_after_created`, still the earliest point) sets it when no fast-path stash
+has anything useful, `register_backend_window` consumes it once `"main"`'s id is known, and a
+late-arriving real fast-path snapshot (checked in `launcher_ipc.rs`'s `Event::Snapshot` arm) can still
+win the race and cancel the pending slow path — richer data preferred whenever available, regardless
+of which side resolves first.
+
+Re-verified live end-to-end with the same subwindow-of-main scenario: the reproject log now shows the
+slow path triggering from `register_backend_window` (well after `"main"`'s native registration, using
+its actual confirmed `window_id`), the subwindow still recreates correctly
+(`kind=Subwindow parent_label=Some("main")`, `skipped=0`), and — critically — the CDP target list shows
+exactly one main-like window (`"Starter workspace"`), confirming no spurious duplicate.
+
 **Phase 4 — overlay UX** (§2.4), as a follow-on, not gating Phases 1-3.
 
 **Phase 5 — E2E test** ("host OOM ⇒ session reprojects", per the parent design doc's §3 acceptance

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -305,6 +305,20 @@ opened plus 2 pre-existing pool-warm windows that had also registered backend wi
 gracefully defaulting 2 legacy rows with no persisted `kind` to `FullInstance` with a warning, rather
 than failing. All 4 appeared as real, correctly-labeled CDP targets.
 
+**Addendum 2026-07-08 (reagent review, PR #2017) — main-parented subwindows were silently skipped.**
+reagent caught a second real bug: `reproject_from_snapshot`'s `label_remap` is seeded only with the
+string `"main"` → `"main"` (the host's own stable label), not srv's UUID for it. `reproject_from_srv`
+built each snapshot's `parent_label` directly from srv's raw `parent_window_id`, so a subwindow
+parented to main carried `windowids[0]`'s literal UUID as its parent — a key the remap table never
+had, so the lookup failed and the subwindow was silently skipped as "parent not found," defeating the
+slow path for the single most common subwindow case. My first live-verification pass never caught
+this because it only tested `FullInstance` windows, no subwindow. Fixed by translating
+`windowids[0]`'s UUID to the `"main"` sentinel before building the snapshot list. Re-verified live
+with a subwindow explicitly parented to main (via `open_subwindow`, `parent_instance_id: "main"`)
+through a full process-tree kill + fresh relaunch: the reproject log now shows
+`kind=Subwindow parent_label=Some("main")` and `skipped=0`, and the subwindow appears as a real CDP
+target with a valid `windowId`.
+
 **Phase 4 — overlay UX** (§2.4), as a follow-on, not gating Phases 1-3.
 
 **Phase 5 — E2E test** ("host OOM ⇒ session reprojects", per the parent design doc's §3 acceptance

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -274,11 +274,36 @@ construction rather than by timing luck. Re-verified live after this second fix 
 isolated instance, same kill/respawn methodology): both recreated windows again registered under
 their own correct labels with zero mislabeling, and appeared as real CDP targets.
 
-**Phase 3 — slow-path fallback from srv.** Read `Client.windowids` + `Window.kind`/
-`parent_window_id` (Step 3) when the launcher's snapshot is empty/unavailable. **App-running
-verification required**: kill the *entire* process tree (launcher + host together) and relaunch from
-scratch, confirm windows still reproject (without exact position/size — see §4 risk — but with
-correct kind/parent/content).
+**Phase 3 — slow-path fallback from srv.** ✅ Done. `reproject_from_srv` (in `creation.rs`) reads
+srv's `Client.windowids` + each window's `kind`/`parent_window_id` (`backend_get_client_window_ids`/
+`backend_get_window_topology`, new blocking read helpers in `client/helpers.rs`, same raw-TCP shape
+as every other `backend_*` helper), skips `windowids[0]` (the entry the frontend's own bootstrap
+already resolves for `"main"`), and converges on the same `reproject_from_snapshot` driver Phase 2
+uses — exactly matching the parent design doc's "both tiers converge on the same per-window
+recreation code path."
+
+Trigger point: `"main"`'s registration (`client/lifecycle.rs`) is now also the fast-vs-slow decision
+point. `UiThreadGate` gained a `reprojected: bool` (decided under the same lock as `ready`/`stashed`)
+so exactly one of {replay a stashed fast-path snapshot, try the slow path} ever runs — necessary
+because a fast-path `Event::Snapshot` can arrive either before or after this decision, and a
+late-arriving one must not double-create on top of an already-run slow path.
+
+**A real bug was caught during live verification, not by reagent this time — by the test itself**:
+the first version's decision logic treated "a stash exists" as "the fast path succeeded," but
+`Event::Snapshot` always stashes *something* when it arrives early, even an empty list. A fresh
+launcher (the full-process-tree-kill case this phase exists for) sends a real, non-stale snapshot
+with zero windows — which the buggy check treated as success, permanently suppressing the slow path
+it was supposed to trigger. Fixed by checking whether the stash actually contains anything beyond
+`"main"` (`has_extra`), not merely whether a stash is `Some`.
+
+**Live verification** (isolated build, full process-tree kill — outer launcher wrapper + inner host
+both killed, letting the Job Object cascade srv's termination too; relaunched fresh from the same
+extracted folder so srv's on-disk data survived while all in-memory state, including the launcher's,
+was gone): the fresh launcher's snapshot correctly came back empty (`window_count=0`), the slow path
+correctly triggered, and reproject recreated all 4 windows srv had on record (the 2 intentionally
+opened plus 2 pre-existing pool-warm windows that had also registered backend window IDs) — including
+gracefully defaulting 2 legacy rows with no persisted `kind` to `FullInstance` with a warning, rather
+than failing. All 4 appeared as real, correctly-labeled CDP targets.
 
 **Phase 4 — overlay UX** (§2.4), as a follow-on, not gating Phases 1-3.
 
@@ -344,10 +369,12 @@ session established.
    fully reprojects with correct kind/parent/content and approximately correct placement (Phase 2,
    live-verified — see the UI-thread-readiness addendum above for the race that had to be fixed
    first).
-3. ⬜ Killing the entire process tree and relaunching confirms a multi-window session reprojects
+3. ✅ Killing the entire process tree and relaunching confirms a multi-window session reprojects
    with correct kind/parent/content, position/size at default placement (Phase 3, live-verified).
-4. ⬜ No regression in existing single-window cold-start behavior (the common case — most users
-   never see more than one window) — this must remain exactly as fast and reliable as today.
+4. ✅ No regression in existing single-window cold-start behavior — confirmed across every Phase 2/3
+   live-verification run in this session: a plain cold start with no extra windows takes the
+   fast-path-empty → slow-path-empty-too (or fast-path-has-data) route and both no-op cleanly, per
+   the idempotent-by-construction design in §2.1. 159 unit tests pass throughout, no regressions.
 5. ⬜ E2E test automating #2 (Phase 5).
 
 ---

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -346,6 +346,22 @@ its actual confirmed `window_id`), the subwindow still recreates correctly
 (`kind=Subwindow parent_label=Some("main")`, `skipped=0`), and — critically — the CDP target list shows
 exactly one main-like window (`"Starter workspace"`), confirming no spurious duplicate.
 
+**Addendum 2026-07-08, round 3 (reagent review, PR #2017) — the state machine had no automated test
+coverage.** A fourth review pass observed, correctly, that `UiThreadGate`'s fast-vs-slow-path decision
+logic (`has_extra`/`reprojected`/`pending_slow_path`) had three real bugs found across three review
+rounds, each caught only by manual live-kill verification — a future edit here would have had nothing
+but that same slow, manual process to catch a regression. Extracted the decision logic (previously
+inline at all three call sites) into pure methods on `UiThreadGate` itself —
+`on_main_ready`/`on_snapshot`/`on_main_backend_window_registered` — each returning an explicit action
+enum rather than mutating state and leaving the caller to infer what happened. Added 10 unit tests
+covering every transition, including the specific races each prior bug involved (late fast-path
+snapshot arriving while the slow path is pending; the slow path firing twice; the slow path running
+when it was never actually pending). `client/lifecycle.rs`, `launcher_ipc.rs`, and
+`commands/window/meta.rs` were rewired to call these methods rather than duplicate the logic next to
+now-tested code that could silently drift from it. Re-verified live after the refactor (same
+subwindow-of-main + full-process-tree-kill scenario): identical success signature — slow path
+triggers from `register_backend_window`, subwindow parent resolves correctly, no duplicate main.
+
 **Phase 4 — overlay UX** (§2.4), as a follow-on, not gating Phases 1-3.
 
 **Phase 5 — E2E test** ("host OOM ⇒ session reprojects", per the parent design doc's §3 acceptance


### PR DESCRIPTION
## Summary
- Implements the slow-path fallback from `SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md`: when no fast-path (launcher-snapshot) data is available — a full process-tree kill where the launcher lost its in-memory history too, or `task dev` standalone mode with no launcher at all — `reproject_from_srv` reads srv's durable `Client.windowids` plus each window's persisted `kind`/`parent_window_id` (SPEC_PILLAR1_STEP3), converging on the exact same `reproject_from_snapshot` driver Phase 2 uses.
- `UiThreadGate` gained a `reprojected` flag (decided under the same lock as `ready`/`stashed`) so exactly one of {fast path, slow path} ever creates windows, regardless of timing.
- **Caught and fixed a real bug during live verification** (not by reagent this time — by the test itself): the first version's decision logic treated "a stash exists" as "fast path succeeded," but `Event::Snapshot` always stashes *something* when it arrives early, even an empty list. A fresh launcher (the exact full-process-tree-kill scenario this phase exists for) sends a real, non-stale empty snapshot — which the buggy check treated as success, permanently suppressing the slow path. Fixed by checking whether the stash actually has anything beyond `"main"`.

See the spec doc's Phase 3 section + 2026-07-07 addendum for the full writeup.

## Test plan
- [x] `cargo test -p agentmux-cef --release` — 159 passed, 0 failed, no regressions
- [x] Isolated live verification: opened 2 windows, killed the **entire process tree** (outer launcher wrapper + inner host, job object cascading srv's termination too — confirmed no orphans), relaunched fresh from the same extracted build (same on-disk data, zero in-memory history anywhere)
- [x] Confirmed pre-fix: the fresh launcher's empty snapshot was wrongly treated as fast-path success, slow path never ran
- [x] Confirmed post-fix: slow path correctly triggered, recreated all 4 windows srv had on record (2 intentionally opened + 2 pool-warm windows also registered with srv), including gracefully defaulting 2 legacy rows with no persisted `kind` to `FullInstance` with a warning — all 4 appeared as real, correctly-labeled CDP targets

<!-- agentmux:agent_id=agenta -->