### PR TITLE
chore: release v0.52.4

### DIFF
--- a/.changesets/1783663406-fix-identity-app-api-link-table-ops-resolve-the-s1-slug-to-t-n2oq.md
+++ b/.changesets/1783663406-fix-identity-app-api-link-table-ops-resolve-the-s1-slug-to-t-n2oq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): App API link-table ops resolve the S1 slug to the definition id; failed upsert no longer orphans the account row

--- a/.changesets/1783682410-fix-agent-enter-submits-askuserquestion-answers-composer-str-8chv.md
+++ b/.changesets/1783682410-fix-agent-enter-submits-askuserquestion-answers-composer-str-8chv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): Enter submits AskUserQuestion answers; composer strip layout + mic centering + curated model defaults

--- a/.changesets/1783698973-feat-armory-identities-tab-becomes-a-read-only-per-agent-vie-lb7w.md
+++ b/.changesets/1783698973-feat-armory-identities-tab-becomes-a-read-only-per-agent-vie-lb7w.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): Identities tab becomes a read-only per-agent view

--- a/.changesets/1783699317-feat-agent-activity-dock-surfaces-subagents-phase-2-of-the-p-ged0.md
+++ b/.changesets/1783699317-feat-agent-activity-dock-surfaces-subagents-phase-2-of-the-p-ged0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): activity dock surfaces subagents (Phase 2 of the pinned dock spec)

--- a/.changesets/1783700131-feat-identity-backend-primitive-for-bundle-free-oauth-accoun-svdd.md
+++ b/.changesets/1783700131-feat-identity-backend-primitive-for-bundle-free-oauth-accoun-svdd.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(identity): backend primitive for bundle-free OAuth account creation

--- a/.changesets/1783700193-feat-armory-mcp-servers-catalog-picker-piloted-on-ableton-li-cnc6.md
+++ b/.changesets/1783700193-feat-armory-mcp-servers-catalog-picker-piloted-on-ableton-li-cnc6.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): MCP Servers catalog picker, piloted on Ableton Live

--- a/.changesets/1783702272-feat-identity-launch-modal-create-from-template-pick-account-wuje.md
+++ b/.changesets/1783702272-feat-identity-launch-modal-create-from-template-pick-account-wuje.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(identity): launch modal + create-from-template pick accounts directly, no bundle

--- a/.changesets/1783702443-fix-titlebar-move-icon-only-under-new-tab-rename-to-show-ico-4kz5.md
+++ b/.changesets/1783702443-fix-titlebar-move-icon-only-under-new-tab-rename-to-show-ico-4kz5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(titlebar): move Icon Only under New Tab, rename to Show Icons Only

--- a/.changesets/1783705327-fix-window-hamburger-icon-precisely-centered-in-the-title-ba-65ho.md
+++ b/.changesets/1783705327-fix-window-hamburger-icon-precisely-centered-in-the-title-ba-65ho.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): hamburger icon precisely centered in the title bar (derived offset, not a hardcoded nudge)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.52.3"
+version = "0.52.4"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,18 @@
 # AgentMux Version History
 
+## 0.52.4 — 2026-07-10
+
+- fix(identity): App API link-table ops resolve the S1 slug to the definition id; failed upsert no longer orphans the account row
+- fix(agent): Enter submits AskUserQuestion answers; composer strip layout + mic centering + curated model defaults
+- feat(armory): Identities tab becomes a read-only per-agent view
+- feat(agent): activity dock surfaces subagents (Phase 2 of the pinned dock spec)
+- feat(identity): backend primitive for bundle-free OAuth account creation
+- feat(armory): MCP Servers catalog picker, piloted on Ableton Live
+- feat(identity): launch modal + create-from-template pick accounts directly, no bundle
+- fix(titlebar): move Icon Only under New Tab, rename to Show Icons Only
+- fix(window): hamburger icon precisely centered in the title bar (derived offset, not a hardcoded nudge)
+
+
 ## 0.52.3 — 2026-07-09
 
 - chore(build): guard stable-channel packaging — clean tree + merged release commit required

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.52.3",
+  "version": "0.52.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.52.3",
+      "version": "0.52.4",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.52.3",
+  "version": "0.52.4",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR consuming 9 pending changesets. Forced `--as patch` (overriding the computed `minor` bump) per explicit request — several `feat(...)` changesets are included and ship under this patch version rather than a minor bump.

0.52.3 -> 0.52.4

- fix(identity): App API link-table ops resolve the S1 slug to the definition id; failed upsert no longer orphans the account row
- fix(agent): Enter submits AskUserQuestion answers; composer strip layout + mic centering + curated model defaults
- feat(armory): Identities tab becomes a read-only per-agent view
- feat(agent): activity dock surfaces subagents (Phase 2 of the pinned dock spec)
- feat(identity): backend primitive for bundle-free OAuth account creation
- feat(armory): MCP Servers catalog picker, piloted on Ableton Live
- feat(identity): launch modal + create-from-template pick accounts directly, no bundle
- fix(titlebar): move Icon Only under New Tab, rename to Show Icons Only
- fix(window): hamburger icon precisely centered in the title bar (derived offset, not a hardcoded nudge)

## Test plan
- [x] `scripts/release.sh --as patch` — all 5 version locations agree at 0.52.4 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md)
- [x] Lockfiles regenerated as part of the bump

<!-- agentmux:agent_id=agenta -->