### PR TITLE
test: muxbus jekt round-trip check (Agent3, retry)

### DIFF
--- a/test/agent3-muxbus-jekt-check.md
+++ b/test/agent3-muxbus-jekt-check.md
@@ -1,0 +1,5 @@
+# Muxbus jekt test
+
+Test PR opened by Agent3 to verify the muxbus review-notification round trip
+(PR review → jekt delivered back via muxbus). Safe to close without merging
+once the jekt is confirmed.


### PR DESCRIPTION
## Summary
- Retry of the muxbus jekt round-trip test, this time opened via the correct Agent3-asaf GitHub identity (not the shared keyring account). First attempt (#2033) was mis-authored and closed.
- Safe to close without merging once confirmed.

<!-- agentmux:agent_id=agent3 -->