### PR TITLE
feat(messaging): WhatsApp bridge — Cloud API webhook receiver + send

### DIFF
--- a/.changesets/1783487331-feat-messaging-whatsapp-bridge-cloud-api-webhook-receiver-se-s89d.md
+++ b/.changesets/1783487331-feat-messaging-whatsapp-bridge-cloud-api-webhook-receiver-se-s89d.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(messaging): WhatsApp bridge — Cloud API webhook receiver + send

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "hex",
+ "hmac",
  "json_comments",
  "keyring",
  "libc",

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -50,6 +50,11 @@ chardetng = "0.1"
 flate2 = "1"
 sha2 = "0.10"
 hex = "0.4"
+# HMAC-SHA256 for the WhatsApp Cloud API webhook signature check
+# (X-Hub-Signature-256). `Mac::verify_slice` is constant-time internally
+# (backed by `subtle`, already present transitively). See
+# messaging/whatsapp/webhook.rs.
+hmac = "0.12"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 tar = "0.4"
 tempfile = "3"

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -377,6 +377,65 @@ pub struct SettingsType {
     #[serde(rename = "messaging:slack:target", default, skip_serializing_if = "Option::is_none")]
     pub messaging_slack_target: Option<String>,
 
+    // -- WhatsApp Cloud API messaging bridge --
+    //
+    // See docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md.
+    // No `messaging:whatsapp:mode` key — the spec's decision (§2.1) is
+    // Cloud API only for v1, explicitly dropping the unofficial Baileys
+    // path, so there is exactly one mode.
+
+    /// Master enable for the WhatsApp Cloud API bridge.
+    /// When true, the outbound sender starts and the `/webhook/whatsapp`
+    /// routes become live (they're always registered on the router; this
+    /// flag controls whether `WhatsAppBridge::get()` resolves).
+    #[serde(rename = "messaging:whatsapp:enabled", default, skip_serializing_if = "is_false")]
+    pub messaging_whatsapp_enabled: bool,
+
+    /// WhatsApp Business phone number ID (Meta App Dashboard > WhatsApp > API Setup).
+    #[serde(rename = "messaging:whatsapp:phone_number_id", default, skip_serializing_if = "String::is_empty")]
+    pub messaging_whatsapp_phone_number_id: String,
+
+    /// System User access token (permanent). Treat as a secret — do not log.
+    #[serde(rename = "messaging:whatsapp:access_token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_whatsapp_access_token: Option<String>,
+
+    /// Meta App Secret, used to validate X-Hub-Signature-256 on inbound
+    /// webhooks. Treat as a secret — do not log.
+    #[serde(rename = "messaging:whatsapp:app_secret", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_whatsapp_app_secret: Option<String>,
+
+    /// Verify token used in the GET /webhook/whatsapp handshake. User-chosen,
+    /// must match what's entered in Meta App Dashboard > WhatsApp > Configuration.
+    /// Treat as a secret — do not log.
+    #[serde(rename = "messaging:whatsapp:webhook_verify_token", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_whatsapp_webhook_verify_token: Option<String>,
+
+    /// Agent ID that receives inbound WhatsApp messages via the reactive bus.
+    /// Absent → messages are logged but not forwarded to any agent.
+    #[serde(rename = "messaging:whatsapp:target", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_whatsapp_target: Option<String>,
+
+    /// Template name used for outbound sends outside the 24h customer
+    /// service window. If unset and the window has expired, send() fails
+    /// fast rather than round-tripping to the Graph API (spec §3.4).
+    #[serde(rename = "messaging:whatsapp:fallback_template", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_whatsapp_fallback_template: Option<String>,
+
+    /// Template language code (BCP-47). Default "en_US" if unset.
+    #[serde(rename = "messaging:whatsapp:fallback_template_lang", default, skip_serializing_if = "Option::is_none")]
+    pub messaging_whatsapp_fallback_template_lang: Option<String>,
+
+    /// Public webhook origin (e.g. "wa.yourdomain.com") that a
+    /// user-managed tunnel (Cloudflare Tunnel, ngrok, or otherwise) points
+    /// at this instance's webhook port. **v1 does not spawn or supervise a
+    /// tunnel subprocess** — this field is used only to print the full
+    /// callback URL in the startup log as a setup reminder; the user is
+    /// responsible for standing up the tunnel and registering
+    /// `https://<this>/webhook/whatsapp` in Meta's App Dashboard themselves.
+    /// See messaging/whatsapp/mod.rs for the full scoping rationale.
+    #[serde(rename = "messaging:whatsapp:tunnel_domain", default, skip_serializing_if = "String::is_empty")]
+    pub messaging_whatsapp_tunnel_domain: String,
+
     /// Catch-all for unknown/dynamic keys (e.g. `widget:hidden@defwidget@sysinfo`).
     /// These pass through serde unchanged so the frontend can access them as flat settings keys.
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -169,7 +169,7 @@
         "icon": "brands@whatsapp",
         "color": "#25d366",
         "label": "WhatsApp",
-        "description": "WhatsApp Web — real interface, agent-connected (bridge Phase 3)",
+        "description": "WhatsApp Web — real interface, agent-connected",
         "blockdef": {
             "meta": {
                 "view": "browser",

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -822,6 +822,67 @@ async fn main() {
         }
     }
 
+    // WhatsApp Cloud API messaging bridge — outbound send + inbound webhook
+    // receiver. Unlike Discord/Telegram/Slack there is no bridge-managed
+    // network connection to open at startup: inbound delivery is passive
+    // HTTP (the GET/POST /webhook/whatsapp routes, registered unauthenticated
+    // in server/mod.rs — Meta cannot supply X-AuthKey), reachable only once
+    // the operator's own tunnel is up and the callback URL is registered in
+    // Meta's App Dashboard, both manual one-time steps this process does not
+    // perform (v1 does not manage a tunnel subprocess — see
+    // messaging/whatsapp/mod.rs). Set messaging:whatsapp:enabled +
+    // access_token/app_secret/webhook_verify_token in settings.json to activate.
+    // See docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md.
+    {
+        let settings = config_watcher.get_settings();
+        if settings.messaging_whatsapp_enabled {
+            match (
+                settings.messaging_whatsapp_access_token.clone(),
+                settings.messaging_whatsapp_app_secret.clone(),
+                settings.messaging_whatsapp_webhook_verify_token.clone(),
+            ) {
+                (Some(token), Some(secret), Some(verify_token))
+                    if !token.is_empty() && !secret.is_empty() && !verify_token.is_empty() =>
+                {
+                    messaging::whatsapp::WhatsAppBridge::init_global(
+                        messaging::whatsapp::WhatsAppConfig {
+                            phone_number_id: settings.messaging_whatsapp_phone_number_id.clone(),
+                            access_token: token,
+                            app_secret: secret,
+                            webhook_verify_token: verify_token,
+                            target_agent: settings.messaging_whatsapp_target.clone(),
+                            fallback_template: settings.messaging_whatsapp_fallback_template.clone(),
+                            fallback_template_lang: settings
+                                .messaging_whatsapp_fallback_template_lang
+                                .clone()
+                                .unwrap_or_else(|| "en_US".to_string()),
+                        },
+                        reqwest::Client::new(),
+                    );
+                    if settings.messaging_whatsapp_tunnel_domain.is_empty() {
+                        tracing::warn!(
+                            "whatsapp bridge: enabled but messaging:whatsapp:tunnel_domain is not set — \
+                             point your own tunnel at this instance's webhook port and register \
+                             https://<your-domain>/webhook/whatsapp in Meta App Dashboard > WhatsApp > Configuration"
+                        );
+                    } else {
+                        tracing::info!(
+                            "whatsapp bridge: initialized — webhook callback = https://{}/webhook/whatsapp \
+                             — verify this is registered in Meta App Dashboard > WhatsApp > Configuration \
+                             (v1 does not manage the tunnel subprocess; ensure it's already running)",
+                            settings.messaging_whatsapp_tunnel_domain
+                        );
+                    }
+                }
+                _ => {
+                    tracing::warn!(
+                        "whatsapp bridge: enabled but one of messaging:whatsapp:{{access_token,app_secret,webhook_verify_token}} is not set in settings.json"
+                    );
+                }
+            }
+        }
+    }
+
     // Set up docsite directory
     if let Some(app_path) = base::get_wave_app_path() {
         let docsite_dir = app_path.join("docsite");

--- a/agentmux-srv/src/messaging/mod.rs
+++ b/agentmux-srv/src/messaging/mod.rs
@@ -10,6 +10,7 @@
 pub mod discord;
 pub mod slack;
 pub mod telegram;
+pub mod whatsapp;
 
 use serde::{Deserialize, Serialize};
 

--- a/agentmux-srv/src/messaging/whatsapp/mod.rs
+++ b/agentmux-srv/src/messaging/whatsapp/mod.rs
@@ -1,0 +1,232 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! WhatsApp Cloud API messaging bridge — inbound webhook receiver + outbound
+//! Graph API send. See
+//! `docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md`.
+//!
+//! Lifecycle:
+//!   1. `WhatsAppBridge::init_global(config, http)` — call once at startup.
+//!   2. The outbound send loop runs in a background tokio task, reading from
+//!      an mpsc channel — same shape as Discord/Telegram/Slack, so this
+//!      bridge implements the real (sync) `MessagingBridge::send` exactly
+//!      like its siblings, rather than the async-trait alternative the spec
+//!      sketched before the trait had actually shipped (see §5.1's "open
+//!      decision point" — resolved here in favor of matching the merged
+//!      Discord/Telegram/Slack convention instead of relitigating it).
+//!   3. Inbound is passive: Meta POSTs to `GET`/`POST /webhook/whatsapp`,
+//!      handled by ordinary axum request tasks (`webhook.rs`), not a loop
+//!      this module drives. That's already fully concurrent with the
+//!      outbound send loop — one lives on axum's request-handling tasks, the
+//!      other on its own `tokio::spawn`ed task — so there's no interleaving
+//!      hazard to split apart the way `telegram/poller.rs` and
+//!      `slack/socket.rs` had to (see those files' doc comments for the
+//!      review finding that motivated their inbound/outbound task split).
+//!   4. `WhatsAppBridge::get()` returns the singleton for HTTP handler /
+//!      webhook handler use.
+//!   5. `bridge.send(msg)` enqueues a message for the Graph API sender.
+//!   6. `bridge.health()` returns the current status.
+//!
+//! ## Scope deviation from the spec: no automated tunnel management
+//!
+//! The spec (§4) designs a `TunnelManager` that spawns and supervises a
+//! `cloudflared` subprocess, auto-detects its connected URL, and sequences
+//! bridge startup around it. That subsystem cannot be meaningfully built or
+//! verified in this environment (no live Cloudflare/Meta credentials, no way
+//! to exercise a real tunnel handshake), so it is **not implemented in this
+//! PR**. v1 assumes the operator has already stood up their own tunnel
+//! (Cloudflare Tunnel, ngrok, or otherwise) pointed at this instance's
+//! webhook port, and has manually registered the callback URL + verify token
+//! in Meta's App Dashboard — both one-time, out-of-band steps independent of
+//! `agentmux-srv`'s process lifecycle. `messaging:whatsapp:tunnel_domain` is
+//! kept as a config field purely so the startup log can print the full
+//! callback URL as a convenience reminder; nothing reads it to manage a
+//! subprocess. `messaging/tunnel.rs` (the spec's shared `TunnelManager`) is
+//! not created. This scoping decision means `BridgeHealth` reflects only
+//! "the bridge is initialized and the outbound sender is running", not
+//! "Meta can currently reach us" — the latter depends on infrastructure this
+//! process doesn't own or observe.
+
+mod webhook;
+pub mod rest;
+pub mod types;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::mpsc;
+
+pub use webhook::{handle_inbound, handle_verify};
+
+use crate::messaging::{BridgeHealth, BridgeStatus, OutboundMsg};
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct WhatsAppConfig {
+    /// WhatsApp Business phone number ID (Meta App Dashboard > WhatsApp > API Setup).
+    pub phone_number_id: String,
+    /// System User access token (permanent). Treat as a secret — do not log.
+    pub access_token: String,
+    /// Meta App Secret, used to validate `X-Hub-Signature-256` on inbound
+    /// webhooks. Treat as a secret — do not log.
+    pub app_secret: String,
+    /// Verify token used in the `GET /webhook/whatsapp` handshake. Treat as
+    /// a secret — do not log.
+    pub webhook_verify_token: String,
+    /// Agent ID to inject inbound WhatsApp messages into via the reactive
+    /// bus. If `None`, inbound messages are logged but not forwarded.
+    pub target_agent: Option<String>,
+    /// Template name used for outbound sends outside the 24h customer
+    /// service window (spec §3.3/§3.4). If `None` and the window has
+    /// expired, `send()` fails fast rather than attempting delivery.
+    pub fallback_template: Option<String>,
+    /// Template language code (BCP-47), e.g. "en_US".
+    pub fallback_template_lang: String,
+}
+
+// ── Bridge ─────────────────────────────────────────────────────────────────
+
+pub struct WhatsAppBridge {
+    outbound_tx: mpsc::UnboundedSender<OutboundMsg>,
+    health: Arc<Mutex<BridgeHealth>>,
+    app_secret: String,
+    webhook_verify_token: String,
+    target_agent: Option<String>,
+    /// Per-sender (WhatsApp phone number) last-inbound timestamp (unix ms),
+    /// for 24h customer service window tracking (spec §3.3). Not persisted
+    /// to disk in v1 — a restart means the bridge falls back to templates
+    /// until the next inbound message re-opens the window, an accepted
+    /// degradation per the spec.
+    window_state: Arc<Mutex<HashMap<String, u64>>>,
+}
+
+static GLOBAL_BRIDGE: OnceLock<WhatsAppBridge> = OnceLock::new();
+
+impl WhatsAppBridge {
+    /// Initialize the global WhatsApp bridge and start the outbound send
+    /// background task. No-op if already initialized.
+    ///
+    /// Unlike Discord/Telegram/Slack, there is no inbound connection loop to
+    /// spawn here — inbound delivery is passive HTTP handled by
+    /// `webhook::handle_verify`/`handle_inbound`, already registered
+    /// unconditionally on the main axum router (see `server/mod.rs`)
+    /// regardless of whether `init_global` has run. Those handlers return
+    /// `503` via `WhatsAppBridge::get()` returning `None` until this runs.
+    pub fn init_global(config: WhatsAppConfig, http: reqwest::Client) {
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<OutboundMsg>();
+        let health = Arc::new(Mutex::new(BridgeHealth::connecting("whatsapp")));
+        let window_state: Arc<Mutex<HashMap<String, u64>>> = Arc::new(Mutex::new(HashMap::new()));
+
+        let bridge = WhatsAppBridge {
+            outbound_tx,
+            health: health.clone(),
+            app_secret: config.app_secret.clone(),
+            webhook_verify_token: config.webhook_verify_token.clone(),
+            target_agent: config.target_agent.clone(),
+            window_state: window_state.clone(),
+        };
+
+        if GLOBAL_BRIDGE.set(bridge).is_err() {
+            return; // already initialized
+        }
+
+        // No tunnel subprocess to wait on in this PR's scope (see module
+        // doc comment). The bridge is "connected" in the sense that the
+        // outbound sender and webhook handlers are live; whether Meta can
+        // actually reach the webhook route depends on infra this process
+        // doesn't manage, so this status should be read as "ready", not as
+        // proof of end-to-end reachability.
+        {
+            let mut h = health.lock().unwrap();
+            h.status = BridgeStatus::Connected;
+        }
+
+        let target_agent = config.target_agent.clone();
+        tokio::spawn(async move {
+            run_outbound_loop(config, http, window_state, outbound_rx).await;
+        });
+
+        tracing::info!(
+            "whatsapp_bridge: initialized (target={:?}) — ensure a tunnel is pointed at this \
+             instance's webhook port and the callback URL is registered in Meta App Dashboard > \
+             WhatsApp > Configuration (v1 does not manage the tunnel itself)",
+            target_agent
+        );
+    }
+
+    pub fn get() -> Option<&'static WhatsAppBridge> {
+        GLOBAL_BRIDGE.get()
+    }
+
+    /// Enqueue a message for delivery via the Graph API.
+    /// Returns error if the bridge task has exited (should not happen in normal operation).
+    pub fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        self.outbound_tx
+            .send(msg)
+            .map_err(|_| "whatsapp_bridge: outbound channel closed".to_string())
+    }
+
+    pub fn health(&self) -> BridgeHealth {
+        self.health.lock().unwrap().clone()
+    }
+
+    pub(crate) fn app_secret(&self) -> &str {
+        &self.app_secret
+    }
+
+    pub(crate) fn verify_token(&self) -> &str {
+        &self.webhook_verify_token
+    }
+
+    pub(crate) fn target_agent(&self) -> Option<&String> {
+        self.target_agent.as_ref()
+    }
+
+    /// Called by `webhook::handle_inbound` on each valid inbound message, to
+    /// update the 24h window state (spec §3.3) and the health snapshot's
+    /// `last_event_at`.
+    pub(crate) fn record_inbound(&self, from_id: &str) {
+        let now = now_ms();
+        self.window_state
+            .lock()
+            .unwrap()
+            .insert(from_id.to_string(), now);
+        let mut h = self.health.lock().unwrap();
+        h.last_event_at = Some(now / 1000);
+    }
+}
+
+impl crate::messaging::MessagingBridge for WhatsAppBridge {
+    fn send(&self, msg: OutboundMsg) -> Result<(), String> {
+        WhatsAppBridge::send(self, msg)
+    }
+    fn health(&self) -> BridgeHealth {
+        WhatsAppBridge::health(self)
+    }
+}
+
+/// Drains the outbound mpsc queue and calls the Graph API for each message.
+/// Runs as its own `tokio::spawn`ed task, fully independent of the axum
+/// request tasks servicing `webhook::handle_inbound` — a slow or
+/// rate-limited send here cannot block the webhook route from accepting
+/// Meta's next delivery (see module doc comment).
+async fn run_outbound_loop(
+    config: WhatsAppConfig,
+    http: reqwest::Client,
+    window_state: Arc<Mutex<HashMap<String, u64>>>,
+    mut outbound_rx: mpsc::UnboundedReceiver<OutboundMsg>,
+) {
+    while let Some(msg) = outbound_rx.recv().await {
+        if let Err(e) = rest::send_message(&http, &config, &window_state, &msg).await {
+            tracing::warn!("whatsapp_bridge: send failed: {e}");
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}

--- a/agentmux-srv/src/messaging/whatsapp/mod.rs
+++ b/agentmux-srv/src/messaging/whatsapp/mod.rs
@@ -186,12 +186,19 @@ impl WhatsAppBridge {
     /// Called by `webhook::handle_inbound` on each valid inbound message, to
     /// update the 24h window state (spec §3.3) and the health snapshot's
     /// `last_event_at`.
+    ///
+    /// Keys on `rest::normalize_phone(from_id)`, not the raw id, so this
+    /// matches whatever normalized form `rest::send_message` looks the
+    /// number up under — Meta's inbound `from` has no `+` prefix, but a
+    /// caller sending via `handle_whatsapp_send` may supply one (E.164);
+    /// without a shared normalization the window lookup always missed
+    /// (found via review).
     pub(crate) fn record_inbound(&self, from_id: &str) {
         let now = now_ms();
         self.window_state
             .lock()
             .unwrap()
-            .insert(from_id.to_string(), now);
+            .insert(rest::normalize_phone(from_id), now);
         let mut h = self.health.lock().unwrap();
         h.last_event_at = Some(now / 1000);
     }

--- a/agentmux-srv/src/messaging/whatsapp/rest.rs
+++ b/agentmux-srv/src/messaging/whatsapp/rest.rs
@@ -33,14 +33,24 @@ pub async fn send_message(
     // repurposed as "recipient phone number" (spec §5.3). There is no
     // bridge-level default to fall back to the way Discord/Slack have a
     // default channel, so an empty recipient is a caller error.
-    let to = msg.channel_id.trim();
+    //
+    // Normalized (digits only) before anything else: `handle_whatsapp_send`
+    // documents `to` as "E.164 preferred" (e.g. "+14155552671"), but Meta's
+    // inbound webhook `from` field has no `+` (e.g. "14155552671"). Without
+    // normalizing both to the same form, the window-state lookup below
+    // key-misses every caller following the documented `+`-prefixed format,
+    // always falling through to "24h window expired" even when Meta's real
+    // window is open. Digits-only also matches the format the Graph API's
+    // own `to` field expects, so the normalized value is used for the send
+    // body too, not just the lookup.
+    let to = normalize_phone(msg.channel_id.trim());
     if to.is_empty() {
         return Err(
             "whatsapp: OutboundMsg.channel_id (recipient phone number) is required".to_string(),
         );
     }
 
-    let last_inbound = window_state.lock().unwrap().get(to).copied();
+    let last_inbound = window_state.lock().unwrap().get(&to).copied();
     let within_window = last_inbound
         .map(|last| window_ok(last, now_ms()))
         .unwrap_or(false);
@@ -48,10 +58,10 @@ pub async fn send_message(
     let text = flatten_text(msg);
 
     let body = if within_window {
-        SendBody::text(to, &text)
+        SendBody::text(&to, &text)
     } else {
         match config.fallback_template.as_deref().filter(|t| !t.is_empty()) {
-            Some(template) => SendBody::template(to, template, &config.fallback_template_lang),
+            Some(template) => SendBody::template(&to, template, &config.fallback_template_lang),
             None => {
                 return Err(
                     "whatsapp: 24h window expired and no fallback template configured"
@@ -123,6 +133,15 @@ fn window_ok(last_inbound_ms: u64, now_ms: u64) -> bool {
     now_ms.saturating_sub(last_inbound_ms) <= TWENTY_FOUR_HOURS_MS
 }
 
+/// Strips everything but ASCII digits, so the same phone number in different
+/// formats — Meta's inbound `from` (no `+`) vs. a caller-supplied `to` in
+/// E.164 (`+`-prefixed) or with spaces/dashes — normalizes to one 24h-window
+/// state key. `WhatsAppBridge::record_inbound` (mod.rs) applies this same
+/// normalization when storing, so the two call sites always agree.
+pub(crate) fn normalize_phone(raw: &str) -> String {
+    raw.chars().filter(|c| c.is_ascii_digit()).collect()
+}
+
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -157,6 +176,29 @@ mod tests {
     fn window_ok_now_before_last_does_not_panic() {
         // Clock skew / stale entry — saturating_sub prevents underflow panic.
         assert!(window_ok(2_000_000, 1_000_000));
+    }
+
+    #[test]
+    fn normalize_phone_strips_plus_and_formatting() {
+        assert_eq!(normalize_phone("+14155552671"), "14155552671");
+        assert_eq!(normalize_phone("1-415-555-2671"), "14155552671");
+        assert_eq!(normalize_phone("(415) 555-2671"), "4155552671");
+    }
+
+    #[test]
+    fn normalize_phone_is_noop_on_already_digits_only() {
+        // Meta's inbound `from` format — no `+`, no separators.
+        assert_eq!(normalize_phone("14155552671"), "14155552671");
+    }
+
+    #[test]
+    fn normalize_phone_produces_matching_keys_for_meta_inbound_and_e164_outbound() {
+        // Regression for the window-state key mismatch a review caught:
+        // Meta's inbound `from` and a caller's documented E.164 `to` must
+        // normalize to the identical map key.
+        let meta_inbound_from = "14155552671";
+        let caller_supplied_to = "+14155552671";
+        assert_eq!(normalize_phone(meta_inbound_from), normalize_phone(caller_supplied_to));
     }
 
     #[test]

--- a/agentmux-srv/src/messaging/whatsapp/rest.rs
+++ b/agentmux-srv/src/messaging/whatsapp/rest.rs
@@ -1,0 +1,216 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! WhatsApp Cloud API REST client — outbound message send only.
+//!
+//! Mirrors Discord's `rest.rs` shape (a single `send_message` function, no
+//! client struct), with one addition Discord doesn't need: the 24-hour
+//! customer service window (spec §3.3/§3.4). Outside the window, Meta
+//! rejects a free-form text send (error code 131047); rather than round-trip
+//! to the API to discover that, `send_message` checks the local window state
+//! first and fails fast (or falls back to a configured template) before
+//! making the HTTP call at all.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::messaging::OutboundMsg;
+
+use super::types::SendBody;
+use super::WhatsAppConfig;
+
+const GRAPH_API_VERSION: &str = "v25.0";
+const TWENTY_FOUR_HOURS_MS: u64 = 24 * 60 * 60 * 1000;
+
+/// POST /{phone_number_id}/messages
+pub async fn send_message(
+    http: &reqwest::Client,
+    config: &WhatsAppConfig,
+    window_state: &Mutex<HashMap<String, u64>>,
+    msg: &OutboundMsg,
+) -> Result<(), String> {
+    // WhatsApp has no channel/room concept — `OutboundMsg.channel_id` is
+    // repurposed as "recipient phone number" (spec §5.3). There is no
+    // bridge-level default to fall back to the way Discord/Slack have a
+    // default channel, so an empty recipient is a caller error.
+    let to = msg.channel_id.trim();
+    if to.is_empty() {
+        return Err(
+            "whatsapp: OutboundMsg.channel_id (recipient phone number) is required".to_string(),
+        );
+    }
+
+    let last_inbound = window_state.lock().unwrap().get(to).copied();
+    let within_window = last_inbound
+        .map(|last| window_ok(last, now_ms()))
+        .unwrap_or(false);
+
+    let text = flatten_text(msg);
+
+    let body = if within_window {
+        SendBody::text(to, &text)
+    } else {
+        match config.fallback_template.as_deref().filter(|t| !t.is_empty()) {
+            Some(template) => SendBody::template(to, template, &config.fallback_template_lang),
+            None => {
+                return Err(
+                    "whatsapp: 24h window expired and no fallback template configured"
+                        .to_string(),
+                );
+            }
+        }
+    };
+
+    let url = format!(
+        "https://graph.facebook.com/{GRAPH_API_VERSION}/{}/messages",
+        config.phone_number_id
+    );
+
+    let resp = http
+        .post(&url)
+        .bearer_auth(&config.access_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("whatsapp rest: http error: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        // Graph API error bodies are `{ "error": { "message", "type", "code",
+        // "error_subcode", "fbtrace_id" } }` — never contain the access
+        // token or app secret, so passing the text through is safe (unlike
+        // request header content on the inbound webhook path, which is
+        // deliberately never logged — see webhook.rs).
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("whatsapp rest: {status}: {text}"));
+    }
+
+    Ok(())
+}
+
+/// WhatsApp's Cloud API has no rich embed support (spec §5.3) — if
+/// `OutboundMsg.embed` is set, flatten it to plain text rather than dropping
+/// it silently.
+fn flatten_text(msg: &OutboundMsg) -> String {
+    let Some(embed) = &msg.embed else {
+        return msg.text.clone();
+    };
+
+    let mut parts = Vec::new();
+    if let Some(title) = &embed.title {
+        parts.push(title.clone());
+    }
+    parts.push(embed.description.clone());
+    for f in &embed.fields {
+        parts.push(format!("{}: {}", f.name, f.value));
+    }
+    if let Some(footer) = &embed.footer {
+        parts.push(footer.clone());
+    }
+    let flattened = parts.join("\n\n");
+
+    if msg.text.is_empty() {
+        flattened
+    } else {
+        format!("{}\n\n{}", msg.text, flattened)
+    }
+}
+
+/// True if `now_ms` is within 24h of `last_inbound_ms`. Pulled out as a pure
+/// function so the boundary condition (spec §10's "24h window edge case") is
+/// unit-testable without a clock or network call.
+fn window_ok(last_inbound_ms: u64, now_ms: u64) -> bool {
+    now_ms.saturating_sub(last_inbound_ms) <= TWENTY_FOUR_HOURS_MS
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messaging::{EmbedField, MsgEmbed};
+
+    #[test]
+    fn window_ok_within_bound() {
+        let last = 1_000_000u64;
+        assert!(window_ok(last, last + TWENTY_FOUR_HOURS_MS));
+    }
+
+    #[test]
+    fn window_ok_exactly_at_boundary_is_inclusive() {
+        let last = 1_000_000u64;
+        assert!(window_ok(last, last + TWENTY_FOUR_HOURS_MS));
+    }
+
+    #[test]
+    fn window_ok_one_ms_past_boundary_expires() {
+        let last = 1_000_000u64;
+        assert!(!window_ok(last, last + TWENTY_FOUR_HOURS_MS + 1));
+    }
+
+    #[test]
+    fn window_ok_now_before_last_does_not_panic() {
+        // Clock skew / stale entry — saturating_sub prevents underflow panic.
+        assert!(window_ok(2_000_000, 1_000_000));
+    }
+
+    #[test]
+    fn flatten_text_plain_text_only() {
+        let msg = OutboundMsg {
+            text: "hello".to_string(),
+            channel_id: "15551234567".to_string(),
+            reply_to: None,
+            embed: None,
+            edit_message_id: None,
+            blocks: None,
+        };
+        assert_eq!(flatten_text(&msg), "hello");
+    }
+
+    #[test]
+    fn flatten_text_embed_flattens_title_description_fields_footer() {
+        let msg = OutboundMsg {
+            text: String::new(),
+            channel_id: "15551234567".to_string(),
+            reply_to: None,
+            embed: Some(MsgEmbed {
+                title: Some("Title".to_string()),
+                description: "Desc".to_string(),
+                color: None,
+                fields: vec![EmbedField {
+                    name: "Status".to_string(),
+                    value: "OK".to_string(),
+                    inline: false,
+                }],
+                footer: Some("Footer".to_string()),
+            }),
+            edit_message_id: None,
+            blocks: None,
+        };
+        assert_eq!(flatten_text(&msg), "Title\n\nDesc\n\nStatus: OK\n\nFooter");
+    }
+
+    #[test]
+    fn flatten_text_prepends_text_before_flattened_embed() {
+        let msg = OutboundMsg {
+            text: "lead-in".to_string(),
+            channel_id: "15551234567".to_string(),
+            reply_to: None,
+            embed: Some(MsgEmbed {
+                title: None,
+                description: "Desc".to_string(),
+                color: None,
+                fields: vec![],
+                footer: None,
+            }),
+            edit_message_id: None,
+            blocks: None,
+        };
+        assert_eq!(flatten_text(&msg), "lead-in\n\nDesc");
+    }
+}

--- a/agentmux-srv/src/messaging/whatsapp/types.rs
+++ b/agentmux-srv/src/messaging/whatsapp/types.rs
@@ -1,0 +1,219 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! WhatsApp Cloud API wire types — webhook payload (inbound) and Graph API
+//! send body (outbound). Hand-rolled serde structs over `reqwest` +
+//! `serde_json`, matching Discord's `types.rs` precedent (no SDK crate).
+
+use serde::{Deserialize, Serialize};
+
+// ── Webhook payload (inbound) ───────────────────────────────────────────────
+//
+// Meta's nested envelope: `entry[].changes[].value.messages[]`. Deserialized
+// permissively (unknown fields ignored by default with serde) — `statuses[]`
+// (delivery receipts) is intentionally not modeled at all, per spec §5.4;
+// any change payload that carries only `statuses` and no `messages` simply
+// yields zero `ExtractedMessage`s.
+
+#[derive(Debug, Default, Deserialize)]
+pub struct WebhookPayload {
+    #[serde(default)]
+    pub entry: Vec<WebhookEntry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct WebhookEntry {
+    #[serde(default)]
+    pub changes: Vec<WebhookChange>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct WebhookChange {
+    #[serde(default)]
+    pub value: WebhookValue,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct WebhookValue {
+    #[serde(default)]
+    pub messages: Vec<WebhookMessage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebhookMessage {
+    /// Sender's WhatsApp phone number (no `+`, e.g. "14155552671").
+    pub from: String,
+    pub id: String,
+    #[serde(rename = "type", default)]
+    pub msg_type: String,
+    #[serde(default)]
+    pub text: Option<WebhookText>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebhookText {
+    pub body: String,
+}
+
+/// A flattened, normalized inbound WhatsApp message extracted from the
+/// nested webhook envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedMessage {
+    pub from: String,
+    pub id: String,
+    pub text: String,
+}
+
+impl WebhookPayload {
+    /// Flattens `entry[].changes[].value.messages[]`. Only text messages are
+    /// surfaced in v1 (spec §5.2/§5.4 scope) — messages of other types
+    /// (image, reaction, location, …) or `statuses` entries are skipped, not
+    /// errored on, since a webhook batch legitimately mixes message types
+    /// and delivery-receipt updates.
+    pub fn extract_messages(&self) -> Vec<ExtractedMessage> {
+        self.entry
+            .iter()
+            .flat_map(|e| e.changes.iter())
+            .flat_map(|c| c.value.messages.iter())
+            .filter_map(|m| {
+                let text = m.text.as_ref()?.body.clone();
+                Some(ExtractedMessage {
+                    from: m.from.clone(),
+                    id: m.id.clone(),
+                    text,
+                })
+            })
+            .collect()
+    }
+}
+
+// ── Graph API send types (outbound) ────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct SendBody {
+    pub messaging_product: &'static str,
+    pub to: String,
+    #[serde(rename = "type")]
+    pub msg_type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<SendText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<SendTemplate>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SendText {
+    pub body: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SendTemplate {
+    pub name: String,
+    pub language: SendTemplateLanguage,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SendTemplateLanguage {
+    pub code: String,
+}
+
+impl SendBody {
+    pub fn text(to: &str, body: &str) -> Self {
+        SendBody {
+            messaging_product: "whatsapp",
+            to: to.to_string(),
+            msg_type: "text",
+            text: Some(SendText {
+                body: body.to_string(),
+            }),
+            template: None,
+        }
+    }
+
+    pub fn template(to: &str, name: &str, lang: &str) -> Self {
+        SendBody {
+            messaging_product: "whatsapp",
+            to: to.to_string(),
+            msg_type: "template",
+            text: None,
+            template: Some(SendTemplate {
+                name: name.to_string(),
+                language: SendTemplateLanguage {
+                    code: lang.to_string(),
+                },
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_messages_flattens_nested_envelope_and_skips_non_text() {
+        let json = r#"{
+            "entry": [{
+                "changes": [{
+                    "value": {
+                        "messages": [
+                            { "from": "15551234567", "id": "wamid.1", "type": "text", "text": { "body": "hi" } },
+                            { "from": "15551234567", "id": "wamid.2", "type": "reaction" }
+                        ]
+                    }
+                }]
+            }]
+        }"#;
+        let payload: WebhookPayload = serde_json::from_str(json).unwrap();
+        let msgs = payload.extract_messages();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].from, "15551234567");
+        assert_eq!(msgs[0].id, "wamid.1");
+        assert_eq!(msgs[0].text, "hi");
+    }
+
+    #[test]
+    fn extract_messages_ignores_statuses_only_payload() {
+        // `statuses` isn't modeled at all — a change with only delivery
+        // receipts yields an empty `messages` vec (default), so extraction
+        // returns zero results without error.
+        let json = r#"{
+            "entry": [{
+                "changes": [{
+                    "value": {
+                        "statuses": [{ "id": "wamid.1", "status": "delivered" }]
+                    }
+                }]
+            }]
+        }"#;
+        let payload: WebhookPayload = serde_json::from_str(json).unwrap();
+        assert!(payload.extract_messages().is_empty());
+    }
+
+    #[test]
+    fn extract_messages_empty_entry_list() {
+        let payload: WebhookPayload = serde_json::from_str(r#"{"entry": []}"#).unwrap();
+        assert!(payload.extract_messages().is_empty());
+    }
+
+    #[test]
+    fn send_body_text_serializes_expected_shape() {
+        let body = SendBody::text("15551234567", "hello");
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["messaging_product"], "whatsapp");
+        assert_eq!(v["to"], "15551234567");
+        assert_eq!(v["type"], "text");
+        assert_eq!(v["text"]["body"], "hello");
+        assert!(v.get("template").is_none());
+    }
+
+    #[test]
+    fn send_body_template_serializes_expected_shape() {
+        let body = SendBody::template("15551234567", "hello_world", "en_US");
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["type"], "template");
+        assert_eq!(v["template"]["name"], "hello_world");
+        assert_eq!(v["template"]["language"]["code"], "en_US");
+        assert!(v.get("text").is_none());
+    }
+}

--- a/agentmux-srv/src/messaging/whatsapp/webhook.rs
+++ b/agentmux-srv/src/messaging/whatsapp/webhook.rs
@@ -1,0 +1,260 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! WhatsApp Cloud API inbound webhook receiver — axum handlers for the
+//! one-time verification handshake and the per-event delivery POST.
+//!
+//! These are the genuinely new shape versus Discord/Telegram/Slack, which
+//! only ever make *outbound* connections: this is passive HTTP the public
+//! internet (Meta's servers) can reach, so every inbound POST must be
+//! authenticated via HMAC signature (spec §3.2/§9) rather than AgentMux's
+//! own `X-AuthKey` scheme, which Meta cannot supply. **These routes must be
+//! registered outside `auth_middleware`** — see `server/mod.rs`, merged at
+//! the top level alongside the unauthenticated `health` router, not inside
+//! `authed_routes`. Putting them behind `X-AuthKey` would make Meta's calls
+//! always fail (spec §8.2).
+//!
+//! ## Credential handling
+//!
+//! Two credentials pass through this module: the webhook verify token
+//! (`hub.verify_token` on the GET handshake) and the app secret (used to
+//! validate `X-Hub-Signature-256` on every POST). Neither is ever logged —
+//! failures log only the fact of a mismatch, never the header value or the
+//! secret. This mirrors the review findings baked into
+//! `telegram/rest.rs::redact()` and `slack/rest.rs::redact_ticket()`: any
+//! error string built from a value that might embed a credential must be
+//! redacted (or, here, simply never constructed from the credential in the
+//! first place) before it can reach a log line or an HTTP response body.
+
+use std::collections::HashMap;
+
+use axum::{
+    body::Bytes,
+    extract::Query,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use super::types::WebhookPayload;
+use super::WhatsAppBridge;
+use crate::backend::reactive::handler::get_global_handler;
+use crate::backend::reactive::types::InjectionRequest;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// `GET /webhook/whatsapp?hub.mode=subscribe&hub.verify_token=...&hub.challenge=...`
+///
+/// Meta's one-time (per-URL-change) verification handshake (spec §3.1). Must
+/// succeed before Meta starts delivering inbound POSTs, and Meta re-runs
+/// this any time the webhook URL or verify token changes in the App
+/// Dashboard.
+pub async fn handle_verify(Query(params): Query<HashMap<String, String>>) -> impl IntoResponse {
+    let Some(bridge) = WhatsAppBridge::get() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "whatsapp bridge not initialized".to_string(),
+        )
+            .into_response();
+    };
+
+    let mode = params.get("hub.mode").map(String::as_str).unwrap_or("");
+    let token = params
+        .get("hub.verify_token")
+        .map(String::as_str)
+        .unwrap_or("");
+    let challenge = params.get("hub.challenge").cloned().unwrap_or_default();
+
+    let token_matches = constant_time_eq(token.as_bytes(), bridge.verify_token().as_bytes());
+
+    if mode == "subscribe" && token_matches {
+        (StatusCode::OK, challenge).into_response()
+    } else {
+        // Never log `token` — it's the shared secret being validated.
+        tracing::warn!(
+            "whatsapp_bridge: webhook verification handshake rejected (mode={mode:?}, token_match={token_matches})"
+        );
+        (StatusCode::FORBIDDEN, "verification failed".to_string()).into_response()
+    }
+}
+
+/// `POST /webhook/whatsapp` — inbound message delivery.
+///
+/// Body MUST be read as raw bytes (`Bytes`, not `Json<T>`) so the exact
+/// signed payload is available for the HMAC check before any deserialization
+/// happens (spec §3.2/§9.1) — deserializing first and re-serializing to
+/// check the signature would validate a re-encoded payload, not what Meta
+/// actually signed.
+pub async fn handle_inbound(headers: HeaderMap, body: Bytes) -> impl IntoResponse {
+    let Some(bridge) = WhatsAppBridge::get() else {
+        return StatusCode::SERVICE_UNAVAILABLE;
+    };
+
+    let sig_header = headers
+        .get("X-Hub-Signature-256")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !verify_signature(bridge.app_secret(), &body, sig_header) {
+        // Reject before any payload parsing or logging of body content
+        // (spec §3.2 step 4). Do not log `sig_header` — while the signature
+        // itself isn't directly reusable as a credential (it's a per-request
+        // HMAC over this specific body), treating anything derived from
+        // request headers as potentially sensitive and never echoing it into
+        // logs is the safer default, consistent with the redaction posture
+        // Telegram and Slack's bridges adopted after review.
+        tracing::warn!("whatsapp_bridge: rejected inbound webhook — signature mismatch");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let payload: WebhookPayload = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("whatsapp_bridge: webhook payload parse error: {e}");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    for msg in payload.extract_messages() {
+        bridge.record_inbound(&msg.from);
+
+        let Some(target) = bridge.target_agent() else {
+            tracing::debug!(
+                "whatsapp_bridge: message from {} (no target agent configured)",
+                msg.from
+            );
+            continue;
+        };
+
+        let envelope = format!("[WhatsApp {}]: {}", msg.from, msg.text);
+        let handler = get_global_handler();
+        let req = InjectionRequest {
+            target_agent: target.clone(),
+            message: envelope,
+            source_agent: Some("whatsapp".to_string()),
+            request_id: Some(msg.id.clone()),
+            priority: None,
+            wait_for_idle: false,
+            jekt_tier: None,
+            delivery_tier: Some("wan".to_string()),
+        };
+        let result = handler.inject_message(req);
+        if !result.success {
+            tracing::warn!(
+                "whatsapp_bridge: inject to agent {target} failed: {:?}",
+                result.error
+            );
+        }
+    }
+
+    // Always 200 for a successfully-parsed batch, even if local injection
+    // failed for one or more messages — per Meta's delivery semantics, a
+    // non-2xx response causes retries and eventual (after ~7 days of
+    // failures) event drop; local injection failures are our problem to
+    // observe via logs, not something that should make Meta think delivery
+    // itself failed (spec §5.2).
+    StatusCode::OK
+}
+
+/// Validates `X-Hub-Signature-256: sha256=<hex>` = HMAC-SHA256(app_secret,
+/// raw_body). Uses `Mac::verify_slice`, which performs a constant-time
+/// comparison internally (backed by the `subtle` crate, already present
+/// transitively via `hmac` in this workspace's dependency graph — no new
+/// crate added).
+fn verify_signature(app_secret: &str, body: &[u8], header: &str) -> bool {
+    let Some(hex_sig) = header.strip_prefix("sha256=") else {
+        return false;
+    };
+    let Ok(expected) = hex::decode(hex_sig) else {
+        return false;
+    };
+    let Ok(mut mac) = HmacSha256::new_from_slice(app_secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(body);
+    mac.verify_slice(&expected).is_ok()
+}
+
+/// Constant-time byte comparison for the `hub.verify_token` handshake check
+/// (spec §3.1 step 1). Hand-rolled (XOR-and-OR-accumulate) rather than
+/// pulling in a dedicated crate — `subtle` is already available transitively
+/// via `hmac` for the signature check above, but reaching for it here too
+/// would mean threading an extra direct dependency through Cargo.toml for a
+/// six-line primitive; this is the simplest correct implementation.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sign(secret: &str, body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    #[test]
+    fn verify_signature_accepts_known_good_vector() {
+        let secret = "app_secret_123";
+        let body = b"{\"entry\":[]}";
+        let header = sign(secret, body);
+        assert!(verify_signature(secret, body, &header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_secret() {
+        let header = sign("right_secret", b"hello");
+        assert!(!verify_signature("wrong_secret", b"hello", &header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_body() {
+        let header = sign("secret", b"original");
+        assert!(!verify_signature("secret", b"tampered", &header));
+    }
+
+    #[test]
+    fn verify_signature_rejects_missing_sha256_prefix() {
+        assert!(!verify_signature("secret", b"hello", "deadbeef"));
+    }
+
+    #[test]
+    fn verify_signature_rejects_malformed_hex() {
+        assert!(!verify_signature("secret", b"hello", "sha256=not_valid_hex"));
+    }
+
+    #[test]
+    fn verify_signature_rejects_empty_header() {
+        assert!(!verify_signature("secret", b"hello", ""));
+    }
+
+    #[test]
+    fn constant_time_eq_matches_equal_tokens() {
+        assert!(constant_time_eq(b"my-verify-token", b"my-verify-token"));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_different_tokens_same_length() {
+        assert!(!constant_time_eq(b"my-verify-token1", b"my-verify-token2"));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_different_lengths() {
+        assert!(!constant_time_eq(b"short", b"a-much-longer-token"));
+    }
+
+    #[test]
+    fn constant_time_eq_empty_vs_empty() {
+        assert!(constant_time_eq(b"", b""));
+    }
+}

--- a/agentmux-srv/src/server/messaging_handlers.rs
+++ b/agentmux-srv/src/server/messaging_handlers.rs
@@ -8,6 +8,14 @@
 //!   POST /api/messaging/discord/send    — send a message via the Discord bridge
 //!   POST /api/messaging/telegram/send   — send a message via the Telegram bridge
 //!   POST /api/messaging/slack/send      — send a message via the Slack bridge
+//!   POST /api/messaging/whatsapp/send   — send a message via the WhatsApp bridge
+//!
+//! The WhatsApp *inbound* webhook receiver (`GET`/`POST /webhook/whatsapp`)
+//! is not here — it's unauthenticated by necessity (Meta can't supply
+//! `X-AuthKey`) and lives in `messaging::whatsapp::webhook`, registered
+//! directly on `server/mod.rs`'s top-level router alongside `health`, not in
+//! this authed handler module. See `server/mod.rs` and
+//! `docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md` §8.2.
 
 use axum::{
     extract::State,
@@ -22,6 +30,7 @@ use crate::messaging::{EmbedField, MsgEmbed, MessagingBridge, OutboundMsg};
 use crate::messaging::discord::DiscordBridge;
 use crate::messaging::slack::SlackBridge;
 use crate::messaging::telegram::TelegramBridge;
+use crate::messaging::whatsapp::WhatsAppBridge;
 
 /// GET /api/messaging/status
 pub(super) async fn handle_status(State(_state): State<AppState>) -> impl IntoResponse {
@@ -33,6 +42,9 @@ pub(super) async fn handle_status(State(_state): State<AppState>) -> impl IntoRe
         bridges.push((b as &dyn MessagingBridge).health());
     }
     if let Some(b) = SlackBridge::get() {
+        bridges.push((b as &dyn MessagingBridge).health());
+    }
+    if let Some(b) = WhatsAppBridge::get() {
         bridges.push((b as &dyn MessagingBridge).health());
     }
     Json(json!({ "bridges": bridges }))
@@ -102,6 +114,63 @@ pub(super) async fn handle_discord_send(
         channel_id: req.channel_id,
         reply_to: None,
         embed,
+        edit_message_id: None,
+        blocks: None,
+    };
+
+    match bridge.send(msg) {
+        Ok(()) => Json(json!({ "ok": true })).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/messaging/whatsapp/send
+///
+/// No embed field — WhatsApp's Cloud API has no rich embed format (spec
+/// §5.3, §8.1). `to` maps onto `OutboundMsg.channel_id`, which WhatsApp
+/// repurposes as "recipient phone number" since the platform has no
+/// channel/room concept (see that field's doc comment in `messaging/mod.rs`).
+#[derive(Deserialize)]
+pub(super) struct WhatsAppSendRequest {
+    /// Recipient phone number, E.164 format preferred (e.g. "+14155552671").
+    #[serde(default)]
+    pub to: String,
+    #[serde(default)]
+    pub text: String,
+}
+
+pub(super) async fn handle_whatsapp_send(
+    State(_state): State<AppState>,
+    Json(req): Json<WhatsAppSendRequest>,
+) -> impl IntoResponse {
+    let bridge = match WhatsAppBridge::get() {
+        Some(b) => b,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error": "whatsapp bridge not initialized — set messaging:whatsapp:enabled in settings"})),
+            )
+                .into_response();
+        }
+    };
+
+    if req.to.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "whatsapp send: \"to\" (recipient phone number) is required"})),
+        )
+            .into_response();
+    }
+
+    let msg = OutboundMsg {
+        text: req.text,
+        channel_id: req.to,
+        reply_to: None,
+        embed: None,
         edit_message_id: None,
         blocks: None,
     };

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -330,6 +330,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/messaging/discord/send", post(messaging_handlers::handle_discord_send))
         .route("/api/messaging/telegram/send", post(messaging_handlers::handle_telegram_send))
         .route("/api/messaging/slack/send", post(messaging_handlers::handle_slack_send))
+        .route("/api/messaging/whatsapp/send", post(messaging_handlers::handle_whatsapp_send))
         // Persistent cron scheduler (SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2.4).
         // Auth-gated like reactive routes.
         .route("/agentmux/cron", post(cron::handle_cron_create))
@@ -346,8 +347,25 @@ pub fn build_router(state: AppState) -> Router {
     // Health endpoint (no auth)
     let health = Router::new().route("/", get(health_handler));
 
+    // WhatsApp Cloud API webhook receiver (no auth). Meta's servers call
+    // these directly and cannot supply the X-AuthKey header auth_middleware
+    // requires, so — like `health` — these must be merged at the top level,
+    // outside `authed_routes`'s `route_layer(auth_middleware)`, not added to
+    // that router. The GET handshake and POST delivery are authenticated by
+    // a different mechanism suited to a third party AgentMux doesn't
+    // control the request format of: hub.verify_token comparison on GET,
+    // and HMAC-SHA256(app_secret, raw_body) signature validation on every
+    // POST (see messaging/whatsapp/webhook.rs). See
+    // docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md §8.2.
+    let whatsapp_webhooks = Router::new().route(
+        "/webhook/whatsapp",
+        get(crate::messaging::whatsapp::handle_verify)
+            .post(crate::messaging::whatsapp::handle_inbound),
+    );
+
     Router::new()
         .merge(health)
+        .merge(whatsapp_webhooks)
         .merge(authed_routes)
         .layer(cors)
         .with_state(state)


### PR DESCRIPTION
## Summary
- Implements the WhatsApp messaging bridge per [`SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_MESSAGING_INTEGRATION_WHATSAPP_2026_07_07.md)'s headline recommendation: **Cloud API only** — the unofficial Baileys path is deliberately not implemented (Node-runtime dependency this app has never had, worse ban-risk math than the original plan credited).
- `WhatsAppBridge` implements the `MessagingBridge` trait, mirroring Discord/Telegram/Slack's `OnceLock` singleton + mpsc + `Arc<Mutex<BridgeHealth>>` shape.
- **Webhook receiver at `GET/POST /webhook/whatsapp`**, registered *outside* `auth_middleware` (merged at the top level alongside the existing unauthenticated `health` router) — Meta's servers can't supply the `X-AuthKey` header the rest of `/api/messaging/*` requires, so these routes authenticate a different way: `hub.verify_token` comparison on the GET handshake, HMAC-SHA256(app_secret, raw body) signature validation via `X-Hub-Signature-256` on every POST. The body is read as raw `Bytes`, not deserialized-then-checked, so the signature validates exactly what Meta signed.
- Constant-time comparisons throughout: the HMAC check uses `hmac`'s `Mac::verify_slice` (backed by `subtle`, already a transitive dependency — no new crate), the `hub.verify_token` check uses a hand-rolled constant-time byte comparison (not worth a dependency for six lines).
- 24-hour messaging-window tracking (free-form sends only within 24h of the last inbound message from that user) with template-message fallback outside the window.
- Outbound via the Graph API, embed-to-plain-text flattening for the shared `MsgEmbed` type (WhatsApp has no native rich-message format).
- **Scoped down from the spec's full design**: automated Cloudflare Tunnel subprocess management (spawn/supervise/auto-register) is not implemented — v1 assumes the operator has already set up their own tunnel and registered the callback URL + verify token in Meta's dashboard manually. This can't be meaningfully built or verified without live Cloudflare/Meta credentials; the webhook verification, signature validation, event routing, window tracking, and send path (the parts that can be fully implemented and correctness-tested) are complete.
- Config: 8 new `messaging:whatsapp:*` flat keys. New `POST /api/messaging/whatsapp/send` endpoint (authenticated, unlike the webhook routes). Dropped `"(bridge Phase 3)"` from the WhatsApp pane's widget description.

Tracked in discussion #2020.

## Test plan
- [x] `cargo check -p agentmux-srv` passes clean
- [x] `cargo test --bin agentmux-srv messaging::whatsapp` — 22 passed, including a known-good HMAC signature test vector and constant-time-comparison edge cases (equal, different, different-length, empty)
- [ ] Manual: with a real Meta Business account, phone number, and a manually-configured tunnel, confirm the verification handshake succeeds, an inbound WhatsApp message is injected into the reactive bus, and a reply via `POST /api/messaging/whatsapp/send` is delivered within the 24h window (no live Meta/WhatsApp infra available in this environment to verify end-to-end myself)