### PR TITLE
fix(tabbar): cross-tab drag stability + hover strobe

### DIFF
--- a/.changesets/1783793263-fix-tabbar-cross-tab-drag-stability-stuck-overlay-cleanup-gh-2ab5.md
+++ b/.changesets/1783793263-fix-tabbar-cross-tab-drag-stability-stuck-overlay-cleanup-gh-2ab5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabbar): cross-tab drag stability (stuck-overlay cleanup, ghost/landing clamp, geometry refresh) + hover strobe

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -5,7 +5,7 @@ import { Logger } from "@/util/logger";
 import { draggable, dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import { isWindows } from "@/util/platformutil";
-import { createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import clsx from "clsx";
 import { Tab } from "./tab";
@@ -230,9 +230,22 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                     // Activate the target overlay BEFORE the switch so the
                     // very first dragover after the tab becomes visible
                     // already hits TileLayout's drop targets.
-                    getLayoutModelForTabById(props.tabId)?.activeDrag._set(true);
+                    const model = getLayoutModelForTabById(props.tabId);
+                    model?.activeDrag._set(true);
                     dragActivatedTabIds.add(props.tabId);
                     props.onSelect();
+                    // The tab was display:none until the switch — its
+                    // layout rects (additionalProps/overlay transforms)
+                    // were computed against a zero-size container, so the
+                    // first hover/drop hit-tests would use garbage
+                    // geometry. Force a tree re-measure once the tab has
+                    // real bounds (double rAF: display flip applies on the
+                    // next frame; measure the one after).
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(() => {
+                            fireAndForget(async () => model?.onTreeStateAtomUpdated(true));
+                        });
+                    });
                 }, SPRING_SWITCH_MS);
             },
             onDragLeave: clearSpring,
@@ -284,6 +297,14 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                     : {}),
             } as JSX.CSSProperties}
         >
+            <Show when={isTileDropHover()} keyed>
+                {/* Attention strobe: 10 flashes at 20ms (200ms total),
+                    riding the tab's top edge, fired the instant a pane
+                    hover begins (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1).
+                    `keyed` remounts the element per hover entry so the
+                    one-shot CSS animation restarts every time. */}
+                <div class="tab-drop-strobe" aria-hidden="true" />
+            </Show>
             <Tab
                 id={props.tabId}
                 active={props.isActive}

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -142,6 +142,25 @@
             }
         }
 
