### PR TITLE
feat(layout): reducer self-heals dangling block references on every write (WRR-style)

### DIFF
--- a/.changesets/1783541170-feat-layout-reducer-self-heals-dangling-block-references-on--t14v.md
+++ b/.changesets/1783541170-feat-layout-reducer-self-heals-dangling-block-references-on--t14v.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(layout): reducer self-heals dangling block references on every layout write (WRR-style)

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -153,6 +153,81 @@ pub fn find_node_id_by_block(tree: &LayoutNode, block_id: &str) -> Option<String
     None
 }
 
+/// Removes every leaf whose `data.block_id` is not in `live_block_ids`,
+/// using the same collapse semantics as an explicit user delete
+/// (`delete_node`'s single-child-parent promotion). Returns the number of
+/// leaves pruned (0 = tree was already clean — the common case, so this is
+/// cheap to call unconditionally on every write).
+///
+/// This is the reducer's referential-integrity enforcement for `db_layout`,
+/// added after
+/// `docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`
+/// found that a single point-fix (notifying the frontend on one specific
+/// delete path) only closes the one mechanism it targets — any other
+/// current or future caller that writes a stale/bad tree without going
+/// through that same notification channel can still leave a dangling
+/// `blockId` behind. Calling this at every layout-tree write site in the
+/// reducer (the single writer of `db_layout` since SPEC_864) makes "no
+/// layout leaf ever references a nonexistent block" an unconditional
+/// invariant of the write path itself, not a property individual callers
+/// have to remember to uphold — the same shape as WRR (Window Reality
+/// Reconciliation, `agentmux-cef/src/wrr/`) enforcing "no window/pool
+/// drift" at the point where reality is observed, rather than trusting
+/// every caller to keep the model in sync.
+///
+/// Re-scans the tree fresh after each removal rather than working off a
+/// pre-computed list of dangling node ids, since `delete_node`'s
+/// single-child collapse can rewrite a surviving parent's id out from
+/// under a stale id — see the comment on `delete_recursive`. Terminates
+/// because each iteration strictly shrinks the tree (bounded by leaf
+/// count).
+pub fn prune_dangling_block_refs(
+    root: &mut Option<LayoutNode>,
+    live_block_ids: &std::collections::HashSet<String>,
+) -> usize {
+    let mut pruned = 0;
+    loop {
+        let Some(tree) = root.as_ref() else { break };
+        let Some(dangling_id) = first_dangling_leaf_id(tree, live_block_ids) else { break };
+        pruned += 1;
+        if tree.id == dangling_id {
+            // Root is itself the dangling leaf (single-block tab) —
+            // delete_node leaves root deletion to the caller.
+            *root = None;
+            continue;
+        }
+        if let Some(t) = root.as_mut() {
+            // A `NodeNotFound` here would mean the id vanished via this
+            // same loop's prior collapse without our fresh re-scan
+            // catching it first — shouldn't happen given the re-scan, but
+            // isn't a correctness problem either way: the node is gone,
+            // which is the outcome we wanted.
+            let _ = delete_node(t, &dangling_id);
+        }
+    }
+    pruned
+}
+
+/// First leaf (depth-first) whose `data.block_id` is set but not present in
+/// `live_block_ids`. `data.block_id` is only ever non-empty on leaves —
+/// container/group nodes have `data: None` (see `ensure_group_node`).
+fn first_dangling_leaf_id(
+    node: &LayoutNode,
+    live_block_ids: &std::collections::HashSet<String>,
+) -> Option<String> {
+    if let Some(data) = &node.data {
+        if !data.block_id.is_empty() && !live_block_ids.contains(&data.block_id) {
+            return Some(node.id.clone());
+        }
+    }
+    for child in &node.children {
+        if let Some(found) = first_dangling_leaf_id(child, live_block_ids) {
+            return Some(found);
+        }
+    }
+    None
+}
+
 // ── Insert-location heuristic ──────────────────────────────────────────────
 
 /// Candidate for insertion location, collected during tree traversal.

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -740,3 +740,99 @@ fn find_node_by_id_does_not_mutate() {
     let _ = find_node_by_id(&root, "n1");
     assert_eq!(root.children.len(), child_count_before);
 }
