### PR TITLE
chore: release v0.52.2

### DIFF
--- a/.changesets/1783641363-feat-agent-consolidate-mode-model-effort-drop-up-pills-into--e3pb.md
+++ b/.changesets/1783641363-feat-agent-consolidate-mode-model-effort-drop-up-pills-into--e3pb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): consolidate Mode/Model/Effort drop-up pills into a single Runtime panel

--- a/.changesets/1783642500-feat-agent-working-indicator-type-out-oscillating-shimmer-mi-mlw6.md
+++ b/.changesets/1783642500-feat-agent-working-indicator-type-out-oscillating-shimmer-mi-mlw6.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): Working-indicator type-out + oscillating shimmer; mic moved from pane header to composer

--- a/.changesets/1783643610-fix-srv-closewindow-prunes-the-store-when-the-reducer-never--o9q3.md
+++ b/.changesets/1783643610-fix-srv-closewindow-prunes-the-store-when-the-reducer-never--o9q3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): CloseWindow prunes the store when the reducer never knew the window (#2051)

--- a/.changesets/1783662441-fix-build-restore-ci-green-package-lock-release-resync-dropp-ca4z.md
+++ b/.changesets/1783662441-fix-build-restore-ci-green-package-lock-release-resync-dropp-ca4z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(build): restore CI-green package-lock — release resync dropped peer entries (react) and broke npm ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.52.1"
+version = "0.52.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,13 @@
 # AgentMux Version History
 
+## 0.52.2 — 2026-07-09
+
+- feat(agent): consolidate Mode/Model/Effort drop-up pills into a single Runtime panel
+- feat(agent): Working-indicator type-out + oscillating shimmer; mic moved from pane header to composer
+- fix(srv): CloseWindow prunes the store when the reducer never knew the window (#2051)
+- fix(build): restore CI-green package-lock — release resync dropped peer entries (react) and broke npm ci
+
+
 ## 0.52.1 — 2026-07-09
 
 - fix(window): end the startup window storm — single-run initApp, reproject GCs never-registered rows
@@ -1932,6 +1940,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.52.1 | 2026-07-09 | 171.6 MiB | 369.5 MiB | |
 | 0.44.0 | 2026-06-10 | 163.9 MiB | 349.8 MiB | |
 | 0.38.13 | 2026-05-26 | 164.8 MiB | 346.2 MiB | |
 | 0.38.11 | 2026-05-26 | 164.8 MiB | 346.1 MiB | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.52.1",
+      "version": "0.52.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release v0.52.2 — consumes 4 changesets (forced patch; one was typed minor and rides along):

- fix(srv): CloseWindow prunes the store when the reducer never knew the window (#2053, closes #2051)
- fix(build): restore CI-green package-lock — release resync dropped peer entries (#2054)
- feat(agent): Working-indicator type-out + oscillating shimmer; mic moved to composer (#2052)
- feat(agent): consolidate Mode/Model/Effort drop-up pills into a single Runtime panel

All 5 version locations verified at 0.52.2 by scripts/release.sh. Lockfile integrity explicitly re-verified this time (`react` peer entries present, `npm ci --dry-run` clean against a bare dir) — guarding against the resync regression #2054 fixed.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)