### PR TITLE
chore: release v0.51.1

### DIFF
--- a/.changesets/1783417054-fix-swarm-key-subagent-completion-off-the-result-event-discr-aqe9.md
+++ b/.changesets/1783417054-fix-swarm-key-subagent-completion-off-the-result-event-discr-aqe9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): key subagent completion off the result-event discriminant, not derived text

--- a/.changesets/1783417480-fix-ambient-cap-concurrent-haiku-spawns-across-the-two-pull--sna1.md
+++ b/.changesets/1783417480-fix-ambient-cap-concurrent-haiku-spawns-across-the-two-pull--sna1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ambient): cap concurrent Haiku spawns across the two pull RPCs

--- a/.changesets/1783417549-feat-host-spec-pillar1-step3-phase-1-setwindowtopology-rpc-f-x5r7.md
+++ b/.changesets/1783417549-feat-host-spec-pillar1-step3-phase-1-setwindowtopology-rpc-f-x5r7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP3 Phase 1 -- SetWindowTopology RPC for window kind + parent linkage

--- a/.changesets/1783433373-fix-agent-reconcile-turnphase-from-backend-truth-at-pane-mou-e7ef.md
+++ b/.changesets/1783433373-fix-agent-reconcile-turnphase-from-backend-truth-at-pane-mou-e7ef.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): reconcile TurnPhase from backend truth at pane mount

--- a/.changesets/1783433910-feat-subagent-brain-spinner-loading-overlay-targeted-info-lo-pgbf.md
+++ b/.changesets/1783433910-feat-subagent-brain-spinner-loading-overlay-targeted-info-lo-pgbf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(subagent): brain-spinner loading overlay + targeted info lookup

--- a/.changesets/1783438502-feat-host-spec-pillar1-step3-phase-2-wire-setwindowtopology--ze46.md
+++ b/.changesets/1783438502-feat-host-spec-pillar1-step3-phase-2-wire-setwindowtopology--ze46.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP3 Phase 2 -- wire SetWindowTopology into window creation

--- a/.changesets/1783438771-fix-subagent-stop-the-register-time-historical-scan-flood-an-vuwk.md
+++ b/.changesets/1783438771-fix-subagent-stop-the-register-time-historical-scan-flood-an-vuwk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(subagent): stop the register-time historical-scan flood and the config-dir-missing race

--- a/.changesets/1783441390-feat-term-terminal-picks-up-the-app-theme-by-default-nq3a.md
+++ b/.changesets/1783441390-feat-term-terminal-picks-up-the-app-theme-by-default-nq3a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(term): terminal picks up the app theme by default

--- a/.changesets/1783447818-fix-browser-pane-macos-linux-click-on-pane-body-now-selects--jh4e.md
+++ b/.changesets/1783447818-fix-browser-pane-macos-linux-click-on-pane-body-now-selects--jh4e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): macOS click on pane body now selects the pane (Linux still open)

--- a/.changesets/1783448218-fix-window-nudge-macos-hamburger-button-2px-up-for-optical-a-g2fs.md
+++ b/.changesets/1783448218-fix-window-nudge-macos-hamburger-button-2px-up-for-optical-a-g2fs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): nudge macOS hamburger button 2px up for optical alignment

--- a/.changesets/1783448715-feat-host-spec-pillar1-step4-phase-1-request-the-launcher-s--cfch.md
+++ b/.changesets/1783448715-feat-host-spec-pillar1-step4-phase-1-request-the-launcher-s--cfch.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP4 Phase 1 -- request the launcher's live window snapshot on connect

--- a/.changesets/1783449619-docs-build-fix-stale-react-vite-references-app-is-solidjs-0mol.md
+++ b/.changesets/1783449619-docs-build-fix-stale-react-vite-references-app-is-solidjs-0mol.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(build): fix stale React/Vite references, app is SolidJS

