### PR TITLE
feat(srv): host:label window-row crumb + crumb-based cleanup fallback (Residual A)

### DIFF
--- a/.changesets/1783793072-feat-srv-persist-host-window-label-as-a-meta-crumb-crumb-bas-xs4o.md
+++ b/.changesets/1783793072-feat-srv-persist-host-window-label-as-a-meta-crumb-crumb-bas-xs4o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): persist host window label as a meta crumb + crumb-based cleanup fallback

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -448,6 +448,68 @@ pub(crate) fn backend_get_client_window_ids(web_endpoint: &str, auth_key: &str) 
     )
 }
 
+/// SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11 Residual 2 — resolve
+/// srv Window rows by the `host:label` meta crumb persisted at CreateWindow
+/// time. Returns ALL matching window ids (the crumb is a hint, not an
+/// identity — labels can recur across host restarts); `None` on transport
+/// failure, `Some(vec![])` on a clean no-match. Same wire shape / blocking
+/// thread contract as `backend_get_client_window_ids` above.
+pub(crate) fn backend_find_window_by_label(
+    web_endpoint: &str,
+    auth_key: &str,
+    label: &str,
+) -> Option<Vec<String>> {
+    use std::io::Write;
+
+    let addr = parse_web_endpoint(web_endpoint, "backend_find_window_by_label")?;
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "FindWindowByLabel",
+        "args": [label],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|e| tracing::warn!(error = %e, "[backend_find_window_by_label] connect failed"))
+        .ok()?;
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| tracing::warn!(error = %e, "[backend_find_window_by_label] write failed"))
+        .ok()?;
+
+    use std::io::Read;
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok()?;
+
+    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
+    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let ids = parsed.get("data")?.as_array()?;
+    Some(
+        ids.iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+    )
+}
+
 /// SPEC_PILLAR1_STEP4 Phase 3 — read one window's persisted `kind` /
 /// `parent_window_id` (Step 3's fields) for the slow-path reproject driver.
 /// Same shape/thread contract as `backend_get_client_window_ids` above.

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -77,6 +77,9 @@ pub(crate) use helpers::backend_set_window_topology;
 // SPEC_PILLAR1_STEP4 Phase 3 — slow-path reproject reads, used by
 // `commands/window/creation.rs::reproject_from_srv`.
 pub(crate) use helpers::{backend_get_client_window_ids, backend_get_window_topology};
+// SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB Residual 2 — crumb-based label
+// resolution for `demote_srv_cleanup`'s no-registration fallback.
+pub(crate) use helpers::backend_find_window_by_label;
 pub(crate) use lifecycle::{
     retry_backend_window_id_lookup, BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
     BACKEND_WINDOW_ID_RETRY_DELAY,

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -654,12 +654,43 @@ pub fn demote_srv_cleanup(state: &Arc<AppState>, label: &str) {
                 crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
             }
             None => {
-                let warn = format!(
-                    "demote_srv_cleanup({}): no backend window ID after retries — srv state may orphan",
-                    lbl
-                );
-                crate::client::dlog(&warn);
-                tracing::warn!("{}", warn);
+                // Registration chain came up empty — the early-close race
+                // shape (#2088's registration moved earlier, but a close can
+                // still land before it) or a lost launcher round-trip. Last
+                // resort (SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB Residual
+                // 2): ask srv to resolve the label via the `host:label`
+                // crumb persisted atomically with row creation. Close ONLY
+                // on an unambiguous single match — the crumb is a hint, and
+                // labels can recur across host restarts; a multi-match means
+                // stale rows from a prior life, where guessing could delete
+                // a window the slow-path reproject still owes the user.
+                match crate::client::backend_find_window_by_label(&web_endpoint, &auth_key, &lbl) {
+                    Some(ids) if ids.len() == 1 => {
+                        let window_id = &ids[0];
+                        crate::client::dlog(&format!(
+                            "demote_srv_cleanup({}): resolved via host:label crumb — backend_close_window window_id={}",
+                            lbl, window_id
+                        ));
+                        crate::client::backend_close_window(&web_endpoint, &auth_key, window_id);
+                    }
+                    Some(ids) => {
+                        let warn = format!(
+                            "demote_srv_cleanup({}): no backend window ID after retries, crumb lookup returned {} match(es) — srv state may orphan",
+                            lbl,
+                            ids.len()
+                        );
+                        crate::client::dlog(&warn);
+                        tracing::warn!("{}", warn);
+                    }
+                    None => {
+                        let warn = format!(
+                            "demote_srv_cleanup({}): no backend window ID after retries, crumb lookup unavailable — srv state may orphan",
+                            lbl
+                        );
+                        crate::client::dlog(&warn);
+                        tracing::warn!("{}", warn);
+                    }
+                }
                 crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
             }
         }

