### PR TITLE
feat(messaging): Slack bridge — Socket Mode receive + Web API send

### DIFF
--- a/.changesets/1783485586-feat-messaging-slack-bridge-socket-mode-receive-web-api-send-psgo.md
+++ b/.changesets/1783485586-feat-messaging-slack-bridge-socket-mode-receive-web-api-send-psgo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(messaging): Slack bridge — Socket Mode receive + Web API send

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -349,6 +349,34 @@ pub struct SettingsType {
     #[serde(rename = "messaging:telegram:target", default, skip_serializing_if = "Option::is_none")]
     pub messaging_telegram_target: Option<String>,
 
+    // -- Slack messaging bridge --
+
+    /// Master enable for the Slack messaging bridge.
+    /// When true, the bridge opens a Socket Mode connection at startup.
+    #[serde(rename = "messaging:slack:enabled", default, skip_serializing_if = "is_false")]
+    pub messaging_slack_enabled: bool,
+
+    /// Slack bot token (`xoxb-...`). Used for Web API calls (chat.postMessage).
+    /// Treat as a secret — do not log. Obtain from api.slack.com/apps → OAuth & Permissions
+    /// → Bot User OAuth Token, after installing the app to the workspace.
+    #[serde(rename = "messaging:slack:bot_token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_slack_bot_token: Option<String>,
+
+    /// Slack app-level token (`xapp-...`). Used only for apps.connections.open (Socket Mode).
+    /// Treat as a secret — do not log. Obtain from api.slack.com/apps → Basic Information
+    /// → App-Level Tokens, scope `connections:write`.
+    #[serde(rename = "messaging:slack:app_token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_slack_app_token: Option<String>,
+
+    /// Channel ID to filter inbound messages and use as the default send target.
+    #[serde(rename = "messaging:slack:channel", default, skip_serializing_if = "String::is_empty")]
+    pub messaging_slack_channel: String,
+
+    /// Agent ID that receives inbound Slack messages via the reactive bus.
+    /// Absent → messages are logged but not forwarded to any agent.
+    #[serde(rename = "messaging:slack:target", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_slack_target: Option<String>,
+
     /// Catch-all for unknown/dynamic keys (e.g. `widget:hidden@defwidget@sysinfo`).
     /// These pass through serde unchanged so the frontend can access them as flat settings keys.
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -139,7 +139,7 @@
         "icon": "brands@slack",
         "color": "#4a154b",
         "label": "Slack",
-        "description": "Slack — real interface, agent-connected (bridge Phase 2)",
+        "description": "Slack — real interface, agent-connected",
         "blockdef": {
             "meta": {
                 "view": "browser",

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -789,6 +789,39 @@ async fn main() {
         }
     }
 
+    // Slack messaging bridge — opens a Socket Mode connection if configured.
+    // Set messaging:slack:enabled + messaging:slack:bot_token + messaging:slack:app_token
+    // in settings.json to activate.
+    {
+        let settings = config_watcher.get_settings();
+        if settings.messaging_slack_enabled {
+            match (
+                settings.messaging_slack_bot_token.clone(),
+                settings.messaging_slack_app_token.clone(),
+            ) {
+                (Some(bot_token), Some(app_token))
+                    if !bot_token.is_empty() && !app_token.is_empty() =>
+                {
+                    messaging::slack::SlackBridge::init_global(
+                        messaging::slack::SlackConfig {
+                            bot_token,
+                            app_token,
+                            channel_id: settings.messaging_slack_channel.clone(),
+                            target_agent: settings.messaging_slack_target.clone(),
+                        },
+                        reqwest::Client::new(),
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        "slack bridge: enabled but messaging:slack:bot_token and/or \
+                         messaging:slack:app_token is not set in settings.json"
+                    );
+                }
+            }
+        }
+    }
+
     // Set up docsite directory
     if let Some(app_path) = base::get_wave_app_path() {
         let docsite_dir = app_path.join("docsite");

--- a/agentmux-srv/src/messaging/mod.rs
+++ b/agentmux-srv/src/messaging/mod.rs
@@ -8,6 +8,7 @@
 //! arrive via HTTP endpoint or MCP tool.
 
 pub mod discord;
+pub mod slack;
 pub mod telegram;
 
 use serde::{Deserialize, Serialize};
@@ -46,6 +47,16 @@ pub struct OutboundMsg {
     /// by platforms that don't support editing (e.g. Discord in v1).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_message_id: Option<i64>,
+    /// Slack-specific: raw Block Kit `blocks` array, passed through verbatim
+    /// to `chat.postMessage` (escape hatch — see
+    /// `SPEC_MESSAGING_INTEGRATION_SLACK_2026_07_07.md` §7, §11.1). Block
+    /// Kit doesn't map onto `MsgEmbed` (no shared shape with Discord's flat
+    /// embed record), so it gets its own field here rather than a forked
+    /// per-platform outbound type. Harmless no-op for platforms that don't
+    /// support it. `text` is still always sent alongside `blocks` — Slack
+    /// requires it as the notification/accessibility fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<Vec<serde_json::Value>>,
 }
 
 /// Rich embed for platforms that support structured output (Discord, Slack).

--- a/agentmux-srv/src/messaging/slack/mod.rs
+++ b/agentmux-srv/src/messaging/slack/mod.rs
@@ -1,0 +1,137 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slack messaging bridge — Socket Mode WebSocket receive + Web API send.
+//!
+//! Lifecycle:
+//!   1. `SlackBridge::init_global(config, http)` — call once at startup.
+//!   2. The Socket Mode loop (inbound) and the outbound send loop run in the
+//!      background as two independent tokio tasks joined by
+//!      `socket::run_bridge` — see that module's doc comment for why they're
+//!      split rather than interleaved (mirrors `telegram/poller.rs`).
+//!   3. `SlackBridge::get()` returns the singleton for HTTP handler use.
+//!   4. `bridge.send(msg)` enqueues a message for the REST client.
+//!   5. `bridge.health()` returns the current connection status.
+//!
+//! Unlike Discord's fixed Gateway URL, Slack's Socket Mode WS URL is
+//! ephemeral and single-use — a fresh URL is fetched via
+//! `apps.connections.open` before every connection attempt (initial connect
+//! and every reconnect), inside the spawned background task. `init_global`
+//! itself does no network I/O and returns immediately, matching Discord's
+//! and Telegram's synchronous, non-blocking init.
+
+mod socket;
+pub mod rest;
+pub mod types;
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::mpsc;
+
+use crate::messaging::{BridgeHealth, OutboundMsg};
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct SlackConfig {
+    /// Bot token (`xoxb-...`) — used for Web API calls (chat.postMessage).
+    pub bot_token: String,
+    /// App-level token (`xapp-...`) — used only for apps.connections.open.
+    pub app_token: String,
+    /// Default channel ID — inbound filter + default outbound target.
+    pub channel_id: String,
+    /// Agent ID to inject inbound Slack messages into via the reactive bus.
+    /// If None, inbound messages are logged but not forwarded.
+    pub target_agent: Option<String>,
+}
+
+// ── Bridge ─────────────────────────────────────────────────────────────────
+
+pub struct SlackBridge {
+    outbound_tx: mpsc::UnboundedSender<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+}
+
+static GLOBAL_BRIDGE: OnceLock<SlackBridge> = OnceLock::new();
+
+impl SlackBridge {
+    /// Initialize the global Slack bridge and start the Socket Mode +
+    /// outbound-send background tasks. No-op if already initialized.
+    pub fn init_global(config: SlackConfig, http: reqwest::Client) {
+        // Startup sanity check (spec §9b) — the two tokens have very
+        // different blast radii (app-level token can only open Socket Mode
+        // connections; bot token can actually read/post), so a swap
+        // produces confusing auth errors. Warn, don't hard-fail.
+        if !config.app_token.starts_with("xapp-") {
+            tracing::warn!(
+                "slack_bridge: messaging:slack:app_token does not start with 'xapp-' — check for a swapped bot/app token"
+            );
+        }
+        if !config.bot_token.starts_with("xoxb-") {
+            tracing::warn!(
+                "slack_bridge: messaging:slack:bot_token does not start with 'xoxb-' — check for a swapped bot/app token"
+            );
+        }
+
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<OutboundMsg>();
+        let health = Arc::new(Mutex::new(BridgeHealth::connecting("slack")));
+
+        let bridge = SlackBridge {
+            outbound_tx,
+            health: health.clone(),
+        };
+
+        if GLOBAL_BRIDGE.set(bridge).is_err() {
+            return; // already initialized
+        }
+
+        let app_token = config.app_token.clone();
+        let bot_token = config.bot_token.clone();
+        let channel_id = config.channel_id.clone();
+        let target_agent = config.target_agent.clone();
+
+        tokio::spawn(async move {
+            socket::run_bridge(
+                app_token,
+                bot_token,
+                channel_id,
+                target_agent,
+                http,
+                outbound_rx,
+                health,
+            )
+            .await;
+        });
+
+        tracing::info!(
+            "slack_bridge: initialized (channel={}, target={:?})",
+            config.channel_id,
+            config.target_agent
+        );
+    }
+
+    pub fn get() -> Option<&'static SlackBridge> {
+        GLOBAL_BRIDGE.get()
+    }
+
+    /// Enqueue a message for delivery via Slack's chat.postMessage.
+    /// Returns error if the bridge task has exited (should not happen in normal operation).
+    pub fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        self.outbound_tx
+            .send(msg)
+            .map_err(|_| "slack_bridge: outbound channel closed".to_string())
+    }
+
+    pub fn health(&self) -> BridgeHealth {
+        self.health.lock().unwrap().clone()
+    }
+}
+
+impl crate::messaging::MessagingBridge for SlackBridge {
+    fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        SlackBridge::send(self, msg)
+    }
+    fn health(&self) -> BridgeHealth {
+        SlackBridge::health(self)
+    }
+}

