### PR TITLE
fix(lifecycle): Pillar 2 Phase 2 — consume the drain verdict at every count-lowering dispatch site

### DIFF
--- a/.changesets/1783749343-fix-lifecycle-consume-the-drain-verdict-at-every-count-lower-o807.md
+++ b/.changesets/1783749343-fix-lifecycle-consume-the-drain-verdict-at-every-count-lower-o807.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(lifecycle): consume the drain verdict at every count-lowering dispatch site (Pillar 2 Phase 2)

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -761,6 +761,12 @@ pub fn demote_promoted_pool_window(
         ));
         return false;
     }
+    // Pillar 2 Phase 2 (sanitize-then-decide §2.4) — a demote-close is the one
+    // close flow that lowers the live-user count WITHOUT an UnregisterBrowser
+    // (the kind flip excludes the window from the count while the browser
+    // stays registered for pool reuse). When this was the last user window,
+    // the drain verdict fires here.
+    crate::ui_tasks::consume_request_drain(state, &dispatch, "demote_pool_window");
 
     // 3. Park the HWND offscreen + hide, mirroring fresh-spawn state.
     unsafe {
@@ -1431,11 +1437,15 @@ fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
     // inline since CEF won't fire it for this label.
     // Phase H.2.d — legacy `state.browsers.lock().remove` removed;
     // reducer's UnregisterBrowser is sole canonical mutation site.
-    state.host_dispatch(
+    let out = state.host_dispatch(
         crate::reducer::HostCommand::UnregisterBrowser {
             label: label.to_string(),
         },
     );
+    // Pillar 2 Phase 2 — the label was already popped+promoted (user-kind), so
+    // this inline unregister can zero the live count; on_before_close's own
+    // consumption never runs on this path (no CEF close will fire).
+    crate::ui_tasks::consume_request_drain(state, &out, "failed_promote_orphan_cleanup");
     state.window_meta.lock().remove(label);
     crate::launcher_ipc::report_window_closed(label.to_string());
     // Refill (graceful path gets this via on_pool_window_destroyed).
@@ -1522,11 +1532,14 @@ pub fn promote_pool_window(
 /// `close_browser` path — `on_before_close` will not fire. Do its job inline.
 #[cfg(not(target_os = "windows"))]
 fn cleanup_failed_promote_orphan_cross_platform(state: &Arc<AppState>, label: &str) {
-    state.host_dispatch(
+    let out = state.host_dispatch(
         crate::reducer::HostCommand::UnregisterBrowser {
             label: label.to_string(),
         },
     );
+    // Pillar 2 Phase 2 — see the Windows variant: the label was already
+    // popped+promoted (user-kind); no close chain will ever consume this.
+    crate::ui_tasks::consume_request_drain(state, &out, "failed_promote_orphan_cleanup_xplat");
     state.window_meta.lock().remove(label);
     crate::launcher_ipc::report_window_closed(label.to_string());
     spawn_pool_window(state);

--- a/agentmux-cef/src/reducer/quit.rs
+++ b/agentmux-cef/src/reducer/quit.rs
@@ -66,17 +66,24 @@ pub(super) fn handle_confirm_drained(state: &mut HostState) -> DispatchOutput {
 // `count_live_user_windows() == 0` itself — the close-edge path is now a pure
 // executor of this module's decision, not a second decision-maker.
 //
-// NOT YET WIRED: the spec's other "settling" call sites — the pool
-// spawn/promote/destroy completion callbacks in `commands/window_pool.rs`
-// (`PopAndPromoteFrontPoolWindow`/`PanePoolWindow*`/etc.) — still discard their
-// `DispatchOutput.request_drain`. This means the actual regression the spec
-// exists to fix (a concurrent pool refill keeping the close-time count
-// non-zero, with nothing re-evaluating once the refill settles) is NOT yet
-// closed — only the common, non-racing close path is now single-authority.
-// `wrr::win_event::maybe_quit_on_last_user_window` and
-// `commands::orphan_reconcile`'s independent `begin_drain` predicate (§3.3)
-// are also untouched. See the spec's §3.2 "correctness obligation" and §7
-// rollout for the remaining steps.
+// WIRED (Pillar 2, sanitize-then-decide Phases 1–2 —
+// SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md): every dispatch site whose
+// command can flip the verdict to Some now consumes `request_drain` via
+// `ui_tasks::consume_request_drain` (posts the shared Stage-1 executor):
+// `unregister_after_parking_close` (the dominant Windows close path), the WRR
+// LOCATIONCHANGE recycle-close detector, `DemotePoolWindow` (the one close
+// flow that lowers the count without an UnregisterBrowser), and the two
+// failed-promote orphan cleanups. `commands::orphan_reconcile` no longer has
+// an independent `begin_drain` predicate — it sanitizes the browsers
+// projection, then reads this module's verdict via the `ReconcileQuit` poke.
+// Deliberately NON-consuming: `on_after_created`'s Dequeue→Register pair (the
+// gap between them would surface a spurious verdict for a second window
+// opening into an otherwise-empty session; the Register lands in the same
+// lock scope of activity and re-blocks it — do not consume there).
+//
+// NOT YET WIRED (Phase 3): `wrr::win_event::maybe_quit_on_last_user_window`
+// still calls `quit_message_loop()` from its own predicate without requiring
+// `QuitState::Draining` — the last independent quit authority.
 
 /// Background PENDING-CREATION labels — warm-pool tab refills (`window-pool-`),
 /// browser-pane children (`browser-pane-`), and floating panes (`floating-`, the

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -367,9 +367,14 @@ pub(crate) fn unregister_after_parking_close(state: &Arc<AppState>, label: &str)
         "[close-window] {} close initiated — dispatching UnregisterBrowser (parked browser fires no on_before_close)",
         label
     );
-    state.host_dispatch(crate::reducer::HostCommand::UnregisterBrowser {
+    let out = state.host_dispatch(crate::reducer::HostCommand::UnregisterBrowser {
         label: label.to_string(),
     });
+    // Pillar 2 Phase 2 — this is the dominant Windows close path; when the
+    // unregistration zeroes the live count, the drain cascade fires HERE
+    // (QuitState finally transitions on this path) instead of the quit
+    // resting solely on WRR's OS-signal gate.
+    consume_request_drain(state, &out, "unregister_after_parking_close");
     if label != "main" {
         // Mirror on_before_close's cache eviction (stale entries break
         // WM_CLOSE routing on label reuse). Main keeps its entry — the
@@ -377,6 +382,49 @@ pub(crate) fn unregister_after_parking_close(state: &Arc<AppState>, label: &str)
         state.window_hwnds.lock().remove(label);
     }
     crate::wrr::win_event::arm_quit_watchdog(state.count_live_user_windows());
+}
+
+/// Pillar 2 Phase 2 (SPEC_PILLAR2_SANITIZE_THEN_DECIDE §2.4) — uniform
+/// consumption of `reconcile_quit`'s decision at a dispatch site. If the
+/// dispatch surfaced a drain verdict, post the Stage-1 executor as a UI task.
+///
+/// Posting (rather than calling `begin_drain_and_cascade` inline) is the
+/// uniformly-safe choice: consumption sites include WINEVENT callbacks
+/// (LOCATIONCHANGE recycle detection) and non-UI command threads (promote
+/// failure cleanup), and a one-loop-turn deferral is harmless — `BeginDrain`
+/// is monotonic/idempotent, so racing consumers (e.g. `on_before_close`'s
+/// inline consumption of the same verdict) are benign; first one wins.
+///
+/// `post_task` can silently drop during teardown (v0.33.492) — but every
+/// consumption site runs while the message loop is healthy by construction
+/// (a drain verdict means nothing has begun tearing down yet; that is the
+/// problem being solved). The entry log below makes any drop visible.
+pub(crate) fn consume_request_drain(
+    state: &Arc<AppState>,
+    out: &crate::reducer::DispatchOutput,
+    site: &str,
+) {
+    let Some(reason) = out.request_drain.clone() else { return };
+    let mut task = BeginDrainCascadeTask::new(state.clone(), reason.clone());
+    let posted = post_task(ThreadId::UI, Some(&mut task));
+    tracing::warn!(
+        target: "wrr",
+        "[drain-consume] site={} reason={:?} — posting begin_drain_and_cascade posted={}",
+        site, reason, posted != 0
+    );
+}
+
+wrap_task! {
+    pub struct BeginDrainCascadeTask {
+        state: Arc<AppState>,
+        reason: crate::state::QuitReason,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            begin_drain_and_cascade(&self.state, self.reason.clone());
+        }
+    }
 }
 
 /// Pillar 2 Stage-1 drain executor (SPEC_PILLAR2_SANITIZE_THEN_DECIDE §1.G) —

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -385,26 +385,42 @@ pub(crate) fn unregister_after_parking_close(state: &Arc<AppState>, label: &str)
 }
 
 /// Pillar 2 Phase 2 (SPEC_PILLAR2_SANITIZE_THEN_DECIDE §2.4) — uniform
-/// consumption of `reconcile_quit`'s decision at a dispatch site. If the
-/// dispatch surfaced a drain verdict, post the Stage-1 executor as a UI task.
+/// consumption of `reconcile_quit`'s decision at a dispatch site.
 ///
-/// Posting (rather than calling `begin_drain_and_cascade` inline) is the
-/// uniformly-safe choice: consumption sites include WINEVENT callbacks
-/// (LOCATIONCHANGE recycle detection) and non-UI command threads (promote
-/// failure cleanup), and a one-loop-turn deferral is harmless — `BeginDrain`
-/// is monotonic/idempotent, so racing consumers (e.g. `on_before_close`'s
-/// inline consumption of the same verdict) are benign; first one wins.
+/// On the CEF UI thread the Stage-1 executor runs INLINE, matching the
+/// `on_before_close` pattern: the cascade must complete before the caller's
+/// next statement, because callers (the WRR LOCATIONCHANGE handler in
+/// particular) re-run the last-window quit gate synchronously right after —
+/// a posted cascade would let `quit_message_loop()` win the race and skip
+/// the graceful Stage-1 pool drain entirely (reagent P1 on PR #2082).
+/// WINEVENT callbacks run on the UI thread, so this covers the
+/// parking-close, LOCATIONCHANGE, and demote sites.
+///
+/// Off the UI thread (promote-failure cleanup can run from command/IPC
+/// threads) the executor is posted as a UI task — a one-loop-turn deferral,
+/// harmless there because nothing on those paths quits synchronously.
+/// `BeginDrain` is monotonic/idempotent, so racing consumers (e.g.
+/// `on_before_close`'s own inline consumption) are benign; first one wins.
 ///
 /// `post_task` can silently drop during teardown (v0.33.492) — but every
 /// consumption site runs while the message loop is healthy by construction
 /// (a drain verdict means nothing has begun tearing down yet; that is the
-/// problem being solved). The entry log below makes any drop visible.
+/// problem being solved). The entry logs below make any drop visible.
 pub(crate) fn consume_request_drain(
     state: &Arc<AppState>,
     out: &crate::reducer::DispatchOutput,
     site: &str,
 ) {
     let Some(reason) = out.request_drain.clone() else { return };
+    if currently_on(ThreadId::UI) != 0 {
+        tracing::warn!(
+            target: "wrr",
+            "[drain-consume] site={} reason={:?} — running begin_drain_and_cascade inline (UI thread)",
+            site, reason
+        );
+        begin_drain_and_cascade(state, reason);
+        return;
+    }
     let mut task = BeginDrainCascadeTask::new(state.clone(), reason.clone());
     let posted = post_task(ThreadId::UI, Some(&mut task));
     tracing::warn!(

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -717,9 +717,11 @@ unsafe extern "system" fn win_event_callback(
                             // Pillar 2 Phase 2 (sanitize-then-decide §2.4) —
                             // consume the drain verdict this dispatch just
                             // computed instead of discarding it: the recycle
-                            // close of the last window now flips QuitState and
-                            // runs the Stage-1 drain (posted as a UI task; this
-                            // WINEVENT callback returns first).
+                            // close of the last window flips QuitState and
+                            // runs the Stage-1 drain INLINE (this WINEVENT
+                            // callback is on the UI thread), so the cascade
+                            // has completed before the gate re-run below —
+                            // the ordering the reagent P1 on #2082 required.
                             crate::ui_tasks::consume_request_drain(
                                 state, &out, "wrr_locationchange_recycle_close",
                             );

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -711,8 +711,17 @@ unsafe extern "system" fn win_event_callback(
                             // never learns this window is gone and stays stuck non-zero forever.
                             // Idempotent: `handle_unregister_browser` no-ops on an
                             // already-removed/unknown label.
-                            state.host_dispatch(
+                            let out = state.host_dispatch(
                                 crate::reducer::HostCommand::UnregisterBrowser { label },
+                            );
+                            // Pillar 2 Phase 2 (sanitize-then-decide §2.4) —
+                            // consume the drain verdict this dispatch just
+                            // computed instead of discarding it: the recycle
+                            // close of the last window now flips QuitState and
+                            // runs the Stage-1 drain (posted as a UI task; this
+                            // WINEVENT callback returns first).
+                            crate::ui_tasks::consume_request_drain(
+                                state, &out, "wrr_locationchange_recycle_close",
                             );
                             // Re-evaluate the quit gate NOW: this LOCATIONCHANGE may be
                             // the last event this window ever fires (HIDE preceded the


### PR DESCRIPTION
## Summary

Phase 2 of `docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md`. **Stacked on #2081** (base set accordingly; merge order #2080 → #2081 → this).

Since PR #1993 the reducer computes `DispatchOutput.request_drain` after every quit-relevant command — and outside `on_before_close`, every site discarded it. This PR adds `ui_tasks::consume_request_drain` (posts the shared Stage-1 executor as a UI task) and wires it at exactly the sites whose command can flip the verdict to `Some` (i.e., lower the live-user count or clear the last user-pending creation):

| Site | Why it can flip the verdict |
|---|---|
| `unregister_after_parking_close` | The dominant Windows close path (#2043). **`QuitState` now transitions on main-window close for the first time**; Stage-1 pool drain runs. |
| WRR LOCATIONCHANGE recycle-close | #2043 Step A's dispatch — last-window recycle close. |
| `DemotePoolWindow` | The one close flow that lowers the count **without** an `UnregisterBrowser` (kind flip only, browser stays registered for pool reuse). |
| Failed-promote orphan cleanups (both platforms) | Label was already popped+promoted (user-kind); no close chain will ever consume for it. |

Deliberately **not** consuming at `on_after_created`'s Dequeue→Register pair — the gap between them would surface a spurious verdict for a second window opening into an otherwise-empty session. Documented in `quit.rs`'s wiring-status header (refreshed by this PR). This consumption-site analysis is only safe because of #2080's arming bit — without it, a pre-main-registration dispatch could consume a spurious startup drain.

Consumption **posts** rather than calling inline: sites include WINEVENT callbacks and non-UI command threads; `BeginDrain` is monotonic/idempotent so racing consumers (e.g. `on_before_close`'s existing inline consumption) are benign — first wins, rest no-op.

This also closes the original racing-pool-refill obligation from `SPEC_PILLAR2_WIRE_RECONCILE_QUIT` §3.2: a refill that kept the close-time count non-zero gets re-evaluated when its own settling dispatch (demote/unregister) lands.

WRR's own quit gate is intentionally untouched this phase — it remains the live cross-check (the cascade should now win every close race; a scenario where WRR's gate fires with `QuitState` still `Running` = a consumption site we missed). Phase 3 (next PR) demotes it to a Draining-gated executor.

## Test plan

- `cargo check -p agentmux-cef` clean; no new warnings in touched files (`window_pool.rs`'s 3 warnings are pre-existing on base — verified by stash-compare).
- 182/182 crate unit tests.
- **Live close matrix (spec §3 Phase 2 gate) — in progress on a packaged build; results will be posted as a PR comment before merge.** Scenarios: solo main close (expect `[drain-consume]` + Stage-1 before WRR's gate line, clean tree exit); 4 windows close-one-non-last (no drain, no watchdog); sequential close-all (clean exit, no orphan — #1676 regression check); demote-close of last promoted window.

Follow-up to #2080/#2081. Refs SPEC_PILLAR2_WIRE_RECONCILE_QUIT §3.2/§3.3.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)