### PR TITLE
docs(specs): drag-session architecture refactor (analysis + design)

### DIFF
--- a/.changesets/1783796014-fix-tabbar-invert-strobe-at-500ms-remove-reduced-motion-resp-j0vv.md
+++ b/.changesets/1783796014-fix-tabbar-invert-strobe-at-500ms-remove-reduced-motion-resp-j0vv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabbar): invert strobe at 500ms, remove reduced-motion respect app-wide, source pane no longer lingers after cross-tab move

--- a/.changesets/1783810085-fix-layout-drag-stabilization-registry-owner-check-prune-de--th86.md
+++ b/.changesets/1783810085-fix-layout-drag-stabilization-registry-owner-check-prune-de--th86.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): drag stabilization — registry owner-check, prune de-fang, persistence Phase A

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -280,6 +280,12 @@ function Block(props: BlockProps): JSX.Element {
     const viewType = createMemo(() => blockData()?.meta?.view);
     const [viewModel, setViewModel] = createSignal<ViewModel>(null);
 
+    // Ownership tracking (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR §3.4):
+    // remember exactly which bcm THIS mount registered and which ViewModels
+    // it created, so cleanup can neither clobber a newer mount's registration
+    // nor dispose a ViewModel it merely adopted from the registry.
+    let registeredBcm: BlockComponentModel | null = null;
+    const createdViewModels: ViewModel[] = [];
     createEffect(() => {
         const view = viewType();
         if (!view) return;
@@ -287,14 +293,24 @@ function Block(props: BlockProps): JSX.Element {
         let vm = bcm?.viewModel;
         if (vm == null || vm.viewType !== view) {
             vm = makeViewModel(props.nodeModel.blockId, view, props.nodeModel);
-            registerBlockComponentModel(props.nodeModel.blockId, { viewModel: vm });
+            createdViewModels.push(vm);
+            registeredBcm = { viewModel: vm };
+            registerBlockComponentModel(props.nodeModel.blockId, registeredBcm);
         }
         setViewModel(vm);
     });
 
     onCleanup(() => {
-        unregisterBlockComponentModel(props.nodeModel.blockId);
-        viewModel()?.dispose?.();
+        if (registeredBcm) {
+            unregisterBlockComponentModel(props.nodeModel.blockId, registeredBcm);
+        }
+        // Dispose only ViewModels this mount CREATED and that are not the
+        // registry's live one (a newer mount may have adopted nothing from
+        // us, but never dispose someone else's live vm out from under them).
+        const liveVm = getBlockComponentModel(props.nodeModel.blockId)?.viewModel;
+        for (const vm of createdViewModels) {
+            if (vm !== liveVm) vm?.dispose?.();
+        }
     });
 
     const ready = createMemo(() => !loading() && !isBlank(props.nodeModel.blockId) && blockData() != null && viewModel() != null);
@@ -330,6 +346,12 @@ function SubBlock(props: SubBlockProps): JSX.Element {
     const viewType = createMemo(() => blockData()?.meta?.view);
     const [viewModel, setViewModel] = createSignal<ViewModel>(null);
 
+    // Ownership tracking (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR §3.4):
+    // remember exactly which bcm THIS mount registered and which ViewModels
+    // it created, so cleanup can neither clobber a newer mount's registration
+    // nor dispose a ViewModel it merely adopted from the registry.
+    let registeredBcm: BlockComponentModel | null = null;
+    const createdViewModels: ViewModel[] = [];
     createEffect(() => {
         const view = viewType();
         if (!view) return;
@@ -337,14 +359,24 @@ function SubBlock(props: SubBlockProps): JSX.Element {
         let vm = bcm?.viewModel;
         if (vm == null || vm.viewType !== view) {
             vm = makeViewModel(props.nodeModel.blockId, view, props.nodeModel as any);
-            registerBlockComponentModel(props.nodeModel.blockId, { viewModel: vm });
+            createdViewModels.push(vm);
+            registeredBcm = { viewModel: vm };
+            registerBlockComponentModel(props.nodeModel.blockId, registeredBcm);
         }
         setViewModel(vm);
     });
 
     onCleanup(() => {
-        unregisterBlockComponentModel(props.nodeModel.blockId);
-        viewModel()?.dispose?.();
+        if (registeredBcm) {
+            unregisterBlockComponentModel(props.nodeModel.blockId, registeredBcm);
+        }
+        // Dispose only ViewModels this mount CREATED and that are not the
+        // registry's live one (a newer mount may have adopted nothing from
+        // us, but never dispose someone else's live vm out from under them).
+        const liveVm = getBlockComponentModel(props.nodeModel.blockId)?.viewModel;
+        for (const vm of createdViewModels) {
+            if (vm !== liveVm) vm?.dispose?.();
+        }
     });
 
     const viewTypeStr = createMemo(() => blockData()?.meta?.view);

--- a/frontend/app/element/modal-layer.scss
+++ b/frontend/app/element/modal-layer.scss
@@ -20,9 +20,3 @@
     from { opacity: 0; transform: translateY(2px); }
     to   { opacity: 1; transform: translateY(0); }
 }
-
-@media (prefers-reduced-motion: reduce) {
-    .modal-layer-content {
-        animation: none;
-    }
-}

--- a/frontend/app/mixins.scss
+++ b/frontend/app/mixins.scss
@@ -120,10 +120,13 @@
     @media (max-width: calc(#{$w} - 1px)) { @content; }
 }
 
-/// Respect user's `prefers-reduced-motion` setting. Wrap any non-
-/// essential animation in this so motion-sensitive users opt out.
+/// Reduced-motion respect removed app-wide (2026-07-11 product
+/// decision — OS "reduce motion" was killing functional motion cues
+/// like drag strobes and drop indicators). The mixin is kept as a
+/// no-op so call sites compile and the decision is easy to revisit;
+/// the wrapped @content is intentionally never emitted.
 @mixin respect-reduced-motion {
-    @media (prefers-reduced-motion: reduce) {
+    @if false {
         @content;
     }
 }

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -126,7 +126,13 @@ export const [termRendererAtom, setTermRendererAtom] = createSignal<"webgl" | "d
 export const reducedMotionSetting = createMemo(() => settingsAtom()?.["window:reducedmotion"]);
 export const [reducedMotionSystemPreference, setReducedMotionSystemPreference] = createSignal(false);
 
-export const prefersReducedMotionAtom = createMemo(() => reducedMotionSetting() || reducedMotionSystemPreference());
+// Reduced-motion respect is removed app-wide (product decision,
+// 2026-07-11): OS-level "reduce motion"/disabled-animations settings were
+// silently killing functional motion cues (drag strobes, drop pulses,
+// insertion indicators) that carry meaning rather than decoration. The
+// setting plumbing above is kept so the decision is easy to revisit, but
+// the atom every consumer reads is hard false.
+export const prefersReducedMotionAtom = createMemo(() => false);
 
 export type { BackendStatusState, BackendDeathInfo } from "./backendStatus";
 export { backendStatusAtom, setBackendStatusAtom, backendDeathInfoAtom, setBackendDeathInfoAtom };

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -525,7 +525,18 @@ export function registerBlockComponentModel(blockId: string, bcm: BlockComponent
     blockComponentModelMap.set(blockId, bcm);
 }
 
-export function unregisterBlockComponentModel(blockId: string) {
+export function unregisterBlockComponentModel(blockId: string, owner?: BlockComponentModel) {
+    // Owner-checked delete (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR §3.4):
+    // every tab stays mounted, so a block can be transiently mounted twice
+    // (e.g. a dangling layout leaf during a cross-tab move). Registration is
+    // last-writer-wins; without this check the FIRST mount's unmount deletes
+    // the SECOND mount's live registration and tears down its atom cache —
+    // leaving the surviving pane unreachable by focus routing (the
+    // "non-responsive tab"). Callers pass the exact bcm they registered; the
+    // delete only proceeds if that bcm still owns the key.
+    if (owner !== undefined && blockComponentModelMap.get(blockId) !== owner) {
+        return;
+    }
     blockComponentModelMap.delete(blockId);
     cleanupBlockAtomCache(blockId);
 }

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -403,6 +403,7 @@ export async function createBlockSplitHorizontally(
     const layoutModel = getLayoutModelForStaticTab();
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
     const newBlockId = await ObjectService.CreateBlock(blockDef, rtOpts);
+    markBlockRecentlyCreated(newBlockId);
     const targetNodeId = layoutModel.getNodeByBlockId(targetBlockId)?.id;
     if (targetNodeId == null) throw new Error(`targetNodeId not found for blockId: ${targetBlockId}`);
     const splitAction: LayoutTreeSplitHorizontalAction = {
@@ -412,7 +413,6 @@ export async function createBlockSplitHorizontally(
         position,
         focused: true,
     };
-    markBlockRecentlyCreated(newBlockId);
     layoutModel.treeReducer(splitAction);
     return newBlockId;
 }
@@ -425,6 +425,7 @@ export async function createBlockSplitVertically(
     const layoutModel = getLayoutModelForStaticTab();
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
     const newBlockId = await ObjectService.CreateBlock(blockDef, rtOpts);
+    markBlockRecentlyCreated(newBlockId);
     const targetNodeId = layoutModel.getNodeByBlockId(targetBlockId)?.id;
     if (targetNodeId == null) throw new Error(`targetNodeId not found for blockId: ${targetBlockId}`);
     const splitAction: LayoutTreeSplitVerticalAction = {
@@ -434,7 +435,6 @@ export async function createBlockSplitVertically(
         position,
         focused: true,
     };
-    markBlockRecentlyCreated(newBlockId);
     layoutModel.treeReducer(splitAction);
     return newBlockId;
 }
@@ -443,6 +443,10 @@ export async function createBlock(blockDef: BlockDef, magnified = false, ephemer
     const layoutModel = getLayoutModelForStaticTab();
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
     const blockId = await ObjectService.CreateBlock(blockDef, rtOpts);
+    // Mark BEFORE branching — the ephemeral path (below) also inserts this
+    // block into the local tree (via addEphemeralNodeToLayout, later) ahead
+    // of tab.blockids catching up, same race as the non-ephemeral path.
+    markBlockRecentlyCreated(blockId);
     if (ephemeral) {
         layoutModel.newEphemeralNode(blockId);
         return blockId;
@@ -453,7 +457,6 @@ export async function createBlock(blockDef: BlockDef, magnified = false, ephemer
         magnified,
         focused: true,
     };
-    markBlockRecentlyCreated(blockId);
     layoutModel.treeReducer(insertNodeAction);
     return blockId;
 }
@@ -462,6 +465,7 @@ export async function replaceBlock(blockId: string, blockDef: BlockDef, focus: b
     const layoutModel = getLayoutModelForStaticTab();
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
     const newBlockId = await ObjectService.CreateBlock(blockDef, rtOpts);
+    markBlockRecentlyCreated(newBlockId);
     setTimeout(() => {
         fireAndForget(() => ObjectService.DeleteBlock(blockId));
     }, 300);

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -11,6 +11,7 @@ import {
     getLayoutModelForStaticTab,
     LayoutTreeActionType,
     LayoutTreeInsertNodeAction,
+    markBlockRecentlyCreated,
     newLayoutNode,
 } from "@/layout/index";
 import {
@@ -411,6 +412,7 @@ export async function createBlockSplitHorizontally(
         position,
         focused: true,
     };
+    markBlockRecentlyCreated(newBlockId);
     layoutModel.treeReducer(splitAction);
     return newBlockId;
 }
@@ -432,6 +434,7 @@ export async function createBlockSplitVertically(
         position,
         focused: true,
     };
+    markBlockRecentlyCreated(newBlockId);
     layoutModel.treeReducer(splitAction);
     return newBlockId;
 }
@@ -450,6 +453,7 @@ export async function createBlock(blockDef: BlockDef, magnified = false, ephemer
         magnified,
         focused: true,
     };
+    markBlockRecentlyCreated(blockId);
     layoutModel.treeReducer(insertNodeAction);
     return blockId;
 }

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -5,7 +5,7 @@ import { Logger } from "@/util/logger";
 import { draggable, dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import { isWindows } from "@/util/platformutil";
-import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
+import { createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 import clsx from "clsx";
 import { Tab } from "./tab";
@@ -297,14 +297,6 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                     : {}),
             } as JSX.CSSProperties}
         >
-            <Show when={isTileDropHover()} keyed>
-                {/* Attention strobe: 10 flashes at 20ms (200ms total),
-                    riding the tab's top edge, fired the instant a pane
-                    hover begins (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1).
-                    `keyed` remounts the element per hover entry so the
-                    one-shot CSS animation restarts every time. */}
-                <div class="tab-drop-strobe" aria-hidden="true" />
-            </Show>
             <Tab
                 id={props.tabId}
                 active={props.isActive}

--- a/frontend/app/tab/tab-presets.ts
+++ b/frontend/app/tab/tab-presets.ts
@@ -3,7 +3,7 @@
 
 import { fullConfigAtom, WOS } from "@/app/store/global";
 import { ObjectService } from "@/app/store/services";
-import { getLayoutModelForTabById } from "@/layout/index";
+import { getLayoutModelForTabById, markBlockRecentlyCreated } from "@/layout/index";
 import {
     LayoutTreeActionType,
     type LayoutTreeInsertNodeAction,
@@ -161,6 +161,10 @@ async function createBlockOnModel(
 ): Promise<string> {
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
     const blockId = await ObjectService.CreateBlock(blockDef, rtOpts, expectedTabId);
+    // Same age-gate as global.ts's createBlock/createBlockSplit* — this
+    // path also inserts the fresh block into the local tree ahead of
+    // tab.blockids catching up (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR).
+    markBlockRecentlyCreated(blockId);
 
     if (splitTargetId === null) {
         const action: LayoutTreeInsertNodeAction = {

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -132,33 +132,22 @@
         // replaces this with a dedicated indicator element.
         transition: padding-left 100ms ease-out, padding-right 100ms ease-out, opacity 0.15s ease;
 
-        // Pane dragged over a tab — highlight with accent border
+        // Pane dragged over a tab — attention strobe then steady pulse
+        // (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1, revised): the instant a
+        // pane hover begins, the tab flashes to its NEGATIVE (filter:
+        // invert) and back 10 times at 50ms intervals (500ms total,
+        // one-shot — the class is re-applied per hover entry, restarting
+        // the animation), then the slower accent-outline pulse carries the
+        // "valid drop target" signal for the rest of the hover.
         &.tile-drop-hover {
             .tab {
                 outline: 2px solid var(--accent-color);
                 outline-offset: -2px;
                 border-radius: 0;
-                animation: tab-drop-pulse 0.8s ease-in-out infinite alternate;
+                animation:
+                    tab-drop-invert-strobe 50ms steps(1, end) 10,
+                    tab-drop-pulse 0.8s ease-in-out infinite alternate;
             }
-        }
-
-        // Attention strobe riding the tab's top edge — 10 flashes at 20ms
-        // (200ms total), one-shot, fired the instant a pane hover begins
-        // (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1). The element is
-        // keyed-remounted per hover entry (droppable-tab.tsx) so the
-        // animation restarts every time; `forwards` holds the final
-        // opacity:0 frame so it vanishes after the burst rather than
-        // freezing visible.
-        .tab-drop-strobe {
-            position: absolute;
-            top: 0;
-            left: 6px;
-            right: 6px;
-            height: 3px;
-            background: var(--accent-color);
-            pointer-events: none;
-            z-index: 2;
-            animation: tab-drop-strobe-flash 20ms steps(1, end) 10 forwards;
         }
 
         // Tab being dragged — reduce opacity
@@ -217,10 +206,11 @@
     100% { transform: scaleX(1.0);  }
 }
 
-// One strobe cycle: visible for the first half (10ms), dark for the
-// second (10ms) — 10 iterations = 10 distinct flashes over 200ms.
-@keyframes tab-drop-strobe-flash {
-    0%   { opacity: 1; }
-    50%  { opacity: 0; }
-    100% { opacity: 0; }
+// One strobe cycle: the tab's negative for the first half (25ms), normal
+// for the second (25ms) — 10 iterations = 10 distinct invert flashes over
+// 500ms.
+@keyframes tab-drop-invert-strobe {
+    0%   { filter: invert(1); }
+    50%  { filter: invert(0); }
+    100% { filter: invert(0); }
 }

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -133,20 +133,35 @@
         transition: padding-left 100ms ease-out, padding-right 100ms ease-out, opacity 0.15s ease;
 
         // Pane dragged over a tab — attention strobe then steady pulse
-        // (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1, revised): the instant a
-        // pane hover begins, the tab flashes to its NEGATIVE (filter:
-        // invert) and back 10 times at 50ms intervals (500ms total,
-        // one-shot — the class is re-applied per hover entry, restarting
-        // the animation), then the slower accent-outline pulse carries the
+        // (SPEC_PANE_DRAG_TO_TAB v3 addendum §A1/A4): the instant a pane
+        // hover begins, the tab flashes to its NEGATIVE (filter: invert)
+        // and back — one-shot, class re-applied per hover entry restarts
+        // the animation — then the slower accent-outline pulse carries the
         // "valid drop target" signal for the rest of the hover.
+        //
+        // Flash rate (review finding on PR #2105, P1): the original design
+        // (10 flashes / 500ms = 20 Hz) exceeded the WCAG 2.3.1 general
+        // flash threshold (max 3 flashes per any 1-second window) — a real
+        // photosensitive-seizure risk, independent of any animation
+        // preference. Reduced to 2 flashes over 800ms (2.5 Hz, safely under
+        // the threshold) — still a clearly visible double-blink. Also
+        // reinstates a targeted `prefers-reduced-motion` opt-out for THIS
+        // flash specifically (dropping straight to the steady pulse):
+        // seizure-trigger content warrants its own escape hatch as a
+        // distinct, more serious category than the general "skip cosmetic
+        // transitions" policy this app otherwise doesn't honor.
         &.tile-drop-hover {
             .tab {
                 outline: 2px solid var(--accent-color);
                 outline-offset: -2px;
                 border-radius: 0;
                 animation:
-                    tab-drop-invert-strobe 50ms steps(1, end) 10,
+                    tab-drop-invert-strobe 400ms steps(1, end) 2,
                     tab-drop-pulse 0.8s ease-in-out infinite alternate;
+
+                @media (prefers-reduced-motion: reduce) {
+                    animation: tab-drop-pulse 0.8s ease-in-out infinite alternate;
+                }
             }
         }
 
@@ -206,9 +221,9 @@
     100% { transform: scaleX(1.0);  }
 }
 
-// One strobe cycle: the tab's negative for the first half (25ms), normal
-// for the second (25ms) — 10 iterations = 10 distinct invert flashes over
-// 500ms.
+// One strobe cycle: the tab's negative for the first half (200ms), normal
+// for the second (200ms) — 2 iterations = 2 distinct invert flashes over
+// 800ms (2.5 Hz — under the WCAG 2.3.1 3-flashes-per-second threshold).
 @keyframes tab-drop-invert-strobe {
     0%   { filter: invert(1); }
     50%  { filter: invert(0); }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -111,6 +111,36 @@ function TabBar(props: TabBarProps): JSX.Element {
     const handleSelect = (tabId: string) => {
         if (tabId === activeTabId()) return;
         setActiveTab(tabId);
+        // TEMPORARY field diagnostic (SPEC_PANE_DRAG_TO_TAB addendum A2 —
+        // the dead-source-tab investigation): after the switch settles,
+        // hit-test the center of the content area and log exactly which
+        // element sits on top, plus the layer states we keep suspecting.
+        // Remove once the wedge is root-caused.
+        setTimeout(() => {
+            try {
+                const cx = Math.floor(window.innerWidth / 2);
+                const cy = Math.floor(window.innerHeight / 2);
+                const el = document.elementFromPoint(cx, cy) as HTMLElement | null;
+                const chain: string[] = [];
+                let cur: HTMLElement | null = el;
+                for (let i = 0; cur && i < 5; i++) {
+                    const cls = typeof cur.className === "string" && cur.className ? `.${cur.className.split(" ").slice(0, 3).join(".")}` : "";
+                    chain.push(`${cur.tagName.toLowerCase()}${cls}`);
+                    cur = cur.parentElement;
+                }
+                const model = getLayoutModelForTabById(tabId);
+                const overlayEl = document.querySelector(".overlay-container") as HTMLElement | null;
+                Logger.info("dnd:diag", "post-switch hit-test", {
+                    tabId,
+                    elementAtCenter: chain,
+                    activeDrag: model?.activeDrag() ?? null,
+                    overlayPointerEvents: overlayEl ? getComputedStyle(overlayEl).pointerEvents : "no-overlay-el",
+                    leafCount: model?.leafs()?.length ?? -1,
+                });
+            } catch (e) {
+                Logger.warn("dnd:diag", "post-switch hit-test failed", { error: String(e) });
+            }
+        }, 900);
     };
 
     const handleClose = (tabId: string) => {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -19,6 +19,8 @@ import { makeORef, getObjectValue, getWaveObjectAtom } from "../store/wos";
 import { ConfirmModal } from "@/element/modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
 import { clearCrossTabDrop, deleteLayoutModelForTab, getLayoutModelForTabById, tileItemType } from "@/layout/index";
+import { setTileDragInFlight } from "@/layout/lib/dragInFlight";
+import { pruneDanglingLeaves } from "@/layout/lib/layoutPersistence";
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { DroppableTab } from "./droppable-tab";
 import {
@@ -424,10 +426,28 @@ function TabBar(props: TabBarProps): JSX.Element {
         const cleanupTileDragState = () => {
             setHoveredDropTabId(null);
             clearCrossTabDrop();
-            for (const tabId of dragActivatedTabIds) {
+            setTileDragInFlight(false);
+            // Reset EVERY tab's overlay, not just the spring-activated
+            // set: the SOURCE tab's activeDrag is normally reset by its
+            // own draggable's onDrop, but that dispatch is skipped
+            // whenever dragend is suppressed (swallowed-drag paths,
+            // source unmounted early, …) — and a stuck overlay is a dead
+            // tab. Safe here because this only runs at end-of-drag.
+            for (const tabId of tabIds()) {
                 getLayoutModelForTabById(tabId)?.activeDrag._set(false);
             }
             dragActivatedTabIds.clear();
+            // Deferred dangling-leaf prune: mid-drag pruning is gated off
+            // (see pruneDanglingLeaves), so the source tab's disowned
+            // leaf is removed HERE, after the gesture and the move RPC's
+            // Tab updates have settled. 250ms comfortably covers the
+            // observed 20-40ms RPC round-trip.
+            setTimeout(() => {
+                for (const tabId of tabIds()) {
+                    const model = getLayoutModelForTabById(tabId);
+                    if (model) pruneDanglingLeaves(model);
+                }
+            }, 250);
         };
         const cleanupTileMonitor = monitorForElements({
             canMonitor: ({ source }) => source.data.type === tileItemType,
@@ -437,7 +457,20 @@ function TabBar(props: TabBarProps): JSX.Element {
             if (dragActivatedTabIds.size > 0) cleanupTileDragState();
         };
         const onWindowPointerDown = () => {
-            if (dragActivatedTabIds.size > 0) cleanupTileDragState();
+            if (dragActivatedTabIds.size > 0) {
+                // Reaching this net means the drag ended UNOBSERVED (no
+                // monitor onDrop, no window dragend) — log loudly with
+                // each tab's overlay state so field diags can pinpoint
+                // what wedged. (SPEC_PANE_DRAG_TO_TAB addendum A2.)
+                Logger.warn("dnd", "pointerdown net fired — drag ended unobserved", {
+                    activated: [...dragActivatedTabIds],
+                    overlays: tabIds().map((id) => ({
+                        tabId: id,
+                        activeDrag: getLayoutModelForTabById(id)?.activeDrag() ?? null,
+                    })),
+                });
+                cleanupTileDragState();
+            }
         };
         window.addEventListener("dragend", onWindowDragEnd);
         window.addEventListener("pointerdown", onWindowPointerDown, true);

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -111,36 +111,6 @@ function TabBar(props: TabBarProps): JSX.Element {
     const handleSelect = (tabId: string) => {
         if (tabId === activeTabId()) return;
         setActiveTab(tabId);
-        // TEMPORARY field diagnostic (SPEC_PANE_DRAG_TO_TAB addendum A2 —
-        // the dead-source-tab investigation): after the switch settles,
-        // hit-test the center of the content area and log exactly which
-        // element sits on top, plus the layer states we keep suspecting.
-        // Remove once the wedge is root-caused.
-        setTimeout(() => {
-            try {
-                const cx = Math.floor(window.innerWidth / 2);
-                const cy = Math.floor(window.innerHeight / 2);
-                const el = document.elementFromPoint(cx, cy) as HTMLElement | null;
-                const chain: string[] = [];
-                let cur: HTMLElement | null = el;
-                for (let i = 0; cur && i < 5; i++) {
-                    const cls = typeof cur.className === "string" && cur.className ? `.${cur.className.split(" ").slice(0, 3).join(".")}` : "";
-                    chain.push(`${cur.tagName.toLowerCase()}${cls}`);
-                    cur = cur.parentElement;
-                }
-                const model = getLayoutModelForTabById(tabId);
-                const overlayEl = document.querySelector(".overlay-container") as HTMLElement | null;
-                Logger.info("dnd:diag", "post-switch hit-test", {
-                    tabId,
-                    elementAtCenter: chain,
-                    activeDrag: model?.activeDrag() ?? null,
-                    overlayPointerEvents: overlayEl ? getComputedStyle(overlayEl).pointerEvents : "no-overlay-el",
-                    leafCount: model?.leafs()?.length ?? -1,
-                });
-            } catch (e) {
-                Logger.warn("dnd:diag", "post-switch hit-test failed", { error: String(e) });
-            }
-        }, 900);
     };
 
     const handleClose = (tabId: string) => {

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -132,32 +132,6 @@
         to   { transform: translateX(calc(11.314px / var(--agent-pane-zoom, 1))); }
     }
 
-    @media (prefers-reduced-motion: reduce) {
-        // Keep the marching ants - this is a small (3px), looping, essential
-        // "agent is working" indicator, not large/parallax motion. Just slow
-        // the march so it's gentle when the OS asks for reduced motion, rather
-        // than swapping to a different effect (an opacity breathe reads as a
-        // glow/"aurora", and `animation: none` freezes the stripe = looks
-        // stuck). CEF maps reduced-motion to the Windows "Animation effects"
-        // toggle (SPI_GETCLIENTAREAANIMATION), so machines with it off land
-        // here. On macOS, "Reduce Motion" in System Settings → Accessibility
-        // → Display triggers this branch.
-        // IMPORTANT: also explicitly set animation-iteration-count: infinite.
-        // Chromium internally limits `infinite` animations to a single
-        // iteration when prefers-reduced-motion fires, so without this override
-        // the ants march once (~1.5s), then freeze — the bug reported on macOS
-        // with Reduce Motion on and on Windows with Animation effects off.
-        .agent-pane-progress-bar--active::before {
-            animation-duration: 1.5s;
-            animation-iteration-count: infinite;
-        }
-
-        // (The Working-row shimmer's reduced-motion slowdown is nested inside
-        // its own rule further down — NOT here. A rule in this block has the
-        // same specificity as the shimmer's `animation:` shorthand but
-        // earlier source order, so the shorthand would always win and the
-        // slowdown would silently never apply.)
-    }
 
     // Back-and-forth highlight sweep for .agent-working-shimmer (below).
     // `alternate` on the animation shorthand does the direction-reversal;
@@ -241,10 +215,6 @@
                     // near the top of the file: it must come after the
                     // `animation:` shorthand above in source order (equal
                     // specificity), or the shorthand's 2.4s always wins.
-                    @media (prefers-reduced-motion: reduce) {
-                        animation-duration: 4.5s;
-                        animation-iteration-count: infinite;
-                    }
                 }
 
                 // Type-out reveal overlay: opaque white glyphs painted over

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -173,11 +173,6 @@
         }
     }
 
-    @media (prefers-reduced-motion: reduce) {
-        .agent-document-streaming-buffer[data-animate] .agent-document-row {
-            transition: none;
-        }
-    }
 
     // === Status Log (terminal-style) ===
     .agent-history-loading {

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -61,13 +61,6 @@
     100%      { transform: rotate(360deg); }
 }
 
-@media (prefers-reduced-motion: reduce) {
-    // Functional loading indicator (and already a discrete flip, not a
-    // continuous spin) — keep it moving, gentler, rather than freezing it.
-    .agent-install-modal-spinner {
-        animation-duration: 3.2s;
-    }
-}
 
 .agent-install-modal-ok {
     color: var(--success-color, #2bd4a8);

--- a/frontend/layout/index.ts
+++ b/frontend/layout/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./lib/layoutModelHooks";
 import { newLayoutNode } from "./lib/layoutNode";
 import { clearCrossTabDrop, redockDraggedPane } from "./lib/crossTabDrag";
+import { markBlockRecentlyCreated } from "./lib/layoutPersistence";
 import type {
     ContentRenderer,
     LayoutNode,
@@ -43,6 +44,7 @@ export {
     getLayoutModelForTabById,
     LayoutModel,
     LayoutTreeActionType,
+    markBlockRecentlyCreated,
     NavigateDirection,
     newLayoutNode,
     redockDraggedPane,

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -28,6 +28,7 @@ import {
 } from "./types";
 import { determineDropDirection } from "./utils";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
+import { setTileDragInFlight } from "./dragInFlight";
 import {
     clampCrossTabDirection,
     clearCrossTabDrop,
@@ -433,6 +434,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     globalDragNodeId = props.node.id;
                     globalDragLayoutModel = props.layoutModel;
                     globalDragNode = props.node;
+                    setTileDragInFlight(true);
                     clearCrossTabDrop();
                     props.layoutModel.activeDrag._set(true);
                     setIsDragging(true);
@@ -447,6 +449,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     globalDragNodeId = null;
                     globalDragLayoutModel = null;
                     globalDragNode = null;
+                    setTileDragInFlight(false);
                     props.layoutModel.activeDrag._set(false);
                     setIsDragging(false);
                     // Do NOT clear currentDragPayload here — fires for ALL drops.

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -33,6 +33,7 @@ import {
 } from "./types";
 import { determineDropDirection } from "./utils";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
+import { setTileDragInFlight } from "./dragInFlight";
 import {
     clampCrossTabDirection,
     clearCrossTabDrop,
@@ -429,6 +430,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     globalDragNodeId = props.node.id;
                     globalDragLayoutModel = props.layoutModel;
                     globalDragNode = props.node;
+                    setTileDragInFlight(true);
                     clearCrossTabDrop();
                     props.layoutModel.activeDrag._set(true);
                     setIsDragging(true);
@@ -444,6 +446,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     globalDragNodeId = null;
                     globalDragLayoutModel = null;
                     globalDragNode = null;
+                    setTileDragInFlight(false);
                     props.layoutModel.activeDrag._set(false);
                     setIsDragging(false);
                     getApi().setJsDragActive(false).catch(() => {});

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -27,6 +27,7 @@ import {
 } from "./types";
 import { determineDropDirection } from "./utils";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
+import { setTileDragInFlight } from "./dragInFlight";
 import {
     clampCrossTabDirection,
     clearCrossTabDrop,
@@ -146,6 +147,7 @@ function TileLayoutComponent(props: TileLayoutProps) {
             if (globalDragLayoutModel?.activeDrag()) {
                 globalDragNodeId = null;
                 globalDragNode = null;
+                setTileDragInFlight(false);
                 globalDragLayoutModel.activeDrag._set(false);
                 globalDragLayoutModel = null;
             }
@@ -519,6 +521,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     globalDragNodeId = props.node.id;
                     globalDragLayoutModel = props.layoutModel;
                     globalDragNode = props.node;
+                    setTileDragInFlight(true);
                     clearCrossTabDrop();
                     props.layoutModel.activeDrag._set(true);
                     setIsDragging(true);
@@ -532,6 +535,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     globalDragNodeId = null;
                     globalDragLayoutModel = null;
                     globalDragNode = null;
+                    setTileDragInFlight(false);
                     props.layoutModel.activeDrag._set(false);
                     setIsDragging(false);
                     // Do NOT clear currentDragPayload here — fires for ALL drops including

--- a/frontend/layout/lib/crossTabDrag.ts
+++ b/frontend/layout/lib/crossTabDrag.ts
@@ -19,9 +19,8 @@ import { WorkspaceService } from "@/app/store/services";
 import { Logger } from "@/util/logger";
 import { fireAndForget } from "@/util/util";
 import { getLayoutModelForTabById } from "./layoutModelHooks";
-import { findNodeByBlockId } from "./layoutNode";
 import { pruneDanglingLeaves } from "./layoutPersistence";
-import { DropDirection, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "./types";
+import { DropDirection } from "./types";
 
 /**
  * Clamp Outer* drop directions to their inner equivalents for CROSS-TAB
@@ -106,27 +105,14 @@ export function redockDraggedPane(opts: {
                 opts.targetBlockId ?? null,
                 opts.direction ?? null,
             );
-            // The backend queues a DeleteNode on the source tab's
-            // pendingbackendactions, but the source frontend's own
-            // debounced persist can race that queue and clobber it (the
-            // documented stale-tree-resurrection issue,
-            // INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION) —
-            // observed in field testing as the pane remaining visible in
-            // BOTH tabs. Remove the source leaf locally right away,
-            // exactly like an in-tab move does (frontend mutates +
-            // persists); the queued backend delete then no-ops on the
-            // already-removed node (idempotent by actionid + missing-node
-            // guard in layoutPersistence).
-            const sourceModel = getLayoutModelForTabById(opts.sourceTabId);
-            const sourceLeaf = sourceModel
-                ? findNodeByBlockId(sourceModel.treeState.rootNode, opts.blockId)
-                : undefined;
-            if (sourceModel && sourceLeaf) {
-                sourceModel.treeReducer({
-                    type: LayoutTreeActionType.DeleteNode,
-                    nodeId: sourceLeaf.id,
-                } as LayoutTreeDeleteNodeAction);
-            }
+            // Do NOT delete the source leaf here: this runs at RPC
+            // completion, which can precede the drag's dragend on a slow
+            // frame — and unmounting the drag source before dragend
+            // suppresses the event entirely, wedging pragmatic's teardown
+            // (the dead-source-tab bug). Source-leaf removal is owned by
+            // the queued backend delete plus the end-of-drag prune pass
+            // (tabbar.tsx cleanup → pruneDanglingLeaves), both of which
+            // run only after the gesture has fully settled.
         } catch (e) {
             Logger.error("dnd", "cross-tab pane redock failed", { error: String(e) });
             // The characteristic failure here is "block X is in tab Y,

--- a/frontend/layout/lib/crossTabDrag.ts
+++ b/frontend/layout/lib/crossTabDrag.ts
@@ -18,7 +18,9 @@ import { atoms } from "@/store/global";
 import { WorkspaceService } from "@/app/store/services";
 import { Logger } from "@/util/logger";
 import { fireAndForget } from "@/util/util";
-import { DropDirection } from "./types";
+import { getLayoutModelForTabById } from "./layoutModelHooks";
+import { findNodeByBlockId } from "./layoutNode";
+import { DropDirection, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "./types";
 
 /**
  * Clamp Outer* drop directions to their inner equivalents for CROSS-TAB
@@ -103,6 +105,27 @@ export function redockDraggedPane(opts: {
                 opts.targetBlockId ?? null,
                 opts.direction ?? null,
             );
+            // The backend queues a DeleteNode on the source tab's
+            // pendingbackendactions, but the source frontend's own
+            // debounced persist can race that queue and clobber it (the
+            // documented stale-tree-resurrection issue,
+            // INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION) —
+            // observed in field testing as the pane remaining visible in
+            // BOTH tabs. Remove the source leaf locally right away,
+            // exactly like an in-tab move does (frontend mutates +
+            // persists); the queued backend delete then no-ops on the
+            // already-removed node (idempotent by actionid + missing-node
+            // guard in layoutPersistence).
+            const sourceModel = getLayoutModelForTabById(opts.sourceTabId);
+            const sourceLeaf = sourceModel
+                ? findNodeByBlockId(sourceModel.treeState.rootNode, opts.blockId)
+                : undefined;
+            if (sourceModel && sourceLeaf) {
+                sourceModel.treeReducer({
+                    type: LayoutTreeActionType.DeleteNode,
+                    nodeId: sourceLeaf.id,
+                } as LayoutTreeDeleteNodeAction);
+            }
         } catch (e) {
             Logger.error("dnd", "cross-tab pane redock failed", { error: String(e) });
         }

--- a/frontend/layout/lib/crossTabDrag.ts
+++ b/frontend/layout/lib/crossTabDrag.ts
@@ -20,6 +20,7 @@ import { Logger } from "@/util/logger";
 import { fireAndForget } from "@/util/util";
 import { getLayoutModelForTabById } from "./layoutModelHooks";
 import { findNodeByBlockId } from "./layoutNode";
+import { pruneDanglingLeaves } from "./layoutPersistence";
 import { DropDirection, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "./types";
 
 /**
@@ -128,6 +129,14 @@ export function redockDraggedPane(opts: {
             }
         } catch (e) {
             Logger.error("dnd", "cross-tab pane redock failed", { error: String(e) });
+            // The characteristic failure here is "block X is in tab Y,
+            // not <sourceTabId>" — i.e. the user dragged a DANGLING leaf
+            // (the source tab rendering a block another tab owns, left
+            // by an earlier lost delete). The move correctly didn't
+            // happen; prune the ghost so the source tab heals instead of
+            // keeping a broken double-mounted pane.
+            const sourceModel = getLayoutModelForTabById(opts.sourceTabId);
+            if (sourceModel) pruneDanglingLeaves(sourceModel);
         }
     });
 }

--- a/frontend/layout/lib/dragInFlight.ts
+++ b/frontend/layout/lib/dragInFlight.ts
@@ -1,0 +1,28 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Zero-dependency module-level flag: is a pane (tile) drag currently in
+// flight? Set by TileLayout's DisplayNode at drag start; cleared at the
+// draggable's own onDrop (dragend), the Win11 swallowed-dragend safety
+// net, and the tab bar's end-of-drag cleanup layers.
+//
+// Exists because `currentDragPayload` is deliberately cleared at DROP
+// time (so CrossWindowDragMonitor's dragend listener skips handled
+// drops) — leaving a ~2ms window between drop and dragend where the
+// payload says "no drag" but the drag source element must still not be
+// unmounted (removing it suppresses dragend entirely and wedges
+// pragmatic's teardown chain). pruneDanglingLeaves gates on THIS flag,
+// which spans the full gesture.
+//
+// Lives in its own module (not crossTabDrag/TileLayout) to stay out of
+// the layoutPersistence ↔ crossTabDrag ↔ TileLayout import cycle.
+
+let tileDragInFlight = false;
+
+export function setTileDragInFlight(inFlight: boolean): void {
+    tileDragInFlight = inFlight;
+}
+
+export function isTileDragInFlight(): boolean {
+    return tileDragInFlight;
+}

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -442,7 +442,19 @@ export class LayoutModel {
                 const showOverlay = this.showOverlay();
                 if (this.displayContainerRef.current) {
                     const displayBoundingRect = this.displayContainerRef.current.getBoundingClientRect();
-                    const newOverlayOffset = displayBoundingRect.top + 2 * displayBoundingRect.height;
+                    // Park with a LARGE constant floor, never purely
+                    // height-derived: when this memo recomputes while the tab
+                    // is hidden (display:none — e.g. a spring-switched
+                    // cross-tab drag ending in another tab), the rect is all
+                    // zeros and a height-derived offset of 0 parks the
+                    // placeholder-container exactly ON TOP of the tab, where
+                    // it eats every click until the next activeDrag toggle —
+                    // the "dead source tab" of the 2026-07-11 field sessions
+                    // (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR).
+                    const newOverlayOffset = Math.max(
+                        100000,
+                        displayBoundingRect.top + 2 * displayBoundingRect.height
+                    );
                     const newTransform = setTransform(
                         {
                             top: activeDrag || showOverlay ? 0 : newOverlayOffset,

--- a/frontend/layout/lib/layoutPersistence.ts
+++ b/frontend/layout/lib/layoutPersistence.ts
@@ -81,6 +81,34 @@ export function onBackendUpdate(model: LayoutModel) {
     // redock failure path.
 }
 
+// Age-gate registry (review finding on SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR
+// PR #2105, P1): createBlock/createBlockSplitHorizontally/createBlockSplit-
+// Vertically (global.ts) insert the new leaf into the local tree
+// SYNCHRONOUSLY via treeReducer, but the block's membership in
+// `tab.blockids` only lands later via an async WaveObject push. Any prune
+// trigger that fires inside that window would see the fresh leaf as
+// "disowned" and delete + persist the deletion — a real, distinct path to
+// the same class of bug pruneDanglingLeaves exists to fix. Call sites for
+// those three functions mark the new block here; pruning skips anything
+// marked within the last RECENT_BLOCK_GRACE_MS.
+const RECENT_BLOCK_GRACE_MS = 3000;
+const recentlyCreatedBlocks = new Map<string, number>();
+
+/** Call immediately after locally inserting a new block's leaf via treeReducer. */
+export function markBlockRecentlyCreated(blockId: string, now: number = Date.now()): void {
+    recentlyCreatedBlocks.set(blockId, now);
+}
+
+function isRecentlyCreated(blockId: string, now: number): boolean {
+    const at = recentlyCreatedBlocks.get(blockId);
+    if (at === undefined) return false;
+    if (now - at > RECENT_BLOCK_GRACE_MS) {
+        recentlyCreatedBlocks.delete(blockId);
+        return false;
+    }
+    return true;
+}
+
 /**
  * Remove leaves whose block is NOT in the tab's `blockids` — dangling
  * references left behind when a frontend's debounced persist clobbers a
@@ -91,9 +119,13 @@ export function onBackendUpdate(model: LayoutModel) {
  * registry breaks — observed as a fully non-responsive tab.
  *
  * Ownership (`Tab.blockids`) is reducer-owned truth, so pruning against
- * it is always safe: this only ever REMOVES leaves for disowned blocks,
- * never touches leaves whose block is owned (a queued insert for a
- * newly-owned block is unaffected — the leaf simply isn't there yet).
+ * it is always safe FOR AN ALREADY-SETTLED leaf: this only ever REMOVES
+ * leaves for disowned blocks. But a block just created via
+ * createBlock/createBlockSplitHorizontally/createBlockSplitVertically is
+ * inserted into the LOCAL tree before its `tab.blockids` membership
+ * round-trips through the backend — such a leaf is age-gated via
+ * `markBlockRecentlyCreated` so this function never deletes it out from
+ * under the user (the round-4-class regression this review caught).
  *
  * Triggers (deliberately sparse — see the round-4 regression note in
  * onBackendUpdate): one-shot at model init (+2s), the tab bar's
@@ -113,10 +145,16 @@ export function pruneDanglingLeaves(model: LayoutModel) {
     // already cleared at drop time) spans the full gesture; the tab bar's
     // end-of-drag cleanup re-runs the prune once the drag has settled.
     if (isTileDragInFlight()) return;
+    const now = Date.now();
     const owned = new Set(tab.blockids);
     const danglingIds: string[] = [];
     walkNodes(rootNode, (node) => {
-        if (!node.children?.length && node.data?.blockId && !owned.has(node.data.blockId)) {
+        if (
+            !node.children?.length &&
+            node.data?.blockId &&
+            !owned.has(node.data.blockId) &&
+            !isRecentlyCreated(node.data.blockId, now)
+        ) {
             danglingIds.push(node.id);
         }
     });

--- a/frontend/layout/lib/layoutPersistence.ts
+++ b/frontend/layout/lib/layoutPersistence.ts
@@ -3,6 +3,7 @@
 
 import { batch } from "solid-js";
 import { fireAndForget } from "@/util/util";
+import { isTileDragInFlight } from "./dragInFlight";
 import { findNodeByBlockId, newLayoutNode, walkNodes } from "./layoutNode";
 import { rebuildMinimizedSet } from "./layoutMinimize";
 import {
@@ -92,6 +93,16 @@ export function pruneDanglingLeaves(model: LayoutModel) {
     const rootNode = model.treeState?.rootNode;
     const tab = model.tabAtom?.();
     if (!rootNode || !tab?.blockids) return;
+    // Never prune while a pane drag is in flight: MoveBlock's Tab update
+    // can reach this window BEFORE the drag's dragend dispatches (observed
+    // 2ms apart in field logs), and deleting the drag-source leaf mid-drag
+    // unmounts the source element — Chromium then never fires dragend on
+    // it, pragmatic's teardown chain (activeDrag reset and monitor onDrop)
+    // is skipped, and the source tab's overlay wedges at
+    // pointer-events:auto. The flag (NOT currentDragPayload, which is
+    // already cleared at drop time) spans the full gesture; the tab bar's
+    // end-of-drag cleanup re-runs the prune once the drag has settled.
+    if (isTileDragInFlight()) return;
     const owned = new Set(tab.blockids);
     const danglingIds: string[] = [];
     walkNodes(rootNode, (node) => {

--- a/frontend/layout/lib/layoutPersistence.ts
+++ b/frontend/layout/lib/layoutPersistence.ts
@@ -3,7 +3,7 @@
 
 import { batch } from "solid-js";
 import { fireAndForget } from "@/util/util";
-import { findNodeByBlockId, newLayoutNode } from "./layoutNode";
+import { findNodeByBlockId, newLayoutNode, walkNodes } from "./layoutNode";
 import { rebuildMinimizedSet } from "./layoutMinimize";
 import {
     LayoutTreeActionType,
@@ -64,7 +64,54 @@ export function onBackendUpdate(model: LayoutModel) {
     const pendingActions = waveObj?.pendingbackendactions;
     if (pendingActions?.length) {
         fireAndForget(() => processPendingBackendActions(model));
+    } else {
+        pruneDanglingLeaves(model);
     }
+}
+
+/**
+ * Remove leaves whose block is NOT in the tab's `blockids` — dangling
+ * references left behind when a frontend's debounced persist clobbers a
+ * queued backend layout action (the stale-tree resurrection issue,
+ * INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08).
+ * A dangling leaf renders a block owned by ANOTHER tab; since every tab
+ * stays mounted, the same block mounts twice and the block-component
+ * registry breaks — observed as a fully non-responsive tab.
+ *
+ * Ownership (`Tab.blockids`) is reducer-owned truth, so pruning against
+ * it is always safe: this only ever REMOVES leaves for disowned blocks,
+ * never touches leaves whose block is owned (a queued insert for a
+ * newly-owned block is unaffected — the leaf simply isn't there yet).
+ *
+ * Reactivity note: this reads `model.tabAtom()` inside the same effect
+ * that drives `onBackendUpdate` (layoutModelHooks), so `Tab` becomes a
+ * tracked dependency — a MoveBlock updating `blockids` re-runs the
+ * effect and prunes even when the queued layout delete was lost.
+ */
+export function pruneDanglingLeaves(model: LayoutModel) {
+    const rootNode = model.treeState?.rootNode;
+    const tab = model.tabAtom?.();
+    if (!rootNode || !tab?.blockids) return;
+    const owned = new Set(tab.blockids);
+    const danglingIds: string[] = [];
+    walkNodes(rootNode, (node) => {
+        if (!node.children?.length && node.data?.blockId && !owned.has(node.data.blockId)) {
+            danglingIds.push(node.id);
+        }
+    });
+    if (!danglingIds.length) return;
+    console.warn("[layout] pruning dangling leaves (blocks not owned by this tab):", danglingIds);
+    for (const nodeId of danglingIds) {
+        model.treeReducer(
+            { type: LayoutTreeActionType.DeleteNode, nodeId } as LayoutTreeDeleteNodeAction,
+            false,
+        );
+    }
+    batch(() => {
+        model.updateTree();
+        model.setter(model.localTreeStateAtom, { ...model.treeState });
+    });
+    model.persistToBackend();
 }
 
 /**
@@ -95,6 +142,7 @@ export async function processPendingBackendActions(model: LayoutModel) {
         model.setter(model.localTreeStateAtom, { ...model.treeState });
     });
     model.persistToBackend();
+    pruneDanglingLeaves(model);
 }
 
 /**

--- a/frontend/layout/lib/layoutPersistence.ts
+++ b/frontend/layout/lib/layoutPersistence.ts
@@ -44,6 +44,12 @@ export function initializeFromWaveObject(model: LayoutModel) {
     } else {
         model.updateTree();
     }
+
+    // One-shot startup heal: remove dangling leaves persisted by an earlier
+    // session's races once Tab + LayoutState have both settled. Deliberately
+    // a delayed single pass, not a reactive subscription — see the
+    // onBackendUpdate note below and SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR §3.5.
+    setTimeout(() => pruneDanglingLeaves(model), 2000);
 }
 
 /**
@@ -65,9 +71,14 @@ export function onBackendUpdate(model: LayoutModel) {
     const pendingActions = waveObj?.pendingbackendactions;
     if (pendingActions?.length) {
         fireAndForget(() => processPendingBackendActions(model));
-    } else {
-        pruneDanglingLeaves(model);
     }
+    // NOTE deliberately NO prune here (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR
+    // §3.5): running it reactively on every Tab/LayoutState change made the
+    // Tab object a tracked dependency and could delete a LEGITIMATE
+    // freshly-created leaf whose block hadn't landed in tab.blockids yet
+    // (the round-4 "drops don't stick" regression). Prune triggers are now:
+    // model init (below), the tab bar's post-drag settle pass, and the
+    // redock failure path.
 }
 
 /**
@@ -84,10 +95,9 @@ export function onBackendUpdate(model: LayoutModel) {
  * never touches leaves whose block is owned (a queued insert for a
  * newly-owned block is unaffected — the leaf simply isn't there yet).
  *
- * Reactivity note: this reads `model.tabAtom()` inside the same effect
- * that drives `onBackendUpdate` (layoutModelHooks), so `Tab` becomes a
- * tracked dependency — a MoveBlock updating `blockids` re-runs the
- * effect and prunes even when the queued layout delete was lost.
+ * Triggers (deliberately sparse — see the round-4 regression note in
+ * onBackendUpdate): one-shot at model init (+2s), the tab bar's
+ * post-drag settle pass, and the redock failure path. NOT reactive.
  */
 export function pruneDanglingLeaves(model: LayoutModel) {
     const rootNode = model.treeState?.rootNode;
@@ -153,7 +163,8 @@ export async function processPendingBackendActions(model: LayoutModel) {
         model.setter(model.localTreeStateAtom, { ...model.treeState });
     });
     model.persistToBackend();
-    pruneDanglingLeaves(model);
+    // No prune here — a just-applied queued INSERT's block may not be in the
+    // frontend's tab.blockids yet (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR §3.5).
 }
 
 /**
@@ -352,7 +363,19 @@ export function persistToBackend(model: LayoutModel) {
         waveObj.focusednodeid = model.treeState.focusedNodeId;
         waveObj.magnifiednodeid = model.treeState.magnifiedNodeId;
         waveObj.leaforder = model.treeState.leafOrder;
-        waveObj.pendingbackendactions = model.treeState.pendingBackendActions;
+        // Persistence Phase A (SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR §3.6):
+        // the pendingbackendactions queue is BACKEND-owned. Never write our
+        // (often stale) local copy — a debounced persist racing a freshly
+        // queued action used to erase it (the stale-tree resurrection
+        // engine). Instead, carry forward the LIVE queue minus the actions
+        // this model has already processed: ordinary persists preserve
+        // unseen actions verbatim, and post-processing persists still clear
+        // consumed ones.
+        const liveQueue = model.getter(model.waveObjectAtom)?.pendingbackendactions;
+        const unprocessed = liveQueue?.filter(
+            (a) => a.actionid && !model.processedActionIds.has(a.actionid)
+        );
+        waveObj.pendingbackendactions = unprocessed?.length ? unprocessed : undefined;
 
         model.setter(model.waveObjectAtom, waveObj);
         model.persistDebounceTimer = null;

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -28,6 +28,11 @@
 
     .placeholder-container {
         z-index: var(--zindex-layout-placeholder-container);
+        // The placeholder is purely visual (its children already carry
+        // pointer-events: none) — the CONTAINER must be too. Without this,
+        // any transform bug that leaves it on-screen turns it into a
+        // full-tab click shield (the dead-source-tab incident).
+        pointer-events: none;
     }
 
     .overlay-container {

--- a/frontend/layout/tests/layoutPersistence.test.ts
+++ b/frontend/layout/tests/layoutPersistence.test.ts
@@ -10,7 +10,7 @@ import { createSignal } from "solid-js";
 import { LayoutModel } from "@/layout/lib/layoutModel";
 import { findNodeByBlockId, newLayoutNode } from "@/layout/lib/layoutNode";
 import { LayoutTreeActionType, LayoutTreeInsertNodeAction } from "@/layout/lib/types";
-import { processPendingBackendActions, pruneDanglingLeaves } from "@/layout/lib/layoutPersistence";
+import { processPendingBackendActions, pruneDanglingLeaves, markBlockRecentlyCreated } from "@/layout/lib/layoutPersistence";
 import type { SignalAtom } from "@/util/util";
 
 // -- Mock store (mirrors layoutModel.test.ts) ----------------------------------
@@ -419,5 +419,55 @@ describe("pruneDanglingLeaves", () => {
         pruneDanglingLeaves(model);
         expect(findBlock(model, "existing")).toBeTruthy();
         expect(findBlock(model, "moved-block")).toBeTruthy();
+    });
+
+    // Review finding on PR #2105 (P1): createBlock/createBlockSplit* insert the
+    // new leaf into the local tree BEFORE tab.blockids catches up. A leaf for a
+    // block marked via markBlockRecentlyCreated must survive a prune that runs
+    // in that window, and must become prunable again once the mark expires.
+    it("does not prune a leaf for a block marked recently created", () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+        const freshLeaf = newLayoutNode(undefined, undefined, undefined, { blockId: "fresh-not-yet-owned" });
+        model.treeReducer({
+            type: LayoutTreeActionType.InsertNode,
+            node: freshLeaf,
+            magnified: false,
+            focused: false,
+        } as LayoutTreeInsertNodeAction);
+        markBlockRecentlyCreated("fresh-not-yet-owned", 1_000_000);
+
+        const originalNow = Date.now;
+        Date.now = () => 1_000_500; // 500ms later — well inside the 3s grace window
+        try {
+            pruneDanglingLeaves(model);
+        } finally {
+            Date.now = originalNow;
+        }
+
+        expect(findBlock(model, "fresh-not-yet-owned")).toBeTruthy();
+        expect(findBlock(model, "existing")).toBeTruthy();
+    });
+
+    it("prunes a leaf once its recently-created mark has expired", () => {
+        const model = createLayoutModel();
+        const staleLeaf = newLayoutNode(undefined, undefined, undefined, { blockId: "was-fresh-now-stale" });
+        model.treeReducer({
+            type: LayoutTreeActionType.InsertNode,
+            node: staleLeaf,
+            magnified: false,
+            focused: false,
+        } as LayoutTreeInsertNodeAction);
+        markBlockRecentlyCreated("was-fresh-now-stale", 1_000_000);
+
+        const originalNow = Date.now;
+        Date.now = () => 1_010_000; // 10s later — past the 3s grace window
+        try {
+            pruneDanglingLeaves(model);
+        } finally {
+            Date.now = originalNow;
+        }
+
+        expect(findBlock(model, "was-fresh-now-stale")).toBeFalsy();
     });
 });

--- a/frontend/layout/tests/layoutPersistence.test.ts
+++ b/frontend/layout/tests/layoutPersistence.test.ts
@@ -10,7 +10,7 @@ import { createSignal } from "solid-js";
 import { LayoutModel } from "@/layout/lib/layoutModel";
 import { findNodeByBlockId, newLayoutNode } from "@/layout/lib/layoutNode";
 import { LayoutTreeActionType, LayoutTreeInsertNodeAction } from "@/layout/lib/types";
-import { processPendingBackendActions } from "@/layout/lib/layoutPersistence";
+import { processPendingBackendActions, pruneDanglingLeaves } from "@/layout/lib/layoutPersistence";
 import type { SignalAtom } from "@/util/util";
 
 // -- Mock store (mirrors layoutModel.test.ts) ----------------------------------
@@ -78,7 +78,12 @@ function createLayoutModel(): LayoutModel {
         meta: {},
         name: "Test",
         layoutstate: "layout-1",
-        blockids: [],
+        // Every block id these tests mount or insert-via-action. In
+        // production Tab.blockids is reducer-owned truth and
+        // pruneDanglingLeaves (layoutPersistence.ts) removes any leaf
+        // whose block isn't in it — a stub that owns nothing would get
+        // every test leaf pruned right after insertion.
+        blockids: ["existing", "moved-block", "new-block", "dup-block"],
     });
     const m = new LayoutModel(getTab);
     m.getBoundingRect = () => ({ top: 0, left: 0, width: 800, height: 600 });
@@ -377,5 +382,42 @@ describe("processPendingBackendActions — Phase 4b Split routes", () => {
         // "new-block" was inserted, "dup-block" was not (duplicate action id)
         expect(findBlock(model, "new-block")).toBeTruthy();
         expect(findBlock(model, "dup-block")).toBeFalsy();
+    });
+});
+
+// -- pruneDanglingLeaves --------------------------------------------------------
+//
+// The stale-tree-resurrection healer (SPEC_PANE_DRAG_TO_TAB addendum A2):
+// a leaf whose block is NOT in the tab's reducer-owned blockids is a
+// dangling reference (renders a block another tab owns, double-mounting
+// it) and must be removed; owned leaves are untouched.
+
+describe("pruneDanglingLeaves", () => {
+    it("removes leaves for blocks the tab does not own, keeps owned ones", () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing"); // in the stub tab's blockids
+        // A dangling leaf — "ghost-block" is NOT in the stub's blockids.
+        const ghost = newLayoutNode(undefined, undefined, undefined, { blockId: "ghost-block" });
+        model.treeReducer({
+            type: LayoutTreeActionType.InsertNode,
+            node: ghost,
+            magnified: false,
+            focused: false,
+        } as LayoutTreeInsertNodeAction);
+        expect(findBlock(model, "ghost-block")).toBeTruthy();
+
+        pruneDanglingLeaves(model);
+
+        expect(findBlock(model, "ghost-block")).toBeFalsy();
+        expect(findBlock(model, "existing")).toBeTruthy();
+    });
+
+    it("no-ops when every leaf is owned", () => {
+        const model = createLayoutModel();
+        insertBlock(model, "existing");
+        insertBlock(model, "moved-block");
+        pruneDanglingLeaves(model);
+        expect(findBlock(model, "existing")).toBeTruthy();
+        expect(findBlock(model, "moved-block")).toBeTruthy();
     });
 });

--- a/specs/SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR_2026_07_11.md
+++ b/specs/SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR_2026_07_11.md
@@ -71,6 +71,31 @@ one-line evidence:
 10. **Dead state drift**: `showOverlay` has no writer but is OR'd into the overlay
     transform — a symptom of an over-grown model.
 
+### 2.1 ROOT CAUSE FOUND (post-spec, via the §7 hit-test probe): the placeholder-container click shield
+
+The post-switch hit-test diagnostic identified the actual dead-tab layer in the
+field: **`div.placeholder-container`** — the purely-visual drag-ghost layer — was
+the top element at the tab center on every wedged tab, while `activeDrag` was
+correctly `false` and the overlay-container was correctly `pointer-events: none`.
+
+Mechanism: `overlayTransform` (`layoutModel.ts:441-455`) parks the placeholder
+"offscreen" at `rect.top + 2 × rect.height` of the display container. When a
+cross-tab drag ends, the SOURCE tab is `display:none` (spring-switched away), so
+`getBoundingClientRect()` is all zeros and the parking spot computes to
+**`top: 0` — exactly covering the tab** — and `.placeholder-container` carried
+no `pointer-events: none` (only its children did). The memo's rect read is
+non-reactive, so re-showing the tab never recomputes; the one event that would
+(a new drag's `activeDrag` toggle) is unreachable because the layer covers the
+drag handles. This single defect produced every field symptom across all four
+rounds: dead source tab, drags that won't start from it, healing on reload,
+re-breaking on the next move.
+
+Fixed immediately (same branch): `pointer-events: none` on the container +
+a large constant parking floor. The refactor's P2 (derived overlay state) and
+the general lesson stand: **decorative layers must be input-transparent by
+construction, and "offscreen" must never be computed from a possibly-zero
+live rect.**
+
 Two load-bearing facts from pragmatic-dnd's source that the refactor builds on:
 
 - **Dispatch order at drop is fixed**: source draggable `onDrop` → drop targets

--- a/specs/SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR_2026_07_11.md
+++ b/specs/SPEC_DRAG_SESSION_ARCHITECTURE_REFACTOR_2026_07_11.md
@@ -1,0 +1,261 @@
+# Spec: Drag-Session Architecture Refactor (Cross-Tab/Cross-Window Drag, Layout Persistence, Block Registry)
+
+**Date:** 2026-07-11
+**Status:** Draft — analysis complete, refactor proposed
+**Repo state:** branch `fix/strobe-invert-reduced-motion-source-delete` @ `fdfb4282` (working tree; `main` @ `8b3bc3b4`)
+**Scope:** The pane/tab drag system end-to-end (gesture state, overlay input capture, cross-tab commit, layout persistence, block-component registry). Supersedes the incremental-fix approach of `SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` addenda A2 rounds 1–4.
+
+---
+
+## 1. Why a refactor: the field-incident record
+
+Four rounds of point fixes over one day, each fixing the previous round's symptom and
+exposing (or creating) the next:
+
+| Round | Symptom | Fix applied | What it exposed |
+|---|---|---|---|
+| 1 | Slash-circle cursor, no hover UI (v1 popover design) | v2 spring-loaded tabs, real drop targets | worked, but… |
+| 2 | Dead target tab after drag | 3-layer overlay cleanup nets; ghost/landing clamp; geometry refresh | source pane lingered in source tab |
+| 3 | Moved pane remained in source tab | local source-delete at RPC completion + reactive `pruneDanglingLeaves` | dead **source** tab (mid-drag unmount suppressing dragend) |
+| 4 | Dead source tab again | `dragInFlight` gate, deferred prune, all-tab overlay reset, probes | drag stopped committing at all; source pane freezes |
+
+Probes from round 4 proved the previous theory insufficient: dragend fired, cleanup ran,
+overlays were reset — **the tab still died**. The final inventory (§2) found *two
+independent* dead-tab mechanisms and one fresh regression, all rooted in the same
+structural defects. Point fixes cannot converge because each new writer/net changes the
+race lattice for the others.
+
+---
+
+## 2. Architectural defects (from the full code inventory, ranked)
+
+Full state/writer tables live in the analysis that produced this spec; the defects, with
+one-line evidence:
+
+1. **Drop-teardown depends on a browser event documented not to fire.** All
+   overlay/`activeDrag` reset hangs off the drop/dragend chain, while pragmatic-dnd's own
+   source states `dragend` "does not fire if the draggable source has been removed during
+   the drag" (`lifecycle-manager.js:264-267`) — and the feature's data flow removes the
+   source leaf mid-gesture.
+2. **`activeDrag` is one boolean with two meanings** ("my own drag" on the source model;
+   "a foreign drag is hovering me" force-set on the spring target) — and the target owns
+   no draggable that could ever reset it (`droppable-tab.tsx:234` sets; only
+   `tabbar.tsx:466` resets).
+3. **The full-surface `.overlay-container` (z-5, `pointer-events:auto` while
+   `activeDrag`) sits ABOVE the pane headers that host the draggables** — a stuck overlay
+   is therefore both "dead tab" *and* "can't start a new drag from this tab," unifying the
+   two headline symptoms (`TileLayout.win32.tsx:640-645`, `theme.scss:116/121`).
+4. **The block-component registry is `Map<blockId, model>` with last-writer-wins register
+   and unconditional delete-on-cleanup**, while every tab stays mounted. Double-mount a
+   block (any dangling leaf) → the LATER mount overwrites the entry → the EARLIER mount's
+   unmount **deletes the survivor's registration and disposes its ViewModel**
+   (`global.ts:522-535`, `block.tsx:290/296`). Focus routing then silently fails for that
+   pane: the second, registry-level dead-tab mechanism.
+5. **Persistence is a blind, un-versioned, whole-`LayoutState` overwrite** on a 100ms
+   debounce — including writing `pendingbackendactions: undefined` after processing
+   (`layoutPersistence.ts:342-360`). Any stale local tree durably clobbers backend prunes
+   AND queued actions. This is the engine of the documented stale-tree resurrection.
+6. **Drag lifecycle state is scattered across ~14 stores in 3 layers** (TileLayout module
+   globals ×3 platform copies, per-model signals, `crossTabDrag`/`dragInFlight`
+   singletons, `tabbar-dnd` signals, `CrossWindowDragMonitor` global) with no single owner.
+7. **Cleanup is defense-in-depth by accretion** — five-plus redundant, differently-gated
+   teardown layers, several keyed on `dragActivatedTabIds`, because no single reliable
+   teardown signal was identified. (One exists — see §3.1.)
+8. **`pruneDanglingLeaves` (round 3-4) tracks the whole `Tab` object reactively and can
+   delete legitimate leaves**: a freshly split/inserted pane whose block isn't in the
+   frontend's `tab.blockids` *yet* gets pruned-and-persisted. **This is the round-4
+   regression that made drops stop sticking.**
+9. **The cross-tab commit fights the frontend's own mutate-then-persist contract** —
+   the source delete had to be deferred (to protect dragend), leaving a double-mount
+   window that must be swept asynchronously (defect 4 fires inside that window).
+10. **Dead state drift**: `showOverlay` has no writer but is OR'd into the overlay
+    transform — a symptom of an over-grown model.
+
+Two load-bearing facts from pragmatic-dnd's source that the refactor builds on:
+
+- **Dispatch order at drop is fixed**: source draggable `onDrop` → drop targets
+  (innermost→outermost) → **monitors last** (`make-adapter.js:16-28`).
+- **Monitor `onDrop` fires for every gesture end** — commit, cancel (ESC/no-target), and
+  even swallowed-dragend via the broken-drag `pointerdown` fallback
+  (`lifecycle-manager.js:126-129`, `detect-broken-drag.js`). **Monitors are the single
+  reliable teardown signal the current code never trusted.**
+
+---
+
+## 3. Design
+
+### 3.1 P1 — One owner: `DragSession` (explicit state machine)
+
+New module `frontend/layout/lib/dragSession.ts`, the sole owner of gesture state:
+
+```
+idle ──onDragStart──▶ dragging ──(monitor onDrop)──▶ settling ──commit/teardown──▶ idle
+```
+
+- **Inputs**: TileLayout draggable callbacks (start), overlay/tab drop-target callbacks
+  (record hover + drop intent), ONE pragmatic monitor (gesture end — reliable per §2).
+- **Owned state** (replaces all of): `globalDragNodeId/LayoutModel/Node`,
+  `dragInFlight`, `crossTabDrop`, `hoveredDropTabId`, `dragActivatedTabIds`,
+  spring timers, `currentDragPayload`'s tile variant.
+- **Derived signals** (read-only for UI): `session.active()`, `session.sourceTabId()`,
+  `session.springTabId()`, `session.hoverTabId()`, `session.dropIntent()`.
+- **All teardown happens in exactly one place** — the monitor-driven `settle()` — making
+  the window-dragend/pointerdown nets and TileLayout's `resetDragState` deletable. The
+  pointerdown net survives only as an assertion+log (it should never fire).
+
+### 3.2 P2 — Overlay input capture becomes derived state
+
+Split `activeDrag`'s two meanings and derive both from the session:
+
+```ts
+// per TileLayout instance
+const overlayInteractive = () =>
+    dragSession.active() &&
+    (dragSession.sourceTabId() === myTabId || dragSession.springTabId() === myTabId);
+```
+
+No imperative set/reset pairs anywhere; when the session hits `idle`, every overlay in
+every tab derives to `pointer-events: none` in the same tick. Delete `showOverlay`.
+`isDragging`/tile styling likewise derive from `session.sourceNodeId()`.
+
+### 3.3 P3 — Commit-after-teardown (kills the dragend-suppression class)
+
+Drop handlers **only record intent** on the session:
+`session.recordDrop({ kind: "cross-tab-redock", blockId, sourceTabId, targetTabId, targetBlockId, direction })`.
+The session executes the RPC in `settling`, strictly AFTER pragmatic teardown completed.
+Consequences:
+
+- Our code can never unmount the drag source mid-gesture — there is no mid-gesture
+  mutation at all.
+- The 250ms deferred prune, the RPC-completion delete, and the dragInFlight gate all
+  become unnecessary; the source leaf is removed by the normal post-commit path while the
+  session is already idle.
+- In-tab moves keep their current synchronous commit (the source element survives an
+  in-tab move; only cross-tab commits were hazardous).
+
+### 3.4 P4 — Block-component registry hardening (independent, do first)
+
+Owner-checked unregister + last-write tracking:
+
+```ts
+function unregisterBlockComponentModel(blockId: string, owner: BlockComponentModel) {
+    if (blockComponentModelMap.get(blockId) === owner) {
+        blockComponentModelMap.delete(blockId);
+        cleanupBlockAtomCache(blockId);
+    } // else: a newer mount owns the key — do not clobber it
+}
+```
+
+…and `Block`'s `onCleanup` disposes only the ViewModel *it* created. This makes
+double-mount survivable regardless of every other defect, and is a ~20-line change with
+its own tests. Even after the drag refactor, transient double-mounts remain possible
+(backend races), so this hardening is required, not optional.
+
+### 3.5 P5 — Prune correctness (fix the round-4 regression)
+
+`pruneDanglingLeaves` stays (the self-healing invariant is right) but:
+
+- runs ONLY when `dragSession.idle()` **and** debounced ≥500ms after the last
+  `Tab`/tree change (no more per-Tab-mutation reactive sweeps);
+- never prunes a leaf younger than the debounce (a fresh split whose block-ownership
+  update is still in flight);
+- triggers: model init, post-`settling`, and the debounced watcher — not the raw
+  `onBackendUpdate` else-branch.
+
+### 3.6 P6 — Persistence discipline (kills the resurrection engine)
+
+Phased, backend-coordinated:
+
+- **Phase A (frontend-only, immediate):** `persistToBackend` stops writing
+  `pendingbackendactions` entirely (queue is backend-owned; srv merges on write). A stale
+  frontend push can then no longer erase queued actions — the clobber becomes a benign
+  re-application.
+- **Phase B (srv):** version/CAS on `Command::LayoutSetTree` + `Store::update`
+  (`WHERE version = ?`); frontend retries on conflict by re-reading + re-applying local
+  intent. This is the durable fix the resurrection investigation already proposed.
+- **Phase C (aspirational, separate spec):** action-based persistence — the frontend
+  sends tree *actions*, srv owns the tree. Removes the dual-writer model entirely.
+
+---
+
+## 4. Immediate stabilization (ship before/with the refactor's first PR)
+
+1. **Registry hardening (§3.4)** — smallest change, removes the worst symptom
+   (permanently dead tab) even when upstream races fire.
+2. **Prune de-fanging (§3.5 triggers only)** — fixes the round-4 "drops don't stick /
+   panes vanish" regression.
+3. **Persistence Phase A (§3.6)** — one-file change, removes the queue-clobber.
+
+With 1–3 in place the feature is usable-if-imperfect while P1–P3 land; alternatively, the
+cross-tab drop commit can be feature-flagged (`tab:crosstabdrag` setting) if field noise
+must stop immediately.
+
+## Non-Goals
+
+- Fixing the pre-existing in-strip **tab reorder** initiation bug (tracked in
+  `SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` addendum A3 — zero `tab-drag started` logs for
+  2+ days; orthogonal, drag never *starts*).
+- The cross-window remount feature's host hook (shipped, unaffected — it reads none of
+  the refactored state).
+- Action-based persistence (Phase C) — separate spec once A/B prove out.
+
+---
+
+## 5. Files Touched (refactor core)
+
+| File | Change |
+|---|---|
+| **New:** `frontend/layout/lib/dragSession.ts` | The FSM: state, derived signals, monitor wiring, `recordDrop`, `settle()` commit executor |
+| `frontend/layout/lib/TileLayout.{win32,darwin,linux}.tsx` | Delete module globals + `resetDragState` net; draggable callbacks feed the session; overlay style derives per §3.2; drop handlers → `recordDrop` |
+| `frontend/layout/lib/crossTabDrag.ts` | Shrinks to the redock RPC helper called by `settle()`; record moves into the session |
+| `frontend/layout/lib/dragInFlight.ts` | **Deleted** (subsumed by session state) |
+| `frontend/app/tab/tabbar-dnd.ts` | `hoveredDropTabId`/`dragActivatedTabIds` replaced by session signals; reorder-only state stays |
+| `frontend/app/tab/droppable-tab.tsx` | Spring timer moves into session (`session.armSpring(tabId)`); tile drop-target records intent |
+| `frontend/app/tab/tabbar.tsx` | Cleanup nets deleted; assertion-only pointerdown probe; strip drop target stays (cursor + payload) |
+| `frontend/app/store/global.ts` + `frontend/app/block/block.tsx` | §3.4 registry hardening |
+| `frontend/layout/lib/layoutPersistence.ts` | §3.5 prune triggers; §3.6 Phase A |
+| `agentmux-srv` (Phase B only) | CAS on layout writes |
+
+---
+
+## 6. Implementation Order
+
+1. §4.1 registry hardening (independent PR-able, unit-tested).
+2. §4.2 prune de-fanging + §4.3 persistence Phase A (restores a usable baseline).
+3. `dragSession.ts` FSM + TileLayout/DroppableTab/tabbar migration (the core refactor;
+   in-tab drag first, cross-tab commit-after-teardown second).
+4. Delete the cleanup nets + dead state (`showOverlay`, `dragInFlight`, module globals).
+5. Persistence Phase B (srv CAS) — separate PR.
+6. Field-test matrix: repeated A↔B pane moves with tab switches between each; ESC
+   cancels; drop on strip/content/desktop; swallowed-dragend simulation (remove source
+   node in devtools mid-drag) must leave every tab interactive.
+
+---
+
+## 7. Testing Guidance
+
+- Unit: DragSession transition table (start→drop→settle→idle; cancel path; broken-drag
+  path via synthetic monitor events); recordDrop intent consumed exactly once.
+- Unit: registry — double-register then first-mount unregister leaves the second
+  registration intact; ViewModel disposal ownership.
+- Unit: prune — never fires while session active; never prunes younger-than-debounce
+  leaves; still removes genuinely dangling leaves.
+- Unit: persist payload excludes `pendingbackendactions` (Phase A).
+- Integration (vitest, jsdom): full cross-tab move commits only after monitor onDrop;
+  source model overlay derives to none on idle without any imperative reset.
+- Manual: the §6.6 matrix, plus diags — `muxlog` must show zero
+  `pointerdown net fired` assertions across a session.
+
+---
+
+## 8. References
+
+- `specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md` (+ addenda A1–A3) — feature spec and field
+  incident log this refactor supersedes procedurally.
+- `docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`
+  — the persistence clobber mechanism and srv-side pruning already landed.
+- `specs/SPEC_CROSS_WINDOW_TAB_REMOUNT_2026_07_11.md` — adjacent feature; unaffected
+  reader of the refactored state.
+- pragmatic-drag-and-drop source: `make-adapter.js` (dispatch order),
+  `lifecycle-manager.js` + `detect-broken-drag.js` (dragend suppression + fallbacks) —
+  the two facts §3 builds on.

--- a/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
+++ b/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
@@ -368,7 +368,18 @@ revisit), the `respect-reduced-motion` SCSS mixin is a no-op, and all raw
    an in-tab move uses — and the queued backend delete no-ops idempotently
    on the already-removed node.
 
-5. **Stale-tree residue (pre-existing, NOT fixed here).** The session's first
+5. **Stale-tree residue — now healed defensively (round 3).**
+   `pruneDanglingLeaves` (layoutPersistence.ts) removes any leaf whose block
+   is not in the tab's reducer-owned `Tab.blockids`, on every backend update
+   and after pending-action processing; reading `tabAtom()` inside the
+   `onBackendUpdate` effect makes `Tab` a tracked dependency, so a MoveBlock
+   updating `blockids` re-runs the effect and prunes even when the queued
+   layout delete was clobbered. A failed redock also prunes the source tab
+   (the characteristic failure IS "dragged a dangling leaf"). Existing
+   corrupted trees self-heal without a data wipe. Historical context below
+   kept for the record:
+
+   **(original note)** The session's first
    redock failed cleanly with *"block …57a30 is in tab 80ec…, not e7f1…"* — the
    source tab was rendering a leaf for a block the backend had already moved
    (residue in the persisted dev data dir from the v1 testing session, which

--- a/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
+++ b/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
@@ -310,15 +310,23 @@ instability: one tab went completely non-responsive, and drop landings were
 "glitchy / inaccurate". Diagnosis from the dev instance's logs plus code reading,
 and the fixes shipped in `fix/cross-tab-drag-stability`:
 
-### A1. Hover strobe (new UX, implemented)
+### A1. Hover strobe (new UX, implemented; revised same day)
 
-On the instant a pane hover begins over a tab button, a 3px accent bar riding the
-tab's TOP edge strobes: **10 flashes at 20ms intervals (200ms total), one-shot**.
-Implemented as a `keyed` SolidJS `<Show>` mount (`droppable-tab.tsx`) so each
-hover entry remounts the element and restarts the CSS animation
-(`tab-drop-strobe-flash`, `steps(1, end)`, 10 iterations, `forwards` holding
-opacity:0 after the burst). Complements — not replaces — the existing slower
-`tab-drop-pulse` outline and the 500ms spring-switch dwell.
+On the instant a pane hover begins over a tab button, the tab flashes to its
+**NEGATIVE** (`filter: invert(1)`) and back: **10 flashes at 50ms intervals
+(500ms total), one-shot**, then the slower `tab-drop-pulse` accent outline
+carries the signal for the rest of the hover. Pure CSS on
+`.tile-drop-hover .tab` — the class is re-applied per hover entry, restarting
+the animation. (v1 of this addendum specced a 3px top-edge bar at 20ms×10 =
+200ms; field feedback: invisible — partly the reduced-motion kill-switch below,
+partly too fast — revised to the full-tab invert at 500ms.)
+
+**Reduced-motion respect removed app-wide** (same session, product decision):
+the OS "reduce motion" setting was silently disabling functional motion cues —
+this strobe, the drop pulse, insertion indicators — which carry meaning, not
+decoration. `prefersReducedMotionAtom` is hard `false` (plumbing kept for easy
+revisit), the `respect-reduced-motion` SCSS mixin is a no-op, and all raw
+`@media (prefers-reduced-motion: reduce)` blocks are removed.
 
 ### A2. Stability fixes
 
@@ -350,7 +358,17 @@ opacity:0 after the burst). Complements — not replaces — the existing slower
    `onTreeStateAtomUpdated(true)` forces a re-measure once the tab has real
    bounds.
 
-4. **Stale-tree residue (pre-existing, NOT fixed here).** The session's first
+4. **Source pane lingering after a cross-tab move.** Field-observed: the
+   moved pane appeared at the destination but ALSO remained rendered in the
+   source tab. The backend queues the source-tab DeleteNode via
+   `pendingbackendactions`, but the source frontend's debounced persist can
+   race and clobber that queue (the same resurrection mechanism as item 5).
+   Fix: `redockDraggedPane` now deletes the source leaf locally immediately
+   after the RPC succeeds — the same frontend-mutates-then-persists contract
+   an in-tab move uses — and the queued backend delete no-ops idempotently
+   on the already-removed node.
+
+5. **Stale-tree residue (pre-existing, NOT fixed here).** The session's first
    redock failed cleanly with *"block …57a30 is in tab 80ec…, not e7f1…"* — the
    source tab was rendering a leaf for a block the backend had already moved
    (residue in the persisted dev data dir from the v1 testing session, which


### PR DESCRIPTION
## Summary
Steps back from four rounds of field point-fixes on the cross-tab pane drag (PR #2100) and proposes an architecture refactor grounded in a full code inventory.

**Key findings** (details + file:line evidence in the spec):
- Two *independent* dead-tab mechanisms: (1) the full-surface drag overlay sits above the pane headers and its reset is imperative from N places — one missed path wedges the tab AND blocks starting new drags from it; (2) the block-component registry is `Map<blockId>` with last-writer-wins register and unconditional delete-on-cleanup, so any double-mounted block (dangling leaf) leaves the surviving pane unregistered → focus routing dead.
- The round-4 regression identified: the reactive `pruneDanglingLeaves` tracks the whole `Tab` object and can delete *legitimate* freshly-created leaves whose block hasn't landed in `tab.blockids` yet — why drops stopped sticking.
- The persistence layer is a blind un-versioned whole-object overwrite (100ms debounce) that also nulls `pendingbackendactions` — the engine of the stale-tree resurrection class.
- Load-bearing pragmatic-dnd facts from its source: monitors fire on commit, cancel, AND swallowed-dragend (broken-drag fallback) — the single reliable teardown signal the current 5-layer cleanup accretion never used.

**Design pillars**: single `DragSession` FSM owning all gesture state; overlay input-capture derived (never imperatively reset); **commit-after-teardown** (drop records intent, RPC executes after the gesture fully ends — structurally kills the dragend-suppression class); registry owner-checked unregister; prune de-fanged to idle+debounced triggers; persistence Phase A (stop writing the queue) → Phase B (CAS).

Includes a 3-item **immediate stabilization** list (registry hardening, prune de-fang, persistence Phase A) restoring a usable baseline before the core refactor, plus an optional feature-flag fallback.

Per repo convention, this PR will be reused for the implementation.

## Test plan
- [x] N/A — documentation only (implementation lands on this branch next)

<!-- agentmux:agent_id=agent3 -->