### PR TITLE
refactor(lifecycle): Pillar 2 sanitize-then-decide Phase 0 — quit arming, ReconcileQuit poke, drain-executor extraction

### DIFF
--- a/.changesets/1783748113-refactor-lifecycle-quit-arming-bit-reconcilequit-poke-drain--w2an.md
+++ b/.changesets/1783748113-refactor-lifecycle-quit-arming-bit-reconcilequit-poke-drain--w2an.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(lifecycle): quit arming bit, ReconcileQuit poke, drain-executor extraction (Pillar 2 sanitize-then-decide Phase 0)

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -10,7 +10,7 @@ use cef::*;
 use crate::state::WindowKind;
 
 use super::helpers::backend_close_window;
-use super::{dlog, AgentMuxHandler, ClosePoolBrowserTask};
+use super::{dlog, AgentMuxHandler};
 #[cfg(target_os = "windows")]
 use super::install_main_window_floater_cascade_hook;
 #[cfg(target_os = "windows")]
@@ -1040,104 +1040,12 @@ impl AgentMuxHandler {
     /// since calling it from inside another browser's `on_before_close`
     /// deadlocks the UI thread (confirmed v0.33.498).
     pub(crate) fn begin_drain_and_cascade(&self, reason: crate::state::QuitReason) {
-        // PR #5 H.5 — flip QuitState Running → Draining via reducer.
-        // Mirrors the pre-PR Phase B.9.3 drain flag: spawn_pool_window
-        // checks `quit_state != Running` (in the reducer's spawn arm)
-        // and skips refill on every subsequent on_pool_window_destroyed
-        // → no new pool browsers added → browsers map can actually
-        // drain. BeginDrain is idempotent — safe if a duplicate
-        // last-close (or a later reconcile) fires.
-        self.state.host_dispatch(crate::reducer::HostCommand::BeginDrain { reason });
-        tracing::warn!(target: "wrr", "[wrr] quit_state=Draining (drain mode)");
-
-        // Phase H.2.b — reducer-aware iteration with fallback + drift logging.
-        // Collect ALL background-only browsers: tab pool (window-pool-*)
-        // AND pane pool (floating-pool-*). Both live in browser_list
-        // (created via CreateWindowTask which clones the main top-level
-        // client). Omitting pane pool windows here means browser_list
-        // never empties on macOS/Linux (init_pane_pool spawns one at
-        // startup), so Stage 2's is_empty() gate never fires and the
-        // host hangs on every quit.
-        let pool_browsers: Vec<cef::Browser> = self
-            .state
-            .list_browsers()
-            .into_iter()
-            .filter(|(label, _)| {
-                label.starts_with("window-pool-") || label.starts_with("floating-pool-")
-            })
-            .map(|(_, b)| b)
-            .collect();
-        tracing::warn!(
-            target: "wrr",
-            "[wrr] stage 1: draining; closing {} pool browser(s) (tab+pane)",
-            pool_browsers.len()
-        );
-
-        // Windows path: prefer Win32 PostMessage(WM_CLOSE) —
-        // bypasses CEF's task queue (proven reliable; smoke
-        // v0.33.500+). When window_handle() returns null
-        // (early/late lifecycle), fall through to the
-        // post_task path so the close still happens — without
-        // the fallback, self.browser_list never empties and
-        // Stage 2 never fires. (codex #601 P1.)
-        #[cfg(target_os = "windows")]
-        {
-            use windows_sys::Win32::Foundation::HWND;
-            use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
-            for (i, mut b) in pool_browsers.into_iter().enumerate() {
-                let hwnd_opt = b.host().and_then(|h| {
-                    let wh = h.window_handle();
-                    if wh.0.is_null() {
-                        None
-                    } else {
-                        Some(wh.0 as HWND)
-                    }
-                });
-                if let Some(hwnd) = hwnd_opt {
-                    let ok = unsafe { PostMessageW(hwnd, WM_CLOSE, 0, 0) };
-                    tracing::debug!(
-                        target: "wrr-trace",
-                        "[trace] stage1[{}] PostMessage(hwnd={:p}, WM_CLOSE) ok={}",
-                        i, hwnd, ok != 0
-                    );
-                } else {
-                    // Fallback: defer close_browser via UI task.
-                    // Same path as non-Windows so the cascade
-                    // still drains.
-                    let mut task = ClosePoolBrowserTask::new(b);
-                    let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
-                    tracing::warn!(
-                        target: "wrr",
-                        "[wrr] stage1[{}] hwnd=null; fell back to post_task(close_browser) posted={}",
-                        i, posted != 0
-                    );
-                }
-            }
-        }
-
-        // Non-Windows path: defer `close_browser` to the UI
-        // thread via `cef::post_task`. Calling close_browser
-        // inline from inside another browser's on_before_close
-        // hangs the UI thread (CEF re-entrance, smoke
-        // v0.33.497 confirmed on Windows; same constraint on
-        // macOS / Linux per CEF docs). Windows prefers
-        // PostMessage(WM_CLOSE) as the primary path (bypasses
-        // CEF's task queue, which proved unreliable in
-        // late-teardown windows — see
-        // `docs/retro/b9-3-quit-thread-analysis.md`).
-        // (reagent #601 P1.)
-        #[cfg(not(target_os = "windows"))]
-        {
-            for (i, b) in pool_browsers.into_iter().enumerate() {
-                let mut task = ClosePoolBrowserTask::new(b);
-                let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
-                tracing::debug!(
-                    target: "wrr-trace",
-                    "[trace] stage1[{}] post_task(close_browser) posted={}",
-                    i, posted != 0
-                );
-            }
-        }
+        // Body extracted to `ui_tasks::begin_drain_and_cascade` (Pillar 2
+        // sanitize-then-decide Phase 0, §1.G) so the executor is callable from
+        // any UI-thread context holding `&Arc<AppState>`, not just this
+        // handler. Zero behavior change — the handler only ever touched
+        // `self.state`.
+        crate::ui_tasks::begin_drain_and_cascade(&self.state, reason);
     }
 }
 

