### PR TITLE
fix(bashwrap): suppress orphaned console window on PTY-fallback pipe path

### DIFF
--- a/.changesets/1783561904-fix-bashwrap-suppress-orphaned-console-window-on-pty-fallbac-sesf.md
+++ b/.changesets/1783561904-fix-bashwrap-suppress-orphaned-console-window-on-pty-fallbac-sesf.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(bashwrap): suppress orphaned console window on PTY-fallback pipe path

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -663,6 +663,12 @@ async fn run_via_pipes(
     // rarely-exercised inner spawn). Same fix as shell_node.rs.
     #[cfg(windows)]
     {
+        // `cmd` is `tokio::process::Command`, which provides `creation_flags`
+        // as a native inherent method on Windows — unlike `std::process::
+        // Command`, no `use std::os::windows::process::CommandExt` is needed
+        // to call it here. Verified via a clean `cargo check --target
+        // x86_64-pc-windows-msvc` (0 errors) and this crate's windows-latest
+        // CI job, both passing without the import. See PR #2042 discussion.
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -647,13 +647,26 @@ async fn run_via_pipes(
     buffered: Arc<Mutex<Vec<u8>>>,
     bash: &std::path::Path,
 ) -> Result<i32> {
-    let mut child = Command::new(bash)
-        .arg("-c")
+    let mut cmd = Command::new(bash);
+    cmd.arg("-c")
         .arg(command)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    // Windows only: bash.exe is a console-subsystem binary, so spawning it
+    // without CREATE_NO_WINDOW pops a new visible (and orphaned-looking)
+    // console window for every fallback exec — this path only runs when
+    // PTY allocation fails, which is why it slipped past
+    // SPEC_ELIMINATE_BASHWRAP_CONSOLE_WINDOWS_2026_06_20's audit (that pass
+    // covered bashwrap's own process subsystem and shell_node.rs, not this
+    // rarely-exercised inner spawn). Same fix as shell_node.rs.
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let mut child = cmd
         .spawn()
         .with_context(|| format!("pipe spawn of bash at {}", bash.display()))?;
 


### PR DESCRIPTION
## Summary

Diagnosed a live issue: dozens of orphaned, blank ("ghosted") console windows accumulating in the taskbar across this shared multi-agent machine, traced to `agentmux-bashwrap`.

`run_via_pipes` (`agentmux-bashwrap/src/bash_wrap.rs`) — the safety-net path used only when PTY allocation fails — spawned `bash.exe` via a plain `tokio::process::Command` with no `CREATE_NO_WINDOW` flag. `bash.exe` is a console-subsystem binary, so every fallback exec popped a new, visible console window that was never suppressed.

`SPEC_ELIMINATE_BASHWRAP_CONSOLE_WINDOWS_2026_06_20` (#1621) already fixed two spawn sites — bashwrap's own process (`windows_subsystem = "windows"`) and the persistent Shell tool (`shell_node.rs`, `CREATE_NO_WINDOW`) — but missed this one. It's an inner spawn bashwrap does of its own accord, only reachable when the primary PTY path fails, so it's easy to miss unless that fallback is actually exercised during verification. Confirmed via `~/.agentmux/logs/agentmux-launcher.log` ("PTY allocation failed — falling back to pipes") and via `Get-CimInstance Win32_Process`, which showed multiple `bash.exe` processes (some nearly 24h old, near-zero CPU) with `agentmux-bashwrap.exe` as an ancestor.

## Fix

Same pattern as `shell_node.rs`: `creation_flags(CREATE_NO_WINDOW)` on the child `Command`, gated `#[cfg(windows)]`, no behavior change on other platforms.

## Test plan

- [x] `cargo check -p agentmux-bashwrap` clean

<!-- agentmux:agent_id=agent1 -->