--- a/agentmux-srv/src/server/service/window.rs
+++ b/agentmux-srv/src/server/service/window.rs
@@ -23,6 +23,36 @@ pub(super) async fn handle_window_service(state: &AppState, call: &WebCallType) 
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
+        // SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11 Residual 2 —
+        // resolve Window rows by the `host:label` meta crumb written at
+        // CreateWindow time. Returns ALL matching window ids (labels can
+        // recur across host restarts — the crumb is a hint, not an
+        // identity); the caller decides what a multi-match means for its
+        // use case. An empty array is a normal answer (row predates the
+        // crumb, or the label never created a row).
+        "FindWindowByLabel" => {
+            let label: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            if label.is_empty() {
+                return WebReturnType::error("FindWindowByLabel: empty label".to_string());
+            }
+            match store.get_all::<Window>() {
+                Ok(wins) => {
+                    let ids: Vec<String> = wins
+                        .into_iter()
+                        .filter(|w| {
+                            w.meta.get("host:label").and_then(|v| v.as_str())
+                                == Some(label.as_str())
+                        })
+                        .map(|w| w.oid)
+                        .collect();
+                    WebReturnType::success(serde_json::json!(ids))
+                }
+                Err(e) => WebReturnType::error(e.to_string()),
+            }
+        }
         // Phase E.5.8 — CreateWindow migrated through the reducer.
         // Two paths: (1) empty workspace_id → CreateWorkspace +
         // CreateTab + CreateWindow as a multi-step dispatch (mirrors
@@ -294,9 +324,45 @@ pub(super) async fn handle_window_service(state: &AppState, call: &WebCallType) 
                     let _ = store.update(&mut win);
                 }
             }
+            // SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11 Residual 2 —
+            // persist the caller's host window label as a meta crumb,
+            // atomically with row creation (optional arg 2; old callers send
+            // two args and skip this). The crumb exists so cleanup paths can
+            // resolve label → window row WITHOUT the host-side registration
+            // chain (`register_backend_window` → launcher shadow), which is
+            // exactly what's missing in the early-close race shape (#2088)
+            // and after a host crash. It is a HINT, not an identity — labels
+            // recur across host restarts — so consumers must treat a miss or
+            // duplicate as "fall back to current behavior," never delete on
+            // crumb evidence alone. Non-fatal on failure: an unattributed
+            // row is the pre-crumb status quo.
+            let host_label: String = service::get_arg(args, 2).unwrap_or_default();
+            let crumb_events = if host_label.is_empty() {
+                Vec::new()
+            } else {
+                let evs = dispatch_to_reducer(
+                    state,
+                    agentmux_common::ipc::Command::UpdateWindowMeta {
+                        window_id: window_id.clone(),
+                        meta_patch: serde_json::json!({ "host:label": host_label }),
+                    },
+                )
+                .await;
+                for ev in &evs {
+                    if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                        tracing::warn!(
+                            window_id = %window_id,
+                            error = %e,
+                            "CreateWindow: host:label crumb write failed — row stays unattributed"
+                        );
+                    }
+                }
+                evs
+            };
             // Publish all events from this multi-step (workspace + tab + window).
             let mut all_events = fresh_workspace_events;
             all_events.extend(win_events);
