### PR TITLE
fix(window): end the startup window storm — single-run initApp + slow-path reproject GC

### DIFF
--- a/.changesets/1783632173-fix-window-end-the-startup-window-storm-single-run-initapp-r-6wsn.md
+++ b/.changesets/1783632173-fix-window-end-the-startup-window-storm-single-run-initapp-r-6wsn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): end the startup window storm — single-run initApp, reproject GCs never-registered rows

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -693,7 +693,7 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
         // translated to the `"main"` sentinel here — otherwise the remap
         // lookup finds nothing and the subwindow is silently skipped as if
         // its parent were missing.
-        let mut extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
+        let extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
         if extra_ids.is_empty() {
             tracing::debug!(
                 target: "reproject",
@@ -703,33 +703,8 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
             return;
         }
 
-        // Safety cap — found live (2026-07-08): a build force-killed many
-        // times over one test session (never a graceful quit) accumulated
-        // 30+ stale `Client.windowids` entries, all recreated at once on the
-        // next cold boot. The direct cause (this function never closing the
-        // OLD id it just reprojected from) is fixed above/below, but that
-        // fix only covers entries THIS function itself creates — a
-        // separate, pre-existing leak (pool-warmup windows registering a
-        // real backend_window_id that's never closed either, since they're
-        // never gracefully closed) can still slowly inflate this list over
-        // many restarts. Bound the worst case regardless of root cause:
-        // recreate at most this many windows per pass; anything beyond that
-        // is left in place (not lost — just not recreated this launch) with
-        // a loud warning, rather than silently opening dozens of windows.
-        let dropped = cap_recreate_list(&mut extra_ids, MAX_SLOW_PATH_RECREATE);
-        if dropped > 0 {
-            tracing::warn!(
-                target: "reproject",
-                total = extra_ids.len() + dropped,
-                recreating = extra_ids.len(),
-                dropped,
-                "[reproject] slow path: Client.windowids has far more entries than a normal \
-                 session should — capping recreation to avoid a runaway window-open storm; \
-                 the rest are left in srv, uncreated, for now"
-            );
-        }
-
         let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
+        let mut garbage: Vec<&String> = Vec::new();
         for window_id in extra_ids {
             let Some((kind, parent_window_id)) = crate::client::backend_get_window_topology(&web_endpoint, &auth_key, window_id) else {
                 tracing::warn!(target: "reproject", window_id = %window_id, "[reproject] slow path: GetWindow failed — skipping this window");
@@ -743,8 +718,18 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
                     agentmux_common::ipc::WindowKind::FullInstance
                 }
                 None => {
-                    tracing::warn!(target: "reproject", window_id = %window_id, "[reproject] slow path: no persisted kind (pre-Step-3 window row?) — defaulting to FullInstance");
-                    agentmux_common::ipc::WindowKind::FullInstance
+                    // No persisted kind means this row never completed a
+                    // `register_backend_window` round trip (Step 3's
+                    // write-through stamps `kind` on every registration,
+                    // main included) — it is an orphan, not a window the
+                    // user ever saw: the frontend double-init strands one
+                    // such row per window creation, and pre-Step-3 rows
+                    // have no restorable identity either. Recreating these
+                    // as FullInstance windows is what turned a polluted
+                    // `Client.windowids` into a window storm on every
+                    // launch. Garbage-collect instead of recreating.
+                    garbage.push(window_id);
+                    continue;
                 }
             };
             let parent_label = parent_window_id.map(|pid| {
@@ -764,6 +749,47 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
                 last_rect: None,
                 foregrounded_since_open: true,
             });
+        }
+
+        // GC the orphans right now — these ids never had a live window, so
+        // there is nothing to confirm before closing (unlike the recreate
+        // path's deferred closures below). `CloseWindow` prunes the
+        // `Client.windowids` entry, deletes the row, and cascades the
+        // orphan's (empty, auto-created) workspace only when no other
+        // window references it — a polluted store self-heals here instead
+        // of feeding next launch's reproject.
+        if !garbage.is_empty() {
+            tracing::warn!(
+                target: "reproject",
+                count = garbage.len(),
+                "[reproject] slow path: garbage-collecting never-registered window rows"
+            );
+            for window_id in garbage {
+                crate::client::backend_close_window(&web_endpoint, &auth_key, window_id);
+            }
+        }
+
+        // Safety cap — found live (2026-07-08): a build force-killed many
+        // times over one test session (never a graceful quit) accumulated
+        // 30+ stale `Client.windowids` entries, all recreated at once on the
+        // next cold boot. Orphan rows are now GC'd above rather than
+        // recreated, but genuinely-restorable entries can still pile up
+        // (e.g. repeated force-kills of real multi-window sessions). Bound
+        // the worst case regardless of root cause: recreate at most this
+        // many windows per pass; anything beyond that is left in place (not
+        // lost — just not recreated this launch) with a loud warning,
+        // rather than silently opening dozens of windows.
+        let dropped = cap_recreate_list(&mut snapshots, MAX_SLOW_PATH_RECREATE);
+        if dropped > 0 {
+            tracing::warn!(
+                target: "reproject",
+                total = snapshots.len() + dropped,
+                recreating = snapshots.len(),
+                dropped,
+                "[reproject] slow path: Client.windowids has far more restorable entries than \
+                 a normal session should — capping recreation to avoid a runaway window-open \
+                 storm; the rest are left in srv, uncreated, for now"
+            );
         }
         tracing::info!(
             target: "reproject",

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -693,7 +693,7 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
         // translated to the `"main"` sentinel here — otherwise the remap
         // lookup finds nothing and the subwindow is silently skipped as if
         // its parent were missing.
-        let extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
+        let mut extra_ids: Vec<&String> = window_ids.iter().filter(|id| *id != &main_window_id).collect();
         if extra_ids.is_empty() {
             tracing::debug!(
                 target: "reproject",
@@ -701,6 +701,25 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
                 "[reproject] slow path: nothing beyond main to recreate"
             );
             return;
+        }
+
+        // Scan cap — every entry costs one blocking GetWindow round trip
+        // (plus one CloseWindow if it turns out to be garbage), all
+        // sequential on this thread, so the per-boot work must stay
+        // bounded no matter how polluted the store is. Entries beyond the
+        // cap are left in srv untouched for the next boot's pass — the
+        // store still converges, just across a few launches instead of a
+        // single unbounded one.
+        let scan_dropped = cap_recreate_list(&mut extra_ids, MAX_SLOW_PATH_SCAN);
+        if scan_dropped > 0 {
+            tracing::warn!(
+                target: "reproject",
+                total = extra_ids.len() + scan_dropped,
+                scanning = extra_ids.len(),
+                dropped = scan_dropped,
+                "[reproject] slow path: Client.windowids has more entries than one boot's \
+                 scan budget — the rest are left in srv for the next launch"
+            );
         }
 
         let mut snapshots: Vec<agentmux_common::ipc::WindowSnapshot> = Vec::new();
@@ -875,6 +894,16 @@ fn get_secondary_window_size(px: i32, py: i32) -> (i32, i32) {
 /// comment at the call site for why this exists (found live, 2026-07-08:
 /// 30+ accumulated `Client.windowids` entries recreated all at once).
 const MAX_SLOW_PATH_RECREATE: usize = 20;
+
+/// Bound on how many `Client.windowids` entries one boot's slow path will
+/// even LOOK at (one blocking GetWindow round trip each, plus a CloseWindow
+/// for each entry classified as garbage — all sequential). Distinct from
+/// `MAX_SLOW_PATH_RECREATE`, which bounds windows actually opened: the scan
+/// budget is deliberately larger so a badly polluted store (the 2026-07-09
+/// storm left 60+ orphan rows per instance) still self-heals in one or two
+/// launches, while a pathologically large list can't turn boot into an
+/// unbounded sequence of network calls (reagent P1, PR #2048).
+const MAX_SLOW_PATH_SCAN: usize = 200;
 
 /// Truncates `items` to at most `max` entries in place; returns how many
 /// were dropped. Extracted as a pure function (reagent P2, PR #2032,

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -492,7 +492,18 @@ async function initHostNewWindow(): Promise<void> {
     }
 }
 
-export async function initApp() {
+// initApp has two callers — bootstrap.ts and this module's self-start below —
+// and in CEF both fire (isHostApp() reads window.__AGENTMUX_IPC_PORT__, which
+// setupCefApi() only sets later, at bootstrap time). It must run exactly once
+// per page: a second concurrent run reaches CreateWindow twice and strands an
+// unregistered Window row in srv's Client.windowids.
+let initAppOnce: Promise<void> | undefined;
+
+export function initApp(): Promise<void> {
+    return (initAppOnce ??= initAppInner());
+}
+
+async function initAppInner() {
     // window.api is guaranteed to exist here — bootstrap.ts calls
     // setupCefApi() before calling initApp().
     // Defensive wait: if a race condition leaves window.api unset, poll briefly.


### PR DESCRIPTION
## The regression (user-visible)

Both stable-channel instances open **dozens of windows on every launch** since v0.51.x. The earlier fixes (#2017/#2032 deferred closes, the 20-window safety cap) did not stop it — they bounded a single boot to 20 windows while the store kept **growing ~20 rows per boot**, so every restart storms again, forever.

Live evidence (this machine, 2026-07-09, stable channel):
- v0.51.2: `Client.windowids` grew **24 → 43 → 62 → 82** across four boots; every boot logged the cap warning and recreated 20 windows.
- v0.52.0: same pattern, 25 → 45 after one boot.
- srv log shows **40 `window.CreateWindow` calls per boot for 20 reprojected windows** (2 per window), and 42 of the 82 persisted window rows have **no `kind`** (never registered).

## Root cause — two bugs compounding

**1. `initApp` runs twice per page in CEF (the fuel).**
`app-init.ts` has a module-level "dev-only" self-start guarded by `!isHostApp()`. `isHostApp()` reads `window.__AGENTMUX_IPC_PORT__`, which `setupCefApi()` only sets *later*, at bootstrap time — so at module evaluation the guard is **always** false in CEF and the self-start always schedules a second `initApp` alongside `bootstrap.ts`'s own call. Each non-main window therefore calls `WindowService.CreateWindow` twice. Only one row ever completes `registerBackendWindow` (and `initWaveWrap`'s `savedInitOpts` latch hid the double-run from the UI), stranding one **never-registered orphan row + `Client.windowids` entry per window creation**. Verified live: the startup-bench timeline shows `fonts-ready`/`isMainWindow-start` firing twice ~2ms apart within a single page load, and 40 `[initTauriNewWindow] Creating new backend objects` lines for 20 windows.

**2. The Step-4 slow-path reproject resurrects those orphans as real windows (the match).**
`reproject_from_srv` runs on every cold boot and defaulted rows with no persisted `kind` to `FullInstance` ("no persisted kind (pre-Step-3 window row?)" warning — that warning fired once per storm window). A kind-less row cannot have completed a `register_backend_window` round trip (the Step-3 write-through stamps `kind` on **every** registration, main included) — it is an orphan the user never saw, not a restorable window. Each resurrected orphan then registered a fresh row (+1) while the deferred close removed only the old one (−1), and the resurrected window's own double-init leaked another orphan — hence the +20/boot growth and a loop that never converges.

## The fix

1. **`frontend/app-init.ts`** — latch `initApp` on a single promise so both callers (bootstrap and the self-start) await the same run. One `CreateWindow` per window, no more orphan rows.
2. **`agentmux-cef/src/commands/window/creation.rs`** — the slow path now **garbage-collects** kind-less rows via `CloseWindow` instead of recreating them: the windowids entry is pruned, the row deleted, and the orphan's empty auto-created workspace cascade-deleted (the existing "any other window references this workspace" guard protects shared workspaces, e.g. a tear-off twin). Polluted stores **self-heal on the first launch of a fixed build** — no manual DB surgery needed in the field. The 20-window safety cap is kept and now applies to the genuinely-restorable set only.

`main` is excluded from the slow path by value (as before) and additionally always has `kind` stamped, so it can never be GC'd.

Trade-off: genuine pre-Step-3 window rows (created ≤ v0.50, before topology persistence existed) also lack `kind` and are now GC'd rather than restored. Given they cannot be restored with correct kind/parent anyway and the alternative is this storm, deletion-with-loud-log is the safer behavior.

## Verification

- `cargo check -p agentmux-cef` clean; all 184 crate unit tests pass; `tsc --noEmit` clean; full vitest suite 1653 passed.
- **Live smoke (fixed build, `task dev`, seeded with a copy of the polluted stable DB — main + 42 orphan rows, `Client.windowids` = 43):**
  - `[reproject] slow path: garbage-collecting never-registered window rows count=42`
  - `[reproject] slow path: recreating windows from srv window_count=0` — **zero windows opened**
  - srv received exactly 42 `window.CloseWindow` calls; post-boot DB: `db_window` 43 → **1** (main only), `windowids` 43 → **1**, `db_workspace` 82 → 40 (exactly the 42 orphan workspaces cascade-deleted; the guard kept every still-referenced one).
  - Fix 1 verified in the same build: the startup-bench timeline shows `isMainWindow-start` firing **once** (previously twice ~2ms apart within one page load).

Fixes the storm reported today on both stable instances. Follow-up candidates (separate PRs): remove the CEF-dead self-start block entirely; srv-side rejection of `CloseWindow` no-op divergence (reducer silently returns no events for unknown windows, which hid this class of leak).

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
