### PR TITLE
feat(tabbar): cross-window tab remount (drag a tab onto another window's header)

### DIFF
--- a/.changesets/1783779616-feat-tabbar-drag-a-tab-onto-another-window-s-header-to-remou-sdj3.md
+++ b/.changesets/1783779616-feat-tabbar-drag-a-tab-onto-another-window-s-header-to-remou-sdj3.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(tabbar): drag a tab onto another window's header to remount it there

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -720,6 +720,55 @@ pub fn tear_off_sc_move_handshake(
     }))
 }
 
+/// Install the global mouse hook for an ordinary in-strip tab drag —
+/// the cross-window tab remount gesture
+/// (specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11 §4.1). Called by the
+/// frontend at tab-drag start; the hook self-uninstalls on mouseup/ESC,
+/// with stop_tab_drag_tracking as the dragend belt-and-suspenders.
+/// No-op on non-Windows (the hook layer is win32-only until the
+/// tear-off spec's Phase 7 trackers land).
+pub fn start_tab_drag_tracking(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let source_label = args
+        .get("sourceWindowLabel")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing sourceWindowLabel".to_string())?
+        .to_string();
+    let tab_id = args
+        .get("tabId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing tabId".to_string())?
+        .to_string();
+    let source_ws_id = args
+        .get("sourceWsId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing sourceWsId".to_string())?
+        .to_string();
+    let is_last_tab = args
+        .get("isLastTab")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    crate::commands::tear_off_hook::start_tab_drag_tracking(
+        state.clone(),
+        source_label,
+        tab_id,
+        source_ws_id,
+        is_last_tab,
+    )?;
+    Ok(serde_json::Value::Null)
+}
+
+/// Stop the active tab-drag hook session, if any. Idempotent — also
+/// safe to call after the hook already self-uninstalled on mouseup, or
+/// after a tear-off handshake superseded the session.
+pub fn stop_tab_drag_tracking() -> Result<serde_json::Value, String> {
+    crate::commands::tear_off_hook::stop_active_hook_session();
+    Ok(serde_json::Value::Null)
+}
+
 /// Poll state.browsers for `label` until its host's HWND is non-null
 /// or the deadline elapses. Returns the HWND as a raw pointer.
 /// Releases the browsers mutex between polls so on_after_created can

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -724,6 +724,17 @@ fn candidate_label_under_cursor_locked(
         if label == &ctx.dragged_label {
             continue;
         }
+        // TabDrag mode: the source window is NOT a candidate. Its own
+        // pragmatic-dnd reorder owns the strip while the cursor is over
+        // it — emitting tearoff:hover-changed at it on every mouse move
+        // would race that (two writers, differently-timed and
+        // differently-converted, on one insertionPoint signal), and
+        // button-up over the source is owned by the in-window reorder
+        // anyway. TearOff mode keeps the source as a candidate: that's
+        // the cancel-back drop target. (reagent PR #2086 P1)
+        if matches!(ctx.mode, HookMode::TabDrag { .. }) && label == &ctx.source_label {
+            continue;
+        }
         if !is_instance_label(label) {
             continue;
         }

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -27,14 +27,24 @@
 //     (skipping the dragged window itself). If the candidate target
 //     changed, emits `tearoff:hover-changed` IPC events to the new
 //     and old candidate's renderers.
-//   * On WM_LBUTTONUP, emits `tearoff:finalize` to the source window's
-//     renderer with the final candidate label + cursor position. The
-//     source-side frontend handles the merge (calls
-//     MoveTabToWorkspace + closes the dragged window).
+//   * On WM_LBUTTONUP, emits a finalisation event: `tearoff:merge` to
+//     the candidate window (which pulls the tab in and closes the
+//     dragged window), `tearoff:cancel-back` to the source (drop on
+//     source window / ESC), or `tearoff:standalone` to the source
+//     (released over nothing).
 //
 // Spec: docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26 §4.3-§4.4
-// Phase 5 (cancel-back-to-source) reuses the same finalize event
-// with a different source-side handler.
+//
+// Cross-window tab remount (specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11):
+// the same hook now also runs in `HookMode::TabDrag` for EVERY tab drag
+// (installed at drag start via `start_tab_drag_tracking`, before any
+// tear-off). In that mode the hover events are identical, but button-up
+// over another window emits `tabdrag:merge-direct` (the tab still lives
+// in its original multi-tab workspace — no temporary tear-off ws exists),
+// and every other outcome emits nothing: the source window's normal
+// in-window reorder / tear-off / HTML5 cross-drag paths own those. If a
+// tear-off fires mid-drag, `start_tear_off_tracking` takes over the
+// session (the previous hook thread is stopped via WM_QUIT).
 
 #[cfg(target_os = "windows")]
 use std::cell::RefCell;
@@ -44,9 +54,26 @@ use std::sync::Arc;
 #[cfg(target_os = "windows")]
 use crate::state::AppState;
 
+/// Which gesture this hook session is tracking. Determines the
+/// button-up finalisation behaviour; hover events are identical.
+#[cfg(target_os = "windows")]
+#[derive(Clone, Copy, PartialEq)]
+enum HookMode {
+    /// A torn-off window is mid-SC_MOVE; the tab lives in a temporary
+    /// single-tab workspace (`dest_ws_id`). Finalisation: merge /
+    /// cancel-back / standalone (the shipped Phase 4/5 behaviour).
+    TearOff,
+    /// An ordinary in-strip tab drag (no tear-off yet). The tab still
+    /// lives in its original workspace (`source_ws_id`). Finalisation:
+    /// `tabdrag:merge-direct` to a candidate window; every other
+    /// outcome is owned by the source window's existing paths.
+    TabDrag { is_last_tab: bool },
+}
+
 #[cfg(target_os = "windows")]
 struct HookContext {
     state: Arc<AppState>,
+    mode: HookMode,
     /// Label of the source window (the one the tab originated from).
     /// Used to skip self-detection during cursor tracking, and as the
     /// destination for the `tearoff:finalize` event.
@@ -91,10 +118,35 @@ thread_local! {
     static HOOK_CTX: RefCell<Option<HookContext>> = const { RefCell::new(None) };
 }
 
+/// Thread id of the currently-running hook session, if any. One hook
+/// session runs at a time: starting a new session (e.g. the tear-off
+/// handshake taking over from a TabDrag session when the drag crosses
+/// TEAR_PAST_PX) posts WM_QUIT to the previous thread first, which
+/// unhooks and exits through its normal loop teardown.
+#[cfg(target_os = "windows")]
+static ACTIVE_HOOK_THREAD: std::sync::Mutex<Option<u32>> = std::sync::Mutex::new(None);
+
+/// Stop the active hook session, if any. Idempotent. Used by the
+/// session-takeover path above and by the frontend's dragend
+/// belt-and-suspenders `stop_tab_drag_tracking` call — a leaked
+/// WH_MOUSE_LL hook degrades every mouse event on the system.
+#[cfg(target_os = "windows")]
+pub fn stop_active_hook_session() {
+    let tid = { ACTIVE_HOOK_THREAD.lock().map(|mut g| g.take()).unwrap_or(None) };
+    if let Some(tid) = tid {
+        unsafe {
+            use windows_sys::Win32::UI::WindowsAndMessaging::{PostThreadMessageW, WM_QUIT};
+            PostThreadMessageW(tid, WM_QUIT, 0, 0);
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn stop_active_hook_session() {}
+
 /// Spawn a hook thread for the duration of a tear-off gesture.
 /// Returns Ok once the hook is installed; the thread runs in the
-/// background until WM_LBUTTONUP arrives or `stop_tear_off_tracking`
-/// is called.
+/// background until WM_LBUTTONUP arrives or the session is stopped.
 ///
 /// Safe to call from a Tokio worker thread — the hook thread is
 /// independent and runs its own message loop.
@@ -109,7 +161,79 @@ pub fn start_tear_off_tracking(
     original_tab_index: usize,
     was_pinned: bool,
 ) -> Result<(), String> {
+    start_hook_session(HookContextSeed {
+        state,
+        mode: HookMode::TearOff,
+        source_label,
+        dragged_label,
+        tab_id,
+        source_ws_id,
+        dest_ws_id,
+        original_tab_index,
+        was_pinned,
+    })
+}
+
+/// Install the hook for an ordinary in-strip tab drag (cross-window
+/// tab remount, specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11 §4.1).
+/// No dragged/destination window exists — the tab is still mounted in
+/// its source workspace. Button-up over another AgentMux window emits
+/// `tabdrag:merge-direct` to it; all other outcomes emit nothing.
+#[cfg(target_os = "windows")]
+pub fn start_tab_drag_tracking(
+    state: Arc<AppState>,
+    source_label: String,
+    tab_id: String,
+    source_ws_id: String,
+    is_last_tab: bool,
+) -> Result<(), String> {
+    start_hook_session(HookContextSeed {
+        state,
+        mode: HookMode::TabDrag { is_last_tab },
+        source_label,
+        dragged_label: String::new(),
+        tab_id,
+        source_ws_id,
+        dest_ws_id: String::new(),
+        original_tab_index: 0,
+        was_pinned: false,
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn start_tab_drag_tracking(
+    _state: std::sync::Arc<crate::state::AppState>,
+    _source_label: String,
+    _tab_id: String,
+    _source_ws_id: String,
+    _is_last_tab: bool,
+) -> Result<(), String> {
+    Ok(())
+}
+
+/// Owned bag of HookContext fields — lets the two public entry points
+/// share one spawn path without threading nine parameters around.
+#[cfg(target_os = "windows")]
+struct HookContextSeed {
+    state: Arc<AppState>,
+    mode: HookMode,
+    source_label: String,
+    dragged_label: String,
+    tab_id: String,
+    source_ws_id: String,
+    dest_ws_id: String,
+    original_tab_index: usize,
+    was_pinned: bool,
+}
+
+#[cfg(target_os = "windows")]
+fn start_hook_session(seed: HookContextSeed) -> Result<(), String> {
     use std::sync::mpsc;
+
+    // One session at a time: a TabDrag session is superseded when the
+    // drag crosses the tear-off threshold and the SC_MOVE handshake
+    // installs a TearOff session.
+    stop_active_hook_session();
 
     // Use a oneshot channel so the spawn returns only after the hook
     // is fully installed. Otherwise PostMessageW(SC_MOVE) could fire
@@ -121,14 +245,15 @@ pub fn start_tear_off_tracking(
         .name("tear-off-hook".to_string())
         .spawn(move || {
             let ctx = HookContext {
-                state,
-                source_label,
-                dragged_label,
-                tab_id,
-                source_ws_id,
-                dest_ws_id,
-                original_tab_index,
-                was_pinned,
+                state: seed.state,
+                mode: seed.mode,
+                source_label: seed.source_label,
+                dragged_label: seed.dragged_label,
+                tab_id: seed.tab_id,
+                source_ws_id: seed.source_ws_id,
+                dest_ws_id: seed.dest_ws_id,
+                original_tab_index: seed.original_tab_index,
+                was_pinned: seed.was_pinned,
                 current_target: RefCell::new(None),
                 finalized: RefCell::new(false),
             };
@@ -191,6 +316,16 @@ pub fn start_tear_off_tracking(
                     return;
                 }
 
+                // Register this thread as the active session so a
+                // superseding start (or stop_tab_drag_tracking) can
+                // post WM_QUIT to it. Registered only after both hooks
+                // installed — a failed install never occupies the slot.
+                let my_tid =
+                    windows_sys::Win32::System::Threading::GetCurrentThreadId();
+                if let Ok(mut g) = ACTIVE_HOOK_THREAD.lock() {
+                    *g = Some(my_tid);
+                }
+
                 let _ = ready_tx.send(Ok(()));
 
                 tracing::info!(
@@ -200,7 +335,8 @@ pub fn start_tear_off_tracking(
 
                 // Standard GetMessage pump. The loop exits when a
                 // hook callback posts WM_QUIT after WM_LBUTTONUP or
-                // VK_ESCAPE.
+                // VK_ESCAPE, or when a superseding session / an
+                // explicit stop posts WM_QUIT to this thread.
                 let mut msg: MSG = std::mem::zeroed();
                 loop {
                     let r = GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0);
@@ -214,6 +350,14 @@ pub fn start_tear_off_tracking(
                 UnhookWindowsHookEx(kb_hook);
                 UnhookWindowsHookEx(mouse_hook);
                 HOOK_CTX.with(|cell| *cell.borrow_mut() = None);
+                // Vacate the active-session slot — but only if it still
+                // points at us (a superseding session may have already
+                // replaced it).
+                if let Ok(mut g) = ACTIVE_HOOK_THREAD.lock() {
+                    if *g == Some(my_tid) {
+                        *g = None;
+                    }
+                }
 
                 tracing::info!(
                     target: "dnd:tearoff",
@@ -275,6 +419,17 @@ unsafe extern "system" fn low_level_keyboard_proc(
                         return;
                     }
                     *ctx.finalized.borrow_mut() = true;
+                    // TabDrag mode: ESC cancels the native OLE drag on
+                    // its own; there is no torn-off window to cancel
+                    // back. Just retire the session silently.
+                    if matches!(ctx.mode, HookMode::TabDrag { .. }) {
+                        tracing::info!(
+                            target: "dnd:tearoff",
+                            tab_id = %ctx.tab_id,
+                            "[dnd:tabdrag] ESC pressed — session retired"
+                        );
+                        return;
+                    }
                     tracing::info!(
                         target: "dnd:tearoff",
                         tab_id = %ctx.tab_id,
@@ -438,6 +593,34 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
             target = ?candidate,
             "[dnd:tearoff] mouseup — finalize"
         );
+
+        // TabDrag mode (cross-window tab remount): the ONLY outcome
+        // this session owns is a release over another window — emit
+        // `tabdrag:merge-direct` and let that window strip-hit-test and
+        // move the tab. Release over the source window (in-window
+        // reorder) or over nothing (HTML5 cross-drag / standalone
+        // paths) is owned by the existing pipelines; emitting nothing
+        // here keeps them un-double-processed.
+        if let HookMode::TabDrag { is_last_tab } = ctx.mode {
+            if let Some(target_label) = &candidate {
+                if target_label != &ctx.source_label {
+                    crate::events::emit_event_to_window(
+                        &ctx.state,
+                        target_label,
+                        "tabdrag:merge-direct",
+                        &serde_json::json!({
+                            "tabId": ctx.tab_id,
+                            "fromWsId": ctx.source_ws_id,
+                            "sourceWindowLabel": ctx.source_label,
+                            "isLastTab": is_last_tab,
+                            "cursorX": cursor_x,
+                            "cursorY": cursor_y,
+                        }),
+                    );
+                }
+            }
+            return;
+        }
 
         match &candidate {
             Some(target_label) if target_label == &ctx.source_label => {

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -326,6 +326,19 @@ async fn route_command(
         "open_window_at_position" => commands::drag::open_window_at_position(state, args),
         "tear_off_pool_promote" => commands::drag::tear_off_pool_promote(state, args),
         "pool_window_ready" => commands::drag::pool_window_ready(state, args),
+        "start_tab_drag_tracking" => {
+            // spawn_blocking — blocks briefly (~ms) on the hook thread's
+            // install-ready channel, same rationale as
+            // tear_off_sc_move_handshake below.
+            let state_clone = state.clone();
+            let args_clone = args.clone();
+            tokio::task::spawn_blocking(move || {
+                commands::drag::start_tab_drag_tracking(&state_clone, &args_clone)
+            })
+            .await
+            .map_err(|e| format!("start_tab_drag_tracking join error: {}", e))?
+        }
+        "stop_tab_drag_tracking" => commands::drag::stop_tab_drag_tracking(),
         "pane_pool_window_ready" => commands::drag::pane_pool_window_ready(state, args),
         "tear_off_sc_move_handshake" => {
             // Wrap in spawn_blocking — the handler polls state.browsers

--- a/frontend/app/drag/DragOverlay.tsx
+++ b/frontend/app/drag/DragOverlay.tsx
@@ -14,6 +14,7 @@
 import { atoms, getApi } from "@/store/global";
 import { WorkspaceService } from "@/app/store/services";
 import { deleteLayoutModelForTab } from "@/layout/index";
+import { wasTabRecentlyMerged } from "@/app/tab/tabbar-dnd";
 import { Logger } from "@/util/logger";
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
@@ -98,6 +99,19 @@ function DragOverlay(): JSX.Element {
                         Logger.error("dnd:overlay", "MoveBlockToTab failed", { error: String(e) });
                     });
                 } else if (data.dragType === "tab" && data.payload.tabId) {
+                    // Cross-window tab remount dedup: if the host mouse
+                    // hook already merged this tab at a strip-accurate
+                    // index (tabdrag:merge-direct, handled in tabbar.tsx),
+                    // this legacy append-merge for the same gesture must
+                    // not run — the backend would reject it anyway (the
+                    // tab already left its claimed source workspace), but
+                    // skipping avoids a guaranteed error log per merge.
+                    if (wasTabRecentlyMerged(data.payload.tabId)) {
+                        Logger.info("dnd:overlay", "cross-window drop: tab already merged via strip drop, skipping", {
+                            tabId: data.payload.tabId,
+                        });
+                        return;
+                    }
                     Logger.info("dnd:overlay", "cross-window drop: moving tab into this window", {
                         tabId: data.payload.tabId,
                         sourceWsId: data.sourceWorkspaceId,

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -47,13 +47,15 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
     let tabWrapRef!: HTMLDivElement;
     const [isDragging, setIsDragging] = createSignal(false);
     const [naturalWidth, setNaturalWidth] = createSignal<number | null>(null);
-    // Own window label, fetched once — drives the lone-tab drag policy
-    // below (a standalone torn-off window's single tab must be draggable
-    // to remount it into another window; main's never is).
-    const [windowLabel, setWindowLabel] = createSignal<string | null>(null);
-    onMount(() => {
-        fireAndForget(async () => setWindowLabel(await getApi().getWindowLabel()));
-    });
+    // Own window label — drives the lone-tab drag policy below (a
+    // standalone torn-off window's single tab must be draggable to
+    // remount it into another window; main's never is). Read
+    // SYNCHRONOUSLY from the URL param (the same authoritative source
+    // app-init.ts uses) rather than the async getWindowLabel() IPC: a
+    // freshly torn-off window is exactly the primary use case, and an
+    // async fetch would leave its lone tab undraggable until the
+    // promise resolved. (reagent PR #2086 P2)
+    const windowLabel = new URLSearchParams(window.location.search).get("windowLabel") || "main";
     // Lone-tab drags are a REMOUNT-ONLY gesture (cross-window tab
     // remount, SPEC_CROSS_WINDOW_TAB_REMOUNT §4.3): reordering a single
     // tab is meaningless, and tearing it off would just leave an empty
@@ -84,9 +86,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
 
         const cleanupDraggable = draggable({
             element: tabWrapRef,
-            canDrag: () =>
-                props.allTabCount > 1 ||
-                (windowLabel() != null && windowLabel() !== "main"),
+            canDrag: () => props.allTabCount > 1 || windowLabel !== "main",
             getInitialData: () => ({
                 tabId: props.tabId,
                 workspaceId: props.workspaceId,
@@ -154,9 +154,8 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 // handshake's own hook install supersedes this session.
                 fireAndForget(async () => {
                     try {
-                        const sourceWindowLabel = await getApi().getWindowLabel();
                         await getApi().startTabDragTracking({
-                            sourceWindowLabel,
+                            sourceWindowLabel: windowLabel,
                             tabId: props.tabId,
                             sourceWsId: props.workspaceId,
                             isLastTab: props.allTabCount === 1,

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -26,6 +26,7 @@ import {
 import { getCurrentDragPayload, setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { getLayoutModelForTabById, redockDraggedPane, tileItemType } from "@/layout/index";
 import { getApi } from "@/store/global";
+import { fireAndForget } from "@/util/util";
 import { setTabGrabOffset } from "./tab-grab-offset";
 
 export interface DroppableTabProps {
@@ -46,6 +47,20 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
     let tabWrapRef!: HTMLDivElement;
     const [isDragging, setIsDragging] = createSignal(false);
     const [naturalWidth, setNaturalWidth] = createSignal<number | null>(null);
+    // Own window label, fetched once — drives the lone-tab drag policy
+    // below (a standalone torn-off window's single tab must be draggable
+    // to remount it into another window; main's never is).
+    const [windowLabel, setWindowLabel] = createSignal<string | null>(null);
+    onMount(() => {
+        fireAndForget(async () => setWindowLabel(await getApi().getWindowLabel()));
+    });
+    // Lone-tab drags are a REMOUNT-ONLY gesture (cross-window tab
+    // remount, SPEC_CROSS_WINDOW_TAB_REMOUNT §4.3): reordering a single
+    // tab is meaningless, and tearing it off would just leave an empty
+    // window behind — but dragging it onto ANOTHER window's strip is how
+    // a torn-off standalone window gets remounted. Allowed for every
+    // window except main (whose last tab must never leave, see spec).
+    const isLoneTabDrag = () => props.allTabCount === 1;
 
     // Gap before (left padding) — this tab is the afterTabId of the insertion point
     const gapBefore = createMemo(() => {
@@ -69,7 +84,9 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
 
         const cleanupDraggable = draggable({
             element: tabWrapRef,
-            canDrag: () => props.allTabCount > 1,
+            canDrag: () =>
+                props.allTabCount > 1 ||
+                (windowLabel() != null && windowLabel() !== "main"),
             getInitialData: () => ({
                 tabId: props.tabId,
                 workspaceId: props.workspaceId,
@@ -119,8 +136,35 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 setGlobalDragTabId(props.tabId);
                 setInsertionPoint(null);
                 setIsDragging(true);
-                setCurrentDragPayload({ kind: "tab", tabId: props.tabId, workspaceId: props.workspaceId });
+                // Lone-tab drags carry NO cross-window payload: the HTML5
+                // pipeline's outcomes for a tab (tear-off to a new window,
+                // append-merge via DragOverlay) are all wrong for a
+                // single-tab window — tear-off would strand an empty
+                // window. The host mouse hook below is the only consumer;
+                // release anywhere but another window's strip is a no-op.
+                if (!isLoneTabDrag()) {
+                    setCurrentDragPayload({ kind: "tab", tabId: props.tabId, workspaceId: props.workspaceId });
+                }
                 getApi().setJsDragActive(true).catch(() => {});
+                // Cross-window tab remount (SPEC_CROSS_WINDOW_TAB_REMOUNT
+                // §4.1): arm the host's global mouse hook for this drag so
+                // a release over another AgentMux window's strip emits
+                // tabdrag:merge-direct to it. No-op off-Windows. If the
+                // drag later crosses the tear-off threshold, the SC_MOVE
+                // handshake's own hook install supersedes this session.
+                fireAndForget(async () => {
+                    try {
+                        const sourceWindowLabel = await getApi().getWindowLabel();
+                        await getApi().startTabDragTracking({
+                            sourceWindowLabel,
+                            tabId: props.tabId,
+                            sourceWsId: props.workspaceId,
+                            isLastTab: props.allTabCount === 1,
+                        });
+                    } catch (e) {
+                        Logger.warn("dnd", "startTabDragTracking failed", { error: String(e) });
+                    }
+                });
                 Logger.info("dnd", "tab-drag started", {
                     tabId: props.tabId,
                     workspaceId: props.workspaceId,
@@ -131,6 +175,14 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 if (!isWindows()) preventUnhandled.stop();
                 setGlobalDragTabId(null);
                 setIsDragging(false);
+                // Belt-and-suspenders hook teardown. Ordinarily the hook
+                // self-uninstalled on the WM_LBUTTONUP that produced this
+                // dragend (LL hooks run before the event reaches the app),
+                // so this is a no-op; it matters for swallowed-dragend
+                // paths. Harmless for a superseding tear-off session too —
+                // that session's own WM_LBUTTONUP already retired it by
+                // the time any dragend fires.
+                fireAndForget(() => getApi().stopTabDragTracking());
                 // Do NOT clear setTabGrabOffset here. pragmatic-dnd's
                 // onDrop fires during the dragend event dispatch, BEFORE
                 // CrossWindowDragMonitor.win32.tsx::handleDragEnd runs.

--- a/frontend/app/tab/tabbar-dnd.test.ts
+++ b/frontend/app/tab/tabbar-dnd.test.ts
@@ -5,6 +5,9 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
     computeInsertIndex,
     computeNearestTab,
+    insertionPointToIndex,
+    markTabMerged,
+    wasTabRecentlyMerged,
     tabWrapperRefs,
     setGlobalDragTabId,
 } from "./tabbar-dnd";
@@ -235,5 +238,57 @@ describe("computeNearestTab", () => {
         // cursor at 60 — closest to tab-a (mid=50) but it's excluded
         // next closest: tab-b (mid=150, dist=90) over tab-c (mid=250, dist=190)
         expect(computeNearestTab(60, 15)?.tabId).toBe("tab-b");
+    });
+});
+
+// ── insertionPointToIndex ─────────────────────────────────────────────────────
+//
+// Cross-window merge/remount index conversion: the incoming tab is NOT in
+// `tabs`, so no removal-shift adjustment (SPEC_CROSS_WINDOW_TAB_REMOUNT §4.2).
+
+describe("insertionPointToIndex", () => {
+    const tabs = ["a", "b", "c"];
+
+    test("null insertion point appends at end", () => {
+        expect(insertionPointToIndex(null, tabs)).toBe(3);
+        expect(insertionPointToIndex(null, [])).toBe(0);
+    });
+
+    test("before the first tab inserts at 0", () => {
+        expect(insertionPointToIndex({ beforeTabId: null, afterTabId: "a" }, tabs)).toBe(0);
+    });
+
+    test("after the last tab appends at end", () => {
+        expect(insertionPointToIndex({ beforeTabId: "c", afterTabId: null }, tabs)).toBe(3);
+    });
+
+    test("between two tabs inserts at the afterTabId position", () => {
+        expect(insertionPointToIndex({ beforeTabId: "a", afterTabId: "b" }, tabs)).toBe(1);
+        expect(insertionPointToIndex({ beforeTabId: "b", afterTabId: "c" }, tabs)).toBe(2);
+    });
+
+    test("unknown afterTabId falls back to append", () => {
+        expect(insertionPointToIndex({ beforeTabId: "a", afterTabId: "ghost" }, tabs)).toBe(3);
+    });
+});
+
+// ── cross-window merge dedup ──────────────────────────────────────────────────
+
+describe("markTabMerged / wasTabRecentlyMerged", () => {
+    test("unmarked tab is not recently merged", () => {
+        expect(wasTabRecentlyMerged("never-marked")).toBe(false);
+    });
+
+    test("marked tab is recently merged within the window", () => {
+        markTabMerged("t1", 1_000_000);
+        expect(wasTabRecentlyMerged("t1", 1_000_100)).toBe(true);
+        expect(wasTabRecentlyMerged("t1", 1_004_999)).toBe(true);
+    });
+
+    test("mark expires after the dedup window and is pruned", () => {
+        markTabMerged("t2", 1_000_000);
+        expect(wasTabRecentlyMerged("t2", 1_006_000)).toBe(false);
+        // Pruned on the expired read — a later in-window read stays false.
+        expect(wasTabRecentlyMerged("t2", 1_000_100)).toBe(false);
     });
 });

--- a/frontend/app/tab/tabbar-dnd.ts
+++ b/frontend/app/tab/tabbar-dnd.ts
@@ -136,3 +136,46 @@ export function computeInsertIndex(
     const rawIndex = side === "left" ? targetIndex : targetIndex + 1;
     return sourceIndex < rawIndex ? rawIndex - 1 : rawIndex;
 }
+
+/**
+ * Convert an insertion point to a numeric index into `tabs` for a tab
+ * arriving from ANOTHER workspace (cross-window merge / remount). The
+ * incoming tab isn't in `tabs`, so no removal-shift adjustment is needed
+ * (unlike computeInsertIndex above, which handles in-strip reorders).
+ * A null insertion point (or unknown afterTabId) appends at the end.
+ */
+export function insertionPointToIndex(ip: InsertionPoint | null, tabs: string[]): number {
+    if (!ip) return tabs.length;
+    if (ip.beforeTabId === null) return 0;
+    if (ip.afterTabId === null) return tabs.length;
+    const idx = tabs.indexOf(ip.afterTabId);
+    return idx < 0 ? tabs.length : idx;
+}
+
+// ── Cross-window merge dedup ────────────────────────────────────────────────
+// A direct cross-window tab remount (tabdrag:merge-direct, emitted by the
+// host's mouse hook) and the legacy HTML5 cross-drag pipeline
+// (DragOverlay's cross-drag-end → MoveTabToWorkspace) can BOTH fire for
+// one gesture — the hook resolves on WM_LBUTTONUP while the source
+// window's dragend independently drives the cross-drag pipeline. Both
+// handlers run in the TARGET window, so a same-context recency mark is
+// enough to make the second one a no-op. The backend would reject the
+// duplicate anyway (the tab has already left its claimed source
+// workspace), but deduping here avoids a guaranteed error-log per merge.
+
+const MERGE_DEDUP_WINDOW_MS = 5000;
+const recentTabMerges = new Map<string, number>();
+
+export function markTabMerged(tabId: string, now: number = Date.now()): void {
+    recentTabMerges.set(tabId, now);
+}
+
+export function wasTabRecentlyMerged(tabId: string, now: number = Date.now()): boolean {
+    const at = recentTabMerges.get(tabId);
+    if (at === undefined) return false;
+    if (now - at > MERGE_DEDUP_WINDOW_MS) {
+        recentTabMerges.delete(tabId);
+        return false;
+    }
+    return true;
+}

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -28,6 +28,8 @@ import {
     bouncingTabId,
     setBouncingTabId,
     computeInsertionPoint,
+    insertionPointToIndex,
+    markTabMerged,
     InsertionPoint,
     tabWrapperRefs,
     setHoveredDropTabId,
@@ -196,7 +198,13 @@ function TabBar(props: TabBarProps): JSX.Element {
             onDrag: ({ source, location }) => {
                 const input = location.current.input;
                 const rect = tabBarScrollRef?.getBoundingClientRect();
-                if (rect && !tearOffFired && input.clientY > rect.bottom + TEAR_PAST_PX) {
+                // tabIds().length > 1: a LONE tab can now be dragged
+                // (remount-only gesture — see DroppableTab.canDrag), but
+                // tearing it off would just trade one single-tab window
+                // for another and strand the empty source. Lone-tab drags
+                // never tear off; their only exit is a cross-window
+                // remount via the host mouse hook.
+                if (rect && !tearOffFired && tabIds().length > 1 && input.clientY > rect.bottom + TEAR_PAST_PX) {
                     tearOffFired = true;
                     const draggedTabId = source.data.tabId as string;
                     const wsId = props.workspace?.oid;
@@ -534,23 +542,10 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 setInsertionPoint(null);
                                 return;
                             }
-                            const ip = computeInsertionPoint(clientX);
-                            const tabs = tabIds();
-                            // Convert insertion point to numeric index. The
-                            // dragged tab isn't in `tabs` (different workspace),
-                            // so no removal-shift adjustment needed (unlike
-                            // executeReorder above).
-                            let insertIdx: number;
-                            if (!ip) {
-                                insertIdx = tabs.length;
-                            } else if (ip.beforeTabId === null) {
-                                insertIdx = 0;
-                            } else if (ip.afterTabId === null) {
-                                insertIdx = tabs.length;
-                            } else {
-                                insertIdx = tabs.indexOf(ip.afterTabId);
-                                if (insertIdx < 0) insertIdx = tabs.length;
-                            }
+                            const insertIdx = insertionPointToIndex(
+                                computeInsertionPoint(clientX),
+                                tabIds(),
+                            );
                             // Tear-off workspaces always carry exactly one
                             // tab, so MoveTabToWorkspace's last-tab guard
                             // would reject this. RestoreTornOffTab bypasses
@@ -582,6 +577,108 @@ function TabBar(props: TabBarProps): JSX.Element {
             trackOrDispose(
                 await listenEvent("tearoff:standalone", (payload) => {
                     Logger.info("dnd", "tearoff:standalone", payload);
+                }),
+            );
+
+            // Cross-window tab remount (SPEC_CROSS_WINDOW_TAB_REMOUNT §4.2):
+            // a tab dragged directly from another window was released over
+            // THIS window (host mouse hook, TabDrag mode). Unlike
+            // tearoff:merge, the tab still lives in its original multi-tab
+            // workspace — no temporary tear-off workspace exists — so the
+            // multi-tab path uses MoveTabToWorkspace (its last-tab guard is
+            // desirable) and only the last-tab path uses RestoreTornOffTab
+            // (which bypasses the guard and deletes the emptied workspace).
+            trackOrDispose(
+                await listenEvent<{
+                    tabId: string;
+                    fromWsId: string;
+                    sourceWindowLabel: string;
+                    isLastTab: boolean;
+                    cursorX: number;
+                    cursorY: number;
+                }>("tabdrag:merge-direct", (payload) => {
+                    setInsertionPoint(null);
+                    fireAndForget(async () => {
+                        try {
+                            const ownWsId = props.workspace?.oid;
+                            if (!ownWsId) {
+                                Logger.warn("dnd", "tabdrag:merge-direct — no own workspace, skipping", payload);
+                                return;
+                            }
+                            if (payload.fromWsId === ownWsId) {
+                                // Shouldn't happen (hook excludes the source
+                                // window), but a same-workspace "move" would
+                                // reorder-to-end; bail defensively.
+                                return;
+                            }
+                            // Strip-area hit test, same as tearoff:merge:
+                            // releasing over this window's CONTENT area is
+                            // not a header drop. The legacy cross-drag
+                            // pipeline (DragOverlay) still handles that
+                            // case as an append-merge, unchanged.
+                            const stripRect = tabBarScrollRef?.getBoundingClientRect();
+                            const clientX = physicalToClientX(payload.cursorX);
+                            const clientY = physicalToClientY(payload.cursorY);
+                            if (
+                                !stripRect ||
+                                clientY < stripRect.top ||
+                                clientY > stripRect.bottom
+                            ) {
+                                Logger.info("dnd", "tabdrag:merge-direct — cursor not over strip, ignoring", payload);
+                                return;
+                            }
+                            const insertIdx = insertionPointToIndex(
+                                computeInsertionPoint(clientX),
+                                tabIds(),
+                            );
+                            // Never close the main window (SPEC §4.3): a
+                            // 1-tab main's last tab stays put rather than
+                            // feeding the last-window quit sequence.
+                            if (payload.isLastTab && payload.sourceWindowLabel === "main") {
+                                Logger.info(
+                                    "dnd",
+                                    "tabdrag:merge-direct — declining last tab of main window",
+                                    payload,
+                                );
+                                return;
+                            }
+                            // Mark BEFORE the awaits — DragOverlay's
+                            // cross-drag-end for the same gesture arrives
+                            // while these RPCs are in flight, and the mark
+                            // is what makes it a no-op.
+                            markTabMerged(payload.tabId);
+                            if (payload.isLastTab) {
+                                await WorkspaceService.RestoreTornOffTab(
+                                    payload.tabId,
+                                    payload.fromWsId,
+                                    ownWsId,
+                                    insertIdx,
+                                );
+                                await getApi().closeWindowByLabel(payload.sourceWindowLabel);
+                            } else {
+                                await WorkspaceService.MoveTabToWorkspace(
+                                    payload.tabId,
+                                    payload.fromWsId,
+                                    ownWsId,
+                                    insertIdx,
+                                );
+                            }
+                            setBouncingTabId(payload.tabId);
+                            setTimeout(() => setBouncingTabId(null), 400);
+                            Logger.info("dnd", "tabdrag:merge-direct complete", {
+                                tabId: payload.tabId,
+                                fromWsId: payload.fromWsId,
+                                ownWsId,
+                                insertIdx,
+                                isLastTab: payload.isLastTab,
+                            });
+                        } catch (e) {
+                            Logger.error("dnd", "tabdrag:merge-direct failed", {
+                                error: String(e),
+                                payload,
+                            });
+                        }
+                    });
                 }),
             );
 

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -269,6 +269,21 @@ declare global {
          *  merge to clean up the dragged window after its tab is moved
          *  into the destination workspace. */
         closeWindowByLabel: (label: string) => Promise<void>;
+        /** Cross-window tab remount (SPEC_CROSS_WINDOW_TAB_REMOUNT §4.1):
+         *  arm the global mouse hook for an ordinary in-strip tab drag.
+         *  On release over another AgentMux window, that window receives
+         *  `tabdrag:merge-direct`. No-op on non-Windows. */
+        startTabDragTracking: (args: {
+            sourceWindowLabel: string;
+            tabId: string;
+            sourceWsId: string;
+            isLastTab: boolean;
+        }) => Promise<void>;
+        /** Belt-and-suspenders hook teardown at dragend — the hook
+         *  self-uninstalls on mouseup/ESC, but a leaked WH_MOUSE_LL hook
+         *  degrades every mouse event on the system, so dragend calls
+         *  this unconditionally. Idempotent. */
+        stopTabDragTracking: () => Promise<void>;
         setDragCursor: () => Promise<void>;
         restoreDragCursor: () => Promise<void>;
         releaseDragCapture: () => Promise<void>;

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -721,6 +721,12 @@ export function buildCefApi(): AppApi {
         closeWindowByLabel: async (label: string) => {
             await invokeCommand("close_window_by_label", { label });
         },
+        startTabDragTracking: async (args) => {
+            await invokeCommand("start_tab_drag_tracking", args);
+        },
+        stopTabDragTracking: async () => {
+            await invokeCommand("stop_tab_drag_tracking");
+        },
 
         // --- Drag cursor & helpers ---
         setDragCursor: async () => {

--- a/specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md
+++ b/specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md
@@ -1,0 +1,164 @@
+# Spec: Cross-Window Tab Remount (Drag a Tab onto Another Window's Header)
+
+**Date:** 2026-07-11
+**Status:** Draft
+**Repo state:** `main` @ `7642454a`
+**Scope:** Dragging a TAB from window A's tab strip and dropping it onto window B's tab strip ("header part"), remounting the tab — with all its panes, layout, and ordering — into window B at a cursor-accurate position. Pane (tile) drags, touch/pen input, and non-AgentMux drop targets are out of scope.
+
+---
+
+## 1. Problem
+
+Tabs can already leave a window: dragging a tab past the strip's bottom edge (`TEAR_PAST_PX = 5`) tears it off into a new window. But there is no *direct* way to move a tab from window A into window B. What a user naturally tries — grab a tab, drag it over window B's tab strip, release — either does nothing useful or, if they happen to pass the tear-off threshold on the way, spawns a throwaway intermediate window they never asked for.
+
+The surprising finding from code investigation: **the hard part already exists.** A full cross-window merge is implemented and working on Windows — but only as the tail end of the tear-off state machine:
+
+1. Drag tab down past the strip → `requestTearOff` spins up a new window (`TearOffTab` saga → warm-pool promote / `openWindowAtPosition` → `tearOffSCMoveHandshake`).
+2. A Win32 `WH_MOUSE_LL` hook (`agentmux-cef/src/commands/tear_off_hook.rs`) then tracks the cursor globally. Hovering another AgentMux window emits `tearoff:hover-changed` to it — which already shows the **standard insertion-point indicator** in that window's strip (`tabbar.tsx` handler → `computeInsertionPoint(clientX)`).
+3. Releasing over that window emits `tearoff:merge`, whose handler (`tabbar.tsx:503-580`) computes the cursor-X-accurate insert index and calls `WorkspaceService.RestoreTornOffTab(tabId, fromWsId, ownWsId, insertIdx)` — moving the tab (blocks + layout travel automatically, see §2.3) and closing the emptied dragged window.
+
+So "drag a tab into another window's header" today means: **tear off into a temporary window first, then drag that window over the target strip**. The remount machinery is solid; the *gesture* is wrong. This spec is about giving the existing merge a first-class direct path — and extending it beyond Windows.
+
+---
+
+## 2. Current Architecture (What Exists — Reuse, Don't Reinvent)
+
+### 2.1 The tear-off state machine (Windows, shipped)
+
+Phases per `docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md` (whose "Phases 2-7 not started" header is stale — Phases 2/4/5/6 are in code):
+
+- **Trigger** (`tabbar.tsx:196-310`): pragmatic-dnd monitor `onDrag`, latched by `tearOffFired`, fires `requestTearOff` when the cursor passes `TEAR_PAST_PX` below the strip.
+- **Host hook** (`tear_off_hook.rs`): installed by `tear_off_sc_move_handshake` (`drag.rs:634-643`) *before* the SC_MOVE post. `WH_MOUSE_LL` + `WH_KEYBOARD_LL` on a dedicated thread. Per mouse-move: `WindowFromPoint` → `GetAncestor(GA_ROOT)` → match against the host browser registry (`candidate_label_under_cursor_locked`, `tear_off_hook.rs:521-556`) → emit `tearoff:hover-changed`/`hover-cleared` to the right window via `emit_event_to_window` (`events.rs:84-105`). On `WM_LBUTTONUP`: `tearoff:merge` (over another window), `tearoff:cancel-back` (over source strip, or ESC), or `tearoff:standalone` (over nothing).
+- **Frontend handlers** (`tabbar.tsx:437-679`): every window listens. `hover-changed` drives the standard insertion-point gap indicator; `merge` computes `insertIdx` and calls `RestoreTornOffTab`; `cancel-back` restores the exact original index (`originalTabIndex`/`wasPinned` captured at drag start).
+- **Strip hit-testing is frontend-side only.** The host resolves cursor → top-level window label; whether the cursor is over the *strip* (vs. content) is decided in each renderer by `cursorY` vs `tabBarScrollRef.getBoundingClientRect()` with physical→CSS px conversion. There is no host-side strip-rect registration.
+
+### 2.2 Backend tab-move (shipped, platform-agnostic)
+
+- `Command::MoveTab` reducer (`agentmux-srv/src/reducer/tab.rs:341-449`): removes the tab id from the source workspace's `tab_ids`, inserts into the destination's at a clamped index, reparents `tab.workspace_id`, emits `TabMoved`. **Blocks and layout state are children of the Tab object — they travel automatically.** Nothing about a tab move touches `blockids` or `layoutstate`.
+- `RestoreTornOffTab` RPC (`workspace.rs:956-1015`) → `restore_torn_off_tab` saga: `MoveTab`, then best-effort `DeleteWorkspace` of the now-empty source. Exists specifically because `MoveTabToWorkspace` (`workspace.rs:849-950`) has a **last-tab guard** that rejects moving a workspace's only tab.
+- `MoveTabToWorkspace` RPC: the general path for multi-tab source workspaces; honors `insertIndex` (clamped); same-workspace short-circuit.
+
+### 2.3 The HTML5 cross-window drag path (legacy for tabs)
+
+`CrossWindowDragMonitor.{win32,darwin,linux}.tsx` + `DragOverlay.tsx`: on a tab drag's `dragend` over another window, the target's `DragOverlay` calls `MoveTabToWorkspace(tabId, sourceWsId, myWsId)` — **no insert index, no strip hit-test** (drops anywhere on the window merges into the active workspace at the end of the strip). On Windows this path is dead for tabs: `requestTearOff` clears `currentDragPayload` at the tear-off threshold precisely so this pipeline doesn't double-process. On macOS/Linux it is the *only* cross-window tab path today.
+
+### 2.4 Known constraint: SC_MOVE doesn't visually engage mid-drag
+
+Per `SPEC_TAB_TEAROFF_NATIVE_DRAG_LOOP_2026-05-07.md` (spec-only, never built): during the HTML5/OLE drag, mouse capture belongs to the source webview, so the torn-off window does not visually follow the cursor — it materializes on mouseup. The `WH_MOUSE_LL` hook still tracks correctly (hover/merge events flow), but the user sees only the OS drag ghost mid-gesture. Any design here must not assume a live window under the cursor.
+
+---
+
+## 3. Goals
+
+1. **Direct gesture**: drag a tab from window A's strip, hover window B's strip → B shows its standard insertion-point indicator live; release → the tab remounts into B at that index. No intermediate throwaway window is created when the drop lands on another window's strip.
+2. Source window keeps working: A stays open if it has other tabs; if the moved tab was A's last, A closes (same policy as merge-today's `closeWindowByLabel` on the emptied dragged window).
+3. Cancel semantics preserved: ESC or dropping back on A's own strip = plain reorder / no-op, never a cross-window move.
+4. Works with the existing tear-off: dragging *down* past the threshold still tears off to a new window (unchanged); the two gestures compose because they share one state machine.
+5. Cross-platform story stated explicitly (win32 first-class; darwin/linux at least reach the `MoveTabToWorkspace`-with-index path).
+
+## Non-Goals
+
+- Making the torn-off window visually follow the cursor (that's `SPEC_TAB_TEAROFF_NATIVE_DRAG_LOOP`'s scope; this spec works with the OS drag ghost).
+- Pane (tile) drags between windows (covered by floating-pane redock + `SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` for in-window).
+- Merging into a *specific tab's layout* (that's a pane-level concept); a tab drop always lands as a sibling tab.
+- Host-side strip-rect registry (nice-to-have hardening; the frontend-side hit-test is kept, see §4.4).
+
+---
+
+## 4. Design
+
+The core idea: **run the tear-off hook for every tab drag, not just after a tear-off** — and defer the "which outcome?" decision to release time.
+
+### 4.1 Deferred-outcome drag
+
+Today the state machine commits to tear-off the moment the cursor passes `TEAR_PAST_PX` (spawns a window mid-drag). Keep that for the downward gesture, but add a parallel *cross-window intent* track:
+
+- On tab-drag start (`DroppableTab.onDragStart`), ask the host to `start_tab_drag_tracking(sourceLabel, tabId, sourceWsId, originalTabIndex)` — a trimmed variant of `start_tear_off_tracking` that installs the same `WH_MOUSE_LL` hook but with **no dragged/destination window** (none exists yet).
+- The hook's per-move logic is unchanged (candidate window under cursor → `tearoff:hover-changed`/`hover-cleared` to it). Window B's existing handler already renders the insertion indicator — zero frontend changes on the target side for hover.
+- On `WM_LBUTTONUP` over a candidate window ≠ source: emit a new **`tabdrag:merge-direct`** event to the candidate, payload `{tabId, fromWsId: sourceWsId, sourceWindowLabel, cursorX, cursorY}`. (Distinct from `tearoff:merge` because the source workspace is a *normal multi-tab* workspace, not a single-tab tear-off orphan.)
+- Over the source window or nothing: emit nothing — the normal in-window pragmatic-dnd reorder / tear-off threshold logic owns those outcomes, exactly as today. The hook must NOT interfere with in-window reorders.
+
+### 4.2 The merge-direct handler (target window)
+
+New branch alongside the `tearoff:merge` handler in `tabbar.tsx`, ~90% shared code:
+
+1. Strip hit-test cursorY (same as `tearoff:merge` — release over B's *content* area is not a tab drop; ignore, and the source's dragend cleanup handles payload clearing).
+2. `insertIdx = computeInsertionPoint(clientX)` → numeric index (shared helper with the existing merge handler — extract the `{beforeTabId, afterTabId}` → index conversion at `tabbar.tsx:537-553` into `tabbar-dnd.ts`).
+3. Call **`MoveTabToWorkspace(tabId, fromWsId, ownWsId, insertIdx)`** — not `RestoreTornOffTab`: the source workspace is a live multi-tab workspace, and the last-tab guard is *desirable* here... with one amendment, §4.3.
+4. Notify the source window (`tabdrag:merged` targeted event) so it can cancel its in-flight pragmatic-dnd bookkeeping (clear `globalDragTabId`, insertion point, payload) and, if it just lost its last tab, close itself.
+
+### 4.3 The last-tab case
+
+`MoveTabToWorkspace`'s guard rejects moving a workspace's only tab (it would strand an empty workspace/window). For a direct cross-window drag of window A's only tab, the right UX is: move the tab AND close window A — functionally identical to today's merge-after-tear-off. Two options:
+
+- **(a) Reuse `RestoreTornOffTab`** for the single-tab case (it exists to bypass the guard and delete the emptied workspace). The frontend picks the RPC by `tabIds().length === 1` at drag start (carried in the hook payload).
+- **(b) Add an `allowLastTab: bool` param to `MoveTabToWorkspace`** that routes through the same saga machinery.
+
+**(a) is recommended** — zero backend changes, the saga already handles workspace deletion best-effort, and semantically "the source workspace ends up empty and gets deleted" is exactly the torn-off-restore contract. The source window closes via the same empty-workspace watcher / `closeWindowByLabel` pattern the merge handler uses today.
+
+### 4.4 Hook lifetime + safety
+
+- `start_tab_drag_tracking` installs on tab-drag start and MUST uninstall on: `WM_LBUTTONUP` (any outcome), ESC, or a `stop_tab_drag_tracking` call from the frontend's dragend (belt-and-suspenders — a hook leak eats global mouse events).
+- If the drag crosses `TEAR_PAST_PX` and `requestTearOff` fires, the tear-off handshake *replaces* the tracking session (its own `start_tear_off_tracking` takes over with the dragged/dest window populated). One session at a time; `start_tear_off_tracking` already tears down a prior hook if present — verify and test this handover.
+- The hook thread already exists and is proven (Phase 4); this adds a second entry point with fewer parameters, not a new mechanism.
+- DPI: cursor coords are physical px; the frontend converts (existing `physicalToClientX/Y` helpers). Multiple past review fixes in this area — reuse the helpers, don't re-derive.
+
+### 4.5 Platform strategy
+
+- **Windows**: full design above (§4.1–§4.4).
+- **macOS/Linux (interim)**: no global hook (Phase 7 stubs). But the HTML5 `CrossWindowDragMonitor` → `DragOverlay` path already fires for tab drags there. Upgrade `DragOverlay`'s tab branch from "append to active workspace, no index" to: forward the drop's cursor position to the tab bar (window-local hit-test), compute `insertIdx` when over the strip, and pass it to `MoveTabToWorkspace`. This gives darwin/linux a functional (if indicator-less mid-drag) version of the feature with purely frontend changes.
+- **macOS/Linux (full)**: blocked on Phase 7 of the tear-off spec (CGEventTap / XQueryPointer trackers). Out of scope here; this spec's hook entry point is designed so those trackers plug into the same `tabdrag:*` events when they land.
+
+### 4.6 UX details
+
+- Hover indicator on B: the existing insertion-point gap (no new visuals). The `tearoff:hover-changed` handler already ignores non-strip hover — unchanged.
+- The dragged tab in A keeps its existing reduced-opacity `tab-dragging` styling; A's own strip continues showing its in-window reorder gap while the cursor is over A. When the cursor is over B, A's insertion point clears (the hook's `hover-cleared` to the previous target covers the B→A transition; A-local pragmatic-dnd covers its own).
+- Landing bounce: reuse `bouncingTabId` on the remounted tab in B (same as reorder), giving drop feedback.
+
+---
+
+## 5. Files Touched
+
+| File | Change |
+|---|---|
+| `agentmux-cef/src/commands/tear_off_hook.rs` | New `start_tab_drag_tracking` entry (no dragged/dest window); `handle_button_up` branch emitting `tabdrag:merge-direct`; teardown-on-handover to `start_tear_off_tracking`; fix the stale `tearoff:finalize` header comment |
+| `agentmux-cef/src/commands/drag.rs` (or new command) | IPC command pair `start_tab_drag_tracking` / `stop_tab_drag_tracking` exposed to the frontend |
+| `frontend/app/tab/droppable-tab.tsx` | Tab-drag start/end: invoke start/stop tracking IPC |
+| `frontend/app/tab/tabbar.tsx` | `tabdrag:merge-direct` handler (shared core with `tearoff:merge`); `tabdrag:merged` source-side cleanup handler; single-tab → `RestoreTornOffTab` routing |
+| `frontend/app/tab/tabbar-dnd.ts` | Extract shared insertion-point→index conversion used by both merge handlers |
+| `frontend/app/drag/DragOverlay.tsx` | darwin/linux interim: strip hit-test + `insertIndex` for the tab branch |
+| `agentmux-srv` | **No changes** (option (a) in §4.3) |
+
+---
+
+## 6. Implementation Order
+
+1. Extract + unit-test the insertion-point→index conversion from the `tearoff:merge` handler (pure refactor, no behavior change).
+2. Host: `start/stop_tab_drag_tracking` + `tabdrag:merge-direct` emission; verify hook handover when `requestTearOff` fires mid-session (the one genuinely new race).
+3. Frontend: wire drag start/end IPC + the `merge-direct`/`merged` handlers; multi-tab source path (`MoveTabToWorkspace` with index).
+4. Single-tab source path (`RestoreTornOffTab` + source-window close).
+5. darwin/linux interim upgrade in `DragOverlay`.
+6. Manual matrix: A→B multi-tab, A→B last-tab (A closes), drop on B's content area (no-op), ESC mid-drag, drag down (tear-off unchanged), rapid A→B→A hover transitions (indicator cleanup), DPR ≠ 1 monitors.
+
+---
+
+## 7. Testing Guidance
+
+- Unit: insertion-point→index conversion (extracted helper) — cursor before first tab, between tabs, after last, empty target strip.
+- Unit (Rust): `handle_button_up` outcome matrix for the new tracking mode — over source / other window / nothing / ESC.
+- Integration: `tabdrag:merge-direct` handler calls `MoveTabToWorkspace` with the computed index for a multi-tab source, `RestoreTornOffTab` for single-tab.
+- Regression: existing tear-off flow (down-drag → new window), merge-after-tear-off, and cancel-back all unchanged — they share the hook, so cover the handover explicitly.
+- Diag: both merge paths log under `dnd` — verify via `muxlog srv grep RestoreTornOffTab` / `MoveTab`.
+
+---
+
+## 8. References
+
+- `docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md` — master tear-off spec (phase model; header stale re: shipped phases).
+- `docs/specs/SPEC_TAB_TEAROFF_NATIVE_DRAG_LOOP_2026-05-07.md` — why the window doesn't follow the cursor mid-drag (spec-only).
+- `docs/specs/SPEC_TAB_TEAROFF_POSITION_AND_PAINT_2026-05-07.md` — `TEAR_PAST_PX`, anchor math.
+- `docs/specs/SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md` — warm-pool window creation.
+- `agentmux-cef/src/commands/tear_off_hook.rs` — the WH_MOUSE_LL hook this spec extends.
+- `agentmux-srv/src/sagas/restore_torn_off_tab.rs`, `agentmux-srv/src/reducer/tab.rs` (`handle_move_tab`) — the move machinery reused as-is.
+- `frontend/app/tab/tabbar.tsx:437-679` — the Phase-4 event handlers the new events slot into.
+- `specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` — the in-window sibling feature (pane→tab); its §7 payload-clearing rules also apply to any new drop consumption added here.

--- a/specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md
+++ b/specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md
@@ -1,7 +1,7 @@
 # Spec: Cross-Window Tab Remount (Drag a Tab onto Another Window's Header)
 
 **Date:** 2026-07-11
-**Status:** Draft
+**Status:** Draft (v2 — open questions resolved against the Pillar 2 lifecycle refactor, §9)
 **Repo state:** `main` @ `7642454a`
 **Scope:** Dragging a TAB from window A's tab strip and dropping it onto window B's tab strip ("header part"), remounting the tab — with all its panes, layout, and ordering — into window B at a cursor-accurate position. Pane (tile) drags, touch/pen input, and non-AgentMux drop targets are out of scope.
 
@@ -94,7 +94,11 @@ New branch alongside the `tearoff:merge` handler in `tabbar.tsx`, ~90% shared co
 - **(a) Reuse `RestoreTornOffTab`** for the single-tab case (it exists to bypass the guard and delete the emptied workspace). The frontend picks the RPC by `tabIds().length === 1` at drag start (carried in the hook payload).
 - **(b) Add an `allowLastTab: bool` param to `MoveTabToWorkspace`** that routes through the same saga machinery.
 
-**(a) is recommended** — zero backend changes, the saga already handles workspace deletion best-effort, and semantically "the source workspace ends up empty and gets deleted" is exactly the torn-off-restore contract. The source window closes via the same empty-workspace watcher / `closeWindowByLabel` pattern the merge handler uses today.
+**(a) is recommended** — zero backend changes, the saga already handles workspace deletion best-effort, and semantically "the source workspace ends up empty and gets deleted" is exactly the torn-off-restore contract.
+
+**Closing the source window — be precise about the mechanism** (verified against the Pillar 2 lifecycle refactor, §9): there is **no** host-side "empty-workspace watcher" that closes windows automatically. The existing `tearoff:merge` handler closes the emptied window *explicitly* — `RestoreTornOffTab` (deletes the emptied source workspace) then `getApi().closeWindowByLabel(draggedWindowLabel)` (`tabbar.tsx:559-565`) — and that explicit call is required, not redundant: the host's `orphan_reconcile` has zero visibility into srv workspaces/tab counts and will never reap a live window because its workspace emptied. Copy that exact two-step pattern.
+
+**Precondition: never `closeWindowByLabel("main")`.** If the dragged tab's source is a 1-tab `main` window, closing `main` feeds the host's last-window quit sequence (`CloseWindowTask` scopes its park/demote logic to non-main windows). Simplest rule: when the source is `main` AND it's the last tab, treat the drop as a no-op (or move-and-leave-main-open via option (b)) — decide at implementation time, but don't fall into quitting the app accidentally.
 
 ### 4.4 Hook lifetime + safety
 
@@ -162,3 +166,54 @@ New branch alongside the `tearoff:merge` handler in `tabbar.tsx`, ~90% shared co
 - `agentmux-srv/src/sagas/restore_torn_off_tab.rs`, `agentmux-srv/src/reducer/tab.rs` (`handle_move_tab`) — the move machinery reused as-is.
 - `frontend/app/tab/tabbar.tsx:437-679` — the Phase-4 event handlers the new events slot into.
 - `specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` — the in-window sibling feature (pane→tab); its §7 payload-clearing rules also apply to any new drop consumption added here.
+- `docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md` — the quit/drain lifecycle this spec's window-close path now runs through (§9).
+
+---
+
+## 9. Resolved Questions (2026-07-11, reconciled against the Pillar 2 lifecycle refactor)
+
+Pillar 2 ("sanitize-then-decide", PRs #2080/#2081/#2084/#2083) landed a major rework of
+the host's quit/drain lifecycle while this spec was in review. Verified findings:
+
+**File overlap: nil.** Pillar 2 touches only `client/lifecycle.rs`, `reducer/{quit,browsers}.rs`,
+`ui_tasks/window.rs`, `commands/{orphan_reconcile,window_pool}.rs`, `wrr/win_event.rs`, `state.rs`.
+None of this spec's files (`tabbar.tsx`, `drag.rs`, `tear_off_hook.rs`, `DragOverlay.tsx`) are
+affected. The only shared surface is behavioral, below.
+
+**Q1 — Is closing the emptied source window safe post-Pillar-2? YES.**
+`closeWindowByLabel` is unchanged. Its WM_CLOSE lands in `CloseWindowTask` →
+`unregister_after_parking_close` (`ui_tasks/window.rs:364-385`), which now consumes the
+reducer's drain verdict. In a merge, the target window B is still live, so
+`should_begin_drain` (`reducer/quit.rs:170-186`) returns `None` — no spurious quit, no race.
+The new invariant we *rely on* rather than fear: if a remount ever leaves **zero** live user
+windows, the host now definitively begins Stage-1 drain + WRR Stage-2 quit — correct behavior,
+not a bug. Hence the `main`-window precondition in §4.3.
+
+**Q2 — "start_tear_off_tracking unreachable on the warm-pool path" (ANALYSIS_PANE_TAB_TEAR_SMOKE_2026_06_19): STALE, verified false on Windows.**
+`requestTearOff` calls `tearOffSCMoveHandshake` with `tabId`/`sourceWsId`/`destWsId` on *both*
+the warm-pool and cold paths (`tabbar.tsx:1038-1055`), and `drag.rs:633-644` installs the hook
+whenever those are non-empty. The "unreachable" flag conflated the Windows installer
+(`tear_off_hook.rs:102`) with the `#[cfg(not(windows))]` no-op stub (`tear_off_hook.rs:236`),
+which is legitimately inert off-Windows. §4.4's handover concern stands, but it's a
+*new-code* concern (two installers, one hook slot), not an existing bug.
+
+**Q3 — Does the new `orphan_reconcile` auto-close or resurrect an emptied window? NEITHER.**
+Terminology collision: Pillar 2's `orphan_reconcile` reconciles the host's `browsers`↔HWND
+projection (dead/hostless HWNDs) — it never inspects srv workspaces or tab counts, never
+closes a live window, never adopts one. The explicit `closeWindowByLabel` in the merge
+handler is therefore required and un-raced. This spec's "orphan *workspaces*" (windowless
+srv rows left by `requestTearOff` failures, `tabbar.tsx:1071-1090`) are a separate srv-side
+concern, untouched by Pillar 2; `RestoreTornOffTab`'s atomic move+delete means this feature
+creates no new ones on the happy path and inherits the existing conservative
+leave-the-orphan stance on failure.
+
+**Q4 — Is there now a canonical "close this window, its workspace emptied" primitive we should
+use instead? NO.** `BeginDrain`/`ReconcileQuit` are whole-host quit machinery, not per-window
+closes. `RestoreTornOffTab` + `closeWindowByLabel` (§4.3) remains the sanctioned pattern —
+Pillar 2 makes it *safer* (the close path's drain verdict is now consumed uniformly), not
+different.
+
+One classification note for implementers: a *promoted pool* window keeps its `window-pool-*`
+label forever but IS a live user window (`BrowserKind::TopLevel { is_pool: false }`,
+`reducer/quit.rs:130-132`). Any logic in this feature that reasons about the source/target
+window must classify by browser kind, never by label prefix.


### PR DESCRIPTION
## Summary
Spec + implementation for dragging a TAB from window A onto window B's tab strip and remounting it there, at a cursor-accurate position — including remounting torn-off standalone windows.

**Spec** (`specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md`): key finding was that the cross-window merge already existed on Windows as the tail end of the tear-off state machine (WH_MOUSE_LL hook → `tearoff:hover-changed`/`tearoff:merge` → `RestoreTornOffTab`); the spec promotes it to a first-class direct gesture. §9 reconciles the open questions against the Pillar 2 lifecycle refactor (verified: explicit `closeWindowByLabel` is required and safe; never close `main`; the stale "hook unreachable on warm-pool path" analysis note is false).

**Implementation**:
- The tear-off hook gains `HookMode::TabDrag`, armed for every tab drag via new `start/stop_tab_drag_tracking` IPC. Release over another window's strip → `tabdrag:merge-direct` to it; every other outcome stays with the existing pipelines. One session at a time (`ACTIVE_HOOK_THREAD`); a mid-drag tear-off supersedes the session; ESC retires it silently.
- Target handler: strip hit-test → cursor-accurate index (`insertionPointToIndex`, extracted from and shared with the `tearoff:merge` handler) → `MoveTabToWorkspace` (multi-tab source) or `RestoreTornOffTab` + `closeWindowByLabel` (lone tab; `main` excluded). Hover indicator came free — the hook's existing hover events already drive it.
- **Lone-tab drags enabled** (previously `canDrag` required >1 tab) as a remount-only gesture: no HTML5 payload, no tear-off threshold, `main` excluded. This is what makes a torn-off standalone window remountable.
- Double-processing guard: target marks merged tabs; `DragOverlay`'s legacy append-merge skips them (5s window).
- No `agentmux-srv` changes; hook remains win32-only (Phase 7 stubs untouched); off-Windows behavior unchanged.

## Test plan
- [x] `cargo check --release -p agentmux-cef` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/ frontend/layout/` — 1601/1601 passing (11 new: `insertionPointToIndex` ×5, merge-dedup ×3, `computeMoveNode` ×3)
- [ ] Manual (Windows, two windows): drag tab A→B strip → B shows insertion gap live, release remounts at that index; drag a torn-off standalone window's lone tab onto another strip → remounts and the empty window closes; ESC mid-drag → no-op; drag down past strip → tear-off unchanged; drop on B's content area → legacy append behavior unchanged
- [ ] Manual: 1-tab main window's tab is not draggable

<!-- agentmux:agent_id=agent3 -->