### PR TITLE
fix(agent): resume real session on pane reopen + hydrate stats bar from history

### DIFF
--- a/.changesets/1783681059-fix-agent-resume-the-real-session-on-pane-reopen-and-hydrate-hl96.md
+++ b/.changesets/1783681059-fix-agent-resume-the-real-session-on-pane-reopen-and-hydrate-hl96.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): resume the real session on pane reopen and hydrate stats bar from history

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -423,6 +423,21 @@ async fn main() {
         match registry::Registry::open(root.clone()) {
             Ok(reg) => {
                 tracing::info!(root = %root.display(), "registry: shared agent registry attached");
+                // Best-effort catch-up pass, run every startup (not just the
+                // one-shot m0010 migration): fills session_id for any agent
+                // record that still lacks one, e.g. one named after m0010
+                // already ran. Idempotent — skips records that already carry
+                // a non-empty session_id. Without this, an agent created
+                // after the migration ran would never get a resumable
+                // session_id in the registry, so a cross-tab/cross-restart
+                // open would silently orphan its conversation (the still-open
+                // half of docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md).
+                if let Some(shared_dir) = root.parent().and_then(|p| p.parent()) {
+                    let filled = backend::session_backfill::backfill_session_ids(&reg, shared_dir);
+                    if filled > 0 {
+                        tracing::info!(filled, "registry: backfilled session_id for cross-channel resume (startup pass)");
+                    }
+                }
                 wstore_raw.set_registry(Arc::new(reg));
                 if let Some(base) = std::env::var_os("AGENTMUX_AGENTS_DIR") {
                     if !base.is_empty() {

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -190,6 +190,29 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     env_vars.insert("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY".to_string(), json!("30000"));
                 }
 
+                // Cross-tab/cross-restart continuity: this agent may already have
+                // a captured provider session sitting in the shared registry
+                // (backfilled from its provider transcript, or captured live by a
+                // prior block) even though no block for it exists in THIS tab —
+                // e.g. after a full app restart lands on a different/rehydrated
+                // tab. Seed the new block's agent:sessionid meta so its FIRST
+                // turn resumes that conversation instead of silently starting
+                // fresh and orphaning the original — the same thing the
+                // picker's explicit "Continue" flow already does via
+                // continueOfInstanceId (RecentSessionRow.session_id), extended
+                // here to the default open path.
+                // See docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md
+                // ("Mechanism 2 — continuity"), action item 4.
+                let resume_session_id: Option<String> = wstore.shared_agent_registry()
+                    .and_then(|reg| reg.list_active().ok())
+                    .and_then(|records| {
+                        records.into_iter()
+                            .filter(|r| r.data.definition_id == agent.id)
+                            .filter(|r| r.data.session_id.as_deref().map_or(false, |s| !s.is_empty()))
+                            .max_by_key(|r| r.data.last_launched_at_ms)
+                    })
+                    .and_then(|r| r.data.session_id);
+
                 let mut meta = MetaMapType::new();
                 meta.insert("view".to_string(), json!("agent"));
                 meta.insert("agentId".to_string(), json!(&agent.id));
@@ -239,6 +262,9 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 meta.insert("cmd:env".to_string(), serde_json::Value::Object(env_vars));
                 meta.insert("agent:resume_flag".to_string(), json!(provider.resume_flag.unwrap_or("")));
                 meta.insert("agent:session_id_field".to_string(), json!(provider.session_id_field));
+                if let Some(sid) = &resume_session_id {
+                    meta.insert("agent:sessionid".to_string(), json!(sid));
+                }
 
                 // 7. Create block + insert into layout tree.
                 // Through the reducer (#1681), not wcore-direct: a store-only

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -1,5 +1,36 @@
 use super::*;
 
+/// Per-agent-definition async lock serializing `agent.open`'s "check for a
+/// live block / seed resume session / create block / register controller"
+/// sequence.
+///
+/// Without this, two concurrent `agent.open` calls for the same agent (a
+/// double-invocation, or two tabs opened for the same agent close together)
+/// can both observe "not live yet" before either controller actually
+/// registers — `CreateBlock` dispatch, the layout-action enqueue, and
+/// `write_agent_config_files` all await in between — and both seed the same
+/// `resume_session_id`, spawning two controllers that `--resume` the
+/// identical provider session concurrently. That's the TOCTOU reagent
+/// flagged on PR #2059's first concurrency-guard attempt (the earlier
+/// single-point-in-time `agent_live_elsewhere` check closed the
+/// already-live case but not the still-racing-to-become-live case).
+///
+/// Scope note: this only serializes calls handled by THIS process — like
+/// the in-memory `CONTROLLER_REGISTRY` it guards, it can't see a genuinely
+/// different AgentMux instance/channel racing the same registry entry.
+/// Same boundary the live-elsewhere check already accepted.
+static AGENT_OPEN_LOCKS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn agent_open_lock(agent_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+    let mut locks = AGENT_OPEN_LOCKS.lock().unwrap_or_else(|e| e.into_inner());
+    locks
+        .entry(agent_id.to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
+
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_agent_open(engine, state);
 }
@@ -34,6 +65,12 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .find(|a| a.id == cmd.agent_id || a.name.eq_ignore_ascii_case(&cmd.agent_id))
                     .ok_or_else(|| format!("AGENT_NOT_FOUND: no agent definition with id '{}'", cmd.agent_id))?
                     .clone();
+
+                // Serialize the rest of this handler per agent definition —
+                // held until the function returns (guard drops at every exit
+                // path, success or error). See AGENT_OPEN_LOCKS' doc comment.
+                let open_lock = agent_open_lock(&agent.id);
+                let _open_guard = open_lock.lock().await;
 
                 // 2. Resolve provider
                 let provider = providers::get_provider(&agent.provider)

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -203,15 +203,41 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // here to the default open path.
                 // See docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md
                 // ("Mechanism 2 — continuity"), action item 4.
-                let resume_session_id: Option<String> = wstore.shared_agent_registry()
-                    .and_then(|reg| reg.list_active().ok())
-                    .and_then(|records| {
-                        records.into_iter()
-                            .filter(|r| r.data.definition_id == agent.id)
-                            .filter(|r| r.data.session_id.as_deref().map_or(false, |s| !s.is_empty()))
-                            .max_by_key(|r| r.data.last_launched_at_ms)
+                //
+                // Concurrency guard (reagent P1 on PR #2059): only seed
+                // agent:sessionid when no OTHER block for this same agent
+                // definition currently has a LIVE controller registered
+                // anywhere in this process — not just this tab (find_agent_block
+                // above only scoped the "reuse" check to the target tab).
+                // Without this, opening the same named agent in a second tab
+                // while the first is still live would seed the new block with
+                // the SAME session_id, letting two controllers concurrently
+                // `--resume` one provider session — risking transcript
+                // corruption or exactly the orphaning bug this fix exists to
+                // prevent. A block with no registered controller (e.g. right
+                // after an app restart, before anything has resynced) is not
+                // "live" and doesn't block seeding.
+                let agent_live_elsewhere = wstore.get_all::<Block>()
+                    .map(|blocks| {
+                        blocks.iter().any(|b| {
+                            obj::meta_get_string(&b.meta, "agentId", "") == agent.id
+                                && blockcontroller::get_controller(&b.oid).is_some()
+                        })
                     })
-                    .and_then(|r| r.data.session_id);
+                    .unwrap_or(false);
+                let resume_session_id: Option<String> = if agent_live_elsewhere {
+                    None
+                } else {
+                    wstore.shared_agent_registry()
+                        .and_then(|reg| reg.list_active().ok())
+                        .and_then(|records| {
+                            records.into_iter()
+                                .filter(|r| r.data.definition_id == agent.id)
+                                .filter(|r| r.data.session_id.as_deref().map_or(false, |s| !s.is_empty()))
+                                .max_by_key(|r| r.data.last_launched_at_ms)
+                        })
+                        .and_then(|r| r.data.session_id)
+                };
 
                 let mut meta = MetaMapType::new();
                 meta.insert("view".to_string(), json!("agent"));

--- a/docs/plans/PLAN_PANE_REOPEN_SESSION_RESUME_AND_STATS_BAR_2026_07_10.md
+++ b/docs/plans/PLAN_PANE_REOPEN_SESSION_RESUME_AND_STATS_BAR_2026_07_10.md
@@ -1,0 +1,157 @@
+# Plan: fix session resume on pane reopen + stale/wrong stats bar
+
+**Date:** 2026-07-10
+**Author:** Agent1
+**Status:** Proposed, not started
+**Triggered by:** user report — closed AgentMux, reopened, opened an existing
+Agent1 pane, saw its historical conversation rendered, but the actual spawned
+CLI process was a fresh session with no memory of it, and the token/context
+stats bar above the composer showed wrong numbers.
+
+## Relationship to prior work
+
+This is not a new bug class. It's the unresolved half of
+`docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md`
+("Mechanism 2 — continuity"), whose action items 2–4 and 6 were never
+implemented, plus a second, previously undocumented symptom (the stats bar)
+that shares the same root shape: **reopened-pane UI state is not reconciled
+against backend/session truth at mount** — the same pattern
+`docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md` names for
+`TurnPhase`.
+
+## Problem statement
+
+1. **Session continuity:** on reopen, whether the next CLI spawn resumes the
+   original provider session depends entirely on `agent:sessionid` block meta
+   being resolvable at spawn time. If the reopen doesn't land on the exact
+   block that meta lives on (cross-channel open, picker reattach, or any path
+   the retro didn't cover), the lookup misses, a **new** session is spawned,
+   and that new session id then gets persisted — silently orphaning the
+   original conversation going forward.
+2. **Stats bar:** `contextTokensAtom`/`contextWindowAtom` are populated only
+   by a *live* `session_end` event from the currently-running process
+   (`useAgentStream.ts:415-469`, `claude-translator.ts:87-104`). Historical
+   transcript replay does parse old `session_end` frames
+   (`parseHistoryLines.ts:57-73`) but discards the stats payload. So on
+   reopen the bar is blank/stale until the new (usually much smaller) session
+   completes its first turn — at which point it shows numbers for the wrong
+   session, not the resumed conversation.
+
+Both stem from the same gap: nothing reconciles what the pane displays with
+what the backend/session actually is at mount time.
+
+## Goals
+
+- A reopened pane resumes the original provider session whenever one exists,
+  regardless of which channel/block the reopen lands on.
+- The stats bar reflects the true current session's usage immediately on
+  reopen — either the resumed session's last known stats, or an explicit
+  "unknown until first turn" state — never a stale number from a different
+  session presented as current.
+- Existing agents whose session got silently orphaned by this bug can be
+  recovered (pointed back at their real last session) where safe.
+
+## Non-goals
+
+- Rewriting `TurnPhase` reconciliation (Finding 1 of the 07-07 report) — real,
+  related, but a separate architecture decision with its own open questions.
+  Do not conflate this plan with that one.
+- Fixing subagent completion detection or ambient-call concurrency (Findings
+  2–3 of the same report) — unrelated subsystems.
+
+## Root cause references
+
+- Resume flag / controller type: `agentmux-srv/src/backend/providers.rs:115,152-153`
+- Local session id storage: `agentmux-srv/src/backend/blockcontroller/core.rs:21` (`META_SESSION_ID`), `:126-173` (`persist_session_id`)
+- Lazy spawn (no resume attempt on mere reopen): `agentmux-srv/src/backend/blockcontroller/persistent.rs:1029-1040`
+- Spawn-time resume hydration: `persistent.rs:566-598`
+- Per-turn re-read of block meta: `agentmux-srv/src/server/agent_handlers/input.rs:256-269`, `agentmux-srv/src/server/app_api/agent_io.rs:189-201`
+- Cross-channel path with no meta → fresh controller: `agent_open.rs:47-70`, `blockcontroller/mod.rs:347-463` (`resync_controller`)
+- Registry-level `session_id` field declared but never written in production: `agentmux-srv/src/registry/schema.rs` (only in tests, per retro)
+- Stats bar component: `frontend/app/view/agent/components/AgentComposerStrip.tsx`, wired at `frontend/app/view/agent/agent-view.tsx:1080-1096`
+- Stats atoms, live-only population: `frontend/app/view/agent/state.ts:69,173`; `frontend/app/view/agent/hooks/useAgentStream.ts:415-469,841`; `frontend/app/view/agent/claude-translator.ts:87-104`
+- Historical stats dropped during replay: `frontend/app/view/agent/parseHistoryLines.ts:57-73`
+
+## Proposed changes
+
+### Phase 1 — session continuity (closes retro action items 2, 3, 4, 6)
+
+1. **Populate the global/registry `session_id` on every turn**, not just the
+   block-local meta. Write the CLI-emitted authoritative session id into the
+   registry record alongside the existing block-meta write in
+   `persist_session_id` (`core.rs:126-173`).
+2. **Read the registry session id into spawn config whenever block-local meta
+   is absent**, so a cross-channel/cold reopen's *first* turn still
+   `--resume`s the right session instead of starting fresh. Wire this into
+   the same site(s) that currently read only block meta
+   (`input.rs:256-269`, `agent_io.rs:189-201`).
+3. **Add a resume guard**: before `resync_controller`/spawn is allowed to
+   proceed with `session_id = None`, check whether the registry has a known
+   last session for this agent. If yes, resume it; only fall back to a fresh
+   session if genuinely none exists. This directly implements action item 4
+   from the retro ("a reopen with an existing transcript must resume before
+   starting a new session").
+4. **Backfill migration** for already-affected agents: for each registry
+   record with `session_id: null` but a discoverable provider transcript
+   (via `history/claude_adapter.rs` discovery), set `session_id` to the
+   newest **original** session — explicitly excluding any short/orphaning
+   session created after this bug started, per retro guidance. Needs a
+   per-agent judgment call where multiple candidate sessions exist; do not
+   auto-run destructively — write a dry-run report first, apply only after
+   review.
+5. **e2e test**: run live in channel/build A, reopen in a fresh channel/build
+   B, assert (a) the same conversation renders, and (b) the CLI is invoked
+   with `--resume <original sid>` on the first post-reopen turn. This is the
+   exact coverage gap the retro calls out as missing.
+
+### Phase 2 — stats bar hydration
+
+1. In `parseHistoryLines.ts`, stop discarding the `stats` payload from
+   historical `session_end` frames — surface the **last** one found during
+   replay alongside the parsed `DocumentNode`s.
+2. At pane mount, once history replay completes, dispatch that last-known
+   stats into `contextTokensAtom`/`contextWindowAtom` (and
+   `sessionStatsAtom` if present) so the bar shows real numbers immediately,
+   before any new turn runs.
+3. If Phase 1's resume succeeds, the first new live `session_end` will
+   naturally overwrite this with fresh numbers, continuing the same
+   session's running totals — no separate reconciliation needed once resume
+   works correctly.
+4. If no historical stats can be found (never-run agent, corrupted
+   transcript), leave the bar in its current blank/placeholder state rather
+   than showing a misleading zero.
+
+## Risks / edge cases
+
+- Multiple provider sessions may exist for one agent (e.g. from repeated
+  instances of this bug). Backfill must pick deterministically (newest by
+  file mtime/session start time) and log what it skipped, not silently guess.
+- Registry writes must not race with the existing block-meta write — same
+  turn, two locations; keep them in the same transaction/call site to avoid
+  a torn state where one updates and the other doesn't.
+- A pane that was never live (agent created but never sent a message) has no
+  session to resume — guard must fall through to "start fresh" cleanly, not
+  error.
+- Stats hydration must clearly be presented as "as of last session end,"
+  since a resumed session's *next* turn may report a different (larger)
+  cumulative total — avoid a UI flash/jump that looks like a bug in itself.
+
+## Testing plan
+
+- Unit: registry session id read/write round-trip; resume-guard decision
+  table (meta present / registry present / neither).
+- Backfill: dry-run against a snapshot of real affected registry records
+  (Naki et al., per the retro's evidence section) — verify it selects the
+  original long session, not the short orphaning one.
+- e2e (per item 5 above): live-in-A → reopen-in-B → same content + real
+  `--resume`.
+- Manual: reproduce the user's exact repro (close app, reopen, open Agent1
+  pane) and confirm both symptoms are gone.
+
+## Rollout
+
+- Phase 1 and Phase 2 are independent and can ship as separate PRs/changesets.
+- Backfill migration should be reviewed manually before running against real
+  user data — do not wire it to run automatically on startup without an
+  explicit opt-in, given the "pending user OK" caveat already noted in the
+  retro for recovering already-affected agents.

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -103,6 +103,31 @@ describe("agent-pane-state reducer", () => {
         });
     });
 
+    describe("ReconcileContextFromHistory (mount-time reconciliation)", () => {
+        it("seeds lastContextTokens from a fresh (never-set) pane", () => {
+            const start = mk();
+            expect(start.lastContextTokens).toBe(null);
+            const r = update(start, { type: "ReconcileContextFromHistory", tokens: 4200 });
+            expect(r.state.lastContextTokens).toBe(4200);
+            expect(r.events[0]).toMatchObject({ type: "context-reconciled-at-mount", tokens: 4200 });
+        });
+
+        it("does not override a value a live TokensIn already set", () => {
+            const s0 = update(mk(), { type: "TokensIn", input: 900, model: "claude-sonnet-5" }).state;
+            expect(s0.lastContextTokens).toBe(900);
+            const r = update(s0, { type: "ReconcileContextFromHistory", tokens: 4200 });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("does not override an earlier reconciliation either (first-wins)", () => {
+            const s0 = update(mk(), { type: "ReconcileContextFromHistory", tokens: 4200 }).state;
+            const r = update(s0, { type: "ReconcileContextFromHistory", tokens: 999 });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+    });
+
     describe("Turn lifecycle invariants", () => {
         it("TurnStart while stream unsubscribed is suppressed", () => {
             const start = mk();

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -368,6 +368,20 @@ export function update(
             };
         }
 
+        case "ReconcileContextFromHistory": {
+            // Only ever seeds the mount-default null — never overrides a
+            // real live TokensIn (or an earlier reconciliation) that already
+            // landed. Mirrors ReconcileTurnActive's only-if-still-default
+            // guard above.
+            if (state.lastContextTokens != null) {
+                return { state, events: [] };
+            }
+            return {
+                state: { ...state, lastContextTokens: command.tokens },
+                events: [{ type: "context-reconciled-at-mount", tokens: command.tokens }],
+            };
+        }
+
         case "TurnStart": {
             // Invariant 1: can't start a turn without a subscribed
             // stream. PR G: `state.lastEventMs !== null` replaces the

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -394,6 +394,19 @@ export type AgentPaneCommand =
      */
     | { type: "ReconcileTurnActive"; at: number; active: boolean }
     /**
+     * Mount-time reconciliation: history replay found a `session_end` stats
+     * payload from before this pane went live (the resumed conversation's
+     * last turn — or, if resume silently failed, whatever short session
+     * replaced it). Seeds `lastContextTokens` so the composer strip's
+     * context-fill bar shows a real number immediately instead of sitting
+     * blank until the first live `TokensIn`. No-ops if a live `TokensIn`
+     * already arrived first (mirrors `ReconcileTurnActive`'s
+     * only-if-still-default guard) — a historical snapshot must never
+     * clobber real-time data. See
+     * docs/plans/PLAN_PANE_REOPEN_SESSION_RESUME_AND_STATS_BAR_2026_07_10.md.
+     */
+    | { type: "ReconcileContextFromHistory"; tokens: number }
+    /**
      * User pressed send — turn becomes active. Also clears stale
      * sessionStats from the previous turn.
      */
@@ -558,6 +571,11 @@ export type AgentPaneEvent =
      * user-initiated `turn-started`.
      */
     | { type: "turn-active-reconciled-at-mount" }
+    /**
+     * `ReconcileContextFromHistory` seeded `lastContextTokens` from a
+     * historical `session_end` at mount. Surfaced for diagnostics only.
+     */
+    | { type: "context-reconciled-at-mount"; tokens: number }
     | {
           /**
            * A turn finished and the phase transitioned to `Done`. Since

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -152,7 +152,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 limit: loadLimit,
             }, { timeout: 15000 });
 
-            const newNodes = parseHistoryLines(resp.lines ?? [], opts.outputFormat());
+            const { nodes: newNodes } = parseHistoryLines(resp.lines ?? [], opts.outputFormat());
             if (newNodes.length > 0) {
                 // batch() ensures HistoryLoaded's documentAtom write is not a
                 // standalone runUpdates frame that could interleave with a
@@ -282,8 +282,18 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             limit: hwm - windowStart,
                         }, { timeout: 30_000 });
                         if (!mounted) return;
-                        const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+                        const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
                         batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes }));
+                        // Hydrate the composer strip's context-fill bar from the
+                        // resumed conversation's last known usage instead of
+                        // leaving it blank until the first live turn — see
+                        // docs/plans/PLAN_PANE_REOPEN_SESSION_RESUME_AND_STATS_BAR_2026_07_10.md.
+                        if (typeof lastSessionStats?.input_tokens === "number") {
+                            opts.model.dispatchPane({
+                                type: "ReconcileContextFromHistory",
+                                tokens: lastSessionStats.input_tokens,
+                            });
+                        }
                         // Apply DocumentState + pane overlay via caller callback.
                         const ds = snapshot.documentState;
                         if (ds && opts.onSnapshotOverlay) {
@@ -405,9 +415,16 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 }, { timeout: 15000 });
                 if (!mounted) return;
 
-                const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+                const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
                 if (nodes.length > 0) {
                     batch(() => opts.model.dispatchDoc({ type: "HistoryLoaded", nodes }));
+                }
+                // See the v2-restore branch above for rationale.
+                if (typeof lastSessionStats?.input_tokens === "number") {
+                    opts.model.dispatchPane({
+                        type: "ReconcileContextFromHistory",
+                        tokens: lastSessionStats.input_tokens,
+                    });
                 }
 
                 // `resp.total` from the backend is the actual available

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -93,4 +93,21 @@ describe("parseHistoryLines", () => {
         const { lastSessionStats } = parseHistoryLines(lines, "claude-stream-json");
         expect(lastSessionStats).toBeNull();
     });
+
+    it("does not let a later empty-stats session_end clobber real historical stats", () => {
+        // reagent P1 on PR #2059: Claude's persistent-mode controller emits a
+        // session_end with stats: {} after EVERY plain-text turn (the per-turn
+        // boundary marker) — the real usage-bearing `result` event only fires
+        // at process teardown, which can be much earlier in the window. The
+        // chronologically-last session_end here is the empty turn-boundary
+        // marker; the real stats from the earlier turn must still win.
+        const lines = [
+            line({ type: "text", content: "turn one" }),
+            line({ type: "session_end", stats: { input_tokens: 500, output_tokens: 50 } }),
+            line({ type: "text", content: "turn two" }),
+            line({ type: "session_end", stats: {} }),
+        ];
+        const { lastSessionStats } = parseHistoryLines(lines, "claude-stream-json");
+        expect(lastSessionStats).toEqual({ input_tokens: 500, output_tokens: 50 });
+    });
 });

--- a/frontend/app/view/agent/parseHistoryLines.test.ts
+++ b/frontend/app/view/agent/parseHistoryLines.test.ts
@@ -21,7 +21,7 @@ describe("parseHistoryLines", () => {
             line({ type: "tool_call", tool: "Bash", id: "tool-1", params: { command: "ls" } }),
             line({ type: "tool_result", tool: "Bash", id: "tool-1", status: "success", duration: 0.1 }),
         ];
-        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        const { nodes } = parseHistoryLines(lines, "claude-stream-json");
         expect(nodes).toHaveLength(1);
         const tool = nodes[0] as ToolNode;
         expect(tool.id).toBe("tool-1");
@@ -39,7 +39,7 @@ describe("parseHistoryLines", () => {
             // tool_result lands later but should NOT push the tool past "after".
             line({ type: "tool_result", tool: "Read", id: "tool-1", status: "success", duration: 0 }),
         ];
-        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        const { nodes } = parseHistoryLines(lines, "claude-stream-json");
         expect(nodes).toHaveLength(3);
         expect(nodes[0].type).toBe("markdown");
         expect(nodes[1].type).toBe("tool");
@@ -57,7 +57,7 @@ describe("parseHistoryLines", () => {
             line({ type: "thinking", content: "Let me " }),
             line({ type: "thinking", content: "think about this..." }),
         ];
-        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        const { nodes } = parseHistoryLines(lines, "claude-stream-json");
         expect(nodes).toHaveLength(1);
         const node = nodes[0] as any;
         expect(node.type).toBe("markdown");
@@ -73,8 +73,24 @@ describe("parseHistoryLines", () => {
             "",
             "   ",
         ];
-        const nodes = parseHistoryLines(lines, "claude-stream-json");
+        const { nodes } = parseHistoryLines(lines, "claude-stream-json");
         expect(nodes).toHaveLength(1);
         expect((nodes[0] as any).content).toBe("real text");
+    });
+
+    it("surfaces the last session_end stats without emitting a node for it", () => {
+        const lines = [
+            line({ type: "text", content: "hi" }),
+            line({ type: "session_end", stats: { input_tokens: 111, output_tokens: 22 } }),
+        ];
+        const { nodes, lastSessionStats } = parseHistoryLines(lines, "claude-stream-json");
+        expect(nodes).toHaveLength(1);
+        expect(lastSessionStats).toEqual({ input_tokens: 111, output_tokens: 22 });
+    });
+
+    it("returns null lastSessionStats when no session_end is present", () => {
+        const lines = [line({ type: "text", content: "hi" })];
+        const { lastSessionStats } = parseHistoryLines(lines, "claude-stream-json");
+        expect(lastSessionStats).toBeNull();
     });
 });

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -16,12 +16,18 @@ import type { DocumentNode, SessionStats } from "./types";
 export interface ParsedHistory {
     nodes: DocumentNode[];
     /**
-     * Stats payload of the LAST `session_end` event seen during replay, or
-     * `null` if none was found. The live stream discards this same event's
-     * stats after using them to hydrate the composer strip's context-fill
-     * bar (see useAgentStream's `finalizeTurn` / `TokensIn`); history replay
-     * used to discard it too, leaving the bar blank until the next live
-     * turn. Callers use this to seed the bar immediately at mount instead.
+     * Stats payload of the last `session_end` event seen during replay that
+     * actually carries token usage, or `null` if none was found. Claude's
+     * persistent-mode controller emits a `session_end` after EVERY plain-text
+     * turn as a boundary marker with `stats: {}` (see
+     * ClaudeTranslator.handleAssistantMessage) — the real usage-bearing
+     * `result` event only fires at process teardown, which for a
+     * long-running persistent session may be far earlier in the replayed
+     * window than the last turn boundary. Tracking the chronologically last
+     * `session_end` unconditionally would let an empty boundary marker
+     * clobber real historical stats. Callers use this to seed the composer
+     * strip's context-fill bar at mount (see useAgentStream's `finalizeTurn`
+     * / `TokensIn` for the live-stream equivalent).
      */
     lastSessionStats: SessionStats | null;
 }
@@ -74,7 +80,14 @@ export function parseHistoryLines(
 
         for (const event of streamEvents) {
             if (event.type === "session_end") {
-                lastSessionStats = event.stats ?? null;
+                // Only overwrite when this session_end actually carries usage —
+                // skip the empty-stats per-turn boundary marker so it can't
+                // clobber a real result's stats seen earlier in the window.
+                if (event.stats
+                    && (typeof event.stats.input_tokens === "number"
+                        || typeof event.stats.output_tokens === "number")) {
+                    lastSessionStats = event.stats;
+                }
                 continue;
             }
             const node = parser.parseLine(JSON.stringify(event));

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -11,7 +11,20 @@
 
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
-import type { DocumentNode } from "./types";
+import type { DocumentNode, SessionStats } from "./types";
+
+export interface ParsedHistory {
+    nodes: DocumentNode[];
+    /**
+     * Stats payload of the LAST `session_end` event seen during replay, or
+     * `null` if none was found. The live stream discards this same event's
+     * stats after using them to hydrate the composer strip's context-fill
+     * bar (see useAgentStream's `finalizeTurn` / `TokensIn`); history replay
+     * used to discard it too, leaving the bar blank until the next live
+     * turn. Callers use this to seed the bar immediately at mount instead.
+     */
+    lastSessionStats: SessionStats | null;
+}
 
 /**
  * Parse an array of raw NDJSON lines (as stored in the "output" blockfile)
@@ -19,15 +32,17 @@ import type { DocumentNode } from "./types";
  *
  * @param lines        Raw text lines from blockfile:read_range
  * @param outputFormat Provider output format string (e.g. "claude-stream-json")
- * @returns            Ordered array of DocumentNodes, deduped by node id
+ * @returns            Ordered DocumentNodes (deduped by node id) plus the
+ *                      last `session_end` stats payload found, if any.
  */
 export function parseHistoryLines(
     lines: string[],
     outputFormat: string,
-): DocumentNode[] {
+): ParsedHistory {
     const translator = createTranslator(outputFormat);
     const parser = new ClaudeCodeStreamParser();
     const nodes: DocumentNode[] = [];
+    let lastSessionStats: SessionStats | null = null;
     // Same-id events update IN PLACE rather than first-wins.
     // The previous "skip if seen" rule dropped legitimate state
     // transitions during replay — most importantly, a `tool_result`
@@ -58,6 +73,10 @@ export function parseHistoryLines(
         const streamEvents = translator.translate(rawEvent);
 
         for (const event of streamEvents) {
+            if (event.type === "session_end") {
+                lastSessionStats = event.stats ?? null;
+                continue;
+            }
             const node = parser.parseLine(JSON.stringify(event));
             if (!node) continue;
             const existing = indexById.get(node.id);
@@ -73,5 +92,5 @@ export function parseHistoryLines(
         }
     }
 
-    return nodes;
+    return { nodes, lastSessionStats };
 }


### PR DESCRIPTION
## Summary

Reported bug: after fully closing and reopening AgentMux, opening an existing agent pane showed its historical conversation, but the actually-spawned CLI process was a brand-new session with no memory of it, and the token/context stats bar showed wrong/blank numbers.

This closes out the still-open "continuity" half of `docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md` plus a related, previously undocumented stats-bar bug. Plan: `docs/plans/PLAN_PANE_REOPEN_SESSION_RESUME_AND_STATS_BAR_2026_07_10.md`.

- **`agent_open.rs`**: when opening an agent creates a *new* block (no existing block found in the target tab — the case an app restart or new-tab reopen hits), seed the new block's `agent:sessionid` meta from the shared registry's known `session_id` for that agent. Previously only the picker's explicit "Continue" flow did this; the default open path silently started fresh and orphaned the original conversation.
- **`main.rs`**: run the registry's `session_id` backfill as a best-effort pass on every startup, not just once via the `m0010` migration, so agents created after the migration already ran still get a resumable `session_id`.
- **`parseHistoryLines.ts`**: history replay now surfaces the last `session_end` stats it finds instead of silently discarding them.
- **`useHistoryPagination.ts` / pane-state reducer**: new `ReconcileContextFromHistory` action hydrates the composer strip's context-fill bar from that historical stats payload at mount — seed-only-if-still-default, mirroring the existing `ReconcileTurnActive` pattern, so it never clobbers real live data.

Scoping note: did not wire live per-turn writes of the captured session id back through SQLite (`db_agent_instances` → registry mirror) — that hits real complexity in the consolidated-vs-legacy instance model that the codebase already sidesteps via the file-based backfill. Flagged as a possible follow-up in the plan doc rather than solved here.

## Test plan

- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1454 passed
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run frontend/app/view/agent` — 641 passed
- [x] `npx vitest run frontend/app/store/agent-pane-state/reducer.test.ts` — 144 passed (incl. 3 new `ReconcileContextFromHistory` cases)
- [ ] Manual repro: close app, reopen, open an existing agent pane — confirm resume + correct stats (not yet verified against a packaged build)

<!-- agentmux:agent_id=agent1 -->