+            all_events.extend(crumb_events);
             publish_events(state, &all_events);
             // Return the Window struct (matches the prior RPC contract).
             match store.must_get::<Window>(&window_id) {
@@ -1143,5 +1209,119 @@ mod close_window_divergence_tests {
         let state = test_state();
         let ret = handle_window_service(&state, &close_call("no-such-window")).await;
         assert!(ret.success, "idempotent CloseWindow failed: {:?}", ret.error);
+    }
+}
+
+#[cfg(test)]
+mod window_label_crumb_tests {
+    use super::handle_window_service;
+    use crate::backend::obj::Window;
+    use crate::backend::service::WebCallType;
+    use crate::server::tests::test_state;
+
+    fn create_call(workspace_id: &str, label: Option<&str>) -> WebCallType {
+        let mut args = vec![
+            serde_json::Value::Null,
+            serde_json::Value::String(workspace_id.to_string()),
+        ];
+        if let Some(l) = label {
+            args.push(serde_json::Value::String(l.to_string()));
+        }
+        WebCallType {
+            service: "window".to_string(),
+            method: "CreateWindow".to_string(),
+            uicontext: None,
+            args,
+        }
+    }
+
+    fn find_call(label: &str) -> WebCallType {
+        WebCallType {
+            service: "window".to_string(),
+            method: "FindWindowByLabel".to_string(),
+            uicontext: None,
+            args: vec![serde_json::Value::String(label.to_string())],
+        }
+    }
+
+    /// The crumb round-trip this exists for: CreateWindow with a label arg
+    /// persists `host:label` on the row, and FindWindowByLabel resolves it
+    /// back to exactly that window id — no host-side registration involved.
+    #[tokio::test]
+    async fn crumb_written_at_create_and_resolvable_by_label() {
+        let state = test_state();
+        let ret = handle_window_service(
+            &state,
+            &create_call("", Some("window-pool-crumbtest1")),
+        )
+        .await;
+        assert!(ret.success, "CreateWindow failed: {:?}", ret.error);
+        let created_id = ret
+            .data
+            .as_ref()
+            .and_then(|d| d.get("oid"))
+            .and_then(|v| v.as_str())
+            .expect("CreateWindow returns the Window with oid")
+            .to_string();
+
+        // The crumb is on the persisted row itself.
+        let row = state
+            .wstore
+            .must_get::<Window>(&created_id)
+            .expect("created window row exists");
+        assert_eq!(
+            row.meta.get("host:label").and_then(|v| v.as_str()),
+            Some("window-pool-crumbtest1"),
+            "host:label crumb missing from the Window row meta"
+        );
+
+        // And resolvable through the read RPC.
+        let found = handle_window_service(&state, &find_call("window-pool-crumbtest1")).await;
+        assert!(found.success, "FindWindowByLabel failed: {:?}", found.error);
+        let ids: Vec<String> =
+            serde_json::from_value(found.data.expect("find returns ids")).unwrap();
+        assert_eq!(ids, vec![created_id]);
+    }
+
+    /// Old two-arg callers keep working and write no crumb — the arg is
+    /// genuinely optional, not silently defaulted to something matchable.
+    #[tokio::test]
+    async fn two_arg_create_window_writes_no_crumb() {
+        let state = test_state();
+        let ret = handle_window_service(&state, &create_call("", None)).await;
+        assert!(ret.success, "CreateWindow failed: {:?}", ret.error);
+        let created_id = ret
+            .data
+            .as_ref()
+            .and_then(|d| d.get("oid"))
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let row = state.wstore.must_get::<Window>(&created_id).unwrap();
+        assert!(
+            !row.meta.contains_key("host:label"),
+            "two-arg CreateWindow must not invent a crumb"
+        );
+    }
+
+    /// A label nothing ever created is a normal empty answer, not an error
+    /// (rows predating the crumb look exactly like this to consumers).
+    #[tokio::test]
+    async fn unknown_label_returns_empty_not_error() {
+        let state = test_state();
+        let found = handle_window_service(&state, &find_call("window-never-existed")).await;
+        assert!(found.success);
+        let ids: Vec<String> =
+            serde_json::from_value(found.data.expect("find returns ids")).unwrap();
+        assert!(ids.is_empty());
+    }
+
+    /// Empty label is a caller bug — reject loudly rather than matching
+    /// every crumbless row's absent key semantics ambiguously.
+    #[tokio::test]
+    async fn empty_label_is_an_error() {
+        let state = test_state();
+        let found = handle_window_service(&state, &find_call("")).await;
+        assert!(!found.success);
     }
 }