--- a/.changesets/1783462886-fix-host-fix-pillar-1-step-4-phase-2-crash-reproject-silentl-4e82.md
+++ b/.changesets/1783462886-fix-host-fix-pillar-1-step-4-phase-2-crash-reproject-silentl-4e82.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(host): fix Pillar 1 Step 4 Phase 2 crash-reproject silently dropping recreated windows

--- a/.changesets/1783464473-fix-window-nudge-macos-hamburger-button-3px-up-for-optical-a-x37c.md
+++ b/.changesets/1783464473-fix-window-nudge-macos-hamburger-button-3px-up-for-optical-a-x37c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): nudge macOS hamburger button 3px up for optical alignment

--- a/.changesets/1783470744-feat-host-spec-pillar1-step4-phase-3-slow-path-srv-reproject-3g29.md
+++ b/.changesets/1783470744-feat-host-spec-pillar1-step4-phase-3-slow-path-srv-reproject-3g29.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP4 Phase 3 - slow-path srv reproject fallback

--- a/.changesets/1783479880-group-swarm-subagents-by-workflow-into-a-collapsible-unit-wi-jvdt.md
+++ b/.changesets/1783479880-group-swarm-subagents-by-workflow-into-a-collapsible-unit-wi-jvdt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Group swarm subagents by workflow into a collapsible unit with active/retired status

--- a/.changesets/1783481288-feat-swarm-inline-expand-subagent-rows-with-haiku-generated--d4tx.md
+++ b/.changesets/1783481288-feat-swarm-inline-expand-subagent-rows-with-haiku-generated--d4tx.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): inline-expand subagent rows with Haiku-generated names, no timestamps

--- a/.changesets/1783482671-docs-messaging-status-snapshot-implementation-ready-specs-fo-oyo3.md
+++ b/.changesets/1783482671-docs-messaging-status-snapshot-implementation-ready-specs-fo-oyo3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(messaging): status snapshot + implementation-ready specs for Telegram/Slack/WhatsApp/Teams bridges

--- a/.changesets/1783483383-feat-messaging-telegram-bridge-long-polling-receive-send-pjbm.md
+++ b/.changesets/1783483383-feat-messaging-telegram-bridge-long-polling-receive-send-pjbm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(messaging): Telegram bridge — long-polling receive + send

--- a/.changesets/1783484234-feat-armory-used-by-n-agents-count-catalog-side-bind-and-age-zu6k.md
+++ b/.changesets/1783484234-feat-armory-used-by-n-agents-count-catalog-side-bind-and-age-zu6k.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): used-by-N-agents count, catalog-side bind, and agent<->catalog deep-linking (#1960)

--- a/.changesets/1783485186-fix-armory-rename-brain-tab-label-to-memory-per-the-composab-bksz.md
+++ b/.changesets/1783485186-fix-armory-rename-brain-tab-label-to-memory-per-the-composab-bksz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): rename 'Brain' tab label to 'Memory' per the composable-model naming decision

--- a/.changesets/1783485586-feat-messaging-slack-bridge-socket-mode-receive-web-api-send-psgo.md
+++ b/.changesets/1783485586-feat-messaging-slack-bridge-socket-mode-receive-web-api-send-psgo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(messaging): Slack bridge — Socket Mode receive + Web API send

--- a/.changesets/1783487331-feat-messaging-whatsapp-bridge-cloud-api-webhook-receiver-se-s89d.md
+++ b/.changesets/1783487331-feat-messaging-whatsapp-bridge-cloud-api-webhook-receiver-se-s89d.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(messaging): WhatsApp bridge — Cloud API webhook receiver + send

--- a/.changesets/1783489663-docs-messaging-status-update-telegram-slack-whatsapp-bridges-m02d.md
+++ b/.changesets/1783489663-docs-messaging-status-update-telegram-slack-whatsapp-bridges-m02d.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(messaging): status update — Telegram/Slack/WhatsApp bridges shipped, Teams deferred

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.51.0"
+version = "0.51.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,33 @@
 # AgentMux Version History
 
