### PR TITLE
fix(srv): CloseWindow prunes the store when the reducer never knew the window (#2051)

### DIFF
--- a/.changesets/1783643610-fix-srv-closewindow-prunes-the-store-when-the-reducer-never--o9q3.md
+++ b/.changesets/1783643610-fix-srv-closewindow-prunes-the-store-when-the-reducer-never--o9q3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): CloseWindow prunes the store when the reducer never knew the window (#2051)

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -640,7 +640,13 @@ fn apply_srv_window_opened(
 /// prune client.windowids FIRST (so any read between the two ops
 /// doesn't see a dangling id), then delete the Window row.
 /// (codex P1 #619.)
-fn apply_srv_window_closed(
+///
+/// `pub(crate)`: besides the `SrvWindowClosed` subscriber arm, the
+/// `CloseWindow` handler calls this directly on its divergence path —
+/// when the reducer never knew the window (silent no-op, no event) but
+/// the store still holds it (#2051). Deliberately defensive/idempotent:
+/// both callers rely on the already-gone cases being safe.
+pub(crate) fn apply_srv_window_closed(
     wstore: &Store,
     window_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/agentmux-srv/src/server/service/window.rs
+++ b/agentmux-srv/src/server/service/window.rs
@@ -352,6 +352,90 @@ pub(super) async fn handle_window_service(state: &AppState, call: &WebCallType) 
             }) {
                 return WebReturnType::error(err_msg);
             }
+            // #2051 — the reducer's CloseWindowInternal is an idempotent
+            // silent no-op on unknown ids (no event emitted). The SQLite
+            // prune below only runs off the SrvWindowClosed event, so
+            // without this branch a window the reducer never knew
+            // (bootstrap skipped it, or state/store desync) returns 200
+            // while its `Client.windowids` entry and Window row survive
+            // forever — the leak class that fueled the #2048 window
+            // storm. Prune the durable store directly and warn about the
+            // divergence; a window that is gone from BOTH sides stays a
+            // clean idempotent success.
+            if close_events.is_empty() {
+                let had_row = ws_id.is_some();
+                let had_client_entry = store
+                    .get_all::<Client>()
+                    .ok()
+                    .and_then(|cs| cs.into_iter().next())
+                    .map(|c| c.windowids.iter().any(|id| id == &window_id))
+                    .unwrap_or(false);
+                if !had_row && !had_client_entry {
+                    return WebReturnType::success_empty();
+                }
+                tracing::warn!(
+                    window_id = %window_id,
+                    had_row,
+                    had_client_entry,
+                    "CloseWindow: window unknown to the reducer but still present in the \
+                     store — pruning defensively (#2051)"
+                );
+                if let Err(e) =
+                    crate::persist_subscriber::apply_srv_window_closed(store, &window_id)
+                {
+                    return WebReturnType::error(format!(
+                        "CloseWindow: divergence prune failed: {}",
+                        e
+                    ));
+                }
+                // Same guarded cascade as the normal path below, but
+                // judged from the store (the reducer has no record of
+                // this window's workspace peers). The prune above already
+                // deleted this window's own row, so any remaining
+                // reference means the workspace is genuinely shared. On a
+                // read error keep the workspace — losing user tabs is
+                // worse than leaking an empty workspace row.
+                if let Some(ws_id) = ws_id {
+                    let any_other_window = store
+                        .get_all::<Window>()
+                        .map(|ws| ws.iter().any(|w| w.workspaceid == ws_id))
+                        .unwrap_or(true);
+                    if !any_other_window {
+                        // A workspace the reducer tracks goes through the
+                        // saga (keeps reducer + store consistent, durable
+                        // provenance). One it never knew — the usual case
+                        // when its window diverged too — would make the
+                        // saga's reducer dispatch error out, so cascade at
+                        // the store layer directly instead.
+                        let reducer_knows_ws = state
+                            .srv_state
+                            .lock()
+                            .await
+                            .workspaces
+                            .contains_key(&ws_id);
+                        if reducer_knows_ws {
+                            if let Err(e) =
+                                crate::sagas::delete_workspace::run(state, ws_id.clone()).await
+                            {
+                                tracing::warn!(
+                                    workspace_id = %ws_id,
+                                    "CloseWindow: divergence-path delete_workspace saga failed: {}",
+                                    e,
+                                );
+                            }
+                        } else if let Err(e) =
+                            crate::backend::wcore::delete_workspace(store, &ws_id)
+                        {
+                            tracing::warn!(
+                                workspace_id = %ws_id,
+                                "CloseWindow: divergence-path store cascade failed: {}",
+                                e,
+                            );
+                        }
+                    }
+                }
+                return WebReturnType::success_empty();
+            }
             for ev in &close_events {
                 if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
                     return WebReturnType::error(format!(
@@ -961,5 +1045,103 @@ mod set_window_topology_tests {
         let state = test_state();
         let ret = handle_window_service(&state, &call("ghost-window", Some("full_instance"), None)).await;
         assert!(!ret.success, "unknown window must error");
+    }
+}
+
+/// #2051 — `CloseWindow` divergence-path tests: the reducer's
+/// `CloseWindowInternal` silently no-ops on ids it never knew, and the
+/// SQLite prune normally rides the `SrvWindowClosed` event — so a window
+/// present only in the store used to survive a "successful" CloseWindow
+/// forever (the leak class behind the #2048 window storm). These pin the
+/// handler's direct-prune fallback.
+#[cfg(test)]
+mod close_window_divergence_tests {
+    use super::handle_window_service;
+    use crate::backend::obj::{Client, Window, Workspace};
+    use crate::backend::service::WebCallType;
+    use crate::backend::wcore;
+    use crate::server::tests::test_state;
+
+    fn close_call(window_id: &str) -> WebCallType {
+        WebCallType {
+            service: "window".to_string(),
+            method: "CloseWindow".to_string(),
+            uicontext: None,
+            args: vec![serde_json::Value::String(window_id.to_string())],
+        }
+    }
+
+    fn client_has_window(state: &crate::server::AppState, window_id: &str) -> bool {
+        state
+            .wstore
+            .get_all::<Client>()
+            .unwrap()
+            .into_iter()
+            .next()
+            .map(|c| c.windowids.iter().any(|id| id == window_id))
+            .unwrap_or(false)
+    }
+
+    /// A window written straight to the store (`wcore::create_window`
+    /// bypasses the reducer — exactly how bootstrap-skipped rows and
+    /// pre-reducer desyncs look) must still be fully pruned by
+    /// CloseWindow: success, row gone, `Client.windowids` entry gone,
+    /// and its now-orphaned workspace cascade-deleted.
+    #[tokio::test]
+    async fn store_only_window_is_pruned_and_workspace_cascades() {
+        let state = test_state();
+        let win = wcore::create_window_full(&state.wstore, "").unwrap();
+        assert!(client_has_window(&state, &win.oid), "precondition: windowids entry");
+        assert!(
+            !state.srv_state.lock().await.windows.contains_key(&win.oid),
+            "precondition: reducer must NOT know this window"
+        );
+
+        let ret = handle_window_service(&state, &close_call(&win.oid)).await;
+        assert!(ret.success, "divergent CloseWindow failed: {:?}", ret.error);
+
+        assert!(
+            state.wstore.get::<Window>(&win.oid).unwrap().is_none(),
+            "Window row must be deleted"
+        );
+        assert!(
+            !client_has_window(&state, &win.oid),
+            "Client.windowids entry must be pruned"
+        );
+        assert!(
+            state.wstore.get::<Workspace>(&win.workspaceid).unwrap().is_none(),
+            "orphaned workspace must cascade-delete"
+        );
+    }
+
+    /// A workspace still referenced by another window must survive the
+    /// divergence-path cascade guard.
+    #[tokio::test]
+    async fn shared_workspace_survives_divergent_close() {
+        let state = test_state();
+        let first = wcore::create_window_full(&state.wstore, "").unwrap();
+        let second =
+            wcore::create_window_full(&state.wstore, &first.workspaceid).unwrap();
+
+        let ret = handle_window_service(&state, &close_call(&first.oid)).await;
+        assert!(ret.success, "divergent CloseWindow failed: {:?}", ret.error);
+
+        assert!(
+            state.wstore.get::<Workspace>(&first.workspaceid).unwrap().is_some(),
+            "workspace referenced by another window must survive"
+        );
+        assert!(
+            state.wstore.get::<Window>(&second.oid).unwrap().is_some(),
+            "the other window must be untouched"
+        );
+    }
+
+    /// A window gone from BOTH the reducer and the store stays a clean
+    /// idempotent success — no error, no phantom prune.
+    #[tokio::test]
+    async fn truly_missing_window_is_an_idempotent_success() {
+        let state = test_state();
+        let ret = handle_window_service(&state, &close_call("no-such-window")).await;
+        assert!(ret.success, "idempotent CloseWindow failed: {:?}", ret.error);
     }
 }


### PR DESCRIPTION
Closes #2051. Hardening follow-up to #2048 (startup window storm).

## Problem

`CloseWindow`'s durable cleanup (prune `Client.windowids`, delete the `Window` row) only runs off the `SrvWindowClosed` event, and the reducer's `CloseWindowInternal` is an idempotent **silent no-op** for ids it never knew — no event, no prune, handler still returns 200. Any window present in SQLite but absent from reducer memory (bootstrap skipped it, store-only writes, state/store desync) therefore survived a "successful" close forever. This is the divergence that let orphan rows accumulate invisibly for weeks and fuel the #2048 storm.

## Fix

In the `CloseWindow` handler, when the reducer dispatch returns **no events**:

- If the window is also absent from the store (no row, no `windowids` entry) → unchanged idempotent success.
- Otherwise `warn!` the divergence (`had_row` / `had_client_entry` fields) and prune the durable store directly via the same defensive transaction the subscriber uses (`apply_srv_window_closed`, now `pub(crate)`).
- Workspace cascade keeps the normal path's "any other window references it" guard, judged from the store (the reducer has no record of this window's peers). A workspace the reducer tracks goes through the existing `delete_workspace` saga; one it never knew is cascaded at the store layer via `wcore::delete_workspace` (the saga's reducer dispatch would error on an unknown workspace).

The reducer arm itself is untouched — its idempotent no-op contract is correct for replay; the divergence is repaired at the handler, where the store is in scope.

## Tests

Three new handler-level tests (`close_window_divergence_tests`):
- `store_only_window_is_pruned_and_workspace_cascades` — a `wcore::create_window_full` window (store + windowids, reducer never sees it) closes with success, row + windowids entry gone, orphaned workspace cascade-deleted.
- `shared_workspace_survives_divergent_close` — the cascade guard: a workspace still referenced by another window survives.
- `truly_missing_window_is_an_idempotent_success` — gone-from-both-sides stays a clean 200.

Full `agentmux-srv` suite green.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
