### PR TITLE
fix(agent): AskUserQuestion Enter-to-submit + composer strip layout + mic centering + curated model defaults

### DIFF
--- a/.changesets/1783682410-fix-agent-enter-submits-askuserquestion-answers-composer-str-8chv.md
+++ b/.changesets/1783682410-fix-agent-enter-submits-askuserquestion-answers-composer-str-8chv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): Enter submits AskUserQuestion answers; composer strip layout + mic centering + curated model defaults

--- a/docs/specs/SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md
+++ b/docs/specs/SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md
@@ -1,0 +1,281 @@
+# SPEC: Composer-strip layout fixes, mic vertical centering, curated model defaults
+
+**Date:** 2026-07-10
+**Status:** Draft — investigated and designed, not yet implemented
+**Author:** AgentA
+**Trigger:** User request — *"lets have the dropdown wider, it is showing ellipsis even though there is plenty of room. it should only show ellipsis if there is no room for the control. On the same bar, move the shell button to the far right. Have the stats centered in the middle. also, the new microphone icon in the conversation input, have it vertically centered as the input height increases as more lines are added. finally, get sonnet 5, and fable 5 as the hard coded default so if the endpoint fails we have the latest .. investigate, put it all together into a spec, write to file"*
+
+This bundles four independent, small UI fixes discovered/designed in one investigation pass. Each is scoped so it can land as its own commit/PR; there is no dependency between them except items 1–2 touching the same file (`AgentComposerStrip.tsx` / `_composer-strip.scss`).
+
+---
+
+## 1. Runtime dropdown shows ellipsis with room to spare
+
+### Current behavior
+
+`AgentRuntimeDropup`'s trigger button (`frontend/app/view/agent/components/AgentRuntimeDropup.tsx:281-295`) renders a live `"Mode · Model · Effort"` summary (e.g. `"Auto · Sonnet 5 · Medium"`) inside `.agent-runtime-dropup-trigger-label`. The trigger and label are styled in `frontend/app/view/agent/styles/_composer-strip.scss:48-79`:
+
+```scss
+.agent-runtime-dropup-trigger {
+    display: inline-flex;
+    ...
+    max-width: 160px;   // <- fixed cap, unconditional
+    ...
+}
+
+.agent-runtime-dropup-trigger-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+```
+
+`max-width: 160px` is a **blanket cap** — it applies regardless of how much room `.agent-composer-strip` actually has. `.agent-composer-strip-controls` (the trigger's flex parent) is `flex-shrink: 0`, and the strip's right zone is pinned via `margin-left: auto`, so in a normal-width or wide pane there is plenty of unused space in the middle of the bar — the trigger still clips at 160px and shows `…` for no reason.
+
+### Fix
+
+Drop the unconditional cap; let the button size to its content (its neighbors already don't compete for the same space — `flex-shrink: 0` on both `.agent-composer-strip-controls` and `.agent-composer-strip-right` means the trigger is never squeezed in normal layouts). Keep `overflow/text-overflow/white-space` on the label as a defensive no-op most of the time, and only reintroduce a `max-width` inside the existing narrow-pane container query, where there genuinely isn't room:
+
+```scss
+.agent-runtime-dropup-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 3px;
+    // max-width removed — size to content; only constrained under real
+    // space pressure (see the ≤320px container query below).
+    ...
+}
+
+// _composer-strip.scss already has this breakpoint (line 236) — add the cap here instead of unconditionally:
+@container modal-mount (max-width: 320px) {
+    .agent-runtime-dropup-trigger { max-width: 120px; }
+    .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
+}
+```
+
+This satisfies "only show ellipsis if there is no room for the control" literally: unconstrained above 320px pane width, truncated only below it.
+
+**Files:** `frontend/app/view/agent/styles/_composer-strip.scss` (lines ~48-53, ~236-243).
+
+---
+
+## 2. Shell button to the far right; stats centered in the bar
+
+### Current behavior
+
+`AgentComposerStrip.tsx:155-215` renders two zones:
+
+- `.agent-composer-strip-controls` (left) — the runtime dropdown.
+- `.agent-composer-strip-right` (`margin-left: auto`) — in DOM order: **Shell button**, stats (`rightText()`), process badge, context text. All four are clustered together at the right edge; "centered" today only means "centered *within that right-edge cluster*," not centered in the bar.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ [Auto · Sonnet 5 · Medium ▴]      [Shell] ↑2.1k↓480 1m12s ⚙3 12k/64k │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Requested
+
+- Shell button moves to the absolute right edge of the bar (last, not first).
+- Stats (`rightText()` — tokens/elapsed) sit visually centered in the *whole bar*, not just within the right cluster.
+
+### Fix — 3-column grid
+
+A flex row with one auto-margin zone can't put something at the mathematical center of the bar while an unrelated-width item sits at the far right — the center point drifts with whatever's on either side. The standard fix (same pattern as a title bar: left controls / centered title / right actions) is a 3-column grid where the outer columns are symmetric (`1fr` each), guaranteeing the center column sits at true center regardless of how wide the left/right content is:
+
+```scss
+.agent-composer-strip {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    // flex-wrap/justify-content/gap rules below adapt accordingly — see
+    // the narrow-width note at the end of this section.
+    gap: var(--space-2);
+    ...
+}
+
+.agent-composer-strip-controls {
+    justify-self: start;
+    // unchanged otherwise
+}
+
+// NEW middle column — just the stats text, nothing else.
+.agent-composer-strip-stats-zone {
+    justify-self: center;
+}
+
+// Right column now holds process badge + ctx text + Shell, in that order —
+// Shell last so it's the rightmost element in the bar.
+.agent-composer-strip-right {
+    justify-self: end;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    // margin-left: auto no longer needed — the grid column does the pinning.
+}
+```
+
+Component change in `AgentComposerStrip.tsx` (`return` block, lines 155-215): pull `rightText()`'s `<span class="agent-composer-strip-stats">` out into its own top-level grid child, and reorder `.agent-composer-strip-right`'s children so the Shell button renders **last**:
+
+```tsx
+<div class="agent-composer-strip" ...>
+    <span class="agent-composer-strip-controls">...</span>
+
+    <Show when={rightText()}>
+        <span class="agent-composer-strip-stats-zone">
+            <span class="agent-composer-strip-stats">{rightText()}</span>
+        </span>
+    </Show>
+
+    <span class="agent-composer-strip-right">
+        <Show when={(props.processCount ?? 0) > 0}>...process badge...</Show>
+        <Show when={ctxText()}>...ctx text...</Show>
+        <button class="agent-composer-strip-log-btn" ...>Shell</button>
+    </span>
+</div>
+```
+
+When `rightText()` is empty (no turn in flight, no session totals yet), the middle grid column simply has no content and collapses to its content width (0) — the two `1fr` side columns are unaffected, so left/right stay correctly positioned either way.
+
+### Open question — narrow-pane fallback
+
+Today, `.agent-composer-strip { flex-wrap: wrap }` lets the right zone drop to its own row below the controls zone once both zones no longer fit on one line (the strip's own header comment describes this). A 3-column grid has no built-in equivalent of "wrap to a second row" — `1fr` columns just shrink toward zero instead of reflowing. Two options for whoever implements this:
+
+1. **Minimal:** keep the existing container-query breakpoints (`≤240px` hides stats/ctx, `≤320px` shrinks the trigger/Shell button — already in `_composer-strip.scss`) and accept that they now do the narrow-width work the old flex-wrap did. Likely sufficient in practice since those breakpoints already strip enough content that a 3-column squeeze shouldn't look broken.
+2. **Safer:** add one more breakpoint (e.g. `≤400px`) that overrides `.agent-composer-strip` back to `display: flex; flex-wrap: wrap` with the old margin-left:auto right-zone rule, preserving the exact old two-row fallback at extreme widths, with the grid layout only active above that threshold.
+
+Recommend starting with option 1 and only adding option 2 if manual testing at very narrow pane widths shows clipping/overlap.
+
+**Files:** `frontend/app/view/agent/components/AgentComposerStrip.tsx` (lines 155-215), `frontend/app/view/agent/styles/_composer-strip.scss` (lines 13-34, 161-172).
+
+---
+
+## 3. Mic icon should vertically center as the composer grows
+
+### Current behavior
+
+`frontend/app/view/agent/styles/_pending-footer.scss:78-88`:
+
+```scss
+.agent-input-mic {
+    position: absolute;
+    top: 3px;
+    right: 5px;
+    z-index: 1;
+}
+```
+
+This is a **deliberate** existing choice, per the comment directly above it — the mic was pinned to the top-right corner specifically so it would *not* drift as the textarea grows past one line (this reverses that choice; the comment should be updated, not just the rule).
+
+The textarea (`.agent-input`, same file, lines 102-138) auto-grows via `field-sizing: content` (no JS) between `min-height: 20px` and `max-height: 200px`, and `.agent-input-container` (line 72) is `position: relative` — the containing block the mic's `position: absolute` resolves against, and it grows in lockstep with the textarea.
+
+### Fix
+
+Track the container's vertical center instead of pinning to a fixed offset from the top — pure CSS, consistent with the codebase's existing zero-JS auto-grow approach (`docs/analysis/agent-typing-lag-trace-2026-04-12.md`, referenced at line 121):
+
+```scss
+// Pinned mic — right edge of the composer, vertically centered against the
+// input's current (growable) height so it tracks the middle of the box as
+// more lines are typed, rather than staying fixed to the top-right corner.
+.agent-input-mic {
+    position: absolute;
+    top: 50%;
+    right: 5px;
+    transform: translateY(-50%);
+    z-index: 1;
+}
+```
+
+At the single-line resting height (`min-height: 20px`) this lands within a couple pixels of the old `top: 3px` pin, so the common case looks effectively unchanged; the visible difference only appears once the box grows past one line, which is exactly the behavior requested.
+
+No change needed to the `:has(.mic-button-wrap) .agent-input { padding-right: 22px }` rule (line 98-100) — that reserves horizontal space only, unaffected by vertical positioning.
+
+**Files:** `frontend/app/view/agent/styles/_pending-footer.scss` (lines 78-88, plus the comment above it).
+
+---
+
+## 4. Hardcode Sonnet 5 / Fable 5 as curated defaults (endpoint-failure fallback)
+
+### Why this matters right now
+
+Confirmed live in this session: the srv log shows `model catalog: HTTP 401 Unauthorized from /v1/models` (`agentmux-srv/src/backend/model_catalog.rs:183-187` treats any non-2xx, including an expired OAuth token, as "fall back to the bundled curated catalog"). When that fetch fails, the dropdown shows whatever is hardcoded in the static list — today that's stale.
+
+### Current curated list
+
+`frontend/app/view/agent/providers/index.ts:198-202`:
+
+```ts
+models: [
+    { value: "opus", label: "Opus 4.8", description: "Claude Opus 4.8 — highest quality", aliases: ["claude-opus"] },
+    { value: "sonnet", label: "Sonnet 4.6", default: true, description: "Claude Sonnet 4.6 — balanced", aliases: ["claude-sonnet"] },
+    { value: "haiku", label: "Haiku 4.5", description: "Claude Haiku 4.5 — fastest", aliases: ["claude-haiku"] },
+],
+```
+
+`value: "sonnet"` is the CLI's own generic alias (always resolves to whatever Sonnet is current), so `--model sonnet` already invokes Sonnet 5 today regardless of this file — only the **label** ("Sonnet 4.6") is stale. Fable has no curated entry at all, so it's invisible whenever the API overlay hasn't (yet, or ever) succeeded.
+
+### Fix
+
+```ts
+models: [
+    { value: "opus", label: "Opus 4.8", description: "Claude Opus 4.8 — highest quality", aliases: ["claude-opus"] },
+    { value: "sonnet", label: "Sonnet 5", default: true, description: "Claude Sonnet 5 — balanced", aliases: ["claude-sonnet"] },
+    { value: "haiku", label: "Haiku 4.5", description: "Claude Haiku 4.5 — fastest", aliases: ["claude-haiku"] },
+    { value: "claude-fable-5", label: "Fable 5", description: "Claude Fable 5" },
+],
+```
+
+- Sonnet's `value` stays the generic alias `"sonnet"` (unchanged behavior for `--model`); only the label/description text is bumped.
+- Fable has no documented generic alias (unlike opus/sonnet/haiku), so its `value` is the concrete model id `claude-fable-5` — confirmed as the right id via existing precedent already in the codebase: `context-window.ts:38` and its test (`context-window.test.ts:15`) already special-case `"claude-fable-5"` for the 1M context-window band. **Not fabricated** here: no `aliases` entry is added, since there's no confirmed short alias for Fable in the CLI — verify against the installed Claude Code CLI's actual accepted `--model` values before shipping if one exists (would let the entry read as a proper alias like the other three, but isn't required for correctness).
+
+### Follow-on correctness issue this surfaces
+
+`setProviderModels()` (`providers/index.ts:569-601`) is what turns "Sonnet 4.6" into "Sonnet 5" automatically once the live API succeeds, by substring-matching each curated entry's `value` against API-returned ids:
+
+```ts
+const family = m.value.toLowerCase();                                    // e.g. "sonnet"
+const matches = apiModels.filter((a) => a.value.toLowerCase().includes(family));
+```
+
+This works indefinitely for opus/sonnet/haiku because their `value` is a short, version-agnostic word — `"claude-sonnet-6".includes("sonnet")` will still match a future version. It does **not** work the same way for the new Fable entry, because its `value` is the *concrete, version-pinned* id `"claude-fable-5"` — a future `"claude-fable-6"` would **not** contain that exact substring, so:
+
+1. The curated Fable row would never auto-refresh to "Fable 6" (stays stuck on "Fable 5" even once the API is reachable and reports a newer version).
+2. Worse, since the new API model wouldn't be `consumed` by step 1, it falls through to step 2 (`byFamily`, grouped by `familyKey()`) and gets **appended as a second, separate "Fable 6" entry** — a visible duplicate in the dropdown.
+
+**Recommended accompanying fix:** change step 1's matching from raw substring (`m.value.toLowerCase()`) to `familyKey()` equality (the same helper step 2 already uses, `providers/index.ts:545-548`):
+
+```ts
+const curated = base.models.map((m) => {
+    const family = familyKey(m.value);   // was: m.value.toLowerCase()
+    const matches = apiModels.filter((a) => familyKey(a.value) === family);
+    ...
+});
+```
+
+`familyKey("sonnet")` → `"sonnet"` (alphabetic tokens, no `-` to split, nothing to strip) and `familyKey("claude-fable-5")` → `"fable"` — both still match their respective families exactly as before for opus/sonnet/haiku, but now Fable (and any future curated entry pinned to a concrete id) auto-refreshes across version bumps the same way, with no duplicate-entry risk. This is a small, low-risk change confined to `setProviderModels()`; recommend shipping it in the same PR as the curated-list addition so the new Fable entry doesn't reintroduce the exact "stale label" bug this whole feature exists to fix.
+
+**Files:** `frontend/app/view/agent/providers/index.ts` (lines 198-202, and optionally 578-584 for the `familyKey()` fix).
+
+---
+
+## Summary of files touched
+
+```
+frontend/app/view/agent/styles/_composer-strip.scss             # 1, 2
+frontend/app/view/agent/components/AgentComposerStrip.tsx       # 2
+frontend/app/view/agent/styles/_pending-footer.scss              # 3
+frontend/app/view/agent/providers/index.ts                       # 4
+```
+
+No backend/Rust changes — `agentmux-srv/src/backend/model_catalog.rs` has no curated fallback of its own; the only hardcoded list lives in the frontend file above.
+
+## Verification plan (once implemented)
+
+1. `npx tsc --noEmit` — no type errors from the `AgentComposerStrip.tsx` JSX restructure.
+2. `task dev` — visually confirm: (a) the runtime trigger shows its full summary un-truncated in a normal-width pane and only ellipsizes below ~320px; (b) Shell sits at the far right with stats visibly centered in the bar at a few different pane widths; (c) the mic icon visibly tracks the vertical center as the composer grows past one line; (d) with the OAuth token still expired (current live state), the `/model` picker shows "Sonnet 5" and "Fable 5" rather than stale/missing entries.
+3. Re-run once Claude Code auth is refreshed to confirm the live API overlay still refreshes labels correctly on top of the new curated defaults (no duplicate Fable entries).
+
+---
+
+*End of spec. Not yet implemented — ready for review/go-ahead per item.*

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -5,9 +5,10 @@
  * AgentComposerStrip — slim 28-32px status row that sits directly above
  * the textarea in the agent pane composer region.
  *
- * LEFT:  AgentRuntimeDropup (single Mode · Model · Effort trigger) · Shell toggle
- * RIGHT: tokens (↑in ↓out) · elapsed · ⚙N process badge ·
- *        context text (12.1k / 64k)
+ * LEFT:   AgentRuntimeDropup (single Mode · Model · Effort trigger)
+ * CENTER: tokens (↑in ↓out) · elapsed — true-centered in the bar
+ * RIGHT:  ⚙N process badge · context text (12.1k / 64k) · Shell toggle
+ *         (Shell is rightmost — SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md)
  *
  * The strip bar itself is not clickable. "Shell" is the sole toggle for
  * the details drawer (ActivityLogPanel + the AgentShellSubblock terminal,
@@ -168,24 +169,20 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                 </Show>
             </span>
 
-            {/* Right zone — Shell toggle + stats + process badge + context text.
-                Floats right via margin-left:auto (not space-between) so it stays
-                pinned right whether it's sharing the row with the controls zone
-                or has wrapped onto its own line at narrow widths — see the
-                flex-wrap rules in _composer-strip.scss. */}
-            <span class="agent-composer-strip-right">
-                <button
-                    type="button"
-                    class="agent-composer-strip-log-btn"
-                    classList={{ "agent-composer-strip-log-btn--active": props.logOpen }}
-                    title={props.logOpen ? "Hide the shell" : "Show the shell (activity log + interactive terminal)"}
-                    onClick={() => props.onToggleLog()}
-                >
-                    Shell
-                </button>
+            {/* Center zone — token/elapsed stats, true-centered in the bar via
+                the grid's middle column (see _composer-strip.scss). The
+                wrapper span always renders (even with no stats yet) so the
+                grid keeps 3 children and the right zone stays in the
+                rightmost column instead of sliding into the middle one. */}
+            <span class="agent-composer-strip-stats-zone">
                 <Show when={rightText()}>
                     <span class="agent-composer-strip-stats">{rightText()}</span>
                 </Show>
+            </span>
+
+            {/* Right zone — process badge + context text + Shell toggle, in
+                that order so Shell is the rightmost element in the bar. */}
+            <span class="agent-composer-strip-right">
                 <Show when={(props.processCount ?? 0) > 0}>
                     <button
                         type="button"
@@ -210,6 +207,15 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                         {ctxText()}
                     </span>
                 </Show>
+                <button
+                    type="button"
+                    class="agent-composer-strip-log-btn"
+                    classList={{ "agent-composer-strip-log-btn--active": props.logOpen }}
+                    title={props.logOpen ? "Hide the shell" : "Show the shell (activity log + interactive terminal)"}
+                    onClick={() => props.onToggleLog()}
+                >
+                    Shell
+                </button>
             </span>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -1,0 +1,130 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Enter/Escape keyboard-handling tests for AgentQuestionPanel (reagent P2,
+ * PR #2060 — this file didn't exist before, so the global capture-phase
+ * keydown listener + its editable-target scoping had no regression
+ * coverage).
+ *
+ * Covers the P1 regression from the same review round: an earlier version
+ * of `isEditableTarget` stopped recognizing a plain `<input>` outside the
+ * panel (e.g. the Ctrl+F search bar, AgentSearchBar.tsx) as something Enter
+ * shouldn't be stolen from, so pressing Enter there silently submitted a
+ * fully-answered pending question.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentQuestionPanel } from "./AgentQuestionPanel";
+import type { ToolNode } from "../types";
+
+afterEach(() => {
+    cleanup();
+});
+
+const singleSelectQuestion = (toolUseId = "q1"): ToolNode => ({
+    type: "tool",
+    id: toolUseId,
+    tool: "Other",
+    params: {},
+    status: "awaiting_answer",
+    collapsed: false,
+    summary: "❓ Waiting for your answer",
+    question: {
+        type: "ask_user_question",
+        tool_use_id: toolUseId,
+        questions: [
+            {
+                question: "Pick a color",
+                header: "Test",
+                multiSelect: false,
+                options: [{ label: "Red" }, { label: "Blue" }],
+            },
+        ],
+    },
+});
+
+function enterOn(el: Element, shiftKey = false): void {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", shiftKey, bubbles: true, cancelable: true }));
+}
+
+function escapeOn(el: Element): void {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+}
+
+describe("AgentQuestionPanel keyboard handling", () => {
+    it("does not submit on Enter before any option is selected", () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        enterOn(document.body);
+        expect(onAnswer).not.toHaveBeenCalled();
+    });
+
+    it("submits on Enter with no prior focus inside the panel, once an option is selected", async () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("radio", { name: /Red/ }));
+
+        // The keystroke's target is document.body — nothing inside the panel
+        // has been clicked into for the keypress itself, matching the
+        // original bug scenario (the panel never auto-focuses).
+        enterOn(document.body);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        expect(onAnswer.mock.calls[0][0].answers_map["Pick a color"]).toBe("Red");
+    });
+
+    it("submits on Enter while the caret is in the 'Other' free-text field", async () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+
+        const user = userEvent.setup();
+        const otherInput = screen.getByPlaceholderText(/Type a custom answer/);
+        await user.type(otherInput, "Green");
+
+        enterOn(otherInput);
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        expect(onAnswer.mock.calls[0][0].answers_map["Pick a color"]).toBe("Green");
+    });
+
+    it("does NOT submit on Enter pressed in an editable input outside the panel (e.g. a search bar)", async () => {
+        const onAnswer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => (
+            <div class="agent-view">
+                <input data-testid="outside-input" type="text" />
+                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />
+            </div>
+        ));
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("radio", { name: /Red/ }));
+
+        const outsideInput = screen.getByTestId("outside-input") as HTMLInputElement;
+        enterOn(outsideInput);
+        expect(onAnswer).not.toHaveBeenCalled();
+    });
+
+    it("Escape defers instead of submitting", async () => {
+        const onAnswer = vi.fn();
+        const onDefer = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onDefer={onDefer} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("radio", { name: /Red/ }));
+
+        escapeOn(document.body);
+        expect(onDefer).toHaveBeenCalledTimes(1);
+        expect(onAnswer).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -147,15 +147,17 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         props.onDefer?.();
     };
 
