### PR TITLE
fix(browser): show the loading brain instead of a blank pane while a page loads

### DIFF
--- a/.changesets/1783800650-fix-browser-show-the-loading-brain-instead-of-a-blank-pane-w-jner.md
+++ b/.changesets/1783800650-fix-browser-show-the-loading-brain-instead-of-a-blank-pane-w-jner.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser): show the loading brain instead of a blank pane while a page loads

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -245,10 +245,15 @@ pub fn on_load_end_browser_pane(state: &Arc<AppState>, browser: &Browser) {
 /// history state changes — navigation start, navigation commit, and after
 /// back/forward. `can_go_back` / `can_go_forward` are provided as direct
 /// parameters (not queried after the fact), so they're guaranteed to reflect
-/// the real committed state rather than the pre-commit race window.
+/// the real committed state rather than the pre-commit race window. Same for
+/// `is_loading` — CEF's actual navigation-controller loading state, forwarded
+/// verbatim so the frontend's loading indicator reflects real top-level
+/// navigations only, not client-side (SPA) route changes, which don't invoke
+/// this callback. See SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md §4.1.
 pub fn on_loading_state_change_browser_pane(
     state: &Arc<AppState>,
     browser: &Browser,
+    is_loading: bool,
     can_go_back: bool,
     can_go_forward: bool,
 ) {
@@ -261,8 +266,8 @@ pub fn on_loading_state_change_browser_pane(
         };
         let block_id_short: String = block_id.chars().take(7).collect();
         tracing::info!(
-            "[browser-pane:diag][{}] emit-nav-state url={:?} url_only=false can_back={} can_forward={}",
-            block_id_short, url, can_go_back, can_go_forward,
+            "[browser-pane:diag][{}] emit-nav-state url={:?} url_only=false is_loading={} can_back={} can_forward={}",
+            block_id_short, url, is_loading, can_go_back, can_go_forward,
         );
         crate::events::emit_event_from_state(
             state,
@@ -272,6 +277,7 @@ pub fn on_loading_state_change_browser_pane(
                 "url": url,
                 "can_go_back": can_go_back,
                 "can_go_forward": can_go_forward,
+                "is_loading": is_loading,
             }),
         );
     } else {

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -17,11 +17,13 @@ impl AgentMuxHandler {
     /// with history commit when called from `on_load_end`).
     ///
     /// For panes: emit `browser-pane-nav-state` so the frontend address
-    /// bar + back/forward buttons reflect CEF's real history state.
+    /// bar + back/forward buttons reflect CEF's real history state, and
+    /// `is_loading` so the pane can show a loading indicator while a real
+    /// top-level navigation is in flight (SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md).
     pub(crate) fn on_loading_state_change(
         &mut self,
         browser: Option<&mut Browser>,
-        _is_loading: i32,
+        is_loading: i32,
         can_go_back: i32,
         can_go_forward: i32,
     ) {
@@ -32,6 +34,7 @@ impl AgentMuxHandler {
             crate::browser_pane::callbacks::on_loading_state_change_browser_pane(
                 &self.state,
                 b,
+                is_loading != 0,
                 can_go_back != 0,
                 can_go_forward != 0,
             );

--- a/docs/specs/SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md
+++ b/docs/specs/SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md
@@ -1,0 +1,167 @@
+# Spec: Loading-Brain Indicator for Browser Panes (Messenger Widgets)
+
+**Date:** 2026-07-11
+**Author:** AgentY
+**Type:** Analysis + implementation-ready design. No code shipped yet.
+**Purpose:** The 5 messenger widgets (Discord, Slack, Telegram, WhatsApp, Teams) — each just a `browser` pane pointed at a pinned URL — show a blank/white native window while the external site's JS bundle boots, which reads as broken rather than loading. Show the existing pulsating `BrainSpinner` (already used elsewhere in the app for pane-loading states) over that gap instead.
+
+---
+
+## 1. The 5 messengers, confirmed
+
+`agentmux-srv/src/config/widgets.json` — all five are the exact same shape, differing only in URL/branding:
+
+| Widget key | Label | URL | Notes |
+|---|---|---|---|
+| `defwidget@discord` | Discord | `https://discord.com/app` | "background bridge" |
+| `defwidget@slack` | Slack | `https://app.slack.com/` | |
+| `defwidget@telegram` | Telegram | `https://web.telegram.org/` | |
+| `defwidget@whatsapp` | WhatsApp | `https://web.whatsapp.com/` | |
+| `defwidget@teams` | Teams | `https://teams.microsoft.com/` | "bridge Phase 3" |
+
+Each entry is `blockdef.meta = {view: "browser", url: "<...>", "browser:show_controls": false}` — per `CLAUDE.md`'s own "Not widgets" note, this is the existing "browser preset" pattern: no dedicated messenger view type exists, they're all just the shared `browser` pane. **This means the fix below is not messenger-specific code — it lives entirely in the shared Browser pane view/model, and every browser pane (messenger or ad hoc) gets it identically.** Messengers are the flagship motivating case (heavy client-side SPAs — Discord/Slack/Teams all ship large JS bundles that visibly take a beat to boot) but not a special case.
+
+---
+
+## 2. Root cause: two real bugs, not just "no indicator exists"
+
+The pulsating brain (`frontend/app/element/BrainSpinner.tsx`, extracted per `docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md`) already covers **stage-one blank** — the gap before a pane's Solid component/`viewModel` resolves at all (`block.tsx`'s `<Suspense fallback={<BrainSpinner/>}>` and `<Show when={ready()} fallback={<BrainSpinner/>}>`). For a browser pane this resolves fast; it is not the gap the user is describing.
+
+**Stage two — the real gap — is unindicated:** once the `BrowserViewComponent` mounts, `browser-view.tsx`'s `createPane()` calls `browser_pane_create` and CEF creates a native Win32 child HWND (`WindowInfo::default().set_as_child(...)`, `agentmux-cef/src/browser_pane/creation.rs:182`) immediately, visible by default. `.browser-placeholder` (the DOM div the HWND is positioned over) renders **nothing** once a URL exists — its only content is an "enter a URL" empty-state, gated on `!model.urlAtom() && !paneCreated()`, i.e. it never shows for the messenger widgets (they always have a URL). So the moment the HWND exists, Chromium's own default blank page paints through — for however long Discord/Slack/etc. take to actually load and render their app, with zero AgentMux-level indicator.
+
+**A `loading` state already exists in the reducer — but is wired wrong, twice:**
+
+`frontend/app/store/browser-pane-state/reducer.ts` already has full, tested, correct machinery for this: `Navigate` sets `loading: true` (line ~540), `TabLoadingChanged` (line 376) atomically sets `{loading, canGoBack, canGoForward}` from CEF's real values, `LoadFinished`/`LoadFailed` clear it. `BrowserViewModel.loadingAtom` (`browser-model.ts:117-119`) projects it. This is exactly the right foundation — **but two things break it before it ever reaches the UI:**
+
+1. **`browser-view.tsx`'s `createPane()` calls `model.onLoad()` immediately after `browser_pane_create` resolves** (line 212) — i.e. the instant the *HWND exists*, not when the *page has loaded*. `onLoad()` dispatches `LoadFinished`, which clears `loading` back to `false` within the same tick `Navigate` set it `true`.
+2. **`browser-model.ts`'s `browser-pane-nav-state` listener unconditionally dispatches `LoadFinished` on every event** (line 398), regardless of which CEF callback produced it. `on_loading_state_change_browser_pane` (`agentmux-cef/src/browser_pane/callbacks.rs:249`) fires on "navigation start, navigation commit, and after back/forward" per its own doc comment — not just completion — so even a mid-navigation event clears `loading`.
+3. **`TabLoadingChanged` — the command built for exactly this — is never dispatched from anywhere in production code** (confirmed: only referenced in `reducer.ts` itself, `types.ts`, and tests). CEF's real `is_loading` boolean is available at the FFI boundary (`agentmux-cef/src/client/navigation.rs:24`, `on_loading_state_change`) but is explicitly discarded as `_is_loading` before it ever reaches `on_loading_state_change_browser_pane` (which only forwards `can_go_back`/`can_go_forward`).
+
+Net: `loadingAtom` is real, tested, reducer-correct state that has never actually reflected reality end-to-end, and is not consumed by `browser-view.tsx`'s JSX at all today (grepped — zero references). This isn't a "build a loading indicator from scratch" task; it's "finish wiring machinery that's already half-built."
+
+---
+
+## 3. The z-order piece already has a proven, reusable answer
+
+A native browser-pane HWND paints above DOM regardless of CSS z-index on Windows (the "airspace problem," `docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md`). The existing fix for this — used today by modals, and (via auto-discovery) menus/tooltips/popovers — is `frontend/app/platform/pane-overlay-auto.ts`: any DOM element tagged `data-pane-overlay` is automatically measured (`MutationObserver` + per-element `ResizeObserver`) and the union of all such rects is punched as a transparent hole through the relevant pane HWND via `SetWindowRgn` (`pane-overlay.ts` → `browser_panes_set_overlay_clip` IPC). Visibility is already opacity-aware: `isOverlayElementVisible()` treats `opacity: 0` as "not clipping" (`pane-overlay-auto.ts:56-63`).
+
+This means **no new native-window-visibility plumbing is needed.** `BrainSpinner`'s existing `fading` prop already sets `opacity: 0` via a `200ms ease-out` transition (`BrainSpinner.scss:25-29`) — that alone is enough to make `pane-overlay-auto.ts` stop clipping the moment the fade completes, automatically restoring full HWND visibility, no coordination code required between "fade the spinner" and "un-punch the hole." Render `<BrainSpinner data-pane-overlay/>` absolutely positioned to fill `.browser-placeholder` (same rect the HWND itself is sized against, via the same `getBoundingClientRect()`), and the existing systems do the rest.
+
+**One caveat worth flagging, not silently assumed away:** every current `data-pane-overlay` consumer (modals, menus, tooltips, popovers) is a small rect. This would be the first full-pane-size (100% coverage) overlay. Nothing in `pane-overlay.ts`/`pane-overlay-auto.ts` caps overlay size, and the mechanism is just a rect union either way — but it's untested at that scale and should be explicitly verified during implementation (does a full-pane `SetWindowRgn(RGN_DIFF)` behave identically to a partial one performance/correctness-wise, given the pane is also being actively resized/positioned by the same-frequency `syncPosition` 200ms poll during this exact window?).
+
+---
+
+## 4. Design
+
+### 4.1 Backend: thread `is_loading` through, stop the blanket `LoadFinished`
+
+`agentmux-cef/src/client/navigation.rs`, `on_loading_state_change`: stop discarding the parameter.
+
+```rust
+pub(crate) fn on_loading_state_change(
+    &mut self,
+    browser: Option<&mut Browser>,
+    is_loading: i32,          // was: _is_loading
+    can_go_back: i32,
+    can_go_forward: i32,
+) {
+    if !self.is_browser_pane { return; }
+    if let Some(b) = browser.as_deref() {
+        crate::browser_pane::callbacks::on_loading_state_change_browser_pane(
+            &self.state, b, is_loading != 0, can_go_back != 0, can_go_forward != 0,
+        );
+    }
+}
+```
+
+`agentmux-cef/src/browser_pane/callbacks.rs`, `on_loading_state_change_browser_pane`: accept and forward `is_loading` in the existing `browser-pane-nav-state` payload (additive field — the frontend already treats unknown/missing fields as no-op per the existing `url_only` convention, so this can't break the address-bar-sync consumer):
+
+```rust
+pub fn on_loading_state_change_browser_pane(
+    state: &Arc<AppState>, browser: &Browser,
+    is_loading: bool, can_go_back: bool, can_go_forward: bool,
+) {
+    // ... existing block_id/url resolution unchanged ...
+    crate::events::emit_event_from_state(state, "browser-pane-nav-state", &serde_json::json!({
+        "block_id": block_id, "url": url,
+        "can_go_back": can_go_back, "can_go_forward": can_go_forward,
+        "is_loading": is_loading,   // NEW
+    }));
+}
+```
+
+No change needed to `on_load_end_browser_pane`'s emit (`url_only: true`) — it stays the address-bar-redirect-catcher it already is; §4.2 below stops treating it as a loading-finished signal.
+
+### 4.2 Frontend model: fix the two premature-`LoadFinished` sites
+
+`browser-model.ts`'s `browser-pane-nav-state` listener — replace the unconditional `LoadFinished` dispatch:
+
+```ts
+// was: this._dispatch({ type: "LoadFinished" }, "nav-state");
+if (payload.is_loading !== undefined) {
+    this._dispatch(
+        { type: "TabLoadingChanged", tabId: <active tab id>, loading: payload.is_loading,
+          canGoBack: payload.can_go_back ?? active.canGoBack, canGoForward: payload.can_go_forward ?? active.canGoForward },
+        "nav-state",
+    );
+}
+```
+
+(Exact tab-id plumbing depends on Phase 1A's active-tab shape already in the reducer — `TabLoadingChanged` requires a `tabId`, so the dispatch needs the active tab's id, available the same way `HistoryUpdated`'s handling already resolves it a few lines up.)
+
+`browser-view.tsx`'s `createPane()` (line 212): **remove the `model.onLoad()` call.** It was firing at "HWND exists" time under a name that reads as "page loaded" — nothing else in this file needs it once `TabLoadingChanged` is correctly wired, and removing it is what stops `loading` from clearing itself within the same tick it was set.
+
+### 4.3 Frontend view: render the spinner
+
+`browser-view.tsx`, inside `.browser-placeholder`, alongside the existing empty-state `<Show>`:
+
+```tsx
+<Show when={model.loadingAtom()}>
+    <BrainSpinner
+        data-pane-overlay
+        class="browser-loading-overlay"
+        fading={!model.loadingAtom() /* see below */}
+    />
+</Show>
+```
+
+Actual fade sequencing needs a local signal (mirroring how `block.tsx`'s callers elsewhere handle `fading`+unmount-after-transition) rather than deriving `fading` from the same atom that gates the `<Show>` — the existing `BrainSpinner` contract is "caller owns unmounting after the transition ends" (per its own doc comment), so this needs a short-lived `[stillMounted, setStillMounted]` signal: set `true` when `loadingAtom` flips `true`→ mount; on `loadingAtom` flipping to `false`, keep mounted with `fading={true}` for ~220ms (matching the CSS transition), then unmount. This is the same pattern `block.tsx`'s existing `BrainSpinner` consumers don't need (they use Suspense/Show unmount directly, no fade) but the tab-reveal-gate/startup-splash precedent (`tab-reveal.ts`, `startup-splash.ts`) already establishes for this exact "hold state briefly for the fade" shape.
+
+`.browser-loading-overlay` CSS: `position: absolute; inset: 0;` inside `.browser-placeholder` (which needs `position: relative` if it isn't already) — must exactly match the placeholder's box so the auto-clip rect lines up with the HWND underneath pixel-for-pixel.
+
+### 4.4 Reload / back-forward — re-arm correctly, without SPA-navigation false triggers
+
+`reload()` and `goBack()`/`goForward()` in `browser-model.ts` already dispatch `LoadStarted` (sets `loading: true`) before firing their IPC — that path is unaffected by this change and should correctly show the spinner again on an explicit reload/back/forward, matching §4.2's now-correct clear-on-`TabLoadingChanged(loading:false)`.
+
+**Deliberately not a concern:** in-app SPA navigation (Discord/Slack channel switches via History API `pushState`) does not trigger CEF's `on_loading_state_change`/`on_load_end` the way a real top-level navigation does — those are LoadHandler callbacks tied to the navigation controller's actual document loads, not client-side routing. So the spinner will not flicker on every channel switch inside an already-loaded messenger. **Worth flagging as a real, if minor, UX cost rather than ignoring:** a multi-hop OAuth/login redirect (Slack/Discord/Teams login flows commonly bounce through 2-3 domains) *is* a sequence of real top-level navigations, so the spinner may show/hide/show again briefly during login. Acceptable — arguably more honest than the current blank-white gap — but call it out for whoever implements this, since "flickery during login" is the kind of thing that reads as a regression if unexpected.
+
+### 4.5 Cross-platform note
+
+The native-child-HWND path (`browser_pane/creation.rs`, `SetWindowRgn`) is Windows-specific — per prior research in this codebase (`docs/specs/SPEC_EXTERNAL_APP_DRIVING_BLENDER_2026_07_03.md` §4.3), macOS/Wayland use CEF's Views-overlay compositing instead of a real child window, where the "airspace problem" this spec's z-order piece (§3) works around may not exist in the same form (no separate native window to be clipped-behind in the first place). **This spec's §4.1/§4.2 (the loading-state plumbing) is platform-agnostic — CEF's LoadHandler callbacks fire identically everywhere.** §4.3's `data-pane-overlay` z-order mechanism needs verification on macOS/Linux specifically: either it already works there for the existing modal/menu overlays (in which case this reuses cleanly), or the Views-overlay path never needed clipping to begin with (in which case a full-pane spinner may just render correctly via normal CSS z-index with no special handling needed at all on those platforms). Flagged as an implementation-time check, not resolved here.
+
+---
+
+## 5. Scope / non-goals
+
+- **No new component.** `BrainSpinner` is reused as-is; no new visual asset.
+- **No new backend command/RPC.** `is_loading` rides the existing `browser-pane-nav-state` event as one additive field.
+- **No messenger-specific code anywhere** — the fix is entirely in the shared `browser` pane view/model/reducer, benefiting every browser pane uniformly (manually-opened panes typing a URL get the same fix for free, since it's the identical `navigate()`/`createPane()` code path).
+- **Does not touch `TabLoadingChanged`'s reducer logic** — it's already correct and tested; this spec's only reducer-adjacent change is finally dispatching it from somewhere real.
+- **Out of scope:** per-tab loading indicators for Phase 1B's not-yet-shipped tab strip (the reducer already tracks `loading` per-tab; this spec only wires the *active* tab's value into the one-pane-one-spinner view that exists today). If/when the tab strip ships, it's a natural, additive consumer of the same now-correct `loading` field per tab.
+
+## 6. Open questions
+
+1. **§4.3's fade-hold pattern** — worth factoring into a small reusable hook (`useFadingSpinner(showWhen: Accessor<boolean>)`) if the same "hold mounted briefly for CSS fade-out, then unmount" shape recurs, rather than hand-rolling it once here. Not blocking — can ship inline first, extract on the second use site.
+2. **§4.5's cross-platform verification** — needs a real macOS/Linux `task dev` check before shipping, not just Windows.
+3. **§3's full-pane-size overlay** — first use of `data-pane-overlay` at 100% pane coverage; worth a manual perf/correctness pass (resize-while-loading, multiple messenger panes open simultaneously) before considering this done, not just a code read.
+4. Should the spinner also show during `reload()`, or only on true first-load? §4.4 already answers yes by construction (reload already dispatches `LoadStarted`) — flagging only in case product wants reload to feel "instant" via some other treatment instead.
+
+## 7. References
+
+- `agentmux-srv/src/config/widgets.json` (lines 121-195) — the 5 messenger widget definitions.
+- `frontend/app/element/BrainSpinner.tsx`/`.scss` — the reusable spinner component.
+- `docs/specs/REPORT_AGENT_PANE_BLANK_LOAD_BRAIN_INDICATOR_2026_07_04.md` — the report that produced `BrainSpinner` for the agent-pane case; this spec is its Browser-pane sibling.
+- `frontend/app/view/browser/browser-view.tsx`, `browser-model.ts` — the shared Browser pane view/model.
+- `frontend/app/store/browser-pane-state/reducer.ts`, `types.ts` — the already-correct, already-tested `loading`/`TabLoadingChanged` reducer machinery this spec finally wires up.
+- `agentmux-cef/src/client/navigation.rs`, `agentmux-cef/src/browser_pane/callbacks.rs`, `agentmux-cef/src/browser_pane/creation.rs` — CEF LoadHandler callbacks and native pane creation.
+- `frontend/app/platform/pane-overlay.ts`, `pane-overlay-auto.ts`, `docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md` — the existing `SetWindowRgn`-based DOM-over-native-pane mechanism this spec reuses for z-order, unmodified.

--- a/frontend/app/view/browser/browser-model.test.ts
+++ b/frontend/app/view/browser/browser-model.test.ts
@@ -41,9 +41,20 @@ vi.mock("@/app/store/wos", () => ({
     getObjectValue: () => ({}),
 }));
 
-import { invokeCommand } from "@/app/platform/ipc";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import { RpcApi } from "@/app/store/rpc-api";
 import { BrowserViewModel } from "./browser-model";
+
+/** Retrieves the handler the model registered for a given event name via
+ *  `listenEvent(name, handler)`, so tests can invoke it directly with a
+ *  synthetic payload instead of needing a real IPC round-trip. */
+function capturedHandler(eventName: string): (payload: any) => void {
+    const call = vi
+        .mocked(listenEvent)
+        .mock.calls.find(([name]) => name === eventName);
+    if (!call) throw new Error(`no listenEvent registration found for "${eventName}"`);
+    return call[1] as (payload: any) => void;
+}
 
 function makeVM() {
     // BlockNodeModel is used only by blockAtom construction — a minimal
@@ -55,6 +66,16 @@ function makeVM() {
     // here to keep the assertions readable.
     vi.clearAllMocks();
     return vm;
+}
+
+/** Same as `makeVM()`, but captures the nav-state handler BEFORE clearing
+ *  mock history (`makeVM`'s clear would wipe `listenEvent`'s recorded
+ *  calls, taking the handler reference with it). */
+function makeVMWithNavStateHandler() {
+    const vm = new BrowserViewModel("test-block-id", {} as never);
+    const navStateHandler = capturedHandler("browser-pane-nav-state");
+    vi.clearAllMocks();
+    return { vm, navStateHandler };
 }
 
 describe("BrowserViewModel lifecycle gating", () => {
@@ -157,5 +178,82 @@ describe("BrowserViewModel lifecycle gating", () => {
         vm.dispose();
         vm.dispose();
         expect(vm.closed).toBe(true);
+    });
+});
+
+// SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md §4.2: the
+// browser-pane-nav-state listener used to unconditionally dispatch
+// LoadFinished on every event (including ones fired at navigation START,
+// not just completion), so `loadingAtom` cleared within the same tick
+// Navigate() set it. These tests pin the fixed behavior — is_loading now
+// drives an accurate TabLoadingChanged dispatch.
+describe("BrowserViewModel nav-state loading wiring", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("loadingAtom starts true after construction (the ctor's initial navigate())", () => {
+        const { vm } = makeVMWithNavStateHandler();
+        expect(vm.loadingAtom()).toBe(true);
+    });
+
+    it("an on_loading_state_change event with is_loading:true does NOT clear loadingAtom (the exact prior bug)", () => {
+        const { vm, navStateHandler } = makeVMWithNavStateHandler();
+        navStateHandler({
+            block_id: "test-block-id",
+            url: "https://example.com",
+            is_loading: true,
+            can_go_back: false,
+            can_go_forward: false,
+        });
+        expect(vm.loadingAtom()).toBe(true);
+    });
+
+    it("an on_loading_state_change event with is_loading:false clears loadingAtom", () => {
+        const { vm, navStateHandler } = makeVMWithNavStateHandler();
+        navStateHandler({
+            block_id: "test-block-id",
+            url: "https://example.com",
+            is_loading: false,
+            can_go_back: true,
+            can_go_forward: false,
+        });
+        expect(vm.loadingAtom()).toBe(false);
+        expect(vm.canGoBackAtom()).toBe(true);
+    });
+
+    it("the url_only (on_load_end) event — no is_loading field — also clears loadingAtom", () => {
+        const { vm, navStateHandler } = makeVMWithNavStateHandler();
+        navStateHandler({
+            block_id: "test-block-id",
+            url: "https://example.com",
+            url_only: true,
+        });
+        expect(vm.loadingAtom()).toBe(false);
+    });
+
+    it("re-navigating after load-finished sets loadingAtom true again, and a subsequent is_loading:false clears it", () => {
+        const { vm, navStateHandler } = makeVMWithNavStateHandler();
+        navStateHandler({ block_id: "test-block-id", url: "https://a.com", is_loading: false, can_go_back: false, can_go_forward: false });
+        expect(vm.loadingAtom()).toBe(false);
+
+        vm.navigate("https://b.com");
+        expect(vm.loadingAtom()).toBe(true);
+
+        navStateHandler({ block_id: "test-block-id", url: "https://b.com", is_loading: false, can_go_back: true, can_go_forward: false });
+        expect(vm.loadingAtom()).toBe(false);
+    });
+
+    it("a nav-state event for a different block_id is ignored", () => {
+        const { vm, navStateHandler } = makeVMWithNavStateHandler();
+        expect(vm.loadingAtom()).toBe(true);
+        navStateHandler({
+            block_id: "some-other-block-id",
+            url: "https://example.com",
+            is_loading: false,
+            can_go_back: false,
+            can_go_forward: false,
+        });
+        expect(vm.loadingAtom()).toBe(true);
     });
 });

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -364,6 +364,7 @@ export class BrowserViewModel implements ViewModel {
             can_go_back?: boolean;
             can_go_forward?: boolean;
             url_only?: boolean;
+            is_loading?: boolean;
         }>("browser-pane-nav-state", (payload) => {
             if (this.closed) {
                 this.diag(`post-close-event-dropped name=browser-pane-nav-state url=${payload.url}`);
@@ -371,7 +372,7 @@ export class BrowserViewModel implements ViewModel {
             }
             if (payload.block_id !== this.blockId) return;
             this.diag(
-                `nav-state recv url=${JSON.stringify(payload.url)} url_only=${!!payload.url_only} can_back=${payload.can_go_back} can_forward=${payload.can_go_forward}`,
+                `nav-state recv url=${JSON.stringify(payload.url)} url_only=${!!payload.url_only} is_loading=${payload.is_loading} can_back=${payload.can_go_back} can_forward=${payload.can_go_forward}`,
             );
             this._dispatch({ type: "UrlConfirmed", url: payload.url }, "nav-state");
             // `url_only` events come from `on_load_end_pane` — they arrive
@@ -395,7 +396,39 @@ export class BrowserViewModel implements ViewModel {
                     "nav-state",
                 );
             }
-            this._dispatch({ type: "LoadFinished" }, "nav-state");
+            // SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md §4.2:
+            // `is_loading` (present only on `on_loading_state_change_pane`
+            // events, never on the `url_only` `on_load_end_pane` ones) is
+            // CEF's real navigation-controller loading state — dispatch the
+            // reducer's TabLoadingChanged, which was built for exactly this
+            // and was never wired up before. This used to unconditionally
+            // dispatch LoadFinished on EVERY nav-state event, including ones
+            // fired at navigation START — clearing `loading` within the same
+            // tick Navigate() had just set it. `on_loading_state_change_pane`
+            // fires on start/commit/back-forward too, so only trust its
+            // `is_loading` value, not "we received an event at all," as the
+            // loading signal.
+            if (payload.is_loading !== undefined) {
+                const activeTabId = bpSnapshot(this.blockId)?.activeTabId;
+                if (activeTabId != null) {
+                    this._dispatch(
+                        {
+                            type: "TabLoadingChanged",
+                            tabId: activeTabId,
+                            loading: payload.is_loading,
+                            canGoBack: payload.can_go_back ?? this.canGoBackAtom(),
+                            canGoForward: payload.can_go_forward ?? this.canGoForwardAtom(),
+                        },
+                        "nav-state",
+                    );
+                }
+            } else {
+                // The url_only (on_load_end) event — main-frame load actually
+                // finished. Kept as a defense-in-depth clear even though
+                // on_loading_state_change_pane's is_loading:false branch
+                // above should already have cleared it.
+                this._dispatch({ type: "LoadFinished" }, "nav-state");
+            }
             // Persist the real URL to block meta so pane restore lands
             // on the last page, not whatever was passed at create time.
             RpcApi.SetMetaCommand(TabRpcClient, {
@@ -510,11 +543,6 @@ export class BrowserViewModel implements ViewModel {
                 this._dispatch({ type: "Navigate", url }, "reload-restore");
             });
         }
-    }
-
-    onLoad(): void {
-        this.diag(`onLoad`);
-        this._dispatch({ type: "LoadFinished" }, "onLoad");
     }
 
     onError(msg: string): void {

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -127,3 +127,24 @@
 .browser-empty-text {
     font-size: 14px;
 }
+
+// Loading-brain overlay shown while a real top-level navigation is in
+// flight (SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md §4.3).
+// Fills .browser-placeholder exactly — same box the native browser-pane
+// HWND is sized/positioned against — so the pane-overlay-auto.ts clip
+// rect lines up with it pixel-for-pixel. `is-fading` drives opacity here
+// (not just on BrainSpinner's own inner element) because
+// pane-overlay-auto.ts's visibility check reads computed opacity on this
+// tagged data-pane-overlay element itself.
+.browser-loading-overlay {
+    position: absolute;
+    inset: 0;
+    background: var(--block-bg-color);
+    opacity: 1;
+
+    &.is-fading {
+        opacity: 0;
+        transition: opacity 200ms ease-out;
+        pointer-events: none;
+    }
+}

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -139,7 +139,12 @@
 .browser-loading-overlay {
     position: absolute;
     inset: 0;
-    background: var(--block-bg-color);
+    // --block-bg-color is translucent in every theme (rgba with alpha < 1) —
+    // needs the opaque `r g b` form (no alpha channel) or the native
+    // browser-pane HWND's own blank page bleeds through underneath, same
+    // reasoning as block.scss:364 / tilelayout.scss:152. A translucent brain
+    // would defeat the point of this overlay (fully masking the blank gap).
+    background-color: rgb(from var(--block-bg-color) r g b);
     opacity: 1;
 
     &.is-fading {

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -8,8 +8,15 @@ import { ModalLayer } from "@/element/ModalLayer";
 import { useModalLayer } from "@/element/modal-layer";
 import { registerPaneRect, unregisterPaneRect } from "@/app/platform/pane-rect-registry";
 import { paneReflowActive, notifyPaneReflow } from "@/app/platform/pane-anim";
+import { BrainSpinner } from "@/app/element/BrainSpinner";
+import { atoms } from "@/store/global";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
+
+// Matches BrainSpinner.scss's `.is-fading` transition duration — the DOM
+// node stays mounted this long after loadingAtom() flips false so the
+// opacity fade actually plays before unmount removes it.
+const LOADING_SPINNER_FADE_MS = 200;
 
 // Compact tag for an Element — used by diag log lines to identify the
 // previous/next active element across focus transitions. Module-scope
@@ -92,6 +99,45 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
     // SolidJS signal — must be reactive so <Show when={!paneCreated()}> re-runs
     // when the pane is created and hides the empty-state placeholder.
     const [paneCreated, setPaneCreated] = createSignal(false);
+
+    // Loading-brain overlay (SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md
+    // §4.3). `model.loadingAtom()` is the source of truth; these two signals
+    // exist only to hold the BrainSpinner mounted for the CSS fade-out
+    // duration after loading finishes — BrainSpinner's own contract is "the
+    // caller owns unmounting it after the transition ends" (see its doc
+    // comment), so a plain `<Show when={model.loadingAtom()}>` would yank it
+    // out instantly with no fade.
+    const [spinnerMounted, setSpinnerMounted] = createSignal(false);
+    const [spinnerFading, setSpinnerFading] = createSignal(false);
+    let spinnerFadeTimeout: ReturnType<typeof setTimeout> | null = null;
+    createEffect(() => {
+        if (model.loadingAtom()) {
+            if (spinnerFadeTimeout) {
+                clearTimeout(spinnerFadeTimeout);
+                spinnerFadeTimeout = null;
+            }
+            setSpinnerFading(false);
+            setSpinnerMounted(true);
+            return;
+        }
+        if (!spinnerMounted()) return;
+        // prefersReducedMotion: BrainSpinner shows/hides instantly (no CSS
+        // transition) in that mode, so holding the node mounted for the
+        // normal fade duration would just be a pointless delay — unmount now.
+        if (atoms.prefersReducedMotionAtom()) {
+            setSpinnerMounted(false);
+            return;
+        }
+        setSpinnerFading(true);
+        spinnerFadeTimeout = setTimeout(() => {
+            spinnerFadeTimeout = null;
+            setSpinnerFading(false);
+            setSpinnerMounted(false);
+        }, LOADING_SPINNER_FADE_MS);
+    });
+    onCleanup(() => {
+        if (spinnerFadeTimeout) clearTimeout(spinnerFadeTimeout);
+    });
 
     // getBoundingClientRect() returns CSS pixels (device-INdependent); CEF
     // and Win32 SetWindowPos expect physical / device pixels. Multiply by
@@ -209,7 +255,14 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
             // Seed the overlay-clip short-circuit registry with the initial
             // rect; subsequent syncPosition ticks keep it current.
             registerPaneRect(model.blockId, paneRectCss());
-            model.onLoad();
+            // NOTE: does NOT call model.onLoad() here anymore. That used to
+            // fire LoadFinished the instant the HWND was CREATED — before
+            // CEF had even started, let alone finished, loading the actual
+            // page — which cleared `loading` within the same tick Navigate()
+            // had just set it true. Real load-finished now comes from the
+            // browser-pane-nav-state listener in browser-model.ts (CEF's
+            // on_loading_state_change/on_load_end). See
+            // docs/specs/SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md §4.2.
         } catch (e) {
             model.onError(`Failed to create browser pane: ${e}`);
         }
@@ -539,6 +592,31 @@ function BrowserViewInner(props: { model: BrowserViewModel }): JSX.Element {
                     <div class="browser-empty">
                         <div class="browser-empty-icon">{"\uD83C\uDF10"}</div>
                         <div class="browser-empty-text">Enter a URL above to browse</div>
+                    </div>
+                </Show>
+
+                {/* `data-pane-overlay`: pane-overlay-auto.ts auto-discovers this
+                    element and punches a matching hole through the native
+                    browser-pane HWND so it's visible above it (the HWND paints
+                    above DOM regardless of CSS z-index \u2014 the "airspace problem",
+                    SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md). No manual overlay
+                    registration needed \u2014 same mechanism modals/menus/tooltips
+                    already use.
+
+                    The fade-out opacity is applied to THIS wrapper (via
+                    is-fading below), not just to BrainSpinner's own internal
+                    fade \u2014 pane-overlay-auto.ts's isOverlayElementVisible()
+                    reads computed opacity on the tagged data-pane-overlay
+                    element itself. Fading only BrainSpinner's inner div would
+                    make it look faded while this outer element stayed at
+                    opacity:1, so the clip hole wouldn't lift until unmount \u2014
+                    losing the "fade and un-punch together" behavior this
+                    design relies on. BrainSpinner's own `fading` prop is
+                    unnecessary here since opacity on this wrapper already
+                    fades everything nested inside it. */}
+                <Show when={spinnerMounted()}>
+                    <div class="browser-loading-overlay" classList={{ "is-fading": spinnerFading() }} data-pane-overlay>
+                        <BrainSpinner />
                     </div>
                 </Show>
             </div>


### PR DESCRIPTION
## Summary

The 5 messenger widgets (Discord, Slack, Telegram, WhatsApp, Teams) are just `browser` panes pointed at a pinned URL (`agentmux-srv/src/config/widgets.json`). While the external site's JS bundle boots, the native CEF child window shows its own blank/white default page — nothing at the AgentMux level covers that gap, which reads as broken rather than loading.

This isn't messenger-specific code, and it isn't "build a loading indicator from scratch" — the reducer already had correct, fully-tested machinery for this (`loading` / `TabLoadingChanged` in `browser-pane-state/reducer.ts`), it just never worked end-to-end because of two real bugs:

1. **`browser-view.tsx`'s `createPane()` called `model.onLoad()`** (dispatching `LoadFinished`) the instant the native HWND was *created* — not when the page had actually *loaded* — clearing `loading` within the same tick `Navigate()` had just set it true. Removed (now dead code, so `onLoad()` itself is deleted too).
2. **`browser-model.ts`'s nav-state listener unconditionally dispatched `LoadFinished` on every `browser-pane-nav-state` event**, including ones CEF fires at navigation *start* (`on_loading_state_change` fires on start/commit/back-forward, not just completion).
3. Bonus: `TabLoadingChanged` — the reducer command already built for exactly this — was never dispatched from anywhere in production code, and CEF's real `is_loading` boolean was available at the FFI boundary but discarded (`agentmux-cef/src/client/navigation.rs`, `_is_loading`).

## Changes
- **`agentmux-cef`**: thread `is_loading` through `on_loading_state_change` → `on_loading_state_change_browser_pane` → the `browser-pane-nav-state` event payload (additive field).
- **`browser-model.ts`**: dispatch `TabLoadingChanged` when `is_loading` is present (the accurate signal); keep `LoadFinished` only for the `url_only` (`on_load_end`) event as a defense-in-depth clear.
- **`browser-view.tsx`**: render the existing `BrainSpinner` over `.browser-placeholder` while `model.loadingAtom()` is true, with a fade-hold pattern (BrainSpinner's contract is "caller owns unmounting after the fade").
- **Z-order**: reuses the existing `data-pane-overlay` auto-clip mechanism (`pane-overlay-auto.ts`) that already solves "DOM must render above the native browser-pane HWND" for modals/menus/tooltips — no new native-window-visibility plumbing needed. The wrapper div's own opacity (not just BrainSpinner's internal fade class) drives the auto-clip visibility check, so the hole-punch clears in sync with the fade-out — see the code comment for why that distinction mattered.

Full design + open questions (cross-platform z-order verification, this being the first full-pane-size use of the overlay-clip mechanism): `docs/specs/SPEC_BROWSER_PANE_LOADING_BRAIN_INDICATOR_2026_07_11.md`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/browser frontend/app/store/browser-pane-state` — 114 passed (incl. 6 new tests pinning the exact prior bug: an `is_loading:true` event must NOT clear `loading`, `is_loading:false` must, the `url_only` defense-in-depth path, re-navigate-after-load-finished, and block_id filtering)
- [ ] `cargo check -p agentmux-cef` — **could not verify locally.** The CEF C++ wrapper build (`libcef_dll_wrapper`, ~100+ `.cc` files via CMake/Ninja) failed 3 times locally with `cannot open compiler generated file`, on different unrelated files each time, including with reduced parallelism — this reads as a local machine/toolchain resource-contention issue, not something my 2-file, ~15-line Rust diff (adding one `bool` parameter and threading it through two existing function signatures) would cause. Visually re-reviewed both changed functions against their call sites for signature/type correctness. Deferring to CI's clean Windows/Ubuntu runners for the actual compile check.
- [ ] Manual: open a messenger widget (or any browser pane) on a cold pane, confirm the brain shows during load and fades out once the page renders; confirm reload/back/forward re-show it; confirm in-app SPA navigation (e.g. switching Discord channels) does NOT re-trigger it.

<!-- agentmux:agent_id=agenty -->