### PR TITLE
feat(agent): Working-indicator type-out + oscillating shimmer; mic moved to composer

### DIFF
--- a/.changesets/1783642500-feat-agent-working-indicator-type-out-oscillating-shimmer-mi-mlw6.md
+++ b/.changesets/1783642500-feat-agent-working-indicator-type-out-oscillating-shimmer-mi-mlw6.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): Working-indicator type-out + oscillating shimmer; mic moved from pane header to composer

--- a/docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md
+++ b/docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md
@@ -1,0 +1,134 @@
+# SPEC: Working-Indicator Shimmer + Mic Button Relocation
+
+**Date:** 2026-07-08
+**Status:** Draft — analysis only, no code changes made
+**Scope:** Frontend only (SolidJS + SCSS). Two independent changes bundled because both touch the Agent pane's conversation chrome:
+
+1. Give the "Working…" indicator a two-phase animation (type-out, then a back-and-forth shimmer sweep), confirm it's theme-bound.
+2. Move the microphone button from the pane's top-right title bar to pinned beside the conversation composer.
+
+Also answers a standing question about the light/white theme's status, since it came up while discussing the indicator's color.
+
+---
+
+## 1. "Working" indicator — current state
+
+Component: `AgentWorkingRow` in `frontend/app/view/agent/components/AgentFooter.tsx:69-171`, rendered directly below `AgentDocumentView` in the conversation area. Structure:
+
+```
+<span class="agent-spinner-dot" />
+<span class="agent-working-row-left">{phrase()}…</span>
+```
+
+CSS: `frontend/app/view/agent/styles/_control-bar.scss`:
+- `.agent-working-row--loading` (~line 171-173): `color: var(--accent-color); background: color-mix(in srgb, var(--accent-color) 4%, transparent);`
+- `.agent-spinner-dot` (~line 241-251): `background: var(--accent-color); box-shadow: 0 0 6px color-mix(in srgb, var(--accent-color) 60%, transparent);`
+
+**Correction to the initial premise:** this is *already* a CSS custom property, not a hardcoded literal. `--accent-color` is defined per-theme — `frontend/app/theme.scss:49` sets the default to `rgb(65, 159, 224)` (blue), and every theme under `frontend/app/themes/` (`catppuccin.scss`, `dracula.scss`, `monokai.scss`, `nord.scss`, `tokyo-night.scss`, `gruvbox.scss`, `midnight.scss`, `high-contrast.scss`) overrides it to its own hue. So switching `window:theme` already recolors the Working indicator today — it *reads* as "always blue" only because the default theme's accent happens to be blue and most sessions run on default. No binding work needed here; flag as a live QA item (cycle through each theme, confirm the indicator visibly changes) rather than a code fix.
+
+There's already a related animated element to build on: `.agent-pane-progress-bar` (`frontend/app/view/agent/agent-view.tsx:873-887`), a 2px gradient bar pinned to the pane top, active under the identical `status.isLoading() || workingFromPhase(...)` condition as the Working row. Its CSS (`_control-bar.scss`, ~line 97-140+) derives an "aurora" sweep via `color-mix()` and CSS relative-color syntax (`hsl(from var(--accent-color) calc(h + 180) ...)`) for a complementary-hue animation — the established house pattern for "animated, theme-adaptive, off of `--accent-color`." The shimmer effect below reuses this pattern rather than inventing a new one.
+
+## 2. Two-phase "Anthropic-style" text animation
+
+This describes the well-known "AI is thinking" text treatment: the label reveals character-by-character on first appearance, then — once fully revealed — a soft highlight band sweeps back and forth across it for as long as the turn is in progress (not a single one-shot pass; an oscillating loop, like a spotlight passing over embossed text).
+
+### Phase A — type-out (once per phrase change)
+
+`phrase()` already exists as a signal (`AgentFooter.tsx`, feeding the current `{phrase()}…` text — phrases rotate, e.g. "Working" → "Thinking" → tool-specific labels during a long turn per `SPEC_AGENT_STATUS_LABELS_2026_06_27.md`). On each phrase change:
+- Reveal the string incrementally, e.g. via a small `createEffect` driving a `revealCount` signal on an interval (~25–35ms/char, tunable), slicing `phrase()` client-side — no new dependency needed, this is the same shape as any JS typewriter effect.
+- Respect `prefers-reduced-motion`: skip straight to fully-revealed state.
+- On unmount / phrase change mid-reveal, cancel the interval (standard `onCleanup`).
+
+### Phase B — shimmer sweep (continuous, while `isLoading`)
+
+Once Phase A completes, apply a `background-clip: text` gradient shimmer:
+
+```scss
+.agent-working-row-left.shimmer {
+    background: linear-gradient(
+        90deg,
+        var(--secondary-text-color) 0%,
+        var(--secondary-text-color) 40%,
+        var(--accent-color) 50%,
+        var(--secondary-text-color) 60%,
+        var(--secondary-text-color) 100%
+    );
+    background-size: 220% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    animation: agent-working-shimmer-sweep 2.4s ease-in-out infinite alternate;
+}
+
+@keyframes agent-working-shimmer-sweep {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -20% 0; }
+}
+```
+
+- `animation-direction: alternate` (folded into the shorthand above) is what produces the "back and forth" motion the user described, rather than a one-directional loop-and-snap.
+- Base tone `--secondary-text-color` with `--accent-color` as the moving highlight keeps it theme-bound the same way the progress bar is; no new tokens needed.
+- No `background-clip: text` usage exists anywhere else in the frontend yet (confirmed via search) — this would be the first, so it's worth a quick cross-platform (Windows/macOS/Linux CEF) render check before shipping, since `-webkit-background-clip: text` support is generally solid in Chromium/CEF but has occasional subpixel-AA quirks worth eyeballing.
+- Gate the shimmer class on the same `status.isLoading()` condition the progress bar already uses, so both stop in lockstep when the turn ends.
+
+### Open question for implementation (not resolved by this spec)
+
+Whether the shimmer should restart from Phase A on *every* phrase change (e.g. "Working" → "Reading file…" re-types each time) or only on the very first phrase of a turn (subsequent phrase swaps just cross-fade under a continuously-running shimmer). The former matches "it types it out the first display" most literally per-phrase; the latter reads calmer during long multi-tool turns. Recommend the former for v1 (simpler, matches the literal request) with a note that it's revisitable.
+
+## 3. Microphone button relocation
+
+### Current state
+
+The mic button is **not** Agent-pane-specific code — it's the shared `MicButton` component (`frontend/app/element/MicButton.tsx`), rendered from the generic frame chrome (`frontend/app/block/blockframe.tsx:255-267`) for *any* pane whose view model exposes `voiceHandle`:
+
+- Conditional on `props.viewModel?.voiceHandle` (`blockframe.tsx:255`), placed in the pane's title-bar icon row (`.block-frame-end-icons`, `frontend/app/block/block.scss:272-306` — a `display:flex` group, `justify-content: space-between`; no `position:absolute`, it's just flex order).
+- **Confirmed exactly two view models implement `voiceHandle`** — `frontend/app/view/term/termViewModel.ts:78,301` (Terminal) and `frontend/app/view/agent/agent-model.ts:43,49` (Agent). No other view model in the codebase defines it, so the mic button today appears **only** on Terminal and Agent panes — not "any pane" as this spec first stated. Every other pane type never shows a `MicButton` at all, so there's nothing to touch there.
+- The Agent-specific tooltip ("Speak into this agent (Ctrl+Shift+V)") is chosen inline via `props.blockView === "agent"` (`blockframe.tsx:262-263`), so the component already has an agent-aware branch to hook into.
+
+**Correction to the initial premise:** no other pane, modal, or composer in the codebase currently renders a mic button pinned beside a text input — `MicButton` has exactly one call site (`blockframe.tsx:256`). If "the standard elsewhere" refers to a specific screen, worth double-checking with whoever raised it before implementation, since it doesn't match what's on disk today. This spec proceeds treating the Agent pane as the first instance of the pattern rather than a port of an existing one.
+
+**Confirmed scope (per follow-up):** only the **Agent pane's** mic moves. The **Terminal pane's** header mic stays exactly where it is today — the `blockframe.tsx` suppression added below must key specifically off `blockView === "agent"`, not remove/hide the shared header mic broadly.
+
+### Target state
+
+Agent pane's composer: `frontend/app/view/agent/components/AgentFooter.tsx:721-722`:
+
+```
+<div class="agent-footer">
+    <div class="agent-input-container">   <!-- position: relative already, _pending-footer.scss:72-76 -->
+        <textarea class="agent-input" ... />
+    </div>
+</div>
+```
+
+`.agent-input-container` is already `position: relative` and currently hosts no buttons at all (Enter submits — no send button, no icon row today), so a mic icon can sit here cleanly:
+
+- Add a new `MicButton` render inside `.agent-input-container`, absolutely positioned to the input's right edge (`position: absolute; right: var(--space-1-5); bottom: ...` — vertically centered or bottom-aligned to match the composer's typical single-line resting height; needs a look at actual `.agent-input` line-height/padding to get this pixel-right, not fully specced here).
+- Reserve right-padding on `.agent-input` (e.g. `padding-right: 28px`) so typed/pasted text doesn't run underneath the icon once the textarea grows past one line.
+- In `blockframe.tsx`, suppress the header-row `MicButton` specifically when `props.blockView === "agent"` (the branch already exists at line 262-263 for tooltip text — extend it to also gate rendering: `<Show when={props.viewModel?.voiceHandle && props.blockView !== "agent"}>`). The Terminal pane's header mic is explicitly **left untouched** — it's the only other pane with `voiceHandle` at all, and this change must not affect it. This is a shared-component change (both panes route through the same `blockframe.tsx`/`MicButton`), so the gate needs to be scoped precisely to `blockView === "agent"`, not to "has voiceHandle" broadly.
+
+### Why the move is safe (behavior-wise)
+
+- `AgentFooter` already owns the voice wiring independent of where the button renders: it registers a `PaneVoiceHandle` on `AgentViewModel.voiceTargetRef` (`AgentFooter.tsx:489-542`, tied into `agent-model.ts:41-51`) so transcripts land in this textarea regardless of the button's DOM position. `MicButton` takes `blockId` + `handle` props and has no positioning assumptions itself.
+- The global `Ctrl+Shift+V` shortcut (`frontend/app/store/keymodel.ts:555-581`) toggles voice independent of button position — no change needed, but its click semantics must stay in sync with `MicButton.tsx:46-63` if that logic is ever touched.
+- No z-index conflict expected: the composer's `.slash-autocomplete` dropdown opens *above* the input (`_slash.scss:84-88`, `bottom: calc(100% + 2px)`), so a mic pinned at the input's right edge doesn't compete with it.
+- `MicButton`'s internal `<Show>` (line 73) hides it entirely when voice is unavailable — the composer layout must not reserve fixed space assuming the icon is always present (avoid hard-coding a permanent gap that looks empty when voice is off).
+
+---
+
+## 4. Status of the light/white theme (context, not an action item here)
+
+No light/white theme exists in the app today — `frontend/app/themes/index.scss` lists 8 themes (midnight, high-contrast, monokai, nord, dracula, catppuccin, tokyo-night, gruvbox), all dark-background. `high-contrast` is a black-background/white-text variant, not a light-background theme.
+
+A research doc already scopes this: `docs/analysis/ANALYSIS_THEME_SYSTEM_LIGHT_THEME_AND_DEPTH_GAPS_2026_07_07.md` (dated 2026-07-07). Its conclusion: the token infrastructure is solid enough that a light theme is "mechanically straightforward" to add, gated behind fixing a handful of hardcoded-dark "nooks" first (phantom tokens, the hand-painted context menu, the pane title bar). It lays out a 4-step order; only step 1 (terminal picking up the app theme, `feat(term): terminal picks up the app theme by default`, #2010, merged 2026-07-07) has shipped since. The light theme itself and its remaining prerequisites are unbuilt — this is an active-but-early research trail, not abandoned or reverted work. Out of scope for this spec; flagging so it isn't re-litigated as a surprise gap.
+
+---
+
+## 5. Summary of what actually needs to change
+
+| Item | Change needed? | Where |
+|---|---|---|
+| Working indicator theme-binding | **No** — already bound via `--accent-color` | n/a |
+| Working indicator type-out + shimmer | **Yes** — new two-phase animation | `AgentFooter.tsx` (reveal signal), `_control-bar.scss` (shimmer keyframes) |
+| Mic button relocation | **Yes** — move render site, suppress in shared header for agent panes only | `blockframe.tsx` (suppress), `AgentFooter.tsx` + its styles (add) |
+| White/light theme | **No action** — pre-existing scoped research, unrelated to this spec | tracked in `ANALYSIS_THEME_SYSTEM_LIGHT_THEME_AND_DEPTH_GAPS_2026_07_07.md` |

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -252,16 +252,18 @@ function EndIcons(props: {
                 </For>
                 <div class="block-frame-btn-separator" aria-hidden="true" />
             </Show>
-            <Show when={props.viewModel?.voiceHandle}>
+            {/* Agent panes render their own mic pinned beside the composer
+                input (AgentFooter.tsx) instead of here — see
+                SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md.
+                Terminal keeps the header mic unchanged. */}
+            <Show when={props.viewModel?.voiceHandle && props.blockView !== "agent"}>
                 <MicButton
                     blockId={props.nodeModel.blockId}
                     handle={props.viewModel.voiceHandle!()}
                     paneTitle={
                         props.blockView === "term"
                             ? "Speak into this terminal (Ctrl+Shift+V)"
-                            : props.blockView === "agent"
-                                ? "Speak into this agent (Ctrl+Shift+V)"
-                                : undefined
+                            : undefined
                     }
                 />
             </Show>

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -10,8 +10,10 @@ import { useTick } from "@/app/hook/useTick";
 import { getVoiceSession, type PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { markEnd, markStart } from "@/perf";
 import { makeORef } from "@/app/store/wos";
+import { atoms } from "@/app/store/global";
 import { ObjectService } from "@/app/store/services";
 import { fireAndForget } from "@/util/util";
+import { MicButton } from "@/app/element/MicButton";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
@@ -66,10 +68,81 @@ interface AgentWorkingRowProps {
     retryAfterMs?: number | null;
 }
 
+/** The exact string the loading row's left zone shows right now — pulled out
+ *  of the JSX ternary chain so both the type-out reveal effect and the
+ *  render itself read the same computed value. */
+function loadingLeftText(props: AgentWorkingRowProps, phrase: string): string {
+    if (props.stopping) return "Stopping…";
+    if (props.waitingReason === "rate_limited") {
+        return props.retryAfterMs != null
+            ? `Rate limited — retrying in ${Math.ceil(props.retryAfterMs / 1000)}s`
+            : "Rate limited — retrying…";
+    }
+    if (props.currentTool) {
+        return props.currentToolArg
+            ? `${props.currentTool}  ·  ${abbreviateArg(props.currentToolArg, 40)}`
+            : props.currentTool;
+    }
+    return `${phrase}…`;
+}
+
 export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     const [phrase, setPhrase] = createSignal(pickThinkingPhrase());
     const [lastPhrase, setLastPhrase] = createSignal(pickThinkingPhrase());
     const tick = useTick(1000);
+
+    // ── Type-out + shimmer ──────────────────────────────────────────────
+    // First display of a new left-zone string (a phrase, tool name, or
+    // status change) reveals character-by-character; once fully revealed,
+    // a gradient highlight sweeps back and forth over it for as long as
+    // this string stays on screen. See
+    // SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md §2.
+    //
+    // Reduced motion: read the app's centralized atom (settings override OR
+    // OS preference — see atoms.prefersReducedMotionAtom / BrainSpinner.tsx),
+    // not a one-off matchMedia() call, so it stays in sync with the same
+    // signal every other animated element in the app honors. Skips the
+    // one-shot type-out (jumps straight to full text, matching modal.tsx's
+    // "brief, non-moving" convention for one-shot reveals under reduced
+    // motion) but keeps the shimmer running — same precedent as
+    // .agent-pane-progress-bar's marching ants above: this is a small,
+    // essential, looping "still working" signal, not large/parallax motion,
+    // so it slows down (CSS below) rather than disappearing entirely.
+    const reducedMotion = atoms.prefersReducedMotionAtom;
+    const leftText = createMemo(() => loadingLeftText(props, phrase()));
+    const [revealed, setRevealed] = createSignal(leftText().length);
+    const [typing, setTyping] = createSignal(false);
+    const REVEAL_CHAR_MS = 28;
+
+    // The shimmer class is ALWAYS on (baked into the class attribute below);
+    // this effect only toggles `.is-typing`, which overlays opaque white
+    // text during the reveal. Toggling the shimmer class itself on every
+    // phrase/tool change would restart the CSS animation from 0% each time
+    // — and since the sweep period doesn't divide evenly into the interval
+    // between tool transitions, the return (right→left) leg kept getting
+    // truncated, so the highlight visibly "went right but never came back"
+    // (found in the sandbox, sandbox/working-shimmer.html on this machine).
+    createEffect(() => {
+        const text = leftText();
+        if (reducedMotion() || !text) {
+            setRevealed(text.length);
+            setTyping(false);
+            return;
+        }
+        setTyping(true);
+        setRevealed(0);
+        const id = setInterval(() => {
+            setRevealed((n) => {
+                const next = n + 1;
+                if (next >= text.length) {
+                    clearInterval(id);
+                    setTyping(false);
+                }
+                return next;
+            });
+        }, REVEAL_CHAR_MS);
+        onCleanup(() => clearInterval(id));
+    });
     const [loadStartMs, setLoadStartMs] = createSignal<number | null>(null);
     const elapsedMs = createMemo(() => {
         const s = loadStartMs();
@@ -149,18 +222,8 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
         >
             <span class="agent-working-row agent-working-row--loading">
                 <span class="agent-spinner-dot" />
-                <span class="agent-working-row-left">
-                    {props.stopping
-                        ? "Stopping…"
-                        : props.waitingReason === "rate_limited"
-                            ? props.retryAfterMs != null
-                                ? `Rate limited — retrying in ${Math.ceil(props.retryAfterMs / 1000)}s`
-                                : "Rate limited — retrying…"
-                        : props.currentTool
-                            ? props.currentToolArg
-                                ? `${props.currentTool}  ·  ${abbreviateArg(props.currentToolArg, 40)}`
-                                : props.currentTool
-                            : `${phrase()}…`}
+                <span class="agent-working-row-left agent-working-shimmer" classList={{ "is-typing": typing() }}>
+                    {leftText().slice(0, revealed())}
                 </span>
                 <span class="agent-working-row-right">{rightText()}</span>
             </span>
@@ -746,6 +809,21 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     }}
                     rows={1}
                 />
+                {/* Pinned to the composer's right edge instead of the pane's
+                    header (moved off blockframe.tsx — see
+                    SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md).
+                    Uses the same viewModel.voiceHandle() the header button
+                    used to, so voice wiring (registerPane, transcript
+                    writes) is unchanged — only the render location moved. */}
+                <Show when={props.viewModel?.voiceHandle}>
+                    <div class="agent-input-mic">
+                        <MicButton
+                            blockId={props.viewModel!.blockId}
+                            handle={props.viewModel!.voiceHandle!()}
+                            paneTitle="Speak into this agent (Ctrl+Shift+V)"
+                        />
+                    </div>
+                </Show>
             </div>
         </div>
     );

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -152,15 +152,11 @@
             animation-iteration-count: infinite;
         }
 
-        // Same precedent applied to the Working-row shimmer: AgentFooter.tsx
-        // still adds .agent-working-shimmer under reduced motion (skips only
-        // the one-shot type-out, per modal.tsx's "brief, non-moving" one-shot
-        // convention) — just slower and reasserting `infinite` for the same
-        // Chromium single-iteration quirk noted above.
-        .agent-working-row-left.agent-working-shimmer {
-            animation-duration: 4.5s;
-            animation-iteration-count: infinite;
-        }
+        // (The Working-row shimmer's reduced-motion slowdown is nested inside
+        // its own rule further down — NOT here. A rule in this block has the
+        // same specificity as the shimmer's `animation:` shorthand but
+        // earlier source order, so the shorthand would always win and the
+        // slowdown would silently never apply.)
     }
 
     // Back-and-forth highlight sweep for .agent-working-shimmer (below).
@@ -236,6 +232,19 @@
                     -webkit-background-clip: text;
                     color: transparent;
                     animation: agent-working-shimmer-sweep 2.4s ease-in-out infinite alternate;
+
+                    // Reduced-motion slowdown — same precedent as the
+                    // marching-ants bar (keep the essential looping "still
+                    // working" signal, just gentler), incl. re-asserting
+                    // `infinite` for Chromium's single-iteration clamp.
+                    // Nested HERE, not in the shared reduced-motion block
+                    // near the top of the file: it must come after the
+                    // `animation:` shorthand above in source order (equal
+                    // specificity), or the shorthand's 2.4s always wins.
+                    @media (prefers-reduced-motion: reduce) {
+                        animation-duration: 4.5s;
+                        animation-iteration-count: infinite;
+                    }
                 }
 
                 // Type-out reveal overlay: opaque white glyphs painted over

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -151,6 +151,36 @@
             animation-duration: 1.5s;
             animation-iteration-count: infinite;
         }
