### PR TITLE
feat(armory): tooltips on rail nav items

### DIFF
--- a/.changesets/1783525880-feat-armory-tooltips-on-collapsed-rail-nav-items-cgni.md
+++ b/.changesets/1783525880-feat-armory-tooltips-on-collapsed-rail-nav-items-cgni.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(armory): tooltips on collapsed rail nav items

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -3,6 +3,7 @@
 
 import { createSignal, For, type JSX } from "solid-js";
 
+import { Tooltip } from "@/app/element/tooltip";
 import { IdentityManager } from "@/app/view/identity/identity-manager";
 import { MemoryManager } from "@/app/view/memory/memory-manager";
 import { AccountsManager } from "@/app/view/accounts/accounts-manager";
@@ -33,16 +34,18 @@ export function ArmoryView(_props: ViewComponentProps<ArmoryViewModel>): JSX.Ele
                 <nav class="bundle-manager-rail" aria-label="Armory section">
                     <For each={RAIL}>
                         {(item) => (
-                            <button
-                                type="button"
-                                class="bundle-manager-rail-item"
-                                classList={{ "is-active": section() === item.id }}
-                                aria-pressed={section() === item.id}
-                                onClick={() => setSection(item.id)}
-                            >
-                                <i class={`fa-sharp fa-solid fa-${item.icon}`} aria-hidden="true" />
-                                <span>{item.label}</span>
-                            </button>
+                            <Tooltip content={item.label} placement="right">
+                                <button
+                                    type="button"
+                                    class="bundle-manager-rail-item"
+                                    classList={{ "is-active": section() === item.id }}
+                                    aria-pressed={section() === item.id}
+                                    onClick={() => setSection(item.id)}
+                                >
+                                    <i class={`fa-sharp fa-solid fa-${item.icon}`} aria-hidden="true" />
+                                    <span>{item.label}</span>
+                                </button>
+                            </Tooltip>
                         )}
                     </For>
                 </nav>


### PR DESCRIPTION
## Summary

The Armory rail collapses to icon-only at container width <=767px (`armory-view.scss:150`), hiding each item's label with no fallback way to identify the icons. Wraps each rail nav button in the existing `Tooltip` component (`frontend/app/element/tooltip.tsx`) — same pattern already used by the widget bar's `ActionWidget` — so hovering any icon shows its label via a floating tooltip, whether the rail is expanded or collapsed.

## Test plan

- [x] `npx tsc --noEmit` clean

<!-- agentmux:agent_id=agent1 -->