### PR TITLE
fix(window): retune the Windows/Linux hamburger position, leave macOS untouched

### DIFF
--- a/.changesets/1783705327-fix-window-hamburger-icon-precisely-centered-in-the-title-ba-65ho.md
+++ b/.changesets/1783705327-fix-window-hamburger-icon-precisely-centered-in-the-title-ba-65ho.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): hamburger icon precisely centered in the title bar (derived offset, not a hardcoded nudge)

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -28,17 +28,24 @@
     // below the bar's TRUE vertical center. `align-items: end` on both
     // containers means tabs/traffic-lights never notice this — they anchor
     // to the bottom regardless — but anything that wants to look centered
-    // in the whole bar (this icon) needs to shift up by roughly that half-
-    // padding amount. `/ -2` is the geometrically-exact term (confirmed via
+    // in the whole bar (this icon) needs to shift up by that half-padding
+    // amount. This term is exact and platform-independent (same padding-top
+    // in all three window-header.*.scss files) — confirmed via
     // getBoundingClientRect(): header center y=16.5, button center y=19.5
-    // unshifted); the `+ 2px` on top is an empirical optical correction —
-    // mathematically-perfect centering (delta=0) still read as too high to
-    // the eye, and +1px still wasn't enough, so this settles 2px below true
-    // geometric center. Kept as a calc() (not a single hardcoded px) so the
-    // geometric half still self-corrects if `--space-1-5` changes; only the
-    // +2px fudge is a fixed empirical constant.
+    // unshifted, i.e. exactly padding-top/2 = 3px off.
+    --hb-geo-center: calc(var(--space-1-5) / -2);
     position: relative;
-    top: calc(var(--space-1-5) / -2 + 2px);
+    // Windows/Linux (this base rule, left-of-tabs placement): exact
+    // geometric centering (--hb-geo-center alone) still read 2px too high
+    // on a live task dev smoke test, so this adds an empirical +2px optical
+    // correction on top (tuned in two rounds: +1px wasn't enough, +2px
+    // was). macOS's `--right` variant below does NOT add this — its own
+    // separate manual tuning history (#2013 "2px up", #2016 "3px up",
+    // i.e. exactly --hb-geo-center with zero extra fudge) already arrived
+    // at pure geometric center reading correctly there, so don't reapply
+    // a Windows-tuned correction to a platform that was never measured
+    // against it.
+    top: calc(var(--hb-geo-center) + 2px);
     // Left-of-tabs placement (Windows/Linux): symmetric 4px margin on both
     // sides so the whitespace left of the hamburger matches the right (which
     // also clears the leading .tab-separator → icon · 10px · 1px sep · 10px ·
@@ -63,9 +70,11 @@
 
     // macOS: pinned to the far right of the title bar, after the action
     // widgets. Add breathing room so it doesn't sit flush against the
-    // window's right frame. Vertical offset is the shared base rule above.
+    // window's right frame. Vertical offset: pure geometric center, no
+    // extra optical fudge — see the comment on --hb-geo-center above.
     &--right {
         margin-left: 4px;
         margin-right: 8px;
+        top: var(--hb-geo-center);
     }
 }

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -28,14 +28,16 @@
     // below the bar's TRUE vertical center. `align-items: end` on both
     // containers means tabs/traffic-lights never notice this — they anchor
     // to the bottom regardless — but anything that wants to look centered
-    // in the whole bar (this icon) needs to shift up by exactly that half-
-    // padding amount. Derived from the variable (not a hardcoded px) so it
-    // self-corrects if `--space-1-5` or the header's padding ever changes —
-    // confirmed empirically via getBoundingClientRect() against a live
-    // instance: header center y=16.5, button center y=19.5 pre-fix, exactly
-    // padding-top/2 = 3px off.
+    // in the whole bar (this icon) needs to shift up by roughly that half-
+    // padding amount. `/ -2` is the geometrically-exact term (confirmed via
+    // getBoundingClientRect(): header center y=16.5, button center y=19.5
+    // unshifted); the `+ 1px` on top is an empirical optical correction —
+    // mathematically-perfect centering (delta=0) still read as 1px too high
+    // to the eye, so this settles 1px below true geometric center. Kept as
+    // a calc() (not a single hardcoded px) so the geometric half still
+    // self-corrects if `--space-1-5` changes; only the +1px fudge is fixed.
     position: relative;
