### PR TITLE
fix(cef): isolated window contexts are in-memory by design — ends the 'Cannot create profile' error on every launch

### DIFF
--- a/.changesets/1783623260-fix-cef-isolated-window-contexts-are-in-memory-by-design-end-jijt.md
+++ b/.changesets/1783623260-fix-cef-isolated-window-contexts-are-in-memory-by-design-end-jijt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): isolated window contexts are in-memory by design — ends the 'Cannot create profile' error logged on every launch since v0.33.x

--- a/agentmux-cef/src/commands/mod.rs
+++ b/agentmux-cef/src/commands/mod.rs
@@ -24,11 +24,32 @@ use crate::state::AppState;
 ///
 /// Each browser window needs its own renderer process to get an isolated
 /// JavaScript context (own `document`, own module state, own SolidJS render tree).
-/// CEF assigns a separate renderer process when the RequestContext has a unique
-/// `cache_path`. We use `<root_cache_path>/browser-contexts/<label>/` — it MUST
-/// be a child of `Settings.root_cache_path` (the cef-cache dir) or CEF rejects it
-/// and falls back to in-memory storage. SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.
-pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Option<cef::RequestContext> {
+/// CEF assigns a separate renderer process when the RequestContext maps to a
+/// unique profile. We request that with an EMPTY `cache_path`: Chrome's profile
+/// initializer (chrome_browser_context.cc) then creates a new/unique
+/// OffTheRecord profile — isolation without any on-disk profile. That is
+/// deliberate, not a compromise:
+///
+/// - Labels embed a per-run UUID, so a disk-backed profile could never be
+///   reused across runs — persistence has no value here. (Browser panes,
+///   where cookie/storage persistence DOES matter, use the shared default
+///   context — `None` — which is disk-backed.)
+/// - A non-empty `cache_path` must be a DIRECT child of
+///   `Settings.root_cache_path` (`cache_path.DirName() == user_data_dir`);
+///   anything deeper logs `Cannot create profile at path …` and falls back to
+///   the same unique-OTR profile. The old `<root>/browser-contexts/<label>/`
+///   layout was one level too deep and hit that error on every isolated
+///   window since v0.33.x (2–22 log lines per launch).
+/// - A VALID direct-child path (`<root>/ctx-<label>`) creates a real Chrome
+///   profile — but browser creation then stalls indefinitely in this host
+///   (no on_after_created / page load; verified live 2026-07-09 on a dev
+///   build). Real per-window profiles are NOT safe in AgentMux's
+///   alloy-style-views-on-chrome-bootstrap setup.
+///
+/// So: empty path = the same unique-OTR behavior the error-fallback has been
+/// (accidentally) providing all along, minus the error line and the risk.
+/// SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.6.
+pub fn create_isolated_request_context(_state: &Arc<AppState>, label: &str) -> Option<cef::RequestContext> {
     // Phase 1 diagnostic tracing (added 2026-05-02 freeze investigation, see
     // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md). The freeze
     // wedges the UI thread inside CEF's Chrome profile-init under concurrent
@@ -37,28 +58,13 @@ pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Op
     let t0 = std::time::Instant::now();
     tracing::info!(label = %label, "[cef-profile-init] entering create_isolated_request_context");
 
-    // Root the per-window context UNDER root_cache_path (the cef-cache dir) so
-    // CEF accepts it — it requires cache_path to be a descendant of
-    // root_cache_path, else it rejects it and falls back to in-memory storage
-    // (SPEC_CEF_LOG_ROBUSTNESS §1). Fall back to a temp dir only if
-    // root_cache_path isn't initialized yet (pre-boot edge).
-    let cache_root = state.cef_cache_dir.lock().clone()
-        .unwrap_or_else(|| {
-            std::env::temp_dir()
-                .join("agentmux-cef-contexts")
-                .to_string_lossy()
-                .to_string()
-        });
-
-    let ctx_path = std::path::PathBuf::from(&cache_root)
-        .join("browser-contexts")
-        .join(label);
-    // Do NOT pre-create the directory — CEF's Chrome profile initializer
-    // (chrome_browser_context.cc) fails when the directory already exists but
-    // has no valid profile structure. Let CEF create and initialize it.
-
+    // Empty cache_path → chrome_browser_context.cc skips the disk-profile
+    // branches entirely and creates a new/unique OffTheRecord profile, with
+    // no error logged and nothing written to disk. See doc comment above for
+    // why the disk-backed alternatives are wrong (grandchild path → error +
+    // this same fallback; direct-child path → browser creation stalls).
     let settings = cef::RequestContextSettings {
-        cache_path: cef::CefString::from(ctx_path.to_str().unwrap_or("")),
+        cache_path: cef::CefString::from(""),
         persist_session_cookies: 0,
         ..Default::default()
     };
@@ -77,9 +83,60 @@ pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Op
     );
 
     if ctx.is_some() {
-        tracing::info!(label = %label, path = %ctx_path.display(), "[cef] created isolated RequestContext");
+        tracing::info!(label = %label, "[cef] created isolated RequestContext (unique off-the-record profile)");
     } else {
         tracing::warn!(label = %label, "[cef] failed to create isolated RequestContext — falling back to shared");
     }
     ctx
+}
+
+/// Delete on-disk litter left by earlier isolated-context path schemes.
+///
+/// Isolated contexts are in-memory (empty cache_path) as of the 2026-07-09
+/// fix, so nothing under cef-cache belongs to them anymore. Two legacy
+/// layouts left dirs behind:
+/// - `browser-contexts/<label>/` — the grandchild layout (≤0.51.x). The
+///   profile itself never initialized (fell back to OTR), but CEF's
+///   request-context layer still dropped partial cache dirs there.
+/// - `ctx-<label>/` — the short-lived direct-child experiment (real Chrome
+///   profiles; never released — the layout stalled browser creation).
+///
+/// Labels embed a per-run UUID, so none of these dirs can ever be referenced
+/// again; delete on sight. Runs off-thread — the trees can hold many small
+/// files and this sits on the startup path.
+pub fn cleanup_legacy_context_dirs(cache_root: &str) {
+    let root = std::path::PathBuf::from(cache_root);
+    let mut stale: Vec<std::path::PathBuf> = Vec::new();
+
+    let legacy = root.join("browser-contexts");
+    if legacy.is_dir() {
+        stale.push(legacy);
+    }
+    if let Ok(entries) = std::fs::read_dir(&root) {
+        for entry in entries.flatten() {
+            if entry.file_name().to_string_lossy().starts_with("ctx-")
+                && entry.path().is_dir()
+            {
+                stale.push(entry.path());
+            }
+        }
+    }
+    if stale.is_empty() {
+        return;
+    }
+    tracing::info!(
+        count = stale.len(),
+        "[cef] removing legacy isolated-context dirs"
+    );
+    std::thread::spawn(move || {
+        for dir in stale {
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                tracing::warn!(
+                    dir = %dir.display(),
+                    error = %e,
+                    "[cef] failed to remove legacy isolated-context dir"
+                );
+            }
+        }
+    });
 }

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -767,10 +767,15 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     }
     tracing::info!("CEF cache dir: {}", data_dir.display());
     let cache_dir = CefString::from(data_dir.to_str().unwrap_or(""));
