### PR TITLE
chore(build): guard stable-channel packaging behind a released-state check

### DIFF
--- a/.changesets/1783664040-chore-build-guard-stable-channel-packaging-clean-tree-merged-yort.md
+++ b/.changesets/1783664040-chore-build-guard-stable-channel-packaging-clean-tree-merged-yort.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(build): guard stable-channel packaging — clean tree + merged release commit required

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -113,9 +113,10 @@ tasks:
             - bash scripts/package.sh {{.CLI_ARGS}}
 
     package:release:
-        desc: 'Like `task package` but (a) strips source maps (~28 MB) and (b) bakes the "stable" channel so the artifact opens the user''s real data dir. Use this for GitHub release artifacts. Local builds (`task package`) keep maps and use the branch-scoped local channel. See docs/specs/SPEC_PORTABLE_SOURCE_MAPS_2026_06_01.md.'
+        desc: 'Like `task package` but (a) strips source maps (~28 MB) and (b) bakes the "stable" channel so the artifact opens the user''s real data dir. Guarded: refuses unless the tree is clean and HEAD is a merged `chore: release v*` commit (AGENTMUX_STABLE_OVERRIDE=1 to bypass). Local builds (`task package`) keep maps and use the branch-scoped local channel. See docs/specs/SPEC_PORTABLE_SOURCE_MAPS_2026_06_01.md.'
         platforms: [windows]
         cmds:
+            - bash scripts/guard-stable-build.sh
             - bash -c 'STRIP_MAPS=1 RELEASE_CHANNEL=stable bash scripts/package.sh {{.CLI_ARGS}}'
 
     package:msix:
@@ -154,9 +155,10 @@ tasks:
             - bash scripts/package-linux.sh {{.CLI_ARGS}}
 
     package:release:linux:
-        desc: 'Like `task package:linux` but bakes the "stable" channel so the artifact opens the user''s real data dir. Use this for GitHub release artifacts. See docs/specs/SPEC_LINUX_APPIMAGE_PER_BUILD_CHANNEL_2026_06_25.md.'
+        desc: 'Like `task package:linux` but bakes the "stable" channel so the artifact opens the user''s real data dir. Guarded: refuses unless the tree is clean and HEAD is a merged `chore: release v*` commit (AGENTMUX_STABLE_OVERRIDE=1 to bypass). See docs/specs/SPEC_LINUX_APPIMAGE_PER_BUILD_CHANNEL_2026_06_25.md.'
         platforms: [linux]
         cmds:
+            - bash scripts/guard-stable-build.sh
             - bash -c 'RELEASE_CHANNEL=stable bash scripts/package-linux.sh {{.CLI_ARGS}}'
 
     check:menu-positioning:

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1940,6 +1940,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.52.2 | 2026-07-09 | 171.6 MiB | 369.5 MiB | |
 | 0.52.1 | 2026-07-09 | 171.6 MiB | 369.5 MiB | |
 | 0.44.0 | 2026-06-10 | 163.9 MiB | 349.8 MiB | |
 | 0.38.13 | 2026-05-26 | 164.8 MiB | 346.2 MiB | |

--- a/scripts/guard-stable-build.sh
+++ b/scripts/guard-stable-build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Stable-channel build guard.
+#
+# Only a released state of the repo may claim the "stable" channel —
+# stable-channel artifacts open the user's REAL data dir, so a build from
+# a dirty tree or an unmerged branch would let not-really-released code
+# write into it. Enforced mechanically here instead of by convention:
+#
+#   1. no tracked modifications in the working tree,
+#   2. HEAD is a `chore: release v*` commit,
+#   3. HEAD is reachable from origin/main (best-effort fetch first).
+#
+# Escape hatch for emergencies: AGENTMUX_STABLE_OVERRIDE=1.
+set -euo pipefail
+
+refuse() {
+    echo "[stable-guard] REFUSED: $1" >&2
+    echo "[stable-guard] stable-channel artifacts open the user's real data dir;" >&2
+    echo "[stable-guard] build from a merged 'chore: release v*' commit with a clean tree," >&2
+    echo "[stable-guard] use 'task package' (isolated local-* channel) for anything else," >&2
+    echo "[stable-guard] or set AGENTMUX_STABLE_OVERRIDE=1 to bypass deliberately." >&2
+    exit 1
+}
+
+if [ "${AGENTMUX_STABLE_OVERRIDE:-0}" = "1" ]; then
+    echo "[stable-guard] AGENTMUX_STABLE_OVERRIDE=1 — skipping release-state checks" >&2
+    exit 0
+fi
+
+if [ -n "$(git status --porcelain -uno)" ]; then
+    refuse "working tree has tracked modifications"
+fi
+
+subject=$(git log -1 --format=%s)
+case "$subject" in
+    "chore: release v"*) ;;
+    *) refuse "HEAD is not a release commit (subject: '$subject')" ;;
+esac
+
+# Best-effort ref refresh; offline builds still validate against the
+# last-known origin/main rather than failing on the fetch itself.
+git fetch origin main -q 2>/dev/null || true
+if ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+    refuse "HEAD is not on origin/main (unmerged or unpushed release commit)"
+fi
+
+echo "[stable-guard] OK: clean tree at released commit $(git rev-parse --short HEAD) ('$subject')"


### PR DESCRIPTION
Makes the stable-channel policy mechanical instead of trusted: `task package:release` / `package:release:linux` now refuse unless

1. the working tree has no tracked modifications,
2. HEAD is a `chore: release v*` commit,
3. HEAD is reachable from `origin/main` (best-effort fetch; offline builds validate against last-known refs).

Rationale: stable-channel artifacts open the user's **real** data dir. A stable build from a dirty tree or unmerged branch lets not-really-released code write into it. Dev/testing builds belong on `task package`'s isolated `local-<branch>-<hash>-<buildid>` channels. Escape hatch: `AGENTMUX_STABLE_OVERRIDE=1`.

Verified all paths live: dirty-tree refusal, non-release-HEAD refusal, pass on main at `56b16f352` (v0.52.2), override bypass.

Also rides along: the auto-appended v0.52.2 portable-size row in VERSION_HISTORY.

Note for a follow-up (observed while testing): the destructive package-lock drift that broke v0.52.1's CI (#2054) regenerates **in the working tree** on this dev box — some local npm invocation rewrites peer/devOptional flags in place, waiting to be swept up by the next `git add -A`. The release script should validate lockfile installability (`npm ci --dry-run` against a bare dir) before committing; happy to add that as a separate PR.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)