### PR TITLE
chore: release v0.52.0

### DIFF
--- a/.changesets/1783550933-feat-jekt-render-jekt-markers-as-jektbubble-in-the-agent-pan-hdkr.md
+++ b/.changesets/1783550933-feat-jekt-render-jekt-markers-as-jektbubble-in-the-agent-pan-hdkr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(jekt): render [JEKT:...] markers as JektBubble in the agent pane

--- a/.changesets/1783551415-fix-identity-resolver-reads-direct-account-links-only-drops--ui1r.md
+++ b/.changesets/1783551415-fix-identity-resolver-reads-direct-account-links-only-drops--ui1r.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(identity): resolver reads direct account links only, drops bundle-binding fallback (#1624 PR-B)

--- a/.changesets/1783561904-fix-bashwrap-suppress-orphaned-console-window-on-pty-fallbac-sesf.md
+++ b/.changesets/1783561904-fix-bashwrap-suppress-orphaned-console-window-on-pty-fallbac-sesf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bashwrap): suppress orphaned console window on PTY-fallback pipe path

--- a/.changesets/1783623260-fix-cef-isolated-window-contexts-are-in-memory-by-design-end-jijt.md
+++ b/.changesets/1783623260-fix-cef-isolated-window-contexts-are-in-memory-by-design-end-jijt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): isolated window contexts are in-memory by design — ends the 'Cannot create profile' error logged on every launch since v0.33.x

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.51.2"
+version = "0.52.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.52.0 — 2026-07-09
+
+- feat(jekt): render [JEKT:...] markers as JektBubble in the agent pane
+- fix(identity): resolver reads direct account links only, drops bundle-binding fallback (#1624 PR-B)
+- fix(bashwrap): suppress orphaned console window on PTY-fallback pipe path
+- fix(cef): isolated window contexts are in-memory by design — ends the 'Cannot create profile' error logged on every launch since v0.33.x
+
+
 ## 0.51.2 — 2026-07-08
 
 - feat(mcp): probe App API + mcp-capabilities.ts — MCP server health check (SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.51.2",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.51.2",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.51.2",
+  "version": "0.52.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Consumes 4 pending changesets (highest type: minor) → 0.51.2 → 0.52.0.

- feat(jekt): render [JEKT:...] markers as JektBubble in the agent pane
- fix(identity): resolver reads direct account links only, drops bundle-binding fallback (#1624 PR-B)
- fix(bashwrap): suppress orphaned console window on PTY-fallback pipe path
- fix(cef): isolated window contexts are in-memory by design — ends the 'Cannot create profile' error logged on every launch since v0.33.x (#2046)

All five version locations verified at 0.52.0 by scripts/release.sh (package.json, Cargo.toml workspace, Cargo.lock, package-lock.json, VERSION_HISTORY.md head). One manual touch-up: restored the blank line between the new section and the 0.51.2 header in VERSION_HISTORY.md.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)