--- a/docs/specs/SPEC_TEST_SRV_SPAWN_GUARDS_2026_07_11.md
+++ b/docs/specs/SPEC_TEST_SRV_SPAWN_GUARDS_2026_07_11.md
@@ -57,10 +57,18 @@ direct child access compiling.
 Panic-unwind runs `Drop`, so a failed assertion now reaps the srv. This covers
 every failure mode except the harness process itself being hard-killed.
 
-### Phase 2 — Windows Job Object (hard-kill coverage, optional)
+### Phase 2 — Windows Job Object (hard-kill + grandchild coverage, REQUIRED)
 
-`Drop` cannot cover `cargo test` itself being terminated (Ctrl+C on some
-shells, CI timeout SIGKILL, OOM-kill of the runner). On Windows, assigning the
+Upgraded from optional to required by live evidence (2026-07-11, same day):
+a full `cargo test -p agentmux-srv` run leaked an srv **`--crash-monitor`
+grandchild** (spawned by the test's srv, not by `spawn_backend` directly),
+which then held an inherited stdout pipe open and hung the calling shell
+pipeline for 20+ minutes after cargo itself had exited. A `Drop` guard on
+the direct child cannot reap grandchildren; a kill-on-close Job Object
+captures the whole tree.
+
+`Drop` also cannot cover `cargo test` itself being terminated (Ctrl+C on
+some shells, CI timeout SIGKILL, OOM-kill of the runner). On Windows, assigning the
 child to a kill-on-close Job Object makes the OS reap it when the test process
 dies, unconditionally:
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -314,6 +314,12 @@ async function initInstanceTracking(): Promise<void> {
  * client/window/workspace/tab data from backend, verifying objects exist,
  * and creating missing ones if needed.
  */
+/** This renderer's CEF window label — `windowLabel` from the boot URL, or
+ *  "main" (the main window's URL carries no label param). */
+function currentWindowLabel(): string {
+    return new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+}
+
 async function initHostWave(): Promise<void> {
     const t0 = performance.now();
     const tlog = (label: string, since: number) => {
@@ -333,7 +339,7 @@ async function initHostWave(): Promise<void> {
         // If no windows exist, create one
         if (!windowId) {
             t = performance.now();
-            const newWindow = await withTimeout(WindowService.CreateWindow(null, ""), RPC_TIMEOUT, "CreateWindow");
+            const newWindow = await withTimeout(WindowService.CreateWindow(null, "", currentWindowLabel()), RPC_TIMEOUT, "CreateWindow");
             tlog("CreateWindow (no windows)", t);
             windowId = newWindow.oid;
         }
@@ -345,7 +351,7 @@ async function initHostWave(): Promise<void> {
 
         if (!windowData) {
             t = performance.now();
-            windowData = await withTimeout(WindowService.CreateWindow(null, ""), RPC_TIMEOUT, "CreateWindow");
+            windowData = await withTimeout(WindowService.CreateWindow(null, "", currentWindowLabel()), RPC_TIMEOUT, "CreateWindow");
             tlog("CreateWindow (fallback)", t);
             windowId = windowData.oid;
         }
@@ -359,7 +365,7 @@ async function initHostWave(): Promise<void> {
             // Workspace missing → recreate entire window
             t = performance.now();
             await withTimeout(WindowService.CloseWindow(windowData.oid), RPC_TIMEOUT, "CloseWindow");
-            windowData = await withTimeout(WindowService.CreateWindow(null, ""), RPC_TIMEOUT, "CreateWindow");
+            windowData = await withTimeout(WindowService.CreateWindow(null, "", currentWindowLabel()), RPC_TIMEOUT, "CreateWindow");
             workspace = await withTimeout(WorkspaceService.GetWorkspace(windowData.workspaceid), RPC_TIMEOUT, "GetWorkspace");
             tlog("Recreate window+workspace", t);
         }
@@ -444,7 +450,7 @@ async function initHostNewWindow(): Promise<void> {
         }
 
         t = performance.now();
-        const newWindow = await withTimeout(WindowService.CreateWindow(null, tearOffWsId), RPC_TIMEOUT, "CreateWindow");
+        const newWindow = await withTimeout(WindowService.CreateWindow(null, tearOffWsId, currentWindowLabel()), RPC_TIMEOUT, "CreateWindow");
         tlog("CreateWindow", t);
 
         // Register label→window_id with the host NOW, not at the end of
@@ -460,7 +466,7 @@ async function initHostNewWindow(): Promise<void> {
         // can no longer happen (task #29 round 2, found by the
         // window-close-baseline E2E suite).
         {
-            const wlabel = new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+            const wlabel = currentWindowLabel();
             getApi().registerBackendWindow(wlabel, newWindow.oid);
         }
 
@@ -1068,7 +1074,7 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     // The CEF host handles cleanup at the right time (after the browser commits to
     // closing), keeping shells grouped under the CEF process in Task Manager.
     {
-        const wlabel = new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+        const wlabel = currentWindowLabel();
         const wid = initOpts.windowId;
         console.log(`[wave] registerBackendWindow decision: wlabel=${wlabel} wid=${wid ?? "(falsy)"}`);
         if (wid) {

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -105,7 +105,11 @@ class WindowServiceType {
     CloseWindow(windowId: string): Promise<void> {
         return WOS.callBackendService("window", "CloseWindow", Array.from(arguments))
     }
-    CreateWindow(winSize: WinSize, workspaceId: string): Promise<WaveWindow> {
+    // `hostLabel` (optional, SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB Residual 2):
+    // the caller's CEF window label, persisted as a `host:label` meta crumb on
+    // the created Window row so srv-side cleanup can attribute rows without
+    // the host registration chain.
+    CreateWindow(winSize: WinSize, workspaceId: string, hostLabel?: string): Promise<WaveWindow> {
         return WOS.callBackendService("window", "CreateWindow", Array.from(arguments))
     }
     GetWindow(windowId: string): Promise<WaveWindow> {


### PR DESCRIPTION
PR A of `SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11.md` (task #15, the #1969 residuals).

## Problem

srv `Window` rows carry no record of which host window label created them, so every cleanup path depends entirely on the host-side registration chain (`register_backend_window` → launcher → shadow map). When that chain hasn't completed — the early-close race shape, narrowed but not eliminated by #2088 — or when the host is gone, nothing can map label → row: `demote_srv_cleanup` gives up with `"srv state may orphan"`.

## Change

- `window.CreateWindow` accepts an **optional third arg** (the caller's CEF window label), persisted as `Window.meta["host:label"]` **atomically with row creation** — reuses the existing `UpdateWindowMeta` command + persistence machinery; no new commands, events, or subscriber arms. Old two-arg callers unchanged (verified by test).
- New `window.FindWindowByLabel` read RPC resolves rows by the crumb, returning **all** matches — the crumb is a hint, not an identity (labels recur across host restarts); consumers decide what multi-match means.
- Frontend passes `currentWindowLabel()` at all four `CreateWindow` call sites (+ dedupes the two inline `windowLabel` lookups onto the helper).
- `demote_srv_cleanup`'s no-registration fallback asks srv for the crumb and closes the row **only on an unambiguous single match**; multi-match / lookup failure keeps the warn-and-orphan status quo — never delete on crumb evidence alone.

## Verification

- 4 new service-level tests (crumb round-trip, two-arg no-crumb, unknown-label → clean empty, empty-label → error). Full suites: srv 1469, host 188, vitest all green.
- Live on a packaged build: `FindWindowByLabel` resolves a fresh window's label to exactly its row id; `main` (an `ensure_initial_data` row predating the crumb) correctly returns empty; open→close cycle still returns `Client.windowids` to baseline.

## Rider

Upgrades `SPEC_TEST_SRV_SPAWN_GUARDS` Phase 2 (Job Object) from optional to **required**, with live evidence from this session: a full `cargo test -p agentmux-srv` run leaked an srv `--crash-monitor` **grandchild** that held the calling shell pipeline open for 20+ minutes after cargo exited — a Drop guard on the direct child cannot reap grandchildren.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)