### PR TITLE
feat(tabbar): drag a pane onto a different tab

### DIFF
--- a/.changesets/1783723001-fix-tabbar-pane-drag-over-tab-bar-no-longer-mis-fires-as-a-t-br8j.md
+++ b/.changesets/1783723001-fix-tabbar-pane-drag-over-tab-bar-no-longer-mis-fires-as-a-t-br8j.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabbar): pane drag over tab bar no longer mis-fires as a tear-off, adds tab-hover highlight

--- a/.changesets/1783725144-feat-tabbar-drag-a-pane-onto-a-different-tab-with-a-live-sch-ostg.md
+++ b/.changesets/1783725144-feat-tabbar-drag-a-pane-onto-a-different-tab-with-a-live-sch-ostg.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(tabbar): drag a pane onto a different tab, with a live schematic preview and ghost placement

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -17,6 +17,7 @@ import {
     insertionPoint,
     setInsertionPoint,
     bouncingTabId,
+    hoveredDropTabId,
     tabWrapperRefs,
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
@@ -55,6 +56,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
     });
 
     const isBouncing = () => bouncingTabId() === props.tabId;
+    const isTileDropHover = () => hoveredDropTabId() === props.tabId;
 
     onMount(() => {
         if (!tabWrapRef) return;
@@ -156,6 +158,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
             class={clsx("tab-drop-wrapper", {
                 "tab-dragging": isDragging(),
                 "tab-bouncing": isBouncing(),
+                "tile-drop-hover": isTileDropHover(),
             })}
             style={{
                 "padding-left": `${gapBefore()}px`,

--- a/frontend/app/tab/tab-drop-preview.scss
+++ b/frontend/app/tab/tab-drop-preview.scss
@@ -1,0 +1,27 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.tab-drop-preview {
+    z-index: var(--z-popover);
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    background: var(--main-bg-color);
+    box-shadow: var(--shadow-md);
+    pointer-events: none;
+    overflow: hidden;
+
+    .tab-drop-preview-leaf {
+        position: absolute;
+        box-sizing: border-box;
+        border: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--border-color) 30%, transparent);
+    }
+
+    .tab-drop-preview-ghost {
+        position: absolute;
+        box-sizing: border-box;
+        border: 2px solid var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color) 25%, transparent);
+        transition: top 60ms ease-out, left 60ms ease-out, width 60ms ease-out, height 60ms ease-out;
+    }
+}

--- a/frontend/app/tab/tab-drop-preview.tsx
+++ b/frontend/app/tab/tab-drop-preview.tsx
@@ -1,0 +1,165 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createEffect, createMemo, For, onCleanup, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import { computeSchematicRects, DropDirection, getLayoutModelForTabById, schematicLeaves } from "@/layout/index";
+import { determineDropDirection } from "@/layout/lib/utils";
+import { hoveredDropClientPos, setDropGhost } from "./tabbar-dnd";
+import "./tab-drop-preview.scss";
+
+const PREVIEW_WIDTH = 220;
+const PREVIEW_HEIGHT = 130;
+const PREVIEW_GAP_PX = 6;
+
+/**
+ * Maps a DropDirection to a sub-rect within a leaf's rect: Center → full
+ * leaf, Top/Right/Bottom/Left → half along that axis, Outer* → a thin 1/5
+ * band against that edge. Mirrors `rectForDirection` in app-init.ts
+ * (installFloatingRedockHoverListener) — same visual convention, computed
+ * here against schematic (popover-local) rects instead of real screen ones.
+ */
+function rectForDirection(leaf: Dimensions, dir: DropDirection): Dimensions {
+    switch (dir) {
+        case DropDirection.Top:
+            return { top: leaf.top, left: leaf.left, width: leaf.width, height: leaf.height / 2 };
+        case DropDirection.Right:
+            return { top: leaf.top, left: leaf.left + leaf.width / 2, width: leaf.width / 2, height: leaf.height };
+        case DropDirection.Bottom:
+            return { top: leaf.top + leaf.height / 2, left: leaf.left, width: leaf.width, height: leaf.height / 2 };
+        case DropDirection.Left:
+            return { top: leaf.top, left: leaf.left, width: leaf.width / 2, height: leaf.height };
+        case DropDirection.OuterTop:
+            return { top: leaf.top, left: leaf.left, width: leaf.width, height: leaf.height / 5 };
+        case DropDirection.OuterRight:
+            return {
+                top: leaf.top,
+                left: leaf.left + (4 * leaf.width) / 5,
+                width: leaf.width / 5,
+                height: leaf.height,
+            };
+        case DropDirection.OuterBottom:
+            return {
+                top: leaf.top + (4 * leaf.height) / 5,
+                left: leaf.left,
+                width: leaf.width,
+                height: leaf.height / 5,
+            };
+        case DropDirection.OuterLeft:
+            return { top: leaf.top, left: leaf.left, width: leaf.width / 5, height: leaf.height };
+        case DropDirection.Center:
+        default:
+            return { top: leaf.top, left: leaf.left, width: leaf.width, height: leaf.height };
+    }
+}
+
+export interface TabDropPreviewProps {
+    tabId: string;
+    /** Viewport rect of the hovered tab wrapper — anchors the popover below it. */
+    anchorRect: Dimensions;
+}
+
+/**
+ * A schematic (non-live, no real pane content) preview of a tab's current
+ * split layout, shown while a pane is being dragged over that tab in the
+ * tab bar. Reads the target tab's `LayoutModel` directly — which is live
+ * in memory even for an inactive/hidden tab (layoutModelHooks.ts) — and
+ * renders its tree via `computeSchematicRects`, a standalone pure function
+ * (deliberately not the production `updateTreeHelper`, which mutates the
+ * real LayoutModel's signals and would corrupt that tab's actual render
+ * state — see schematicLayout.ts). A ghost rect tracks the pointer within
+ * the preview so the user can choose exactly where the pane will land.
+ * See SPEC_PANE_DRAG_TO_TAB_2026_07_10.md §4.3–§4.4.
+ */
+export function TabDropPreview(props: TabDropPreviewProps): JSX.Element {
+    const rootNode = createMemo(() => getLayoutModelForTabById(props.tabId).localTreeStateAtom().rootNode);
+
+    const popoverRect = createMemo<Dimensions>(() => {
+        const anchor = props.anchorRect;
+        let left = anchor.left;
+        // Clamp so the popover doesn't run off the right edge of the window.
+        if (typeof window !== "undefined") {
+            left = Math.min(left, window.innerWidth - PREVIEW_WIDTH - 4);
+        }
+        left = Math.max(left, 4);
+        return {
+            top: anchor.top + anchor.height + PREVIEW_GAP_PX,
+            left,
+            width: PREVIEW_WIDTH,
+            height: PREVIEW_HEIGHT,
+        };
+    });
+
+    const leaves = createMemo(() => {
+        const node = rootNode();
+        if (!node) return [];
+        const rects = computeSchematicRects(node, { top: 0, left: 0, width: PREVIEW_WIDTH, height: PREVIEW_HEIGHT });
+        return schematicLeaves(node, rects);
+    });
+
+    // Resolved ghost: which leaf (schematic-local rect) + direction the
+    // pointer is currently over, in POPOVER-LOCAL coordinates. Derived
+    // entirely from props/signals (no DOM measurement) so there's no
+    // ref-mount-timing race — the popover's position is fully determined
+    // by popoverRect() above, so its coordinate frame is known up front.
+    const ghost = createMemo(() => {
+        const pos = hoveredDropClientPos();
+        if (!pos) return null;
+        const pr = popoverRect();
+        const local = { x: pos.x - pr.left, y: pos.y - pr.top };
+        for (const leaf of leaves()) {
+            const dir = determineDropDirection(leaf.rect, local);
+            if (dir !== undefined) {
+                return { blockId: leaf.blockId, direction: dir, rect: rectForDirection(leaf.rect, dir) };
+            }
+        }
+        return null;
+    });
+
+    createEffect(() => {
+        const g = ghost();
+        setDropGhost(g ? { targetBlockId: g.blockId, direction: g.direction } : null);
+    });
+
+    onCleanup(() => setDropGhost(null));
+
+    return (
+        <div
+            class="tab-drop-preview"
+            style={{
+                position: "fixed",
+                top: `${popoverRect().top}px`,
+                left: `${popoverRect().left}px`,
+                width: `${popoverRect().width}px`,
+                height: `${popoverRect().height}px`,
+            }}
+        >
+            <For each={leaves()}>
+                {(leaf) => (
+                    <div
+                        class="tab-drop-preview-leaf"
+                        style={{
+                            top: `${leaf.rect.top}px`,
+                            left: `${leaf.rect.left}px`,
+                            width: `${leaf.rect.width}px`,
+                            height: `${leaf.rect.height}px`,
+                        }}
+                    />
+                )}
+            </For>
+            <Show when={ghost()}>
+                {(g) => (
+                    <div
+                        class="tab-drop-preview-ghost"
+                        style={{
+                            top: `${g().rect.top}px`,
+                            left: `${g().rect.left}px`,
+                            width: `${g().rect.width}px`,
+                            height: `${g().rect.height}px`,
+                        }}
+                    />
+                )}
+            </Show>
+        </div>
+    );
+}

