### PR TITLE
docs(specs): mark Ableton MCP pilot Phase B owned by AgentY

### DIFF
--- a/docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md
+++ b/docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md
@@ -148,12 +148,12 @@ No change to `build_mcp_config_from_refs`'s output shape — `config_hash`/`prer
 
 ## 7. Phasing
 
-| Phase | Scope | Depends on |
-|---|---|---|
-| **A** | §4.1 structured config UI + interpolation, §4.4 health probe + `mcp-capabilities.ts`, §5 migration | none — pure additive extension of the shipped Phase 1 primitive |
-| **B** | §4.6 catalog UI + the Ableton catalog entry + pilot acceptance bar (§6) | Phase A (needs the probe to render the remediation string) |
-| **C** | §4.2 secrets-via-Account indirection, §4.3 OAuth (DCR + static fallback) | Phase A; reuses existing Account/OAuth infra, additive |
-| **D** | §4.5 tool introspection/disable, §4.7 config-hash pinning | Phase A; D's approval-gate *enforcement* is explicitly deferred to the future Policy primitive — D here only stores the data it needs |
+| Phase | Scope | Depends on | Owner |
+|---|---|---|---|
+| **A** | §4.1 structured config UI + interpolation, §4.4 health probe + `mcp-capabilities.ts`, §5 migration | none — pure additive extension of the shipped Phase 1 primitive | Shipped (#2030) |
+| **B** | §4.6 catalog UI + the Ableton catalog entry + pilot acceptance bar (§6) | Phase A (needs the probe to render the remediation string) | AgentY (2026-07-10) — building on the shipped Phase A probe; TouchDesigner/ComfyUI entries fold in as follow-ons once the Ableton pattern validates, per this section's own recommendation, not a separate track |
+| **C** | §4.2 secrets-via-Account indirection, §4.3 OAuth (DCR + static fallback) | Phase A; reuses existing Account/OAuth infra, additive | Open |
+| **D** | §4.5 tool introspection/disable, §4.7 config-hash pinning | Phase A; D's approval-gate *enforcement* is explicitly deferred to the future Policy primitive — D here only stores the data it needs | Open |
 
 Ableton MCP (Phase B) intentionally ships **before** OAuth (Phase C) — it validates the highest-value, lowest-risk slice (structured config + health probe) end-to-end on a real third-party server before the OAuth surface (the piece with the largest security blast radius per §3's CVE notes) gets built.
 


### PR DESCRIPTION
## Summary

- Coordinated with AgentY over muxbus: they independently built a catalog UI on top of the shipped Phase A probe (#2030) and caught an RPC-name collision (`mcp.catalog.probe`) before opening a PR.
- Phase B (§4.6 catalog UI + Ableton entry) was open on my end — no branch/PR in flight — so AgentY is taking it forward.
- This just records that in the spec's phasing table so no one else picks up Phase B in parallel.

<!-- agentmux:agent_id=agent1 -->