### PR TITLE
chore: release v0.53.0

### DIFF
--- a/.changesets/1783681059-fix-agent-resume-the-real-session-on-pane-reopen-and-hydrate-hl96.md
+++ b/.changesets/1783681059-fix-agent-resume-the-real-session-on-pane-reopen-and-hydrate-hl96.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): resume the real session on pane reopen and hydrate stats bar from history

--- a/.changesets/1783723001-fix-tabbar-pane-drag-over-tab-bar-no-longer-mis-fires-as-a-t-br8j.md
+++ b/.changesets/1783723001-fix-tabbar-pane-drag-over-tab-bar-no-longer-mis-fires-as-a-t-br8j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabbar): pane drag over tab bar no longer mis-fires as a tear-off, adds tab-hover highlight

--- a/.changesets/1783725144-feat-tabbar-drag-a-pane-onto-a-different-tab-with-a-live-sch-ostg.md
+++ b/.changesets/1783725144-feat-tabbar-drag-a-pane-onto-a-different-tab-with-a-live-sch-ostg.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tabbar): drag a pane onto a different tab, with a live schematic preview and ghost placement

--- a/.changesets/1783731171-chore-identity-delete-dead-identitymanager-bundle-crud-ui-av3c.md
+++ b/.changesets/1783731171-chore-identity-delete-dead-identitymanager-bundle-crud-ui-av3c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(identity): delete dead IdentityManager bundle-CRUD UI

--- a/.changesets/1783731654-feat-jekt-incoming-jekts-visible-on-persistent-agents-outgoi-xewg.md
+++ b/.changesets/1783731654-feat-jekt-incoming-jekts-visible-on-persistent-agents-outgoi-xewg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(jekt): incoming jekts visible on persistent agents + outgoing sender echo (§3.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.52.4"
+version = "0.53.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.52.4"
+version = "0.53.0"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.52.4"
+version = "0.53.0"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.52.4"
+version = "0.53.0"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.52.4"
+version = "0.53.0"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.52.4"
+version = "0.53.0"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.52.4"
+version = "0.53.0"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,14 @@
 # AgentMux Version History
 
+## 0.53.0 — 2026-07-10
+
+- fix(agent): resume the real session on pane reopen and hydrate stats bar from history
+- fix(tabbar): pane drag over tab bar no longer mis-fires as a tear-off, adds tab-hover highlight
+- feat(tabbar): drag a pane onto a different tab, with a live schematic preview and ghost placement
+- chore(identity): delete dead IdentityManager bundle-CRUD UI
+- feat(jekt): incoming jekts visible on persistent agents + outgoing sender echo (§3.2)
+
+
 ## 0.52.4 — 2026-07-10
 
 - fix(identity): App API link-table ops resolve the S1 slug to the definition id; failed upsert no longer orphans the account row

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.52.4",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.52.4",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.52.4",
+  "version": "0.53.0",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR — consumes the 5 pending changesets, bumps 0.52.4 → 0.53.0 (minor, highest queued bump type).

- fix(agent): resume the real session on pane reopen and hydrate stats bar from history
- fix(tabbar): pane drag over tab bar no longer mis-fires as a tear-off, adds tab-hover highlight
- feat(tabbar): drag a pane onto a different tab, with a live schematic preview and ghost placement
- chore(identity): delete dead IdentityManager bundle-CRUD UI
- feat(jekt): incoming jekts visible on persistent agents + outgoing sender echo (§3.2)

All 5 version locations (`package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`, `VERSION_HISTORY.md`) verified consistent at 0.53.0 via `task release`.

**Note:** v0.51.x/v0.52.x were bumped in-tree via prior merged release PRs but never actually tagged — no git tag or GitHub Release exists past v0.50.3. Once this merges, I'll push the `v0.53.0` tag directly to trigger `.github/workflows/release.yml` (build all platforms, publish GitHub Release, dispatch the landing page deploy), catching the repo up to its actual committed version.

<!-- agentmux:agent_id=agentx -->