+
+        // Same precedent applied to the Working-row shimmer: AgentFooter.tsx
+        // still adds .agent-working-shimmer under reduced motion (skips only
+        // the one-shot type-out, per modal.tsx's "brief, non-moving" one-shot
+        // convention) — just slower and reasserting `infinite` for the same
+        // Chromium single-iteration quirk noted above.
+        .agent-working-row-left.agent-working-shimmer {
+            animation-duration: 4.5s;
+            animation-iteration-count: infinite;
+        }
+    }
+
+    // Back-and-forth highlight sweep for .agent-working-shimmer (below).
+    // `alternate` on the animation shorthand does the direction-reversal;
+    // this keyframe only needs to describe one pass.
+    //
+    // Endpoint math — these keep the WHOLE highlight band on-screen for the
+    // entire sweep (flush-left ↔ flush-right), so it never slides off an
+    // edge or thins out at the turning points. With `background-position:
+    // P%` on an X%-wide image, the image's left edge sits at container-x =
+    // (100-X)·(P/100), and the band spans image-fractions [lo,hi] of it.
+    // Solving band-flush-left and band-flush-right for the values used here
+    // (X=220, band [40%,60%] ⇒ 44 container-units wide):
+    //   P_left  = lo·X/(X-100)                    = 40·220/120  = 73.333%
+    //   P_right = 100·(100 - 44 - (lo/100)·X)/(100-X) = 100·(-32)/(-120) = 26.667%
+    // If band stops or background-size change, these must be re-derived
+    // (sandbox/working-shimmer.html on the dev machine computes them live).
+    @keyframes agent-working-shimmer-sweep {
+        0%   { background-position: 73.333% 0; }
+        100% { background-position: 26.667% 0; }
     }
 
     // === Working Row ===
