### PR TITLE
fix(tabbar): pane drag over tab bar no longer mis-fires as a tear-off

### DIFF
--- a/.changesets/1783723001-fix-tabbar-pane-drag-over-tab-bar-no-longer-mis-fires-as-a-t-br8j.md
+++ b/.changesets/1783723001-fix-tabbar-pane-drag-over-tab-bar-no-longer-mis-fires-as-a-t-br8j.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabbar): pane drag over tab bar no longer mis-fires as a tear-off, adds tab-hover highlight

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -17,6 +17,7 @@ import {
     insertionPoint,
     setInsertionPoint,
     bouncingTabId,
+    hoveredDropTabId,
     tabWrapperRefs,
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
@@ -55,6 +56,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
     });
 
     const isBouncing = () => bouncingTabId() === props.tabId;
+    const isTileDropHover = () => hoveredDropTabId() === props.tabId;
 
     onMount(() => {
         if (!tabWrapRef) return;
@@ -156,6 +158,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
             class={clsx("tab-drop-wrapper", {
                 "tab-dragging": isDragging(),
                 "tab-bouncing": isBouncing(),
+                "tile-drop-hover": isTileDropHover(),
             })}
             style={{
                 "padding-left": `${gapBefore()}px`,

--- a/frontend/app/tab/tabbar-dnd.test.ts
+++ b/frontend/app/tab/tabbar-dnd.test.ts
@@ -5,6 +5,7 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
     computeInsertIndex,
     computeNearestTab,
+    computeHoveredTab,
     tabWrapperRefs,
     setGlobalDragTabId,
 } from "./tabbar-dnd";
@@ -235,5 +236,58 @@ describe("computeNearestTab", () => {
         // cursor at 60 — closest to tab-a (mid=50) but it's excluded
         // next closest: tab-b (mid=150, dist=90) over tab-c (mid=250, dist=190)
         expect(computeNearestTab(60, 15)?.tabId).toBe("tab-b");
+    });
+});
+
+// ── computeHoveredTab ─────────────────────────────────────────────────────────
+//
+// Point-in-rect hit test for the pane→tab drag drop target
+// (SPEC_PANE_DRAG_TO_TAB_2026_07_10.md §4.1) — distinct from computeNearestTab
+// (midpoint-distance, used for tab reorder gaps): a pane hovering a tab must
+// land ONLY while literally over that tab's rect, not "nearest" to it.
+
+describe("computeHoveredTab", () => {
+    beforeEach(() => {
+        tabWrapperRefs.clear();
+    });
+
+    afterEach(() => {
+        tabWrapperRefs.clear();
+    });
+
+    test("returns null when no tabs registered", () => {
+        expect(computeHoveredTab(50, 15)).toBeNull();
+    });
+
+    test("returns the tab whose rect contains the point", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        tabWrapperRefs.set("tab-b", makeFakeEl(100, 100));
+        expect(computeHoveredTab(150, 15)).toBe("tab-b");
+        expect(computeHoveredTab(50, 15)).toBe("tab-a");
+    });
+
+    test("returns null when the point is between/outside all tab rects", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        tabWrapperRefs.set("tab-b", makeFakeEl(150, 100));
+        expect(computeHoveredTab(120, 15)).toBeNull();
+        expect(computeHoveredTab(-10, 15)).toBeNull();
+    });
+
+    test("returns null when the point is over a tab's rect vertically but not the excluded tab, and excludes the source tab", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        // Hovering squarely over tab-a, but tab-a is the pane's own current
+        // tab — dragging a pane over its own tab is a no-op, not a target.
+        expect(computeHoveredTab(50, 15, "tab-a")).toBeNull();
+    });
+
+    test("does not match when the point is outside the rect's vertical bounds", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100)); // top:0 bottom:30 per makeFakeEl
+        expect(computeHoveredTab(50, 45)).toBeNull();
+    });
+
+    test("excludeTabId still allows matching a different, non-excluded tab", () => {
+        tabWrapperRefs.set("tab-a", makeFakeEl(0, 100));
+        tabWrapperRefs.set("tab-b", makeFakeEl(100, 100));
+        expect(computeHoveredTab(150, 15, "tab-a")).toBe("tab-b");
     });
 });

--- a/frontend/app/tab/tabbar-dnd.ts
+++ b/frontend/app/tab/tabbar-dnd.ts
@@ -30,8 +30,35 @@ export const [insertionPoint, setInsertionPoint] = createSignal<InsertionPoint |
 // Which tab (by id) should play the landing bounce animation.
 export const [bouncingTabId, setBouncingTabId] = createSignal<string | null>(null);
 
+// Which tab (by id), if any, is currently a valid drop target for a
+// pane (tile) being dragged over the tab bar. Drives the `.tile-drop-hover`
+// pulse (see tabbar.scss) — the frontend half of
+// SPEC_PANE_DRAG_TO_TAB_2026_07_10.md's "tab flashes" UX beat.
+export const [hoveredDropTabId, setHoveredDropTabId] = createSignal<string | null>(null);
+
 // Registry of tab wrapper elements, keyed by tabId.
 export const tabWrapperRefs = new Map<string, HTMLDivElement>();