-    // `<input>` covers both the radio/checkbox options AND the "Other"
-    // free-text field — none of them treat Enter as "insert a newline", so
-    // Enter should submit from any of them, same as the Submit button. Only
-    // a real multi-line field (a `<textarea>` elsewhere in the pane, e.g. the
-    // composer) or a contentEditable region needs Enter left alone.
-    const isTypingTarget = (target: EventTarget | null): boolean => {
+    // Any `<input>`/`<textarea>`/contentEditable is "editable" — this is the
+    // broad check (reagent P1, PR #2060: an earlier version of this file
+    // narrowed it to TEXTAREA/contentEditable only, so it no longer
+    // recognized a plain text `<input>` elsewhere in the pane — e.g. the
+    // Ctrl+F search bar, AgentSearchBar.tsx — as something Enter shouldn't
+    // be stolen from, silently submitting a fully-answered pending question
+    // while the user was just navigating search matches).
+    const isEditableTarget = (target: EventTarget | null): boolean => {
         const el = target as HTMLElement | null;
         if (!el) return false;
-        if (el.tagName === "TEXTAREA") return true;
+        if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") return true;
         return el.isContentEditable;
     };
 
@@ -167,11 +169,18 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         const paneRoot = rootRef?.closest(".agent-view") as HTMLElement | null;
         if (paneRoot && target && !paneRoot.contains(target)) return;
 
+        // Whether the keystroke actually originated inside this panel's own
+        // DOM (an option, the "Other" input, or the panel root itself) —
+        // mirrors AgentDecisionPanel's `inPanel` (AgentDecisionPanel.tsx:208).
+        const inPanel = !!rootRef && !!target && rootRef.contains(target);
+
         if (e.key === "Enter" && !e.shiftKey) {
-            // Don't hijack Enter in a real multi-line field elsewhere in the
-            // pane (e.g. the composer textarea) — everything inside this
-            // panel (options, "Other" input) submits on Enter instead.
-            if (isTypingTarget(target)) return;
+            // Outside the panel, don't hijack Enter from a real editable
+            // control elsewhere in the pane (composer textarea, Ctrl+F
+            // search input, etc.). Inside the panel, every control (options,
+            // "Other" free-text input) submits on Enter regardless — none of
+            // them treat Enter as "insert a newline".
+            if (!inPanel && isEditableTarget(target)) return;
             e.preventDefault();
             submit();
         } else if (e.key === "Escape") {

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -11,7 +11,7 @@
  * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
  */
 
-import { createEffect, createMemo, createSignal, For, Show, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import type { AskUserQuestionAnswer, AskUserQuestionRequest, ToolNode } from "../types";
 import "./AgentQuestionPanel.scss";
@@ -147,11 +147,31 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         props.onDefer?.();
     };
 
-    const onKeyDown = (e: KeyboardEvent) => {
+    // `<input>` covers both the radio/checkbox options AND the "Other"
+    // free-text field — none of them treat Enter as "insert a newline", so
+    // Enter should submit from any of them, same as the Submit button. Only
+    // a real multi-line field (a `<textarea>` elsewhere in the pane, e.g. the
+    // composer) or a contentEditable region needs Enter left alone.
+    const isTypingTarget = (target: EventTarget | null): boolean => {
+        const el = target as HTMLElement | null;
+        if (!el) return false;
+        if (el.tagName === "TEXTAREA") return true;
+        return el.isContentEditable;
+    };
+
+    const handleKey = (e: KeyboardEvent) => {
+        const target = e.target as HTMLElement | null;
+        // Scope to this panel's own pane so a question in pane A doesn't
+        // react to keystrokes typed in pane B. Mirrors AgentDecisionPanel
+        // (codex P1, PR #556).
+        const paneRoot = rootRef?.closest(".agent-view") as HTMLElement | null;
+        if (paneRoot && target && !paneRoot.contains(target)) return;
+
         if (e.key === "Enter" && !e.shiftKey) {
-            // Don't hijack Enter while typing in an "Other" field.
-            const tag = (e.target as HTMLElement | null)?.tagName;
-            if (tag === "INPUT" || tag === "TEXTAREA") return;
+            // Don't hijack Enter in a real multi-line field elsewhere in the
+            // pane (e.g. the composer textarea) — everything inside this
+            // panel (options, "Other" input) submits on Enter instead.
+            if (isTypingTarget(target)) return;
             e.preventDefault();
             submit();
         } else if (e.key === "Escape") {
@@ -159,6 +179,17 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
             defer();
         }
     };
+
+    // Global capture-phase listener, mirroring AgentDecisionPanel: the panel
+    // has tabindex=-1 and never auto-focuses, so a plain onKeyDown on the
+    // root div only fired once the user had already clicked something
+    // inside it — Enter otherwise never reached the handler at all.
+    createEffect(() => {
+        if (!request()) return;
+        const onWindowKey = (e: KeyboardEvent) => handleKey(e);
+        window.addEventListener("keydown", onWindowKey, true);
+        onCleanup(() => window.removeEventListener("keydown", onWindowKey, true));
+    });
 
     return (
         <Show when={request()} keyed>
@@ -168,6 +199,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                     fallback={
                         <button
                             type="button"
+                            ref={(el) => (rootRef = el)}
                             class="agent-question-panel-minimized"
                             onClick={() => setMinimized(false)}
                         >
@@ -185,7 +217,6 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                         role="group"
                         aria-label="Agent question"
                         tabindex={-1}
-                        onKeyDown={onKeyDown}
                     >
                         <div class="agent-question-panel-header">
                             <span class="agent-question-panel-icon" aria-hidden="true">❓</span>

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -197,8 +197,14 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // trap for any `models.find(m => m.default)` reader.
         models: [
             { value: "opus", label: "Opus 4.8", description: "Claude Opus 4.8 — highest quality", aliases: ["claude-opus"] },
-            { value: "sonnet", label: "Sonnet 4.6", default: true, description: "Claude Sonnet 4.6 — balanced", aliases: ["claude-sonnet"] },
+            { value: "sonnet", label: "Sonnet 5", default: true, description: "Claude Sonnet 5 — balanced", aliases: ["claude-sonnet"] },
             { value: "haiku", label: "Haiku 4.5", description: "Claude Haiku 4.5 — fastest", aliases: ["claude-haiku"] },
+            // No confirmed generic "fable" alias (unlike opus/sonnet/haiku above), so this
+            // pins the concrete model id directly — same id already relied on by
+            // context-window.ts's 1M-context-window band. Kept current here so the
+            // offline/API-failure fallback still shows it (see setProviderModels below
+            // for how this stays in sync with the live catalog once reachable).
+            { value: "claude-fable-5", label: "Fable 5", description: "Claude Fable 5" },
         ],
     },
     codex: {
@@ -556,14 +562,23 @@ function cleanLabel(label: string): string {
 /**
  * Fold the authoritative catalog into a provider's model list. Behavior-
  * preserving by design:
- *  - Curated family entries (opus/sonnet/haiku) keep their short `value` (which
- *    `--model` resolves to the current version), `default` marker, `aliases`,
- *    and `description`; only their **label** is refreshed to the newest matching
+ *  - Curated family entries (opus/sonnet/haiku/fable) keep their curated
+ *    `value` (for opus/sonnet/haiku, a short alias `--model` resolves to the
+ *    current version; fable has no such alias yet, so its `value` is the
+ *    concrete pinned id instead), `default` marker, `aliases`, and
+ *    `description`; only their **label** is refreshed to the newest matching
  *    API model. This is what turns "Sonnet 4.6" into "Sonnet 5" without changing
  *    what `--model` receives or breaking `models.find(m => m.default)`.
- *  - Families the curated list doesn't cover (Fable today, any future family)
- *    are appended automatically, one newest entry each, using the concrete API
- *    id as `value` (always a valid `--model` target). No family is hardcoded.
+ *  - Families the curated list doesn't cover (any future family) are appended
+ *    automatically, one newest entry each, using the concrete API id as
+ *    `value` (always a valid `--model` target). No family is hardcoded.
+ *  - Matching uses `familyKey()` (alphabetic tokens, "claude" stripped, digits
+ *    dropped) rather than a raw substring test, so a *version-pinned* curated
+ *    `value` (fable's `claude-fable-5`) still matches a future API version
+ *    (`claude-fable-6`) the same way a generic alias (`sonnet`) already does —
+ *    a plain `.includes()` test would only match the exact pinned string,
+ *    leaving the curated row stale AND appending a duplicate "extra" entry
+ *    once a newer version showed up in the API.
  * Empty input (no token / macOS Keychain / offline) is a no-op → static list.
  */
 export function setProviderModels(id: string, apiModels: ProviderModel[]): void {
@@ -576,8 +591,8 @@ export function setProviderModels(id: string, apiModels: ProviderModel[]): void 
 
     // 1. Refresh curated family labels from the newest API model in that family.
     const curated = base.models.map((m) => {
-        const family = m.value.toLowerCase();
-        const matches = apiModels.filter((a) => a.value.toLowerCase().includes(family));
+        const family = familyKey(m.value);
+        const matches = apiModels.filter((a) => familyKey(a.value) === family);
         if (matches.length === 0) return m;
         matches.forEach((a) => consumed.add(a.value)); // don't re-surface as an "extra"
         return { ...m, label: cleanLabel(pickNewest(matches).label) };

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -1,22 +1,23 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// AgentComposerStrip — slim 28-32px status row above the textarea, growing to
-// two rows at narrow widths (see the flex-wrap rules below).
-//   LEFT:  AgentRuntimeDropup (single Mode · Model · Effort trigger)
-//   RIGHT: Shell toggle · token stats · elapsed · process badge · context text
-//          (floats right via margin-left:auto; wraps onto its own row below
-//          the controls zone once both zones no longer fit on one line)
+// AgentComposerStrip — slim 28-32px status row above the textarea.
+//   LEFT:   AgentRuntimeDropup (single Mode · Model · Effort trigger)
+//   CENTER: token/elapsed stats, true-centered in the bar
+//   RIGHT:  process badge · context text · Shell toggle (Shell is rightmost)
+// 3-column grid (1fr auto 1fr) so the center column sits at the bar's
+// mathematical center regardless of how wide the left/right content is —
+// a flex row with one auto-margin zone can't do that once something sits
+// to the right of the auto-margin zone too (Shell used to be left-most in
+// that zone; now it's the last child of the right column instead).
 
 @use "../../../mixins.scss";
 
 .agent-composer-strip {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
-    justify-content: flex-start;
     gap: var(--space-2);
-    row-gap: var(--space-1);
     min-height: 28px;
     padding: var(--space-1) var(--space-2);
     font-size: 11px;
@@ -33,24 +34,32 @@
     }
 }
 
-// ── Controls zone (left) ────────────────────────────────────────────────────
+// ── Controls zone (left column) ─────────────────────────────────────────────
 
 .agent-composer-strip-controls {
     display: flex;
     align-items: center;
     gap: var(--space-1);
-    flex-shrink: 0;
+    justify-self: start;
+}
+
+// ── Stats zone (center column) ──────────────────────────────────────────────
+
+.agent-composer-strip-stats-zone {
+    justify-self: center;
 }
 
 // The consolidated Mode/Model/Effort trigger — a single <button> laying out
 // a "Mode · Model · Effort" summary label + up-caret; same slim-pill footprint
-// as the former three separate selects/drop-ups combined into one.
+// as the former three separate selects/drop-ups combined into one. No fixed
+// max-width — sizes to its content; a cap only reappears under real space
+// pressure (see the ≤320px container query below), so it only ellipsizes
+// when the pane genuinely has no room for it.
 .agent-runtime-dropup-trigger {
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
     gap: 3px;
-    max-width: 160px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
     border-radius: 0;
@@ -158,17 +167,17 @@
     }
 }
 
-// ── Right zone ──────────────────────────────────────────────────────────────
-// margin-left:auto (not space-between on the parent) pins this zone to the
-// right edge whether it's sharing the row with the controls zone or has
-// wrapped onto its own row — see .agent-composer-strip's flex-wrap.
+// ── Right zone (right column) ───────────────────────────────────────────────
+// Process badge · context text · Shell toggle, in that order — Shell last so
+// it's the rightmost element in the whole bar. justify-self:end pins the
+// column to the grid's right edge (the grid, not a margin trick, does the
+// pinning now).
 
 .agent-composer-strip-right {
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
-    flex-shrink: 0;
-    margin-left: auto;
+    justify-self: end;
 }
 
 .agent-composer-strip-stats {
@@ -240,6 +249,9 @@
     // SPEC_COMPOSER_STRIP_RESPONSIVE_ARCHITECTURE_2026_07_02. Progressive
     // collapse — short/icon/combined forms — is the follow-up.)
     .agent-composer-strip-log-btn { font-size: 9px; padding: 1px 3px; }
+    // Only reintroduce a cap here, where the pane genuinely doesn't have
+    // room for the trigger's full "Mode · Model · Effort" summary.
+    .agent-runtime-dropup-trigger { max-width: 120px; }
 }
 
 // ── Resizable details drawer (ResizableDetailsDrawer.tsx) ──────────────────

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -75,15 +75,16 @@
             gap: 1px;
             position: relative;
 
-            // Pinned mic — right edge of the composer, matching the
-            // header mic's old top-right feel but anchored to the input
-            // itself. Sits in the container's top-right corner rather than
-            // vertically centered against the textarea's full (growable)
-            // height, so it doesn't drift as the box grows past one line.
+            // Pinned mic — right edge of the composer, vertically centered
+            // against the input's current (growable) height so it tracks the
+            // middle of the box as more lines are typed, rather than staying
+            // fixed to the top-right corner (the earlier behavior — reversed
+            // per explicit request, SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md).
             .agent-input-mic {
                 position: absolute;
-                top: 3px;
+                top: 50%;
                 right: 5px;
+                transform: translateY(-50%);
                 z-index: 1;
             }
 


### PR DESCRIPTION
## Summary
- **AskUserQuestion Enter-to-submit**: `AgentQuestionPanel` never auto-focuses (tabindex=-1), so its local `onKeyDown` only fired after the user had already clicked into it — Enter otherwise did nothing. Fixed with the same global capture-phase keydown pattern `AgentDecisionPanel` already uses for the identical bug. Also loosened which targets block Enter: only a real multi-line field (the composer's `<textarea>`) or contentEditable should block it — the panel's own radio/checkbox options and the "Other" free-text `<input>` now all submit on Enter, since none of them treat Enter as "insert a newline."
- **Runtime dropdown ellipsis**: `.agent-runtime-dropup-trigger` had a fixed `max-width: 160px`, so it ellipsized even with plenty of room in the bar. Removed the unconditional cap; a width cap now only applies inside the existing `≤320px` container query, where there's a real space constraint.
- **Composer strip layout**: converted to a 3-column grid (`1fr auto 1fr`) so stats sit at the bar's true center regardless of left/right content width, and moved Shell to be the rightmost control (previously it was first in the right-edge cluster).
- **Mic icon**: now vertically centers via `top: 50%; transform: translateY(-50%)` as the composer's textarea grows, instead of staying pinned to the top-right corner.
- **Curated Claude model fallback**: bumped the hardcoded Sonnet label to "Sonnet 5" and added a curated "Fable 5" entry, so the `/model` picker shows current models even when the live catalog fetch fails (observed live on this branch: `HTTP 401` from an expired OAuth token). Also fixed `setProviderModels()`'s family-matching to use `familyKey()` instead of a raw substring test, so a version-pinned curated entry (fable has no generic alias) still auto-refreshes across future API versions instead of leaving a stale duplicate.

Full design writeup: `docs/specs/SPEC_COMPOSER_STRIP_LAYOUT_MIC_CENTER_MODEL_DEFAULTS_2026_07_10.md`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx stylelint` on both edited SCSS files — clean
- [x] `npx vitest run frontend/app/view/agent` — 52 files / 639 tests pass, no regressions
- [x] Enter-to-submit verified live in a `task dev` build (radio/checkbox selection case); typing-in-"Other" case verified live by the user after a follow-up fix
- [ ] Composer strip layout / mic centering / model defaults not yet visually re-verified live in this exact form — recommend a quick `task dev` click-through before merge

<!-- agentmux:agent_id=agenta -->