### PR TITLE
feat(swarm): inline-expand subagent rows with Haiku names, no timestamps

### DIFF
--- a/.changesets/1783481288-feat-swarm-inline-expand-subagent-rows-with-haiku-generated--d4tx.md
+++ b/.changesets/1783481288-feat-swarm-inline-expand-subagent-rows-with-haiku-generated--d4tx.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): inline-expand subagent rows with Haiku-generated names, no timestamps

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -50,6 +50,10 @@ pub struct SubagentInfo {
     /// Some("wf_<id>") when this subagent runs inside a Workflow tool run
     /// (JSONL under `subagents/workflows/<id>/`); None for direct subagents.
     pub workflow_id: Option<String>,
+    /// Concise Haiku-generated name, set once on-demand when a client first
+    /// expands this subagent (see `subagent.GenerateName`). None until then
+    /// — callers fall back to `slug`/`agent_id` themselves.
+    pub display_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -478,6 +482,47 @@ impl SubagentWatcher {
         None
     }
 
+    /// Set a subagent's Haiku-generated display name and broadcast
+    /// `subagent:named` so every client watching this session picks up the
+    /// result, not just the one that triggered the naming call. Returns
+    /// `false` if the subagent isn't tracked (e.g. it aged out between the
+    /// RPC firing and resolving) — the caller should treat that as a no-op,
+    /// not an error.
+    pub fn set_display_name(&self, agent_id: &str, display_name: &str) -> bool {
+        let found = {
+            let mut sessions = self.sessions.lock().unwrap();
+            let mut found = false;
+            for session in sessions.values_mut() {
+                if let Some(state) = session.subagents.get_mut(agent_id) {
+                    state.info.display_name = Some(display_name.to_string());
+                    found = true;
+                    break;
+                }
+            }
+            found
+        };
+        // Mutex released here — broadcast outside the lock
+
+        if found {
+            let named_event = WSEventType {
+                eventtype: WS_EVENT_RPC.to_string(),
+                oref: String::new(),
+                data: Some(json!({
+                    "command": "eventrecv",
+                    "data": {
+                        "event": "subagent:named",
+                        "data": {
+                            "agentId": agent_id,
+                            "displayName": display_name,
+                        }
+                    }
+                })),
+            };
+            self.event_bus.broadcast_event(&named_event);
+        }
+        found
+    }
+
     // ── Internal methods ──────────────────────────────────────────────────
 
     /// Backfill subagents that already existed before this pane (re)opened,
@@ -618,6 +663,7 @@ impl SubagentWatcher {
                         event_count: 0,
                         model: None,
                         workflow_id: None,
+                        display_name: None,
                     },
                     file_offset: 0,
                     events: Vec::new(),
@@ -1051,6 +1097,52 @@ fn read_jsonl_from_offset(
     Ok((events, current_offset, meta))
 }
 
+/// Read just the subagent's own initial task prompt from the first JSONL
+/// line (a `"type":"user"` init record) — used by `subagent.GenerateName` as
+/// the source text for the Haiku naming call. Deliberately bypasses the
+/// events cache/offset machinery `read_jsonl_from_offset` uses: naming only
+/// ever needs the first line, is called at most once per subagent (cached
+/// via `display_name` thereafter), and must work even for a subagent whose
+/// events haven't been scanned into `SubagentState` yet.
+///
+/// `message.content` is either a plain string or an array of content blocks
+/// (mirrors the two shapes `parse_event_type`'s "assistant" arm already
+/// handles) — both are accepted here.
+pub(crate) fn read_task_prompt(jsonl_path: &str) -> Option<String> {
+    let file = std::fs::File::open(jsonl_path).ok()?;
+    let mut reader = BufReader::new(file);
+    let mut first_line = String::new();
+    reader.read_line(&mut first_line).ok()?;
+
+    let value: serde_json::Value = serde_json::from_str(first_line.trim()).ok()?;
+    if value.get("type").and_then(|v| v.as_str()) != Some("user") {
+        return None;
+    }
+    let content = value.get("message")?.get("content")?;
+
+    if let Some(text) = content.as_str() {
+        let trimmed = text.trim();
+        return (!trimmed.is_empty()).then(|| trimmed.to_string());
+    }
+
+    if let Some(arr) = content.as_array() {
+        let texts: Vec<&str> = arr
+            .iter()
+            .filter_map(|block| {
+                if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                    block.get("text").and_then(|t| t.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let joined = texts.join("\n").trim().to_string();
+        return (!joined.is_empty()).then_some(joined);
+    }
+
+    None
+}
+
 /// Parse a JSONL line into a SubagentEventType based on the `type` field.
 fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEventType> {
     let event_type = value.get("type").and_then(|v| v.as_str())?;
@@ -1347,6 +1439,7 @@ mod tests {
                 event_count: 0,
                 model: None,
                 workflow_id: None,
+                display_name: None,
             },
             file_offset: 0,
             events: Vec::new(),
@@ -1398,6 +1491,78 @@ mod tests {
         assert_eq!(found.parent_agent, "parent-1");
 
         assert!(watcher.get_info("never-spawned").is_none());
+    }
+
+    #[test]
+    fn set_display_name_updates_info_and_reports_found() {
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            s1.subagents.insert("sub-a".to_string(), fixture_state("parent-1", "sub-a", "s1"));
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        assert!(watcher.set_display_name("sub-a", "Refactor shell module"));
+        let info = watcher.get_info("sub-a").expect("sub-a should be found");
+        assert_eq!(info.display_name.as_deref(), Some("Refactor shell module"));
+    }
+
+    #[test]
+    fn set_display_name_on_unknown_agent_is_noop_and_reports_not_found() {
+        let watcher = fixture_watcher();
+        assert!(!watcher.set_display_name("never-spawned", "Some name"));
+    }
+
+    #[test]
+    fn read_task_prompt_extracts_plain_string_content_from_first_line() {
+        let dir = std::env::temp_dir().join(format!("amx-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-prompt-string.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Analyze the shell module\"}}\n\
+             {\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+        )
+        .unwrap();
+
+        let prompt = read_task_prompt(jsonl_path.to_str().unwrap());
+        assert_eq!(prompt.as_deref(), Some("Analyze the shell module"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_task_prompt_extracts_joined_text_blocks_from_content_array() {
+        let dir = std::env::temp_dir().join(format!("amx-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-prompt-array.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Part one\"},{\"type\":\"text\",\"text\":\"Part two\"}]}}\n",
+        )
+        .unwrap();
+
+        let prompt = read_task_prompt(jsonl_path.to_str().unwrap());
+        assert_eq!(prompt.as_deref(), Some("Part one\nPart two"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_task_prompt_returns_none_when_first_line_is_not_a_user_record() {
+        let dir = std::env::temp_dir().join(format!("amx-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-prompt-none.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+        )
+        .unwrap();
+
+        assert!(read_task_prompt(jsonl_path.to_str().unwrap()).is_none());
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -119,7 +119,7 @@ fn register_session_export_handler(engine: &Arc<WshRpcEngine>, state: &AppState)
 /// user-facing pane-header/ghost-text request, and vice versa.
 const MAX_CONCURRENT_PULL_CALLS: usize = 2;
 
-fn pull_call_semaphore() -> &'static tokio::sync::Semaphore {
+pub(crate) fn pull_call_semaphore() -> &'static tokio::sync::Semaphore {
     static SEM: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
     SEM.get_or_init(|| tokio::sync::Semaphore::new(MAX_CONCURRENT_PULL_CALLS))
 }
@@ -186,6 +186,94 @@ pub(crate) async fn generate_pushed_activity_summary(
     let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
     drop(guard);
     result.filter(|(summary, _)| !summary.is_empty())
+}
+
+/// Ambient-call purpose tag for the on-demand subagent display name (see
+/// `generate_subagent_name`). One-shot per subagent — `generation` is always
+/// the constant `1` since a name, once generated, is cached on
+/// `SubagentInfo.display_name` and never regenerated; there is no "newer
+/// turn" to supersede an in-flight naming call the way there is for the
+/// per-turn pull RPCs above.
+const AMBIENT_PURPOSE_SUBAGENT_NAME: &str = "subagent_name";
+
+/// Generate (or return the already-cached) concise Haiku display name for a
+/// subagent. Called on-demand the first time a client expands that
+/// subagent's row in the Swarm view — see `("subagent", "GenerateName")` in
+/// `server::service::misc`. Subagents have no `Block`/meta of their own, so
+/// this borrows the parent block's CLI path + auth env, and reads the
+/// subagent's own initial task prompt directly off its JSONL (available
+/// immediately even for a still-running subagent, unlike a transcript
+/// summary which needs output to summarize).
+///
+/// Returns `None` when there's nothing to name (unknown subagent, no task
+/// prompt on the first JSONL line, parent block unresolvable, or the call
+/// was superseded/capped/failed) — callers should treat that as "leave the
+/// row showing its slug/id fallback," not an error.
+pub(crate) async fn generate_subagent_name(
+    wstore: &Store,
+    subagent_watcher: &Arc<crate::backend::subagent_watcher::SubagentWatcher>,
+    agent_id: &str,
+) -> Option<String> {
+    let info = subagent_watcher.get_info(agent_id)?;
+    if let Some(existing) = info.display_name {
+        return Some(existing);
+    }
+
+    let key = crate::ambient::AmbientCallKey::new(agent_id.to_string(), AMBIENT_PURPOSE_SUBAGENT_NAME);
+    let guard = match crate::ambient::gateway().admit(key, 1) {
+        crate::ambient::Admission::Proceed(guard) => guard,
+        crate::ambient::Admission::StaleOnArrival => return None,
+    };
+    let cancel = guard.cancellation();
+
+    // Same cross-block concurrency cap as the pull RPCs above — a user
+    // rapidly expanding several subagent rows shouldn't spawn unbounded
+    // concurrent Haiku CLIs either.
+    let permit = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        permit = pull_call_semaphore().acquire() => permit.ok(),
+    };
+    let Some(_permit) = permit else {
+        drop(guard);
+        return None;
+    };
+
+    let Some(task_prompt) = crate::backend::subagent_watcher::read_task_prompt(&info.jsonl_path) else {
+        drop(guard);
+        return None;
+    };
+
+    let block: Block = match wstore.get(&info.parent_block_id) {
+        Ok(Some(b)) => b,
+        _ => {
+            drop(guard);
+            return None;
+        }
+    };
+    let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
+    if cli_path.is_empty() {
+        drop(guard);
+        return None;
+    }
+
+    let prompt = format!(
+        "Give a concise ~5-word name for this task. \
+         No punctuation, no quotes, no preamble — respond with just the name.\n\n\
+         Task:\n\n{task_prompt}"
+    );
+
+    let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
+    drop(guard);
+
+    let (name, _tokens) = result?;
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    subagent_watcher.set_display_name(agent_id, &name);
+    Some(name)
 }
 
 fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -429,7 +517,7 @@ fn read_recent_activity_digest(
 /// stream-json line (same `usage` shape the main turn pipeline parses —
 /// see `agents::translator::claude::parse_usage`), so ambient calls are
 /// never silently excluded from token accounting.
-pub(super) async fn invoke_ambient_haiku_call(
+pub(crate) async fn invoke_ambient_haiku_call(
     cli_path: &str,
     prompt: &str,
     meta: &obj::MetaMapType,

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -208,15 +208,17 @@ const AMBIENT_PURPOSE_SUBAGENT_NAME: &str = "subagent_name";
 /// Returns `None` when there's nothing to name (unknown subagent, no task
 /// prompt on the first JSONL line, parent block unresolvable, or the call
 /// was superseded/capped/failed) — callers should treat that as "leave the
-/// row showing its slug/id fallback," not an error.
+/// row showing its slug/id fallback," not an error. A cache hit (name
+/// already generated) returns the cached name with `tokens: None` — there's
+/// no new spend to report.
 pub(crate) async fn generate_subagent_name(
     wstore: &Store,
     subagent_watcher: &Arc<crate::backend::subagent_watcher::SubagentWatcher>,
     agent_id: &str,
-) -> Option<String> {
+) -> Option<(String, Option<crate::agents::TokenCounts>)> {
     let info = subagent_watcher.get_info(agent_id)?;
     if let Some(existing) = info.display_name {
-        return Some(existing);
+        return Some((existing, None));
     }
 
     let key = crate::ambient::AmbientCallKey::new(agent_id.to_string(), AMBIENT_PURPOSE_SUBAGENT_NAME);
@@ -266,14 +268,14 @@ pub(crate) async fn generate_subagent_name(
     let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
     drop(guard);
 
-    let (name, _tokens) = result?;
+    let (name, tokens) = result?;
     let name = name.trim().to_string();
     if name.is_empty() {
         return None;
     }
 
     subagent_watcher.set_display_name(agent_id, &name);
-    Some(name)
+    Some((name, tokens))
 }
 
 fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppState) {

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -69,6 +69,19 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
             let info = state.subagent_watcher.get_info(&agent_id);
             WebReturnType::success(serde_json::to_value(&info).unwrap_or(serde_json::Value::Null))
         }
+        ("subagent", "GenerateName") => {
+            let agent_id: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let display_name = super::super::app_api::session::generate_subagent_name(
+                &state.wstore,
+                &state.subagent_watcher,
+                &agent_id,
+            )
+            .await;
+            WebReturnType::success(serde_json::json!({ "displayName": display_name }))
+        }
         // ---- HistoryService ----
         ("history", "List") => {
             let provider: Option<String> = service::get_optional_arg(args, 0).unwrap_or(None);

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -74,13 +74,17 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            let display_name = super::super::app_api::session::generate_subagent_name(
+            let result = super::super::app_api::session::generate_subagent_name(
                 &state.wstore,
                 &state.subagent_watcher,
                 &agent_id,
             )
             .await;
-            WebReturnType::success(serde_json::json!({ "displayName": display_name }))
+            let (display_name, tokens) = match result {
+                Some((name, tokens)) => (Some(name), tokens),
+                None => (None, None),
+            };
+            WebReturnType::success(serde_json::json!({ "displayName": display_name, "tokens": tokens }))
         }
         // ---- HistoryService ----
         ("history", "List") => {

--- a/docs/specs/REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md
+++ b/docs/specs/REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md
@@ -1,0 +1,222 @@
+# Report: Subagent detail view — inline expand, no timestamps, Haiku-generated names
+
+**Status:** Implemented (branch `agentx/subagent-detail-ux`, stacked on
+`agentx/swarm-workflow-grouping` / PR #2018).
+**Author:** AgentX
+**Date:** 2026-07-07
+**Triggered by:** user usability feedback after the workflow-grouping fix
+(Finding 4 of `REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`): "when
+clicking the subagent ID, we need it to expand with the content .. we
+dont need a timestamp for every line, remove that .. also, can we get the
+ambient haiku to efficiently rename the line to a 5 word concise. when
+expanding, you can [see] the subagent's name and other meta data, and
+below the log, no extra spaces or timestamps."
+
+## Requirements, restated precisely
+
+1. Clicking a subagent row in the Swarm tree expands **inline** (same
+   pattern as the new `WorkflowGroupRow`) instead of opening a new split
+   pane.
+2. Per-event timestamps are removed from the log.
+3. Each subagent gets a concise, Haiku-generated ~5-word name instead of
+   its raw slug/hash — used both as the collapsed row's label and the
+   expanded header's title.
+4. Expanded layout: name + metadata at the top, log content below, no
+   timestamps, tightened spacing (no "extra spaces").
+
+## Current state (grounded in the code)
+
+**Today's flow**: `SubagentRow` (`swarm-view.tsx:298-320`) `onClick` calls
+`openSubagentPane` (`subagent-pane-manager.ts:28-87`), which creates a
+**new split-pane block** (`view: "subagent"`) running the standalone
+`SubagentView`/`SubagentViewModel` (`frontend/app/view/subagent/`). That
+component is a real `ViewModel` — constructor takes `(blockId, nodeModel)`,
+reads `subagent:id` off **block meta** (`subagent-model.ts:77-79`), and
+ties its 3 event subscriptions + `loadHistory()`
+(`subagent.GetHistory`/`GetInfo` RPCs) to pane lifecycle via `dispose()`.
+
+**Today's header** (`subagent-view.tsx:88-117`): icon, `slug || agent_id`,
+7-char id, status badge, `event_count` + "events", `elapsed()` string,
+model. **Today's event rows** (`SubagentEventItem`, L153-166): a
+`.subagent-event-time` timestamp span, then `EventContent` — switches on
+event type (`text`/`result` → `<pre>`; `tool_use`/`tool_result` →
+collapsible headers; `progress` → spinner + text).
+
+**Raw display names are ugly by design, not by bug**: `slug` comes from
+the subagent's own JSONL first line's `"slug"` field
+(`subagent_watcher.rs:1004-1012`); if the CLI didn't write one, it falls
+back to the raw `agentId` hash (`:1013-1027`) — confirmed live: Lark's 15
+loose subagents (spread across June 22-30, genuinely unrelated individual
+Task-tool calls, not a workflow) all show as bare hashes for exactly this
+reason.
+
+## Proposed design
+
+### 1. Inline expand (replaces the new-pane navigation)
+
+Reuse `WorkflowGroupRow`'s pattern exactly (`swarm-view.tsx:266-294`):
+local `const [expanded, setExpanded] = createSignal(false)` on
+`SubagentRow`, toggled on click, `<Show when={expanded()}>` revealing the
+detail content beneath the row instead of calling `openSubagentPane`.
+
+The data-fetching logic in `SubagentViewModel` is reusable but not as-is —
+it's a `ViewModel` shell (needs `blockId`, implements `dispose()` tied to
+pane unmount, reads `subagentId` from block meta instead of a prop).
+Extract the substance (3 `waveEventSubscribe` handlers +
+`loadHistory()`/`subagent.GetHistory`+`GetInfo`) into a plain function
+taking `subagentId: string` directly — e.g.
+`useSubagentDetail(subagentId): { events, info, status }` — callable from
+a `SubagentRow`'s local scope, cleaned up via Solid's `onCleanup` instead
+of a `dispose()` method.
+
+**Open question — what happens to the old pane path?** Once `SubagentRow`
+expands inline, `openSubagentPane`/`subagent-pane-manager.ts`/the
+standalone `SubagentView` pane type have no remaining caller (per
+`CLAUDE.md`'s own "Not widgets" table, clicking a subagent in Swarm was
+already the *only* documented entry point). Recommend retiring them in the
+same change rather than leaving now-dead code — but flagging this
+explicitly since it's a deletion, not purely additive.
+
+### 2. Remove per-line timestamps, tighten spacing
+
+Delete `.subagent-event-time` (`subagent-view.tsx:156` /
+`subagent-view.scss:142-149`) from the row template. Drop the `.subagent-event`
+flex-row wrapper's now-unneeded time column and its `min-width: 56px`
+reservation; reduce `.subagent-event` padding
+(`subagent-view.scss:131-140`) and `.subagent-events` container padding
+(`:113-117`) to remove the "extra spaces" called out.
+
+### 3. Expanded layout: name + metadata header, log below
+
+Matches today's structural intent already (`subagent-view.tsx:88-133`
+already puts a header above the scrollable event list) — just needs the
+timestamp/spacing trims above, plus swapping the displayed name for the
+Haiku-generated one (§4) and confirming which metadata fields stay: slug/
+name, short id, status, event count, model — parent agent + session id
+are already fetched (`ActiveSubagent`/`SubagentInfo` both carry them) and
+could be added to the header now that there's room without a full pane's
+worth of chrome.
+
+### 4. Haiku-generated concise name
+
+**Trigger: on-demand, cached — not eager for every backfilled subagent.**
+This is the load-bearing decision. A single agent's *current* session can
+carry hundreds of subagents (confirmed live: Lark has 227 total — 15 loose
++ 2 workflow runs of 106 each). Naming all of them eagerly on every pane
+reopen would mean up to 227 Haiku CLI spawns per reopen for one agent —
+directly reintroducing the cost/latency problem
+`REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md` Finding 3 (ambient
+concurrency cap) was written to prevent, just from a new call site. Naming
+**lazily, on first expand, then caching the result** means a Haiku call
+only ever fires for a subagent a human actually looked at — matches "get
+the ambient haiku to *efficiently* rename" directly.
+
+**Source content: the subagent's own initial task prompt**, not a
+transcript summary. The subagent's first JSONL line already carries the
+task description handed to it (the same content `read_recent_activity_digest`-style
+extraction reads for the existing ambient summaries) — cheap, available
+immediately even for a still-running subagent (no need to wait for
+output), and a closer match to "what was this subagent *for*" than a
+summary of what it produced.
+
+**Backend**:
+- New `AMBIENT_PURPOSE_SUBAGENT_NAME` purpose tag, admitted through the
+  existing `crate::ambient::gateway()` — `AmbientCallKey{entity_id:
+  agent_id, purpose: "subagent_name"}`. Since a name is generated once and
+  never needs regenerating, `generation` can be a constant (e.g. `1`) —
+  admission is inherently one-shot per subagent, no supersede-on-retry
+  complexity to design for.
+- Reuses `invoke_ambient_haiku_call` unchanged (same CLI-spawn/timeout/
+  cancel-race machinery `session.rs` already has) — new prompt: "Give a
+  concise ~5-word name for this task. No punctuation, no quotes." + the
+  subagent's first-line content.
+- Route through the same `pull_call_semaphore`-style cap as the two
+  existing pull RPCs (`session.rs`'s `MAX_CONCURRENT_PULL_CALLS`) — a user
+  rapidly expanding several subagent rows in a row shouldn't spawn
+  unbounded concurrent Haiku CLIs either.
+- New field `SubagentInfo.display_name: Option<String>`, set once the
+  Haiku call resolves; broadcast via a new `subagent:named { agentId,
+  displayName }` WS event so every client watching that session (not just
+  the one that triggered the naming) picks up the result — the collapsed
+  row's label updates too, not only the expanded view, and a second
+  expand-click by anyone doesn't refire the call (cached on the backend
+  struct, `GetInfo`/`ListActive` return it going forward).
+- New RPC: `subagent.GenerateName(agent_id)` (or piggyback on `GetHistory`/
+  `GetInfo`'s existing call site if simpler) — fired once, the first time
+  a given subagent is expanded client-side.
+
+**Frontend**:
+- `ActiveSubagent`/`SubagentInfo`-derived types gain `display_name: string
+  | null`. Row label preference: `display_name ?? slug ?? agent_id.slice(0,7)`.
+- `swarm-model.ts` subscribes to the new `subagent:named` event and
+  patches the matching entry in `subagentsAtom` in place (same pattern
+  already used for `subagent:spawned`/`subagent:completed`).
+- The inline-expand handler (§1) fires the naming RPC once, only if
+  `display_name` isn't already set.
+
+## Implementation plan (file-by-file, once approved)
+
+**Backend**:
+- `agentmux-srv/src/backend/subagent_watcher.rs` — add `display_name`
+  field to `SubagentInfo`; new method to set it + broadcast
+  `subagent:named`.
+- `agentmux-srv/src/server/app_api/session.rs` or a new
+  `subagent_naming.rs` — new ambient-purpose constant, `pull_call_semaphore`-gated
+  handler calling `invoke_ambient_haiku_call` with the new prompt.
+- `agentmux-srv/src/server/service/misc.rs` — register
+  `subagent.GenerateName`.
+
+**Frontend**:
+- `frontend/app/view/swarm/swarm-model.ts` — `display_name` field;
+  `subagent:named` subscription + in-place patch.
+- `frontend/app/view/swarm/swarm-view.tsx` — `SubagentRow` gains local
+  `expanded` signal (mirrors `WorkflowGroupRow`); on first expand, calls
+  the new naming RPC if unnamed, and `useSubagentDetail(agent_id)` for the
+  event log; renders the trimmed header + no-timestamp log inline.
+- New `frontend/app/view/swarm/useSubagentDetail.ts` (or inline in
+  `swarm-view.tsx` if small enough) — extracted data-fetching logic from
+  `SubagentViewModel`, taking `subagentId` directly.
+- `frontend/app/view/swarm/swarm-view.scss` — trimmed spacing, no
+  timestamp column, name/metadata header + log-body layout for the
+  expanded state.
+- Retire (pending confirmation, see §1's open question):
+  `frontend/app/view/subagent/subagent-view.tsx`,
+  `frontend/app/view/subagent/subagent-model.ts`,
+  `frontend/app/store/subagent-pane-manager.ts`.
+
+## Resolution of the open questions (implemented per "use best judgment")
+
+1. **Standalone `SubagentView` pane: kept, not retired.** Discovered during
+   implementation that `agent-view.tsx`'s `handleSubagentClick` (a subagent
+   link rendered *inline in an agent's own transcript*, e.g. a Task-tool
+   invocation) also calls `openSubagentPane` — a second, independent entry
+   point beyond the Swarm tree that `CLAUDE.md`'s "Not widgets" table didn't
+   account for. Retiring the pane would have broken that click-through, so
+   `subagent-view.tsx` / `subagent-model.ts` / `subagent-pane-manager.ts`
+   are untouched; only the Swarm tree's own row click now expands inline
+   instead of calling `openSubagentPane`.
+2. **Naming trigger: on-demand at first expand**, as recommended — implemented
+   exactly as designed (§4).
+3. **Header metadata**: name, short id, event count, model (when present),
+   parent agent. Elapsed-time and a separate status badge were dropped from
+   the inline header (the row's own `AgentStatusChip` already shows status
+   one line above; repeating it in the expanded panel added noise without
+   new information).
+
+## Implementation notes (post-hoc)
+
+- **Row remount instability discovered and fixed.** `SwarmViewModel.buildTree()`
+  reconstructs fresh `WorkflowGroup`/`ActiveSubagent`-wrapping objects on
+  every recompute (`groupSubagentsByWorkflow`'s `.map()`), and `tree()`
+  recomputes on every `agentStatusesAtom` tick (i.e. very often during an
+  active turn — every `controllerstatus` event). SolidJS's `<For>` diffs
+  list items by reference, so this was silently remounting every row
+  (including the just-shipped `WorkflowGroupRow`) far more often than any
+  actual data change — collapsing any row a user had expanded within
+  roughly one status tick. Fixed by lifting expand state and per-subagent
+  detail fetch/subscribe state off the row components and onto
+  `SwarmViewModel` (`expandedIdsAtom` keyed by `workflowId`/`agent_id`,
+  `getSubagentDetail` cache keyed by `agent_id`), plus
+  `mergeSubagentsPreservingIdentity` so `loadSubagents()`'s full-list
+  reload reuses old object references for unchanged subagents instead of
+  handing `<For>` a fresh object per entry every time.

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { groupSubagentsByWorkflow, isWorkflowGroup, mergeSubagentsPreservingIdentity, type ActiveSubagent } from "./swarm-model";
+import {
+    groupSubagentsByWorkflow,
+    isWorkflowGroup,
+    mergeSubagentsPreservingIdentity,
+    pruneGroupIdentityCache,
+    stabilizeGroupIdentity,
+    type ActiveSubagent,
+    type WorkflowGroup,
+} from "./swarm-model";
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -159,5 +167,57 @@ describe("mergeSubagentsPreservingIdentity", () => {
         const next = [mk({ agent_id: "a1" })];
         const merged = mergeSubagentsPreservingIdentity(prev, next);
         expect(merged[0]).toBe(next[0]);
+    });
+});
+
+describe("stabilizeGroupIdentity", () => {
+    it("reuses the cached WorkflowGroup reference when nothing about the group changed", () => {
+        const cache = new Map<string, WorkflowGroup>();
+        const members = [mk({ agent_id: "a1", workflow_id: "wf_1" })];
+        const first = groupSubagentsByWorkflow(members);
+        const stabilizedFirst = stabilizeGroupIdentity(cache, first);
+
+        // A second, independently-built (but content-identical) group for the
+        // same workflow — mirrors what a fresh groupSubagentsByWorkflow() call
+        // produces on an unrelated buildTree() recompute.
+        const second = groupSubagentsByWorkflow(members);
+        const stabilizedSecond = stabilizeGroupIdentity(cache, second);
+
+        expect(stabilizedSecond[0]).toBe(stabilizedFirst[0]);
+    });
+
+    it("returns a fresh reference when the group's member set actually changed", () => {
+        const cache = new Map<string, WorkflowGroup>();
+        const first = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1", status: "active" })]);
+        const stabilizedFirst = stabilizeGroupIdentity(cache, first);
+
+        const second = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed" })]);
+        const stabilizedSecond = stabilizeGroupIdentity(cache, second);
+
+        expect(stabilizedSecond[0]).not.toBe(stabilizedFirst[0]);
+    });
+
+    it("passes loose (non-group) subagents through unchanged", () => {
+        const cache = new Map<string, WorkflowGroup>();
+        const loose = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: null })]);
+        const stabilized = stabilizeGroupIdentity(cache, loose);
+        expect(stabilized[0]).toBe(loose[0]);
+        expect(cache.size).toBe(0);
+    });
+});
+
+describe("pruneGroupIdentityCache", () => {
+    it("drops entries for workflows no longer live, keeps the rest", () => {
+        const cache = new Map<string, WorkflowGroup>();
+        const groupA = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_a" })]);
+        const groupB = groupSubagentsByWorkflow([mk({ agent_id: "b1", workflow_id: "wf_b" })]);
+        stabilizeGroupIdentity(cache, groupA);
+        stabilizeGroupIdentity(cache, groupB);
+        expect(cache.size).toBe(2);
+
+        pruneGroupIdentityCache(cache, new Set(["wf_a"]));
+        expect(cache.size).toBe(1);
+        expect(cache.has("wf_a")).toBe(true);
+        expect(cache.has("wf_b")).toBe(false);
     });
 });

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { groupSubagentsByWorkflow, isWorkflowGroup, type ActiveSubagent } from "./swarm-model";
+import { groupSubagentsByWorkflow, isWorkflowGroup, mergeSubagentsPreservingIdentity, type ActiveSubagent } from "./swarm-model";
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -15,6 +15,7 @@ function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id"
         event_count: 1,
         model: null,
         workflow_id: null,
+        display_name: null,
         ...overrides,
     };
 }
@@ -120,5 +121,43 @@ describe("groupSubagentsByWorkflow", () => {
         // newest-loose (900) > wf_1 group (500) > old-loose (100)
         expect(isWorkflowGroup(result[0]) ? result[0].workflowId : result[0].agent_id).toBe("newest-loose");
         expect(isWorkflowGroup(result[2]) ? result[2].workflowId : result[2].agent_id).toBe("old-loose");
+    });
+});
+
+describe("mergeSubagentsPreservingIdentity", () => {
+    it("reuses the old object reference for an entry whose fields are unchanged", () => {
+        const prev = [mk({ agent_id: "a1", slug: "foo" })];
+        const next = [mk({ agent_id: "a1", slug: "foo" })];
+        const merged = mergeSubagentsPreservingIdentity(prev, next);
+        expect(merged[0]).toBe(prev[0]);
+    });
+
+    it("uses the new object when a field actually changed", () => {
+        const prev = [mk({ agent_id: "a1", status: "active" })];
+        const next = [mk({ agent_id: "a1", status: "completed" })];
+        const merged = mergeSubagentsPreservingIdentity(prev, next);
+        expect(merged[0]).toBe(next[0]);
+        expect(merged[0].status).toBe("completed");
+    });
+
+    it("only replaces the changed entry, leaving unrelated entries' references untouched", () => {
+        const prev = [
+            mk({ agent_id: "a1", status: "active" }),
+            mk({ agent_id: "a2", status: "active" }),
+        ];
+        const next = [
+            mk({ agent_id: "a1", status: "completed" }), // changed
+            mk({ agent_id: "a2", status: "active" }), // unchanged
+        ];
+        const merged = mergeSubagentsPreservingIdentity(prev, next);
+        expect(merged[0]).toBe(next[0]);
+        expect(merged[1]).toBe(prev[1]);
+    });
+
+    it("uses the new object for a subagent with no prior entry", () => {
+        const prev: ActiveSubagent[] = [];
+        const next = [mk({ agent_id: "a1" })];
+        const merged = mergeSubagentsPreservingIdentity(prev, next);
+        expect(merged[0]).toBe(next[0]);
     });
 });

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -162,6 +162,61 @@ export function mergeSubagentsPreservingIdentity(
     });
 }
 
+function shallowEqualGroup(a: WorkflowGroup, b: WorkflowGroup): boolean {
+    return (
+        a.name === b.name &&
+        a.activeCount === b.activeCount &&
+        a.totalCount === b.totalCount &&
+        a.status === b.status &&
+        a.lastEventAt === b.lastEventAt &&
+        a.subagents.length === b.subagents.length &&
+        a.subagents.every((m, i) => m === b.subagents[i])
+    );
+}
+
+/**
+ * Stabilize `WorkflowGroup` wrapper identity across `buildTree()` calls,
+ * mirroring `mergeSubagentsPreservingIdentity` one level up.
+ * `groupSubagentsByWorkflow` is a pure function — it unconditionally builds
+ * a brand-new `WorkflowGroup` object per call, even when every member
+ * (already reference-stable thanks to `mergeSubagentsPreservingIdentity`)
+ * is unchanged. Left alone, that fresh wrapper still remounts
+ * `WorkflowGroupRow` — and everything nested inside an expanded one
+ * (`SubagentRow`, `SubagentDetailPane`, `SubagentDetailEvent`) — on every
+ * unrelated tree recompute, which for a workflow group (the highest-volume
+ * case: a single run can spawn dozens of subagents) defeats the very
+ * remount fix `expandedIdsAtom`/`getSubagentDetail` were meant to provide.
+ *
+ * `cache` is a `Map<workflowId, WorkflowGroup>` the caller keeps around
+ * (one per `SwarmViewModel`), shared and called once per BLOCK within one
+ * `buildTree()` pass — this function only reuses-or-replaces into `cache`,
+ * it never prunes it (pruning here, scoped to one block's children, would
+ * evict entries a DIFFERENT block's call just wrote). Callers doing a full
+ * multi-block tree rebuild should prune the cache once afterward against
+ * every workflowId seen across the whole tree — see `pruneGroupIdentityCache`.
+ */
+export function stabilizeGroupIdentity(
+    cache: Map<string, WorkflowGroup>,
+    children: SwarmChild[]
+): SwarmChild[] {
+    return children.map((child) => {
+        if (!isWorkflowGroup(child)) return child;
+        const old = cache.get(child.workflowId);
+        const stable = old && shallowEqualGroup(old, child) ? old : child;
+        cache.set(child.workflowId, stable);
+        return stable;
+    });
+}
+
+/** Drop cache entries for workflows no longer present anywhere in the tree
+ *  — call once after a full `buildTree()` pass, not per-block (see
+ *  `stabilizeGroupIdentity`), so it can't grow unbounded across sessions. */
+export function pruneGroupIdentityCache(cache: Map<string, WorkflowGroup>, liveWorkflowIds: Set<string>): void {
+    for (const key of [...cache.keys()]) {
+        if (!liveWorkflowIds.has(key)) cache.delete(key);
+    }
+}
+
 // ── Subagent detail (inline-expand event log) ───────────────────────────
 
 export interface SubagentDetail {
@@ -177,11 +232,11 @@ export interface SubagentDetail {
  * subagent:activity/subagent:completed. Deliberately NOT tied to a
  * component's render lifecycle (no `onCleanup`): `SwarmViewModel` caches
  * one of these per expanded subagent (`getSubagentDetail`) so it survives
- * the frequent `<For>` remounts `tree()` causes (see
- * `mergeSubagentsPreservingIdentity` and `groupSubagentsByWorkflow` above —
- * workflow-group wrapper objects are rebuilt on every recompute regardless
- * of whether their members changed) instead of refetching/resubscribing on
- * every incidental re-render while a row is open.
+ * `<For>` remounts `tree()` can still cause for unrelated reasons, instead
+ * of refetching/resubscribing on every incidental re-render while a row is
+ * open. See `mergeSubagentsPreservingIdentity` and `stabilizeGroupIdentity`
+ * above for how row/wrapper object identity itself is kept stable in the
+ * first place.
  */
 export function createSubagentDetail(subagentId: string): SubagentDetail {
     const [events, setEvents] = createSignal<SubagentEvent[]>([]);
@@ -327,6 +382,16 @@ export class SwarmViewModel implements ViewModel {
     // resubscribe from scratch — potentially several times a second while a
     // row is open during an active turn.
     private detailCache = new Map<string, SubagentDetail>();
+
+    // Persisted across buildTree() calls so stabilizeGroupIdentity can reuse
+    // the same WorkflowGroup wrapper object when a group's own content is
+    // unchanged — without this, expandedIds/detailCache above still don't
+    // help a subagent NESTED inside a workflow group, since <For> remounts
+    // the whole WorkflowGroupRow subtree (SubagentRow, SubagentDetailPane,
+    // SubagentDetailEvent — including the latter's own local `expanded`
+    // signal for a tool_use/tool_result toggle) whenever the group's own
+    // wrapper reference changes, which is every buildTree() call otherwise.
+    private groupIdentityCache = new Map<string, WorkflowGroup>();
 
     private unsubs: (() => void)[] = [];
     // Per-block controllerstatus unsubs — cleaned up when block list refreshes
@@ -525,7 +590,7 @@ export class SwarmViewModel implements ViewModel {
         const parentIds = subagents.map((s) => s.parent_block_id).filter(Boolean);
         const allBlockIds = [...new Set([...blockIds, ...parentIds])];
 
-        return allBlockIds.map((blockId) => {
+        const nodes = allBlockIds.map((blockId) => {
             const blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
             const block = blockAtom();
             const agentName =
@@ -537,11 +602,19 @@ export class SwarmViewModel implements ViewModel {
             const rawCtx = block?.meta?.["term:ctx-tokens"];
             const contextTokens = typeof rawCtx === "number" ? rawCtx : null;
             const agentStatus = statuses.get(blockId) ?? "idle";
-            const children = groupSubagentsByWorkflow(
-                subagents.filter((s) => s.parent_block_id === blockId)
+            const children = stabilizeGroupIdentity(
+                this.groupIdentityCache,
+                groupSubagentsByWorkflow(subagents.filter((s) => s.parent_block_id === blockId))
             );
             return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, subagents: children };
         });
+
+        // Prune once per full pass (not per-block — see stabilizeGroupIdentity)
+        // against every workflow_id live anywhere in the flat subagent list.
+        const liveWorkflowIds = new Set(subagents.map((s) => s.workflow_id).filter((id): id is string => !!id));
+        pruneGroupIdentityCache(this.groupIdentityCache, liveWorkflowIds);
+
+        return nodes;
     }
 
     dispose(): void {
@@ -550,5 +623,6 @@ export class SwarmViewModel implements ViewModel {
         this.blockUnsubs = [];
         for (const detail of this.detailCache.values()) detail.dispose();
         this.detailCache.clear();
+        this.groupIdentityCache.clear();
     }
 }

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -28,7 +28,26 @@ export interface ActiveSubagent {
     // typed away here. Some("wf_<id>") for a Task/Workflow-tool run that
     // spawned multiple subagents together; null for a standalone subagent.
     workflow_id: string | null;
+    // Concise Haiku-generated name (SubagentInfo.display_name, Rust). Null
+    // until a client expands this subagent's row for the first time — see
+    // `subagent.GenerateName` / the `subagent:named` event below.
+    display_name: string | null;
 }
+
+// ── Subagent event log (inline-expand detail) ───────────────────────────
+
+export interface SubagentEvent {
+    agent_id: string;
+    event_type: SubagentEventType;
+    timestamp: number;
+}
+
+export type SubagentEventType =
+    | { type: "text"; content: string }
+    | { type: "tool_use"; name: string; input_summary: string }
+    | { type: "tool_result"; is_error: boolean; preview: string }
+    | { type: "progress"; output: string }
+    | { type: "result"; content: string };
 
 /**
  * A group of subagents spawned together by one Task/Workflow-tool run
@@ -106,6 +125,129 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
     return [...loose, ...groups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
 }
 
+function shallowEqualSubagent(a: ActiveSubagent, b: ActiveSubagent): boolean {
+    return (
+        a.slug === b.slug &&
+        a.status === b.status &&
+        a.last_event_at === b.last_event_at &&
+        a.event_count === b.event_count &&
+        a.model === b.model &&
+        a.workflow_id === b.workflow_id &&
+        a.display_name === b.display_name &&
+        a.parent_agent === b.parent_agent &&
+        a.parent_block_id === b.parent_block_id &&
+        a.session_id === b.session_id
+    );
+}
+
+/**
+ * Merge a freshly-fetched subagent list into the previous one, reusing the
+ * OLD object reference for any entry whose fields are unchanged. `ListActive`
+ * returns a brand-new JSON-deserialized array on every call — without this,
+ * every subagent (not just the one that actually changed) gets a fresh
+ * object identity on every spawn/completed refresh, and SolidJS's `<For>`
+ * (which diffs list items by reference, not value) tears down and remounts
+ * every row in the tree on every refresh, silently collapsing any row a
+ * user has expanded. See
+ * docs/specs/REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md.
+ */
+export function mergeSubagentsPreservingIdentity(
+    prev: ActiveSubagent[],
+    next: ActiveSubagent[]
+): ActiveSubagent[] {
+    const prevById = new Map(prev.map((s) => [s.agent_id, s]));
+    return next.map((incoming) => {
+        const old = prevById.get(incoming.agent_id);
+        return old && shallowEqualSubagent(old, incoming) ? old : incoming;
+    });
+}
+
+// ── Subagent detail (inline-expand event log) ───────────────────────────
+
+export interface SubagentDetail {
+    eventsAtom: Accessor<SubagentEvent[]>;
+    infoAtom: Accessor<ActiveSubagent | null>;
+    statusAtom: Accessor<"active" | "completed" | "loading">;
+    dispose: () => void;
+}
+
+/**
+ * Plain-function counterpart of the retired SubagentViewModel — fetches one
+ * subagent's event history + info once and keeps them live via
+ * subagent:activity/subagent:completed. Deliberately NOT tied to a
+ * component's render lifecycle (no `onCleanup`): `SwarmViewModel` caches
+ * one of these per expanded subagent (`getSubagentDetail`) so it survives
+ * the frequent `<For>` remounts `tree()` causes (see
+ * `mergeSubagentsPreservingIdentity` and `groupSubagentsByWorkflow` above —
+ * workflow-group wrapper objects are rebuilt on every recompute regardless
+ * of whether their members changed) instead of refetching/resubscribing on
+ * every incidental re-render while a row is open.
+ */
+export function createSubagentDetail(subagentId: string): SubagentDetail {
+    const [events, setEvents] = createSignal<SubagentEvent[]>([]);
+    const [info, setInfo] = createSignal<ActiveSubagent | null>(null);
+    const [status, setStatus] = createSignal<"active" | "completed" | "loading">("loading");
+
+    const unsubs: (() => void)[] = [];
+
+    const unsubActivity = waveEventSubscribe({
+        eventType: "subagent:activity",
+        handler: (event: WaveEvent) => {
+            const data = event?.data as any;
+            if (data?.agentId !== subagentId) return;
+            const newEvents = (data?.events as SubagentEvent[]) ?? [];
+            if (newEvents.length > 0) setEvents((prev) => [...prev, ...newEvents]);
+            if (data?.totalEvents != null) {
+                setInfo((prev) => (prev ? { ...prev, event_count: data.totalEvents } : prev));
+            }
+        },
+    });
+    if (unsubActivity) unsubs.push(unsubActivity);
+
+    const unsubCompleted = waveEventSubscribe({
+        eventType: "subagent:completed",
+        handler: (event: WaveEvent) => {
+            const data = event?.data as any;
+            if (data?.agentId !== subagentId) return;
+            setStatus("completed");
+            setInfo((prev) => (prev ? { ...prev, status: "completed" } : prev));
+        },
+    });
+    if (unsubCompleted) unsubs.push(unsubCompleted);
+
+    void (async () => {
+        try {
+            const result = await callBackendService("subagent", "GetHistory", [subagentId, 500]);
+            setEvents((result as SubagentEvent[]) ?? []);
+            setStatus("active");
+        } catch {
+            setStatus("active");
+        }
+        // Targeted single-agent lookup (not ListActive's full scan) — this
+        // subagent may have spawned before this pane opened, so its
+        // subagent:spawned event already fired and won't refire.
+        try {
+            const result = await callBackendService("subagent", "GetInfo", [subagentId]);
+            if (result) {
+                const match = result as ActiveSubagent;
+                setInfo(match);
+                setStatus(match.status);
+            }
+        } catch {
+            // ignore
+        }
+    })();
+
+    return {
+        eventsAtom: events,
+        infoAtom: info,
+        statusAtom: status,
+        dispose: () => {
+            for (const unsub of unsubs) unsub();
+        },
+    };
+}
+
 // ── Status derivation ────────────────────────────────────────────────────
 
 /**
@@ -164,20 +306,27 @@ export class SwarmViewModel implements ViewModel {
     loadingAtom: Accessor<boolean> = this._loading[0];
     private setLoading: Setter<boolean> = this._loading[1];
 
-    // Workflow groups the user has expanded, keyed by workflowId. Lives
-    // here, not as WorkflowGroupRow-local component state: `buildTree()`
-    // calls `groupSubagentsByWorkflow`, which builds brand-new WorkflowGroup
-    // wrapper objects on every recompute — including when an UNRELATED block
-    // changes (any subagent spawn/complete event, any `term:ctx-tokens` or
-    // activity-summary meta update touches `tree()`'s dependencies). Since
-    // `<For>` diffs list items by reference, a fresh wrapper object remounts
-    // WorkflowGroupRow and silently resets a local `expanded` signal on
-    // essentially every tree refresh — precisely while watching an active
-    // workflow's progress, the case this feature targets. Keying expand
-    // state by a stable string id here survives that churn.
+    // Rows the user has expanded — keyed by workflowId (WorkflowGroupRow) or
+    // agent_id (SubagentRow). Lives here, not as row-local component state:
+    // `tree()` recomputes on every trackedBlockIds/subagents/agentStatuses
+    // change (agentStatuses updates on every controllerstatus tick — very
+    // frequent during an active turn) and rebuilds fresh WorkflowGroup/
+    // AgentTreeNode wrapper objects every time regardless of whether that
+    // row's own data changed, so `<For>`'s reference-diffing remounts row
+    // components far more often than "the user actually changed something."
+    // Local expand state would silently collapse on the very next unrelated
+    // status tick; keying by a stable string id here survives that churn.
     private _expandedIds = createSignal<Set<string>>(new Set());
     expandedIdsAtom: Accessor<Set<string>> = this._expandedIds[0];
     private setExpandedIds: Setter<Set<string>> = this._expandedIds[1];
+
+    // One SubagentDetail per currently-expanded subagent, created lazily on
+    // first expand. Same rationale as expandedIds above: if this fetch+
+    // subscribe lifecycle lived inside the row component instead, every
+    // incidental remount (see above) would refetch GetHistory/GetInfo and
+    // resubscribe from scratch — potentially several times a second while a
+    // row is open during an active turn.
+    private detailCache = new Map<string, SubagentDetail>();
 
     private unsubs: (() => void)[] = [];
     // Per-block controllerstatus unsubs — cleaned up when block list refreshes
@@ -200,6 +349,23 @@ export class SwarmViewModel implements ViewModel {
             handler: () => void this.loadSubagents(),
         });
         if (unsubCompleted) this.unsubs.push(unsubCompleted);
+
+        // Patch display_name in place (not a full loadSubagents() reload) so
+        // every client watching this session picks up a generated name —
+        // not just the one whose expand click triggered subagent.GenerateName.
+        const unsubNamed = waveEventSubscribe({
+            eventType: "subagent:named",
+            handler: (event: WaveEvent) => {
+                const data = event?.data as any;
+                const agentId = data?.agentId;
+                const displayName = data?.displayName;
+                if (!agentId || !displayName) return;
+                this.setSubagents((prev) =>
+                    prev.map((s) => (s.agent_id === agentId ? { ...s, display_name: displayName } : s))
+                );
+            },
+        });
+        if (unsubNamed) this.unsubs.push(unsubNamed);
 
         // When process trackers change, refresh the block list
         const unsubProcAdded = waveEventSubscribe({
@@ -260,16 +426,19 @@ export class SwarmViewModel implements ViewModel {
         try {
             const result = await callBackendService("subagent", "ListActive", []);
             const list = (result as ActiveSubagent[]) ?? [];
-            this.setSubagents(list);
+            this.setSubagents((prev) => mergeSubagentsPreservingIdentity(prev, list));
         } catch {
             // silently ignore
         }
     };
 
+    // ── Row expand/collapse (workflow groups + subagent detail) ──────────
+
     isExpanded(id: string): boolean {
         return this.expandedIdsAtom().has(id);
     }
 
+    /** Generic toggle — used by WorkflowGroupRow (no data-fetching side effects). */
     toggleExpanded(id: string): void {
         this.setExpandedIds((prev) => {
             const next = new Set(prev);
@@ -277,6 +446,27 @@ export class SwarmViewModel implements ViewModel {
             else next.add(id);
             return next;
         });
+    }
+
+    /** SubagentRow's toggle — also tears down the cached SubagentDetail
+     *  (and its WS subscriptions) on collapse, so a subagent a user opened
+     *  once and moved on from doesn't keep a live subscription forever. */
+    toggleSubagentExpanded(agentId: string): void {
+        const wasExpanded = this.isExpanded(agentId);
+        this.toggleExpanded(agentId);
+        if (wasExpanded) {
+            this.detailCache.get(agentId)?.dispose();
+            this.detailCache.delete(agentId);
+        }
+    }
+
+    getSubagentDetail(agentId: string): SubagentDetail {
+        let detail = this.detailCache.get(agentId);
+        if (!detail) {
+            detail = createSubagentDetail(agentId);
+            this.detailCache.set(agentId, detail);
+        }
+        return detail;
     }
 
     // Subscribe to controllerstatus events for each tracked block and
@@ -358,5 +548,7 @@ export class SwarmViewModel implements ViewModel {
         for (const unsub of [...this.unsubs, ...this.blockUnsubs]) unsub();
         this.unsubs = [];
         this.blockUnsubs = [];
+        for (const detail of this.detailCache.values()) detail.dispose();
+        this.detailCache.clear();
     }
 }

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -216,6 +216,15 @@
 
 // ── Subagent child row ───────────────────────────────────────────────────
 
+.swarm-subagent-group {
+    display: flex;
+    flex-direction: column;
+
+    &--completed {
+        opacity: 0.85;
+    }
+}
+
 .swarm-subagent-row {
     display: flex;
     align-items: center;
@@ -243,6 +252,113 @@
         white-space: nowrap;
         color: var(--main-text-color);
     }
+}
+
+.swarm-subagent-expand-icon {
+    width: 10px;
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    flex-shrink: 0;
+}
+
+// ── Subagent inline detail (expanded event log) ──────────────────────────
+
+.swarm-subagent-detail {
+    display: flex;
+    flex-direction: column;
+    margin: 0 6px 4px 30px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--panel-bg-color, var(--main-bg-color));
+    max-height: 320px;
+    overflow: hidden;
+}
+
+.swarm-subagent-detail-header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
+}
+
+.swarm-subagent-detail-name {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--main-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.swarm-subagent-detail-meta {
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+}
+
+.swarm-subagent-detail-log {
+    overflow-y: auto;
+    padding: 2px 8px 4px;
+}
+
+.swarm-subagent-detail-loading,
+.swarm-subagent-detail-empty {
+    padding: 8px 0;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+}
+
+.swarm-subagent-detail-text {
+    margin: 2px 0;
+    font-size: 11px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-family: var(--termfontfamily, monospace);
+
+    &--error {
+        color: var(--error-color);
+    }
+}
+
+.swarm-subagent-detail-tool {
+    margin: 1px 0;
+}
+
+.swarm-subagent-detail-tool-header {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    cursor: default;
+    padding: 1px 0;
+    font-size: 11px;
+    user-select: none;
+
+    &:hover {
+        color: var(--accent-color);
+    }
+
+    &--error {
+        color: var(--error-color);
+    }
+}
+
+.swarm-subagent-detail-tool-name {
+    font-family: var(--termfontfamily, monospace);
+    font-weight: 600;
+    color: var(--accent-color);
+}
+
+.swarm-subagent-detail-progress {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    padding: 1px 0;
 }
 
 // ── Haiku activity summary ───────────────────────────────────────────────

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -352,6 +352,14 @@
     color: var(--accent-color);
 }
 
+.swarm-subagent-detail-expand-icon {
+    width: 10px;
+    font-size: 9px;
+    text-align: center;
+    color: var(--secondary-text-color);
+    flex-shrink: 0;
+}
+
 .swarm-subagent-detail-progress {
     display: flex;
     align-items: center;

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowGroup } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowGroup, SubagentDetail, SubagentEvent } from "./swarm-model";
 import { isWorkflowGroup } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
-import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
+import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { WOS, workspace, setActiveTab, atoms, getApi } from "@/app/store/global";
@@ -256,7 +256,7 @@ function AgentRow({
                 <For each={node.subagents}>
                     {(child) => isWorkflowGroup(child)
                         ? <WorkflowGroupRow group={child} model={model} />
-                        : <SubagentRow sub={child} />}
+                        : <SubagentRow sub={child} model={model} />}
                 </For>
             </div>
         </div>
@@ -290,7 +290,7 @@ function WorkflowGroupRow({ group, model }: { group: WorkflowGroup; model: Swarm
             <Show when={expanded()}>
                 <div class="swarm-workflow-members">
                     <For each={group.subagents}>
-                        {(sub) => <SubagentRow sub={sub} />}
+                        {(sub) => <SubagentRow sub={sub} model={model} />}
                     </For>
                 </div>
             </Show>
@@ -300,28 +300,122 @@ function WorkflowGroupRow({ group, model }: { group: WorkflowGroup; model: Swarm
 
 // ── Subagent child row ───────────────────────────────────────────────────
 
-function SubagentRow({ sub }: { sub: ActiveSubagent }): JSX.Element {
-    const handleOpen = () => {
-        if (isSubagentPaneOpen(sub.agent_id)) return;
-        void openSubagentPane({
-            subagentId: sub.agent_id,
-            slug: sub.slug,
-            parentAgent: sub.parent_agent,
-            parentBlockId: sub.parent_block_id,
-            sessionId: sub.session_id,
-        });
+function SubagentRow({ sub, model }: { sub: ActiveSubagent; model: SwarmViewModel }): JSX.Element {
+    const expanded = createMemo(() => model.isExpanded(sub.agent_id));
+    const displayLabel = createMemo(() => sub.display_name || sub.slug || sub.agent_id.substring(0, 7));
+
+    const handleToggle = () => {
+        const wasExpanded = expanded();
+        model.toggleSubagentExpanded(sub.agent_id);
+        if (!wasExpanded && !sub.display_name) {
+            // Fire-and-forget — the row picks up the result via the
+            // subagent:named event (swarm-model.ts), not this call's return.
+            void callBackendService("subagent", "GenerateName", [sub.agent_id]);
+        }
     };
 
     return (
-        <div
-            class={`swarm-subagent-row swarm-subagent-row--${sub.status}`}
-            onClick={handleOpen}
-            title={sub.slug || sub.agent_id}
-        >
-            <span class="swarm-subagent-slug">{sub.slug || sub.agent_id.substring(0, 7)}</span>
-            <AgentStatusChip status={sub.status === "active" ? "working" : "idle"} />
+        <div class={`swarm-subagent-group swarm-subagent-group--${sub.status}`}>
+            <div
+                class={`swarm-subagent-row swarm-subagent-row--${sub.status}`}
+                onClick={handleToggle}
+                title={displayLabel()}
+            >
+                <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-expand-icon`} />
+                <span class="swarm-subagent-slug">{displayLabel()}</span>
+                <AgentStatusChip status={sub.status === "active" ? "working" : "idle"} />
+            </div>
+            <Show when={expanded()}>
+                <SubagentDetailPane sub={sub} detail={model.getSubagentDetail(sub.agent_id)} />
+            </Show>
         </div>
     );
+}
+
+// ── Subagent inline detail (expanded event log) ──────────────────────────
+
+function SubagentDetailPane({ sub, detail }: { sub: ActiveSubagent; detail: SubagentDetail }): JSX.Element {
+    const info = detail.infoAtom;
+    const events = detail.eventsAtom;
+    const status = detail.statusAtom;
+
+    const name = createMemo(() =>
+        info()?.display_name || sub.display_name || info()?.slug || sub.slug || sub.agent_id.substring(0, 7)
+    );
+    const modelName = createMemo(() => info()?.model ?? sub.model);
+    const eventCount = createMemo(() => info()?.event_count ?? sub.event_count);
+
+    return (
+        <div class="swarm-subagent-detail">
+            <div class="swarm-subagent-detail-header">
+                <span class="swarm-subagent-detail-name">{name()}</span>
+                <span class="swarm-subagent-detail-meta">{sub.agent_id.substring(0, 7)}</span>
+                <span class="swarm-subagent-detail-meta">{eventCount()} events</span>
+                <Show when={modelName()}>
+                    <span class="swarm-subagent-detail-meta">{modelName()}</span>
+                </Show>
+                <span class="swarm-subagent-detail-meta">{sub.parent_agent}</span>
+            </div>
+            <div class="swarm-subagent-detail-log">
+                <Show when={status() === "loading"}>
+                    <div class="swarm-subagent-detail-loading">Loading…</div>
+                </Show>
+                <Show when={events().length === 0 && status() !== "loading"}>
+                    <div class="swarm-subagent-detail-empty">No activity yet</div>
+                </Show>
+                <For each={events()}>{(event) => <SubagentDetailEvent event={event} />}</For>
+            </div>
+        </div>
+    );
+}
+
+function SubagentDetailEvent({ event }: { event: SubagentEvent }): JSX.Element {
+    const et = event.event_type;
+    const [expanded, setExpanded] = createSignal(false);
+
+    switch (et.type) {
+        case "text":
+        case "result":
+            return <pre class="swarm-subagent-detail-text">{et.content}</pre>;
+        case "tool_use":
+            return (
+                <div class="swarm-subagent-detail-tool">
+                    <div class="swarm-subagent-detail-tool-header" onClick={() => setExpanded(!expanded())}>
+                        <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-detail-expand-icon`} />
+                        <span class="swarm-subagent-detail-tool-name">{et.name}</span>
+                    </div>
+                    <Show when={expanded()}>
+                        <pre class="swarm-subagent-detail-text">{et.input_summary}</pre>
+                    </Show>
+                </div>
+            );
+        case "tool_result":
+            return (
+                <div class="swarm-subagent-detail-tool">
+                    <div
+                        class={`swarm-subagent-detail-tool-header ${et.is_error ? "swarm-subagent-detail-tool-header--error" : ""}`}
+                        onClick={() => setExpanded(!expanded())}
+                    >
+                        <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-detail-expand-icon`} />
+                        <span>{et.is_error ? "Error" : "Result"}</span>
+                    </div>
+                    <Show when={expanded()}>
+                        <pre class={`swarm-subagent-detail-text ${et.is_error ? "swarm-subagent-detail-text--error" : ""}`}>
+                            {et.preview}
+                        </pre>
+                    </Show>
+                </div>
+            );
+        case "progress":
+            return (
+                <div class="swarm-subagent-detail-progress">
+                    <i class="fa-solid fa-spinner fa-spin" />
+                    <span>{et.output}</span>
+                </div>
+            );
+        default:
+            return null;
+    }
 }
 
 // ── Status chip ──────────────────────────────────────────────────────────

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -12,6 +12,7 @@ import { WOS, workspace, setActiveTab, atoms, getApi } from "@/app/store/global"
 import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
 import { getBlockTurnPhase } from "@/app/store/agentActivity";
 import { WorkspaceService } from "@/app/store/services";
+import { recordTurn } from "@/app/store/token-usage";
 import "./swarm-view.scss";
 
 // Navigate to the pane for a given block ID, switching tabs and windows as needed.
@@ -308,9 +309,12 @@ function SubagentRow({ sub, model }: { sub: ActiveSubagent; model: SwarmViewMode
         const wasExpanded = expanded();
         model.toggleSubagentExpanded(sub.agent_id);
         if (!wasExpanded && !sub.display_name) {
-            // Fire-and-forget — the row picks up the result via the
-            // subagent:named event (swarm-model.ts), not this call's return.
-            void callBackendService("subagent", "GenerateName", [sub.agent_id]);
+            // Fire-and-forget — the row's label/detail header picks up the
+            // name via the subagent:named event (swarm-model.ts), not this
+            // call's return; we only need the return here for cost accounting.
+            void callBackendService("subagent", "GenerateName", [sub.agent_id]).then((result: any) => {
+                if (result?.tokens) recordTurn("ambient:subagent_name", result.tokens);
+            });
         }
     };
 


### PR DESCRIPTION
## Summary
Stacked on #2018 (workflow grouping) — targets that branch until it merges.

- Clicking a subagent row in the Swarm tree now expands **inline** (same pattern as `WorkflowGroupRow`) instead of opening a new split pane.
- Per-event timestamps removed from the log; spacing trimmed.
- Expanded header shows a concise ~5-word **Haiku-generated name** instead of the raw slug/hash, plus short id, event count, model, parent agent.
- Naming is **on-demand** (fired once on first expand, cached on the backend `SubagentInfo.display_name` thereafter, broadcast via a new `subagent:named` event) — not eager, to avoid spawning a Haiku CLI per subagent on every pane reopen for a session with hundreds of subagents.
- New backend: `AMBIENT_PURPOSE_SUBAGENT_NAME` (one-shot, `generation=1`) admitted through the existing Ambient Model Call gateway, reuses `invoke_ambient_haiku_call` + the existing `pull_call_semaphore` cross-block concurrency cap. New RPC: `subagent.GenerateName`.

### Row-remount bug found + fixed along the way
`buildTree()` rebuilds fresh wrapper objects every recompute (frequent — every `controllerstatus` tick), so SolidJS's `<For>` (reference-diffed) was silently remounting every row far more often than any real data change, collapsing any expanded row (including the just-shipped `WorkflowGroupRow` from #2018) within about one status tick. Fixed by lifting expand state + per-subagent detail-fetch state onto `SwarmViewModel` (keyed by `workflowId`/`agent_id` instead of row-local signals), and reusing old object references for unchanged subagents in `loadSubagents()`.

### Scope note
The standalone `SubagentView` pane is **kept, not retired** — `agent-view.tsx`'s `handleSubagentClick` (a subagent link inside an agent's own transcript) is a second, independent entry point into it beyond the Swarm tree; retiring it would have broken that click-through.

Full design writeup: `docs/specs/REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md`.

## Test plan
- [x] Backend: 5 new `subagent_watcher` tests (`set_display_name`, `read_task_prompt` × 3) + all 30 existing tests pass
- [x] Frontend: 4 new `mergeSubagentsPreservingIdentity` tests + all 12 existing `swarm-model` tests pass
- [x] `tsc --noEmit` clean, `stylelint` clean on added lines

<!-- agentmux:agent_id=agentx -->