+
+/**
+ * Returns the tabId whose wrapper rect contains (clientX, clientY), or null
+ * if the point isn't over any registered tab. `excludeTabId` is normally the
+ * pane's own current tab — dragging a pane over the tab it's already in is
+ * a no-op, not a valid drop target.
+ */
+export function computeHoveredTab(
+    clientX: number,
+    clientY: number,
+    excludeTabId?: string | null
+): string | null {
+    for (const [tabId, el] of tabWrapperRefs) {
+        if (tabId === excludeTabId) continue;
+        const rect = el.getBoundingClientRect();
+        if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+            return tabId;
+        }
+    }
+    return null;
+}
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -18,7 +18,7 @@ import { TabRpcClient } from "@/store/rpc-util";
 import { makeORef, getObjectValue, getWaveObjectAtom } from "../store/wos";
 import { ConfirmModal } from "@/element/modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
-import { deleteLayoutModelForTab } from "@/layout/index";
+import { deleteLayoutModelForTab, tileItemType } from "@/layout/index";
 import { DroppableTab } from "./droppable-tab";
 import {
     tabItemType,
@@ -29,6 +29,8 @@ import {
     computeInsertionPoint,
     InsertionPoint,
     tabWrapperRefs,
+    setHoveredDropTabId,
+    computeHoveredTab,
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { Logger } from "@/util/logger";
@@ -367,6 +369,49 @@ function TabBar(props: TabBarProps): JSX.Element {
             },
         });
         onCleanup(cleanup);
+
+        // Pane (tile) drags: tab-level drop UI (SPEC_PANE_DRAG_TO_TAB_2026_07_10.md).
+        // A pane can only be dragged from the currently active tab — every
+        // other tab is `display:none` (workspace.tsx keeps them mounted but
+        // hidden) and so cannot receive the pointer events needed to start
+        // a drag — so `atoms.activeTabId()` is always the drag's source tab
+        // for the lifetime of a single drag gesture (it cannot change while
+        // the mouse button is held).
+        const cleanupTileDrop = monitorForElements({
+            canMonitor: ({ source }) => source.data.type === tileItemType,
+            onDrag: ({ location }) => {
+                const input = location.current.input;
+                setHoveredDropTabId(
+                    computeHoveredTab(input.clientX, input.clientY, atoms.activeTabId()),
+                );
+            },
+            onDrop: ({ location }) => {
+                setHoveredDropTabId(null);
+
+                // Without this, a pane dropped over the tab bar would leave
+                // `currentDragPayload` set (TileLayout's own onDrop
+                // deliberately doesn't clear it — see its comment —
+                // because it fires for every drop, including in-window ones
+                // already handled by an OverlayNode drop target). The
+                // unhandled payload then reaches CrossWindowDragMonitor's
+                // dragend listener, which finds no other AgentMux window
+                // under the cursor and misinterprets the release as a
+                // tear-off, spawning an unwanted floating pane window.
+                // Consume the drop here so that mis-fire becomes a no-op.
+                // (The actual cross-tab move lands in a later phase of the
+                // spec — this only prevents the tear-off regression.)
+                const input = location.current.input;
+                const rect = tabBarScrollRef?.getBoundingClientRect();
+                const dropInsideBar =
+                    rect != null &&
+                    input.clientX >= rect.left && input.clientX <= rect.right &&
+                    input.clientY >= rect.top && input.clientY <= rect.bottom;
+                if (dropInsideBar) {
+                    setCurrentDragPayload(null);
+                }
+            },
+        });
+        onCleanup(cleanupTileDrop);
     });
 
     // Phase 4 — listen for the host's tear-off events. Each AgentMux


### PR DESCRIPTION
## Summary
- Fixes a real, reproducible bug: dragging a pane and releasing it over the tab bar spawns an unwanted floating pane window (the release is misread by `CrossWindowDragMonitor` as a tear-off, since nothing clears `currentDragPayload` for an in-window pane drop over the bar today).
- Adds a `tileItemType` monitor on the tab bar that consumes the drop (clearing the payload) and, piggybacking on the same hit-test, tracks which tab (if any) is currently hovered via a new `hoveredDropTabId` signal + `computeHoveredTab` helper in `tabbar-dnd.ts`.
- Wires `hoveredDropTabId` into `DroppableTab` via a `tile-drop-hover` class — this class and its accent-color pulse keyframe already existed in `tabbar.scss`, fully styled but never referenced anywhere in the codebase; this PR is the first thing to actually use it.
- No visible cross-tab move yet (that's the schematic preview + ghost + backend RPC, tracked as follow-up work) — this PR only fixes the tear-off regression and lights up the tab-hover highlight.

Implements steps 1–2 of `specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md`'s implementation order (see #2073).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/tab/` — 28/28 passing, including 6 new `computeHoveredTab` cases
- [ ] Manual: drag a pane over a sibling tab and release — confirm no floating window spawns, confirm the sibling tab pulses while hovered and stops pulsing over the pane's own current tab

<!-- agentmux:agent_id=agent3 -->