### PR TITLE
fix(titlebar): move Icon Only under New Tab, rename to Show Icons Only

### DIFF
--- a/.changesets/1783702443-fix-titlebar-move-icon-only-under-new-tab-rename-to-show-ico-4kz5.md
+++ b/.changesets/1783702443-fix-titlebar-move-icon-only-under-new-tab-rename-to-show-ico-4kz5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(titlebar): move Icon Only under New Tab, rename to Show Icons Only

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -528,28 +528,13 @@ const ActionWidgets = (): JSX.Element => {
     }
 
     // ── Context menus ─────────────────────────────────────────────────────────
-
-    const handleBarContextMenu = (e: MouseEvent) => {
-        e.preventDefault();
-        e.stopPropagation(); // prevent bubbling to window-header onContextMenu (opens TitleBarContextMenu)
-        ContextMenuModel.showContextMenu(
-            [
-                {
-                    label: "Icon Only",
-                    type: "checkbox",
-                    checked: iconOnly(),
-                    click: () => {
-                        fireAndForget(async () => {
-                            await RpcApi.SetConfigCommand(TabRpcClient, {
-                                "widget:icononly": !iconOnly(),
-                            } as any);
-                        });
-                    },
-                },
-            ],
-            e
-        );
-    };
+    // Right-clicking the gaps between pinned widgets used to open its own
+    // one-item ("Icon Only") menu here, separate from — and hidden behind —
+    // the unified TitleBarContextMenu the rest of the empty tab-bar space
+    // opens. Removed: the bar's own onContextMenu no longer intercepts the
+    // event, so it now bubbles up to window-header's handler like any other
+    // empty-space right-click, landing on the single shared menu (which
+    // already has its own "Show Icons Only" entry).
 
     const handlePinnedContextMenu = (e: MouseEvent, key: string) => {
         e.preventDefault();
@@ -580,7 +565,6 @@ const ActionWidgets = (): JSX.Element => {
                 class="action-widgets"
                 data-testid="action-widgets"
                 data-drag-region="false"
-                onContextMenu={handleBarContextMenu}
             >
                 <For each={visiblePinnedWidgets()}>
                     {({ key, widget }, idx) => (

--- a/frontend/app/window/titlebar-context-menu.tsx
+++ b/frontend/app/window/titlebar-context-menu.tsx
@@ -74,6 +74,15 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
             },
         });
 
+        items.push({
+            type: "checkbox",
+            label: "Show Icons Only",
+            checked: iconOnly(),
+            click: () => {
+                toggleIconOnly();
+            },
+        });
+
         const widgetEntries = Object.entries(widgets())
             .filter(([key]) => key.startsWith("defwidget@"))
             .sort(([, a]: any, [, b]: any) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0));
@@ -96,16 +105,6 @@ const TitleBarContextMenu = (props: TitleBarContextMenuProps): JSX.Element => {
                 }),
             });
         }
-
-        items.push({ type: "separator" });
-        items.push({
-            type: "checkbox",
-            label: "Icon Only",
-            checked: iconOnly(),
-            click: () => {
-                toggleIconOnly();
-            },
-        });
 
         return items;
     };


### PR DESCRIPTION
## Summary
- Moved the tab bar's empty-space right-click menu's "Icon Only" toggle from the very bottom (below the conditional Pin Widgets section) to directly under New Tab, and renamed it to "Show Icons Only" (trailing "Only" matches the existing widget:icononly setting key and common UI convention like "Read Only").
- Removed a second, duplicate context menu: right-clicking the gaps between pinned widgets in the tab bar opened its own separate one-item ("Icon Only") popup instead of the unified menu everywhere else — action-widgets.tsx's handleBarContextMenu was stopping propagation and showing its own ContextMenuModel popup rather than letting the click bubble up to window-header's handler. Removed entirely; that area now falls through to the same shared TitleBarContextMenu.

Net result: right-clicking any empty space in the tab bar — including between widgets — opens one single, consistent menu with "Show Icons Only" right under "New Tab".

## Test plan
- [x] npx tsc --noEmit — clean
- [ ] Not click-tested live — small, low-risk menu-consolidation change

<!-- agentmux:agent_id=agenta -->