### PR TITLE
feat(identity): launch modal + create-from-template pick accounts directly

### DIFF
--- a/.changesets/1783702272-feat-identity-launch-modal-create-from-template-pick-account-wuje.md
+++ b/.changesets/1783702272-feat-identity-launch-modal-create-from-template-pick-account-wuje.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(identity): launch modal + create-from-template pick accounts directly, no bundle

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -12,7 +12,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
-import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
+import { AgentAddAccountModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
 import { AgentNewMemoryModalPanel } from "@/app/view/agent/components/AgentNewMemoryModal";
 import { AgentCreateFromTemplateModalPanel } from "@/app/view/agent/components/AgentCreateFromTemplateModal";
 import { BrowserAuthModalPanel } from "@/app/view/browser/components/BrowserAuthModal";
@@ -31,8 +31,8 @@ export function requestLabel(req: ModalLayerRequest): string {
     switch (req.kind) {
         case "launch-agent":
             return `Launch ${req.agent.name}`;
-        case "new-identity":
-            return "New Identity";
+        case "add-account":
+            return "Add Account";
         case "new-memory":
             return "New Preset";
         case "agent-prereqs":
@@ -77,54 +77,31 @@ export function renderRequest(
                             }
                         }}
                         initialFormState={req.initialFormState}
-                        autoStartAuth={req.autoStartAuth}
-                        onRequestNewIdentity={req.onRequestNewIdentity}
+                        onRequestAddAccount={req.onRequestAddAccount}
                         onRequestNewMemory={req.onRequestNewMemory}
                     />
                 ),
             };