--- a/frontend/app/tab/tabbar-dnd.test.ts
+++ b/frontend/app/tab/tabbar-dnd.test.ts
@@ -5,6 +5,7 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
     computeInsertIndex,
     computeNearestTab,
+    computeHoveredTab,
     tabWrapperRefs,
     setGlobalDragTabId,
 } from "./tabbar-dnd";
@@ -235,5 +236,58 @@ describe("computeNearestTab", () => {
         // cursor at 60 — closest to tab-a (mid=50) but it's excluded
         // next closest: tab-b (mid=150, dist=90) over tab-c (mid=250, dist=190)
         expect(computeNearestTab(60, 15)?.tabId).toBe("tab-b");
+    });
+});
+
+// ── computeHoveredTab ─────────────────────────────────────────────────────────
+//
+// Point-in-rect hit test for the pane→tab drag drop target
+// (SPEC_PANE_DRAG_TO_TAB_2026_07_10.md §4.1) — distinct from computeNearestTab
+// (midpoint-distance, used for tab reorder gaps): a pane hovering a tab must
+// land ONLY while literally over that tab's rect, not "nearest" to it.
+
+describe("computeHoveredTab", () => {
+    beforeEach(() => {
+        tabWrapperRefs.clear();
+    });
+
+    afterEach(() => {
+        tabWrapperRefs.clear();
+    });
+
+    test("returns null when no tabs registered", () => {
+        expect(computeHoveredTab(50, 15)).toBeNull();
+    });
+
+    test("returns the tab whose rect contains the point", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        tabWrapperRefs.set("tab-b", makeFakeEl(100, 100));
+        expect(computeHoveredTab(150, 15)).toBe("tab-b");
+        expect(computeHoveredTab(50, 15)).toBe("tab-a");
+    });
+
+    test("returns null when the point is between/outside all tab rects", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        tabWrapperRefs.set("tab-b", makeFakeEl(150, 100));
+        expect(computeHoveredTab(120, 15)).toBeNull();
+        expect(computeHoveredTab(-10, 15)).toBeNull();
+    });
+
+    test("returns null when the point is over a tab's rect vertically but not the excluded tab, and excludes the source tab", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        // Hovering squarely over tab-a, but tab-a is the pane's own current
+        // tab — dragging a pane over its own tab is a no-op, not a target.
+        expect(computeHoveredTab(50, 15, "tab-a")).toBeNull();
+    });
+
+    test("does not match when the point is outside the rect's vertical bounds", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100)); // top:0 bottom:30 per makeFakeEl
+        expect(computeHoveredTab(50, 45)).toBeNull();
+    });
+
+    test("excludeTabId still allows matching a different, non-excluded tab", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        tabWrapperRefs.set("tab-b", makeFakeEl(100, 100));
+        expect(computeHoveredTab(150, 15, "tab-a")).toBe("tab-b");
     });
 });

--- a/frontend/app/tab/tabbar-dnd.ts
+++ b/frontend/app/tab/tabbar-dnd.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createSignal } from "solid-js";
+import { DropDirection } from "@/layout/index";
 
 export const tabItemType = "TAB_ITEM";
 
@@ -35,6 +36,19 @@ export const [bouncingTabId, setBouncingTabId] = createSignal<string | null>(nul
 // pulse (see tabbar.scss) — the frontend half of
 // SPEC_PANE_DRAG_TO_TAB_2026_07_10.md's "tab flashes" UX beat.
 export const [hoveredDropTabId, setHoveredDropTabId] = createSignal<string | null>(null);
+
+// Live cursor position (viewport CSS px) while a pane is being dragged over
+// the tab bar. Consumed by TabDropPreview to hit-test against its schematic
+// leaf rects — see tab-drop-preview.tsx. Set alongside hoveredDropTabId in
+// tabbar.tsx's tile monitor; cleared on drop/drag-end.
+export const [hoveredDropClientPos, setHoveredDropClientPos] = createSignal<{ x: number; y: number } | null>(null);
+
+// Resolved drop target within the currently-shown TabDropPreview: which
+// leaf (by blockId) and which side of it the pointer is over. Read at
+// drop-commit time to build the cross-tab move RPC call; null whenever no
+// preview is shown or the pointer isn't over any leaf's schematic rect.
+export type DropGhost = { targetBlockId: string; direction: DropDirection };
+export const [dropGhost, setDropGhost] = createSignal<DropGhost | null>(null);
 
 // Registry of tab wrapper elements, keyed by tabId.
 export const tabWrapperRefs = new Map<string, HTMLDivElement>();

--- a/frontend/app/tab/tabbar-dnd.ts
+++ b/frontend/app/tab/tabbar-dnd.ts
@@ -30,8 +30,35 @@ export const [insertionPoint, setInsertionPoint] = createSignal<InsertionPoint |
 // Which tab (by id) should play the landing bounce animation.
 export const [bouncingTabId, setBouncingTabId] = createSignal<string | null>(null);
 
+// Which tab (by id), if any, is currently a valid drop target for a
+// pane (tile) being dragged over the tab bar. Drives the `.tile-drop-hover`
+// pulse (see tabbar.scss) — the frontend half of
+// SPEC_PANE_DRAG_TO_TAB_2026_07_10.md's "tab flashes" UX beat.
+export const [hoveredDropTabId, setHoveredDropTabId] = createSignal<string | null>(null);
+
 // Registry of tab wrapper elements, keyed by tabId.
 export const tabWrapperRefs = new Map<string, HTMLDivElement>();
+
+/**
+ * Returns the tabId whose wrapper rect contains (clientX, clientY), or null
+ * if the point isn't over any registered tab. `excludeTabId` is normally the
+ * pane's own current tab — dragging a pane over the tab it's already in is
+ * a no-op, not a valid drop target.
+ */
+export function computeHoveredTab(
+    clientX: number,
+    clientY: number,
+    excludeTabId?: string | null
+): string | null {
+    for (const [tabId, el] of tabWrapperRefs) {
+        if (tabId === excludeTabId) continue;
+        const rect = el.getBoundingClientRect();
+        if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+            return tabId;
+        }
+    }
+    return null;
+}
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -18,7 +18,7 @@ import { TabRpcClient } from "@/store/rpc-util";
 import { makeORef, getObjectValue, getWaveObjectAtom } from "../store/wos";
 import { ConfirmModal } from "@/element/modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
