### PR TITLE
feat(mcp): protocol-level health probe (mcp.probe/mcp.catalog.probe) + mcp-capabilities.ts

### DIFF
--- a/.changesets/1783484561-feat-mcp-probe-app-api-mcp-capabilities-ts-mcp-server-health-6898.md
+++ b/.changesets/1783484561-feat-mcp-probe-app-api-mcp-capabilities-ts-mcp-server-health-6898.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): probe App API + mcp-capabilities.ts — MCP server health check (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08)

--- a/agentmux-srv/src/backend/mcp_probe.rs
+++ b/agentmux-srv/src/backend/mcp_probe.rs
@@ -129,7 +129,12 @@ async fn probe_stdio(config: &Value) -> ProbeResult {
         .unwrap_or_default();
 
     let mut cmd = Command::new(command);
-    cmd.args(&args).envs(env).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null());
+    cmd.args(&args)
+        .envs(env)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,

--- a/agentmux-srv/src/backend/mcp_probe.rs
+++ b/agentmux-srv/src/backend/mcp_probe.rs
@@ -1,0 +1,323 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! MCP server health/prerequisite probe
+//! (docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md §4.4).
+//!
+//! Opens a short-lived MCP client connection to a configured server — spawns
+//! the stdio process (or POSTs to the http url), performs the `initialize`
+//! handshake, then `tools/list` — and reports whether it's reachable at all.
+//!
+//! This is a protocol-level probe only. For a server like ableton-mcp, a
+//! successful probe means the MCP process itself started and speaks the
+//! protocol — NOT that the underlying app (Ableton Live) is running, since
+//! that dependency is only exercised when a tool is actually called. That
+//! gap is why the catalog's `prereq_note` (static remediation text, §4.6)
+//! exists alongside this dynamic check, not instead of it.
+//!
+//! Deliberately hand-rolled rather than pulling in an MCP client SDK crate
+//! (e.g. `rmcp`): `agentmux-mcp/src/main.rs` already hand-rolls the *server*
+//! side of this exact newline-delimited JSON-RPC 2.0 wire format, so a
+//! probe-only client follows the same house style instead of adding a new
+//! dependency for a handshake this small.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(8);
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeStatus {
+    Connected,
+    Unreachable,
+    HandshakeFailed,
+    InvalidConfig,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProbeResult {
+    pub status: ProbeStatus,
+    pub tool_count: Option<usize>,
+    pub server_name: Option<String>,
+    pub server_version: Option<String>,
+    pub error: Option<String>,
+}
+
+impl ProbeResult {
+    fn empty(status: ProbeStatus, error: Option<String>) -> Self {
+        Self { status, tool_count: None, server_name: None, server_version: None, error }
+    }
+    fn invalid(msg: impl Into<String>) -> Self {
+        Self::empty(ProbeStatus::InvalidConfig, Some(msg.into()))
+    }
+    fn unreachable(msg: impl Into<String>) -> Self {
+        Self::empty(ProbeStatus::Unreachable, Some(msg.into()))
+    }
+    fn handshake_failed(msg: impl Into<String>) -> Self {
+        Self::empty(ProbeStatus::HandshakeFailed, Some(msg.into()))
+    }
+    fn connected(server_name: Option<String>, server_version: Option<String>, tool_count: Option<usize>) -> Self {
+        Self { status: ProbeStatus::Connected, tool_count, server_name, server_version, error: None }
+    }
+}
+
+/// Probe a server given its `transport` (`"stdio"` | `"http"` | `"sse"` |
+/// any other free-text value from the pre-v11 field, treated as stdio for
+/// back-compat) and its raw `config` JSON blob — the exact object
+/// `agent_config::build_mcp_config_from_refs` merges into `.mcp.json`.
+pub async fn probe(transport: &str, config_json: &str) -> ProbeResult {
+    let config: Value = match serde_json::from_str(config_json) {
+        Ok(v) => v,
+        Err(e) => return ProbeResult::invalid(format!("config is not valid JSON: {e}")),
+    };
+
+    let is_http = matches!(transport, "http" | "sse" | "streamable-http") || config.get("url").is_some();
+
+    let outcome = if is_http {
+        timeout(PROBE_TIMEOUT, probe_http(&config)).await
+    } else {
+        timeout(PROBE_TIMEOUT, probe_stdio(&config)).await
+    };
+
+    match outcome {
+        Ok(result) => result,
+        Err(_) => ProbeResult::handshake_failed(format!("no response within {}s", PROBE_TIMEOUT.as_secs())),
+    }
+}
+
+fn initialize_request() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": { "name": "agentmux-probe", "version": env!("CARGO_PKG_VERSION") },
+        },
+    })
+}
+
+fn tools_list_request() -> Value {
+    json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} })
+}
+
+// ── stdio ────────────────────────────────────────────────────────────────
+
+async fn probe_stdio(config: &Value) -> ProbeResult {
+    let command = match config.get("command").and_then(|v| v.as_str()) {
+        Some(c) if !c.is_empty() => c,
+        _ => return ProbeResult::invalid("stdio config missing a non-empty \"command\" string"),
+    };
+    let args: Vec<String> = config
+        .get("args")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str().map(str::to_string)).collect())
+        .unwrap_or_default();
+    let env: Vec<(String, String)> = config
+        .get("env")
+        .and_then(|v| v.as_object())
+        .map(|m| m.iter().filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string()))).collect())
+        .unwrap_or_default();
+
+    let mut cmd = Command::new(command);
+    cmd.args(&args).envs(env).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return ProbeResult::unreachable(format!("failed to start \"{command}\": {e}")),
+    };
+
+    let mut stdin = match child.stdin.take() {
+        Some(s) => s,
+        None => return ProbeResult::unreachable("failed to open child stdin"),
+    };
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => return ProbeResult::unreachable("failed to open child stdout"),
+    };
+    let mut reader = BufReader::new(stdout);
+
+    let result = run_stdio_handshake(&mut stdin, &mut reader).await;
+    let _ = child.start_kill(); // probe is ephemeral — never leave it running
+    result
+}
+
+async fn run_stdio_handshake<W, R>(stdin: &mut W, reader: &mut R) -> ProbeResult
+where
+    W: AsyncWrite + Unpin,
+    R: AsyncBufRead + Unpin,
+{
+    if let Err(e) = write_line(stdin, &initialize_request()).await {
+        return ProbeResult::unreachable(format!("failed to write initialize request: {e}"));
+    }
+    let init_resp = match read_json_line(reader).await {
+        Ok(Some(v)) => v,
+        Ok(None) => return ProbeResult::handshake_failed("process closed stdout before responding to initialize"),
+        Err(e) => return ProbeResult::handshake_failed(format!("failed to read initialize response: {e}")),
+    };
+    if let Some(err) = init_resp.get("error") {
+        return ProbeResult::handshake_failed(format!("server rejected initialize: {err}"));
+    }
+    let server_info = init_resp.pointer("/result/serverInfo").cloned().unwrap_or(Value::Null);
+    let server_name = server_info.get("name").and_then(|v| v.as_str()).map(str::to_string);
+    let server_version = server_info.get("version").and_then(|v| v.as_str()).map(str::to_string);
+
+    // notifications/initialized has no id and expects no response — best-effort.
+    let _ = write_line(stdin, &json!({"jsonrpc": "2.0", "method": "notifications/initialized"})).await;
+
+    if write_line(stdin, &tools_list_request()).await.is_err() {
+        // The handshake itself already succeeded even if tools/list couldn't be sent.
+        return ProbeResult::connected(server_name, server_version, None);
+    }
+    let tool_count = match read_json_line(reader).await {
+        Ok(Some(v)) => v.pointer("/result/tools").and_then(|t| t.as_array()).map(|a| a.len()),
+        _ => None,
+    };
+
+    ProbeResult::connected(server_name, server_version, tool_count)
+}
+
+async fn write_line<W: AsyncWrite + Unpin>(w: &mut W, v: &Value) -> std::io::Result<()> {
+    let s = serde_json::to_string(v).unwrap_or_default();
+    w.write_all(s.as_bytes()).await?;
+    w.write_all(b"\n").await?;
+    w.flush().await
+}
+
+/// Reads lines until one parses as JSON (skipping blank lines or stray
+/// non-JSON output, e.g. a server printing a startup banner to stdout),
+/// or the stream closes.
+async fn read_json_line<R: AsyncBufRead + Unpin>(r: &mut R) -> std::io::Result<Option<Value>> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = r.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+            return Ok(Some(v));
+        }
+    }
+}
+
+// ── http (Streamable HTTP transport) ────────────────────────────────────
+
+async fn probe_http(config: &Value) -> ProbeResult {
+    let url = match config.get("url").and_then(|v| v.as_str()) {
+        Some(u) if !u.is_empty() => u,
+        _ => return ProbeResult::invalid("http config missing a non-empty \"url\" string"),
+    };
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Some(h) = config.get("headers").and_then(|v| v.as_object()) {
+        for (k, v) in h {
+            let (Ok(name), Some(val)) = (reqwest::header::HeaderName::from_bytes(k.as_bytes()), v.as_str()) else {
+                continue;
+            };
+            if let Ok(hv) = reqwest::header::HeaderValue::from_str(val) {
+                headers.insert(name, hv);
+            }
+        }
+    }
+    let client = match reqwest::Client::builder().default_headers(headers).timeout(PROBE_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => return ProbeResult::invalid(format!("failed to build http client: {e}")),
+    };
+
+    let init_resp = match post_jsonrpc(&client, url, &initialize_request()).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if let Some(err) = init_resp.get("error") {
+        return ProbeResult::handshake_failed(format!("server rejected initialize: {err}"));
+    }
+    let server_info = init_resp.pointer("/result/serverInfo").cloned().unwrap_or(Value::Null);
+    let server_name = server_info.get("name").and_then(|v| v.as_str()).map(str::to_string);
+    let server_version = server_info.get("version").and_then(|v| v.as_str()).map(str::to_string);
+
+    let tool_count = match post_jsonrpc(&client, url, &tools_list_request()).await {
+        Ok(v) => v.pointer("/result/tools").and_then(|t| t.as_array()).map(|a| a.len()),
+        Err(_) => None, // reachability + handshake already proven above
+    };
+
+    ProbeResult::connected(server_name, server_version, tool_count)
+}
+
+/// POSTs one JSON-RPC request and returns the first JSON object in the
+/// response body — handling both a plain `application/json` body and a
+/// Streamable HTTP `text/event-stream` framing (`event: message\ndata:
+/// {...}\n\n`), since a probe only needs the first frame either way.
+async fn post_jsonrpc(client: &reqwest::Client, url: &str, req: &Value) -> Result<Value, ProbeResult> {
+    let resp = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(req)
+        .send()
+        .await
+        .map_err(|e| ProbeResult::unreachable(format!("request failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        return Err(ProbeResult::handshake_failed(format!("server returned HTTP {}", resp.status())));
+    }
+    let body = resp.text().await.map_err(|e| ProbeResult::handshake_failed(format!("failed to read response body: {e}")))?;
+    let json_line = body.lines().find(|l| l.trim_start().starts_with('{')).unwrap_or(body.trim());
+    serde_json::from_str(json_line).map_err(|e| ProbeResult::handshake_failed(format!("non-JSON response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_json_config_is_reported_as_invalid_config() {
+        let result = probe("stdio", "{not json").await;
+        assert!(matches!(result.status, ProbeStatus::InvalidConfig));
+        assert!(result.error.unwrap().contains("not valid JSON"));
+    }
+
+    #[tokio::test]
+    async fn stdio_config_missing_command_is_invalid() {
+        let result = probe("stdio", "{}").await;
+        assert!(matches!(result.status, ProbeStatus::InvalidConfig));
+        assert!(result.error.unwrap().contains("command"));
+    }
+
+    #[tokio::test]
+    async fn stdio_config_with_unresolvable_binary_is_unreachable() {
+        let config = json!({ "command": "definitely-not-a-real-agentmux-probe-binary-xyz" }).to_string();
+        let result = probe("stdio", &config).await;
+        assert!(matches!(result.status, ProbeStatus::Unreachable), "expected Unreachable, got {:?}", result.status);
+    }
+
+    #[tokio::test]
+    async fn http_config_missing_url_is_invalid() {
+        let result = probe("http", "{}").await;
+        assert!(matches!(result.status, ProbeStatus::InvalidConfig));
+        assert!(result.error.unwrap().contains("url"));
+    }
+
+    #[tokio::test]
+    async fn http_transport_is_inferred_from_url_field_even_without_explicit_kind() {
+        // transport is still the free-text pre-v11 field; a config that
+        // carries "url" should route to the http probe regardless of what
+        // (if anything) the transport string says.
+        let config = json!({ "url": "http://127.0.0.1:1/nonexistent" }).to_string();
+        let result = probe("stdio", &config).await;
+        assert!(matches!(result.status, ProbeStatus::Unreachable), "expected Unreachable, got {:?}", result.status);
+    }
+}

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -5,6 +5,7 @@
 pub mod agent_config;
 pub mod agent_session;
 pub mod blockcontroller;
+pub mod mcp_probe;
 /// Phase E.4.B Phase 4 — pure layout-tree helpers (Rust port of layoutTree.ts).
 pub mod layout;
 pub mod providers;

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -336,12 +336,17 @@ pub const COMMAND_MCP_UPSERT: &str = "mcp.upsert";
 pub const COMMAND_MCP_DELETE: &str = "mcp.delete";
 pub const COMMAND_MCP_BIND: &str = "mcp.bind";
 pub const COMMAND_MCP_UNBIND: &str = "mcp.unbind";
+// Health/prerequisite probe (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md §4.4):
+// opens a short-lived MCP client connection and reports whether the server
+// actually speaks the protocol, distinct from "does the JSON parse."
+pub const COMMAND_MCP_PROBE: &str = "mcp.probe";
 
 // App API — Armory-level MCP Server catalog (global servers only,
 // window-scoped — no agent_id, no check_s1 — mirrors bundle.* auth shape).
 pub const COMMAND_MCP_CATALOG_LIST: &str = "mcp.catalog.list";
 pub const COMMAND_MCP_CATALOG_UPSERT: &str = "mcp.catalog.upsert";
 pub const COMMAND_MCP_CATALOG_DELETE: &str = "mcp.catalog.delete";
+pub const COMMAND_MCP_CATALOG_PROBE: &str = "mcp.catalog.probe";
 
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -380,7 +380,7 @@ fn register_mcp_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 if let Some(existing) = wstore.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.catalog.delete: {e}"))?
                 {
-    if !existing.is_global {
+                    if !existing.is_global {
                         return Err("FORBIDDEN: cannot delete a private MCP server via the catalog".to_string());
                     }
                 }

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -17,9 +17,11 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_mcp_delete(engine, state);
     register_mcp_bind(engine, state);
     register_mcp_unbind(engine, state);
+    register_mcp_probe(engine, state);
     register_mcp_catalog_list(engine, state);
     register_mcp_catalog_upsert(engine, state);
     register_mcp_catalog_delete(engine, state);
+    register_mcp_catalog_probe(engine, state);
 }
 
 fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -240,6 +242,38 @@ fn register_mcp_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
+/// Health/prerequisite probe for one of this agent's own or bound-global
+/// servers (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md §4.4).
+/// Opens a short-lived MCP connection and reports whether the server
+/// actually speaks the protocol — distinct from `mcp.upsert`'s "is this
+/// valid JSON" check, which tells you nothing about reachability.
+fn register_mcp_probe(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_PROBE,
+        Box::new(move |data, ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.probe: {e}"))?;
+                check_s1(&ctx, &req.agent_id)?;
+                if !wstore.mcp_server_is_accessible_to(&req.agent_id, &req.id)
+                    .map_err(|e| format!("mcp.probe: {e}"))?
+                {
+                    return Err("FORBIDDEN: MCP server not accessible to this agent".to_string());
+                }
+                let server = wstore.mcp_server_get(&req.id)
+                    .map_err(|e| format!("mcp.probe: {e}"))?
+                    .ok_or_else(|| "mcp.probe: MCP server not found".to_string())?;
+                let result = crate::backend::mcp_probe::probe(&server.transport, &server.config).await;
+                Ok(Some(serde_json::to_value(&result).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
 fn register_mcp_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     engine.register_handler(
@@ -346,7 +380,7 @@ fn register_mcp_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 if let Some(existing) = wstore.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.catalog.delete: {e}"))?
                 {
-                    if !existing.is_global {
+    if !existing.is_global {
                         return Err("FORBIDDEN: cannot delete a private MCP server via the catalog".to_string());
                     }
                 }
@@ -359,6 +393,35 @@ fn register_mcp_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     });
                 }
                 Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+}
+
+/// Health/prerequisite probe for a global catalog server, callable without
+/// an agent context (mirrors mcp.catalog.*'s window-scoped, no-`check_s1`
+/// shape) — this is what lets the Armory's MCP Servers tab show a
+/// connected/error status per row before any agent has bound the server.
+/// See SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md §4.4.
+fn register_mcp_catalog_probe(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_PROBE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.catalog.probe: {e}"))?;
+                let server = wstore.mcp_server_get(&req.id)
+                    .map_err(|e| format!("mcp.catalog.probe: {e}"))?
+                    .ok_or_else(|| "mcp.catalog.probe: MCP server not found".to_string())?;
+                if !server.is_global {
+                    return Err("FORBIDDEN: mcp.catalog.probe only probes global servers".to_string());
+                }
+                let result = crate::backend::mcp_probe::probe(&server.transport, &server.config).await;
+                Ok(Some(serde_json::to_value(&result).map_err(|e| e.to_string())?))
             })
         }),
     );

--- a/docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md
+++ b/docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md
@@ -1,0 +1,176 @@
+# Spec: MCP integration parity with Claude Desktop / Cursor, piloted on Ableton MCP
+
+**Date:** 2026-07-08
+**Author:** Agent1
+**Status:** Proposal
+**Related:** `agentmux-srv/src/server/app_api/mcp.rs`, `agentmux-srv/src/backend/storage/mcp_servers.rs`, `agentmux-srv/src/backend/agent_config.rs`, `frontend/app/view/mcp/`, `frontend/app/view/agent/agent-mcp-model.ts`, `frontend/app/store/toolchain-capabilities.ts`, `frontend/app/view/accounts/oauth-catalog.ts`
+**Governing context:** `docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md` (MCP Server is a first-class composable-model primitive as of Phase 1, PR #1877), `docs/specs/EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md` (Armory IA, deferred **Policy** primitive), `docs/specs/SPEC_RENAME_TRUST_CENTER_TO_ARMORY_2026_07_02.md` (Armory umbrella)
+
+---
+
+## 1. Summary
+
+AgentMux's MCP Server primitive today is a **name + transport string + opaque JSON blob**, hand-typed by the user and merged verbatim into `.mcp.json`. That covers the mechanical case (an already-correct JSON snippet gets to the agent) but covers none of what makes Claude Desktop's and Cursor's MCP integrations *usable*: structured config with variable interpolation, OAuth for remote servers, a health/prerequisite check before the agent ever calls a tool, tool-level introspection and approval, and a catalog/one-click-install flow instead of "paste JSON here."
+
+This spec (a) inventories that gap against Claude Desktop and Cursor's current (mid-2026) feature sets, (b) proposes an incremental design that extends the existing `McpServer` primitive rather than replacing it, and (c) uses **[ahujasid/ableton-mcp](https://github.com/ahujasid/ableton-mcp)** as the first real-world integration to build and validate against, because it exercises the single gap that matters most and is currently invisible: an **external, AgentMux-uncontrollable prerequisite** (Ableton Live running, with a manually-installed Remote Script selected as the active Control Surface) that today fails silently as a hung or cryptic tool call three turns into a conversation, instead of a clear, actionable status in the Armory before the agent ever tries.
+
+---
+
+## 2. Current state (as of `a9eb7da9`, 2026-07-08)
+
+The v1 composable-model `McpServer` primitive (Phase 1 of the Preset→Bundle refactor, already shipped):
+
+- **Storage** (`mcp_servers.rs`, `migrations.rs:416-441`): `db_mcp_servers(id, name, transport TEXT DEFAULT 'stdio', config TEXT DEFAULT '{}', is_global, created_at, updated_at)` + `db_agent_mcp_ref(agent_id, mcp_id)` bind table. `config` is an opaque JSON string — the store never looks inside it.
+- **App API** (`app_api/mcp.rs`): `mcp.list/get/upsert/delete/bind/unbind` (agent-scoped, `check_s1`-gated) + `mcp.catalog.list/upsert/delete` (window-scoped, global rows only — the Armory's **MCP Servers** tab, `armory-view.tsx:20`).
+- **Launch-time merge** (`agent_config.rs:320` `build_mcp_config_from_refs`): synthesizes the reserved `agentmux` entry, layers the legacy blob, then layers each bound `McpServer.config` **as-is** under `mcpServers.<name>` in `.mcp.json`. Whatever JSON the user typed is whatever Claude Code receives — AgentMux never validates it beyond "is it a JSON object."
+- **UI** (`AgentMcpModal.tsx`, `mcp-manager.tsx`): a name field, a free-text transport field (defaults `"stdio"`, not validated against known values), and a raw JSON `<textarea>` for `config`. No connect test, no tool list, no distinction between `stdio`/`sse`/`streamable-http` beyond what the user happens to type inside the blob.
+
+**What this means concretely:** adding a server that needs an env var means pasting a literal secret into the textarea (stored in SQLite in plaintext); adding a remote OAuth-authenticated server means the user must obtain a token out-of-band and paste it into a `headers` object by hand; and there is **no feedback loop** — `mcp.upsert` succeeds as long as the JSON parses, whether or not the server is real, reachable, or ever starts. `toolchain-capabilities.ts` already solved exactly this "is X actually available right now" problem for CLI toolchains (path probe + liveness probe, cached, shared, pollable) — nothing analogous exists for MCP servers.
+
+---
+
+## 3. Feature inventory: Claude Desktop / Cursor vs. AgentMux today
+
+| Capability | Claude Desktop (2026) | Cursor (2026) | AgentMux today | Gap |
+|---|---|---|---|---|
+| Structured stdio config (command/args/env) | Yes (`.mcpb`/DXT manifest or manual JSON) | Yes, `mcpServers.<name>.{command,args,env}` | Raw JSON blob only — same shape is *possible* but the UI never structures it | UI/validation gap |
+| Remote transport (Streamable HTTP) | Yes — Custom Connectors, MCP protocol 2025-11-25 | Yes — `url` + `headers` | Possible via raw JSON (`transport` field is a free string, unvalidated) | No structured remote form, no transport enum |
+| Variable interpolation (`${env:VAR}`, `${workspaceFolder}`, etc.) | N/A (manifest-based, not textual interpolation) | Yes — resolves in `command`/`args`/`env`/`url`/`headers` | **None** — secrets must be typed literally into the JSON blob | **Critical: plaintext secrets in DB** |
+| OAuth — dynamic client registration | Yes, directory connectors auto-handle it | Yes (DCR, falling back to static creds) | **None** — no OAuth flow wired to the MCP primitive at all (AgentMux *has* a general OAuth flow for Accounts, `oauth-catalog.ts` + `oauth_client.rs`, but it is not reachable from MCP server setup) | Missing entirely |
+| OAuth — static client id/secret fallback | Advanced settings on custom connector | `auth` object in `mcp.json` (`CLIENT_ID`/`CLIENT_SECRET`/scopes) | None | Missing entirely |
+| One-click install / catalog | Connectors directory (439+ verified integrations, 2-click OAuth) + `.dxt`/`.mcpb` double-click install | "Add Custom MCP" editor + community list links | Manual JSON only; Armory catalog only stores what a human already typed | Missing entirely |
+| Health / liveness check before use | Implicit — connector shows connected/error state | Server list shows "Needs login" / error states | **None** — `mcp.upsert` only validates JSON syntax; a broken/unreachable server is indistinguishable from a working one until an agent tries to call it | **Critical UX gap — this is what the Ableton pilot targets** |
+| Tool/resource/prompt introspection | Yes — tool list shown per connector | Yes — "MCP Tools" panel lists discovered tools | None — AgentMux never queries the server's `tools/list`; the config is trusted blind | Missing entirely |
+| Per-tool / per-call approval | Permission prompt per tool call, scoped review at OAuth grant time | Prompt per tool call by default; "Yolo mode" to bypass; CLI `--approve-mcps` | None at the MCP layer (general tool-call UI exists — `ToolOverlayLog.tsx` — but has no approval gate concept) | Missing; intersects the deferred **Policy** primitive (`EXPLAINER_COMPOSABLE_MODEL…md` §7 item 2) |
+| Trust pinned to resolved command, not just name (anti "MCPoison"/CVE-2025-54136) | N/A (sandboxed manifest execution) | Patched post-CVE — re-prompts on config change | **Partially accidental**: `is_global` servers are immutable to non-owners (`mcp.upsert` rejects mutating a global server) and per-agent private servers require an existing bind ref to edit — but there is no explicit "this config changed since you approved it" signal | Needs explicit config-hash pinning |
+| Secrets never stored in plaintext | Enforced by connector/manifest model | Guidance-level (`${env:VAR}`) — still opt-in | Config blob stores literal values including secrets | Needs env-ref indirection into AgentMux's existing Account credential store |
+
+---
+
+## 4. Design
+
+The guiding principle: **extend, don't replace.** `McpServer{id, name, transport, config, is_global}` stays the wire contract that `build_mcp_config_from_refs` merges into `.mcp.json` — every change below either adds optional structure *around* `config` or adds new fields that are additive at the DB/App-API layer, matching how MCP Servers + Skills were bolted on as primitives in Phase 1 without disturbing the older preset blob path.
+
+### 4.1 Structured config + variable interpolation
+
+Add a `kind: "stdio" | "http"` (replaces the free-text `transport` string, with `"stdio"` as the migrated default) and let the UI render one of two structured forms instead of a bare textarea:
+
+- **stdio:** `command`, `args[]`, `env{}` (key/value rows, not one JSON blob)
+- **http:** `url`, `headers{}`
+
+Both forms still serialize to exactly the JSON object `agent_config.rs` already merges — no backend change to the merge path. The textarea remains available as an "Advanced / raw JSON" escape hatch (parity with Cursor, which lets you hand-edit `mcp.json` directly even though it also has structured UI).
+
+Interpolation: support `${env:NAME}` inside `command`/`args`/`env`/`url`/`headers` values, resolved **at agent-launch config-build time** in `agent_config.rs` (not at rest) — so a value like `{"env": {"API_KEY": "${env:ABLETON_API_KEY}"}}` never persists a secret to SQLite. `${agentHome}`/`${workspaceFolder}` resolve the same way Cursor's do, using values `agent_config.rs` already has in scope for this agent.
+
+### 4.2 Secrets via the existing Account primitive, not new plaintext storage
+
+Rather than inventing a parallel secrets store, let an MCP server's `env`/`headers` values reference an **Account** (already a first-class primitive with its own encrypted-at-rest credential handling per `SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md`) by id: `${account:<id>:token}`. This reuses infrastructure instead of building a second vault, and matches the composable-model philosophy ("reference, don't copy" — `EXPLAINER_COMPOSABLE_MODEL…md` §2).
+
+### 4.3 OAuth for remote (`http`) MCP servers
+
+Generalize the Accounts OAuth flow (`identity/oauth_client.rs` `config_for`, `oauth-catalog.ts`) from "known providers" (GitHub/Google/Slack) to **arbitrary remote MCP servers**, mirroring both vendors' two paths:
+
+- **Dynamic Client Registration** (Cursor's default, matches MCP spec's DCR flow) — attempt first.
+- **Static client id/secret fallback** (Cursor's `auth` object; Claude Desktop's "Advanced settings" on a custom connector) — when DCR isn't supported, the Armory MCP-server form collects `client_id`/`client_secret`/scopes and stores them as an Account, same as today's BYO OAuth path.
+
+Redirect URI: reuse the existing AgentMux desktop-app callback scheme (already wired for Account OAuth) rather than inventing a second one, and identify the in-flight server the same way Cursor does — via the OAuth `state` param — since AgentMux, like Cursor, is a desktop app with one native callback handler.
+
+### 4.4 Health / prerequisite probe
+
+New App API command `mcp.probe(agent_id, id)`: opens a short-lived MCP client connection, performs the `initialize` handshake, and — on success — `tools/list` (and `resources/list`/`prompts/list` where the server declares those capabilities). Returns `{status: "connected"|"unreachable"|"handshake_failed", tool_count, resource_count, prompt_count, server_info, error}`.
+
+Frontend: a new `mcp-capabilities.ts` module, structurally identical to `toolchain-capabilities.ts` (module-level `createStore`, `ensureCapability`/`watchCapability`, in-flight de-dup) — same pattern, new domain. The Armory MCP Servers list gets a status pill per server (Connected · N tools / Not connected / Error) instead of the current name-only row, polling while the Armory tab is open the same way the Toolchain widget polls Docker liveness.
+
+This is the piece the Ableton pilot is written to prove out end-to-end (§6).
+
+### 4.5 Tool/resource/prompt introspection + approval gate
+
+`mcp.probe`'s tool list feeds two things:
+
+1. **Read-only display** in the Armory (what does this server actually offer) and in the per-agent MCP tab (what will this agent be able to call) — parity with Cursor's "MCP Tools" panel and Claude's per-connector tool list.
+2. **Per-tool enable/disable**, stored as a new `disabled_tools: string[]` field on the agent↔server bind row (`db_agent_mcp_ref`) — an agent can bind a server but suppress specific tools, same granularity Claude Desktop offers per connector.
+
+Full per-call **approval prompting** (Cursor's "click Run tool to proceed" / Claude's permission dialog) is **out of scope for this spec's Phase A–C** — it is correctly the deferred **Policy** primitive's job (`EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md` §7 item 2: "hooks + `.claude/settings.json` permissions... deferred to a later phase"). This spec only prepares the ground: `disabled_tools` and the introspected tool list are exactly the inputs a future Policy primitive needs, so they should land now even though enforcement lands later.
+
+### 4.6 Catalog / one-click install
+
+A small built-in manifest catalog (Armory → MCP Servers → "+ Browse catalog", alongside the existing "+ New MCP server"), each entry describing: display name, `kind`, templated `config` (with `${...}` placeholders for anything user-specific), required env vars with human labels, a free-text **prerequisites** field, and a docs link. Selecting an entry pre-fills the structured form (§4.1) instead of requiring the user to author JSON from scratch — this is AgentMux's analogue of Claude's Connectors directory and Smithery-style `npx @smithery/cli install`, scoped down to "pre-filled form," not a remote package registry (no new supply-chain trust surface introduced by this spec).
+
+### 4.7 Trust hardening (config-hash pinning)
+
+Record a hash of the resolved `(command, args, config)` tuple at bind time. If a **global** server's config changes after an agent has bound it, `mcp.list` flags it `needs_reapproval: true` instead of silently picking up the new command on next launch — directly closing the CVE-2025-54136 ("MCPoison") pattern where trust was bound to a server *name* rather than what it actually executes. New entries appearing in a global catalog already require an explicit bind (§ current state) — this closes the "already-bound server gets silently redefined" gap CVE-2025-54135 also touched on.
+
+---
+
+## 5. Data model changes
+
+Additive only — no destructive migration:
+
+```sql
+-- db_mcp_servers: transport stays TEXT but the value set narrows to "stdio"|"http";
+-- existing free-text values that aren't one of those two stay valid (raw-JSON escape hatch).
+ALTER TABLE db_mcp_servers ADD COLUMN config_hash   TEXT NOT NULL DEFAULT '';
+ALTER TABLE db_mcp_servers ADD COLUMN prereq_note   TEXT NOT NULL DEFAULT ''; -- catalog-sourced remediation text (§4.4/§6)
+
+-- db_agent_mcp_ref: per-bind state, not per-server
+ALTER TABLE db_agent_mcp_ref ADD COLUMN disabled_tools TEXT NOT NULL DEFAULT '[]'; -- JSON string[]
+ALTER TABLE db_agent_mcp_ref ADD COLUMN approved_hash  TEXT NOT NULL DEFAULT ''; -- config_hash at bind time (§4.7)
+```
+
+No change to `build_mcp_config_from_refs`'s output shape — `config_hash`/`prereq_note`/`disabled_tools`/`approved_hash` are all Armory/App-API-side metadata, never written into `.mcp.json`.
+
+## 6. Real-world pilot: Ableton MCP
+
+**Why this one first.** Ableton MCP is `stdio` transport (no OAuth needed — keeps the pilot decoupled from §4.3, the highest-risk piece), needs no secrets (keeps it decoupled from §4.2), and its entire failure mode today is exactly §4.4's gap: nothing in AgentMux can currently tell a user *why* the agent's tool calls are hanging or erroring when the actual cause is "you haven't opened Ableton Live yet" or "the Remote Script isn't installed in the right folder for your Live version."
+
+**What ahujasid/ableton-mcp requires** (verified against upstream docs, 2026-07-08):
+- Ableton Live 10+, Python 3.8+, `uv`/`uvx` on PATH.
+- A Remote Script (`AbletonMCP_Remote_Script/__init__.py`) manually copied into Ableton's Remote Scripts folder — **Live 10.1.13 through 12 requires the User Library path** (`%USERPROFILE%\Documents\Ableton\User Library\Remote Scripts\AbletonMCP\`), not the older Preferences path, which Live 12+ no longer scans.
+- Ableton's Preferences → Link/MIDI → Control Surface set to `AbletonMCP` (Input/Output: None — it's a socket server, not a MIDI device).
+- A TCP socket on `localhost:9877` (default; user-changeable, but both the Remote Script and the MCP server's config must agree).
+- The MCP server itself: `{"command": "uvx", "args": ["ableton-mcp"]}` — no persisted secret.
+
+**Catalog entry (§4.6):**
+
+```json
+{
+  "name": "Ableton Live",
+  "kind": "stdio",
+  "config": { "command": "uvx", "args": ["ableton-mcp"] },
+  "prereq_note": "Requires Ableton Live 10+ running with the AbletonMCP Remote Script installed and selected as the active Control Surface (Preferences → Link, Tempo & MIDI). See docs link.",
+  "docs_url": "https://github.com/ahujasid/ableton-mcp"
+}
+```
+
+**Health probe (§4.4) applied here:** `mcp.probe` attempts the stdio handshake; `uvx ableton-mcp` starts regardless of Ableton's state (it's the Remote Script's socket connect that fails), so the probe's `handshake_failed` / timeout case is what actually surfaces — the Armory status pill should read **"MCP process started, but Ableton isn't responding on 9877 — is Live running with AbletonMCP selected as Control Surface?"** rather than a bare "Error." This is the concrete acceptance bar for §4.4, not a generic "connected/not connected" toggle: the pilot is done when a user who hasn't opened Ableton yet sees *that* sentence in the Armory, in-app, before ever spawning an agent — not a stack trace three tool calls deep in a transcript.
+
+**Non-goals for the pilot:** no OAuth (not needed), no tool-approval enforcement (§4.5 stays introspection-only for this pilot), no bundling/packaging the Remote Script inside AgentMux — installing it into Ableton's folder remains a documented manual step (linked from `prereq_note`), same as it is for every other MCP client; AgentMux does not attempt to write into a third-party app's data directory on the user's behalf.
+
+## 7. Phasing
+
+| Phase | Scope | Depends on |
+|---|---|---|
+| **A** | §4.1 structured config UI + interpolation, §4.4 health probe + `mcp-capabilities.ts`, §5 migration | none — pure additive extension of the shipped Phase 1 primitive |
+| **B** | §4.6 catalog UI + the Ableton catalog entry + pilot acceptance bar (§6) | Phase A (needs the probe to render the remediation string) |
+| **C** | §4.2 secrets-via-Account indirection, §4.3 OAuth (DCR + static fallback) | Phase A; reuses existing Account/OAuth infra, additive |
+| **D** | §4.5 tool introspection/disable, §4.7 config-hash pinning | Phase A; D's approval-gate *enforcement* is explicitly deferred to the future Policy primitive — D here only stores the data it needs |
+
+Ableton MCP (Phase B) intentionally ships **before** OAuth (Phase C) — it validates the highest-value, lowest-risk slice (structured config + health probe) end-to-end on a real third-party server before the OAuth surface (the piece with the largest security blast radius per §3's CVE notes) gets built.
+
+## 8. Open questions for product decision
+
+1. Does the catalog (§4.6) ship with just Ableton MCP as a proof of concept, or a small starter set (filesystem, GitHub, Slack — mirroring what's already got Account-provider wiring in `oauth-catalog.ts`)? Recommend: ship with Ableton MCP alone for Phase B; expand the catalog only after the pattern is validated.
+2. Where does `disabled_tools` enforcement actually live once the Policy primitive exists — does Policy subsume `db_agent_mcp_ref.disabled_tools`, or does Policy read it as an input? Needs a decision before Phase D locks its schema.
+3. Should `mcp.probe` run automatically (e.g., on every Armory MCP tab mount, like Docker's liveness probe) or only on explicit "Test connection" click? Automatic matches Claude/Cursor's ambient status; but an MCP server's `initialize` handshake may have side effects (some servers log a connection, spin up resources) that a passive diagnostics view shouldn't trigger repeatedly. Recommend: on-mount + manual refresh + the same 4s poll-while-open pattern `toolchain-capabilities.ts` already uses for Docker, since that precedent already made this call for a comparable case.
+
+## 9. Sources
+
+- [Claude Help Center — Getting started with local MCP servers](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+- [Claude Help Center — Custom connectors via remote MCP](https://support.claude.com/en/articles/11503834-build-custom-connectors-via-remote-mcp-servers)
+- [Claude Platform Docs — MCP connector](https://platform.claude.com/docs/en/agents-and-tools/mcp-connector)
+- [Pluto Security — Claude extension ecosystem security map](https://pluto.security/blog/claude-extension-ecosystem-security-practitioner-guide/) (DXT sandboxing / injection-chaining incident)
+- [Cursor Docs — MCP](https://cursor.com/docs/mcp)
+- [TrueFoundry — MCP Authentication in Cursor](https://www.truefoundry.com/blog/mcp-authentication-in-cursor-oauth-api-keys-and-secure-configuration) (DCR + static OAuth, CVE-2025-54136/54135)
+- [WorkOS — Understanding MCP features: Tools, Resources, Prompts, Sampling, Roots, Elicitation](https://workos.com/blog/mcp-features-guide)
+- [ahujasid/ableton-mcp](https://github.com/ahujasid/ableton-mcp)
+- [mcp.directory — Ableton Live MCP Server install & setup](https://mcp.directory/servers/ableton-live)

--- a/frontend/app/store/mcp-capabilities.test.ts
+++ b/frontend/app/store/mcp-capabilities.test.ts
@@ -1,0 +1,131 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for the mcp-capabilities store — the MCP-server analogue of
+// toolchain-capabilities.ts, backed by mcp.catalog.probe.
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        McpCatalogProbeCommand: vi.fn(),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { RpcApi } from "@/app/store/rpc-api";
+import {
+    ensureMcpCapability,
+    refreshMcpCapability,
+    getMcpCapability,
+    isMcpConnected,
+    watchMcpCapability,
+    resetMcpCapabilities,
+} from "./mcp-capabilities";
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    resetMcpCapabilities();
+});
+
+describe("probe result mapping", () => {
+    test("a connected server reports status + tool count", async () => {
+        vi.mocked(RpcApi.McpCatalogProbeCommand).mockResolvedValue({
+            status: "connected", tool_count: 12, server_name: "AbletonMCP", server_version: "1.0.0", error: null,
+        } as any);
+
+        const result = await ensureMcpCapability("srv-1");
+
+        expect(result.status).toBe("connected");
+        expect(result.toolCount).toBe(12);
+        expect(result.serverName).toBe("AbletonMCP");
+        expect(isMcpConnected("srv-1")).toBe(true);
+    });
+
+    test("a handshake failure (e.g. Ableton not running) is not the same as unreachable", async () => {
+        vi.mocked(RpcApi.McpCatalogProbeCommand).mockResolvedValue({
+            status: "handshake_failed", tool_count: null, server_name: null, server_version: null,
+            error: "no response within 8s",
+        } as any);
+
+        const result = await ensureMcpCapability("srv-ableton");
+
+        expect(result.status).toBe("handshake_failed");
+        expect(isMcpConnected("srv-ableton")).toBe(false);
+    });
+
+    test("RPC rejection maps to unreachable, not a thrown error", async () => {
+        vi.mocked(RpcApi.McpCatalogProbeCommand).mockRejectedValue(new Error("connection reset"));
+
+        const result = await ensureMcpCapability("srv-2");
+
+        expect(result.status).toBe("unreachable");
+        expect(result.error).toBe("connection reset");
+    });
+});
+
+describe("caching + concurrent-call de-duplication", () => {
+    test("two concurrent ensureMcpCapability calls for the same id share one RPC", async () => {
+        let resolveRpc!: (v: any) => void;
+        vi.mocked(RpcApi.McpCatalogProbeCommand).mockReturnValue(
+            new Promise((resolve) => { resolveRpc = resolve; }) as any,
+        );
+
+        const p1 = ensureMcpCapability("srv-3");
+        const p2 = ensureMcpCapability("srv-3");
+        resolveRpc({ status: "connected", tool_count: 3, server_name: null, server_version: null, error: null });
+
+        const [r1, r2] = await Promise.all([p1, p2]);
+        expect(r1).toEqual(r2);
+        expect(RpcApi.McpCatalogProbeCommand).toHaveBeenCalledTimes(1);
+    });
+
+    test("a second call after completion reuses the cached result without a new RPC", async () => {
+        vi.mocked(RpcApi.McpCatalogProbeCommand).mockResolvedValue({
+            status: "connected", tool_count: 1, server_name: null, server_version: null, error: null,
+        } as any);
+
+        await ensureMcpCapability("srv-4");
+        await ensureMcpCapability("srv-4");
+
+        expect(RpcApi.McpCatalogProbeCommand).toHaveBeenCalledTimes(1);
+    });
+
+    test("refreshMcpCapability bypasses the cache and re-probes", async () => {
+        vi.mocked(RpcApi.McpCatalogProbeCommand)
+            .mockResolvedValueOnce({ status: "unreachable", tool_count: null, server_name: null, server_version: null, error: "e1" } as any)
+            .mockResolvedValueOnce({ status: "connected", tool_count: 5, server_name: null, server_version: null, error: null } as any);
+
+        await ensureMcpCapability("srv-5");
+        const refreshed = await refreshMcpCapability("srv-5");
+
+        expect(refreshed.status).toBe("connected");
+        expect(RpcApi.McpCatalogProbeCommand).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("watchMcpCapability polling", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    test("polls at the given interval until stopped", async () => {
+        vi.mocked(RpcApi.McpCatalogProbeCommand).mockResolvedValue({
+            status: "connected", tool_count: 1, server_name: null, server_version: null, error: null,
+        } as any);
+
+        const stop = watchMcpCapability("srv-6", 1000);
+        await vi.advanceTimersByTimeAsync(0); // flush the immediate ensure call
+        expect(RpcApi.McpCatalogProbeCommand).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(RpcApi.McpCatalogProbeCommand).toHaveBeenCalledTimes(2);
+
+        stop();
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(RpcApi.McpCatalogProbeCommand).toHaveBeenCalledTimes(2);
+    });
+});
+
+test("getMcpCapability returns unknown for a server that was never probed", () => {
+    expect(getMcpCapability("never-probed")).toEqual({ status: "unknown" });
+});

--- a/frontend/app/store/mcp-capabilities.ts
+++ b/frontend/app/store/mcp-capabilities.ts
@@ -1,0 +1,132 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * mcp-capabilities — "is this MCP server actually reachable right now,"
+ * the MCP-server analogue of toolchain-capabilities.ts's CLI/daemon probes.
+ * Same shape deliberately: module-level `createStore`, `ensureCapability`/
+ * `watchCapability`, in-flight de-dup so two mounted consumers (e.g. an
+ * Armory catalog row and a future per-agent status pill) never fire
+ * duplicate probes or disagree with each other.
+ *
+ * Backed by `mcp.catalog.probe` (agentmux-srv/src/server/app_api/mcp.rs) —
+ * the window-scoped, agent-independent probe, since the primary consumer is
+ * the Armory's MCP Servers catalog, which has no agent context. Keyed by
+ * MCP server id, not a fixed catalog of known tool ids (toolchain-catalog.ts
+ * enumerates a small fixed set of CLIs; MCP servers are user-defined rows).
+ *
+ * See docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md §4.4.
+ * A "connected" result means the MCP handshake succeeded — it does NOT mean
+ * every prerequisite the server itself depends on is satisfied (e.g.
+ * ableton-mcp's process starts and answers `initialize` whether or not
+ * Ableton Live is actually running; that gap is why a catalog entry's
+ * `prereq_note` static remediation text matters alongside this dynamic
+ * check, not instead of it).
+ */
+
+import { createStore, reconcile } from "solid-js/store";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+const PROBE_TIMEOUT_MS = 10000;
+
+export type McpCapabilityStatus = "unknown" | "checking" | McpProbeResult["status"];
+
+export interface McpCapabilityState {
+    status: McpCapabilityStatus;
+    toolCount?: number;
+    serverName?: string;
+    serverVersion?: string;
+    error?: string;
+    checkedAt?: number;
+}
+
+const UNKNOWN: McpCapabilityState = { status: "unknown" };
+
+const [capabilities, setCapabilities] = createStore<Record<string, McpCapabilityState>>({});
+const inFlight = new Map<string, Promise<McpCapabilityState>>();
+
+/** Current cached state for MCP server `id` — `{status:"unknown"}` if never probed. */
+export function getMcpCapability(id: string): McpCapabilityState {
+    return capabilities[id] ?? UNKNOWN;
+}
+
+/** True iff the last completed probe for `id` found the server reachable. */
+export function isMcpConnected(id: string): boolean {
+    return capabilities[id]?.status === "connected";
+}
+
+async function probeOne(id: string): Promise<McpCapabilityState> {
+    try {
+        const r = await RpcApi.McpCatalogProbeCommand(TabRpcClient, { id }, { timeout: PROBE_TIMEOUT_MS });
+        return {
+            status: r.status,
+            toolCount: r.tool_count ?? undefined,
+            serverName: r.server_name ?? undefined,
+            serverVersion: r.server_version ?? undefined,
+            error: r.error ?? undefined,
+            checkedAt: Date.now(),
+        };
+    } catch (e) {
+        return { status: "unreachable", error: (e as Error).message ?? String(e), checkedAt: Date.now() };
+    }
+}
+
+/**
+ * Ensures a probe for MCP server `id` has run at least once (or is
+ * currently running), returning its result. Concurrent callers for the
+ * same `id` share one in-flight RPC. `force: true` starts a fresh probe
+ * even if a cached result already exists, but still joins an
+ * already-in-flight probe rather than starting a second redundant one.
+ */
+export function ensureMcpCapability(id: string, opts?: { force?: boolean }): Promise<McpCapabilityState> {
+    const existing = inFlight.get(id);
+    if (existing) return existing;
+
+    if (!opts?.force) {
+        const cached = capabilities[id];
+        if (cached && cached.status !== "unknown" && cached.status !== "checking") {
+            return Promise.resolve(cached);
+        }
+    }
+
+    setCapabilities(id, (prev) => ({ ...(prev ?? UNKNOWN), status: "checking" }));
+    const promise = probeOne(id).then((state) => {
+        setCapabilities(id, state);
+        inFlight.delete(id);
+        return state;
+    });
+    inFlight.set(id, promise);
+    return promise;
+}
+
+/** Forces a fresh probe for `id`, bypassing any cached (non-in-flight) result. */
+export function refreshMcpCapability(id: string): Promise<McpCapabilityState> {
+    return ensureMcpCapability(id, { force: true });
+}
+
+/**
+ * Polls a capability every `intervalMs` while the caller holds the
+ * returned stop function (call it from `onCleanup`) — lets an open Armory
+ * MCP Servers tab notice "the user just started Ableton Live" within a
+ * few seconds, same pattern as toolchain-capabilities.ts's Docker liveness
+ * polling.
+ */
+export function watchMcpCapability(id: string, intervalMs = 4000): () => void {
+    void ensureMcpCapability(id);
+    const handle = setInterval(() => {
+        void ensureMcpCapability(id, { force: true });
+    }, intervalMs);
+    return () => clearInterval(handle);
+}
+
+/**
+ * Clears all cached capability state and in-flight probes. Module-level
+ * singleton shared across the whole app — tests that render multiple
+ * consumers with different mocked RPC results across cases must call this
+ * in `beforeEach`, or a later case will see a prior case's cached result.
+ */
+export function resetMcpCapabilities(): void {
+    setCapabilities(reconcile({}));
+    inFlight.clear();
+}

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -59,6 +59,15 @@ export const McpApi = {
         return client.rpcCall("mcp.unbind", data, opts);
     },
 
+    /** Health/prerequisite probe — see McpProbeResult (gotypes.d.ts). */
+    McpProbeCommand(
+        client: RpcClient,
+        data: { agent_id: string; id: string },
+        opts?: RpcOpts,
+    ): Promise<McpProbeResult> {
+        return client.rpcCall("mcp.probe", data, opts);
+    },
+
     // ── Armory catalog (global servers only, no agent_id) ──────────────────
 
     McpCatalogListCommand(
@@ -83,5 +92,15 @@ export const McpApi = {
         opts?: RpcOpts,
     ): Promise<{ deleted: boolean }> {
         return client.rpcCall("mcp.catalog.delete", data, opts);
+    },
+
+    /** Health/prerequisite probe for a global catalog server — no agent_id
+     *  (mirrors mcp.catalog.*'s window-scoped shape). See McpProbeResult. */
+    McpCatalogProbeCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<McpProbeResult> {
+        return client.rpcCall("mcp.catalog.probe", data, opts);
     },
 };

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -433,6 +433,18 @@ declare global {
      *  this — `mcp.get`/`mcp.upsert`/`mcp.catalog.list` return bare McpServer. */
     type McpServerListItem = McpServer & { bound_to_agent: boolean };
 
+    /** `mcp.probe`/`mcp.catalog.probe`'s response shape — a protocol-level
+     *  health check (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md
+     *  §4.4). "connected" means the MCP handshake succeeded, not that any
+     *  external app/prerequisite the server itself depends on is available. */
+    type McpProbeResult = {
+        status: "connected" | "unreachable" | "handshake_failed" | "invalid_config";
+        tool_count: number | null;
+        server_name: string | null;
+        server_version: string | null;
+        error: string | null;
+    };
+
     /** `skill.list`'s response shape — see McpServerListItem. */
     type SkillListItem = Skill & { bound_to_agent: boolean };
 


### PR DESCRIPTION
## Summary

First implementation slice of `docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md` — the gap analysis vs. Claude Desktop/Cursor's MCP feature sets, piloted end-to-end on ahujasid/ableton-mcp.

- `agentmux-srv/src/backend/mcp_probe.rs` (new): a hand-rolled MCP client probe — spawns the stdio process (or POSTs to an `http` url), does the `initialize` handshake, then `tools/list`. Hand-rolled to match `agentmux-mcp/src/main.rs`'s existing hand-rolled server-side JSON-RPC framing rather than adding an SDK crate (`rmcp`) for a probe this small. 5 unit tests.
- `mcp.probe` (agent-scoped) and `mcp.catalog.probe` (window-scoped, global-only — mirrors `mcp.catalog.*`'s existing no-agent-context shape) registered in `app_api/mcp.rs`, purely additive.
- `frontend/app/store/mcp-capabilities.ts` (new): mirrors `toolchain-capabilities.ts`'s cached/shared/in-flight-deduped/pollable pattern, for MCP servers instead of CLI tools. 8 unit tests.

A "connected" result means the MCP handshake succeeded — **not** that every prerequisite the server itself depends on is satisfied (ableton-mcp's process starts and answers `initialize` whether or not Ableton Live is running; that's why the spec's catalog `prereq_note` static remediation text still matters, not addressed in this PR).

## Scope note

Deliberately does **not** touch `McpManager.tsx`, `AgentMcpModal.tsx`, `mcp_servers.rs`, or `mcp.catalog.list` — coordinated with Agent2 (#1960, the Armory MCP/Skills catalog UI gaps) to avoid overlapping in-flight edits to those files. No UI wiring yet; that lands once #1960 reshapes `McpManager.tsx` and this can be rebased on top of it.

## Test plan

- [x] `cargo check -p agentmux-srv` clean
- [x] `cargo test -p agentmux-srv mcp_probe` — 5/5 passing
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/store/mcp-capabilities.test.ts test/contract/rpc-contract.test.ts` — 12/12 passing

<!-- agentmux:agent_id=agent1 -->