### PR TITLE
fix(armory): rename "Brain" tab label to "Memory"

### DIFF
--- a/.changesets/1783485186-fix-armory-rename-brain-tab-label-to-memory-per-the-composab-bksz.md
+++ b/.changesets/1783485186-fix-armory-rename-brain-tab-label-to-memory-per-the-composab-bksz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): rename 'Brain' tab label to 'Memory' per the composable-model naming decision

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -15,7 +15,7 @@ import "./armory-view.scss";
 const RAIL: { id: ArmorySection; label: string; icon: string }[] = [
     { id: "accounts",   label: "Accounts",   icon: "key" },
     { id: "identities", label: "Identities", icon: "id-card" },
-    { id: "brain",      label: "Brain",      icon: "brain" },
+    { id: "brain",      label: "Memory",     icon: "brain" },
     { id: "memories",   label: "Bundles",    icon: "layer-group" },
     { id: "mcp",        label: "MCP Servers", icon: "plug" },
     { id: "skills",     label: "Skills",      icon: "wand-magic-sparkles" },

--- a/frontend/app/view/brain/global-brain-manager.tsx
+++ b/frontend/app/view/brain/global-brain-manager.tsx
@@ -1,9 +1,12 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// GlobalBrainManager — the Armory "Brain" tab. Presents the
-// workspace-wide global brain (is_global Memory bundles) as an ordered list
-// of editable sections that compose into every agent's CLAUDE.md at launch.
+// GlobalBrainManager — the Armory "Memory" tab (labeled "Brain" prior to the
+// PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md §4.2 naming decision — "the
+// brain" is a colloquial nickname, "Memory" is the canonical term). Presents
+// the workspace-wide global brain (is_global Memory bundles) as an ordered
+// list of editable sections that compose into every agent's CLAUDE.md at
+// launch.
 //
 // Context-free: owns its own GlobalBrainViewModel and drives off the
 // bundle_* RPCs. Spec: SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md.

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -1,8 +1,10 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// GlobalBrainViewModel — drives the Armory "Brain" tab: the
-// workspace-wide global brain that every agent inherits at launch.
+// GlobalBrainViewModel — drives the Armory "Memory" tab (labeled "Brain"
+// prior to the PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md §4.2 naming
+// decision): the workspace-wide global brain that every agent inherits at
+// launch.
 //
 // A "section" is a Memory bundle with is_global=true. The global brain is
 // the ordered list of those sections; their instructions concatenate into

--- a/frontend/app/view/brain/global-brain.scss
+++ b/frontend/app/view/brain/global-brain.scss
@@ -1,8 +1,10 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Styles for the Armory "Brain" tab (GlobalBrainManager). Renders
-// inside the bundle-manager pane, which provides the scroll container.
+// Styles for the Armory "Memory" tab (GlobalBrainManager, labeled "Brain"
+// prior to the naming decision in PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+// §4.2). Renders inside the bundle-manager pane, which provides the scroll
+// container.
 
 .global-brain {
     display: flex;


### PR DESCRIPTION
## Summary

Small follow-up split out of #2024 (Armory pane consolidation tracking). `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md` §4.2 decides the canonical term:

> **Memory** matches the native concept + the `memory.*` App API — no UI/backend split; "the brain" stays a colloquial nickname, not the canonical term.

The Armory rail's tab (`GlobalBrainManager`) was still labeled "Brain". This PR renames the user-facing label to "Memory" — text only, same pattern as the Trust Center → Armory and Preset → Bundle renames (UI label first, internal/backend names unchanged: `bundle_*` RPCs, `global-brain-*` files/classes/CSS, `db_memory_bundles` all stay as-is). Updated the doc comments in the three touched files that described the tab by its old label, for consistency.

## Known naming overlap (tracked, not fixed here)

This tab is literally `is_global` rows of `db_memory_bundles` presented as ordered sections (concatenated into every agent's CLAUDE.md) — it shares its backing table with the separate "Bundles" tab (full CRUD over the same table, not filtered to global). Renaming this tab to "Memory" while "Bundles" keeps its own label is a little confusing given they're the same underlying primitive today; the clean fix is the `db_memory_bundles` → `db_bundles` rename + true separation described in the proposal, which is still pending — tracked in #2024 (item 3, Bundle-as-container v2). Flagging so this doesn't get lost, not blocking this label fix.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Grepped for test/snapshot references to the old "Brain" label string — none found
- [ ] Reviewer: open Armory, confirm the tab reads "Memory" and still renders the same global-brain-section CRUD

<!-- agentmux:agent_id=agent2 -->