+        // Attention strobe riding the tab's top edge — 10 flashes at 20ms
+        // (200ms total), one-shot, fired the instant a pane hover begins
+        // (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1). The element is
+        // keyed-remounted per hover entry (droppable-tab.tsx) so the
+        // animation restarts every time; `forwards` holds the final
+        // opacity:0 frame so it vanishes after the burst rather than
+        // freezing visible.
+        .tab-drop-strobe {
+            position: absolute;
+            top: 0;
+            left: 6px;
+            right: 6px;
+            height: 3px;
+            background: var(--accent-color);
+            pointer-events: none;
+            z-index: 2;
+            animation: tab-drop-strobe-flash 20ms steps(1, end) 10 forwards;
+        }
+
         // Tab being dragged — reduce opacity
         &.tab-dragging {
             opacity: 0.35;
@@ -196,4 +215,12 @@
     55%  { transform: scaleX(1.04); }
     80%  { transform: scaleX(0.98); }
     100% { transform: scaleX(1.0);  }
+}
+
+// One strobe cycle: visible for the first half (10ms), dark for the
+// second (10ms) — 10 iterations = 10 distinct flashes over 200ms.
+@keyframes tab-drop-strobe-flash {
+    0%   { opacity: 1; }
+    50%  { opacity: 0; }
+    100% { opacity: 0; }
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -408,21 +408,45 @@ function TabBar(props: TabBarProps): JSX.Element {
         //    spring-switched through (their activeDrag was set by
         //    DroppableTab; TileLayout's own cleanup only covers the SOURCE
         //    tab's model).
+        //
+        //    A stuck activeDrag is a DEAD TAB — the overlay-container sits
+        //    over the entire tile area with pointer-events:auto and eats
+        //    every click — so the cleanup runs from three layers:
+        //    a) pragmatic's monitor onDrop (normal path),
+        //    b) a window dragend listener (pragmatic's dispatch can be
+        //       skipped on Win11 swallowed-drag paths — same rationale as
+        //       TileLayout's own resetDragState safety net),
+        //    c) a capture-phase pointerdown listener: a pointerdown cannot
+        //       happen mid-drag (the button is held), so any pointerdown
+        //       with spring-activated tabs still recorded means the drag
+        //       ended without (a) or (b) firing — clean up before the
+        //       stuck overlay swallows the click's target.
+        const cleanupTileDragState = () => {
+            setHoveredDropTabId(null);
+            clearCrossTabDrop();
+            for (const tabId of dragActivatedTabIds) {
+                getLayoutModelForTabById(tabId)?.activeDrag._set(false);
+            }
+            dragActivatedTabIds.clear();
+        };
         const cleanupTileMonitor = monitorForElements({
             canMonitor: ({ source }) => source.data.type === tileItemType,
-            onDrop: () => {
-                setHoveredDropTabId(null);
-                clearCrossTabDrop();
-                for (const tabId of dragActivatedTabIds) {
-                    getLayoutModelForTabById(tabId)?.activeDrag._set(false);
-                }
-                dragActivatedTabIds.clear();
-            },
+            onDrop: cleanupTileDragState,
         });
+        const onWindowDragEnd = () => {
+            if (dragActivatedTabIds.size > 0) cleanupTileDragState();
+        };
+        const onWindowPointerDown = () => {
+            if (dragActivatedTabIds.size > 0) cleanupTileDragState();
+        };
+        window.addEventListener("dragend", onWindowDragEnd);
+        window.addEventListener("pointerdown", onWindowPointerDown, true);
 
         onCleanup(() => {
             cleanupStripDrop();
             cleanupTileMonitor();
+            window.removeEventListener("dragend", onWindowDragEnd);
+            window.removeEventListener("pointerdown", onWindowPointerDown, true);
         });
     });
 

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -28,7 +28,13 @@ import {
 } from "./types";
 import { determineDropDirection } from "./utils";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
-import { clearCrossTabDrop, noteCrossTabDrop, redockDraggedPane, takeCrossTabDropFor } from "./crossTabDrag";
+import {
+    clampCrossTabDirection,
+    clearCrossTabDrop,
+    noteCrossTabDrop,
+    redockDraggedPane,
+    takeCrossTabDropFor,
+} from "./crossTabDrag";
 
 export const tileItemType = "TILE_ITEM";
 
@@ -599,7 +605,9 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         };
 
         const crossTab = isCrossTabDrag(props.layoutModel);