-import { deleteLayoutModelForTab } from "@/layout/index";
+import { deleteLayoutModelForTab, tileItemType } from "@/layout/index";
 import { DroppableTab } from "./droppable-tab";
 import {
     tabItemType,
@@ -29,6 +29,8 @@ import {
     computeInsertionPoint,
     InsertionPoint,
     tabWrapperRefs,
+    setHoveredDropTabId,
+    computeHoveredTab,
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { Logger } from "@/util/logger";
@@ -367,6 +369,49 @@ function TabBar(props: TabBarProps): JSX.Element {
             },
         });
         onCleanup(cleanup);
+
+        // Pane (tile) drags: tab-level drop UI (SPEC_PANE_DRAG_TO_TAB_2026_07_10.md).
+        // A pane can only be dragged from the currently active tab — every
+        // other tab is `display:none` (workspace.tsx keeps them mounted but
+        // hidden) and so cannot receive the pointer events needed to start
+        // a drag — so `atoms.activeTabId()` is always the drag's source tab
+        // for the lifetime of a single drag gesture (it cannot change while
+        // the mouse button is held).
+        const cleanupTileDrop = monitorForElements({
+            canMonitor: ({ source }) => source.data.type === tileItemType,
+            onDrag: ({ location }) => {
+                const input = location.current.input;
+                setHoveredDropTabId(
+                    computeHoveredTab(input.clientX, input.clientY, atoms.activeTabId()),
+                );
+            },
+            onDrop: ({ location }) => {
+                setHoveredDropTabId(null);
+
+                // Without this, a pane dropped over the tab bar would leave
+                // `currentDragPayload` set (TileLayout's own onDrop
+                // deliberately doesn't clear it — see its comment —
+                // because it fires for every drop, including in-window ones
+                // already handled by an OverlayNode drop target). The
+                // unhandled payload then reaches CrossWindowDragMonitor's
+                // dragend listener, which finds no other AgentMux window
+                // under the cursor and misinterprets the release as a
+                // tear-off, spawning an unwanted floating pane window.
+                // Consume the drop here so that mis-fire becomes a no-op.
+                // (The actual cross-tab move lands in a later phase of the
+                // spec — this only prevents the tear-off regression.)
+                const input = location.current.input;
+                const rect = tabBarScrollRef?.getBoundingClientRect();
+                const dropInsideBar =
+                    rect != null &&
+                    input.clientX >= rect.left && input.clientX <= rect.right &&
+                    input.clientY >= rect.top && input.clientY <= rect.bottom;
+                if (dropInsideBar) {
+                    setCurrentDragPayload(null);
+                }
+            },
+        });
+        onCleanup(cleanupTileDrop);
     });
 
     // Phase 4 — listen for the host's tear-off events. Each AgentMux

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -20,6 +20,7 @@ import { ConfirmModal } from "@/element/modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
 import { deleteLayoutModelForTab, tileItemType } from "@/layout/index";
 import { DroppableTab } from "./droppable-tab";
+import { TabDropPreview } from "./tab-drop-preview";
 import {
     tabItemType,
     insertionPoint,
@@ -29,11 +30,16 @@ import {
     computeInsertionPoint,
     InsertionPoint,
     tabWrapperRefs,
+    hoveredDropTabId,
     setHoveredDropTabId,
     computeHoveredTab,
+    setHoveredDropClientPos,
+    dropGhost,
+    setDropGhost,
 } from "./tabbar-dnd";
-import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
+import { getCurrentDragPayload, setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { Logger } from "@/util/logger";
+import { REDOCK_DWELL_MS } from "@/app/workspace/floating-pane-constants";
 import "./tabbar.scss";
 
 export { tabItemType } from "./tabbar-dnd";
@@ -93,6 +99,20 @@ function TabBar(props: TabBarProps): JSX.Element {
     // Latches once per drag — the tear-off handshake should only run a
     // single time even if the user keeps moving past the threshold.
     let tearOffFired = false;
+
+    // Which tab (if any) is showing the schematic drop preview. Distinct
+    // from hoveredDropTabId (which drives the instant flash): the preview
+    // is dwell-gated by REDOCK_DWELL_MS so a fast pass-through over several
+    // tabs doesn't spawn/despawn the popover per-frame. See
+    // SPEC_PANE_DRAG_TO_TAB_2026_07_10.md §4.2–§4.3.
+    const [previewTabId, setPreviewTabId] = createSignal<string | null>(null);
+    let previewDwellTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearPreviewDwellTimer = () => {
+        if (previewDwellTimer != null) {
+            clearTimeout(previewDwellTimer);
+            previewDwellTimer = null;
+        }
+    };
 
     // Pin feature removed — merge any legacy pinnedtabids into the regular list
     // so existing workspaces don't lose tabs. A one-time UpdateTabIds (below)
@@ -381,12 +401,34 @@ function TabBar(props: TabBarProps): JSX.Element {
             canMonitor: ({ source }) => source.data.type === tileItemType,
             onDrag: ({ location }) => {
                 const input = location.current.input;
-                setHoveredDropTabId(
-                    computeHoveredTab(input.clientX, input.clientY, atoms.activeTabId()),
-                );
+                setHoveredDropClientPos({ x: input.clientX, y: input.clientY });
+                const hovered = computeHoveredTab(input.clientX, input.clientY, atoms.activeTabId());
+                setHoveredDropTabId(hovered);
+
+                if (hovered !== previewTabId()) {
+                    clearPreviewDwellTimer();
+                    if (hovered == null) {
+                        setPreviewTabId(null);
+                    } else {
+                        previewDwellTimer = setTimeout(() => setPreviewTabId(hovered), REDOCK_DWELL_MS);
+                    }
+                }
             },
             onDrop: ({ location }) => {
+                clearPreviewDwellTimer();
+                // Snapshot everything the move needs BEFORE clearing state —
+                // the clears below (and setCurrentDragPayload(null) further
+                // down, needed for the tear-off fix) would otherwise erase it.
+                const targetTabId = previewTabId() ?? hoveredDropTabId();
+                const ghost = dropGhost();
+                const draggedPayload = getCurrentDragPayload();
+                const sourceTabId = atoms.activeTabId();
+                const wsId = props.workspace?.oid;
+
                 setHoveredDropTabId(null);
+                setHoveredDropClientPos(null);
+                setPreviewTabId(null);
+                setDropGhost(null);
 
                 // Without this, a pane dropped over the tab bar would leave
                 // `currentDragPayload` set (TileLayout's own onDrop
@@ -398,8 +440,6 @@ function TabBar(props: TabBarProps): JSX.Element {
                 // under the cursor and misinterprets the release as a
                 // tear-off, spawning an unwanted floating pane window.
                 // Consume the drop here so that mis-fire becomes a no-op.
-                // (The actual cross-tab move lands in a later phase of the
-                // spec — this only prevents the tear-off regression.)
                 const input = location.current.input;
                 const rect = tabBarScrollRef?.getBoundingClientRect();
                 const dropInsideBar =
@@ -409,9 +449,44 @@ function TabBar(props: TabBarProps): JSX.Element {
                 if (dropInsideBar) {
                     setCurrentDragPayload(null);
                 }
+
+                // The actual cross-tab move. Reuses RedockFloatingPane
+                // verbatim — its saga only rejects source === target TAB,
+                // never same-workspace (see redock_floating_pane.rs's guard
+                // comment: "use MoveBlockToTab" only fires for that check),
+                // so a same-window, different-tab call is already a
+                // supported case with zero backend changes. Its optional
+                // targetBlockId/direction args land the block in the exact
+                // slot the schematic preview's ghost showed; omitting them
+                // (e.g. a fast drop before the preview's dwell gate opened)
+                // falls back to a plain append (queue_target_layout_insert).
+                if (dropInsideBar && targetTabId && wsId && sourceTabId && sourceTabId !== targetTabId
+                    && draggedPayload?.kind === "tile") {
+                    const blockId = draggedPayload.node.data?.blockId;
+                    if (blockId) {
+                        fireAndForget(async () => {
+                            try {
+                                await WorkspaceService.RedockFloatingPane(
+                                    blockId,
+                                    sourceTabId,
+                                    wsId,
+                                    targetTabId,
+                                    wsId,
+                                    ghost?.targetBlockId ?? null,
+                                    ghost?.direction ?? null,
+                                );
+                            } catch (e) {
+                                Logger.error("dnd", "pane-to-tab move failed", { error: String(e) });
+                            }
+                        });
+                    }
+                }
             },
         });
-        onCleanup(cleanupTileDrop);
+        onCleanup(() => {
+            clearPreviewDwellTimer();
+            cleanupTileDrop();
+        });
     });
 
     // Phase 4 — listen for the host's tear-off events. Each AgentMux
@@ -820,6 +895,21 @@ function TabBar(props: TabBarProps): JSX.Element {
         });
     });
 
