### PR TITLE
fix(identity): App API link-table ops resolve S1 slug to definition id (#1624 PR-C precursor)

### DIFF
--- a/.changesets/1783663406-fix-identity-app-api-link-table-ops-resolve-the-s1-slug-to-t-n2oq.md
+++ b/.changesets/1783663406-fix-identity-app-api-link-table-ops-resolve-the-s1-slug-to-t-n2oq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): App API link-table ops resolve the S1 slug to the definition id; failed upsert no longer orphans the account row

--- a/agentmux-srv/src/server/app_api/identity.rs
+++ b/agentmux-srv/src/server/app_api/identity.rs
@@ -152,8 +152,16 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
                     return Err(format!("identity.account.upsert: db: {e}"));
                 }
 
-                // Steps 2+4: replace provider link (unlink old, link new).
-                let _ = id_store.agent_identity_unlink(&def_id, &req.provider);
+                // Step 2/4: (re)point the agent's provider link at this account.
+                // agent_identity_link's own `ON CONFLICT(agent_id, provider) DO
+                // UPDATE` already overwrites whatever account_id was linked
+                // before, so no separate unlink is needed for the success path.
+                // A preceding unlink-then-link was here previously (reagent P1 on
+                // PR #2056): now that def_id resolves correctly, an unlink that
+                // succeeds followed by a link that fails would permanently drop
+                // the agent's existing provider link with no compensation (the
+                // failure branch below only cleans up for is_new accounts) —
+                // removed rather than adding yet another compensating delete.
                 if let Err(e) = id_store.agent_identity_link(&def_id, &account_id, &req.provider) {
                     // Only clean up for new accounts — on the update path the
                     // account still exists in the DB and may be linked to other providers,

--- a/agentmux-srv/src/server/app_api/identity.rs
+++ b/agentmux-srv/src/server/app_api/identity.rs
@@ -26,14 +26,14 @@ fn register_identity_self_accounts(engine: &Arc<WshRpcEngine>, state: &AppState)
 }
 
 fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let id_store = state.id_store.clone();