-    top: calc(var(--space-1-5) / -2);
+    top: calc(var(--space-1-5) / -2 + 1px);
     // Left-of-tabs placement (Windows/Linux): symmetric 4px margin on both
     // sides so the whitespace left of the hamburger matches the right (which
     // also clears the leading .tab-separator → icon · 10px · 1px sep · 10px ·

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -31,13 +31,14 @@
     // in the whole bar (this icon) needs to shift up by roughly that half-
     // padding amount. `/ -2` is the geometrically-exact term (confirmed via
     // getBoundingClientRect(): header center y=16.5, button center y=19.5
-    // unshifted); the `+ 1px` on top is an empirical optical correction —
-    // mathematically-perfect centering (delta=0) still read as 1px too high
-    // to the eye, so this settles 1px below true geometric center. Kept as
-    // a calc() (not a single hardcoded px) so the geometric half still
-    // self-corrects if `--space-1-5` changes; only the +1px fudge is fixed.
+    // unshifted); the `+ 2px` on top is an empirical optical correction —
+    // mathematically-perfect centering (delta=0) still read as too high to
+    // the eye, and +1px still wasn't enough, so this settles 2px below true
+    // geometric center. Kept as a calc() (not a single hardcoded px) so the
+    // geometric half still self-corrects if `--space-1-5` changes; only the
+    // +2px fudge is a fixed empirical constant.
     position: relative;
-    top: calc(var(--space-1-5) / -2 + 1px);
+    top: calc(var(--space-1-5) / -2 + 2px);
     // Left-of-tabs placement (Windows/Linux): symmetric 4px margin on both
     // sides so the whitespace left of the hamburger matches the right (which
     // also clears the leading .tab-separator → icon · 10px · 1px sep · 10px ·

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -20,6 +20,22 @@
     -webkit-app-region: no-drag;
     cursor: default;
     align-self: center;
+    // `.window-header` is 33px tall but has `padding-top: var(--space-1-5)`
+    // and no padding-bottom (window-header.*.scss) — its content box (where
+    // `align-self: center` actually centers this button, whether nested
+    // directly in `.window-header` (macOS `--right`) or one level down in
+    // `.tab-bar`, which adds no padding of its own) sits `padding-top / 2`
+    // below the bar's TRUE vertical center. `align-items: end` on both
+    // containers means tabs/traffic-lights never notice this — they anchor
+    // to the bottom regardless — but anything that wants to look centered
+    // in the whole bar (this icon) needs to shift up by exactly that half-
+    // padding amount. Derived from the variable (not a hardcoded px) so it
+    // self-corrects if `--space-1-5` or the header's padding ever changes —
+    // confirmed empirically via getBoundingClientRect() against a live
+    // instance: header center y=16.5, button center y=19.5 pre-fix, exactly
+    // padding-top/2 = 3px off.
+    position: relative;
+    top: calc(var(--space-1-5) / -2);
     // Left-of-tabs placement (Windows/Linux): symmetric 4px margin on both
     // sides so the whitespace left of the hamburger matches the right (which
     // also clears the leading .tab-separator → icon · 10px · 1px sep · 10px ·
@@ -44,12 +60,9 @@
 
     // macOS: pinned to the far right of the title bar, after the action
     // widgets. Add breathing room so it doesn't sit flush against the
-    // window's right frame.
+    // window's right frame. Vertical offset is the shared base rule above.
     &--right {
         margin-left: 4px;
         margin-right: 8px;
-        // 3px optical alignment nudge vs. the other title-bar icons.
-        position: relative;
-        top: -3px;
     }
 }

--- a/frontend/app/window/hamburger-menu.scss
+++ b/frontend/app/window/hamburger-menu.scss
@@ -20,32 +20,16 @@
     -webkit-app-region: no-drag;
     cursor: default;
     align-self: center;