@@ -178,6 +208,46 @@
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
+
+                // Always applied while loading (AgentFooter.tsx bakes the
+                // class in statically) — a soft highlight band sweeps back
+                // and forth across the text. The animation must run
+                // CONTINUOUSLY across phrase/tool changes: re-adding the
+                // class per phrase restarts the animation at 0%, which
+                // truncates the return leg of the sweep every time a tool
+                // transition lands mid-cycle (validated in the sandbox).
+                // During the type-out reveal the `.is-typing` variant below
+                // overlays opaque text without touching the animation.
+                // `--secondary-text-color` base + `--accent-color` highlight
+                // keeps it theme-adaptive the same way .agent-pane-progress-bar
+                // derives its sweep from --accent-color. `alternate` direction
+                // is what makes the sweep reverse instead of snapping back.
+                &.agent-working-shimmer {
+                    background-image: linear-gradient(
+                        90deg,
+                        var(--secondary-text-color) 0%,
+                        var(--secondary-text-color) 40%,
+                        var(--accent-color) 50%,
+                        var(--secondary-text-color) 60%,
+                        var(--secondary-text-color) 100%
+                    );
+                    background-size: 220% 100%;
+                    background-clip: text;
+                    -webkit-background-clip: text;
+                    color: transparent;
+                    animation: agent-working-shimmer-sweep 2.4s ease-in-out infinite alternate;
+                }
+
+                // Type-out reveal overlay: opaque white glyphs painted over
+                // the (still-running) shimmer. Keep background-clip as
+                // `text` — resetting it would un-clip the gradient into a
+                // full near-white box behind the typing text. With the clip
+                // intact and an opaque -webkit-text-fill-color, the glyphs
+                // simply cover the clipped gradient until the reveal ends.
+                &.agent-working-shimmer.is-typing {
+                    color: var(--main-text-color);
+                    -webkit-text-fill-color: var(--main-text-color);
+                }
             }
 
             .agent-working-row-right {

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -87,9 +87,21 @@
                 z-index: 1;
             }
 