-    let broker = state.broker.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_IDENTITY_ACCOUNT_UPSERT,
         Box::new(move |data, ctx| {
-            let id_store = id_store.clone();
-            let broker = broker.clone();
+            let state = state.clone();
             Box::pin(async move {
+                let id_store = &state.id_store;
+                let broker = &state.broker;
                 #[derive(serde::Deserialize)]
                 #[serde(rename_all = "snake_case")]
                 struct Req {
@@ -55,6 +55,13 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
                     return Err("identity.account.upsert: secret must not be empty".to_string());
                 }
 
+                // The link table is keyed by definition id; req.agent_id is
+                // the S1 slug. Resolve once, use for every link-table call
+                // below. See resolve_agent_definition_id (mod.rs) for the
+                // two failure modes writing the slug causes.
+                let def_id = resolve_agent_definition_id(&state, &req.agent_id)
+                    .map_err(|e| format!("identity.account.upsert: {e}"))?;
+
                 let is_new = req.account_id.is_empty();
                 let account_id = if is_new {
                     uuid::Uuid::new_v4().to_string()
@@ -63,7 +70,7 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
                     // linked to the calling agent, so callers can't overwrite
                     // another agent's credentials by guessing a UUID.
                     let links = id_store
-                        .agent_identity_list_for_agent(&req.agent_id)
+                        .agent_identity_list_for_agent(&def_id)
                         .map_err(|e| format!("identity.account.upsert: {e}"))?;
                     let owned = links.iter().any(|l| l.account_id == req.account_id);
                     if !owned {
@@ -146,12 +153,16 @@ fn register_identity_account_upsert(engine: &Arc<WshRpcEngine>, state: &AppState
                 }
 
                 // Steps 2+4: replace provider link (unlink old, link new).
-                let _ = id_store.agent_identity_unlink(&req.agent_id, &req.provider);
-                if let Err(e) = id_store.agent_identity_link(&req.agent_id, &account_id, &req.provider) {
-                    // Only clean up keychain for new accounts — on the update path the
+                let _ = id_store.agent_identity_unlink(&def_id, &req.provider);
+                if let Err(e) = id_store.agent_identity_link(&def_id, &account_id, &req.provider) {
+                    // Only clean up for new accounts — on the update path the
                     // account still exists in the DB and may be linked to other providers,
                     // so deleting the keychain secret would destroy a valid credential.
+                    // Delete the just-upserted db_identity_accounts row too, not only the
+                    // keychain secret: without it a failed link left an orphaned,
+                    // unlinked account row behind (agent3's report on #1624 PR-C).
                     if is_new {
+                        let _ = id_store.identity_delete(&account_id);
                         let aid = account_id.clone();
                         let _ = tokio::task::spawn_blocking(move || {
                             crate::identity::secret_store::delete(&aid)
@@ -228,22 +239,26 @@ fn register_identity_account_validate(engine: &Arc<WshRpcEngine>, state: &AppSta
 }
 
 fn register_identity_self_unlink(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let id_store = state.id_store.clone();
-    let broker = state.broker.clone();
+    let state = state.clone();
     engine.register_handler(
         COMMAND_IDENTITY_SELF_UNLINK,
         Box::new(move |data, ctx| {
-            let id_store = id_store.clone();
-            let broker = broker.clone();
+            let state = state.clone();
             Box::pin(async move {
+                let id_store = &state.id_store;
+                let broker = &state.broker;
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, provider: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("identity.self.unlink: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
 
+                // Link rows are keyed by definition id, not the S1 slug —
+                // unlinking by slug always matched zero rows (silent no-op).
+                let def_id = resolve_agent_definition_id(&state, &req.agent_id)
+                    .map_err(|e| format!("identity.self.unlink: {e}"))?;
                 let unlinked = id_store
-                    .agent_identity_unlink(&req.agent_id, &req.provider)
+                    .agent_identity_unlink(&def_id, &req.provider)
                     .map_err(|e| format!("identity.self.unlink: {e}"))?;
                 if unlinked {
                     broker.publish(crate::backend::wps::WaveEvent {

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -488,7 +488,11 @@ pub(crate) async fn identity_self_accounts_impl(
     state: &AppState,
     agent_id: &str,
 ) -> Result<serde_json::Value, String> {
-    let links = state.id_store.agent_identity_list_for_agent(agent_id)
+    // Link rows are keyed by definition id, not the S1 slug callers
+    // authenticate with — see resolve_agent_definition_id.
+    let def_id = resolve_agent_definition_id(state, agent_id)
+        .map_err(|e| format!("identity.self.accounts: {e}"))?;
+    let links = state.id_store.agent_identity_list_for_agent(&def_id)
         .map_err(|e| format!("identity.self.accounts: {e}"))?;
     let mut accounts = Vec::new();
     for link in &links {
@@ -514,7 +518,11 @@ pub(crate) async fn identity_account_validate_stored_impl(
     agent_id: &str,
     account_id: &str,
 ) -> Result<serde_json::Value, String> {
-    let links = state.id_store.agent_identity_list_for_agent(agent_id)
+    // Link rows are keyed by definition id, not the S1 slug — without the
+    // resolution this ownership check always saw zero links and rejected.
+    let def_id = resolve_agent_definition_id(state, agent_id)
+        .map_err(|e| format!("identity.account.validate: {e}"))?;
+    let links = state.id_store.agent_identity_list_for_agent(&def_id)
         .map_err(|e| format!("identity.account.validate: {e}"))?;
     if !links.iter().any(|l| l.account_id == account_id) {
         return Err("FORBIDDEN: account not linked to this agent".to_string());
@@ -807,6 +815,42 @@ pub(super) fn check_s1(ctx: &RpcContext, req_agent_id: &str) -> Result<(), Strin
         return Err("FORBIDDEN: agent_id mismatch".to_string());
     }
     Ok(())
+}
+
+/// Resolve an S1-authenticated agent id (the slug — AGENTMUX_AGENT_ID /
+/// bus:register id, e.g. "Agent3") to the agent's DEFINITION id, which is
+/// what `db_agent_identity_links.agent_id` stores (== `AgentDefinition.id`;
+/// see m0013 and `identity/resolver.rs::resolve_bindings_for_instance`).
+///
+/// Every link-table operation reached from the App API must go through
+/// this: App API callers authenticate with the slug, but writing the slug
+/// into the link table either trips the per-channel schema's
+/// `FOREIGN KEY (agent_id) REFERENCES db_agent_definitions(id)` (loud
+/// "FOREIGN KEY constraint failed" — the id_store fallback path when the
+/// 0011 shared-store backfill hasn't applied), or — on the shared store,
+/// whose links table carries no agent_id FK — silently writes a row keyed
+/// by slug that the resolver (which reads by definition id) can never
+/// match. Reads have the mirror-image bug: listing links by slug always
+/// returns empty, so ownership checks reject and unlinks no-op.
+///
+/// A caller that already holds a definition id passes through unchanged
+/// (verified against `agent_def_get`), so internal non-S1 callers of the
+/// shared `*_impl` helpers stay valid.
+pub(super) fn resolve_agent_definition_id(
+    state: &AppState,
+    agent_id: &str,
+) -> Result<String, String> {
+    if let Ok(Some(instance)) = state.wstore.instance_get_by_name(agent_id) {
+        if !instance.definition_id.is_empty() {
+            return Ok(instance.definition_id);
+        }
+    }
+    if let Ok(Some(_)) = state.wstore.agent_def_get(agent_id) {
+        return Ok(agent_id.to_string());
+    }
+    Err(format!(
+        "unknown agent '{agent_id}': no instance with that name and no definition with that id"
+    ))
 }
 
 /// Current unix time in milliseconds (0 if the clock is before the epoch).

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1185,3 +1185,54 @@ async fn introspection_lists_return_collections() {
         assert!(!json[key].as_array().unwrap().is_empty(), "{path} non-empty");
     }
 }
+
+/// `resolve_agent_definition_id` maps the S1-authenticated agent slug
+/// (instance_name) to the definition id that keys
+/// `db_agent_identity_links`, passes real definition ids through
+/// unchanged, and errors on unknown ids. Guards the #1624 PR-C fix for
+/// identity.account.upsert/self.accounts/self.unlink writing the slug
+/// into the link table (FK failure on per-channel stores; silent
+/// resolver-invisible rows on the shared store).
+#[tokio::test]
+async fn resolve_agent_definition_id_maps_slug_and_passes_through_def_id() {
+    let state = test_state();
+
+    let mut def: crate::backend::storage::AgentDefinition = serde_json::from_value(serde_json::json!({
+        "id": "def-test-1", // caller-assigned; agent_def_insert stores it as-is
+        "slug": "testslug",
+        "name": "TestSlug",
+        "icon": "robot",
+        "provider": "claude",
+        "description": "test agent",
+        "created_at": 1,
+    }))
+    .expect("definition fixture");
+    state.wstore.agent_def_insert(&mut def).expect("insert definition");
+
+    let inst: crate::backend::storage::AgentInstance = serde_json::from_value(serde_json::json!({
+        "id": "inst-1",
+        "definition_id": def.id,
+        "status": "running",
+        "started_at": 1,
+        "created_at": 1,
+        "identity_id": "",
+        "memory_id": "",
+        "instance_name": "TestSlug",
+        "working_directory": "",
+    }))
+    .expect("instance fixture");
+    state.wstore.instance_create(&inst).expect("create instance");
+
+    // Slug → definition id.
+    let resolved = super::app_api::resolve_agent_definition_id(&state, "TestSlug")
+        .expect("slug resolves");
+    assert_eq!(resolved, def.id);
+
+    // A definition id passes through unchanged (internal non-S1 callers).
+    let passthrough = super::app_api::resolve_agent_definition_id(&state, &def.id)
+        .expect("definition id passes through");
+    assert_eq!(passthrough, def.id);
+
+    // Unknown ids error instead of silently writing bogus link rows.
+    assert!(super::app_api::resolve_agent_definition_id(&state, "no-such-agent").is_err());
+}


### PR DESCRIPTION
## Summary

Fixes the `identity.account.upsert` bug agent3 reported while self-linking a GitHub identity account, plus the wider blast radius found while verifying it. Part of the #1624 PR-C track (folds agent3's findings in ahead of the main PR-C write-path deprecation).

`db_agent_identity_links.agent_id` stores the agent **definition id** (`AgentDefinition.id` — see m0013 and `identity/resolver.rs`, #2041). But every App API identity handler passed `req.agent_id` — the S1-authenticated **slug** (`AGENTMUX_AGENT_ID` / `bus:register` id) — straight into the link-table calls. Failure mode depends on which store `id_store` routes to:

- **Per-channel fallback** (0011 shared-store backfill not applied): the links table carries `FOREIGN KEY (agent_id) REFERENCES db_agent_definitions(id)` → every upsert fails loudly with `FOREIGN KEY constraint failed` (agent3's repro).
- **Shared store**: its links-table variant has **no** agent_id FK → the write "succeeds" but keys the row by slug, which the resolver (reading by definition id since #2041) can never match. Silently broken instead of loudly.

Reads had the mirror-image bug — listing links by slug always returned empty — so `identity.self.accounts` returned nothing, the upsert **ownership check always rejected updates** (any `account_id`-carrying call got FORBIDDEN), `identity.account.validate`'s stored path always rejected, and `identity.self.unlink` always no-oped. All four surfaces were effectively unusable for normal (slug-authenticated) agent callers.

## Fix

- New `resolve_agent_definition_id()` (`app_api/mod.rs`): slug → definition id via `instance_get_by_name` (the codebase's established slug-lookup convention, cf. `native_memory_handlers.rs`), with passthrough for callers that already hold a definition id (`agent_def_get` verified) so internal non-S1 callers of the shared `*_impl` helpers stay valid. Unknown ids error instead of writing resolver-invisible rows.
- Applied in: `identity.account.upsert` (ownership check + unlink + link), `identity_self_accounts_impl`, `identity_account_validate_stored_impl`, `identity.self.unlink`.
- **Orphaned-row cleanup** (agent3's second finding): a failed link during upsert now deletes the just-upserted `db_identity_accounts` row for new accounts — previously only the keychain secret was compensated, stranding an orphaned unlinked account row per failed call.
- Change events (`agentidentities:changed:*`) keep the slug key — no subscribers exist yet, and callers know themselves by slug.

## Test plan

- [x] New test `resolve_agent_definition_id_maps_slug_and_passes_through_def_id` (slug→def-id, def-id passthrough, unknown-id error)
- [x] `cargo test -p agentmux-srv identity` — 101/101 passing
- [x] `cargo check -p agentmux-srv` clean

cc agent3 — both findings from your jekt are in here; the OAuth-flow + bind/unbind bundle-write gaps documented in #2041 remain for the main PR-C.

<!-- agentmux:agent_id=agent1 -->