### PR TITLE
fix(tabs): rest workspace tabs at Chrome's standard 232px width

### DIFF
--- a/.changesets/1783527221-fix-tabs-workspace-tabs-rest-at-chrome-s-standard-232px-widt-23wj.md
+++ b/.changesets/1783527221-fix-tabs-workspace-tabs-rest-at-chrome-s-standard-232px-widt-23wj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): workspace tabs rest at Chrome's standard 232px width instead of collapsing to short-label content width

--- a/.changesets/1783539589-feat-tabs-random-color-for-new-tabs-min-window-width-380px-o-uv3x.md
+++ b/.changesets/1783539589-feat-tabs-random-color-for-new-tabs-min-window-width-380px-o-uv3x.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tabs): random color for new tabs; min window width 380px on Windows

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -43,6 +43,18 @@ wrap_window_delegate! {
                 height: 800,
             }
         }
+
+        // Windows only: floor the window at 380px wide so the tab strip and
+        // widget bar can't be resized into an unusably cramped state. No
+        // extra height floor beyond CEF/Windows' own default — only width
+        // is constrained here.
+        #[cfg(target_os = "windows")]
+        fn minimum_size(&self, _view: Option<&mut View>) -> Size {
+            Size {
+                width: 380,
+                height: 1,
+            }
+        }
     }
 
     impl PanelDelegate {}

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -706,12 +706,16 @@ export function removeNotification(id: string) {
 // ---------------------------------------------------------------------------
 
 /**
- * Default color for newly-created tabs. Matches the "Blue" entry in
- * TAB_COLORS and the startup-tab color applied by tabbar.tsx — every
- * new tab now starts the same way as the first one. Users can change
- * the colour per-tab via the right-click menu after creation.
+ * Picks a random color for a newly-created tab, so successive tabs read
+ * as visually distinct at a glance instead of all defaulting to the same
+ * hue. The first (startup) tab is unaffected — it keeps its fixed "Blue"
+ * standard color, applied separately by the startup-tab backfill in
+ * tabbar.tsx. Users can still change the colour per-tab via the
+ * right-click menu after creation.
  */
-const DEFAULT_NEW_TAB_COLOR = "#3b82f6";
+function randomNewTabColor(): string {
+    return TAB_COLORS[Math.floor(Math.random() * TAB_COLORS.length)].hex;
+}
 
 export function createTab() {
     const ws = workspace();
@@ -732,7 +736,7 @@ export function createTab() {
             const tabId = await WorkspaceService.CreateTab(ws.oid, "", true, false);
             await ObjectService.UpdateObjectMeta(
                 WOS.makeORef("tab", tabId),
-                { "tab:color": DEFAULT_NEW_TAB_COLOR } as MetaType,
+                { "tab:color": randomNewTabColor() } as MetaType,
             );
             // Default-layout preset (agent + sysinfo + swarm). Lives in
             // a single central module so any future tab-creation path

--- a/frontend/app/tab/tab-measure.ts
+++ b/frontend/app/tab/tab-measure.ts
@@ -22,8 +22,17 @@ function getCtx(): CanvasRenderingContext2D | null {
 const TAB_PADDING_BUDGET = 52;
 export const TAB_MIN_WIDTH = 60;
 export const TAB_MAX_WIDTH = 260;
+// Chrome's own tab strip renders every tab at a fixed 232px (DIPs) — see
+// `TabStyle::GetStandardWidth()` / `kTabWidth` in
+// chrome/browser/ui/tabs/tab_style.cc — and only shrinks tabs below that
+// uniformly under crowding, never because a single label happens to be
+// short. Used as the resting-width floor here so a freshly-named (or
+// short-named) tab still reads as a normal-sized tab instead of shrinking
+// to hug its own text; longer labels can still grow past it, up to
+// TAB_MAX_WIDTH.
+export const TAB_STANDARD_WIDTH = 232;
 
-const DEFAULT_TAB_WIDTH = 160;
+const DEFAULT_TAB_WIDTH = TAB_STANDARD_WIDTH;
 
 /**
  * Measures the natural pixel width for a workspace tab with the given label.
@@ -42,5 +51,5 @@ export function measureTabWidth(label: string): number {
 
     const textWidth = ctx.measureText(label).width;
     const natural = Math.ceil(textWidth) + TAB_PADDING_BUDGET;
-    return Math.min(Math.max(natural, TAB_MIN_WIDTH), TAB_MAX_WIDTH);
+    return Math.min(Math.max(natural, TAB_STANDARD_WIDTH), TAB_MAX_WIDTH);
 }

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -47,7 +47,7 @@
         white-space: nowrap;
         border-radius: 0;
         // Bound min-width so the flex-shrink contract on `.tab`
-        // (`flex: 0 1 var(--tab-natural-width, 160px)`) actually propagates here.
+        // (`flex: 0 1 var(--tab-natural-width, 232px)`) actually propagates here.
         // Without this, `.tab-inner`'s default `min-width: auto`
         // pins it to its content's natural width, so a shrinking
         // `.tab` would clip the inner row from the right edge

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -7,13 +7,16 @@
     // Content-aware tab sizing (VS Code model): each tab's preferred width
     // is measured from its label text via canvas.measureText() and injected
     // as `--tab-natural-width` inline style on the wrapper by DroppableTab.
-    // This matches VS Code's "shrink" mode — short labels get narrow tabs,
-    // long labels get wide tabs, and all shrink proportionally under pressure.
+    // The measured width floors at TAB_STANDARD_WIDTH (232px — Chrome's own
+    // tab strip standard width, tab-measure.ts) so a short/default label
+    // still reads as a normal-sized tab at rest; long labels can still grow
+    // past it, up to 260px. All tabs shrink proportionally under pressure.
     // Spec: specs/SPEC_TAB_CONTENT_AWARE_SIZING_2026-06-14.md.
     //
-    // `--tab-natural-width` fallback (160px) covers the initial paint before
-    // JS has run a measurement. Floor at 60px keeps the close button reachable.
-    // Cap at 260px prevents very long labels from dominating the bar.
+    // `--tab-natural-width` fallback (232px, matches TAB_STANDARD_WIDTH)
+    // covers the initial paint before JS has run a measurement. Floor at
+    // 60px keeps the close button reachable. Cap at 260px prevents very
+    // long labels from dominating the bar.
     --ws-tab-min: 60px;
     --ws-tab-max: 260px;
 
@@ -57,11 +60,11 @@
         // sprawl to fill slack — the `.tab-bar-fill` filler absorbs that.
         // shrink=1 so all tabs compress proportionally under overflow;
         // `.name`'s `text-overflow: ellipsis` trips once the tab narrows
-        // past its text. The 160px fallback covers initial paint before JS.
+        // past its text. The 232px fallback covers initial paint before JS.
         .tab {
             position: relative;
             opacity: 1;
-            flex: 0 1 var(--tab-natural-width, 160px);
+            flex: 0 1 var(--tab-natural-width, 232px);
             min-width: var(--ws-tab-min);
             max-width: var(--ws-tab-max);
             overflow: hidden;
@@ -115,8 +118,8 @@
         // Wrapper mirrors the inner .tab sizing contract so both shrink
         // in lockstep. `--tab-natural-width` is set as an inline style
         // by DroppableTab once Tab fires onNaturalWidth; falls back to
-        // 160px until JS measures the label.
-        flex: 0 1 var(--tab-natural-width, 160px);
+        // 232px until JS measures the label.
+        flex: 0 1 var(--tab-natural-width, 232px);
         min-width: var(--ws-tab-min);
         max-width: var(--ws-tab-max);
         display: flex;


### PR DESCRIPTION
## Summary

Workspace tabs looked too narrow at rest — `measureTabWidth()` (`frontend/app/tab/tab-measure.ts`) sized each tab's flex-basis purely from its own label's canvas-measured text width, clamped only to `[TAB_MIN_WIDTH (60), TAB_MAX_WIDTH (260)]`. A short or freshly-created tab collapsed to hug its own text (well under 100px in many cases) instead of reading as a normal-sized tab.

Chrome's own tab strip doesn't do this: every tab renders at a fixed standard width (`TabStyle::GetStandardWidth()` == 232 DIPs, `kTabWidth` in `chrome/browser/ui/tabs/tab_style.cc`) and only shrinks tabs uniformly under crowding — never because one label happens to be short.

Floors the measured natural width at a new `TAB_STANDARD_WIDTH = 232` (Chrome's value) instead of `TAB_MIN_WIDTH`, so short/default labels now rest at the same width Chrome uses. Longer labels can still grow past it, up to the existing 260px cap. Also updates the `--tab-natural-width` CSS fallback (used for the first paint before JS measures) from 160px to 232px to match, avoiding a layout jump.

`TAB_MIN_WIDTH` (60px) is unchanged — it's still the hard floor `.tab`/`.tab-drop-wrapper` shrink to under real crowding.

## Tabs thinning near the widget bar

Verified this is already handled by existing machinery, no new code needed:
- `.tab-bar { flex: 1 1 auto; min-width: 0 }` (`tabbar.scss`) means the tab bar absorbs available space in the header row; `.system-status` (widget bar) has no `min-width: 0`, so by default flexbox it won't shrink below its own content's minimum — the squeeze falls on the tab bar first.
- Each `.tab` has `flex: 0 1 var(--tab-natural-width)` with `min-width: var(--ws-tab-min)` (60px) — shrinks proportionally as the bar narrows.
- `action-widgets.tsx`'s existing 3-tier progressive collapse (`SPEC_TOPBAR_PROGRESSIVE_COLLAPSE_2026_06_05.md`) reserves a per-tab width (`TAB_COLLAPSE_RESERVE_PX = 100`) and drops widget labels to icon-only *before* tabs get squeezed past that reserve, then clips pinned icons into the "More" overflow if tabs are still tight at a tighter reserve (`TAB_COLLAPSE_RESERVE_ICON_PX = 70`).

## Follow-up additions

- **Random new-tab color**: `createTab()` (`frontend/app/store/global.ts`) previously assigned every new tab the same fixed "Blue" as the first (startup) tab. Now picks a random entry from `TAB_COLORS` so successive tabs read as visually distinct at a glance. The first tab is unaffected — it keeps the fixed Blue standard color via the existing startup-tab backfill in `tabbar.tsx`.
- **380px minimum window width (Windows)**: added a `#[cfg(target_os = "windows")]` `ViewDelegate::minimum_size` override in `AgentMuxWindowDelegate` (`agentmux-cef/src/app.rs`), mirroring the existing `preferred_size` override, so the main window can't be resized narrower than 380px and crush the tab strip / widget bar. No additional height floor imposed — width only, per the ask.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `cargo check -p agentmux-cef` clean
- [x] Verified live in a `task dev` build on this branch: tab widths, random new-tab colors, and the 380px Windows floor all confirmed working by the user in the running app.

<!-- agentmux:agent_id=agent1 -->