--- a/agentmux-cef/src/reducer/browsers.rs
+++ b/agentmux-cef/src/reducer/browsers.rs
@@ -35,6 +35,11 @@ pub(super) fn handle_register_browser(
             registered_at: Instant::now(),
         },
     );
+    // Quit arming (SPEC_PILLAR2_SANITIZE_THEN_DECIDE §1.E): the first live
+    // user window arms `should_begin_drain`. Monotonic — never cleared.
+    if super::quit::is_live_user_window(&kind) {
+        state.saw_live_user_window = true;
+    }
     let v = state.bump_version();
     DispatchOutput {
         events: vec![HostEvent::BrowserRegistered { label, kind, version: v }],

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -112,6 +112,18 @@ pub struct HostState {
     /// `AppState.is_quitting: AtomicBool`.
     pub quit_state: QuitState,
 
+    /// H.5 — quit arming (SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md §1.E).
+    /// Monotonic: set by `RegisterBrowser` on the first live user window
+    /// (`TopLevel { is_pool: false }`), never cleared. `should_begin_drain`
+    /// refuses to drain while false — the startup gap between process start and
+    /// main's `on_after_created` has zero registered windows AND zero pending
+    /// creations (main's creation path never enqueues one), so an unarmed
+    /// `reconcile_quit` would otherwise hand `Some(LastWindowClosed)` to any
+    /// quit-relevant dispatch in that window. The reducer-side analog of WRR's
+    /// `HAD_VISIBLE_USER_WINDOW` (armed earlier — registration precedes SHOW —
+    /// which is safe: once registered, the live count itself blocks drain).
+    pub saw_live_user_window: bool,
+
     /// H.6 — top-level window creation runner state (queue, in-flight,
     /// history). Event-driven; no watchdog. **Currently DORMANT** — the
     /// reducer arms (`EnqueueTopLevelWindow`, `TopLevelCallbackFired`,
@@ -174,6 +186,7 @@ impl Default for HostState {
             pool: PoolState::default(),
             pane_pool: PanePoolState::default(),
             quit_state: QuitState::default(),
+            saw_live_user_window: false,
             top_level_creation: TopLevelCreationState::default(),
             window_opacities: HashMap::new(),
             pane_window_states: HashMap::new(),
@@ -401,6 +414,15 @@ pub enum HostCommand {
     /// Transition Draining → Quit.
     ConfirmDrained,
 
+    /// Pure no-op poke: mutates nothing, but is quit-relevant, so `update`
+    /// recomputes `reconcile_quit` and surfaces it via
+    /// `DispatchOutput::request_drain`. Exists for executors that reach a
+    /// decision point with zero state-changing dispatches to ride (the
+    /// level-trigger needs an edge): `orphan_reconcile`'s
+    /// nothing-to-close-but-maybe-drain arm. NOT a polling mechanism — never
+    /// wire it into hot paths. SPEC_PILLAR2_SANITIZE_THEN_DECIDE §1.H.
+    ReconcileQuit,
+
     // ── H.6 — top-level window creation runner ──────────────────────────
 
     /// Caller requests a top-level window. Reducer either:
@@ -570,6 +592,7 @@ impl std::fmt::Debug for HostCommand {
                 .field("reason", reason)
                 .finish(),
             HostCommand::ConfirmDrained => f.write_str("ConfirmDrained"),
+            HostCommand::ReconcileQuit => f.write_str("ReconcileQuit"),
             HostCommand::EnqueueTopLevelWindow { request } => f
                 .debug_struct("EnqueueTopLevelWindow")
                 .field("label", &request.label)
@@ -1049,6 +1072,9 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         // H.5 quit
         HostCommand::BeginDrain { reason } => quit::handle_begin_drain(state, reason),
         HostCommand::ConfirmDrained => quit::handle_confirm_drained(state),
+        // Pure poke — no state change; the quit-relevant recomputation below
+        // does the only work this command exists for.
+        HostCommand::ReconcileQuit => DispatchOutput::default(),
         // H.6 top-level runner
         HostCommand::EnqueueTopLevelWindow { request } => {
             top_level::handle_enqueue_top_level_window(state, request)

--- a/agentmux-cef/src/reducer/quit.rs
+++ b/agentmux-cef/src/reducer/quit.rs
@@ -143,15 +143,25 @@ pub(super) fn user_creation_in_flight(state: &HostState) -> bool {
 }
 
 /// Pure decision: should the host begin draining NOW? `Some(reason)` iff the host
-/// is `Running`, no live user-visible window remains, and no user-initiated
-/// creation is in flight. Safe to call after every transition — once
-/// `Draining`/`Quit` it returns `None` (the transition is monotonic — see
-/// `handle_begin_drain`). CEF-free so the full truth table is unit-testable.
+/// is armed (a live user window has registered at least once this process —
+/// `HostState::saw_live_user_window`, §1.E of the sanitize-then-decide spec),
+/// `Running`, no live user-visible window remains, and no user-initiated
+/// creation is in flight. Unarmed covers the startup gap: main's creation path
+/// enqueues no `PendingWindowCreation`, so before its `RegisterBrowser` lands
+/// both other inputs read "drainable" — without the arming gate, any
+/// quit-relevant dispatch in that window would surface a spurious drain
+/// request. Safe to call after every transition — once `Draining`/`Quit` it
+/// returns `None` (the transition is monotonic — see `handle_begin_drain`).
+/// CEF-free so the full truth table is unit-testable.
 pub(super) fn should_begin_drain(
+    armed: bool,
     live_user_windows: usize,
     user_creation_in_flight: bool,
     quit_state: &QuitState,
 ) -> Option<QuitReason> {
+    if !armed {
+        return None;
+    }
     if !matches!(quit_state, QuitState::Running) {
         return None;
     }
@@ -162,9 +172,10 @@ pub(super) fn should_begin_drain(
 }
 
 /// Level-triggered quit reconciliation over the full `HostState`. Composes the
-/// three reads above. Returns the drain reason iff it is safe to begin draining.
+/// reads above. Returns the drain reason iff it is safe to begin draining.
 pub(super) fn reconcile_quit(state: &HostState) -> Option<QuitReason> {
     should_begin_drain(
+        state.saw_live_user_window,
         count_live_user_windows(state),
         user_creation_in_flight(state),
         &state.quit_state,

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -997,26 +997,34 @@ fn is_live_user_window_classifies_by_is_pool_not_label() {
 /// The full decision truth table (CEF-free pure core).
 #[test]
 fn should_begin_drain_truth_table() {
-    // Running + zero user windows + no creation in flight → begin draining.
+    // Armed + Running + zero user windows + no creation in flight → begin draining.
     assert_eq!(
-        should_begin_drain(0, false, &QuitState::Running),
+        should_begin_drain(true, 0, false, &QuitState::Running),
         Some(QuitReason::LastWindowClosed)
     );
     // A live user window blocks drain.
-    assert_eq!(should_begin_drain(1, false, &QuitState::Running), None);
+    assert_eq!(should_begin_drain(true, 1, false, &QuitState::Running), None);
     // §10.2 corner: a user creation in flight blocks drain even at zero
     // registered windows — never quit while the user's "New Window" is loading.
-    assert_eq!(should_begin_drain(0, true, &QuitState::Running), None);
+    assert_eq!(should_begin_drain(true, 0, true, &QuitState::Running), None);
     // Already draining / quit → never re-drains (monotonic with handle_begin_drain).
     assert_eq!(
         should_begin_drain(
+            true,
             0,
             false,
             &QuitState::Draining { reason: QuitReason::LastWindowClosed }
         ),
         None
     );
-    assert_eq!(should_begin_drain(0, false, &QuitState::Quit), None);
+    assert_eq!(should_begin_drain(true, 0, false, &QuitState::Quit), None);
+    // UNARMED (sanitize-then-decide §1.E): the startup gap — no live user
+    // window has ever registered — must never drain, even though every other
+    // input reads "drainable" (main's creation path enqueues no pending entry,
+    // so this exact input combination is live between process start and main's
+    // RegisterBrowser).
+    assert_eq!(should_begin_drain(false, 0, false, &QuitState::Running), None);
+    assert_eq!(should_begin_drain(false, 0, true, &QuitState::Running), None);
 }
 
 /// Only USER-initiated creations block drain; pool/pane background creations don't.
@@ -1045,11 +1053,27 @@ fn user_creation_in_flight_ignores_background_labels() {
     );
 }
 
+/// A fresh (pre-first-window) state must NOT drain: `HostState::default()` is
+/// unarmed. This pins the §1.E fix — before the arming bit, this exact state
+/// (the startup gap) read as drainable, a latent startup-quit for any future
+/// `request_drain` consumer.
+#[test]
+fn reconcile_quit_never_drains_unarmed_fresh_state() {
+    let state = HostState::default();
+    assert_eq!(
+        reconcile_quit(&state),
+        None,
+        "unarmed (pre-first-window) state must never request a drain"
+    );
+}
+
 /// After the last user window deregisters (no browsers, no pending creation),
-/// reconcile drains. (Composed over real `HostState`.)
+/// reconcile drains. (Composed over real `HostState`; armed = a live user
+/// window registered at some point this process, as `RegisterBrowser` does.)
 #[test]
 fn reconcile_quit_drains_when_no_windows_and_no_pending_creation() {
-    let state = HostState::default();
+    let mut state = HostState::default();
+    state.saw_live_user_window = true;
     assert_eq!(reconcile_quit(&state), Some(QuitReason::LastWindowClosed));
 }
 
@@ -1059,6 +1083,7 @@ fn reconcile_quit_drains_when_no_windows_and_no_pending_creation() {
 #[test]
 fn reconcile_quit_deferred_while_user_creation_pending() {
     let mut state = HostState::default();
+    state.saw_live_user_window = true;
     update(
         &mut state,
         HostCommand::EnqueuePendingWindowCreation { entry: entry("window-fresh-uuid") },
@@ -1076,6 +1101,7 @@ fn reconcile_quit_deferred_while_user_creation_pending() {
 #[test]
 fn reconcile_quit_drains_despite_pending_pool_refill() {
     let mut state = HostState::default();
+    state.saw_live_user_window = true;
     update(
         &mut state,
         HostCommand::EnqueuePendingWindowCreation { entry: entry("window-pool-refill-1") },
@@ -1087,6 +1113,7 @@ fn reconcile_quit_drains_despite_pending_pool_refill() {
 #[test]
 fn reconcile_quit_noop_once_draining() {
     let mut state = HostState::default();
+    state.saw_live_user_window = true; // isolate the Draining gate from the arming gate
     update(&mut state, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
     assert_eq!(reconcile_quit(&state), None);
 }
@@ -1120,7 +1147,8 @@ fn is_quit_relevant_guard_membership() {
 /// command, and skips it on a quit-irrelevant one even when the state would drain.
 #[test]
 fn update_surfaces_request_drain_only_for_relevant_commands() {
-    let mut state = HostState::default(); // Running, no windows, no pending → drainable
+    let mut state = HostState::default(); // Running, no windows, no pending
+    state.saw_live_user_window = true; // armed → drainable
     let out = update(&mut state, HostCommand::DequeuePendingWindowCreation);
     assert_eq!(
         out.request_drain,
@@ -1135,4 +1163,50 @@ fn update_surfaces_request_drain_only_for_relevant_commands() {
         out2.request_drain, None,
         "quit-irrelevant command must not compute a drain request"
     );
+}
+
+// ── Sanitize-then-decide Phase 0 (SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11) ──
+
+/// `ReconcileQuit` is a pure poke: it mutates nothing (no events, no version
+/// bump) and only surfaces the standing `reconcile_quit` verdict via
+/// `request_drain` — the edge a level-triggered executor rides when it has no
+/// state-changing dispatch of its own (§1.H).
+#[test]
+fn reconcile_quit_poke_surfaces_verdict_without_mutation() {
+    let mut state = HostState::default();
+    state.saw_live_user_window = true;
+    let version_before = state.event_version;
+    let out = update(&mut state, HostCommand::ReconcileQuit);
+    assert_eq!(
+        out.request_drain,
+        Some(QuitReason::LastWindowClosed),
+        "armed drainable state → poke surfaces the drain verdict"
+    );
+    assert!(out.events.is_empty(), "poke must emit no events");
+    assert_eq!(state.event_version, version_before, "poke must not bump version");
+}
+
+/// The poke respects every gate the composed decision has: unarmed and
+/// already-draining states both answer `None`.
+#[test]
+fn reconcile_quit_poke_respects_arming_and_monotonicity() {
+    // Unarmed fresh state (the startup gap) → None.
+    let mut fresh = HostState::default();
+    let out = update(&mut fresh, HostCommand::ReconcileQuit);
+    assert_eq!(out.request_drain, None, "unarmed poke must not drain");
+
+    // Armed but already draining → None (monotonic).
+    let mut draining = HostState::default();
+    draining.saw_live_user_window = true;
+    update(&mut draining, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
+    let out2 = update(&mut draining, HostCommand::ReconcileQuit);
+    assert_eq!(out2.request_drain, None, "poke after BeginDrain must not re-drain");
+}
+
+/// `ReconcileQuit` must never enter the `is_quit_relevant` exclusion list —
+/// surfacing the verdict is its entire purpose.
+#[test]
+fn reconcile_quit_poke_is_quit_relevant() {
+    use super::is_quit_relevant;
+    assert!(is_quit_relevant(&HostCommand::ReconcileQuit));
 }

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -379,6 +379,121 @@ pub(crate) fn unregister_after_parking_close(state: &Arc<AppState>, label: &str)
     crate::wrr::win_event::arm_quit_watchdog(state.count_live_user_windows());
 }
 
+/// Pillar 2 Stage-1 drain executor (SPEC_PILLAR2_SANITIZE_THEN_DECIDE §1.G) —
+/// the ACTION half of the decision/action split (`reducer/quit.rs:49-54`).
+/// Callers must have already observed `reconcile_quit`'s decision via
+/// `DispatchOutput.request_drain` (the DECISION) before calling this — it does
+/// not re-check anything, it just executes. Extracted verbatim from
+/// `AgentMuxHandler::begin_drain_and_cascade` (which now delegates here) so it
+/// is callable from any UI-thread context that holds `&Arc<AppState>` — the
+/// close-edge in `on_before_close`, and (Phase 2) the parking-close /
+/// LOCATIONCHANGE / pool-settling dispatch sites.
+///
+/// UI-THREAD ONLY. Only flips `QuitState` and closes the (already-hidden) pool
+/// browsers. Never calls `quit_message_loop()` — that is Stage 2, gated
+/// separately (`on_before_close`'s `browser_list.is_empty()` on macOS/Linux;
+/// WRR's OS-signal executor on Windows), since calling it from inside another
+/// browser's `on_before_close` deadlocks the UI thread (confirmed v0.33.498).
+pub(crate) fn begin_drain_and_cascade(state: &Arc<AppState>, reason: crate::state::QuitReason) {
+    // PR #5 H.5 — flip QuitState Running → Draining via reducer.
+    // Mirrors the pre-PR Phase B.9.3 drain flag: spawn_pool_window
+    // checks `quit_state != Running` (in the reducer's spawn arm)
+    // and skips refill on every subsequent on_pool_window_destroyed
+    // → no new pool browsers added → browsers map can actually
+    // drain. BeginDrain is idempotent — safe if a duplicate
+    // last-close (or a later reconcile) fires.
+    state.host_dispatch(crate::reducer::HostCommand::BeginDrain { reason });
+    tracing::warn!(target: "wrr", "[wrr] quit_state=Draining (drain mode)");
+
+    // Phase H.2.b — reducer-aware iteration with fallback + drift logging.
+    // Collect ALL background-only browsers: tab pool (window-pool-*)
+    // AND pane pool (floating-pool-*). Both live in browser_list
+    // (created via CreateWindowTask which clones the main top-level
+    // client). Omitting pane pool windows here means browser_list
+    // never empties on macOS/Linux (init_pane_pool spawns one at
+    // startup), so Stage 2's is_empty() gate never fires and the
+    // host hangs on every quit.
+    let pool_browsers: Vec<cef::Browser> = state
+        .list_browsers()
+        .into_iter()
+        .filter(|(label, _)| {
+            label.starts_with("window-pool-") || label.starts_with("floating-pool-")
+        })
+        .map(|(_, b)| b)
+        .collect();
+    tracing::warn!(
+        target: "wrr",
+        "[wrr] stage 1: draining; closing {} pool browser(s) (tab+pane)",
+        pool_browsers.len()
+    );
+
+    // Windows path: prefer Win32 PostMessage(WM_CLOSE) —
+    // bypasses CEF's task queue (proven reliable; smoke
+    // v0.33.500+). When window_handle() returns null
+    // (early/late lifecycle), fall through to the
+    // post_task path so the close still happens — without
+    // the fallback, self.browser_list never empties and
+    // Stage 2 never fires. (codex #601 P1.)
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::Foundation::HWND;
+        use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+        for (i, mut b) in pool_browsers.into_iter().enumerate() {
+            let hwnd_opt = b.host().and_then(|h| {
+                let wh = h.window_handle();
+                if wh.0.is_null() {
+                    None
+                } else {
+                    Some(wh.0 as HWND)
+                }
+            });
+            if let Some(hwnd) = hwnd_opt {
+                let ok = unsafe { PostMessageW(hwnd, WM_CLOSE, 0, 0) };
+                tracing::debug!(
+                    target: "wrr-trace",
+                    "[trace] stage1[{}] PostMessage(hwnd={:p}, WM_CLOSE) ok={}",
+                    i, hwnd, ok != 0
+                );
+            } else {
+                // Fallback: defer close_browser via UI task.
+                // Same path as non-Windows so the cascade
+                // still drains.
+                let mut task = crate::client::ClosePoolBrowserTask::new(b);
+                let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
+                tracing::warn!(
+                    target: "wrr",
+                    "[wrr] stage1[{}] hwnd=null; fell back to post_task(close_browser) posted={}",
+                    i, posted != 0
+                );
+            }
+        }
+    }
+
+    // Non-Windows path: defer `close_browser` to the UI
+    // thread via `cef::post_task`. Calling close_browser
+    // inline from inside another browser's on_before_close
+    // hangs the UI thread (CEF re-entrance, smoke
+    // v0.33.497 confirmed on Windows; same constraint on
+    // macOS / Linux per CEF docs). Windows prefers
+    // PostMessage(WM_CLOSE) as the primary path (bypasses
+    // CEF's task queue, which proved unreliable in
+    // late-teardown windows — see
+    // `docs/retro/b9-3-quit-thread-analysis.md`).
+    // (reagent #601 P1.)
+    #[cfg(not(target_os = "windows"))]
+    {
+        for (i, b) in pool_browsers.into_iter().enumerate() {
+            let mut task = crate::client::ClosePoolBrowserTask::new(b);
+            let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
+            tracing::debug!(
+                target: "wrr-trace",
+                "[trace] stage1[{}] post_task(close_browser) posted={}",
+                i, posted != 0
+            );
+        }
+    }
+}
+
 pub fn post_close_window(state: &Arc<AppState>, label: &str) {
     let mut task = CloseWindowTask::new(state.clone(), label.to_string());
     post_task(ThreadId::UI, Some(&mut task));

--- a/docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md
+++ b/docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md
@@ -1,0 +1,308 @@
+# Pillar 2 — Sanitize-Then-Decide: Retiring the Last Two Independent Quit Authorities
+
+**Date:** 2026-07-11
+**Type:** Design spec (design-first per program discipline — window/lifecycle code here is
+deadlock-sensitive and has repeatedly punished plausible-looking fixes)
+**Status:** Phases 0–1 planned for immediate implementation; 2–3 staged behind live matrix
+**Builds on:** `SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md` (Stage 2 first slice merged,
+PR #1993), `SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` (merged, PR #2043),
+`SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md` (§5.1/§10 — `reconcile_quit` itself)
+**Resolves:** SPEC_PILLAR2 §3.3's two open rows (WRR demotion, `orphan_reconcile` merge) and
+§7 rollout steps 3–4, via the **sanitize-then-decide** variant (no new guard field carrying
+Race B — rationale in §2.3, which this spec's own research pass strengthened: the alternative
+would have modeled a state the reducer already models).
+
+---
+
+## 0. TL;DR
+
+After PR #1993 and #2043, "should the host quit?" still has **three** deciders:
+
+1. `reducer::quit::reconcile_quit` — the intended single authority (pure fn of `HostState`).
+   Consumed only by `client::on_before_close`.
+2. `wrr::win_event::maybe_quit_on_last_user_window` — decides from
+   `armed && visible == 0 && registered == 0` and calls `quit_message_loop()` directly,
+   without `QuitState` ever transitioning. Post-#2043 it is *safe* (it can no longer fire
+   while the reducer disagrees) but it is still an independent authority: on Windows, the
+   dominant quit path never flips `QuitState` and never runs the Stage-1 drain.
+3. `commands::orphan_reconcile::plan_reconcile` — computes its own `begin_drain`
+   (`safe_to_drain`) from launcher-shadow keys + pool sets + a live HWND probe, with the
+   "Race B" `freshly_promoted` guard.
+
+This spec retires #2 and #3 as authorities. Both become **sanitize → decide → execute**:
+first repair the reducer's `browsers` projection to match probed reality (dispatching the
+*already-existing* commands — `UnregisterBrowser`, or `close_browser` whose cleanup chain
+dispatches it), then consume the `DispatchOutput.request_drain` the reducer already computes
+after every quit-relevant dispatch, then execute via the shared
+`begin_drain_and_cascade` executor. No decision logic remains outside `reconcile_quit`.
+The #2043 watchdog stays, permanently, as the bounded desync backstop.
+
+---
+
+## 1. Findings from the 2026-07-11 implementation-readiness pass
+
+These were verified against `main` (d321e6c2) and they simplify the design relative to the
+first draft of this spec:
+
+### 1.A — Race B is already modeled by the reducer; no new command or field is needed
+
+`handle_pop_and_promote_front_pool_window` and `handle_promote_pool_window`
+(`reducer/pool.rs:104-105, 138-141`) flip the browser handle to
+`TopLevel { is_pool: false }` **synchronously, inside the promote dispatch** — before the
+window is shown or the launcher echo lands. So a "freshly promoted" window is already
+counted by `count_live_user_windows`, and `reconcile_quit` already refuses to drain while
+one exists.
+
+`plan_reconcile`'s Race-B guard exists only because its `live_user_count` is derived from
+**launcher-shadow membership** (`shadow_window_meta`, which lags by a full
+host→launcher→host echo) instead of the reducer's own `browsers` map. The guard is
+compensation for reading a *slower* projection — switching the decision to `reconcile_quit`
+makes it structurally unnecessary. The first draft's `MarkBrowserPromoted` command is
+dropped: it would have "repaired" state that is not stale.
+
+### 1.B — The genuinely stale direction is dead/hostless zombies, and the repair commands already exist
+
+A window that dies without any close flow (crash, external kill) leaves a stale
+`TopLevel { is_pool: false }` entry in `browsers` — which blocks `reconcile_quit` forever.
+This is the projection staleness that actually matters, and `orphan_reconcile` already owns
+both repair mechanisms:
+
+- `Dead` → `close_browser(force=1)` — CEF's cleanup chain runs `on_before_close`, which
+  dispatches `UnregisterBrowser` *and* (since PR #1993) consumes `request_drain` itself.
+- `Hostless` → direct `HostCommand::UnregisterBrowser` dispatch.
+
+So "sanitize" is not new machinery — it is the existing classification and close actions,
+kept exactly as they are. What gets **deleted** is the parallel decision layered on top:
+`ReconcilePlan.begin_drain`, `live_user_count`, and the `freshly_promoted` drain-block.
+
+### 1.C — Pending-creation semantics are already identical
+
+`quit.rs::is_background_pending_creation_label` (window-pool-/browser-pane-/floating-)
+mirrors `orphan_reconcile.rs:302-304` exactly — each side's comment cites the other. No
+convergence work needed; a shared-predicate refactor is optional hygiene, not a fix.
+
+### 1.D — One real behavioral delta: floaters and the shadow-based count
+
+`plan_reconcile`'s `live_user_count` counts any non-`browser-pane-` label present in both
+`browsers` and `shadow_window_meta` — including `floating-*` entries if the launcher mirrors
+them. `reconcile_quit` excludes floaters **by type** (invariant FP-LIFE: floaters die with
+the last top-level window), as does WRR's visible-count. Post-migration, a lone live floater
+no longer blocks the orphan path's drain. This is an intentional alignment with the
+documented invariant and with the other two deciders, not a regression. (Phase 1's tests
+pin it.)
+
+### 1.E — A pre-registration arming gap in `reconcile_quit` (must fix BEFORE adding consumers)
+
+WRR's gate is armed by `HAD_VISIBLE_USER_WINDOW` (set on first `EVENT_OBJECT_SHOW`).
+`reconcile_quit` has no arming equivalent, and the main window's startup creation path
+(`app.rs::on_context_initialized`) does **not** enqueue a `PendingWindowCreation`. So
+between process start and main's `RegisterBrowser` (at `on_after_created`),
+`count_live_user_windows() == 0` with nothing pending — `reconcile_quit` would return
+`Some(LastWindowClosed)` to any quit-relevant dispatch in that window. Today that is
+latent (the only consumer, `on_before_close`, cannot fire before a browser exists, and
+`init_pool()` runs from `on_after_created("main")`), but Phase 2 adds consumers at dispatch
+sites — the latent verdict would become a live startup quit.
+
+**Fix (Phase 0):** a monotonic `saw_live_user_window: bool` on `HostState`, set by
+`handle_register_browser` on the first `TopLevel { is_pool: false }` registration, required
+by `should_begin_drain`. Registration-armed is strictly earlier than WRR's show-armed, and
+safe: after registration the live count itself blocks drain until a real close. Under §7a
+this is a derived, reconstructable bit (a reprojecting host re-registers windows and
+re-arms), not new authority.
+
+### 1.F — Stage 2 on Windows cannot ride `on_before_close`; WRR's quit becomes the gated Stage-2 executor
+
+`begin_drain_and_cascade` (extracted in #1993) flips `QuitState` and closes pool browsers
+(Stage 1) but never calls `quit_message_loop()` — that is Stage 2, gated on
+`client::browser_list.is_empty()` **inside `on_before_close`**. On Windows CEF 148, parking
+closes never fire `on_before_close`, so `browser_list` never empties: Stage 2 is
+structurally unreachable there, which is *why* WRR's direct quit is the real Windows exit
+path. Full demotion therefore does not delete WRR's quit — it **gates it on the reducer's
+decision**: `should_quit_on_last_window` gains a `draining` input (true iff
+`QuitState` is `Draining`/`Quit`). WRR then executes only a quit the reducer already
+decided; `visible == 0 && registered == 0 && !draining` means a consumption site was
+missed, and it arms the watchdog (which quits late with the loud desync log) instead of
+quitting silently on its own authority.
+
+### 1.G — The executor only needs `AppState`; a free-function extraction unlocks every call site
+
+`begin_drain_and_cascade` touches nothing on `AgentMuxHandler` except `self.state`. Moving
+the body to `ui_tasks::begin_drain_and_cascade(state: &Arc<AppState>, reason)` (the handler
+method delegating) makes it callable from `unregister_after_parking_close`, the
+LOCATIONCHANGE recycle detector, the pool settling callbacks, and `orphan_reconcile` — all
+of which already hold `&Arc<AppState>` on the UI thread. Zero behavior change.
+
+### 1.H — A level-trigger needs an edge to ride: `HostCommand::ReconcileQuit`
+
+`orphan_reconcile` can reach its decision point with **zero** sanitize dispatches (its
+"nothing to close but drain requested" arm — `state.browsers` already empty). With the
+decision moving into `DispatchOutput.request_drain`, that case has no dispatch to carry
+the verdict. Phase 0 adds `HostCommand::ReconcileQuit` — a pure no-op command whose only
+effect is `update()`'s existing quit-relevant recomputation. It introduces no new
+transition; it is a poke that lets an executor *ask* the standing question through the
+standard channel.
+
+---
+
+## 2. Target design
+
+### 2.1 — `orphan_reconcile`: plan → sanitize → decide → execute
+
+`plan_reconcile` keeps its classification (Dead/Hostless/Live × shadow/pool-set membership —
+it is good, tested, deterministic) as the **sanitize planner**. Changes:
+
+- `ReconcilePlan.begin_drain` is **deleted**; `live_user_count` and the `freshly_promoted`
+  drain-block go with it. `freshly_promoted` remains as a diagnostic list (the log line
+  stays — it is a useful race telemetry) but carries no authority.
+- The pending-creation flag no longer feeds a local drain predicate; it keeps its one
+  *mechanism* role: deferring zombie reaps while a user creation is in flight (the close
+  chain itself could otherwise race the creation — the existing
+  `plan_pending_creation_blocks_zombie_close` behavior, preserved verbatim).
+- Orchestrator flow becomes:
+
+```
+1. HWND-probe on the UI thread (unchanged)
+2. plan_reconcile → { closes }                       // sanitize plan, no verdict
+3. execute closes (Dead → close_browser(force=1);    // repairs the projection;
+   Hostless → UnregisterBrowser dispatch)            // Hostless still drain-gated, see below
+4. dispatch ReconcileQuit → request_drain            // THE decision, from reconcile_quit
+5. if Some(reason): ui_tasks::begin_drain_and_cascade(state, reason)
+6. hostless-entries special case: if any hostless was unregistered and drain fired,
+   drive quit_message_loop() directly (unchanged — UnregisterBrowser cannot empty
+   client::browser_list, so Stage 2 can never fire for them; this call is Stage-2
+   execution from a posted UI task, the context production has proven for months)
+```
+
+Ordering note: the Hostless→UnregisterBrowser action stays gated on the drain verdict (as
+today) because outside drain it bypasses `on_pool_window_destroyed` bookkeeping and creates
+pool-reducer drift (existing, documented behavior). The gate's *source* changes from
+`plan.begin_drain` to the step-4 verdict; execution order becomes probe → dead-zombie
+closes → ReconcileQuit poke → verdict → (hostless unregisters + cascade) — one extra poke
+after the hostless unregisters is harmless (BeginDrain is monotonic/idempotent).
+
+### 2.2 — WRR: reporter roles unchanged, quit gated on the reducer's decision
+
+- `should_quit_on_last_window(armed, visible, registered)` →
+  `should_quit_on_last_window(armed, draining, visible, registered)`; happy-path quit
+  requires all four. The truth-table tests extend accordingly.
+- `is_reducer_lagging_os` widens to cover "counts agree but nobody decided"
+  (`visible == 0 && (registered > 0 || !draining)`) — both flavors of desync arm the same
+  watchdog, whose recheck-then-quit-on-OS-signal behavior is unchanged.
+- The `QUIT_INITIATED`/`HAD_VISIBLE_USER_WINDOW` statics, the HIDE/DESTROY/LOCATIONCHANGE
+  reporter dispatches, and the watchdog are untouched.
+
+### 2.3 — Why sanitize-then-decide beats a new `HostState` guard field (now conclusive)
+
+The first draft argued this on hygiene grounds. §1.A makes it conclusive: the state the
+guard field would have carried (`freshly_promoted`) **already exists in the reducer** as
+`TopLevel { is_pool: false }` — a guard field would have been a second, slower copy of a
+fact the authority already holds, maintained by a side channel, consumed by one reader.
+The Race-B lesson generalizes: when a decision site disagrees with `reconcile_quit`, first
+ask whether its extra input is (a) a fact the reducer already models (→ just read the
+reducer), (b) staleness in the reducer's projection (→ sanitize, then read), or (c) a
+genuinely missing input (→ only then extend `HostState`). Race B was (a); dead zombies are
+(b); the arming bit (§1.E) is the one genuine (c) found — and it is a monotonic bool, not
+a mirrored collection.
+
+### 2.4 — Consumption sites (Phase 2)
+
+`unregister_after_parking_close`, the LOCATIONCHANGE recycle-close dispatch, and the
+`window_pool.rs` settling callbacks currently discard `DispatchOutput.request_drain`. Each
+gains: `if let Some(reason) = out.request_drain { ui_tasks::begin_drain_and_cascade(&state, reason); }`.
+All run on the UI thread (WINEVENT callbacks and CEF tasks); the cascade dispatches
+`BeginDrain` (idempotent — racing consumers are harmless) and posts pool closes
+asynchronously, never calling `quit_message_loop` inline. This is also what finally closes
+the **racing-pool-refill regression** the original reconcile_quit spec §3.2 exists for: a
+refill that kept the close-time count non-zero now gets re-evaluated when its own settling
+dispatch lands.
+
+On Windows the sequence for a solo main close becomes: parking close →
+`UnregisterBrowser` (#2043) → `request_drain: Some` → **cascade: Draining + pool WM_CLOSE**
+→ pool parking closes → LOCATIONCHANGE unregisters → WRR gate (now also `draining=true`) →
+`quit_message_loop`. Same exit, but `QuitState` finally transitions on the dominant path,
+Stage-1 drain runs, and every decider agreed.
+
+---
+
+## 3. Phased plan
+
+Each phase lands independently and leaves every existing test green.
+
+**Phase 0 — foundations (no live-path behavior change).**
+(a) `saw_live_user_window` arming bit (§1.E): `HostState` field + `handle_register_browser`
+set + `should_begin_drain` input + reducer truth-table tests.
+(b) `HostCommand::ReconcileQuit` no-op poke (§1.H) + test that it computes `request_drain`.
+(c) Extract `begin_drain_and_cascade` to `ui_tasks` free function; handler delegates (§1.G).
+(d) This spec into `docs/specs/`.
+Verification: `cargo check -p agentmux-cef`, full crate unit tests. The arming bit is the
+only semantic change and is strictly drain-narrowing, in a window where no consumer exists.
+
+**Phase 1 — `orphan_reconcile` sanitize-then-decide (§2.1).**
+Planner: delete `begin_drain`/`live_user_count`/Race-B block; rewrite the plan tests to
+assert closes-only planning plus new reducer-level tests asserting the drain verdict for
+the same scenarios (the truth table moves, it doesn't shrink). Orchestrator: flow per §2.1.
+Verification: unit suites; live orphan scenarios are hard to stage deterministically
+(they need launcher-detected orphan states), so this phase leans on the moved truth-table
+tests plus the fact that every *mechanism* (probe, close actions, direct quit contexts) is
+untouched. The PR must say exactly that.
+
+**Phase 2 — consumption sites (§2.4).** After this, closing the last window on Windows
+flips `QuitState` for the first time. Live matrix required before merge (see §4): #2043's
+matrix (solo main close ~30ms exit; 4-windows-close-one survives; sequential close-all,
+`#1676` orphan check) plus watchdog-fire injection. WRR's own un-gated quit is still active
+this phase and acts as the cross-check: every scenario should show the cascade firing
+*before* WRR's gate.
+
+**Phase 3 — WRR draining gate (§2.2).** Small diff on top of Phase 2; same live matrix,
+plus OS-initiated closes (external `WM_CLOSE`, task-manager end-window) and a
+deliberately-broken consumption site in a scratch build to confirm
+quit-late-with-loud-log rather than hang.
+
+**Phase 4 — doc closure.** SPEC_PILLAR2 §3.3 rows → done; quit.rs header "NOT YET WIRED"
+paragraph rewritten; program status snapshot refreshed.
+
+## 4. Risks / honest caveats
+
+- **Live verification is the gate for Phases 2–3, not unit tests.** #2043 had two
+  live-caught intermediate regressions; on_before_close deadlocks (v0.33.498) and silent
+  `post_task` drops are documented in this exact code. Phases 2–3 do not merge on green
+  unit tests alone.
+- **Phase 1's live trigger is rare by construction** (launcher-emitted `HostShouldQuit`
+  on orphan detection). Mitigation: mechanisms untouched; decision movement covered by the
+  relocated truth table; the diagnostic logs (`freshly_promoted`, close plans) are kept so
+  any field regression is attributable.
+- **`ReconcileQuit` poke frequency:** dispatched only from `orphan_reconcile`'s pass (rare).
+  It must never be wired into hot paths — it is not a polling mechanism.
+- **macOS/Linux:** the consumption sites in Phase 2 are Windows-gated where the premise is
+  CEF-148 parking (`unregister_after_parking_close`, LOCATIONCHANGE); the pool settling
+  callbacks are cross-platform and give macOS/Linux the refill-race fix. Phase 3 is
+  Windows-only by construction. `classify_hwnd`'s hard-coded-Live limitation on
+  macOS/Linux (#1569) is unchanged.
+
+## 5. Explicitly out of scope
+
+- Pillar 1 Step 6 (saga collapse) — sequenced after crash-reproject bake time.
+- The strong reducer-authority intent-flip (discussion doc §7b).
+- `orphan_reconcile`'s existence/merging into a periodic reconciler.
+- The macOS/Linux orphan liveness gap (#1569).
+- `Client.windowids` slow growth from abandoned promotions (Step-4 spec 2026-07-08 addendum).
+
+## 6. Definition of done
+
+Phases 0–4 merged; grep gate: no `quit_message_loop()` call sites outside (a) Stage 2 in
+`on_before_close`, (b) the watchdog recheck, (c) `orphan_reconcile`'s two documented
+Stage-2 executions, (d) WRR's draining-gated executor; `ReconcilePlan` has no `begin_drain`;
+`should_quit_on_last_window` requires `draining`; SPEC_PILLAR2 §3.3 both rows closed.
+
+## 7. Sources
+
+- `agentmux-cef/src/reducer/quit.rs`, `reducer/pool.rs` (promotion kind-flip),
+  `reducer/mod.rs` (`is_quit_relevant`, `update`'s request_drain recomputation)
+- `agentmux-cef/src/wrr/win_event.rs` (gate, watchdog, LOCATIONCHANGE detector, arming)
+- `agentmux-cef/src/commands/orphan_reconcile.rs` (planner + orchestrator + test matrix)
+- `agentmux-cef/src/client/lifecycle.rs` (`on_before_close` consumption,
+  `begin_drain_and_cascade`, Stage-2 gate, RegisterBrowser kind derivation)
+- `agentmux-cef/src/ui_tasks/window.rs` (`unregister_after_parking_close`)
+- `agentmux-cef/src/app.rs` (main-window startup path — no pending-creation enqueue)
+- `docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md` §3.3 + 2026-07-08 addendum
+- `docs/specs/SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md`; PR #1993, #2043 descriptions


### PR DESCRIPTION
## Summary

Phase 0 of `docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md` (included in this PR) — the design that retires the last two independent quit authorities (`wrr::maybe_quit_on_last_user_window`'s direct quit and `orphan_reconcile`'s `begin_drain`) by making both **sanitize → decide → execute** consumers of `reconcile_quit`. This PR is the foundations slice: no live close-path behavior changes.

**The spec supersedes the first-draft direction discussed in SPEC_PILLAR2 §3.3.** A fresh implementation-readiness pass (spec §1) found:
- **Race B is already modeled by the reducer** — promotion flips `is_pool:false` synchronously (`reducer/pool.rs`), so `reconcile_quit` already refuses to drain while a freshly-promoted window exists. `plan_reconcile`'s guard compensates for reading the *slower* launcher-shadow projection; no new guard field or `MarkBrowserPromoted` command is needed.
- **The genuinely stale direction is dead/hostless zombies** blocking `reconcile_quit` forever — and the repair commands already exist in `orphan_reconcile` (Phase 1 removes only its parallel *decision*).
- **A real latent bug (fixed here): the startup arming gap.** Main's creation path enqueues no `PendingWindowCreation`, so between process start and main's `RegisterBrowser`, `reconcile_quit` read as drainable. Harmless today (the only consumer can't fire pre-browser), but a live startup-quit the moment Phase 2 wires dispatch-site consumers.

## Changes

1. **`HostState.saw_live_user_window`** — monotonic arming bit, set on first live-user `RegisterBrowser`; `should_begin_drain` refuses to drain unarmed. Reducer-side analog of WRR's `HAD_VISIBLE_USER_WINDOW` (armed at registration, which is earlier and safe — once registered, the live count itself blocks drain).
2. **`HostCommand::ReconcileQuit`** — pure no-op poke; only effect is `update()`'s existing quit-relevant `request_drain` recomputation. For executors that reach a decision point with zero state-changing dispatches (orphan_reconcile's nothing-to-close arm, Phase 1). Documented as NOT a polling mechanism.
3. **`begin_drain_and_cascade` extracted** to `ui_tasks::begin_drain_and_cascade(state, reason)`; the `AgentMuxHandler` method delegates. The body only ever touched `self.state` — zero behavior change. Unlocks Phase 2's consumption sites (parking-close, LOCATIONCHANGE, pool settling), which hold `&Arc<AppState>` but no handler.

## Test plan

- `cargo check -p agentmux-cef` clean (no new warnings in touched files).
- **188/188 crate unit tests** (184 existing + 4 new), parallel AND single-threaded runs. New coverage: unarmed-fresh-state never drains (pins the §1.E fix — this exact assertion was previously *inverted*: `HostState::default()` was drainable); poke surfaces verdict with zero mutation (no events, no version bump); poke respects arming + Draining monotonicity; poke is quit-relevant.
- The #2043-documented `browser_pane::hwnd` parallel flake did not reproduce in this run.
- No live-path verification needed for this slice: the executor extraction is mechanical (delegation), the poke has no callers yet, and the arming bit only *narrows* drain in a window where no `request_drain` consumer exists.

Phases 1–3 (orphan_reconcile restructure, dispatch-site consumption, WRR draining gate) land as separate PRs; Phases 2–3 gate on the live close matrix per the spec's §4.

Follow-up to #1993 / #2043 — implements the "full retirement of the parallel authority" left open in SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md §3.3 and SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md's scope notes.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)