--- a/agentmux-srv/src/messaging/slack/rest.rs
+++ b/agentmux-srv/src/messaging/slack/rest.rs
@@ -1,0 +1,236 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slack Web API REST client — `apps.connections.open` (Socket Mode URL
+//! fetch) + `chat.postMessage` for outbound delivery.
+//!
+//! Rate limiting: v1 implements only per-channel ~1msg/s spacing (enforced
+//! by the caller in `socket.rs`'s outbound loop) and reactive
+//! `429`/`Retry-After` backoff. Full token-bucket accounting for every
+//! documented Slack API tier is explicitly out of scope (spec §2.6) —
+//! mirrors Discord's and Telegram's `rest.rs`, neither of which does
+//! header-driven throttling beyond reacting to a rate-limit signal.
+//!
+//! Secret-in-error-message hygiene: both Slack tokens (`xoxb-`/`xapp-`) are
+//! sent as `Authorization: Bearer` headers, never embedded in request URLs —
+//! unlike Telegram's `bot{token}` path convention — so `reqwest::Error`'s
+//! `Display` (which can embed request URLs on connection failures) does not
+//! leak either token via that vector, and no `redact()`-style scrubbing of
+//! `reqwest::Error` text is needed here the way `telegram/rest.rs` needs it.
+//! The one Slack-specific value that *is* both URL-embedded and secret is
+//! the Socket Mode WS URL's `ticket=` query param returned by
+//! `apps.connections.open`: it's a single-use, short-lived credential (spec
+//! §2.1, §9.6). We never pass that URL through this module's error paths
+//! (the WS connect happens in `socket.rs`), but we still provide
+//! `redact_ticket` here so any code that logs the URL (today: one `debug!`
+//! call in `socket.rs`) redacts it first — unnecessary exposure in a log
+//! that can persist long past the ticket's few-seconds validity window is
+//! not worth the convenience of an unredacted log line.
+
+use std::time::Duration;
+
+use super::types::{OpenConnectionResponse, PostMessageBody, PostMessageResponse};
+use crate::messaging::OutboundMsg;
+
+const SLACK_API: &str = "https://slack.com/api";
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+
+/// Error from a Slack Web API call, carrying the `Retry-After` seconds when
+/// present (429 responses only — Slack signals rate limits via the HTTP
+/// header, not a response-body field like Telegram's `parameters.retry_after`
+/// — spec §2.6).
+#[derive(Debug, Clone)]
+pub struct SlackApiError {
+    pub message: String,
+    pub retry_after: Option<u64>,
+}
+
+impl std::fmt::Display for SlackApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl SlackApiError {
+    fn simple(message: impl Into<String>) -> Self {
+        SlackApiError {
+            message: message.into(),
+            retry_after: None,
+        }
+    }
+}
+
+/// Redacts the single-use `ticket` query param from a Socket Mode WS URL
+/// before it's ever logged (spec §9.6). Leaves the rest of the URL (host,
+/// `app_id`, path) intact since that part isn't secret and is useful for
+/// debugging connection issues.
+pub fn redact_ticket(url: &str) -> String {
+    let Some(idx) = url.find("ticket=") else {
+        return url.to_string();
+    };
+    let value_start = idx + "ticket=".len();
+    let end = url[value_start..]
+        .find('&')
+        .map(|i| value_start + i)
+        .unwrap_or(url.len());
+    format!("{}ticket=***{}", &url[..idx], &url[end..])
+}
+
+/// Parses an HTTP `Retry-After` header value (seconds, per RFC 9110 — Slack
+/// always sends the delta-seconds form, never the HTTP-date form).
+fn parse_retry_after(value: &str) -> Option<u64> {
+    value.trim().parse::<u64>().ok()
+}
+
+/// POST apps.connections.open — `Authorization: Bearer {app_token}`. Returns
+/// the ephemeral Socket Mode WS URL. Must be called before the initial
+/// connect and before every reconnect (spec §2.1) — the URL is single-use
+/// and short-lived; never cache/reuse it.
+pub async fn open_connection(http: &reqwest::Client, app_token: &str) -> Result<String, String> {
+    let resp = http
+        .post(format!("{SLACK_API}/apps.connections.open"))
+        .header("Authorization", format!("Bearer {app_token}"))
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .send()
+        .await
+        .map_err(|e| format!("slack rest: apps.connections.open http error: {e}"))?;
+
+    let status = resp.status();
+    let body: OpenConnectionResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("slack rest: apps.connections.open parse error: {e}"))?;
+
+    if !status.is_success() || !body.ok {
+        return Err(format!(
+            "slack rest: apps.connections.open failed ({status}): {}",
+            body.error.unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+
+    body.url
+        .ok_or_else(|| "slack rest: apps.connections.open ok but no url".to_string())
+}
+
+/// POST chat.postMessage — `Authorization: Bearer {bot_token}`. MUST check
+/// `body.ok`, not just HTTP status: Slack's REST responses are HTTP 200 even
+/// on many logical failures (e.g. `channel_not_found`, `not_in_channel`) —
+/// spec §2.4.
+pub async fn post_message(
+    http: &reqwest::Client,
+    bot_token: &str,
+    channel_id: &str,
+    msg: &OutboundMsg,
+) -> Result<(), SlackApiError> {
+    let body = PostMessageBody {
+        channel: channel_id.to_string(),
+        text: msg.text.clone(),
+        blocks: msg.blocks.clone(),
+    };
+
+    let resp = http
+        .post(format!("{SLACK_API}/chat.postMessage"))
+        .header("Authorization", format!("Bearer {bot_token}"))
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| SlackApiError::simple(format!("slack rest: chat.postMessage http error: {e}")))?;
+
+    let status = resp.status();
+    let retry_after = if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        resp.headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_retry_after)
+    } else {
+        None
+    };
+
+    let parsed: PostMessageResponse = resp.json().await.map_err(|e| SlackApiError {
+        message: format!("slack rest: chat.postMessage parse error: {e}"),
+        retry_after,
+    })?;
+
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS || !parsed.ok {
+        return Err(SlackApiError {
+            message: format!(
+                "slack rest: chat.postMessage failed ({status}): {}",
+                parsed.error.unwrap_or_else(|| "unknown error".to_string())
+            ),
+            retry_after,
+        });
+    }
+
+    Ok(())
+}
+
+/// POST to a slash-command `response_url`. Stub for the deferred-response
+/// path (spec §2.5, §4.3) — not called anywhere in v1 scope; slash commands
+/// are explicitly out of scope for this PR. Kept so the module shape doesn't
+/// need rework when they land.
+#[allow(dead_code)]
+pub async fn post_response_url(
+    http: &reqwest::Client,
+    response_url: &str,
+    body: serde_json::Value,
+) -> Result<(), String> {
+    let resp = http
+        .post(response_url)
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("slack rest: response_url post http error: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("slack rest: response_url post failed: {}", resp.status()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_ticket_strips_value_keeps_rest_of_url() {
+        let url = "wss://wss-primary.slack.com/link/?ticket=abc123secret&app_id=A1";
+        let redacted = redact_ticket(url);
+        assert!(!redacted.contains("abc123secret"), "ticket leaked into: {redacted}");
+        assert!(redacted.contains("ticket=***"));
+        assert!(redacted.contains("app_id=A1"));
+        assert!(redacted.starts_with("wss://wss-primary.slack.com/link/?"));
+    }
+
+    #[test]
+    fn redact_ticket_handles_ticket_as_last_param() {
+        let url = "wss://wss-primary.slack.com/link/?app_id=A1&ticket=abc123secret";
+        let redacted = redact_ticket(url);
+        assert!(!redacted.contains("abc123secret"));
+        assert!(redacted.ends_with("ticket=***"));
+    }
+
+    #[test]
+    fn redact_ticket_noop_when_no_ticket_param() {
+        let url = "wss://wss-primary.slack.com/link/?app_id=A1";
+        assert_eq!(redact_ticket(url), url);
+    }
+
+    #[test]
+    fn parse_retry_after_parses_plain_seconds() {
+        assert_eq!(parse_retry_after("30"), Some(30));
+    }
+
+    #[test]
+    fn parse_retry_after_trims_whitespace() {
+        assert_eq!(parse_retry_after("  5  "), Some(5));
+    }
+
+    #[test]
+    fn parse_retry_after_none_on_http_date_form() {
+        // Slack always sends delta-seconds, but guard against the HTTP-date
+        // form anyway rather than panicking/misbehaving on it.
+        assert_eq!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT"), None);
+    }
+}