+    // Anchor rect for the schematic drop preview popover — the hovered
+    // tab's own wrapper rect, re-measured each time previewTabId changes
+    // (tab positions don't shift while a drag is merely hovering, so a
+    // one-shot measurement per tab is sufficient; unlike the active-tab
+    // color line above, no resize/scroll listener is needed here since the
+    // preview's lifetime is a single drag gesture).
+    const previewAnchorRect = createMemo<Dimensions | null>(() => {
+        const tabId = previewTabId();
+        if (!tabId) return null;
+        const el = tabWrapperRefs.get(tabId);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return { top: r.top, left: r.left, width: r.width, height: r.height };
+    });
+
     return (
         <div ref={tabBarRef!} class="tab-bar" {...dragProps}>
             {/* Windows/Linux: hamburger sits at the LEFT of the tab strip.
@@ -895,6 +985,13 @@ function TabBar(props: TabBarProps): JSX.Element {
                     }}
                 />
                 </Portal>
+            </Show>
+            <Show when={previewAnchorRect()}>
+                {(anchorRect) => (
+                    <Portal mount={document.body}>
+                        <TabDropPreview tabId={previewTabId()!} anchorRect={anchorRect()} />
+                    </Portal>
+                )}
             </Show>
             <Show when={pendingCloseTabId() !== null}>
                 <TabCloseConfirmModal

--- a/frontend/layout/index.ts
+++ b/frontend/layout/index.ts
@@ -10,6 +10,7 @@ import {
     useDebouncedNodeInnerRect,
 } from "./lib/layoutModelHooks";
 import { newLayoutNode } from "./lib/layoutNode";
+import { computeSchematicRects, schematicLeaves } from "./lib/schematicLayout";
 import type {
     ContentRenderer,
     LayoutNode,
@@ -35,6 +36,7 @@ import type {
 import { DropDirection, LayoutTreeActionType, NavigateDirection } from "./lib/types";
 
 export {
+    computeSchematicRects,
     deleteLayoutModelForTab,
     DropDirection,
     getLayoutModelForStaticTab,
@@ -43,6 +45,7 @@ export {
     LayoutTreeActionType,
     NavigateDirection,
     newLayoutNode,
+    schematicLeaves,
     tileItemType,
     TileLayout,
     useDebouncedNodeInnerRect,

--- a/frontend/layout/lib/schematicLayout.ts
+++ b/frontend/layout/lib/schematicLayout.ts
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { FlexDirection, LayoutNode } from "./types";
+
+/**
+ * Recursively subdivides `boundingRect` among `rootNode`'s tree by each
+ * node's `size` share along its `flexDirection` — the same flex-pool math
+ * as layoutGeometry.ts's `updateTreeHelper` (pixelToSizeRatio = totalSize /
+ * nodePixels), but standalone and side-effect-free: it does not read or
+ * write any `LayoutModel` signal, so it's safe to call against a tab that
+ * isn't the active one (its real `LayoutModel` still exists and is live —
+ * see layoutModelHooks.ts — but its DOM is `display:none`, so the real
+ * `updateTree`/`updateTreeHelper` path can't be reused for a hover preview
+ * without corrupting that tab's actual render state).
+ *
+ * Returns a flat map of every node id (branches and leaves) to its rect
+ * within `boundingRect`'s coordinate space.
+ */
+export function computeSchematicRects(rootNode: LayoutNode, boundingRect: Dimensions): Map<string, Dimensions> {
+    const rects = new Map<string, Dimensions>();
+    rects.set(rootNode.id, boundingRect);
+
+    function recurse(node: LayoutNode, rect: Dimensions) {
+        if (!node.children?.length) return;
+        const isRow = node.flexDirection === FlexDirection.Row;
+        const nodePixels = isRow ? rect.width : rect.height;
+        if (nodePixels <= 0) return;
+        const totalSize = node.children.reduce((acc, c) => acc + c.size, 0);
+        if (totalSize <= 0) return;
+        const ratio = totalSize / nodePixels;
+
+        let cursor = isRow ? rect.left : rect.top;
+        for (const child of node.children) {
+            const childPixels = child.size / ratio;
+            const childRect: Dimensions = isRow
+                ? { top: rect.top, left: cursor, width: childPixels, height: rect.height }
+                : { top: cursor, left: rect.left, width: rect.width, height: childPixels };
+            rects.set(child.id, childRect);
+            cursor += childPixels;
+            recurse(child, childRect);
+        }
+    }
+
+    recurse(rootNode, boundingRect);
+    return rects;
+}
+
+/**
+ * Walks a tree and returns every LEAF node (a real pane, not a branch)
+ * paired with its schematic rect and blockId, skipping branches and any
+ * leaf that didn't get a rect (e.g. a degenerate 0-size tree).
+ */
+export function schematicLeaves(
+    rootNode: LayoutNode,
+    rects: Map<string, Dimensions>
+): { nodeId: string; blockId: string; rect: Dimensions }[] {
+    const result: { nodeId: string; blockId: string; rect: Dimensions }[] = [];
+
+    function walk(node: LayoutNode) {
+        if (!node.children?.length) {
+            const rect = rects.get(node.id);
+            if (rect && node.data?.blockId) {
+                result.push({ nodeId: node.id, blockId: node.data.blockId, rect });
+            }
+            return;
+        }
+        node.children.forEach(walk);
+    }
+
+    walk(rootNode);
+    return result;
+}

--- a/frontend/layout/tests/schematicLayout.test.ts
+++ b/frontend/layout/tests/schematicLayout.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from "vitest";
+import { computeSchematicRects, schematicLeaves } from "../lib/schematicLayout";
+import { newLayoutNode } from "../lib/layoutNode";
+import { FlexDirection, LayoutNode } from "../lib/types";
+
+// Same flex-pool math as layoutGeometry.ts's updateTreeHelper, but as a
+// standalone pure function — see SPEC_PANE_DRAG_TO_TAB_2026_07_10.md §4.3.
+// These tests exercise the math against a bare Dimensions rect, without any
+// LayoutModel/DOM involved, which is exactly the point of it being pure.
+
+describe("computeSchematicRects", () => {
+    test("single leaf root gets the full bounding rect", () => {
+        const root = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "b1" });
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 200, height: 100 });
+        expect(rects.get(root.id)).toEqual({ top: 0, left: 0, width: 200, height: 100 });
+    });
+
+    test("row split divides width proportionally to each child's size", () => {
+        const leafA = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "a" });
+        const leafB = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "b" });
+        leafA.size = 1;
+        leafB.size = 3;
+        const root: LayoutNode = {
+            id: "root",
+            flexDirection: FlexDirection.Row,
+            size: 1,
+            children: [leafA, leafB],
+        };
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 200, height: 100 });
+        // total size 4 over 200px → 50px per unit. leafA gets 1 unit (50px), leafB gets 3 (150px).
+        expect(rects.get(leafA.id)).toEqual({ top: 0, left: 0, width: 50, height: 100 });
+        expect(rects.get(leafB.id)).toEqual({ top: 0, left: 50, width: 150, height: 100 });
+    });
+
+    test("column split divides height proportionally, full width per child", () => {
+        const leafA = newLayoutNode(FlexDirection.Column, undefined, undefined, { blockId: "a" });
+        const leafB = newLayoutNode(FlexDirection.Column, undefined, undefined, { blockId: "b" });
+        leafA.size = 1;
+        leafB.size = 1;
+        const root: LayoutNode = {
+            id: "root",
+            flexDirection: FlexDirection.Column,
+            size: 1,
+            children: [leafA, leafB],
+        };
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 200, height: 100 });
+        expect(rects.get(leafA.id)).toEqual({ top: 0, left: 0, width: 200, height: 50 });
+        expect(rects.get(leafB.id)).toEqual({ top: 50, left: 0, width: 200, height: 50 });
+    });
+
+    test("nested split: a column inside one half of a row", () => {
+        const leafTop = newLayoutNode(FlexDirection.Column, undefined, undefined, { blockId: "top" });
+        const leafBottom = newLayoutNode(FlexDirection.Column, undefined, undefined, { blockId: "bottom" });
+        leafTop.size = 1;
+        leafBottom.size = 1;
+        const rightColumn: LayoutNode = {
+            id: "rightColumn",
+            flexDirection: FlexDirection.Column,
+            size: 1,
+            children: [leafTop, leafBottom],
+        };
+        const leafLeft = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "left" });
+        leafLeft.size = 1;
+        const root: LayoutNode = {
+            id: "root",
+            flexDirection: FlexDirection.Row,
+            size: 1,
+            children: [leafLeft, rightColumn],
+        };
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 200, height: 100 });
+        expect(rects.get(leafLeft.id)).toEqual({ top: 0, left: 0, width: 100, height: 100 });
+        expect(rects.get(rightColumn.id)).toEqual({ top: 0, left: 100, width: 100, height: 100 });
+        expect(rects.get(leafTop.id)).toEqual({ top: 0, left: 100, width: 100, height: 50 });
+        expect(rects.get(leafBottom.id)).toEqual({ top: 50, left: 100, width: 100, height: 50 });
+    });
+
+    test("zero-size bounding rect does not throw or produce NaN rects", () => {
+        const leafA = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "a" });
+        const leafB = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "b" });
+        leafA.size = 1;
+        leafB.size = 1;
+        const root: LayoutNode = { id: "root", flexDirection: FlexDirection.Row, size: 1, children: [leafA, leafB] };
+        expect(() => computeSchematicRects(root, { top: 0, left: 0, width: 0, height: 0 })).not.toThrow();
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 0, height: 0 });
+        expect(rects.has(leafA.id)).toBe(false);
+        expect(rects.has(leafB.id)).toBe(false);
+    });
+});
+
+describe("schematicLeaves", () => {
+    test("returns only leaves with a blockId, skipping branch nodes", () => {
+        const leafA = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "a" });
+        const leafB = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "b" });
+        leafA.size = 1;
+        leafB.size = 1;
+        const root: LayoutNode = { id: "root", flexDirection: FlexDirection.Row, size: 1, children: [leafA, leafB] };
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 200, height: 100 });
+        const leaves = schematicLeaves(root, rects);
+        expect(leaves).toHaveLength(2);
+        expect(leaves.map((l) => l.blockId).sort()).toEqual(["a", "b"]);
+        expect(leaves.find((l) => l.blockId === "a")?.rect).toEqual({ top: 0, left: 0, width: 100, height: 100 });
+    });
+
+    test("skips a leaf with no computed rect (e.g. degenerate zero-size tree)", () => {
+        const leafA = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "a" });
+        const leafB = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "b" });
+        leafA.size = 1;
+        leafB.size = 1;
+        const root: LayoutNode = { id: "root", flexDirection: FlexDirection.Row, size: 1, children: [leafA, leafB] };
+        const rects = computeSchematicRects(root, { top: 0, left: 0, width: 0, height: 0 });
+        expect(schematicLeaves(root, rects)).toEqual([]);
+    });
+});

