### PR TITLE
feat(agent): activity dock surfaces subagents (Phase 2 of the pinned dock spec)

### DIFF
--- a/.changesets/1783699317-feat-agent-activity-dock-surfaces-subagents-phase-2-of-the-p-ged0.md
+++ b/.changesets/1783699317-feat-agent-activity-dock-surfaces-subagents-phase-2-of-the-p-ged0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): activity dock surfaces subagents (Phase 2 of the pinned dock spec)

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -43,6 +43,11 @@ pub struct SubagentInfo {
     pub parent_agent: String,
     pub parent_block_id: String,
     pub session_id: String,
+    /// Unix ms when this subagent was first observed (set once, at
+    /// creation, never updated) — distinct from `last_event_at`, which
+    /// advances on every journal read. Needed by the frontend's activity
+    /// dock to render an elapsed timer / sort by spawn recency.
+    pub spawned_at: u64,
     pub last_event_at: u64,
     pub status: SubagentStatus,
     pub event_count: usize,
@@ -658,6 +663,7 @@ impl SubagentWatcher {
                         parent_agent: parent_agent.to_string(),
                         parent_block_id: parent_block_id.to_string(),
                         session_id: session_id.clone(),
+                        spawned_at: now_millis(),
                         last_event_at: now_millis(),
                         status: SubagentStatus::Active,
                         event_count: 0,
@@ -1434,6 +1440,7 @@ mod tests {
                 parent_agent: parent_agent.to_string(),
                 parent_block_id: String::new(),
                 session_id: session_id.to_string(),
+                spawned_at: 0,
                 last_event_at: 0,
                 status: SubagentStatus::Active,
                 event_count: 0,

--- a/frontend/app/view/agent/activity/subagent-adapter.test.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { ActiveSubagent } from "../../swarm/swarm-model";
+import { subagentActivities, subagentToActivity } from "./subagent-adapter";
+
+function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
+    return {
+        slug: "some-slug",
+        parent_agent: "parent",
+        parent_block_id: "block-1",
+        session_id: "session-1",
+        status: "active",
+        spawned_at: 1000,
+        last_event_at: 1000,
+        event_count: 0,
+        model: null,
+        workflow_id: null,
+        display_name: null,
+        ...overrides,
+    };
+}
+
+describe("subagentToActivity", () => {
+    it("maps active → running, using startedAt from spawned_at", () => {
+        const a = subagentToActivity(mk({ agent_id: "a1", status: "active", spawned_at: 500 }));
+        expect(a.kind).toBe("subagent");
+        expect(a.status).toBe("running");
+        expect(a.startedAt).toBe(500);
+        expect(a.endedAt).toBeUndefined();
+    });
+
+    it("maps completed → done, using last_event_at as endedAt", () => {
+        const a = subagentToActivity(mk({ agent_id: "a1", status: "completed", last_event_at: 900 }));
+        expect(a.status).toBe("done");
+        expect(a.endedAt).toBe(900);
+    });
+
+    it("prefers display_name, falling back to slug then agent_id", () => {
+        expect(subagentToActivity(mk({ agent_id: "a1", display_name: "Fixing auth" })).title).toBe("Fixing auth");
+        expect(subagentToActivity(mk({ agent_id: "a1", display_name: null, slug: "cool-slug" })).title).toBe("cool-slug");
+        expect(subagentToActivity(mk({ agent_id: "a1", display_name: null, slug: "" })).title).toBe("a1");
+    });
+
+    it("is never stoppable — no cancel RPC exists for subagents today", () => {
+        expect(subagentToActivity(mk({ agent_id: "a1", status: "active" })).canStop).toBe(false);
+    });
+
+    it("carries the source ActiveSubagent for the row's tail + expanded view", () => {
+        const sub = mk({ agent_id: "a1" });
+        expect(subagentToActivity(sub).subagent).toBe(sub);
+    });
+});
+
+describe("subagentActivities", () => {
+    it("filters to only the given block's subagents", () => {
+        const all = [
+            mk({ agent_id: "a1", parent_block_id: "block-1" }),
+            mk({ agent_id: "a2", parent_block_id: "block-2" }),
+            mk({ agent_id: "a3", parent_block_id: "block-1" }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result.map((a) => a.id)).toEqual(["a1", "a3"]);
+    });
+
+    it("returns an empty array when no subagents match the block", () => {
+        expect(subagentActivities([mk({ agent_id: "a1", parent_block_id: "block-2" })], "block-1")).toEqual([]);
+    });
+});

--- a/frontend/app/view/agent/activity/subagent-adapter.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.ts
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Subagent adapter — maps `ActiveSubagent`s (swarm-model.ts, sourced from the
+ * shared `subagent-source.ts` singleton) onto `PinnedActivity` for the dock,
+ * filtered to one agent pane's own spawns (`parent_block_id`). Phase 2 of the
+ * dock — proves the `PinnedActivity` abstraction generalizes beyond shells.
+ *
+ * `canStop` is always `false`: no subagent-cancel RPC/UI exists anywhere in
+ * the app today (confirmed — `AgentStopCommand` targets a pane's own agent
+ * process, not a subagent by `agent_id`; the Swarm pane itself has no cancel
+ * action either). Wiring a real cancel is its own follow-up, not invented
+ * here just because the dock's row chrome has a stop button slot.
+ *
+ * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md (§3, §7)
+ */
+
+import type { ActiveSubagent } from "../../swarm/swarm-model";
+import type { ActivityStatus, PinnedActivity } from "./types";
+
+function subagentStatusToActivity(s: ActiveSubagent["status"]): ActivityStatus {
+    switch (s) {
+        case "active": return "running";
+        case "completed": return "done";
+    }
+}
+
+export function subagentToActivity(s: ActiveSubagent): PinnedActivity {
+    return {
+        id: s.agent_id,
+        kind: "subagent",
+        // `||`, not `??` — an empty-string slug (before the watcher reads the
+        // JSONL's first line) must fall through to agent_id, same as
+        // swarm-view.tsx's own equivalent fallback chain.
+        title: s.display_name || s.slug || s.agent_id,
+        status: subagentStatusToActivity(s.status),
+        startedAt: s.spawned_at,
+        // last_event_at at the moment a subagent completes is its own
+        // result event's timestamp — the closest thing to an "ended at"
+        // ActiveSubagent exposes (there is no dedicated field).
+        endedAt: s.status === "completed" ? s.last_event_at : undefined,
+        canStop: false,
+        subagent: s,
+    };
+}
+
+/** This pane's own subagents (`parent_block_id === blockId`), mapped to activities. */
+export function subagentActivities(all: ReadonlyArray<ActiveSubagent>, blockId: string): PinnedActivity[] {
+    const out: PinnedActivity[] = [];
+    for (const s of all) {
+        if (s.parent_block_id === blockId) out.push(subagentToActivity(s));
+    }
+    return out;
+}

--- a/frontend/app/view/agent/activity/subagent-source.ts
+++ b/frontend/app/view/agent/activity/subagent-source.ts
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared, app-lifetime source of every active/recent subagent, for the
+ * activity dock's subagent adapter. One module-level singleton instead of a
+ * per-`ActivityDock`-instance fetch+subscribe: every agent pane's dock reads
+ * the same signal, so opening N panes costs one `ListActive` poll cycle, not
+ * N. Mirrors `SwarmViewModel`'s own `loadSubagents` + event wiring
+ * (`swarm-model.ts`), just as a bare singleton rather than a per-pane
+ * ViewModel — the dock only needs the list, not Swarm's tree/expand-state
+ * machinery.
+ *
+ * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md §3, §7
+ * (subagent adapter).
+ */
+
+import { callBackendService } from "@/app/store/wos";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { createSignal, type Accessor } from "solid-js";
+import { mergeSubagentsPreservingIdentity, type ActiveSubagent } from "../../swarm/swarm-model";
+
+const [allSubagents, setAllSubagents] = createSignal<ActiveSubagent[]>([]);
+
+async function refresh(): Promise<void> {
+    try {
+        const result = await callBackendService("subagent", "ListActive", []);
+        const list = (result as ActiveSubagent[]) ?? [];
+        setAllSubagents((prev) => mergeSubagentsPreservingIdentity(prev, list));
+    } catch {
+        // silently ignore — dock just shows no subagent rows this refresh
+    }
+}
+
+// Started once at module load (ES modules are singletons — every importer
+// shares this one subscription set), never torn down: the dock's subagent
+// rows should reflect swarm-wide activity for the lifetime of the app, same
+// as `providers/index.ts`'s `modelOverlay` singleton.
+void refresh();
+waveEventSubscribe({ eventType: "subagent:spawned", handler: () => void refresh() });
+waveEventSubscribe({ eventType: "subagent:completed", handler: () => void refresh() });
+waveEventSubscribe({
+    eventType: "subagent:named",
+    handler: (event: WaveEvent) => {
+        const data = event?.data as { agentId?: string; displayName?: string } | undefined;
+        if (!data?.agentId || !data.displayName) return;
+        setAllSubagents((prev) =>
+            prev.map((s) => (s.agent_id === data.agentId ? { ...s, display_name: data.displayName! } : s))
+        );
+    },
+});
+
+/** Every subagent currently known (active or recently completed), across the
+ *  whole app. Callers filter by `parent_block_id` for their own pane. */
+export const allSubagentsAtom: Accessor<ActiveSubagent[]> = allSubagents;

--- a/frontend/app/view/agent/activity/types.ts
+++ b/frontend/app/view/agent/activity/types.ts
@@ -6,13 +6,15 @@
  *
  * Anything long-running an agent spawns (a shell, a cron, a subagent) maps onto
  * this contract and renders as a uniform row in the dock at the top of the
- * agent pane. Phase 1 implements only the `shell` kind; `cron` and `subagent`
- * adapters slot in later without touching the dock/row chrome.
+ * agent pane. Phase 1 implemented the `shell` kind; Phase 2 (this file) adds
+ * `subagent`. `cron` still has no adapter — it's sugar over a `shell` per the
+ * spec (§6), not yet built.
  *
  * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md
  */
 
 import type { ShellNode } from "../types";
+import type { ActiveSubagent } from "../../swarm/swarm-model";
 
 export type ActivityKind = "shell" | "cron" | "subagent";
 
@@ -34,6 +36,8 @@ export interface PinnedActivity {
     // ── Kind-specific source, read by the row's tail + Expanded view ──
     /** Present when `kind === "shell"` (also "cron", which is a shell). */
     shell?: ShellNode;
+    /** Present when `kind === "subagent"`. */
+    subagent?: ActiveSubagent;
 }
 
 /** Per-kind sigil; colored by status in CSS. */

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1072,6 +1072,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 SPEC_ACTIVITY_DOCK_BOTTOM_MOVE_2026_06_20. */}
             <ActivityDock
                 documentAtom={agentAtoms().documentAtom}
+                blockId={model.blockId}
             />
 
             {/* Composer status strip — single 28-32px row with live

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -3,8 +3,8 @@
 
 /**
  * ActivityDock — a strip pinned above the composer listing every long-running
- * activity (Phase 1: shells) as a uniform row. Click a row → its live view
- * expands in the dock; click again → collapses.
+ * activity (shells + subagents spawned by this pane) as a uniform row. Click
+ * a row → its live view expands in the dock; click again → collapses.
  *
  * Expansion state is local to the dock (`expandedIds` signal). It is intentionally
  * NOT shared with `documentState.pinnedNodes` — that shared state caused the
@@ -23,6 +23,8 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { ActivityRow } from "./ActivityRow";
 import { shellActivities } from "../activity/shell-adapter";
+import { subagentActivities } from "../activity/subagent-adapter";
+import { allSubagentsAtom } from "../activity/subagent-source";
 import { RETENTION_MS, type ActivityKind, type ActivityStatus, type PinnedActivity } from "../activity/types";
 import type { SignalPair } from "../state";
 import type { DocumentNode } from "../types";
@@ -44,6 +46,10 @@ function overflowSummary(items: PinnedActivity[]): string {
 
 interface ActivityDockProps {
     documentAtom: SignalPair<DocumentNode[]>;
+    /** This pane's own block id — scopes the subagent adapter to subagents
+     *  spawned by THIS agent (D5: the dock is block-scoped), same as shells
+     *  are already scoped by living in this pane's own document. */
+    blockId: string;
 }
 
 export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
@@ -55,7 +61,10 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
     // expanding in the dock does not also expand the inline PersistentShellBlock.
     const [expandedIds, setExpandedIds] = createSignal<Set<string>>(new Set());
 
-    const allActivities = createMemo(() => shellActivities(nodes()));
+    const allActivities = createMemo(() => [
+        ...shellActivities(nodes()),
+        ...subagentActivities(allSubagentsAtom(), props.blockId),
+    ]);
 
     const activityById = createMemo(() => {
         const m = new Map<string, PinnedActivity>();

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -21,6 +21,8 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX 
 import { useTick } from "@/app/hook/useTick";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { callBackendService } from "@/app/store/wos";
+import { recordTurn } from "@/app/store/token-usage";
 import { ActivityRow } from "./ActivityRow";
 import { shellActivities } from "../activity/shell-adapter";
 import { subagentActivities } from "../activity/subagent-adapter";
@@ -148,12 +150,26 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
     });
 
     const togglePin = (id: string): void => {
+        const wasExpanded = expandedIds().has(id);
         setExpandedIds((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);
             else next.add(id);
             return next;
         });
+        // First-expand-ever name generation — mirrors SubagentRow.handleToggle
+        // (swarm-view.tsx). Without this, a subagent expanded only via the
+        // dock (never via the Swarm pane) would permanently show its raw
+        // slug/agent_id: nothing else triggers GenerateName (reagent P2, PR
+        // #2062).
+        if (!wasExpanded) {
+            const a = activityById().get(id);
+            if (a?.kind === "subagent" && a.subagent && !a.subagent.display_name) {
+                void callBackendService("subagent", "GenerateName", [id]).then((result: any) => {
+                    if (result?.tokens) recordTurn("ambient:subagent_name", result.tokens);
+                });
+            }
+        }
     };
 
     const stop = (id: string): void => {

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -10,12 +10,29 @@
  */
 
 import clsx from "clsx";
-import { For, Show, createMemo, type JSX } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
+import { createSubagentDetail, type SubagentDetail, type SubagentEvent } from "../../swarm/swarm-model";
 import { KIND_SIGIL, type PinnedActivity } from "../activity/types";
 import type { ToolLogChunk } from "../types";
+
+/** One-line text summary per subagent event kind — deliberately simpler than
+ *  the Swarm pane's own `SubagentDetailEvent` (no per-event expand/collapse,
+ *  no dedicated CSS): the dock reuses the existing shell-log line chrome
+ *  (`.agent-tool-log-line`) instead of depending on `swarm-view.scss`, which
+ *  only loads once the user has opened a Swarm pane this session. */
+function subagentEventLine(e: SubagentEvent): string {
+    const t = e.event_type;
+    switch (t.type) {
+        case "text": return t.content;
+        case "result": return t.content;
+        case "progress": return t.output;
+        case "tool_use": return `→ ${t.name}`;
+        case "tool_result": return t.is_error ? `✗ ${t.preview}` : t.preview;
+    }
+}
 
 const KIND_CLASS: Record<string, string> = {
     stdout: "agent-tool-log-line--stdout",
@@ -62,14 +79,24 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
     });
 
     const tail = createMemo((): string | undefined => {
-        const sh = props.activity()?.shell;
-        if (!sh) return undefined;
-        const chunks = sh.log.chunks;
-        for (let i = chunks.length - 1; i >= 0; i--) {
-            const c = chunks[i];
-            if ((c.kind === "stdout" || c.kind === "stderr") && c.content.trim()) {
-                return c.content.trim();
+        const a = props.activity();
+        if (!a) return undefined;
+        if (a.shell) {
+            const chunks = a.shell.log.chunks;
+            for (let i = chunks.length - 1; i >= 0; i--) {
+                const c = chunks[i];
+                if ((c.kind === "stdout" || c.kind === "stderr") && c.content.trim()) {
+                    return c.content.trim();
+                }
             }
+            return undefined;
+        }
+        if (a.subagent) {
+            // Cheap tail from data already on ActiveSubagent — no extra
+            // fetch/subscribe just to render a collapsed row's tail (that
+            // cost is reserved for the expanded view, below).
+            const n = a.subagent.event_count;
+            return n > 0 ? `${n} event${n === 1 ? "" : "s"}` : undefined;
         }
         return undefined;
     });
@@ -81,6 +108,22 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
         return sh
             ? chunkCap(sh.log.chunks as ToolLogChunk[])
             : { chunks: [] as ToolLogChunk[], hiddenLines: 0 };
+    });
+
+    // Expanded subagent transcript — created only while this row is actually
+    // expanded (mirrors SwarmViewModel's own lazy `getSubagentDetail` cache),
+    // disposed on collapse/unmount so an idle dock isn't holding N live
+    // event subscriptions for subagents nobody is looking at.
+    const [subagentDetail, setSubagentDetail] = createSignal<SubagentDetail | null>(null);
+    createEffect(() => {
+        const sub = props.activity()?.subagent;
+        if (!props.expanded() || !sub) {
+            setSubagentDetail(null);
+            return;
+        }
+        const detail = createSubagentDetail(sub.agent_id);
+        setSubagentDetail(detail);
+        onCleanup(() => detail.dispose());
     });
 
     return (
@@ -136,6 +179,23 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
                             <Show when={a().shell!.log.open}>
                                 <div class="agent-shell-streaming-indicator" />
                             </Show>
+                        </div>
+                    </Show>
+
+                    <Show when={props.expanded() && a().subagent}>
+                        <div
+                            class="agent-activity-log agent-tool-overlay-log"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <Show when={subagentDetail()?.statusAtom() === "loading"}>
+                                <pre class="agent-tool-log-line">Loading…</pre>
+                            </Show>
+                            <Show when={subagentDetail() && subagentDetail()!.eventsAtom().length === 0 && subagentDetail()!.statusAtom() !== "loading"}>
+                                <pre class="agent-tool-log-line">No activity yet</pre>
+                            </Show>
+                            <For each={subagentDetail()?.eventsAtom() ?? []}>
+                                {(event) => <pre class="agent-tool-log-line">{subagentEventLine(event)}</pre>}
+                            </For>
                         </div>
                     </Show>
                 </div>

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -19,6 +19,7 @@ function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id"
         parent_block_id: "block-1",
         session_id: "session-1",
         status: "completed",
+        spawned_at: 0,
         last_event_at: 0,
         event_count: 1,
         model: null,

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -21,6 +21,9 @@ export interface ActiveSubagent {
     parent_block_id: string;
     session_id: string;
     status: "active" | "completed";
+    /** Unix ms when this subagent was first observed — set once, immutable.
+     *  Distinct from `last_event_at`, which advances on every journal read. */
+    spawned_at: number;
     last_event_at: number;
     event_count: number;
     model: string | null;


### PR DESCRIPTION
## Summary

`SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md` designed the pinned activity dock as a kind-pluggable abstraction (`shell | cron | subagent`), but only Phase 1 (the shell adapter) ever shipped — subagents (Task-tool runs) spawned by an agent pane were only visible in the separate Swarm pane, not in the pane's own dock. This closes that gap: subagents this pane spawned now show up as dock rows, click-to-expand their live transcript in place, same as shells already do.

- **`agentmux-srv/subagent_watcher.rs`**: added `spawned_at` to `SubagentInfo` — there was no spawn timestamp exposed to the frontend to drive the dock's elapsed timer / newest-first ordering (only `last_event_at`, which advances on every journal read, not just at creation).
- **`activity/subagent-source.ts`** (new): one app-lifetime singleton (`ListActive` + `subagent:spawned/completed/named` subscriptions) shared by every open agent pane's dock, instead of each pane polling independently — mirrors `SwarmViewModel`'s own wiring as a bare signal.
- **`activity/subagent-adapter.ts`** (new): `ActiveSubagent → PinnedActivity`, filtered to this pane's own `parent_block_id` (dock is block-scoped per the spec's D5). `canStop` is always `false` — confirmed no subagent-cancel RPC/UI exists anywhere in the app today (not even in the Swarm pane itself), so this doesn't invent one just because the row chrome has a stop-button slot.
- **`ActivityRow.tsx`**: tail shows `"N events"` (cheap, from data already on `ActiveSubagent`); expanded view lazily creates/disposes a `createSubagentDetail()` subscription only while a row is actually expanded, rendering plain-text lines via the existing `.agent-tool-log-line` chrome rather than reusing Swarm's richer `SubagentDetailPane` (which depends on `swarm-view.scss`, only loaded once a Swarm pane has been opened).

## Test plan
- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv subagent_watcher` — 30 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent frontend/app/view/swarm` — 55 files / 667 tests pass, no regressions
- [x] New `subagent-adapter.test.ts` — 7 tests covering status mapping, title fallback (caught and fixed a real `??` vs `||` bug on empty-string slug), block filtering, and the always-`canStop: false` decision
- [ ] Not yet click-tested live in a running build — recommend a `task dev` pass (spawn a Task-tool subagent from an agent pane, confirm it appears in that pane's dock and expands to show its transcript) before merge

<!-- agentmux:agent_id=agenta -->