### PR TITLE
feat(agent): consolidate Mode/Model/Effort drop-up pills into a single Runtime panel

### DIFF
--- a/.changesets/1783641363-feat-agent-consolidate-mode-model-effort-drop-up-pills-into--e3pb.md
+++ b/.changesets/1783641363-feat-agent-consolidate-mode-model-effort-drop-up-pills-into--e3pb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): consolidate Mode/Model/Effort drop-up pills into a single Runtime panel

--- a/docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md
+++ b/docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md
@@ -1,0 +1,232 @@
+# SPEC: Consolidate Mode / Model / Effort into a single Runtime dropup
+
+**Date:** 2026-07-09
+**Status:** Approved — open questions resolved, ready to implement
+**Author:** Agent2
+**Trigger:** User request — *"switch the Bypass/Model/effort dropups with a single panel dropup ... think of good names for the button. The panel includes all the options and models and effort, listed out efficiently."*
+**Revision note:** This spec was originally drafted against a stale checkout that predated commit `9f86d917` (#1922, *"Mode/Model/Effort drop-ups (replace native `<select>`)"*) and its dependents (#1912, #1920, #1926). That work already replaced the old native `<select>`s with three separate `FlyoutMenu`-based drop-up pills directly in `AgentComposerStrip`. This revision retargets the same consolidation goal at that current architecture. §2 (naming) and §9 (resolved open questions) are unaffected by the retarget and carry over unchanged; everything else is rewritten.
+
+---
+
+## 1. Why
+
+Today `AgentComposerStrip` renders Mode, Model, and Effort as **three separate drop-up pills**, each an independent `FlyoutMenu` (`placement="top-start"`) — a `StripSelect` helper wraps each one (`AgentComposerStrip.tsx`, prior to this change). This already replaced the older `<select>`-based `AgentControlBar` UI (per `SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02`), so the "no more native chrome, opens upward" goal is done — but the user's actual ask, one consolidated control instead of three, is still open: three separate trigger pills sit side by side, each independently clickable, each with its own popup.
+
+This spec replaces those three pills with **one button that opens one floating panel** containing all three axes, grouped under labeled sections and keyboard-navigable — reusing the exact positioning primitives `FlyoutMenu` itself uses (so it looks and behaves like a native part of the app, not a bolted-on widget), but as a bespoke component, because `FlyoutMenu` only renders a flat `MenuItem[]` list and has no concept of grouped sections with headers (confirmed by reading `frontend/app/element/flyoutmenu.tsx` — no section/group field on `MenuItem`, no content-injection point besides the trigger).
+
+**Prior art check:** `SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02.md` §3 sketches a "Tier TINY (<240px)" fallback where the three pills collapse into one combined chip (`⚙ Byp·Son·XHi ▴`) purely as a narrow-viewport degradation — the three-pill layout is otherwise kept at every wider tier in that spec. This spec supersedes that narrow-tier idea: the single consolidated control becomes the *only* form, at every width, not just a <240px fallback. Nothing else in either composer-strip spec proposes a universal single-button design.
+
+---
+
+## 2. Naming the button
+
+The button's label doubles as a live summary (mode · model · effort), so the *name* only matters as a fallback/aria-label and as the word used in docs, `/help`, and hover tooltips. Four candidates, ranked:
+
+| Name | Rationale | Downside |
+|---|---|---|
+| **`Runtime`** (recommended) | Zero new vocabulary — the codebase already calls this exact bundle `AgentRuntimeConfig`, stores it under meta key `agent:runtime`, builds it via `buildRuntimeArgs()`, and the existing `/runtime` command *already* prints it back to the user as `"runtime config — permission: x · model: y · effort: z"`. Adopting "Runtime" as the button name means the mental model, the code, and the slash command all say the same word. | Slightly abstract to a first-time user vs. more concrete names. |
+| `Loadout` | Gaming-flavored, memorable, evokes "how you're configured for this run." Short. | Introduces a brand-new term with no precedent anywhere in the codebase or docs. |
+| `Controls` | Was the exact word `AgentControlBar` used historically (`▸ Controls` chevron) — no longer applicable since that chevron/label is already gone from the current UI. | Generic — doesn't hint at *what* it controls; easy to confuse with other UI chrome. |
+| `Dial` | Short, playful, "turning a dial" fits adjusting mode/model/effort. Terminal-aesthetic-friendly. | No existing precedent; slightly cute for a tool used by professionals under time pressure. |
+
+**Recommendation: `Runtime`.** It's the only option that requires zero new terminology anywhere else in the product (help text, `/runtime`, code identifiers all already agree).
+
+The button itself does **not** render the word "Runtime" in its default state — it renders the live summary instead (e.g. `Bypass · Sonnet · High`), the same way the current three pills already show live values individually. "Runtime" appears as: the panel's `aria-label`, and in docs/tooltips only.
+
+---
+
+## 3. Visual layout — before / after
+
+### 3.1 Before (current `main`)
+
+Three independent drop-up pills, each its own `FlyoutMenu`:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ [Bypass ▴] [Sonnet 4.6 ▴] [high ▴]  [Shell]      ↑2.1k ↓480  1m12s  ⚙3  12.1k/64k │
+└──────────────────────────────────────────────────────────────────────┘
+```
+Clicking any one pill opens only that pill's own popup — three separate click targets, three separate popups, no shared view across axes.
+
+### 3.2 After (proposed)
+
+One button, one popup, all three axes grouped inside it:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ [Bypass · Sonnet 4.6 · high ▴]  [Shell]      ↑2.1k ↓480  1m12s  ⚙3  12.1k/64k │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 The panel — expanded state
+
+Floats **upward** from the trigger (`placement: "top-start"`, same primitive `FlyoutMenu` uses — `computeMenuPosition` + `@floating-ui/dom` `autoUpdate`), grouped into three labeled sections:
+
+```
+┌─ mode ──────────────────────────┐
+│  ✓ Bypass (no prompts)          │
+│    Auto (AI classifier)         │
+│    Accept Edits                 │
+│    Plan (read-only)             │
+│    Default (prompt all)         │
+├─ model ─────────────────────────┤
+│    Opus 4.8                     │
+│  ✓ Sonnet 4.6                   │
+│    Haiku 4.5                    │
+├─ effort ────────────────────────┤
+│    low                          │
+│    medium                       │
+│  ✓ high                         │
+│    xhigh                        │
+│    max                          │
+└──────────────────────────────────┘
+[Bypass · Sonnet 4.6 · high ▴]   ← trigger stays in place, panel floats above it
+```
+
+Legend / behavior notes:
+- Check mark (`✓`, via the same `.menu-item-check` / `fa-check` convention `FlyoutMenu` uses) marks the current selection per section — no custom marker glyph invented.
+- Mode's left-border color accent (permission-mode color coding) carries over from the current trigger pill onto the *consolidated* trigger's left edge.
+- Section headers (`mode` / `model` / `effort`, lowercase to match the current Effort option casing convention) are non-interactive; arrow-key navigation skips over them.
+- Model options are **registry-driven** (`getProvider(providerId)?.models`), so this list reflects whatever the live catalog overlay has resolved to at click time — not a hardcoded 3-item list.
+
+### 3.4 Narrow-pane behavior
+
+No change needed to the existing container-query rules: a single trigger pill is *narrower* than the three-pill layout it replaces, so the current 240px/320px breakpoints in `_composer-strip.scss` keep working without adjustment — this consolidation is itself a simplification of the exact narrow-width problem `SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02` was solving.
+
+---
+
+## 4. Panel content rules
+
+### 4.1 Structure
+
+Single scrollable panel (reusing the app's `.menu` chrome, the same base class every `FlyoutMenu` popup uses), three labeled groups (`mode`, `model`, `effort`), each rendering its existing enum in existing UI-label order — **no reordering**, so muscle memory from the current three pills transfers directly:
+
+- **mode** — `PermissionMode`, 5 values, same `menuLabel` descriptive text the current `MODE_OPTIONS` constant already defines (`"Bypass (no prompts)"`, etc.).
+- **model** — from `getProvider(providerId)?.models` (falls back to the same 3-entry static list `AgentComposerStrip` currently falls back to when a provider defines none). No invented copy — labels come straight from the registry.
+- **effort** — `EffortLevel`, 5 values (low/medium/high/xhigh/max), same plain lowercase labels the current `EFFORT_OPTIONS` constant already uses.
+
+No new data modeling — this is a straight reuse of the same three constants/registry call the three-pill implementation already has, just rendered in one grouped list instead of three separate `FlyoutMenu` instances.
+
+### 4.2 Provider-conditional rendering
+
+The current implementation gates the **entire** controls zone on `providerId === "claude"` (`showControls()` in `AgentComposerStrip.tsx`) — non-Claude providers (codex/gemini/kimi) see no Mode/Model/Effort UI at all today. This consolidation preserves that exact gate rather than expanding it: the whole `AgentRuntimeDropup` is wrapped in the same `<Show when={showControls()}>` the three pills were wrapped in. Extending Mode-only visibility to non-Claude providers (which the original draft of this spec proposed, based on `buildRuntimeArgs.ts`'s per-provider `--yolo` capability) is **out of scope** here — it would be a scope expansion beyond "consolidate the existing three pills," not implied by the user's request, and would deviate from a gate the current codebase owners deliberately chose. Tracked as a possible follow-up, not part of this change.
+
+### 4.3 Data-inconsistency check
+
+The original draft of this spec flagged `docs/specs/agent-pane-runtime-controls.md`'s "Effort defaults to High" line as stale against a `DEFAULT_RUNTIME_CONFIG.effort` of `"medium"`. On current `main`, `DEFAULT_RUNTIME_CONFIG.effort` is `"high"` (`types.ts`) — the doc line is now **accurate**, and no longer needs the fix this spec originally proposed. Confirmed by reading current `types.ts` before writing this revision; no doc change ships with this PR.
+
+---
+
+## 5. Interaction & keyboard rules
+
+- **Open:** click the trigger button. No dedicated keyboard shortcut for v1 — see §9.1 (unaffected by the retarget).
+- **Navigate:** `↑`/`↓` move through every option row across all three sections, treating section headers as non-stops.
+- **Letter-jump:** typing a letter jumps to the next row whose label starts with it.
+- **Select:** `Enter` applies the highlighted row's value for its section and **stays open** — deliberate departure from `FlyoutMenu`'s close-on-select (`handleOnClick` in `flyoutmenu.tsx` always calls `onOpenChangeMenu(false)` after a leaf click), because the whole point of consolidating is letting one visit touch Mode, then Model, then Effort without reopening. See §9.2.
+- **Close:** `Esc`, or click outside the panel (mirrors `FlyoutMenu`'s own `handleClickOutside` pattern). Clicking the trigger again also toggles closed.
+- Every selection calls `applyRuntimeChange(blockId, provider, updatedConfig)` — the exact same function the three-pill implementation already calls (writes `agent:runtime` meta, and additionally resyncs the persistent controller process for Claude). No data-model or RPC-path changes.
+
+---
+
+## 6. Component restructure
+
+### 6.1 New
+
+- `frontend/app/view/agent/components/AgentRuntimeDropup.tsx` — the trigger button + floating panel. Positioning reuses the exact primitives `FlyoutMenu` uses (`@floating-ui/dom` `autoUpdate` + `computeMenuPosition` from `@/app/util/menu-position` + `Portal` + `data-pane-overlay`, `placement: "top-start"`, `avoidNativePanes: false`) rather than reinventing positioning — this keeps native-pane-HWND clipping and edge-avoidance behavior identical to every other popup in the app. Owns transient open/close + keyboard-selection-index state as local Solid signals (not reducer-owned — this is ephemeral UI state, same reasoning as `FlyoutMenu`'s own `isOpen` signal).
+
+### 6.2 Deleted (from `AgentComposerStrip.tsx`)
+
+- The `StripSelect` helper component.
+- The `MODE_OPTIONS` / `EFFORT_OPTIONS` / `PERMISSION_COLORS` constants and the `MODEL_OPTIONS` fallback (all move into `AgentRuntimeDropup.tsx`).
+- The `runtime()` / `updateRuntime()` locals (their logic moves into `AgentRuntimeDropup.tsx`, which reads/writes block meta directly given `blockId`/`blockAtom`/`providerId`).
+- The `FlyoutMenu` import (no longer used directly by this file).
+
+`AgentControlBar.tsx` is **not touched** by this change — its Mode/Model/Effort UI was already removed in a prior PR (#1912); it now holds only session-management banners/buttons, unrelated to this consolidation.
+
+### 6.3 Modified
+
+- `frontend/app/view/agent/components/AgentComposerStrip.tsx` — replace the three `<StripSelect>` invocations inside `<Show when={showControls()}>` with one `<AgentRuntimeDropup blockId={...} blockAtom={...} providerId={...} />`.
+- `frontend/app/view/agent/styles/_composer-strip.scss` — replace `.agent-composer-strip-select*` and `.menu.strip-flyout*` rules with `.agent-runtime-dropup-trigger*` / `.menu.agent-runtime-dropup-panel` / `.agent-runtime-dropup-section` rules (same visual language: `border-radius: 0`, same border/color-mix conventions, same 10px font scale).
+
+---
+
+## 7. Edge cases
+
+| Case | Behavior |
+|---|---|
+| Panel open, agent starts a new turn from elsewhere (e.g. voice input) | Panel stays open — a user may deliberately be queuing runtime changes for the *next* turn while a message is in flight. |
+| Panel open, pane loses focus/unmounts | Closes for free (local signal, component unmount tears down the `autoUpdate` cleanup same as `FlyoutMenu`'s `onCleanup`). |
+| Non-Claude provider | Entire trigger + panel hidden, matching current `showControls()` gating exactly (§4.2) — no partial/Mode-only display. |
+| Live model-catalog overlay resolves after panel already opened | Panel re-renders with the new labels automatically — `getProvider()` reads a reactive Solid signal (`modelOverlay`), and the panel's row list is built from a plain function called in JSX, so it's inside Solid's tracking scope. No manual subscription needed. |
+| `--prefers-reduced-motion` | No slide/fade transition — `FlyoutMenu` itself has none either (it just toggles `isOpen`), so this matches existing behavior with zero extra work. |
+
+---
+
+## 8. Out of scope (deferred follow-ups)
+
+- **Extending Mode visibility to non-Claude providers** — a real scope expansion beyond consolidating the existing three pills; not requested, deviates from the current deliberate gate (§4.2). Worth a separate spec if wanted.
+- **A dedicated keyboard shortcut to open the panel** — resolved against for v1, see §9.1.
+- **Reordering options within a section** — explicitly not doing this (§4.1); stability over cleverness.
+- **Progressive-collapse tiers from `SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02` §3** — moot once there's only one trigger pill instead of three; that spec's narrow-width problem was specifically about *three* pills competing for space.
+
+---
+
+## 9. Resolved decisions (formerly open questions)
+
+Unaffected by the architecture retarget — same reasoning applies whether the trigger being replaced was a native `<select>` or a `FlyoutMenu` pill.
+
+### 9.1 Keyboard shortcut to open the panel directly
+
+**Decision: no new chord for v1.** The button remains the mouse/discoverability path; `/model`, `/effort`, `/permission-mode` (and the freeform `/bypass`, `/plan`) remain the keyboard-first power-user path.
+
+- **Best practice:** command-palette-style chords converge almost universally on `Cmd/Ctrl+K` or `Cmd/Ctrl+Shift+P`, and chords are explicitly "best reserved for power-user contexts" — not every action needs a shortcut, and any new chord must avoid colliding with conventions already claimed elsewhere in the same app ([Command Palette UX Patterns](https://medium.com/design-bootcamp/command-palette-ux-patterns-1-d6b6e68f30c1), [UX Patterns for Developers — Command Palette](https://uxpatterns.dev/patterns/advanced/command-palette), [Quentin Golsteyn — Keyboard shortcuts on the web](https://golsteyn.com/writing/designing-keyboard-shortcuts/)).
+- **Codebase precedent:** `Ctrl:P` opens the app's `CommandPaletteModal`; `Cmd:k` already clears the terminal in terminal-focused panes. No free `Cmd/Ctrl+K`-style slot exists, and the obvious mnemonic `Ctrl:R` collides with the browser/OS "reload" convention.
+- Revisit only if user feedback shows the click-to-open button is a measured bottleneck for power users.
+
+### 9.2 Does selecting a value close the panel?
+
+**Decision: stays open** — `Enter` or a click applies the highlighted/clicked row and the panel remains open; it closes only on `Esc`, outside-click, or re-clicking the trigger.
+
+- **Best practice:** dropdown-interaction literature draws a sharp line between single-select controls (close immediately) and controls hosting **multiple independent choices in one place** (stay open across selections) ([NN/g — Listboxes vs. Dropdown Lists](https://www.nngroup.com/articles/listbox-dropdown/), [UXPin — Dropdown Interaction Patterns](https://www.uxpin.com/studio/blog/dropdown-interaction-patterns-a-complete-guide/)). This panel is the second kind: three independent axes, not one value from one list.
+- **Codebase precedent:** generic single-value pickers (`FlyoutMenu`, `SlashCommandPicker`, native context menus) close on the first click. But purpose-built multi-control popovers (`HostPopover`, `TokenBreakdownPopover`) stay open across interactions, closing only via outside-click/Esc — the closer precedent for a panel hosting three independent settings.
+
+### 9.3 Hide vs. disable for inapplicable options
+
+**Decision: hide entirely**, not disabled-and-grayed — this now applies one level higher than originally scoped (§4.2): the *whole panel* is hidden for non-Claude providers (matching the current `showControls()` gate) rather than individual rows being hidden/disabled *within* an always-visible panel. The original per-option reasoning (structural vs. contextual unavailability — [Smashing Magazine — Hidden vs. Disabled in UX](https://www.smashingmagazine.com/2024/05/hidden-vs-disabled-ux/)) still applies to *why* it's hidden rather than disabled, just resolved at the provider-gate level instead of a within-panel level, since that's what the current codebase actually does.
+
+---
+
+## 10. Acceptance criteria
+
+1. One always-visible trigger button in `AgentComposerStrip` (when `showControls()` is true) shows a live `Mode · Model · Effort` summary, replacing the three separate pills.
+2. Clicking it opens a single floating panel using the same positioning primitives `FlyoutMenu` uses (`computeMenuPosition` + `autoUpdate`, `placement: "top-start"`), grouped into `mode`/`model`/`effort` sections in existing option order.
+3. Model options are read from `getProvider(providerId)?.models` (registry/live-overlay-driven), not a hardcoded list.
+4. Keyboard nav (`↑↓`, letter-jump, `Enter`, `Esc`) works across all rows/sections; `Enter` does not auto-close (§9.2).
+5. Selecting a value calls the same `applyRuntimeChange(blockId, provider, updatedConfig)` every current control already calls — zero data-model or RPC-path changes.
+6. Non-Claude providers see no trigger/panel at all, matching current behavior exactly (§4.2) — no regression, no scope expansion.
+7. `StripSelect` and the three-pill JSX are fully removed from `AgentComposerStrip.tsx`; `AgentControlBar.tsx` is untouched.
+
+---
+
+## 11. Files this change touches
+
+```
+# New
+frontend/app/view/agent/components/AgentRuntimeDropup.tsx       NEW
+
+# Modified
+frontend/app/view/agent/components/AgentComposerStrip.tsx       replace 3 StripSelect pills with 1 AgentRuntimeDropup
+frontend/app/view/agent/styles/_composer-strip.scss             replace .agent-composer-strip-select*/.strip-flyout* with .agent-runtime-dropup-*
+
+# Unchanged (reused, not modified)
+frontend/app/view/agent/runtime-apply.ts                        applyRuntimeChange — reused as-is
+frontend/app/view/agent/providers/index.ts                      getProvider/.models registry — reused as-is
+frontend/app/view/agent/buildRuntimeArgs.ts                      no data-model changes
+frontend/app/view/agent/types.ts                                 AgentRuntimeConfig/EffortLevel unchanged
+frontend/app/view/agent/components/AgentControlBar.tsx           untouched — no Mode/Model/Effort content remains there
+frontend/app/element/flyoutmenu.tsx                              not reused directly (flat MenuItem[] can't express grouped sections) but its positioning primitives are
+```
+
+---
+
+*End of spec. Ready for review + go/no-go decision.*

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -5,112 +5,23 @@
  * AgentComposerStrip — slim 28-32px status row that sits directly above
  * the textarea in the agent pane composer region.
  *
- * LEFT:  Mode · Model · Effort drop-ups (open upward) · Shell toggle
+ * LEFT:  AgentRuntimeDropup (single Mode · Model · Effort trigger) · Shell toggle
  * RIGHT: tokens (↑in ↓out) · elapsed · ⚙N process badge ·
  *        context text (12.1k / 64k)
  *
  * The strip bar itself is not clickable. "Shell" is the sole toggle for
  * the details drawer (ActivityLogPanel + the AgentShellSubblock terminal,
- * SPEC_AGENT_SHELL_XTERM_TERMINAL_2026_07_03.md). Chevron and shell history panel removed per
- * SPEC_COMPOSER_STRIP_AND_HOST_POLISH_2026_06_25.md. Mode/Model/Effort are
- * top-level dropdowns here (Mode was previously a read-only pill + a nested
- * control in the Log region) per SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02.
+ * SPEC_AGENT_SHELL_XTERM_TERMINAL_2026_07_03.md). Mode/Model/Effort used to be
+ * three separate FlyoutMenu drop-up pills here (SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02
+ * Fix 7); they're now consolidated into one AgentRuntimeDropup trigger + panel
+ * — see docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md.
  */
 
-import { Show, createEffect, createMemo, createSignal, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
 import { compactionThreshold } from "@/app/store/agent-pane-state/context-window";
-import { getRuntimeConfig } from "../buildRuntimeArgs";
-import { applyRuntimeChange } from "../runtime-apply";
-import { getProvider } from "../providers";
-import { FlyoutMenu } from "@/app/element/flyoutmenu";
-import type { AgentRuntimeConfig, EffortLevel, ModelChoice, PermissionMode, SessionStats, TurnTokens } from "../types";
-
-// ── Constants ──────────────────────────────────────────────────────────────
-
-const PERMISSION_COLORS: Record<PermissionMode, string> = {
-    bypass: "var(--error-color, #ef4444)",
-    auto: "var(--accent-color, #3b82f6)",
-    acceptEdits: "var(--warning-color, #eab308)",
-    plan: "var(--success-color, #22c55e)",
-    default: "var(--main-text-color)",
-};
-
-const MODEL_OPTIONS = [
-    { value: "opus", label: "Opus" },
-    { value: "sonnet", label: "Sonnet" },
-    { value: "haiku", label: "Haiku" },
-] as const;
-
-const EFFORT_OPTIONS = [
-    { value: "low", label: "low" },
-    { value: "medium", label: "medium" },
-    { value: "high", label: "high" },
-    { value: "xhigh", label: "xhigh" },
-    { value: "max", label: "max" },
-] as const;
-
-// Mode: trigger shows the short `label`; the menu shows `menuLabel` (the
-// descriptive form) when present.
-const MODE_OPTIONS = [
-    { value: "bypass", label: "Bypass", menuLabel: "Bypass (no prompts)" },
-    { value: "auto", label: "Auto", menuLabel: "Auto (AI classifier)" },
-    { value: "acceptEdits", label: "Accept Edits" },
-    { value: "plan", label: "Plan", menuLabel: "Plan (read-only)" },
-    { value: "default", label: "Default", menuLabel: "Default (prompt all)" },
-] as const;
-
-// ── Drop-up select ───────────────────────────────────────────────────────────
-
-/**
- * A strip control rendered as a **drop-up**: the trigger is the same slim pill
- * as before, but the popup opens *upward* (via FlyoutMenu `placement="top-start"`)
- * with the app's own menu styling instead of the browser's native `<select>`
- * chrome. Each row is a uniform-height menu item; the selected row carries a
- * radio check. Effort uses `horizontal` to lay its options out in a single row.
- * See SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02 Fix 7.
- */
-function StripSelect(props: {
-    current: string | undefined;
-    options: readonly { value: string; label: string; menuLabel?: string }[];
-    onSelect: (value: string) => void;
-    title: string;
-    /** BEM modifier suffix on the trigger, e.g. "--mode" | "--model" | "--effort". */
-    modifier: string;
-    /** Color stripe on the trigger's left edge (Mode → permission color). */
-    leftColor?: string;
-    /** Lay the popup options out horizontally (Effort). */
-    horizontal?: boolean;
-}): JSX.Element {
-    const currentLabel = (): string =>
-        props.options.find((o) => o.value === props.current)?.label ?? props.current ?? "";
-    // Reactive: Solid wraps this prop expression in a getter, so FlyoutMenu's
-    // <For each={items}> re-reads it when `current` changes — the check mark
-    // and label stay in sync after a selection.
-    const items = (): MenuItem[] =>
-        props.options.map((o) => ({
-            label: o.menuLabel ?? o.label,
-            checked: o.value === props.current,
-            onClick: () => props.onSelect(o.value),
-        }));
-    return (
-        <FlyoutMenu
-            placement="top-start"
-            className={`strip-flyout${props.horizontal ? " strip-flyout--horizontal" : ""}`}
-            items={items()}
-        >
-            <button
-                type="button"
-                class={`agent-composer-strip-select agent-composer-strip-select${props.modifier}`}
-                title={props.title}
-                style={props.leftColor ? { "border-left": `3px solid ${props.leftColor}` } : undefined}
-            >
-                <span class="agent-composer-strip-select-label">{currentLabel()}</span>
-                <span class="agent-composer-strip-select-caret" aria-hidden="true">▴</span>
-            </button>
-        </FlyoutMenu>
-    );
-}
+import { Show, createEffect, createMemo, createSignal, type JSX } from "solid-js";
+import type { SessionStats, TurnTokens } from "../types";
+import { AgentRuntimeDropup } from "./AgentRuntimeDropup";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -219,24 +130,6 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
         return parts.join("  ·  ");
     });
 
-    // Mode/model/effort — derived from blockAtom meta when available.
-    const runtime = () =>
-        props.blockAtom ? getRuntimeConfig(props.blockAtom()?.meta) : null;
-
-    const updateRuntime = async (patch: { permissionMode?: PermissionMode; model?: ModelChoice; effort?: EffortLevel }): Promise<void> => {
-        const r = runtime();
-        if (!r || !props.blockId || !props.providerId) return;
-        try {
-            await applyRuntimeChange(
-                props.blockId,
-                getProvider(props.providerId),
-                { ...r, ...patch } as AgentRuntimeConfig,
-            );
-        } catch {
-            // Silent — settings retry on next change.
-        }
-    };
-
     // Show model/effort controls only for Claude agents (controls are claude-specific;
     // non-claude providers (codex/gemini/kimi) have different model enumerations and
     // buildRuntimeArgs silently drops effort for them — spec §1.3).
@@ -260,46 +153,17 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
     };
 
     return (
-        <div
-            class="agent-composer-strip"
-            classList={{ "agent-composer-strip--expanded": props.logOpen }}
-        >
-            {/* Controls zone — mode/model/effort selects + Log button.
-                All three runtime controls now live here at the strip's top
-                level (Mode was previously a read-only pill + a nested control
-                inside the Log details region — see
-                SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02). Each reads its
-                value from `runtime()` (which falls back to
-                DEFAULT_RUNTIME_CONFIG), so the displayed state matches the
-                flags the agent actually runs with from first paint. */}
+        <div class="agent-composer-strip" classList={{ "agent-composer-strip--expanded": props.logOpen }}>
+            {/* Controls zone — the consolidated Mode/Model/Effort trigger +
+                panel, plus the Log button. Reads/writes block meta directly
+                (blockId/blockAtom/providerId), so the displayed state matches
+                the flags the agent actually runs with from first paint. */}
             <span class="agent-composer-strip-controls">
                 <Show when={showControls()}>
-                    {/* Drop-ups (open upward) replace the native <select>s — see
-                        SPEC_COMPOSER_STRIP_MODE_TOPLEVEL Fix 7. Model options are
-                        registry-driven (single source with /model), so an
-                        API-sourced catalog surfaces new labels automatically. */}
-                    <StripSelect
-                        current={runtime()?.permissionMode ?? "default"}
-                        options={MODE_OPTIONS}
-                        onSelect={(v) => void updateRuntime({ permissionMode: v as PermissionMode })}
-                        title="Permission mode — how the agent asks before running tools. Applies on the next turn."
-                        modifier="--mode"
-                        leftColor={PERMISSION_COLORS[runtime()?.permissionMode ?? "default"]}
-                    />
-                    <StripSelect
-                        current={runtime()?.model}
-                        options={getProvider(props.providerId)?.models ?? MODEL_OPTIONS}
-                        onSelect={(v) => void updateRuntime({ model: v as ModelChoice })}
-                        title="Model — which model the agent uses. Applies on the next turn."
-                        modifier="--model"
-                    />
-                    <StripSelect
-                        current={runtime()?.effort}
-                        options={EFFORT_OPTIONS}
-                        onSelect={(v) => void updateRuntime({ effort: v as EffortLevel })}
-                        title="Reasoning effort — how hard the model thinks per turn. Applies on the next turn."
-                        modifier="--effort"
-                        horizontal
+                    <AgentRuntimeDropup
+                        blockId={props.blockId ?? ""}
+                        blockAtom={props.blockAtom ?? (() => undefined)}
+                        providerId={props.providerId ?? ""}
                     />
                 </Show>
             </span>
@@ -337,9 +201,11 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 <Show when={ctxText()}>
                     <span
                         class={`agent-composer-strip-ctx ${ctxClass()}`}
-                        title={props.contextTokens != null
-                            ? contextTitle(props.contextTokens, props.contextWindow)
-                            : undefined}
+                        title={
+                            props.contextTokens != null
+                                ? contextTitle(props.contextTokens, props.contextWindow)
+                                : undefined
+                        }
                     >
                         {ctxText()}
                     </span>

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -24,7 +24,7 @@
 
 import { assertMenuInPaintableArea, computeMenuPosition } from "@/app/util/menu-position";
 import { autoUpdate } from "@floating-ui/dom";
-import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { getRuntimeConfig } from "../buildRuntimeArgs";
 import { getProvider, type ProviderModel } from "../providers";
@@ -185,7 +185,7 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
         } else if (e.key === "Escape") {
             e.preventDefault();
             setOpen(false);
-        } else if (e.key.length === 1 && /[a-z0-9]/i.test(e.key)) {
+        } else if (!e.ctrlKey && !e.metaKey && !e.altKey && e.key.length === 1 && /[a-z0-9]/i.test(e.key)) {
             const k = e.key.toLowerCase();
             const idx = build().options.findIndex((o) => o.label.toLowerCase().startsWith(k));
             if (idx >= 0) {
@@ -196,21 +196,26 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
     };
 
     const handleClickOutside = (e: MouseEvent) => {
-        if (!open()) return;
         const target = e.target as Node;
         if (referenceEl?.contains(target) || floatingEl?.contains(target)) return;
         setOpen(false);
     };
 
-    onMount(() => {
+    // Both listeners are scoped to the panel's open lifetime via this effect
+    // (not onMount, which would span the trigger's entire mount lifetime —
+    // reagentx-workflow P0 on this PR: a document-wide keydown listener that
+    // outlives `open()` intercepts Enter/Escape/letters everywhere, including
+    // the composer textarea, even while the panel is closed).
+    createEffect(() => {
+        if (!open()) return;
         document.addEventListener("mousedown", handleClickOutside);
         document.addEventListener("keydown", handleKeyDown, true);
+        onCleanup(() => {
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("keydown", handleKeyDown, true);
+        });
     });
-    onCleanup(() => {
-        document.removeEventListener("mousedown", handleClickOutside);
-        document.removeEventListener("keydown", handleKeyDown, true);
-        cleanupAutoUpdate?.();
-    });
+    onCleanup(() => cleanupAutoUpdate?.());
 
     // Positioning mirrors flyoutmenu.tsx's updatePosition/registerFloating
     // exactly (same primitive, same avoidNativePanes:false rationale — this

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -1,0 +1,318 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentRuntimeDropup — single trigger + floating panel consolidating the
+ * Mode / Model / Effort drop-ups that used to be three separate FlyoutMenu
+ * pills in AgentComposerStrip (SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02
+ * Fix 7). One button shows a live "Mode · Model · Effort" summary; the panel
+ * floats upward from it, grouped into three labeled sections, and stays open
+ * across selections so one visit can touch all three axes (deliberate
+ * departure from FlyoutMenu's close-on-select — SPEC §9.2).
+ *
+ * Reuses the same positioning primitives FlyoutMenu itself uses
+ * (@floating-ui/dom autoUpdate + computeMenuPosition + Portal +
+ * data-pane-overlay) rather than FlyoutMenu directly: FlyoutMenu only renders
+ * a flat MenuItem[] list and has no concept of grouped sections with headers.
+ *
+ * Model options stay registry-driven via getProvider(providerId)?.models
+ * (live-overlaid from the providers.models RPC, same as the prior three-pill
+ * implementation) so an API-sourced catalog surfaces new labels automatically.
+ *
+ * Spec: docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md.
+ */
+
+import { assertMenuInPaintableArea, computeMenuPosition } from "@/app/util/menu-position";
+import { autoUpdate } from "@floating-ui/dom";
+import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import { getRuntimeConfig } from "../buildRuntimeArgs";
+import { getProvider, type ProviderModel } from "../providers";
+import { applyRuntimeChange } from "../runtime-apply";
+import type { AgentRuntimeConfig, EffortLevel, PermissionMode } from "../types";
+
+/** Serialize a MenuPositionResult.style the same way flyoutmenu.tsx does. */
+function styleToString(s: JSX.CSSProperties): string {
+    return `position:${s.position};left:${s.left};top:${s.top}`;
+}
+
+const PERMISSION_COLORS: Record<PermissionMode, string> = {
+    bypass: "var(--error-color, #ef4444)",
+    auto: "var(--accent-color, #3b82f6)",
+    acceptEdits: "var(--warning-color, #eab308)",
+    plan: "var(--success-color, #22c55e)",
+    default: "var(--main-text-color)",
+};
+
+// Mode: trigger shows the short `label`; the panel shows `menuLabel` (the
+// descriptive form) when present — matches the prior StripSelect convention.
+const MODE_OPTIONS = [
+    { value: "bypass", label: "Bypass", menuLabel: "Bypass (no prompts)" },
+    { value: "auto", label: "Auto", menuLabel: "Auto (AI classifier)" },
+    { value: "acceptEdits", label: "Accept Edits" },
+    { value: "plan", label: "Plan", menuLabel: "Plan (read-only)" },
+    { value: "default", label: "Default", menuLabel: "Default (prompt all)" },
+] as const;
+
+// Fallback when a provider defines no static model list — matches the prior
+// StripSelect fallback exactly.
+const FALLBACK_MODEL_OPTIONS: ProviderModel[] = [
+    { value: "opus", label: "Opus" },
+    { value: "sonnet", label: "Sonnet" },
+    { value: "haiku", label: "Haiku" },
+];
+
+const EFFORT_OPTIONS = [
+    { value: "low", label: "low" },
+    { value: "medium", label: "medium" },
+    { value: "high", label: "high" },
+    { value: "xhigh", label: "xhigh" },
+    { value: "max", label: "max" },
+] as const;
+
+type Section = "mode" | "model" | "effort";
+
+interface OptionRow {
+    section: Section;
+    value: string;
+    label: string;
+    description?: string;
+    current: boolean;
+    color?: string;
+}
+
+type Row = { kind: "header"; section: Section } | (OptionRow & { kind: "option" });
+
+interface AgentRuntimeDropupProps {
+    blockId: string;
+    blockAtom: () => Block | undefined;
+    providerId: string;
+}
+
+export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element => {
+    const [open, setOpen] = createSignal(false);
+    const [selectedOptIndex, setSelectedOptIndex] = createSignal(0);
+    const [floatingStyle, setFloatingStyle] = createSignal("position:fixed;left:0px;top:0px");
+
+    let referenceEl: HTMLButtonElement | undefined;
+    let floatingEl: HTMLDivElement | undefined;
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const runtime = (): AgentRuntimeConfig => getRuntimeConfig(props.blockAtom()?.meta);
+
+    const updateRuntime = async (patch: Partial<AgentRuntimeConfig>) => {
+        try {
+            await applyRuntimeChange(props.blockId, getProvider(props.providerId), { ...runtime(), ...patch });
+        } catch {
+            // Silent — settings retry on next change (matches the prior
+            // AgentComposerStrip.updateRuntime tolerance).
+        }
+    };
+
+    const modelOptions = (): ProviderModel[] => getProvider(props.providerId)?.models ?? FALLBACK_MODEL_OPTIONS;
+
+    const modelLabel = (value: string): string => modelOptions().find((o) => o.value === value)?.label ?? value;
+    const effortLabel = (value: string): string => EFFORT_OPTIONS.find((o) => o.value === value)?.label ?? value;
+    const modeLabel = (value: string): string => MODE_OPTIONS.find((o) => o.value === value)?.label ?? value;
+
+    const compactSummary = (): string => {
+        const r = runtime();
+        return [modeLabel(r.permissionMode), modelLabel(r.model), effortLabel(r.effort)].join(" · ");
+    };
+
+    // Single pass builds both the render list (rows, incl. section headers)
+    // and the flat option list keyboard nav / selection walks.
+    const build = (): { rows: Row[]; options: OptionRow[] } => {
+        const r = runtime();
+        const rows: Row[] = [];
+        const options: OptionRow[] = [];
+
+        const addSection = <T extends { value: string; label: string; menuLabel?: string; description?: string }>(
+            section: Section,
+            opts: readonly T[],
+            currentValue: string,
+            withColor: boolean
+        ) => {
+            rows.push({ kind: "header", section });
+            for (const o of opts) {
+                const row: OptionRow = {
+                    section,
+                    value: o.value,
+                    label: o.menuLabel ?? o.label,
+                    description: o.description,
+                    current: currentValue === o.value,
+                    color: withColor ? PERMISSION_COLORS[o.value as PermissionMode] : undefined,
+                };
+                rows.push({ kind: "option", ...row });
+                options.push(row);
+            }
+        };
+
+        addSection("mode", MODE_OPTIONS, r.permissionMode, true);
+        addSection("model", modelOptions(), r.model, false);
+        addSection("effort", EFFORT_OPTIONS, r.effort, false);
+        return { rows, options };
+    };
+
+    const move = (delta: number) => {
+        const { options } = build();
+        if (options.length === 0) return;
+        setSelectedOptIndex((i) => (i + delta + options.length) % options.length);
+    };
+
+    // Enter applies and keeps the panel open — deliberate departure from
+    // FlyoutMenu's close-on-select. This panel hosts three independent axes,
+    // not one value from one list; SPEC §9.2.
+    const applySelection = async (idx: number) => {
+        const { options } = build();
+        const choice = options[idx];
+        if (!choice) return;
+        if (choice.section === "mode") await updateRuntime({ permissionMode: choice.value as PermissionMode });
+        else if (choice.section === "model") await updateRuntime({ model: choice.value });
+        else await updateRuntime({ effort: choice.value as EffortLevel });
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            move(1);
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            move(-1);
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            void applySelection(selectedOptIndex());
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            setOpen(false);
+        } else if (e.key.length === 1 && /[a-z0-9]/i.test(e.key)) {
+            const k = e.key.toLowerCase();
+            const idx = build().options.findIndex((o) => o.label.toLowerCase().startsWith(k));
+            if (idx >= 0) {
+                e.preventDefault();
+                setSelectedOptIndex(idx);
+            }
+        }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+        if (!open()) return;
+        const target = e.target as Node;
+        if (referenceEl?.contains(target) || floatingEl?.contains(target)) return;
+        setOpen(false);
+    };
+
+    onMount(() => {
+        document.addEventListener("mousedown", handleClickOutside);
+        document.addEventListener("keydown", handleKeyDown, true);
+    });
+    onCleanup(() => {
+        document.removeEventListener("mousedown", handleClickOutside);
+        document.removeEventListener("keydown", handleKeyDown, true);
+        cleanupAutoUpdate?.();
+    });
+
+    // Positioning mirrors flyoutmenu.tsx's updatePosition/registerFloating
+    // exactly (same primitive, same avoidNativePanes:false rationale — this
+    // panel also carries data-pane-overlay so it should open in place at its
+    // anchor, not get pushed toward the window edge by a native pane rect).
+    const updatePosition = async () => {
+        if (!referenceEl || !floatingEl) return;
+        const pos = await computeMenuPosition(
+            { anchor: referenceEl, placement: "top-start", avoidNativePanes: false },
+            floatingEl
+        );
+        setFloatingStyle(styleToString(pos.style));
+    };
+
+    const registerFloating = (el: HTMLDivElement) => {
+        floatingEl = el;
+        requestAnimationFrame(() => {
+            if (!(referenceEl instanceof Element) || !(floatingEl instanceof Element)) return;
+            cleanupAutoUpdate?.();
+            cleanupAutoUpdate = autoUpdate(referenceEl, floatingEl, updatePosition);
+            assertMenuInPaintableArea(el, "agent-runtime-dropup");
+        });
+    };
+
+    const toggleOpen = () => {
+        if (open()) {
+            setOpen(false);
+            return;
+        }
+        const { options } = build();
+        const idx = options.findIndex((o) => o.section === "mode" && o.current);
+        setSelectedOptIndex(idx >= 0 ? idx : 0);
+        setOpen(true);
+    };
+
+    return (
+        <>
+            <button
+                type="button"
+                ref={referenceEl}
+                class="agent-runtime-dropup-trigger"
+                style={{ "border-left": `3px solid ${PERMISSION_COLORS[runtime().permissionMode]}` }}
+                title="Mode / Model / Effort — applies on the next turn"
+                aria-haspopup="listbox"
+                aria-expanded={open()}
+                aria-label={`Runtime settings: ${compactSummary()}`}
+                onClick={() => toggleOpen()}
+            >
+                <span class="agent-runtime-dropup-trigger-label">{compactSummary()}</span>
+                <span class="agent-runtime-dropup-trigger-caret" aria-hidden="true">
+                    ▴
+                </span>
+            </button>
+            <Show when={open()}>
+                <Portal>
+                    <div
+                        ref={registerFloating}
+                        class="menu agent-runtime-dropup-panel"
+                        style={floatingStyle()}
+                        data-pane-overlay
+                        role="listbox"
+                        aria-label="Runtime settings"
+                    >
+                        <For each={build().rows}>
+                            {(row) => {
+                                if (row.kind === "header") {
+                                    return <div class="agent-runtime-dropup-section">{row.section}</div>;
+                                }
+                                const optIndex = () =>
+                                    build().options.findIndex(
+                                        (o) => o.section === row.section && o.value === row.value
+                                    );
+                                return (
+                                    <div
+                                        class="menu-item agent-runtime-dropup-row"
+                                        classList={{ active: optIndex() === selectedOptIndex() }}
+                                        role="option"
+                                        aria-selected={row.current}
+                                        onMouseEnter={() => setSelectedOptIndex(optIndex())}
+                                        onClick={() => {
+                                            const idx = optIndex();
+                                            setSelectedOptIndex(idx);
+                                            void applySelection(idx);
+                                        }}
+                                    >
+                                        <i
+                                            class={`fa-solid fa-fw menu-item-icon menu-item-check${row.current ? " fa-check" : ""}`}
+                                            style={row.color ? { color: row.color } : undefined}
+                                        />
+                                        <span class="label">{row.label}</span>
+                                        <Show when={row.description}>
+                                            <span class="agent-runtime-dropup-description">{row.description}</span>
+                                        </Show>
+                                    </div>
+                                );
+                            }}
+                        </For>
+                    </div>
+                </Portal>
+            </Show>
+        </>
+    );
+};
+
+AgentRuntimeDropup.displayName = "AgentRuntimeDropup";

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -172,7 +172,22 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
         else await updateRuntime({ effort: choice.value as EffortLevel });
     };
 
+    // True only while DOM focus is actually inside the trigger or panel.
+    // The panel deliberately stays open across selections (§9.2), so a user
+    // can select a row and then Tab — or something else calls
+    // textareaRef.focus() programmatically (e.g. AgentFooter's
+    // acceptCompletion()) — without any mousedown outside the panel ever
+    // firing. Without this guard, handleKeyDown would still be attached and
+    // would swallow the next Enter/letter typed into the now-focused
+    // composer textarea. reagentx-workflow P0 round 2 on this PR.
+    const focusWithinDropup = (): boolean => {
+        const active = document.activeElement;
+        if (!active) return false;
+        return !!(referenceEl?.contains(active) || floatingEl?.contains(active));
+    };
+
     const handleKeyDown = (e: KeyboardEvent) => {
+        if (!focusWithinDropup()) return;
         if (e.key === "ArrowDown") {
             e.preventDefault();
             move(1);
@@ -201,18 +216,27 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
         setOpen(false);
     };
 
-    // Both listeners are scoped to the panel's open lifetime via this effect
-    // (not onMount, which would span the trigger's entire mount lifetime —
-    // reagentx-workflow P0 on this PR: a document-wide keydown listener that
-    // outlives `open()` intercepts Enter/Escape/letters everywhere, including
-    // the composer textarea, even while the panel is closed).
+    // Closes the panel as soon as focus moves outside it by ANY means (Tab,
+    // a programmatic .focus() call elsewhere, etc.), not just a mousedown —
+    // keeps the panel from staying invisibly "open" (and its listeners
+    // attached) once the user has clearly moved on. Belt-and-suspenders with
+    // the focusWithinDropup() guard in handleKeyDown above.
+    const handleFocusChange = () => {
+        if (!focusWithinDropup()) setOpen(false);
+    };
+
+    // All three listeners are scoped to the panel's open lifetime via this
+    // effect (not onMount, which would span the trigger's entire mount
+    // lifetime — reagentx-workflow P0 round 1 on this PR).
     createEffect(() => {
         if (!open()) return;
         document.addEventListener("mousedown", handleClickOutside);
         document.addEventListener("keydown", handleKeyDown, true);
+        document.addEventListener("focusin", handleFocusChange);
         onCleanup(() => {
             document.removeEventListener("mousedown", handleClickOutside);
             document.removeEventListener("keydown", handleKeyDown, true);
+            document.removeEventListener("focusin", handleFocusChange);
         });
     });
     onCleanup(() => cleanupAutoUpdate?.());

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -3,7 +3,7 @@
 
 // AgentComposerStrip — slim 28-32px status row above the textarea, growing to
 // two rows at narrow widths (see the flex-wrap rules below).
-//   LEFT:  mode select · model select · effort select
+//   LEFT:  AgentRuntimeDropup (single Mode · Model · Effort trigger)
 //   RIGHT: Shell toggle · token stats · elapsed · process badge · context text
 //          (floats right via margin-left:auto; wraps onto its own row below
 //          the controls zone once both zones no longer fit on one line)
@@ -42,33 +42,24 @@
     flex-shrink: 0;
 }
 
-// The drop-up trigger. Same slim pill as the former <select>, but a <button>
-// laying out a label + up-caret; the popup is a portaled FlyoutMenu (see below).
-.agent-composer-strip-select {
+// The consolidated Mode/Model/Effort trigger — a single <button> laying out
+// a "Mode · Model · Effort" summary label + up-caret; same slim-pill footprint
+// as the former three separate selects/drop-ups combined into one.
+.agent-runtime-dropup-trigger {
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
     gap: 3px;
-    appearance: none;
-    -webkit-appearance: none;
+    max-width: 160px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
     border-radius: 0;
     color: var(--secondary-text-color);
     font: inherit;
     font-size: 10px;
-    padding: 1px var(--space-1);
+    padding: 1px var(--space-1-5);
     cursor: default;
     outline: none;
-
-    // Tight widths so the strip stays compact. Keyed on explicit modifier
-    // classes (not :nth-child) so control order can change without breaking
-    // widths — see SPEC_COMPOSER_STRIP_MODE_TOPLEVEL_2026_07_02.
-    // Mode also carries a color-coded left border (permission mode); the extra
-    // left padding keeps its label clear of the accent stripe.
-    &--mode { min-width: 68px; padding-left: var(--space-1-5); }
-    &--model { min-width: 62px; }
-    &--effort { min-width: 58px; }
 
     &:hover {
         border-color: var(--border-color);
@@ -81,43 +72,57 @@
     }
 }
 
-.agent-composer-strip-select-label {
+.agent-runtime-dropup-trigger-label {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.agent-composer-strip-select-caret {
+.agent-runtime-dropup-trigger-caret {
     font-size: 8px;
     line-height: 1;
     opacity: 0.7;
     flex-shrink: 0;
 }
 
-// The drop-up popup itself (portaled to <body> by FlyoutMenu, so this is a
-// top-level global rule). Inherits the app's clean `.menu` chrome — the whole
-// point of ditching the native <select> — and just tightens rows to strip
-// scale so each entry matches the collapsed control's height/style.
-.menu.strip-flyout {
-    min-width: 0;
+// The panel itself (portaled to <body>, so this is a top-level global rule).
+// Inherits the app's clean `.menu` chrome (same as any FlyoutMenu) and adds
+// grouped section headers, which FlyoutMenu's flat MenuItem[] list can't
+// express — see docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md.
+.menu.agent-runtime-dropup-panel {
+    min-width: 180px;
     font-size: 10px;
 
-    .menu-item {
+    .agent-runtime-dropup-row {
         padding: 2px var(--space-1-5);
         min-height: 0;
     }
+}
 
-    // Effort: options in a single horizontal row of equal-height chips.
-    &.strip-flyout--horizontal {
-        display: flex;
-        flex-direction: row;
-        gap: 2px;
+.agent-runtime-dropup-section {
+    padding: var(--space-1) var(--space-1-5) 2px;
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--secondary-text-color);
+    opacity: 0.75;
 
-        .menu-item {
-            white-space: nowrap;
-            justify-content: center;
-        }
+    &:not(:first-child) {
+        margin-top: var(--space-0-5);
+        border-top: 1px solid var(--border-color);
+        padding-top: var(--space-1-5);
     }
+}
+
+.agent-runtime-dropup-description {
+    margin-left: var(--space-1);
+    color: var(--secondary-text-color);
+    font-size: 9px;
+    opacity: 0.8;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 // Shell toggle — deliberately accent-colored at rest (not just when open) so
@@ -229,7 +234,7 @@
 }
 
 @container modal-mount (max-width: 320px) {
-    // Keep the runtime controls visible — the drop-up pills are compact enough.
+    // Keep the runtime dropup visible — one compact trigger fits easily.
     // (Previously `.agent-composer-strip-select { display:none }` here hid
     // Mode/Model/Effort on any pane ≤320px, leaving only Log — see
     // SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02. Progressive

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,7 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
@@ -275,6 +275,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -869,6 +870,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -917,6 +919,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1014,7 +1017,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1031,7 +1033,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1048,7 +1049,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1065,7 +1065,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1082,7 +1081,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1099,7 +1097,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1116,7 +1113,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1133,7 +1129,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,7 +1145,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1167,7 +1161,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,7 +1177,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1201,7 +1193,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1218,7 +1209,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1235,7 +1225,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,7 +1241,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1269,7 +1257,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1286,7 +1273,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1303,7 +1289,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1320,7 +1305,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1337,7 +1321,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1354,7 +1337,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1371,7 +1353,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1388,7 +1369,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1405,7 +1385,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,7 +1401,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1439,7 +1417,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1667,6 +1644,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1884,7 +1872,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1924,7 +1911,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1945,7 +1931,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,7 +1951,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1987,7 +1971,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,7 +1991,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2029,7 +2011,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2050,7 +2031,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2071,7 +2051,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2092,7 +2071,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2113,7 +2091,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2134,7 +2111,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2155,7 +2131,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2176,7 +2151,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2256,7 +2230,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2270,7 +2243,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,7 +2256,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,7 +2269,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2312,7 +2282,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2326,7 +2295,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2340,7 +2308,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2354,7 +2321,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2368,7 +2334,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2382,7 +2347,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2396,7 +2360,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,7 +2373,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2424,7 +2386,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,7 +2399,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2452,7 +2412,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,7 +2425,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,7 +2438,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,7 +2451,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2508,7 +2464,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2522,7 +2477,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2536,7 +2490,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2550,7 +2503,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,7 +2516,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2578,7 +2529,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2592,7 +2542,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2978,6 +2927,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3415,6 +3365,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3433,8 +3384,9 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -3453,7 +3405,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/user-event": {
@@ -3895,8 +3847,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3990,6 +3943,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4460,6 +4414,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4496,6 +4451,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4551,7 +4507,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -4756,6 +4712,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -4769,6 +4726,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4935,7 +4899,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5127,7 +5091,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -5154,6 +5118,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5563,6 +5528,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5773,7 +5739,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5909,7 +5875,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5976,6 +5942,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6274,7 +6241,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6391,7 +6357,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7107,7 +7072,7 @@
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.7.tgz",
       "integrity": "sha512-47Xb+LFbZ/ZIjQMj6Q5J3IfK7PJFuqRdFOC9FpGgRTK6U2dAEVmkR9hp58qU4FpYux5YXpneDwkj2EP6lppzFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7152,7 +7117,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7269,7 +7234,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7289,7 +7254,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7480,7 +7445,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7659,6 +7624,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7709,7 +7675,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7742,7 +7708,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7763,7 +7728,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7784,7 +7748,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7805,7 +7768,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7826,7 +7788,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7847,7 +7808,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7868,7 +7828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7889,7 +7848,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7910,7 +7868,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7931,7 +7888,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7952,7 +7908,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8036,6 +7991,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8565,6 +8532,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9201,7 +9169,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9234,7 +9203,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9285,7 +9254,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9335,7 +9303,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9646,7 +9613,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9686,7 +9652,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9702,6 +9667,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9785,6 +9751,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9816,6 +9783,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9956,6 +9924,19 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -9967,7 +9948,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9981,7 +9962,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -10352,8 +10333,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10454,8 +10435,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10501,6 +10483,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10623,6 +10606,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10648,6 +10632,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10831,7 +10836,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -10913,6 +10918,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11349,7 +11355,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11374,6 +11381,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11465,7 +11498,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11688,13 +11720,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -11713,7 +11746,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11743,6 +11775,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11801,7 +11834,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11822,6 +11855,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -12045,8 +12079,8 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12205,7 +12239,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12222,7 +12255,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12239,7 +12271,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12256,7 +12287,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12273,7 +12303,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12290,7 +12319,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12307,7 +12335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12324,7 +12351,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12341,7 +12367,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12358,7 +12383,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12375,7 +12399,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12392,7 +12415,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12409,7 +12431,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12426,7 +12447,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12443,7 +12463,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12460,7 +12479,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12477,7 +12495,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12494,7 +12511,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12511,7 +12527,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12528,7 +12543,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12545,7 +12559,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12562,7 +12575,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12579,7 +12591,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12596,7 +12607,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12613,7 +12623,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12630,7 +12639,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12644,7 +12652,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12686,7 +12693,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12722,6 +12728,7 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",


### PR DESCRIPTION
## Summary
- Replaces the three separate `FlyoutMenu` drop-up pills (Mode / Model / Effort) in `AgentComposerStrip` with **one trigger button** that opens **one floating panel**, grouped into labeled Mode/Model/Effort sections.
- Selecting a row applies immediately and **keeps the panel open** (deliberate departure from `FlyoutMenu`'s close-on-select) — one visit can touch all three axes instead of reopening three separate popups.
- Reuses `FlyoutMenu`'s own positioning primitives (`computeMenuPosition` + `autoUpdate` + `Portal` + `data-pane-overlay`, same `placement: "top-start"`) rather than `FlyoutMenu` itself — `FlyoutMenu` only renders a flat `MenuItem[]` list with no concept of grouped sections/headers.
- Model options stay **registry-driven** via `getProvider(providerId)?.models` (live-overlaid from the model-catalog RPC), same as the prior three-pill implementation.
- Runtime writes go through the existing `applyRuntimeChange()` — **zero data-model or RPC-path changes**.
- Non-Claude providers see no trigger/panel at all, matching the current `showControls()` gate exactly — no scope expansion.
- `AgentControlBar.tsx` is untouched (it already holds only session-management UI, unrelated to this consolidation).

Full rationale — button naming (`Runtime`), why the panel stays open on select, and why inapplicable providers are hidden entirely rather than shown disabled — is in `docs/specs/SPEC_AGENT_RUNTIME_DROPUP_2026_07_09.md`, each resolved against both general UX best-practice research and this codebase's own existing precedent.

## Test plan
- [x] `tsc --noEmit` — zero errors in touched files (one unrelated pre-existing environment gap noted, not from this change)
- [x] `prettier --write` — clean
- [x] `stylelint` on the modified SCSS — clean
- [ ] CI
- [ ] Manual: open an agent pane, click the consolidated trigger, verify Mode/Model/Effort selections apply and the panel stays open across selections, closes on Esc/outside-click

<!-- agentmux:agent_id=agent2 -->