--- a/agentmux-srv/src/messaging/slack/socket.rs
+++ b/agentmux-srv/src/messaging/slack/socket.rs
@@ -325,8 +325,29 @@ async fn run_session(
                             FrameOutcome::Continue => {}
                             FrameOutcome::Closed => return Ok(()),
                             FrameOutcome::WarningReceived => {
-                                if cutover_pending {
-                                    tracing::debug!("slack_bridge: duplicate disconnect warning while a cutover is already in flight — ignoring");
+                                // Guard on `old.is_some()` too, not just
+                                // `cutover_pending`: a warning arriving on the
+                                // newly-promoted primary before the previous
+                                // retiring connection (`old`) has finished
+                                // draining must not start a second cutover —
+                                // its success arm below unconditionally
+                                // overwrites `old`, which would silently drop
+                                // the still-open first retiring connection
+                                // instead of finishing its drain, violating
+                                // "at most two live socket halves." Worst case
+                                // of ignoring it: Slack force-closes this
+                                // primary at the end of its warning window,
+                                // which falls through to the plain
+                                // unexpected-close error path below and
+                                // reconnects via the outer session retry loop
+                                // — the same degraded-but-safe fallback this
+                                // module already accepts when a cutover
+                                // connect attempt itself fails (see the `Err`
+                                // arm above).
+                                if cutover_pending || old.is_some() {
+                                    tracing::debug!(
+                                        "slack_bridge: disconnect warning while a cutover is already in flight or draining — ignoring"
+                                    );
                                 } else {
                                     tracing::info!("slack_bridge: disconnect warning received — starting make-before-break reconnect");
                                     cutover_pending = true;
@@ -607,9 +628,11 @@ async fn handle_outbound(
                     channel_last_sent.insert(channel_id.clone(), Instant::now());
                     channel_backoff_secs.remove(&channel_id);
                 }
-                Err(e2) => {
+                Err(e2) if e2.retry_after.is_some() => {
+                    // Still rate-limited after the single Retry-After wait —
+                    // apply exponential channel backoff.
                     tracing::warn!(
-                        "slack_bridge: retry after rate limit still failed for #{channel_id}: {e2}"
+                        "slack_bridge: retry after rate limit still rate-limited for #{channel_id}: {e2}"
                     );
                     let current = channel_backoff_secs
                         .get(&channel_id)
@@ -617,6 +640,15 @@ async fn handle_outbound(
                         .unwrap_or(RECONNECT_DELAY_SECS);
                     channel_backoff_until.insert(channel_id.clone(), Instant::now() + Duration::from_secs(current));
                     channel_backoff_secs.insert(channel_id, next_backoff_secs(current));
+                }
+                Err(e2) => {
+                    // A different, non-rate-limit failure (e.g.
+                    // channel_not_found, invalid_auth) — don't conflate it
+                    // with throttling by scheduling a rate-limit backoff;
+                    // just log it, matching the plain-failure arm below.
+                    tracing::warn!(
+                        "slack_bridge: retry after rate limit failed for #{channel_id} for an unrelated reason: {e2}"
+                    );
                 }
             }
         }

--- a/agentmux-srv/src/messaging/slack/socket.rs
+++ b/agentmux-srv/src/messaging/slack/socket.rs
@@ -1,0 +1,734 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slack Socket Mode connection lifecycle: `apps.connections.open`, the
+//! hello/events_api/disconnect-warning state machine, per-event ACK, the
+//! make-before-break reconnect-on-warning dance, and the 5-minute
+//! dead-connection timer — plus the outbound `chat.postMessage` sender.
+//!
+//! ## Two independent tasks, not one interleaved loop
+//!
+//! `run_bridge` joins the inbound socket loop (`run_socket_loop`) and the
+//! outbound send loop (`run_outbound_loop`) via `tokio::join!`, exactly like
+//! `telegram/poller.rs::run_poll_loop` joins its inbound/outbound loops —
+//! see that file's doc comment for the full review finding that motivated
+//! the split (an interleaved `tokio::select!` let an outbound
+//! backoff-sleep block inbound polling for as long as the backoff lasted).
+//! The same coupling would be worse for Slack: the inbound loop must ACK
+//! every `events_api` envelope within a hard 3-second deadline (spec §2.2),
+//! so anything that could delay servicing inbound frames — including an
+//! outbound rate-limit wait — must live on a fully separate task. The two
+//! loops share no state; outbound doesn't touch the WebSocket at all, it
+//! only calls `rest::post_message`.
+//!
+//! ## Make-before-break reconnect-on-warning (spec §2.3)
+//!
+//! This is entirely internal to `run_socket_loop`'s per-connection state
+//! (`run_session`), not a second top-level task — the dance is about
+//! managing one logical inbound connection's lifecycle, which is exactly
+//! what `run_socket_loop` already owns.
+//!
+//! `run_session` holds at most two live socket halves at once:
+//! - `primary: WsHalf` — the currently-active connection. All *new* inbound
+//!   processing (routing, ACKs for anything just arriving) happens here.
+//! - `old: Option<WsHalf>` — set only during the ~10s window between a
+//!   `disconnect: warning` and Slack force-closing that connection. Frames
+//!   still arriving here (Slack can route events to it right up until the
+//!   close) are drained and ACKed exactly like `primary`'s, just not
+//!   promoted to primary status.
+//!
+//! When a `warning` arrives on `primary`, we don't tear the connection down
+//! and reconnect — we kick off a *second*, independent connect (fetch a
+//! fresh URL via `apps.connections.open`, open a new WS, wait for its
+//! `hello`) while continuing to service `primary` unmodified. That connect
+//! runs as a pinned, boxed future (`cutover_connect`) polled as one more
+//! `tokio::select!` branch each loop iteration — the same technique
+//! `discord/gateway.rs` uses for its heartbeat-interval sleep (`hb_sleep`):
+//! a `Pin<Box<dyn Future>>` defaulting to `std::future::pending()` when
+//! there's nothing in flight, swapped in only when there's real async work
+//! to track. This is what makes the second connect genuinely concurrent
+//! with continuing to drain `primary` within a single task, no extra
+//! `tokio::spawn` required.
+//!
+//! Once that future resolves successfully (new socket reached `hello`), the
+//! *next* loop iteration promotes it: `old = Some(mem::replace(primary,
+//! new))`. From that point on, `primary`'s branch handles all new frames as
+//! usual, and a second `tokio::select!` branch (guarded by `old.is_some()`,
+//! built from the `next_frame` helper below so it evaluates to
+//! `std::future::pending()` — i.e. never fires — when `old` is `None`)
+//! keeps draining and ACKing `old` until it errors or closes, at which
+//! point it's dropped. A duplicate `warning` arriving while a cutover is
+//! already in flight is logged and ignored (`cutover_pending` guard) rather
+//! than launching a second concurrent connect.
+//!
+//! An unexpected close on `primary` with no prior warning (network blip,
+//! Slack silently dying, etc.) is the plain backoff path: `run_session`
+//! returns `Err`, and the outer `run_socket_loop` retry loop reconnects
+//! after an exponentially-increasing delay (capped at 60s, matching
+//! Discord's `RECONNECT_DELAY_SECS`/`MAX_RECONNECT_DELAY_SECS` constants),
+//! always fetching a fresh URL first (never retrying a stale one).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{
+    connect_async_tls_with_config, tungstenite::Message, MaybeTlsStream, WebSocketStream,
+};
+
+use crate::backend::reactive::handler::get_global_handler;
+use crate::backend::reactive::types::InjectionRequest;
+use crate::messaging::{BridgeHealth, BridgeStatus, OutboundMsg};
+
+use super::rest;
+use super::types::{AckFrame, EventsApiPayload, SlackEvent, SocketEnvelope};
+
+const RECONNECT_DELAY_SECS: u64 = 5;
+const MAX_RECONNECT_DELAY_SECS: u64 = 60;
+
+/// Proactive dead-connection heuristic (spec §2.3): if no frame of any kind
+/// has arrived in this long, force a reconnect even though nothing signaled
+/// a close.
+const DEAD_CONN_TIMEOUT_SECS: u64 = 300;
+
+/// Minimum spacing between two outbound sends to the same channel (spec
+/// §2.6 — "~1 msg/s/channel", enforced with a bit of headroom).
+const CHANNEL_MIN_SPACING: Duration = Duration::from_millis(1100);
+
+/// Timeout waiting for the first frame (must be `hello`) after connecting.
+const HELLO_TIMEOUT_SECS: u64 = 10;
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type WsWrite = SplitSink<WsStream, Message>;
+type WsRead = SplitStream<WsStream>;
+
+struct WsHalf {
+    write: WsWrite,
+    read: WsRead,
+}
+
+/// Orchestrates the two independent tasks described in the module doc
+/// comment. Called once from `SlackBridge::init_global`'s spawned task.
+pub async fn run_bridge(
+    app_token: String,
+    bot_token: String,
+    channel_id: String,
+    target_agent: Option<String>,
+    http: reqwest::Client,
+    outbound_rx: mpsc::UnboundedReceiver<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+) {
+    let outbound_http = http.clone();
+    let default_channel = channel_id.clone();
+    tokio::join!(
+        run_socket_loop(app_token, channel_id, target_agent, http, health),
+        run_outbound_loop(outbound_http, bot_token, default_channel, outbound_rx),
+    );
+}
+
+// ── Inbound: Socket Mode connection lifecycle ───────────────────────────────
+
+/// Outer retry-forever loop: fetch a fresh WS URL, run a session until it
+/// ends (cleanly or with an error), back off, repeat. Every attempt —
+/// initial connect included — fetches a new URL via `apps.connections.open`
+/// (spec §2.1: the URL is single-use, there is no Discord-style constant
+/// Gateway URL to fall back to).
+async fn run_socket_loop(
+    app_token: String,
+    channel_id: String,
+    target_agent: Option<String>,
+    http: reqwest::Client,
+    health: Arc<Mutex<BridgeHealth>>,
+) {
+    let mut delay_secs = RECONNECT_DELAY_SECS;
+
+    loop {
+        {
+            let mut h = health.lock().unwrap();
+            h.status = BridgeStatus::Connecting;
+        }
+
+        let session_start = Instant::now();
+
+        match connect_and_run(&app_token, &channel_id, &target_agent, &http, &health).await {
+            Ok(()) => {
+                tracing::info!("slack_bridge: session ended cleanly");
+            }
+            Err(e) => {
+                tracing::warn!("slack_bridge: session error: {e}");
+                let mut h = health.lock().unwrap();
+                h.status = BridgeStatus::Error;
+                h.error = Some(e);
+                h.reconnect_count += 1;
+            }
+        }
+
+        if session_start.elapsed().as_secs() > 30 {
+            delay_secs = RECONNECT_DELAY_SECS;
+        }
+
+        {
+            let mut h = health.lock().unwrap();
+            if h.status != BridgeStatus::Error {
+                h.status = BridgeStatus::Disconnected;
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+        delay_secs = (delay_secs * 2).min(MAX_RECONNECT_DELAY_SECS);
+    }
+}
+
+async fn connect_and_run(
+    app_token: &str,
+    channel_id: &str,
+    target_agent: &Option<String>,
+    http: &reqwest::Client,
+    health: &Arc<Mutex<BridgeHealth>>,
+) -> Result<(), String> {
+    let mut primary = open_and_await_hello(app_token, http).await?;
+
+    {
+        let mut h = health.lock().unwrap();
+        h.status = BridgeStatus::Connected;
+        h.error = None;
+        h.last_event_at = Some(unix_secs());
+    }
+    tracing::info!("slack_bridge: connected (hello received)");
+
+    run_session(app_token, channel_id, target_agent, http, health, &mut primary).await
+}
+
+/// Fetches a fresh Socket Mode URL and connects, waiting for the mandatory
+/// first `hello` frame (spec §2.1, §4.1). Used both for the initial connect
+/// and for the cutover half of the make-before-break dance.
+async fn open_and_await_hello(app_token: &str, http: &reqwest::Client) -> Result<WsHalf, String> {
+    let url = rest::open_connection(http, app_token).await?;
+    tracing::debug!(
+        "slack_bridge: opened connection ({})",
+        rest::redact_ticket(&url)
+    );
+
+    let request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .uri(&url)
+        .body(())
+        .map_err(|e| format!("slack_bridge: build ws request: {e}"))?;
+
+    let (ws_stream, _) = connect_async_tls_with_config(request, None, false, None)
+        .await
+        .map_err(|e| format!("slack_bridge: ws connect: {e}"))?;
+
+    let (write, mut read) = ws_stream.split();
+
+    match tokio::time::timeout(Duration::from_secs(HELLO_TIMEOUT_SECS), read.next()).await {
+        Ok(Some(Ok(Message::Text(text)))) => match serde_json::from_str::<SocketEnvelope>(&text) {
+            Ok(SocketEnvelope::Hello(_)) => Ok(WsHalf { write, read }),
+            Ok(_) => Err("slack_bridge: expected hello as first frame, got a different envelope type".to_string()),
+            Err(e) => Err(format!("slack_bridge: parse first frame: {e}")),
+        },
+        Ok(Some(Ok(_))) => Err("slack_bridge: expected hello as first frame, got a non-text frame".to_string()),
+        Ok(Some(Err(e))) => Err(format!("slack_bridge: ws recv error awaiting hello: {e}")),
+        Ok(None) => Err("slack_bridge: socket closed before hello".to_string()),
+        Err(_) => Err("slack_bridge: timed out waiting for hello".to_string()),
+    }
+}
+
+/// Await a frame on `old` if present, else never resolve. Lets the cutover
+/// socket's read half participate in the same `tokio::select!` as
+/// `primary`'s without needing a separate task — mirrors how
+/// `discord/gateway.rs` boxes an optional sleep future for its heartbeat.
+async fn next_frame(
+    old: &mut Option<WsHalf>,
+) -> Option<Result<Message, tokio_tungstenite::tungstenite::Error>> {
+    match old {
+        Some(half) => half.read.next().await,
+        None => std::future::pending().await,
+    }
+}
+
+enum FrameOutcome {
+    Continue,
+    WarningReceived,
+    Closed,
+}
+
+/// Runs one connection's session loop, holding at most two live socket
+/// halves (`primary` + optionally `old`, see module doc comment).
+///
+/// Returns `Ok(())` on a clean close (primary closed with no error) or
+/// `Err(e)` on anything reconnect-worthy (unexpected close, dead-connection
+/// timeout, ws send/recv error). Either way the caller (`run_socket_loop`)
+/// starts a fresh session with a freshly-fetched URL.
+async fn run_session(
+    app_token: &str,
+    channel_id: &str,
+    target_agent: &Option<String>,
+    http: &reqwest::Client,
+    health: &Arc<Mutex<BridgeHealth>>,
+    primary: &mut WsHalf,
+) -> Result<(), String> {
+    let mut old: Option<WsHalf> = None;
+    let mut cutover_pending = false;
+
+    let mut cutover_connect: std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<WsHalf, String>> + Send>,
+    > = Box::pin(std::future::pending());
+
+    let mut dead_conn_sleep = Box::pin(tokio::time::sleep(Duration::from_secs(
+        DEAD_CONN_TIMEOUT_SECS,
+    )));
+
+    loop {
+        tokio::select! {
+            // Proactive dead-connection heuristic (spec §2.3).
+            _ = &mut dead_conn_sleep => {
+                return Err(format!(
+                    "no frames received for {DEAD_CONN_TIMEOUT_SECS}s — treating connection as dead"
+                ));
+            }
+
+            // Cutover connect finished (success or failure).
+            result = &mut cutover_connect, if cutover_pending => {
+                cutover_pending = false;
+                cutover_connect = Box::pin(std::future::pending());
+                match result {
+                    Ok(new_half) => {
+                        tracing::info!("slack_bridge: cutover connection ready (hello received) — promoting to primary");
+                        let retiring = std::mem::replace(primary, new_half);
+                        old = Some(retiring);
+                        dead_conn_sleep = Box::pin(tokio::time::sleep(Duration::from_secs(DEAD_CONN_TIMEOUT_SECS)));
+                        let mut h = health.lock().unwrap();
+                        h.last_event_at = Some(unix_secs());
+                    }
+                    Err(e) => {
+                        // Stay on the current primary — it may still get
+                        // force-closed by Slack at the end of the warning
+                        // period, at which point the plain unexpected-close
+                        // path (primary.read.next() below) takes over.
+                        tracing::warn!("slack_bridge: cutover connect failed: {e} — staying on current primary until it closes");
+                    }
+                }
+            }
+
+            // Frame on the active (primary) socket.
+            frame = primary.read.next() => {
+                match frame {
+                    None => return Ok(()),
+                    Some(Err(e)) => return Err(format!("ws recv (primary): {e}")),
+                    Some(Ok(msg)) => {
+                        dead_conn_sleep = Box::pin(tokio::time::sleep(Duration::from_secs(DEAD_CONN_TIMEOUT_SECS)));
+                        let outcome = handle_frame(msg, &mut primary.write, channel_id, target_agent, health).await?;
+                        match outcome {
+                            FrameOutcome::Continue => {}
+                            FrameOutcome::Closed => return Ok(()),
+                            FrameOutcome::WarningReceived => {
+                                if cutover_pending {
+                                    tracing::debug!("slack_bridge: duplicate disconnect warning while a cutover is already in flight — ignoring");
+                                } else {
+                                    tracing::info!("slack_bridge: disconnect warning received — starting make-before-break reconnect");
+                                    cutover_pending = true;
+                                    let app_token = app_token.to_string();
+                                    let http = http.clone();
+                                    cutover_connect = Box::pin(async move { open_and_await_hello(&app_token, &http).await });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Frame on the retiring (old) socket — only polled once a
+            // cutover has actually promoted a new primary.
+            frame = next_frame(&mut old), if old.is_some() => {
+                match frame {
+                    None | Some(Err(_)) => {
+                        tracing::debug!("slack_bridge: old socket closed/errored after cutover — discarding");
+                        old = None;
+                    }
+                    Some(Ok(msg)) => {
+                        // Best-effort: ACK/drain the old socket, but don't
+                        // let its errors tear down the (already-promoted)
+                        // primary session.
+                        if let Some(half) = old.as_mut() {
+                            match handle_frame(msg, &mut half.write, channel_id, target_agent, health).await {
+                                Ok(FrameOutcome::Closed) => {
+                                    tracing::info!("slack_bridge: old socket closed cleanly after cutover");
+                                    old = None;
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::debug!("slack_bridge: old socket error after cutover (harmless — draining): {e}");
+                                    old = None;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Handles one WS frame: ACKs `events_api`/`slash_commands` envelopes
+/// immediately (before any parsing/routing — spec §2.2's hard 3-second
+/// requirement), then routes `events_api` payloads to the reactive bus.
+async fn handle_frame(
+    msg: Message,
+    write: &mut WsWrite,
+    channel_id: &str,
+    target_agent: &Option<String>,
+    health: &Arc<Mutex<BridgeHealth>>,
+) -> Result<FrameOutcome, String> {
+    match msg {
+        Message::Text(text) => {
+            let envelope: SocketEnvelope = match serde_json::from_str(&text) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("slack_bridge: parse error: {e}");
+                    return Ok(FrameOutcome::Continue);
+                }
+            };
+
+            match envelope {
+                SocketEnvelope::Hello(_) => {
+                    tracing::debug!("slack_bridge: hello frame on an already-active socket");
+                    Ok(FrameOutcome::Continue)
+                }
+                SocketEnvelope::EventsApi(ev) => {
+                    ack_envelope(write, &ev.envelope_id).await?;
+                    route_event(ev.payload, channel_id, target_agent, health);
+                    Ok(FrameOutcome::Continue)
+                }
+                SocketEnvelope::SlashCommands(ev) => {
+                    // ACK required same as any other envelope (spec §2.5),
+                    // but slash commands are out of scope for this PR — no
+                    // further handling.
+                    ack_envelope(write, &ev.envelope_id).await?;
+                    tracing::debug!("slack_bridge: received slash_commands envelope (not handled — out of scope for this PR)");
+                    Ok(FrameOutcome::Continue)
+                }
+                SocketEnvelope::Disconnect(d) => {
+                    if d.reason.as_deref() == Some("warning") {
+                        Ok(FrameOutcome::WarningReceived)
+                    } else {
+                        tracing::info!("slack_bridge: disconnect frame (reason={:?})", d.reason);
+                        Ok(FrameOutcome::Closed)
+                    }
+                }
+                SocketEnvelope::Unknown => {
+                    tracing::debug!("slack_bridge: unhandled envelope type");
+                    Ok(FrameOutcome::Continue)
+                }
+            }
+        }
+        Message::Ping(data) => {
+            let _ = write.send(Message::Pong(data)).await;
+            Ok(FrameOutcome::Continue)
+        }
+        Message::Close(_) => Ok(FrameOutcome::Closed),
+        _ => Ok(FrameOutcome::Continue),
+    }
+}
+
+/// Sends `{"envelope_id": "..."}` back on the socket the envelope arrived
+/// on. Kept allocation-light and infallible-as-possible per spec §2.2's
+/// note that the ACK path should stay cheap and unconditional.
+async fn ack_envelope(write: &mut WsWrite, envelope_id: &str) -> Result<(), String> {
+    let ack = AckFrame {
+        envelope_id: envelope_id.to_string(),
+    };
+    let ack_json = serde_json::to_string(&ack).unwrap_or_default();
+    write
+        .send(Message::Text(ack_json.into()))
+        .await
+        .map_err(|e| format!("slack_bridge: ack send: {e}"))
+}
+
+/// True when a `SlackEvent` should be routed to the reactive bus: right
+/// event type, right channel, not self-authored. Pure/testable without a
+/// real socket.
+fn should_route(event: &SlackEvent, channel_id: &str) -> bool {
+    if event.bot_id.is_some() {
+        return false; // spec §9.4 — bot-message loop prevention
+    }
+    if event.type_ != "message" && event.type_ != "app_mention" {
+        return false;
+    }
+    event.channel.as_deref() == Some(channel_id) // spec §9.3 — channel allowlist
+}
+
+fn route_event(
+    payload: Option<EventsApiPayload>,
+    channel_id: &str,
+    target_agent: &Option<String>,
+    health: &Arc<Mutex<BridgeHealth>>,
+) {
+    let Some(event) = payload.and_then(|p| p.event) else {
+        return;
+    };
+
+    if !should_route(&event, channel_id) {
+        return;
+    }
+
+    {
+        let mut h = health.lock().unwrap();
+        h.last_event_at = Some(unix_secs());
+    }
+
+    let Some(target) = target_agent else {
+        tracing::debug!("slack_bridge: event in #{channel_id} (no target agent configured)");
+        return;
+    };
+
+    let user = event.user.as_deref().unwrap_or("unknown");
+    let text = event.text.as_deref().unwrap_or("");
+    let envelope = format!("[Slack #{channel_id} @{user}]: {text}");
+
+    let handler = get_global_handler();
+    let req = InjectionRequest {
+        target_agent: target.clone(),
+        message: envelope,
+        source_agent: Some("slack".to_string()),
+        request_id: event.ts.clone(),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: Some("wan".to_string()),
+    };
+    let result = handler.inject_message(req);
+    if result.success {
+        tracing::debug!("slack_bridge: injected msg from {user} to agent {target}");
+    } else {
+        tracing::warn!(
+            "slack_bridge: inject to agent {target} failed: {:?}",
+            result.error
+        );
+    }
+}
+
+// ── Outbound: chat.postMessage sender ───────────────────────────────────────
+
+async fn run_outbound_loop(
+    http: reqwest::Client,
+    bot_token: String,
+    default_channel_id: String,
+    mut outbound_rx: mpsc::UnboundedReceiver<OutboundMsg>,
+) {
+    // Per-channel outbound rate limiting (spec §2.6, v1 scope: spacing +
+    // reactive 429 backoff only). Owned entirely by this task — never
+    // shared with the inbound loop.
+    let mut channel_last_sent: HashMap<String, Instant> = HashMap::new();
+    let mut channel_backoff_until: HashMap<String, Instant> = HashMap::new();
+    let mut channel_backoff_secs: HashMap<String, u64> = HashMap::new();
+
+    while let Some(msg) = outbound_rx.recv().await {
+        handle_outbound(
+            &http,
+            &bot_token,
+            &default_channel_id,
+            msg,
+            &mut channel_last_sent,
+            &mut channel_backoff_until,
+            &mut channel_backoff_secs,
+        )
+        .await;
+    }
+}
+
+/// Resolves an `OutboundMsg.channel_id` (empty → bridge default) into the
+/// channel id to send to. Pure/testable.
+fn resolve_channel_id(channel_id: &str, default_channel_id: &str) -> Option<String> {
+    if !channel_id.is_empty() {
+        return Some(channel_id.to_string());
+    }
+    if default_channel_id.is_empty() {
+        return None;
+    }
+    Some(default_channel_id.to_string())
+}
+
+/// Next backoff duration after a repeated failure, doubling and capped —
+/// same family used for reconnects (spec §2.6: "on repeated 429s apply the
+/// same exponential backoff used for reconnects"). Pure/testable.
+fn next_backoff_secs(current: u64) -> u64 {
+    (current * 2).min(MAX_RECONNECT_DELAY_SECS)
+}
+
+async fn handle_outbound(
+    http: &reqwest::Client,
+    bot_token: &str,
+    default_channel_id: &str,
+    msg: OutboundMsg,
+    channel_last_sent: &mut HashMap<String, Instant>,
+    channel_backoff_until: &mut HashMap<String, Instant>,
+    channel_backoff_secs: &mut HashMap<String, u64>,
+) {
+    let Some(channel_id) = resolve_channel_id(&msg.channel_id, default_channel_id) else {
+        tracing::warn!(
+            "slack_bridge: send dropped — no channel_id (empty channel_id and no messaging:slack:channel configured)"
+        );
+        return;
+    };
+
+    if let Some(until) = channel_backoff_until.get(&channel_id).copied() {
+        let now = Instant::now();
+        if now < until {
+            tokio::time::sleep(until - now).await;
+        }
+        channel_backoff_until.remove(&channel_id);
+    }
+
+    if let Some(last) = channel_last_sent.get(&channel_id) {
+        let elapsed = last.elapsed();
+        if elapsed < CHANNEL_MIN_SPACING {
+            tokio::time::sleep(CHANNEL_MIN_SPACING - elapsed).await;
+        }
+    }
+
+    match rest::post_message(http, bot_token, &channel_id, &msg).await {
+        Ok(()) => {
+            channel_last_sent.insert(channel_id.clone(), Instant::now());
+            channel_backoff_secs.remove(&channel_id);
+        }
+        Err(e) if e.retry_after.is_some() => {
+            // Spec §2.6: on 429, wait Retry-After then retry once.
+            let retry_after = e.retry_after.unwrap();
+            tracing::warn!(
+                "slack_bridge: rate limited sending to #{channel_id}, retry_after={retry_after}s — waiting then retrying once"
+            );
+            tokio::time::sleep(Duration::from_secs(retry_after)).await;
+
+            match rest::post_message(http, bot_token, &channel_id, &msg).await {
+                Ok(()) => {
+                    channel_last_sent.insert(channel_id.clone(), Instant::now());
+                    channel_backoff_secs.remove(&channel_id);
+                }
+                Err(e2) => {
+                    tracing::warn!(
+                        "slack_bridge: retry after rate limit still failed for #{channel_id}: {e2}"
+                    );
+                    let current = channel_backoff_secs
+                        .get(&channel_id)
+                        .copied()
+                        .unwrap_or(RECONNECT_DELAY_SECS);
+                    channel_backoff_until.insert(channel_id.clone(), Instant::now() + Duration::from_secs(current));
+                    channel_backoff_secs.insert(channel_id, next_backoff_secs(current));
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("slack_bridge: send to #{channel_id} failed: {e}");
+        }
+    }
+}
+
+fn unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::types::SlackEvent;
+
+    fn event(type_: &str, channel: Option<&str>, bot_id: Option<&str>) -> SlackEvent {
+        SlackEvent {
+            type_: type_.to_string(),
+            channel: channel.map(str::to_string),
+            user: Some("U1".to_string()),
+            text: Some("hi".to_string()),
+            ts: Some("123.4".to_string()),
+            bot_id: bot_id.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn should_route_accepts_message_in_configured_channel() {
+        let e = event("message", Some("C1"), None);
+        assert!(should_route(&e, "C1"));
+    }
+
+    #[test]
+    fn should_route_accepts_app_mention() {
+        let e = event("app_mention", Some("C1"), None);
+        assert!(should_route(&e, "C1"));
+    }
+
+    #[test]
+    fn should_route_rejects_other_channel() {
+        let e = event("message", Some("C2"), None);
+        assert!(!should_route(&e, "C1"));
+    }
+
+    #[test]
+    fn should_route_rejects_missing_channel() {
+        let e = event("message", None, None);
+        assert!(!should_route(&e, "C1"));
+    }
+
+    #[test]
+    fn should_route_rejects_bot_authored_events() {
+        let e = event("message", Some("C1"), Some("B1"));
+        assert!(!should_route(&e, "C1"));
+    }
+
+    #[test]
+    fn should_route_rejects_unrelated_event_types() {
+        let e = event("channel_join", Some("C1"), None);
+        assert!(!should_route(&e, "C1"));
+    }
+
+    #[test]
+    fn resolve_channel_id_uses_explicit_channel_when_present() {
+        assert_eq!(resolve_channel_id("C1", "C_default"), Some("C1".to_string()));
+    }
+
+    #[test]
+    fn resolve_channel_id_falls_back_to_default_when_empty() {
+        assert_eq!(resolve_channel_id("", "C_default"), Some("C_default".to_string()));
+    }
+
+    #[test]
+    fn resolve_channel_id_none_when_both_empty() {
+        assert_eq!(resolve_channel_id("", ""), None);
+    }
+
+    #[test]
+    fn next_backoff_secs_doubles() {
+        assert_eq!(next_backoff_secs(5), 10);
+        assert_eq!(next_backoff_secs(10), 20);
+    }
+
+    #[test]
+    fn next_backoff_secs_caps_at_max() {
+        assert_eq!(next_backoff_secs(45), MAX_RECONNECT_DELAY_SECS);
+        assert_eq!(next_backoff_secs(60), MAX_RECONNECT_DELAY_SECS);
+    }
+
+    // ── Reconnect-on-warning state transition (no real socket needed) ──────
+
+    #[test]
+    fn duplicate_warning_while_cutover_pending_is_a_noop_decision() {
+        // Mirrors the guard in run_session's WarningReceived arm: a second
+        // warning while `cutover_pending` is true must not start a second
+        // concurrent connect. This is the pure boolean condition that
+        // guards that branch.
+        let cutover_pending = true;
+        let should_start_new_cutover = !cutover_pending;
+        assert!(!should_start_new_cutover);
+    }
+
+    #[test]
+    fn fresh_warning_when_not_pending_starts_cutover() {
+        let cutover_pending = false;
+        let should_start_new_cutover = !cutover_pending;
+        assert!(should_start_new_cutover);
+    }
+}

--- a/agentmux-srv/src/messaging/slack/types.rs
+++ b/agentmux-srv/src/messaging/slack/types.rs
@@ -1,0 +1,213 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slack Socket Mode + Web API wire types.
+//!
+//! Block Kit is represented as raw `serde_json::Value` rather than a typed
+//! enum tree (spec §4.4, §7, §11.2) — Slack's block/element/object surface
+//! is large and evolving; a raw escape hatch is the deliberate v1 choice.
+
+use serde::{Deserialize, Serialize};
+
+// ── Socket Mode inbound envelope ────────────────────────────────────────────
+
+/// Tagged on the wire `"type"` field. `SlashCommands` is parsed for forward
+/// compatibility (an envelope of this kind can arrive if the app has any
+/// slash command registered) but its payload is not modeled/acted on — slash
+/// command handling is explicitly out of scope for this PR (spec §2.5, §10
+/// Phase 4).
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SocketEnvelope {
+    /// Content unused today — only the variant tag matters (first-frame
+    /// check in `socket.rs::open_and_await_hello`, reconnect-ack log line in
+    /// `handle_frame`).
+    #[allow(dead_code)]
+    Hello(HelloFrame),
+    EventsApi(EventsApiEnvelope),
+    Disconnect(DisconnectFrame),
+    SlashCommands(SlashCommandsEnvelope),
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HelloFrame {
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub num_connections: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventsApiEnvelope {
+    pub envelope_id: String,
+    #[serde(default)]
+    pub payload: Option<EventsApiPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventsApiPayload {
+    #[serde(default)]
+    pub event: Option<SlackEvent>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlackEvent {
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub ts: Option<String>,
+    /// Present on bot-authored events, including this bridge's own posts —
+    /// used for self-message loop prevention (spec §9.4).
+    #[serde(default)]
+    pub bot_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DisconnectFrame {
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Present for wire-compatibility only — not routed/acted on (see module doc).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct SlashCommandsEnvelope {
+    pub envelope_id: String,
+    #[serde(default)]
+    pub payload: Option<serde_json::Value>,
+}
+
+// ── Socket Mode outbound (ACK) ──────────────────────────────────────────────
+
+/// Sent back on the same socket a `events_api`/`slash_commands` envelope
+/// arrived on, within 3 seconds of receipt (spec §2.2 — hard correctness
+/// requirement).
+#[derive(Debug, Serialize)]
+pub struct AckFrame {
+    pub envelope_id: String,
+}
+
+// ── Web API: apps.connections.open ──────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct OpenConnectionResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+// ── Web API: chat.postMessage ───────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct PostMessageBody {
+    pub channel: String,
+    /// Always sent, even alongside `blocks` — Slack uses it as the
+    /// notification/accessibility fallback (spec §2.4).
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PostMessageResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hello_frame() {
+        let json = r#"{"type": "hello", "num_connections": 1, "connection_info": {"app_id": "A1"}}"#;
+        let env: SocketEnvelope = serde_json::from_str(json).unwrap();
+        assert!(matches!(env, SocketEnvelope::Hello(_)));
+    }
+
+    #[test]
+    fn parses_disconnect_warning_frame() {
+        let json = r#"{"type": "disconnect", "reason": "warning"}"#;
+        let env: SocketEnvelope = serde_json::from_str(json).unwrap();
+        match env {
+            SocketEnvelope::Disconnect(d) => assert_eq!(d.reason.as_deref(), Some("warning")),
+            other => panic!("expected Disconnect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_events_api_envelope_with_message_event() {
+        let json = r#"{
+            "envelope_id": "95869",
+            "type": "events_api",
+            "accepts_response_payload": false,
+            "payload": {
+                "event": {"type": "message", "channel": "C1", "user": "U1", "text": "hi", "ts": "123.4"}
+            }
+        }"#;
+        let env: SocketEnvelope = serde_json::from_str(json).unwrap();
+        match env {
+            SocketEnvelope::EventsApi(e) => {
+                assert_eq!(e.envelope_id, "95869");
+                let event = e.payload.unwrap().event.unwrap();
+                assert_eq!(event.type_, "message");
+                assert_eq!(event.channel.as_deref(), Some("C1"));
+                assert_eq!(event.text.as_deref(), Some("hi"));
+                assert!(event.bot_id.is_none());
+            }
+            other => panic!("expected EventsApi, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_events_api_envelope_with_bot_id() {
+        let json = r#"{
+            "envelope_id": "1",
+            "type": "events_api",
+            "payload": {"event": {"type": "message", "channel": "C1", "bot_id": "B1"}}
+        }"#;
+        let env: SocketEnvelope = serde_json::from_str(json).unwrap();
+        match env {
+            SocketEnvelope::EventsApi(e) => {
+                let event = e.payload.unwrap().event.unwrap();
+                assert_eq!(event.bot_id.as_deref(), Some("B1"));
+            }
+            other => panic!("expected EventsApi, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_envelope_type_does_not_error() {
+        let json = r#"{"type": "some_future_type", "foo": "bar"}"#;
+        let env: SocketEnvelope = serde_json::from_str(json).unwrap();
+        assert!(matches!(env, SocketEnvelope::Unknown));
+    }
+
+    #[test]
+    fn ack_frame_serializes_envelope_id_only() {
+        let ack = AckFrame { envelope_id: "95869".to_string() };
+        let json = serde_json::to_string(&ack).unwrap();
+        assert_eq!(json, r#"{"envelope_id":"95869"}"#);
+    }
+
+    #[test]
+    fn post_message_body_omits_blocks_when_none() {
+        let body = PostMessageBody {
+            channel: "C1".to_string(),
+            text: "hi".to_string(),
+            blocks: None,
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(!json.contains("blocks"));
+    }
+}

--- a/agentmux-srv/src/server/messaging_handlers.rs
+++ b/agentmux-srv/src/server/messaging_handlers.rs
@@ -7,6 +7,7 @@
 //!   GET  /api/messaging/status          — health of all active bridges
 //!   POST /api/messaging/discord/send    — send a message via the Discord bridge
 //!   POST /api/messaging/telegram/send   — send a message via the Telegram bridge
+//!   POST /api/messaging/slack/send      — send a message via the Slack bridge
 
 use axum::{
     extract::State,
@@ -19,6 +20,7 @@ use serde_json::json;
 use super::AppState;
 use crate::messaging::{EmbedField, MsgEmbed, MessagingBridge, OutboundMsg};
 use crate::messaging::discord::DiscordBridge;
+use crate::messaging::slack::SlackBridge;
 use crate::messaging::telegram::TelegramBridge;
 
 /// GET /api/messaging/status
@@ -28,6 +30,9 @@ pub(super) async fn handle_status(State(_state): State<AppState>) -> impl IntoRe
         bridges.push((b as &dyn MessagingBridge).health());
     }
     if let Some(b) = TelegramBridge::get() {
+        bridges.push((b as &dyn MessagingBridge).health());
+    }
+    if let Some(b) = SlackBridge::get() {
         bridges.push((b as &dyn MessagingBridge).health());
     }
     Json(json!({ "bridges": bridges }))
@@ -98,6 +103,7 @@ pub(super) async fn handle_discord_send(
         reply_to: None,
         embed,
         edit_message_id: None,
+        blocks: None,
     };
 
     match bridge.send(msg) {
@@ -145,6 +151,103 @@ pub(super) async fn handle_telegram_send(
         reply_to: None,
         embed: None,
         edit_message_id: req.edit_message_id,
+        blocks: None,
+    };
+
+    match bridge.send(msg) {
+        Ok(()) => Json(json!({ "ok": true })).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/messaging/slack/send
+///
+/// Dual path (spec §7): a raw Block Kit `blocks` escape hatch, a title/body
+/// convenience path that synthesizes a minimal 2-block message server-side,
+/// or plain `text` only. Block Kit doesn't map onto the shared `MsgEmbed`
+/// struct (see `OutboundMsg.blocks` doc comment in `messaging/mod.rs`), so
+/// this handler builds `blocks: Vec<serde_json::Value>` directly rather than
+/// reusing the Discord embed request shape.
+#[derive(Deserialize)]
+pub(super) struct SlackSendRequest {
+    /// Plain text — always sent as the top-level "text" field (required by
+    /// Slack as the fallback/notification string even when blocks are
+    /// present).
+    #[serde(default)]
+    pub text: String,
+    /// Override channel. Empty → use the bridge's default channel.
+    #[serde(default)]
+    pub channel_id: String,
+    /// Optional convenience path: a title + body rendered as a simple
+    /// two-block Block Kit message (header + section).
+    pub title: Option<String>,
+    pub body: Option<String>,
+    /// Escape hatch: raw Block Kit `blocks` array, passed through verbatim
+    /// to chat.postMessage. If present, takes precedence over title/body.
+    pub blocks: Option<Vec<serde_json::Value>>,
+}
+
+pub(super) async fn handle_slack_send(
+    State(_state): State<AppState>,
+    Json(req): Json<SlackSendRequest>,
+) -> impl IntoResponse {
+    let bridge = match SlackBridge::get() {
+        Some(b) => b,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error": "slack bridge not initialized — set messaging:slack:enabled in settings"})),
+            )
+                .into_response();
+        }
+    };
+
+    let blocks = if let Some(raw_blocks) = req.blocks {
+        Some(raw_blocks)
+    } else if req.title.is_some() || req.body.is_some() {
+        let mut blocks = vec![];
+        if let Some(title) = &req.title {
+            blocks.push(json!({
+                "type": "header",
+                "text": { "type": "plain_text", "text": title }
+            }));
+        }
+        if let Some(body) = &req.body {
+            blocks.push(json!({
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": body }
+            }));
+        }
+        Some(blocks)
+    } else {
+        None
+    };
+
+    let text = if req.text.is_empty() {
+        // Slack requires non-empty `text` as the fallback string even when
+        // `blocks` carries the real content — synthesize one from
+        // title/body so a title/body-only request doesn't fail Slack-side.
+        match (&req.title, &req.body) {
+            (Some(t), Some(b)) => format!("{t}: {b}"),
+            (Some(t), None) => t.clone(),
+            (None, Some(b)) => b.clone(),
+            (None, None) => String::new(),
+        }
+    } else {
+        req.text
+    };
+
+    let msg = OutboundMsg {
+        text,
+        channel_id: req.channel_id,
+        reply_to: None,
+        embed: None,
+        edit_message_id: None,
+        blocks,
     };
 
     match bridge.send(msg) {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -329,6 +329,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/messaging/status", get(messaging_handlers::handle_status))
         .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
         .route("/api/messaging/telegram/send", post(messaging_handlers::handle_telegram_send))
+        .route("/api/messaging/slack/send", post(messaging_handlers::handle_slack_send))
         // Persistent cron scheduler (SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2.4).
         // Auth-gated like reactive routes.
         .route("/agentmux/cron", post(cron::handle_cron_create))


### PR DESCRIPTION
## Summary
- Implements the Slack messaging bridge per [`SPEC_MESSAGING_INTEGRATION_SLACK_2026_07_07.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_MESSAGING_INTEGRATION_SLACK_2026_07_07.md), pure Rust in `agentmux-srv` (overriding the original master plan's Electron/Node.js assumption, matching the Discord/Telegram precedent).
- `SlackBridge` implements the `MessagingBridge` trait formalized in the Telegram PR (#2022).
- **Two fully independent tasks** (`tokio::join!`) for the Socket Mode WS connection and outbound sending — same structure as Telegram's bridge, adopted specifically because Telegram's review caught that mixing inbound/outbound in one `select!` loop lets outbound bursts starve inbound delivery.
- **Make-before-break reconnect-on-warning**: on Slack's `disconnect: warning` frame, opens a second WS connection concurrently (via one more `tokio::select!` branch, no extra task) while continuing to service the current connection; on success, swaps it in as primary and drains/ACKs the retiring connection until it closes. No message-loss window during Slack's ~hourly Socket Mode connection refresh.
- **3-second event ACK**: every `events_api` envelope is ACK'd immediately, before routing to the reactive bus — satisfies Slack's hard ACK-within-3s requirement independent of injection latency.
- 5-minute silent-death heuristic (proactive reconnect if no frames arrive in 300s — a documented Slack Socket Mode failure mode).
- Redacts the Socket Mode WS URL's short-lived `ticket=` query param before it's ever logged (the two long-lived tokens are header-based, so they don't have Telegram's URL-embedded-token leak vector — but the ticket does).
- Outbound via `chat.postMessage`: simple text/title convenience path plus a raw Block Kit JSON escape hatch (`OutboundMsg.blocks`) rather than forcing Block Kit through the shared `MsgEmbed` struct.
- Config: 5 new `messaging:slack:*` flat keys (two tokens — `bot_token` xoxb-, `app_token` xapp-). New `POST /api/messaging/slack/send` endpoint. Dropped `"(bridge Phase 2)"` from the Slack pane's widget description.
- Out of scope for this PR (per the spec's own phasing): slash-command deferred-response handling.

Tracked in discussion #2020.

## Test plan
- [x] `cargo check -p agentmux-srv` passes clean, zero warnings from the new code
- [x] `cargo test --bin agentmux-srv messaging` — 35 passed (26 new Slack tests + 9 existing Discord/Telegram)
- [ ] Manual: configure `messaging:slack:*` in `settings.json`, confirm a message in the configured channel is injected into the reactive bus, a reply via `POST /api/messaging/slack/send` appears in the real Slack client, and the connection survives Slack's ~hourly Socket Mode refresh without dropping messages (no Slack app/tokens available in this environment to verify end-to-end myself)