+
+// ── pruneDanglingBlockRefs ────────────────────────────────────────────────────
+// Reducer-write-path self-healing added after
+// docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md —
+// "no layout leaf ever references a nonexistent block" as an unconditional
+// invariant of the write path, not something individual callers must
+// remember to uphold correctly.
+
+fn live(ids: &[&str]) -> std::collections::HashSet<String> {
+    ids.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn prune_is_a_noop_on_a_clean_tree() {
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Row,
+        10.0,
+        vec![leaf("a", "ba", 5.0), leaf("b", "bb", 5.0)],
+    ));
+    let before = root.clone();
+    let pruned = prune_dangling_block_refs(&mut root, &live(&["ba", "bb"]));
+    assert_eq!(pruned, 0);
+    assert_eq!(root, before);
+}
+
+#[test]
+fn prune_is_a_noop_on_an_empty_tree() {
+    let mut root: Option<LayoutNode> = None;
+    let pruned = prune_dangling_block_refs(&mut root, &live(&["ba"]));
+    assert_eq!(pruned, 0);
+    assert!(root.is_none());
+}
+
+#[test]
+fn prune_clears_the_tree_when_root_is_the_sole_dangling_leaf() {
+    // The exact shape of the bug this closes: a single-block tab whose
+    // block was deleted, leaving the root itself as the dangling leaf.
+    let mut root = Some(leaf("only", "deleted-block", 1.0));
+    let pruned = prune_dangling_block_refs(&mut root, &live(&[]));
+    assert_eq!(pruned, 1);
+    assert!(root.is_none());
+}
+
+#[test]
+fn prune_removes_a_non_root_dangling_leaf_and_collapses_the_sole_survivor() {
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Row,
+        10.0,
+        vec![leaf("a", "ba", 5.0), leaf("b", "deleted-block", 5.0)],
+    ));
+    let pruned = prune_dangling_block_refs(&mut root, &live(&["ba"]));
+    assert_eq!(pruned, 1);
+    // delete_node's single-child collapse promotes "a" into root's place —
+    // same behavior an explicit user delete would produce.
+    let r = root.unwrap();
+    assert_eq!(r.id, "a");
+    assert_eq!(r.data.as_ref().unwrap().block_id, "ba");
+    assert!(r.children.is_empty());
+}
+
+#[test]
+fn prune_removes_multiple_dangling_leaves_in_one_pass() {
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Row,
+        10.0,
+        vec![
+            leaf("a", "ba", 3.0),
+            leaf("b", "gone-1", 3.0),
+            leaf("c", "gone-2", 3.0),
+        ],
+    ));
+    let pruned = prune_dangling_block_refs(&mut root, &live(&["ba"]));
+    assert_eq!(pruned, 2);
+    let r = root.unwrap();
+    // Down to the sole survivor — same single-child collapse as above.
+    assert_eq!(r.data.as_ref().unwrap().block_id, "ba");
+}
+
+#[test]
+fn prune_leaves_container_nodes_alone() {
+    // Container/group nodes have data: None — must never be mistaken for
+    // a dangling leaf just because their (nonexistent) block_id can't
+    // match anything live.
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Row,
+        10.0,
+        vec![leaf("a", "ba", 5.0)],
+    ));
+    let pruned = prune_dangling_block_refs(&mut root, &live(&["ba"]));
+    assert_eq!(pruned, 0);
+    assert_eq!(root.unwrap().id, "root");
+}

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -2542,6 +2542,27 @@ mod tests {
         (state, tab)
     }
 