-    // `.window-header` is 33px tall but has `padding-top: var(--space-1-5)`
-    // and no padding-bottom (window-header.*.scss) — its content box (where
-    // `align-self: center` actually centers this button, whether nested
-    // directly in `.window-header` (macOS `--right`) or one level down in
-    // `.tab-bar`, which adds no padding of its own) sits `padding-top / 2`
-    // below the bar's TRUE vertical center. `align-items: end` on both
-    // containers means tabs/traffic-lights never notice this — they anchor
-    // to the bottom regardless — but anything that wants to look centered
-    // in the whole bar (this icon) needs to shift up by that half-padding
-    // amount. This term is exact and platform-independent (same padding-top
-    // in all three window-header.*.scss files) — confirmed via
-    // getBoundingClientRect(): header center y=16.5, button center y=19.5
-    // unshifted, i.e. exactly padding-top/2 = 3px off.
-    --hb-geo-center: calc(var(--space-1-5) / -2);
+    // Windows/Linux left-of-tabs placement: manually tuned against a live
+    // task dev instance (three rounds: geometric center alone read too
+    // high, +1px still wasn't enough, +2px was) — independent of macOS's
+    // `--right` placement below, which has its own separate manual tuning
+    // history and is not derived from or related to this value. The two
+    // platforms sit in different contexts (different neighboring elements,
+    // different margins) and are tuned independently, not from one shared
+    // formula.
     position: relative;
-    // Windows/Linux (this base rule, left-of-tabs placement): exact
-    // geometric centering (--hb-geo-center alone) still read 2px too high
-    // on a live task dev smoke test, so this adds an empirical +2px optical
-    // correction on top (tuned in two rounds: +1px wasn't enough, +2px
-    // was). macOS's `--right` variant below does NOT add this — its own
-    // separate manual tuning history (#2013 "2px up", #2016 "3px up",
-    // i.e. exactly --hb-geo-center with zero extra fudge) already arrived
-    // at pure geometric center reading correctly there, so don't reapply
-    // a Windows-tuned correction to a platform that was never measured
-    // against it.
-    top: calc(var(--hb-geo-center) + 2px);
+    top: calc(var(--space-1-5) / -2 + 2px);
     // Left-of-tabs placement (Windows/Linux): symmetric 4px margin on both
     // sides so the whitespace left of the hamburger matches the right (which
     // also clears the leading .tab-separator → icon · 10px · 1px sep · 10px ·
@@ -70,11 +54,12 @@
 
     // macOS: pinned to the far right of the title bar, after the action
     // widgets. Add breathing room so it doesn't sit flush against the
-    // window's right frame. Vertical offset: pure geometric center, no
-    // extra optical fudge — see the comment on --hb-geo-center above.
+    // window's right frame.
     &--right {
         margin-left: 4px;
         margin-right: 8px;
-        top: var(--hb-geo-center);
+        // 3px optical alignment nudge vs. the other title-bar icons.
+        position: relative;
+        top: -3px;
     }
 }


### PR DESCRIPTION
## Summary

Both the macOS and Windows/Linux hamburger positions are independently, manually-tuned values based on live visual feedback — not one geometric formula with a per-platform correction on top (an earlier commit on this branch briefly framed it that way based on a coincidental numeric match; corrected per review).

**macOS (`--right` variant): left completely untouched.** Restored to be byte-for-byte identical to its pre-existing state from #2013/#2016 (`top: -3px`) — confirmed via diff against that commit.

**Windows/Linux (base `.hamburger-btn` rule, left-of-tabs placement): retuned, independent of macOS.** Was previously un-nudged entirely (align-self: center only). Measured the real geometry live via CDP getBoundingClientRect() against a running instance and iterated with live feedback:
- Exact geometric center (`calc(var(--space-1-5) / -2)`, derived from `.window-header`'s `padding-top` with no `padding-bottom`) — still read too high.
- `+1px` on top — still not enough.
- `+2px` on top — settled correctly: `top: calc(var(--space-1-5) / -2 + 2px)`.

## Test plan
- [x] `npx stylelint frontend/app/window/hamburger-menu.scss` — clean
- [x] `npx tsc --noEmit` — clean (no TS touched, full project check)
- [x] Live-verified via CDP against a running `task dev` (Windows) instance at each step
- [x] macOS block diffed byte-for-byte against #2016 to confirm it's unchanged

<!-- agentmux:agent_id=agenta -->