-        case "new-identity":
+        case "add-account":
             return {
                 label: requestLabel(req),
                 panel: (
-                    <AgentNewIdentityModalPanel
+                    <AgentAddAccountModalPanel
+                        provider={req.provider}
                         initialName={req.initialName}
-                        purpose={req.purpose}
-                        // The layer owns the RPC + chaining so its
-                        // `submitting()` flag (which gates safeClose)
-                        // tracks the in-flight call. Mirrors the
-                        // launch-agent dispatch above — reagent P1 on
-                        // PR #911.
-                        onSubmit={async ({ name, description }) => {
-                            setSubmitting(true);
-                            try {
-                                // Wire convention from identity-pane-
-                                // model.ts:bundleDraftToWire — empty id
-                                // triggers server-side uuid; 0 timestamps
-                                // trigger server-side now-stamping. Keeps
-                                // id/timestamp handling in one place
-                                // (codex P2 on PR #910 round 3).
-                                const bundle = await RpcApi.UpsertIdentityBundleCommand(
-                                    TabRpcClient,
-                                    {
-                                        id: "",
-                                        name,
-                                        description,
-                                        is_blank: false,
-                                        created_at: 0,
-                                        updated_at: 0,
-                                    },
-                                );
-                                setSubmitting(false);
-                                // Caller's onCreated does modalLayer.replace
-                                // back to Launch with the new id
-                                // preselected — that's what unmounts this
-                                // panel. We don't `api.close()` here.
-                                req.onCreated(bundle.id, bundle.name);
-                            } catch (e) {
-                                setSubmitting(false);
-                                throw e;
-                            }
+                        // Unlike the old bundle flow, the RPC
+                        // (`account.key.verify`) lives inside the panel
+                        // itself — it needs to run the live-probe
+                        // before knowing the resulting account id, and
+                        // the panel already tracks its own submitting
+                        // state for that. This callback just forwards
+                        // the result to the caller's chain.
+                        onSubmit={async ({ accountId }) => {
+                            // Caller's onCreated does modalLayer.replace
+                            // back to Launch with the new id
+                            // preselected — that's what unmounts this
+                            // panel. We don't `api.close()` here.
+                            req.onCreated(accountId);
                         }}
                         // Caller's onCancel does modalLayer.replace back to
                         // Launch with the prior selection intact. Running
@@ -226,7 +203,7 @@ export function renderRequest(
                         // (spec note on CreateFromTemplateRequest) so
                         // `submitting()` covers both RPC steps and ESC
                         // / backdrop dismiss stay blocked end-to-end.
-                        onSubmit={async ({ name, identityId, memoryId, agentType }) => {
+                        onSubmit={async ({ name, accountId, memoryId, agentType }) => {
                             setSubmitting(true);
                             try {
                                 const resp = await RpcApi.AgentDefCreateFromTemplateCommand(
@@ -234,7 +211,7 @@ export function renderRequest(
                                     {
                                         template_id: req.template.id,
                                         name,
-                                        identity_id: identityId,
+                                        identity_id: accountId,
                                         memory_id: memoryId,
                                         // Persist the chosen runtime on the
                                         // new user-owned definition so later

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -19,7 +19,7 @@ export type ModalLayerRequest =
     | LaunchAgentRequest
     | InstallAgentRequest
     | AgentPrereqRequest
-    | NewIdentityBundleRequest
+    | AddAccountRequest
     | NewMemoryBundleRequest
     | CreateFromTemplateRequest
     | BrowserAuthRequest
@@ -41,36 +41,20 @@ export interface LaunchAgentRequest {
      */
     onSubmit: (overrides: LaunchAgentSubmit) => Promise<void> | void;
     /** Initial form state for the launch modal — used by the
-     *  "+ New" → create → replace-back flow to restore the user's
-     *  in-progress edits (name, runtime, image, identity, memory)
-     *  across the new-bundle round-trip. */
+     *  "+ Add account" → create → replace-back flow to restore the
+     *  user's in-progress edits (name, runtime, image, account, memory)
+     *  across the round-trip. */
     initialFormState?: Partial<LaunchFormStateWire>;
-    /** When true, the launch modal fires its OAuth `startConnect()`
-     *  exactly once on mount. Set by the OAuth-Connect → New Identity
-     *  → launch round-trip (spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md
-     *  §2): after the user names the bundle and clicks Continue, the
-     *  launch modal re-opens with the new identity preselected and
-     *  this hint set, so OAuth resumes automatically against the
-     *  freshly-named bundle instead of waiting for a second click. */
-    autoStartAuth?: boolean;
-    /** Optional callback fired when the user wants to create a new
-     *  identity bundle. Caller is expected to call
-     *  modalLayer.replace(newIdentityRequest) — the picker does this.
+    /** Optional callback fired when the user wants to add a new
+     *  (manual/API-key) account. Caller is expected to call
+     *  modalLayer.replace(addAccountRequest) — the picker does this.
      *  The `current` snapshot carries the modal's live form state so
-     *  the picker can preserve it across the new-bundle round-trip.
-     *
-     *  `purpose` distinguishes the two entry points:
-     *   - `"create"` (the plain `+ New identity` button): create a
-     *     named bundle and return to the launch form.
-     *   - `"oauth-continue"` (the OAuth Connect `needs-bundle` click):
-     *     create a named bundle, return to the launch form with the
-     *     new id preselected AND `autoStartAuth` set so OAuth resumes
-     *     automatically against the named bundle.
-     *  Spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
-    onRequestNewIdentity?: (
-        current: LaunchFormStateWire,
-        purpose: "create" | "oauth-continue",
-    ) => void;
+     *  the picker can preserve it across the round-trip. Issue #1624
+     *  PR-C Part B — OAuth Connect no longer routes through this
+     *  callback (it starts directly from the launch modal's auth
+     *  panel); this now only fires for the "+ Add account" button.
+     *  Replaces `onRequestNewIdentity`. */
+    onRequestAddAccount?: (current: LaunchFormStateWire) => void;
     /** Same for "+ New memory". */
     onRequestNewMemory?: (current: LaunchFormStateWire) => void;
 }
@@ -82,7 +66,7 @@ export interface LaunchFormStateWire {
     name: string;
     runtime: "host" | "container";
     image: string;
-    identityId: string;
+    accountId: string;
     memoryId: string;
     /** Continuation context — the `continueOfId` from the Continue
      *  dropdown. `null` = "— New agent —". Threaded through the
@@ -153,31 +137,32 @@ export interface AgentPrereqRequest {
 }
 
 /**
- * "+ New" affordance on the Launch modal's Identity row creates an
- * empty Identity bundle. Connector setup (Claude/Codex/GitHub/AWS)
- * happens in the Identity pane afterward.
+ * "+ Add account" affordance on the Launch modal's Identity row —
+ * creates a manual/API-key `IdentityAccount` directly (no bundle).
+ * OAuth Connect no longer routes through this modal (issue #1624
+ * PR-C Part B — it starts directly from the launch modal's auth
+ * panel, which mints the account backend-side).
  *
- * The actual UpsertIdentityBundle RPC is owned by the layer so its
+ * The actual account.key.verify RPC is owned by the layer so its
  * `submitting()` flag (which gates safeClose) tracks the in-flight
  * call. Callers only supply the chain callbacks for after-success / on-cancel.
  *
- * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md. Replaces
+ * `NewIdentityBundleRequest`.
  */
-export interface NewIdentityBundleRequest {
-    kind: "new-identity";
+export interface AddAccountRequest {
+    kind: "add-account";
     originBlockId: string;
+    /** Provider the new account is scoped to — the agent's own
+     *  provider (accounts are provider-specific, unlike the old
+     *  provider-agnostic bundle system). */
+    provider: string;
     /** Initial value for the name field. Usually empty. */
     initialName?: string;
-    /** Why the modal opened — controls the primary button label only
-     *  ("Create" vs "Continue"). `"create"` (default) is the plain
-     *  `+ New identity` button; `"oauth-continue"` is the OAuth-Connect
-     *  (`needs-bundle`) interposition. Spec
-     *  SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
-    purpose?: "create" | "oauth-continue";
-    /** Called after the bundle is persisted on disk. Caller should
+    /** Called after the account is persisted. Caller should
      *  `modalLayer.replace(launchRequest)` with the new id preselected;
      *  the layer does NOT close after this fires. */
-    onCreated: (bundleId: string, bundleName: string) => void;
+    onCreated: (accountId: string) => void;
     /** Called when the user clicks Cancel. Caller should
      *  `modalLayer.replace(launchRequest)` with the prior selection
      *  intact, OR `modalLayer.close()` to exit. The layer does NOT
@@ -238,7 +223,7 @@ export interface CreateFromTemplateRequest {
      *  layer can keep `submitting()` true across the launch await. */
     onCreatedAndLaunch: (
         newDefinitionId: string,
-        identityId: string,
+        accountId: string,
         memoryId: string,
         name: string,
         /** Runtime the user picked in the modal. The launch override

--- a/frontend/app/store/launch-flow-state/index.ts
+++ b/frontend/app/store/launch-flow-state/index.ts
@@ -5,16 +5,16 @@ export { createLaunchFlowStore } from "./launch-flow-store";
 export type { LaunchFlowStore, LaunchFlowStoreOptions } from "./launch-flow-store";
 export { update } from "./reducer";
 export {
+    accountsForProvider,
+    accountSuppliesProvider,
     canSubmit,
     continueLocksIdentity,
     continueLocksMemory,
-    hasMatchingBinding,
     initialForm,
     initialResourceList,
     initialState,
     initialSubmit,
     isContinue,
-    realIdentities,
     realMemories,
 } from "./types";
 export type {

--- a/frontend/app/store/launch-flow-state/launch-flow-store.test.ts
+++ b/frontend/app/store/launch-flow-state/launch-flow-store.test.ts
@@ -14,7 +14,7 @@ describe("createLaunchFlowStore", () => {
     it("starts in initial state", () => {
         const { state } = createLaunchFlowStore();
         expect(state.form.name).toBe("");
-        expect(state.form.identityId).toBe("");
+        expect(state.form.accountId).toBe("");
         expect(state.closed).toBe(false);
     });
 
@@ -24,24 +24,27 @@ describe("createLaunchFlowStore", () => {
         expect(state.form.name).toBe("hello");
     });
 
-    it("eventSink receives emitted events", () => {
+    it("eventSink receives emitted Auth events (AccountChanged emits none)", () => {
         const events: LaunchFlowEvent[] = [];
         const { dispatch } = createLaunchFlowStore({
             eventSink: (e) => events.push(e),
         });
-        dispatch({ type: "IdentityChanged", identityId: "a" });
-        expect(events).toEqual([{ type: "FetchBindings", identityId: "a" }]);
+        // Issue #1624 PR-C Part B — AccountChanged no longer emits a
+        // FetchBindings event (accounts load once and are filtered
+        // client-side; there's no per-selection binding fetch).
+        dispatch({ type: "AccountChanged", accountId: "a" });
+        expect(events).toEqual([]);
     });
 
     it("multiple dispatches preserve field-leaf reactivity (Store identity)", () => {
-        // Updating only name shouldn't recreate the identities subtree.
+        // Updating only name shouldn't recreate the accounts subtree.
         const { state, dispatch } = createLaunchFlowStore();
-        const idsRefBefore = state.identities;
+        const accountsRefBefore = state.accounts;
         dispatch({ type: "NameChanged", name: "x" });
         // Solid's reconcile preserves unchanged subtree identity.
-        // Reading state.identities again after the name dispatch
+        // Reading state.accounts again after the name dispatch
         // should yield the same proxy.
-        expect(state.identities).toBe(idsRefBefore);
+        expect(state.accounts).toBe(accountsRefBefore);
     });
 
     it("no-op dispatches don't fire eventSink", () => {
@@ -67,17 +70,16 @@ describe("createLaunchFlowStore", () => {
 
         it("captures emitted events alongside the command", () => {
             const { dispatch } = createLaunchFlowStore();
-            dispatch({ type: "IdentityChanged", identityId: "ident-a" });
+            dispatch({ type: "AccountChanged", accountId: "acct-a" });
             const records = getRecentDispatches();
-            expect(records[0].events).toEqual([
-                { type: "FetchBindings", identityId: "ident-a" },
-            ]);
+            // Issue #1624 PR-C Part B — AccountChanged emits no events.
+            expect(records[0].events).toEqual([]);
         });
 
         it("tags source — defaults to 'user', honors explicit override", () => {
             const { dispatch } = createLaunchFlowStore();
             dispatch({ type: "NameChanged", name: "alpha" });
-            dispatch({ type: "IdentitiesLoading" }, "system");
+            dispatch({ type: "AccountsLoading" }, "system");
             const records = getRecentDispatches();
             expect(records[0].source).toBe("user");
             expect(records[1].source).toBe("system");

--- a/frontend/app/store/launch-flow-state/reducer.test.ts
+++ b/frontend/app/store/launch-flow-state/reducer.test.ts
@@ -5,25 +5,32 @@ import { describe, expect, it } from "vitest";
 
 import { update } from "./reducer";
 import {
+    accountsForProvider,
+    accountSuppliesProvider,
     canSubmit,
     continueLocksIdentity,
     continueLocksMemory,
-    hasMatchingBinding,
     initialState,
     isContinue,
-    realIdentities,
     realMemories,
     type LaunchFlowCommand,
     type LaunchFlowState,
 } from "./types";
+import type { Account } from "@/app/view/identity/identity-model";
 
-// Test fixtures. Match the wire shapes in frontend/types/gotypes.d.ts.
-const ident = (id: string, name: string, is_blank = false): IdentityBundle => ({
+// Test fixtures. Match the wire shapes in frontend/types/gotypes.d.ts
+// and frontend/app/view/identity/identity-model.ts.
+const acct = (id: string, name: string, provider = "claude"): Account => ({
     id,
     name,
-    is_blank,
-    created_at: 0,
-    updated_at: 0,
+    provider: provider as Account["provider"],
+    kind: "oauth",
+    secret_ref: { backend: "env" },
+    context: {},
+    assigned_agents: [],
+    status: "valid",
+    created_at: "",
+    updated_at: "",
 });
 
 const mem = (id: string, name: string, is_blank = false): Memory => ({
@@ -34,28 +41,20 @@ const mem = (id: string, name: string, is_blank = false): Memory => ({
     updated_at: 0,
 });
 
-const binding = (identityId: string, provider: string): IdentityBinding => ({
-    identity_id: identityId,
-    provider,
-    account_id: "acc-1",
-});
-
 const dispatch = (state: LaunchFlowState, cmd: LaunchFlowCommand) => update(state, cmd);
 
 // ── Reducer transitions ────────────────────────────────────────────
 
 describe("launch-flow-state reducer", () => {
     describe("initial state", () => {
-        it("starts with empty form + no bundles + not closed", () => {
+        it("starts with empty form + no accounts/memories + not closed", () => {
             const s = initialState();
             expect(s.form.name).toBe("");
-            expect(s.form.identityId).toBe("");
+            expect(s.form.accountId).toBe("");
             expect(s.form.memoryId).toBe("");
             expect(s.form.continueOfId).toBe(null);
-            expect(s.identities.list).toEqual([]);
+            expect(s.accounts.list).toEqual([]);
             expect(s.memories.list).toEqual([]);
-            expect(s.bindings).toEqual({});
-            expect(s.bindingsLoading).toEqual({});
             expect(s.submit.inFlight).toBe(false);
             expect(s.closed).toBe(false);
         });
@@ -72,11 +71,11 @@ describe("launch-flow-state reducer", () => {
         it("applies initial form overrides", () => {
             const s = dispatch(initialState(), {
                 type: "Opened",
-                initial: { name: "carry", runtime: "container", identityId: "a" },
+                initial: { name: "carry", runtime: "container", accountId: "a" },
             }).state;
             expect(s.form.name).toBe("carry");
             expect(s.form.runtime).toBe("container");
-            expect(s.form.identityId).toBe("a");
+            expect(s.form.accountId).toBe("a");
         });
 
         it("clears the closed flag (reopen)", () => {
@@ -86,31 +85,11 @@ describe("launch-flow-state reducer", () => {
             expect(s.closed).toBe(false);
         });
 
-        it("emits FetchBindings for an uncached preselected identityId", () => {
+        it("emits no events (accounts load once, no per-selection fetch)", () => {
             const r = update(initialState(), {
                 type: "Opened",
-                initial: { identityId: "preselect-a" },
+                initial: { accountId: "preselect-a" },
             });
-            expect(r.events).toEqual([
-                { type: "FetchBindings", identityId: "preselect-a" },
-            ]);
-        });
-
-        it("does NOT emit FetchBindings when preselected identity already cached", () => {
-            let s = dispatch(initialState(), {
-                type: "BindingsLoaded",
-                identityId: "preselect-a",
-                bindings: [],
-            }).state;
-            const r = update(s, {
-                type: "Opened",
-                initial: { identityId: "preselect-a" },
-            });
-            expect(r.events).toEqual([]);
-        });
-
-        it("does NOT emit FetchBindings when initial identityId is empty", () => {
-            const r = update(initialState(), { type: "Opened", initial: { identityId: "" } });
             expect(r.events).toEqual([]);
         });
     });
@@ -135,34 +114,21 @@ describe("launch-flow-state reducer", () => {
         });
     });
 
-    describe("IdentityChanged", () => {
-        it("updates identityId", () => {
-            const s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
-            expect(s.form.identityId).toBe("a");
+    describe("AccountChanged", () => {
+        it("updates accountId", () => {
+            const s = dispatch(initialState(), { type: "AccountChanged", accountId: "a" }).state;
+            expect(s.form.accountId).toBe("a");
         });
 
-        it("emits FetchBindings on selection of an uncached real id", () => {
-            const r = update(initialState(), { type: "IdentityChanged", identityId: "a" });
-            expect(r.events).toEqual([{ type: "FetchBindings", identityId: "a" }]);
-        });
-
-        it("does NOT emit FetchBindings when selecting the empty id", () => {
-            const r = update(initialState(), { type: "IdentityChanged", identityId: "" });
+        it("emits no events — accounts are already loaded client-side", () => {
+            const r = update(initialState(), { type: "AccountChanged", accountId: "a" });
             expect(r.events).toEqual([]);
         });
 
-        it("does NOT emit FetchBindings when bindings already cached", () => {
-            let s = initialState();
-            s = dispatch(s, { type: "BindingsLoaded", identityId: "a", bindings: [] }).state;
-            const r = update(s, { type: "IdentityChanged", identityId: "a" });
-            expect(r.events).toEqual([]);
-        });
-
-        it("does NOT emit FetchBindings when bindings query is already in flight", () => {
-            let s = initialState();
-            s = dispatch(s, { type: "BindingsLoading", identityId: "a" }).state;
-            const r = update(s, { type: "IdentityChanged", identityId: "a" });
-            expect(r.events).toEqual([]);
+        it("set-to-current is a no-op (same state identity)", () => {
+            const s0 = dispatch(initialState(), { type: "AccountChanged", accountId: "a" }).state;
+            const r = update(s0, { type: "AccountChanged", accountId: "a" });
+            expect(r.state).toBe(s0);
         });
     });
 
@@ -171,11 +137,11 @@ describe("launch-flow-state reducer", () => {
             const s = dispatch(initialState(), {
                 type: "ContinueOfChanged",
                 continueOfId: "inst-1",
-                carry: { name: "prev", identityId: "a", memoryId: "m" },
+                carry: { name: "prev", accountId: "a", memoryId: "m" },
             }).state;
             expect(s.form.continueOfId).toBe("inst-1");
             expect(s.form.name).toBe("prev");
-            expect(s.form.identityId).toBe("a");
+            expect(s.form.accountId).toBe("a");
             expect(s.form.memoryId).toBe("m");
             expect(continueLocksIdentity(s)).toBe(true);
             expect(continueLocksMemory(s)).toBe(true);
@@ -185,7 +151,7 @@ describe("launch-flow-state reducer", () => {
             const s = dispatch(initialState(), {
                 type: "ContinueOfChanged",
                 continueOfId: "inst-legacy",
-                carry: { name: "old", identityId: "", memoryId: "" },
+                carry: { name: "old", accountId: "", memoryId: "" },
             }).state;
             expect(isContinue(s)).toBe(true);
             // Legacy continuation — user must pick replacements
@@ -193,29 +159,11 @@ describe("launch-flow-state reducer", () => {
             expect(continueLocksMemory(s)).toBe(false);
         });
 
-        it("emits FetchBindings for uncached real carry-over identity", () => {
-            const r = update(initialState(), {
-                type: "ContinueOfChanged",
-                continueOfId: "inst-1",
-                carry: { name: "prev", identityId: "a", memoryId: "m" },
-            });
-            expect(r.events).toEqual([{ type: "FetchBindings", identityId: "a" }]);
-        });
-
-        it("does NOT emit FetchBindings for empty carry-over identity (legacy)", () => {
-            const r = update(initialState(), {
-                type: "ContinueOfChanged",
-                continueOfId: "inst-legacy",
-                carry: { name: "old", identityId: "", memoryId: "" },
-            });
-            expect(r.events).toEqual([]);
-        });
-
         it("re-dispatch with same continueOfId is a no-op (preserves edits)", () => {
             let s = dispatch(initialState(), {
                 type: "ContinueOfChanged",
                 continueOfId: "inst-1",
-                carry: { name: "prev", identityId: "a", memoryId: "m" },
+                carry: { name: "prev", accountId: "a", memoryId: "m" },
             }).state;
             // User edits name mid-flow
             s = dispatch(s, { type: "NameChanged", name: "edited" }).state;
@@ -223,7 +171,7 @@ describe("launch-flow-state reducer", () => {
             const r = update(s, {
                 type: "ContinueOfChanged",
                 continueOfId: "inst-1",
-                carry: { name: "prev", identityId: "a", memoryId: "m" },
+                carry: { name: "prev", accountId: "a", memoryId: "m" },
             });
             expect(r.state).toBe(s);
             expect(r.state.form.name).toBe("edited");
@@ -233,37 +181,45 @@ describe("launch-flow-state reducer", () => {
             let s = dispatch(initialState(), {
                 type: "ContinueOfChanged",
                 continueOfId: "inst-1",
-                carry: { name: "prev", identityId: "a", memoryId: "m" },
+                carry: { name: "prev", accountId: "a", memoryId: "m" },
             }).state;
             s = dispatch(s, { type: "ContinueOfChanged", continueOfId: null }).state;
             expect(s.form.continueOfId).toBe(null);
             expect(s.form.name).toBe("");
-            expect(s.form.identityId).toBe("");
+            expect(s.form.accountId).toBe("");
             expect(s.form.memoryId).toBe("");
             expect(isContinue(s)).toBe(false);
         });
     });
 
-    describe("identities resource", () => {
-        it("IdentitiesLoading sets loading + clears error", () => {
-            let s = dispatch(initialState(), { type: "IdentitiesFailed", error: "old" }).state;
-            s = dispatch(s, { type: "IdentitiesLoading" }).state;
-            expect(s.identities.loading).toBe(true);
-            expect(s.identities.error).toBe(null);
+    describe("accounts resource", () => {
+        it("AccountsLoading sets loading + clears error", () => {
+            let s = dispatch(initialState(), { type: "AccountsFailed", error: "old" }).state;
+            s = dispatch(s, { type: "AccountsLoading" }).state;
+            expect(s.accounts.loading).toBe(true);
+            expect(s.accounts.error).toBe(null);
         });
 
-        it("IdentitiesLoaded sets list + clears loading", () => {
-            const a = ident("a", "A");
-            const s = dispatch(initialState(), { type: "IdentitiesLoaded", list: [a] }).state;
-            expect(s.identities.list).toEqual([a]);
-            expect(s.identities.loading).toBe(false);
+        it("AccountsLoaded sets list + clears loading", () => {
+            const a = acct("a", "A");
+            const s = dispatch(initialState(), { type: "AccountsLoaded", list: [a] }).state;
+            expect(s.accounts.list).toEqual([a]);
+            expect(s.accounts.loading).toBe(false);
         });
 
-        it("realIdentities selector filters is_blank", () => {
-            const a = ident("a", "A");
-            const b = ident("blank", "Blank", true);
-            const s = dispatch(initialState(), { type: "IdentitiesLoaded", list: [b, a] }).state;
-            expect(realIdentities(s)).toEqual([a]);
+        it("AccountsFailed sets error + clears loading", () => {
+            let s = dispatch(initialState(), { type: "AccountsLoading" }).state;
+            s = dispatch(s, { type: "AccountsFailed", error: "boom" }).state;
+            expect(s.accounts.error).toBe("boom");
+            expect(s.accounts.loading).toBe(false);
+        });
+
+        it("accountsForProvider selector filters by provider", () => {
+            const a = acct("a", "A", "claude");
+            const b = acct("b", "B", "codex");
+            const s = dispatch(initialState(), { type: "AccountsLoaded", list: [a, b] }).state;
+            expect(accountsForProvider(s, "claude")).toEqual([a]);
+            expect(accountsForProvider(s, "codex")).toEqual([b]);
         });
 
         it("realMemories selector filters is_blank", () => {
@@ -274,56 +230,23 @@ describe("launch-flow-state reducer", () => {
         });
     });
 
-    describe("bindings", () => {
-        it("BindingsLoading sets per-id loading flag", () => {
-            const s = dispatch(initialState(), { type: "BindingsLoading", identityId: "a" }).state;
-            expect(s.bindingsLoading.a).toBe(true);
+    describe("accountSuppliesProvider selector", () => {
+        it("true when the selected account matches the provider", () => {
+            const a = acct("a", "A", "claude");
+            let s = dispatch(initialState(), { type: "AccountsLoaded", list: [a] }).state;
+            s = dispatch(s, { type: "AccountChanged", accountId: "a" }).state;
+            expect(accountSuppliesProvider(s, "claude")).toBe(true);
+            expect(accountSuppliesProvider(s, "codex")).toBe(false);
         });
 
-        it("BindingsLoaded sets list + clears loading", () => {
-            let s = dispatch(initialState(), { type: "BindingsLoading", identityId: "a" }).state;
-            const bs = [binding("a", "claude")];
-            s = dispatch(s, { type: "BindingsLoaded", identityId: "a", bindings: bs }).state;
-            expect(s.bindings.a).toEqual(bs);
-            expect(s.bindingsLoading.a).toBeUndefined();
-        });
-
-        it("BindingsChanged updates list without touching loading flag", () => {
-            // Simulates a backend push event arriving after the resource settled.
-            let s = dispatch(initialState(), {
-                type: "BindingsLoaded",
-                identityId: "a",
-                bindings: [],
-            }).state;
-            const bs = [binding("a", "claude")];
-            s = dispatch(s, { type: "BindingsChanged", identityId: "a", bindings: bs }).state;
-            expect(s.bindings.a).toEqual(bs);
-            expect(s.bindingsLoading.a).toBeUndefined();
-        });
-
-        it("hasMatchingBinding selector — provider match", () => {
-            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
-            s = dispatch(s, {
-                type: "BindingsLoaded",
-                identityId: "a",
-                bindings: [binding("a", "claude")],
-            }).state;
-            expect(hasMatchingBinding(s, "claude")).toBe(true);
-            expect(hasMatchingBinding(s, "codex")).toBe(false);
-        });
-
-        it("hasMatchingBinding returns false while bindings loading", () => {
-            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
-            s = dispatch(s, { type: "BindingsLoading", identityId: "a" }).state;
-            // Even if cache has stale data from a prior selection, the
-            // in-flight load is treated as "no match" — the gate stays on.
-            // (anti-vacuity guard for the race fixed in #910 round 5).
-            expect(hasMatchingBinding(s, "claude")).toBe(false);
-        });
-
-        it("hasMatchingBinding returns false on empty identityId", () => {
+        it("false when no account is selected", () => {
             const s = initialState();
-            expect(hasMatchingBinding(s, "claude")).toBe(false);
+            expect(accountSuppliesProvider(s, "claude")).toBe(false);
+        });
+
+        it("false when the selected id isn't in the loaded list", () => {
+            const s = dispatch(initialState(), { type: "AccountChanged", accountId: "ghost" }).state;
+            expect(accountSuppliesProvider(s, "claude")).toBe(false);
         });
     });
 
@@ -380,9 +303,9 @@ describe("launch-flow-state reducer", () => {
         it("Auth Selected drives inner reducer + updates outer state", () => {
             const r = update(initialState(), {
                 type: "Auth",
-                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-account" },
             });
-            // SelectionKind for "needs-bundle" → "unauthenticated"
+            // SelectionKind for "needs-account" → "unauthenticated"
             expect(r.state.auth.kind).toBe("unauthenticated");
             expect(r.state.auth.providerId).toBe("claude");
         });
@@ -390,14 +313,14 @@ describe("launch-flow-state reducer", () => {
         it("Auth no-op (same inner state) returns the same outer state", () => {
             const s0 = update(initialState(), {
                 type: "Auth",
-                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-account" },
             }).state;
             // Re-dispatching the same selection is the inner reducer's
             // own no-op surface. We just verify the outer wrapper
             // doesn't fabricate a state-change either.
             const r = update(s0, {
                 type: "Auth",
-                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-account" },
             });
             expect(r.state.auth).toBe(s0.auth);
         });
@@ -408,7 +331,7 @@ describe("launch-flow-state reducer", () => {
             // OAuth start RPC via `StartAuth` event.
             let s = update(initialState(), {
                 type: "Auth",
-                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-account" },
             }).state;
             const r = update(s, { type: "Auth", cmd: { type: "ConnectClicked" } });
             // Outer events should contain at least one wrapped Auth
@@ -431,7 +354,7 @@ describe("launch-flow-state reducer", () => {
                 cmd: {
                     type: "Selected",
                     providerId: "claude",
-                    bundleId: "ident-work",
+                    bundleId: "acct-work",
                     outcome: "ready",
                 },
             }).state;
@@ -463,33 +386,16 @@ describe("launch-flow-state reducer", () => {
             expect(s.auth.kind).toBe("ready");
         });
 
-        it("auth.kind survives IdentitiesLoaded + MemoriesLoaded", () => {
+        it("auth.kind survives AccountsLoaded + MemoriesLoaded", () => {
             let s = setupReady();
             const before = s.auth;
             s = update(s, {
-                type: "IdentitiesLoaded",
-                list: [ident("ident-work", "Work")],
+                type: "AccountsLoaded",
+                list: [acct("acct-work", "Work")],
             }).state;
             s = update(s, {
                 type: "MemoriesLoaded",
                 list: [mem("mem-notes", "Notes")],
-            }).state;
-            expect(s.auth).toBe(before);
-            expect(s.auth.kind).toBe("ready");
-        });
-
-        it("auth.kind survives BindingsLoaded + BindingsChanged", () => {
-            let s = setupReady();
-            const before = s.auth;
-            s = update(s, {
-                type: "BindingsLoaded",
-                identityId: "ident-work",
-                bindings: [binding("ident-work", "claude")],
-            }).state;
-            s = update(s, {
-                type: "BindingsChanged",
-                identityId: "ident-work",
-                bindings: [binding("ident-work", "claude")],
             }).state;
             expect(s.auth).toBe(before);
             expect(s.auth.kind).toBe("ready");
@@ -506,18 +412,18 @@ describe("launch-flow-state reducer", () => {
 
         it("form state survives Auth Connect (auth path doesn't touch form)", () => {
             let s = update(initialState(), { type: "NameChanged", name: "carry-name" }).state;
-            s = update(s, { type: "IdentityChanged", identityId: "ident-a" }).state;
+            s = update(s, { type: "AccountChanged", accountId: "acct-a" }).state;
             s = update(s, { type: "MemoryChanged", memoryId: "mem-a" }).state;
             const formBefore = s.form;
             // Drive auth machine
             s = update(s, {
                 type: "Auth",
-                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-account" },
             }).state;
             s = update(s, { type: "Auth", cmd: { type: "ConnectClicked" } }).state;
             expect(s.form).toBe(formBefore);
             expect(s.form.name).toBe("carry-name");
-            expect(s.form.identityId).toBe("ident-a");
+            expect(s.form.accountId).toBe("acct-a");
             expect(s.form.memoryId).toBe("mem-a");
         });
     });
@@ -535,24 +441,24 @@ describe("launch-flow-state reducer", () => {
             expect(canSubmit(s, { ...baseAuth, nameValid: false })).toBe(false);
         });
 
-        it("blocks when identityId empty", () => {
+        it("blocks when accountId empty", () => {
             const s = initialState();
             expect(canSubmit(s, baseAuth)).toBe(false);
         });
 
         it("blocks when memoryId empty", () => {
-            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            let s = dispatch(initialState(), { type: "AccountChanged", accountId: "a" }).state;
             expect(canSubmit(s, baseAuth)).toBe(false);
         });
 
         it("blocks when authReady false", () => {
-            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            let s = dispatch(initialState(), { type: "AccountChanged", accountId: "a" }).state;
             s = dispatch(s, { type: "MemoryChanged", memoryId: "m" }).state;
             expect(canSubmit(s, { ...baseAuth, authReady: false })).toBe(false);
         });
 
-        it("passes when name + identity + memory + auth are all good", () => {
-            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+        it("passes when name + account + memory + auth are all good", () => {
+            let s = dispatch(initialState(), { type: "AccountChanged", accountId: "a" }).state;
             s = dispatch(s, { type: "MemoryChanged", memoryId: "m" }).state;
             expect(canSubmit(s, baseAuth)).toBe(true);
         });

--- a/frontend/app/store/launch-flow-state/reducer.ts
+++ b/frontend/app/store/launch-flow-state/reducer.ts
@@ -21,21 +21,6 @@ import type {
 } from "./types";
 import { initialForm } from "./types";
 
-/** Helper: emit `FetchBindings` exactly when an identityId is real
- *  (non-empty), not yet cached, and not already in flight. Three
- *  commands trigger this fetch (Opened with preselect,
- *  IdentityChanged, ContinueOfChanged with carry-over), so the
- *  predicate lives here to keep the rule in one place. */
-function maybeFetchBindings(
-    state: LaunchFlowState,
-    identityId: string,
-): LaunchFlowEvent[] {
-    if (identityId === "") return [];
-    if (state.bindings[identityId] !== undefined) return [];
-    if (state.bindingsLoading[identityId]) return [];
-    return [{ type: "FetchBindings", identityId }];
-}
-
 export function update(
     state: LaunchFlowState,
     command: LaunchFlowCommand,
@@ -55,7 +40,7 @@ export function update(
                 form: { ...initialForm(), ...command.initial },
                 closed: false,
             };
-            return { state: next, events: maybeFetchBindings(state, next.form.identityId) };
+            return { state: next, events: [] };
         }
 
         case "NameChanged": {
@@ -82,13 +67,13 @@ export function update(
             };
         }
 
-        case "IdentityChanged": {
-            if (state.form.identityId === command.identityId) {
+        case "AccountChanged": {
+            if (state.form.accountId === command.accountId) {
                 return { state, events: [] };
             }
             return {
-                state: { ...state, form: { ...state.form, identityId: command.identityId } },
-                events: maybeFetchBindings(state, command.identityId),
+                state: { ...state, form: { ...state.form, accountId: command.accountId } },
+                events: [],
             };
         }
 
@@ -118,44 +103,42 @@ export function update(
                     // Carry-over (or clear) the form fields when the
                     // user picks a row. `carry` is supplied by the
                     // caller because the row's instance_name /
-                    // identity_id / memory_id translation (legacy
-                    // "" or "blank" → "") is a view concern.
+                    // account id / memory_id translation (legacy ""
+                    // or "blank" → "", or an unresolvable pre-PR-C
+                    // bundle id on an old row → "") is a view concern.
                     name: command.carry?.name ?? "",
-                    identityId: command.carry?.identityId ?? "",
+                    accountId: command.carry?.accountId ?? "",
                     memoryId: command.carry?.memoryId ?? "",
                 },
             };
-            return {
-                state: next,
-                events: maybeFetchBindings(state, next.form.identityId),
-            };
+            return { state: next, events: [] };
         }
 
-        case "IdentitiesLoading": {
+        case "AccountsLoading": {
             return {
                 state: {
                     ...state,
-                    identities: { ...state.identities, loading: true, error: null },
+                    accounts: { ...state.accounts, loading: true, error: null },
                 },
                 events: [],
             };
         }
 
-        case "IdentitiesLoaded": {
+        case "AccountsLoaded": {
             return {
                 state: {
                     ...state,
-                    identities: { list: command.list, loading: false, error: null },
+                    accounts: { list: command.list, loading: false, error: null },
                 },
                 events: [],
             };
         }
 
-        case "IdentitiesFailed": {
+        case "AccountsFailed": {
             return {
                 state: {
                     ...state,
-                    identities: { ...state.identities, loading: false, error: command.error },
+                    accounts: { ...state.accounts, loading: false, error: command.error },
                 },
                 events: [],
             };
@@ -178,39 +161,6 @@ export function update(
         case "MemoriesFailed": {
             return {
                 state: { ...state, memories: { ...state.memories, loading: false, error: command.error } },
-                events: [],
-            };
-        }
-
-        case "BindingsLoading": {
-            return {
-                state: {
-                    ...state,
-                    bindingsLoading: { ...state.bindingsLoading, [command.identityId]: true },
-                },
-                events: [],
-            };
-        }
-
-        case "BindingsLoaded":
-        case "BindingsChanged": {
-            // Both commands write the new bindings array. They differ
-            // only in what they do to the per-id loading flag:
-            //   - BindingsLoaded settles a fetch the reducer asked
-            //     for via FetchBindings → clears the loading flag.
-            //   - BindingsChanged is a backend push event arriving
-            //     unsolicited (no in-flight fetch) → leaves the
-            //     loading flag alone (likely already absent).
-            const nextLoading = { ...state.bindingsLoading };
-            if (command.type === "BindingsLoaded") {
-                delete nextLoading[command.identityId];
-            }
-            return {
-                state: {
-                    ...state,
-                    bindings: { ...state.bindings, [command.identityId]: command.bindings },
-                    bindingsLoading: nextLoading,
-                },
                 events: [],
             };
         }

--- a/frontend/app/store/launch-flow-state/types.ts
+++ b/frontend/app/store/launch-flow-state/types.ts
@@ -28,6 +28,7 @@
 
 import type { AuthCommand, AuthEvent, AuthState } from "@/app/view/agent/auth/auth-state";
 import { initialState as initialAuthState } from "@/app/view/agent/auth/auth-state";
+import type { Account } from "@/app/view/identity/identity-model";
 
 /** Editable Launch-modal form fields. Empty strings mean "no
  *  selection"; the view's submit predicate blocks Launch until the
@@ -36,8 +37,12 @@ export interface LaunchForm {
     name: string;
     runtime: "host" | "container";
     image: string;
-    /** Selected Identity bundle id. `""` = unselected. */
-    identityId: string;
+    /** Selected account id for the agent's own provider. `""` =
+     *  unselected. Issue #1624 PR-C Part B — was `identityId` (a
+     *  bundle id) before this; the launch modal now picks an account
+     *  directly instead of a named bundle that (hopefully) has a
+     *  binding for this provider. */
+    accountId: string;
     /** Selected Memory bundle id. `""` = unselected. */
     memoryId: string;
     /** When set, this launch is a continuation of a prior named
@@ -50,7 +55,7 @@ export const initialForm = (): LaunchForm => ({
     name: "",
     runtime: "container",
     image: "",
-    identityId: "",
+    accountId: "",
     memoryId: "",
     continueOfId: null,
 });
@@ -83,18 +88,15 @@ export const initialSubmit = (): SubmitStatus => ({
 /** Top-level reducer state. */
 export interface LaunchFlowState {
     form: LaunchForm;
-    identities: ResourceList<IdentityBundle>;
+    /** All loaded accounts (every provider, not pre-filtered) — the
+     *  view narrows to the agent's own provider via
+     *  `accountsForProvider`. Was `identities: ResourceList<IdentityBundle>`
+     *  before issue #1624 PR-C Part B; account lists load once and are
+     *  filtered client-side, so unlike bundles there's no per-selection
+     *  fetch needed (see the removed `bindings`/`bindingsLoading` slices
+     *  below). */
+    accounts: ResourceList<Account>;
     memories: ResourceList<Memory>;
-    /** Per-identity binding cache. Keyed on `identityId`. Push-
-     *  updated via `BindingsLoaded` (initial load) and `BindingsChanged`
-     *  (subsequent backend events). Empty value means "no bindings yet
-     *  / hasn't been queried"; the view distinguishes via the loading
-     *  side-channel below. */
-    bindings: Record<string, IdentityBinding[]>;
-    /** Identity ids whose bindings query is currently in flight.
-     *  Used by the view to render the auth gate as "loading" so a
-     *  fast Connect click doesn't slip through the race. */
-    bindingsLoading: Record<string, boolean>;
     submit: SubmitStatus;
     /** Folded-in OAuth state machine. The `Auth` command wraps an
      *  `AuthCommand` from auth-state.ts; the reducer delegates to
@@ -107,10 +109,8 @@ export interface LaunchFlowState {
 
 export const initialState = (): LaunchFlowState => ({
     form: initialForm(),
-    identities: initialResourceList<IdentityBundle>(),
+    accounts: initialResourceList<Account>(),
     memories: initialResourceList<Memory>(),
-    bindings: {},
-    bindingsLoading: {},
     submit: initialSubmit(),
     auth: initialAuthState(),
     closed: false,
@@ -126,10 +126,9 @@ export type LaunchFlowCommand =
     | { type: "NameChanged"; name: string }
     | { type: "RuntimeChanged"; runtime: "host" | "container" }
     | { type: "ImageChanged"; image: string }
-    /** Setting identity to `""` clears it (e.g. on legacy
-     *  continuation with no carry-over). The view auto-picks the
-     *  first non-blank bundle elsewhere. */
-    | { type: "IdentityChanged"; identityId: string }
+    /** Setting account to `""` clears it (e.g. on legacy
+     *  continuation with no carry-over). */
+    | { type: "AccountChanged"; accountId: string }
     | { type: "MemoryChanged"; memoryId: string }
     /** Continue dropdown — `null` = "— New agent —". Setting to a
      *  real instance id locks per-row selectors with the carry-over
@@ -137,21 +136,15 @@ export type LaunchFlowCommand =
     | {
           type: "ContinueOfChanged";
           continueOfId: string | null;
-          carry?: { name: string; identityId: string; memoryId: string };
+          carry?: { name: string; accountId: string; memoryId: string };
       }
     /** Resource lifecycle commands. */
-    | { type: "IdentitiesLoading" }
-    | { type: "IdentitiesLoaded"; list: IdentityBundle[] }
-    | { type: "IdentitiesFailed"; error: string }
+    | { type: "AccountsLoading" }
+    | { type: "AccountsLoaded"; list: Account[] }
+    | { type: "AccountsFailed"; error: string }
     | { type: "MemoriesLoading" }
     | { type: "MemoriesLoaded"; list: Memory[] }
     | { type: "MemoriesFailed"; error: string }
-    /** Bindings push events. `BindingsChanged` is the wire shape the
-     *  backend will emit in Stage 2c; until then it's only used by
-     *  unit tests. */
-    | { type: "BindingsLoading"; identityId: string }
-    | { type: "BindingsLoaded"; identityId: string; bindings: IdentityBinding[] }
-    | { type: "BindingsChanged"; identityId: string; bindings: IdentityBinding[] }
     /** Submit lifecycle. */
     | { type: "SubmitClicked" }
     | { type: "SubmitSucceeded" }
@@ -168,13 +161,10 @@ export type LaunchFlowCommand =
  *  stays pure; emits these for the view to dispatch onto the wire.
  *  Each event is keyed/tagged so the view can dedupe in-flight RPCs. */
 export type LaunchFlowEvent =
-    /** Fetch bindings for an identity that just became selected and
-     *  has no cached entry. */
-    | { type: "FetchBindings"; identityId: string }
     /** Pass-through of an auth-state event so the view can run the
      *  side-effect (RPC, openExternal, etc.). Wraps `AuthEvent` from
      *  auth-state.ts. */
-    | { type: "Auth"; event: AuthEvent };
+    { type: "Auth"; event: AuthEvent };
 
 export interface ReducerResult {
     state: LaunchFlowState;
@@ -186,10 +176,13 @@ export interface ReducerResult {
 // Pure read-only derivations over state. The view calls these instead
 // of repeating logic — keeps the cross-product testable in one place.
 
-/** Real (non-blank) identity bundles, filtering out any
- *  back-compat `is_blank` singleton the backend may still return. */
-export function realIdentities(state: LaunchFlowState): IdentityBundle[] {
-    return state.identities.list.filter((b) => !b.is_blank);
+/** Loaded accounts for one provider — the launch modal's Account
+ *  dropdown only ever shows accounts for the agent's own provider
+ *  (an agent has exactly one primary provider). Replaces
+ *  `realIdentities` (which filtered out the bundle system's
+ *  `is_blank` singleton — accounts have no such concept). */
+export function accountsForProvider(state: LaunchFlowState, providerId: string): Account[] {
+    return state.accounts.list.filter((a) => a.provider === providerId);
 }
 
 /** Real (non-blank) memory bundles. */
@@ -203,30 +196,31 @@ export function isContinue(state: LaunchFlowState): boolean {
     return state.form.continueOfId !== null;
 }
 
-/** Per-row continuation lock. Identity selector locks ONLY when
+/** Per-row continuation lock. Account selector locks ONLY when
  *  the continued row carried a real (non-empty, non-legacy-"blank")
- *  identity_id. Legacy carry-overs leave the selector editable so
+ *  account id. Legacy carry-overs leave the selector editable so
  *  the user can pick a replacement (codex P1 on PR #916). */
 export function continueLocksIdentity(state: LaunchFlowState): boolean {
-    return isContinue(state) && state.form.identityId !== "";
+    return isContinue(state) && state.form.accountId !== "";
 }
 
 export function continueLocksMemory(state: LaunchFlowState): boolean {
     return isContinue(state) && state.form.memoryId !== "";
 }
 
-/** Whether the selected identity bundle has a binding for the given
- *  provider. Used by the auth-gate predicate. While bindings are
- *  loading, returns false (safe — the gate stays on). */
-export function hasMatchingBinding(
+/** Whether the selected account actually supplies credentials for
+ *  the given provider. Used by the auth-gate predicate. Replaces
+ *  `hasMatchingBinding` — with a single account selection instead of
+ *  a bundle-of-bindings, this is a direct lookup against the already-
+ *  loaded account list, no per-selection fetch/loading state needed. */
+export function accountSuppliesProvider(
     state: LaunchFlowState,
     providerId: string,
 ): boolean {
-    const id = state.form.identityId;
+    const id = state.form.accountId;
     if (!id) return false;
-    if (state.bindingsLoading[id]) return false;
-    const bindings = state.bindings[id] ?? [];
-    return bindings.some((b) => b.provider === providerId);
+    const account = state.accounts.list.find((a) => a.id === id);
+    return account?.provider === providerId;
 }
 
 /** Whether Launch can fire. Combines form completeness with the
@@ -239,7 +233,7 @@ export function canSubmit(
 ): boolean {
     if (state.submit.inFlight) return false;
     if (!opts.nameValid) return false;
-    if (state.form.identityId === "") return false;
+    if (state.form.accountId === "") return false;
     if (state.form.memoryId === "") return false;
     if (!opts.authReady) return false;
     return true;

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -559,7 +559,12 @@ export class AgentViewModel implements ViewModel {
                     // PR-F.3: launch modal carries the user's bundle
                     // picks. Empty / "blank" → backend resolver short-
                     // circuits so the agent inherits ambient creds.
-                    identity_id: overrides?.identityId,
+                    // Issue #1624 PR-C Part B — `accountId` replaces
+                    // the old bundle-id `identityId`; this column
+                    // keeps its name (`identity_id`) since it's a
+                    // legacy `db_agent_instances` field, not part of
+                    // the new direct-link system.
+                    identity_id: overrides?.accountId,
                     memory_id: overrides?.memoryId,
                     // v8: named-agent continuation. The instance name
                     // is the AGENTMUX_AGENT_ID the user picked in the
@@ -588,55 +593,28 @@ export class AgentViewModel implements ViewModel {
                 );
             }
 
-            // Write-through: RECONCILE this agent definition's direct
-            // agent<->account links to exactly match the selected Identity
-            // bundle's bindings (add/update AND remove), in addition to
-            // (not instead of) the bundle-based instance.identity_id above.
+            // Write-through: link this agent definition directly to the
+            // selected account for its own provider. Issue #1624 PR-C
+            // Part B — the launch modal now picks an account directly
+            // (no bundle-of-bindings to reconcile against), so this
+            // collapses to a single upsert. `agent_identity_link`'s
+            // `ON CONFLICT(agent_id, provider) DO UPDATE` (identities.rs)
+            // makes one call correct without a diff/unlink pass.
             //
-            // Must be a full reconcile, not additive-only: the resolver
-            // (agentmux-srv/src/identity/resolver.rs's
-            // resolve_bindings_for_instance) treats ANY existing direct
-            // link for this definition as authoritative and skips the
-            // bundle path entirely. So on a relaunch/continue of the SAME
-            // definition with a different bundle — one that drops a
-            // provider, or "blank" for ambient creds — a stale direct link
-            // left over from an earlier launch would keep silently
-            // overriding the new selection. Reagent P1 on #1950 caught
-            // this in the additive-only version.
-            //
-            // This just makes sure every launch's direct-link set matches
-            // its bundle pick from day one, so the bundle-fallback path
-            // can eventually be removed without a live-credential
-            // regression. Best-effort, same as the instance-row write
-            // above: a failure here doesn't abort the launch, since the
-            // agent already started and the bundle path still works as a
-            // fallback. See
-            // docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md §3.
+            // Best-effort, same as the instance-row write above: a
+            // failure here doesn't abort the launch, since the agent
+            // already started. This also covers the accepted migration
+            // gap where a pre-issue-#1624-PR-C continuation carries a
+            // stale bundle id instead of a real account id — the RPC
+            // fails gracefully and just logs a warning. See
+            // docs/specs/SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md.
             try {
-                const identityId = overrides?.identityId;
-                const bindings =
-                    identityId && identityId !== "blank"
-                        ? await RpcApi.ListIdentityBindingsCommand(TabRpcClient, { identity_id: identityId })
-                        : [];
-                const targetProviders = new Set((bindings ?? []).map((b) => b.provider));
-
-                const existingLinks = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
-                    agent_id: agent.id,
-                });
-                for (const link of existingLinks ?? []) {
-                    if (!targetProviders.has(link.provider)) {
-                        await RpcApi.UnlinkAgentIdentityCommand(TabRpcClient, {
-                            agent_id: agent.id,
-                            provider: link.provider,
-                        });
-                    }
-                }
-
-                for (const binding of bindings ?? []) {
+                const accountId = overrides?.accountId;
+                if (accountId && accountId !== "blank") {
                     await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
                         agent_id: agent.id,
-                        account_id: binding.account_id,
-                        provider: binding.provider,
+                        account_id: accountId,
+                        provider: agent.provider,
                     });
                 }
             } catch (e: any) {

--- a/frontend/app/view/agent/auth/auth-flow-controller.test.ts
+++ b/frontend/app/view/agent/auth/auth-flow-controller.test.ts
@@ -56,7 +56,7 @@ describe("AuthFlowController", () => {
         await createRoot(async (dispose) => {
             const timers = fakeTimers();
             const ctrl = new AuthFlowController({ rpc: fakeRpc(), timers });
-            ctrl.selected("claude", "b1", "needs-bundle");
+            ctrl.selected("claude", "b1", "needs-account");
             expect(ctrl.state().kind).toBe("unauthenticated");
             expect(ctrl.state().providerId).toBe("claude");
             dispose();
@@ -77,7 +77,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: ["login"],
@@ -112,7 +112,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -140,7 +140,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -171,7 +171,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -180,7 +180,7 @@ describe("AuthFlowController", () => {
             expect(ctrl.state().kind).toBe("waiting");
             expect(ctrl.state().sessionId).toBe("s1");
             // User switches provider while OAuth is in-flight.
-            ctrl.selected("openai", "", "needs-bundle");
+            ctrl.selected("openai", "", "needs-account");
             // Microtask flush so the fire-and-forget cancel resolves.
             await Promise.resolve();
             await Promise.resolve();
@@ -208,7 +208,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -244,7 +244,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             const connectP = ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -280,7 +280,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -308,7 +308,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("openclaw", "", "needs-bundle");
+            ctrl.selected("openclaw", "", "needs-account");
             await ctrl.submitApiKey("sk-test", "my-key-account");
             expect(ctrl.state().kind).toBe("ready");
             expect(ctrl.state().bundleId).toBe("persisted-bundle");
@@ -327,7 +327,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("openclaw", "", "needs-bundle");
+            ctrl.selected("openclaw", "", "needs-account");
             await ctrl.submitApiKey("sk-bad", "default");
             expect(ctrl.state().kind).toBe("failed");
             expect(ctrl.state().error).toBe("invalid key");
@@ -346,7 +346,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -367,7 +367,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -395,7 +395,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],
@@ -427,7 +427,7 @@ describe("AuthFlowController", () => {
                 }),
                 timers,
             });
-            ctrl.selected("claude", "", "needs-bundle");
+            ctrl.selected("claude", "", "needs-account");
             await ctrl.connect({
                 cliPath: "/x",
                 authLoginArgs: [],

--- a/frontend/app/view/agent/auth/auth-flow-controller.ts
+++ b/frontend/app/view/agent/auth/auth-flow-controller.ts
@@ -32,11 +32,19 @@ import {
 } from "./auth-state";
 
 /** Backend-facing RPC surface. Allowed to be injected so tests can
- *  swap in a stub. Production passes the `defaultAuthRpc` adapter. */
+ *  swap in a stub. Production passes the `defaultAuthRpc` adapter.
+ *
+ *  `start()`'s request shape is direct-account only (issue #1624
+ *  PR-C Part B) — `AuthFlowController` has exactly one production
+ *  consumer (`AgentLaunchModal`, via `PreLaunchAuthPanel`), and that
+ *  caller always wants a standalone account, never a bundle. No
+ *  `intoBundleId` field: there is no remaining bundle-mode caller of
+ *  this interface to keep it for. */
 export interface AuthRpc {
     start(req: {
         providerId: string;
-        intoBundleId?: string;
+        directAccount: true;
+        existingAccountId?: string;
         cliPath: string;
         authLoginArgs: string[];
         authCheckArgs: string[];
@@ -255,7 +263,13 @@ export class AuthFlowController {
         try {
             const { sessionId, authUrl } = await this.rpc.start({
                 providerId: s.providerId,
-                intoBundleId: s.intoBundleId || undefined,
+                directAccount: true,
+                // `intoBundleId` (unrenamed — see auth-state.ts's
+                // foldPolled comment) carries the account id to
+                // reconnect into when the outcome was `expired`/
+                // `needs-account` against an already-selected account;
+                // empty for a genuinely fresh connect.
+                existingAccountId: s.intoBundleId || undefined,
                 cliPath: cli.cliPath,
                 authLoginArgs: cli.authLoginArgs,
                 authCheckArgs: cli.authCheckArgs,

--- a/frontend/app/view/agent/auth/auth-state.test.ts
+++ b/frontend/app/view/agent/auth/auth-state.test.ts
@@ -38,16 +38,14 @@ describe("auth-state reducer", () => {
             expect(r.state.kind).toBe("expired");
         });
 
-        it("transitions to `unauthenticated` for needs-account and needs-bundle", () => {
-            for (const outcome of ["needs-account", "needs-bundle"] as const) {
-                const r = update(initialState(), {
-                    type: "Selected",
-                    providerId: "claude",
-                    bundleId: "b1",
-                    outcome,
-                });
-                expect(r.state.kind).toBe("unauthenticated");
-            }
+        it("transitions to `unauthenticated` for needs-account", () => {
+            const r = update(initialState(), {
+                type: "Selected",
+                providerId: "claude",
+                bundleId: "b1",
+                outcome: "needs-account",
+            });
+            expect(r.state.kind).toBe("unauthenticated");
         });
 
         it("clears prior session + error state on selection change", () => {
@@ -751,16 +749,6 @@ describe("auth-state reducer", () => {
                     outcome: "needs-account",
                 });
                 expect(r.state.intoBundleId).toBe("existing-b1");
-            });
-
-            it("needs-bundle → intoBundleId = '' (new bundle)", () => {
-                const r = update(initialState(), {
-                    type: "Selected",
-                    providerId: "claude",
-                    bundleId: "",
-                    outcome: "needs-bundle",
-                });
-                expect(r.state.intoBundleId).toBe("");
             });
 
             it("ready → intoBundleId = '' (no save flow needed)", () => {

--- a/frontend/app/view/agent/auth/auth-state.ts
+++ b/frontend/app/view/agent/auth/auth-state.ts
@@ -56,14 +56,20 @@ export type AuthSessionStatusWire =
     | { status: "success"; bundleId: string; email: string | null; accountId?: string }
     | { status: "failed"; error: string };
 
-/** Outcome of the modal's bundle/provider selection. The view computes
- *  this from the dropdown + the loaded `IdentityBundle` / `Memory`
- *  lists and dispatches `Selected` once. */
+/** Outcome of the modal's account/provider selection. The view computes
+ *  this from the dropdown + the loaded account list and dispatches
+ *  `Selected` once.
+ *
+ *  Issue #1624 PR-C Part B dropped `"needs-bundle"` (blank-singleton —
+ *  Connect creates a new bundle first): the launch modal no longer has
+ *  a bundle picker to be blank, so that outcome can never be produced
+ *  by any caller. `selectionKind()` already treated it identically to
+ *  `"needs-account"`, so removing it is a pure type-level prune, no
+ *  reducer behavior change. */
 export type SelectionOutcome =
-    | "ready" // bundle has authenticated account for this provider
-    | "expired" // bundle has account but stale (re-auth needed)
-    | "needs-account" // bundle exists but no account for this provider
-    | "needs-bundle"; // blank singleton — Connect creates new bundle
+    | "ready" // account is authenticated for this provider
+    | "expired" // account exists but stale (re-auth needed)
+    | "needs-account"; // no account selected (or selected account doesn't match this provider)
 
 export interface AuthState {
     /** Terminal flag set by `Disposed`. Post-close commands are no-ops. */
@@ -293,7 +299,6 @@ const selectionKind = (outcome: SelectionOutcome): AuthState["kind"] => {
         case "expired":
             return "expired";
         case "needs-account":
-        case "needs-bundle":
             return "unauthenticated";
     }
 };
@@ -792,11 +797,25 @@ function foldPolled(state: AuthState, status: AuthSessionStatusWire): ReducerRes
             // the same RPC) or as a defensive late-Polled landing
             // after BundleSaved. The OAuth path goes through
             // `authenticated` → SaveBundleClicked → BundleSaved → ready.
+            //
+            // Issue #1624 PR-C Part B: a direct-account session (no
+            // bundle involved) reports its result via `status.accountId`
+            // instead of `status.bundleId` (which is `""` in that
+            // mode). `AuthState.bundleId`/the `succeeded` event's
+            // `bundleId` are deliberately NOT renamed here — this
+            // reducer has too much regression-pinned history (P1/P2
+            // fixes from #845/#847/#849/#850/#853/#981) to risk a
+            // sweeping rename for this PR. The field just carries
+            // "whatever terminal id this session produced" — an
+            // account id in direct-account mode, a bundle id
+            // otherwise. The caller (AgentLaunchModal) knows which
+            // mode it's in and treats the value accordingly.
+            const terminalId = status.accountId || status.bundleId;
             return {
                 state: {
                     ...state,
                     kind: "ready",
-                    bundleId: status.bundleId,
+                    bundleId: terminalId,
                     sessionId: "",
                     authUrl: "",
                     deviceCode: null,
@@ -805,7 +824,7 @@ function foldPolled(state: AuthState, status: AuthSessionStatusWire): ReducerRes
                 events: [
                     {
                         type: "succeeded",
-                        bundleId: status.bundleId,
+                        bundleId: terminalId,
                         email: status.email,
                     },
                 ],

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.test.tsx
@@ -7,8 +7,8 @@
  *
  * Covered:
  *  - default name field pre-fills with the template's name
- *  - Identity + Memory selects render the bundles list (empty option
- *    represents ambient creds / vanilla CLI sentinels)
+ *  - Identity + Memory selects render the accounts / bundles list
+ *    (empty option represents ambient creds / vanilla CLI sentinels)
  *  - clicking Create fires onSubmit with the form snapshot
  *  - the Create button is disabled while submitting
  *  - error from onSubmit surfaces in the panel body
@@ -19,7 +19,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
-        ListIdentityBundlesCommand: vi.fn(),
         ListMemoriesCommand: vi.fn(),
         // Mount-time daemon probe (drives the host/container dropdown).
         // Default → no reachable runtime → host-only.
@@ -27,9 +26,13 @@ vi.mock("@/app/store/rpc-api", () => ({
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/view/identity/identity-model", () => ({
+    refreshAccountCache: vi.fn(),
+}));
 
 import { AgentCreateFromTemplateModalPanel } from "./AgentCreateFromTemplateModal";
 import { resetCapabilities } from "@/app/store/toolchain-capabilities";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
 
 let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
 
@@ -61,8 +64,8 @@ beforeEach(async () => {
     // into the next via the shared cache.
     resetCapabilities();
     ({ RpcApi } = await import("@/app/store/rpc-api"));
-    vi.mocked(RpcApi.ListIdentityBundlesCommand).mockResolvedValue([
-        { id: "id-work", name: "Work", description: "", is_blank: false } as any,
+    vi.mocked(refreshAccountCache).mockResolvedValue([
+        { id: "id-work", name: "Work", provider: "claude" } as any,
     ]);
     vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([
         { id: "mem-notes", name: "Notes", is_blank: false } as any,
@@ -119,9 +122,10 @@ describe("AgentCreateFromTemplateModalPanel", () => {
         });
         const args = onSubmit.mock.calls[0][0];
         expect(args.name).toBe("Mary");
-        // Identity + Memory auto-picked from the first non-blank
-        // bundle each.
-        expect(args.identityId).toBe("id-work");
+        // Identity auto-picked from the first available account for
+        // the template's provider; Memory from the first non-blank
+        // bundle.
+        expect(args.accountId).toBe("id-work");
         expect(args.memoryId).toBe("mem-notes");
         // No Docker → runtime defaults to host (never a mode that
         // can't actually start).

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -29,10 +29,11 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
+import { refreshAccountCache, type Account } from "@/app/view/identity/identity-model";
 
 export interface CreateFromTemplateFormData {
     name: string;
-    identityId: string;
+    accountId: string;
     memoryId: string;
     /** Where the new agent runs. Chosen here at instantiation time —
      *  it is NOT a property of the template (a template is runtime-
@@ -55,9 +56,9 @@ export const AgentCreateFromTemplateModalPanel = (
     props: AgentCreateFromTemplateModalPanelProps,
 ): JSX.Element => {
     const [name, setName] = createSignal(props.initialName ?? props.template.name);
-    const [identityId, setIdentityId] = createSignal("");
+    const [accountId, setAccountId] = createSignal("");
     const [memoryId, setMemoryId] = createSignal("");
-    const [identities, setIdentities] = createSignal<IdentityBundle[]>([]);
+    const [accounts, setAccounts] = createSignal<Account[]>([]);
     const [memories, setMemories] = createSignal<Memory[]>([]);
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
@@ -109,14 +110,16 @@ export const AgentCreateFromTemplateModalPanel = (
         setRuntime(v);
     };
 
-    // Load bundle lists on mount. Bindings are stored on the
+    // Load account + memory lists on mount. The account list is
+    // filtered to the template's own provider (accounts are provider-
+    // specific — issue #1624 PR-C Part B). Bindings are stored on the
     // db_agent_instances row at launch time; the empty string sentinel
     // means "ambient creds / vanilla CLI" so an empty selection is OK.
     onMount(() => {
         void (async () => {
             try {
-                const list = await RpcApi.ListIdentityBundlesCommand(TabRpcClient, {});
-                setIdentities(list ?? []);
+                const list = await refreshAccountCache();
+                setAccounts(list.filter((a) => a.provider === props.template.provider));
             } catch {
                 /* non-fatal; user can still create without binding */
             }
@@ -129,17 +132,15 @@ export const AgentCreateFromTemplateModalPanel = (
         })();
     });
 
-    // Default-pick the first real bundle once the lists land, matching
-    // the launch modal's UX (saves a click for users with existing
-    // bundles). `is_blank` rows are back-compat singletons we filter
-    // out — empty string is the "ambient" sentinel and is the empty-
-    // list default anyway.
-    const realIdentities = createMemo(() => identities().filter((b) => !b.is_blank));
+    // Default-pick the first available account once the list lands,
+    // matching the launch modal's UX (saves a click for users with
+    // existing accounts). `is_blank` rows are a bundle-only concept —
+    // accounts have no such thing.
     const realMemories = createMemo(() => memories().filter((m) => !m.is_blank));
     createEffect(() => {
-        if (identityId()) return;
-        const first = realIdentities()[0];
-        if (first) setIdentityId(first.id);
+        if (accountId()) return;
+        const first = accounts()[0];
+        if (first) setAccountId(first.id);
     });
     createEffect(() => {
         if (memoryId()) return;
@@ -159,7 +160,7 @@ export const AgentCreateFromTemplateModalPanel = (
         try {
             await props.onSubmit({
                 name: name().trim(),
-                identityId: identityId(),
+                accountId: accountId(),
                 memoryId: memoryId(),
                 agentType: runtime(),
             });
@@ -240,14 +241,16 @@ export const AgentCreateFromTemplateModalPanel = (
                     <span class="agent-new-bundle-modal-label">Identity</span>
                     <select
                         class="agent-new-bundle-modal-input"
-                        value={identityId()}
-                        onChange={(e) => setIdentityId(e.currentTarget.value)}
+                        value={accountId()}
+                        onChange={(e) => setAccountId(e.currentTarget.value)}
                         disabled={submitting()}
                         data-testid="create-from-template-identity-select"
                     >
                         <option value="">(ambient credentials)</option>
-                        <For each={realIdentities()}>
-                            {(b) => <option value={b.id}>{b.name}</option>}
+                        <For each={accounts()}>
+                            {(a) => (
+                                <option value={a.id}>{a.display_name?.trim() || a.name}</option>
+                            )}
                         </For>
                     </select>
                 </label>

--- a/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx
@@ -27,9 +27,7 @@ import { resetCapabilities } from "@/app/store/toolchain-capabilities";
 
 vi.mock("@/app/store/rpc-api", () => {
     const RpcApi = {
-        ListIdentityBundlesCommand: vi.fn(),
         ListMemoriesCommand: vi.fn(),
-        ListIdentityBindingsCommand: vi.fn(),
         ListNamedAgentsCommand: vi.fn(),
         // Backs the shared toolchain-capabilities store's Docker liveness
         // probe — this modal polls it (watchCapability("docker")) for the
@@ -42,6 +40,14 @@ vi.mock("@/app/store/rpc-api", () => {
 });
 
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+// Issue #1624 PR-C Part B — the launch modal sources accounts from the
+// shared account cache instead of `ListIdentityBundlesCommand`/
+// `ListIdentityBindingsCommand`.
+vi.mock("@/app/view/identity/identity-model", () => ({
+    refreshAccountCache: vi.fn(),
+    subscribeAccountChanges: vi.fn(() => () => {}),
+}));
 
 vi.mock("@/app/store/wps", () => ({
     waveEventSubscribe: vi.fn(() => () => {}),
@@ -109,13 +115,18 @@ const claudeAgent = {
     is_seeded: 0,
 } as AgentDefinition;
 
-const workIdentity: IdentityBundle = {
-    id: "ident-work",
+const workAccount = {
+    id: "acct-work",
     name: "Work",
-    is_blank: false,
-    created_at: ts(),
-    updated_at: ts(),
-};
+    provider: "claude",
+    kind: "oauth",
+    secret_ref: { backend: "env" },
+    context: {},
+    assigned_agents: [],
+    status: "valid",
+    created_at: "",
+    updated_at: "",
+} as unknown as import("@/app/view/identity/identity-model").Account;
 
 const notesMemory: Memory = {
     id: "mem-notes",
@@ -133,22 +144,17 @@ const personalMemory: Memory = {
     updated_at: ts(),
 };
 
-const claudeBinding: IdentityBinding = {
-    identity_id: "ident-work",
-    provider: "claude",
-    account_id: "acc-1",
-};
-
-// Pull the mocked RpcApi after vi.mock has run.
+// Pull the mocked RpcApi + identity-model after vi.mock has run.
 let RpcApi: typeof import("@/app/store/rpc-api").RpcApi;
+let refreshAccountCache: typeof import("@/app/view/identity/identity-model").refreshAccountCache;
 
 beforeEach(async () => {
     vi.clearAllMocks();
     resetCapabilities();
     ({ RpcApi } = await import("@/app/store/rpc-api"));
-    vi.mocked(RpcApi.ListIdentityBundlesCommand).mockResolvedValue([workIdentity]);
+    ({ refreshAccountCache } = await import("@/app/view/identity/identity-model"));
+    vi.mocked(refreshAccountCache).mockResolvedValue([workAccount]);
     vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([notesMemory, personalMemory]);
-    vi.mocked(RpcApi.ListIdentityBindingsCommand).mockResolvedValue([claudeBinding]);
     vi.mocked(RpcApi.ListNamedAgentsCommand).mockResolvedValue([]);
 });
 
@@ -159,10 +165,8 @@ afterEach(() => {
 // ── Tests ───────────────────────────────────────────────────────────
 
 describe("AgentLaunchModal — memory change must not reset auth state (§6.10)", () => {
-    // The §6.10 requirement holds — changing the bundle does NOT reset auth
-    // (asserted below). This test had gone stale on the "Memory bundle" → "Bundle"
-    // rename (the select's aria-label is now "Bundle"); the stale selector read as
-    // an auth "regression" when CI first ran it. Selector fixed; logic unchanged.
+    // The §6.10 requirement holds — changing the Bundle does NOT reset
+    // auth (asserted below).
     it("preserves auth-ready state across a Memory selection change", async () => {
         const user = userEvent.setup();
         const onSubmit = vi.fn();
@@ -175,26 +179,24 @@ describe("AgentLaunchModal — memory change must not reset auth state (§6.10)"
             />
         ));
 
-        // Wait for identities + memories + bindings to settle. The
-        // auto-pick effect runs after IdentitiesLoaded fires, then
-        // the FetchBindings event sink runs and dispatches
-        // BindingsLoaded.  The Identity selector renders once
-        // identities are loaded.
-        const identitySelect = await screen.findByLabelText("Identity bundle");
+        // Wait for accounts + memories to settle. The auto-pick effect
+        // runs after AccountsLoaded fires. The Account selector renders
+        // once accounts for the agent's provider are loaded.
+        const identitySelect = await screen.findByLabelText("Account");
         const memorySelect = await screen.findByLabelText("Bundle");
 
-        // Verify the auto-pick wired the bound identity. With Work
-        // bundle bound to claude, the Connect panel must NOT mount.
-        expect((identitySelect as HTMLSelectElement).value).toBe("ident-work");
+        // Verify the auto-pick wired the Work account. It supplies
+        // claude creds, so the Connect panel must NOT mount.
+        expect((identitySelect as HTMLSelectElement).value).toBe("acct-work");
 
         // Type a valid agent name.
         await user.type(screen.getByLabelText("Agent name"), "alpha");
 
-        // Auth should already be "ready" because hasMatchingBinding
-        // for claude on Work is true. The Connect button is the
-        // tell — it appears inside PreLaunchAuthPanel when
-        // authRequired() is true.  Asserting its absence is the
-        // strongest stable signal that the panel didn't mount.
+        // Auth should already be "ready" because the Work account
+        // supplies claude creds. The Connect button is the tell — it
+        // appears inside PreLaunchAuthPanel when authRequired() is
+        // true. Asserting its absence is the strongest stable signal
+        // that the panel didn't mount.
         expect(
             screen.queryByRole("button", { name: /connect/i }),
         ).not.toBeInTheDocument();
@@ -206,7 +208,7 @@ describe("AgentLaunchModal — memory change must not reset auth state (§6.10)"
         expect(
             screen.queryByRole("button", { name: /connect/i }),
         ).not.toBeInTheDocument();
-        expect((identitySelect as HTMLSelectElement).value).toBe("ident-work");
+        expect((identitySelect as HTMLSelectElement).value).toBe("acct-work");
         expect((memorySelect as HTMLSelectElement).value).toBe("mem-personal");
     });
 });

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -23,10 +23,10 @@ import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities
 import { waveEventSubscribe } from "@/app/store/wps";
 import {
     createLaunchFlowStore,
+    accountsForProvider,
+    accountSuppliesProvider,
     continueLocksIdentity as flowContinueLocksIdentity,
     continueLocksMemory as flowContinueLocksMemory,
-    hasMatchingBinding,
-    realIdentities,
     realMemories,
 } from "@/app/store/launch-flow-state";
 
@@ -35,11 +35,7 @@ import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slu
 import { getProvider } from "../providers";
 import { PreLaunchAuthPanel } from "./PreLaunchAuthPanel";
 import { AuthFlowController } from "../auth";
-import {
-    loadAccounts,
-    refreshAccountCache,
-    subscribeAccountChanges,
-} from "@/app/view/identity/identity-model";
+import { refreshAccountCache } from "@/app/view/identity/identity-model";
 
 export interface LaunchOverrides {
     /** Instance name — written into AGENTMUX_AGENT_ID and used to
@@ -52,9 +48,10 @@ export interface LaunchOverrides {
     environment: "local" | "docker";
     /** Only set when agentType === "container". */
     containerImage?: string;
-    /** Selected Identity bundle id. Required (non-empty) at submit;
-     *  the form blocks Launch until the user picks or creates one. */
-    identityId: string;
+    /** Selected account id. Required (non-empty) at submit; the form
+     *  blocks Launch until the user picks or creates one. Issue #1624
+     *  PR-C Part B — was `identityId` (a bundle id). */
+    accountId: string;
     /** Selected Memory bundle id. Required (non-empty) at submit. */
     memoryId: string;
     /** v8 — when set, this launch is a continuation of a prior named
@@ -86,25 +83,15 @@ interface AgentLaunchModalPanelProps {
      *  Codex P2 on PR #910 rounds 6 + 7: rounds 1-6 only restored
      *  identity/memory selection; round 7 added the rest of the form. */
     initialFormState?: Partial<LaunchFormState>;
-    /** When true, the OAuth Connect panel fires `startConnect()` once
-     *  on mount — set by the OAuth-Connect → New Identity → launch
-     *  round-trip so the user doesn't re-click Connect after naming
-     *  the bundle. Spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
-    autoStartAuth?: boolean;
-    /** Called when the "+" / empty-state New buttons fire, OR when the
-     *  OAuth Connect panel needs the New Identity modal interposed
-     *  (`purpose: "oauth-continue"`). The picker is expected to chain
-     *  `modalLayer.replace(newIdentityRequest)` — this component doesn't
-     *  know how to build that request.
-     *
-     *  The current launch form state is passed through so the picker
-     *  can preserve it across the new-bundle round-trip; `purpose`
-     *  tells the picker whether to set `autoStartAuth` on the return
-     *  launch request. */
-    onRequestNewIdentity?: (
-        current: LaunchFormState,
-        purpose: "create" | "oauth-continue",
-    ) => void;
+    /** Called when the "+ Add account" button fires — the picker is
+     *  expected to chain `modalLayer.replace(addAccountRequest)` — this
+     *  component doesn't know how to build that request. The current
+     *  launch form state is passed through so the picker can preserve
+     *  it across the round-trip. Issue #1624 PR-C Part B — OAuth
+     *  Connect no longer routes through this callback (it starts
+     *  directly from `PreLaunchAuthPanel`); this now only fires for
+     *  manual/API-key account creation. Replaces `onRequestNewIdentity`. */
+    onRequestAddAccount?: (current: LaunchFormState) => void;
     onRequestNewMemory?: (current: LaunchFormState) => void;
 }
 
@@ -115,7 +102,7 @@ export interface LaunchFormState {
     name: string;
     runtime: "host" | "container";
     image: string;
-    identityId: string;
+    accountId: string;
     memoryId: string;
     /** Continuation context. `null` = "— New agent —". Round-trip
      *  preserved alongside the form fields so Continue mode survives
@@ -129,6 +116,11 @@ export interface LaunchFormState {
 export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
     const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
     const displayName = () => catalog()?.displayName ?? props.agent.name;
+    // Declared early — `createMemo`'s first run is synchronous (unlike
+    // `createEffect`, which defers to after setup completes), so any
+    // memo below that reads `provider()` needs the binding to already
+    // exist at the point it's created.
+    const provider = createMemo(() => getProvider(props.agent.provider));
 
     // Form + submit state live in the launch-flow-state reducer slice
     // (Stage 2b/2c of SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).
@@ -139,24 +131,18 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // stay unchanged.
     //
     // What's still local (Stage 2d candidates):
-    //  - `identities`, `memories`, `selectedBundleBindings` — local
-    //    resources. Stage 2d migrates them to the store with push-
-    //    based binding events.
+    //  - `memories` — local resource.
     //  - `namedAgents` (continuation list) — out of slice scope.
     //  - `authController` — auth state stays in its own controller
     //    (lifted to this component in Stage 1).
     // Reducer events drive side-effects. The store calls `eventSink`
-    // every time the reducer emits one; we wire `FetchBindings` to
-    // run the listidentitybindings RPC + dispatch back into the
-    // store. Defining the store with the sink at creation time
-    // means the `Opened` dispatch below (with potentially preselected
-    // identityId) goes through the sink immediately.
+    // every time the reducer emits one; the only wrapped event left
+    // is `Auth` (issue #1624 PR-C Part B removed `FetchBindings` —
+    // accounts load once and are filtered client-side, no per-
+    // selection binding fetch needed). Auth events are handled by the
+    // AuthFlowController itself, not here.
     const flow = createLaunchFlowStore({
-        eventSink: (event) => {
-            if (event.type === "FetchBindings") {
-                void fetchBindings(event.identityId);
-            }
-        },
+        eventSink: () => {},
     });
     flow.dispatch({ type: "Opened", initial: props.initialFormState });
     const name = () => flow.state.form.name;
@@ -166,9 +152,9 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         flow.dispatch({ type: "RuntimeChanged", runtime: v });
     const image = () => flow.state.form.image;
     const setImage = (v: string) => flow.dispatch({ type: "ImageChanged", image: v });
-    const identityId = () => flow.state.form.identityId;
-    const setIdentityId = (v: string) =>
-        flow.dispatch({ type: "IdentityChanged", identityId: v });
+    const accountId = () => flow.state.form.accountId;
+    const setAccountId = (v: string) =>
+        flow.dispatch({ type: "AccountChanged", accountId: v });
     const memoryId = () => flow.state.form.memoryId;
     const setMemoryId = (v: string) =>
         flow.dispatch({ type: "MemoryChanged", memoryId: v });
@@ -182,19 +168,22 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
 
     onCleanup(() => flow.dispatch({ type: "Closed" }));
 
-    // Identities + Memories now live in the reducer slice
+    // Accounts + Memories now live in the reducer slice
     // (Stage 2c.2 of SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).
-    // `loadIdentities` / `loadMemories` are async wrappers around the
-    // RPCs that dispatch the loading lifecycle commands; the view
-    // reads via `flow.state.identities.list` etc. Existing accessor
-    // names (`identities()`, `memories()`) are kept as thin façades.
-    const loadIdentities = async () => {
-        flow.dispatch({ type: "IdentitiesLoading" });
+    // `loadAccountsIntoForm` / `loadMemories` are async wrappers that
+    // dispatch the loading lifecycle commands; the view reads via
+    // `flow.state.accounts.list` etc. Issue #1624 PR-C Part B —
+    // accounts source from the shared account cache
+    // (`identity-model.ts`) instead of `ListIdentityBundlesCommand`,
+    // and load once (no per-selection binding fetch needed — an
+    // account's `provider` is already known client-side).
+    const loadAccountsIntoForm = async () => {
+        flow.dispatch({ type: "AccountsLoading" });
         try {
-            const list = await RpcApi.ListIdentityBundlesCommand(TabRpcClient, {});
-            flow.dispatch({ type: "IdentitiesLoaded", list: list ?? [] });
+            const list = await refreshAccountCache();
+            flow.dispatch({ type: "AccountsLoaded", list });
         } catch (e: any) {
-            flow.dispatch({ type: "IdentitiesFailed", error: String(e?.message ?? e) });
+            flow.dispatch({ type: "AccountsFailed", error: String(e?.message ?? e) });
         }
     };
     const loadMemories = async () => {
@@ -206,26 +195,41 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
             flow.dispatch({ type: "MemoriesFailed", error: String(e?.message ?? e) });
         }
     };
-    void loadIdentities();
+    void loadAccountsIntoForm();
     void loadMemories();
-    const identities = () => flow.state.identities.list;
     const memories = () => flow.state.memories.list;
 
-    // Empty-state predicate via the slice's `realIdentities` /
-    // `realMemories` selectors, which filter out any back-compat
-    // `is_blank` singleton.
-    const hasUserIdentities = createMemo(() => realIdentities(flow.state).length > 0);
+    // Cross-tab + cross-pane reactivity: the shared account cache
+    // (`identity-model.ts`) isn't itself subscribed to the backend's
+    // `identityaccounts:changed` broadcast — callers refresh it
+    // explicitly. Subscribe here so an account created/verified from
+    // another tab (or this modal's own OAuth/API-key flows) keeps the
+    // dropdown + status live without a manual reopen. Replaces the
+    // old `identitybundlebindings:changed:<id>` subscription (bundle
+    // bindings no longer exist in this flow).
+    createEffect(() => {
+        const unsub = waveEventSubscribe({
+            eventType: "identityaccounts:changed",
+            handler: () => void loadAccountsIntoForm(),
+        });
+        onCleanup(unsub);
+    });
+
+    // Empty-state predicate — accounts for the agent's own provider.
+    const hasAccountsForProvider = createMemo(
+        () => accountsForProvider(flow.state, provider()?.id ?? "").length > 0,
+    );
     const hasUserMemories = createMemo(() => realMemories(flow.state).length > 0);
 
-    // Auto-pick the first available bundle when nothing is selected
-    // yet — saves a click for users with existing bundles. Gated on
-    // `!isContinue()` so legacy-continuation rows don't get filled
-    // with an unrelated bundle's credentials.
+    // Auto-pick the first available account for this provider when
+    // nothing is selected yet — saves a click for users with existing
+    // accounts. Gated on `!isContinue()` so legacy-continuation rows
+    // don't get filled with an unrelated account's credentials.
     createEffect(() => {
         if (isContinue()) return;
-        if (identityId()) return;
-        const firstReal = realIdentities(flow.state)[0];
-        if (firstReal) setIdentityId(firstReal.id);
+        if (accountId()) return;
+        const first = accountsForProvider(flow.state, provider()?.id ?? "")[0];
+        if (first) setAccountId(first.id);
     });
     createEffect(() => {
         if (isContinue()) return;
@@ -245,7 +249,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         name: name(),
         runtime: runtime(),
         image: image(),
-        identityId: identityId(),
+        accountId: accountId(),
         memoryId: memoryId(),
         // Capture continuation context so the `+ New bundle` round-trip
         // restores Continue mode on return; without this the launch
@@ -253,12 +257,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         // gate wrongly re-engages.
         continueOfId: flow.state.form.continueOfId,
     });
-    // The plain `+ New identity` button uses `purpose: "create"`. The
-    // OAuth Connect (`needs-bundle`) interposition routes through the
-    // same callback with `purpose: "oauth-continue"` — see the
-    // PreLaunchAuthPanel `onRequestNewIdentity` wiring below.
-    const handleNewIdentity = () =>
-        props.onRequestNewIdentity?.(snapshot(), "create");
+    // OAuth Connect no longer routes through this callback (issue
+    // #1624 PR-C Part B) — it fires only for the "+ Add account"
+    // (manual/API-key) path now.
+    const handleAddAccount = () => props.onRequestAddAccount?.(snapshot());
     const handleNewMemory = () => props.onRequestNewMemory?.(snapshot());
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
@@ -314,12 +316,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                 ? null
                 : (namedAgents() ?? []).find((r) => r.instance_id === id) ?? null;
         // Legacy rows may carry "" or "blank" identity_id/memory_id
-        // from before the blank-removal. Treat both as "no carry-over"
-        // so the user must pick a real bundle for the continuation.
+        // from before the blank-removal, or (pre-issue-#1624-PR-C rows)
+        // a bundle id that no longer resolves to an account. Treat all
+        // three as "no carry-over" so the user must pick a real account
+        // for the continuation — see the plan's migration note; an
+        // unresolvable carried id already falls back to "re-pick" here
+        // rather than needing a backend resolution step.
         const carry = row
             ? {
                   name: row.instance_name,
-                  identityId:
+                  accountId:
                       row.identity_id && row.identity_id !== "blank"
                           ? row.identity_id
                           : "",
@@ -429,180 +435,83 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     });
     onCleanup(() => authController.dispose());
     const authStateKind = () => flow.state.auth.kind;
-    const onBundleCreated = (bundleId: string) => {
-        // The new bundle was just persisted backend-side. Switch the
-        // dropdown to it AND refetch the identities list so the new
-        // row appears in the dropdown options (otherwise hover/options
-        // would show stale data until reopen).
+    const onAccountCreated = (accId: string) => {
+        // The new account was just persisted backend-side (OAuth or
+        // API-key). Switch the dropdown to it AND refresh the account
+        // cache so the new row appears in the dropdown options
+        // (otherwise hover/options would show stale data until reopen).
         //
-        // Defense-in-depth — `PreLaunchAuthPanel` filters
-        // `pending-bundle-for-...` placeholders before calling, but
-        // guard here too so any future call site can't poison the
-        // dropdown with a non-existent bundle row.
-        if (!bundleId || bundleId.startsWith("pending-bundle-for-")) {
-            return;
-        }
-        setIdentityId(bundleId);
-        void loadIdentities();
+        // Defense-in-depth — guard against an empty id so a future call
+        // site can't poison the dropdown with a non-existent row.
+        if (!accId) return;
+        setAccountId(accId);
+        void loadAccountsIntoForm();
     };
-    const provider = createMemo(() => getProvider(props.agent.provider));
 
-    // Bindings for the currently selected identity bundle — used by
-    // authRequired() to detect non-blank bundles that have no
-    // credential binding for the agent's provider (e.g. a "Work"
-    // identity created via "+ New" but never connected to Claude/Codex
-    // yet). Reagent + codex P1 on PR #910 round 3 — without this
-    // check, "+ New" could bypass the OAuth gate entirely.
-    // Bindings now live in the reducer slice (Stage 2c.3). The store
-    // emits `FetchBindings` events whenever an identity is selected
-    // (IdentityChanged / Opened / ContinueOfChanged for uncached id).
-    // We respond by running the RPC + dispatching BindingsLoading →
-    // BindingsLoaded. The reducer's `hasMatchingBinding(state, providerId)`
-    // selector handles the race guard (loading → false) that the
-    // legacy memo did inline.
-    async function fetchBindings(id: string): Promise<void> {
-        if (!id || id.startsWith("pending-bundle-for-")) return;
-        flow.dispatch({ type: "BindingsLoading", identityId: id });
-        try {
-            const list = await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
-                identity_id: id,
-            });
-            flow.dispatch({ type: "BindingsLoaded", identityId: id, bindings: list ?? [] });
-        } catch {
-            // Settle the loading flag with an empty list — same
-            // safe-default the prior createResource catch returned.
-            flow.dispatch({ type: "BindingsLoaded", identityId: id, bindings: [] });
-        }
-    }
+    // True when the selected account actually supplies credentials for
+    // the agent's provider. Replaces `bundleHasMatchingBinding` — with
+    // a direct account selection instead of a bundle-of-bindings, this
+    // is a plain lookup against the already-loaded account list (issue
+    // #1624 PR-C Part B).
+    const accountSupplies = createMemo(() =>
+        accountSuppliesProvider(flow.state, provider()?.id ?? ""),
+    );
 
-    // Cross-tab + cross-pane reactivity: subscribe to the backend's
-    // `identitybundlebindings:changed:<id>` push event so a bind/
-    // unbind in another tab's Identity pane updates this modal
-    // without a manual refetch. Re-subscribes on identityId change
-    // since the event name embeds the identity id.
-    createEffect(() => {
-        const id = identityId();
-        if (!id) return;
-        const unsub = waveEventSubscribe({
-            eventType: `identitybundlebindings:changed:${id}`,
-            handler: () => {
-                void (async () => {
-                    // Refresh the account cache too. The backend's
-                    // expiry probe (PR D) updates IdentityAccount.status
-                    // and publishes this same event — without refreshing
-                    // accounts here, `bundleBindingStatus` reads stale
-                    // status from the in-memory cache until something
-                    // unrelated triggers a refresh. codex P2 on #982.
-                    void refreshAccountCache();
-                    try {
-                        const list = await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
-                            identity_id: id,
-                        });
-                        flow.dispatch({
-                            type: "BindingsChanged",
-                            identityId: id,
-                            bindings: list ?? [],
-                        });
-                    } catch {
-                        // Best-effort; leave the cache unchanged on
-                        // failure so the user can still launch with
-                        // whatever the last good fetch saw.
-                    }
-                })();
-            },
-        });
-        onCleanup(unsub);
+    // The selected account's own `status` field. Replaces
+    // `bundleBindingStatus` — no bundle→binding→account join needed
+    // anymore, `flow.state.accounts.list` is already reactive (updated
+    // by `loadAccountsIntoForm` on the `identityaccounts:changed`
+    // subscription above), so no separate cache-tick signal is needed
+    // either.
+    const selectedAccountStatus = createMemo<string | null>(() => {
+        const id = accountId();
+        if (!id) return null;
+        return flow.state.accounts.list.find((a) => a.id === id)?.status ?? null;
     });
 
-    const bundleHasMatchingBinding = createMemo(() => {
-        const providerId = provider()?.id;
-        if (!providerId) return false;
-        return hasMatchingBinding(flow.state, providerId);
-    });
-
-    // Account-cache backed memo that resolves the bound account row for
-    // the current (identity, provider) pair and exposes its `status`
-    // string. Per spec §4.4 the canonical oauth-class values are
-    // `"valid" | "expired" | "needs_reauth" | "unknown"`. Returns `null`
-    // when there's no matching binding or the account row isn't in the
-    // cache yet — the consumer (`PreLaunchAuthPanel`) treats `null` as
-    // "no status info, use generic wording".
-    //
-    // The cache is the same one `IdentityPaneViewModel` subscribes to,
-    // so a status flip pushed by the backend's expiry probe
-    // (`identitybundlebindings:changed:<id>` → refreshes cache)
-    // reactively updates this memo and re-renders the panel.
-    const [accountCacheTick, setAccountCacheTick] = createSignal(0);
-    const accountCacheUnsub = subscribeAccountChanges(() => {
-        setAccountCacheTick((n) => n + 1);
-    });
-    onCleanup(accountCacheUnsub);
-    const bundleBindingStatus = createMemo<string | null>(() => {
-        accountCacheTick();
-        const id = flow.state.form.identityId;
-        const providerId = provider()?.id;
-        if (!id || !providerId) return null;
-        const bindings = flow.state.bindings[id] ?? [];
-        const b = bindings.find((bb) => bb.provider === providerId);
-        if (!b) return null;
-        const acc = loadAccounts().find((a) => a.id === b.account_id);
-        return acc?.status ?? null;
-    });
-
-    // True when the bound account is in an oauth-class state that
+    // True when the selected account is in an oauth-class state that
     // benefits from a Reconnect nudge — strictly a wording trigger, not
     // a launch-blocker (spec §4.4: "wording-only nudge"). The Launch
-    // button stays enabled because the binding still counts; the CLI
+    // button stays enabled because the account still counts; the CLI
     // will refresh on its first call.
-    const bundleNeedsReconnectNudge = createMemo(() => {
-        const s = bundleBindingStatus();
+    const accountNeedsReconnectNudge = createMemo(() => {
+        const s = selectedAccountStatus();
         return s === "needs_reauth" || s === "expired";
     });
 
     // Auth gate applies to fresh launches of OAuth providers when the
-    // selected identity can't supply credentials for the agent's
+    // selected account can't supply credentials for the agent's
     // provider. That's true when:
     //
-    // - `blank`/empty is selected — ambient creds, OAuth flow runs once.
-    // - A non-blank bundle without a matching provider binding —
-    //   e.g. "+ New" just created an empty "Work" bundle. Reagent +
-    //   codex P1 on PR #910 round 3.
+    // - No account selected — ambient creds, OAuth flow runs once.
+    // - A selected account for a different provider.
     //
     // Bypasses:
     // - `isContinue` — prior launch already produced creds.
-    // - API-key providers (kimi/pi) — until the backend
-    //   `auth.submitapikey` persists bundles (PR C-2), the gate would
-    //   deadlock. Their existing `launch-flow.ts` Phase 2 prompts for
-    //   the key in-line. Reagent + codex P1 on #847.
+    // - API-key providers (kimi/pi) — their existing `launch-flow.ts`
+    //   Phase 2 prompts for the key in-line. Reagent + codex P1 on #847.
     //
     // Hard auth-blockers: launch CANNOT proceed without the user
     // completing OAuth. Drives both the panel mount AND the launch
     // gate.
-    //
-    // (Historical note: PRs A–E of SPEC_OAUTH_IDENTITY_BUNDLES wired
-    //  oauth-class providers — including openclaw — through real
-    //  per-bundle credential dirs, so the previous `provider.id ===
-    //  "openclaw"` always-gate is no longer needed. The standard
-    //  `hasMatchingBinding` path handles every oauth provider.
-    //  PR F cleanup, 2026-05-22.)
     const authBlocksLaunch = () =>
         !isContinue()
         && provider()?.authType === "oauth"
         && (
-            identityId() === ""
-            || !bundleHasMatchingBinding()
+            accountId() === ""
+            || !accountSupplies()
         );
     // Soft nudges: show the Connect CTA (with status-aware wording)
-    // when the binding is present but its account status is
-    // `needs_reauth` / `expired`. Per spec §4.4 this is a "wording-only
-    // nudge" — does NOT block Launch. The CLI's own refresh path
-    // handles the rest on first call; the nudge just gives the user a
-    // one-click path to refresh proactively.
+    // when the account is selected but its status is `needs_reauth` /
+    // `expired`. Per spec §4.4 this is a "wording-only nudge" — does
+    // NOT block Launch. The CLI's own refresh path handles the rest on
+    // first call; the nudge just gives the user a one-click path to
+    // refresh proactively.
     const authNeedsReconnectWording = () =>
         !isContinue()
         && provider()?.authType === "oauth"
-        && bundleHasMatchingBinding()
-        && bundleNeedsReconnectNudge();
+        && accountSupplies()
+        && accountNeedsReconnectNudge();
     // Mount the panel for EITHER reason (hard block or soft nudge).
     const authRequired = () => authBlocksLaunch() || authNeedsReconnectWording();
     // Launch-readiness gate. Note this only consults `authBlocksLaunch`
@@ -613,7 +522,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     const canSubmit = () =>
         !submitting()
         && slugifyInstanceName(name()).length > 0
-        && identityId() !== ""
+        && accountId() !== ""
         && memoryId() !== ""
         && authReady();
 
@@ -633,7 +542,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                 agentType: runtime(),
                 environment: runtime() === "container" ? "docker" : "local",
                 containerImage: runtime() === "container" ? resolvedImage() : undefined,
-                identityId: identityId(),
+                accountId: accountId(),
                 memoryId: memoryId(),
                 // v8 — when continuing a past agent, thread the id +
                 // working directory through. Launch flow uses
@@ -835,58 +744,60 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                         <div class="agent-launch-modal-bundle-row">
                             <span class="agent-launch-modal-bundle-row-label">Identity</span>
                             <Show
-                                when={hasUserIdentities()}
+                                when={hasAccountsForProvider()}
                                 fallback={
                                     <button
                                         type="button"
                                         class="agent-launch-modal-bundle-empty-btn"
-                                        onClick={handleNewIdentity}
+                                        onClick={handleAddAccount}
                                         disabled={
                                             submitting() ||
                                             continueLocksIdentity() ||
-                                            !props.onRequestNewIdentity
+                                            !props.onRequestAddAccount
                                         }
                                         title={
-                                            props.onRequestNewIdentity
+                                            props.onRequestAddAccount
                                                 ? undefined
                                                 : "Coming soon"
                                         }
                                     >
-                                        + New identity bundle...
+                                        + Add {provider()?.displayName ?? "account"}...
                                     </button>
                                 }
                             >
                                 <select
                                     class="agent-launch-modal-input"
-                                    value={identityId()}
-                                    onChange={(e) => setIdentityId(e.currentTarget.value)}
+                                    value={accountId()}
+                                    onChange={(e) => setAccountId(e.currentTarget.value)}
                                     disabled={submitting() || continueLocksIdentity()}
-                                    aria-label="Identity bundle"
+                                    aria-label="Account"
                                 >
-                                    <Show when={!identityId()}>
-                                        <option value="" disabled>— Pick an identity —</option>
+                                    <Show when={!accountId()}>
+                                        <option value="" disabled>— Pick an account —</option>
                                     </Show>
-                                    <For each={(identities() ?? []).filter((b) => !b.is_blank)}>
-                                        {(bundle) => (
-                                            <option value={bundle.id}>{bundle.name}</option>
+                                    <For each={accountsForProvider(flow.state, provider()?.id ?? "")}>
+                                        {(account) => (
+                                            <option value={account.id}>
+                                                {account.display_name?.trim() || account.name}
+                                            </option>
                                         )}
                                     </For>
                                 </select>
                                 <button
                                     type="button"
                                     class="agent-launch-modal-bundle-new-btn"
-                                    onClick={handleNewIdentity}
+                                    onClick={handleAddAccount}
                                     disabled={
                                         submitting() ||
                                         continueLocksIdentity() ||
-                                        !props.onRequestNewIdentity
+                                        !props.onRequestAddAccount
                                     }
                                     title={
-                                        props.onRequestNewIdentity
-                                            ? "New identity bundle..."
+                                        props.onRequestAddAccount
+                                            ? `Add ${provider()?.displayName ?? "account"}...`
                                             : "Coming soon"
                                     }
-                                    aria-label="New identity bundle"
+                                    aria-label="Add account"
                                 >
                                     +
                                 </button>
@@ -973,30 +884,23 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                      * Pre-launch OAuth panel (spec:
                      * SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md).
                      * Shows the Connect CTA whenever the selected
-                     * identity can't supply creds for this provider —
-                     * blank singleton, openclaw, or a non-blank bundle
-                     * without a matching binding (e.g. "+ New" just
-                     * created an empty bundle). The panel uses
-                     * `hasMatchingBinding` to compute its own outcome
-                     * so non-blank-but-empty bundles don't shortcut
-                     * to `ready`.
+                     * account can't supply creds for this provider — no
+                     * account selected, or a selected account for a
+                     * different provider. Issue #1624 PR-C Part B: OAuth
+                     * Connect starts directly (no "+ New identity"
+                     * interposition) — the backend mints the account.
                      */}
                     <Show when={authRequired()}>
                         <PreLaunchAuthPanel
                             provider={provider()}
-                            identityId={identityId}
-                            hasMatchingBinding={bundleHasMatchingBinding}
-                            bindingStatus={bundleBindingStatus}
+                            accountId={accountId}
+                            accountSuppliesProvider={accountSupplies}
+                            accountStatus={selectedAccountStatus}
                             controller={authController}
-                            onBundleCreated={onBundleCreated}
-                            autoStartAuth={props.initialFormState != null && props.autoStartAuth === true}
-                            onRequestNewIdentity={
-                                props.onRequestNewIdentity
-                                    ? () =>
-                                          props.onRequestNewIdentity?.(
-                                              snapshot(),
-                                              "oauth-continue",
-                                          )
+                            onAccountCreated={onAccountCreated}
+                            onRequestAddAccount={
+                                props.onRequestAddAccount
+                                    ? () => props.onRequestAddAccount?.(snapshot())
                                     : undefined
                             }
                             disabled={submitting()}

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -2,80 +2,70 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentNewIdentityModalPanel — creates an empty Identity bundle from
- * the Launch modal's "+ New" affordance. Identity bundles are generic
- * credential containers (Claude / Codex / Gemini / OpenClaw OAuth +
- * GitHub + AWS + …), NOT provider-scoped — so the create form is
- * deliberately small: just name + description. Connector setup
- * happens later in the Identity pane.
+ * AgentAddAccountModalPanel — adds a manual/API-key account from the
+ * Launch modal's "+ Add account" affordance. Issue #1624 PR-C Part B:
+ * accounts are provider-scoped (unlike the old provider-agnostic
+ * Identity bundle this modal used to create), so the form only needs
+ * a name + API key for the caller-supplied provider. OAuth Connect no
+ * longer routes through this modal — it starts directly from the
+ * launch modal's auth panel, which mints the account backend-side.
  *
- * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ * Mirrors the key-entry flow in identity-view.tsx's Armory Accounts
+ * tab (`AccountKeyVerifyCommand`, `validate: true`).
  */
 
 import { createSignal, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 
-export interface NewIdentityFormData {
-    name: string;
-    description: string;
+export interface AddAccountFormData {
+    accountId: string;
 }
 
-interface AgentNewIdentityModalPanelProps {
+interface AgentAddAccountModalPanelProps {
+    /** Provider the new account is scoped to. */
+    provider: string;
     /** Suggested initial name (often empty). */
     initialName?: string;
-    /** Why this modal was opened — controls only the primary button
-     *  label, nothing else about the form:
-     *   - `"create"` (default): plain `+ New identity` button — the
-     *     primary action reads "Create" (creates a named bundle and
-     *     returns to the launch form).
-     *   - `"oauth-continue"`: the OAuth Connect (`needs-bundle`) click
-     *     interposed this modal first — the primary action reads
-     *     "Continue" because the caller chains into OAuth after the
-     *     bundle is created.
-     *  Spec: SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
-    purpose?: "create" | "oauth-continue";
     onCancel: () => void;
     /** Runs the RPC + downstream chaining. Owned by the layer so its
      *  `submitting()` signal correctly gates ESC / backdrop while the
-     *  RPC is in flight (mirrors the Launch modal pattern). Reagent
-     *  P1 on PR #911 — panel-local submitting wasn't visible to the
-     *  layer's safeClose, so users could ESC mid-RPC and the resolved
-     *  promise would re-open Launch unexpectedly. */
-    onSubmit: (formData: NewIdentityFormData) => Promise<void>;
+     *  RPC is in flight (mirrors the Launch modal pattern). */
+    onSubmit: (formData: AddAccountFormData) => Promise<void>;
 }
 
-export const AgentNewIdentityModalPanel = (
-    props: AgentNewIdentityModalPanelProps,
+export const AgentAddAccountModalPanel = (
+    props: AgentAddAccountModalPanelProps,
 ): JSX.Element => {
     const [name, setName] = createSignal(props.initialName ?? "");
-    const [description, setDescription] = createSignal("");
+    const [apiKey, setApiKey] = createSignal("");
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
 
-    const canSubmit = () => name().trim().length > 0 && !submitting();
-
-    // Primary-button label. `oauth-continue` callers chain into OAuth
-    // after the bundle is created, so "Continue" reads better than
-    // "Create" — spec §2 decision 4. The progress label tracks the
-    // same split so the in-flight state stays coherent.
-    const purpose = () => props.purpose ?? "create";
-    const primaryLabel = () => {
-        if (submitting()) {
-            return purpose() === "oauth-continue" ? "Continuing…" : "Creating…";
-        }
-        return purpose() === "oauth-continue" ? "Continue" : "Create";
-    };
+    const canSubmit = () =>
+        name().trim().length > 0 && apiKey().trim().length > 0 && !submitting();
 
     const submit = async () => {
         if (!canSubmit()) return;
         setSubmitting(true);
         setError(null);
         try {
-            await props.onSubmit({
+            const res = await RpcApi.AccountKeyVerifyCommand(TabRpcClient, {
+                provider: props.provider,
                 name: name().trim(),
-                description: description().trim(),
+                apiKey: apiKey().trim(),
+                validate: true,
             });
+            if (!res.valid || !res.accountId) {
+                setError(res.error ?? "Validation failed");
+                setSubmitting(false);
+                return;
+            }
+            // Drop the plaintext from the form immediately.
+            setApiKey("");
+            await props.onSubmit({ accountId: res.accountId });
             // On success the layer unmounts this panel via the
             // request's chained modalLayer.replace. The reset is for
             // the fragile case where the caller's chain doesn't fire.
@@ -98,11 +88,10 @@ export const AgentNewIdentityModalPanel = (
     return (
         <>
             <header class="modal-panel-header">
-                <h2 class="modal-panel-title">New Identity</h2>
+                <h2 class="modal-panel-title">Add Account</h2>
                 <p class="modal-panel-description">
-                    An Identity holds credentials your agent uses — Claude /
-                    Codex / Gemini / OpenClaw OAuth + GitHub / AWS / etc.
-                    Same Identity works across providers.
+                    Stores an API key in the OS keychain and validates it with a
+                    single live probe.
                 </p>
             </header>
             <div class="modal-panel-body agent-new-bundle-modal-body">
@@ -120,23 +109,17 @@ export const AgentNewIdentityModalPanel = (
                     />
                 </label>
                 <label class="agent-new-bundle-modal-field">
-                    <span class="agent-new-bundle-modal-label">
-                        Description <span class="agent-new-bundle-modal-optional">(optional)</span>
-                    </span>
+                    <span class="agent-new-bundle-modal-label">API key</span>
                     <input
-                        type="text"
+                        type="password"
                         class="agent-new-bundle-modal-input"
-                        placeholder="What's this Identity for?"
-                        value={description()}
-                        onInput={(e) => setDescription(e.currentTarget.value)}
+                        placeholder="sk-…"
+                        value={apiKey()}
+                        onInput={(e) => setApiKey(e.currentTarget.value)}
                         onKeyDown={onKeyDown}
                         disabled={submitting()}
                     />
                 </label>
-                <p class="agent-new-bundle-modal-hint">
-                    You'll add connections (Claude, GitHub, AWS, …) in the
-                    Identity pane after creating this bundle.
-                </p>
                 {error() && (
                     <div class="agent-new-bundle-modal-error">{error()}</div>
                 )}
@@ -150,11 +133,11 @@ export const AgentNewIdentityModalPanel = (
                     className="green solid"
                     disabled={!canSubmit()}
                 >
-                    {primaryLabel()}
+                    {submitting() ? "Validating…" : "Add"}
                 </Button>
             </footer>
         </>
     );
 };
 
-AgentNewIdentityModalPanel.displayName = "AgentNewIdentityModalPanel";
+AgentAddAccountModalPanel.displayName = "AgentAddAccountModalPanel";

--- a/frontend/app/view/agent/components/AgentPicker.test.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.test.tsx
@@ -336,7 +336,7 @@ describe("AgentPicker — two-tier layout (Phase 1)", () => {
         expect(stubAgent.agent_type).toBe("container");
         expect(overrides.agentType).toBe("container");
         expect(overrides.environment).toBe("docker");
-        expect(overrides.identityId).toBe("id-work");
+        expect(overrides.accountId).toBe("id-work");
         expect(overrides.memoryId).toBe("mem-notes");
         expect(overrides.instanceName).toBe("Mary");
         expect(overrides.continueOfInstanceId).toBeUndefined();

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -151,25 +151,18 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // to `modalLayer.replace()` for a crossfade (no shell teardown).
     //
     // `initialFormState` carries the user's in-progress launch-form
-    // edits through the "+ New identity/memory" round-trip — name,
-    // runtime, image, identity, memory. Spec: Phase β of
+    // edits through the "+ Add account / + New memory" round-trip —
+    // name, runtime, image, account, memory. Spec: Phase β of
     // SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md; codex P2 on
     // round 7 expanded preservation from identity+memory only to the
     // full form.
     const buildLaunchRequest = (
         agent: AgentDefinition,
         initialFormState?: Partial<LaunchFormStateWire>,
-        // When set, the re-opened launch modal fires its OAuth
-        // `startConnect()` once on mount. Used by the OAuth-Connect →
-        // New Identity → launch round-trip so the user doesn't re-click
-        // Connect after naming the bundle — spec
-        // SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2.
-        autoStartAuth?: boolean,
     ) => ({
         kind: "launch-agent" as const,
         agent,
         originBlockId: props.model.blockId,
-        autoStartAuth,
         onSubmit: async (overrides: LaunchOverrides) => {
             setLaunching(agent.id);
             try {
@@ -186,38 +179,24 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             }
         },
         initialFormState,
-        onRequestNewIdentity: (
-            current: LaunchFormStateWire,
-            purpose: "create" | "oauth-continue",
-        ) => {
+        // OAuth Connect no longer routes through this callback (issue
+        // #1624 PR-C Part B) — it starts directly from the launch
+        // modal's auth panel. This now only fires for the "+ Add
+        // account" (manual/API-key) button.
+        onRequestAddAccount: (current: LaunchFormStateWire) => {
             // Thread the user's whole live form snapshot through the
-            // new-identity round-trip so name/runtime/image/memory
-            // survive alongside the freshly-created identity id.
-            //
-            // Two entry points share this chain (spec §2):
-            //  - `"create"`  — the plain `+ New identity` button. On
-            //    Continue/Create, return to the launch form with the
-            //    new id selected; the user clicks Launch when ready.
-            //  - `"oauth-continue"` — the OAuth Connect (`needs-bundle`)
-            //    click. The New Identity modal's primary button reads
-            //    "Continue"; on success the launch form re-opens with
-            //    the new id selected AND `autoStartAuth` set so OAuth
-            //    resumes automatically against the freshly-named
-            //    bundle.
+            // add-account round-trip so name/runtime/image/memory
+            // survive alongside the freshly-created account id.
             modalLayer.replace({
-                kind: "new-identity" as const,
+                kind: "add-account" as const,
                 originBlockId: props.model.blockId,
-                purpose,
+                provider: agent.provider,
                 onCreated: (id: string) => {
                     modalLayer.replace(
-                        buildLaunchRequest(
-                            agent,
-                            {
-                                ...current,
-                                identityId: id,
-                            },
-                            purpose === "oauth-continue",
-                        ),
+                        buildLaunchRequest(agent, {
+                            ...current,
+                            accountId: id,
+                        }),
                     );
                 },
                 onCancel: () => {
@@ -226,9 +205,9 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             });
         },
         onRequestNewMemory: (current: LaunchFormStateWire) => {
-            // Mirror of onRequestNewIdentity above — thread the live
+            // Mirror of onRequestAddAccount above — thread the live
             // form snapshot through the new-memory round-trip so the
-            // user's other edits (name, runtime, image, identity)
+            // user's other edits (name, runtime, image, account)
             // survive alongside the freshly-created memory id.
             modalLayer.replace({
                 kind: "new-memory" as const,
@@ -284,7 +263,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 instanceName: row.instance_name,
                 agentType: (def.agent_type as "host" | "container") || "host",
                 environment: def.agent_type === "container" ? "docker" : "local",
-                identityId: row.identity_id,
+                accountId: row.identity_id,
                 memoryId: row.memory_id,
                 continueOfInstanceId: row.instance_id,
                 workDirOverride: row.working_directory,
@@ -316,7 +295,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 instanceName: branchLabel,
                 agentType: (forkedDef.agent_type as "host" | "container") || "host",
                 environment: forkedDef.agent_type === "container" ? "docker" : "local",
-                identityId: row.identity_id,
+                accountId: row.identity_id,
                 memoryId: row.memory_id,
             });
         } finally {
@@ -422,14 +401,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const autoContinue = async (agent: AgentDefinition) => {
         setLaunching(agent.id);
         try {
-            // Identity / memory are launch-time picks that aren't
+            // Account / memory are launch-time picks that aren't
             // stored on the AgentDefinition itself — they live on the
             // last NamedAgentRow for this definition. We auto-continue
             // by reusing the most-recent instance's pair so the spawn
             // resolves credentials the same way as the previous run.
             // Empty strings are fine: the backend resolver treats them
-            // as "use ambient credentials" (matches the blank bundle).
-            let identityId = "";
+            // as "use ambient credentials".
+            let accountId = "";
             let memoryId = "";
             try {
                 const rows = await RpcApi.ListNamedAgentsCommand(TabRpcClient, {
@@ -439,7 +418,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     (a, b) => (b.started_at ?? 0) - (a.started_at ?? 0),
                 )[0];
                 if (mostRecent) {
-                    identityId = mostRecent.identity_id && mostRecent.identity_id !== "blank"
+                    accountId = mostRecent.identity_id && mostRecent.identity_id !== "blank"
                         ? mostRecent.identity_id : "";
                     memoryId = mostRecent.memory_id && mostRecent.memory_id !== "blank"
                         ? mostRecent.memory_id : "";
@@ -451,7 +430,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 instanceName: agent.name,
                 agentType: (agent.agent_type as "host" | "container") || "host",
                 environment: agent.agent_type === "container" ? "docker" : "local",
-                identityId,
+                accountId,
                 memoryId,
                 // No `continueOfInstanceId` — the agent's session
                 // zone IS continuous now (E1, PR #1007). The new pane
@@ -482,7 +461,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             kind: "create-from-template" as const,
             template,
             originBlockId: props.model.blockId,
-            onCreatedAndLaunch: async (newDefId, identityIdSel, memoryIdSel, name, agentType) => {
+            onCreatedAndLaunch: async (newDefId, accountIdSel, memoryIdSel, name, agentType) => {
                 // The new definition is user-owned and carries the
                 // template's provider + cmd config. Build an
                 // AgentDefinition stub good enough for the launch flow
@@ -519,7 +498,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         instanceName: name,
                         agentType,
                         environment: agentType === "container" ? "docker" : "local",
-                        identityId: identityIdSel,
+                        accountId: accountIdSel,
                         memoryId: memoryIdSel,
                         // No `continueOfInstanceId` — the new definition
                         // has no prior session; its agent-anchored zone

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -51,32 +51,22 @@ import "./PreLaunchAuthPanel.scss";
 export interface PreLaunchAuthPanelProps {
     /** The provider to authenticate. */
     provider: ProviderDefinition | undefined;
-    /** Currently-selected identity bundle id, or "" if the user hasn't
-     *  picked one yet. The empty case triggers the Connect CTA so OAuth
-     *  can mint a fresh bundle. */
-    identityId: Accessor<string>;
-    /** True when the selected non-blank bundle has a binding for the
-     *  agent's provider. When false (or while bindings are still
-     *  loading), the panel routes to `needs-bundle` so the user goes
-     *  through the OAuth flow before Launch enables. */
-    hasMatchingBinding: Accessor<boolean>;
-    /** Status of the bound account for this (bundle, provider) pair,
-     *  or `null` when there's no matching binding. Per spec §4.4 the
-     *  oauth-class canonical values are `"valid" | "expired" |
-     *  "needs_reauth" | "unknown"`. When the panel sees `"expired"` /
-     *  `"needs_reauth"` together with `hasMatchingBinding=true`, the
-     *  Connect CTA's wording shifts from "Connect to <Provider>" to
-     *  "<Provider> credentials need reconnecting" — same OAuth flow,
-     *  just a clearer nudge. Optional: callers that don't surface
-     *  account status fall through to the generic wording.
-     *
-     *  Note: this does NOT change the launch-gate. A non-blank bundle
-     *  with a matching binding still counts toward `hasMatchingBinding`
-     *  even if its status is `expired` / `needs_reauth`; the agent CLI
-     *  will trigger its own OAuth refresh on first call. The wording
-     *  exists to surface the situation so the user can act proactively
-     *  via the Reconnect button in the bundle manager. */
-    bindingStatus?: Accessor<string | null>;
+    /** Currently-selected account id, or "" if the user hasn't picked
+     *  one yet. Issue #1624 PR-C Part B — was `identityId` (a bundle
+     *  id); OAuth Connect no longer requires a pre-selected account,
+     *  so the empty case is just "nothing chosen yet," not a gate. */
+    accountId: Accessor<string>;
+    /** True when the selected account actually supplies credentials
+     *  for the agent's provider. Replaces `hasMatchingBinding`. */
+    accountSuppliesProvider: Accessor<boolean>;
+    /** The selected account's own `status` field (`"valid" |
+     *  "expired" | "needs_reauth" | "unknown"` for oauth-class
+     *  accounts), or `null` when no account is selected. Replaces
+     *  `bindingStatus` — with a direct account selection instead of a
+     *  bundle→binding→account join, this is just the account's own
+     *  status. When `"expired"`/`"needs_reauth"`, the Connect CTA's
+     *  wording shifts to "credentials need reconnecting". */
+    accountStatus?: Accessor<string | null>;
     /** Auth flow controller — owned by the Launch modal so its
      *  lifetime spans the whole modal, not just the panel's
      *  conditional mount. Lifting fixed the "memory change forgot
@@ -84,27 +74,15 @@ export interface PreLaunchAuthPanelProps {
      *  destroyed an internally-constructed controller along with it.
      *  See docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md. */
     controller: AuthFlowController;
-    /** Called when a new bundle is created via OAuth or API-key
-     *  submission — parent should refresh the identity list and
-     *  switch the dropdown to this new bundle. */
-    onBundleCreated: (bundleId: string) => void;
-    /** Called when the user clicks Connect and the outcome is
-     *  `needs-bundle` (no identity bundle selected — a genuinely
-     *  fresh OAuth). Instead of starting OAuth immediately the panel
-     *  asks the parent to interpose the New Identity modal so the
-     *  user names the bundle first; OAuth then resumes against the
-     *  named bundle. When omitted the panel falls back to starting
-     *  OAuth directly (legacy behaviour). Spec
-     *  SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
-    onRequestNewIdentity?: () => void;
-    /** When true, the panel fires its OAuth `startConnect()` exactly
-     *  once on mount — used by the New Identity → launch round-trip so
-     *  the user doesn't have to click Connect a second time after
-     *  naming the bundle. Spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2.
-     *  The auto-start only fires from a connect-able state
-     *  (`unauthenticated` / `expired`); a panel that already shows
-     *  `ready` / `waiting` is left alone. */
-    autoStartAuth?: boolean;
+    /** Called when a new account is created via OAuth — parent should
+     *  refresh the account list and select it. Replaces
+     *  `onBundleCreated`. */
+    onAccountCreated: (accountId: string) => void;
+    /** Called when the user clicks "+ Add account" for a manual
+     *  (API-key) account — separate from OAuth Connect, which no
+     *  longer needs any pre-step (issue #1624 PR-C Part B removed the
+     *  "+ New identity bundle" interposition; OAuth starts directly). */
+    onRequestAddAccount?: () => void;
     /** Inline-disabled flag mirroring the modal's submitting state.
      *  Prevents starting a Connect mid-launch. */
     disabled?: boolean;
@@ -139,24 +117,21 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         }
     });
 
-    // Forward `succeeded` / `api-key-accepted` to bundle-creation
-    // callback so the modal swaps its Identity selection to the
-    // newly-persisted bundle id. Skip placeholder ids
-    // (`pending-bundle-for-<sid>`) — those are pre-persistence
-    // synthetic ids; the real id arrives via the next state
-    // transition.
+    // Forward `succeeded` to account-creation callback so the modal
+    // selects the newly-persisted account. Replaces the old bundle-id
+    // placeholder filter (`pending-bundle-for-<sid>`) — that synthetic
+    // only ever applied to the legacy bundle path; a direct-account
+    // session's `bundleId` (see auth-state.ts's foldPolled comment for
+    // why the field itself isn't renamed) is either empty (failure, no
+    // persist) or a real account id, never a placeholder.
     createEffect(() => {
         const s = controller.state();
-        if (
-            s.kind === "ready" &&
-            s.bundleId &&
-            !s.bundleId.startsWith("pending-bundle-for-")
-        ) {
-            props.onBundleCreated(s.bundleId);
+        if (s.kind === "ready" && s.bundleId) {
+            props.onAccountCreated(s.bundleId);
         }
     });
 
-    // When the identity dropdown changes, drive the controller's
+    // When the account dropdown changes, drive the controller's
     // `selected` action. The outcome is computed below.
     //
     // `untrack` around the controller call: `controller.selected()`
@@ -167,60 +142,29 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     // dispatches `Selected`, wiping any in-flight session. That's
     // exactly the bug the diagnostic logs caught.
     createEffect(() => {
-        const id = props.identityId();
+        const id = props.accountId();
         const prov = props.provider;
-        // Track hasMatchingBinding so the effect re-fires when
-        // bindings finish loading — without this, a freshly created
-        // "+ New" bundle that initially reports `hasMatchingBinding=
-        // false` would never re-dispatch to `ready` once the user
-        // connects an account.
-        const hasBinding = props.hasMatchingBinding();
+        const suppliesProvider = props.accountSuppliesProvider();
         if (!prov) return;
-        // "" id (no bundle selected) tells the controller / backend
-        // to create a fresh bundle as part of the OAuth flow.
-        untrack(() => controller.selected(prov.id, id, outcomeFor(id, prov.id, hasBinding)));
+        // "" id (no account selected) is a genuinely fresh connect —
+        // the reducer's `Selected` command still takes a "bundleId"-
+        // named field (unrenamed, see auth-state.ts), but the value
+        // here is an account id.
+        untrack(() => controller.selected(prov.id, id, outcomeFor(id, suppliesProvider)));
     });
 
-    // Connect / Retry click handler. The OAuth invariant per
-    // SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md §4.5 is that OAuth
-    // never starts without a bundle id in hand — tokens always land
-    // INSIDE a known bundle dir, never ambient. So:
-    //   - empty identityId → route to New Identity modal first; OAuth
-    //     resumes against the new bundle on the autoStartAuth round
-    //     trip. The parent's `onRequestNewIdentity` owns the
-    //     modalLayer.replace chain into that modal.
-    //   - empty identityId AND no `onRequestNewIdentity` callback →
-    //     refuse to start OAuth. This is a guard against a future
-    //     parent forgetting to wire the callback; a silent ambient-
-    //     creds OAuth would re-open the §4.5 hole this PR closes.
-    //     Surface a failed state so the user sees something instead
-    //     of a dead Connect button.
-    //   - non-empty identityId → straight to OAuth. Reused for
-    //     `needs-account`, `expired`, and openclaw's force-fresh
-    //     `needs-bundle` (where outcomeFor() returns `needs-bundle`
-    //     even with a bundle selected — the gate is on the actual
-    //     identityId, not the outcome).
+    // Connect / Retry click handler. Issue #1624 PR-C Part B: OAuth no
+    // longer requires a pre-selected account — the backend mints one
+    // directly (`direct_account: true` in auth-flow-controller.ts's
+    // `connect()`). This used to gate on `identityId() === ""` and
+    // route through a "+ New identity bundle" interposition
+    // (SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md §4.5's "OAuth never
+    // starts without a bundle id" invariant) — that invariant no
+    // longer applies; the per-account isolation dir is resolved
+    // server-side regardless of whether an account was pre-selected.
     const handleConnect = (): void => {
         const prov = props.provider;
         if (!prov) return;
-        if (props.identityId() === "") {
-            if (props.onRequestNewIdentity) {
-                props.onRequestNewIdentity();
-                return;
-            }
-            // OAuth-without-bundle invariant — no quiet fallback to
-            // ambient OAuth (would defeat the per-bundle isolation
-            // PR C wires). Bail visibly.
-            console.warn(
-                "[auth-diag] handleConnect: empty identityId and no onRequestNewIdentity callback — refusing to start OAuth (PR C invariant)",
-            );
-            controller.failConnect(
-                new Error(
-                    "OAuth requires a named Identity bundle. Click '+ New identity' first.",
-                ),
-            );
-            return;
-        }
         void startConnect(controller, prov);
     };
 
@@ -247,7 +191,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         }
         const ok = await seedGlobalLogin(prov.id, seedLog, configDir);
         if (ok) {
-            controller.markSeeded(props.identityId());
+            controller.markSeeded(props.accountId());
         } else {
             controller.failConnect(
                 new Error(
@@ -256,24 +200,6 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
             );
         }
     };
-
-    // Auto-start OAuth once on mount when the parent set `autoStartAuth`
-    // — the New Identity → launch round-trip (spec §2). By this point
-    // the user has named + created the bundle, so the dropdown carries
-    // a non-blank `identityId` and `outcomeFor()` resolves to
-    // `needs-account`; `handleConnect()` therefore routes straight to
-    // OAuth (NOT back into the New Identity modal) with `intoBundleId`
-    // = the new bundle. Guarded so it fires exactly once and only from
-    // a connect-able state — a re-render must not re-trigger it, and a
-    // panel that's already `waiting`/`ready` is left untouched.
-    let autoStartFired = false;
-    createEffect(() => {
-        if (!props.autoStartAuth || autoStartFired) return;
-        const kind = controller.state().kind;
-        if (kind !== "unauthenticated" && kind !== "expired") return;
-        autoStartFired = true;
-        untrack(() => handleConnect());
-    });
 
     // No onCleanup here — controller lifetime is owned by the parent
     // (AgentLaunchModal). Disposing on panel unmount would destroy
@@ -284,30 +210,31 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     return (
         <div class="pre-launch-auth-panel">
             <Switch>
-                {/* A bound binding that the backend's expiry probe
-                    flagged stale (`needs_reauth` / `expired`) lands the
-                    controller in `ready` because outcomeFor() only
-                    looks at "has a binding?". Without this arm the
+                {/* An account the backend's expiry probe flagged stale
+                    (`needs_reauth` / `expired`) lands the controller in
+                    `ready` because outcomeFor() only looks at "does the
+                    account supply this provider?". Without this arm the
                     panel would render <ReadyBanner /> and the
                     reconnect wording in ConnectCta would never be
                     seen — the user would have no signal their
                     credentials need refreshing. Match BEFORE the
                     generic ready arm so the reconnect CTA wins.
                     Clicking Connect re-runs OAuth into the SAME
-                    bundle dir (PR C invariant), refreshing the
+                    account's isolation dir (existingAccountId in
+                    auth-flow-controller.ts's connect()), refreshing the
                     token in place. codex P1 on #982. */}
                 <Match
                     when={
                         controller.state().kind === "ready" &&
-                        (props.bindingStatus?.() === "needs_reauth" ||
-                            props.bindingStatus?.() === "expired")
+                        (props.accountStatus?.() === "needs_reauth" ||
+                            props.accountStatus?.() === "expired")
                     }
                 >
                     <ConnectCta
                         provider={props.provider}
                         state={controller.state()}
-                        bindingStatus={props.bindingStatus?.() ?? null}
-                        hasBinding={props.hasMatchingBinding()}
+                        accountStatus={props.accountStatus?.() ?? null}
+                        hasAccount={props.accountSuppliesProvider()}
                         onConnect={() => handleConnect()}
                         canSeed={props.provider?.id === "claude"}
                         onUseExistingLogin={() => void handleUseExistingLogin()}
@@ -359,8 +286,8 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                     <ConnectCta
                         provider={props.provider}
                         state={controller.state()}
-                        bindingStatus={props.bindingStatus?.() ?? null}
-                        hasBinding={props.hasMatchingBinding()}
+                        accountStatus={props.accountStatus?.() ?? null}
+                        hasAccount={props.accountSuppliesProvider()}
                         onConnect={() => handleConnect()}
                         canSeed={props.provider?.id === "claude"}
                         onUseExistingLogin={() => void handleUseExistingLogin()}
@@ -372,31 +299,15 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     );
 };
 
-/** Compute the SelectionOutcome from the bundle id and its binding
- *  state. Treat:
- *   - blank singleton or "+ New"-just-created (no matching binding)
- *     → `needs-bundle` (Connect creates new or attaches a binding).
- *   - non-blank bundle WITH a binding for this provider → `ready`. */
+/** Compute the SelectionOutcome from the account id and whether it
+ *  supplies the agent's provider. No account selected, or a selected
+ *  account for a different provider, → `needs-account`; a matching
+ *  account → `ready`. */
 function outcomeFor(
-    identityId: string,
-    providerId: string | undefined,
-    hasMatchingBinding: boolean,
+    accountId: string,
+    accountSuppliesProvider: boolean,
 ): SelectionOutcome {
-    // (Historical note: openclaw previously short-circuited to
-    //  `needs-bundle` here as a Phase α stub because identity bundles
-    //  didn't store openclaw auth. PRs A–E of
-    //  SPEC_OAUTH_IDENTITY_BUNDLES gave openclaw real per-bundle
-    //  credential dirs + bindings, so the standard binding-driven
-    //  outcome path handles it now. PR F cleanup, 2026-05-22.)
-    if (!identityId) return "needs-bundle";
-    // Reagent + codex P1 on PR #910 round 3 — a non-blank bundle
-    // without a binding for the agent's provider can't supply creds
-    // (e.g. "+ New identity" created an empty "Work" bundle that the
-    // user hasn't connected yet). Use `needs-account` (NOT
-    // `needs-bundle`) so the reducer preserves `intoBundleId` and
-    // OAuth lands on THIS bundle instead of creating a fresh one
-    // (codex P1 round 4 — `needs-bundle` clears the bundle id).
-    if (!hasMatchingBinding) return "needs-account";
+    if (!accountId || !accountSuppliesProvider) return "needs-account";
     return "ready";
 }
 
@@ -486,16 +397,15 @@ async function startConnect(
 const ConnectCta = (p: {
     provider: ProviderDefinition | undefined;
     state: AuthState;
-    /** `IdentityAccount.status` of the bound row for this (bundle,
-     *  provider) pair, or `null` when no binding exists yet. Drives
-     *  the spec §4.4 status-aware wording when the user has a
-     *  binding but its tokens are `expired` / `needs_reauth`. */
-    bindingStatus: string | null;
-    /** True when `hasMatchingBinding(state, provider)` is true — gates
-     *  the reconnect-wording branch so it only triggers when there IS
-     *  a binding to refresh (the no-binding case keeps the generic
-     *  Connect CTA wording the user already knows). */
-    hasBinding: boolean;
+    /** The selected account's own `status`, or `null` when no account
+     *  is selected. Drives the spec §4.4 status-aware wording when
+     *  the account's tokens are `expired` / `needs_reauth`. */
+    accountStatus: string | null;
+    /** True when `accountSuppliesProvider(state, provider)` is true —
+     *  gates the reconnect-wording branch so it only triggers when
+     *  there IS an account to refresh (the no-account case keeps the
+     *  generic Connect CTA wording the user already knows). */
+    hasAccount: boolean;
     onConnect: () => void;
     /** True for providers where seed-from-global is the path (Claude
      *  v2.1.x — in-app OAuth can't open a browser under our spawn, so the
@@ -509,15 +419,15 @@ const ConnectCta = (p: {
         p.provider ? getCliCatalogEntry(p.provider.id) : undefined;
     const providerLabel = () => p.provider?.displayName ?? "this provider";
     const isExpired = () => p.state.kind === "expired";
-    // Spec §4.4 — when the user has a binding for this provider but
-    // its account status flags a reconnect (expired / needs_reauth),
-    // shift to the "credentials need reconnecting" wording. Same
-    // Connect button, same OAuth flow underneath; just a clearer nudge
-    // so the user understands they're refreshing a known login rather
-    // than starting fresh.
+    // Spec §4.4 — when the user has an account for this provider but
+    // its status flags a reconnect (expired / needs_reauth), shift to
+    // the "credentials need reconnecting" wording. Same Connect
+    // button, same OAuth flow underneath; just a clearer nudge so the
+    // user understands they're refreshing a known login rather than
+    // starting fresh.
     const needsReconnect = () =>
-        p.hasBinding &&
-        (p.bindingStatus === "needs_reauth" || p.bindingStatus === "expired");
+        p.hasAccount &&
+        (p.accountStatus === "needs_reauth" || p.accountStatus === "expired");
     return (
         <div class="pre-launch-auth-panel-cta">
             <div class="pre-launch-auth-panel-warning">
@@ -549,10 +459,10 @@ const ConnectCta = (p: {
                         </Button>
                         <div class="pre-launch-auth-panel-hint">
                             {needsReconnect()
-                                ? `Re-runs OAuth into your existing Identity bundle. Launch stays available — your CLI will refresh on first call.`
+                                ? `Re-runs OAuth into your existing account. Launch stays available — your CLI will refresh on first call.`
                                 : `Opens browser → ${providerLabel()} login → returns to AgentMux.
-                                Tokens get saved into a new Identity bundle so the next
-                                agent doesn't have to re-authenticate.`}
+                                Tokens get saved as a new account so the next agent doesn't
+                                have to re-authenticate.`}
                         </div>
                     </>
                 }


### PR DESCRIPTION
## Summary

PR 3 of 3 for issue #1624 PR-C Part B (docs/specs/SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md). Stacked on #2065 (PR 2, backend primitive).

- `AgentLaunchModal`'s Identity picker now lists `IdentityAccount`s filtered to the agent's own provider instead of a provider-agnostic bundle-of-bindings. OAuth Connect starts immediately (no "+ New identity" pre-step) — the backend mints the account directly (PR 2).
- `PreLaunchAuthPanel` drops the old gate that routed OAuth through a bundle-creation modal first.
- "+ Add account" (manual/API-key) repurposes the old "+ New identity" modal to call `account.key.verify` directly.
- `AgentCreateFromTemplateModal`'s Identity dropdown sources from the account cache (filtered to the template's provider) instead of `ListIdentityBundlesCommand`.
- `agent-model.ts`'s `launchAgentDefinition` write-through reconcile collapses from a fetch-bindings-then-diff-then-unlink/link loop to a single `LinkAgentIdentityCommand` upsert (`ON CONFLICT(agent_id, provider) DO UPDATE` makes this correct without a diff pass).
- `launch-flow-state`'s reducer/types rename `identityId`→`accountId`, `identities`→`accounts`, and drop the `bindings`/`bindingsLoading` slices and `FetchBindings` event entirely (accounts load once and are filtered client-side — no per-selection RPC needed).
- `auth-state.ts`/`auth-flow-controller.ts`: dropped the `"needs-bundle"` outcome (folds into `"needs-account"`); `AuthState.bundleId`/`intoBundleId` field names are deliberately NOT renamed (too much regression-pinned history in this file) — they now carry account-id values in the new direct-account mode, documented inline.

**Known migration gap (documented in code, not silently discovered in review):** pre-existing `NamedAgentRow`/`RecentSessionRow.identity_id` values from before this PR are bundle ids, not account ids. Continuing/forking/auto-continuing such a row carries that stale id through; the write-through reconcile's RPC call fails gracefully (try/catch, warns, doesn't block launch) and the account dropdown falls back to "unselected" on next open. Accepted as a one-time UX rough edge, not a regression — matches the approved plan.

The legacy bundle system (`db_identity_bundles`/`db_identity_bindings`, every `bundle_*` RPC handler, the agent-pane's own `view: "identity"` settings tab) is fully untouched — this is a frontend write-surface migration, not a backend API deletion.

## Test plan

- [x] `tsc --noEmit` clean across the whole frontend
- [x] `vitest run` — 52 test files / 638 tests passing in `frontend/app/view/agent` + `frontend/app/element` (includes the rewritten `reducer.test.ts`, `launch-flow-store.test.ts`, `auth-state.test.ts`, `auth-flow-controller.test.ts`, `AgentLaunchModal.integration.test.tsx`, `AgentCreateFromTemplateModal.test.tsx`, `AgentPicker.test.tsx`)
- [ ] Manual `task dev`: create agent via API-key account
- [ ] Manual `task dev`: create agent via fresh OAuth (no pre-existing account)
- [ ] Manual `task dev`: relaunch/Continue an existing agent
- [ ] Manual `task dev`: create-from-template modal

<!-- agentmux:agent_id=agentx -->