### PR TITLE
fix(ambient): sanitize Haiku summaries against leaked markdown fences

### DIFF
--- a/.changesets/1783551089-fix-ambient-sanitize-haiku-summaries-against-leaked-markdown-20tb.md
+++ b/.changesets/1783551089-fix-ambient-sanitize-haiku-summaries-against-leaked-markdown-20tb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ambient): sanitize Haiku summaries against leaked markdown fences

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -179,7 +179,8 @@ pub(crate) async fn generate_pushed_activity_summary(
 
     let prompt = format!(
         "Summarize in {word_target} words or fewer what is currently being worked on. \
-         Use a short terse phrase with no quotes or punctuation.\n\n\
+         Plain text only — no markdown, no code fences, no backticks, no quotes, \
+         no punctuation, no preamble.\n\n\
          Recent activity:\n\n{extracted}"
     );
 
@@ -260,8 +261,9 @@ pub(crate) async fn generate_subagent_name(
     }
 
     let prompt = format!(
-        "Give a concise ~5-word name for this task. \
-         No punctuation, no quotes, no preamble — respond with just the name.\n\n\
+        "Give a concise ~5-word name for this task. Plain text only — no markdown, \
+         no code fences, no backticks, no punctuation, no quotes, no preamble. \
+         Respond with just the name.\n\n\
          Task:\n\n{task_prompt}"
     );
 
@@ -340,7 +342,8 @@ fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppStat
 
                 let prompt = format!(
                     "Summarize in {word_target} words or fewer what is currently being worked on. \
-                     Use a short terse phrase with no quotes or punctuation.\n\n\
+                     Plain text only — no markdown, no code fences, no backticks, no quotes, \
+                     no punctuation, no preamble.\n\n\
                      Recent activity:\n\n{extracted}"
                 );
 
@@ -435,9 +438,10 @@ fn register_session_next_prompt_suggestion(engine: &Arc<WshRpcEngine>, state: &A
                 let prompt = format!(
                     "Based on this recent activity, predict ONE short, natural next \
                      message the user might send to continue the conversation. \
-                     Respond with just that message and nothing else — no quotes, \
-                     no explanation, no preamble. If nothing plausible comes to mind, \
-                     respond with an empty string.\n\n\
+                     Respond with just that message and nothing else — plain text only, \
+                     no markdown, no code fences, no backticks, no quotes, no explanation, \
+                     no preamble. If nothing plausible comes to mind, respond with an \
+                     empty string.\n\n\
                      Recent activity:\n\n{extracted}"
                 );
 
@@ -612,11 +616,69 @@ pub(crate) async fn invoke_ambient_haiku_call(
         }
     }
 
+    let last_text = sanitize_ambient_text(&last_text);
     if last_text.is_empty() {
         return Err("no text in activity CLI response".to_string());
     }
 
     Ok((last_text, tokens))
+}
+
+/// Defends against the model wrapping its answer in markdown despite every
+/// ambient-call prompt asking for a bare line of plain text — instruction-
+/// following isn't guaranteed, and an unwrapped fence is exactly what
+/// produces a literal ` ``` `/newline/` ``` ` blob on a UI surface that
+/// renders this text verbatim (e.g. the ghost-text composer placeholder,
+/// which has no markdown renderer). Applied once here so every current and
+/// future `invoke_ambient_haiku_call` caller is covered, not just the one
+/// that first surfaced the bug.
+///
+/// Strips a wrapping code fence and wrapping quote characters, repeatedly (a
+/// model can nest both), then trims. A result left with nothing but
+/// backticks (e.g. an empty fence) collapses to "" so callers' existing
+/// empty-string handling (skip writing ghost text / filter out the summary)
+/// covers it without any caller-side change.
+fn sanitize_ambient_text(raw: &str) -> String {
+    let mut s = raw.trim().to_string();
+    for _ in 0..4 {
+        let before = s.clone();
+        if let Some(inner) = strip_wrapping_fence(&s) {
+            s = inner;
+        }
+        s = s
+            .trim_matches(|c: char| {
+                matches!(c, '"' | '\'' | '\u{201C}' | '\u{201D}' | '\u{2018}' | '\u{2019}')
+            })
+            .trim()
+            .to_string();
+        if s == before {
+            break;
+        }
+    }
+    if !s.is_empty() && s.chars().all(|c| c == '`') {
+        s.clear();
+    }
+    s
+}
+
+/// Strip a wrapping code fence (triple-backtick, optionally with a language
+/// tag on the opening line, or a single inline backtick) if the *entire*
+/// string is wrapped — a fence-like substring embedded mid-sentence is left
+/// alone. Returns the un-fenced inner text (not yet trimmed of quotes).
+fn strip_wrapping_fence(s: &str) -> Option<String> {
+    let s = s.trim();
+    for fence in ["```", "`"] {
+        if s.len() >= fence.len() * 2 && s.starts_with(fence) && s.ends_with(fence) {
+            let mut inner = &s[fence.len()..s.len() - fence.len()];
+            if fence == "```" {
+                if let Some(nl) = inner.find('\n') {
+                    inner = &inner[nl + 1..];
+                }
+            }
+            return Some(inner.trim().to_string());
+        }
+    }
+    None
 }
 
 /// Extract meaningful text from raw stream-json lines for digest summarization.
