### PR TITLE
fix(jekt): echo outgoing SendMessage jekts into the sender's own pane

### DIFF
--- a/.changesets/1783731370-fix-jekt-echo-outgoing-sendmessage-jekts-into-the-sender-s-o-z4it.md
+++ b/.changesets/1783731370-fix-jekt-echo-outgoing-sendmessage-jekts-into-the-sender-s-o-z4it.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(jekt): echo outgoing SendMessage jekts into the sender's own pane

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -919,7 +919,14 @@ async fn call_tool(
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
 
             if result.get("success").and_then(|v| v.as_bool()) == Some(true) {
-                Ok(format!("Message sent to {to}"))
+                // Prefer the server's [JEKT:...] echo (SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md
+                // §2.4) so the sender's own pane renders a JektBubble like the
+                // recipient's does. Falls back to the plain confirmation string
+                // against an older server that doesn't send `echo` yet.
+                match result.get("echo").and_then(|v| v.as_str()) {
+                    Some(echo) => Ok(echo.to_string()),
+                    None => Ok(format!("Message sent to {to}")),
+                }
             } else {
                 let err = result
                     .get("error")

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use super::sanitize::{format_injected_message, is_sensitive_message, sanitize_message, validate_agent_id, wrap_jekt_message};
+use super::sanitize::{format_injected_message, is_sensitive_message, sanitize_message, validate_agent_id, wrap_jekt_message, JektTrailer};
 use super::types::*;
 use super::{now_unix_millis, sha256_hex, AUDIT_LOG_MAX, RATE_LIMIT_MAX};
 
@@ -211,6 +211,7 @@ impl Handler {
                 block_id: None,
                 error: Some("rate limit exceeded".to_string()),
                 timestamp: now,
+                echo: None,
             };
         }
 
@@ -222,6 +223,7 @@ impl Handler {
                 block_id: None,
                 error: Some(format!("invalid agent ID: {}", req.target_agent)),
                 timestamp: now,
+                echo: None,
             };
         }
 
@@ -248,6 +250,7 @@ impl Handler {
                     block_id: None,
                     error: Some(err),
                     timestamp: now,
+                    echo: None,
                 };
             }
         };
@@ -283,6 +286,24 @@ impl Handler {
             delivery_tier,
             &request_id,
             priority,
+            JektTrailer::ReplyHint,
+        );
+
+        // Sender-facing echo of the same message, for the SendMessage tool
+        // result — same content, different trailer (§2.1/§2.2 of
+        // SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md: "Reply: bus:inject to
+        // {self}" would be nonsensical read back in the sender's own pane).
+        // Computed once, moved into whichever of the two success returns
+        // below actually fires — the two are mutually exclusive per call.
+        let echo = wrap_jekt_message(
+            &sanitized,
+            req.source_agent.as_deref(),
+            &req.target_agent,
+            effective_tier,
+            delivery_tier,
+            &request_id,
+            priority,
+            JektTrailer::DeliveredStatus,
         );
 
         // Legacy source-prefix format preserved for PTY controllers that don't
@@ -323,6 +344,7 @@ impl Handler {
                         block_id: Some(block_id),
                         error: None,
                         timestamp: now,
+                        echo: Some(echo),
                     };
                 }
                 Ok(false) => {
@@ -353,6 +375,7 @@ impl Handler {
                         block_id: Some(block_id),
                         error: Some(e),
                         timestamp: now,
+                        echo: None,
                     };
                 }
             }
@@ -378,6 +401,7 @@ impl Handler {
                     block_id: Some(block_id),
                     error: Some(err),
                     timestamp: now,
+                    echo: None,
                 };
             }
         };
@@ -416,6 +440,7 @@ impl Handler {
                 block_id: Some(block_id),
                 error: Some(e),
                 timestamp: now,
+                echo: None,
             };
         }
 
@@ -448,6 +473,7 @@ impl Handler {
             block_id: Some(block_id),
             error: None,
             timestamp: now,
+            echo: Some(echo),
         }
     }
 

--- a/agentmux-srv/src/backend/reactive/sanitize.rs
+++ b/agentmux-srv/src/backend/reactive/sanitize.rs
@@ -190,6 +190,20 @@ pub fn is_sensitive_message(msg: &str) -> bool {
         || SENSITIVE_WHOLE_WORD_KEYWORDS.iter().any(|kw| contains_whole_word(&lower, kw))
 }
 
