### PR TITLE
docs: implementation specs for the #1969 residuals + test srv-spawn guards (+ stale bridge comment fix)

### DIFF
--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -438,14 +438,14 @@ async fn dispatch_event(event: Event, wstore: Arc<Store>, event_bus: Arc<EventBu
         // (see the post-event-state guarantee above), so the read sees
         // post-event tree state.
         //
-        // The remaining tree events (Insert/Delete/Move/Swap/Resize/
-        // Replace/Split*) are still persisted via wcore-direct in their
-        // RPC handlers — they DON'T yet appear in `apply_event_to_wstore`.
-        // If the bridge broadcast LayoutState for those, the read could
-        // race ahead of the wcore-direct write. They remain covered by
-        // their handlers' existing `success_with_updates(...)` response
-        // broadcasts (Codex P2 on PR #861) until their persistence
-        // migrates here in a later phase.
+        // The remaining tree events ARE persisted by the subscriber now
+        // (SPEC_864 phases 2-5, #1970-#1981 — wcore-direct layout writes
+        // are retired; this comment predated that migration). They are
+        // still deliberately NOT bridged, but for a different reason than
+        // the original wcore-direct race: see the srv-IPC-path caveat on
+        // the granular-events note below. They remain covered by their
+        // handlers' existing `success_with_updates(...)` response
+        // broadcasts (Codex P2 on PR #861).
         Event::FocusedNodeChanged { tab_id, .. }
         | Event::MagnifiedNodeChanged { tab_id, .. } => {
             emit_layout_for_tab(&wstore, &event_bus, tab_id, "Focused/MagnifiedNodeChanged").await;

--- a/docs/specs/SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11.md
+++ b/docs/specs/SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11.md
@@ -1,0 +1,142 @@
+# SPEC: Pool adoption for foreign labels + srv window-row label crumb + non-Windows close verification
+
+**Date:** 2026-07-11
+**Status:** Ready for implementation
+**Tracking:** session task #15 (the residuals deliberately left open by the
+window-pool coverage work, ~PR #1969 era, and referenced by
+`CloseWindowTask`'s "Known residual" comment in `agentmux-cef/src/ui_tasks/window.rs`)
+**Related:** #2087/#2088/#2089 (the `Client.windowids` leak class — closed),
+`SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md`, `retro-window-lifecycle-leak-2026-07-04.md`
+
+Three independent residuals, ordered by value. They share a theme — the window
+close/recycle machinery keys on the `window-pool-` label prefix and on
+host-side registration state, and both assumptions have known gaps — but they
+are separately shippable PRs.
+
+---
+
+## Residual 1 — pool adoption for foreign `window-{uuid}` labels
+
+### Problem
+
+`CloseWindowTask` (Windows) demotes a closing window back into the warm pool
+only when its label starts with `window-pool-` — the pool handshake
+(`pool_window_ready` → queue entry → promote) keys on that prefix. Cold-path
+and drag-tear-off windows get `window-{uuid}` labels, so their close falls to
+the park-and-blank path: srv state IS cleaned (post-#2087), but the parked
+renderer (~100MB commit) is never reclaimed and never reused.
+
+In the default flow this is rare — `open_new_window` serves from the pool
+whenever it's non-empty — but every pool-exhausted open (rapid multi-window
+creation, pool refill latency) mints a foreign label whose eventual close
+permanently strands a renderer. Over a long session these accumulate exactly
+like the pre-#2000 renderer leaks did, just at a lower rate.
+
+### Design — adopt at demote time
+
+At the `CloseWindowTask` demote gate, when the label is `window-*` but not
+`window-pool-*` and the pool is below its demote cap:
+
+1. Run the same eligibility steps as `demote_promoted_pool_window` (strict
+   HWND resolution, reducer `DemotePoolWindow` — which must learn to accept
+   an adoption, flipping `is_pool: true` for a label it has never seen as
+   pool-side).
+2. **Relabel on reload:** the browser reloads to the pool boot URL with a
+   fresh `window-pool-{uuid}` label in the query string. The renderer's
+   pool-wait bootstrap sends `pool_window_ready` with the NEW label; from the
+   handshake's perspective this is indistinguishable from a fresh spawn.
+   The old foreign label is scrubbed from every host map (`window_hwnds`,
+   reducer browsers registry re-keyed via UnregisterBrowser + fresh
+   RegisterBrowser under the new label — NOT mutation in place, so every
+   existing invariant about label lifetime holds).
+3. Launcher ledger: `report_window_closed(old_label)` (already happens) +
+   `report_pool_window_added(new_label)` — the count mirrors stay paired.
+
+Rejected alternative — teaching the whole pool machinery to accept arbitrary
+`window-*` labels — touches every prefix check in window_pool.rs, the reducer,
+and the frontend pool gate (`isPoolMode` reads `pool=1`, not the label), for
+no benefit over relabeling at the single adoption point.
+
+### Verification
+
+`AGENTMUX_DEBUG_CLOSE=1` + the E2E harness: exhaust the pool (open windows
+until a `window-{uuid}` label appears), close it, assert (a) renderer count
+returns to baseline (wmic, `--type=renderer` filtered), (b) the pool gained a
+warm entry, (c) `Client.windowids` unchanged (regression guard on #2087).
+
+---
+
+## Residual 2 — srv window-row label crumb
+
+### Problem
+
+srv `Window` rows carry no record of which host window label created them.
+Every cleanup path resolves label → `window_id` exclusively through the
+host-side registration chain (`register_backend_window` →
+launcher → `shadow_backend_window_ids`). When that chain hasn't completed —
+the #2088 race, closed but only for the initHostNewWindow path — or when the
+host process is simply gone (crash forensics), nothing can map a label to its
+row. `demote_srv_cleanup`'s fallback today is "log `srv state may orphan` and
+give up."
+
+### Design
+
+Write the label as a meta key on the Window row at creation time:
+
+- Frontend `initHostNewWindow` already knows both (`windowLabel` from the URL,
+  `newWindow.oid` from CreateWindow) — pass the label as a new optional arg to
+  `window.CreateWindow`, persisted into `Window.meta["host:label"]`.
+- srv: `CreateWindow` handler threads it through the reducer command; the
+  persist subscriber writes it with the row. No new table, no migration —
+  `meta` is already a `MetaMapType`.
+- Consumers (all optional, additive):
+  - `demote_srv_cleanup`'s no-registration fallback can ask srv
+    `window.FindByLabel` (new lightweight read RPC filtering on the meta key)
+    before giving up.
+  - Crash forensics / `muxlog`-era debugging: rows become attributable.
+- The crumb is a **hint, not an identity**: labels are reused across host
+  restarts (`main`) and adoption (Residual 1) relabels windows, so consumers
+  must treat a miss or a stale value as "fall back to current behavior,"
+  never delete on crumb evidence alone.
+
+### Verification
+
+Unit test on the srv handler (crumb persisted + FindByLabel resolves);
+E2E: close a window within the registration gap (the #2088 repro shape) and
+assert the fallback now closes the row via the crumb.
+
+---
+
+## Residual 3 — non-Windows close-path verification
+
+### Problem
+
+Every close-path finding since 2026-07-04 (CEF-148 parking, demote, imperative
+srv cleanup, #2087–#2089) was established and verified on Windows only. On
+macOS/Linux the code takes different branches (`window.close()` Views path,
+`on_before_close` believed to fire properly — "no parked-browser evidence
+there yet", per `demote_promoted_pool_window`'s doc comment). "Believed" is
+not "verified": if parking also happens there, those platforms still leak srv
+rows on every secondary-window close.
+
+### Scope (verification only — no code unless it fails)
+
+On macOS and Linux (`task dev`, launcher-in-loop):
+
+1. Open + close a secondary window via chrome ✕, IPC `closeWindowByLabel`,
+   and the OS close (Cmd+W / window-manager close button).
+2. Assert `Client.windowids` returns to baseline each time (the
+   `window-close-baseline` E2E suite is Windows-gated today — lifting the
+   `IS_WINDOWS` gate for these two suites IS the deliverable if the paths
+   pass; a platform-specific fix spec is the deliverable if they don't).
+3. Confirm `on_before_close` actually fires there (close-debug trace).
+
+---
+
+## Suggested PR slicing
+
+1. PR A — Residual 2 (crumb): smallest, pure additive, unblocks better
+   fallbacks everywhere.
+2. PR B — Residual 1 (adoption): Windows-only, riskiest, needs live verify.
+3. PR C — Residual 3: verification pass; either lifts the E2E platform gate
+   or produces a new fix spec.

--- a/docs/specs/SPEC_TEST_SRV_SPAWN_GUARDS_2026_07_11.md
+++ b/docs/specs/SPEC_TEST_SRV_SPAWN_GUARDS_2026_07_11.md
@@ -1,0 +1,91 @@
+# SPEC: Guard integration-test srv spawns (kill_on_drop / Job Object)
+
+**Date:** 2026-07-11
+**Status:** Ready for implementation
+**Tracking:** session task #16
+**Scope:** `agentmux-srv/tests/` (test infrastructure only — no product code)
+
+## Problem
+
+`agentmux-srv/tests/integration_test.rs::spawn_backend()` spawns a real
+`agentmux-srv` subprocess via `std::process::Command::spawn()` and returns the
+raw `Child`. Every test cleans up with an explicit `child.kill()` at the end of
+its body — which never runs if any assertion between spawn and kill fails:
+panic unwinds past the kill, the test harness reports the failure, and the srv
+process **stays alive indefinitely** on the developer machine / CI runner.
+
+Each leaked srv holds:
+- two listening sockets (web + ws),
+- an open SQLite store under the temp/test data dir,
+- shell subprocesses it may have spawned for blocks.
+
+On a dev machine this pollutes `tasklist` and can confuse instance discovery
+(`muxlog ls`, wmic-based sweeps); on CI it accumulates until the runner
+recycles. The E2E suites (`test/e2e/harness.ts`) already solved this class for
+their instance spawns (wrapper-first kill + scoped wmic sweep in
+`teardownInstance`); the Rust integration tests have no equivalent.
+
+`subprocess_io.rs` spawns short-lived OS utilities as test *subjects* — those
+exit on their own and are out of scope, but the audit in Phase 1 should confirm
+none of them can block forever.
+
+## Design
+
+### Phase 1 — RAII kill guard (cross-platform, the actual fix)
+
+Add a `KillOnDrop(std::process::Child)` wrapper in the test support code:
+
+```rust
+/// Kills the wrapped child on drop — including drop-during-panic-unwind,
+/// which is exactly when the explicit end-of-test `kill()` never runs.
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait(); // reap — avoid a zombie on unix
+    }
+}
+```
+
+`spawn_backend()` returns `(KillOnDrop, ...)` instead of a bare `Child`; tests
+keep the guard alive for their duration and drop it (implicitly) at scope end.
+The explicit `child.kill()` calls at the end of each test are deleted — the
+guard owns cleanup unconditionally. `Deref`/`DerefMut` to `Child` keeps any
+direct child access compiling.
+
+Panic-unwind runs `Drop`, so a failed assertion now reaps the srv. This covers
+every failure mode except the harness process itself being hard-killed.
+
+### Phase 2 — Windows Job Object (hard-kill coverage, optional)
+
+`Drop` cannot cover `cargo test` itself being terminated (Ctrl+C on some
+shells, CI timeout SIGKILL, OOM-kill of the runner). On Windows, assigning the
+child to a kill-on-close Job Object makes the OS reap it when the test process
+dies, unconditionally:
+
+- Small `#[cfg(target_os = "windows")]` helper in the test support module:
+  create an anonymous Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`,
+  `AssignProcessToJobObject` right after spawn, hold the job handle inside
+  `KillOnDrop` so it closes (→ OS kills the child) no matter how the process
+  exits.
+- This mirrors what `agentmux-launcher/src/job_object.rs` does for production
+  (J0); the test helper stays local to `tests/` rather than exporting the
+  launcher's internals across crates — the API surface needed is ~15 lines of
+  `windows-sys` calls. **Isolation invariants I2/I3 apply**: the job is
+  anonymous (unnamed), created by the test itself, and can only ever contain
+  processes the test spawned.
+- Unix: process groups would be the analog; deferred — `Drop` + CI runner
+  containerization already covers the realistic leak paths there.
+
+## Definition of done
+
+1. `spawn_backend()` returns a guard; no test in `integration_test.rs` calls
+   `kill()` manually.
+2. A deliberately-failing scratch test (assert right after spawn) leaves zero
+   `agentmux-srv` processes behind — verified with `tasklist | grep` before/
+   after on Windows.
+3. (Phase 2) Killing the `cargo test` process mid-run leaves zero srv
+   processes on Windows.
+4. `subprocess_io.rs` audited: subject processes either self-terminate or get
+   the same guard.


### PR DESCRIPTION
Part of the 2026-07-11 tracking cleanup (closed #864, #1605, #1606, #376, Discussion #1680; status maps on #942/#768; new trackers #2091 muxbus-ws handshake, #2092 launcher-side teardown backstop).

**Two implementation-ready specs for the remaining window-lifecycle backlog:**

1. `SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11.md` — the three residuals the pool-coverage work deliberately left open, sliced as three independently-shippable PRs:
   - **A. srv window-row label crumb** (`Window.meta["host:label"]` at CreateWindow) — gives `demote_srv_cleanup` a real fallback instead of "srv state may orphan", and makes rows attributable in crash forensics. Hint-not-identity semantics spelled out.
   - **B. pool adoption for foreign `window-{uuid}` labels** — relabel-at-demote so pool-exhausted cold-path windows stop stranding a ~100MB parked renderer per close (the "Known residual" in `CloseWindowTask`).
   - **C. non-Windows close-path verification** — every parking/demote/cleanup finding since 07-04 is Windows-verified only; deliverable is either lifting the E2E suites' platform gate or a platform fix spec.

2. `SPEC_TEST_SRV_SPAWN_GUARDS_2026_07_11.md` — `spawn_backend()` in the srv integration tests returns a bare `Child` whose cleanup `kill()` never runs on assertion failure, leaking srv processes on dev machines and CI. Phase 1: RAII `KillOnDrop` guard; Phase 2: anonymous kill-on-close Job Object on Windows (test-local, upholds I2/I3).

**Plus one code-comment correction** surfaced by the #864 closure audit: `wave_obj_bridge.rs` still claimed the granular layout-tree events are persisted wcore-direct — that migration completed in SPEC_864 phases 2–5 (#1970–#1981); the comment now points at the actual (srv-IPC read race) reason those events stay unbridged.

No changeset: docs + a comment-only fix.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)