@@ -720,5 +782,59 @@ mod pull_call_semaphore_tests {
         // Releasing one frees a slot for the next caller.
         held.pop();
         assert!(sem.try_acquire().is_ok(), "releasing a permit must free a slot");
+    }
+}
+
+#[cfg(test)]
+mod sanitize_ambient_text_tests {
+    use super::*;
+
+    #[test]
+    fn passes_plain_text_through_unchanged() {
+        assert_eq!(sanitize_ambient_text("Run the tests"), "Run the tests");
+    }
+
+    #[test]
+    fn strips_a_triple_backtick_fence() {
+        assert_eq!(sanitize_ambient_text("```\nRun the tests\n```"), "Run the tests");
+    }
+
+    #[test]
+    fn strips_a_fence_with_a_language_tag() {
+        assert_eq!(sanitize_ambient_text("```text\nRun the tests\n```"), "Run the tests");
+    }
+
+    #[test]
+    fn empty_fence_collapses_to_empty_string() {
+        assert_eq!(sanitize_ambient_text("```\n```"), "");
+        assert_eq!(sanitize_ambient_text("``````"), "");
+    }
+
+    #[test]
+    fn strips_wrapping_single_backticks() {
+        assert_eq!(sanitize_ambient_text("`Run the tests`"), "Run the tests");
+    }
+
+    #[test]
+    fn strips_wrapping_quotes() {
+        assert_eq!(sanitize_ambient_text("\"Run the tests\""), "Run the tests");
+        assert_eq!(sanitize_ambient_text("'Run the tests'"), "Run the tests");
+        assert_eq!(sanitize_ambient_text("\u{201C}Run the tests\u{201D}"), "Run the tests");
+    }
+
+    #[test]
+    fn strips_nested_fence_and_quotes() {
+        assert_eq!(sanitize_ambient_text("```\n\"Run the tests\"\n```"), "Run the tests");
+    }
+
+    #[test]
+    fn leaves_an_embedded_fence_like_substring_alone() {
+        let s = "Run `npm test` next";
+        assert_eq!(sanitize_ambient_text(s), s);
+    }
+
+    #[test]
+    fn lone_backticks_with_no_content_collapse_to_empty() {
+        assert_eq!(sanitize_ambient_text("```"), "");
     }
 }