-        const direction = determineDropDirection(bestRect, clampedOffset);
+        const rawDirection = determineDropDirection(bestRect, clampedOffset);
+        // Cross-tab Outer* clamp — see clampCrossTabDirection.
+        const direction = crossTab ? clampCrossTabDirection(rawDirection) : rawDirection;
         props.layoutModel.treeReducer({
             type: LayoutTreeActionType.ComputeMove,
             nodeId: bestLeafId,
@@ -690,7 +698,11 @@ const OverlayNode = (props: OverlayNodeProps) => {
         if (props.layoutModel.displayContainerRef?.current && additionalProps()?.rect) {
             const containerRect = props.layoutModel.displayContainerRef.current.getBoundingClientRect();
             const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
-            const direction = determineDropDirection(additionalProps().rect, offset);
+            const rawDirection = determineDropDirection(additionalProps().rect, offset);
+            // Cross-tab: Outer* directions are clamped to their inner
+            // equivalents so the ghost matches the committed split — see
+            // clampCrossTabDirection in crossTabDrag.ts.
+            const direction = crossTab ? clampCrossTabDirection(rawDirection) : rawDirection;
             props.layoutModel.treeReducer({
                 type: LayoutTreeActionType.ComputeMove,
                 nodeId: props.node.id,

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -33,7 +33,13 @@ import {
 } from "./types";
 import { determineDropDirection } from "./utils";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
-import { clearCrossTabDrop, noteCrossTabDrop, redockDraggedPane, takeCrossTabDropFor } from "./crossTabDrag";
+import {
+    clampCrossTabDirection,
+    clearCrossTabDrop,
+    noteCrossTabDrop,
+    redockDraggedPane,
+    takeCrossTabDropFor,
+} from "./crossTabDrag";
 
 export const tileItemType = "TILE_ITEM";
 
@@ -597,7 +603,9 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         };
 
         const crossTab = isCrossTabDrag(props.layoutModel);
-        const direction = determineDropDirection(bestRect, clampedOffset);
+        const rawDirection = determineDropDirection(bestRect, clampedOffset);
+        // Cross-tab Outer* clamp — see clampCrossTabDirection.
+        const direction = crossTab ? clampCrossTabDirection(rawDirection) : rawDirection;
         props.layoutModel.treeReducer({
             type: LayoutTreeActionType.ComputeMove,
             nodeId: bestLeafId,
@@ -688,7 +696,11 @@ const OverlayNode = (props: OverlayNodeProps) => {
         if (props.layoutModel.displayContainerRef?.current && additionalProps()?.rect) {
             const containerRect = props.layoutModel.displayContainerRef.current.getBoundingClientRect();
             const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
-            const direction = determineDropDirection(additionalProps().rect, offset);
+            const rawDirection = determineDropDirection(additionalProps().rect, offset);
+            // Cross-tab: Outer* directions are clamped to their inner
+            // equivalents so the ghost matches the committed split — see
+            // clampCrossTabDirection in crossTabDrag.ts.
+            const direction = crossTab ? clampCrossTabDirection(rawDirection) : rawDirection;
             props.layoutModel.treeReducer({
                 type: LayoutTreeActionType.ComputeMove,
                 nodeId: props.node.id,

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -27,7 +27,13 @@ import {
 } from "./types";
 import { determineDropDirection } from "./utils";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
-import { clearCrossTabDrop, noteCrossTabDrop, redockDraggedPane, takeCrossTabDropFor } from "./crossTabDrag";
+import {
+    clampCrossTabDirection,
+    clearCrossTabDrop,
+    noteCrossTabDrop,
+    redockDraggedPane,
+    takeCrossTabDropFor,
+} from "./crossTabDrag";
 
 export const tileItemType = "TILE_ITEM";
 
@@ -712,7 +718,9 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         };
 
         const crossTab = isCrossTabDrag(props.layoutModel);
-        const direction = determineDropDirection(bestRect, clampedOffset);
+        const rawDirection = determineDropDirection(bestRect, clampedOffset);
+        // Cross-tab Outer* clamp — see clampCrossTabDirection.
+        const direction = crossTab ? clampCrossTabDirection(rawDirection) : rawDirection;
         props.layoutModel.treeReducer({
             type: LayoutTreeActionType.ComputeMove,
             nodeId: bestLeafId,
@@ -810,7 +818,11 @@ const OverlayNode = (props: OverlayNodeProps) => {
         if (props.layoutModel.displayContainerRef?.current && additionalProps()?.rect) {
             const containerRect = props.layoutModel.displayContainerRef.current.getBoundingClientRect();
             const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
-            const direction = determineDropDirection(additionalProps().rect, offset);
+            const rawDirection = determineDropDirection(additionalProps().rect, offset);
+            // Cross-tab: Outer* directions are clamped to their inner
+            // equivalents so the ghost matches the committed split — see
+            // clampCrossTabDirection in crossTabDrag.ts.
+            const direction = crossTab ? clampCrossTabDirection(rawDirection) : rawDirection;
             props.layoutModel.treeReducer({
                 type: LayoutTreeActionType.ComputeMove,
                 nodeId: props.node.id,

--- a/frontend/layout/lib/crossTabDrag.ts
+++ b/frontend/layout/lib/crossTabDrag.ts
@@ -20,6 +20,25 @@ import { Logger } from "@/util/logger";
 import { fireAndForget } from "@/util/util";
 import { DropDirection } from "./types";
 
+/**
+ * Clamp Outer* drop directions to their inner equivalents for CROSS-TAB
+ * drags. In-tab, Outer* commits a Move that inserts at the grandparent
+ * level (spanning the full cross axis) — and the ghost placeholder
+ * previews exactly that. But a cross-tab drop commits through
+ * RedockFloatingPane → queue_target_layout_split, which can only express
+ * "split THIS leaf" (Outer* becomes a 20% band of the target leaf) — a
+ * visibly different result from what the ghost showed. Clamping to the
+ * inner direction makes preview and commit agree: both are a half-split
+ * of the hovered leaf.
+ */
+export function clampCrossTabDirection(dir: DropDirection | undefined): DropDirection | undefined {
+    if (dir === undefined) return undefined;
+    if (dir >= DropDirection.OuterTop && dir <= DropDirection.OuterLeft) {
+        return (dir - 4) as DropDirection;
+    }
+    return dir;
+}
+
 export type CrossTabDropRecord = {
     blockId: string;
     sourceTabId: string;

--- a/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
+++ b/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
@@ -1,7 +1,7 @@
 # Spec: Pane Drag-to-Tab (Cross-Tab Pane Relocation via Drag & Drop)
 
 **Date:** 2026-07-10
-**Status:** Draft (v2 — spring-loaded tabs revision, same day)
+**Status:** Draft (v3 — field-testing addendum 2026-07-11, see end of file)
 **Repo state:** `main` @ `42b95715`
 **Scope:** In-window pane drag onto the tab bar (dropping a tile-layout pane onto a *different tab in the same window*). Cross-window drag (already handled by `DragOverlay`/`CrossWindowDragMonitor`) and touch/pen input are out of scope.
 
@@ -300,3 +300,109 @@ This spec's new tab-bar drop target (§4.1) must call `event.preventDefault()`-e
 - `frontend/app/tab/tabbar.tsx`, `tabbar-dnd.ts`, `droppable-tab.tsx` — existing tab-reorder drag to extend.
 - `frontend/app-init.ts:113-273` (`installFloatingRedockHoverListener`) — direction/ghost-rect vocabulary to reuse in §4.4.
 - `agentmux-srv/src/sagas/redock_floating_pane.rs`, `agentmux-srv/src/server/service/layout_helpers.rs`, `workspace.rs:1151-1230` — backend pattern this spec's new RPC should mirror.
+
+---
+
+## Addendum v3 (2026-07-11): field-testing fixes, strobe indicator, and the tab-reorder bug
+
+First real-usage session (two tabs, repeated pane moves back and forth) surfaced
+instability: one tab went completely non-responsive, and drop landings were
+"glitchy / inaccurate". Diagnosis from the dev instance's logs plus code reading,
+and the fixes shipped in `fix/cross-tab-drag-stability`:
+
+### A1. Hover strobe (new UX, implemented)
+
+On the instant a pane hover begins over a tab button, a 3px accent bar riding the
+tab's TOP edge strobes: **10 flashes at 20ms intervals (200ms total), one-shot**.
+Implemented as a `keyed` SolidJS `<Show>` mount (`droppable-tab.tsx`) so each
+hover entry remounts the element and restarts the CSS animation
+(`tab-drop-strobe-flash`, `steps(1, end)`, 10 iterations, `forwards` holding
+opacity:0 after the burst). Complements — not replaces — the existing slower
+`tab-drop-pulse` outline and the 500ms spring-switch dwell.
+
+### A2. Stability fixes
+
+1. **Dead tab (stuck overlay).** A spring switch force-sets the target tab's
+   `LayoutModel.activeDrag`, which flips its overlay-container to
+   `pointer-events: auto` over the whole tile area. Cleanup previously had one
+   layer (the tab bar's pragmatic tile monitor `onDrop`); if that dispatch is
+   missed (Win11 swallowed-dragend class of paths — the same reason TileLayout
+   has its own window-dragend `resetDragState` net), the overlay stays up and
+   the tab eats every click: **completely non-responsive**. Cleanup now runs
+   from three layers: monitor `onDrop`, a window `dragend` listener, and a
+   capture-phase `pointerdown` listener (a pointerdown cannot happen mid-drag,
+   so any pointerdown with spring-activated tabs still recorded means the drag
+   ended unobserved — clean up before the click hits the stuck overlay).
+
+2. **Ghost/landing mismatch on Outer directions.** All observed drops resolved
+   `direction: 7` (OuterLeft). In-tab, Outer* commits a Move inserting at the
+   grandparent level — and the ghost previews that. Cross-tab commits go through
+   `queue_target_layout_split`, where Outer* means "20% band of the target
+   leaf" — a visibly different landing than the preview. Fix:
+   `clampCrossTabDirection` maps Outer*→inner for cross-tab drags at BOTH the
+   ComputeMove (ghost) and drop-record sites, so preview and commit agree
+   (half-split of the hovered leaf).
+
+3. **Stale geometry right after the spring switch.** The target tab's layout
+   rects were computed while it was `display:none` (zero-size container), so
+   the first hover/drop hit-tests after the switch used garbage geometry —
+   the "glitchy landing". Fix: after `setActiveTab`, a double-rAF
+   `onTreeStateAtomUpdated(true)` forces a re-measure once the tab has real
+   bounds.
+
+4. **Stale-tree residue (pre-existing, NOT fixed here).** The session's first
+   redock failed cleanly with *"block …57a30 is in tab 80ec…, not e7f1…"* — the
+   source tab was rendering a leaf for a block the backend had already moved
+   (residue in the persisted dev data dir from the v1 testing session, which
+   fired blind append-redocks at the RPC level even though its hover UI never
+   showed). A dangling leaf also double-mounts the block (all tabs stay
+   mounted), clobbering the block-component registry — a second candidate for
+   the dead-tab symptom. This is the known
+   `INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08` issue;
+   wiping the dev channel's data dir (`~/.agentmux/dev/main/<hash>/data`)
+   clears the corrupted layout state for testing. A defensive
+   prune-dangling-leaves pass on tab load is the proper fix and stays with
+   that investigation, not this spec.
+
+### A3. Tab reorder positioning bug (OPEN — debug plan)
+
+Reported: dragging a TAB within the strip shows a bounce-like animation but the
+order never changes. Log evidence is stark and narrows this a lot:
+
+- **Zero `tab-drag started`** lines (logged unconditionally in
+  `DroppableTab.draggable.onDragStart`) in the entire dev-instance session —
+  the drag never starts as a pragmatic drag at all.
+- **Zero `ReorderTab` RPCs** in every srv log back through 2026-07-10 —
+  i.e. in-strip reorder has not successfully executed for at least two days,
+  predating the remount work. This is NOT a regression from the
+  cross-window-remount changes (whose tab-drag code paths all sit behind that
+  never-firing `onDragStart`).
+
+Since `onDragStart` never fires, the failure is at drag *initiation*:
+prioritized suspects, in test order —
+
+1. **`onGenerateDragPreview` throwing.** It runs before `onDragStart`
+   (pragmatic dispatch order) and does DOM measurement + `setTabGrabOffset`;
+   an exception here kills the gesture silently. Wrap in try/catch + log.
+2. **The native drag never starting** — check whether `dragstart` even fires
+   on `.tab-drop-wrapper` (add a temporary capture listener). If not: something
+   is intercepting `mousedown`/`pointerdown` before the browser's drag
+   threshold — candidates: the title-bar JS window-drag path
+   (`useWindowDrag` / `isInDragRegion` walking up from the tab despite
+   `data-drag-region="false"`), or a full-surface overlay (the active-tab
+   color-line portal is `pointer-events: none`, but verify the pane-overlay /
+   `data-pane-overlay` airspace punching isn't leaving an invisible native
+   hole over the strip).
+3. **The `Tab` component swallowing the gesture** — it has its own
+   `onDragStart={() => {}}` prop and click/dblclick handling; verify nothing
+   inside calls `preventDefault()` on `dragstart`/`mousedown`.
+4. Once initiation works, re-verify the drop half: `computeInsertionPoint`'s
+   gap math against the content-aware tab widths
+   (`SPEC_TAB_CONTENT_AWARE_SIZING`) — the bounce-without-reorder symptom
+   would ALSO appear if `executeReorder`'s `ReorderTab` RPC failed silently,
+   but the absence of `tab-drag started` rules that ordering out for now.
+
+The "bounce" the user sees cannot be `tab-bouncing` (only set on successful
+reorder/merge paths, none of which logged) — most likely it's the OS drag-image
+snap-back animation of a rejected native drag, which is consistent with the
+drag never being accepted by any drop target.


### PR DESCRIPTION
## Summary
Fixes from the first real-usage session of the spring-loaded pane drag (unstable behavior: one tab completely non-responsive, glitchy drop landings), plus the requested hover strobe. Spec addendum v3 in `SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` documents everything, including the diag evidence.

- **Dead tab fixed**: a spring-switched tab's `activeDrag` overlay could stay stuck at `pointer-events: auto` (eating every click) if pragmatic's monitor `onDrop` was missed. Cleanup now runs from three layers — monitor `onDrop`, window `dragend`, and a capture-phase `pointerdown` (a pointerdown can't happen mid-drag, so one arriving with spring-activated state means the drag ended unobserved).
- **Ghost/landing mismatch fixed**: diags showed every drop resolving `direction: 7` (OuterLeft); cross-tab Outer* directions preview a grandparent-level Move but commit a 20% leaf band via the redock backend. `clampCrossTabDirection` maps Outer*→inner at both the ghost and record sites so preview and commit agree.
- **Glitchy landing fixed**: the spring-switched tab's layout rects were computed while `display:none`; a double-rAF forced re-measure runs after the switch.
- **New hover strobe**: 10 flashes at 20ms intervals (200ms total) riding the tab's top edge, restarting on every hover entry (keyed remount).
- **Documented, not fixed here**: (a) stale-tree residue in the persisted dev data (pre-existing `INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION` issue — the session's one failed redock and the likely second cause of the dead tab); (b) the in-strip **tab reorder bug** (addendum A3): zero `tab-drag started` logs and zero `ReorderTab` RPCs across two days — tab drags never start as pragmatic drags, predating the remount work — with a prioritized debug plan.

## Test plan
- [x] `npx tsc --noEmit` clean; stylelint clean
- [x] `npx vitest run frontend/app/tab/ frontend/layout/` — 108/108 passing
- [ ] Manual: pane drag across tabs repeatedly — no dead tab afterward; if a tab ever wedges, the next click anywhere revives it (pointerdown net)
- [ ] Manual: cross-tab drop near a pane edge — the committed layout matches the ghost (half-split, no 20% sliver)
- [ ] Manual: hover a pane over a tab — 200ms strobe burst on the tab's top edge, restarts on re-entry

<!-- agentmux:agent_id=agent3 -->