+/// Which trailer line `wrap_jekt_message` appends — the same message content
+/// needs a different closing line depending on whose pane it renders in.
+/// `Reply: bus:inject to {from}` only makes sense for the recipient reading
+/// their own incoming jekt; echoing that exact line back into the sender's
+/// own pane would read as "reply to yourself." See
+/// SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.1/§2.2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JektTrailer {
+    /// Recipient-facing (the injected message): "Reply: bus:inject to {from}".
+    ReplyHint,
+    /// Sender-facing (the `SendMessage` tool-result echo): "Status: delivered".
+    DeliveredStatus,
+}
+
 /// Wrap an injected message with a structured `[JEKT:...]` marker block.
 ///
 /// The marker is machine-parseable (first line) and human-readable (the rest).
@@ -202,6 +216,7 @@ pub fn wrap_jekt_message(
     delivery_tier: &str,
     msg_id: &str,
     priority: &str,
+    trailer: JektTrailer,
 ) -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let ts_secs = SystemTime::now()
@@ -222,10 +237,13 @@ pub fn wrap_jekt_message(
         ""
     };
 
-    let reply_hint = format!("Reply: bus:inject to {from}");
+    let trailer_line = match trailer {
+        JektTrailer::ReplyHint => format!("Reply: bus:inject to {from}"),
+        JektTrailer::DeliveredStatus => "Status: delivered".to_string(),
+    };
 
     format!(
-        "{structured_tag}\n────────────────────────────────────────────────────────────\nFrom: {from} | To: {target_agent} | ts={ts_secs}{sensitive_warning}\n{msg}\n────────────────────────────────────────────────────────────\n{reply_hint}\n[/JEKT]"
+        "{structured_tag}\n────────────────────────────────────────────────────────────\nFrom: {from} | To: {target_agent} | ts={ts_secs}{sensitive_warning}\n{msg}\n────────────────────────────────────────────────────────────\n{trailer_line}\n[/JEKT]"
     )
 }
 

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -282,6 +282,33 @@ fn test_handler_inject_agent_not_found() {
 
     assert!(!resp.success);
     assert!(resp.error.unwrap().contains("agent not found"));
+    // SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.6: nothing was ever sent, so
+    // there's nothing to echo back — don't fabricate one for a failure.
+    assert!(resp.echo.is_none());
+}
+
+// -- wrap_jekt_message trailer tests --
+
+#[test]
+fn test_wrap_jekt_message_reply_hint_trailer_unchanged() {
+    let wrapped = wrap_jekt_message(
+        "hi", Some("AgentA"), "AgentB", "coord", "host", "msg-1", "normal",
+        JektTrailer::ReplyHint,
+    );
+    assert!(wrapped.contains("Reply: bus:inject to AgentA"));
+    assert!(!wrapped.contains("Status: delivered"));
+}
+
+#[test]
+fn test_wrap_jekt_message_delivered_status_trailer() {
+    let wrapped = wrap_jekt_message(
+        "hi", Some("AgentA"), "AgentB", "coord", "host", "msg-1", "normal",
+        JektTrailer::DeliveredStatus,
+    );
+    assert!(wrapped.contains("Status: delivered"));
+    // The sender-facing echo must never carry the recipient-facing "reply to
+    // yourself" line — the exact bug this spec's design phase caught.
+    assert!(!wrapped.contains("Reply: bus:inject"));
 }
 
 // `#[tokio::test]` because `Handler::inject_message` internally
@@ -318,6 +345,16 @@ async fn test_handler_inject_success() {
     assert!(resp.success);
     assert_eq!(resp.request_id, "req-1");
     assert_eq!(resp.block_id.as_deref(), Some("block1"));
+
+    // SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.3/§2.5: a successful send
+    // carries a sender-facing echo, using the DeliveredStatus trailer (not
+    // the recipient-facing ReplyHint the injected payload below uses).
+    let echo = resp.echo.clone().expect("echo present on success");
+    assert!(echo.contains("[JEKT:"), "echo carries the JEKT open marker");
+    assert!(echo.contains("[/JEKT]"), "echo carries the JEKT close marker");
+    assert!(echo.contains("hello"), "echo carries the message payload");
+    assert!(echo.contains("Status: delivered"), "echo uses the delivered-status trailer");
+    assert!(!echo.contains("Reply: bus:inject"), "echo must not carry the recipient-facing reply hint");
 
     let calls = sent.lock().unwrap();
     // Production sequence (handler.rs:268-280): clear `\r`, then
@@ -636,6 +673,7 @@ fn test_injection_response_serde() {
         block_id: Some("block-abc".to_string()),
         error: None,
         timestamp: 1700000000000,
+        echo: None,
     };
 
     let json = serde_json::to_string(&resp).unwrap();

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -64,6 +64,12 @@ pub struct InjectionResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     pub timestamp: u64,
+    /// Sender-facing echo of the delivered `[JEKT:...]` block — `Some` only
+    /// on success, so `agentmux-mcp`'s `SendMessage` can return it as the
+    /// tool result instead of a bare confirmation string. See
+    /// SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.3.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub echo: Option<String>,
 }
 
 /// Agent registration record.

