### PR TITLE
feat(jekt): incoming jekts visible on persistent agents + outgoing sender echo (§3.2)

### DIFF
--- a/.changesets/1783731654-feat-jekt-incoming-jekts-visible-on-persistent-agents-outgoi-xewg.md
+++ b/.changesets/1783731654-feat-jekt-incoming-jekts-visible-on-persistent-agents-outgoi-xewg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(jekt): incoming jekts visible on persistent agents + outgoing sender echo (§3.2)

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -381,14 +381,38 @@ impl PersistentSubprocessController {
                 "content": message
             }
         });
+        let json_str = json_msg.to_string();
 
-        let inner = self.inner.lock().unwrap();
-        let tx = inner
-            .stdin_tx
-            .as_ref()
-            .ok_or("persistent process not running")?;
-        tx.try_send(json_msg.to_string())
-            .map_err(|e| format!("stdin send failed: {e}"))
+        {
+            let inner = self.inner.lock().unwrap();
+            let tx = inner
+                .stdin_tx
+                .as_ref()
+                .ok_or("persistent process not running")?;
+            tx.try_send(json_str.clone())
+                .map_err(|e| format!("stdin send failed: {e}"))?;
+        }
+
+        // Persist the injected message to the blockfile WITH a live event —
+        // unlike `send_message`, there is no `agent-message-accepted` pending
+        // echo to pair with (nothing was typed in the UI), so without this the
+        // injection is invisible to the human operator: a silent injection,
+        // which SPEC_JEKT_SECURITY_AND_VISIBILITY §3.1/G1 forbids. The live
+        // blockfile append renders it in the open pane; the persisted line lets
+        // `parseHistoryLines` rebuild the node on reopen.
+        if let Some(ref broker) = self.broker {
+            let global_zone = super::shell::resolve_global_output_zone(&self.wstore, &self.block_id);
+            let line_with_newline = format!("{json_str}\n");
+            super::shell::handle_append_block_file(
+                broker,
+                &self.block_id,
+                crate::backend::agent_session::OUTPUT_FILE,
+                line_with_newline.as_bytes(),
+                self.filestore.as_ref(),
+                global_zone.as_deref(),
+            );
+        }
+        Ok(())
     }
 
     /// Answer a parked AskUserQuestion via the Agent SDK **control protocol**.

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -211,6 +211,7 @@ impl Handler {
                 block_id: None,
                 error: Some("rate limit exceeded".to_string()),
                 timestamp: now,
+                effective_tier: None,
             };
         }
 
@@ -222,6 +223,7 @@ impl Handler {
                 block_id: None,
                 error: Some(format!("invalid agent ID: {}", req.target_agent)),
                 timestamp: now,
+                effective_tier: None,
             };
         }
 
@@ -248,6 +250,7 @@ impl Handler {
                     block_id: None,
                     error: Some(err),
                     timestamp: now,
+                    effective_tier: None,
                 };
             }
         };
@@ -323,6 +326,7 @@ impl Handler {
                         block_id: Some(block_id),
                         error: None,
                         timestamp: now,
+                        effective_tier: Some(effective_tier.to_string()),
                     };
                 }
                 Ok(false) => {
@@ -353,6 +357,7 @@ impl Handler {
                         block_id: Some(block_id),
                         error: Some(e),
                         timestamp: now,
+                        effective_tier: Some(effective_tier.to_string()),
                     };
                 }
             }
@@ -378,6 +383,7 @@ impl Handler {
                     block_id: Some(block_id),
                     error: Some(err),
                     timestamp: now,
+                    effective_tier: Some(effective_tier.to_string()),
                 };
             }
         };
@@ -416,6 +422,7 @@ impl Handler {
                 block_id: Some(block_id),
                 error: Some(e),
                 timestamp: now,
+                effective_tier: Some(effective_tier.to_string()),
             };
         }
 