+    /// Registers a minimal `BlockRecord` for `block_id` in `state.blocks`,
+    /// so a test-constructed leaf referencing it survives
+    /// `prune_dangling_block_refs` (added alongside `LayoutSetTree` and the
+    /// `apply_atomic`-routed arms — see
+    /// `docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`).
+    /// Real callers always have a live `BlockRecord` before a layout leaf
+    /// can reference it (`CreateBlock` populates `state.blocks` before any
+    /// layout insert for that block can be dispatched — verified via
+    /// `server::service::object`'s create-block handler); these
+    /// lower-level reducer tests construct trees directly and need this
+    /// explicit seed to match that real precondition.
+    fn seed_block(state: &mut State, tab_id: &str, block_id: &str) {
+        state.blocks.insert(
+            block_id.to_string(),
+            crate::state::BlockRecord {
+                block_id: block_id.to_string(),
+                tab_id: tab_id.to_string(),
+            },
+        );
+    }
+
     #[test]
     fn layout_clear_wipes_rootnode_focus_magnify_and_emits_event() {
         let (mut state, tab_id) = fresh_tab();
@@ -2660,6 +2681,8 @@ mod tests {
     #[test]
     fn layout_set_tree_replaces_rootnode_wholesale() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "b1");
+        seed_block(&mut state, &tab_id, "b2");
         state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("old", "b1"));
 
         let new_tree = Some(leaf_node("new", "b2"));
@@ -2696,12 +2719,57 @@ mod tests {
         assert!(state.tabs[&tab_id].rootnode.is_none());
     }
 