+            // Reserve right padding for the pinned mic only when the mic is
+            // actually rendered. MicButton hides itself entirely (internal
+            // <Show>, MicButton.tsx) when voice is unavailable or
+            // voice:enabled is false — the .agent-input-mic wrapper stays
+            // mounted but empty, so keying off :has(.mic-button-wrap)
+            // tracks the button's own visibility logic without duplicating
+            // it here. Scoped to this one small container; not the
+            // tab-switch-hot path where :has() is banned (tabbar.scss).
+            &:has(.mic-button-wrap) .agent-input {
+                padding-right: 22px;
+            }
+
             .agent-input {
                 width: 100%;
-                padding: 3px 22px 3px var(--space-1);
+                padding: 3px var(--space-1);
                 background: var(--main-bg-color);
                 border: 1px solid var(--border-color);
                 border-radius: 0;

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -75,9 +75,21 @@
             gap: 1px;
             position: relative;
 
+            // Pinned mic — right edge of the composer, matching the
+            // header mic's old top-right feel but anchored to the input
+            // itself. Sits in the container's top-right corner rather than
+            // vertically centered against the textarea's full (growable)
+            // height, so it doesn't drift as the box grows past one line.
+            .agent-input-mic {
+                position: absolute;
+                top: 3px;
+                right: 5px;
+                z-index: 1;
+            }
+
             .agent-input {
                 width: 100%;
-                padding: 3px var(--space-1);
+                padding: 3px 22px 3px var(--space-1);
                 background: var(--main-bg-color);
                 border: 1px solid var(--border-color);
                 border-radius: 0;


### PR DESCRIPTION
## Summary

Two Agent-pane conversation-chrome refinements, spec'd in `docs/specs/SPEC_AGENT_WORKING_INDICATOR_SHIMMER_AND_MIC_RELOCATION_2026_07_08.md` (included).

### Working indicator — type-out + shimmer

Each new left-zone string in `AgentWorkingRow` (thinking phrase, tool label, rate-limit status) now types out character-by-character in white, then a theme-bound highlight band sweeps back and forth over it continuously while the turn runs. Colors derive from `--accent-color`/`--secondary-text-color`/`--main-text-color`, so all 8 themes adapt automatically (same pattern as the marching-ants progress bar).

Three non-obvious behaviors were iterated and validated in a standalone HTML sandbox before landing:

- **Continuous animation, `.is-typing` overlay:** the shimmer class is baked in statically; phrase changes only toggle an overlay class. Re-adding the shimmer class per phrase restarts the CSS animation at 0%, which truncates the return sweep whenever a tool transition lands mid-cycle — the highlight visibly "goes right but never comes back."
- **Clip stays `text` during type-out:** the overlay paints opaque glyphs via `-webkit-text-fill-color` over the still-clipped gradient. Resetting `background-clip` instead un-clips the gradient into a near-white box painted behind the typing text.
- **On-screen sweep endpoints:** keyframes use computed endpoints (73.333% / 26.667% for the 220% gradient with a [40%,60%] band) that slide the whole band flush-left ↔ flush-right without leaving the visible text. A naive `200% → -20%` sweep spends most of each pass with the band fully off-screen. Derivation is in the keyframes comment.

Reduced motion reads the centralized `atoms.prefersReducedMotionAtom` (settings override OR OS preference — important on Windows machines with "Animation effects" off, where a raw `matchMedia` check silently disables everything), skips the one-shot type-out, and keeps the shimmer at a slower duration with the Chromium `infinite`-iteration override — same convention as the marching-ants bar.

### Mic button → composer

The mic moves out of the shared pane-header icon row into the Agent composer, pinned to the input's right edge (right-padding reserved so text never runs under it). `blockframe.tsx` suppresses the header mic for `blockView === "agent"` only — **Terminal panes keep their header mic unchanged** (the only other pane type with `voiceHandle`). Voice wiring is untouched: same `viewModel.voiceHandle()`, same `Ctrl+Shift+V` path, transcripts still land in this textarea via the `PaneVoiceHandle` registered by `AgentFooter`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx stylelint` clean on both touched SCSS files
- [x] Mic relocation verified live in `task dev` (composer mic present, terminal header mic unchanged)
- [x] Type-out + shimmer iterated/validated in a live sandbox (looping phrases, tuned values recorded); final constants ported here
- [ ] Final visual pass in `task dev` on this exact commit — parked per request, verify before merge

<!-- agentmux:agent_id=agent1 -->