### PR TITLE
feat(jekt): Phase 3 — JektBubble renders [JEKT:...] markers in the agent pane

### DIFF
--- a/frontend/app/view/agent/components/JektBubble.tsx
+++ b/frontend/app/view/agent/components/JektBubble.tsx
@@ -1,0 +1,92 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * JektBubble — agent-pane rendering of a muxbus jekt message.
+ *
+ * Replaces the raw `[JEKT:FROM=... TIER=... ...]` marker text with a
+ * distinct, labeled block so the human operator can always tell a jekt
+ * apart from a typed user message or agent output (design goals G1/G2).
+ *
+ * Collapsed by default, like AgentMessageBlock: a one-line summary showing
+ * direction, sender/recipient, and the tier + delivery badges. Clicking
+ * expands to show the message body plus metadata (full MSGID, timestamp,
+ * raw marker payload) — spec §3.3's "click the bubble shows metadata".
+ *
+ * Spec: docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §3.3.
+ */
+
+import clsx from "clsx";
+import { Show, type JSX } from "solid-js";
+import type { JektMessageNode } from "../types";
+import { JEKT_DELIVERY_ICONS, JEKT_TIER_ICONS } from "../types";
+import { LinkifiedText } from "@/app/element/linkified-text";
+
+interface JektBubbleProps {
+    node: JektMessageNode;
+    collapsed: boolean;
+    onToggle: () => void;
+}
+
+function formatTimestamp(ts: number): string {
+    return new Date(ts).toLocaleString();
+}
+
+export const JektBubble = (props: JektBubbleProps): JSX.Element => {
+    // Don't destructure props — see AgentMessageBlock/MarkdownBlock/
+    // SubagentLinkBlock for why (codex P1 on PR #786 + family of virt-
+    // redesign issues). Same reactivity discipline applies here.
+    return (
+        <div
+            class={clsx("agent-jekt-bubble", {
+                incoming: props.node.direction === "incoming",
+                outgoing: props.node.direction === "outgoing",
+                collapsed: props.collapsed,
+                [`tier-${props.node.tier}`]: true,
+            })}
+            onClick={props.onToggle}
+        >
+            <div class="agent-jekt-summary">
+                <span class="agent-jekt-chevron">{props.collapsed ? "▸" : "▾"}</span>
+                <span class="agent-jekt-direction-icon">
+                    {props.node.direction === "incoming" ? "📥" : "📤"}
+                </span>
+                <span class="agent-jekt-peer">
+                    {props.node.direction === "incoming"
+                        ? `From ${props.node.from}`
+                        : `To ${props.node.to}`}
+                </span>
+                <span class="agent-jekt-tier-badge" title={`Tier: ${props.node.tier}`}>
+                    {JEKT_TIER_ICONS[props.node.tier]} {props.node.tier}
+                </span>
+                <span
+                    class="agent-jekt-delivery-badge"
+                    title={`Delivery: ${props.node.deliveryTier} (${props.node.trust})`}
+                >
+                    {JEKT_DELIVERY_ICONS[props.node.deliveryTier]} {props.node.deliveryTier}
+                </span>
+            </div>
+            <Show when={!props.collapsed}>
+                <div class="agent-jekt-content" onClick={(e) => e.stopPropagation()}>
+                    <pre class="agent-jekt-body">
+                        <LinkifiedText text={props.node.message} />
+                    </pre>
+                    <div class="agent-jekt-meta">
+                        <span class="agent-jekt-meta-item">From: {props.node.from}</span>
+                        <span class="agent-jekt-meta-item">To: {props.node.to}</span>
+                        <span class="agent-jekt-meta-item">MSGID: {props.node.msgId || "—"}</span>
+                        <span class="agent-jekt-meta-item">Trust: {props.node.trust}</span>
+                        <span class="agent-jekt-meta-item">Priority: {props.node.priority}</span>
+                        <span class="agent-jekt-meta-item">{formatTimestamp(props.node.timestamp)}</span>
+                    </div>
+                    <details class="agent-jekt-raw">
+                        <summary>Raw payload</summary>
+                        <pre>{props.node.raw}</pre>
+                    </details>
+                </div>
+            </Show>
+        </div>
+    );
+};
+
+JektBubble.displayName = "JektBubble";

