### PR TITLE
feat(pool): adopt foreign window-{uuid} labels into the warm pool on close (Residual B)

### DIFF
--- a/.changesets/1783796274-feat-pool-adopt-foreign-window-uuid-labels-into-the-warm-poo-5fhv.md
+++ b/.changesets/1783796274-feat-pool-adopt-foreign-window-uuid-labels-into-the-warm-poo-5fhv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(pool): adopt foreign window-{uuid} labels into the warm pool on close (renderer reuse instead of park-and-blank)

--- a/agentmux-cef/src/commands/orphan_reconcile.rs
+++ b/agentmux-cef/src/commands/orphan_reconcile.rs
@@ -408,10 +408,16 @@ fn ui_thread_reconcile(state: &Arc<AppState>) {
     // flight and Stage 1 found no pool inventory to close — no CEF lifecycle
     // event will ever advance Stage 2 (stale `client::browser_list` entries
     // we can't see from here may even be blocking it). Drive quit directly.
+    // Type-based tab-pool membership (+ prefix for the pane pool) — same
+    // reasoning as Stage 1's sweep: an ADOPTED pool window's foreign label
+    // (SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB Residual 1) would make a
+    // prefix-only count read 0 here and drive quit_message_loop with a live
+    // pool browser still registered.
+    let tab_pool_labels = state.pool_side_top_level_labels();
     let pool_inventory = state
         .list_browsers()
         .iter()
-        .filter(|(l, _)| l.starts_with("window-pool-") || l.starts_with("floating-pool-"))
+        .filter(|(l, _)| tab_pool_labels.contains(l) || l.starts_with("floating-pool-"))
         .count();
     if plan.zombie_closes.is_empty() && pool_inventory == 0 {
         tracing::warn!(

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -77,11 +77,15 @@ fn pool_window_views() -> &'static Mutex<HashMap<String, cef::Window>> {
     POOL_WINDOW_VIEWS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Cache a pool window's CEF Views `Window` (called from `on_window_created`,
-/// where the Window is valid). No-op for non-pool labels.
+/// Cache a pool window's CEF Views `Window` (called from `on_window_created`
+/// for fresh spawns, and from `demote_promoted_pool_window` for demotes —
+/// including ADOPTED foreign `window-{uuid}` labels, Residual 1 of
+/// SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11, which is why the
+/// caller-bug guard accepts the broad `window-` prefix rather than
+/// `window-pool-`). No-op for non-window labels.
 #[cfg(target_os = "windows")]
 pub fn cache_pool_window_view(label: &str, window: &cef::Window) {
-    if !label.starts_with("window-pool-") {
+    if !label.starts_with("window-") {
         return;
     }
     pool_window_views()
@@ -934,7 +938,14 @@ pub fn park_and_blank_window(state: &Arc<AppState>, label: &str) -> bool {
 }
 
 pub fn mark_pool_window_renderer_ready(state: &Arc<AppState>, label: &str) {
-    if !label.starts_with("window-pool-") {
+    // Broad `window-` guard (was `window-pool-`): an ADOPTED foreign
+    // `window-{uuid}` label (Residual 1, SPEC_POOL_ADOPTION_AND_WINDOW_ROW_
+    // CRUMB_2026_07_11) re-sends `pool_window_ready` after its demote reload
+    // and must re-enter the queue like any other demoted window. The REAL
+    // membership gate is the reducer's `handle_pool_ready`, which only moves
+    // labels that are actually in `pool.unpromoted` — a spurious ready signal
+    // from a non-pool-side window is an idempotent no-op there.
+    if !label.starts_with("window-") {
         return;
     }
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -855,9 +855,12 @@ pub fn demote_promoted_pool_window(
 }
 
 /// SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md — close path for `window-*`
-/// windows that CANNOT demote into the pool (beyond `POOL_DEMOTE_CAP`, or a
-/// foreign `window-{uuid}` label the pool handshake's `window-pool-` prefix
-/// gate rejects). The round-5 destroy these closes used to take parks the
+/// windows that CANNOT demote into the pool: beyond `POOL_DEMOTE_CAP`, no
+/// strict HWND, or the reducer rejected the demote. (Foreign `window-{uuid}`
+/// labels are no longer categorically excluded — Residual 1 of
+/// SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11 adopts them through
+/// the same demote gates; this fallback now only sees one when a gate
+/// refuses.) The round-5 destroy these closes used to take parks the
 /// browser anyway (CEF 148 Views, no `on_before_close` — live-verified in the
 /// quit-gate work) with the FULL workspace page still running: xterm WebGL
 /// surfaces (SwiftShader = CPU shared memory = pagefile-backed commit),

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -860,6 +860,39 @@ fn pool_demote_already_pool_side_is_rejected() {
     assert_eq!(state.pool.queue.len(), 1, "no duplicate insertion");
 }
 
+/// Residual 1 (SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11) — pool
+/// ADOPTION: a foreign `window-{uuid}` label that never entered the pool via
+/// a spawn (cold-path or tear-off window, minted when the pool was empty)
+/// runs the exact same demote → ready → promote cycle as a `window-pool-*`
+/// label. Pool membership is the `unpromoted`/`queue` sets + the is_pool
+/// flag, never the label string — this test is the reducer-level contract
+/// for that.
+#[test]
+fn pool_adoption_foreign_label_full_cycle() {
+    let mut state = HostState::default();
+
+    // A label the pool has never seen — no spawn, no prior promote.
+    let out = update(&mut state, HostCommand::DemotePoolWindow { label: "window-abc123".into() });
+    assert!(out.pool_demote_accepted, "adoption of a foreign window-* label must be accepted");
+    assert!(state.pool.unpromoted.contains("window-abc123"));
+
+    // The demote reload boots the renderer in pool mode; its ready signal
+    // moves the adopted label into the serving queue like any other.
+    update(&mut state, HostCommand::PoolWindowReady { label: "window-abc123".into() });
+    assert!(!state.pool.unpromoted.contains("window-abc123"));
+    assert_eq!(state.pool.queue.len(), 1);
+
+    // And it serves the next promote.
+    let out = update(&mut state, HostCommand::PopAndPromoteFrontPoolWindow);
+    assert_eq!(out.promoted_pool_label.as_deref(), Some("window-abc123"));
+
+    // Double-adopt of the same label while pool-side stays rejected
+    // (idempotency contract unchanged by adoption).
+    update(&mut state, HostCommand::DemotePoolWindow { label: "window-abc123".into() });
+    let out = update(&mut state, HostCommand::DemotePoolWindow { label: "window-abc123".into() });
+    assert!(!out.pool_demote_accepted);
+}
+
 /// Demote does NOT touch the respawn semaphore — a demote mid-spawn must
 /// not let a second spawn start.
 #[test]

--- a/agentmux-cef/src/srv_event_bridge.rs
+++ b/agentmux-cef/src/srv_event_bridge.rs
@@ -41,9 +41,19 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     let code = CefString::from(script.as_str());
     let url = CefString::from("");
 
-    // Phase H.2.b — reducer-aware iteration with fallback.
+    // Phase H.2.b — reducer-aware iteration with fallback. Pool-side skip is
+    // BY TYPE (reducer is_pool flag) so an adopted pool window's foreign
+    // `window-{uuid}` label (SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB Residual
+    // 1) is skipped exactly like a `window-pool-*` one — its parked renderer
+    // shows the pool boot page and has no srv-event consumers. `window-pool-`
+    // stays as a fast-path prefix (covers spawns racing browser
+    // registration); `browser-pane-` is prefix-only as before.
+    let tab_pool_labels = state.pool_side_top_level_labels();
     for (label, browser) in state.list_browsers() {
-        if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
+        if label.starts_with("window-pool-")
+            || label.starts_with("browser-pane-")
+            || tab_pool_labels.contains(&label)
+        {
             continue;
         }
         if let Some(frame) = browser.main_frame() {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -1433,6 +1433,28 @@ impl AppState {
         crate::reducer::count_live_user_windows(&self.host_state.lock())
     }
 
+    /// Labels of registered TAB-pool-side top-level browsers — decided
+    /// PURELY BY TYPE (`BrowserKind::TopLevel { is_pool: true }`), never by
+    /// label prefix, the same doctrine as `count_live_user_windows` above.
+    /// SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11 Residual 1: an
+    /// ADOPTED pool window keeps its foreign `window-{uuid}` label while
+    /// being genuinely pool-side, so any pool enumeration still filtering on
+    /// the `window-pool-` prefix (the pre-adoption shortcut) silently skips
+    /// it — in the quit-drain sweeps that meant Stage 2 could hang on an
+    /// unswept adopted browser. Does NOT include the pane pool
+    /// (`floating-pool-*`, `BrowserKind::Floater`) — pane-pool adoption is
+    /// out of scope; callers that sweep both compose this with the
+    /// `floating-pool-` prefix as before. Single host_state lock.
+    pub fn pool_side_top_level_labels(&self) -> std::collections::HashSet<String> {
+        self.host_state
+            .lock()
+            .browsers
+            .iter()
+            .filter(|(_, h)| matches!(h.kind, BrowserKind::TopLevel { is_pool: true }))
+            .map(|(l, _)| l.clone())
+            .collect()
+    }
+
     /// Reverse lookup: find the label whose cached HWND matches `hwnd`.
     /// Used by the win-event HIDE handler to map an OS-level window hide to a
     /// logical `report_window_closed` call, covering close paths (Alt+F4,

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -146,13 +146,24 @@ wrap_task! {
                 #[cfg(target_os = "windows")]
                 if self.label.starts_with("window-") {
                     crate::commands::window_pool::demote_srv_cleanup(&self.state, &self.label);
-                    if self.label.starts_with("window-pool-")
-                        && crate::commands::window_pool::demote_promoted_pool_window(
-                            &self.state,
-                            &self.label,
-                            &window,
-                        )
-                    {
+                    // Residual 1 (SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11)
+                    // — demote is attempted for EVERY window-* label, not just
+                    // window-pool-*: a cold-path / tear-off `window-{uuid}`
+                    // window is structurally identical to a promoted pool
+                    // window, and adopting it into the warm pool reuses its
+                    // renderer instead of stranding ~100MB in a park-and-blank.
+                    // Safe because pool membership is tracked by the reducer's
+                    // is_pool flag + unpromoted/queue sets, and every quit-path
+                    // pool enumeration is type-based (pool_side_top_level_labels)
+                    // — the label string is not a pool identity anywhere that
+                    // matters post-adoption. Demote's own gates (cap, strict
+                    // HWND, reducer accept) still apply; a refusal falls through
+                    // to park-and-blank exactly as before.
+                    if crate::commands::window_pool::demote_promoted_pool_window(
+                        &self.state,
+                        &self.label,
+                        &window,
+                    ) {
                         return;
                     }
                     // SPEC_PARK_AND_BLANK_CLOSE_2026_07_09.md — a non-demotable
@@ -491,11 +502,19 @@ pub(crate) fn begin_drain_and_cascade(state: &Arc<AppState>, reason: crate::stat
     // never empties on macOS/Linux (init_pane_pool spawns one at
     // startup), so Stage 2's is_empty() gate never fires and the
     // host hangs on every quit.
+    // Tab-pool membership BY TYPE (reducer `is_pool` flag), not label prefix:
+    // an ADOPTED pool window (Residual 1, SPEC_POOL_ADOPTION_AND_WINDOW_ROW_
+    // CRUMB_2026_07_11) keeps its foreign `window-{uuid}` label while being
+    // genuinely pool-side — a prefix filter would skip it here, leaving an
+    // unswept browser that blocks Stage 2's `browser_list.is_empty()` gate.
+    // The pane pool stays prefix-matched (`floating-pool-*` — pane-pool
+    // adoption is out of scope).
+    let tab_pool_labels = state.pool_side_top_level_labels();
     let pool_browsers: Vec<cef::Browser> = state
         .list_browsers()
         .into_iter()
         .filter(|(label, _)| {
-            label.starts_with("window-pool-") || label.starts_with("floating-pool-")
+            tab_pool_labels.contains(label) || label.starts_with("floating-pool-")
         })
         .map(|(_, b)| b)
         .collect();


### PR DESCRIPTION
PR B of `SPEC_POOL_ADOPTION_AND_WINDOW_ROW_CRUMB_2026_07_11.md` (task #15). Follow-up to #2094 (Residual A).

## Problem

Cold-path and tear-off windows (`window-{uuid}` labels, minted whenever the pool is exhausted) could never re-enter the warm pool: `CloseWindowTask`'s demote gate keyed on the `window-pool-` label prefix, so their close fell to park-and-blank — srv state cleaned (post-#2087), but **~100MB of renderer stranded per close**, accumulating over long sessions (the "Known residual" in `CloseWindowTask`'s own comment).

## Design — no relabeling

The spec's fallback design (relabel-at-adopt) proved unnecessary: Pillar 2 already made everything that matters classify pool-ness **by type** — the reducer's `is_pool` flag + `unpromoted`/`queue` sets, "decided PURELY BY TYPE … never by label-prefix" (`reducer/quit.rs`). This PR completes that doctrine instead of fighting it:

- `CloseWindowTask` attempts demote for **every** `window-*` label. Demote's own gates (capacity cap, strict HWND resolution, reducer membership) still apply; a refusal falls through to park-and-blank exactly as before.
- The two quit-path pool enumerations still filtering by prefix go type-based via a new `AppState::pool_side_top_level_labels()`: **Stage 1's drain sweep** (an adopted browser invisible to it would block Stage 2's `browser_list.is_empty()` gate) and **orphan_reconcile's nothing-will-pump inventory** (a miscount of 0 would drive `quit_message_loop` with a live pool browser registered). The pane pool (`floating-pool-`) stays prefix-matched — pane adoption is out of scope.
- `srv_event_bridge`'s pool skip adds the type-based check (adopted parked renderers show the pool boot page; no srv-event consumers).
- `cache_pool_window_view` / `mark_pool_window_renderer_ready` caller-bug guards relax from `window-pool-` to `window-`; the real membership gate is the reducer's `handle_pool_ready`, which idempotently no-ops any label not in `unpromoted`.

## Verification

- New reducer test: foreign-label adopt → ready → **re-promote** cycle + double-adopt idempotency. 189 host tests pass. (One unrelated flake observed once — `allow_pane_focus_once_swap_returns_prev_and_clears`, a shared-static parallel-test race; passes on rerun and on unmodified main.)
- **Live on a packaged build, full cycle**: exhausted the pool (4 rapid opens → 2 pool-served + 2 cold `window-{uuid}`); closed a cold one → close trace shows `demoted back into pool` + srv row closed (HTTP 200) + its CDP target reloaded to the `pool=1` boot URL under the foreign label; a subsequent `openNewWindow` **was served by the adopted label** (instant open, renderer reused, fresh workspace, correct title); close-all then exits cleanly with **zero** leftover processes — the type-based sweep reaps adopted entries.

Remaining from the spec after this: Residual C (non-Windows close-path verification) — needs macOS/Linux hardware.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)