### PR TITLE
chore: release v0.51.2

### DIFF
--- a/.changesets/1783484561-feat-mcp-probe-app-api-mcp-capabilities-ts-mcp-server-health-6898.md
+++ b/.changesets/1783484561-feat-mcp-probe-app-api-mcp-capabilities-ts-mcp-server-health-6898.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): probe App API + mcp-capabilities.ts — MCP server health check (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08)

--- a/.changesets/1783503158-feat-host-spec-pillar1-step4-phase-4-5-restoring-session-ove-zy9e.md
+++ b/.changesets/1783503158-feat-host-spec-pillar1-step4-phase-4-5-restoring-session-ove-zy9e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(host): SPEC_PILLAR1_STEP4 Phase 4/5 - restoring-session overlay + crash-reproject E2E test

--- a/.changesets/1783524916-fix-layout-delete-block-now-notifies-frontends-of-the-layout-dxoj.md
+++ b/.changesets/1783524916-fix-layout-delete-block-now-notifies-frontends-of-the-layout-dxoj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): delete_block now notifies frontends of the layout prune, closing a stale-tree resurrection race

--- a/.changesets/1783525880-feat-armory-tooltips-on-collapsed-rail-nav-items-cgni.md
+++ b/.changesets/1783525880-feat-armory-tooltips-on-collapsed-rail-nav-items-cgni.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): tooltips on collapsed rail nav items

--- a/.changesets/1783527221-fix-tabs-workspace-tabs-rest-at-chrome-s-standard-232px-widt-23wj.md
+++ b/.changesets/1783527221-fix-tabs-workspace-tabs-rest-at-chrome-s-standard-232px-widt-23wj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): workspace tabs rest at Chrome's standard 232px width instead of collapsing to short-label content width

--- a/.changesets/1783539589-feat-tabs-random-color-for-new-tabs-min-window-width-380px-o-uv3x.md
+++ b/.changesets/1783539589-feat-tabs-random-color-for-new-tabs-min-window-width-380px-o-uv3x.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tabs): random color for new tabs; min window width 380px on Windows

--- a/.changesets/1783541170-feat-layout-reducer-self-heals-dangling-block-references-on--t14v.md
+++ b/.changesets/1783541170-feat-layout-reducer-self-heals-dangling-block-references-on--t14v.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(layout): reducer self-heals dangling block references on every layout write (WRR-style)

--- a/.changesets/1783551089-fix-ambient-sanitize-haiku-summaries-against-leaked-markdown-20tb.md
+++ b/.changesets/1783551089-fix-ambient-sanitize-haiku-summaries-against-leaked-markdown-20tb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ambient): sanitize Haiku summaries against leaked markdown fences

--- a/.changesets/1783574431-fix-host-wrr-last-window-quit-no-longer-fires-while-live-windows-remain.md
+++ b/.changesets/1783574431-fix-host-wrr-last-window-quit-no-longer-fires-while-live-windows-remain.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(host): WRR last-window quit no longer fires while live windows remain — quit gate now requires reducer agreement, parking closes feed the reducer, 3s desync watchdog (SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08)

--- a/.changesets/1783578948-fix-host-park-and-blank-non-demotable-window-closes.md
+++ b/.changesets/1783578948-fix-host-park-and-blank-non-demotable-window-closes.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(host): park-and-blank non-demotable window closes — closed windows no longer keep the full workspace running invisibly (~90MB commit each) (SPEC_PARK_AND_BLANK_CLOSE_2026_07_09)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.51.1"
+version = "0.51.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,19 @@
 # AgentMux Version History
 
+## 0.51.2 — 2026-07-08
+
+- feat(mcp): probe App API + mcp-capabilities.ts — MCP server health check (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08)
+- feat(host): SPEC_PILLAR1_STEP4 Phase 4/5 - restoring-session overlay + crash-reproject E2E test
+- fix(layout): delete_block now notifies frontends of the layout prune, closing a stale-tree resurrection race
+- feat(armory): tooltips on collapsed rail nav items
+- fix(tabs): workspace tabs rest at Chrome's standard 232px width instead of collapsing to short-label content width
+- feat(tabs): random color for new tabs; min window width 380px on Windows
+- feat(layout): reducer self-heals dangling block references on every layout write (WRR-style)
+- fix(ambient): sanitize Haiku summaries against leaked markdown fences
+- fix(host): WRR last-window quit no longer fires while live windows remain — quit gate now requires reducer agreement, parking closes feed the reducer, 3s desync watchdog (SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08)
+- fix(host): park-and-blank non-demotable window closes — closed windows no longer keep the full workspace running invisibly (~90MB commit each) (SPEC_PARK_AND_BLANK_CLOSE_2026_07_09)
+
+
 ## 0.51.1 — 2026-07-08
 
 - fix(swarm): key subagent completion off the result-event discriminant, not derived text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Patch release consuming 10 pending changesets — headline items:

- **fix(host): WRR last-window quit no longer fires while live windows remain** (#2043) — the false-exit bug (closing a non-last window could kill the whole host).
- **fix(host): park-and-blank non-demotable window closes** (#2044) — the commit/pagefile leak (~90MB per closed window, closed windows kept full workspaces running invisibly).

Plus the layout self-heal, delete_block frontend notify, tabs/armory UI items, MCP probe, and Pillar 1 Step 4 Phase 4/5 already merged to main.

`task release:patch` output: all 5 version locations agree at 0.51.2; VERSION_HISTORY updated; changesets consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)