@@ -448,6 +455,7 @@ impl Handler {
             block_id: Some(block_id),
             error: None,
             timestamp: now,
+            effective_tier: Some(effective_tier.to_string()),
         }
     }
 

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -636,6 +636,7 @@ fn test_injection_response_serde() {
         block_id: Some("block-abc".to_string()),
         error: None,
         timestamp: 1700000000000,
+        effective_tier: Some("coord".to_string()),
     };
 
     let json = serde_json::to_string(&resp).unwrap();

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -64,6 +64,10 @@ pub struct InjectionResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     pub timestamp: u64,
+    /// Tier the handler actually applied (after keyword/network escalation).
+    /// Consumed by the sender-echo path so it doesn't re-derive escalation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_tier: Option<String>,
 }
 
 /// Agent registration record.

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -15,6 +15,70 @@ use crate::backend::base;
 
 use super::AppState;
 
+/// Echo a successfully-sent jekt into the SENDER's own pane
+/// (SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2).
+///
+/// Appends a `{"type":"user",...}` NDJSON line carrying the same
+/// `[JEKT:...]` marker block the receiver got (re-wrapped with identical
+/// fields) to the sender's `output` blockfile — live WPS append (renders
+/// immediately in an open agent view), persisted history
+/// (`parseHistoryLines` rebuilds on reopen), and global transcript mirror.
+/// The frontend's `tryParseJekt` sees FROM == this pane's agent and renders
+/// it as an *outgoing* JektBubble (stream-parser.ts direction detection —
+/// this is the producer that comment says doesn't exist yet).
+///
+/// No-op when the sender isn't a registered agent on this instance (cron,
+/// external callers) or is messaging itself (the incoming marker already
+/// lands in the same pane).
+pub(super) fn echo_jekt_to_sender(
+    state: &AppState,
+    source_agent: Option<&str>,
+    target_agent: &str,
+    message: &str,
+    msgid: &str,
+    effective_tier: Option<&str>,
+    delivery_tier: &str,
+    priority: &str,
+) {
+    let Some(src) = source_agent.filter(|s| !s.is_empty()) else {
+        return;
+    };
+    if src.eq_ignore_ascii_case(target_agent) {
+        return;
+    }
+    let Some(sender_reg) = state.reactive_handler.get_agent(src) else {
+        return;
+    };
+
+    let sanitized = crate::backend::reactive::sanitize::sanitize_message(message);
+    let wrapped = crate::backend::reactive::sanitize::wrap_jekt_message(
+        &sanitized,
+        Some(&sender_reg.agent_id),
+        target_agent,
+        effective_tier.unwrap_or("coord"),
+        delivery_tier,
+        msgid,
+        priority,
+    );
+    let line = serde_json::json!({
+        "type": "user",
+        "message": { "role": "user", "content": wrapped }
+    });
+    let data = format!("{line}\n");
+    let global_zone = crate::backend::blockcontroller::shell::resolve_global_output_zone(
+        &Some(state.wstore.clone()),
+        &sender_reg.block_id,
+    );
+    crate::backend::blockcontroller::shell::handle_append_block_file(
+        &state.broker,
+        &sender_reg.block_id,
+        crate::backend::agent_session::OUTPUT_FILE,
+        data.as_bytes(),
+        Some(&state.filestore),
+        global_zone.as_deref(),
+    );
+}
+
 pub(super) async fn handle_reactive_inject(
     State(state): State<AppState>,
     Json(req): Json<InjectionRequest>,
@@ -29,6 +93,16 @@ pub(super) async fn handle_reactive_inject(
     // 1. Try local ReactiveHandler first (fast path — same instance).
     let resp = state.reactive_handler.inject_message(req.clone());
     if resp.success {
+        echo_jekt_to_sender(
+            &state,
+            req.source_agent.as_deref(),
+            &req.target_agent,
+            &req.message,
+            &resp.request_id,
+            resp.effective_tier.as_deref(),
+            req.delivery_tier.as_deref().unwrap_or("host"),
+            req.priority.as_deref().unwrap_or("normal"),
+        );
         return Json(serde_json::to_value(&resp).unwrap_or_default());
     }
 
@@ -58,6 +132,18 @@ pub(super) async fn handle_reactive_inject(
                 match fwd.send().await {
                     Ok(r) if r.status().is_success() => {
                         if let Ok(body) = r.json::<serde_json::Value>().await {
+                            if body.get("success").and_then(|v| v.as_bool()) == Some(true) {
+                                echo_jekt_to_sender(
+                                    &state,
+                                    req.source_agent.as_deref(),
+                                    &req.target_agent,
+                                    &req.message,
+                                    body.get("request_id").and_then(|v| v.as_str()).unwrap_or(""),
+                                    body.get("effective_tier").and_then(|v| v.as_str()),
+                                    "host",
+                                    req.priority.as_deref().unwrap_or("normal"),
+                                );
+                            }
                             return Json(body);
                         }
                     }
@@ -113,6 +199,16 @@ pub(super) async fn handle_reactive_inject(
                             );
                             state.lan_discovery.evict_agent(&req.target_agent);
                         } else {
+                            echo_jekt_to_sender(
+                                &state,
+                                req.source_agent.as_deref(),
+                                &req.target_agent,
+                                &req.message,
+                                body.get("request_id").and_then(|v| v.as_str()).unwrap_or(""),
+                                body.get("effective_tier").and_then(|v| v.as_str()),
+                                "lan",
+                                req.priority.as_deref().unwrap_or("normal"),
+                            );
                             return Json(body);
                         }
                     }

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -427,6 +427,17 @@ async fn handle_incoming_text(
                     };
                     let resp = state.reactive_handler.inject_message(reactive_req);
                     if resp.success {
+                        // Sender-side echo (SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2)
+                        super::reactive::echo_jekt_to_sender(
+                            state,
+                            Some(from),
+                            target,
+                            message,
+                            &resp.request_id,
+                            resp.effective_tier.as_deref(),
+                            "host",
+                            incoming.priority.as_deref().unwrap_or("normal"),
+                        );
                         let ack = json!({ "type": "bus:injected", "via": "pty", "block_id": resp.block_id });
                         let msg = serde_json::to_string(&ack).unwrap_or_default();
                         if socket.send(Message::Text(msg.into())).await.is_err() {
@@ -454,6 +465,19 @@ async fn handle_incoming_text(
                     };
                     match state.messagebus.inject(from, target, message, priority) {
                         Ok(msg_id) => {
+                            // Sender-side echo for the messagebus fallback path.
+                            // Tier is unknown here (no ReactiveHandler wrap) — None
+                            // renders as the default "coord".
+                            super::reactive::echo_jekt_to_sender(
+                                state,
+                                Some(from),
+                                target,
+                                message,
+                                &msg_id,
+                                None,
+                                "host",
+                                incoming.priority.as_deref().unwrap_or("normal"),
+                            );
                             let ack = json!({ "type": "bus:injected", "via": "messagebus", "message_id": msg_id });
                             let msg = serde_json::to_string(&ack).unwrap_or_default();
                             if socket.send(Message::Text(msg.into())).await.is_err() {

--- a/docs/specs/jekt-visibility-completion.md
+++ b/docs/specs/jekt-visibility-completion.md
@@ -1,0 +1,106 @@
+# Spec: Jekt Visibility Completion — persistent-agent visibility + outgoing echo
+
+**Date:** 2026-07-10
+**Author:** Agent2
+**Status:** Implemented (this PR)
+**Parent spec:** `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` (completes §3.1 for
+persistent agents, implements §3.2)
+**Builds on:** PR #2031 (Phase 3 — `JektBubble` renders `[JEKT:...]` markers)
+
+---
+
+## 1. Findings — the two gaps left after PR #2031
+
+PR #2031 shipped the frontend: `tryParseJekt` (stream-parser.ts) turns a `[JEKT:...]`
+marker inside a user message into a `JektMessageNode`, rendered by `JektBubble` with
+direction support ("incoming"/"outgoing") already built in. But two producer-side gaps
+mean the bubble rarely fires where it matters most:
+
+### 1.1 Incoming jekts never reach the pane on persistent agents
+
+For **persistent stream-json agents** (all Claude Code panes), the injection path is
+`Handler::inject_message` → `deliver_agent_message` →
+`PersistentSubprocessController::send_user_message`, which wrote the wrapped jekt
+**only to the process stdin**. Compare `send_message` (the user-typed path), which also
+persists the line to the blockfile so the frontend can build a node. `send_user_message`
+did neither — so the agent received and acted on the jekt while the human operator's
+conversation view showed **nothing**. A silent injection, which parent-spec G1 forbids.
+`tryParseJekt` never ran because the marker never landed in the `output` stream.
+
+(PTY-based agents were unaffected — keystroke echo makes the raw marker visible in
+xterm. The gap is specific to structured-channel delivery.)
+
+### 1.2 No outgoing echo producer (§3.2)
+
+`stream-parser.ts` (`tryParseJekt`) explicitly notes direction detection is "not yet
+emitted by any producer today". Nothing wrote an outgoing record to the sender's pane,
+and `setAgentId` — which direction detection depends on — was never called in
+production code, only tests.
+
+## 2. Changes
+
+### 2.1 Incoming visibility (backend)
+
+`PersistentSubprocessController::send_user_message` now persists the injected
+`{"type":"user",...}` line to the blockfile **with a live WPS append event**
+(`handle_append_block_file`), mirroring to the global transcript zone. Non-silent —
+unlike `send_message` there is no `agent-message-accepted` pending-echo to pair with,
+so there is no duplicate-node risk. The open pane renders the jekt live (Phase 3 bubble
+now fires); `parseHistoryLines` rebuilds it on reopen.
+
+### 2.2 Outgoing echo (backend, §3.2)
+
+New `echo_jekt_to_sender` (`server/reactive.rs`): on successful injection, append to the
+**sender's** `output` blockfile a `{"type":"user",...}` line carrying the same
+`[JEKT:...]` marker the receiver got (re-wrapped via `wrap_jekt_message` with identical
+FROM/TO/TIER/DELIVERY/MSGID/PRIORITY fields). The frontend's existing `tryParseJekt`
+sees FROM == this pane's agent → renders an **outgoing** `JektBubble`. No new wire
+format; the dormant direction support in #2031 becomes live.
+
+Wired into every send path:
+- `handle_reactive_inject` — local success, cross-instance forward success (tier 2),
+  LAN peer forward success (tier 3). The first hop is always the sender's own instance,
+  which is where the sender's pane lives.
+- WS `bus:inject` — direct success and messagebus-fallback success.
+
+Skipped when the sender isn't a registered agent on this instance (cron, external
+callers) or is messaging itself. `InjectionResponse` gains an `effective_tier` field so
+the echo reuses the handler's escalation result instead of re-deriving it.
+
+### 2.3 Direction activation (frontend)
+
+`parser.setAgentId` is now actually called in production:
+- `useAgentStream` accepts `agentName` and sets it on every parser (re)construction.
+- `parseHistoryLines` accepts an optional `agentName` param; `useHistoryPagination`
+  threads it via a new `agentName` accessor option.
+- `agent-view.tsx` passes `block.meta.agentName` to both hooks.
+
+Without a name, direction falls back to "incoming" — the only pre-echo behavior, so
+older callers are unaffected.
+
+## 3. Files Changed
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | `send_user_message`: persist + live event after stdin send |
+| `agentmux-srv/src/backend/reactive/types.rs` | `InjectionResponse.effective_tier` |
+| `agentmux-srv/src/backend/reactive/handler.rs` | populate `effective_tier` |
+| `agentmux-srv/src/backend/reactive/tests.rs` | fixture update |
+| `agentmux-srv/src/server/reactive.rs` | `echo_jekt_to_sender` + wire into 3 success paths |
+| `agentmux-srv/src/server/websocket.rs` | echo in `bus:inject` (direct + messagebus fallback) |
+| `frontend/app/view/agent/useAgentStream.ts` | `agentName` opt → `setAgentId` |
+| `frontend/app/view/agent/parseHistoryLines.ts` | `agentName` param → `setAgentId` |
+| `frontend/app/view/agent/hooks/useHistoryPagination.ts` | thread `agentName` accessor |
+| `frontend/app/view/agent/agent-view.tsx` | pass `block.meta.agentName` to both hooks |
+
+## 4. Testing
+
+1. Persistent agent A → `SendMessage` → persistent agent B: B's pane shows an incoming
+   JektBubble live (no reload); A's pane shows an outgoing bubble. Reopen both panes →
+   bubbles rebuilt from history with correct directions.
+2. Sensitive-keyword message → incoming bubble renders with sensitive styling (existing
+   #2031 behavior, now reachable on persistent agents).
+3. Cron-fired inject (unregistered sender) → target sees bubble; no sender echo, no
+   error.
+4. Agent messaging itself → single incoming marker, no duplicate echo.
+5. PTY-agent target → keystroke delivery unchanged; sender still gets the outgoing echo.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -375,6 +375,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         blockId: model.blockId,
         model: paneModel,
         outputFormat,
+        // Jekt direction detection during replay: FROM == this agent →
+        // outgoing bubble (SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2).
+        agentName,
         definitionId: agentId,
         onHistoryReady: () => {
             historyReadyFn?.();
@@ -552,6 +555,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // Provider id (lowercase catalog key) attributes completed-turn
         // tokens to the correct row in the status-bar token-usage store.
         provider: providerKey(),
+        // Jekt direction detection on the live stream: FROM == this agent
+        // → outgoing bubble (SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2).
+        agentName: agentName(),
     });
 
     // Mutable ref to the scrollToBottom function exposed by

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -60,6 +60,14 @@ export interface UseHistoryPaginationOptions {
      */
     outputFormat: Accessor<string>;
     /**
+     * This pane's agent name (`block.meta.agentName`), threaded to
+     * `parseHistoryLines` → `parser.setAgentId` so replayed jekt markers
+     * resolve direction (FROM == this agent → outgoing bubble). Accessor
+     * because block meta loads asynchronously, same as `outputFormat`.
+     * Optional; missing name falls back to "incoming".
+     */
+    agentName?: Accessor<string>;
+    /**
      * Option E (PR #1007 backend / this PR frontend): agent definition
      * id, used to read the snapshot from the agent-anchored session
      * zone `agent:<definitionId>:current` instead of the per-block
@@ -152,7 +160,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 limit: loadLimit,
             }, { timeout: 15000 });
 
-            const { nodes: newNodes } = parseHistoryLines(resp.lines ?? [], opts.outputFormat());
+            const { nodes: newNodes } = parseHistoryLines(resp.lines ?? [], opts.outputFormat(), opts.agentName?.());
             if (newNodes.length > 0) {
                 // batch() ensures HistoryLoaded's documentAtom write is not a
                 // standalone runUpdates frame that could interleave with a
@@ -282,7 +290,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             limit: hwm - windowStart,
                         }, { timeout: 30_000 });
                         if (!mounted) return;
-                        const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+                        const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat(), opts.agentName?.());
                         batch(() => opts.model.dispatchDoc({ type: "HistoryRestored", fromSnapshot: true, nodes }));
                         // Hydrate the composer strip's context-fill bar from the
                         // resumed conversation's last known usage instead of
@@ -415,7 +423,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 }, { timeout: 15000 });
                 if (!mounted) return;
 
-                const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+                const { nodes, lastSessionStats } = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat(), opts.agentName?.());
                 if (nodes.length > 0) {
                     batch(() => opts.model.dispatchDoc({ type: "HistoryLoaded", nodes }));
                 }

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -38,15 +38,22 @@ export interface ParsedHistory {
  *
  * @param lines        Raw text lines from blockfile:read_range
  * @param outputFormat Provider output format string (e.g. "claude-stream-json")
+ * @param agentName    This pane's agent name (`block.meta.agentName`).
+ *                     Threaded to `parser.setAgentId` so jekt direction
+ *                     detection works during replay — an echoed outgoing jekt
+ *                     (FROM == this agent) must rebuild as an outgoing bubble.
+ *                     Optional; missing name falls back to "incoming".
  * @returns            Ordered DocumentNodes (deduped by node id) plus the
  *                      last `session_end` stats payload found, if any.
  */
 export function parseHistoryLines(
     lines: string[],
     outputFormat: string,
+    agentName?: string,
 ): ParsedHistory {
     const translator = createTranslator(outputFormat);
     const parser = new ClaudeCodeStreamParser();
+    if (agentName) parser.setAgentId(agentName);
     const nodes: DocumentNode[] = [];
     let lastSessionStats: SessionStats | null = null;
     // Same-id events update IN PLACE rather than first-wins.

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -104,6 +104,15 @@ interface UseAgentStreamOpts {
      * work). Per SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §5.1.
      */
     provider?: string;
+    /**
+     * This pane's agent name (`block.meta.agentName`). Threaded to
+     * `parser.setAgentId` so jekt direction detection works: an echoed
+     * outgoing jekt has FROM == this agent and must render as an outgoing
+     * bubble, not incoming (stream-parser `tryParseJekt`). Optional —
+     * missing name means direction falls back to "incoming", the only
+     * pre-echo behavior. SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2.
+     */
+    agentName?: string;
 }
 
 /**
@@ -118,6 +127,7 @@ export function useAgentStream({
     pendingMessagesAtom,
     enabled,
     provider,
+    agentName,
 }: UseAgentStreamOpts): void {
     // Read-side accessors only — all writes route through dispatchPane.
     // Maintaining this contract is how the agent pane stays 100%
@@ -136,6 +146,7 @@ export function useAgentStream({
     let lineBuffer = "";
     let translator = createTranslator(outputFormat);
     let parser = new ClaudeCodeStreamParser();
+    if (agentName) parser.setAgentId(agentName);
     // nodeIdSet remains for fast in-batch dedup (the reducer also dedups,
     // but checking here avoids enqueuing already-seen nodes into pendingNew).
     let nodeIdSet = new Set<string>();
@@ -397,6 +408,7 @@ export function useAgentStream({
         lineBuffer = "";
         translator = createTranslator(outputFormat);
         parser = new ClaudeCodeStreamParser();
+        if (agentName) parser.setAgentId(agentName);
         nodeIdSet = new Set();
         pendingNew = [];
         pendingUpdates = [];
@@ -670,6 +682,7 @@ export function useAgentStream({
         parser = new ClaudeCodeStreamParser({
             skipIds: () => getNodeIdSet(blockId),
         });
+        if (agentName) parser.setAgentId(agentName);
 
         // Two reducers signaled in lockstep: pane-state owns the streaming
         // metadata (active flag), agent-document owns the session phase


### PR DESCRIPTION
## Summary

Completes `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01` §3.1 for persistent agents and implements §3.2 (outgoing echo), building directly on #2031's `JektBubble`.

### Problem

Two producer-side gaps meant #2031's bubble rarely fired where it matters most:

1. **Silent injection on persistent agents.** `send_user_message` (the muxbus delivery path for stream-json agents — all Claude Code panes) wrote the wrapped `[JEKT:...]` block **only to the process stdin**. The agent received and acted on the jekt; the human operator's pane showed nothing, live or in history. This violates the parent spec's G1 ("human can always see which messages entered an agent pane via jekt").
2. **No outgoing echo producer.** `tryParseJekt`'s direction detection shipped in #2031 with the comment "not yet emitted by any producer today" — and `setAgentId` was only ever called in tests, so even the incoming/outgoing split was dormant.

### Changes

**Backend**
- `send_user_message` now persists the injected jekt line to the blockfile with a live WPS append (mirrors `send_message`'s persistence; non-silent because injected jekts have no `agent-message-accepted` pending echo to pair with — no duplicate-node risk).
- New `echo_jekt_to_sender` (`server/reactive.rs`): on successful injection, appends the same `[JEKT:...]` marker (re-wrapped with identical FROM/TO/TIER/DELIVERY/MSGID fields) to the **sender's** output blockfile as a `user` line. `tryParseJekt` sees FROM == self → outgoing bubble. Wired into all send paths: local inject, cross-instance forward, LAN forward, WS `bus:inject` (direct + messagebus fallback). Skips unregistered senders (cron) and self-sends.
- `InjectionResponse.effective_tier` exposes the handler's escalation result so the echo doesn't re-derive keyword/network escalation.

**Frontend**
- Activates #2031's dormant direction detection: `useAgentStream` and `parseHistoryLines` accept the pane's `agentName` (threaded from `block.meta.agentName` via `agent-view` / `useHistoryPagination`) and call `parser.setAgentId`, so echoed outgoing jekts render as outgoing — live and in history replay. Missing name falls back to "incoming", the only pre-echo behavior.

Spec/findings doc: `docs/specs/jekt-visibility-completion.md`

## Testing

- `cargo check -p agentmux-srv` clean; 52 reactive tests pass
- `tsc --noEmit` clean; all 653 agent-view vitest tests pass
- Changeset added (`patch`)

Manual verification plan (needs two live agent panes): A → SendMessage → B shows incoming bubble on B live + outgoing bubble on A; both rebuilt with correct directions after pane reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agent2 -->