--- a/docs/specs/SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md
+++ b/docs/specs/SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md
@@ -1,0 +1,192 @@
+# Spec: Outgoing Jekt Echo — Make Muxbus Messages Visible on the Sender's Side
+
+**Date:** 2026-07-10
+**Author:** AgentY
+**Type:** Implementation-ready fix. No code shipped yet.
+**Purpose:** Close the gap between `docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` §3.2 (spec'd) and what actually shipped in v0.52.0 (only the incoming half) — a human watching the *sending* agent's pane currently sees nothing distinctive when that agent calls `SendMessage`, only a bare tool-result string. This spec makes the sender's pane show the same `JektBubble` treatment the recipient's pane already gets.
+
+---
+
+## 1. Problem, verified against current code (2026-07-10)
+
+`SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` §3.2 calls for:
+
+> When an agent calls `SendMessage`, the host echoes the outgoing jekt to the agent's own pane output ... This gives the human operator a visible record of what the agent sent and whether delivery was confirmed.
+
+**What actually shipped (v0.52.0, `feat(jekt): render [JEKT:...] markers as JektBubble in the agent pane`):**
+
+- **Incoming, fully working.** `agentmux-srv/src/backend/reactive/handler.rs`'s `handle_reactive_inject` wraps the message via `wrap_jekt_message(...)` (`sanitize.rs:197-230`) and injects the wrapped block as the recipient's next input. The frontend's `tryParseJekt` (`frontend/app/view/agent/stream-parser.ts:547-590`), wired into `userMessageToNode`, detects the `[JEKT:...]...[/JEKT]` block and renders a `JektBubble` (`frontend/app/view/agent/components/JektBubble.tsx`).
+- **Outgoing, never implemented.** `agentmux-mcp/src/main.rs`'s `SendMessage` handler (line 869) POSTs to `/agentmux/reactive/inject` and, on success, returns the plain string `Ok(format!("Message sent to {to}"))` as the tool result — not a JEKT-formatted block. This return value flows through `toolResultToNode` (`stream-parser.ts:429-465`), which has **no jekt-detection at all** — it always builds a generic collapsed `ToolBlock`. `tryParseJekt` is only ever called from `userMessageToNode` (`stream-parser.ts:524`), not from the tool-result path.
+
+The frontend is already half-ready for this: `tryParseJekt`'s own comment says outgoing direction is "handled here so JektBubble is ready when it is [emitted]" (`stream-parser.ts:566-567`) — confirming this was a known, deliberately-deferred gap, not an oversight. It was just never fed a producer.
+
+**Net effect matching the user report:** the human sees jekt bubbles on the receiving agent's pane, but the sending agent's pane shows nothing but a bland collapsed tool-result row reading "Message sent to X" — no sender-visible record of the message, tier, or delivery status.
+
+---
+
+## 2. Design
+
+Reuse the existing `wrap_jekt_message` formatting rather than inventing a second marker format — the frontend parser is format-coupled to it (`JEKT_BLOCK_RE`, `parseJektTagFields`), so anything else would need its own parser branch for no benefit.
+
+### 2.1 A caught bug in the naive version of this design
+
+The obvious first cut — have the server return the *exact same* wrapped string it already computed for the recipient, and have `SendMessage` return that as the tool result — is wrong. `wrap_jekt_message`'s trailer line is:
+
+```
+Reply: bus:inject to {from}
+```
+
+`{from}` is the *sender* (`source_agent`). That line is correct advice when the recipient reads it ("reply to whoever sent this"). But if the identical string is echoed back into the **sender's own pane**, the sender would see "Reply: bus:inject to {themselves}" — nonsensical, and actively confusing for the human watching that pane. This has to be a distinct trailer, not a verbatim reuse.
+
+### 2.2 `wrap_jekt_message` gains a trailer variant
+
+`agentmux-srv/src/backend/reactive/sanitize.rs`:
+
+```rust
+pub enum JektTrailer {
+    /// Recipient-facing: "Reply: bus:inject to {from}".
+    ReplyHint,
+    /// Sender-facing echo: "Status: delivered".
+    DeliveredStatus,
+}
+
+pub fn wrap_jekt_message(
+    msg: &str,
+    source_agent: Option<&str>,
+    target_agent: &str,
+    effective_tier: &str,
+    delivery_tier: &str,
+    msg_id: &str,
+    priority: &str,
+    trailer: JektTrailer,
+) -> String {
+    // ... unchanged body ...
+    let trailer_line = match trailer {
+        JektTrailer::ReplyHint => format!("Reply: bus:inject to {from}"),
+        JektTrailer::DeliveredStatus => "Status: delivered".to_string(),
+    };
+    // ... use trailer_line where reply_hint was used ...
+}
+```
+
+The one existing call site (`handler.rs:278-286`, building the recipient's injected message) passes `JektTrailer::ReplyHint` — behavior-preserving, zero change to what's already shipped and working. A `#[derive(Clone, Copy)]` enum over a bare `bool` (`is_echo: bool`) — self-documenting at call sites, and room for a third variant later (e.g. `Failed` for a delivery failure) without another signature change.
+
+Also add `STATUS=delivered` to the structured tag itself for the echo variant (spec §3.2's own example includes it) — the frontend's `JektMessageNode` type doesn't currently have a `status` field, and this spec doesn't require adding one (§2.4 covers what the frontend actually needs); it's fine for `STATUS=delivered` to live only in the human-readable trailer for now, not the structured tag, keeping the parser's required-field set (`FROM`/`TO`) unchanged. Revisit if a future "pending/failed" state needs the frontend to branch on it.
+
+### 2.3 `InjectionResponse` carries the echo string
+
+`agentmux-srv/src/backend/reactive/types.rs`:
+
+```rust
+pub struct InjectionResponse {
+    pub success: bool,
+    pub request_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub timestamp: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub echo: Option<String>,   // NEW — the JEKT block for the sender's own pane
+}
+```
+
+`handle_reactive_inject` (`handler.rs`) builds a second wrap call alongside the existing one, only on the success path (no `echo` on failure — see §2.5):
+
+```rust
+let echo = wrap_jekt_message(
+    &sanitized, req.source_agent.as_deref(), &req.target_agent,
+    effective_tier, delivery_tier, &request_id, priority,
+    JektTrailer::DeliveredStatus,
+);
+```
+
+Set `response.echo = Some(echo)` on the success path only.
+
+### 2.4 `agentmux-mcp`'s `SendMessage` returns the echo, not a bare string
+
+`agentmux-mcp/src/main.rs`, `"SendMessage"` arm (currently line 869-930): after the existing success check, use `result.get("echo")` if present, falling back to today's string if an older server doesn't send it (forward/backward compat across mismatched host/mcp-tool versions during a rollout):
+
+```rust
+if result.get("success").and_then(|v| v.as_bool()) == Some(true) {
+    match result.get("echo").and_then(|v| v.as_str()) {
+        Some(echo) => Ok(echo.to_string()),
+        None => Ok(format!("Message sent to {to}")), // older server, no echo field
+    }
+} else {
+    // unchanged failure path
+}
+```
+
+### 2.5 Frontend: detect a jekt block inside a tool result
+
+`stream-parser.ts`'s `toolResultToNode` (429-465) needs the same jekt-sniffing `tryParseJekt` already does for user messages, but tool results carry the text in `event.result`, not `event.message`, and only for the `SendMessage` tool specifically (no other tool should have its output speculatively parsed as a jekt block, even if it happened to match the regex by coincidence — narrow the check by tool name, not just content shape):
+
+```ts
+private toolResultToNode(event: ToolResultEvent): DocumentNode {
+    const toolCall = this.pendingToolCalls.get(event.id);
+    const params = toolCall?.params || {};
+    const toolName = (event.tool && event.tool !== "Unknown") ? event.tool : (toolCall?.tool || "Unknown");
+    this.pendingToolCalls.delete(event.id);
+
+    if (toolName === "SendMessage" && typeof event.result === "string") {
+        const jekt = this.tryParseJektText(event.result, event.timestamp);
+        if (jekt) return jekt;
+    }
+    // ... existing generic ToolBlock path, unchanged ...
+}
+```
+
+This requires factoring `tryParseJekt`'s body (547-590) into a `tryParseJektText(text: string, timestamp?: number): JektMessageNode | null` that both `userMessageToNode` and `toolResultToNode` call — a pure refactor, no behavior change to the existing incoming path.
+
+**Direction detection already works unmodified.** `tryParseJektText`'s existing direction logic (`stream-parser.ts:569-573`) — `FROM === currentAgentId && TO !== currentAgentId → outgoing` — already does the right thing here: the echo's `FROM` is the sending agent itself (this pane's `currentAgentId`), so it's naturally classified `outgoing` without any new logic. This is exactly the case the original comment said the direction logic was "ready" for.
+
+### 2.6 Failure case — no echo, don't fabricate one
+
+On delivery failure (`result.success !== true`), `SendMessage` keeps returning today's plain error string (`"Message delivery failed: {err}"`) — not a jekt block. A failed send was never delivered, so there's no "this is what got sent" record to show; inventing a fake jekt bubble for a failure would misrepresent something that didn't happen. The existing collapsed `ToolBlock` (red border, ✗ icon) is already the correct treatment for a failed tool call — this spec doesn't change that path.
+
+---
+
+## 3. Data flow, before / after
+
+**Before:**
+```
+Agent calls SendMessage → agentmux-mcp POSTs /agentmux/reactive/inject
+  → recipient's pane: [JEKT:FROM=... TO=...] injected → JektBubble ✓
+  → sender's pane: tool_result "Message sent to X" → generic ToolBlock ✗ (the gap)
+```
+
+**After:**
+```
+Agent calls SendMessage → agentmux-mcp POSTs /agentmux/reactive/inject
+  → recipient's pane: [JEKT:FROM=... TO=... Reply: bus:inject to <sender>] injected → JektBubble ✓ (unchanged)
+  → response.echo = [JEKT:FROM=... TO=... Status: delivered] (new, sender-appropriate trailer)
+  → agentmux-mcp returns response.echo as the SendMessage tool result
+  → sender's pane: tool_result matches JEKT_BLOCK_RE (SendMessage-gated) → JektBubble, direction=outgoing ✓
+```
+
+---
+
+## 4. Scope / non-goals
+
+- **No new wire format.** Same `[JEKT:...]...[/JEKT]` structured tag and regex; only the human-readable trailer line differs by variant.
+- **No `db_agent_mcp_ref`/muxbus protocol changes.** This is purely: (a) the server also returns the block it already builds, via one new response field; (b) the MCP tool relays it instead of a canned string; (c) the frontend recognizes it in one additional, narrowly-gated code path.
+- **STATUS field kept out of the structured tag for now** (§2.2) — avoids widening `JektMessageNode`'s required fields for a status this spec doesn't need machine-readable yet.
+- **Delivery-failure bubbles are explicitly out of scope** (§2.6) — the existing failed-ToolBlock treatment already covers it correctly; don't build a second failure-representation.
+- **Tier-2/3/4 delivery (LAN/WAN)** — `handle_reactive_inject` already computes `delivery_tier` for all tiers today; this spec's echo reuses whatever tier it resolved, so cross-tier sends get an accurate echo with no extra plumbing.
+
+## 5. Test plan (for the implementing PR)
+
+- Rust: unit test on `wrap_jekt_message` asserting the two trailer variants produce the expected trailer line and that `ReplyHint`'s existing output is byte-for-byt identical to pre-change output (regression guard on the one already-shipped call site).
+- Rust: `handle_reactive_inject` test asserting `response.echo` is `Some` on success and `None` on every failure branch (rate limit, invalid agent, agent not found).
+- Frontend: `stream-parser.test.ts` (or wherever `tryParseJekt`'s existing incoming-path tests live) gets a new case: a `tool_result` event for tool `"SendMessage"` whose `result` is a well-formed `[JEKT:FROM=self TO=other ...]` block parses to a `JektMessageNode` with `direction: "outgoing"`; a `tool_result` for any *other* tool containing incidentally jekt-shaped text does **not** get parsed as a jekt (confirms the tool-name gate in §2.5).
+- Manual: two agents, `SendMessage` A→B — confirm A's own pane shows an outgoing `JektBubble` (right-aligned per §3.3 of the governing spec, paper-plane icon) alongside B's existing incoming bubble.
+
+## 6. References
+
+- `docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` — governing spec, §3.2 is what this implements.
+- `agentmux-srv/src/backend/reactive/handler.rs`, `sanitize.rs`, `types.rs` — current incoming-only implementation.
+- `agentmux-mcp/src/main.rs:869-930` — `SendMessage` tool handler.
+- `frontend/app/view/agent/stream-parser.ts:429-465, 524, 547-590` — `toolResultToNode`, `userMessageToNode`, `tryParseJekt`.
+- `frontend/app/view/agent/components/JektBubble.tsx` — rendering, already direction-aware.
+- `VERSION_HISTORY.md` 0.52.0 — `feat(jekt): render [JEKT:...] markers as JektBubble in the agent pane` (the shipped incoming-only half).

--- a/frontend/app/view/agent/stream-parser.test.ts
+++ b/frontend/app/view/agent/stream-parser.test.ts
@@ -556,6 +556,75 @@ describe("jekt marker detection", () => {
         const node = parser.parseStreamEvent({ type: "user_message", message: "[not a jekt] just talking about brackets" });
         expect(node!.type).toBe("user_message");
     });
+
+    test("strips a Status: trailer the same way a Reply: trailer is stripped", () => {
+        const message =
+            `[JEKT:FROM=agentx TO=agent3 TIER=coord DELIVERY=host TRUST=host-verified MSGID=abc123 PRIORITY=normal TS=1783386012]\n` +
+            `────────────────────────────────────────────────────────────\n` +
+            `From: agentx | To: agent3 | ts=1783386012\n` +
+            `Hey, can you review PR #25?\n` +
+            `────────────────────────────────────────────────────────────\n` +
+            `Status: delivered\n` +
+            `[/JEKT]`;
+        const node = parser.parseStreamEvent({ type: "user_message", message });
+        const jekt = node as import("./types").JektMessageNode;
+        expect(jekt.type).toBe("jekt_message");
+        expect(jekt.message).toBe("Hey, can you review PR #25?");
+    });
+});
+
+// ── Outgoing jekt echo — SendMessage tool result (SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md) ──
+
+describe("outgoing jekt echo via SendMessage tool result", () => {
+    const jektEcho = (overrides: Partial<{ from: string; to: string }> = {}) => {
+        const f = { from: "agentx", to: "agent3", ...overrides };
+        return `[JEKT:FROM=${f.from} TO=${f.to} TIER=coord DELIVERY=host TRUST=host-verified MSGID=abc123 PRIORITY=normal TS=1783386012]\n` +
+            `────────────────────────────────────────────────────────────\n` +
+            `From: ${f.from} | To: ${f.to} | ts=1783386012\n` +
+            `Hey, can you review PR #25?\n` +
+            `────────────────────────────────────────────────────────────\n` +
+            `Status: delivered\n` +
+            `[/JEKT]`;
+    };
+
+    test("a successful SendMessage result carrying a jekt block parses to jekt_message", () => {
+        parser.setAgentId("agentx");
+        const node = parser.parseStreamEvent({
+            type: "tool_result", id: "tool-1", tool: "SendMessage", status: "success", result: jektEcho(),
+        });
+        expect(node!.type).toBe("jekt_message");
+        const jekt = node as import("./types").JektMessageNode;
+        expect(jekt.direction).toBe("outgoing");
+        expect(jekt.message).toBe("Hey, can you review PR #25?");
+    });
+
+    test("the jekt node's id matches the tool_result's id, so it replaces the running tool placeholder in place", () => {
+        const node = parser.parseStreamEvent({
+            type: "tool_result", id: "tool-42", tool: "SendMessage", status: "success", result: jektEcho(),
+        });
+        expect(node!.id).toBe("tool-42");
+    });
+
+    test("a failed SendMessage result is NOT jekt-parsed even if it happens to be jekt-shaped", () => {
+        const node = parser.parseStreamEvent({
+            type: "tool_result", id: "tool-2", tool: "SendMessage", status: "failed", result: jektEcho(),
+        });
+        expect(node!.type).toBe("tool");
+    });
+
+    test("a different tool's result is NOT jekt-parsed even if it happens to be jekt-shaped", () => {
+        const node = parser.parseStreamEvent({
+            type: "tool_result", id: "tool-3", tool: "Bash", status: "success", result: jektEcho(),
+        });
+        expect(node!.type).toBe("tool");
+    });
+
+    test("a SendMessage result that isn't a well-formed jekt block falls back to a plain tool node", () => {
+        const node = parser.parseStreamEvent({
+            type: "tool_result", id: "tool-4", tool: "SendMessage", status: "success", result: "Message sent to Agent1",
+        });
+        expect(node!.type).toBe("tool");
+    });
 });
 
 // ── error_result → AgentErrorNode (P1.3) ────────────────────────────────────

--- a/frontend/app/view/agent/stream-parser.ts
+++ b/frontend/app/view/agent/stream-parser.ts
@@ -75,10 +75,12 @@ function parseJektTagFields(tag: string): Record<string, string> {
 /**
  * Strips the presentational scaffolding both jekt-wrapping implementations
  * add around the actual message (divider lines, the "From: X | To: Y | ..."
- * header line, the sensitive-tier warning, the reply hint), leaving just
- * what the sender actually typed/sent. Best-effort: any line that doesn't
- * match a known scaffolding shape is kept, so an unrecognized wrapper
- * variant degrades to showing extra context rather than losing content.
+ * header line, the sensitive-tier warning, the trailer line — "Reply: ..."
+ * on an incoming jekt, "Status: ..." on an outgoing echo, see
+ * SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.2/§2.5), leaving just what the
+ * sender actually typed/sent. Best-effort: any line that doesn't match a
+ * known scaffolding shape is kept, so an unrecognized wrapper variant
+ * degrades to showing extra context rather than losing content.
  */
 function stripJektEnvelope(body: string, tier: JektTier): string {
     const lines = body.split("\n");
@@ -97,7 +99,7 @@ function stripJektEnvelope(body: string, tier: JektTier): string {
         start++;
         if ((lines[start] ?? "") === "") start++;
     }
-    if (/^Reply:/.test(lines[end - 1] ?? "")) end--;
+    if (/^(Reply|Status):/.test(lines[end - 1] ?? "")) end--;
     if (/^─+$/.test(lines[end - 1] ?? "")) end--;
 
     return lines.slice(start, end).join("\n").trim();
@@ -436,6 +438,25 @@ export class ClaudeCodeStreamParser {
         // Remove from pending
         this.pendingToolCalls.delete(event.id);
 
+        // Outgoing jekt echo (SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.4/§2.5):
+        // a successful SendMessage's result now carries the server's
+        // [JEKT:...] echo instead of a bare confirmation string. Gated on
+        // tool name + success status, not just "does the text look like a
+        // jekt block" — no other tool's output should be speculatively
+        // reparsed this way even if it happened to match the shape.
+        if (toolName === "SendMessage" && event.status === "success" && typeof event.result === "string") {
+            // ToolResultEvent carries no timestamp of its own — tryParseJektText
+            // defaults to Date.now(), same as it would for a missing one here.
+            const jekt = this.tryParseJektText(event.result);
+            // id MUST be event.id, not tryParseJektText's freshly-generated
+            // jekt-N id — this method's contract (see the doc comment above)
+            // is that its return value replaces the running placeholder tool
+            // node of the same id; a mismatched id would leave that
+            // placeholder stuck at "running" forever alongside an orphaned
+            // jekt node instead of replacing it in place.
+            if (jekt) return { ...jekt, id: event.id };
+        }
+
         const summary = this.generateToolSummary(
             toolName,
             params,
@@ -534,18 +555,32 @@ export class ClaudeCodeStreamParser {
         };
     }
 
+    /** Thin wrapper over `tryParseJektText` for the incoming (user-message)
+     *  path — see that method for the actual detection/parsing logic. */
+    private tryParseJekt(event: UserMessageEvent): JektMessageNode | null {
+        return this.tryParseJektText(event.message, event.timestamp);
+    }
+
     /**
-     * Detects a `[JEKT:...]...[/JEKT]` marker block occupying the whole
-     * user-message payload and, if found, parses it into a `JektMessageNode`
-     * instead of the plain-text `UserMessageNode` the marker would otherwise
-     * render as. Returns null for anything that isn't a well-formed jekt
-     * block — including malformed/partial markers — so those fall through to
-     * normal plain-text rendering rather than being silently dropped.
+     * Detects a `[JEKT:...]...[/JEKT]` marker block occupying the whole of
+     * `text` and, if found, parses it into a `JektMessageNode`. Returns null
+     * for anything that isn't a well-formed jekt block — including
+     * malformed/partial markers — so those fall through to normal rendering
+     * (plain text for a user message, a generic ToolBlock for a tool result)
+     * rather than being silently dropped.
+     *
+     * Shared by both directions: `userMessageToNode` (incoming — the host
+     * injects a `[JEKT:...]` block as this agent's next input) and
+     * `toolResultToNode` (outgoing — `SendMessage`'s tool result now carries
+     * the server's echo of the same block, see
+     * SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md §2.4/§2.5). Direction is derived
+     * from the FROM/TO fields against `currentAgentId`, not from which
+     * caller invoked this — both call sites hand it raw text.
      *
      * Spec: docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md §3.3.
      */
-    private tryParseJekt(event: UserMessageEvent): JektMessageNode | null {
-        const match = JEKT_BLOCK_RE.exec(event.message.trim());
+    private tryParseJektText(text: string, timestamp?: number): JektMessageNode | null {
+        const match = JEKT_BLOCK_RE.exec(text.trim());
         if (!match) return null;
 
         const fields = parseJektTagFields(match[1]);
@@ -561,11 +596,8 @@ export class ClaudeCodeStreamParser {
             : "wan";
         const trust: JektTrust = fields.TRUST === "host-verified" ? "host-verified" : "network-claimed";
 
-        // Direction mirrors agentMessageToNode: incoming when this agent is
-        // the declared recipient, outgoing when it's the declared sender
-        // (spec §3.2's outgoing echo — not yet emitted by any producer today,
-        // but handled here so JektBubble is ready when it is). Falls back to
-        // incoming, the only case any current producer emits.
+        // Incoming when this agent is the declared recipient, outgoing when
+        // it's the declared sender. Falls back to incoming.
         const lowerAgentId = this.currentAgentId?.toLowerCase();
         const direction: "incoming" | "outgoing" =
             lowerAgentId && fields.FROM.toLowerCase() === lowerAgentId && fields.TO.toLowerCase() !== lowerAgentId
@@ -578,14 +610,14 @@ export class ClaudeCodeStreamParser {
             from: fields.FROM,
             to: fields.TO,
             message: stripJektEnvelope(match[2], tier),
-            raw: event.message,
+            raw: text,
             tier,
             deliveryTier,
             trust,
             msgId: fields.MSGID || "",
             priority: fields.PRIORITY === "urgent" ? "urgent" : "normal",
             direction,
-            timestamp: event.timestamp || Date.now(),
+            timestamp: timestamp || Date.now(),
         };
     }
 


### PR DESCRIPTION
## Summary

`SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` §3.2 calls for the host to echo an outgoing jekt back into the sending agent's own pane, symmetric to the incoming `JektBubble` that already renders on the recipient's side (shipped in v0.52.0). That half never actually shipped — `SendMessage`'s tool result was just a bare `"Message sent to X"` string, and the frontend only ever ran jekt-detection inside user-message events, never tool results. Net effect: a human watching the sender's pane saw a generic collapsed `ToolBlock`, nothing distinctive, while the recipient's pane correctly showed a `JektBubble`.

- **`agentmux-srv`**: `wrap_jekt_message` gains a `JektTrailer` (`ReplyHint` vs `DeliveredStatus`). Reusing the identical wrapped string for both directions would tell the sender "Reply: bus:inject to {themselves}" — caught this while designing, so the echo gets its own trailer instead of a byte-for-byte copy of the recipient's block. `InjectionResponse.echo: Option<String>` carries it, `Some` only on the two success paths, `None` on every failure path.
- **`agentmux-mcp`**: `SendMessage` returns `response.echo` as the tool result when present, falling back to the old plain string against an older server (forward/back compat during a mixed-version rollout).
- **frontend**: `tryParseJekt`'s body is factored into `tryParseJektText(text, timestamp?)`, shared by `userMessageToNode` (incoming, unchanged behavior) and a new check in `toolResultToNode`, gated on tool name `"SendMessage"` + `status: "success"` — not "any tool output that happens to look jekt-shaped." The returned node's `id` is forced to `event.id` so it replaces the running tool placeholder in place instead of leaving it stuck alongside an orphaned jekt node.

Full design doc: `docs/specs/SPEC_JEKT_OUTGOING_ECHO_2026_07_10.md`.

## Test plan
- [x] `cargo check -p agentmux-srv -p agentmux-mcp` — clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1467 passed (incl. 4 new: `wrap_jekt_message` trailer variants, echo present-on-success/absent-on-failure)
- [x] `cargo test -p agentmux-mcp` — 4 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent/stream-parser.test.ts` — 52 passed (incl. 6 new: outgoing echo parses to `jekt_message`, id-replacement, failure/wrong-tool/malformed all correctly fall back to a plain tool node)
- [x] `npx vitest run frontend/app/view/agent` (full suite, regression check) — 656 passed
- [ ] Manual: two agents, `SendMessage` A→B — confirm A's own pane now shows an outgoing `JektBubble` (right-aligned, paper-plane icon per the governing spec §3.3) alongside B's existing incoming bubble

<!-- agentmux:agent_id=agenty -->