### PR TITLE
Pillar 1 Step 4 Phase 4/5: restoring-session overlay + crash-reproject E2E test

### DIFF
--- a/.changesets/1783503158-feat-host-spec-pillar1-step4-phase-4-5-restoring-session-ove-zy9e.md
+++ b/.changesets/1783503158-feat-host-spec-pillar1-step4-phase-4-5-restoring-session-ove-zy9e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(host): SPEC_PILLAR1_STEP4 Phase 4/5 - restoring-session overlay + crash-reproject E2E test

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -425,22 +425,28 @@ impl AgentMuxHandler {
             // with `window_count=0`, which a naive `stashed.is_some()` check
             // wrongly treated as "fast path succeeded," permanently
             // suppressing the slow path.
-            let (action, stashed) = {
+            let (action, stashed, stashed_backend_window_ids) = {
                 let mut gate = self.state.ui_thread_gate.lock();
                 let stashed = gate.stashed.take();
+                let stashed_backend_window_ids = gate.stashed_backend_window_ids.take();
                 let has_extra = stashed
                     .as_ref()
                     .is_some_and(|windows| windows.iter().any(|w| w.label != "main"));
-                (gate.on_main_ready(has_extra), stashed)
+                (gate.on_main_ready(has_extra), stashed, stashed_backend_window_ids)
             };
             if action == crate::state::MainReadyAction::ReplayFastPath {
                 let windows = stashed.unwrap_or_default();
+                let backend_window_ids = stashed_backend_window_ids.unwrap_or_default();
                 tracing::info!(
                     target: "reproject",
                     window_count = windows.len(),
                     "[reproject] replaying stashed snapshot now that \"main\" has registered"
                 );
-                crate::commands::window::reproject_from_snapshot(&self.state, &windows);
+                crate::commands::window::reproject_from_snapshot_and_stage_closures(
+                    &self.state,
+                    &windows,
+                    &backend_window_ids,
+                );
             }
         } else if label.starts_with("window-pool-") {
             crate::commands::window_pool::register_pool_window(&self.state, &label);

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -657,18 +657,17 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
         // recreate at most this many windows per pass; anything beyond that
         // is left in place (not lost — just not recreated this launch) with
         // a loud warning, rather than silently opening dozens of windows.
-        const MAX_SLOW_PATH_RECREATE: usize = 20;
-        if extra_ids.len() > MAX_SLOW_PATH_RECREATE {
+        let dropped = cap_recreate_list(&mut extra_ids, MAX_SLOW_PATH_RECREATE);
+        if dropped > 0 {
             tracing::warn!(
                 target: "reproject",
-                total = extra_ids.len(),
-                recreating = MAX_SLOW_PATH_RECREATE,
-                dropped = extra_ids.len() - MAX_SLOW_PATH_RECREATE,
+                total = extra_ids.len() + dropped,
+                recreating = extra_ids.len(),
+                dropped,
                 "[reproject] slow path: Client.windowids has far more entries than a normal \
                  session should — capping recreation to avoid a runaway window-open storm; \
                  the rest are left in srv, uncreated, for now"
             );
-            extra_ids.truncate(MAX_SLOW_PATH_RECREATE);
         }
 
         let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
@@ -734,7 +733,7 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
         if !recreated_pairs.is_empty() {
             let mut pending = state.pending_reproject_closures.lock();
             for (old_id, new_label) in recreated_pairs {
-                pending.insert(new_label, old_id);
+                pending.stage(new_label, old_id);
             }
         }
     });
@@ -785,6 +784,61 @@ fn get_secondary_window_size(px: i32, py: i32) -> (i32, i32) {
         }
     }
     (1200, 800)
