### PR TITLE
test(e2e): windowids-baseline suite + fix early-close srv-row orphan race

### DIFF
--- a/.changesets/1783767260-fix-frontend-register-backend-window-id-right-after-createwi-olw3.md
+++ b/.changesets/1783767260-fix-frontend-register-backend-window-id-right-after-createwi-olw3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(frontend): register backend window id right after CreateWindow, closing the early-close srv-row orphan race

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -447,6 +447,23 @@ async function initHostNewWindow(): Promise<void> {
         const newWindow = await withTimeout(WindowService.CreateWindow(null, tearOffWsId), RPC_TIMEOUT, "CreateWindow");
         tlog("CreateWindow", t);
 
+        // Register label→window_id with the host NOW, not at the end of
+        // initWave (which also registers — idempotently — after render):
+        // the srv window row exists as of this line, and every host close
+        // path (on_before_close, demote_srv_cleanup) resolves WHICH srv row
+        // to close through this registration. A window closed in the
+        // seconds between CreateWindow and initWave's late registration —
+        // e.g. a tear-off merged straight back — used to orphan its srv
+        // row forever: the close's demote reloads this renderer to the
+        // pool boot URL, so the late registration never arrives, and the
+        // host's bounded registration-race retry waits for an event that
+        // can no longer happen (task #29 round 2, found by the
+        // window-close-baseline E2E suite).
+        {
+            const wlabel = new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+            getApi().registerBackendWindow(wlabel, newWindow.oid);
+        }
+
         // Get the workspace that was auto-created with the window
         t = performance.now();
         const workspace = await withTimeout(WorkspaceService.GetWorkspace(newWindow.workspaceid), RPC_TIMEOUT, "GetWorkspace");

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "package:portable": "task package:portable",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "test:e2e": "vitest run test/e2e",
+    "test:e2e": "vitest run --no-file-parallelism test/e2e",
     "clean": "task clean",
     "lint:scss": "stylelint \"frontend/**/*.scss\" --allow-empty-input"
   },

--- a/test/e2e/crash-reproject.e2e.test.ts
+++ b/test/e2e/crash-reproject.e2e.test.ts
@@ -28,19 +28,22 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
-import path from "node:path";
-import fs from "node:fs";
-// Deliberately NOT the `ws` npm package: its package.json maps a "browser"
-// field to a stub that throws ("ws does not work in the browser"), and the
-// repo's shared vitest.config.ts merges in the frontend's own vite.config
-// (browser-oriented resolution needed for the rest of this test suite) —
-// that resolution applies even under `@vitest-environment node` and even
-// via `createRequire` (vite-node intercepts Node's own `require` too, not
-// just ESM imports). Node's own native `WebSocket` (global since Node 22,
-// undici-backed) sidesteps this entirely — it's a process global, not
-// something resolved through Vite's module graph at all. Its API is
-// DOM-style (`addEventListener`, not `ws`'s EventEmitter `.on()`).
+// CDP wire helpers, isolated-instance boot/teardown, and wmic process
+// discovery live in the shared harness (extracted verbatim from this file
+// when the window-close-baseline suite was added) — including the
+// native-WebSocket-instead-of-`ws` rationale, documented there.
+import {
+    bootInstance,
+    teardownInstance,
+    evalInMainWindow,
+    findCdpPort,
+    findVersionedHostPid,
+    killPid,
+    listCdpTargets,
+    sleep,
+    type CdpTarget,
+    type E2eInstance,
+} from "./harness";
 
 const BUILD_DIR = process.env.AGENTMUX_E2E_BUILD_DIR;
 const IS_WINDOWS = process.platform === "win32";
@@ -54,188 +57,24 @@ if (!RUN) {
     console.log(`[crash-reproject e2e] skipped — ${reason}`);
 }
 
