### PR TITLE
fix(instance-panel): floating panes focus on click + inline opacity controls

### DIFF
--- a/.changesets/1783796221-fix-instance-panel-floating-panes-focus-on-click-inline-opac-5poq.md
+++ b/.changesets/1783796221-fix-instance-panel-floating-panes-focus-on-click-inline-opac-5poq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(instance-panel): floating panes focus on click + inline opacity controls

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -108,6 +108,21 @@ pub(crate) fn floater_debug_snapshot() -> Vec<(String, isize)> {
         .unwrap_or_default()
 }
 
+/// Resolve a floater's HWND by its window label ("floating-<uuid>").
+///
+/// Floaters are raw `WS_POPUP` HWNDs with the CEF browser embedded as a
+/// child — they have no CEF Views `Window`, so any label-addressed window
+/// operation (focus, opacity) must branch to Win32 via this lookup instead
+/// of `get_window_on_ui` (whose `browser_view.window()` returns None for
+/// floaters and silently no-ops). Spec:
+/// docs/specs/instance-panel-floating-panes.md §2.
+pub(crate) fn floater_hwnd_for_label(label: &str) -> Option<isize> {
+    ACTIVE_FLOATER_HWNDS
+        .lock()
+        .ok()
+        .and_then(|m| m.get(label).map(|(fh, _)| *fh))
+}
+
 /// Return the Win32 window-class name for floating panes, suffixed with
 /// the launcher-supplied `AGENTMUX_IPC_HASH` (= `hash(data_dir, version)`)
 /// so that two parallel AgentMux instances register distinct class atoms

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -668,6 +668,26 @@ wrap_task! {
 
     impl Task {
         fn execute(&self) {
+            // Floating panes are raw WS_POPUP HWNDs with no CEF Views
+            // Window — the Views lookup below returns None for them, which
+            // made focus a silent no-op (InstancePanel's floating rows did
+            // nothing on click). Branch to Win32 via the floater registry
+            // first. Spec: docs/specs/instance-panel-floating-panes.md §3.1.
+            #[cfg(target_os = "windows")]
+            if let Some(hwnd) = crate::floating_pane::floater_hwnd_for_label(&self.label) {
+                use windows_sys::Win32::UI::WindowsAndMessaging::{
+                    IsIconic, SetForegroundWindow, ShowWindow, SW_RESTORE,
+                };
+                unsafe {
+                    // Restore first — SetForegroundWindow on a minimized
+                    // window activates it without un-minimizing.
+                    if IsIconic(hwnd as _) != 0 {
+                        ShowWindow(hwnd as _, SW_RESTORE);
+                    }
+                    SetForegroundWindow(hwnd as _);
+                }
+                return;
+            }
             if let Some(window) = get_window_on_ui(&self.state, &self.label) {
                 window.activate();
             }

--- a/docs/specs/instance-panel-floating-panes.md
+++ b/docs/specs/instance-panel-floating-panes.md
@@ -1,0 +1,184 @@
+# Spec: Instance Panel — Floating-Pane Focus Fix, Opacity Controls, Condensed Rows
+
+**Date:** 2026-07-11
+**Author:** Agent2
+**Status:** Implemented (this PR)
+**Surface:** version pill (status bar) → `InstancePanel` popover
+**Related:** `SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md` (issue #810),
+`SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01` (window alpha)
+
+---
+
+## 1. Problem
+
+Clicking the version pill in the status bar (`StatusBar.tsx:95-112`) opens the
+`InstancePanel`, which lists this process's windows and floating panes. Three issues:
+
+1. **Clicking a floating pane does not bring it to the foreground.** The row's click
+   handler runs, but the focus silently no-ops (root cause in §2).
+2. **Floating panes have no opacity control.** Window rows get an opacity slider;
+   floating-pane rows are name-only, even though the OS-level mechanism
+   (`WS_EX_LAYERED` + `SetLayeredWindowAttributes`) works on any HWND.
+3. **Rows are too tall.** Each window costs two rows (name row + separate opacity
+   row), so a handful of windows + floaters makes the popover scroll. Name and
+   opacity slider should share one line.
+
+## 2. Root cause of the focus no-op (verified)
+
+The floating-pane row calls `handleFocusPane(entry.label)` → `getApi().focusWindow(label)`
+(`InstancePanel.tsx:159-165, 588`) → CEF IPC `focus_window`
+(`agentmux-cef/src/commands/window/meta.rs:160-164`) → `post_focus_window` →
+`FocusWindowTask` (`ui_tasks/window.rs:373-391`):
+
+```rust
+fn execute(&self) {
+    if let Some(window) = get_window_on_ui(&self.state, &self.label) {
+        window.activate();
+    }
+}
+```
+
+`get_window_on_ui` (`ui_tasks/mod.rs:49-54`) resolves label → CEF browser →
+`browser_view.window()` — a **CEF Views** window lookup. But a floating pane is not a
+Views window: it's a raw Win32 `WS_POPUP | WS_EX_TOOLWINDOW` HWND with the CEF browser
+embedded via `WindowInfo::set_as_child` (`floating_pane.rs`). `browser_view.window()`
+returns `None` for it, so `FocusWindowTask` falls through and does nothing. Main
+windows focus fine; floaters never do.
+
+The floater HWNDs are already tracked: `ACTIVE_FLOATER_HWNDS`
+(`floating_pane.rs:78`), keyed by label (`"floating-<uuid>"`) →
+`(floater_hwnd, parent_main_hwnd)`. Today it's only read by
+`floater_debug_snapshot()` — there is no public label→HWND getter.
+
+## 3. Changes
+
+### 3.1 Focus: make `focus_window` floater-aware (backend)
+
+In `post_focus_window` / `FocusWindowTask` (or a branch in the `focus_window` command
+before posting), handle `floating-*` labels via the registry:
+
+1. Add `pub(crate) fn floater_hwnd_for_label(label: &str) -> Option<isize>` to
+   `floating_pane.rs` (next to `floater_debug_snapshot`).
+2. In `FocusWindowTask::execute`, before the Views lookup:
+
+```rust
+#[cfg(target_os = "windows")]
+if let Some(hwnd) = crate::floating_pane::floater_hwnd_for_label(&self.label) {
+    unsafe {
+        // Restore first — SetForegroundWindow on a minimized window
+        // activates it without un-minimizing.
+        if IsIconic(hwnd as _) != 0 {
+            ShowWindow(hwnd as _, SW_RESTORE);
+        }
+        SetForegroundWindow(hwnd as _);
+    }
+    return;
+}
+// existing Views path for main windows
+```
+
+`SetForegroundWindow` succeeds here without `AllowSetForegroundWindow` because the
+call originates from a click in this same process's foreground window. Falls through
+to the existing Views path for every non-floater label — no behavior change for main
+windows. (Floaters are Windows-only today, matching `floating_pane.rs`'s cfg.)
+
+### 3.2 Opacity: floating-pane rows get the same slider (backend + frontend)
+
+**Backend.** No change needed — verified during implementation: the reducer
+(`handle_set_window_opacity`) doesn't filter labels, the Win32 apply arm resolves
+HWNDs via `state.window_hwnds` (which floater creation registers into,
+`floating_pane.rs`), and the srv opacity write-through already deliberately skips
+labels without a `backend_window_id` (floaters have no srv `Window` row). So
+`setWindowOpacity("floating-<uuid>", …)` works end-to-end today; only the UI was
+missing.
+
+**Frontend.** Reuse the existing slider (min 0.35, max 1.0, step 0.05) on floating
+rows. Two adaptations:
+
+- `dispatchWindowOpacity` events and `liveWindowOpacity` lookups are keyed by
+  `windowId`; floating panes have `windowId: null` (`FloatingPaneEntry`,
+  `store/global.ts:176-180`). Key the opacity store by **label** instead — labels are
+  unique across both windows and floaters, and the IPC side-effect
+  (`setWindowOpacity(label, value)`) already takes the label.
+- **No persistence for floaters in v1.** Window opacity persists via
+  `window:opacity` meta on the `WaveWindow` object (`InstancePanel.tsx:538-554`);
+  floaters have no backing window object, and they don't survive an app restart
+  anyway. Session-only: slider drives live IPC only, skips the
+  `ObjectService.UpdateObjectMeta` branch. If floaters later gain persisted state,
+  opacity joins it.
+
+### 3.3 Condensed rows: name + opacity on one line (frontend)
+
+Merge the separate `instance-panel-opacity-row` into the name row for **both**
+sections. One row per window/floater:
+
+```
+┌─ AgentMux v0.52.4 ─────────────────────────────────────────────┐
+│  …instance info (version, channel, runtime)…                   │
+├────────────────────────────────────────────────────────────────┤
+│ This process — 2 windows                                       │
+│                                                                │
+│  ● main         [this]        Opacity ▓▓▓▓▓▓▓▓▓▓ 100%          │
+│  ○ research                   Opacity ▓▓▓▓▓▓▓░░░  70%          │
+├────────────────────────────────────────────────────────────────┤
+│ Floating panes — 2                                             │
+│                                                                │
+│  ◈ agent: Kimi                Opacity ▓▓▓▓▓▓▓▓▓▓ 100%          │
+│  ◈ terminal                   Opacity ▓▓▓▓▓░░░░░  55%          │
+├────────────────────────────────────────────────────────────────┤
+│  …maintenance / footer…                                        │
+└────────────────────────────────────────────────────────────────┘
+
+Row anatomy (shared by both sections):
+
+  ● main            [this]      Opacity ▓▓▓▓▓▓▓░░░ 70%
+  ─ ─────────────── ──────      ─────── ────────── ───
+  │ │               │           │       │          └─ live % readout
+  │ │               │           │       └─ <input type=range> 0.35–1.0
+  │ │               │           └─ label, hidden below ~360px panel width
+  │ │               └─ badge, current window only
+  │ └─ name — click: focus · dblclick/F2: rename (windows only)
+  └─ ● current window / ○ other window / ◈ floating pane
+```
+
+Layout rules:
+
+- Name gets `flex: 1 1 auto; min-width: 0` with ellipsis truncation; the slider
+  block (`flex: 0 0 auto`) keeps a fixed width (~120px slider + 4ch value) so
+  percentages align in a column across rows.
+- Click/keyboard semantics are split by hit area: the name region keeps the existing
+  focus/rename handlers (`InstancePanel.tsx:433-470`); the slider region keeps
+  `stopPropagation` so dragging never triggers focus (`InstancePanel.tsx:518`).
+- Rename mode (windows only): the input replaces the name span; the slider stays
+  visible and functional (unchanged handlers).
+- The slider renders only when opacity is controllable — windows: `entry.windowId`
+  present (existing gate); floaters: always (label-keyed).
+- The `Opacity` text label is dropped entirely at this panel's fixed 320px width —
+  a `title`/`aria-label` on the slider carries the affordance; the row never wraps
+  to two lines.
+
+## 4. Files Changed
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/src/floating_pane.rs` | Add `floater_hwnd_for_label(label)` getter |
+| `agentmux-cef/src/ui_tasks/window.rs` | `FocusWindowTask`: floater branch (restore + `SetForegroundWindow`) before Views path |
+| `frontend/app/store/window-opacity-store.ts` | Key live-opacity store by label instead of windowId |
+| `frontend/app/statusbar/InstancePanel.tsx` | Merge opacity slider into name row (windows), add slider to floating rows, drop meta-persist for floaters |
+| `frontend/app/statusbar/_instance-panel.scss` | Inline opacity control, fixed slider column |
+
+## 5. Testing
+
+1. Tear a pane off into a floating window, open the version pill panel, click the
+   floating row → floater comes to the foreground. Minimize the floater first →
+   click restores **and** foregrounds it. Main-window rows still focus as before.
+2. Drag the floater row's slider → floater becomes translucent live; release at
+   100% → `WS_EX_LAYERED` is removed (`remove_window_opacity` path). Window-row
+   sliders keep persisting via `window:opacity` meta; floater opacity does not
+   persist across app restart (documented v1 behavior).
+3. Rows render one line each: long window/floater names truncate with ellipsis and
+   never push the slider off-row; percentages align vertically.
+4. Rename (dblclick/F2) still works on window rows with the inline slider present;
+   slider drag never triggers focus or rename on either row type.
+5. Keyboard: Tab reaches name region then slider; Enter/Space on name focuses the
+   window/floater; arrow keys on the slider adjust opacity without focusing.

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -295,6 +295,69 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         performRename(windowId, trimmed);
     };
 
+    // Inline opacity control — shares one row with the window/pane name
+    // (docs/specs/instance-panel-floating-panes.md §3.3). `persistWindowId`
+    // present → window rows persist to `window:opacity` meta on release;
+    // null → floating panes, session-only (a floater has no backing window
+    // object to persist to, and doesn't survive an app restart anyway).
+    // stopPropagation on all three event kinds so a slider drag/keypress
+    // never triggers the row's focus or rename handlers.
+    const OpacityControl = (p: {
+        label: string;
+        persistWindowId: string | null;
+        currentOpacity: () => number;
+    }): JSX.Element => (
+        <span
+            class="instance-panel-opacity"
+            onClick={(e) => e.stopPropagation()}
+            onDblClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+        >
+            <input
+                type="range"
+                class="instance-panel-opacity-slider"
+                min={0.35}
+                max={1.0}
+                step={0.05}
+                value={p.currentOpacity()}
+                title="Opacity"
+                aria-label="Opacity"
+                onInput={(e) => {
+                    const val = parseFloat(e.currentTarget.value);
+                    dispatchWindowOpacity({
+                        type: "SetWindowOpacity",
+                        label: p.label,
+                        opacity: val,
+                        source: "user",
+                    });
+                }}
+                onChange={(e) => {
+                    if (!p.persistWindowId) return; // floater: session-only
+                    const raw = parseFloat(e.currentTarget.value);
+                    const val = Math.round(raw * 100) / 100;
+                    // Set window:transparent alongside window:opacity so
+                    // AppSettingsUpdater applies it correctly on restore.
+                    const fullyOpaque = val >= 1.0;
+                    ObjectService.UpdateObjectMeta(
+                        makeORef("window", p.persistWindowId),
+                        {
+                            "window:opacity": fullyOpaque ? null : val,
+                            "window:transparent": fullyOpaque ? false : true,
+                        } as MetaType,
+                    ).catch((err) =>
+                        console.error("[InstancePanel] opacity persist failed:", err),
+                    );
+                }}
+            />
+            <span class="instance-panel-opacity-value">
+                {/* Live store value tracks the drag tick-by-tick; falls back
+                    to the row's resolved opacity when the store has no entry
+                    yet this session. */}
+                {Math.round((liveWindowOpacity(p.label) ?? p.currentOpacity()) * 100)}%
+            </span>
+        </span>
+    );
+
     // Panel-unmount cleanup:
     //   1. Cancel any pending focus timer so it doesn't fire after
     //      the panel is gone (focus call would still hit a real
@@ -511,60 +574,18 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                 <Show when={isCurrent() && !isEditing()}>
                                     <span class="instance-panel-window-badge">this</span>
                                 </Show>
-                            </div>
-                            <Show when={!!entry.windowId}>
-                                <div
-                                    class="instance-panel-opacity-row"
-                                    onClick={(e) => e.stopPropagation()}
-                                >
-                                    <span class="instance-panel-opacity-label">Opacity</span>
-                                    <input
-                                        type="range"
-                                        class="instance-panel-opacity-slider"
-                                        min={0.35}
-                                        max={1.0}
-                                        step={0.05}
-                                        value={currentOpacity()}
-                                        onInput={(e) => {
-                                            const val = parseFloat(e.currentTarget.value);
-                                            dispatchWindowOpacity({
-                                                type: "SetWindowOpacity",
-                                                windowId: entry.windowId!,
-                                                label: entry.label,
-                                                opacity: val,
-                                                source: "user",
-                                            });
-                                        }}
-                                        onChange={(e) => {
-                                            const raw = parseFloat(e.currentTarget.value);
-                                            const val = Math.round(raw * 100) / 100;
-                                            if (!entry.windowId) return;
-                                            // Set window:transparent alongside window:opacity so
-                                            // AppSettingsUpdater applies it correctly on restore.
-                                            const fullyOpaque = val >= 1.0;
-                                            ObjectService.UpdateObjectMeta(
-                                                makeORef("window", entry.windowId),
-                                                {
-                                                    "window:opacity": fullyOpaque ? null : val,
-                                                    "window:transparent": fullyOpaque ? false : true,
-                                                } as MetaType,
-                                            ).catch((err) =>
-                                                console.error("[InstancePanel] opacity persist failed:", err),
-                                            );
-                                        }}
+                                {/* Inline opacity — name + slider share one row
+                                    (instance-panel-floating-panes.md §3.3). Stays
+                                    visible during rename; its own stopPropagation
+                                    keeps drags from focusing/renaming. */}
+                                <Show when={!!entry.windowId}>
+                                    <OpacityControl
+                                        label={entry.label}
+                                        persistWindowId={entry.windowId}
+                                        currentOpacity={currentOpacity}
                                     />
-                                    <span class="instance-panel-opacity-value">
-                                        {/* Live store value tracks the drag tick-by-tick;
-                                            falls back to the persisted meta when the store
-                                            has no entry yet. The slider <input> and its
-                                            onInput/onChange handlers are deliberately
-                                            untouched — only this label is reactive. */}
-                                        {Math.round(
-                                            (liveWindowOpacity(entry.windowId) ?? currentOpacity()) * 100,
-                                        )}%
-                                    </span>
-                                </div>
-                            </Show>
+                                </Show>
+                            </div>
                             </>
                         );
                     }}
@@ -600,6 +621,16 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                 <span class="instance-panel-pane-name">
                                     {resolveFloatingName(entry, i())}
                                 </span>
+                                {/* Floaters get the same inline opacity control
+                                    as windows (instance-panel-floating-panes.md
+                                    §3.2). Session-only: no backing window object
+                                    to persist to, so persistWindowId is null and
+                                    the resolved value comes from the live store. */}
+                                <OpacityControl
+                                    label={entry.label}
+                                    persistWindowId={null}
+                                    currentOpacity={() => liveWindowOpacity(entry.label) ?? 1.0}
+                                />
                             </div>
                         )}
                     </For>

--- a/frontend/app/statusbar/_instance-panel.scss
+++ b/frontend/app/statusbar/_instance-panel.scss
@@ -165,7 +165,8 @@
 
 // Floating pane rows — same geometry as .instance-panel-window-row but the
 // leading icon uses secondary colour (panes are not primary windows) and
-// there is no "this" badge or opacity slider.
+// there is no "this" badge. Carries the same inline opacity control as
+// window rows (docs/specs/instance-panel-floating-panes.md §3.2).
 .instance-panel-pane-row {
     display: flex;
     align-items: center;
@@ -209,24 +210,22 @@
     font-style: italic;
 }
 
-// Per-window opacity slider (SPEC_PER_WINDOW_OPACITY_2026-05-14.md §3)
-.instance-panel-opacity-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1-5);
-    padding: 2px var(--space-1-5) var(--space-1);
-    width: 100%;
-}
-
-.instance-panel-opacity-label {
+// Inline per-row opacity control (SPEC_PER_WINDOW_OPACITY_2026-05-14.md §3,
+// condensed onto the name row by instance-panel-floating-panes.md §3.3).
+// Fixed-width slider + value columns so percentages align vertically across
+// window and floating-pane rows; the name column's ellipsis absorbs overflow
+// and the row never wraps to two lines. The "Opacity" text label is dropped
+// at this panel width (320px) — title/aria-label carry the affordance.
+.instance-panel-opacity {
     flex: 0 0 auto;
-    font-size: 11px;
-    color: var(--secondary-text-color, rgb(from var(--main-text-color) r g b / 0.6));
-    width: 44px;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
 }
 
 .instance-panel-opacity-slider {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
+    width: 72px;
     height: 4px;
     accent-color: var(--accent-color);
     cursor: default;

--- a/frontend/app/store/window-opacity-store.ts
+++ b/frontend/app/store/window-opacity-store.ts
@@ -52,12 +52,13 @@ export function dispatchWindowOpacity(command: WindowOpacityCommand): void {
 }
 
 /**
- * Reactive read of the live opacity the store currently holds for a window,
+ * Reactive read of the live opacity the store currently holds for a window
+ * or floating pane (keyed by label — instance-panel-floating-panes.md §3.2),
  * or `undefined` when the store has no entry yet (nothing dispatched for it
  * this session). Read inside a reactive context (e.g. JSX), it re-runs on
  * every `dispatchWindowOpacity` — so a slider's % label tracks the drag.
  */
-export function liveWindowOpacity(windowId: string | undefined): number | undefined {
-    if (!windowId) return undefined;
-    return state().opacities[windowId];
+export function liveWindowOpacity(label: string | undefined): number | undefined {
+    if (!label) return undefined;
+    return state().opacities[label];
 }

--- a/frontend/app/store/window-opacity/reducer.test.ts
+++ b/frontend/app/store/window-opacity/reducer.test.ts
@@ -9,57 +9,73 @@ describe("window-opacity reducer", () => {
     it("applies opacity in range", () => {
         const { state, events } = update(initialState(), {
             type: "SetWindowOpacity",
-            windowId: "win-1",
             label: "main",
             opacity: 0.75,
             source: "user",
         });
-        expect(state.opacities["win-1"]).toBe(0.75);
+        expect(state.opacities["main"]).toBe(0.75);
         expect(events).toEqual([
-            { type: "window-opacity-applied", windowId: "win-1", label: "main", opacity: 0.75 },
+            { type: "window-opacity-applied", label: "main", opacity: 0.75 },
         ]);
     });
 
     it("clears entry when opacity >= 1.0", () => {
-        const seed = { opacities: { "win-1": 0.75 } };
+        const seed = { opacities: { main: 0.75 } };
         const { state, events } = update(seed, {
             type: "SetWindowOpacity",
-            windowId: "win-1",
             label: "main",
             opacity: 1.0,
             source: "user",
         });
-        expect(state.opacities["win-1"]).toBeUndefined();
+        expect(state.opacities["main"]).toBeUndefined();
         expect(events[0].type).toBe("window-opacity-cleared");
     });
 
     it("clamps below minimum to 0.35", () => {
         const { state } = update(initialState(), {
             type: "SetWindowOpacity",
-            windowId: "win-1",
             label: "main",
             opacity: 0.1,
             source: "user",
         });
-        expect(state.opacities["win-1"]).toBe(0.35);
+        expect(state.opacities["main"]).toBe(0.35);
     });
 
     it("clamps above 1.0 and clears entry", () => {
         const { state } = update(initialState(), {
             type: "SetWindowOpacity",
-            windowId: "win-1",
             label: "main",
             opacity: 1.5,
             source: "user",
         });
-        expect(state.opacities["win-1"]).toBeUndefined();
+        expect(state.opacities["main"]).toBeUndefined();
+    });
+
+    // Floating panes share the same slice keyed by label — a floater's
+    // "floating-<uuid>" label coexists with main-window labels
+    // (instance-panel-floating-panes.md §3.2).
+    it("tracks a floating-pane label independently of windows", () => {
+        const first = update(initialState(), {
+            type: "SetWindowOpacity",
+            label: "floating-abc",
+            opacity: 0.55,
+            source: "user",
+        });
+        const { state } = update(first.state, {
+            type: "SetWindowOpacity",
+            label: "main",
+            opacity: 0.75,
+            source: "user",
+        });
+        expect(state.opacities["floating-abc"]).toBe(0.55);
+        expect(state.opacities["main"]).toBe(0.75);
     });
 
     it("WindowClosed removes entry", () => {
-        const seed = { opacities: { "win-1": 0.75, "win-2": 0.5 } };
-        const { state, events } = update(seed, { type: "WindowClosed", windowId: "win-1" });
-        expect(state.opacities["win-1"]).toBeUndefined();
-        expect(state.opacities["win-2"]).toBe(0.5);
+        const seed = { opacities: { main: 0.75, research: 0.5 } };
+        const { state, events } = update(seed, { type: "WindowClosed", label: "main" });
+        expect(state.opacities["main"]).toBeUndefined();
+        expect(state.opacities["research"]).toBe(0.5);
         expect(events[0].type).toBe("window-opacity-entry-removed");
     });
 
@@ -67,11 +83,10 @@ describe("window-opacity reducer", () => {
         const original = initialState();
         update(original, {
             type: "SetWindowOpacity",
-            windowId: "win-1",
             label: "main",
             opacity: 0.75,
             source: "user",
         });
-        expect(original.opacities["win-1"]).toBeUndefined();
+        expect(original.opacities["main"]).toBeUndefined();
     });
 });

--- a/frontend/app/store/window-opacity/reducer.ts
+++ b/frontend/app/store/window-opacity/reducer.ts
@@ -12,6 +12,9 @@
  *   2. No I/O inside the reducer. IPC calls live in window-opacity-store.ts.
  *   3. WindowClosed removes the entry without emitting an IPC event —
  *      the native window is already gone by the time this fires.
+ *
+ * Keyed by window label — covers both main windows and floating panes
+ * (instance-panel-floating-panes.md §3.2).
  */
 
 import type {
@@ -30,13 +33,12 @@ export function update(
         case "SetWindowOpacity": {
             const opacity = Math.max(OPACITY_MIN, Math.min(1.0, command.opacity));
             if (opacity >= 1.0) {
-                const { [command.windowId]: _, ...rest } = state.opacities;
+                const { [command.label]: _, ...rest } = state.opacities;
                 return {
                     state: { opacities: rest },
                     events: [
                         {
                             type: "window-opacity-cleared",
-                            windowId: command.windowId,
                             label: command.label,
                         },
                     ],
@@ -44,12 +46,11 @@ export function update(
             }
             return {
                 state: {
-                    opacities: { ...state.opacities, [command.windowId]: opacity },
+                    opacities: { ...state.opacities, [command.label]: opacity },
                 },
                 events: [
                     {
                         type: "window-opacity-applied",
-                        windowId: command.windowId,
                         label: command.label,
                         opacity,
                     },
@@ -58,10 +59,10 @@ export function update(
         }
 
         case "WindowClosed": {
-            const { [command.windowId]: _, ...rest } = state.opacities;
+            const { [command.label]: _, ...rest } = state.opacities;
             return {
                 state: { opacities: rest },
-                events: [{ type: "window-opacity-entry-removed", windowId: command.windowId }],
+                events: [{ type: "window-opacity-entry-removed", label: command.label }],
             };
         }
 

--- a/frontend/app/store/window-opacity/types.ts
+++ b/frontend/app/store/window-opacity/types.ts
@@ -6,14 +6,18 @@
  * See SPEC_PER_WINDOW_OPACITY_2026-05-14.md §7.2 and
  * docs/specs/frontend-reducer-conventions-2026-05-03.md.
  *
- * Tracks the current opacity (0.35–1.0) for each window by windowId.
+ * Tracks the current opacity (0.35–1.0) for each window by **label**.
+ * Keyed by label (not windowId) since instance-panel-floating-panes.md §3.2:
+ * floating panes participate in the slider UI but have `windowId: null` —
+ * labels are unique across both main windows and floaters, and the IPC
+ * side-effect (`setWindowOpacity(label, …)`) is label-addressed anyway.
  * Absent = fully opaque (1.0). Win32 side-effect (SetLayeredWindowAttributes)
  * is applied by the dispatch layer, not inside the reducer.
  */
 
 /** Reducer state — per-window opacity map. */
 export interface WindowOpacityState {
-    /** windowId → opacity in [0.35, 1.0]. Absent means fully opaque. */
+    /** window label → opacity in [0.35, 1.0]. Absent means fully opaque. */
     opacities: Record<string, number>;
 }
 
@@ -29,21 +33,20 @@ export type WindowOpacityCommand =
      */
     | {
           type: "SetWindowOpacity";
-          windowId: string;
           label: string;
           opacity: number;
           source: "user" | "restore";
       }
-    /** Window was closed — clean up its opacity entry. */
-    | { type: "WindowClosed"; windowId: string };
+    /** Window (or floating pane) was closed — clean up its opacity entry. */
+    | { type: "WindowClosed"; label: string };
 
 export type WindowOpacityEvent =
     /** Opacity applied (0.35 ≤ opacity < 1.0). Dispatch layer fires IPC. */
-    | { type: "window-opacity-applied"; windowId: string; label: string; opacity: number }
+    | { type: "window-opacity-applied"; label: string; opacity: number }
     /** Opacity cleared (≥ 1.0 → remove WS_EX_LAYERED). Dispatch layer fires IPC. */
-    | { type: "window-opacity-cleared"; windowId: string; label: string }
+    | { type: "window-opacity-cleared"; label: string }
     /** Window closed — entry removed, no IPC call needed. */
-    | { type: "window-opacity-entry-removed"; windowId: string };
+    | { type: "window-opacity-entry-removed"; label: string };
 
 export interface ReducerResult {
     state: WindowOpacityState;


### PR DESCRIPTION
## Summary

Implements `docs/specs/instance-panel-floating-panes.md` (spec included in this PR). Three changes to the version pill's InstancePanel:

### 1. Clicking a floating pane now brings it to the foreground

Root cause: `FocusWindowTask` resolves labels through CEF Views (`get_window_on_ui` → `browser_view.window()`), but a floating pane is a raw `WS_POPUP | WS_EX_TOOLWINDOW` HWND with the browser embedded via `set_as_child` — no Views window exists, so the lookup returned `None` and focus silently no-oped. Fix: new `floater_hwnd_for_label` getter on the existing `ACTIVE_FLOATER_HWNDS` registry + a Win32 branch in `FocusWindowTask` (`ShowWindow(SW_RESTORE)` if minimized, then `SetForegroundWindow`) for `floating-*` labels. Main-window focus is untouched.

### 2. Floating panes get the same opacity slider as windows

Verified during implementation that the **backend already supports this end-to-end** (reducer doesn't filter labels; the Win32 apply arm resolves via `state.window_hwnds`, which floater creation registers into; the srv write-through already skips floaters deliberately) — only the UI was missing. The window-opacity slice is re-keyed by **label** instead of windowId (floaters have `windowId: null`; labels are unique across both kinds; the IPC is label-addressed anyway). Floater opacity is session-only — there's no backing window object to persist to and floaters don't survive restarts.

### 3. Condensed rows — name + slider on one line

The separate per-window opacity row is merged into the name row via a shared inline `OpacityControl`, used by both sections. Fixed slider/value column widths keep percentages aligned; `stopPropagation` on the control keeps drags from triggering row focus/rename; the `Opacity` text label is dropped at the panel's 320px width (title/aria-label carry it).

```
│ This process — 2 windows                             │
│  ● main         [this]        ▓▓▓▓▓▓▓▓▓▓ 100%        │
│  ○ research                   ▓▓▓▓▓▓▓░░░  70%        │
├──────────────────────────────────────────────────────┤
│ Floating panes — 2                                   │
│  ◈ agent: Kimi                ▓▓▓▓▓▓▓▓▓▓ 100%        │
│  ◈ terminal                   ▓▓▓▓▓░░░░░  55%        │
```

## Testing

- `cargo check -p agentmux-cef` clean
- `tsc --noEmit` clean; window-opacity reducer tests updated + new floating-label test (7 pass); `stylelint` clean
- Changeset added (`patch`)

Manual verification plan: tear off a pane → version pill → click floating row (foregrounds, including from minimized), drag its slider (live translucency, no focus trigger), confirm window rows still focus/rename/persist opacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=agent2 -->