### PR TITLE
docs: Pillar 2 doc closure — §3.3 rows resolved, sanitize-then-decide marked implemented

### DIFF
--- a/docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md
+++ b/docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md
@@ -3,7 +3,7 @@
 **Date:** 2026-07-11
 **Type:** Design spec (design-first per program discipline — window/lifecycle code here is
 deadlock-sensitive and has repeatedly punished plausible-looking fixes)
-**Status:** Phases 0–1 planned for immediate implementation; 2–3 staged behind live matrix
+**Status:** IMPLEMENTED & MERGED 2026-07-11 — Phases 0–3 landed as #2080, #2081, #2084 (replacement for auto-closed #2082), #2083; live close matrix passed on the merged code (results: PR #2082/#2083 comments), including a zombie-hang reproduction fixed by the watchdog re-arm (#2083 tip)
 **Builds on:** `SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md` (Stage 2 first slice merged,
 PR #1993), `SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` (merged, PR #2043),
 `SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md` (§5.1/§10 — `reconcile_quit` itself)

--- a/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
+++ b/docs/specs/SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md
@@ -149,11 +149,21 @@ returns once not `Running` (`quit.rs:15`), and `BeginDrain` is documented idempo
   independently rather than deferring to `reconcile_quit`/`request_drain`) — it only prevents WRR
   from firing when the reducer disagrees. Full retirement of the parallel authority (this section's
   original scope) remains open.
-- **`commands::orphan_reconcile`** — not started. Its `plan.begin_drain` computation
-  (`orphan_reconcile.rs:189,345`) is still independent of `reconcile_quit`; per the research done
-  2026-07-07 it also carries a "Race B" (`freshly_promoted`) guard with no `HostState` equivalent —
-  merging it away needs either a new `HostState` field or a two-phase "sanitize state.browsers, then
-  trust reconcile_quit" design, not a direct swap either.
+
+  **RESOLVED 2026-07-11 — full retirement landed.** SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md
+  Phases 2-3 (PRs #2084, #2083): every count-lowering dispatch site consumes request_drain (the
+  parking-close path flips QuitState on main-window close — the channel this section said was
+  missing), and should_quit_on_last_window now requires QuitState::Draining, demoting WRR to the
+  Windows Stage-2 executor of reconcile_quit decisions. The quit watchdog (re-arming while
+  draining-with-zero-registered) is the bounded backstop. Live close matrix on the merged code:
+  PR #2082/#2083 comments.
+- **`commands::orphan_reconcile`** — **RESOLVED 2026-07-11** (PR #2081): the two-phase "sanitize
+  state.browsers, then trust reconcile_quit" design shipped — `begin_drain`/`live_user_count`/Race-B
+  authority deleted; the planner classifies sanitize work only and the verdict comes from the
+  `ReconcileQuit` poke. (Race B turned out to be already modeled by the reducer: promotion flips
+  `is_pool:false` synchronously — see SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md §1.A.)
+  Originally: not started; its independent `plan.begin_drain` carried a "Race B"
+  (`freshly_promoted`) guard with no `HostState` equivalent.
 
 ## 4. Exact code changes
 


### PR DESCRIPTION
Phase 4 (doc closure) of `SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md`, following the merges of #2080 → #2081 → #2084 → #2083:

- `SPEC_PILLAR2_WIRE_RECONCILE_QUIT_2026_06_29.md` §3.3: the WRR row gains a RESOLVED addendum (full retirement landed — Phase-2 consumption sites + the Draining-gated Stage-2 executor), and the `orphan_reconcile` row is marked resolved via the shipped sanitize-then-decide design, with the Race-B finding (already modeled by the reducer) noted.
- `SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md` status line records the merged PRs and live-verification results (close matrix + zombie-hang reproduction).

Docs-only; no changeset (same precedent as #1934/#1994/#2009). The remaining quit.rs wiring-status comment was already updated in-code by #2083.

Follow-up to #2083.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)