-// ── CDP helpers (same wire-level approach as the session's own
-//    `.verify_step4p2_cdp.mjs` scratch script, formalized here). ──────────
-
-interface CdpTarget {
-    title: string;
-    url: string;
-    webSocketDebuggerUrl: string;
-}
-
-async function listCdpTargets(port: number): Promise<CdpTarget[]> {
-    const res = await fetch(`http://127.0.0.1:${port}/json/list`);
-    if (!res.ok) throw new Error(`CDP /json/list returned ${res.status}`);
-    return (await res.json()) as CdpTarget[];
-}
-
-function wsConnect(url: string): Promise<WebSocket> {
-    return new Promise((resolve, reject) => {
-        const ws = new WebSocket(url);
-        ws.addEventListener("open", () => resolve(ws));
-        ws.addEventListener("error", (ev) => reject(new Error(String((ev as any).message ?? ev))));
-    });
-}
-
-let msgId = 1;
-function wsSend(ws: WebSocket, method: string, params?: unknown): Promise<any> {
-    return new Promise((resolve, reject) => {
-        const id = msgId++;
-        const handler = (event: MessageEvent) => {
-            const msg = JSON.parse(String(event.data));
-            if (msg.id === id) {
-                ws.removeEventListener("message", handler);
-                if (msg.error) reject(new Error(JSON.stringify(msg.error)));
-                else resolve(msg.result);
-            }
-        };
-        ws.addEventListener("message", handler);
-        ws.send(JSON.stringify({ id, method, params }));
-    });
-}
-
-/** Evaluate `expression` in the main window's page (found by title substring). */
-async function evalInMainWindow(port: number, expression: string): Promise<any> {
-    const targets = await listCdpTargets(port);
-    const main = targets.find((t) => t.title.includes("Starter workspace"));
-    if (!main) throw new Error("main window's CDP target not found");
-    const ws = await wsConnect(main.webSocketDebuggerUrl);
-    await wsSend(ws, "Runtime.enable");
-    const result = await wsSend(ws, "Runtime.evaluate", {
-        expression,
-        awaitPromise: true,
-        returnByValue: true,
-    });
-    ws.close();
-    if (result.exceptionDetails) {
-        throw new Error(`eval failed: ${JSON.stringify(result.exceptionDetails)}`);
-    }
-    return result.result.value;
-}
-
-// ── Process helpers ───────────────────────────────────────────────────────
-
-/** All AGENTMUX_* env vars scrubbed — an isolated instance, not sharing
- *  state with any already-running dev/portable instance on this machine. */
-function scrubbedEnv(): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = {};
-    for (const [k, v] of Object.entries(process.env)) {
-        if (!k.startsWith("AGENTMUX_")) env[k] = v;
-    }
-    return env;
-}
-
-function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/** Poll `netstat` for the two ports a freshly-created host PID listens on
- *  (IPC + CDP — CDP is whichever of the pair actually answers /json/list). */
-async function findCdpPort(pid: number, timeoutMs: number): Promise<number> {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-        const out = execSync("netstat -ano", { encoding: "utf8" });
-        const ports = out
-            .split("\n")
-            .filter((l) => {
-                if (!l.includes("LISTENING")) return false;
-                // Exact match on the trailing PID column — `endsWith` would
-                // false-positive-match e.g. pid=88 against a line ending in
-                // "988" (a real substring, not a real match).
-                const cols = l.trim().split(/\s+/);
-                return Number(cols[cols.length - 1]) === pid;
-            })
-            .map((l) => {
-                const m = l.match(/127\.0\.0\.1:(\d+)/);
-                return m ? Number(m[1]) : null;
-            })
-            .filter((p): p is number => p !== null);
-        for (const port of ports) {
-            try {
-                const targets = await listCdpTargets(port);
-                if (targets.length > 0) return port;
-            } catch {
-                // this port is the IPC port, not CDP — try the next one
-            }
-        }
-        await sleep(500);
-    }
-    throw new Error(`CDP port for PID ${pid} not found within ${timeoutMs}ms`);
-}
-
-function killPid(pid: number): void {
-    try {
-        execSync(`taskkill /PID ${pid} /F`, { stdio: "ignore" });
-    } catch {
-        // already gone — fine
-    }
-}
-
 describe.skipIf(!RUN)("crash-reproject E2E: host OOM ⇒ session reprojects", () => {
-    let outerWrapperPid: number | null = null;
+    let inst: E2eInstance | null = null;
     let hostPid: number | null = null;
-    let logPath: string;
 
     beforeAll(async () => {
-        const exePath = path.join(BUILD_DIR!, "agentmux.exe");
-        if (!fs.existsSync(exePath)) {
-            throw new Error(`AGENTMUX_E2E_BUILD_DIR does not contain agentmux.exe: ${exePath}`);
-        }
-        logPath = path.join(BUILD_DIR!, "..", "crash-reproject-e2e.log");
-        const logFd = fs.openSync(logPath, "w");
-        const child: ChildProcess = spawn(exePath, [], {
-            cwd: BUILD_DIR,
-            env: scrubbedEnv(),
-            detached: true,
-            stdio: ["ignore", logFd, logFd],
-        });
-        child.unref();
-
-        // The spawned `agentmux.exe` is the outer launcher wrapper; the exe
-        // name inside the build dir's `runtime/` (the actual CEF host) is
-        // versioned (`agentmux-X.Y.Z.exe`) — find it by reading the log or
-        // by process name once it starts. `wmic`'s CommandLine match on
-        // "agentmux.exe" catches the wrapper itself; the host process has a
-        // distinct versioned name, discovered via the same query with a
-        // wildcard-free match against whatever's actually running.
-        await sleep(3000); // let the wrapper spawn its children
-        hostPid = await findVersionedHostPid(BUILD_DIR!, 20000);
-        outerWrapperPid = child.pid ?? null;
+        inst = await bootInstance(BUILD_DIR!, "crash-reproject-e2e.log");
+        hostPid = inst.hostPid;
     }, 30000);
 
     afterAll(async () => {
-        // Kill the wrapper FIRST, not the host: killing `hostPid` while the
-        // wrapper is still alive makes the launcher's own crash-restart
-        // logic (the exact mechanism under test) treat that as a real crash
-        // and spawn yet another replacement — a race that can leave an
-        // orphaned instance behind if this hook's two kills interleave with
-        // the launcher's own respawn. Killing the wrapper first tears down
-        // its Job Object, which should cascade-kill every child (including
-        // any host it's mid-respawn on) in one shot.
-        if (outerWrapperPid) killPid(outerWrapperPid);
-        if (hostPid) killPid(hostPid);
-        await sleep(1000);
-        // Defensive final sweep: guarantee no leaked process from this
-        // specific build dir survives this suite, regardless of any race
-        // above — never by image name (that would hit every other AgentMux
-        // instance on the machine, including a real one the user has open;
-        // see CLAUDE.md's "CRITICAL: Never Kill AgentMux by Image Name").
-        // Scoped to this exact BUILD_DIR's own process tree only.
-        try {
-            const out = execSync(
-                `wmic process where "(name like 'agentmux-%' or name='agentmux.exe')" get ProcessId,CommandLine /format:csv`,
-                { encoding: "utf8" },
-            );
-            const buildDirBackslash = BUILD_DIR!.replace(/\//g, "\\");
-            for (const line of out.split("\n").map((l) => l.trim()).filter(Boolean)) {
-                if (line.startsWith("Node,")) continue;
-                if (!line.includes(buildDirBackslash)) continue;
-                const parts = line.split(",");
-                const pid = Number(parts[parts.length - 1]);
-                if (Number.isFinite(pid) && pid > 0) killPid(pid);
-            }
-        } catch {
-            // best-effort — nothing left to sweep, or wmic itself is gone
+        // Teardown kills the wrapper FIRST (killing the host while the
+        // wrapper lives triggers the exact crash-restart mechanism under
+        // test), then sweeps this build dir's own process tree — see
+        // `teardownInstance`. Keep `inst.hostPid` current so the sweep's
+        // direct kill hits the RESPAWNED host, not the long-dead first one.
+        if (inst) {
+            inst.hostPid = hostPid;
+            await teardownInstance(BUILD_DIR!, inst);
         }
     });
 
@@ -300,59 +139,3 @@ describe.skipIf(!RUN)("crash-reproject E2E: host OOM ⇒ session reprojects", ()
         expect(mainTarget).toBeDefined();
     }, 90000);
 });
-
-/** Find the CEF host process (versioned exe name, e.g. `agentmux-0.51.0.exe`
- *  — distinct from the outer `agentmux.exe` wrapper, the `agentmux-srv-*`
- *  sidecar, and `agentmux-mcp.exe`) inside `buildDir`'s own process tree,
- *  excluding any `--type=` child and (optionally) a known-stale `excludePid`
- *  (used when polling for the POST-crash respawn, so a still-terminating
- *  old PID doesn't get picked up as "the new one").
- *
- *  Deliberately does NOT embed `buildDir` in the WQL query string: a first
- *  version did (`CommandLine like '%<buildDir>%'`), which is a
- *  self-referential match — `execSync` runs this exact query via
- *  `cmd.exe /c wmic ...`, and that invocation's OWN command line contains
- *  the literal `buildDir` string (it's part of the query!), so wmic matched
- *  its own querying process (and any other shell wrapper on the machine
- *  whose command line happened to mention the build path) ahead of the
- *  real host. Filtering on `Name` first (a strict `agentmux-<digits>.<digits>.<digits>.exe`
- *  pattern) and only checking `buildDir` as a secondary disambiguator in JS
- *  avoids this class of bug entirely. */
-async function findVersionedHostPid(
-    buildDir: string,
-    timeoutMs: number,
-    excludePid?: number,
-): Promise<number> {
-    const deadline = Date.now() + timeoutMs;
-    const hostNamePattern = /^agentmux-\d+\.\d+\.\d+\.exe$/i;
-    // Real Windows command lines (as wmic reports them) always use
-    // backslashes. `buildDir` can arrive as `C:/Users/...` (forward
-    // slashes) when this suite is invoked from Git Bash/MSYS2, which
-    // auto-converts POSIX-looking env var values for non-MSYS child
-    // processes — normalize before substring-matching or this never finds
-    // anything.
-    const buildDirBackslash = buildDir.replace(/\//g, "\\");
-    while (Date.now() < deadline) {
-        try {
-            const out = execSync(
-                `wmic process where "name like 'agentmux-%'" get ProcessId,Name,CommandLine /format:csv`,
-                { encoding: "utf8" },
-            );
-            const lines = out.split("\n").map((l) => l.trim()).filter(Boolean);
-            for (const line of lines) {
-                if (line.startsWith("Node,")) continue; // CSV header
-                if (line.includes("--type=")) continue; // gpu/utility/renderer child
-                if (!line.includes(buildDirBackslash)) continue; // a different instance's process
-                const parts = line.split(",");
-                const pid = Number(parts[parts.length - 1]);
-                const name = parts[parts.length - 2];
-                if (!hostNamePattern.test(name)) continue; // srv sidecar / mcp / wrapper
-                if (Number.isFinite(pid) && pid > 0 && pid !== excludePid) return pid;
-            }
-        } catch {
-            // transient — process tree still forming
-        }
-        await sleep(500);
-    }
-    throw new Error(`versioned host process under ${buildDir} not found within ${timeoutMs}ms`);
-}

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -1,0 +1,276 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared harness for the opt-in E2E suites (`AGENTMUX_E2E_BUILD_DIR`-gated,
+ * Windows-only). Extracted verbatim from `crash-reproject.e2e.test.ts`
+ * (SPEC_PILLAR1_STEP4 Phase 5) when the window-close-baseline suite was
+ * added — the CDP wire helpers, the isolated-instance boot/teardown, and
+ * the wmic-based process discovery are identical for every suite that
+ * drives a real packaged build.
+ *
+ * Deliberately NOT the `ws` npm package for CDP websockets: its
+ * package.json maps a "browser" field to a stub that throws ("ws does not
+ * work in the browser"), and the repo's shared vitest.config.ts merges in
+ * the frontend's own vite.config (browser-oriented resolution needed for
+ * the rest of the test suite) — that resolution applies even under
+ * `@vitest-environment node` and even via `createRequire` (vite-node
+ * intercepts Node's own `require` too, not just ESM imports). Node's own
+ * native `WebSocket` (global since Node 22, undici-backed) sidesteps this
+ * entirely — it's a process global, not something resolved through Vite's
+ * module graph at all. Its API is DOM-style (`addEventListener`, not
+ * `ws`'s EventEmitter `.on()`).
+ */
+
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+
+// ── CDP helpers ───────────────────────────────────────────────────────────
+
+export interface CdpTarget {
+    title: string;
+    url: string;
+    webSocketDebuggerUrl: string;
+}
+
+export async function listCdpTargets(port: number): Promise<CdpTarget[]> {
+    const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+    if (!res.ok) throw new Error(`CDP /json/list returned ${res.status}`);
+    return (await res.json()) as CdpTarget[];
+}
+
+export function wsConnect(url: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+        const ws = new WebSocket(url);
+        ws.addEventListener("open", () => resolve(ws));
+        ws.addEventListener("error", (ev) => reject(new Error(String((ev as any).message ?? ev))));
+    });
+}
+
+let msgId = 1;
+export function wsSend(ws: WebSocket, method: string, params?: unknown): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const id = msgId++;
+        const handler = (event: MessageEvent) => {
+            const msg = JSON.parse(String(event.data));
+            if (msg.id === id) {
+                ws.removeEventListener("message", handler);
+                if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+                else resolve(msg.result);
+            }
+        };
+        ws.addEventListener("message", handler);
+        ws.send(JSON.stringify({ id, method, params }));
+    });
+}
+
+/** Evaluate `expression` in the main window's page (found by title substring). */
+export async function evalInMainWindow(port: number, expression: string): Promise<any> {
+    const targets = await listCdpTargets(port);
+    const main = targets.find((t) => t.title.includes("Starter workspace"));
+    if (!main) throw new Error("main window's CDP target not found");
+    const ws = await wsConnect(main.webSocketDebuggerUrl);
+    await wsSend(ws, "Runtime.enable");
+    const result = await wsSend(ws, "Runtime.evaluate", {
+        expression,
+        awaitPromise: true,
+        returnByValue: true,
+    });
+    ws.close();
+    if (result.exceptionDetails) {
+        throw new Error(`eval failed: ${JSON.stringify(result.exceptionDetails)}`);
+    }
+    return result.result.value;
+}
+
+// ── Process helpers ───────────────────────────────────────────────────────
+
+/** All AGENTMUX_* env vars scrubbed — an isolated instance, not sharing
+ *  state with any already-running dev/portable instance on this machine.
+ *  `AGENTMUX_DEBUG_CLOSE` is the one deliberate pass-through: it's a
+ *  pure diagnostic (close-path trace to %TEMP%\agentmux-close-debug.txt),
+ *  not instance state, and being able to set it on an E2E run is exactly
+ *  how close-path failures in these suites get diagnosed. */
+export function scrubbedEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {};
+    for (const [k, v] of Object.entries(process.env)) {
+        if (!k.startsWith("AGENTMUX_") || k === "AGENTMUX_DEBUG_CLOSE") env[k] = v;
+    }
+    return env;
+}
+
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Poll `netstat` for the two ports a freshly-created host PID listens on
+ *  (IPC + CDP — CDP is whichever of the pair actually answers /json/list). */
+export async function findCdpPort(pid: number, timeoutMs: number): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const out = execSync("netstat -ano", { encoding: "utf8" });
+        const ports = out
+            .split("\n")
+            .filter((l) => {
+                if (!l.includes("LISTENING")) return false;
+                // Exact match on the trailing PID column — `endsWith` would
+                // false-positive-match e.g. pid=88 against a line ending in
+                // "988" (a real substring, not a real match).
+                const cols = l.trim().split(/\s+/);
+                return Number(cols[cols.length - 1]) === pid;
+            })
+            .map((l) => {
+                const m = l.match(/127\.0\.0\.1:(\d+)/);
+                return m ? Number(m[1]) : null;
+            })
+            .filter((p): p is number => p !== null);
+        for (const port of ports) {
+            try {
+                const targets = await listCdpTargets(port);
+                if (targets.length > 0) return port;
+            } catch {
+                // this port is the IPC port, not CDP — try the next one
+            }
+        }
+        await sleep(500);
+    }
+    throw new Error(`CDP port for PID ${pid} not found within ${timeoutMs}ms`);
+}
+
+export function killPid(pid: number): void {
+    try {
+        execSync(`taskkill /PID ${pid} /F`, { stdio: "ignore" });
+    } catch {
+        // already gone — fine
+    }
+}
+
+/** Find the CEF host process (versioned exe name, e.g. `agentmux-0.51.0.exe`
+ *  — distinct from the outer `agentmux.exe` wrapper, the `agentmux-srv-*`
+ *  sidecar, and `agentmux-mcp.exe`) inside `buildDir`'s own process tree,
+ *  excluding any `--type=` child and (optionally) a known-stale `excludePid`
+ *  (used when polling for the POST-crash respawn, so a still-terminating
+ *  old PID doesn't get picked up as "the new one").
+ *
+ *  Deliberately does NOT embed `buildDir` in the WQL query string: a first
+ *  version did (`CommandLine like '%<buildDir>%'`), which is a
+ *  self-referential match — `execSync` runs this exact query via
+ *  `cmd.exe /c wmic ...`, and that invocation's OWN command line contains
+ *  the literal `buildDir` string (it's part of the query!), so wmic matched
+ *  its own querying process (and any other shell wrapper on the machine
+ *  whose command line happened to mention the build path) ahead of the
+ *  real host. Filtering on `Name` first (a strict `agentmux-<digits>.<digits>.<digits>.exe`
+ *  pattern) and only checking `buildDir` as a secondary disambiguator in JS
+ *  avoids this class of bug entirely. */
+export async function findVersionedHostPid(
+    buildDir: string,
+    timeoutMs: number,
+    excludePid?: number,
+): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    const hostNamePattern = /^agentmux-\d+\.\d+\.\d+\.exe$/i;
+    // Real Windows command lines (as wmic reports them) always use
+    // backslashes. `buildDir` can arrive as `C:/Users/...` (forward
+    // slashes) when this suite is invoked from Git Bash/MSYS2, which
+    // auto-converts POSIX-looking env var values for non-MSYS child
+    // processes — normalize before substring-matching or this never finds
+    // anything.
+    const buildDirBackslash = buildDir.replace(/\//g, "\\");
+    while (Date.now() < deadline) {
+        try {
+            const out = execSync(
+                `wmic process where "name like 'agentmux-%'" get ProcessId,Name,CommandLine /format:csv`,
+                { encoding: "utf8" },
+            );
+            const lines = out.split("\n").map((l) => l.trim()).filter(Boolean);
+            for (const line of lines) {
+                if (line.startsWith("Node,")) continue; // CSV header
+                if (line.includes("--type=")) continue; // gpu/utility/renderer child
+                if (!line.includes(buildDirBackslash)) continue; // a different instance's process
+                const parts = line.split(",");
+                const pid = Number(parts[parts.length - 1]);
+                const name = parts[parts.length - 2];
+                if (!hostNamePattern.test(name)) continue; // srv sidecar / mcp / wrapper
+                if (Number.isFinite(pid) && pid > 0 && pid !== excludePid) return pid;
+            }
+        } catch {
+            // transient — process tree still forming
+        }
+        await sleep(500);
+    }
+    throw new Error(`versioned host process under ${buildDir} not found within ${timeoutMs}ms`);
+}
+
+// ── Isolated-instance boot / teardown ─────────────────────────────────────
+
+export interface E2eInstance {
+    outerWrapperPid: number | null;
+    hostPid: number | null;
+    logPath: string;
+}
+
+/** Spawn the packaged build's outer `agentmux.exe` wrapper detached with a
+ *  scrubbed env, wait for its versioned host process to appear, and return
+ *  both PIDs. `logName` disambiguates each suite's launcher output file. */
+export async function bootInstance(buildDir: string, logName: string): Promise<E2eInstance> {
+    const exePath = path.join(buildDir, "agentmux.exe");
+    if (!fs.existsSync(exePath)) {
+        throw new Error(`AGENTMUX_E2E_BUILD_DIR does not contain agentmux.exe: ${exePath}`);
+    }
+    const logPath = path.join(buildDir, "..", logName);
+    const logFd = fs.openSync(logPath, "w");
+    const child: ChildProcess = spawn(exePath, [], {
+        cwd: buildDir,
+        env: scrubbedEnv(),
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+    });
+    child.unref();
+
+    // The spawned `agentmux.exe` is the outer launcher wrapper; the exe
+    // name inside the build dir's `runtime/` (the actual CEF host) is
+    // versioned (`agentmux-X.Y.Z.exe`) — discovered by process name once
+    // it starts.
+    await sleep(3000); // let the wrapper spawn its children
+    const hostPid = await findVersionedHostPid(buildDir, 20000);
+    return { outerWrapperPid: child.pid ?? null, hostPid, logPath };
+}
+
+/** Tear down an instance booted by `bootInstance`.
+ *
+ *  Kill the wrapper FIRST, not the host: killing `hostPid` while the
+ *  wrapper is still alive makes the launcher's own crash-restart logic
+ *  treat that as a real crash and spawn yet another replacement — a race
+ *  that can leave an orphaned instance behind if the two kills interleave
+ *  with the launcher's own respawn. Killing the wrapper first tears down
+ *  its Job Object, which should cascade-kill every child (including any
+ *  host it's mid-respawn on) in one shot.
+ *
+ *  Then a defensive final sweep guarantees no leaked process from this
+ *  specific build dir survives, regardless of any race above — never by
+ *  image name (that would hit every other AgentMux instance on the
+ *  machine, including a real one the user has open; see CLAUDE.md's
+ *  "CRITICAL: Never Kill AgentMux by Image Name"). Scoped to this exact
+ *  build dir's own process tree only. */
+export async function teardownInstance(buildDir: string, inst: E2eInstance): Promise<void> {
+    if (inst.outerWrapperPid) killPid(inst.outerWrapperPid);
+    if (inst.hostPid) killPid(inst.hostPid);
+    await sleep(1000);
+    try {
+        const out = execSync(
+            `wmic process where "(name like 'agentmux-%' or name='agentmux.exe')" get ProcessId,CommandLine /format:csv`,
+            { encoding: "utf8" },
+        );
+        const buildDirBackslash = buildDir.replace(/\//g, "\\");
+        for (const line of out.split("\n").map((l) => l.trim()).filter(Boolean)) {
+            if (line.startsWith("Node,")) continue;
+            if (!line.includes(buildDirBackslash)) continue;
+            const parts = line.split(",");
+            const pid = Number(parts[parts.length - 1]);
+            if (Number.isFinite(pid) && pid > 0) killPid(pid);
+        }
+    } catch {
+        // best-effort — nothing left to sweep, or wmic itself is gone
+    }
+}

--- a/test/e2e/window-close-baseline.e2e.test.ts
+++ b/test/e2e/window-close-baseline.e2e.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * E2E regression test for the `Client.windowids` window-close baseline
+ * (task #29): every open+close cycle of a secondary window must return
+ * srv's durable window list to its pre-open state — through BOTH close
+ * entry points, since they route differently in the host:
+ *
+ *   - `close_window` (custom chrome ✕ button, Cmd+W) — the path Round 6
+ *     of retro-window-lifecycle-leak-2026-07-04 made clean;
+ *   - `close_window_by_label` (tear-off merge path) — which posted a raw
+ *     WM_CLOSE that CEF 148's Views wndproc turns into a parked browser
+ *     with NO srv cleanup, leaking the window's srv rows and windowids
+ *     entry forever (fixed alongside this test).
+ *
+ * `Client.windowids` is the slow-path crash-reproject's source of truth
+ * (SPEC_PILLAR1_STEP4): every leaked entry here becomes a phantom window
+ * resurrected on some future crash recovery, which is how this leak was
+ * originally discovered.
+ *
+ * Same opt-in gate as `crash-reproject.e2e.test.ts` (a real packaged
+ * build is required):
+ *
+ *   AGENTMUX_E2E_BUILD_DIR="/c/Users/you/Desktop/agentmux-...-x64-portable" \
+ *     npx vitest run test/e2e/window-close-baseline.e2e.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+    bootInstance,
+    teardownInstance,
+    evalInMainWindow,
+    findCdpPort,
+    sleep,
+    type E2eInstance,
+} from "./harness";
+
+const BUILD_DIR = process.env.AGENTMUX_E2E_BUILD_DIR;
+const IS_WINDOWS = process.platform === "win32";
+const RUN = Boolean(BUILD_DIR) && IS_WINDOWS;
+
+if (!RUN) {
+    const reason = !BUILD_DIR
+        ? "AGENTMUX_E2E_BUILD_DIR not set"
+        : `unsupported platform (${process.platform}, Windows-only)`;
+    // eslint-disable-next-line no-console
+    console.log(`[window-close-baseline e2e] skipped — ${reason}`);
+}
+
+/** Fetch srv's `Client.windowids` via the same `client.GetClientData` RPC
+ *  the host's own slow-path reproject reads, driven from the main window's
+ *  page context (which holds the web endpoint + auth key). */
+function windowIdsExpr(): string {
+    return `(async () => {
+        const ep = window.__WAVE_SERVER_WEB_ENDPOINT__;
+        const key = await window.api.getAuthKey();
+        const res = await fetch("http://" + ep + "/agentmux/service", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-AuthKey": key },
+            body: JSON.stringify({ service: "client", method: "GetClientData", args: [], uicontext: null }),
+        });
+        const j = await res.json();
+        return (j && j.data && j.data.windowids) || j.windowids || [];
+    })()`;
+}
+
+/** Poll until `Client.windowids` has exactly `expected` entries (the srv
+ *  cleanup runs on a background thread with a bounded registration-race
+ *  retry — see `demote_srv_cleanup` — so a fixed sleep would be flaky). */
+async function pollWindowIdsCount(port: number, expected: number, timeoutMs: number): Promise<string[]> {
+    const deadline = Date.now() + timeoutMs;
+    let ids: string[] = [];
+    while (Date.now() < deadline) {
+        ids = await evalInMainWindow(port, windowIdsExpr());
+        if (ids.length === expected) return ids;
+        await sleep(1000);
+    }
+    return ids;
+}
+
+/** Open one window, close it via `closeExpr`, and assert `Client.windowids`
+ *  returns to its pre-open state.
+ *
+ *  All assertions are RELATIVE to the observed pre-open baseline, never an
+ *  absolute count: suites in this directory share the build's per-build
+ *  data dir (`--no-file-parallelism` serializes them, but srv state is
+ *  durable across boots BY DESIGN — it's the crash-reproject slow path's
+ *  source of truth), and the crash-reproject suite deliberately leaves the
+ *  window it recreated behind. An absolute `=== 1` here would couple this
+ *  suite to file ordering; open→N+1, close→N is the actual invariant. */
+async function runOpenCloseCycle(port: number, closeExpr: (label: string) => string): Promise<void> {
+    const baseline: string[] = await evalInMainWindow(port, windowIdsExpr());
+    expect(baseline.length).toBeGreaterThanOrEqual(1); // at least main is registered
+
+    const newLabel = await evalInMainWindow(port, "window.api.openNewWindow()");
+    expect(typeof newLabel).toBe("string");
+
+    // The new window's own bootstrap registers one more srv window row.
+    const afterOpen = await pollWindowIdsCount(port, baseline.length + 1, 20000);
+    expect(afterOpen.length).toBe(baseline.length + 1);
+
+    await evalInMainWindow(port, closeExpr(newLabel));
+
+    const afterClose = await pollWindowIdsCount(port, baseline.length, 20000);
+    expect(afterClose.length).toBe(baseline.length);
+    // Same SET of rows as before the open — the new row is gone and no
+    // pre-existing row (e.g. main's) was collateral damage.
+    expect([...afterClose].sort()).toEqual([...baseline].sort());
+}
+
+describe.skipIf(!RUN)("window-close baseline: Client.windowids returns to baseline", () => {
+    let inst: E2eInstance | null = null;
+    let port = 0;
+
+    beforeAll(async () => {
+        inst = await bootInstance(BUILD_DIR!, "window-close-baseline-e2e.log");
+        port = await findCdpPort(inst.hostPid!, 15000);
+        // Let main's own bootstrap (workspace init + register_backend_window)
+        // land before measuring any baseline — and, if a prior suite left
+        // durable window rows behind, let the slow-path reproject finish
+        // recreating them so the count is stable before the first test reads
+        // it. "Stable" = two consecutive reads 3s apart agree.
+        const deadline = Date.now() + 30000;
+        let prev = -1;
+        while (Date.now() < deadline) {
+            const ids: string[] = await evalInMainWindow(port, windowIdsExpr());
+            if (ids.length >= 1 && ids.length === prev) break;
+            prev = ids.length;
+            await sleep(3000);
+        }
+    }, 60000);
+
+    afterAll(async () => {
+        if (inst) await teardownInstance(BUILD_DIR!, inst);
+    });
+
+    it("open + closeWindow (chrome ✕ path) returns windowids to baseline", async () => {
+        await runOpenCloseCycle(port, (label) => `window.api.closeWindow(${JSON.stringify(label)})`);
+    }, 90000);
+
+    it("open + closeWindowByLabel (tear-off merge path) returns windowids to baseline", async () => {
+        // Regression for task #29 round 2: this exact sequence used to leave
+        // the promoted window's srv row orphaned forever (raw WM_CLOSE →
+        // parked browser → demote_srv_cleanup never ran).
+        await runOpenCloseCycle(port, (label) => `window.api.closeWindowByLabel(${JSON.stringify(label)})`);
+    }, 90000);
+});


### PR DESCRIPTION
## What

Follow-up to #2087 — adds the automated regression coverage for the `Client.windowids` leak class (task #9), and fixes a real race the new suite immediately caught.

### 1. New E2E suite: `window-close-baseline.e2e.test.ts`

Open one window, close it via **each** host close path — `close_window` (chrome ✕ route) and `close_window_by_label` (tear-off merge route, the one #2087 fixed) — and assert srv's `Client.windowids` returns to its pre-open state. Assertions are **relative** to the observed baseline, never absolute: suites share the build's per-build data dir, and srv window rows are durable across boots *by design* (they're the crash-reproject slow path's source of truth; the crash suite deliberately leaves its recreated window behind).

Shared boot/teardown/CDP machinery extracted verbatim from `crash-reproject.e2e.test.ts` into `test/e2e/harness.ts`. `test:e2e` now runs `--no-file-parallelism`: two suites booting the same build concurrently would collide on the single-instance pipe (I1) — the second boot would forward to the first instance instead of launching.

### 2. Product fix the suite caught: early-close orphans the srv row

The frontend registered `label→window_id` with the host only at the **end of initWave** — seconds after the srv row exists (created by `CreateWindow` early in `initHostNewWindow`). A window closed inside that gap — e.g. a tear-off merged straight back — orphaned its srv row **forever**:

- the close's demote reloads the renderer to the pool boot URL, so the late registration never arrives;
- `demote_srv_cleanup`'s bounded registration-race retry then waits for an event that can no longer happen (`no backend window ID after retries — srv state may orphan` in the close trace);
- the srv row + windowids entry leak — the same class #2087 fixed, via a different hole.

Fix: register immediately after `CreateWindow` returns. The initWave-end registration stays — it covers main's path and is idempotent (`PendingReprojectClosures.confirm` fires at most once; the shadow-map insert is same-value).

`scrubbedEnv` now passes through `AGENTMUX_DEBUG_CLOSE` (pure diagnostic, not instance state) — being able to trace the close path on an E2E run is exactly how this race was diagnosed.

## Verification

- All 3 E2E tests pass against a packaged build of this branch (previously: both baseline tests failed with the close silently orphaning the row).
- Suite skips cleanly without `AGENTMUX_E2E_BUILD_DIR` (3 skipped, plain `npm test` unaffected: 1669 passed).
- No leaked processes after teardown (wmic sweep scoped to the build dir).

Follow-up to #2087. Task #9; the remaining OS-entry-point gap (Alt+F4/taskbar WM_CLOSE) stays tracked as task #30.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)