-    // Expose root_cache_path so per-window RequestContexts root their cache_path
-    // UNDER it — CEF requires a descendant of root_cache_path, else it falls back
-    // to in-memory storage. SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.
+    // Expose root_cache_path. Per-window RequestContexts no longer place
+    // anything under it (they are in-memory — see
+    // `create_isolated_request_context`), but the legacy-litter sweep below
+    // and future consumers still need the resolved path.
     *app_state.cef_cache_dir.lock() = Some(data_dir.to_string_lossy().to_string());
+    // Remove dirs left by the earlier isolated-context path schemes
+    // (`browser-contexts/`, `ctx-*`) — labels are per-run UUIDs, so they can
+    // never be referenced again. SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.6.
+    crate::commands::cleanup_legacy_context_dirs(&data_dir.to_string_lossy());
 
     // Configure CEF settings.
     // Pick a FREE remote-debugging port instead of a fixed one: AgentMux runs

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -847,11 +847,12 @@ pub struct AppState {
     /// pane targets. See `docs/specs/SPEC_BROWSER_DOM_API.md` §6.
     pub debug_port: Mutex<u16>,
 
-    /// CEF `root_cache_path` (the version's `cef-cache` dir). Stored so
-    /// per-window RequestContexts (`create_isolated_request_context`) root their
-    /// `cache_path` UNDER it — CEF requires every context cache_path to be a
-    /// descendant of root_cache_path, else it rejects it and falls back to
-    /// in-memory storage. See SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.
+    /// CEF `root_cache_path` (the version's `cef-cache` dir). Per-window
+    /// RequestContexts are in-memory (unique off-the-record profiles — see
+    /// `create_isolated_request_context`) and place nothing under it; the
+    /// resolved path is kept for the startup legacy-litter sweep
+    /// (`cleanup_legacy_context_dirs`) and any future consumers. See
+    /// SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md §1.6.
     pub cef_cache_dir: Mutex<Option<String>>,
 
     // Phase B.1 removed `job_handle` (was Windows-only). Launcher

--- a/docs/specs/SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md
+++ b/docs/specs/SPEC_CEF_LOG_ROBUSTNESS_2026_06_20.md
@@ -85,6 +85,52 @@ Implementation:
 - The on-disk `cef-cache/browser-contexts/<label>/` dir exists after a window
   opens.
 
+### 1.6 Amendment (2026-07-09) — §1.4 was wrong twice over; isolated contexts are now in-memory BY DESIGN
+
+Three findings from the 2026-07-09 investigation (each verified against CEF
+source and/or live instances):
+
+**(a) §1.4 didn't fix the error — it changed its signature.** The
+`<cef-cache>/browser-contexts/<label>` layout passed CEF's request-context
+descendant check (`context.cc:161` disappeared) but failed the **stricter**
+check in Chrome's profile initializer, `chrome_browser_context.cc`: a
+non-empty profile path must be a **direct child** of `root_cache_path`
+(`cache_path.DirName() == user_data_dir`). A grandchild logs `Cannot create
+profile at path …` and falls back to a **new/unique off-the-record profile**.
+This fired on 100% of launches since v0.33.x (2 pool windows at startup; up
+to 22 lines on a session-restore start), so §1.3's "lost capability" was
+never restored — but window isolation kept working, because the unique-OTR
+fallback provides it.
+
+**(b) The "obvious" fix — a valid direct-child path — is a trap.** Tested
+live (dev build, 2026-07-09): `<cef-cache>/ctx-<label>` makes
+`request_context_create_context` succeed and Chrome materializes a full
+profile on disk, but **browser creation then stalls indefinitely** — for the
+pool window `on_after_created` fired and the page never loaded; for a
+subsequent `open_new_window` even `on_after_created` never fired. No error
+is logged anywhere; the window simply never appears. Real per-window Chrome
+profiles are NOT safe in AgentMux's alloy-style-views-on-chrome-bootstrap
+host. Do not retry this without solving the stall.
+
+**(c) Persistence was never a coherent goal for these contexts.** Isolated
+windows' labels embed a per-run UUID — a disk profile could never be
+re-attached across runs. Browser panes, where cookie/localStorage
+persistence actually matters, use the shared default (disk-backed) context.
+
+**Fix shipped:** `create_isolated_request_context` passes an **empty**
+`cache_path`. `chrome_browser_context.cc` skips both disk-profile branches
+and creates the same new/unique OTR profile as the old error-fallback —
+identical proven behavior, zero error lines, zero disk litter. A startup
+sweep (`cleanup_legacy_context_dirs`) removes leftover `browser-contexts/`
+and `ctx-*` trees.
+
+**Verify:** launch → `grep -c "Cannot create profile\|context.cc:1"
+cef-debug.log` → 0; pool reaches target (2× `pool window renderer ready`);
+`open_new_window` produces a working window; no new dirs under `cef-cache`
+beyond Chromium's own. The §1.5 cookie-persistence check is RETIRED for
+isolated windows (persistence is out of scope by design); it remains valid
+for browser panes via the default context.
+
 ---
 
 ## 2. Error 2 — `bind()` collision on the remote-debugging port


### PR DESCRIPTION
## Problem

Every launch since v0.33.x has logged `ERROR:...chrome_browser_context.cc:116] Cannot create profile at path ...` — 2 lines per cold start (pool pre-warm), up to 22 on session-restore starts. 100% reproduction across every recorded launch on every version.

## Root cause

Chrome's profile initializer accepts a RequestContext `cache_path` only if it equals `root_cache_path` or is its **direct child** (`cache_path.DirName() == user_data_dir` — verified against CEF source). Our per-window isolated contexts used `<root>/browser-contexts/<label>` — a **grandchild** — so every isolated window (pool pre-warm, tear-off, `open_new_window`) hit the error and fell back to a new/unique off-the-record profile. The 0.49.0 fix (SPEC_CEF_LOG_ROBUSTNESS §1.4) moved the tree under cef-cache, which satisfied the request-context-level descendant check (`context.cc:161`) but kept the grandchild shape — it only changed the error signature.

## Why NOT the obvious fix (valid direct-child path)

Tested live on a dev build (2026-07-09): `<cef-cache>/ctx-<label>` makes profile creation succeed (full profile materializes on disk) — but **browser creation then stalls indefinitely and silently**: the pool window fired `on_after_created` but never loaded its page (no CDP target, no console, no renderer-ready in 3+ hours); a subsequent `open_new_window` never even reached `on_after_created`. No error logged anywhere. Real per-window Chrome profiles are not safe in this host's alloy-style-Views-on-chrome-bootstrap setup. Documented as a trap in spec §1.6.

## Fix

Pass an **empty** `cache_path`: `chrome_browser_context.cc` then skips both disk-profile branches and creates the same new/unique OTR profile the error fallback has been (accidentally) providing all along — identical proven behavior, zero error lines, zero disk litter. This is by-design, not a compromise: isolated-window labels embed a per-run UUID so a disk profile could never be re-attached across runs, and browser panes (where persistence matters) use the shared default disk-backed context.

Also adds `cleanup_legacy_context_dirs`: a startup sweep of the `browser-contexts/` and `ctx-*` litter left by the old layouts.

## Verification (portable build, env-scrubbed isolated instance)

- `grep -c "Cannot create profile\|context.cc:1" cef-debug.log` → **0** across two launches (previously ≥2 per launch); zero ERROR lines of any kind
- Pool fills to target and handshakes: `pool window renderer ready` ×4
- `openNewWindow` via CDP: **warm pool promote** works end-to-end — window registers in `listWindows`, URL flips from `pool=1` to workspace boot, pool self-refills with a new window that also loads
- Legacy sweep: planted `browser-contexts/` + `ctx-*` dirs removed on relaunch (`removing legacy isolated-context dirs count=2`)
- `cargo check -p agentmux-cef` clean (no new warnings)

Follow-up to the 0.49.0 §1.4 fix; spec §1.6 amendment records all findings including the direct-child stall trap.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)