### PR TITLE
fix(host): park-and-blank non-demotable window closes (renderer-zombie commit leak)

### DIFF
--- a/.changesets/1783578948-fix-host-park-and-blank-non-demotable-window-closes.md
+++ b/.changesets/1783578948-fix-host-park-and-blank-non-demotable-window-closes.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(host): park-and-blank non-demotable window closes — closed windows no longer keep the full workspace running invisibly (~90MB commit each) (SPEC_PARK_AND_BLANK_CLOSE_2026_07_09)

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -813,6 +813,89 @@ pub fn demote_promoted_pool_window(
     true
 }
 
+/// SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md — close path for `window-*`
+/// windows that CANNOT demote into the pool (beyond `POOL_DEMOTE_CAP`, or a
+/// foreign `window-{uuid}` label the pool handshake's `window-pool-` prefix
+/// gate rejects). The round-5 destroy these closes used to take parks the
+/// browser anyway (CEF 148 Views, no `on_before_close` — live-verified in the
+/// quit-gate work) with the FULL workspace page still running: xterm WebGL
+/// surfaces (SwiftShader = CPU shared memory = pagefile-backed commit),
+/// websockets, timers — ~90MB+ commit per closed window, measured. Parking
+/// DELIBERATELY and blanking the content turns that zombie into an inert
+/// `about:blank` page.
+///
+/// Same primitives and same discipline as `demote_promoted_pool_window`:
+/// strict HWND resolution FIRST with a mutation-free failure path (caller
+/// falls back to the round-5 destroy), then park + hide + blank + unregister.
+/// The `load_url` MUST precede the `UnregisterBrowser` dispatch —
+/// `get_browser` resolves through `state.browsers` (the ordering lesson the
+/// quit-gate spec learned live).
+///
+/// Returns `true` when the window was parked (caller stops); `false` leaves
+/// all state untouched.
+#[cfg(target_os = "windows")]
+pub fn park_and_blank_window(state: &Arc<AppState>, label: &str) -> bool {
+    use cef::{ImplBrowser, ImplFrame};
+
+    // 1. Strict HWND only — never EnumWindows (round-5 safety note: a loose
+    // fallback can resolve MAIN for an unknown label).
+    let hwnd = unsafe { super::window::resolve_window_hwnd_strict(state, label) };
+    let Some(hwnd) = hwnd else {
+        crate::client::dlog(&format!(
+            "park_and_blank({}): no strict HWND — round-5 fallback (no state mutated)",
+            label
+        ));
+        return false;
+    };
+    let main_hwnd = state.window_hwnds.lock().get("main").copied();
+    if main_hwnd == Some(hwnd as isize) {
+        crate::client::dlog(&format!(
+            "park_and_blank({}): strict HWND resolved to MAIN — refusing, round-5 fallback",
+            label
+        ));
+        return false;
+    }
+
+    // 2. Park off-screen (keep size — no reuse planned) + strip from the
+    // taskbar; set_taskbar_hidden also fully hides the window.
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            SetWindowPos, HWND_TOP, SWP_NOACTIVATE, SWP_NOSIZE,
+        };
+        SetWindowPos(
+            hwnd,
+            HWND_TOP,
+            POOL_OFFSCREEN_X,
+            POOL_OFFSCREEN_Y,
+            0,
+            0,
+            SWP_NOACTIVATE | SWP_NOSIZE,
+        );
+    }
+    set_taskbar_hidden(hwnd, true);
+    state.window_hwnds.lock().remove(label);
+
+    // 3. Blank the content — releases the workspace app (WebGL, websockets,
+    // timers). Same load_url-on-a-parked-window call demote's step 5 has
+    // proven for months.
+    if let Some(mut browser) = state.get_browser(label) {
+        if let Some(frame) = browser.main_frame() {
+            frame.load_url(Some(&cef::CefString::from("about:blank")));
+        }
+    }
+
+    // 4. Shared parking-close discipline (PR #2043): UnregisterBrowser +
+    // quit-watchdog arm.
+    crate::ui_tasks::unregister_after_parking_close(state, label);
+
+    tracing::info!(
+        target: "wrr",
+        label = %label,
+        "[close-window] parked-and-blanked (non-demotable close; renderer kept, workspace unloaded)"
+    );
+    true
+}
+
 pub fn mark_pool_window_renderer_ready(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("window-pool-") {
         return;

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -155,6 +155,22 @@ wrap_task! {
                     {
                         return;
                     }
+                    // SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md — a non-demotable
+                    // window-* close (pool at cap, or a foreign window-{uuid}
+                    // the pool prefix gate rejects) used to fall to the round-5
+                    // destroy, which parks the browser anyway (no
+                    // on_before_close on this build) with the FULL workspace
+                    // page still running — ~90MB+ commit leaked per close,
+                    // measured. Park deliberately and blank the content
+                    // instead; round 5 remains the strict-HWND-failure
+                    // fallback (and the working path for floaters, which are
+                    // not window-* and never reach this branch).
+                    if crate::commands::window_pool::park_and_blank_window(
+                        &self.state,
+                        &self.label,
+                    ) {
+                        return;
+                    }
                     // fall through to round-5 destroy below
                 }
                 #[cfg(target_os = "windows")]
@@ -345,7 +361,7 @@ wrap_task! {
 /// `on_before_close` runs the full cleanup chain, and a parallel dispatch
 /// would break that chain's label-by-identity lookup.
 #[cfg(target_os = "windows")]
-fn unregister_after_parking_close(state: &Arc<AppState>, label: &str) {
+pub(crate) fn unregister_after_parking_close(state: &Arc<AppState>, label: &str) {
     tracing::info!(
         target: "wrr",
         "[close-window] {} close initiated — dispatching UnregisterBrowser (parked browser fires no on_before_close)",

--- a/docs/specs/SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md
+++ b/docs/specs/SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md
@@ -1,0 +1,100 @@
+# SPEC — Park-and-blank for non-demotable window closes (renderer-zombie commit leak)
+
+- **Status:** Implemented, live-verified (see §5 results in PR)
+- **Date:** 2026-07-09
+- **Author:** AgentA
+- **Sibling of:** `SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` (same root mechanism — CEF 148
+  Views parks browsers on every close/destroy sequence; that spec fixed the *accounting*
+  consequence, this one fixes the *memory* consequence).
+- **Reported by:** user — pagefile/commit growth 7→18.5GB with one page open, build ≥0.51.0
+  (i.e. AFTER the PR #1939 + PR #2000 leak fixes — this is a distinct leak).
+
+---
+
+## 1. The measured leak
+
+Controlled churn experiment (2026-07-09, isolated instance, fresh channel, 3 cycles of
+open-5-windows/close-5):
+
+| Stage | CEF processes | Private commit | System commit | Zombie workspace pages |
+|---|---|---|---|---|
+| Fresh instance | 9 | 540 MB | 18.76 GB | 0 |
+| After cycle 1 | 14 | 1,145 MB | 19.43 GB | 3 |
+| After cycle 3 | 20 | 1,755 MB | 20.08 GB | 9 |
+| After kill | 0 | — | 18.23 GB (baseline 18.15) | — |
+
+~90 MB commit per closed window, linear, fully attributed (releases on process exit). The
+zombie pages are worse than the private numbers suggest: each keeps the FULL workspace app
+running invisibly — xterm WebGL canvases (SwiftShader software-GL on current Windows builds =
+CPU shared-memory surfaces = pagefile-backed commit visible in NO process's private bytes),
+live websockets to srv, timers.
+
+## 2. Root cause
+
+`CloseWindowTask` routes a closing `window-*` window three ways:
+1. **Demote** (`window-pool-*` label AND pool below `POOL_DEMOTE_CAP = target+2`) — correct:
+   parks off-screen, hides from taskbar, **reloads to the lightweight `pool=1` boot page**
+   (`window_pool.rs:797-805`), re-enters the pool. No leak.
+2. **Round-5 destroy** (everything else) — `close_browser(1)` + native `DestroyWindow`. On CEF
+   148/Windows the browser is PARKED anyway (live-verified in the quit-gate work:
+   `on_before_close` never fires), and — the gap this spec closes — **the parked browser keeps
+   its workspace page loaded forever**. Round-5 kills the HWND but never unloads the content.
+3. Round-3 fallback (strict-HWND failure) — same parked outcome.
+
+So every close beyond the demote cap, and every foreign `window-{uuid}` close (cold-path,
+tear-off, reproject — they can't demote: the pool handshake gates on the `window-pool-` prefix,
+`window_pool.rs:817`), leaks a full running workspace.
+
+## 3. Design 1 — park-and-blank (this spec)
+
+For non-demotable `window-*` closes, don't attempt the destroy CEF won't honor. Do exactly what
+demote does, minus the pool bookkeeping, plus a blank navigation:
+
+```
+park_and_blank_window(state, label) -> bool   // window_pool.rs, next to demote
+  1. resolve_window_hwnd_strict — failure → false, nothing mutated (same discipline as
+     demote step 1 / round-5; caller falls through to the old round-5 path).
+     Explicit main-HWND guard, parity with round-5.
+  2. Park: SetWindowPos off-screen (POOL_OFFSCREEN_X/Y, SWP_NOSIZE) + set_taskbar_hidden(true)
+     (which also fully hides the window) + evict the window_hwnds cache entry.
+  3. Blank: browser.main_frame().load_url("about:blank") — the SAME call demote's step 5 uses
+     on an already-parked window (proven to work there). Tears down the workspace app: WebGL
+     surfaces, websockets, timers all release. MUST run BEFORE step 4 (get_browser resolves
+     through state.browsers — the ordering lesson from the quit-gate spec, learned live).
+  4. unregister_after_parking_close(state, label) — the shared parking-close discipline from
+     PR #2043: UnregisterBrowser dispatch + quit-watchdog arm.
+```
+
+Call site: `CloseWindowTask`, after the demote attempt, before round-5. Round-5 remains as the
+strict-HWND-failure fallback and as the (working) path for floaters, whose owned-popup
+`DestroyWindow` DOES fire `on_before_close` (#1957 mechanism) — floaters are not routed through
+park-and-blank.
+
+**Effect:** a closed non-demotable window becomes an inert, invisible, `about:blank` parked
+browser (~20-30MB) instead of a hidden full workspace (~90-150MB+shared). Renderer *count*
+still grows with churn (CEF won't give the process back — rounds 2-5 of the July retro proved
+no close API reaches a parked Views browser), but each zombie is cheap and idle.
+
+## 4. Explicitly out of scope (Design 2 — the named follow-up)
+
+**Pool adoption via relabel:** `RelabelBrowser` exists in the reducer; relabeling a foreign
+`window-{uuid}` to `window-pool-*` and demoting it properly would make closed windows reusable
+warm inventory and actually bound the renderer count. Rejected for this PR: it walks straight
+into the L4 label-prefix minefield (~20 prefix-classification sites,
+`SPEC_REDUCER_SSOT_CONSOLIDATION_2026_06_22.md`) and needs cross-process label propagation
+(launcher mirror, srv window ids). Do it after L4's typed `BrowserKind` lands, if ever.
+
+Also out of scope: raising `POOL_DEMOTE_CAP` (parked-blank overflow is now cheap, cap keeps the
+*useful* pool bounded), and the SwiftShader-vs-hardware-GL question (orthogonal; park-and-blank
+shrinks the zombie regardless of GL backend).
+
+## 5. Verification
+
+Repeat the §1 churn experiment on a portable build:
+1. Closed windows appear as `about:blank` CDP targets — zero `workspaceId=` zombie pages.
+2. System-commit growth per cycle drops from ~0.65GB to near-flat (renderer processes still
+   accumulate but blank; expect ≤ ~30MB/window).
+3. Close-all-then-main still exits the full tree via the clean quit gate (no regression of
+   PR #2043 — parked-blank browsers are unregistered, so `registered` reaches 0; process exit
+   reaps them like every parked browser today).
+4. Demote path unchanged: first closes still enter the pool and reopen instantly.


### PR DESCRIPTION
## Problem

User-reported commit/pagefile growth (7→18.5GB with one page open) on ≥0.51.0 — i.e. **after** the PR #1939 and PR #2000 leak fixes. Controlled churn experiment (3 cycles of open-5/close-5, isolated instance): **~90MB commit per closed window, linear**, plus each closed window kept the FULL workspace app running invisibly — xterm WebGL canvases (SwiftShader software-GL = CPU shared-memory surfaces = pagefile-backed commit attributable to no process), live websockets to srv, timers. 9 zombie workspace pages after 15 closes.

## Root cause

Closes that can't demote into the warm pool (beyond `POOL_DEMOTE_CAP`, or foreign `window-{uuid}` labels the pool handshake's `window-pool-` prefix gate rejects) take the round-5 destroy — which on CEF 148/Windows **parks the browser anyway** (established in #2043: no `on_before_close` fires) and, unlike the demote path, **never unloads the page content**. Demote reloads to the lightweight `pool=1` boot page; round-5 leaves the workspace running forever.

## Fix (SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md, design 1)

`park_and_blank_window` — for non-demotable `window-*` closes, skip the destroy CEF won't honor and reuse the demote path's proven primitives: strict-HWND-first with mutation-free failure (falls back to round-5), park off-screen, `set_taskbar_hidden` (fully hides), evict the hwnd cache, then `load_url("about:blank")` (the same parked-window navigation demote's step 5 has proven), then the shared parking-close discipline from #2043 (`UnregisterBrowser` + quit-watchdog arm). Floaters keep their working round-5 path untouched; macOS/Linux unchanged.

## Verification (same methodology as the diagnosis)

| Metric | Before (0.51.0) | After (this PR) |
|---|---|---|
| Zombie workspace pages after 15 closes | 9 | **0** (all `about:blank`) |
| System-commit growth, 15 closes | +1.32 GB | **+0.36 GB** |
| Private commit per leaked renderer | ~110 MB | ~52 MB |
| Close-all-then-main | clean exit | clean exit, clean gate, no watchdog (#2043 regression check) |
| Demote path | pool refills to 5 | unchanged |

Renderer *process count* still grows with churn — CEF gives no API that reclaims a parked Views browser (rounds 2–5 of the July retro) — but each zombie is now inert and cheap. **Design 2** (pool adoption via `RelabelBrowser`, which would actually bound the count) is scoped in the spec as the follow-up, blocked on L4 typed `BrowserKind`.

184/184 unit tests. Changeset included (patch).

Follow-up to #2043 — same root mechanism (CEF 148 parks browsers on every close); that PR fixed the accounting consequence, this one fixes the memory consequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)