### PR TITLE
chore: release v0.53.1

### DIFF
--- a/.changesets/1783747588-fix-tabbar-pane-drag-to-tab-reworked-as-spring-loaded-tabs-r-r4q7.md
+++ b/.changesets/1783747588-fix-tabbar-pane-drag-to-tab-reworked-as-spring-loaded-tabs-r-r4q7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabbar): pane drag-to-tab reworked as spring-loaded tabs (real drop targets, switch-on-dwell, in-layout ghost)

--- a/.changesets/1783748113-refactor-lifecycle-quit-arming-bit-reconcilequit-poke-drain--w2an.md
+++ b/.changesets/1783748113-refactor-lifecycle-quit-arming-bit-reconcilequit-poke-drain--w2an.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(lifecycle): quit arming bit, ReconcileQuit poke, drain-executor extraction (Pillar 2 sanitize-then-decide Phase 0)

--- a/.changesets/1783748841-refactor-lifecycle-orphan-reconcile-becomes-sanitize-then-de-gqw4.md
+++ b/.changesets/1783748841-refactor-lifecycle-orphan-reconcile-becomes-sanitize-then-de-gqw4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(lifecycle): orphan_reconcile becomes sanitize-then-decide — drain verdict moves to reconcile_quit

--- a/.changesets/1783749343-fix-lifecycle-consume-the-drain-verdict-at-every-count-lower-o807.md
+++ b/.changesets/1783749343-fix-lifecycle-consume-the-drain-verdict-at-every-count-lower-o807.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lifecycle): consume the drain verdict at every count-lowering dispatch site (Pillar 2 Phase 2)

--- a/.changesets/1783749719-refactor-lifecycle-wrr-quit-demoted-to-draining-gated-stage--b6vb.md
+++ b/.changesets/1783749719-refactor-lifecycle-wrr-quit-demoted-to-draining-gated-stage--b6vb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(lifecycle): WRR quit demoted to Draining-gated Stage-2 executor (Pillar 2 Phase 3)

--- a/.changesets/1783765484-fix-window-close-window-by-label-routes-window-closes-throug-yhih.md
+++ b/.changesets/1783765484-fix-window-close-window-by-label-routes-window-closes-throug-yhih.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): close_window_by_label routes window-* closes through CloseWindowTask so srv window rows are cleaned up

--- a/.changesets/1783767260-fix-frontend-register-backend-window-id-right-after-createwi-olw3.md
+++ b/.changesets/1783767260-fix-frontend-register-backend-window-id-right-after-createwi-olw3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(frontend): register backend window id right after CreateWindow, closing the early-close srv-row orphan race

--- a/.changesets/1783773195-fix-window-route-os-level-wm-close-alt-f4-taskbar-on-seconda-6qx0.md
+++ b/.changesets/1783773195-fix-window-route-os-level-wm-close-alt-f4-taskbar-on-seconda-6qx0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): route OS-level WM_CLOSE (Alt+F4/taskbar) on secondary windows through CloseWindowTask

--- a/.changesets/1783779616-feat-tabbar-drag-a-tab-onto-another-window-s-header-to-remou-sdj3.md
+++ b/.changesets/1783779616-feat-tabbar-drag-a-tab-onto-another-window-s-header-to-remou-sdj3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tabbar): drag a tab onto another window's header to remount it there

--- a/.changesets/1783793072-feat-srv-persist-host-window-label-as-a-meta-crumb-crumb-bas-xs4o.md
+++ b/.changesets/1783793072-feat-srv-persist-host-window-label-as-a-meta-crumb-crumb-bas-xs4o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): persist host window label as a meta crumb + crumb-based cleanup fallback

--- a/.changesets/1783793641-test-srv-raii-job-object-guards-for-integration-test-srv-spa-q36e.md
+++ b/.changesets/1783793641-test-srv-raii-job-object-guards-for-integration-test-srv-spa-q36e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(srv): RAII + Job Object guards for integration-test srv spawns (no more leaked children on test failure)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.53.0"
+version = "0.53.1"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.53.1 — 2026-07-11
+
+- fix(tabbar): pane drag-to-tab reworked as spring-loaded tabs (real drop targets, switch-on-dwell, in-layout ghost)
+- refactor(lifecycle): quit arming bit, ReconcileQuit poke, drain-executor extraction (Pillar 2 sanitize-then-decide Phase 0)
+- refactor(lifecycle): orphan_reconcile becomes sanitize-then-decide — drain verdict moves to reconcile_quit
+- fix(lifecycle): consume the drain verdict at every count-lowering dispatch site (Pillar 2 Phase 2)
+- refactor(lifecycle): WRR quit demoted to Draining-gated Stage-2 executor (Pillar 2 Phase 3)
+- fix(window): close_window_by_label routes window-* closes through CloseWindowTask so srv window rows are cleaned up
+- fix(frontend): register backend window id right after CreateWindow, closing the early-close srv-row orphan race
+- fix(window): route OS-level WM_CLOSE (Alt+F4/taskbar) on secondary windows through CloseWindowTask
+- feat(tabbar): drag a tab onto another window's header to remount it there
+- feat(srv): persist host window label as a meta crumb + crumb-based cleanup fallback
+- test(srv): RAII + Job Object guards for integration-test srv spawns (no more leaked children on test failure)
+
+
 ## 0.53.0 — 2026-07-10
 
 - fix(agent): resume the real session on pane reopen and hydrate stats bar from history

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.53.0",
+      "version": "0.53.1",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Patch release (explicit `--as patch` override) consuming all 11 pending changesets — the Pillar 2 sanitize-then-decide refactors, the complete `Client.windowids` leak-class closure (#2087/#2088/#2089), the srv window-row crumb (#2094), the test spawn guards (#2096), and the two tabbar features (#2079, #2086-era remount).

Release-consistency invariant verified by `scripts/release.sh`: `VERSION_HISTORY.md` head, `package.json`, `Cargo.toml` workspace, `Cargo.lock` members, and `package-lock.json` all agree at **0.53.1**.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)