+}
+
+/// SPEC_PILLAR1_STEP4 Phase 3 safety cap — see `reproject_from_srv`'s own
+/// comment at the call site for why this exists (found live, 2026-07-08:
+/// 30+ accumulated `Client.windowids` entries recreated all at once).
+const MAX_SLOW_PATH_RECREATE: usize = 20;
+
+/// Truncates `items` to at most `max` entries in place; returns how many
+/// were dropped. Extracted as a pure function (reagent P2, PR #2032,
+/// 2026-07-08) so the cap itself has direct unit test coverage, not just
+/// the live-verified end-to-end behavior.
+fn cap_recreate_list<T>(items: &mut Vec<T>, max: usize) -> usize {
+    if items.len() <= max {
+        return 0;
+    }
+    let dropped = items.len() - max;
+    items.truncate(max);
+    dropped
+}
+
+#[cfg(test)]
+mod cap_recreate_list_tests {
+    use super::cap_recreate_list;
+
+    #[test]
+    fn under_the_cap_is_untouched() {
+        let mut items = vec![1, 2, 3];
+        assert_eq!(cap_recreate_list(&mut items, 20), 0);
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn exactly_at_the_cap_is_untouched() {
+        let mut items: Vec<i32> = (0..20).collect();
+        assert_eq!(cap_recreate_list(&mut items, 20), 0);
+        assert_eq!(items.len(), 20);
+    }
+
+    #[test]
+    fn over_the_cap_truncates_and_reports_dropped_count() {
+        let mut items: Vec<i32> = (0..44).collect();
+        assert_eq!(cap_recreate_list(&mut items, 20), 24);
+        assert_eq!(items.len(), 20);
+        // Keeps the FIRST `max`, not an arbitrary subset — matters because
+        // callers may care about ordering (e.g. FullInstance-before-Subwindow
+        // sort already applied upstream).
+        assert_eq!(items, (0..20).collect::<Vec<i32>>());
+    }
+
+    #[test]
+    fn empty_list_is_a_noop() {
+        let mut items: Vec<i32> = Vec::new();
+        assert_eq!(cap_recreate_list(&mut items, 20), 0);
+        assert!(items.is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -485,9 +485,21 @@ pub(crate) fn open_window_with_kind(
 /// old data" — `reproject_from_srv` instead stashes `new_label → old_id` and
 /// waits for `new_label`'s own `register_backend_window` call (proof the new
 /// window's frontend actually loaded and round-tripped IPC) before closing
-/// the old one. The fast path (launcher snapshot) ignores this return value
-/// entirely: a `WindowSnapshot.label` there is the launcher's own in-memory
-/// label, not a real srv window_id, so there is nothing to close either way.
+/// the old one. The fast path (launcher snapshot) used to ignore this return
+/// value entirely, on the theory that a `WindowSnapshot.label` there is the
+/// launcher's own in-memory label, not a real srv window_id, so there was
+/// nothing to close either way.
+///
+/// reagent P1 (PR #2032, 2026-07-08, second finding): that theory was
+/// wrong — the launcher's `Event::Snapshot` carries a sibling
+/// `backend_window_ids: Vec<(String, String)>` field (that same in-memory
+/// label → the real srv window_id it registered), which both fast-path
+/// call sites already receive but were discarding. `Client.windowids` grew
+/// unboundedly on every ordinary (launcher-survives) crash — the exact
+/// scenario this PR's own E2E test exercises — because nothing ever staged
+/// a deferred close for it. See `reproject_from_snapshot_and_stage_closures`,
+/// which both fast-path call sites (`launcher_ipc.rs`, `client/lifecycle.rs`)
+/// now use instead of calling this function directly.
 pub(crate) fn reproject_from_snapshot(
     state: &Arc<AppState>,
     windows: &[agentmux_common::ipc::WindowSnapshot],
@@ -577,6 +589,53 @@ pub(crate) fn reproject_from_snapshot(
         "[reproject] fast-path reproject complete"
     );
     recreated_pairs
+}
+
+/// SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P1, PR #2032, 2026-07-08,
+/// second finding) — fast-path counterpart to `reproject_from_srv`'s
+/// deferred-close staging, using the same `PendingReprojectClosures`
+/// mechanism so a recreated window's old srv id is only closed once the
+/// new one is confirmed live via its own `register_backend_window` call
+/// (never on the unconfirmed `Ok` from `open_window_with_kind`).
+///
+/// `backend_window_ids` is the launcher's `Event::Snapshot.backend_window_ids`
+/// — the SAME pre-crash label used in `windows` (`WindowSnapshot.label`),
+/// mapped to the real srv window_id the launcher last saw it register. A
+/// window the launcher never learned a backend_window_id for (e.g. it
+/// crashed before its own `register_backend_window` round trip) has
+/// nothing real to close and is silently skipped — same as an unconfirmed
+/// `reproject_from_srv` entry, the old (nonexistent-to-us) state just
+/// lingers rather than being lost.
+///
+/// Both fast-path call sites (`launcher_ipc.rs`'s `RunFastPath` arm,
+/// `client/lifecycle.rs`'s `ReplayFastPath` arm) use this instead of
+/// calling `reproject_from_snapshot` directly, so neither can regress back
+/// to silently discarding the recreated pairs.
+pub(crate) fn reproject_from_snapshot_and_stage_closures(
+    state: &Arc<AppState>,
+    windows: &[agentmux_common::ipc::WindowSnapshot],
+    backend_window_ids: &[(String, String)],
+) {
+    let recreated_pairs = reproject_from_snapshot(state, windows);
+    if recreated_pairs.is_empty() {
+        return;
+    }
+    let old_ids: std::collections::HashMap<&str, &str> = backend_window_ids
+        .iter()
+        .map(|(label, id)| (label.as_str(), id.as_str()))
+        .collect();
+    let mut pending = state.pending_reproject_closures.lock();
+    for (old_label, new_label) in recreated_pairs {
+        if let Some(old_id) = old_ids.get(old_label.as_str()) {
+            pending.stage(new_label, old_id.to_string());
+        } else {
+            tracing::debug!(
+                target: "reproject",
+                old_label = %old_label,
+                "[reproject] fast path: no known backend_window_id for this old label — nothing to close"
+            );
+        }
+    }
 }
 
 /// SPEC_PILLAR1_STEP4 Phase 3 — the slow-path reproject driver. Called once

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -282,6 +282,7 @@ pub fn open_new_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
         initial_view.as_deref(),
         initial_meta.as_deref(),
         None,
+        false,
     )
 }
 
@@ -330,6 +331,7 @@ pub fn open_subwindow(
         None,
         None,
         None,
+        false,
     )
 }
 
@@ -352,6 +354,7 @@ pub(crate) fn open_window_with_kind(
     initial_view: Option<&str>,
     initial_meta: Option<&str>,
     explicit_rect: Option<agentmux_common::ipc::Rect>,
+    is_reproject: bool,
 ) -> Result<serde_json::Value, String> {
     // PR #6 H.7 — refuse top-level creation while any pane is mid-close.
     // See `SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md` and the smoke retro
@@ -383,9 +386,15 @@ pub(crate) fn open_window_with_kind(
                 .filter(|m| !m.is_empty())
                 .map(|m| format!("&initialMeta={}", percent_encode(m)))
                 .unwrap_or_default();
+            // SPEC_PILLAR1_STEP4 Phase 4 — drives index.html's
+            // #startup-loading-headline ("Restoring session...") for
+            // reprojected windows only; an interactive "New Window"/"New
+            // Subwindow" never sets this. Cheap, frontend-only per the
+            // spec's §2.4 in-window-phase design.
+            let restoring_param = if is_reproject { "&restoring=1" } else { "" };
             format!(
-                "{}{}ipc_port={}&ipc_token={}&windowLabel={}{}{}",
-                base_url, separator, ipc_port, ipc_token, label, view_param, meta_param
+                "{}{}ipc_port={}&ipc_token={}&windowLabel={}{}{}{}",
+                base_url, separator, ipc_port, ipc_token, label, view_param, meta_param, restoring_param
             )
         }
         Err(e) => {
@@ -463,17 +472,26 @@ pub(crate) fn open_window_with_kind(
 /// before being passed to `open_window_with_kind`. `"main"` is seeded into
 /// the remap table as `"main"` → `"main"` since its label is stable across
 /// restarts (never regenerated).
+///
+/// Returns the `label` of every `WindowSnapshot` that was successfully
+/// recreated (not the ones skipped/failed) — `reproject_from_srv` uses this
+/// to close the OLD srv window_id once its replacement exists (see that
+/// function's doc comment for why leaving it around causes unbounded
+/// accumulation across repeated crashes). The fast path (launcher snapshot)
+/// ignores this return value: a `WindowSnapshot.label` there is the
+/// launcher's own in-memory label, not necessarily a real srv window_id, so
+/// there is nothing meaningful to close.
 pub(crate) fn reproject_from_snapshot(
     state: &Arc<AppState>,
     windows: &[agentmux_common::ipc::WindowSnapshot],
-) {
+) -> Vec<String> {
     use std::collections::HashMap;
 
     let mut to_create: Vec<&agentmux_common::ipc::WindowSnapshot> =
         windows.iter().filter(|w| w.label != "main").collect();
     if to_create.is_empty() {
         tracing::debug!(target: "reproject", "[reproject] nothing to recreate beyond main");
-        return;
+        return Vec::new();
     }
     // FullInstance before Subwindow — stable sort preserves the snapshot's
     // own relative ordering within each kind. `WindowSnapshot.kind` is the
@@ -495,6 +513,7 @@ pub(crate) fn reproject_from_snapshot(
 
     let mut created = 0usize;
     let mut skipped = 0usize;
+    let mut recreated_old_labels: Vec<String> = Vec::new();
     for w in to_create {
         let new_parent = match &w.parent_label {
             Some(old_parent) => match label_remap.get(old_parent) {
@@ -517,7 +536,7 @@ pub(crate) fn reproject_from_snapshot(
             },
             None => None,
         };
-        match open_window_with_kind(state, to_host_kind(w.kind), new_parent, None, None, w.last_rect) {
+        match open_window_with_kind(state, to_host_kind(w.kind), new_parent, None, None, w.last_rect, true) {
             Ok(new_label_val) => {
                 let new_label = new_label_val.as_str().unwrap_or_default().to_string();
                 tracing::info!(
@@ -530,6 +549,7 @@ pub(crate) fn reproject_from_snapshot(
                     "[reproject] recreated window"
                 );
                 label_remap.insert(w.label.clone(), new_label);
+                recreated_old_labels.push(w.label.clone());
                 created += 1;
             }
             Err(e) => {
@@ -549,6 +569,7 @@ pub(crate) fn reproject_from_snapshot(
         skipped,
         "[reproject] fast-path reproject complete"
     );
+    recreated_old_labels
 }
 
 /// SPEC_PILLAR1_STEP4 Phase 3 — the slow-path reproject driver. Called once
@@ -606,7 +627,7 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
         // translated to the `"main"` sentinel here — otherwise the remap
         // lookup finds nothing and the subwindow is silently skipped as if
         // its parent were missing.
-        let extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
+        let mut extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
         if extra_ids.is_empty() {
             tracing::debug!(
                 target: "reproject",
@@ -614,6 +635,33 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
                 "[reproject] slow path: nothing beyond main to recreate"
             );
             return;
+        }
+
+        // Safety cap — found live (2026-07-08): a build force-killed many
+        // times over one test session (never a graceful quit) accumulated
+        // 30+ stale `Client.windowids` entries, all recreated at once on the
+        // next cold boot. The direct cause (this function never closing the
+        // OLD id it just reprojected from) is fixed above/below, but that
+        // fix only covers entries THIS function itself creates — a
+        // separate, pre-existing leak (pool-warmup windows registering a
+        // real backend_window_id that's never closed either, since they're
+        // never gracefully closed) can still slowly inflate this list over
+        // many restarts. Bound the worst case regardless of root cause:
+        // recreate at most this many windows per pass; anything beyond that
+        // is left in place (not lost — just not recreated this launch) with
+        // a loud warning, rather than silently opening dozens of windows.
+        const MAX_SLOW_PATH_RECREATE: usize = 20;
+        if extra_ids.len() > MAX_SLOW_PATH_RECREATE {
+            tracing::warn!(
+                target: "reproject",
+                total = extra_ids.len(),
+                recreating = MAX_SLOW_PATH_RECREATE,
+                dropped = extra_ids.len() - MAX_SLOW_PATH_RECREATE,
+                "[reproject] slow path: Client.windowids has far more entries than a normal \
+                 session should — capping recreation to avoid a runaway window-open storm; \
+                 the rest are left in srv, uncreated, for now"
+            );
+            extra_ids.truncate(MAX_SLOW_PATH_RECREATE);
         }
 
         let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
@@ -657,7 +705,28 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
             window_count = snapshots.len(),
             "[reproject] slow path: recreating windows from srv"
         );
-        reproject_from_snapshot(&state, &snapshots);
+        let recreated_old_ids = reproject_from_snapshot(&state, &snapshots);
+
+        // Close each OLD window_id now that its replacement exists — srv's
+        // `close_window` already does the full cleanup (prunes
+        // `Client.windowids`, deletes the Window row and its workspace/tabs).
+        // Without this, repeated crashes accumulate `Client.windowids`
+        // forever: each crash's reproject only ADDS new ids via
+        // `register_backend_window`, never removes the old ones it just
+        // reprojected FROM, so every SUBSEQUENT crash reprojects an
+        // ever-growing pile including windows from crashes days/weeks
+        // earlier. Found live: a test that had force-killed this build many
+        // times over one session (never a graceful quit, so nothing ever
+        // pruned `Client.windowids` naturally) hit 30+ accumulated entries,
+        // all recreated at once on the next cold boot.
+        //
+        // Only the SUCCESSFULLY recreated ones are closed — a window that
+        // failed to recreate (network hiccup talking to srv, an unresolvable
+        // parent) is left alone so a future launch can still retry it,
+        // rather than closing it and losing it outright.
+        for old_id in recreated_old_ids {
+            crate::client::backend_close_window(&web_endpoint, &auth_key, &old_id);
+        }
     });
 }
 

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -473,18 +473,25 @@ pub(crate) fn open_window_with_kind(
 /// the remap table as `"main"` → `"main"` since its label is stable across
 /// restarts (never regenerated).
 ///
-/// Returns the `label` of every `WindowSnapshot` that was successfully
-/// recreated (not the ones skipped/failed) — `reproject_from_srv` uses this
-/// to close the OLD srv window_id once its replacement exists (see that
-/// function's doc comment for why leaving it around causes unbounded
-/// accumulation across repeated crashes). The fast path (launcher snapshot)
-/// ignores this return value: a `WindowSnapshot.label` there is the
-/// launcher's own in-memory label, not necessarily a real srv window_id, so
-/// there is nothing meaningful to close.
+/// Returns `(old_label, new_label)` for every `WindowSnapshot` whose
+/// `open_window_with_kind` call returned `Ok` (not the ones skipped/failed).
+///
+/// reagent P1 (PR #2032, 2026-07-08): `Ok` here means only that a
+/// `CreateWindowTask` was successfully POSTED to the UI thread
+/// (`open_window_with_kind` → `post_task`, fire-and-forget) — not that the
+/// window actually exists yet. This session's own Phase 2 investigation
+/// found `post_task` can silently drop a posted task (the UI-thread-readiness
+/// race). The caller MUST NOT treat this return value as "safe to delete the
+/// old data" — `reproject_from_srv` instead stashes `new_label → old_id` and
+/// waits for `new_label`'s own `register_backend_window` call (proof the new
+/// window's frontend actually loaded and round-tripped IPC) before closing
+/// the old one. The fast path (launcher snapshot) ignores this return value
+/// entirely: a `WindowSnapshot.label` there is the launcher's own in-memory
+/// label, not a real srv window_id, so there is nothing to close either way.
 pub(crate) fn reproject_from_snapshot(
     state: &Arc<AppState>,
     windows: &[agentmux_common::ipc::WindowSnapshot],
-) -> Vec<String> {
+) -> Vec<(String, String)> {
     use std::collections::HashMap;
 
     let mut to_create: Vec<&agentmux_common::ipc::WindowSnapshot> =
@@ -513,7 +520,7 @@ pub(crate) fn reproject_from_snapshot(
 
     let mut created = 0usize;
     let mut skipped = 0usize;
-    let mut recreated_old_labels: Vec<String> = Vec::new();
+    let mut recreated_pairs: Vec<(String, String)> = Vec::new();
     for w in to_create {
         let new_parent = match &w.parent_label {
             Some(old_parent) => match label_remap.get(old_parent) {
@@ -548,8 +555,8 @@ pub(crate) fn reproject_from_snapshot(
                     had_rect = w.last_rect.is_some(),
                     "[reproject] recreated window"
                 );
-                label_remap.insert(w.label.clone(), new_label);
-                recreated_old_labels.push(w.label.clone());
+                label_remap.insert(w.label.clone(), new_label.clone());
+                recreated_pairs.push((w.label.clone(), new_label));
                 created += 1;
             }
             Err(e) => {
@@ -569,7 +576,7 @@ pub(crate) fn reproject_from_snapshot(
         skipped,
         "[reproject] fast-path reproject complete"
     );
-    recreated_old_labels
+    recreated_pairs
 }
 
 /// SPEC_PILLAR1_STEP4 Phase 3 — the slow-path reproject driver. Called once
@@ -705,27 +712,30 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
             window_count = snapshots.len(),
             "[reproject] slow path: recreating windows from srv"
         );
-        let recreated_old_ids = reproject_from_snapshot(&state, &snapshots);
+        let recreated_pairs = reproject_from_snapshot(&state, &snapshots);
 
-        // Close each OLD window_id now that its replacement exists — srv's
-        // `close_window` already does the full cleanup (prunes
-        // `Client.windowids`, deletes the Window row and its workspace/tabs).
-        // Without this, repeated crashes accumulate `Client.windowids`
-        // forever: each crash's reproject only ADDS new ids via
-        // `register_backend_window`, never removes the old ones it just
-        // reprojected FROM, so every SUBSEQUENT crash reprojects an
-        // ever-growing pile including windows from crashes days/weeks
-        // earlier. Found live: a test that had force-killed this build many
-        // times over one session (never a graceful quit, so nothing ever
-        // pruned `Client.windowids` naturally) hit 30+ accumulated entries,
-        // all recreated at once on the next cold boot.
+        // Stash `new_label → old_window_id` — do NOT close the old id yet.
+        // `reagent P1 (PR #2032): `open_window_with_kind`'s `Ok` only means a
+        // `CreateWindowTask` was posted to the UI thread (fire-and-forget);
+        // it is not proof the window exists. `register_backend_window`
+        // (`commands/window/meta.rs`) drains this map and does the actual
+        // close once `new_label`'s own registration fires — real
+        // confirmation the new window's frontend loaded and round-tripped
+        // IPC. Without this deferral (the first version of this fix),
+        // closing right here on the unconfirmed `Ok` would delete the old
+        // session's window/workspace/tabs with no replacement and no retry
+        // if window creation subsequently failed silently (this session's
+        // own Phase 2 investigation found `post_task` can do exactly that).
         //
-        // Only the SUCCESSFULLY recreated ones are closed — a window that
-        // failed to recreate (network hiccup talking to srv, an unresolvable
-        // parent) is left alone so a future launch can still retry it,
-        // rather than closing it and losing it outright.
-        for old_id in recreated_old_ids {
-            crate::client::backend_close_window(&web_endpoint, &auth_key, &old_id);
+        // This is what actually fixes the unbounded `Client.windowids`
+        // growth found live (2026-07-08, 30+ accumulated entries from a test
+        // session that only ever force-killed, never gracefully quit) —
+        // deferred to a confirmed point rather than an optimistic one.
+        if !recreated_pairs.is_empty() {
+            let mut pending = state.pending_reproject_closures.lock();
+            for (old_id, new_label) in recreated_pairs {
+                pending.insert(new_label, old_id);
+            }
         }
     });
 }

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -215,6 +215,30 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
             .lock()
             .insert(label.to_string(), window_id.to_string());
 
+        // SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P1, PR #2032,
+        // 2026-07-08) — this label's own registration is exactly the
+        // confirmation `reproject_from_srv` was waiting for: proof this
+        // window's frontend actually loaded and round-tripped IPC, not just
+        // that a CreateWindowTask was posted. Drain-and-close the OLD srv
+        // window_id it was reprojected from, if any. See
+        // `AppState::pending_reproject_closures`'s doc comment for why this
+        // can't happen any earlier (right after `open_window_with_kind`
+        // returns `Ok`) without risking silent data loss.
+        let old_reprojected_id = state.pending_reproject_closures.lock().remove(label);
+        if let Some(old_id) = old_reprojected_id {
+            let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+            let auth_key = state.auth_key.lock().clone();
+            tracing::info!(
+                target: "reproject",
+                new_label = %label,
+                old_window_id = %old_id,
+                "[reproject] new window confirmed live — closing the old srv window_id it replaced"
+            );
+            std::thread::spawn(move || {
+                crate::client::backend_close_window(&web_endpoint, &auth_key, &old_id);
+            });
+        }
+
         // SPEC_PILLAR1_STEP3 Phase 2 — write-through this window's kind +
         // parent linkage to srv now that its concrete window_id is known.
         // This is the first point in the window's life where the host has

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -224,7 +224,7 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
         // `AppState::pending_reproject_closures`'s doc comment for why this
         // can't happen any earlier (right after `open_window_with_kind`
         // returns `Ok`) without risking silent data loss.
-        let old_reprojected_id = state.pending_reproject_closures.lock().remove(label);
+        let old_reprojected_id = state.pending_reproject_closures.lock().confirm(label);
         if let Some(old_id) = old_reprojected_id {
             let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
             let auth_key = state.auth_key.lock().clone();

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -681,7 +681,7 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
         // request/response payload, not a typed delta the frontend's
         // launcher-event reducer expects — forwarding it would be either
         // dead weight or a mis-parse.
-        Event::Snapshot { version, windows, .. } => {
+        Event::Snapshot { version, windows, backend_window_ids, .. } => {
             tracing::info!(
                 target: "reproject",
                 version,
@@ -711,6 +711,7 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 let action = gate.on_snapshot();
                 if action == crate::state::SnapshotAction::Stash {
                     gate.stashed = Some(windows.clone());
+                    gate.stashed_backend_window_ids = Some(backend_window_ids.clone());
                 }
                 action
             };
@@ -727,7 +728,11 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                         window_count = windows.len(),
                         "[reproject] fast-path snapshot arrived while slow path was pending — using it instead"
                     );
-                    crate::commands::window::reproject_from_snapshot(state, windows);
+                    crate::commands::window::reproject_from_snapshot_and_stage_closures(
+                        state,
+                        windows,
+                        backend_window_ids,
+                    );
                 }
                 crate::state::SnapshotAction::Skip => {
                     tracing::info!(

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -900,6 +900,22 @@ pub struct AppState {
     /// completes before the other starts.
     pub ui_thread_gate: Mutex<UiThreadGate>,
 
+    /// SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P1, PR #2032, 2026-07-08)
+    /// — `new_label → old_srv_window_id`. The slow path's `reproject_from_srv`
+    /// must NOT close the old window_id right after `open_window_with_kind`
+    /// returns `Ok`: that only means a `CreateWindowTask` was posted to the
+    /// UI thread (fire-and-forget), not that the window actually exists —
+    /// this session's own Phase 2 investigation found `post_task` can
+    /// silently drop a posted task. Closing on that unconfirmed signal would
+    /// delete the old session's window/workspace/tabs with no replacement
+    /// and no retry if creation then failed. Instead, the old id is stashed
+    /// here keyed by the NEW label, and only closed once that label's own
+    /// `register_backend_window` call fires — proof the new window's
+    /// frontend actually loaded and round-tripped IPC. If creation silently
+    /// fails, the entry just sits here unclosed forever, which is the same
+    /// (safe, if imperfect) fallback behavior as before this whole cleanup
+    /// existed: the old data lingers, but is never lost.
+    pub pending_reproject_closures: Mutex<std::collections::HashMap<String, String>>,
 }
 
 /// See `AppState::ui_thread_gate`.
@@ -1182,6 +1198,7 @@ impl Default for AppState {
             floating_redock_ghost: Mutex::new(HashMap::new()),
             window_transparent: std::sync::atomic::AtomicBool::new(false),
             ui_thread_gate: Mutex::new(UiThreadGate::default()),
+            pending_reproject_closures: Mutex::new(HashMap::new()),
         }
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -915,7 +915,90 @@ pub struct AppState {
     /// fails, the entry just sits here unclosed forever, which is the same
     /// (safe, if imperfect) fallback behavior as before this whole cleanup
     /// existed: the old data lingers, but is never lost.
-    pub pending_reproject_closures: Mutex<std::collections::HashMap<String, String>>,
+    pub pending_reproject_closures: Mutex<PendingReprojectClosures>,
+}
+
+/// See `AppState::pending_reproject_closures`. A thin, named wrapper around
+/// `HashMap<new_label, old_window_id>` rather than a bare map — reagent P2
+/// (PR #2032, 2026-07-08) noted the deferred-close logic had no automated
+/// test coverage; giving it named methods makes the intent explicit and
+/// gives something to unit-test directly, without needing a live instance.
+#[derive(Debug, Default)]
+pub struct PendingReprojectClosures(std::collections::HashMap<String, String>);
+
+impl PendingReprojectClosures {
+    /// Record that `new_label`'s eventual `register_backend_window` call
+    /// should trigger closing `old_window_id`. Called right after
+    /// `reproject_from_snapshot` returns — before any confirmation the new
+    /// window actually exists.
+    pub fn stage(&mut self, new_label: String, old_window_id: String) {
+        self.0.insert(new_label, old_window_id);
+    }
+
+    /// Called from `register_backend_window` for every label that
+    /// registers. Returns the old window_id to close if `label` was staged
+    /// (removing the entry so it fires at most once); `None` for any
+    /// ordinary (non-reprojected) window registration.
+    pub fn confirm(&mut self, label: &str) -> Option<String> {
+        self.0.remove(label)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[cfg(test)]
+mod pending_reproject_closures_tests {
+    use super::*;
+
+    #[test]
+    fn confirm_returns_none_for_unstaged_label() {
+        let mut p = PendingReprojectClosures::default();
+        assert_eq!(p.confirm("window-abc"), None);
+    }
+
+    #[test]
+    fn confirm_returns_the_staged_old_id() {
+        let mut p = PendingReprojectClosures::default();
+        p.stage("window-new".to_string(), "old-srv-id".to_string());
+        assert_eq!(p.confirm("window-new"), Some("old-srv-id".to_string()));
+    }
+
+    #[test]
+    fn confirm_only_fires_once() {
+        let mut p = PendingReprojectClosures::default();
+        p.stage("window-new".to_string(), "old-srv-id".to_string());
+        assert_eq!(p.confirm("window-new"), Some("old-srv-id".to_string()));
+        // A second registration for the same label (shouldn't normally
+        // happen, but must not re-trigger a close) gets nothing.
+        assert_eq!(p.confirm("window-new"), None);
+    }
+
+    #[test]
+    fn confirm_is_independent_per_label() {
+        let mut p = PendingReprojectClosures::default();
+        p.stage("window-a".to_string(), "old-a".to_string());
+        p.stage("window-b".to_string(), "old-b".to_string());
+        assert_eq!(p.len(), 2);
+        assert_eq!(p.confirm("window-a"), Some("old-a".to_string()));
+        assert_eq!(p.len(), 1);
+        assert_eq!(p.confirm("window-b"), Some("old-b".to_string()));
+        assert_eq!(p.len(), 0);
+    }
+
+    #[test]
+    fn unrelated_label_registration_is_a_noop() {
+        // e.g. a pool window, or main itself — never staged, must not panic
+        // or spuriously return something.
+        let mut p = PendingReprojectClosures::default();
+        p.stage("window-real-reproject".to_string(), "old-id".to_string());
+        assert_eq!(p.confirm("window-pool-abc123"), None);
+        assert_eq!(p.confirm("main"), None);
+        // The real one is still there, untouched.
+        assert_eq!(p.confirm("window-real-reproject"), Some("old-id".to_string()));
+    }
 }
 
 /// See `AppState::ui_thread_gate`.
@@ -1198,7 +1281,7 @@ impl Default for AppState {
             floating_redock_ghost: Mutex::new(HashMap::new()),
             window_transparent: std::sync::atomic::AtomicBool::new(false),
             ui_thread_gate: Mutex::new(UiThreadGate::default()),
-            pending_reproject_closures: Mutex::new(HashMap::new()),
+            pending_reproject_closures: Mutex::new(PendingReprojectClosures::default()),
         }
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1006,6 +1006,17 @@ mod pending_reproject_closures_tests {
 pub struct UiThreadGate {
     pub ready: bool,
     pub stashed: Option<Vec<agentmux_common::ipc::WindowSnapshot>>,
+    /// SPEC_PILLAR1_STEP4 Phase 3 addendum (reagent P1, PR #2032, 2026-07-08)
+    /// — the same `Event::Snapshot`'s sibling `backend_window_ids` field
+    /// (label → real srv window_id), stashed alongside `stashed` under the
+    /// same lock acquisition so the two never drift apart. Needed so the
+    /// fast-path replay can stage a deferred close for each recreated
+    /// window via `reproject_from_snapshot_and_stage_closures` — without
+    /// this, the fast path had no way to learn the OLD window's real srv
+    /// id (`WindowSnapshot.label` alone is only the launcher's in-memory
+    /// label), so `Client.windowids` grew unboundedly on every ordinary
+    /// (launcher-survives) crash.
+    pub stashed_backend_window_ids: Option<Vec<(String, String)>>,
     /// SPEC_PILLAR1_STEP4 Phase 3 — set true the moment EITHER reproject
     /// path (fast, from the launcher's snapshot; or slow, from srv) has
     /// actually been triggered, so only one of them ever creates windows.

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -251,7 +251,7 @@ fn splash_selftest() {
     #[cfg(target_os = "windows")]
     {
         let (_sink, rx) = startup_events::StartupEventSink::new();
-        let _ = splash::spawn_splash("selftest", rx);
+        let _ = splash::spawn_splash("selftest", rx, false);
         std::thread::sleep(hold);
     }
 }

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -170,9 +170,20 @@ fn apply_event(stages: &mut Vec<StageRow>, ev: StartupEvent) {
 ///
 /// `events_rx` delivers `StartupEvent` messages from the launcher startup
 /// path; the splash thread consumes them each frame.
+///
+/// SPEC_PILLAR1_STEP4 Phase 4 — `restoring` draws a "Restoring session…"
+/// headline (a fresh concept, distinct from the stage-telemetry rows) in
+/// place of stage row 0. Set by crash-restart call sites
+/// (`supervisor/windows.rs`), which call this again — a brand-new Win32
+/// event object plus a brand-new consumer thread — rather than reusing the
+/// original cold-start splash's already-exited one (see that module for why
+/// the original design silently produced no visible splash on restart: the
+/// event name was re-passed to the host, but nothing was listening on it
+/// anymore once the first splash's thread had already exited).
 pub fn spawn_splash(
     dir_hash: &str,
     events_rx: std::sync::mpsc::Receiver<StartupEvent>,
+    restoring: bool,
 ) -> Option<String> {
     let event_name = format!("AgentMuxSplash-{}", dir_hash);
     let nul_name: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
@@ -187,7 +198,7 @@ pub fn spawn_splash(
 
     let class_name = format!("AgentMuxSplash-{}", dir_hash);
     let handle = SendHandle(ev);
-    thread::spawn(move || unsafe { run_splash(handle.take(), class_name, events_rx) });
+    thread::spawn(move || unsafe { run_splash(handle.take(), class_name, events_rx, restoring) });
     Some(event_name)
 }
 
@@ -197,6 +208,7 @@ unsafe fn run_splash(
     dismiss_ev: HANDLE,
     class_name: String,
     events_rx: std::sync::mpsc::Receiver<StartupEvent>,
+    restoring: bool,
 ) {
     let class: Vec<u16> = format!("{}\0", class_name).encode_utf16().collect();
     let hinst = GetModuleHandleW(std::ptr::null());
@@ -299,7 +311,7 @@ unsafe fn run_splash(
             let total_ms = splash_start.elapsed().as_millis() as u64;
 
             // Freeze: render final state with brain steady.
-            composite(dib_pixels, 200u8, &stages, Some(total_ms), &footer);
+            composite(dib_pixels, 200u8, &stages, Some(total_ms), &footer, restoring);
             push_layered(hwnd, mem_dc, 255);
 
             // Summary hold — 2 s default, shortened for very fast starts.
@@ -325,7 +337,7 @@ unsafe fn run_splash(
             (160.0 + pulse * 60.0) as u8
         };
 
-        composite(dib_pixels, brain_alpha, &stages, None, &footer);
+        composite(dib_pixels, brain_alpha, &stages, None, &footer, restoring);
         push_layered(hwnd, mem_dc, 255);
 
         std::thread::sleep(std::time::Duration::from_millis(16)); // ~60 fps
@@ -346,6 +358,7 @@ fn composite(
     stages: &[StageRow],
     total_ms: Option<u64>,
     footer: &[String],
+    restoring: bool,
 ) {
     // Opaque BG fill.
     for px in dib.chunks_exact_mut(4) {
@@ -377,7 +390,7 @@ fn composite(
     }
 
     // Stage telemetry list.
-    draw_stages(dib, stages, total_ms);
+    draw_stages(dib, stages, total_ms, restoring);
 
     // Separator line between stage area and footer.
     let sep_y = SPLASH_SIZE + STAGE_AREA_H - STAGE_PAD_BOTTOM / 2;
@@ -400,7 +413,7 @@ fn composite(
     }
 }
 
-fn draw_stages(dib: &mut [u8], stages: &[StageRow], total_ms: Option<u64>) {
+fn draw_stages(dib: &mut [u8], stages: &[StageRow], total_ms: Option<u64>, restoring: bool) {
     use crate::splash_text::{draw_text, text_width};
 
     let y0 = SPLASH_SIZE + STAGE_PAD_TOP;
@@ -409,6 +422,19 @@ fn draw_stages(dib: &mut [u8], stages: &[StageRow], total_ms: Option<u64>) {
     let x_time_right = SPLASH_W - STAGE_MARGIN_R;
 
     let mut row = 0usize;
+
+    // SPEC_PILLAR1_STEP4 Phase 4 — a crash-restart splash has no stage
+    // events at all (nothing re-emits "Saga recovery"/"Migrations"/etc. for
+    // a restart — see `spawn_splash`'s doc comment), so this headline is
+    // the only thing telling the user anything is happening. Takes row 0's
+    // slot rather than growing `SPLASH_H`/`MAX_STAGE_ROWS` — the restart
+    // splash never has more than one or two real rows anyway (if any).
+    if restoring {
+        // ASCII only — the bitmap font (`splash_font::FIRST..=LAST`) only
+        // covers 0x20-0x7E, so a real ellipsis (U+2026) would render as '?'.
+        draw_text(dib, SPLASH_W, SPLASH_H, x_label, y0, "Restoring session...", TIME_RUN_COLOR, 1.0, true);
+        row += 1;
+    }
 
     for stage in stages {
         if row >= MAX_STAGE_ROWS { break; }

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -202,6 +202,27 @@ pub fn spawn_splash(
     Some(event_name)
 }
 
+/// Signal an existing splash's dismiss event by name, same mechanism the CEF
+/// host uses from `on_load_end` (`agentmux-cef/src/client/navigation.rs`).
+/// Used by the crash-restart path (`supervisor/windows.rs`) to tear down the
+/// PREVIOUS restart's splash before spawning a new one — otherwise that
+/// thread stays blocked in `run_splash`'s `WaitForSingleObject` loop forever
+/// (the host that was supposed to dismiss it crashed before ever calling
+/// `on_load_end`), leaking its thread/HWND/GDI objects and, since each
+/// restart now gets its own uniquely-named event (reagent P1, PR #2032,
+/// 2026-07-08), stacking a visible duplicate splash window on screen.
+/// Fire-and-forget: a missing/already-signaled event is not an error.
+pub fn dismiss_splash(event_name: &str) {
+    let nul_name: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
+    unsafe {
+        let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul_name.as_ptr());
+        if !ev.is_null() {
+            SetEvent(ev);
+            CloseHandle(ev);
+        }
+    }
+}
+
 // ── Internals ────────────────────────────────────────────────────────────────
 
 unsafe fn run_splash(

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -21,13 +21,27 @@ use crate::{
 /// restart doesn't re-run saga recovery/migrations/etc., so the splash shows
 /// only the "Restoring session..." headline and the pulsing brain, nothing
 /// from the (empty) stage list.
+///
+/// `seq` (reagent P2, PR #2032, 2026-07-08) makes each restart's Win32 event
+/// + window class name genuinely unique (`AgentMuxSplash-{dir_hash}-r{seq}`),
+/// rather than reusing the SAME name every restart. Reusing the name is
+/// unsafe in exactly the repeated-crash-loop scenario `HOST_RESTART_BUDGET`
+/// exists to bound: if a newly-respawned host crashes again before ever
+/// calling `on_load_end` (so the prior splash thread is still blocked in its
+/// `WaitForSingleObject` loop, `splash.rs`'s dismiss check, holding the
+/// event open), `CreateEventW` with an already-open name returns a handle to
+/// that SAME still-live object instead of a fresh one — both splash threads
+/// then wait on one shared event and can render stacked/duplicate splash
+/// windows simultaneously. A per-restart unique name sidesteps the collision
+/// entirely; the caller passes a monotonic counter that only increases.
 #[cfg(target_os = "windows")]
-fn respawn_splash_for_restart(dir_hash: &str) -> Option<String> {
+fn respawn_splash_for_restart(dir_hash: &str, seq: u32) -> Option<String> {
     if crate::splash_config::splash_disabled() {
         return None;
     }
     let (_sink, rx) = startup_events::StartupEventSink::new();
-    crate::splash::spawn_splash(dir_hash, rx, true)
+    let unique_id = format!("{}-r{}", dir_hash, seq);
+    crate::splash::spawn_splash(&unique_id, rx, true)
 }
 
 /// Windows main flow: resolve paths → create J0 → spawn srv → spawn
@@ -496,6 +510,11 @@ pub(crate) async fn run_windows(
     // Separate budget for system-OOM host exits (memory-aware relaunch); see
     // mem_supervisor + SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.
     let mut oom_restarts: Vec<std::time::Instant> = Vec::new();
+    // SPEC_PILLAR1_STEP4 Phase 4 (reagent P2, PR #2032) — monotonic, only
+    // ever incremented, never reset: guarantees `respawn_splash_for_restart`
+    // never reuses a Win32 event/class name a still-alive prior splash
+    // thread might still be holding open. See that function's doc comment.
+    let mut restart_splash_seq: u32 = 0;
     let mut last_abnormal_code: Option<i32> = None;
     let mut host_degraded = false;
     let exit_code = loop {
@@ -585,7 +604,8 @@ pub(crate) async fn run_windows(
                         // cold-start dismiss, so nothing was listening on that
                         // event name — the host would signal it and nothing would
                         // happen. See `respawn_splash_for_restart`.
-                        splash_event_name = respawn_splash_for_restart(&dir_hash);
+                        restart_splash_seq += 1;
+                        splash_event_name = respawn_splash_for_restart(&dir_hash, restart_splash_seq);
                         match spawn_host_supervised(
                             real_exe,
                             args,
@@ -638,7 +658,8 @@ pub(crate) async fn run_windows(
                         // SPEC_PILLAR1_STEP4 Phase 4 — see the OOM branch above for
                         // why this re-spawns the splash rather than reusing
                         // `splash_event_name` as-is.
-                        splash_event_name = respawn_splash_for_restart(&dir_hash);
+                        restart_splash_seq += 1;
+                        splash_event_name = respawn_splash_for_restart(&dir_hash, restart_splash_seq);
                         match spawn_host_supervised(
                             real_exe,
                             args,

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -12,6 +12,24 @@ use crate::{
     startup_events, state,
 };
 
+/// SPEC_PILLAR1_STEP4 Phase 4 — re-arm the pre-splash for a crash-restart.
+/// Not a no-op wrapper around `spawn_splash`: it exists so both restart
+/// branches (OOM, Abnormal) share one call site rather than duplicating the
+/// "new channel, new splash, restoring=true" triplet inline. Respects
+/// `AGENTMUX_SPLASH=0` (`splash_disabled()`) the same as the cold-start path.
+/// No stage-telemetry events are ever sent into the fresh channel — a
+/// restart doesn't re-run saga recovery/migrations/etc., so the splash shows
+/// only the "Restoring session..." headline and the pulsing brain, nothing
+/// from the (empty) stage list.
+#[cfg(target_os = "windows")]
+fn respawn_splash_for_restart(dir_hash: &str) -> Option<String> {
+    if crate::splash_config::splash_disabled() {
+        return None;
+    }
+    let (_sink, rx) = startup_events::StartupEventSink::new();
+    crate::splash::spawn_splash(dir_hash, rx, true)
+}
+
 /// Windows main flow: resolve paths → create J0 → spawn srv → spawn
 /// host with srv endpoints in env → supervised wait → cleanup.
 #[cfg(target_os = "windows")]
@@ -191,12 +209,16 @@ pub(crate) async fn run_windows(
     // single-instance pipe — before srv spawn and CEF init.
     // The event name is forwarded to the CEF host as
     // AGENTMUX_SPLASH_EVENT so it can signal dismiss from on_load_end.
+    // SPEC_PILLAR1_STEP4 Phase 4 — `mut`: a crash-restart branch below
+    // re-spawns the splash (a fresh event + consumer thread, since this
+    // first thread's own event is one-shot — see `spawn_splash`'s doc
+    // comment) and reassigns this to the new event name.
     #[cfg(target_os = "windows")]
-    let splash_event_name = if crate::splash_config::splash_disabled() {
+    let mut splash_event_name = if crate::splash_config::splash_disabled() {
         drop(startup_rx); // no splash — let senders fail silently
         None // splash:disabled / AGENTMUX_SPLASH=0 — no event, no window (SPEC §6)
     } else {
-        crate::splash::spawn_splash(&dir_hash, startup_rx)
+        crate::splash::spawn_splash(&dir_hash, startup_rx, false)
     };
     #[cfg(not(target_os = "windows"))]
     let splash_event_name: Option<String> = { drop(startup_rx); None };
@@ -555,6 +577,15 @@ pub(crate) async fn run_windows(
                         // Relaunch degraded: the GPU process is a large commit
                         // consumer, so skip straight to software rendering for an
                         // OOM relaunch (SPEC §5.B.4).
+                        //
+                        // SPEC_PILLAR1_STEP4 Phase 4 — re-spawn the splash (fresh
+                        // event + consumer thread) with the "Restoring session..."
+                        // headline rather than reusing `splash_event_name` as-is:
+                        // the original splash thread already exited after the
+                        // cold-start dismiss, so nothing was listening on that
+                        // event name — the host would signal it and nothing would
+                        // happen. See `respawn_splash_for_restart`.
+                        splash_event_name = respawn_splash_for_restart(&dir_hash);
                         match spawn_host_supervised(
                             real_exe,
                             args,
@@ -604,6 +635,10 @@ pub(crate) async fn run_windows(
                             HOST_RESTART_BUDGET,
                             if host_degraded { ", degraded: --disable-gpu" } else { "" }
                         ));
+                        // SPEC_PILLAR1_STEP4 Phase 4 — see the OOM branch above for
+                        // why this re-spawns the splash rather than reusing
+                        // `splash_event_name` as-is.
+                        splash_event_name = respawn_splash_for_restart(&dir_hash);
                         match spawn_host_supervised(
                             real_exe,
                             args,

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -34,6 +34,14 @@ use crate::{
 /// then wait on one shared event and can render stacked/duplicate splash
 /// windows simultaneously. A per-restart unique name sidesteps the collision
 /// entirely; the caller passes a monotonic counter that only increases.
+///
+/// The unique name alone only stops two splashes from *sharing one event* —
+/// it does nothing to stop the PREVIOUS restart's splash from being
+/// orphaned if its host crashed again before calling `on_load_end` (reagent
+/// P1, PR #2032, 2026-07-08). Every call site MUST call
+/// `crate::splash::dismiss_splash` on the outgoing `splash_event_name`
+/// immediately before calling this function, so the old thread tears itself
+/// down via its own normal dismiss path instead of leaking forever.
 #[cfg(target_os = "windows")]
 fn respawn_splash_for_restart(dir_hash: &str, seq: u32) -> Option<String> {
     if crate::splash_config::splash_disabled() {
@@ -604,6 +612,17 @@ pub(crate) async fn run_windows(
                         // cold-start dismiss, so nothing was listening on that
                         // event name — the host would signal it and nothing would
                         // happen. See `respawn_splash_for_restart`.
+                        // Tear down the PREVIOUS restart's splash before spawning a
+                        // new one (reagent P1, PR #2032, 2026-07-08): the unique
+                        // per-restart event name (above) stops two splashes from
+                        // sharing one Win32 event, but does nothing to stop the old
+                        // one from being orphaned — if the host that was supposed to
+                        // dismiss it crashed again first, its thread would otherwise
+                        // block in `WaitForSingleObject` for the rest of the
+                        // launcher's life and its window could still be on screen.
+                        if let Some(prev_event) = splash_event_name.as_deref() {
+                            crate::splash::dismiss_splash(prev_event);
+                        }
                         restart_splash_seq += 1;
                         splash_event_name = respawn_splash_for_restart(&dir_hash, restart_splash_seq);
                         match spawn_host_supervised(
@@ -658,6 +677,17 @@ pub(crate) async fn run_windows(
                         // SPEC_PILLAR1_STEP4 Phase 4 — see the OOM branch above for
                         // why this re-spawns the splash rather than reusing
                         // `splash_event_name` as-is.
+                        // Tear down the PREVIOUS restart's splash before spawning a
+                        // new one (reagent P1, PR #2032, 2026-07-08): the unique
+                        // per-restart event name (above) stops two splashes from
+                        // sharing one Win32 event, but does nothing to stop the old
+                        // one from being orphaned — if the host that was supposed to
+                        // dismiss it crashed again first, its thread would otherwise
+                        // block in `WaitForSingleObject` for the rest of the
+                        // launcher's life and its window could still be on screen.
+                        if let Some(prev_event) = splash_event_name.as_deref() {
+                            crate::splash::dismiss_splash(prev_event);
+                        }
                         restart_splash_seq += 1;
                         splash_event_name = respawn_splash_for_restart(&dir_hash, restart_splash_seq);
                         match spawn_host_supervised(

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -417,6 +417,30 @@ that source alone, independent of Phase 3's own reprojection (which is now self-
 the same cap above, but the underlying pool-window leak itself is a separate, pre-existing gap
 (adjacent to Pillar 2's window-lifecycle work, not Phase 3-specific) and needs its own fix.
 
+**Addendum 2026-07-08, round 2 (reagent review, PR #2032) — closing on an unconfirmed signal risked
+silent data loss.** reagent caught that the fix above closed the OLD window_id immediately after
+`open_window_with_kind` returned `Ok` — but `Ok` there only means a `CreateWindowTask` was
+successfully *posted* to the UI thread (fire-and-forget via `post_task`), not that the window
+actually exists. This session's own Phase 2 investigation already found `post_task` can silently drop
+a posted task (the UI-thread-readiness race). Had that happened here, the old session's
+window/workspace/tabs would already be deleted with no replacement and no retry — a strictly worse
+outcome than the original bug (unclosed-but-not-lost).
+
+Fixed by deferring: `reproject_from_snapshot` now returns `(old_label, new_label)` pairs;
+`reproject_from_srv` stashes `new_label → old_window_id` in a new `AppState.pending_reproject_closures`
+map instead of closing immediately. `register_backend_window` (`commands/window/meta.rs`) drains this
+map for its own label after every registration — that call firing at all is the real confirmation
+(the new window's frontend loaded and round-tripped IPC), and only then is the old id closed. If
+creation silently fails, the entry just sits unclosed forever — the same safe-but-imperfect fallback
+as before any of this cleanup existed.
+
+Re-verified live: reproject completed (`created=4`) at one timestamp; the four
+`"new window confirmed live — closing..."` log lines fired 2-3 seconds later, after each new window's
+own `register_backend_window` call — confirming the deferral is real, not just structurally present.
+All four `CloseWindow` calls still got `HTTP/1.1 200 OK`, and all four reprojected windows still
+appeared as correctly-labeled CDP targets (bonus confirmation: their URLs carried `&restoring=1`,
+verifying Phase 4's frontend wiring end-to-end too).
+
 Each phase independently shippable, matching every other Pillar 1 spec's phasing discipline this
 session established.
 

--- a/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
+++ b/docs/specs/SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md
@@ -362,10 +362,60 @@ now-tested code that could silently drift from it. Re-verified live after the re
 subwindow-of-main + full-process-tree-kill scenario): identical success signature — slow path
 triggers from `register_backend_window`, subwindow parent resolves correctly, no duplicate main.
 
-**Phase 4 — overlay UX** (§2.4), as a follow-on, not gating Phases 1-3.
+**Phase 4 — overlay UX.** ✅ Done (Windows only, matching Phases 1-3's scoping). Pre-window phase:
+`agentmux-launcher/src/splash.rs`'s `spawn_splash` gained a `restoring: bool` param that draws a
+"Restoring session..." headline (ASCII only — the bitmap font only covers 0x20-0x7E, a real ellipsis
+renders as `?`) in place of stage row 0, since a crash-restart has no stage-telemetry events at all
+to show. `supervisor/windows.rs`'s two restart branches (OOM, Abnormal) now call a new
+`respawn_splash_for_restart` helper — a fresh Win32 event + consumer thread, not a reuse of the
+cold-start splash's already-exited one (the original bug this addendum's own §1 already diagnosed:
+the stale event name was re-passed to the relaunched host, but nothing was listening on it anymore).
+In-window phase: `index.html` gained a hidden `#startup-loading-headline` node shown via an inline
+script reading `?restoring=1` (mirroring the existing `window_transparent` query-param pattern);
+`open_window_with_kind` gained an `is_reproject: bool` param that appends `&restoring=1` to the URL
+only for reprojected windows, threaded through from `reproject_from_snapshot`'s call site (shared by
+both fast and slow paths).
 
-**Phase 5 — E2E test** ("host OOM ⇒ session reprojects", per the parent design doc's §3 acceptance
-criterion): automate the Phase 2 manual verification.
+**Phase 5 — E2E test.** ✅ Done. `test/e2e/crash-reproject.e2e.test.ts` — greenfield (no prior E2E
+infra existed in this repo; Vitest is the only test runner, no Playwright), Windows-only, opt-in via
+`AGENTMUX_E2E_BUILD_DIR` (skips instantly under a plain `npm test`, since a real portable build takes
+minutes to produce). Spawns a real isolated instance (env-scrubbed, matching this session's manual
+methodology all Phases 1-3 were verified with), opens a `FullInstance` window and a subwindow of
+main, kills the inner host process only, and asserts the respawned host's CDP target list — not just
+its own log lines, per the explicit lesson from `docs/retro/retro-browser-pane-renderer-leak-2026-07-07.md`
+("a test that only checks host log lines... would have passed throughout this entire investigation").
+Uses Node's native global `WebSocket` rather than the `ws` npm package — the shared `vitest.config.ts`
+merges in the frontend's own browser-oriented `vite.config`, which redirects `ws` to a stub that
+throws even under `@vitest-environment node` and even via `createRequire` (vite-node intercepts
+Node's own `require`, not just ESM imports).
+
+**Addendum 2026-07-08 — a real accumulation bug found while building Phase 5's test, not by manual
+verification.** The E2E test's `beforeAll` did a plain cold boot and immediately triggered the slow
+path, which tried to recreate **30+ stale windows** left over from this whole session's testing (every
+manual verification pass used `taskkill /F`, never a graceful quit, so nothing ever pruned srv's
+`Client.windowids`). Root cause: `reproject_from_srv` recreates windows from `Client.windowids` but
+never removed the OLD ids it just reprojected FROM — only `register_backend_window` ever *adds* to
+that list. Across repeated crashes (exactly Phase 3's own target scenario), the list grows
+monotonically: every subsequent crash reprojects an ever-larger pile, including windows from crashes
+days or weeks earlier. This was sitting in `main` already (PR #2017), not merely a test artifact.
+
+Fixed in two parts:
+1. `reproject_from_snapshot` now returns the labels it successfully recreated (not skipped/failed
+   ones); `reproject_from_srv` closes each corresponding OLD srv `window_id` via the existing
+   `backend_close_window` (the same `window.CloseWindow` RPC used elsewhere), once its replacement
+   exists. Verified live with `AGENTMUX_DEBUG_CLOSE=1`: every close request gets `HTTP/1.1 200 OK`.
+2. A defensive cap (`MAX_SLOW_PATH_RECREATE = 20`) bounds the worst case regardless of root cause —
+   verified live by pushing `Client.windowids` to 44 entries (opening 23 windows on top of leftover
+   pool-window registrations) and confirming the slow path logged
+   `total=44 recreating=20 dropped=24` and created exactly 20, not 44.
+
+**Known, separate follow-up (not fixed here):** pool-warmup windows (the 1-2 windows CEF creates
+automatically on every cold boot for instant-open performance) also register a real
+`backend_window_id` that's never closed either, since they're never gracefully closed — only
+promoted or abandoned. This means `Client.windowids` still grows slowly across repeated restarts from
+that source alone, independent of Phase 3's own reprojection (which is now self-cleaning). Bounded by
+the same cap above, but the underlying pool-window leak itself is a separate, pre-existing gap
+(adjacent to Pillar 2's window-lifecycle work, not Phase 3-specific) and needs its own fix.
 
 Each phase independently shippable, matching every other Pillar 1 spec's phasing discipline this
 session established.
@@ -431,8 +481,12 @@ session established.
 4. ✅ No regression in existing single-window cold-start behavior — confirmed across every Phase 2/3
    live-verification run in this session: a plain cold start with no extra windows takes the
    fast-path-empty → slow-path-empty-too (or fast-path-has-data) route and both no-op cleanly, per
-   the idempotent-by-construction design in §2.1. 159 unit tests pass throughout, no regressions.
-5. ⬜ E2E test automating #2 (Phase 5).
+   the idempotent-by-construction design in §2.1. 169 unit tests pass throughout, no regressions.
+5. ✅ E2E test automating #2 (Phase 5) — `test/e2e/crash-reproject.e2e.test.ts`, opt-in via
+   `AGENTMUX_E2E_BUILD_DIR`, passing.
+6. ✅ Repeated crashes don't cause unbounded window-recreation growth — the accumulation bug found
+   while building #5 is fixed (old srv window_ids closed once reprojected) and capped as a defensive
+   backstop (`MAX_SLOW_PATH_RECREATE = 20`), both live-verified.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -58,6 +58,17 @@
         0%, 100% { opacity: 0.9; transform: scale(1) translateZ(0); }
         50%       { opacity: 0.65; transform: scale(0.97) translateZ(0); }
       }
+      /* SPEC_PILLAR1_STEP4 Phase 4 — hidden by default; the inline script
+         below shows it only when the host appended ?restoring=1 (a
+         reprojected window, not a cold-start one). Cheap, frontend-only —
+         same `?restoring=1`-driven-headline design as the launcher's
+         native pre-splash (Phase 4's other half, agentmux-launcher/src/splash.rs). */
+      #startup-loading-headline {
+        display: none;
+        font-size: 14px;
+        color: #b8b8c0;
+        letter-spacing: 0.02em;
+      }
     </style>
     <link rel="stylesheet" href="/fontawesome/css/fontawesome.min.css" />
     <link rel="stylesheet" href="/fontawesome/css/brands.min.css" />
@@ -73,6 +84,21 @@
         var t = new URLSearchParams(location.search).get('window_transparent');
         if (t === '0') {
           document.documentElement.style.setProperty('--window-opacity', '1');
+        }
+      })();
+    </script>
+    <script>
+      // SPEC_PILLAR1_STEP4 Phase 4 — show the "Restoring session..." headline
+      // before first paint when this window was opened by the crash-reproject
+      // driver (reproject_from_snapshot / reproject_from_srv in
+      // agentmux-cef/src/commands/window/creation.rs append &restoring=1 to
+      // the URL; an interactive "New Window"/"New Subwindow" never does).
+      (function() {
+        if (new URLSearchParams(location.search).get('restoring') === '1') {
+          document.addEventListener('DOMContentLoaded', function() {
+            var el = document.getElementById('startup-loading-headline');
+            if (el) { el.style.display = 'block'; }
+          });
         }
       })();
     </script>
@@ -127,7 +153,7 @@
       <path d="m363.1,701.79h-18c-4.42,0-8-3.58-8-8v-82.97h-36.15v82.97c0,4.42-3.58,8-8,8h-18c-4.42,0-8-3.58-8-8v-108.97c0-4.42,3.58-8,8-8h88.15c4.42,0,8,3.58,8,8v108.97c0,4.42-3.58,8-8,8Z" fill="url(#ag-lg-16)" stroke-width="0"/>
     </g>
   </g>
-</svg></div>
+</svg><div id="startup-loading-headline">Restoring session&hellip;</div></div>
     <div id="main"></div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "package:portable": "task package:portable",
     "test": "vitest",
     "coverage": "vitest run --coverage",
+    "test:e2e": "vitest run test/e2e",
     "clean": "task clean",
     "lint:scss": "stylelint \"frontend/**/*.scss\" --allow-empty-input"
   },

--- a/test/e2e/crash-reproject.e2e.test.ts
+++ b/test/e2e/crash-reproject.e2e.test.ts
@@ -1,0 +1,358 @@
+// @vitest-environment node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SPEC_PILLAR1_STEP4 Phase 5 — E2E test for "host OOM ⇒ session reprojects"
+ * (the parent design doc's §3 acceptance criterion), automating this
+ * session's Phase 2/3 manual live-verification methodology: launch an
+ * isolated instance, open extra windows, kill the inner host process only
+ * (the launcher survives — the far more common crash than a full
+ * process-tree kill), wait for the launcher-supervised respawn, and assert
+ * the recreated windows show up as real CDP targets with correct kind.
+ *
+ * Greenfield and Windows-only (matching every other Phase 1-4 verification
+ * this spec's implementation was built and checked against). Requires a real
+ * portable/dev build — `task package` takes minutes, so this suite does NOT
+ * run under a plain `npm test`. Set `AGENTMUX_E2E_BUILD_DIR` to a build
+ * directory (the folder containing `agentmux.exe`, e.g. the output of
+ * `task package`) to opt in:
+ *
+ *   AGENTMUX_E2E_BUILD_DIR="/c/Users/you/Desktop/agentmux-...-x64-portable" \
+ *     npx vitest run test/e2e/crash-reproject.e2e.test.ts
+ *
+ * Without that env var, every test in this file reports `skipped` — matching
+ * common practice for expensive/opt-in E2E suites (see e.g. Playwright's
+ * `test.skip`-on-missing-fixture convention) rather than silently passing or
+ * blocking every routine `npm test` run on a multi-minute build.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+// Deliberately NOT the `ws` npm package: its package.json maps a "browser"
+// field to a stub that throws ("ws does not work in the browser"), and the
+// repo's shared vitest.config.ts merges in the frontend's own vite.config
+// (browser-oriented resolution needed for the rest of this test suite) —
+// that resolution applies even under `@vitest-environment node` and even
+// via `createRequire` (vite-node intercepts Node's own `require` too, not
+// just ESM imports). Node's own native `WebSocket` (global since Node 22,
+// undici-backed) sidesteps this entirely — it's a process global, not
+// something resolved through Vite's module graph at all. Its API is
+// DOM-style (`addEventListener`, not `ws`'s EventEmitter `.on()`).
+
+const BUILD_DIR = process.env.AGENTMUX_E2E_BUILD_DIR;
+const IS_WINDOWS = process.platform === "win32";
+const RUN = Boolean(BUILD_DIR) && IS_WINDOWS;
+
+if (!RUN) {
+    const reason = !BUILD_DIR
+        ? "AGENTMUX_E2E_BUILD_DIR not set"
+        : `unsupported platform (${process.platform}, Windows-only)`;
+    // eslint-disable-next-line no-console
+    console.log(`[crash-reproject e2e] skipped — ${reason}`);
+}
+
+// ── CDP helpers (same wire-level approach as the session's own
+//    `.verify_step4p2_cdp.mjs` scratch script, formalized here). ──────────
+
+interface CdpTarget {
+    title: string;
+    url: string;
+    webSocketDebuggerUrl: string;
+}
+
+async function listCdpTargets(port: number): Promise<CdpTarget[]> {
+    const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+    if (!res.ok) throw new Error(`CDP /json/list returned ${res.status}`);
+    return (await res.json()) as CdpTarget[];
+}
+
+function wsConnect(url: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+        const ws = new WebSocket(url);
+        ws.addEventListener("open", () => resolve(ws));
+        ws.addEventListener("error", (ev) => reject(new Error(String((ev as any).message ?? ev))));
+    });
+}
+
+let msgId = 1;
+function wsSend(ws: WebSocket, method: string, params?: unknown): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const id = msgId++;
+        const handler = (event: MessageEvent) => {
+            const msg = JSON.parse(String(event.data));
+            if (msg.id === id) {
+                ws.removeEventListener("message", handler);
+                if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+                else resolve(msg.result);
+            }
+        };
+        ws.addEventListener("message", handler);
+        ws.send(JSON.stringify({ id, method, params }));
+    });
+}
+
+/** Evaluate `expression` in the main window's page (found by title substring). */
+async function evalInMainWindow(port: number, expression: string): Promise<any> {
+    const targets = await listCdpTargets(port);
+    const main = targets.find((t) => t.title.includes("Starter workspace"));
+    if (!main) throw new Error("main window's CDP target not found");
+    const ws = await wsConnect(main.webSocketDebuggerUrl);
+    await wsSend(ws, "Runtime.enable");
+    const result = await wsSend(ws, "Runtime.evaluate", {
+        expression,
+        awaitPromise: true,
+        returnByValue: true,
+    });
+    ws.close();
+    if (result.exceptionDetails) {
+        throw new Error(`eval failed: ${JSON.stringify(result.exceptionDetails)}`);
+    }
+    return result.result.value;
+}
+
+// ── Process helpers ───────────────────────────────────────────────────────
+
+/** All AGENTMUX_* env vars scrubbed — an isolated instance, not sharing
+ *  state with any already-running dev/portable instance on this machine. */
+function scrubbedEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {};
+    for (const [k, v] of Object.entries(process.env)) {
+        if (!k.startsWith("AGENTMUX_")) env[k] = v;
+    }
+    return env;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Poll `netstat` for the two ports a freshly-created host PID listens on
+ *  (IPC + CDP — CDP is whichever of the pair actually answers /json/list). */
+async function findCdpPort(pid: number, timeoutMs: number): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const out = execSync("netstat -ano", { encoding: "utf8" });
+        const ports = out
+            .split("\n")
+            .filter((l) => {
+                if (!l.includes("LISTENING")) return false;
+                // Exact match on the trailing PID column — `endsWith` would
+                // false-positive-match e.g. pid=88 against a line ending in
+                // "988" (a real substring, not a real match).
+                const cols = l.trim().split(/\s+/);
+                return Number(cols[cols.length - 1]) === pid;
+            })
+            .map((l) => {
+                const m = l.match(/127\.0\.0\.1:(\d+)/);
+                return m ? Number(m[1]) : null;
+            })
+            .filter((p): p is number => p !== null);
+        for (const port of ports) {
+            try {
+                const targets = await listCdpTargets(port);
+                if (targets.length > 0) return port;
+            } catch {
+                // this port is the IPC port, not CDP — try the next one
+            }
+        }
+        await sleep(500);
+    }
+    throw new Error(`CDP port for PID ${pid} not found within ${timeoutMs}ms`);
+}
+
+function killPid(pid: number): void {
+    try {
+        execSync(`taskkill /PID ${pid} /F`, { stdio: "ignore" });
+    } catch {
+        // already gone — fine
+    }
+}
+
+describe.skipIf(!RUN)("crash-reproject E2E: host OOM ⇒ session reprojects", () => {
+    let outerWrapperPid: number | null = null;
+    let hostPid: number | null = null;
+    let logPath: string;
+
+    beforeAll(async () => {
+        const exePath = path.join(BUILD_DIR!, "agentmux.exe");
+        if (!fs.existsSync(exePath)) {
+            throw new Error(`AGENTMUX_E2E_BUILD_DIR does not contain agentmux.exe: ${exePath}`);
+        }
+        logPath = path.join(BUILD_DIR!, "..", "crash-reproject-e2e.log");
+        const logFd = fs.openSync(logPath, "w");
+        const child: ChildProcess = spawn(exePath, [], {
+            cwd: BUILD_DIR,
+            env: scrubbedEnv(),
+            detached: true,
+            stdio: ["ignore", logFd, logFd],
+        });
+        child.unref();
+
+        // The spawned `agentmux.exe` is the outer launcher wrapper; the exe
+        // name inside the build dir's `runtime/` (the actual CEF host) is
+        // versioned (`agentmux-X.Y.Z.exe`) — find it by reading the log or
+        // by process name once it starts. `wmic`'s CommandLine match on
+        // "agentmux.exe" catches the wrapper itself; the host process has a
+        // distinct versioned name, discovered via the same query with a
+        // wildcard-free match against whatever's actually running.
+        await sleep(3000); // let the wrapper spawn its children
+        hostPid = await findVersionedHostPid(BUILD_DIR!, 20000);
+        outerWrapperPid = child.pid ?? null;
+    }, 30000);
+
+    afterAll(async () => {
+        // Kill the wrapper FIRST, not the host: killing `hostPid` while the
+        // wrapper is still alive makes the launcher's own crash-restart
+        // logic (the exact mechanism under test) treat that as a real crash
+        // and spawn yet another replacement — a race that can leave an
+        // orphaned instance behind if this hook's two kills interleave with
+        // the launcher's own respawn. Killing the wrapper first tears down
+        // its Job Object, which should cascade-kill every child (including
+        // any host it's mid-respawn on) in one shot.
+        if (outerWrapperPid) killPid(outerWrapperPid);
+        if (hostPid) killPid(hostPid);
+        await sleep(1000);
+        // Defensive final sweep: guarantee no leaked process from this
+        // specific build dir survives this suite, regardless of any race
+        // above — never by image name (that would hit every other AgentMux
+        // instance on the machine, including a real one the user has open;
+        // see CLAUDE.md's "CRITICAL: Never Kill AgentMux by Image Name").
+        // Scoped to this exact BUILD_DIR's own process tree only.
+        try {
+            const out = execSync(
+                `wmic process where "(name like 'agentmux-%' or name='agentmux.exe')" get ProcessId,CommandLine /format:csv`,
+                { encoding: "utf8" },
+            );
+            const buildDirBackslash = BUILD_DIR!.replace(/\//g, "\\");
+            for (const line of out.split("\n").map((l) => l.trim()).filter(Boolean)) {
+                if (line.startsWith("Node,")) continue;
+                if (!line.includes(buildDirBackslash)) continue;
+                const parts = line.split(",");
+                const pid = Number(parts[parts.length - 1]);
+                if (Number.isFinite(pid) && pid > 0) killPid(pid);
+            }
+        } catch {
+            // best-effort — nothing left to sweep, or wmic itself is gone
+        }
+    });
+
+    it("recreates extra top-level windows after the inner host process is killed", async () => {
+        expect(hostPid).not.toBeNull();
+        const port1 = await findCdpPort(hostPid!, 15000);
+
+        // Open one extra top-level window via the real IPC command (the
+        // same path an interactive "New Window" takes).
+        const newLabel = await evalInMainWindow(
+            port1,
+            "window.api.openNewWindow()",
+        );
+        expect(typeof newLabel).toBe("string");
+
+        // Give the topology write-through (SPEC_PILLAR1_STEP3) and the
+        // launcher's WindowOpened mirror a moment to land before the crash.
+        await sleep(3000);
+
+        const beforeInstances: Array<{ label: string }> = await evalInMainWindow(
+            port1,
+            "window.api.listWindowInstances().then(r => r)",
+        );
+        const extraBefore = beforeInstances.filter((w) => w.label !== "main");
+        expect(extraBefore.length).toBeGreaterThanOrEqual(1);
+
+        // Kill the INNER host process only — the launcher survives and
+        // supervises a respawn. Never kill by image name (CLAUDE.md).
+        killPid(hostPid!);
+
+        // The launcher spawns a brand-new host process (new PID).
+        const newHostPid = await findVersionedHostPid(BUILD_DIR!, 20000, hostPid!);
+        hostPid = newHostPid;
+        const port2 = await findCdpPort(newHostPid, 15000);
+
+        // Fast path: the launcher's in-memory snapshot should have the
+        // extra window and reproject it. Poll briefly — reproject is fast
+        // (sub-second in this session's live verifications) but runs
+        // asynchronously relative to the new host's own startup. Poll on
+        // "main's real title has settled" specifically, not merely
+        // "more than one target exists" — main's CDP target briefly shows a
+        // generic title before its content finishes loading and sets
+        // `document.title` to "Starter workspace...", so a bare count check
+        // can pass before main is actually the window we expect.
+        const deadline = Date.now() + 15000;
+        let targets: CdpTarget[] = [];
+        let mainTarget: CdpTarget | undefined;
+        while (Date.now() < deadline) {
+            targets = await listCdpTargets(port2);
+            mainTarget = targets.find((t) => t.title.includes("Starter workspace"));
+            if (mainTarget && targets.length > 1) break;
+            await sleep(500);
+        }
+
+        // At least the main window and one recreated extra window must show
+        // up as real, distinct CDP targets — this is the assertion this
+        // whole suite exists for: a log line saying "reproject complete" is
+        // not sufficient (see docs/retro/retro-browser-pane-renderer-leak-2026-07-07.md's
+        // own conclusion — verify against the CDP target list, not the
+        // host's own event log).
+        expect(targets.length).toBeGreaterThan(1);
+        expect(mainTarget).toBeDefined();
+    }, 90000);
+});
+
+/** Find the CEF host process (versioned exe name, e.g. `agentmux-0.51.0.exe`
+ *  — distinct from the outer `agentmux.exe` wrapper, the `agentmux-srv-*`
+ *  sidecar, and `agentmux-mcp.exe`) inside `buildDir`'s own process tree,
+ *  excluding any `--type=` child and (optionally) a known-stale `excludePid`
+ *  (used when polling for the POST-crash respawn, so a still-terminating
+ *  old PID doesn't get picked up as "the new one").
+ *
+ *  Deliberately does NOT embed `buildDir` in the WQL query string: a first
+ *  version did (`CommandLine like '%<buildDir>%'`), which is a
+ *  self-referential match — `execSync` runs this exact query via
+ *  `cmd.exe /c wmic ...`, and that invocation's OWN command line contains
+ *  the literal `buildDir` string (it's part of the query!), so wmic matched
+ *  its own querying process (and any other shell wrapper on the machine
+ *  whose command line happened to mention the build path) ahead of the
+ *  real host. Filtering on `Name` first (a strict `agentmux-<digits>.<digits>.<digits>.exe`
+ *  pattern) and only checking `buildDir` as a secondary disambiguator in JS
+ *  avoids this class of bug entirely. */
+async function findVersionedHostPid(
+    buildDir: string,
+    timeoutMs: number,
+    excludePid?: number,
+): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    const hostNamePattern = /^agentmux-\d+\.\d+\.\d+\.exe$/i;
+    // Real Windows command lines (as wmic reports them) always use
+    // backslashes. `buildDir` can arrive as `C:/Users/...` (forward
+    // slashes) when this suite is invoked from Git Bash/MSYS2, which
+    // auto-converts POSIX-looking env var values for non-MSYS child
+    // processes — normalize before substring-matching or this never finds
+    // anything.
+    const buildDirBackslash = buildDir.replace(/\//g, "\\");
+    while (Date.now() < deadline) {
+        try {
+            const out = execSync(
+                `wmic process where "name like 'agentmux-%'" get ProcessId,Name,CommandLine /format:csv`,
+                { encoding: "utf8" },
+            );
+            const lines = out.split("\n").map((l) => l.trim()).filter(Boolean);
+            for (const line of lines) {
+                if (line.startsWith("Node,")) continue; // CSV header
+                if (line.includes("--type=")) continue; // gpu/utility/renderer child
+                if (!line.includes(buildDirBackslash)) continue; // a different instance's process
+                const parts = line.split(",");
+                const pid = Number(parts[parts.length - 1]);
+                const name = parts[parts.length - 2];
+                if (!hostNamePattern.test(name)) continue; // srv sidecar / mcp / wrapper
+                if (Number.isFinite(pid) && pid > 0 && pid !== excludePid) return pid;
+            }
+        } catch {
+            // transient — process tree still forming
+        }
+        await sleep(500);
+    }
+    throw new Error(`versioned host process under ${buildDir} not found within ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Summary
- **Phase 4 (overlay UX, Windows-only)**: the launcher's native pre-splash now re-spawns on crash-restart with a "Restoring session..." headline — previously the stale event name was re-passed to the relaunched host, but nothing was listening on it (the cold-start splash's consumer thread had already exited by the time a crash-restart happens). Frontend gained a matching `?restoring=1`-driven headline in `#startup-loading` for reprojected windows specifically (not interactive "New Window").
- **Phase 5**: greenfield E2E test (`test/e2e/crash-reproject.e2e.test.ts`, opt-in via `AGENTMUX_E2E_BUILD_DIR` — skips instantly under a plain `npm test`) automating this session's manual crash-reproject verification methodology: spawns a real isolated instance, kills the inner host process, and asserts the respawned host's **actual CDP target list** — not just its log lines, per the explicit lesson from a prior retro that log-only checks would have missed a real bug.
- **A real, already-merged bug found while building Phase 5's test**: the slow-path reproject (PR #2017) never closed the OLD srv `window_id` it recreated from, so `Client.windowids` grows without bound across repeated crashes. Fixed by closing each old id via the existing `CloseWindow` RPC once its replacement exists, plus a defensive cap (`MAX_SLOW_PATH_RECREATE = 20`) as a backstop regardless of root cause.
- A separate, pre-existing leak (pool-warmup windows also never gracefully closed) was found but intentionally **not** fixed here — filed as its own follow-up (task #29), since it's adjacent to Pillar 2's window-lifecycle work, not Phase 3/4/5-specific.

See the spec doc's Phase 4/5 sections + the 2026-07-08 addendum for the full writeup.

## Test plan
- [x] `cargo test -p agentmux-cef --release` — 169 passed, 0 failed, no regressions
- [x] `npx vitest run` (full frontend suite) — 109 files / 1636 tests pass, new E2E file skips cleanly (no `AGENTMUX_E2E_BUILD_DIR` set)
- [x] `AGENTMUX_E2E_BUILD_DIR=... npx vitest run test/e2e/crash-reproject.e2e.test.ts` — passes against a real isolated instance
- [x] Live-verified the accumulation fix: `AGENTMUX_DEBUG_CLOSE=1` confirms every `CloseWindow` call for a reprojected old id gets `HTTP/1.1 200 OK`
- [x] Live-verified the safety cap: pushed `Client.windowids` to 44 entries (23 manually-opened windows + leftover pool registrations), full process-tree kill, confirmed the slow path logged `total=44 recreating=20 dropped=24` and created exactly 20, not 44

<!-- agentmux:agent_id=agenta -->