### PR TITLE
docs(messaging): status snapshot + implementation-ready specs for Telegram/Slack/WhatsApp/Teams

### DIFF
--- a/.changesets/1783482671-docs-messaging-status-snapshot-implementation-ready-specs-fo-oyo3.md
+++ b/.changesets/1783482671-docs-messaging-status-snapshot-implementation-ready-specs-fo-oyo3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(messaging): status snapshot + implementation-ready specs for Telegram/Slack/WhatsApp/Teams bridges

--- a/docs/specs/SPEC_MESSAGING_INTEGRATION_SLACK_2026_07_07.md
+++ b/docs/specs/SPEC_MESSAGING_INTEGRATION_SLACK_2026_07_07.md
@@ -1,0 +1,459 @@
+# Spec: Messaging App Integration — Slack
+
+**Date:** 2026-07-07
+**Status:** Draft — ready to implement
+**Scope:** Rust implementation of a Slack bridge (Socket Mode + Web API) in `agentmux-srv`, mirroring the shipped Discord bridge. Pane layer (webview) already exists.
+
+---
+
+## 1. Goal / context
+
+AgentMux embeds messaging apps as two layers: a **pane** (a `browser` widget pointed at the real web app) and a **bridge** (a background process that lets an agent read/send messages through that same app). The full cross-platform architecture, decision matrix, and original per-platform protocol research live in `docs/specs/SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md` §1–§3.3 — read that first; this spec does not re-derive the Slack protocol from scratch, it translates the plan's §3.3 research into the actual Rust module shape this repo uses.
+
+The Slack **pane** already shipped: `agentmux-srv/src/config/widgets.json` lines 136–150 define `defwidget@slack` as a `browser` widget pointed at `https://app.slack.com/`, description `"Slack — real interface, agent-connected (bridge Phase 2)"`. This spec is that "Phase 2" — the bridge.
+
+The Discord bridge shipped in PR #1763 (merged 2026-06-24) as pure Rust inside `agentmux-srv`, using hand-rolled `tokio-tungstenite` + `reqwest`, no SDK crate, no separate process. That is the load-bearing precedent for this spec (see §3).
+
+Reference implementation to mirror throughout: `agentmux-srv/src/messaging/discord/{mod,gateway,rest,types}.rs`.
+
+---
+
+## 2. Protocol design (condensed from the master plan, Slack-specific)
+
+### 2.1 Connection lifecycle overview
+
+Slack Socket Mode has one structural difference from Discord Gateway that shapes the whole module: Discord's Gateway URL (`wss://gateway.discord.gg`) is a fixed, well-known constant. Slack's Socket Mode URL is **ephemeral** — a fresh, single-use WS URL must be requested via a REST call before every connection attempt (initial connect *and* every reconnect). There is no equivalent of Discord's RESUME; every new connection is effectively a full re-identify at the transport level, though Slack's *application*-level state (subscriptions, event delivery) is stateless per-connection so this costs nothing but an extra round trip.
+
+```
+POST https://slack.com/api/apps.connections.open
+Authorization: Bearer xapp-{app_token}
+→ 200 {"ok": true, "url": "wss://wss-primary.slack.com/link/?ticket=...&app_id=..."}
+```
+
+Connect to the returned URL immediately — tickets are single-use and short-lived (treat as "use within seconds", never cache/reuse). On any connect failure, retry `apps.connections.open` with backoff (see §9).
+
+### 2.2 Event envelope + the 3-second ACK
+
+Once connected, Slack pushes JSON frames. The two relevant envelope types:
+
+```json
+// Hello (first frame after connect)
+{"type": "hello", "num_connections": 1, "connection_info": {"app_id": "A..."}}
+
+// Events API envelope (the actual payload we care about)
+{
+  "envelope_id": "95869...",
+  "type": "events_api",
+  "accepts_response_payload": false,
+  "payload": {
+    "event": {"type": "message", "channel": "C...", "user": "U...", "text": "...", "ts": "..."}
+  }
+}
+```
+
+**Hard correctness requirement:** every envelope carrying an `envelope_id` must be ACKed within 3 seconds by sending `{"envelope_id": "<id>"}` back on the **same socket it arrived on**. Missing the ACK does not just risk a retry — Slack will eventually stop delivering events over the connection and (per Slack's own docs) this failure mode is silent from the client's point of view. The ACK must happen unconditionally, before any business logic that could fail or block — i.e. read the frame, ACK immediately, *then* parse/route the payload. This mirrors Discord's HEARTBEAT_ACK handling in spirit (bounded-latency protocol-level response required to keep the connection alive) but the deadline here is much tighter (3s vs. Discord's ~41s heartbeat interval) and is per-event rather than per-interval.
+
+### 2.3 Reconnect-on-warning — the trickiest part
+
+Slack proactively recycles Socket Mode connections roughly hourly and signals this ahead of time:
+
+```json
+{"type": "disconnect", "reason": "warning"}
+```
+
+This arrives **~10 seconds before** Slack will actually close the socket. The naive approach — wait for the close, then reconnect — creates a message-loss window: events that Slack routes to the about-to-die connection between the warning and the close, or during the reconnect gap, can be missed if the new connection isn't ready in time.
+
+**Correct pattern (make-before-break):**
+1. On receiving `{"type": "disconnect", "reason": "warning"}`, immediately call `apps.connections.open` again to get a *second* ephemeral URL.
+2. Open a second WebSocket to that URL in parallel, **while keeping the first connection alive and still ACKing events on it**.
+3. Once the second socket reaches `hello`, treat it as the active connection for all *new* inbound processing; keep draining/ACKing any remaining frames on the old socket until it closes on its own (Slack closes it after the warning period) or a `link_disabled`-equivalent signal appears.
+4. Discard the old socket handle once closed.
+
+This is a two-socket, cutover-not-teardown-then-standup design — structurally different from Discord's RESUME (which is teardown-then-reconnect-with-replay). Implement it as an explicit state machine with (at most) two live `WebSocketStream` handles rather than trying to force it into the same single-connection loop Discord uses. See §4.2 for the concrete task shape.
+
+**On unexpected close** (no prior warning — network blip, etc.): exponential backoff starting at 1s, doubling, capped at 60s, matching Discord's existing backoff constants (`RECONNECT_DELAY_SECS` / `MAX_RECONNECT_DELAY_SECS` in `gateway.rs`) for consistency. Each retry re-fetches a fresh URL via `apps.connections.open` (never retry the same stale URL).
+
+**Proactive dead-connection heuristic:** Slack has a documented failure mode where a Socket Mode connection reports itself open but silently stops delivering events (no close frame, no warning). Mitigate with a timer: if no frame of any kind (including Slack's periodic pings, if any) has been received for **5 minutes**, force-close and reconnect via the same cutover-or-backoff path. Track `last_event_at` the same way `gateway.rs` does for Discord's health struct, and drive the timer off that field.
+
+### 2.4 Outbound — Web API
+
+```
+POST https://slack.com/api/chat.postMessage
+Authorization: Bearer xoxb-{bot_token}
+Content-Type: application/json
+{"channel": "C...", "text": "fallback text", "blocks": [ ... ]}
+```
+
+Always send `text` even when `blocks` is present — it's the fallback used for push notifications and accessibility surfaces. Slack's REST response is HTTP 200 even on many logical failures; the real success signal is the `"ok": true` field in the JSON body — check it explicitly, don't rely on status code alone (this is a real divergence from Discord's REST, which uses HTTP status faithfully).
+
+### 2.5 Slash command deferred response
+
+```
+1. Slash command interaction arrives as a distinct envelope type ("slash_commands") — ACK the envelope within 3s same as any other event.
+2. If synchronous work fits in that window, return payload immediately: {"envelope_id": "...", "payload": {"text": "...", "response_type": "ephemeral"}}
+3. Otherwise ACK with just {"envelope_id": "..."} (empty ack) and do the work async, then:
+   POST {response_url} {"text": "result", "response_type": "in_channel", "blocks": [...]}
+   → response_url is valid for 5 uses within 30 minutes of the original command.
+```
+
+Not required for the MVP (see §10) but the module should have an obvious extension point for it (a `response_url` field threaded through the routed command payload).
+
+### 2.6 Rate limits
+
+| Surface | Limit | Notes |
+|---|---|---|
+| `chat.postMessage` | ~1 msg/s/channel (Special tier, bursts tolerated briefly) | Queue + backoff on 429, don't drop |
+| Most read methods (`conversations.*`) | Tier 3, 50+/min | Not used in MVP (no read-side REST calls needed — Socket Mode delivers everything) |
+| Socket Mode connections | 10 max concurrently per app | The make-before-break dance in §2.3 briefly uses 2; well under the cap |
+| Slash command `response_url` | 5 calls / 30 min window | Enforce client-side if/when slash commands are added |
+| `apps.connections.open` | Not separately documented as a hard cap, but treat as expensive — never poll it, only call on initial connect / warning / backoff retry | |
+
+On any `429` from `chat.postMessage`: read `Retry-After` header (seconds), wait, retry once; on repeated 429s apply the same exponential backoff used for reconnects. Never busy-loop retry.
+
+---
+
+## 3. Rust-not-Node correction (override of the master plan)
+
+The master plan (`SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md` §3.3, §4 Phase 3) specified Slack as **Electron main-process Node.js**, using `@slack/socket-mode` + `@slack/web-api`, bridged to the Rust core via IPC. That assumption is **overridden** by this spec for two reasons:
+
+1. **This app is not Electron.** AgentMux's desktop host is a CEF-based Rust process (`agentmux-cef`) with `agentmux-srv` as the Rust backend. There is no Electron main process anywhere in this codebase for an IPC bridge to terminate into. The plan's Node.js assumption was written before (or without accounting for) that architectural fact.
+2. **Discord already proved the Rust-only pattern in production.** PR #1763 implemented Discord's Gateway WebSocket + REST entirely in `agentmux-srv` using raw `tokio-tungstenite` and `reqwest`, with hand-rolled `serde_json` wire types (`agentmux-srv/src/messaging/discord/`) — not even a Discord SDK crate (`twilight`/`serenity`), despite the plan recommending one. There is no reason Slack's Socket Mode — which is protocol-wise simpler than Discord's Gateway (no bitmask intents, no RESUME/session-replay semantics, no per-shard identify limits) — should regress to a heavier, cross-process Node.js design.
+
+**Decision: implement Slack as pure Rust inside `agentmux-srv`, in a `messaging/slack/` module structurally identical to `messaging/discord/`.** No Node.js process, no Electron, no IPC bridge, no new external process to supervise, package, or crash-recover.
+
+**Crate choice:** raw `tokio-tungstenite` (already a dependency — `agentmux-srv/Cargo.toml` line 58, version `0.24`) for the WebSocket, `reqwest` (already a dependency, line 38) for the Web API. This matches Discord's dependency footprint exactly — zero new crates required for the transport layer.
+
+**Alternative considered and rejected:** `slack-morphism` (unofficial Rust Slack SDK, has Socket Mode + Web API + Block Kit typed builders). It's a reasonable crate and would save some hand-rolled serde work, particularly for Block Kit's deeply nested/variant-heavy JSON shape. Rejected for MVP because (a) it's unofficial and adds a third-party dependency surface for exactly the kind of protocol logic Discord proved is tractable to hand-roll in an afternoon, (b) pulling in its own Block Kit type system creates a second Block Kit representation to reconcile against whatever escape-hatch/raw-JSON path we build (§7), and (c) dependency-footprint consistency with Discord was an explicit design goal from the task that spawned this spec. If Block Kit hand-rolling turns out to be a bigger time sink than expected during implementation, revisit — `slack-morphism` is the fallback, not a rejected-forever option.
+
+---
+
+## 4. Rust module layout
+
+Mirror `agentmux-srv/src/messaging/discord/` exactly:
+
+```
+agentmux-srv/src/messaging/slack/
+├── mod.rs        — SlackConfig, SlackBridge, GLOBAL_BRIDGE, init_global(), get(), send(), health()
+├── socket.rs      — Socket Mode connection lifecycle: apps.connections.open, the hello/events_api/
+│                    disconnect-warning state machine, ACK, make-before-break reconnect, dead-conn timer
+├── rest.rs        — Web API client: chat.postMessage (+ response_url POST for slash commands, deferred)
+└── types.rs       — wire types: envelope structs, event payload structs, Block Kit types, REST body types
+```
+
+(Naming note: Discord's equivalent file is `gateway.rs`; Slack's is named `socket.rs` since "Socket Mode" is Slack's own term and avoids implying Gateway-specific semantics like RESUME that don't apply here.)
+
+### 4.1 `mod.rs` — config, bridge, lifecycle
+
+```rust
+// agentmux-srv/src/messaging/slack/mod.rs
+
+mod socket;
+pub mod rest;
+pub mod types;
+
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::mpsc;
+use crate::messaging::{BridgeHealth, OutboundMsg};
+
+#[derive(Debug, Clone)]
+pub struct SlackConfig {
+    /// Bot token (`xoxb-...`) — used for chat.postMessage via Web API.
+    pub bot_token: String,
+    /// App-level token (`xapp-...`) — used only for apps.connections.open.
+    pub app_token: String,
+    /// Default channel ID — inbound filter + default outbound target.
+    pub channel_id: String,
+    /// Agent ID to inject inbound Slack messages into via the reactive bus.
+    pub target_agent: Option<String>,
+}
+
+pub struct SlackBridge {
+    outbound_tx: mpsc::UnboundedSender<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+}
+
+static GLOBAL_BRIDGE: OnceLock<SlackBridge> = OnceLock::new();
+
+impl SlackBridge {
+    /// Initialize the global Slack bridge and start the Socket Mode background task.
+    /// No-op if already initialized. The first `apps.connections.open` call happens
+    /// inside the spawned task, not here — init_global itself does no network I/O
+    /// and returns immediately, matching Discord's synchronous, non-blocking init.
+    pub fn init_global(config: SlackConfig, http: reqwest::Client) { /* ... */ }
+
+    pub fn get() -> Option<&'static SlackBridge> { GLOBAL_BRIDGE.get() }
+
+    /// Enqueue a message for delivery via chat.postMessage. Sync, fire-and-forget
+    /// onto the internal mpsc channel — matches Discord's DiscordBridge::send shape.
+    pub fn send(&self, msg: OutboundMsg) -> Result<(), String> { /* ... */ }
+
+    pub fn health(&self) -> BridgeHealth { self.health.lock().unwrap().clone() }
+
+    pub fn platform(&self) -> &'static str { "slack" }
+}
+```
+
+`init_global`'s spawned task does: `apps.connections.open` (async REST call) → on success, hand the URL to `socket::run_socket_loop(...)` which owns the full state machine from §2.1–§2.3, including subsequent `apps.connections.open` calls for reconnects/warnings. This is the key structural delta from Discord: Discord's `run_gateway_loop` connects directly to a constant URL; Slack's loop must fetch a URL as step zero of every connection attempt, including the very first one. Model this as `run_socket_loop` internally calling a `fetch_ws_url(app_token, http) -> Result<String, String>` helper before each `connect_async`, rather than accepting a URL as a parameter the way Discord's `run_session` does.
+
+### 4.2 `socket.rs` — connection lifecycle sketch
+
+State machine, roughly:
+
+```rust
+enum ConnState {
+    Single(WsHandle),                    // normal steady-state, one live socket
+    Cutover { old: WsHandle, new: WsHandle }, // between warning and old-socket close
+}
+```
+
+Main loop (`run_socket_loop`) responsibilities:
+- Outer retry loop with backoff (mirrors Discord's `run_gateway_loop` outer loop: connect → run_session-equivalent → on error, sleep(delay), double delay capped at 60s, reset delay after a session survives >30s).
+- Inner per-connection loop (`run_session`-equivalent) using `tokio::select!` over: inbound WS frames, the outbound `mpsc::UnboundedReceiver<OutboundMsg>` (routes to `rest::post_message`, same as Discord), and — new vs. Discord — a `dead_conn_timer` (`tokio::time::sleep` reset on every received frame; fires after 5 min idle → treat as reconnect-worthy).
+- On `{"type": "hello"}`: mark connected, update health.
+- On `{"type": "disconnect", "reason": "warning"}`: kick off the make-before-break sequence from §2.3 — this is the one part of the loop that needs to hold two socket handles simultaneously; implement it as a nested async block that opens the second connection, waits for its `hello`, then swaps which handle is "primary" for outbound-relevant bookkeeping (health `last_event_at`, etc.), while a second `tokio::select!` continues draining/ACKing the old socket until it closes.
+- On any `events_api` envelope: ACK immediately (send `{"envelope_id": ...}` before doing anything else), then parse `payload.event`, filter to configured channel, skip bot's own messages (Slack sets `bot_id` on bot-authored events — check for its presence the same way Discord checks `author.bot`), and inject into the reactive bus via `get_global_handler().inject_message(...)` exactly as `discord/gateway.rs::handle_dispatch` does for `MESSAGE_CREATE` (same `InjectionRequest` shape, `source_agent: Some("slack")`, envelope text prefixed e.g. `[Slack #channel @user]: text`).
+
+### 4.3 `rest.rs`
+
+```rust
+pub async fn open_connection(http: &reqwest::Client, app_token: &str) -> Result<String, String>;
+// POST apps.connections.open, Bearer {app_token}, returns the "url" field.
+
+pub async fn post_message(http: &reqwest::Client, bot_token: &str, channel_id: &str, msg: &OutboundMsg) -> Result<(), String>;
+// POST chat.postMessage, Bearer {bot_token}. MUST check body.ok, not just HTTP status (see §2.4).
+
+pub async fn post_response_url(http: &reqwest::Client, response_url: &str, body: serde_json::Value) -> Result<(), String>;
+// For slash-command deferred replies (future — see §10). Included now as a stub so the
+// module shape doesn't need rework when slash commands land.
+```
+
+### 4.4 `types.rs`
+
+Wire types needed: `SocketEnvelope` (tagged on `"type"`: `hello` / `events_api` / `disconnect` / `slash_commands`), `EventsApiPayload`, `SlackEvent` (`type`, `channel`, `user`, `text`, `ts`, `bot_id: Option<String>`), `AckFrame { envelope_id: String }`, `OpenConnectionResponse { ok: bool, url: Option<String>, error: Option<String> }`, `PostMessageBody { channel: String, text: String, blocks: Option<Vec<serde_json::Value>> }`, `PostMessageResponse { ok: bool, error: Option<String> }`. Block Kit types: see §7 — recommend representing blocks as `Vec<serde_json::Value>` rather than a fully typed enum tree for MVP (escape hatch, not a hand-rolled Block Kit DSL — see §11).
+
+---
+
+## 5. Config schema additions (`wconfig/types.rs`)
+
+Follow the exact flat, serde-renamed convention at `agentmux-srv/src/backend/wconfig/types.rs` lines 300–324 (Discord's block). Insert a parallel `-- Slack messaging bridge --` section immediately after it:
+
+```rust
+    // -- Slack messaging bridge --
+
+    /// Master enable for the Slack messaging bridge.
+    /// When true, the bridge opens a Socket Mode connection at startup.
+    #[serde(rename = "messaging:slack:enabled", default, skip_serializing_if = "is_false")]
+    pub messaging_slack_enabled: bool,
+
+    /// Slack bot token (`xoxb-...`). Used for Web API calls (chat.postMessage).
+    /// Treat as a secret — do not log. Obtain from api.slack.com/apps → OAuth & Permissions
+    /// → Bot User OAuth Token, after installing the app to the workspace.
+    #[serde(rename = "messaging:slack:bot_token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_slack_bot_token: Option<String>,
+
+    /// Slack app-level token (`xapp-...`). Used only for apps.connections.open (Socket Mode).
+    /// Treat as a secret — do not log. Obtain from api.slack.com/apps → Basic Information
+    /// → App-Level Tokens, scope `connections:write`.
+    #[serde(rename = "messaging:slack:app_token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_slack_app_token: Option<String>,
+
+    /// Channel ID to filter inbound messages and use as the default send target.
+    #[serde(rename = "messaging:slack:channel", default, skip_serializing_if = "String::is_empty")]
+    pub messaging_slack_channel: String,
+
+    /// Agent ID that receives inbound Slack messages via the reactive bus.
+    /// Absent → messages are logged but not forwarded to any agent.
+    #[serde(rename = "messaging:slack:target", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_slack_target: Option<String>,
+```
+
+Two token fields, not one — this is the one structural delta from Discord's config block, required by Slack's two-token Socket Mode design (App-Level Token for the WS handshake, Bot Token for REST sends). No `guild`-equivalent field is needed (Slack has no guild-scoping concept analogous to Discord's per-guild slash command registration at MVP scope — see §10, slash commands deferred).
+
+**User-facing setup checklist** (mirrors the plan's §3.3 setup steps, condensed for the settings UI / docs):
+1. Create a Slack app at api.slack.com/apps → "From an app manifest" (recommended — faster than manual scope clicking).
+2. App Settings → Socket Mode → toggle on → generate an App-Level Token with the `connections:write` scope. Copy the `xapp-...` value.
+3. App Settings → Event Subscriptions → enable → subscribe to bot events: `message.channels` (or `message.im` for DMs) and `app_mention`.
+4. App Settings → OAuth & Permissions → Bot Token Scopes: add `chat:write`, `channels:read`, `channels:history` (or `im:history`/`im:read`/`im:write` for DM-only use), `app_mentions:read`.
+5. Install App to Workspace (OAuth & Permissions → Install to Workspace). Copy the Bot User OAuth Token (`xoxb-...`).
+6. Invite the bot to the target channel: `/invite @your-bot-name` in Slack.
+7. Enter both tokens + channel ID into AgentMux settings (`messaging:slack:app_token`, `messaging:slack:bot_token`, `messaging:slack:channel`), set `messaging:slack:enabled = true`.
+
+---
+
+## 6. Startup wiring (`main.rs`)
+
+Mirror `agentmux-srv/src/main.rs` lines 731–755 (Discord's wiring block), inserted immediately after it:
+
+```rust
+    // Slack messaging bridge — opens a Socket Mode connection if configured.
+    // Set messaging:slack:enabled + messaging:slack:bot_token + messaging:slack:app_token
+    // in settings.json to activate.
+    {
+        let settings = config_watcher.get_settings();
+        if settings.messaging_slack_enabled {
+            match (
+                settings.messaging_slack_bot_token.clone(),
+                settings.messaging_slack_app_token.clone(),
+            ) {
+                (Some(bot_token), Some(app_token))
+                    if !bot_token.is_empty() && !app_token.is_empty() =>
+                {
+                    messaging::slack::SlackBridge::init_global(
+                        messaging::slack::SlackConfig {
+                            bot_token,
+                            app_token,
+                            channel_id: settings.messaging_slack_channel.clone(),
+                            target_agent: settings.messaging_slack_target.clone(),
+                        },
+                        reqwest::Client::new(),
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        "slack bridge: enabled but messaging:slack:bot_token and/or \
+                         messaging:slack:app_token is not set in settings.json"
+                    );
+                }
+            }
+        }
+    }
+```
+
+Note on the async-first-connect concern flagged in the task: `SlackBridge::init_global` itself stays synchronous and non-blocking, identical in shape to Discord's — it only builds the mpsc channel, stores the `SlackBridge` in `GLOBAL_BRIDGE`, and `tokio::spawn`s the background task. The `apps.connections.open` call that Discord doesn't need happens *inside* that spawned task (start of `socket::run_socket_loop`), not in `init_global` or in `main.rs`'s startup path. This keeps `main.rs`'s startup sequence non-blocking regardless of Slack API latency or a transient failure to open the first connection — exactly the same failure-isolation property Discord's wiring already has (a slow/broken Discord Gateway can't hang server startup either).
+
+Add `pub mod slack;` to `agentmux-srv/src/messaging/mod.rs` alongside the existing `pub mod discord;`.
+
+---
+
+## 7. HTTP endpoints
+
+Mirror `agentmux-srv/src/server/messaging_handlers.rs`. Add:
+
+```
+POST /api/messaging/slack/send
+```
+
+registered in `agentmux-srv/src/server/mod.rs` alongside the existing Discord route (line 330):
+```rust
+.route("/api/messaging/slack/send", post(messaging_handlers::handle_slack_send))
+```
+
+Extend `handle_status` (line 23–29) to also push `SlackBridge::get().map(|b| b.health())` into the `bridges` array, same pattern as the Discord line.
+
+### Design decision: Block Kit vs. simple text
+
+Discord's embed (`MsgEmbed`) and Slack's Block Kit are **not** structurally compatible — Discord embeds are a flat title/description/fields/color/footer record; Block Kit is a heterogeneous array of typed block objects (`section`, `header`, `divider`, `actions`, `rich_text`, ...) with nested `mrkdwn`/`plain_text` text objects and no direct "color" concept (color exists only via the deprecated `attachments` legacy API, not Block Kit proper). Forcing Slack through the shared `MsgEmbed` struct would either drop most of Block Kit's expressiveness or require `MsgEmbed` to grow Slack-specific fields that don't apply to Discord — neither is good.
+
+**Recommendation: dual path on the request body**, simple-text convenience + raw-JSON escape hatch, no forced reuse of `MsgEmbed`:
+
+```rust
+#[derive(Deserialize)]
+pub(super) struct SlackSendRequest {
+    /// Plain text — always sent as the top-level "text" field (required by Slack
+    /// as the fallback/notification string even when blocks are present).
+    #[serde(default)]
+    pub text: String,
+    /// Override channel. Empty → use the bridge's default channel.
+    #[serde(default)]
+    pub channel_id: String,
+    /// Optional convenience path: a title + body rendered as a simple two-block
+    /// Block Kit message (header + section) — covers the common "agent result"
+    /// case without the caller needing to know Block Kit's JSON shape.
+    pub title: Option<String>,
+    pub body: Option<String>,
+    /// Escape hatch: raw Block Kit `blocks` array, passed through verbatim to
+    /// chat.postMessage. If present, takes precedence over title/body.
+    pub blocks: Option<Vec<serde_json::Value>>,
+}
+```
+
+Routing logic in the handler: if `blocks` is `Some`, use it as-is (full power, caller's responsibility to produce valid Block Kit JSON). Else if `title`/`body` is `Some`, synthesize a minimal 2-block message (`header` + `section` with `mrkdwn` text) server-side. Else send plain `text` only (no `blocks` key at all — valid Slack Chat API usage). This gives simple callers (e.g. an agent's `send_message` MCP tool call) a low-effort path while not blocking richer use cases behind a hand-rolled typed Block Kit builder that would need to track Slack's fairly large and evolving block-type surface. See §11 for the explicit open decision on whether to later build a typed builder.
+
+`handle_status`/`handle_slack_send` otherwise follow `handle_discord_send`'s shape 1:1: `SlackBridge::get()` → 503 with a clear "not initialized" error if `None`, else build `OutboundMsg` (reusing the existing shared `text`/`channel_id`/`reply_to` fields; `embed` stays `None` for Slack sends since Block Kit doesn't map to `MsgEmbed` — the Block Kit JSON needs its own field, not `OutboundMsg.embed`). **Follow-up note:** this means `OutboundMsg` needs a new `blocks: Option<Vec<serde_json::Value>>` field (or the Slack bridge needs its own outbound message type instead of reusing `OutboundMsg`) — call this out explicitly as an implementation-time decision in §11 rather than resolving it here, since it interacts with whatever shape the `MessagingBridge` trait (§8) ends up taking.
+
+---
+
+## 8. `MessagingBridge` trait compatibility
+
+As of this writing there is no `MessagingBridge` trait in `agentmux-srv/src/messaging/mod.rs` — only the shared types (`InboundMsg`, `OutboundMsg`, `MsgEmbed`, `EmbedField`, `BridgeHealth`, `BridgeStatus`). A sibling spec, `docs/specs/SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md`, is formalizing that trait concurrently with this one as part of adding the Telegram bridge (the next platform after Discord in the roadmap). Do not block Slack implementation on that spec landing first — design `SlackBridge` to be trivially adaptable to it once it exists.
+
+Expected rough shape (per the task brief, reconcile exactly against the Telegram spec at implementation time):
+
+```rust
+trait MessagingBridge: Send + Sync {
+    fn platform(&self) -> &'static str;
+    fn send(&self, msg: OutboundMsg) -> Result<(), String>;   // sync, mpsc fire-and-forget
+    fn health(&self) -> BridgeHealth;
+}
+```
+
+`init_global(config, http_client)` stays a free function/static per module (as sketched in §4.1), not a trait method — Rust traits can't express a polymorphic associated constructor across heterogeneous `Config` types cleanly, and Discord already established the free-function convention. `SlackBridge` as designed in §4.1 already satisfies this shape (`platform()`, `send()`, `health()` all present) — implementing the trait once it lands should be a mechanical `impl MessagingBridge for SlackBridge { ... }` with no restructuring, assuming the trait's `send`/`health` signatures match what's above. If the Telegram spec's trait ends up requiring `async fn start()`/`async fn stop()` (as the original master plan's §2.5 sketch had), reconcile by having `init_global` remain the actual start-and-spawn entry point and add thin `start()`/`stop()` trait methods that delegate to it / signal the background task to exit via a oneshot or `CancellationToken` — not designed further here since it depends on the Telegram spec's final shape.
+
+---
+
+## 9. Security considerations specific to Slack
+
+1. **Two distinct token types, two distinct blast radii.** The App-Level Token (`xapp-...`, scope `connections:write`) can only open Socket Mode connections — it cannot read messages or post on its own; it's not meaningful without an active event subscription setup on the app. The Bot Token (`xoxb-...`) is the one that can actually read/post per its granted scopes. Store both in `settings.json` following the existing plaintext-in-local-config convention already used for the Discord bot token (`messaging:discord:token`) — this repo's established pattern, despite the master plan's original OS-keychain recommendation (§6.1 of the plan), evidently was not followed for Discord either; stay consistent with what actually shipped rather than introducing a keychain path unilaterally for Slack alone. Never log either token (mirror `rest.rs`'s existing discipline of not printing `Authorization` header values).
+2. **Scope minimization.** Only request the bot scopes actually used: `chat:write`, `channels:read`, `channels:history` (or `im:*` variants if DM-only), `app_mentions:read`. Do not request `admin.*`, `channels:manage`, or any workspace-wide management scopes — this bridge only needs to read and post in one pre-configured channel.
+3. **Channel allowlist, matching Discord's pattern.** Inbound events are filtered to `messaging:slack:channel` only (see §4.2, "filter to configured channel") — same allowlist-first principle as the master plan §6.2 and as Discord's existing `if msg.channel_id != channel_id { return; }` check in `gateway.rs` line 397.
+4. **Bot-message loop prevention.** Slack sets `bot_id` on events authored by any bot (including this one) — check for its presence and skip, mirroring Discord's `author.bot` check, to avoid the bridge reacting to its own posted messages.
+5. **No secrets in outbound Block Kit payloads.** Same principle as the master plan §6.4 — agent-generated text flowing into `chat.postMessage` should not carry API keys/tokens; out of scope to build automated secret-scanning for MVP, but worth a code comment flagging it as a known gap (matches Discord's current state — no such scanning exists there either).
+6. **App-Level Token exposure via Socket Mode ticket.** The ephemeral WS URL returned by `apps.connections.open` embeds a single-use ticket; treat it with the same care as a bearer token in transit (don't log the full URL at `info` level — log only that a connection was opened, at most a truncated/redacted URL at `debug`).
+
+---
+
+## 9b. Known failure modes / rate limits
+
+| Failure mode | Symptom | Mitigation |
+|---|---|---|
+| Missed 3s ACK deadline | Slack silently reduces/stops event delivery over that connection | ACK before parsing/routing (§2.2); keep the ACK path allocation-light and infallible where possible |
+| `disconnect: warning` mishandled as wait-then-reconnect | Message-loss window during the ~10s before forced close | Make-before-break dance (§2.3) — non-negotiable, this is the spec's core correctness requirement |
+| Silent connection death (no warning, no close frame) | Bridge shows "connected" but events stop arriving indefinitely | 5-minute no-event force-reconnect timer (§2.3) |
+| `apps.connections.open` 429/5xx during backoff retry | Reconnect loop stalls | Same exponential backoff as unexpected-close path; cap at 60s; never busy-loop |
+| `chat.postMessage` returns HTTP 200 with `"ok": false` | Message silently "sent" but not delivered (e.g. `channel_not_found`, `not_in_channel`, `invalid_auth`) | Explicitly check `ok` field, surface `error` string in bridge health / logs (§2.4) |
+| Rate limit on `chat.postMessage` (~1/s/channel) | 429 with `Retry-After` header | Respect `Retry-After`, single retry, then same backoff family as reconnects (§2.6) |
+| Two tokens confused (bot token used for `apps.connections.open`, or app token used for `chat.postMessage`) | Auth failures with confusing errors (`invalid_auth`, `not_allowed_token_type`) | Config field names make the distinction explicit (`bot_token` vs `app_token`); consider a startup sanity check that `bot_token` starts with `xoxb-` and `app_token` starts with `xapp-`, warn (not hard-fail) on mismatch |
+| Bot not invited to configured channel | `chat.postMessage` returns `not_in_channel`; inbound events never arrive for that channel | Document as setup step 6 (§5); consider surfacing this specific error string distinctly in bridge health |
+
+---
+
+## 10. Implementation checklist (phased, PR-sized)
+
+**Phase 1 — Foundation + one-way send (1 PR)**
+- [ ] `agentmux-srv/src/messaging/slack/types.rs` — envelope, event, REST body/response wire types
+- [ ] `agentmux-srv/src/messaging/slack/rest.rs` — `open_connection`, `post_message` (with `ok` field check)
+- [ ] `agentmux-srv/src/messaging/slack/mod.rs` — `SlackConfig`, `SlackBridge`, `init_global`/`get`/`send`/`health`
+- [ ] `agentmux-srv/src/messaging/slack/socket.rs` — connect via `open_connection`, handle `hello`, ACK `events_api` envelopes (log-only, no routing yet), basic backoff reconnect (no warning-cutover yet — plain reconnect is acceptable for this PR)
+- [ ] `pub mod slack;` in `messaging/mod.rs`
+- [ ] Config fields in `wconfig/types.rs` (§5)
+- [ ] Startup wiring in `main.rs` (§6)
+- [ ] `POST /api/messaging/slack/send` handler + route registration (§7, text-only + title/body convenience path; raw `blocks` escape hatch can land same PR or next)
+- **Success criteria:** bot appears online in Slack (visible via presence or a manual `chat.postMessage` test through the new endpoint); a message posted via the endpoint appears in the configured channel.
+
+**Phase 2 — Inbound routing + reconnect correctness (1 PR)**
+- [ ] Route `events_api` → reactive bus injection (`get_global_handler().inject_message(...)`, mirroring `discord/gateway.rs::handle_dispatch`'s `MESSAGE_CREATE` handling), with channel filter + `bot_id` self-message filter
+- [ ] Implement the make-before-break warning-cutover state machine (§2.3, §4.2) — this is the phase where the two-socket logic actually lands
+- [ ] 5-minute dead-connection force-reconnect timer
+- [ ] Extend `handle_status` to include Slack bridge health
+- **Success criteria:** user posts in the configured Slack channel, agent receives it via `read_messages` and can reply; bridge survives an hour of idle connection (crossing at least one Slack-initiated `warning` cycle) without a visible gap in `health().last_event_at`.
+
+**Phase 3 — Block Kit escape hatch + polish (1 PR)**
+- [ ] `blocks: Option<Vec<serde_json::Value>>` raw passthrough on the send endpoint if not already done in Phase 1
+- [ ] Rate-limit handling: `Retry-After` respect + backoff on `chat.postMessage` 429s
+- [ ] Update `widgets.json` line 142 description string from `"Slack — real interface, agent-connected (bridge Phase 2)"` to something reflecting the bridge is now live (e.g. `"Slack — real interface, agent-connected"`, matching Discord's description string exactly)
+- **Success criteria:** an agent can post a Block Kit message (e.g. header + section + divider) via the raw `blocks` field and it renders correctly in the Slack client.
+
+**Phase 4 — Slash commands (future, not required for MVP)**
+- [ ] `response_url` deferred-response path (§2.5, §4.3 stub)
+- [ ] Slash command registration/config (Slack slash commands are configured in the app manifest/dashboard, not registered at runtime like Discord's guild-scoped commands — mostly a docs/setup-checklist addition, not new runtime code)
+- Out of scope for this spec's phased delivery; noted for completeness since the master plan's §3.3 covers it.
+
+---
+
+## 11. Open decision points for the implementer
+
+1. **`OutboundMsg.blocks` vs. a separate Slack-specific outbound type.** §7 flags that Block Kit doesn't fit `MsgEmbed`. The cleanest fix is probably adding an `Option<Vec<serde_json::Value>>` field directly to the shared `OutboundMsg` struct in `messaging/mod.rs` (harmless no-op for Discord, `#[serde(skip_serializing_if = "Option::is_none")]`) rather than forking a `SlackOutboundMsg` type — but this should be decided jointly with whatever the Telegram spec's `MessagingBridge` trait work settles on for the shared envelope shape, since a second concurrent spec is touching the same file. Flagging rather than resolving here to avoid a merge conflict in intent.
+2. **Full typed Block Kit builder vs. raw JSON forever.** This spec recommends raw `serde_json::Value` blocks (§4.4, §7) for MVP — lowest implementation cost, matches "ready to implement" scope. A typed Block Kit DSL (enum per block type, builder pattern) would be nicer for future agent-facing convenience APIs (e.g. a `send_slack_result(title, fields, actions)` MCP-level helper) but is a genuinely large surface (Slack has ~15 block types and a dozen-plus element/object types as of 2026) and should be scoped as its own follow-up spec if/when there's a concrete driving use case, not spent on speculatively now.
+3. **`slack-morphism` re-evaluation.** §3 rejects it for MVP on dependency-footprint-consistency grounds. If hand-rolling the Socket Mode state machine (particularly the make-before-break cutover in §2.3) proves meaningfully harder than Discord's RESUME logic during implementation, it's worth a quick spike comparing hand-rolled vs. `slack-morphism`'s Socket Mode client before committing further engineering time — this spec's recommendation is a starting position, not a irreversible constraint.
+4. **Token storage: settings.json plaintext vs. OS keychain.** §9.1 notes this repo's actual Discord precedent stores the token in `settings.json` (not keychain, despite the master plan's original §6.1 recommendation). This spec follows the precedent for consistency, but if there's an in-flight effort elsewhere in the codebase to move Discord's token to keychain storage, Slack's two tokens should move with it in the same change rather than diverging.
+5. **Slash commands (§10 Phase 4) and DM support.** Both are explicitly out of scope for the phased plan above (single fixed channel, no interactive commands). If DM support becomes a near-term requirement, the config schema (§5) would need a mode switch (channel-scoped vs. DM-scoped) and the `im:*` scopes noted in the setup checklist (§5, step 4) instead of `channels:*` — worth deciding whether that's a variant of this bridge or a genuinely separate `target` concept before Phase 4 starts.

--- a/docs/specs/SPEC_MESSAGING_INTEGRATION_TEAMS_2026_07_07.md
+++ b/docs/specs/SPEC_MESSAGING_INTEGRATION_TEAMS_2026_07_07.md
@@ -1,0 +1,477 @@
+# Spec: Messaging App Integration — Microsoft Teams
+
+**Date:** 2026-07-07
+**Status:** Draft — design complete, sequencing/priority TBD (see §2)
+**Scope:** Rust bridge design for Microsoft Teams, the fifth and last platform in `SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md`. The webview pane already ships (`defwidget@teams` in `agentmux-srv/src/config/widgets.json`); this spec covers the background bridge that lets an agent read/send messages through it.
+
+---
+
+## 1. Goal and context
+
+`SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md` (§1–§2) lays out the two-layer pattern used for all five messaging integrations: a CEF webview pane showing the real platform UI, plus an invisible background "bridge" process that lets an agent read inbound messages and post replies through the same native surface the user is looking at. Discord shipped first, in pure Rust, as PR #1763 (2026-06-24) — see `agentmux-srv/src/messaging/discord/`. This spec adapts that shape to Teams.
+
+The master plan's own verdict on Teams (§3.5, §8) is blunt: **"Implement Last."** Every other platform in the five (Telegram, Discord, Slack, WhatsApp) can be bridged with nothing more than a bot token or app credentials the user controls personally. Teams cannot — it requires an Azure subscription, an Entra ID (AAD) tenant, and admin-gated app sideloading, none of which exist for a personal Microsoft account. This spec does not relitigate that verdict; it treats it as settled input and designs accordingly (§2).
+
+This is a companion to two sibling specs written concurrently: `SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md` (formalizes a `MessagingBridge` trait as Discord's shape gets generalized to a second platform) and `SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md` (designs the first webhook-receiver bridge, since WhatsApp Cloud API — like Teams — is inbound-via-HTTP-POST rather than inbound-via-outbound-WebSocket like Discord/Telegram/Slack). Both may not exist on disk at the time this is read; where this spec depends on their conclusions, it says so explicitly and gives its own default.
+
+---
+
+## 2. Should we build this, and when
+
+**Recommendation: design now (this document), implement only on demonstrated demand from a user inside an M365 tenant. Do not schedule it as part of the routine Telegram → Slack → WhatsApp → Teams rollout implied by the master plan's phase numbering.**
+
+Reasoning:
+
+1. **The audience that can use this at all is a strict subset of AgentMux's users, and it is not knowable in advance who that is.** Discord, Telegram, Slack, and WhatsApp all work with credentials an individual can generate for themselves in minutes, for free, with no organizational gatekeeper. Teams requires all of the following simultaneously:
+   - A Microsoft 365 **organizational** account (personal `outlook.com`/`hotmail.com` MSA accounts cannot install Teams bots — this is a hard platform restriction, not a configuration gap).
+   - An Azure subscription (free tier F0 suffices for the bot resource, but still requires a credit card on file in most signup flows).
+   - An Entra ID tenant matching the M365 org (usually already exists for a corporate user; does not exist for a personal deployment).
+   - A tenant admin willing to enable "Upload custom apps" in Teams Admin Center, or the user personally holding that role — many corporate users do not, and cannot self-serve this.
+   - A publicly reachable HTTPS endpoint reachable from Azure's IP ranges (§5).
+
+   A hobbyist, freelancer, or anyone running AgentMux against a personal Microsoft account gets zero value from this integration no matter how well it is built. This is different from WhatsApp's friction (business verification, tunnel setup) or Slack's (workspace admin approval for a *personal* workspace the user usually owns) — those are surmountable by one determined individual. Teams' friction floor includes an org that the individual developer may not control.
+
+2. **The master plan already ranks it last by value/friction (§8 decision matrix) and calls it "Implement Last" explicitly (§3.5, §4 Phase 5).** Nothing has changed since 2026-06-24 that revises that ranking upward. This spec exists so that *if* the call is made to build it, there is a concrete, implementable design ready — not because the ranking should be revisited.
+
+3. **Sequencing recommendation:** keep Teams behind the other three (Telegram, Slack, WhatsApp) indefinitely, gated on one of:
+   - A specific user request from someone who confirms they have (a) an M365 org account, (b) Azure access, and (c) sideloading rights or an admin willing to grant them, **or**
+   - AgentMux itself moving into a team/enterprise distribution model where a shared Entra app registration could serve many tenants at once (multi-tenant bot registration — see §14 open decision) — at that point the setup burden shifts from "every user configures their own Azure Bot" to "AgentMux ships one, tenant admins consent once," which meaningfully changes the friction calculus and would be worth revisiting this spec's sequencing call.
+
+   Until either condition holds, this spec should sit in `docs/specs/` as a ready-to-build design, not an active roadmap item.
+
+4. **This is not an argument to under-build the design.** Sections 3–14 below are implementation-ready to the same standard as the Discord POC spec and the shipped Discord code. If a developer picks this up because condition (3) above is met, they should be able to work from this document directly.
+
+---
+
+## 3. Setup prerequisites (restated from the master plan, user-facing)
+
+These steps are unavoidably heavy and must be surfaced to the user *before* they enable the Teams bridge in settings — ideally as a checklist gate in the settings UI, not just documentation, so a user without an M365 org finds out in step 1 rather than step 4.
+
+1. **Confirm M365 org account.** Personal Microsoft accounts (MSA) cannot install Teams bots. If the user's Teams sign-in is a personal `outlook.com` address, stop here.
+2. **Register an app in Entra ID** (Azure Portal → Entra ID → App registrations → New registration). Note the `Application (client) ID` and the `Directory (tenant) ID`. Create a client secret (Certificates & secrets → New client secret) — this is the `app_password`.
+3. **Create an Azure Bot resource** (Azure Portal → Create a resource → "Azure Bot"). Free tier (F0) has no message volume charge. Link it to the Entra app from step 2. Under "Channels," enable the **Microsoft Teams** channel.
+4. **Set the messaging endpoint** on the Azure Bot resource to `https://<public-endpoint>/api/messages` (see §5 for what fills in `<public-endpoint>`).
+5. **Build and sideload the Teams app package** — a zip containing `manifest.json` (schema version 1.16+, referencing the bot's `Application ID`) plus two icons (192x192 color, 32x32 outline). Upload via Teams client → Apps → "Manage your apps" → "Upload an app" → "Upload a custom app." **This step requires either the user to hold upload rights personally, or a tenant admin to have enabled "Upload custom apps" in Teams Admin Center** (Teams Admin Center → Teams apps → Setup policies). This is the step most likely to silently block a well-intentioned individual user; call it out explicitly in the settings UI, before asking for Azure credentials.
+6. **Personal dev/test tenant option:** if the user does not have qualifying M365 access, the free Microsoft 365 Developer Program grants an E5 sandbox tenant (subject to program eligibility and periodic renewal activity requirements) — mention this as the self-serve path for individual developers who want to build/test this integration without a corporate tenant. M365 Business Basic (~$6/user/month) is the paid fallback.
+
+---
+
+## 4. Protocol design (condensed)
+
+Full protocol detail is in the master plan §3.5; this section translates it into what the Rust implementation actually needs to do.
+
+- **Inbound:** Azure Bot Service is a mandatory relay. There is no direct client-to-Teams connection of any kind (unlike Discord's Gateway or Telegram's long-poll, both outbound-only). Azure receives the Teams-side event and re-POSTs a Bot Framework **Activity** object to *our* registered endpoint: `POST /api/messages`. This is a webhook receiver, not a client connection — closer in shape to the WhatsApp Cloud API receiver pattern than to Discord/Telegram/Slack.
+- **Activity shape** (subset relevant to text messages):
+  ```json
+  {
+    "type": "message",
+    "id": "<activity id>",
+    "timestamp": "2026-07-07T12:00:00.000Z",
+    "serviceUrl": "https://smba.trafficmanager.net/teams/",
+    "channelId": "msteams",
+    "from": { "id": "29:1abc...", "name": "User Name", "aadObjectId": "..." },
+    "conversation": { "id": "19:abc...@thread.v2", "tenantId": "..." },
+    "recipient": { "id": "28:<bot app id>", "name": "AgentMux" },
+    "text": "Hello agent"
+  }
+  ```
+- **Every inbound request must be JWT-validated before the body is trusted** (see §11 — non-negotiable). Only after validation does the activity get normalized into `InboundMsg` and injected into the reactive bus, matching the pattern Discord's `handle_dispatch` uses for `MESSAGE_CREATE` in `agentmux-srv/src/messaging/discord/gateway.rs:378-440`.
+- **Outbound / proactive messaging:** unlike Discord (fixed `channel_id`) or Telegram (fixed `chat_id`), Teams has no long-lived address you can just POST to ahead of time. The *only* way to message a user is:
+  1. Reply directly within an existing turn — `POST {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}` (a reply to an inbound activity, always available with data from that inbound request), or
+  2. Proactively initiate — requires a previously **persisted** `conversationReference` captured from *some* earlier inbound activity from that user, then `POST {serviceUrl}/v3/conversations` (or `.../activities`) using it. This is what makes agent-initiated ("agent speaks first") Teams messages fundamentally different infrastructure from the other four platforms — see §6.
+- **Outbound auth:** Bot Framework REST calls need a bearer token obtained via OAuth2 client-credentials grant against `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` (or the multi-tenant `botframework.com` endpoint depending on app type), using `app_id` + `app_password` as the client credentials, scope `https://api.botframework.com/.default`. Cache the token and refresh before its ~1hr expiry — do not fetch per-message.
+- **Rich output:** Adaptive Cards (JSON body under `attachments[].content` with `contentType: "application/vnd.microsoft.card.adaptive"`), following the master plan's §3.5 example. This plays the same role as Discord's `MsgEmbed` / Slack's Block Kit.
+- **No Rust SDK exists for Bot Framework.** The master plan confirms this (§3.5: "For Rust: no official SDK — raw HTTP with `reqwest` for outbound + `axum` to receive Bot Framework activities"). Unlike Discord (`twilight-rs` vs `serenity` decision) or Telegram (`teloxide`), there is no framework choice to make here — raw `reqwest` + hand-rolled `serde_json` structs, matching exactly what Discord's `rest.rs`/`types.rs` already do, is not a fallback option, it is the only option. This is, ironically, the one dimension on which Teams is *simpler* to slot into the existing codebase than Slack would be (Slack has an official but Node-only SDK, creating a language-boundary decision Teams doesn't have).
+
+---
+
+## 5. Tunnel / relay: Dev Tunnels vs. Azure App Service
+
+Azure Bot Service must be able to reach the bot's `/api/messages` endpoint over public HTTPS. Two real options (the master plan §3.5 and §5.1 both mention these):
+
+**Option A — Dev Tunnels (Microsoft's tool, free with a GitHub/Microsoft account).**
+- Pros: symmetric with how WhatsApp's `TunnelManager` abstraction already needs to exist (§5.1 of the master plan; shared with WhatsApp's Cloudflare Tunnel need) — reuse the same subprocess-lifecycle code, just a different `TunnelProvider` variant. Persistent named tunnels once configured (unlike ngrok's free tier, which reassigns the URL every restart). Native fit for a desktop app: the bridge process runs locally, `devtunnel` is a companion subprocess AgentMux manages, exactly like `cloudflared` for WhatsApp.
+- Cons: yet another local subprocess dependency, another point of failure that shows up as "bridge down" without an obvious cause to a non-technical user; devtunnel CLI must be installed and authenticated once per user.
+
+**Option B — Azure App Service (F1 free tier, 60 CPU-min/day).**
+- Pros: **eliminates the tunnel dependency entirely in production.** The bot endpoint runs *in* Azure, next to Azure Bot Service — no local subprocess, no NAT traversal, no "is my laptop's tunnel still up" failure mode. This is qualitatively different from every other tunnel option in this entire messaging-integrations project: it is the only "no tunnel" answer for a platform that mandates a public endpoint.
+- Cons: this is no longer "AgentMux desktop app talks to messaging API" (the architecture this whole plan is built around) — it is "AgentMux desktop app talks to *an Azure-hosted proxy component* that AgentMux would need to deploy and maintain," and that proxy has to somehow route the received activity back to the user's local AgentMux instance (their agent, their reactive bus) — which reintroduces exactly the "public relay to a private machine" problem the tunnel was solving, just moved one hop over. F1's 60 CPU-min/day free quota is easy to exceed under any real traffic and the app needs to be deployed/updated by *someone* (the user, or AgentMux centrally) — a new piece of infrastructure ownership that doesn't exist for any other platform in this plan.
+
+**Recommendation: Dev Tunnels (Option A).** It keeps the architecture consistent with the rest of the project (local process + `TunnelManager`, matching WhatsApp), keeps the user's message content and the bridge's connection to the reactive bus entirely on their own machine (no new component holding conversation data), and reuses infrastructure this project needs to build anyway for WhatsApp. Azure App Service is worth revisiting only if AgentMux ever moves to centrally hosting relay infrastructure for many users (the same trigger condition as the multi-tenant bot registration idea in §2 point 3) — at that point it stops being "one user's tunnel" and becomes "AgentMux's hosted relay," a materially different product decision out of scope here.
+
+Config field: `messaging:teams:tunnel` — same flat-key convention as WhatsApp's (§8), value `"devtunnel"` (default if Teams is enabled) or `"manual"` (user supplies their own public URL, e.g. they already run one for other purposes).
+
+---
+
+## 6. `conversationReference` persistence — the one genuinely new piece of infrastructure
+
+None of Discord, Telegram, Slack, or WhatsApp need this. Each of those sends to a fixed, pre-configured address (`channel_id`, `chat_id`, `channel_id`, `phone_number_id`+recipient) that the user types into settings once. Teams has no equivalent fixed address for *proactive* sends — the address (`conversationReference`, which bundles `conversation.id`, `serviceUrl`, `bot`, `channelId`, and the user's `from`/`user` identity) only exists after the user has messaged the bot at least once, and it must be captured from that inbound activity and persisted for later reuse. Without it, the Teams bridge can only *reply* within a turn the user started — it can never have the agent speak first (e.g., "build finished," "approval needed") the way the other four platforms can.
+
+### 6.1 Where this lives
+
+The existing storage layer already has exactly this shape of problem solved twice: `db_mcp_servers` (`agentmux-srv/src/backend/storage/mcp_servers.rs`) and `db_muxbus_credentials` (`agentmux-srv/src/backend/storage/migrations.rs:444-454`) are both small, `Store`-backed SQLite tables added by a per-subsystem file that does `impl Store { ... }` against the shared `rusqlite::Connection` in `Store` (`agentmux-srv/src/backend/storage/store.rs`). This is the established pattern for "a new small durable record type that isn't a full StoreObj" — reuse it rather than inventing a KV store, a JSON file on disk, or piggybacking it into `wconfig` settings (settings are for user-editable config, not for opaque runtime state captured from inbound events).
+
+**New file:** `agentmux-srv/src/backend/storage/messaging_conversations.rs`, following the `mcp_servers.rs` template (struct + `impl Store` methods, no new module system needed — it's registered the same way `mod mcp_servers;` is in `storage/mod.rs`).
+
+**New table** (add to the flat `CREATE TABLE IF NOT EXISTS` batch in `migrations.rs`, bump `OBJECT_SCHEMA_VERSION` from 10 to 11):
+
+```sql
+CREATE TABLE IF NOT EXISTS db_messaging_conversation_refs (
+    id               TEXT PRIMARY KEY,   -- "{platform}:{user_id}", e.g. "teams:29:1abc..."
+    platform         TEXT NOT NULL,      -- "teams" (future-proofs for any other proactive-messaging platform)
+    external_user_id TEXT NOT NULL,      -- Teams: activity.from.id
+    conversation_ref TEXT NOT NULL,      -- full serialized ConversationReference JSON
+    display_name     TEXT NOT NULL DEFAULT '',
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messaging_conv_refs_platform ON db_messaging_conversation_refs(platform);
+```
+
+`conversation_ref` stores the whole Bot Framework `ConversationReference` object as a JSON blob (`conversation`, `serviceUrl`, `bot`, `user`, `channelId`) rather than being split into typed columns — this mirrors how `db_mcp_servers.config` already stores an opaque JSON blob (`mcp_servers.rs:9-11` comment: "the full server object JSON... that gets merged into `.mcp.json`") for the same reason: the shape is platform-defined and evolves outside our control, and we round-trip it rather than re-model it.
+
+### 6.2 Write path
+
+On every inbound activity in the webhook receiver (§7, `webhook.rs`), after JWT validation and before/alongside forwarding to the reactive bus: build a `ConversationReference` from the activity (`TurnContext.getConversationReference()` equivalent — done by hand since there's no SDK, straightforward field copy per Activity schema) and upsert it into `db_messaging_conversation_refs` keyed by `"teams:{from.id}"`. This keeps the stored reference fresh (covers the case where a `serviceUrl` or conversation ID changes, e.g. user moves from a 1:1 chat to a channel).
+
+### 6.3 Read path
+
+`POST /api/messaging/teams/send` (§10) looks up the target user's row by `external_user_id` (or by a friendly `display_name` the user configured, resolved server-side), deserializes `conversation_ref`, and uses it to either reply-in-conversation or call `POST {serviceUrl}/v3/conversations` for a fresh proactive turn. If no row exists yet for the target user, the send fails with a clear error ("no prior Teams message from this user — proactive send requires the user to have messaged the bot at least once") rather than silently no-op'ing — this is a real, expected failure mode users need surfaced (§12).
+
+---
+
+## 7. Rust module layout
+
+Mirrors `agentmux-srv/src/messaging/discord/` (`mod.rs` + `gateway.rs` + `rest.rs` + `types.rs`), adapted for a webhook receiver instead of an outbound Gateway WS — no `gateway.rs` equivalent (no persistent connection to manage, no heartbeat/resume state machine), replaced by `webhook.rs` (a set of axum handler functions, not a background task).
+
+```
+agentmux-srv/src/messaging/teams/
+├── mod.rs      // Config, Bridge struct, GLOBAL_BRIDGE OnceLock, init_global(), get(), send(), health()
+├── webhook.rs  // axum handler(s) for POST /api/messages: JWT validation, activity parsing,
+│               // conversationReference upsert, InjectionRequest into reactive bus
+├── rest.rs     // outbound: OAuth2 client-credentials token fetch/cache, send-activity POST,
+│               // proactive-conversation POST, Adaptive Card builder
+└── types.rs    // Activity, ConversationReference, ConversationAccount, ChannelAccount,
+                // AdaptiveCard wire types (serde structs), JWKS/JWT claim types
+```
+
+### 7.1 `mod.rs` — reconciling with the (not-yet-formalized) `MessagingBridge` trait
+
+As of Discord's ship, no `MessagingBridge` trait exists yet — `DiscordBridge` is a concrete struct with an ad hoc method set (`init_global`, `get`, `send`, `health`; see `agentmux-srv/src/messaging/discord/mod.rs:49-96`). The Telegram spec (`SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md`) is expected to formalize this into a real trait, roughly:
+
+```rust
+trait MessagingBridge: Send + Sync {
+    fn platform(&self) -> &'static str;
+    fn send(&self, msg: OutboundMsg) -> Result<(), String>;  // sync, mpsc-based like Discord's
+    fn health(&self) -> BridgeHealth;
+}
+```
+
+`TeamsBridge` should implement this trait once it lands (reconcile the exact shape with the Telegram spec at implementation time — do not implement Teams first and let the trait be shaped around it, since Teams' `send()` has a materially different failure mode — "no conversationReference for this user" — than the other platforms' "network/rate-limit error," and the trait's `Result<(), String>` error type needs to accommodate that cleanly for all implementers, not just Teams).
+
+Structural difference from Discord's `mod.rs`: Discord's `init_global` spawns a background tokio task (`gateway::run_gateway_loop`) that owns the persistent WS connection and both directions of traffic. Teams has no persistent connection to own — inbound arrives via axum route registered once at server startup (§9), and there is no long-running task loop at all. `TeamsBridge` still holds an `mpsc::UnboundedSender<OutboundMsg>` for symmetry with the trait/other bridges, but the receiving side is a lightweight task that just calls `rest::send_activity` per message — no reconnect/resume state machine needed, no `Session` struct equivalent.
+
+```rust
+pub struct TeamsConfig {
+    pub app_id: String,
+    pub app_password: String,   // client secret, keychain-backed in practice
+    pub tenant_id: String,
+    pub tunnel: TunnelSetting,  // "devtunnel" | "manual"
+}
+
+pub struct TeamsBridge {
+    outbound_tx: mpsc::UnboundedSender<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+    // token cache lives in rest.rs behind a Mutex<Option<CachedToken>>, not here —
+    // mirrors keeping wire-protocol state out of the bridge struct in Discord's design.
+}
+
+static GLOBAL_BRIDGE: OnceLock<TeamsBridge> = OnceLock::new();
+
+impl TeamsBridge {
+    pub fn init_global(config: TeamsConfig, http: reqwest::Client) { /* spawns outbound-send task, not a connection loop */ }
+    pub fn get() -> Option<&'static TeamsBridge> { GLOBAL_BRIDGE.get() }
+    pub fn send(&self, msg: OutboundMsg) -> Result<(), String> { /* enqueue; async task resolves conversationReference + posts */ }
+    pub fn health(&self) -> BridgeHealth { /* Connected once webhook has received ≥1 valid activity; Connecting until then */ }
+}
+```
+
+Note `health()`'s semantics differ from Discord's meaningfully: Discord's `Connected` means "Gateway WS is currently open." Teams has no persistent connection to be "connected" to — there is nothing to be up or down except the local webhook receiver (which is just always-up as part of the main axum server) and the Dev Tunnel subprocess. Recommend: `Connected` = tunnel is up and endpoint is registered; `Error` = tunnel down or last outbound send failed; `latency_ms`/`reconnect_count` are not meaningful for this platform and should read `None`/`0` rather than being repurposed.
+
+---
+
+## 8. Config schema additions
+
+Following the **actual** flat serde-renamed key convention in `agentmux-srv/src/backend/wconfig/types.rs:300-324` — **not** the master plan's §2.6 `[messaging.teams]` TOML table example, which does not match how config is actually implemented anywhere in this codebase and should be treated as informal/illustrative only, not a schema reference. Discord's real fields (`messaging_discord_enabled`, `messaging_discord_token`, `messaging_discord_channel`, `messaging_discord_target`, `messaging_discord_guild`) are flat `Option<T>`/`bool`/`String` fields on the single settings struct, each with its own `#[serde(rename = "messaging:discord:...")]`. Teams follows the identical shape:
+
+```rust
+// -- Teams messaging bridge settings --
+// See docs/specs/SPEC_MESSAGING_INTEGRATION_TEAMS_2026_07_07.md.
+// NOTE: Teams requires an M365 org + Azure Bot resource + admin-enabled
+// sideloading — see §3 of the spec. This is not self-serve for personal
+// Microsoft accounts; the settings UI should gate on user confirmation
+// before accepting these fields.
+
+/// Master enable for the Teams messaging bridge.
+#[serde(rename = "messaging:teams:enabled", default, skip_serializing_if = "is_false")]
+pub messaging_teams_enabled: bool,
+
+/// Entra ID application (client) ID for the registered bot app.
+#[serde(rename = "messaging:teams:app_id", default, skip_serializing_if = "Option::is_none")]
+pub messaging_teams_app_id: Option<String>,
+
+/// Client secret for the Entra ID app. Treat as a secret — do not log.
+#[serde(rename = "messaging:teams:app_password", default, skip_serializing_if = "Option::is_none")]
+pub messaging_teams_app_password: Option<String>,
+
+/// Entra ID (AAD) tenant ID that the app is registered under.
+#[serde(rename = "messaging:teams:tenant_id", default, skip_serializing_if = "Option::is_none")]
+pub messaging_teams_tenant_id: Option<String>,
+
+/// Agent ID that receives inbound Teams messages via the reactive bus.
+/// Absent → messages are logged but not forwarded to any agent.
+#[serde(rename = "messaging:teams:target", default, skip_serializing_if = "Option::is_none")]
+pub messaging_teams_target: Option<String>,
+
+/// Tunnel provider for the public /api/messages endpoint. "devtunnel" (default
+/// when enabled) or "manual" (user supplies their own public URL below).
+#[serde(rename = "messaging:teams:tunnel", default, skip_serializing_if = "String::is_empty")]
+pub messaging_teams_tunnel: String,
+
+/// User-supplied public URL when tunnel = "manual". Ignored otherwise.
+#[serde(rename = "messaging:teams:manual_url", default, skip_serializing_if = "Option::is_none")]
+pub messaging_teams_manual_url: Option<String>,
+```
+
+`app_password` (and, for consistency with Discord's `token` field, arguably `app_id`/`tenant_id` too, though those are not secret) should route through the same OS-keychain storage path used for `messaging_discord_token` once that lands — check how Discord's settings UI actually stores the token today (as of the Discord PoC ship it may still be plaintext-in-settings pending a keychain integration pass; if so, Teams should not regress ahead of that fix and should follow whatever Discord ends up doing, not invent a separate path).
+
+---
+
+## 9. Startup wiring
+
+Mirrors the Discord block in `agentmux-srv/src/main.rs:725-753`, with one added step: the tunnel must be up and its URL known *before* the bot's messaging endpoint is meaningfully reachable, so — unlike Discord, which just spawns its gateway task — Teams startup has a real sequencing dependency (same concern flagged for WhatsApp in the task brief).
+
+```rust
+// Teams messaging bridge — receives Bot Framework activities via the shared
+// axum server at POST /api/messages. Requires a public tunnel (Dev Tunnels
+// by default) since Azure Bot Service relays to a public HTTPS endpoint.
+// Set messaging:teams:enabled + app_id/app_password/tenant_id in settings.json
+// to activate. See docs/specs/SPEC_MESSAGING_INTEGRATION_TEAMS_2026_07_07.md.
+{
+    let settings = config_watcher.get_settings();
+    if settings.messaging_teams_enabled {
+        match (
+            settings.messaging_teams_app_id.clone(),
+            settings.messaging_teams_app_password.clone(),
+            settings.messaging_teams_tenant_id.clone(),
+        ) {
+            (Some(app_id), Some(app_password), Some(tenant_id))
+                if !app_id.is_empty() && !app_password.is_empty() =>
+            {
+                // 1. Ensure the tunnel is up first — the bridge has nothing
+                //    useful to do until Azure can reach us. This is a hard
+                //    ordering requirement, unlike Discord's fire-and-forget
+                //    gateway spawn: an unregistered/stale tunnel URL means
+                //    every inbound message from Teams silently never arrives
+                //    (Azure retries briefly, then gives up — no local error).
+                let tunnel = tunnel_manager::ensure_url(TunnelProvider::from_settings(&settings)).await;
+                match tunnel {
+                    Ok(public_url) => {
+                        messaging::teams::TeamsBridge::init_global(
+                            messaging::teams::TeamsConfig {
+                                app_id,
+                                app_password,
+                                tenant_id,
+                                target_agent: settings.messaging_teams_target.clone(),
+                            },
+                            reqwest::Client::new(),
+                        );
+                        tracing::info!(
+                            "teams bridge: initialized, public endpoint {}/api/messages \
+                             (must match the Azure Bot resource's messaging endpoint)",
+                            public_url
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("teams bridge: tunnel setup failed, bridge not started: {e}");
+                    }
+                }
+            }
+            _ => {
+                tracing::warn!(
+                    "teams bridge: enabled but app_id/app_password/tenant_id are not fully set in settings.json"
+                );
+            }
+        }
+    }
+}
+```
+
+The `/api/messages` axum route itself (§10) should be registered **unconditionally** at server startup, same as `/api/messaging/status` — it just returns 503 or is a no-op if `TeamsBridge::get()` is `None`, matching the existing `handle_discord_send` pattern in `messaging_handlers.rs:63-72`. This avoids needing to conditionally register routes based on settings, which the current router doesn't appear to support cleanly.
+
+`tunnel_manager` here refers to the shared `TunnelManager` abstraction from the master plan §5.1 — this spec assumes it gets built as part of (or before) WhatsApp's bridge, since WhatsApp needs it too and is sequenced ahead of Teams regardless of this spec's §2 recommendation. Teams does not introduce the tunnel abstraction; it is the second consumer of it.
+
+---
+
+## 10. HTTP endpoints
+
+Extends `agentmux-srv/src/server/messaging_handlers.rs`'s existing routes (`GET /api/messaging/status`, `POST /api/messaging/discord/send`) with two more:
+
+### 10.1 `POST /api/messaging/teams/send`
+
+Unlike Discord's `handle_discord_send` (stateless: text + channel_id in, POST out), Teams sending must resolve a `conversationReference` first (§6.3):
+
+```rust
+#[derive(Deserialize)]
+pub(super) struct TeamsSendRequest {
+    /// External Teams user ID (activity.from.id) or a resolvable display name.
+    pub target_user: String,
+    #[serde(default)]
+    pub text: String,
+    /// Optional Adaptive Card body (JSON), sent as an attachment alongside/instead of text.
+    pub adaptive_card: Option<serde_json::Value>,
+}
+
+pub(super) async fn handle_teams_send(
+    State(state): State<AppState>,
+    Json(req): Json<TeamsSendRequest>,
+) -> impl IntoResponse {
+    let bridge = match TeamsBridge::get() {
+        Some(b) => b,
+        None => return (StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "teams bridge not initialized — set messaging:teams:enabled in settings"})))
+            .into_response(),
+    };
+
+    // Resolve conversationReference — the step with no Discord/Slack/WhatsApp equivalent.
+    let conv_ref = match state.store.messaging_conversation_ref("teams", &req.target_user) {
+        Ok(Some(r)) => r,
+        Ok(None) => return (StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": format!(
+                "no prior Teams message from user '{}' — proactive send requires the user \
+                 to have messaged the bot at least once first", req.target_user)})))
+            .into_response(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))).into_response(),
+    };
+
+    match bridge.send(OutboundMsg { /* text, embed→adaptive_card mapping, conv_ref carried via reply_to or a Teams-specific extension */ }) {
+        Ok(()) => Json(json!({ "ok": true })).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response(),
+    }
+}
+```
+
+Note `OutboundMsg` (`agentmux-srv/src/messaging/mod.rs:33-43`) as it exists today has no field for "which external user" — its `channel_id`/`reply_to` model fits Discord/Slack/Telegram's fixed-channel-address model. Teams needs the resolved `conversationReference` (or at minimum the `target_user` key to re-resolve it) threaded through to `rest.rs`. Cleanest option: resolve the `conversationReference` in the handler (as above) and pass it to the bridge as part of a Teams-specific outbound message type that wraps `OutboundMsg`, rather than stretching the shared `OutboundMsg` struct with a Teams-only field — keep the shared envelope shared, and let each bridge's `send()` accept `OutboundMsg` plus whatever platform-specific addressing it privately needs resolved before calling `send()`. This is a concrete decision the implementer should reconcile with however Telegram/WhatsApp's specs end up shaping `OutboundMsg` — flagged as an open point in §14.
+
+### 10.2 `POST /api/messages` — Bot Framework activity receiver
+
+This is the inbound side; registered as a top-level route (not under `/api/messaging/`, since Azure Bot Service expects exactly `/api/messages` as the path — this is fixed by the Bot Framework contract, not our naming convention, and must match what's configured on the Azure Bot resource in §3 step 4).
+
+```rust
+pub(super) async fn handle_bot_framework_activity(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    // 1. JWT validation is mandatory and happens before anything else touches
+    //    the body — see §11. Reject with 401 on any validation failure.
+    let claims = match webhook::validate_jwt(&headers, &state.teams_app_id).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("teams webhook: JWT validation failed: {e}");
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+    };
+
+    let activity: Activity = match serde_json::from_slice(&body) {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!("teams webhook: activity parse error: {e}");
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+    };
+
+    webhook::handle_activity(activity, claims, &state).await;
+
+    // Bot Framework expects a 200 with an empty body (or 202) to acknowledge
+    // receipt — it does not wait for the reply to be sent synchronously.
+    StatusCode::OK.into_response()
+}
+```
+
+This route is registered on the **existing** axum server (same `Router` that serves `/api/messaging/*` and everything else) — not a second HTTP server on a different port. This matches the framing in the task brief and the general shape WhatsApp's webhook receiver needs too (both are "add an axum route," not "stand up a new server").
+
+---
+
+## 11. Security — JWT validation (non-negotiable)
+
+This is the single most important correctness/security requirement in this spec, called out per the task brief as non-negotiable, and worth stating precisely rather than just gesturing at "validate the JWT":
+
+1. Every `POST /api/messages` request carries an `Authorization: Bearer <jwt>` header. **Reject any request missing this header outright — do not process the body.**
+2. Fetch (and cache, with reasonable TTL — the keys rotate infrequently) the OpenID configuration at `https://login.botframework.com/v1/.well-known/openidconfiguration`, which points to the JWKS at `https://login.botframework.com/v1/.well-known/keys`. Do not hardcode key material; always resolve via the JWKS endpoint so key rotation doesn't break the bridge.
+3. Validate the JWT signature against the matching key in the JWKS (match by `kid` in the JWT header).
+4. Validate claims:
+   - `iss` (issuer) must be `https://api.botframework.com`.
+   - `aud` (audience) must equal our own `app_id` (the Entra app's client ID) — **this is the check that stops another Azure Bot Service tenant/app from being able to inject fake activities into our endpoint.** Do not skip this even though signature validation alone might feel sufficient — the JWKS keys are shared across all Bot Framework apps, so audience is what scopes trust to *this* bot specifically.
+   - `exp`/`nbf` (standard expiry window) must be valid at request time.
+   - `serviceurl` claim (if present) should match the activity body's `serviceUrl` field — mismatch is a signal of a forged/replayed request.
+5. Only after all of the above passes should the activity body be parsed and forwarded to the reactive bus.
+6. As a secondary layer (defense in depth, not a substitute for JWT validation): once `target_agent` and any per-tenant/per-user allowlist config exist, apply the same "allowlist-first" principle the master plan states for every platform (§6 point 2) — only forward activities from the configured `tenant_id`; reject and do not respond to messages from other tenants even if the JWT is otherwise valid (relevant if the Entra app is ever registered as multi-tenant, §14).
+
+No Rust crate in this codebase currently does Bot Framework JWT validation — implement with a general JWT library (e.g. `jsonwebtoken` crate, already a reasonable ecosystem-standard choice) doing RS256 verification against the fetched JWKS, structured similarly to how any other JWKS-based verification would be done; there is nothing Teams-specific about the JWT mechanics themselves, only about which issuer/audience/JWKS URL to point at.
+
+---
+
+## 12. Known failure modes / rate limits
+
+From the master plan §3.5, plus failure modes specific to the proactive-messaging design in §6:
+
+| Failure mode | Cause | Mitigation |
+|---|---|---|
+| Inbound messages never arrive, no local error | Tunnel URL stale/expired, or Azure Bot resource's messaging endpoint out of sync with current tunnel URL | Dev Tunnels should use a **persistent named tunnel** (not ephemeral), configured once; health check should periodically verify the tunnel is still serving the expected URL, not just that the subprocess is alive |
+| `POST /api/messaging/teams/send` fails with "no prior message from user" | No `conversationReference` row yet for that user (§6.3) | Expected, not a bug — surface clearly in UI/error message; document that the user must message the bot first before the agent can speak first to them |
+| 401 on inbound webhook | JWT validation failure — could be a genuine attack, could be a misconfigured `app_id`/tenant, could be JWKS cache staleness after Microsoft rotates keys | Log the specific claim that failed (issuer/audience/expiry/signature) to distinguish attack from misconfiguration; do not silently drop — surface in bridge health as an error state |
+| Rate limiting | Per-bot-per-thread: 7 sends/second, 60/30s, 1800/hour. Global per-app-per-tenant: 50 RPS (master plan §3.5) | Queue and backoff like Discord's `rest.rs` 429 handling; per-thread limits mean a burst to one conversation shouldn't starve others — track per-`conversation.id`, not globally, mirroring Telegram's per-chat vs. global scope distinction (master plan §3.2) |
+| Sideloading blocked by tenant policy | Admin has not enabled "Upload custom apps," discovered only at step 5 of setup | Cannot be mitigated in code — this is why §3's setup checklist puts this check early and the settings UI should warn about it before collecting Azure credentials, not after |
+| `app_password` (client secret) expiry | Entra client secrets have a mandatory expiry (max ~24 months) | Surface expiry date in bridge health/settings if obtainable from the Entra app metadata; otherwise, document that the user must rotate manually and update settings — bridge should fail loudly (401 from Microsoft's token endpoint) rather than silently stop sending |
+| Duplicate/out-of-order activities | Azure may retry delivery on transient failure | Bot Framework activities carry a stable `id` — dedupe on `(conversation.id, activity.id)` before forwarding to the reactive bus, similar in spirit to Telegram's offset-based idempotency requirement (master plan §3.2), though the mechanism differs (dedup set, not offset) since delivery here is push-based, not poll-based |
+
+---
+
+## 13. Implementation checklist — phased, PR-sized
+
+Assuming the §2 gate is met and implementation is greenlit:
+
+1. **PR 1 — Storage + shared `TunnelManager` foundation** (if not already landed by WhatsApp's spec):
+   - `agentmux-srv/src/backend/storage/messaging_conversations.rs` + migration bump to `OBJECT_SCHEMA_VERSION = 11` (or whatever it is by then), per §6.1.
+   - `TunnelManager` with at least `DevTunnel` and `Manual` providers wired (may already exist from WhatsApp's PR — if so, this PR just adds the `DevTunnel` variant if WhatsApp only built `CloudflareTunnel`).
+2. **PR 2 — Teams module skeleton + JWT validation + webhook receiver, no outbound yet:**
+   - `agentmux-srv/src/messaging/teams/{mod.rs,webhook.rs,types.rs}`.
+   - `POST /api/messages` route wired unconditionally in the server, 503 until configured.
+   - JWT validation against Bot Connector JWKS (§11) — this should ship even before outbound works, since an unvalidated receiver must never be exposed even transiently.
+   - `conversationReference` capture + upsert into the new table on every valid inbound activity.
+   - Success criteria: bot appears reachable to Azure (messaging endpoint healthcheck passes), inbound text messages get logged and a row appears in `db_messaging_conversation_refs`; no reply sent yet.
+3. **PR 3 — Outbound send (reply + proactive) + config + startup wiring:**
+   - `rest.rs`: OAuth2 client-credentials token fetch/cache, reply-to-activity POST, proactive-conversation POST.
+   - `POST /api/messaging/teams/send` per §10.1.
+   - Config fields per §8, startup wiring per §9.
+   - Success criteria: user messages the bot in Teams, agent (or a manual test POST) replies, reply appears in the real Teams client; a second, unprompted proactive send to the same user also succeeds using the persisted `conversationReference`.
+4. **PR 4 — Adaptive Cards + reactive bus integration:**
+   - Adaptive Card builder (rendering the shared `AgentOutput`/`MsgEmbed`-equivalent structure the way Discord renders to `MsgEmbed`, once that shared shape is finalized across platforms).
+   - Full inbound → reactive bus → agent → outbound round trip via `InjectionRequest`, matching Discord's `gateway.rs:406-439` pattern.
+   - Warden widget "Internet" section row for Teams bridge health (`BridgeHealth`, per §5.4 of the master plan) — update `widgets.json`'s Teams pane description away from "(bridge Phase 3)" once this lands.
+5. **PR 5 — Settings UI + setup documentation:**
+   - Settings pane gating on the §3 checklist (M365 org confirmation, sideloading admin check) before accepting Azure credentials.
+   - Full walkthrough doc for Entra app registration, Azure Bot resource creation, manifest build, sideloading.
+
+Each PR should land only when the §2 gating condition (real user demand from an M365-tenant user) is active — do not build ahead of that trigger speculatively, per §2's recommendation.
+
+---
+
+## 14. Open decision points for the implementer
+
+- **Multi-tenant vs. single-tenant Entra app registration.** This spec assumes single-tenant (the user's own Entra app, their own tenant) throughout, matching "every user configures their own Azure Bot" in §2. A multi-tenant app (AgentMux registers one Entra app usable across any consenting tenant) would remove most of steps 2–3 in §3 for end users but shifts significant ownership (consent flow, admin consent UX, a shared app AgentMux must maintain) onto the AgentMux project itself. Flagged in §2 as the condition under which this spec's low-priority sequencing should be revisited — not decided here.
+- **`OutboundMsg` extension shape for per-user addressing.** §10.1 flags that Teams needs to thread a resolved `conversationReference` (or a `target_user` key) through to the bridge's `send()`, which the current shared `OutboundMsg` struct has no field for. Whether this becomes a new optional field on the shared struct, a platform-specific wrapper type, or something the `MessagingBridge` trait's `send()` signature accommodates generically (e.g., an `Any`-like extension point) should be decided jointly with however Telegram/WhatsApp's specs evolve `OutboundMsg` — resolve at implementation time, not speculatively here.
+- **Token cache invalidation on `app_password` rotation.** If a user rotates their Entra client secret without restarting AgentMux, the cached OAuth2 bearer token remains valid until its own ~1hr expiry, but the *next* token fetch will fail if the settings-file secret was updated without the running process re-reading it. Decide whether `rest.rs`'s token cache should watch the config-reload signal (the existing `config_watcher` mechanism startup already uses) and proactively invalidate, or just let the natural next-fetch failure surface as a bridge health error.
+- **Dedup window for retried activities** (§12, last row): an in-memory `HashSet<(conversation_id, activity_id)>` with periodic eviction is sufficient for a single-process desktop app and avoids a third storage table; confirm this is adequate rather than persisting dedup state, since a restart naturally clearing the dedup set is an acceptable (Azure will simply retry-deliver, which is idempotent at the reactive-bus level via `InjectionRequest.request_id`, matching how Discord already passes `msg.id` as `request_id` in `gateway.rs:420`).
+- **Whether `health()`'s `Connected` state should also verify the Dev Tunnel subprocess is alive**, not just that the local webhook route exists — since (per §12's first failure mode) the most likely real-world failure is a silently-stale tunnel with no local symptom. Recommend yes — `TeamsBridge::health()` should poll `TunnelManager::status()` rather than reporting `Connected` purely because the axum route was registered at startup.

--- a/docs/specs/SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md
+++ b/docs/specs/SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md
@@ -1,0 +1,542 @@
+# Spec: Messaging App Integration — Telegram
+
+**Date:** 2026-07-07
+**Status:** Draft — ready to implement
+**Scope:** Rust bridge implementation for the Telegram pane (webview already shipped), plus formalization of the `MessagingBridge` trait shared with Discord
+
+---
+
+## 1. Goal / context
+
+The master plan (`docs/specs/SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md`) defines the two-layer pane+bridge architecture for embedding messaging apps in AgentMux: a CEF pane shows the real web app, an invisible background bridge lets an agent read/send through the platform's API. That plan's §2–§3 and §5–§6 cover the architecture, protocol research, common abstractions, and security posture in full — this spec does not repeat them, only what's specific to Telegram and to reconciling the plan with what actually shipped.
+
+Discord shipped in PR #1763 (merged 2026-06-24) as the first bridge (`agentmux-srv/src/messaging/discord/`). It validated the pane+bridge split end-to-end but diverged from the plan in three material ways this spec inherits:
+
+1. **No `MessagingBridge` trait exists yet.** `DiscordBridge` is a concrete struct with `init_global`/`get`/`send`/`health`, not a trait impl. §3 below resolves this — Telegram is the platform that formalizes it.
+2. **Config is flat serde-renamed keys**, not the nested TOML tables the plan's §2.6 sketches (`[messaging.discord]`). Real keys look like `messaging:discord:enabled`, `messaging:discord:token`. Telegram follows the same convention (§5).
+3. **No SDK crates.** Discord hand-rolls the Gateway protocol with `tokio-tungstenite` + `reqwest` + `serde_json` rather than pulling in `twilight-rs`/`serenity`. This spec recommends the same posture for Telegram (§2.5), overriding the plan's `teloxide` recommendation.
+
+The Telegram **pane** already exists: `agentmux-srv/src/config/widgets.json` (`defwidget@telegram`, ~line 151) points at `https://web.telegram.org/` with description `"Telegram Web — real interface, agent-connected (bridge Phase 2)"`. This spec is what makes that description true. Once the bridge lands, drop the `"(bridge Phase 2)"` qualifier (tracked in the checklist, §10).
+
+Why Telegram is next and is the cheapest of the remaining four: no public URL, no webhook, no tunnel, no gateway session/resume state machine — long polling from a single desktop process is the entire receive path, and Telegram's own server enforces single-poller-per-token, which maps naturally onto AgentMux's single-desktop-instance model (see §9).
+
+---
+
+## 2. Protocol design
+
+Full research lives in the master plan §3.2; this section condenses it into exact endpoints/payloads for implementation and calls out where this spec goes further than the plan.
+
+### 2.1 Receiving — long polling
+
+```
+GET https://api.telegram.org/bot{TOKEN}/getUpdates
+    ?timeout=30
+    &offset={last_update_id + 1}
+    &allowed_updates=["message","callback_query"]
+```
+
+- `timeout=30`: long-poll up to 30s; Telegram returns immediately when an update is available. Use a `reqwest::Client` with a request timeout of at least 35s (30s server-side wait + margin) — do **not** use the client's default short timeout, it will spuriously abort in-flight polls.
+- **Offset discipline**: advance the stored offset to `max(update_id) + 1` only *after* every update in the batch has been handed to the injection handler (or otherwise durably processed). If the process crashes mid-batch, the same batch is redelivered on restart — handlers must be idempotent. Idempotency here is achieved the same way Discord achieves it for `MESSAGE_CREATE`: the reactive bus injection call is keyed by `request_id` (Telegram: `update_id` or `message.message_id`), so duplicate injections are a non-issue at the bus layer if it already dedupes, and harmless (a re-injected message) if it doesn't — no additional offset-side de-dup needed.
+- Offset is **in-memory only** for v1 (mirrors Discord — no session persistence across restarts either). On restart, omit `offset` on the first call and take the most recent batch; do not attempt to backfill missed messages while offline. This is called out explicitly as an accepted gap, not an oversight (§11).
+
+### 2.2 Sending
+
+```
+POST https://api.telegram.org/bot{TOKEN}/sendMessage
+{
+  "chat_id": 123456789,
+  "text": "<b>Agent output</b>",
+  "parse_mode": "HTML",
+  "reply_markup": { "inline_keyboard": [...] }   // optional
+}
+```
+
+Use `parse_mode: "HTML"` for all agent-generated output (simpler escaping than MarkdownV2 — only `<`, `>`, `&` require escaping via `&lt;`/`&gt;`/`&amp;`). The `rest.rs` module owns this escaping; never hand raw agent text to `sendMessage` without escaping first, mirroring Discord's `rest::send_message` which JSON-encodes but does not need HTML escaping since Discord uses its own markdown.
+
+### 2.3 Message editing (streaming simulation)
+
+```
+POST .../editMessageText
+{"chat_id": ..., "message_id": ..., "text": "...", "parse_mode": "HTML"}
+```
+
+v1 scope note: `OutboundMsg` (see §4.1) gains an optional `edit_message_id` field so a caller can edit an existing message instead of sending a new one. The poller/sender does not itself implement a streaming-output orchestration loop in v1 — that's an agent-side concern (an agent that wants streaming output sends an initial `OutboundMsg`, receives back the platform message id via the HTTP response, and issues subsequent sends with `edit_message_id` set). See §7 for the response shape change this requires relative to Discord's fire-and-forget `{"ok": true}`.
+
+### 2.4 Inline keyboards and callback queries
+
+```json
+{"inline_keyboard": [[
+  {"text": "Approve", "callback_data": "approve"},
+  {"text": "Cancel", "callback_data": "cancel"}
+]]}
+```
+
+Inbound `callback_query` updates arrive via the same `getUpdates` poll (included in `allowed_updates`). On receipt:
+1. Call `answerCallbackQuery` within **60 seconds** (`POST .../answerCallbackQuery {"callback_query_id": "..."}`) — this clears the client-side button spinner; failing to call it is not fatal but leaves the user's UI in a loading state.
+2. Optionally follow with `editMessageReplyMarkup` to update/remove the buttons.
+3. Route the callback as an inbound message into the reactive bus the same way a text message is (envelope carries `callback_data` as the message body, prefixed distinctly, e.g. `[Telegram callback @user]: approve`), so the agent can act on it via the same `read_messages` path used for text.
+
+v1 scope: implement the poll-side plumbing for `callback_query` (parse it, answer it, inject it) but do not build a generic "action button" authoring API for agents in this PR — that's follow-on work once there's a concrete agent use case driving the keyboard layout (§11).
+
+### 2.5 Rate limits
+
+| Scope | Limit | Handling |
+|---|---|---|
+| Single chat | 1 msg/second | Per-chat outbound queue with 1.1s minimum spacing (jittered) |
+| Group chat | 20 msg/minute | Per-chat token bucket, refills over 60s |
+| Global (all chats) | ~30 msg/second | Global token bucket shared across all outbound sends |
+| `429` response | carries `parameters.retry_after` (seconds) and `parameters.scope` (`"chat"` or `"user"`, added Bot API 7.8) | On `chat` scope: pause only that chat's queue for `retry_after` + jitter. On global/unscoped: pause all outbound for `retry_after` + jitter. Never pre-throttle proactively beyond the queue spacing above — react to actual `429`s. |
+
+v1 scope: implement the per-chat 1 msg/s spacing (cheap, prevents the common case) and `429` handling with `retry_after` backoff. Do **not** implement full token-bucket accounting for the 20/min and 30/s tiers in the first PR — a single misbehaving high-volume agent hitting those ceilings is an edge case, not the common path, and Discord's REST client shipped with equivalent minimalism (`rest.rs` logs 429s and returns an error, full header-driven rate limiting deferred). Track this as a fast-follow (§11), not a blocker.
+
+### 2.6 Rust library decision: hand-roll with `reqwest`, do not add `teloxide`
+
+The master plan §3.2 recommends `teloxide` (full Tokio-native Bot API framework). This spec overrides that recommendation. Rationale:
+
+- **Precedent.** Discord shipped by hand-rolling the Gateway protocol with `tokio-tungstenite` + `reqwest` + `serde_json`, explicitly rejecting `twilight-rs`/`serenity` even though the plan recommended them. The codebase now has an established pattern: platform bridges are thin, purpose-built clients over the specific subset of the API AgentMux needs (send message, poll updates, answer callbacks), not full SDK integrations.
+- **Telegram's Bot API is simpler than Discord's Gateway.** There's no session/resume/heartbeat state machine to hand-roll — long polling is a plain HTTP GET loop. The amount of code `teloxide` would save here is much smaller than what hand-rolling the Gateway WS protocol would have cost, so the "avoid a heavy dependency" argument that justified skipping `twilight-rs` applies at least as strongly, and the "avoid re-deriving hard protocol logic" argument that might justify pulling in a library is much weaker.
+- **Dependency footprint.** `teloxide` pulls in its own async runtime glue, a dispatcher/handler DSL, and a large transitive dependency tree. AgentMux already has `reqwest` (with `rustls-tls`, `json`) in `Cargo.toml` — zero new dependencies needed for a `getUpdates`/`sendMessage` client.
+- **Control.** Hand-rolling keeps the bridge's shape (mpsc channel + `Arc<Mutex<BridgeHealth>>` + background tokio task) uniform across platforms, which matters more now that `MessagingBridge` is being formalized (§3) — a `teloxide::Dispatcher`-owned event loop would fight that shape rather than fit it.
+
+**Decision: no new crate.** Implement `messaging/telegram/` with `reqwest` (already a dependency) for both the polling GET and the sending POSTs. No WebSocket library is needed (long polling is plain HTTP).
+
+---
+
+## 3. The trait decision
+
+### 3.1 Problem
+
+`agentmux-srv/src/messaging/mod.rs` currently declares only shared data types (`InboundMsg`, `OutboundMsg`, `MsgEmbed`, `EmbedField`, `BridgeHealth`, `BridgeStatus`) and a `pub mod discord;`. There is no `MessagingBridge` trait, even though the master plan sketched one in §2.5/§5.1. `DiscordBridge` is a concrete struct: `init_global(config, http)`, `get() -> Option<&'static DiscordBridge>`, `send(&self, msg) -> Result<(), String>`, `health(&self) -> BridgeHealth`.
+
+With only one implementation this was the right call — premature abstraction over a single concrete type buys nothing. Telegram is the second real implementation, which is exactly the point at which the abstraction earns its keep: `handle_status` (`agentmux-srv/src/server/messaging_handlers.rs`) currently special-cases Discord (`if let Some(bridge) = DiscordBridge::get() { bridges.push(bridge.health()); }`); with two platforms this either grows a second hand-copied `if let` (fine at 2, ugly at 4-5 once Slack/WhatsApp/Teams land) or the aggregation becomes `for platform in registered_bridges() { ... }` over a trait object.
+
+**Decision: formalize `MessagingBridge` now.** Telegram implements it from day one; `DiscordBridge` is retrofitted to implement it in the same PR (or the PR immediately before Telegram's protocol work — see Phase in §10). This spec makes the recommendation and specifies the mechanical retrofit; per the coordinating plan, Telegram is the platform that executes it.
+
+### 3.2 Trait definition — sync `send`/`health`, not the plan's `async`
+
+The master plan's sketch (§2.5) used `async fn send` and `async fn stop`. This spec deliberately diverges:
+
+```rust
+// agentmux-srv/src/messaging/mod.rs
+
+use std::sync::Arc;
+
+/// Common interface implemented by every platform bridge (Discord, Telegram, …).
+///
+/// Bridges are singletons accessed via `get()`-style static accessors on the
+/// concrete type (see `DiscordBridge::get()`, `TelegramBridge::get()`) for the
+/// call sites that know their platform statically (e.g. platform-specific HTTP
+/// handlers). This trait exists for call sites that need to treat bridges
+/// polymorphically — today, only `handle_status`'s aggregation loop.
+pub trait MessagingBridge: Send + Sync {
+    /// Static platform identifier: "discord", "telegram", etc.
+    fn platform(&self) -> &'static str;
+
+    /// Enqueue a message for delivery. Fire-and-forget: pushes onto the
+    /// bridge's internal mpsc channel and returns as soon as the send is
+    /// queued, not once it's delivered. Matches the existing Discord
+    /// contract exactly — see rationale below.
+    fn send(&self, msg: OutboundMsg) -> Result<(), String>;
+
+    /// Current connection/health snapshot. Cheap, non-blocking (reads an
+    /// `Arc<Mutex<BridgeHealth>>` guarded by a short-lived lock).
+    fn health(&self) -> BridgeHealth;
+}
+```
+
+Note what's *not* in this trait: `start()`/`stop()`/`platform()`-as-constructor. Rationale:
+
+- **`send`/`health` stay sync.** Both existing methods on `DiscordBridge` are already sync and cannot block: `send` pushes onto an `mpsc::UnboundedSender` (non-blocking, returns `Result` immediately based on whether the receiver is still alive), and `health` takes a `Mutex` lock held only long enough to `clone()` a small struct. Making them `async fn` would require every call site (`messaging_handlers.rs` handlers, which are themselves async axum handlers, so this is a low-cost change there) to `.await` a call that never actually awaits anything — pure ceremony. More importantly, retrofitting `DiscordBridge` under an `async fn send` signature would still resolve to the same non-blocking channel push, so the `async` keyword would be lying about the method's actual behavior. Sync signatures document the fire-and-forget contract accurately: the *bridge's* background task is what does the awaiting (the gateway/poller loop `await`s the HTTP send), not the caller.
+- **No `start()`/`stop()` in the trait.** Both bridges follow an `init_global(config, ...)` pattern instead: initialize a process-wide singleton once at startup, spawn its background task, and never tear it down for the lifetime of the process (there is no runtime "disable this bridge" flow yet — disabling requires restarting AgentMux with `messaging:discord:enabled = false` / `messaging:telegram:enabled = false`, per the existing `main.rs` wiring). Because `init_global` differs per platform (different `Config` struct shape) it cannot be a trait method with a uniform signature without an ugly `Box<dyn Any>` config parameter. Keep `init_global`/`get()` as inherent (non-trait) associated functions on each concrete bridge type, exactly as `DiscordBridge` already does. If a real stop/reconfigure flow is needed later (tracked as an open question in §11), add `fn stop(&self)` then, once there's a concrete caller and a concrete idea of what "stop" should do to the background task (cooperative cancellation via a `CancellationToken` most likely) — do not speculate on that shape now.
+- **`platform()` is included** because it's the one piece `handle_status`'s aggregation actually needs today (to key the JSON status array by platform name) that isn't already derivable from `health().platform` — actually, `BridgeHealth.platform` already carries this, so `platform()` on the trait is redundant with `health().platform`. **Decision: omit `platform()` from the trait entirely**, get it via `health().platform` instead, keeping the trait to exactly the two methods (`send`, `health`) that have real polymorphic call sites today. (Revise the trait sketch above accordingly — final trait is `send` + `health` only.)
+
+Final trait:
+
+```rust
+pub trait MessagingBridge: Send + Sync {
+    fn send(&self, msg: OutboundMsg) -> Result<(), String>;
+    fn health(&self) -> BridgeHealth;
+}
+```
+
+### 3.3 Discord retrofit — mechanical, no behavior change
+
+In `agentmux-srv/src/messaging/discord/mod.rs`, add:
+
+```rust
+impl crate::messaging::MessagingBridge for DiscordBridge {
+    fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        DiscordBridge::send(self, msg)
+    }
+    fn health(&self) -> BridgeHealth {
+        DiscordBridge::health(self)
+    }
+}
+```
+
+(The inherent `send`/`health` methods are kept as-is and remain the primary call path for `messaging_handlers::handle_discord_send`, which knows it's talking to Discord specifically and has no reason to go through a trait object. The trait impl exists purely so `&dyn MessagingBridge` can be constructed where polymorphism is needed.) This is a pure additive change — zero risk to existing behavior, no changes to `gateway.rs`, `rest.rs`, `types.rs`, or the inherent method bodies.
+
+### 3.4 Where the trait is actually used
+
+`handle_status` (`agentmux-srv/src/server/messaging_handlers.rs`) becomes:
+
+```rust
+pub(super) async fn handle_status(State(_state): State<AppState>) -> impl IntoResponse {
+    let mut bridges: Vec<BridgeHealth> = vec![];
+    if let Some(b) = DiscordBridge::get() {
+        bridges.push((b as &dyn MessagingBridge).health());
+    }
+    if let Some(b) = TelegramBridge::get() {
+        bridges.push((b as &dyn MessagingBridge).health());
+    }
+    Json(json!({ "bridges": bridges }))
+}
+```
+
+This is honest about the current state: even with the trait formalized, there is still one `if let` per platform, because each bridge's `get()` is a distinct static accessor on a distinct type (`Option<&'static DiscordBridge>` vs `Option<&'static TelegramBridge>`) — Rust has no ambient registry of "all initialized bridges" without additional machinery (e.g. a `Vec<&'static dyn MessagingBridge>` populated at `init_global` time via a `OnceLock<Mutex<Vec<...>>>` registry). **Recommendation: do not build that registry yet.** At 2 platforms the `if let` chain is more readable than a registry abstraction; revisit when a 3rd platform (Slack) lands and the chain would grow to 3 — that's the point where a shared `register_bridge(&'static dyn MessagingBridge)` call inside each `init_global` starts paying for itself. Note this explicitly as a deferred decision (§11), not an oversight.
+
+---
+
+## 4. Rust module layout
+
+Mirrors `agentmux-srv/src/messaging/discord/` exactly, with `gateway.rs` renamed to `poller.rs` since Telegram has no persistent WebSocket session:
+
+```
+agentmux-srv/src/messaging/telegram/
+├── mod.rs      // Config, TelegramBridge struct, GLOBAL_BRIDGE OnceLock, init_global/get/send/health
+├── poller.rs   // long-polling loop: getUpdates → dispatch → offset advance; outbound mpsc → REST send
+├── rest.rs     // sendMessage / editMessageText / answerCallbackQuery / editMessageReplyMarkup
+└── types.rs    // Update, Message, CallbackQuery, Chat, User wire types; outbound body structs
+```
+
+`agentmux-srv/src/messaging/mod.rs` gains `pub mod telegram;` alongside the existing `pub mod discord;`, plus the `MessagingBridge` trait from §3.2.
+
+### 4.1 `mod.rs`
+
+```rust
+mod poller;
+pub mod rest;
+pub mod types;
+
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::mpsc;
+use crate::messaging::{BridgeHealth, OutboundMsg};
+
+#[derive(Debug, Clone)]
+pub struct TelegramConfig {
+    /// Bot token from @BotFather.
+    pub token: String,
+    /// Allowlisted chat IDs. Inbound updates from chats not in this list are
+    /// silently dropped (no reply, no injection, no log-level above debug).
+    pub allowed_chat_ids: Vec<i64>,
+    /// Default chat ID for outbound sends when OutboundMsg doesn't override one.
+    /// Reuses `OutboundMsg.channel_id` as a stringified chat_id (see §7 note).
+    pub default_chat_id: Option<i64>,
+    /// Agent ID to inject inbound Telegram messages into via the reactive bus.
+    pub target_agent: Option<String>,
+}
+
+pub struct TelegramBridge {
+    outbound_tx: mpsc::UnboundedSender<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+}
+
+static GLOBAL_BRIDGE: OnceLock<TelegramBridge> = OnceLock::new();
+
+impl TelegramBridge {
+    pub fn init_global(config: TelegramConfig, http: reqwest::Client) {
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<OutboundMsg>();
+        let health = Arc::new(Mutex::new(BridgeHealth::connecting("telegram")));
+        let bridge = TelegramBridge { outbound_tx, health: health.clone() };
+        if GLOBAL_BRIDGE.set(bridge).is_err() {
+            return; // already initialized
+        }
+        tokio::spawn(async move {
+            poller::run_poll_loop(config, http, outbound_rx, health).await;
+        });
+    }
+
+    pub fn get() -> Option<&'static TelegramBridge> { GLOBAL_BRIDGE.get() }
+
+    pub fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        self.outbound_tx.send(msg)
+            .map_err(|_| "telegram_bridge: outbound channel closed".to_string())
+    }
+
+    pub fn health(&self) -> BridgeHealth {
+        self.health.lock().unwrap().clone()
+    }
+}
+
+impl crate::messaging::MessagingBridge for TelegramBridge {
+    fn send(&self, msg: OutboundMsg) -> Result<(), String> { TelegramBridge::send(self, msg) }
+    fn health(&self) -> BridgeHealth { TelegramBridge::health(self) }
+}
+```
+
+Note on reusing `OutboundMsg.channel_id`: Telegram addresses by numeric `chat_id`, not a channel string, but `OutboundMsg` is a cross-platform shared type (`agentmux-srv/src/messaging/mod.rs`) and should not sprout a Telegram-only field. `channel_id: String` is reused to carry the chat id as a decimal string (e.g. `"123456789"`); `poller.rs`/`rest.rs` parse it with `str::parse::<i64>()` and fall back to `config.default_chat_id` when empty, exactly mirroring how Discord treats an empty `channel_id` as "use the bridge's default channel." This keeps `OutboundMsg` platform-agnostic rather than special-casing it per platform — the alternative (a `platform_target: PlatformTarget` enum) is not justified by two platforms and is left as a §11 open question if a third chat-id-shaped platform (e.g. Slack's `channel`) shows the same need.
+
+### 4.2 `poller.rs` — shape mirrors `gateway.rs`'s `run_gateway_loop`/`run_session` split
+
+```rust
+pub async fn run_poll_loop(
+    config: TelegramConfig,
+    http: reqwest::Client,
+    mut outbound_rx: mpsc::UnboundedReceiver<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+) {
+    let mut offset: i64 = 0;
+    loop {
+        tokio::select! {
+            // Outbound: agent → Telegram REST (checked opportunistically between polls)
+            Some(msg) = outbound_rx.recv() => {
+                if let Err(e) = rest::send_or_edit(&http, &config.token, &config, &msg).await {
+                    tracing::warn!("telegram_bridge: send failed: {e}");
+                }
+            }
+            // Inbound: long poll
+            result = rest::get_updates(&http, &config.token, offset) => {
+                match result {
+                    Ok(updates) => {
+                        { let mut h = health.lock().unwrap();
+                          h.status = BridgeStatus::Connected; h.error = None; }
+                        for update in &updates {
+                            handle_update(update, &config, &health);
+                        }
+                        if let Some(last) = updates.last() {
+                            offset = last.update_id + 1;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("telegram_bridge: getUpdates failed: {e}");
+                        let mut h = health.lock().unwrap();
+                        h.status = BridgeStatus::Error;
+                        h.error = Some(e);
+                        h.reconnect_count += 1;
+                        drop(h);
+                        tokio::time::sleep(Duration::from_secs(5)).await; // backoff before retry
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+This is a plain retry-forever loop (no session/resume state — there is no session), matching Discord's `run_gateway_loop` outer retry shell but without the inner `run_session` complexity, since long polling has no connection to lose beyond a single HTTP request. `handle_update` plays the same role as `gateway.rs`'s `handle_dispatch`: filters by `allowed_chat_ids`, ignores bot-authored messages, builds the `[Telegram @username]: text` envelope, and calls `get_global_handler().inject_message(InjectionRequest { ... source_agent: Some("telegram".into()), request_id: Some(update.update_id.to_string()), delivery_tier: Some("wan".into()), ... })` — same call shape Discord uses in `gateway.rs` line ~414-425.
+
+### 4.3 `rest.rs`
+
+Functions: `get_updates(http, token, offset) -> Result<Vec<Update>, String>`, `send_message`, `edit_message_text`, `answer_callback_query`, `edit_message_reply_markup` — each a thin `reqwest` POST/GET against `https://api.telegram.org/bot{token}/{method}`, parsing Telegram's `{"ok": bool, "result": ..., "error_code": ..., "description": ..., "parameters": {"retry_after": ..., "scope": ...}}` envelope. `send_or_edit` dispatches to `send_message` or `edit_message_text` based on whether `OutboundMsg` carries an `edit_message_id` (per §2.3).
+
+### 4.4 `types.rs`
+
+Wire types: `Update { update_id, message: Option<Message>, callback_query: Option<CallbackQuery> }`, `Message { message_id, chat: Chat, from: Option<User>, text: Option<String>, date: i64 }`, `Chat { id, type_: String }`, `User { id, username: Option<String>, is_bot: bool }`, `CallbackQuery { id, from: User, data: Option<String>, message: Option<Message> }`, plus outbound body structs (`SendMessageBody`, `EditMessageTextBody`, `AnswerCallbackQueryBody`, `InlineKeyboardMarkup`, `InlineKeyboardButton`) — same hand-rolled `serde` struct pattern as `discord/types.rs`.
+
+---
+
+## 5. Config schema additions
+
+`agentmux-srv/src/backend/wconfig/types.rs`, adjacent to the existing `messaging:discord:*` block (~line 300-325), following the same flat-key convention:
+
+```rust
+// -- Messaging bridge settings (Telegram) --
+
+/// Master enable for the Telegram messaging bridge.
+/// When true, the bridge starts long-polling getUpdates at startup.
+#[serde(rename = "messaging:telegram:enabled", default, skip_serializing_if = "is_false")]
+pub messaging_telegram_enabled: bool,
+
+/// Telegram bot token from @BotFather. Treat as a secret — do not log.
+#[serde(rename = "messaging:telegram:token", default, skip_serializing_if = "Option::is_none")]
+pub messaging_telegram_token: Option<String>,
+
+/// Comma-separated allowlist of chat IDs permitted to reach the bridge.
+/// Inbound updates from any other chat are silently dropped.
+/// Stored as a string (not Vec<i64>) to keep the flat-key/settings.json
+/// convention simple — parsed to Vec<i64> at startup wiring time.
+#[serde(rename = "messaging:telegram:allowed_chats", default, skip_serializing_if = "String::is_empty")]
+pub messaging_telegram_allowed_chats: String,
+
+/// Default chat ID for outbound sends when a request doesn't override one.
+#[serde(rename = "messaging:telegram:default_chat", default, skip_serializing_if = "Option::is_none")]
+pub messaging_telegram_default_chat: Option<String>,
+
+/// Agent ID that receives inbound Telegram messages via the reactive bus.
+/// Absent → messages are logged but not forwarded to any agent.
+#[serde(rename = "messaging:telegram:target", default, skip_serializing_if = "Option::is_none")]
+pub messaging_telegram_target: Option<String>,
+```
+
+Note on `allowed_chats` as a comma-separated string rather than `Vec<i64>`: `messaging_discord_*` fields are all scalar (`bool`/`Option<String>`/`String`) — there's no existing precedent in this struct for a `Vec<T>`-valued settings key, and introducing one raises questions (serde-rename on a list field, how it round-trips through whatever settings-editing UI exists) that are out of scope here. A comma-separated string parsed at the `main.rs` call site (`"123,456,789".split(',').filter_map(|s| s.trim().parse().ok()).collect()`) is the minimal-diff choice consistent with every other field in this struct. If a future platform needs a genuine list-valued setting, standardize the approach there rather than one-offing it for Telegram.
+
+---
+
+## 6. Startup wiring
+
+`agentmux-srv/src/main.rs`, immediately after the existing Discord block (~line 731-754), same shape:
+
+```rust
+// Telegram messaging bridge — long-polls getUpdates if configured.
+// Set messaging:telegram:enabled + messaging:telegram:token in settings.json to activate.
+{
+    let settings = config_watcher.get_settings();
+    if settings.messaging_telegram_enabled {
+        match settings.messaging_telegram_token.clone() {
+            Some(token) if !token.is_empty() => {
+                let allowed_chat_ids = settings
+                    .messaging_telegram_allowed_chats
+                    .split(',')
+                    .filter_map(|s| s.trim().parse::<i64>().ok())
+                    .collect::<Vec<_>>();
+                let default_chat_id = settings
+                    .messaging_telegram_default_chat
+                    .as_deref()
+                    .and_then(|s| s.parse::<i64>().ok());
+                messaging::telegram::TelegramBridge::init_global(
+                    messaging::telegram::TelegramConfig {
+                        token,
+                        allowed_chat_ids,
+                        default_chat_id,
+                        target_agent: settings.messaging_telegram_target.clone(),
+                    },
+                    reqwest::Client::new(),
+                );
+            }
+            _ => {
+                tracing::warn!(
+                    "telegram bridge: enabled but messaging:telegram:token is not set in settings.json"
+                );
+            }
+        }
+    }
+}
+```
+
+Placed directly after the Discord block so both bridges initialize together and the startup sequence stays easy to scan; no shared "init all messaging bridges" loop is introduced in this PR (that refactor belongs with the bridge-registry idea noted in §3.4/§11, deferred until a 3rd platform makes the duplication actually costly).
+
+---
+
+## 7. HTTP endpoints
+
+`agentmux-srv/src/messaging/mod.rs` (or wherever `MessagingBridge` lands — §3.2) exports the trait; `agentmux-srv/src/server/messaging_handlers.rs` gains:
+
+```rust
+use crate::messaging::telegram::TelegramBridge;
+use crate::messaging::MessagingBridge;
+```
+
+### 7.1 `handle_status` — updated per §3.4
+
+Aggregates both bridges' `health()` into the existing `{"bridges": [...]}` array shape — no response-shape change, just one more entry once Telegram is configured.
+
+### 7.2 `POST /api/messaging/telegram/send`
+
+```rust
+/// POST /api/messaging/telegram/send
+#[derive(Deserialize)]
+pub(super) struct TelegramSendRequest {
+    #[serde(default)]
+    pub text: String,
+    /// Override chat. Empty → use the bridge's default chat (messaging:telegram:default_chat).
+    #[serde(default)]
+    pub chat_id: String,
+    /// If set, edits this existing message instead of sending a new one
+    /// (see spec §2.3 — streaming-output simulation).
+    pub edit_message_id: Option<i64>,
+    /// Optional inline keyboard, one row per Vec entry.
+    #[serde(default)]
+    pub inline_keyboard: Vec<Vec<TelegramButtonRequest>>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct TelegramButtonRequest {
+    pub text: String,
+    pub callback_data: String,
+}
+```
+
+Handler mirrors `handle_discord_send`'s shape (look up the bridge via `TelegramBridge::get()`, 503 if uninitialized, build `OutboundMsg`, call `bridge.send(msg)`, return `{"ok": true}` on success / 500 with `{"error": ...}` on channel-closed).
+
+**One deliberate deviation from the Discord endpoint's response shape:** because Telegram's edit-for-streaming pattern (§2.3) requires the caller to learn the `message_id` of a message it just sent in order to edit it later, and because `send()` on `MessagingBridge`/`TelegramBridge` is fire-and-forget over an mpsc channel (no synchronous round-trip to Telegram's API, so the handler cannot know the resulting `message_id` at return time), **v1 does not thread `message_id` back through the HTTP response.** A caller wanting to edit a message must independently track `chat_id` + a caller-assigned correlation id, or (simpler, and the recommended path) avoid editing entirely and rely on Telegram's native message grouping for streaming-style updates. Threading a synchronous send-and-return-message-id path through would require either making `send()` async-with-response (breaking the sync contract established in §3.2 and diverging from Discord) or adding a second, separate "synchronous send" API distinct from the fire-and-forget one. Neither is justified by a concrete caller yet — left as an explicit open question in §11, not silently dropped.
+
+`agentmux-srv/src/server/mod.rs` gains one route registration alongside the existing two:
+
+```rust
+.route("/api/messaging/telegram/send", post(messaging_handlers::handle_telegram_send))
+```
+
+---
+
+## 8. Security considerations specific to Telegram
+
+Builds on the master plan §6 (credentials in keychain — note: today Discord's token is read from plaintext `settings.json`, not OS keychain, despite the plan's §6.1 requirement; this is an existing gap this spec inherits rather than fixes, call it out explicitly rather than silently perpetuating it — see §11):
+
+1. **Allowlist is mandatory, not optional, for Telegram specifically.** Unlike Discord (where a bot is scoped to guilds it's explicitly invited to, so "reachability" is already gated by the invite step), a Telegram bot's username is public and anyone who knows it can start a DM or add it to a group — there is no invite-approval step equivalent to Discord's OAuth flow. `allowed_chat_ids` (§5) is therefore the *only* gate, and `poller.rs`'s `handle_update` must check it before any other processing, silently dropping (not replying to) messages from unlisted chats — replying at all would confirm the bot is alive and invite enumeration, per the master plan §3.2's existing guidance.
+2. **`callback_data` is attacker-controllable input** the moment the allowlist is bypassed by a listed-but-compromised chat, or even within an allowed chat by any member of a group chat the bot is in. Treat `callback_data` string content the same as inbound message text: untrusted, never `eval`'d or used to construct file paths/shell commands, only matched against a fixed set of expected action strings the bridge itself generated.
+3. **Bot privacy mode.** By default (`/setprivacy` on @BotFather, default state is `enabled`) a bot added to a group only receives messages that mention it or reply to it — not the full group stream. This is a *security-positive* default and this spec does not recommend disabling it (`/setprivacy off`) unless a specific AgentMux use case needs full-group visibility; document this as a user-facing setup note (§10) rather than defaulting to the more permissive mode.
+4. **Token in logs.** `rest.rs` must never log the full request URL if the token is embedded in the path (`https://api.telegram.org/bot{TOKEN}/...`) — this is a sharper footgun than Discord's `Authorization: Bot {token}` header, since header values are less likely to be accidentally logged by generic HTTP tracing than URL paths are. Redact the token segment in any `tracing::` call that includes the URL (e.g. log `"telegram_bridge: getUpdates request"` without the URL, or with the token segment replaced by `***`).
+
+---
+
+## 9. Known failure modes / rate limits
+
+(Rate limit table already given in §2.5; this section covers non-rate-limit failure modes, mirroring the "Known failure modes" subsections in both source docs.)
+
+- **409 Conflict on `getUpdates`.** Returned when a second `getUpdates` long-poll is already open for the same token (e.g. AgentMux running twice, or a stray webhook still registered on the same bot). Per the master plan, this is a *feature* for AgentMux's single-desktop-instance model — it prevents split-brain message handling — but the bridge must surface it clearly: on `409`, set `BridgeHealth.status = Error` with `error = Some("telegram: another getUpdates poller is active for this token (409) — check for a duplicate AgentMux instance or a registered webhook")`, back off (same 5s→60s exponential pattern as Discord's reconnect delay), and keep retrying rather than giving up permanently (the conflicting instance may exit).
+- **Webhook/polling conflict.** If a webhook was ever registered for this bot token (e.g. by a prior non-AgentMux integration), `getUpdates` fails until `deleteWebhook` is called. v1 does not proactively call `deleteWebhook` at startup — document this as a manual troubleshooting step (§10 setup notes) rather than silently mutating the bot's webhook config on every startup, since AgentMux cannot know whether the user intentionally has a webhook configured elsewhere.
+- **Long-poll timeout vs. HTTP client timeout mismatch.** Covered in §2.1 — the `reqwest::Client` used for `get_updates` must have a per-request timeout longer than Telegram's own `timeout=30` parameter, or every poll will spuriously error out right as data would have arrived. Use a dedicated client (or `.timeout()` override on the request builder) distinct from whatever default client `rest.rs`'s send methods use, since sends should time out much faster (a stuck `sendMessage` call blocking the poll loop for 30s+ is worse than a 30s-timeout getUpdates call, given the `tokio::select!` structure in §4.2 processes outbound sends and inbound polls on the same task).
+- **Malformed/oversized updates.** As with Discord's `MESSAGE_CREATE` parse failures (`gateway.rs` line ~383-389), a single malformed `Update` in a batch must not abort the whole batch — parse each `Update` independently inside the loop in `poller.rs`, `tracing::warn!` and `continue` past parse failures for that one item, and — critically — still advance the offset past it (an update that will never parse successfully should not permanently wedge the poll loop by being retried forever).
+
+---
+
+## 10. Implementation checklist — phased, PR-sized chunks
+
+Mirrors the Discord POC's phased style, made concrete against this codebase's actual shape.
+
+**PR 1 — Formalize `MessagingBridge` trait + Discord retrofit (small, low-risk, unblocks PR 2-4)**
+- Add `MessagingBridge` trait to `agentmux-srv/src/messaging/mod.rs` (§3.2 final form: `send` + `health` only).
+- Add `impl MessagingBridge for DiscordBridge` to `discord/mod.rs` (§3.3) — additive, no behavior change.
+- Update `handle_status` in `messaging_handlers.rs` to go through `&dyn MessagingBridge` for the health aggregation (§3.4), still one `if let` per platform.
+- No new endpoints, no config changes. Verify: existing Discord bridge tests/manual smoke test still pass unmodified.
+
+**PR 2 — Telegram module skeleton + long-poll receive path**
+- `agentmux-srv/src/messaging/telegram/{mod,poller,rest,types}.rs` per §4.
+- `mod.rs`: `TelegramConfig`, `TelegramBridge`, `init_global`/`get`/`send`/`health`, `impl MessagingBridge`.
+- `poller.rs`: `run_poll_loop` — `getUpdates` long polling, offset advance, allowlist filtering, envelope construction, reactive-bus injection (mirrors `gateway.rs::handle_dispatch`'s `MESSAGE_CREATE` handling, §9's malformed-update handling included).
+- `rest.rs`: `get_updates` only in this PR (send path is PR 3).
+- `types.rs`: `Update`, `Message`, `Chat`, `User` (inbound-only types for this PR; `CallbackQuery` can land here or in PR 4).
+- Config: add the 5 `messaging:telegram:*` fields to `wconfig/types.rs` (§5).
+- Startup wiring in `main.rs` (§6).
+- Success criterion: a message sent to the configured bot in an allowlisted chat is injected into the reactive bus and visible to the target agent via `read_messages`. No outbound path yet (verify via logs/reactive-bus inspection, not a reply).
+
+**PR 3 — Outbound send + HTTP endpoint**
+- `rest.rs`: `send_message`, `edit_message_text`, HTML-escaping helper (§2.2).
+- `poller.rs`: wire the `outbound_rx` arm of the `tokio::select!` to call `rest::send_or_edit` (§4.2).
+- `messaging_handlers.rs`: `TelegramSendRequest`/`handle_telegram_send` (§7.2), route registration in `server/mod.rs`.
+- Per-chat 1 msg/s spacing + `429`/`retry_after` handling (§2.5 — v1 scope, not full token-bucket accounting).
+- Success criterion: `POST /api/messaging/telegram/send` delivers a message visible in the Telegram pane's live chat; round-trip (user message in → agent reply out) works end-to-end, matching Discord's Phase 2 success criterion.
+
+**PR 4 — Inline keyboards + callback queries**
+- `types.rs`: `CallbackQuery`, `InlineKeyboardMarkup`/`InlineKeyboardButton` outbound types.
+- `rest.rs`: `answer_callback_query`, `edit_message_reply_markup`.
+- `poller.rs`: handle `callback_query` updates — allowlist check, `answerCallbackQuery` within 60s, inject as a distinct envelope into the reactive bus (§2.4).
+- `messaging_handlers.rs`: extend `TelegramSendRequest` with `inline_keyboard` (§7.2) if not already added in PR 3.
+- Success criterion: an outbound message with an inline keyboard is tappable in the real Telegram client; the tap is delivered to the target agent and the button spinner clears.
+
+**PR 5 — Pane description + polish**
+- `agentmux-srv/src/config/widgets.json`: update `defwidget@telegram`'s `description` to drop the `"(bridge Phase 2)"` qualifier, e.g. `"Telegram Web — real interface, agent-connected"` (matches the already-bridge-complete Discord entry's description string, which has no phase qualifier).
+- Any settings-UI surface for entering the bot token / allowed chat IDs, if such a UI exists for Discord's equivalent fields (out of scope to design here if it doesn't yet exist for Discord either — check parity at implementation time rather than building a Telegram-only settings UI ahead of Discord getting one).
+
+---
+
+## 11. Open decision points — explicitly not resolved here
+
+1. **Credentials in plaintext `settings.json` vs. OS keychain.** The master plan §6.1 mandates keychain storage; both Discord (shipped) and this Telegram spec store the token as a plaintext settings field (`messaging_discord_token` / `messaging_telegram_token`). This is a pre-existing gap this spec inherits rather than fixes. If/when Discord's token storage is migrated to keychain, Telegram's should follow the same migration in lockstep — do not fix it for one platform and not the other.
+2. **Bridge registry for `handle_status`.** Deferred per §3.4 until a 3rd platform (Slack) makes the per-platform `if let` chain in `handle_status` unwieldy enough to justify a `register_bridge()`-based registry.
+3. **`OutboundMsg` growing a platform-target enum** instead of overloading `channel_id` as a stringified chat id (§4.1). Revisit if a 3rd platform's addressing scheme doesn't fit the "stringified single identifier" shape either.
+4. **Synchronous send-and-get-message-id API** for the streaming-edit pattern (§2.3, §7.2). Not built in v1 because there's no concrete caller yet; if an agent workflow needs it, design it as an additive second entry point rather than changing `send()`'s existing fire-and-forget contract.
+5. **Full token-bucket rate limiting** for the 20/min-per-group and ~30/s-global tiers (§2.5). v1 only implements per-chat 1 msg/s spacing and reactive `429` backoff.
+6. **Offline backfill.** No attempt to fetch messages missed while AgentMux was not running (offset resets to "most recent" on restart, §2.1). If a use case emerges for catching up on missed messages, that's a deliberate scope addition, not a bug fix.
+7. **Proactive `deleteWebhook` call at startup** to avoid the webhook/polling conflict noted in §9. Left as a manual troubleshooting step rather than an automatic mutation of the bot's configuration.
+8. **Settings UI** for token/allowlist entry — parity with whatever exists (or doesn't yet) for Discord, not designed fresh here (§10, PR 5).

--- a/docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md
+++ b/docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md
@@ -1,0 +1,692 @@
+# Spec: Messaging App Integration — WhatsApp
+
+**Date:** 2026-07-07
+**Status:** Draft — ready to implement (Cloud API); Path B (Baileys) deferred out of v1, see §2
+**Scope:** Rust bridge design for WhatsApp inside `agentmux-srv`, adapting the master messaging plan and the shipped Discord bridge shape to WhatsApp's webhook-based protocol
+
+---
+
+## 1. Goal and context
+
+Extend AgentMux's messaging integrations (see `docs/specs/SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md`, the master plan) to WhatsApp. The pane layer already exists — `defwidget@whatsapp` in `agentmux-srv/src/config/widgets.json` (lines ~166-180) points a browser pane at `https://web.whatsapp.com/`, with description `"WhatsApp Web — real interface, agent-connected (bridge Phase 3)"`. This spec designs the bridge layer: the background process that lets an agent read/send WhatsApp messages through the real Meta Cloud API while the user keeps using the native WhatsApp Web UI in the pane, exactly as Discord already does for Discord.com.
+
+Discord shipped in PR #1763 (merged 2026-06-24) as a pure-Rust bridge inside `agentmux-srv` — no Node.js sidecar, no Electron (this app is CEF-hosted Rust; `agentmux-cef` is the host process, there is no Electron main process anywhere in this codebase). That fact drives every architectural call in this spec, and it directly contradicts two assumptions in the master plan (§2.6's config format, and §3.4/§4's implicit Electron-Node sidecar for Baileys). Both are corrected below.
+
+This spec covers **WhatsApp only**. It reuses the master plan's protocol research (webhook verification, signature validation, 24h window, pricing/rate limits) rather than re-deriving it, and translates it into the actual Rust module shape established by `agentmux-srv/src/messaging/discord/`.
+
+---
+
+## 2. The two-path decision: Cloud API vs. Baileys
+
+### 2.1 Recommendation: ship Cloud API only in v1. Do not build Path B (Baileys) in this codebase.
+
+The master plan (§3.4, §4 Phase 4) called for supporting both paths, with Baileys running "in the Electron main process (pure Node.js)." That assumption is now known to be false — there is no Electron process in AgentMux's architecture, and Discord's implementation proves the intended shape for every messaging bridge is a Tokio task inside `agentmux-srv`. Baileys is a Node.js-only library (WhatsApp Web's Noise+Signal protocol implementation); there is no maintained Rust port. This is a real architectural fork, not a config toggle, and the plan ducked it.
+
+Weighing the three options named in the task brief:
+
+**(a) Standalone Node.js subprocess, supervised by `agentmux-srv`, talking over a local Unix socket or loopback HTTP.**
+This is the closest match to what the master plan wanted, and it is technically buildable — `agentmux-srv` already spawns and supervises subprocesses elsewhere (see the toolchain manager and persistent shell node specs). But it introduces a Node.js runtime dependency this app has never had before: bundling a Node runtime (or requiring the user to have one — `docs/specs/nodejs-detection-notification.md` shows this project already has to handle "user doesn't have Node" as a real, recurring failure case for *other* features), managing its lifecycle across app restarts/crashes/updates, persisting Baileys' encrypted auth-state blob across sessions, and building a second wire protocol (subprocess IPC) in addition to the Meta webhook protocol. That is a large amount of net-new infrastructure for one platform's unofficial path.
+
+**(b) Cloud API only — drop Baileys from v1.**
+The Cloud API is already the "official, no-ban-risk, framework-consistent" path per the master plan's own framing (§3.4 Path A), and it fits the Discord-proven module shape almost exactly (webhook receiver in place of Gateway WS, REST send is REST send either way). It has zero new runtime dependencies. Its downsides — business verification lead time, a public HTTPS endpoint via tunnel, template-message costs outside the 24h window — are real but bounded and already well understood from the plan's research.
+
+**(c) A maintained Rust WhatsApp Web protocol crate.**
+I am not confident one exists in a maintained state as of this writing. There have been scattered community experiments reverse-engineering the WhatsApp Web multi-device protocol in Rust, but nothing at the maturity or activity level of Baileys (which itself requires continuous protocol-drift maintenance from a team actively tracking WhatsApp Web releases). Do not assume such a crate exists; do not build on top of one without a concrete, current crates.io link verified at implementation time. Treat this option as closed unless that verification happens.
+
+**Decision: (b).** Ship Cloud API only. The Node-subprocess cost in (a) is disproportionate to the value of an unofficial, ban-risk-bearing path when the official path already covers the core "agent reads/sends WhatsApp through the real UI" use case for the overwhelmingly common case (a developer's own number, moderate volume, personal productivity use). The ban-risk math in the plan itself (§3.4: 15-30% ban rate for bots that send proactive messages, which is exactly what an AI agent bridge does most of the time) combined with Meta's AI-chatbot policy tension (see §10 below) makes Baileys a worse bet than the plan credited it for. If user demand later justifies it, Path B should be revisited as its own spec with the Node-subprocess architecture spelled out in full — it should not be smuggled in as a config variant of this bridge.
+
+**Consequence for `messaging/mod.rs` and the eventual `MessagingBridge` trait:** design the trait (see §5) so a future `WhatsAppBaileysBridge` could implement it later without a rework — the trait itself is protocol-agnostic — but write zero Baileys code now. The `messaging:whatsapp:mode` config key from the master plan is dropped; v1 has exactly one mode.
+
+### 2.2 What this changes vs. the master plan
+
+- Master plan §4 Phase 4 "Deliverables" list a Baileys Electron sidecar with QR code UI and ban-risk warning banner as in-scope for the WhatsApp phase. Out of scope for this spec/v1.
+- Master plan §2.6 config shows `mode = "cloud_api" | "bridge"`. Dropped; see §6.
+- Master plan §6.6 ("WhatsApp ban risk disclosure... persistent warning in Settings UI, user must acknowledge before enabling") is Path-B-only and therefore not implemented in v1. If Path B ships later, that requirement carries forward unchanged.
+
+---
+
+## 3. Cloud API protocol design (condensed)
+
+This restates the master plan's §3.4 Path A research, condensed to what the implementer needs, translated into this repo's conventions. Full protocol detail (rate limit tables, template examples) is in the master plan; not repeated here except where it drives a design decision.
+
+### 3.1 Webhook verification handshake (one-time, on registration)
+
+Meta calls `GET /webhook/whatsapp?hub.mode=subscribe&hub.verify_token={TOKEN}&hub.challenge={RANDOM}`. The handler must:
+1. Compare `hub.verify_token` against the configured `messaging:whatsapp:webhook_verify_token` using constant-time comparison.
+2. On match, return HTTP 200 with the raw `hub.challenge` value as the plaintext body (not JSON-wrapped).
+3. On mismatch, return 403.
+
+This must succeed before Meta will start delivering inbound webhook POSTs, and Meta re-runs this handshake any time the webhook URL or verify token is changed in the App Dashboard — this is why tunnel sequencing matters (§4).
+
+### 3.2 Inbound signature validation (every POST, non-negotiable)
+
+Every inbound `POST /webhook/whatsapp` carries `X-Hub-Signature-256: sha256=<hex>`, an HMAC-SHA256 of the *raw* request body using the Meta App Secret (`messaging:whatsapp:app_secret`) as key. The handler must:
+1. Read the raw body bytes before any JSON deserialization (axum's `Bytes` extractor, not `Json<T>`, so the exact bytes that were signed are available).
+2. Compute HMAC-SHA256(app_secret, raw_body).
+3. Compare to the header value using a constant-time comparator (e.g. `subtle::ConstantTimeEq`, or `ring::hmac::verify` which is constant-time internally).
+4. Reject with 401 on any mismatch or missing header — before touching the payload. No payload parsing, no logging of body content, on a failed check.
+
+This is the one new wire-security primitive this bridge needs that Discord's Gateway-only, outbound-only design never required (Discord never receives unauthenticated inbound traffic from the public internet). See §9 for the exact code shape.
+
+### 3.3 24-hour customer service window
+
+WhatsApp only allows free-form text replies within 24 hours of the user's last inbound message to that phone number. Outside the window, only pre-approved template messages may be sent. The bridge must track, per `from_id` (the user's WhatsApp phone number in the inbound payload), the timestamp of their last inbound message, and on outbound send: if `now - last_inbound_at <= 24h`, send free-form text; else, fall back to a template message (or fail with a clear error surfaced to the agent, if no template is configured — do not silently drop).
+
+State: an in-memory `HashMap<String, u64>` (phone number → last-inbound-unix-ms) inside the bridge, guarded the same way `DiscordBridge`'s health is (`Arc<Mutex<...>>`). Not persisted to disk in v1 — a restart simply means the bridge falls back to templates until the next inbound message re-opens the window, which is an acceptable degradation (matches the plan's "best pattern: user initiates → agent responds within window" framing).
+
+### 3.4 Template fallback
+
+Template name/language are configured per-deployment (`messaging:whatsapp:fallback_template`, `messaging:whatsapp:fallback_template_lang`, default `"en_US"`). If unset and the window has expired, `send()` returns `Err("whatsapp: 24h window expired and no fallback template configured")` rather than attempting delivery — Meta would reject a free-form send outside the window anyway (error code 131047), so this fails fast locally instead of round-tripping to the API first.
+
+### 3.5 Tunnel requirement
+
+Unlike Discord (pure outbound Gateway WS, works behind NAT with zero public exposure), the Cloud API's webhook delivery mechanism requires Meta to reach an HTTPS URL you control. There is no long-polling alternative for Cloud API (that's Baileys' advantage, which is exactly why Path B looked attractive in the plan — see §2). A public tunnel is mandatory whenever `messaging:whatsapp:enabled = true`. See §4.
+
+---
+
+## 4. Tunnel management
+
+### 4.1 Applying the plan's `TunnelManager` (§5.1) to WhatsApp specifically
+
+The master plan's §5.1 sketches a shared `TunnelManager` abstraction because three platforms (WhatsApp Cloud API, Slack HTTP fallback, Teams) may need a public URL. WhatsApp is the first of the three to actually get built, so this spec is where `TunnelManager` needs to go from sketch to real code — but scoped minimally: only the `CloudflareTunnel` provider needs to exist for this PR; `DevTunnel`, `NgrokFree`, and `Manual` variants can stay as enum cases with `todo!()`/unimplemented bodies until Teams or a Slack HTTP-fallback path actually needs them, so this spec doesn't block on unrelated provider work.
+
+```rust
+// agentmux-srv/src/messaging/tunnel.rs — new shared module (not whatsapp-specific)
+
+pub enum TunnelProvider {
+    CloudflareTunnel { name: String, domain: String },
+    DevTunnel { name: String },      // unimplemented until Teams
+    NgrokFree,                        // unimplemented until needed
+    Manual { url: String },           // user supplies their own — always available, zero-code
+}
+
+pub struct TunnelManager {
+    provider: TunnelProvider,
+    local_port: u16,
+    child: Mutex<Option<tokio::process::Child>>,
+    status: Mutex<TunnelStatus>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TunnelStatus {
+    Down,
+    Starting,
+    Up { url: String },
+    Error(String),
+}
+
+impl TunnelManager {
+    /// Starts the tunnel subprocess if not already running, and blocks (with a
+    /// timeout, e.g. 30s) until the tunnel reports itself connected — determined
+    /// by scraping cloudflared's stdout for its "Registered tunnel connection"
+    /// line, since cloudflared has no local status HTTP endpoint by default.
+    pub async fn ensure_url(&self) -> Result<String, String>;
+    pub fn current_url(&self) -> Option<String>;
+    pub fn status(&self) -> TunnelStatus;
+}
+```
+
+For `Manual { url }` (user runs their own reverse proxy / already has a domain routed to the machine), `ensure_url()` is a no-op that returns the configured URL immediately — this is the fallback path for users who don't want AgentMux managing a `cloudflared` subprocess at all, and it should be the documented "if in doubt" option since it has zero new subprocess-supervision surface.
+
+### 4.2 Cloudflare Tunnel setup (user-performed, one-time)
+
+Per the master plan's §3.4 research, unchanged:
+```bash
+cloudflared tunnel login
+cloudflared tunnel create agentmux-whatsapp
+cloudflared tunnel route dns agentmux-whatsapp wa.yourdomain.com
+```
+AgentMux then manages `cloudflared tunnel run agentmux-whatsapp` as a supervised subprocess (same pattern as other externally-managed subprocesses in this codebase — see the toolchain manager). The resulting `https://wa.yourdomain.com` is registered once in Meta's App Dashboard and does not change across restarts, which is why Cloudflare Tunnel (not the free ngrok tier, which rotates URLs) is the recommended default.
+
+**Security-relevant detail specific to this design, not present in the master plan:** the axum router in `agentmux-srv/src/server/mod.rs` applies `auth_middleware` (`X-AuthKey` header check) to nearly every route via `route_layer`, including the existing `/api/messaging/*` routes (lines ~329-330, confirmed by reading `server/mod.rs`). If the Cloudflare Tunnel ingress is configured to forward the tunnel's entire hostname to the local server's port with no path restriction, **the whole authed API surface becomes reachable from the public internet** (protected only by the same `X-AuthKey` that local callers use — a single static per-instance secret, not designed to withstand internet-facing brute force). The webhook route itself is deliberately unauthenticated (Meta cannot supply `X-AuthKey`; see §5), so this is not a "the webhook is insecure" problem, it's a "don't expose unrelated authenticated routes to the internet by accident" problem.
+
+**Recommendation:** scope the `cloudflared` ingress rule to the webhook path only, using a `config.yml` ingress rule rather than the simpler quick-tunnel default:
+```yaml
+tunnel: agentmux-whatsapp
+credentials-file: /path/to/creds.json
+ingress:
+  - hostname: wa.yourdomain.com
+    path: ^/webhook/whatsapp$
+    service: http://localhost:PORT
+  - service: http_status:404
+```
+This keeps the webhook receiver on the same axum router/port as the rest of the app (per §5's recommendation) while ensuring the tunnel itself — not application-layer auth — is the boundary that keeps the authed routes off the public internet. Document this ingress config in the user-facing setup guide; it is not optional.
+
+### 4.3 "Ensure tunnel up before webhook registration" sequencing
+
+Startup wiring (§7) must sequence:
+1. Bridge init begins → `TunnelManager::ensure_url().await` (blocks until tunnel reports connected, or times out and surfaces `BridgeStatus::Error`).
+2. Compare the resolved tunnel URL + `/webhook/whatsapp` against what's currently registered in Meta's App Dashboard for this phone number (Meta does not expose a "get current webhook URL" read API for Cloud API apps in the way this implies — in practice this comparison is against the last URL AgentMux itself registered, stored locally, not queried from Meta). If it differs from the last-known-registered URL (first run, or the tunnel URL changed), log a clear one-time instruction: **the user must open Meta App Dashboard → WhatsApp → Configuration and paste the callback URL + verify token manually** — Meta's webhook subscription UI does not have a public API for programmatic registration by third-party apps; this is a manual step every time the URL changes, which is exactly why the plan recommends the durable Cloudflare named-tunnel over the free ngrok tier (URL never changes after first setup).
+3. Only after the tunnel is confirmed up does the bridge mark itself `BridgeStatus::Connecting` → the webhook route becomes meaningful to Meta as soon as the verification handshake (§3.1) succeeds, which happens on Meta's schedule (whenever the user completes step 2 in the dashboard), not on a fixed timeline the bridge controls.
+
+This differs materially from Discord, where `init_global()` unconditionally spawns the Gateway loop and there's nothing to "wait for" before the bridge can start receiving — WhatsApp's inbound path is inert until a human completes an out-of-band dashboard step, and the bridge's health status should say so explicitly (`BridgeStatus::Connecting` with an `error`-adjacent hint, not a bare "Connecting" that looks like it'll resolve itself).
+
+---
+
+## 5. Rust module layout
+
+Mirrors `agentmux-srv/src/messaging/discord/` (`mod.rs` + `gateway.rs` + `rest.rs` + `types.rs`), with `gateway.rs` (outbound-only Gateway WS client) replaced by `webhook.rs` (inbound HTTP receiver — the genuinely new shape versus Discord, which only ever makes outbound connections).
+
+```
+agentmux-srv/src/messaging/whatsapp/
+├── mod.rs        // Config, Bridge, GLOBAL_BRIDGE, init_global(), get(), send(), health()
+├── webhook.rs     // axum handlers: GET verification handshake, POST inbound receiver + HMAC check
+├── rest.rs        // outbound send via Graph API (POST /{phone_number_id}/messages)
+└── types.rs       // Graph API + webhook payload wire types (serde structs)
+
+agentmux-srv/src/messaging/
+├── mod.rs         // add `pub mod whatsapp;` alongside existing `pub mod discord;`
+└── tunnel.rs      // new shared TunnelManager (§4.1) — not whatsapp-specific, lives at this level
+```
+
+### 5.1 `mod.rs` — shape
+
+```rust
+// agentmux-srv/src/messaging/whatsapp/mod.rs
+
+mod webhook;
+pub mod rest;
+pub mod types;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use crate::messaging::{BridgeHealth, OutboundMsg};
+use crate::messaging::tunnel::TunnelManager;
+
+#[derive(Debug, Clone)]
+pub struct WhatsAppConfig {
+    pub phone_number_id: String,
+    pub access_token: String,        // System User token (permanent)
+    pub app_secret: String,          // for X-Hub-Signature-256 validation
+    pub webhook_verify_token: String,
+    pub target_agent: Option<String>,
+    pub fallback_template: Option<String>,
+    pub fallback_template_lang: String, // default "en_US"
+    pub tunnel_domain: String,       // e.g. "wa.yourdomain.com"
+    pub tunnel_name: String,         // e.g. "agentmux-whatsapp"
+}
+
+pub struct WhatsAppBridge {
+    outbound_http: reqwest::Client,
+    config: WhatsAppConfig,
+    health: Arc<Mutex<BridgeHealth>>,
+    /// Per-user (phone number) last-inbound timestamp, for 24h window tracking (§3.3).
+    window_state: Arc<Mutex<HashMap<String, u64>>>,
+    tunnel: Arc<TunnelManager>,
+}
+
+static GLOBAL_BRIDGE: OnceLock<WhatsAppBridge> = OnceLock::new();
+
+impl WhatsAppBridge {
+    /// Initialize the global WhatsApp bridge: start the tunnel, then mark the
+    /// bridge ready to receive on the webhook routes (already registered on the
+    /// main axum router regardless of init state — see §8). No-op if already
+    /// initialized. Unlike Discord, this does not spawn a long-lived reconnect
+    /// loop; the "connection" is Meta's HTTP calls to us, which are stateless.
+    pub fn init_global(config: WhatsAppConfig, http: reqwest::Client) {
+        let health = Arc::new(Mutex::new(BridgeHealth::connecting("whatsapp")));
+        let tunnel = Arc::new(TunnelManager::new_cloudflare(
+            config.tunnel_name.clone(),
+            config.tunnel_domain.clone(),
+            /* local_port */ crate::server::LOCAL_PORT,
+        ));
+
+        let bridge = WhatsAppBridge {
+            outbound_http: http,
+            config: config.clone(),
+            health: health.clone(),
+            window_state: Arc::new(Mutex::new(HashMap::new())),
+            tunnel: tunnel.clone(),
+        };
+
+        if GLOBAL_BRIDGE.set(bridge).is_err() {
+            return; // already initialized
+        }
+
+        tokio::spawn(async move {
+            match tunnel.ensure_url().await {
+                Ok(url) => {
+                    tracing::info!(
+                        "whatsapp_bridge: tunnel up at {url}, webhook callback = {url}/webhook/whatsapp \
+                         — verify this is registered in Meta App Dashboard > WhatsApp > Configuration"
+                    );
+                    let mut h = health.lock().unwrap();
+                    h.status = crate::messaging::BridgeStatus::Connected;
+                }
+                Err(e) => {
+                    tracing::error!("whatsapp_bridge: tunnel failed to start: {e}");
+                    let mut h = health.lock().unwrap();
+                    h.status = crate::messaging::BridgeStatus::Error;
+                    h.error = Some(format!("tunnel: {e}"));
+                }
+            }
+        });
+    }
+
+    pub fn get() -> Option<&'static WhatsAppBridge> { GLOBAL_BRIDGE.get() }
+
+    /// Send via Graph API. Sync signature (mpsc-free, unlike Discord) because
+    /// there's no background loop to hand off to — send is a direct outbound
+    /// REST call, so this is `async fn` awaited by the HTTP handler directly.
+    /// (This is the one place WhatsApp's shape *simplifies* vs. Discord's
+    /// mpsc-channel pattern: Discord needs the channel because REST calls must
+    /// interleave with the Gateway loop's single mutable WS handle; WhatsApp
+    /// has no equivalent shared mutable resource to serialize against.)
+    pub async fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        rest::send_message(&self.outbound_http, &self.config, &self.window_state, &msg).await
+    }
+
+    pub fn health(&self) -> BridgeHealth {
+        self.health.lock().unwrap().clone()
+    }
+
+    /// Called by webhook.rs on each valid inbound message, to update the 24h
+    /// window state and inject into the reactive bus.
+    pub(crate) fn record_inbound(&self, from_id: &str) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        self.window_state.lock().unwrap().insert(from_id.to_string(), now);
+        let mut h = self.health.lock().unwrap();
+        h.last_event_at = Some(now / 1000);
+    }
+}
+```
+
+**Reconciling with the eventual `MessagingBridge` trait:** the task brief specifies the trait shape as `fn platform(&self) -> &'static str`, `fn send(&self, msg: OutboundMsg) -> Result<(), String>` (sync, mpsc-based like Discord's), `fn health(&self) -> BridgeHealth`. WhatsApp's `send()` is naturally `async` (a direct REST call, no mpsc handoff needed — see the comment above). When the trait lands (concurrently with Telegram per `SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md`, if that file exists at implementation time), reconcile by either (a) making the trait's `send` async (`async fn send(&self, msg: OutboundMsg) -> Result<(), String>`, requiring `#[async_trait]` or a Rust edition with native async-in-traits support), or (b) keeping `WhatsAppBridge::send` sync at the trait boundary by wrapping the async REST call in a small internal mpsc + background task purely for trait uniformity, even though it isn't structurally required the way Discord's is. **Recommendation: prefer (a).** Forcing a synchronous trait signature onto a bridge whose native shape is a direct async REST call adds a redundant channel and task for no benefit — Telegram's `teloxide` dispatcher is also fundamentally async, so this reconciliation problem isn't WhatsApp-specific and the trait should just be async from the start. Flag this explicitly for whoever lands the trait.
+
+### 5.2 `webhook.rs` — inbound receiver
+
+```rust
+// agentmux-srv/src/messaging/whatsapp/webhook.rs
+
+use axum::{
+    body::Bytes,
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+use super::WhatsAppBridge;
+use super::types::WebhookPayload;
+use crate::backend::reactive::handler::get_global_handler;
+use crate::backend::reactive::types::InjectionRequest;
+
+/// GET /webhook/whatsapp — Meta's one-time (per-URL-change) verification handshake.
+pub async fn handle_verify(Query(params): Query<std::collections::HashMap<String, String>>) -> impl IntoResponse {
+    let Some(bridge) = WhatsAppBridge::get() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "bridge not initialized").into_response();
+    };
+    let mode = params.get("hub.mode").map(String::as_str);
+    let token = params.get("hub.verify_token").map(String::as_str).unwrap_or("");
+    let challenge = params.get("hub.challenge").cloned().unwrap_or_default();
+
+    let expected = bridge.verify_token();
+    let ok = mode == Some("subscribe")
+        && token.as_bytes().ct_eq(expected.as_bytes()).unwrap_u8() == 1;
+
+    if ok {
+        (StatusCode::OK, challenge).into_response()
+    } else {
+        (StatusCode::FORBIDDEN, "verification failed").into_response()
+    }
+}
+
+/// POST /webhook/whatsapp — inbound message delivery. Body MUST be read as raw
+/// bytes (not Json<T>) so the exact signed payload is available for HMAC check
+/// before any deserialization happens.
+pub async fn handle_inbound(headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    let Some(bridge) = WhatsAppBridge::get() else {
+        return StatusCode::SERVICE_UNAVAILABLE;
+    };
+
+    // §3.2 — signature validation is mandatory and happens before parsing.
+    let sig_header = headers
+        .get("X-Hub-Signature-256")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !verify_signature(bridge.app_secret(), &body, sig_header) {
+        tracing::warn!("whatsapp_bridge: rejected inbound webhook — signature mismatch");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let payload: WebhookPayload = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("whatsapp_bridge: parse error: {e}");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    for msg in payload.extract_messages() {
+        bridge.record_inbound(&msg.from);
+        let Some(target) = bridge.target_agent() else { continue };
+        let envelope = format!("[WhatsApp {}]: {}", msg.from, msg.text);
+        let handler = get_global_handler();
+        let req = InjectionRequest {
+            target_agent: target.clone(),
+            message: envelope,
+            source_agent: Some("whatsapp".to_string()),
+            request_id: Some(msg.id.clone()),
+            priority: None,
+            wait_for_idle: false,
+            jekt_tier: None,
+            delivery_tier: Some("wan".to_string()),
+        };
+        let _ = handler.inject_message(req);
+    }
+
+    StatusCode::OK
+}
+
+fn verify_signature(app_secret: &str, body: &[u8], header: &str) -> bool {
+    let Some(hex_sig) = header.strip_prefix("sha256=") else { return false };
+    let Ok(expected) = hex::decode(hex_sig) else { return false };
+
+    type HmacSha256 = Hmac<Sha256>;
+    let Ok(mut mac) = HmacSha256::new_from_slice(app_secret.as_bytes()) else { return false };
+    mac.update(body);
+    mac.verify_slice(&expected).is_ok() // constant-time internally
+}
+```
+
+Always return `200 OK` for successfully-processed (or intentionally-ignored, e.g. status-update) webhook events, even if injection into the reactive bus failed — per Meta's delivery semantics, a non-2xx response causes retries and eventually (after repeated failures over ~7 days, per the master plan §3.4) event delivery is dropped entirely; local injection failures should be logged, not surfaced as delivery failures to Meta.
+
+### 5.3 `rest.rs` — outbound send
+
+Mirrors Discord's `rest.rs` shape (single `send_message` function, no client struct), but adds the 24h-window branch (§3.3/§3.4):
+
+```rust
+pub async fn send_message(
+    http: &reqwest::Client,
+    config: &WhatsAppConfig,
+    window_state: &Mutex<HashMap<String, u64>>,
+    msg: &OutboundMsg,
+) -> Result<(), String> {
+    let to = &msg.channel_id; // WhatsApp has no channel concept; channel_id carries the recipient phone number
+    let within_window = window_state
+        .lock()
+        .unwrap()
+        .get(to)
+        .map(|&last| now_ms() - last <= 24 * 60 * 60 * 1000)
+        .unwrap_or(false);
+
+    let url = format!(
+        "https://graph.facebook.com/v25.0/{}/messages",
+        config.phone_number_id
+    );
+
+    let body = if within_window {
+        types::SendBody::text(to, &msg.text)
+    } else {
+        let Some(template) = config.fallback_template.as_ref() else {
+            return Err("whatsapp: 24h window expired and no fallback template configured".into());
+        };
+        types::SendBody::template(to, template, &config.fallback_template_lang)
+    };
+
+    let resp = http
+        .post(&url)
+        .bearer_auth(&config.access_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("whatsapp rest: http error: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("whatsapp rest: {status}: {text}"));
+    }
+    Ok(())
+}
+```
+
+Note `OutboundMsg.channel_id` is repurposed as "recipient phone number in E.164 format" for WhatsApp — there is no channel/room concept on this platform, just 1:1 conversations with phone numbers. This should be called out in `OutboundMsg`'s doc comment in `messaging/mod.rs` when this lands, since the field name is Discord-flavored.
+
+`MsgEmbed` does not map to WhatsApp (no rich embed support in the Cloud API's free-form message types — per the master plan §5.3, `WhatsAppBridge: → text (no rich format) or template`). If `OutboundMsg.embed` is set, flatten it to plain text (`title\n\ndescription\n\nfield: value...`) rather than dropping it silently.
+
+### 5.4 `types.rs`
+
+Hand-rolled serde structs for: `WebhookPayload` (Meta's nested `entry[].changes[].value.messages[]` envelope — deserialize permissively, ignore `statuses` array entries which are delivery receipts, not messages), `SendBody` (text and template variants), Graph API error envelope. No SDK crate, matching Discord's `rest.rs`/`types.rs` precedent of hand-rolled JSON over `reqwest` + `serde_json`.
+
+---
+
+## 6. Config schema additions
+
+Following the flat serde-renamed-key convention in `agentmux-srv/src/backend/wconfig/types.rs` (confirmed at lines ~300-324 for the shipped Discord keys) — **not** the master plan §2.6's `[messaging.whatsapp]` TOML table, which does not match how config is actually stored in this codebase. That correction applies to all five platforms in the plan, not just WhatsApp; this spec fixes it for WhatsApp's fields as the concrete example.
+
+Add to `SettingsType` (or wherever `messaging_discord_*` fields live) in `wconfig/types.rs`:
+
+```rust
+// -- WhatsApp Cloud API bridge settings --
+
+/// Master enable for the WhatsApp Cloud API bridge.
+#[serde(rename = "messaging:whatsapp:enabled", default, skip_serializing_if = "is_false")]
+pub messaging_whatsapp_enabled: bool,
+
+/// WhatsApp Business phone number ID (from Meta App Dashboard > WhatsApp > API Setup).
+#[serde(rename = "messaging:whatsapp:phone_number_id", default, skip_serializing_if = "String::is_empty")]
+pub messaging_whatsapp_phone_number_id: String,
+
+/// System User access token (permanent). Treat as a secret — do not log.
+#[serde(rename = "messaging:whatsapp:access_token", default, skip_serializing_if = "Option::is_none")]
+pub messaging_whatsapp_access_token: Option<String>,
+
+/// Meta App Secret, used to validate X-Hub-Signature-256 on inbound webhooks.
+/// Treat as a secret — do not log.
+#[serde(rename = "messaging:whatsapp:app_secret", default, skip_serializing_if = "Option::is_none")]
+pub messaging_whatsapp_app_secret: Option<String>,
+
+/// Verify token used in the GET /webhook/whatsapp handshake. User-chosen,
+/// must match what's entered in Meta App Dashboard > WhatsApp > Configuration.
+#[serde(rename = "messaging:whatsapp:webhook_verify_token", default, skip_serializing_if = "Option::is_none")]
+pub messaging_whatsapp_webhook_verify_token: Option<String>,
+
+/// Agent ID that receives inbound WhatsApp messages via the reactive bus.
+#[serde(rename = "messaging:whatsapp:target", default, skip_serializing_if = "Option::is_none")]
+pub messaging_whatsapp_target: Option<String>,
+
+/// Template name used for outbound sends outside the 24h customer service window.
+#[serde(rename = "messaging:whatsapp:fallback_template", default, skip_serializing_if = "Option::is_none")]
+pub messaging_whatsapp_fallback_template: Option<String>,
+
+/// Template language code. Default "en_US" if unset.
+#[serde(rename = "messaging:whatsapp:fallback_template_lang", default, skip_serializing_if = "Option::is_none")]
+pub messaging_whatsapp_fallback_template_lang: Option<String>,
+
+/// Cloudflare Tunnel name (must already exist — created via `cloudflared tunnel create`).
+#[serde(rename = "messaging:whatsapp:tunnel_name", default, skip_serializing_if = "String::is_empty")]
+pub messaging_whatsapp_tunnel_name: String,
+
+/// Domain the tunnel is routed to (e.g. "wa.yourdomain.com").
+#[serde(rename = "messaging:whatsapp:tunnel_domain", default, skip_serializing_if = "String::is_empty")]
+pub messaging_whatsapp_tunnel_domain: String,
+```
+
+No `messaging:whatsapp:mode` key (see §2.1 — Cloud API is the only mode). If Path B is ever built as a follow-on spec, it should get its own key namespace (e.g. `messaging:whatsapp_bridge:*`) rather than retrofitting a `mode` switch onto this bridge's config, since the two paths have almost no config fields in common (phone number ID + tokens vs. QR pairing + session file path) and conflating them under one enabled/mode toggle would make both harder to reason about.
+
+Credentials (`access_token`, `app_secret`, `webhook_verify_token`) should go through the same OS-keychain storage path as `messaging:discord:token` once that exists for Discord (per master plan §6.1 — confirm at implementation time whether Discord's token is actually keychain-backed yet or still plaintext in `settings.json`, since the shipped code in `messaging_discord_token: Option<String>` gives no indication either way from the type alone; align WhatsApp with whatever Discord's actual current-state answer is, don't let this spec assume the plan's aspiration is already true).
+
+---
+
+## 7. Startup wiring
+
+Mirrors `agentmux-srv/src/main.rs` lines ~731-755 (Discord wiring), with two structural additions specific to WhatsApp: tunnel-before-webhook sequencing (already encapsulated inside `WhatsAppBridge::init_global`, see §5.1) and a startup log reminding the user to check the Meta Dashboard registration.
+
+```rust
+// agentmux-srv/src/main.rs — insert after the existing Discord bridge block (~line 755)
+
+// WhatsApp Cloud API messaging bridge — starts the Cloudflare Tunnel, then
+// waits for Meta's webhook verification handshake to complete before it can
+// receive anything (unlike Discord, there is no "connect" the bridge itself
+// initiates — inbound is passive HTTP delivery gated by tunnel + Meta's own
+// dashboard registration state). See docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md.
+{
+    let settings = config_watcher.get_settings();
+    if settings.messaging_whatsapp_enabled {
+        match (
+            settings.messaging_whatsapp_access_token.clone(),
+            settings.messaging_whatsapp_app_secret.clone(),
+            settings.messaging_whatsapp_webhook_verify_token.clone(),
+        ) {
+            (Some(token), Some(secret), Some(verify_token))
+                if !token.is_empty() && !secret.is_empty() && !verify_token.is_empty() =>
+            {
+                messaging::whatsapp::WhatsAppBridge::init_global(
+                    messaging::whatsapp::WhatsAppConfig {
+                        phone_number_id: settings.messaging_whatsapp_phone_number_id.clone(),
+                        access_token: token,
+                        app_secret: secret,
+                        webhook_verify_token: verify_token,
+                        target_agent: settings.messaging_whatsapp_target.clone(),
+                        fallback_template: settings.messaging_whatsapp_fallback_template.clone(),
+                        fallback_template_lang: settings
+                            .messaging_whatsapp_fallback_template_lang
+                            .clone()
+                            .unwrap_or_else(|| "en_US".to_string()),
+                        tunnel_domain: settings.messaging_whatsapp_tunnel_domain.clone(),
+                        tunnel_name: settings.messaging_whatsapp_tunnel_name.clone(),
+                    },
+                    reqwest::Client::new(),
+                );
+            }
+            _ => {
+                tracing::warn!(
+                    "whatsapp bridge: enabled but one of messaging:whatsapp:{{access_token,app_secret,webhook_verify_token}} is not set in settings.json"
+                );
+            }
+        }
+    }
+}
+```
+
+The tunnel-start-and-wait happens inside the spawned task in `init_global` (§5.1), not inline here — `main.rs`'s startup sequence must not block server boot on a tunnel subprocess (which can take several seconds, or fail entirely if `cloudflared` isn't installed). This matches Discord's fire-and-forget `tokio::spawn` pattern; the difference is purely in what the spawned task does before it can call itself "connected."
+
+---
+
+## 8. HTTP endpoints
+
+### 8.1 `POST /api/messaging/whatsapp/send` — authed, same group as Discord's send endpoint
+
+Added to `agentmux-srv/src/server/messaging_handlers.rs` alongside `handle_discord_send`, and to `agentmux-srv/src/server/mod.rs`'s `authed_routes` (same `route_layer(auth_middleware)` group as `/api/messaging/discord/send`, line ~330):
+
+```rust
+.route("/api/messaging/whatsapp/send", post(messaging_handlers::handle_whatsapp_send))
+```
+
+Request body: `{ "to": "+1...", "text": "..." }` (no embed field — WhatsApp has no rich format, see §5.3). Also extend `handle_status` (line ~24-29 in `messaging_handlers.rs`) to include `WhatsAppBridge::get().map(|b| b.health())` in the `bridges` array, same pattern as Discord.
+
+### 8.2 `GET /webhook/whatsapp` and `POST /webhook/whatsapp` — unauthenticated, NOT in the authed route group
+
+This is the one deliberate departure from "everything goes through the same authed group as `/api/messaging/*`." These routes must be merged at the same level as `health` in `server/mod.rs` (line ~347, `Router::new().merge(health).merge(authed_routes)...`) — outside `route_layer(auth_middleware)` — because Meta cannot supply the `X-AuthKey` header the middleware requires. Recommended registration:
+
+```rust
+// server/mod.rs, alongside the `health` router definition (~line 345)
+let webhooks = Router::new()
+    .route("/webhook/whatsapp", get(messaging::whatsapp::webhook::handle_verify))
+    .route("/webhook/whatsapp", post(messaging::whatsapp::webhook::handle_inbound));
+
+Router::new()
+    .merge(health)
+    .merge(webhooks)
+    .merge(authed_routes)
+    .layer(cors)
+    .with_state(state)
+```
+
+**Recommendation confirmed (per the task brief's investigation prompt): keep this on the same axum router/port as the rest of the API, do not stand up a second HTTP server.** The only reason to prefer a second server would be to physically firewall the webhook surface from the authed API surface, but that's already achieved at the tunnel layer (§4.2's ingress path restriction), which is a cleaner boundary than a second in-process listener — it means the public internet only ever reaches `localhost:PORT` through a `cloudflared` process that itself only forwards one path, regardless of how many routes the axum app internally exposes. A second server would duplicate the axum `AppState`, CORS config, and TLS/graceful-shutdown wiring for no corresponding security gain, since the real gate is the tunnel's ingress rule, not which in-process router handled the request.
+
+This is unauthenticated by AgentMux's own auth scheme by necessity, but not unauthenticated in the security sense — see §9, the HMAC check on every POST *is* the authentication for this endpoint, just via a different mechanism (shared-secret HMAC instead of `X-AuthKey`) suited to a third party (Meta) that AgentMux doesn't control the request format of.
+
+---
+
+## 9. Security
+
+1. **Webhook signature validation is non-negotiable — exact check spelled out in §5.2.** `X-Hub-Signature-256: sha256=<hex>` = `HMAC-SHA256(app_secret, raw_body)`. Must be validated against the *raw* body bytes before any JSON parsing (an axum `Bytes` extractor, not `Json<T>` — deserializing first and re-serializing to check the signature would validate a re-encoded payload, not what Meta actually signed, and is also vulnerable to any subtle round-trip formatting difference). Must use a constant-time comparator (`hmac::Mac::verify_slice`, which is constant-time internally, or explicit `subtle::ConstantTimeEq` if hand-rolling the comparison). Reject with `401` before any further processing — no payload deserialization, no logging of body content — on mismatch or missing header.
+
+2. **Credentials never logged.** `access_token`, `app_secret`, `webhook_verify_token` follow the same "treat as secret" doc-comment convention as `messaging_discord_token` in `wconfig/types.rs`. None of these three should ever appear in a `tracing::info!`/`warn!`/`error!` call — the startup log in §7 deliberately logs only which fields are *missing*, never their values.
+
+3. **Allowlist is implicit, not configured.** Unlike Discord (explicit `channel_id` filter) or the master plan's Telegram design (`allowed_chat_ids`), WhatsApp Cloud API inbound is inherently scoped to the one `phone_number_id` you registered — Meta only delivers messages sent *to* your business number, so there is no equivalent "unknown source" surface to allowlist against at the AgentMux layer. No `allowed_senders` config is needed for v1. (If group-messaging or multi-number support is ever added, revisit this.)
+
+4. **Tunnel ingress scoping is a security control, not just tidiness.** See §4.2 — the `cloudflared` ingress rule must restrict the public hostname to the `/webhook/whatsapp` path only. Document this as a required setup step, not an optional hardening tip; failing to do this exposes the entire authed AgentMux API surface (agent control, pane management, memory read/write) to the internet, gated only by the same static `X-AuthKey` used for trusted local/LAN callers.
+
+5. **No secrets in outbound messages.** Same principle as master plan §6.4: agent-generated WhatsApp message text should be scanned for common secret patterns (API key shapes, token prefixes) before send, consistent with whatever mechanism is (or will be) shared across all bridges — this is not WhatsApp-specific and should reuse Discord's approach once Discord has one; flag as a shared follow-up if it doesn't exist yet.
+
+6. **Ban-risk disclosure UI — not applicable to v1.** The master plan's §6.6 requirement ("Baileys path shows a persistent warning... user must acknowledge before enabling") is scoped to Path B only. Since this spec does not implement Path B (§2.1), no disclosure UI is built here. If Path B is revisited later, that requirement is unchanged and must ship with it — a Path-B spec should not skip it just because Cloud API shipped without an equivalent warning (Cloud API's risk profile, per §10, is a different kind of risk — policy/ToS ambiguity, not account-ban — and deserves its own, milder disclosure; see §10).
+
+---
+
+## 10. Known failure modes, rate limits, policy risk
+
+**Currency note (per the task's correction requirement):** the figures below are restated as "per the master plan, as of 2026-06-24" rather than asserted as current fact, because Meta's developer policy pages and Cloud API pricing are exactly the kind of external, frequently-revised source that can silently drift between spec-writing and implementation. **Re-verify against Meta's live developer docs (developers.facebook.com/docs/whatsapp) immediately before implementation**, not at spec-writing time.
+
+- **Pricing, per the master plan as of 2026-06-24:** service messages (user-initiated, within window) and utility templates within window: free. Utility templates outside window: $0.004/message (US). Marketing templates: $0.025/message (US), banned for US recipients since April 2025 per the plan's research. At ~100 conversations/month, the plan estimates $0-$0.40/month in API charges. **Do not hardcode these figures into user-facing copy without re-checking them; if implementation happens more than a few weeks after this spec, treat every number in this paragraph as unverified.**
+
+- **Policy risk, per the master plan as of 2026-06-24:** Meta's "AI chatbot" policy (dated October 2025 in the plan) prohibits using WhatsApp as the delivery channel for a general-purpose AI assistant distributed to others; a developer's private bot serving only their own use is characterized in the plan as "gray area." **This framing should be re-verified, not assumed** — policy language and enforcement posture are exactly the sort of thing that moves between a plan being written and a feature shipping, and getting this wrong risks the user's WhatsApp Business number (and possibly their underlying personal Meta/Facebook account, depending on how account linkage works) being suspended. AgentMux's user-facing copy for this feature (Settings UI description, setup docs) should frame it explicitly as a personal productivity bridge for the user's own conversations, not as a chatbot product, and should link to Meta's current policy page rather than restating a summary that could be stale by the time a user reads it.
+
+- **Rate limits, per the master plan as of 2026-06-24** (re-verify before relying on these for capacity planning): default messaging tier 1,000 unique users/24h; 80 messages/second; per-recipient burst ~1 msg/6s, 45 in 6s then cooldown. On any 429/rate-limit response from the Graph API, the bridge should log and surface the error to the caller (agent's `send` call fails with a clear message) rather than silently dropping — matching the "queue and retry, not drop silently" principle in master plan §6.5, though a v1 implementation may reasonably just fail fast and let the agent/user retry rather than building a retry queue (see §12 open decision points).
+
+- **Webhook delivery drop after repeated failures:** Meta stops retrying (and drops) undelivered webhook events after approximately 7 days of failed delivery (master plan §3.4, citing this as the reason Hookdeck's event queue/replay feature is useful for the ngrok path). Since this spec recommends Cloudflare Tunnel with a stable URL (§4.2), sustained delivery failure should only happen if `agentmux-srv` itself is down for an extended period or the tunnel subprocess dies without being restarted — worth a health-check / alert consideration at implementation time, out of scope to design fully here.
+
+- **Tunnel subprocess failure modes:** `cloudflared` not installed (`ensure_url()` should fail fast with a clear "install cloudflared" error, not a generic timeout); tunnel credentials expired/revoked; DNS route removed from the Cloudflare dashboard outside AgentMux's control. All three should map to `BridgeStatus::Error` with a human-readable `error` string, surfaced in the Warden widget per master plan §2.7.
+
+- **24h window edge case:** a message sent right at the boundary (e.g. 23h59m after last inbound) may succeed as free-form on the bridge's local clock check but be rejected by Meta's server-side clock if there's clock skew or network latency pushes it just past 24h. Treat Meta's rejection (error code 131047) as authoritative — on that specific error code, retry once as a template send if one is configured, rather than surfacing a raw failure for what is a legitimate race condition rather than a config error.
+
+---
+
+## 11. Implementation checklist — phased PR-sized chunks
+
+**PR 1 — Module skeleton + outbound send only (no webhook, no tunnel).**
+- `messaging/whatsapp/mod.rs`, `rest.rs`, `types.rs` (send path only)
+- Config fields in `wconfig/types.rs` (§6), minus tunnel fields
+- `POST /api/messaging/whatsapp/send` handler + route (§8.1)
+- Manual test: send a text message to a pre-verified test number via the Cloud API test credentials Meta provides for free during app review setup (no tunnel needed for outbound-only testing — Meta's test number doesn't require a live webhook to receive a send)
+- Success criteria: agent can send a WhatsApp message via the Cloud API test number
+
+**PR 2 — `TunnelManager` (Cloudflare provider only) + tunnel lifecycle.**
+- `messaging/tunnel.rs`
+- Subprocess supervision: start, detect "connected" from stdout, stop on shutdown
+- No WhatsApp-specific code in this PR — this is shared infrastructure per master plan §5.1
+- Success criteria: `cloudflared tunnel run` subprocess starts, `TunnelManager::status()` reflects `Up { url }` once connected, process is cleanly terminated on `agentmux-srv` shutdown
+
+**PR 3 — Webhook receiver + signature validation + 24h window tracking.**
+- `messaging/whatsapp/webhook.rs` (§5.2)
+- `GET /webhook/whatsapp` and `POST /webhook/whatsapp` routes registered outside the authed group (§8.2)
+- HMAC-SHA256 validation (§9.1)
+- Window-state tracking wired into `rest.rs`'s send path (§3.3, §3.4)
+- Success criteria: Meta's verification handshake succeeds against a real tunnel URL; a message sent to the WhatsApp Business number appears injected into the target agent's reactive bus; an agent reply within 24h delivers as free-form text and appears in the user's real WhatsApp app
+
+**PR 4 — Startup wiring + tunnel-before-webhook sequencing + Warden status row.**
+- `main.rs` wiring (§7)
+- `messaging_handlers.rs::handle_status` extended to include WhatsApp health (§8.1)
+- Warden widget "Internet" section row for WhatsApp (master plan §2.7) — tunnel status + last-event timestamp
+- `widgets.json`'s `defwidget@whatsapp` description updated to drop "(bridge Phase 3)" once this lands
+- Success criteria: full restart cycle — `agentmux-srv` starts, tunnel comes up, webhook is live, Warden shows `Connected`, all without manual intervention beyond the one-time Meta Dashboard URL registration
+
+**PR 5 (optional, follow-on) — Template message builder UI + fallback configuration surface.**
+- Settings UI for `fallback_template` / `fallback_template_lang`
+- Out of scope for this spec's Rust-side design; noted for completeness since §3.4's fail-fast behavior needs a config surface for users to actually set a template
+
+Each PR should get its own changeset per this repo's convention (`task changeset -- patch "feat: whatsapp ..."`), matching the master plan's phase breakdown style.
+
+---
+
+## 12. Open decision points explicitly left for the implementer
+
+1. **Retry/queue behavior on rate-limit or transient failure.** §10 recommends fail-fast for v1; master plan §6.5 recommends "queue and retry, not drop silently" as a cross-platform principle. This spec does not resolve that tension for WhatsApp specifically — pick one at implementation time based on how it's resolved (if at all) for Discord/Telegram, for consistency across bridges.
+
+2. **Credential storage: keychain vs. `settings.json`.** §6 flags that this spec cannot confirm whether Discord's token is actually keychain-backed today or still plaintext, since the type (`Option<String>`) doesn't encode that. Resolve by inspecting the actual current Discord credential-handling code path at implementation time and match it — don't let WhatsApp's credential handling diverge from whatever Discord actually does today, only from what the master plan aspirationally said it should do.
+
+3. **`MessagingBridge` trait async signature.** §5.1 recommends the trait's `send` be `async fn`, diverging from the task brief's suggested sync/mpsc shape (which was modeled on Discord's specific need for a channel, not a general requirement). Needs to be settled jointly with whoever implements Telegram, since both platforms are naturally async-send and neither needs Discord's mpsc pattern.
+
+4. **`TunnelManager`'s "connected" detection.** §4.1 sketches scraping `cloudflared`'s stdout for a connection-established log line, since `cloudflared` has no local status HTTP endpoint by default in the basic invocation. Verify this against the actual `cloudflared` version/flags AgentMux ends up shipping/requiring — some `cloudflared` configurations do expose a local metrics/health endpoint (`--metrics` flag) which would be a more robust signal than log-scraping; evaluate at implementation time.
+
+5. **Path B (Baileys) revisit trigger.** No formal criteria are set for when/if Path B should be reconsidered. Suggest treating this as user-demand-driven (e.g. a threshold number of feature requests for personal-number support without business verification) rather than pre-committing to a timeline, given the Node-subprocess architecture cost identified in §2.1.
+
+6. **Whether `agentmux-srv` should bundle/require `cloudflared` as a managed download** (like it may already do for other external tool dependencies — check the toolchain manager spec for precedent) versus requiring the user to install it themselves via their OS package manager. Not resolved here; affects the onboarding UX for §4.2's setup steps.

--- a/docs/status/STATUS_MESSENGER_APP_INTEGRATIONS_2026_07_07.md
+++ b/docs/status/STATUS_MESSENGER_APP_INTEGRATIONS_2026_07_07.md
@@ -1,0 +1,132 @@
+# Status — Messenger App Integrations (Discord / Slack / Telegram / WhatsApp / Teams)
+
+**Date:** 2026-07-07
+**Type:** Living status doc (snapshot of a dormant program)
+**Program:** Embed the 5 highest-reach messaging apps as real, agent-connected panes inside
+AgentMux, per `SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md`. No dedicated GitHub issue or
+discussion exists for this feature — it has been tracked entirely through specs + merged PRs.
+The adjacent, broader "OpenClaw as a universal agent-to-human channel router" vision (issue
+[#102](https://github.com/agentmuxai/agentmux/issues/102)) is a separate, longer-term,
+not-yet-built path and should not be confused with this one.
+
+---
+
+## 1. Where we are (one-glance)
+
+| Workstream | State |
+|---|---|
+| Pane layer (all 5 apps as CEF webview panes) | ✅ Shipped — merged in #1763 (2026-06-24), icons fixed in #1777 (2026-06-25) |
+| Bridge framework (`MessagingBridge` trait, shared scaffold) | ✅ Merged (#1763) — `agentmux-srv/src/messaging/mod.rs` |
+| **Discord bridge (Phase 1)** | ✅ **Implemented and functional** — Gateway WS + REST send, opt-in via `settings.json`, `POST /api/messaging/discord/send` |
+| Slack bridge (Phase 2) | ⬜ Not started — pane only, widget description says "(bridge Phase 2)" |
+| Telegram bridge (Phase 2) | ⬜ Not started — pane only, widget description says "(bridge Phase 2)" |
+| WhatsApp bridge (Phase 3) | ⬜ Not started — pane only, widget description says "(bridge Phase 3)"; also policy-blocked, see §4 |
+| Teams bridge (Phase 3) | ⬜ Not started — pane only, widget description says "(bridge Phase 3)"; "Implement Last" per spec, enterprise-only |
+| Bridge health surfaced in Warden widget | ⬜ Not started — Warden's "Internet" section is still a stub |
+| Settings UI for messaging bridges | ⬜ Not started — Discord bridge is config-file-only (no in-app UI) |
+| Pluggable/community bridge system (Signal, Matrix, iMessage, WeChat, …) | ⬜ Not spec'd — referenced but the API design doc doesn't exist yet |
+| Program activity | 🔴 **Dormant ~11 days.** Last touch: 2026-07-01 (#1876, an unrelated security-tier fix to already-shipped Discord code — not new platform work). No open PR or active branch for any of the remaining 4 bridges. |
+
+---
+
+## 2. What's actually implemented today
+
+**All 5 apps are, right now, plain webview panes** — a CEF browser widget pointed at the
+platform's real web app (`discord.com/app`, `app.slack.com`, `web.telegram.org`,
+`web.whatsapp.com`, `teams.microsoft.com`), address bar hidden. Registered as built-in
+("Tier 1") widgets in `agentmux-srv/src/config/widgets.json:121-195`. This is the user's
+correct read — no custom chat UI exists for any of them; the messaging app *is* the UI.
+
+**Discord is the one exception**, and it's a real, working exception, not a stub:
+`agentmux-srv/src/messaging/discord/` (~700 LOC across `gateway.rs`, `rest.rs`, `types.rs`,
+`mod.rs`) implements an actual Discord Gateway WebSocket client (HELLO → IDENTIFY/RESUME →
+heartbeat → `MESSAGE_CREATE`) plus REST send (`POST /channels/{id}/messages`). It starts only
+if `messaging.discord.enabled` + `messaging.discord.token` are set
+(`agentmux-srv/src/main.rs:731-750`), and is reachable via `POST /api/messaging/discord/send`.
+An agent can already read/send Discord messages that appear natively in the pane a human is
+looking at — the actual point of "refining the integration" beyond a plain webview.
+
+Notably, the implementation diverged from the original plan: the POC spec recommended the
+`serenity`/`twilight-rs` crates, but the shipped code uses raw `tokio-tungstenite` + `reqwest`
+directly — a pragmatic zero-new-dependency choice that worked.
+
+Slack, Telegram, WhatsApp, and Teams have **no bridge code** — no subdirectory under
+`messaging/`, none of the platform-specific libraries the plan calls for
+(`teloxide`, `@slack/socket-mode`, Baileys) are in `Cargo.lock`. This isn't hidden: each
+widget's own description string in `widgets.json` says "(bridge Phase 2)" / "(bridge Phase 3)"
+today, visible in the app.
+
+## 3. The plan for "refining the integration"
+
+Three specs, all dated 2026-06-24, all still `Status: Draft` (none promoted to
+approved/implemented despite Discord already shipping in `main`):
+
+- **`SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md`** — the master plan. Two-layer
+  architecture (pane + background bridge), a `MessagingBridge` trait every platform
+  implements, a `TunnelManager` for platforms needing a public webhook URL (WhatsApp Cloud,
+  Teams), and a 5-phase roadmap: **Telegram → Discord → Slack → WhatsApp → Teams** (note
+  Discord actually shipped first, out of the planned order). §7 explicitly frames all of this
+  as a stopgap: once OpenClaw ships, a single `OpenClawBridge` could implement the same trait
+  and retire the per-platform bridges.
+- **`SPEC_MESSAGING_INTEGRATION_DISCORD_POC_2026_06_24.md`** — the Discord POC spec, executed
+  (with the crate substitution noted above).
+- **`ANALYSIS_PLUGIN_WIDGET_MESSAGING_INTEGRATION_2026_06_24.md`** — sizing/architecture.
+  Proposes a Tier 1 (built-in) / Tier 2 (external-UI) / Tier 3 (background-daemon) widget
+  model to formalize where bridges belong; all 5 raw bridges would add well under 1MB to the
+  binary. Flags a future Tier 4 plugin system for community-contributed bridges as
+  **"❌ Not spec'd."**
+
+Concretely, "refining the integration" means: background bridges (agent posts/reads through
+the real UI, not a custom re-implementation), rich per-platform output (Discord Embeds,
+Telegram inline keyboards, Slack Block Kit, Teams Adaptive Cards), bridge connection-health
+surfaced in the Warden widget, OS-keychain credential storage + webhook signature validation,
+and eventually a pluggable system for community-contributed platforms. Native SDK embedding,
+notification badges, a unified inbox, and deep linking are **not** part of the stated plan —
+don't assume those are coming.
+
+## 4. Per-platform status + known blockers
+
+| App | Bridge status | Notable blocker/limitation from the spec |
+|---|---|---|
+| Discord | ✅ Live | Heartbeat-ghost risk (bot silently stops receiving events); needs proactive reconnect on OS wake-from-sleep. No external health monitor exists yet. |
+| Slack | Not started | Socket Mode connections refresh ~hourly and can silently stop delivering after days — needs proactive reconnect + a 5-min-no-event force-reconnect heuristic. |
+| Telegram | Not started | Lowest-friction of the remaining four (long-polling, no tunnel needed) — a reasonable next pick despite not being first historically. |
+| WhatsApp | Not started | Most complex. Official Cloud API needs Meta Business verification (2-10 days) + a dedicated number + a public HTTPS webhook (tunnel required). **Meta's Oct-2025 policy bans using WhatsApp as a delivery channel for a general-purpose AI assistant distributed to others** — spec says a personal single-user bot is "gray area" and to frame AgentMux's use as a personal productivity bridge, not a chatbot product. Unofficial (Baileys) path carries a 15-30% account-ban risk for bots that message new contacts proactively; spec requires a persistent user-acknowledged warning banner before enabling it. |
+| Teams | Not started | Explicitly "Implement Last." Requires Azure Bot Service + an Azure subscription + Entra ID tenant + admin-gated app sideloading. **Not usable at all for personal/non-enterprise users.** |
+
+## 5. Tracking
+
+No dedicated tracking issue or discussion thread exists for this feature by name. Work has
+been tracked purely through the three specs above and two merged PRs:
+
+- PR [#1763](https://github.com/agentmuxai/agentmux/pull/1763) — bridge framework + Discord
+  Gateway integration (merged 2026-06-24).
+- PR [#1777](https://github.com/agentmuxai/agentmux/pull/1777) — FontAwesome brand-icon fix
+  for the 5 widgets, which originally rendered blank (merged 2026-06-25).
+
+Issue [#102](https://github.com/agentmuxai/agentmux/issues/102) ("OpenClaw — Open-Source Agent
+Deployment Platform", open) is adjacent but distinct: it envisions an agent reaching a human
+through *any* channel (Discord/Telegram/Slack/Signal/iMessage/WhatsApp) via ACP, not
+platform-specific bridges. A pinned maintainer comment on that issue already flags it needs
+re-scoping to `SPEC_OPENCLAW_AGENT_2026_05_17.md` or closing as superseded — it should **not**
+be treated as the tracking issue for the webview/bridge work described here.
+
+## 6. Gaps / recommended next step
+
+- **No settings UI.** The only way to enable the Discord bridge is hand-editing
+  `settings.json` — there's no in-app affordance to paste a token, which likely limits who's
+  even using the one bridge that exists.
+- **No health visibility.** `BridgeHealth` is designed in the spec but not wired into the
+  Warden widget's "Internet" section (itself still a stub), so a silently-dead Discord bridge
+  (the heartbeat-ghost failure mode called out above) would currently go unnoticed.
+- **Docs drift**: `docs/specs/pane-types.md` still lists 9 pane types while `widgets.json`
+  registers 17 — Discord/Slack/Telegram/WhatsApp/Teams are among the ones missing from that
+  doc (independently flagged in `docs/reports/REPORT_REPO_HEALTH_AUDIT_2026_07_05.md:256`).
+- **Program has stalled at 1 of 5 bridges** with no open work. If resuming, Telegram is the
+  cheapest next platform (no tunnel/webhook infra, unlike WhatsApp/Teams) and would validate
+  the shared `MessagingBridge` trait against a second, different protocol shape
+  (long-polling vs. Discord's WebSocket Gateway) before investing further.
+- Given OpenClaw is explicitly named in the plan as the eventual replacement for
+  per-platform bridges, it may be worth deciding whether to keep hand-rolling Phases 2-5 or
+  wait for OpenClaw's channel-routing to mature — that's a real fork in the road the specs
+  themselves flag but don't resolve.


### PR DESCRIPTION
## Summary
- Adds `docs/status/STATUS_MESSENGER_APP_INTEGRATIONS_2026_07_07.md` — status snapshot of the messenger-app-embed program (Discord shipped via #1763, the other 4 platforms pane-only, program dormant ~11 days).
- Adds 4 new specs translating the original `SPEC_MESSAGING_INTEGRATIONS_PLAN_2026_06_24.md` into implementation-ready designs grounded in what Discord's shipped code actually looks like, not just the pre-implementation plan:
  - `SPEC_MESSAGING_INTEGRATION_TELEGRAM_2026_07_07.md` — also formalizes a `MessagingBridge` trait + Discord retrofit plan (Telegram is the 2nd bridge, the point where the abstraction earns its keep).
  - `SPEC_MESSAGING_INTEGRATION_SLACK_2026_07_07.md` — corrects the plan's Electron/Node assumption to pure Rust.
  - `SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md` — recommends Cloud API only for v1, dropping the unofficial Baileys path.
  - `SPEC_MESSAGING_INTEGRATION_TEAMS_2026_07_07.md` — honest "design now, build on demonstrated M365-tenant demand" framing.
- Tracked in discussion #2020, which links to these paths.

Docs only — no code changes.

## Test plan
- N/A (documentation-only change)