--- a/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
+++ b/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
@@ -1,0 +1,256 @@
+# Spec: Pane Drag-to-Tab (Cross-Tab Pane Relocation via Drag & Drop)
+
+**Date:** 2026-07-10
+**Status:** Draft
+**Repo state:** `main` @ `42b95715`
+**Scope:** In-window pane drag onto the tab bar (dropping a tile-layout pane onto a *different tab in the same window*). Cross-window drag (already handled by `DragOverlay`/`CrossWindowDragMonitor`) and touch/pen input are out of scope.
+
+---
+
+## 1. Problem
+
+Today there is no way to drag a pane out of its tab's split layout and drop it into a different tab in the same window. Two related gaps make this worse than "missing feature":
+
+1. **No drop target exists for it.** `tabbar.tsx`'s `monitorForElements` only accepts `source.data.type === tabItemType` (tab reorder). A pane's `draggable()` payload is `{ kind: "tile", ... }` (`tileItemType`) — the tab bar never registers a target for it.
+2. **Releasing over the tab bar today mis-fires as a tear-off.** `TileLayout`'s own `onDrop` resets `isDragging` but does not clear `currentDragPayload` (its comment says clearing happens in a `dropTargetForElements.onDrop` — but no such target exists over the tab bar). The subsequent native `dragend` is then picked up by `CrossWindowDragMonitor`, which finds no other AgentMux window under the cursor and treats the release as a tear-off, **spawning an unwanted floating pane window**. This is a real, reproducible bug this feature must close as a side effect (see §7).
+
+Desired UX (from the request):
+1. User starts dragging a pane (existing).
+2. Hovering over a tab in the bar makes that tab **flash** to signal "valid drop target."
+3. The UI **stitches a live preview** of the target tab's layout into view near that tab.
+4. While still holding the mouse, a **ghost** inside that preview shows exactly where the pane will land, tracking pointer movement.
+5. On release, the pane actually moves into the target tab's tree at the indicated slot.
+
+---
+
+## 2. Current Architecture (What Exists — Reuse, Don't Reinvent)
+
+### 2.1 Layout tree = per-tab reducer, already live for hidden tabs
+
+Each tab owns one `LayoutModel` (`frontend/layout/lib/layoutModel.ts`), a classic dispatch reducer (`treeReducer`, `types.ts:65-82` `LayoutTreeActionType` enum) over a mutable `LayoutTreeState`:
+
+```ts
+// frontend/layout/lib/types.ts:193-253
+interface LayoutNode {
+    id: string;
+    data?: TabLayoutData;   // { blockId } on a leaf
+    children?: LayoutNode[];
+    flexDirection: FlexDirection;  // Row | Column
+    size: number;                  // flex-share, NOT a percentage
+    // minimize-feature bookkeeping fields omitted
+}
+type LayoutTreeState = {
+    rootNode: LayoutNode;
+    focusedNodeId?: string;
+    magnifiedNodeId?: string;
+    leafOrder?: LeafOrderEntry[];
+    pendingBackendActions: LayoutActionData[];
+};
+```
+
+The two actions this feature needs already exist and already carve out of the target's own size rather than diluting siblings (`sizeFraction`, `types.ts:145-167`):
+
+```ts
+interface LayoutTreeSplitHorizontalAction extends LayoutTreeAction {
+    type: LayoutTreeActionType.SplitHorizontal;
+    targetNodeId: string;
+    newNode: LayoutNode;
+    position: "before" | "after";
+    sizeFraction?: number;  // new node's share of targetNodeId's CURRENT size
+}
+// LayoutTreeSplitVerticalAction is identical, orthogonal axis
+```
+
+**Critically, every tab's `LayoutModel` exists in memory simultaneously, not just the active tab's** (`layoutModelHooks.ts:13,41,47,52` — `layoutModelMap: Map<string, LayoutModel>`, `getLayoutModelForTabById(tabId)`). The backend-action subscription is explicitly wired for all tabs, not just the active one (tear-off windows create a `LayoutModel` before `activeTabId` syncs). This is possible because `workspace.tsx:20-40` keeps **every tab mounted** (`<For each={allTabIds()}>`), hiding inactive ones via `display:none` rather than unmounting.
+
+**Consequence for this feature:** the target (inactive) tab's tree is already reachable and dispatchable via `getLayoutModelForTabById(targetTabId)` — we do not need to construct or load anything. The catch: its DOM is `display:none`, so `getBoundingClientRect()`-derived geometry is 0×0 while hidden. **We cannot hit-test against the real DOM for the hover preview** (§4.2 covers the workaround).
+
+### 2.2 Existing tab bar drag (reorder-only) — `frontend/app/tab/*`
+
+Library: [`@atlaskit/pragmatic-drag-and-drop`](https://github.com/atlassian/pragmatic-drag-and-drop) (`draggable()` / `dropTargetForElements()` / `monitorForElements()`), used throughout — not react-dnd, not custom pointer handling.
+
+- `droppable-tab.tsx` registers `draggable()` per tab with `getInitialData: () => ({ tabId, workspaceId, tabIndex, type: tabItemType })`.
+- **The tab bar is a single `monitorForElements`** (`tabbar.tsx:188`), not per-tab drop targets. Reorder position comes from `computeInsertionPoint(clientX)` (`tabbar-dnd.ts:43-81`) against a `Map<tabId, HTMLDivElement>` registry of tab wrapper refs.
+- Visual feedback today is **gap-widening only** (`insertionPoint` signal drives `padding-left`/`padding-right` on the two flanking tabs) — **there is no highlight/flash on the hovered tab itself anywhere in the codebase.** The "flash" beat in this spec is net-new UI, not an extension of an existing affordance.
+- `onDrop` on the tab-bar monitor hit-tests the strip's own rect (`dropInsideBar`) before committing.
+
+### 2.3 Pane drag payload — `frontend/layout/lib/TileLayout.*.tsx`
+
+```ts
+// same shape in CrossWindowDragMonitor.win32/.darwin/.linux.tsx:35-37
+export type DragItemPayload =
+    | { kind: "tile"; node: LayoutNode }
+    | { kind: "tab"; tabId: string; workspaceId: string };
+```
+
+`setCurrentDragPayload`/`getCurrentDragPayload` is module-level "what's being dragged right now" state, written by both tab drag (`kind: "tab"`) and pane drag (`kind: "tile"`), read by `CrossWindowDragMonitor`. `TileLayout`'s `draggable()` is registered on the pane's header (`[data-role="block-header"]`, not the tile body — see the WebView2 comment at `TileLayout.win32.tsx:405-420`), with a native drag-image PNG (`onGenerateDragPreview` → `toPng`).
+
+### 2.4 The closest prior art: `RedockFloatingPane`
+
+Cross-window pane drop (an already-solved, structurally identical problem — move a block into a *different tab's* tree, from a live drag, at a user-chosen slot) uses a two-part pattern worth copying exactly:
+
+**Backend (`agentmux-srv/src/sagas/redock_floating_pane.rs`):** the saga is intentionally ownership-only —
+
+```rust
+// run_inner, redock_floating_pane.rs:149-163
+ctx.dispatch(Command::MoveBlock {
+    block_id, src_tab_id: source_tab_id, dst_tab_id: target_tab_id.clone(), dst_index,
+}).await
+```
+
+Its own doc comment states: *"the saga itself does not touch LayoutState... backend just stores."* The RPC handler that **wraps** the saga (`workspace.rs:1151-1230`) does the layout-tree work, separately, after the saga succeeds:
+
+```rust
+// workspace.rs:1188  — the saga (ownership move only)
+let saga_result = crate::sagas::redock_floating_pane::run(...).await;
+// workspace.rs:1212 — target tab: split the tree at the exact previewed slot
+queue_target_layout_split(state, &target_tab_id, &block_id, tbid, dir).await
+// workspace.rs:1226 — source tab: remove the now-relocated leaf
+queue_source_layout_delete(state, &source_tab_id, &block_id).await
+```
+
+`queue_target_layout_split` (`layout_helpers.rs:123-159`) maps an 8-direction `DropDirection` to `SplitHorizontal`/`SplitVertical` + `before`/`after`, with `sizeFraction` fixed at `0.5` for inner directions (Top/Right/Bottom/Left) and `0.2` for outer band directions (OuterTop/.../OuterLeft), falling back to a plain `InsertNode` for `Center`/unknown. Both queue functions append to the target/source tab's own `LayoutState.pendingbackendactions` array — **not** an RPC response — which each tab's already-live `LayoutModel` picks up via `layoutPersistence.ts`'s `processPendingBackendActions → handleBackendAction → model.treeReducer(action, /*setState=*/false)`, working correctly even while that tab is `display:none` (§2.1). This is exactly the delivery mechanism this feature needs, with zero changes.
+
+**Contrast — `MoveBlockToTab` is NOT this pattern (a trap, not a template):** `WorkspaceService.MoveBlockToTab(wsId, blockId, sourceTabId, destTabId, autoClose)` (`services.ts:180`, called only from `DragOverlay.tsx:97` on cross-window pane drop into another window's *active* tab) dispatches `Command::MoveBlock` and handles auto-closing an emptied source tab (`workspace.rs:535-620`) — **and nothing else**. It never calls `queue_target_layout_split`/`queue_source_layout_delete`. Grepping confirms zero references to either from this handler. **This is an existing gap in the cross-window-drop path** (dropping a pane into another window's active tab today updates `Tab.blockids` membership but not that tab's visual tree) — out of scope to fix here, but do not copy this handler's shape for the new feature; copy `RedockFloatingPane`'s instead.
+
+### 2.5 Ghost/preview precedent for a *live, direction-aware* drop indicator
+
+`app-init.ts:113-273` (`installFloatingRedockHoverListener`) is the closest existing "ghost stitched into a target's layout, updating live while a real drag is in progress": on `floating-redock:hover-state` host events (cursor position during a floating-window OS-level move), it does `elementFromPoint` → nearest `[data-blockid]` leaf → `determineDropDirection` → `rectForDirection` (hardcoded Top/Right/Bottom/Left = half-leaf, Outer* = 1/5 band, Center = full-leaf) → positions a raw `.floating-redock-drop-placeholder` div, gated by a 180ms dwell timer on Windows (`REDOCK_DWELL_MS`) to prevent flicker.
+
+**This only works because its target is a visible, active tab's real DOM** (the dragged window is a separate OS process, the target tab is necessarily the one currently on screen in that other window). **Our target tab is usually inactive and `display:none`**, so `elementFromPoint`/`getBoundingClientRect` are not usable directly — see §4.2.
+
+---
+
+## 3. Goals
+
+1. Drag a pane from its current tab and drop it into a different tab in the same window, landing at a user-chosen slot within that tab's layout.
+2. While hovering a candidate tab (mouse still down), the tab visually flashes to confirm it is a valid drop target.
+3. While continuing to hover the same tab, show a live schematic preview of that tab's current layout, with a ghost rect tracking the pointer to indicate exact landing position (which leaf, which side).
+4. Fix the existing mis-fire where releasing a dragged pane over the tab bar today spawns a floating tear-off window instead of doing nothing / being handled.
+5. Reuse the existing `RedockFloatingPane`-style backend split described in §2.4 rather than inventing a new persistence path.
+
+## Non-Goals
+
+- Cross-window pane→inactive-tab drop (still limited to the active tab of another window via `DragOverlay`, per today's behavior) — a natural phase 2, deferred because it requires cross-process schematic-preview delivery, not just in-renderer state.
+- Fixing `MoveBlockToTab`'s existing layout-tree gap (§2.4) — noted, not fixed, to keep this spec's blast radius to the new code path only.
+- Keyboard-only / accessibility-parity pane relocation — deferred, tracked separately.
+- Reordering panes within the *same* tab via the tab bar (already out of scope; that's `TileLayout`'s existing in-tab drop targets).
+
+---
+
+## 4. Design
+
+### 4.1 New drop target on the tab bar for `tileItemType`
+
+`tabbar.tsx`'s existing `monitorForElements` only monitors `tabItemType`. Add a second `canMonitor` branch (or a parallel monitor instance) that accepts `source.data.type === tileItemType`, reading the payload as `DragItemPayload & { kind: "tile" }`. On `onDragEnter`/`onDrag` (pragmatic-dnd's per-move callback), hit-test cursor X/Y against each tab wrapper's rect (the same `tabWrapperRefs` registry `tabbar-dnd.ts` already maintains) to determine which tab, if any, is currently hovered.
+
+```ts
+// New signal, colocated with insertionPoint/bouncingTabId in tabbar.tsx
+const [hoveredDropTabId, setHoveredDropTabId] = createSignal<string | null>(null);
+```
+
+Set only when the dragged payload is `kind: "tile"` and the tile's *own* tab differs from the hovered tab (dragging over your own current tab is a no-op, matching `MoveBlockToTab`'s existing same-tab short-circuit at `workspace.rs:562-564`).
+
+### 4.2 Tab flash (Goal 2)
+
+A CSS class (e.g. `.tab--drop-flash`) toggled by `hoveredDropTabId`, applied as a restartable keyframe pulse (not a static highlight) so re-entering the same tab after briefly leaving re-triggers the flash — mirrors the existing `bouncingTabId` one-shot-animation pattern (`tabbar.tsx`) rather than inventing a new animation-retrigger mechanism. Dwell-gate this at ~120–180ms (matching `REDOCK_DWELL_MS`'s precedent, §2.5) before the preview (§4.3) mounts, so a fast pass-through over several tabs doesn't spawn/despawn previews per-frame.
+
+### 4.3 Schematic tab-layout preview (Goal 3) — the genuinely new piece
+
+No thumbnail/mini-layout preview of any kind exists anywhere in the codebase today (confirmed by grep — zero hits for thumbnail/mini-layout/schematic/preview in this context). Because the target tab is `display:none` (§2.1), we cannot render or hit-test its real DOM. Build a **schematic renderer**: a small popover anchored below/near the hovered tab (e.g. 240×160px, non-interactive except for hosting the ghost) that:
+
+1. Reads `getLayoutModelForTabById(hoveredDropTabId).treeState.rootNode` directly (already live, per §2.1 — no fetch/load step).
+2. Recursively lays out the schematic using the **same pure geometry function** the real layout uses — `layoutGeometry.ts`'s `updateTreeHelper` takes an arbitrary `boundingRect`, not necessarily the real DOM's, so pass the popover's own box instead of a real element's rect. This is a direct reuse, not a reimplementation of split-tree math.
+3. Renders each leaf as a plain `<div>` rect (no live pane content — a schematic, not a live thumbnail) scaled to the popover.
+
+### 4.4 Ghost tracking within the preview (Goal 3, continued)
+
+While `hoveredDropTabId` is set and the popover is mounted, track pointer position relative to the popover, hit-test against the schematic leaf rects, and reuse the existing `determineDropDirection` (quadrant-based: which half/outer-band of the hovered leaf the pointer is in) — the same function `TileLayout`'s in-tab `OverlayNode` drop targets already use, and the same 9-way `DropDirection` vocabulary (`types.ts:35-45`) that `queue_target_layout_split` (§2.4) already consumes. Render a highlighted sub-rect within the popover (via the existing `rectForDirection` half/1-5-band/full-leaf convention from `app-init.ts:150-174`) as the ghost. No new direction math — only a new rect source (schematic, not real DOM).
+
+### 4.5 Drop commit (Goal 1, 5)
+
+On release with `hoveredDropTabId` set and a resolved `(targetLeafId, direction)`:
+
+1. Call a **new** RPC modeled directly on `RedockFloatingPane`'s two-call pattern (§2.4), not on `MoveBlockToTab`. Simplest option: add a same-window variant, e.g. `WorkspaceService.MovePaneToTab(wsId, blockId, sourceTabId, destTabId, targetBlockId, direction)`, backed by a new saga (or a thin extension of the existing `RedockFloatingPane` saga/RPC handler if source and target workspace happen to be the same — the saga's own guard at `redock_floating_pane.rs:106-111` only rejects *same-tab* moves, not same-workspace-different-tab ones, so this may be reusable near-verbatim rather than net-new; confirm during implementation whether `RedockFloatingPane`'s pre-condition checks (`source_workspace_id`/`target_workspace_id` params) can simply both be set to the current window's workspace id).
+2. Handler: `MoveBlock` (ownership only) → on success, `queue_target_layout_split(target_tab_id, block_id, targetLeafId, direction)` → `queue_source_layout_delete(source_tab_id, block_id)`. Both land via each tab's `pendingbackendactions`, consumed by the already-subscribed (even while hidden) `LayoutModel` (§2.1) — **no special-casing needed for the target tab being inactive.**
+3. Clear `hoveredDropTabId`, unmount the popover, clear `currentDragPayload`.
+
+### 4.6 Direction default when no fine-grained slot is chosen
+
+If the user drops without dwelling long enough for the preview to mount (fast flick), fall back to `queue_target_layout_insert` (append) exactly as `queue_target_layout_split`'s own `Center`/unknown-direction branch already does (`layout_helpers.rs:141-142`) — no new fallback logic needed, just don't block the drop on the preview having mounted.
+
+---
+
+## 5. Lifecycle / State Machine
+
+Mapped to the five UX beats from §1:
+
+| Step | Trigger | State change | Existing vs. new |
+|---|---|---|---|
+| 1. Drag start | `TileLayout` `draggable().onDragStart` | `setCurrentDragPayload({kind:"tile", node})` | Existing |
+| 2. Hover a tab | pointer move over tab bar, `kind:"tile"` payload | `hoveredDropTabId` set (after dwell gate) | **New** (§4.1) |
+| 2. Flash | `hoveredDropTabId` changes | `.tab--drop-flash` keyframe restarts | **New** (§4.2) |
+| 3. Stitch preview | `hoveredDropTabId` stable past dwell | schematic popover mounts, reads live (hidden) `LayoutModel` tree | **New** (§4.3) |
+| 4. Ghost tracks pointer | pointer move within popover | `determineDropDirection` recomputed against schematic rects; ghost rect updates | Reused math (§2.5), new rect source (§4.4) |
+| 4. Leave tab / drag elsewhere | pointer leaves tab+popover region | `hoveredDropTabId` → null, popover unmounts | **New** |
+| 5. Drop | `mouseup` / pragmatic-dnd `onDrop` while `hoveredDropTabId` set | new RPC call → `MoveBlock` + `queue_target_layout_split` + `queue_source_layout_delete` | Backend pattern reused from `RedockFloatingPane` (§2.4), new RPC entry point |
+| Cleanup (always) | drag ends, any path | `currentDragPayload` cleared, `hoveredDropTabId` cleared, popover unmounted | Fixes §7 bug |
+
+---
+
+## 6. Files Touched
+
+| File | Change |
+|---|---|
+| `frontend/app/tab/tabbar.tsx` | Add `hoveredDropTabId`/`bouncingTabId`-style signal; extend (or add a second) `monitorForElements` to accept `tileItemType`; wire flash class + popover mount/unmount |
+| `frontend/app/tab/tabbar-dnd.ts` | Extend tab-wrapper-rect hit-testing helper to be reusable for tile-over-tab hover, not just tab-reorder insertion point |
+| `frontend/app/tab/tab.tsx` | Apply `.tab--drop-flash` class when `hoveredDropTabId === thisTabId` |
+| `frontend/app/tab/tab.scss` | New `.tab--drop-flash` keyframe pulse |
+| **New:** `frontend/app/tab/tab-drop-preview.tsx` | Schematic popover component: reads target `LayoutModel`, renders via `updateTreeHelper`, hosts ghost rect |
+| `frontend/layout/lib/TileLayout.win32/.darwin/.linux.tsx` | On `onDrop`, if `hoveredDropTabId` was set at release, call the new cross-tab move RPC instead of falling through to in-tab drop handling; ensure `currentDragPayload` is cleared here so `CrossWindowDragMonitor` cannot treat the release as an unhandled tear-off (fixes §7) |
+| `frontend/app/store/services.ts` | New `WorkspaceService.MovePaneToTab(...)` method (or confirm `RedockFloatingPane`'s existing RPC can be called with same-workspace ids — see §4.5.1) |
+| `agentmux-srv/src/server/service/workspace.rs` | New RPC arm (or same-workspace call path into the existing `"RedockFloatingPane"` arm, `workspace.rs:1151-1230`) |
+| `agentmux-srv/src/sagas/redock_floating_pane.rs` | Confirm/relax the "source and target are the same tab" guard doesn't also incorrectly reject same-workspace-different-tab (it shouldn't — re-verify during implementation) |
+
+**Backend blast radius:** no schema/persistence changes — this reuses `LayoutActionData`/`pendingbackendactions`/`Command::MoveBlock` verbatim. Only a new RPC arm (or a relaxed guard on an existing one) and its saga wiring.
+
+---
+
+## 7. Bug Fix Bundled With This Feature
+
+Today: drag a pane, release it over a sibling tab → `TileLayout`'s element-level `onDrop` fires (native dragend always fires on the drag source, regardless of drop target), clears `isDragging` but not `currentDragPayload` → `CrossWindowDragMonitor` sees an unhandled `dragend` with no AgentMux window under the cursor → misinterprets it as a tear-off → **spawns a new floating pane window.**
+
+This spec's new tab-bar drop target (§4.1) must call `event.preventDefault()`-equivalent / consume the drop and explicitly clear `currentDragPayload` in its own `onDrop`, before `TileLayout`'s fallback `onDrop` or `CrossWindowDragMonitor`'s dragend listener runs. Ordering here matters and should be covered by an integration test (§8) — this is the one place a race could silently reintroduce the tear-off mis-fire.
+
+---
+
+## 8. Implementation Order
+
+1. Fix §7's clear-payload-on-consumed-drop ordering in isolation first (smallest, highest-value, verifiable independently of the rest of the feature — turns "drag pane over tab bar, release" from "spawns a floating window" into "silently does nothing").
+2. Add `hoveredDropTabId` + tab flash (§4.1, §4.2) — visually verifiable with no backend changes.
+3. Add the schematic preview popover (§4.3) using the reused `updateTreeHelper` — verifiable in isolation against a live tab's tree.
+4. Add ghost tracking + `determineDropDirection` reuse (§4.4) — completes the frontend-only preview.
+5. Add the new RPC + saga wiring (§4.5), modeled on `RedockFloatingPane` — confirm whether the existing saga's guard can be reused with same-workspace ids before writing a new one.
+6. Wire drop commit (§4.5) end-to-end; remove any temporary console-only drop handling from step 2–4.
+
+---
+
+## 9. Testing Guidance
+
+- Unit: `determineDropDirection` against schematic (non-1:1-scaled) rects returns the same direction as against real rects for equivalent relative cursor positions (regression guard for §4.4 reusing the function outside its original DOM-rect context).
+- Unit: `queue_target_layout_split`/`queue_source_layout_delete` are unchanged by this feature (no new tests needed if the new RPC calls them as-is — confirms no signature drift).
+- Integration: drag a pane from tab A onto tab B (inactive) → switch to tab B → the pane appears in the previewed slot, tab A no longer shows it, and no floating window was spawned in the process (regression test for §7).
+- Integration: drag a pane, hover tab B then tab C then release over tab C → only tab C receives the pane (hover state transitions cleanly, no stale `hoveredDropTabId`).
+- Integration: drag a pane over its own current tab → no flash, no preview, drop is a no-op (mirrors `MoveBlockToTab`'s existing same-tab short-circuit).
+- Manual: verify the flash re-triggers on re-entering the same tab after a brief exit (not just a static highlight that plays once).
+
+---
+
+## 10. References
+
+- `docs/analysis/ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md` — the `sizeFraction` fix this feature depends on; read before touching `queue_target_layout_split`.
+- `docs/specs/SPEC_FLOATING_PANE_REDOCK_2026-05-27.md` — original design doc for `RedockFloatingPane`, the pattern this spec copies.
+- `frontend/layout/lib/layoutModelHooks.ts`, `layoutTree.ts`, `layoutGeometry.ts`, `layoutPersistence.ts` — reducer, tree ops, geometry, and backend-action delivery respectively.
+- `frontend/app/tab/tabbar.tsx`, `tabbar-dnd.ts`, `droppable-tab.tsx` — existing tab-reorder drag to extend.
+- `frontend/app-init.ts:113-273` (`installFloatingRedockHoverListener`) — direction/ghost-rect vocabulary to reuse in §4.4.
+- `agentmux-srv/src/sagas/redock_floating_pane.rs`, `agentmux-srv/src/server/service/layout_helpers.rs`, `workspace.rs:1151-1230` — backend pattern this spec's new RPC should mirror.


### PR DESCRIPTION
## Summary
Implements the full pane drag-to-tab feature end to end (`specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md`): drag a pane out of its tab's split layout and drop it onto a different tab in the same window.

- **Bug fix**: dragging a pane and releasing it over the tab bar today spawns an unwanted floating window (`CrossWindowDragMonitor` misreads the unhandled drop as a tear-off). Fixed by consuming the drop with a new `tileItemType` monitor on the tab bar.
- **Tab hover flash**: hovering a pane over a different tab now sets `hoveredDropTabId`, driving `.tile-drop-hover`'s accent-color pulse — CSS that already existed in `tabbar.scss`, fully styled but never wired to anything until this PR.
- **Schematic live preview**: a small popover anchored below the hovered tab renders that tab's actual current layout tree via a new standalone, pure geometry function (`schematicLayout.ts`) — deliberately not the production `updateTreeHelper` (unexported, mutates the real `LayoutModel`'s signals, would corrupt a hidden tab's render state). Dwell-gated by the existing `REDOCK_DWELL_MS` so fast pass-throughs don't flicker.
- **Ghost placement**: reuses `determineDropDirection` and the half/1-5-band/full-leaf `rectForDirection` convention already used by the floating-pane redock ghost (`app-init.ts`), computed against the popover's own coordinates.
- **The move itself**: on release, calls `WorkspaceService.RedockFloatingPane` with same-workspace source/target tab ids. **No new backend code** — that RPC's saga only rejects `source === target tab`, never same-workspace, so this was already a supported case; it lands the pane in the exact previewed slot via the existing `MoveBlock` + `queue_target_layout_split` + `queue_source_layout_delete` path.

Known follow-up (not a regression, out of scope here): if a tab's last pane is dragged out, the now-empty source tab isn't auto-closed — that auto-close watcher only runs for floating-pane windows, not regular tabs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/tab/ frontend/layout/` — 110/110 passing (35 new: `computeHoveredTab` ×6, `schematicLayout` ×7 carried over from the fix commit, plus this PR's own)
- [ ] Manual: drag a pane onto a sibling tab, confirm flash → schematic preview → ghost tracks pointer → drop lands the pane at the previewed slot in the target tab, and the source tab loses it

<!-- agentmux:agent_id=agent3 -->