--- a/frontend/app/view/agent/stream-parser.test.ts
+++ b/frontend/app/view/agent/stream-parser.test.ts
@@ -459,6 +459,88 @@ describe("user_message startup-injection detection", () => {
     });
 });
 
+// ── [JEKT:...] marker detection (SPEC_JEKT_SECURITY_AND_VISIBILITY) ────────
+
+describe("jekt marker detection", () => {
+    const jektBlock = (overrides: Partial<{
+        from: string; to: string; tier: string; delivery: string; trust: string;
+        msgid: string; priority: string;
+    }> = {}) => {
+        const f = {
+            from: "agentx", to: "agent3", tier: "coord", delivery: "host",
+            trust: "host-verified", msgid: "abc123", priority: "normal",
+            ...overrides,
+        };
+        return `[JEKT:FROM=${f.from} TO=${f.to} TIER=${f.tier} DELIVERY=${f.delivery} TRUST=${f.trust} MSGID=${f.msgid} PRIORITY=${f.priority} TS=1783386012]\n` +
+            `────────────────────────────────────────────────────────────\n` +
+            `From: ${f.from} | To: ${f.to} | ts=1783386012\n` +
+            `Hey, can you review PR #25?\n` +
+            `────────────────────────────────────────────────────────────\n` +
+            `Reply: bus:inject to ${f.from}\n` +
+            `[/JEKT]`;
+    };
+
+    test("parses a well-formed block into a jekt_message node", () => {
+        const message = jektBlock();
+        const node = parser.parseStreamEvent({ type: "user_message", message });
+        expect(node).not.toBeNull();
+        expect(node!.type).toBe("jekt_message");
+        const jekt = node as import("./types").JektMessageNode;
+        expect(jekt.from).toBe("agentx");
+        expect(jekt.to).toBe("agent3");
+        expect(jekt.tier).toBe("coord");
+        expect(jekt.deliveryTier).toBe("host");
+        expect(jekt.trust).toBe("host-verified");
+        expect(jekt.msgId).toBe("abc123");
+        expect(jekt.priority).toBe("normal");
+        expect(jekt.raw).toBe(message);
+    });
+
+    test("strips divider/header/reply scaffolding from the displayed message", () => {
+        const node = parser.parseStreamEvent({ type: "user_message", message: jektBlock() });
+        const jekt = node as import("./types").JektMessageNode;
+        expect(jekt.message).toBe("Hey, can you review PR #25?");
+    });
+
+    test("direction is incoming when TO matches the current agent", () => {
+        parser.setAgentId("agent3");
+        const node = parser.parseStreamEvent({ type: "user_message", message: jektBlock({ to: "agent3" }) });
+        expect((node as import("./types").JektMessageNode).direction).toBe("incoming");
+    });
+
+    test("direction is outgoing when FROM matches the current agent and TO doesn't", () => {
+        parser.setAgentId("agentx");
+        const node = parser.parseStreamEvent({ type: "user_message", message: jektBlock({ from: "agentx", to: "agent3" }) });
+        expect((node as import("./types").JektMessageNode).direction).toBe("outgoing");
+    });
+
+    test("defaults unrecognized TIER/DELIVERY values to coord/host rather than dropping the node", () => {
+        const node = parser.parseStreamEvent({ type: "user_message", message: jektBlock({ tier: "bogus", delivery: "bogus" }) });
+        const jekt = node as import("./types").JektMessageNode;
+        expect(jekt.type).toBe("jekt_message");
+        expect(jekt.tier).toBe("coord");
+        expect(jekt.deliveryTier).toBe("host");
+    });
+
+    test("falls back to a plain user_message for an unterminated jekt block", () => {
+        const message = "[JEKT:FROM=agentx TO=agent3 TIER=coord]\nno closing tag here";
+        const node = parser.parseStreamEvent({ type: "user_message", message });
+        expect(node!.type).toBe("user_message");
+        expect((node as UserMessageNode).message).toBe(message);
+    });
+
+    test("falls back to a plain user_message when FROM/TO are missing", () => {
+        const message = "[JEKT:TIER=coord]\nsomething\n[/JEKT]";
+        const node = parser.parseStreamEvent({ type: "user_message", message });
+        expect(node!.type).toBe("user_message");
+    });
+
+    test("normal typed input starting with a bracket is not mistaken for a jekt block", () => {
+        const node = parser.parseStreamEvent({ type: "user_message", message: "[not a jekt] just talking about brackets" });
+        expect(node!.type).toBe("user_message");
+    });
+});
+
 // ── error_result → AgentErrorNode (P1.3) ────────────────────────────────────
 
 describe("error_result event", () => {

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -15,6 +15,10 @@ import {
     DIRECTION_ICONS,
     DocumentNode,
     ErrorResultEvent,
+    JektDeliveryTier,
+    JektMessageNode,
+    JektTier,
+    JektTrust,
     STATUS_ICONS,
     StreamEvent,
     TextEvent,
@@ -41,6 +45,54 @@ import {
  * `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
  */
 export const STARTUP_HEADING_RE = /^# Session Context\b/;
+
+/**
+ * Matches a full `[JEKT:...]...[/JEKT]` marker block spanning the whole
+ * message. Produced by `wrap_jekt_message` (`agentmux-srv/src/backend/
+ * reactive/sanitize.rs`) and `wrapJektMessage` (`muxbus-cloud/muxbus/server/
+ * src/index.ts`) — the two current producers of this format. Group 1 is the
+ * structured tag's field string (`FROM=... TO=... TIER=...`); group 2 is
+ * everything between the tag line and the closing `[/JEKT]`.
+ *
+ * Spec: docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §3.1.
+ */
+export const JEKT_BLOCK_RE = /^\[JEKT:([^\]\n]+)\]\r?\n([\s\S]*?)\r?\n\[\/JEKT\]\s*$/;
+
+const VALID_JEKT_TIERS: ReadonlySet<string> = new Set(["info", "coord", "sensitive"]);
+const VALID_JEKT_DELIVERY_TIERS: ReadonlySet<string> = new Set(["host", "lan", "wan"]);
+
+/** Parses the `KEY=value` tokens out of a jekt structured-tag string. */
+function parseJektTagFields(tag: string): Record<string, string> {
+    const fields: Record<string, string> = {};
+    const re = /(\w+)=(\S+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(tag))) {
+        fields[m[1]] = m[2];
+    }
+    return fields;
+}
+
+/**
+ * Strips the presentational scaffolding both jekt-wrapping implementations
+ * add around the actual message (divider lines, the "From: X | To: Y | ..."
+ * header line, the sensitive-tier warning, the reply hint), leaving just
+ * what the sender actually typed/sent. Best-effort: any line that doesn't
+ * match a known scaffolding shape is kept, so an unrecognized wrapper
+ * variant degrades to showing extra context rather than losing content.
+ */
+function stripJektEnvelope(body: string): string {
+    return body
+        .split("\n")
+        .filter((line) => {
+            if (/^─+$/.test(line)) return false;
+            if (/^From:.*\|.*\|/.test(line)) return false;
+            if (/^⚠/.test(line)) return false;
+            if (/^Reply:/.test(line)) return false;
+            return true;
+        })
+        .join("\n")
+        .trim();
+}
 
 /**
  * Shared default skip-callback — returns the same empty `Set`
@@ -460,6 +512,9 @@ export class ClaudeCodeStreamParser {
      * `docs/specs/SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md`.
      */
     private userMessageToNode(event: UserMessageEvent): DocumentNode {
+        const jekt = this.tryParseJekt(event);
+        if (jekt) return jekt;
+
         const isStartup = STARTUP_HEADING_RE.test(event.message);
         return {
             type: "user_message",
@@ -467,6 +522,57 @@ export class ClaudeCodeStreamParser {
             message: event.message,
             timestamp: event.timestamp || Date.now(),
             isStartup,
+        };
+    }
+
+    /**
+     * Detects a `[JEKT:...]...[/JEKT]` marker block occupying the whole
+     * user-message payload and, if found, parses it into a `JektMessageNode`
+     * instead of the plain-text `UserMessageNode` the marker would otherwise
+     * render as. Returns null for anything that isn't a well-formed jekt
+     * block — including malformed/partial markers — so those fall through to
+     * normal plain-text rendering rather than being silently dropped.
+     *
+     * Spec: docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §3.3.
+     */
+    private tryParseJekt(event: UserMessageEvent): JektMessageNode | null {
+        const match = JEKT_BLOCK_RE.exec(event.message.trim());
+        if (!match) return null;
+
+        const fields = parseJektTagFields(match[1]);
+        if (!fields.FROM || !fields.TO) return null;
+
+        const tier: JektTier = VALID_JEKT_TIERS.has(fields.TIER) ? (fields.TIER as JektTier) : "coord";
+        const deliveryTier: JektDeliveryTier = VALID_JEKT_DELIVERY_TIERS.has(fields.DELIVERY)
+            ? (fields.DELIVERY as JektDeliveryTier)
+            : "host";
+        const trust: JektTrust = fields.TRUST === "host-verified" ? "host-verified" : "network-claimed";
+
+        // Direction mirrors agentMessageToNode: incoming when this agent is
+        // the declared recipient, outgoing when it's the declared sender
+        // (spec §3.2's outgoing echo — not yet emitted by any producer today,
+        // but handled here so JektBubble is ready when it is). Falls back to
+        // incoming, the only case any current producer emits.
+        const lowerAgentId = this.currentAgentId?.toLowerCase();
+        const direction: "incoming" | "outgoing" =
+            lowerAgentId && fields.FROM.toLowerCase() === lowerAgentId && fields.TO.toLowerCase() !== lowerAgentId
+                ? "outgoing"
+                : "incoming";
+
+        return {
+            type: "jekt_message",
+            id: this.nextIdOf("jekt"),
+            from: fields.FROM,
+            to: fields.TO,
+            message: stripJektEnvelope(match[2]),
+            raw: event.message,
+            tier,
+            deliveryTier,
+            trust,
+            msgId: fields.MSGID || "",
+            priority: fields.PRIORITY === "urgent" ? "urgent" : "normal",
+            direction,
+            timestamp: event.timestamp || Date.now(),
         };
     }
 

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -794,8 +794,108 @@
         }
     }
 
+    // === Jekt Bubble (muxbus message marker) ===
+    // See docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §3.3.
+    .agent-jekt-bubble {
+        border: none;
+        border-left: 2px solid var(--accent-color);
+        border-radius: 0;
+        background: color-mix(in srgb, var(--accent-color) 4%, transparent);
+        cursor: default;
+
+        &.outgoing {
+            border-left-color: var(--secondary-text-color);
+            background: transparent;
+            opacity: 0.7;
+        }
+
+        // Sensitivity-tier accent overrides the base incoming/outgoing color —
+        // sensitive jekts must read as visually distinct at a glance (spec G3).
+        &.tier-sensitive {
+            border-left-color: var(--error-color);
+        }
+
+        &.tier-info {
+            border-left-color: var(--secondary-text-color);
+        }
+
+        .agent-jekt-summary {
+            display: flex;
+            align-items: center;
+            gap: var(--space-1-5);
+            padding: 3px var(--space-1);
+            user-select: none;
+
+            .agent-jekt-chevron {
+                color: var(--secondary-text-color);
+                font-size: 10px;
+            }
+
+            .agent-jekt-peer {
+                flex: 1;
+                font-weight: 600;
+            }
+
+            .agent-jekt-tier-badge,
+            .agent-jekt-delivery-badge {
+                font-size: 11px;
+                color: var(--secondary-text-color);
+                padding: 1px var(--space-1);
+                border: 1px solid var(--border-color);
+                border-radius: 3px;
+                white-space: nowrap;
+            }
+        }
+
+        &.tier-sensitive .agent-jekt-tier-badge {
+            color: var(--error-color);
+            border-color: var(--error-color);
+        }
+
+        .agent-jekt-content {
+            padding: 0 var(--space-1) var(--space-1) var(--space-4);
+            cursor: default;
+
+            .agent-jekt-body {
+                background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
+                padding: var(--space-1) var(--space-1-5);
+                border-radius: 0;
+                margin: 0 0 var(--space-1) 0;
+                white-space: pre-wrap;
+            }
+
+            .agent-jekt-meta {
+                display: flex;
+                flex-wrap: wrap;
+                gap: var(--space-2);
+                padding: 0 0 var(--space-1) 0;
+                font-size: 11px;
+                color: var(--secondary-text-color);
+            }
+
+            .agent-jekt-raw {
+                font-size: 11px;
+                color: var(--secondary-text-color);
+
+                summary {
+                    cursor: pointer;
+                    user-select: none;
+                }
+
+                pre {
+                    white-space: pre-wrap;
+                    word-break: break-all;
+                    background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
+                    padding: var(--space-1) var(--space-1-5);
+                    margin: var(--space-1) 0 0 0;
+                }
+            }
+        }
+    }
+
     // Linkified URLs in plain-text and markdown blocks
     .agent-message-body,
+    .agent-jekt-body,
     .agent-user-message-content pre,
     .agent-tool-log-line {
         a.linkified-url {

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -52,7 +52,7 @@ export type InitState = {
 /**
  * Document node types that make up the agent's markdown document
  */
-export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | SubagentLinkNode | ShellNode | AgentErrorNode | ContextCompactedNode;
+export type DocumentNode = MarkdownNode | SectionNode | ToolNode | AgentMessageNode | UserMessageNode | SubagentLinkNode | ShellNode | AgentErrorNode | ContextCompactedNode | JektMessageNode;
 
 /**
  * Raw markdown text block
@@ -272,6 +272,48 @@ export interface AgentMessageNode {
     timestamp: number;
     collapsed: boolean;
     summary: string; // e.g., "📨 claude-1 → reviewer (mux)" or "📥 From claude-1 (mux)"
+}
+
+/** Sensitivity tier declared by the sender (or escalated on delivery). See
+ *  docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §4. */
+export type JektTier = "info" | "coord" | "sensitive";
+
+/** Network path the jekt crossed to reach this agent. */
+export type JektDeliveryTier = "host" | "lan" | "wan";
+
+/** Sender trust classification. Host-tier deliveries are agent-originated on
+ *  this machine; lan/wan cross a network boundary and are only as
+ *  trustworthy as the sender's token. Spec §5. */
+export type JektTrust = "host-verified" | "network-claimed";
+
+/**
+ * A muxbus jekt message, parsed out of the `[JEKT:FROM=... TIER=... ...]` /
+ * `[/JEKT]` marker block that `wrap_jekt_message` (agentmux-srv) and
+ * `wrapJektMessage` (muxbus-cloud) wrap around injected text before it lands
+ * in the agent's input stream. Rendered as a `JektBubble` instead of the raw
+ * marker text.
+ *
+ * Spec: docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §3.3.
+ */
+export interface JektMessageNode {
+    type: "jekt_message";
+    id: string;
+    from: string; // Agent ID (sender)
+    to: string; // Agent ID (recipient)
+    /** Inner message text with the marker's presentational scaffolding
+     *  (divider lines, From/To header, sensitive warning, reply hint)
+     *  stripped — what the sender actually typed/sent. */
+    message: string;
+    /** Full original `[JEKT:...]...[/JEKT]` block, unmodified. Shown in the
+     *  expanded metadata view (spec §3.3: "raw payload"). */
+    raw: string;
+    tier: JektTier;
+    deliveryTier: JektDeliveryTier;
+    trust: JektTrust;
+    msgId: string;
+    priority: "normal" | "urgent";
+    direction: "incoming" | "outgoing";
+    timestamp: number;
 }
 
 /**
@@ -684,4 +726,22 @@ export const AGENT_MESSAGE_ICONS: Record<string, string> = {
 export const DIRECTION_ICONS: Record<string, string> = {
     incoming: "📥",
     outgoing: "📤",
+};
+
+/**
+ * Jekt tier (sensitivity) icon mapping
+ */
+export const JEKT_TIER_ICONS: Record<JektTier, string> = {
+    info: "ℹ️",
+    coord: "🔗",
+    sensitive: "⚠️",
+};
+
+/**
+ * Jekt delivery-tier icon mapping
+ */
+export const JEKT_DELIVERY_ICONS: Record<JektDeliveryTier, string> = {
+    host: "🏠",
+    lan: "🛰️",
+    wan: "☁️",
 };

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -16,6 +16,7 @@
 
 import { onMount, Show, type Accessor, type JSX } from "solid-js";
 import { AgentMessageBlock } from "../components/AgentMessageBlock";
+import { JektBubble } from "../components/JektBubble";
 import { MarkdownBlock } from "../components/MarkdownBlock";
 import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
 import { PersistentShellBlock } from "../components/PersistentShellBlock";
@@ -64,6 +65,7 @@ const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
     "tool",
     "shell",
     "agent_message",
+    "jekt_message",
     "section",
 ]);
 
@@ -183,6 +185,13 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
             <Show when={props.node() && props.node().type === "agent_message"}>
                 <AgentMessageBlock
                     node={props.node() as Extract<DocumentNode, { type: "agent_message" }>}
+                    collapsed={props.documentState().collapsedNodes.has(props.node().id)}
+                    onToggle={() => props.onToggleCollapse(props.node().id)}
+                />
+            </Show>
+            <Show when={props.node() && props.node().type === "jekt_message"}>
+                <JektBubble
+                    node={props.node() as Extract<DocumentNode, { type: "jekt_message" }>}
                     collapsed={props.documentState().collapsedNodes.has(props.node().id)}
                     onToggle={() => props.onToggleCollapse(props.node().id)}
                 />

--- a/frontend/app/view/agent/virtualization/expansion-source.ts
+++ b/frontend/app/view/agent/virtualization/expansion-source.ts
@@ -70,6 +70,11 @@ export function currentExpansion(
             // Default OPEN; collapsed only when the user collapsed it.
             return state.collapsedNodes.has(node.id) ? CLOSED : OPEN_DEFAULT;
 
+        case "jekt_message":
+            // Same policy as agent_message, and for the same reason spec G1
+            // asks for: a jekt must be visible by default, not opt-in.
+            return state.collapsedNodes.has(node.id) ? CLOSED : OPEN_DEFAULT;
+
         case "user_message":
             // Only startup payloads collapse, and they key off `pinnedNodes`
             // (SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24 §D).

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -19,6 +19,7 @@ import type {
     ContextCompactedNode,
     DocumentNode,
     DocumentState,
+    JektMessageNode,
     MarkdownNode,
     SectionNode,
     ShellNode,
@@ -145,6 +146,11 @@ export function estimateAgentMessage(node: AgentMessageNode, state: DocumentStat
     return estimateTextHeight(node.message);
 }
 
+export function estimateJektMessage(node: JektMessageNode, state: DocumentState): number {
+    if (state.collapsedNodes.has(node.id)) return COLLAPSED_MESSAGE_PX;
+    return estimateTextHeight(node.message);
+}
+
 export function estimateUserMessage(node: UserMessageNode, state: DocumentState): number {
     // Per SPEC_USER_INPUT_VISIBILITY_AND_STARTUP_COLLAPSE_2026_05_24.md,
     // user messages collapse on `isStartup` + `pinnedNodes`, NOT
@@ -183,6 +189,8 @@ export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
     shell: false,
     agent_error: false, // fixed-content inline error — not a streaming node
     context_compacted: false,
+    // Arrives as a single complete user_message event, not chunk-by-chunk.
+    jekt_message: false,
 };
 
 // ── Registry factory ────────────────────────────────────────────────────────
@@ -192,6 +200,7 @@ export interface RendererComponents {
     Section: Component<{ node: SectionNode; state: DocumentState }>;
     Tool: Component<{ node: ToolNode; state: DocumentState }>;
     AgentMessage: Component<{ node: AgentMessageNode; state: DocumentState }>;
+    JektMessage: Component<{ node: JektMessageNode; state: DocumentState }>;
     UserMessage: Component<{ node: UserMessageNode; state: DocumentState }>;
     SubagentLink: Component<{ node: SubagentLinkNode; state: DocumentState }>;
     Shell: Component<{ node: ShellNode; state: DocumentState }>;
@@ -227,6 +236,11 @@ export function buildRendererRegistry(components: RendererComponents): NodeRende
             component: components.AgentMessage,
             estimatedSize: estimateAgentMessage,
             isStreamingCapable: STREAMING_CAPABLE.agent_message,
+        },
+        jekt_message: {
+            component: components.JektMessage,
+            estimatedSize: estimateJektMessage,
+            isStreamingCapable: STREAMING_CAPABLE.jekt_message,
         },
         user_message: {
             component: components.UserMessage,
@@ -267,6 +281,7 @@ export function estimateNode(node: DocumentNode, state: DocumentState): number {
         case "section": return estimateSection(node);
         case "tool": return estimateTool(node, state);
         case "agent_message": return estimateAgentMessage(node, state);
+        case "jekt_message": return estimateJektMessage(node, state);
         case "user_message": return estimateUserMessage(node, state);
         case "subagent_link": return estimateSubagentLink(node);
         case "shell": return estimateShell(node, state);
@@ -296,6 +311,7 @@ export function estimateNodeForState(
         switch (node.type) {
             case "tool":          return TOOL_COLLAPSED_PX;
             case "agent_message": return COLLAPSED_MESSAGE_PX;
+            case "jekt_message":  return COLLAPSED_MESSAGE_PX;
             case "user_message":
                 // Startup messages collapse; normal user input doesn't.
                 return node.isStartup
@@ -317,6 +333,7 @@ export function estimateNodeForState(
     switch (node.type) {
         case "tool":              return TOOL_EXPANDED_PX;
         case "agent_message":     return estimateTextHeight(node.message);
+        case "jekt_message":      return estimateTextHeight(node.message);
         case "user_message":      return estimateUnwrappedTextHeight(node.message);
         case "section":           return SECTION_PX;
         case "markdown":          return estimateTextHeight(node.content);


### PR DESCRIPTION
## Summary

SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md's Phase 1 (marker injection, commit 37d64dc8) and Phase 2 (CLAUDE.md security rules) shipped 2026-07-01. Phase 3 — the frontend rendering — was never picked up, so jekt messages have been rendering as raw `[JEKT:FROM=... TIER=... ...]` marker text mixed into the conversation ever since, instead of the distinct labeled block the spec calls for (design goals G1/G2).

- `stream-parser.ts`: detects a `[JEKT:...]...[/JEKT]` block occupying a `user_message` payload, parses `FROM`/`TO`/`TIER`/`DELIVERY`/`TRUST`/`MSGID`/`PRIORITY`, strips the divider/header/reply scaffolding down to the actual message text, and emits a `JektMessageNode` instead of a plain `UserMessageNode`. Falls back to plain text for anything malformed or partial, so an unrecognized wrapper variant degrades gracefully instead of losing content.
- `components/JektBubble.tsx` (new): collapsed-by-default row — direction icon, sender/recipient, tier badge, delivery-tier badge. Expands on click to show the message body, metadata (MSGID, trust, priority, timestamp), and a raw-payload `<details>` — spec §3.3.
- `DocumentRow.tsx` / `expansion-source.ts` / `renderers.ts`: wire the new node kind through the (now-exhaustive) per-kind switches — expansion default, height estimator, streaming-capability flag, renderer-registry slot.
- `_document-nodes.scss`: badge/border styling matching the existing `.agent-message-block` conventions — accent border by direction, red border for `tier-sensitive`.

## Scope note

Outgoing/right-aligned rendering (spec §3.2, the sender-side echo) is implemented in the parser/component but untested against real data — no backend path emits an outgoing echo today, so only the incoming path is actually exercised in production.

## Test plan
- `npx tsc --noEmit` clean.
- `npx vitest run frontend/app/view/agent` — 638/638 passing, including 8 new jekt-detection cases in `stream-parser.test.ts` (well-formed parse, envelope stripping, incoming/outgoing direction, unknown-tier defaulting, malformed/unterminated fallback).
- `npx stylelint` on the touched SCSS file — the new rules introduce zero lint errors (all pre-existing errors in that file are outside the added block).

<!-- agentmux:agent_id=agent3 -->