+## 0.51.1 — 2026-07-08
+
+- fix(swarm): key subagent completion off the result-event discriminant, not derived text
+- fix(ambient): cap concurrent Haiku spawns across the two pull RPCs
+- feat(host): SPEC_PILLAR1_STEP3 Phase 1 -- SetWindowTopology RPC for window kind + parent linkage
+- fix(agent): reconcile TurnPhase from backend truth at pane mount
+- feat(subagent): brain-spinner loading overlay + targeted info lookup
+- feat(host): SPEC_PILLAR1_STEP3 Phase 2 -- wire SetWindowTopology into window creation
+- fix(subagent): stop the register-time historical-scan flood and the config-dir-missing race
+- feat(term): terminal picks up the app theme by default
+- fix(browser-pane): macOS click on pane body now selects the pane (Linux still open)
+- fix(window): nudge macOS hamburger button 2px up for optical alignment
+- feat(host): SPEC_PILLAR1_STEP4 Phase 1 -- request the launcher's live window snapshot on connect
+- docs(build): fix stale React/Vite references, app is SolidJS
+- fix(host): fix Pillar 1 Step 4 Phase 2 crash-reproject silently dropping recreated windows
+- fix(window): nudge macOS hamburger button 3px up for optical alignment
+- feat(host): SPEC_PILLAR1_STEP4 Phase 3 - slow-path srv reproject fallback
+- Group swarm subagents by workflow into a collapsible unit with active/retired status
+- feat(swarm): inline-expand subagent rows with Haiku-generated names, no timestamps
+- docs(messaging): status snapshot + implementation-ready specs for Telegram/Slack/WhatsApp/Teams bridges
+- feat(messaging): Telegram bridge — long-polling receive + send
+- feat(armory): used-by-N-agents count, catalog-side bind, and agent<->catalog deep-linking (#1960)
+- fix(armory): rename 'Brain' tab label to 'Memory' per the composable-model naming decision
+- feat(messaging): Slack bridge — Socket Mode receive + Web API send
+- feat(messaging): WhatsApp bridge — Cloud API webhook receiver + send
+- docs(messaging): status update — Telegram/Slack/WhatsApp bridges shipped, Teams deferred
+
+
 ## 0.51.0 — 2026-07-07
 
 - feat(host): SPEC_PILLAR1_STEP2 Phase 2 — wire per-window opacity write-through + crash-restart read-back

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -27,7 +27,6 @@
 - feat(messaging): WhatsApp bridge — Cloud API webhook receiver + send
 - docs(messaging): status update — Telegram/Slack/WhatsApp bridges shipped, Teams deferred
 
-
 ## 0.51.0 — 2026-07-07
 
 - feat(host): SPEC_PILLAR1_STEP2 Phase 2 — wire per-window opacity write-through + crash-restart read-back

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.51.0",
+      "version": "0.51.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Consumes 24 pending changesets accumulated on `main` and bumps `0.51.0` → `0.51.1`.
- Bump type manually overridden to **patch**, per explicit request, rather than the auto-computed **minor** (two of the 24 changesets — the armory used-by-N-agents feature and a swarm inline-expand feature — are tagged `minor`; the rest are `patch`).
- Updates `VERSION_HISTORY.md`, `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, and deletes the 24 consumed `.changesets/*.md` files.
- All 5 version locations verified consistent at `0.51.1` before commit.

## Test plan
- [x] `scripts/bump-wrapper.sh patch` ran clean, synced `package-lock.json` and regenerated `Cargo.lock`.
- [x] Release-consistency check (package.json / Cargo.toml / package-lock.json / Cargo.lock / VERSION_HISTORY.md) — all agree at `0.51.1`.
- [ ] CI

<!-- agentmux:agent_id=agent2 -->