### PR TITLE
chore: release v0.52.3

### DIFF
--- a/.changesets/1783664040-chore-build-guard-stable-channel-packaging-clean-tree-merged-yort.md
+++ b/.changesets/1783664040-chore-build-guard-stable-channel-packaging-clean-tree-merged-yort.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(build): guard stable-channel packaging — clean tree + merged release commit required

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.52.2"
+version = "0.52.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,10 @@
 # AgentMux Version History
 
+## 0.52.3 — 2026-07-09
+
+- chore(build): guard stable-channel packaging — clean tree + merged release commit required
+
+
 ## 0.52.2 — 2026-07-09
 
 - feat(agent): consolidate Mode/Model/Effort drop-up pills into a single Runtime panel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.52.2",
+      "version": "0.52.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release v0.52.3 — consumes one changeset:

- chore(build): guard stable-channel packaging — clean tree + merged release commit required (#2057)

Lockfile integrity verified against a bare dir (`npm ci --dry-run` OK, react/peer entries intact). All 5 version locations at 0.52.3 per scripts/release.sh.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)