--- a/docs/specs/SPEC_AMBIENT_SUMMARY_SANITIZATION_AND_TERSENESS_2026_07_08.md
+++ b/docs/specs/SPEC_AMBIENT_SUMMARY_SANITIZATION_AND_TERSENESS_2026_07_08.md
@@ -1,0 +1,197 @@
+# SPEC: Ambient Haiku-Summary Sanitization + Terseness Pass
+
+**Date:** 2026-07-08
+**Status:** Draft — root cause confirmed, fix proposed, not yet implemented
+**Related:** `agentmux-srv/src/server/app_api/session.rs`, `agentmux-srv/src/ambient/mod.rs`,
+`frontend/app/view/agent/hooks/useNextPromptSuggestion.ts`,
+`frontend/app/view/agent/components/AgentFooter.tsx`,
+`docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md`,
+`docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md`
+
+---
+
+## 0. TL;DR
+
+Users occasionally see a literal ` ``` ` / newline / ` ``` ` blob appear in the
+**composer's empty input box** — "for no reason." Root cause confirmed: it's
+the ghost-text next-prompt suggestion (`term:next_prompt_suggestion`), which
+is Haiku-generated text written verbatim into the textarea's `placeholder`
+attribute with zero sanitization anywhere in the pipeline. Haiku occasionally
+wraps its one-line answer in a markdown code fence (a common model habit,
+worse when recent activity is code-heavy); an empty or near-empty fence
+renders as exactly the reported artifact.
+
+Two changes:
+
+1. **Sanitize** ambient-call output at its one choke point
+   (`invoke_ambient_haiku_call`) so a fence/quote-wrapped response can never
+   reach a UI surface unmodified — fixes the bug for this and every future
+   ambient-call purpose, not just this one.
+2. **Tighten** the three existing ambient prompt templates to explicitly
+   forbid markdown/formatting and push harder for terse, factual, flourish-free
+   phrasing — reduces how often the model reaches for a fence in the first
+   place, and addresses the separate ask that these summaries read as overly
+   wordy/flowery today.
+
+---
+
+## 1. Root cause (confirmed by reading current `main`, not inferred)
+
+Three RPCs share one Haiku call site,
+`invoke_ambient_haiku_call()` (`agentmux-srv/src/server/app_api/session.rs:522`):
+
+| Purpose | Prompt (current) | Consumer | Rendering surface |
+|---|---|---|---|
+| `activity_summary` | "Summarize in {word_target} words or fewer what is currently being worked on. Use a short terse phrase with no quotes or punctuation." (`session.rs:180-184`) | pane header / Swarm label | text node |
+| `subagent_name` | "Give a concise ~5-word name for this task. No punctuation, no quotes, no preamble — respond with just the name." (`session.rs:262-266`) | Swarm row label | text node |
+| `next_prompt_suggestion` | "...predict ONE short, natural next message... Respond with just that message and nothing else — no quotes, no explanation, no preamble. If nothing plausible comes to mind, respond with an empty string." (`session.rs:435-441`) | **composer ghost text** | `<textarea placeholder>` |
+
+None of the three prompts mention markdown or code fences. All three trust
+the model to follow "no quotes/no punctuation/no preamble" instructions
+literally, with no server-side check.
+
+The confirmed leak path, end to end:
+
+1. `session.rs:444` — `invoke_ambient_haiku_call` returns Haiku's raw text,
+   unmodified, as `suggestion`.
+2. `useNextPromptSuggestion.ts:100-106` — writes `result.suggestion` straight
+   to `term:next_prompt_suggestion` block meta if non-empty; no trim, no
+   format check.
+3. `AgentFooter.tsx:346-349` — `placeholder` memo: `if (suggestion) return
+   suggestion;` — returned verbatim, no processing.
+4. `AgentFooter.tsx:734` — `placeholder={placeholder()}` on the composer
+   `<textarea>`. A native HTML placeholder renders literal text, including
+   backticks and embedded newlines, exactly as given — no markdown
+   interpretation exists anywhere in this path (unlike message-history
+   rendering, which goes through the markdown renderer).
+
+So when Haiku answers with, e.g., a fenced empty block instead of a bare
+sentence or an actual empty string, the textarea shows the fence literally:
+line 1 "` ``` `", line 2 "` ``` `" — the exact artifact reported ("```
+newline ```" in the input box, no visible cause because it's ghost text, not
+anything the user typed).
+
+`activity_summary` and `subagent_name` share the same unsanitized call site
+and are exposed to the same failure mode; they're just less visible (short
+header labels rarely get long enough content for a fence to look "empty" the
+same way) and haven't been reported, but the same fix protects them.
+
+Note: an older full-CLI, multi-sentence "session digest" banner
+(`SessionDigestCommand` / `useSessionDigest.ts` / `SessionDigestBanner.tsx`)
+existed at one point but is confirmed **removed** from current `main` — the
+three purposes above are the entire current surface for AI-generated summary
+text.
+
+---
+
+## 2. Proposed fix
+
+### 2.1 Sanitize at the shared choke point (primary fix)
+
+Add a sanitizer inside `invoke_ambient_haiku_call` (`session.rs`), applied to
+every purpose uniformly, immediately before the text is returned:
+
+```rust
+/// Defends against the model wrapping its answer in markdown despite being
+/// told not to — every ambient-call prompt asks for a bare line of text, but
+/// instruction-following isn't guaranteed. Strips a single wrapping code
+/// fence (with or without a language tag), strips wrapping single/double/
+/// smart quotes, then trims whitespace. Never partial — either the whole
+/// wrapper comes off or the text is returned as-is (a fence-like substring
+/// in the middle of real content is left alone; only wrapping is stripped).
+fn sanitize_ambient_text(raw: &str) -> String {
+    let mut s = raw.trim();
+    if let Some(inner) = strip_wrapping_fence(s) {
+        s = inner.trim();
+    }
+    s.trim_matches(|c| matches!(c, '"' | '\'' | '\u{201C}' | '\u{201D}' | '\u{2018}' | '\u{2019}'))
+        .trim()
+        .to_string()
+}
+```
+
+(`strip_wrapping_fence` — regex or manual scan for a leading ` ``` `
+optionally followed by a language tag and newline, and a trailing ` ``` `,
+returning the content between; `None` if the string isn't fully wrapped.)
+
+Call sites (`register_session_activity_summary`, `generate_subagent_name`,
+`register_session_next_prompt_suggestion`) need no change — they all funnel
+through `invoke_ambient_haiku_call`, so fixing it there fixes all three at
+once, and any future ambient-call purpose gets the same protection for free
+(same "one place owns it" principle the ghost-text spec already used for
+frontend precedence).
+
+After sanitizing, treat an empty result exactly like today's "empty string"
+/ "CLI failed" path:
+- `next_prompt_suggestion`: `empty_suggestion_result()` — no ghost text shown.
+- `activity_summary`: already filtered by `.filter(|(summary, _)| !summary.is_empty())` (`session.rs:188`) — falls through unchanged.
+- `subagent_name`: already checked via `if name.is_empty()` (`session.rs:273`) — falls through unchanged.
+
+No caller-side changes needed beyond this one function.
+
+### 2.2 Tighten the three prompts (defense in depth + the terseness ask)
+
+Reduce how often the model reaches for formatting at all, and make the
+output read as flatter/more factual — same intent, tighter wording:
+
+- **`activity_summary`** (`session.rs:180-184` / `341-344`, both copies —
+  keep them identical, they're duplicated for the pushed-vs-pulled call
+  paths):
+  `"Summarize in {word_target} words or fewer what is currently being worked
+  on. Plain text only — no markdown, no code fences, no backticks, no
+  quotes, no punctuation, no preamble."`
+- **`subagent_name`** (`session.rs:262-266`):
+  `"Give a concise ~5-word name for this task. Plain text only — no
+  markdown, no code fences, no backticks, no punctuation, no quotes, no
+  preamble. Respond with just the name."`
+- **`next_prompt_suggestion`** (`session.rs:435-441`):
+  `"Based on this recent activity, predict ONE short, natural next message
+  the user might send to continue the conversation. Respond with just that
+  message and nothing else — plain text only, no markdown, no code fences,
+  no backticks, no quotes, no explanation, no preamble. If nothing plausible
+  comes to mind, respond with an empty string."`
+
+These are prompt-level nudges, not a substitute for §2.1 — a model can still
+ignore instructions; §2.1 is what makes the fix actually reliable.
+
+### 2.3 Not doing (out of scope)
+
+- No frontend sanitization layer. The composer already treats
+  `term:next_prompt_suggestion` as trusted, pre-cleaned text once §2.1 ships
+  server-side; adding a second stripping layer client-side would be the kind
+  of redundant defensive code the project avoids, and would invite drift
+  between the two copies.
+- No settings toggle / behavior change to when these calls fire — this spec
+  only touches output cleanliness and phrasing, not the Ambient Model Call
+  gateway's admission/coalescing logic, which is unrelated and already works.
+
+---
+
+## 3. Test plan
+
+- Unit tests for `sanitize_ambient_text` (colocated with
+  `invoke_ambient_haiku_call` in `session.rs`):
+  - Plain sentence passes through unchanged.
+  - ` ```\ntext\n``` ` → `text`.
+  - ` ```rust\ntext\n``` ` (language tag) → `text`.
+  - ` ```\n``` ` (empty fence — the reported bug) → `""`.
+  - Leading/trailing quote wrapping (`"text"`, `'text'`, curly quotes) → `text`.
+  - A fence-like substring embedded mid-sentence (not wrapping the whole
+    string) is left alone.
+- `next_prompt_suggestion` regression case: feed a canned Haiku response of
+  literal ` ```\n``` ` through the full handler, assert
+  `NextPromptSuggestionResult.suggestion == ""` (so the frontend never writes
+  it to block meta).
+- Manual: force a code-heavy recent-activity window (e.g. a session that just
+  ran a big diff/tool dump) and confirm the ghost-text suggestion that
+  appears in the composer is a plain sentence, never a fence.
+
+---
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/server/app_api/session.rs` | Add `sanitize_ambient_text` + `strip_wrapping_fence`; apply inside `invoke_ambient_haiku_call` before returning; tighten the three prompt strings (§2.2); unit tests. |
+
+No frontend changes (§2.3).


### PR DESCRIPTION
## Summary

Users occasionally saw a literal ` ``` ` / newline / ` ``` ` blob appear in the
composer's empty input box, "for no reason." Root cause: the ghost-text
next-prompt suggestion (`term:next_prompt_suggestion`) is Haiku-generated text
written raw into the textarea's `placeholder` attribute — a native HTML
placeholder renders text verbatim, with zero markdown interpretation anywhere
in that path. Haiku occasionally wraps its one-line answer in a markdown code
fence despite the prompt telling it not to; an empty/near-empty fence renders
as exactly the reported artifact. `activity_summary` and `subagent_name` share
the same unsanitized call site (`invoke_ambient_haiku_call`) and were exposed
to the same failure mode, just less visibly.

- `sanitize_ambient_text()` / `strip_wrapping_fence()` (new, in
  `agentmux-srv/src/server/app_api/session.rs`), applied once inside
  `invoke_ambient_haiku_call` right before returning — covers all three
  current ambient-call purposes and any future one from a single choke point.
  Strips a wrapping code fence (triple-backtick, with or without a language
  tag, or single inline backtick) and wrapping quote characters, repeatedly.
  An all-backtick leftover (e.g. an empty fence) collapses to `""`, so each
  caller's existing empty-result handling (skip writing ghost text / filter
  out the summary / treat as no name) covers it with zero caller-side changes.
- Tightened all three ambient prompts (`activity_summary` — both the pull and
  pushed copies, `subagent_name`, `next_prompt_suggestion`) to explicitly
  forbid markdown/code fences/backticks and push harder for terse,
  flourish-free plain text. Defense in depth alongside the sanitizer, and
  separately addresses these summaries reading as unnecessarily wordy.
- Spec: `docs/specs/SPEC_AMBIENT_SUMMARY_SANITIZATION_AND_TERSENESS_2026_07_08.md`
  (root-cause writeup with exact file/line citations, fix design, test plan).

## Test plan

- [x] 9 new unit tests for `sanitize_ambient_text` (plain text passthrough,
  triple-backtick fence with/without language tag, empty fence → `""`, single
  backtick wrap, quote wrap incl. curly quotes, nested fence+quotes, embedded
  fence-like substring left alone, lone backticks → `""`) — all passing.
- [x] `cargo test -p agentmux-srv session` — 101/101 passing (including the
  new sanitizer tests and the existing `pull_call_semaphore` tests unaffected).
- [x] `cargo check -p agentmux-srv` — clean (pre-existing warnings only,
  unrelated to this change).
- [ ] Reviewer: no frontend change needed — `useNextPromptSuggestion.ts` and
  `AgentFooter.tsx` already trust the RPC result verbatim, which is now safe
  once the backend sanitizes at the source.

<!-- agentmux:agent_id=agenty -->