+    /// End-to-end regression for
+    /// docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md:
+    /// a wholesale tree push — the exact vector a stale frontend copy used
+    /// to resurrect a deleted block's leaf through — must self-heal
+    /// instead of persisting the dangling reference. Only "ba" is
+    /// registered as live; "gone" is not (simulating a block deleted
+    /// before this push landed, e.g. from a stale frontend LayoutModel).
+    #[test]
+    fn layout_set_tree_self_heals_a_dangling_block_ref_in_the_pushed_tree() {
+        let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+
+        let pushed_tree = agentmux_common::LayoutNode {
+            id: "root".into(),
+            children: vec![leaf_node("a", "ba"), leaf_node("b", "gone")],
+            ..Default::default()
+        };
+        let events = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: Some(pushed_tree),
+                correlation_id: "corr".into(),
+                slices: None,
+            },
+            &ctx(1),
+        );
+
+        assert!(matches!(&events[0], Event::LayoutTreeReplaced { .. }));
+        assert!(tree_has(&state, &tab_id, "a"), "live block's leaf survives");
+        assert!(!tree_has(&state, &tab_id, "b"), "dangling leaf pruned, not persisted");
+        // Event::LayoutTreeReplaced's own new_tree must reflect the healed
+        // tree too, not the caller's original — this is what the persist
+        // subscriber writes to db_layout, so a pruned reducer state with a
+        // stale event would just move the divergence downstream.
+        if let Event::LayoutTreeReplaced { new_tree, .. } = &events[0] {
+            let root = new_tree.as_ref().unwrap();
+            assert!(
+                !root.children.iter().any(|c| c.id == "b"),
+                "emitted event's new_tree must already reflect the prune"
+            );
+        }
+    }
+
     /// SPEC_864 Phase 2 — a slice-carrying full-row push applies focus/
     /// magnify to the TabRecord (empty = clear) and echoes the slices on
     /// the emitted event for the persist subscriber.
     #[test]
     fn layout_set_tree_with_slices_applies_focus_magnify() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "b1");
         state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "stale".into();
 
         let events = update(
@@ -2864,6 +2932,7 @@ mod tests {
         // Symmetry guard: Some(new_tree) must NOT clear focused/
         // magnified — caller may have set them deliberately.
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "b");
         state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "n".into();
         state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "n".into();
         let _ = update(
@@ -3010,6 +3079,9 @@ mod tests {
     #[test]
     fn layout_move_node_reparents_and_emits_event() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bb");
+        seed_block(&mut state, &tab_id, "bc");
         state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(group_node(
             "root",
             vec![
@@ -3040,6 +3112,8 @@ mod tests {
     #[test]
     fn layout_swap_nodes_swaps_positions() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bb");
         state.tabs.get_mut(&tab_id).unwrap().rootnode =
             Some(group_node("root", vec![leaf_node("a", "ba"), leaf_node("b", "bb")]));
         let events = update(
@@ -3061,6 +3135,8 @@ mod tests {
     #[test]
     fn layout_resize_nodes_applies_sizes() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bb");
         state.tabs.get_mut(&tab_id).unwrap().rootnode =
             Some(group_node("root", vec![leaf_node("a", "ba"), leaf_node("b", "bb")]));
         let events = update(
@@ -3084,6 +3160,9 @@ mod tests {
     #[test]
     fn layout_replace_node_swaps_in_new_and_honours_focus() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bb");
+        seed_block(&mut state, &tab_id, "bx");
         state.tabs.get_mut(&tab_id).unwrap().rootnode =
             Some(group_node("root", vec![leaf_node("a", "ba"), leaf_node("b", "bb")]));
         let events = update(
@@ -3145,6 +3224,8 @@ mod tests {
     #[test]
     fn layout_split_horizontal_wraps_root_and_focuses_new() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bx");
         state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("a", "ba"));
         let events = update(
             &mut state,
@@ -3170,6 +3251,8 @@ mod tests {
     #[test]
     fn layout_split_vertical_wraps_root() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bx");
         state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("a", "ba"));
         let events = update(
             &mut state,
@@ -3192,6 +3275,9 @@ mod tests {
     #[test]
     fn layout_insert_node_at_index_inserts_after_path() {
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "ba");
+        seed_block(&mut state, &tab_id, "bb");
+        seed_block(&mut state, &tab_id, "bx");
         state.tabs.get_mut(&tab_id).unwrap().rootnode =
             Some(group_node("root", vec![leaf_node("a", "ba"), leaf_node("b", "bb")]));
         let events = update(
@@ -3217,6 +3303,7 @@ mod tests {
         // Matches the frontend oracle (insertNodeAtIndex promotes to root on
         // an empty tree; layoutTree.ts:303-304) — not a reject.
         let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "b");
         let events = update(
             &mut state,
             Command::LayoutInsertNodeAtIndex {

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -90,6 +90,9 @@ pub(super) fn handle_layout_set_tree(
     correlation_id: String,
     slices: Option<agentmux_common::LayoutClientSlices>,
 ) -> Vec<Event> {
+    // Computed before the `state.tabs` borrow below — `blocks` and `tabs`
+    // are disjoint fields, but an owned snapshot avoids any doubt.
+    let live_blocks: std::collections::HashSet<String> = state.blocks.keys().cloned().collect();
     let Some(tab) = state.tabs.get_mut(&tab_id) else {
         let v = state.bump_version();
         return vec![Event::Error {
@@ -115,6 +118,26 @@ pub(super) fn handle_layout_set_tree(
         tab.focused_node_id = String::new();
         tab.magnified_node_id = String::new();
     }
+    // Referential-integrity enforcement (see
+    // `backend::layout::prune_dangling_block_refs`'s doc comment): this is
+    // the exact vector — a wholesale tree push — that let a stale frontend
+    // copy resurrect a deleted block's leaf
+    // (INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md).
+    // Re-derive `new_tree`/the event from the now-authoritative (possibly
+    // pruned) `tab.rootnode` rather than the caller's original value, so
+    // what gets persisted matches what the reducer actually holds — a
+    // pruned `tab.rootnode` with a stale `new_tree` in the emitted event
+    // would just move the divergence downstream instead of closing it.
+    let pruned = crate::backend::layout::prune_dangling_block_refs(&mut tab.rootnode, &live_blocks);
+    if pruned > 0 {
+        reconcile_focus_magnify(tab);
+        tracing::warn!(
+            tab_id = %tab_id,
+            pruned,
+            "reducer: LayoutSetTree pruned dangling layout leaf/leaves referencing since-deleted blocks"
+        );
+    }
+    let new_tree = tab.rootnode.clone();
     let v = state.bump_version();
     vec![Event::LayoutTreeReplaced {
         tab_id,
@@ -653,6 +676,7 @@ pub(super) fn handle_layout_insert_node_at_index(
 ) -> Vec<Event> {
     let new_id = node.id.clone();
     let node_event = node.clone();
+    let live_blocks: std::collections::HashSet<String> = state.blocks.keys().cloned().collect();
     let Some(tab) = state.tabs.get_mut(&tab_id) else {
         return unknown_tab(state, "LayoutInsertNodeAtIndex", &tab_id);
     };
@@ -689,6 +713,17 @@ pub(super) fn handle_layout_insert_node_at_index(
     }
     if magnify_after {
         tab.magnified_node_id = new_id;
+    }
+    // Referential-integrity enforcement, same choke point as
+    // `handle_layout_set_tree` — see `prune_dangling_block_refs`'s doc
+    // comment. The caller-supplied `node` could carry a stale `block_id`.
+    let pruned = crate::backend::layout::prune_dangling_block_refs(&mut tab.rootnode, &live_blocks);
+    if pruned > 0 {
+        tracing::warn!(
+            tab_id = %tab_id,
+            pruned,
+            "reducer: LayoutInsertNodeAtIndex pruned dangling layout leaf/leaves referencing since-deleted blocks"
+        );
     }
     reconcile_focus_magnify(tab);
     let new_tree = tab.rootnode.clone();
@@ -736,5 +771,25 @@ where
         return Err(op_error(state, format!("{} balance: {} (tab {})", op, e, tab_id)));
     }
     tab.rootnode = Some(working);
+    // Referential-integrity enforcement, same choke point as
+    // `handle_layout_set_tree` — see `prune_dangling_block_refs`'s doc
+    // comment. `replace_node`/`split_horizontal`/`split_vertical` accept a
+    // caller-supplied new node that could carry a stale `block_id`; this
+    // also opportunistically cleans up any pre-existing dangling leaf a
+    // move/swap/resize just happened to touch, for free. Every caller of
+    // `apply_atomic` already calls `reconcile_focus_magnify` on its own
+    // next line, so a pruned focused/magnified id is handled there — no
+    // need to duplicate that call here.
+    let live_blocks: std::collections::HashSet<String> = state.blocks.keys().cloned().collect();
+    let tab = state.tabs.get_mut(tab_id).expect("tab present — just written above");
+    let pruned = crate::backend::layout::prune_dangling_block_refs(&mut tab.rootnode, &live_blocks);
+    if pruned > 0 {
+        tracing::warn!(
+            tab_id = %tab_id,
+            op,
+            pruned,
+            "reducer: pruned dangling layout leaf/leaves referencing since-deleted blocks"
+        );
+    }
     Ok(())
 }

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -522,6 +522,22 @@ async fn update_object_layout_push_single_write_and_coherent_reducer() {
     let tab = wstore.get::<Tab>(&tab_id).unwrap().unwrap();
     let layout_oid = tab.layoutstate.clone();
 
+    // The push below references block "b-1" directly (a predetermined id
+    // the test asserts on) rather than one the reducer would assign via
+    // Command::CreateBlock, so it's seeded straight into reducer state.
+    // Required since prune_dangling_block_refs (added alongside
+    // LayoutSetTree — see
+    // docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md)
+    // now prunes any pushed leaf whose block_id isn't live, and this test's
+    // "b-1" was never otherwise registered.
+    {
+        let mut s = srv_state.lock().await;
+        s.blocks.insert(
+            "b-1".to_string(),
+            crate::state::BlockRecord { block_id: "b-1".to_string(), tab_id: tab_id.clone() },
+        );
+    }
+
     // Seed a pending backend action (as a redock would); the push below
     // omits pendingbackendactions — the ack must clear it.
     {
@@ -751,6 +767,18 @@ async fn layout_seeders_route_through_reducer_coherently() {
             _ => None,
         })
         .unwrap();
+    // Seeded straight into reducer state (predetermined block ids the test
+    // asserts on, not reducer-assigned) — required since
+    // prune_dangling_block_refs (added alongside LayoutSetTree/the
+    // reducer-routed seeders — see
+    // docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md)
+    // now prunes any seeded leaf whose block_id isn't live.
+    for bid in ["b-agent", "b-sysinfo", "b-swarm"] {
+        srv_state.lock().await.blocks.insert(
+            bid.to_string(),
+            crate::state::BlockRecord { block_id: bid.to_string(), tab_id: tab1.clone() },
+        );
+    }
     let (tree, focused, leaforder) =
         crate::backend::wcore::default_three_pane_tree("b-agent", "b-sysinfo", "b-swarm");
     crate::server::service::seed_layout_via_reducer(
@@ -789,6 +817,10 @@ async fn layout_seeders_route_through_reducer_coherently() {
             _ => None,
         })
         .unwrap();
+    srv_state.lock().await.blocks.insert(
+        "b-moved".to_string(),
+        crate::state::BlockRecord { block_id: "b-moved".to_string(), tab_id: tab2.clone() },
+    );
     crate::server::service::setup_torn_off_block_layout(&state, &tab2, "b-moved")
         .await
         .expect("tear-off seed via reducer");
@@ -906,6 +938,20 @@ async fn layout_stays_coherent_across_full_mutation_lifecycle() {
             _ => None,
         })
         .unwrap();
+
+    // Every block id this test's layout tree ever references, seeded
+    // straight into reducer state up front (predetermined ids the test
+    // asserts on throughout, not reducer-assigned) — required since
+    // prune_dangling_block_refs (added alongside every reducer-routed
+    // layout-tree write in this lifecycle — see
+    // docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md)
+    // now prunes any leaf whose block_id isn't live.
+    for bid in ["b1", "b2", "b3", "b-fe"] {
+        srv_state.lock().await.blocks.insert(
+            bid.to_string(),
+            crate::state::BlockRecord { block_id: bid.to_string(), tab_id: tab_id.clone() },
+        );
+    }
 
     // Seed: single leaf via the reducer-routed tear-off-style seeder.
     crate::server::service::setup_torn_off_block_layout(&state, &tab_id, "b1")

--- a/docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md
+++ b/docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md
@@ -1,11 +1,14 @@
 # Investigation: Dead-space layout leaf referencing a deleted block
 
 **Date:** 2026-07-08
-**Status:** Root cause confirmed by code (not live-reproduced through the CEF frontend);
-Mechanism A fixed — `agentmux-srv/src/sagas/delete_block.rs` Step 2b now queues a
-`pendingbackendactions` delete via `queue_source_layout_delete`, same channel tear-off
-already uses. Mechanism B (saga-step non-atomicity) and the missing CAS on `Store::update`
-remain open, tracked as follow-ons in §Recommended fix.
+**Status:** Root cause confirmed by code (not live-reproduced through the CEF frontend).
+Mechanism A fixed at the point of origin — `agentmux-srv/src/sagas/delete_block.rs` Step 2b
+now queues a `pendingbackendactions` delete via `queue_source_layout_delete`, same channel
+tear-off already uses. **Also fixed systemically** — every reducer layout-tree write path now
+self-heals any dangling block reference unconditionally (§WRR-style self-healing invariant
+below), so the invariant holds regardless of which caller or future bug produces a stale
+tree. Mechanism B (saga-step non-atomicity) and the missing CAS on `Store::update` remain
+open, tracked as follow-ons in §Recommended fix.
 **Component:** `agentmux-srv` reducer/layout persistence, `frontend/layout/lib/layoutPersistence.ts`
 **Reported by:** user, dev instance (`v0.51.0`, built 2026-07-07 11:13:02, HEAD `8bea4a52`)
 **Relation to Pillar 1 (host reproject, `SPEC_PILLAR1_*`):** not causal — Pillar 1's reproject
@@ -290,3 +293,75 @@ Both are things SPEC_864's own docs already flag as open/undecided (see
 `docs/handoff/HANDOFF_864_AUTHORITY_AND_WINDOW_LIFECYCLE_2026_07_05.md:58` on the CAS
 question specifically) rather than novel findings here — worth tracking as follow-ons, not
 blockers for the Mechanism A fix.
+
+## Follow-up: WRR-style self-healing invariant (implemented)
+
+The Mechanism A fix above closes the *one specific call site* (`delete_block`) that produced
+this incident. It does not, by itself, guarantee "no layout leaf ever references a
+nonexistent block" as a property of the system — any other current or future caller that
+writes a stale or bad tree without going through the same notification channel could still
+leave a dangling reference behind, and the fix does nothing for corruption that already
+exists in a persisted `db_layout` row.
+
+Requested explicitly: an invariant enforced the same way WRR (Window Reality Reconciliation,
+`agentmux-cef/src/wrr/`) enforces "no window/pool drift" — not a periodic scan/timer, but a
+check applied at the exact point reality is written, so drift structurally cannot accumulate
+regardless of which caller or bug would otherwise have produced it.
+
+**Implementation:** `agentmux-srv/src/backend/layout/mod.rs::prune_dangling_block_refs(root,
+live_block_ids)` — a pure function that walks a layout tree and removes every leaf whose
+`data.block_id` isn't in the live set, reusing `delete_node`'s existing tested collapse
+semantics (single-child-parent promotion) rather than new tree-surgery logic. Re-scans fresh
+after each removal (`delete_node`'s collapse can rewrite a surviving parent's id out from
+under a pre-computed target list).
+
+Wired into the reducer — the single writer of `db_layout` since SPEC_864 — at every
+tree-mutating command:
+- `handle_layout_set_tree` (`reducer/layout.rs`) — the exact vector that caused this
+  incident (a wholesale tree push). The emitted `Event::LayoutTreeReplaced`'s `new_tree` is
+  re-derived from the *post-prune* `tab.rootnode`, not the caller's original value — pruning
+  reducer state alone while persisting the caller's stale value would just move the
+  divergence downstream instead of closing it.
+- `apply_atomic` (`reducer/layout.rs`) — the shared choke point for
+  `LayoutMoveNode`/`LayoutSwapNodes`/`LayoutResizeNodes`/`LayoutReplaceNode`/
+  `LayoutSplitHorizontal`/`LayoutSplitVertical`. `LayoutReplaceNode` and the two split arms
+  accept a caller-supplied new node that could itself carry a stale `block_id`; move/swap/
+  resize can't introduce a *new* dangling reference but get the check for free, which also
+  opportunistically cleans up any pre-existing corruption a routine edit happens to touch.
+- `handle_layout_insert_node_at_index` — same reasoning as the split arms (caller-supplied
+  node).
+
+**Deliberately left uncovered**, with reasoning, not an oversight:
+- `handle_layout_insert_node` (`LayoutInsertNode`) — its emitted event carries no `new_tree`
+  field (only the inserted `node`/`parent_id`/`index`), so it's unclear without further
+  investigation whether the persist subscriber for this event type reads a full tree from
+  reducer state or reconstructs one independently from the event's fields; pruning
+  `tab.rootnode` alone might not correctly propagate to what gets persisted. Also, this
+  handler introduces exactly one brand-new node — if *that* node's own `block_id` is invalid,
+  silently insert-then-immediately-prune is arguably the wrong UX compared to rejecting the
+  insert outright, which is a different design question than resurrection-prevention.
+- The deletion-path handlers (`handle_layout_delete_node`, `handle_layout_delete_node_by_block`)
+  and `handle_layout_clear` — these remove nodes or wipe the tree; they cannot structurally
+  introduce a *new* dangling reference, so there's nothing for this check to catch there.
+
+**Test seeding note:** ~14 pre-existing reducer/server layout tests constructed trees with
+block ids that were never registered in `state.blocks` (a legitimate simplification before
+this invariant existed — they were testing pure tree mechanics, not block lifecycle). Real
+production callers always have a live `BlockRecord` before a layout leaf can reference it
+(verified: `server::service::object`'s create-block handler dispatches `CreateBlock` through
+the reducer, populating `state.blocks`, before any client can have a confirmed `block_id` to
+insert into a layout). Fixed by seeding matching `BlockRecord`s in each affected test rather
+than weakening the invariant. Added a `seed_block` test helper
+(`agentmux-srv/src/reducer.rs`) for this. All 1441 tests in the `agentmux-srv` suite pass
+after the fix, including 7 new tests covering `prune_dangling_block_refs` directly
+(`backend/layout/tests.rs`) and one reducer-level end-to-end regression test
+(`layout_set_tree_self_heals_a_dangling_block_ref_in_the_pushed_tree`) proving a wholesale
+`LayoutSetTree` push carrying a dangling leaf now self-heals instead of persisting it.
+
+**What this does and doesn't guarantee:** going forward, no *new* write through a covered
+command can leave `db_layout` holding a leaf whose block doesn't exist — this holds
+regardless of which caller or future bug would otherwise have produced the stale write, which
+is the actual "guaranteed no empty slots" property that was asked for. It does not
+retroactively repair rows already corrupted before this landed (a one-off data cleanup,
+separate from this fix), and it doesn't cover the two handlers noted above as deliberately
+out of scope.


### PR DESCRIPTION
## Summary
- Follow-up to #2036, which closed the one specific call site (`delete_block`) that produced the dead-space incident. That fix doesn't guarantee "no layout leaf ever references a nonexistent block" as a system property — any other current or future caller that writes a stale/bad tree without going through the same notification channel could still leave a dangling reference behind.
- **Requested explicitly**: an invariant enforced the same way WRR (Window Reality Reconciliation, `agentmux-cef/src/wrr/`) enforces "no window/pool drift" — not a periodic scan/timer, but a check applied at the exact point reality is written, so drift structurally cannot accumulate regardless of which caller or bug would otherwise have produced it.
- Adds `backend::layout::prune_dangling_block_refs`, a pure function reusing `delete_node`'s existing tested collapse semantics (single-child-parent promotion), wired into every layout-tree-mutating reducer command:
  - `handle_layout_set_tree` — the exact vector that caused the original incident (a wholesale tree push).
  - `apply_atomic` — the shared choke point for `LayoutMoveNode`/`LayoutSwapNodes`/`LayoutResizeNodes`/`LayoutReplaceNode`/`LayoutSplitHorizontal`/`LayoutSplitVertical`.
  - `LayoutInsertNodeAtIndex`.
- **Deliberately left uncovered** (reasoning in the investigation doc): `LayoutInsertNode` (its event carries no `new_tree`, unclear whether pruning reducer state alone would correctly propagate to persistence without further investigation) and the deletion-path handlers / `LayoutClear` (structurally can't introduce a *new* dangling reference).
- ~14 pre-existing reducer/server tests constructed layout trees with block ids never registered in `state.blocks` — a fine simplification before this invariant existed. Fixed by seeding matching `BlockRecord`s in each (verified real production callers always have a live `BlockRecord` before a layout leaf can reference it), rather than weakening the check.
- Added 7 new tests: 6 pure `prune_dangling_block_refs` cases (clean tree no-op, empty tree no-op, root-is-sole-dangling-leaf, non-root leaf + collapse, multiple dangling leaves, container nodes never mistaken for leaves) and 1 reducer-level end-to-end regression test proving a wholesale `LayoutSetTree` push carrying a dangling leaf now self-heals instead of persisting it.
- Full investigation write-up updated: `docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`.
- **Does not** retroactively repair already-corrupted `db_layout` rows — a separate one-off data cleanup, not part of this fix.

## Test plan
- [x] `cargo test --bin agentmux-srv layout` — 139 passed (132 pre-existing + 7 new), 0 failed
- [x] `cargo test --bin agentmux-srv` (full suite) — 1441 passed, 0 failed, 4 ignored (pre-existing ignores, unrelated)