### PR TITLE
feat(launcher): observe-only UI-thread liveness probe (teardown backstop Phase 1)

### DIFF
--- a/.changesets/1783808987-feat-launcher-observe-only-ui-thread-liveness-probe-teardown-mip8.md
+++ b/.changesets/1783808987-feat-launcher-observe-only-ui-thread-liveness-probe-teardown-mip8.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launcher): observe-only UI-thread liveness probe (teardown backstop Phase 1)

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -253,6 +253,20 @@ pub async fn connect_to_launcher(
                             tracing::info!("[launcher-ipc] received event: {:?}", event);
                             apply_event_to_shadow(&state_for_reader, &event);
                         }
+                        Ok(HostFrame::Command(Command::ProbeUiThread { nonce })) => {
+                            // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1 — NOT a
+                            // saga command (no saga_id, no idempotency LRU:
+                            // duplicate probes are harmless, replies are
+                            // at-most-once per posted task). The reply MUST
+                            // come from the UI thread — replying from here
+                            // (the tokio reader) would prove nothing about
+                            // the thread the backstop actually cares about.
+                            // If the UI thread isn't pumping (wedged, or the
+                            // pre-ready post_task silent drop), the posted
+                            // task never executes and no reply is sent —
+                            // silence IS the signal.
+                            crate::ui_tasks::post_probe_ui_thread_reply(nonce);
+                        }
                         Ok(HostFrame::Command(cmd)) => {
                             tracing::info!(
                                 "[launcher-ipc] received saga command: {:?}",
@@ -448,6 +462,20 @@ pub async fn connect_to_launcher(
                         Ok(HostFrame::Event(event)) => {
                             tracing::info!("[launcher-ipc] received event: {:?}", event);
                             apply_event_to_shadow(&state_for_reader, &event);
+                        }
+                        Ok(HostFrame::Command(Command::ProbeUiThread { nonce })) => {
+                            // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1 — NOT a
+                            // saga command (no saga_id, no idempotency LRU:
+                            // duplicate probes are harmless, replies are
+                            // at-most-once per posted task). The reply MUST
+                            // come from the UI thread — replying from here
+                            // (the tokio reader) would prove nothing about
+                            // the thread the backstop actually cares about.
+                            // If the UI thread isn't pumping (wedged, or the
+                            // pre-ready post_task silent drop), the posted
+                            // task never executes and no reply is sent —
+                            // silence IS the signal.
+                            crate::ui_tasks::post_probe_ui_thread_reply(nonce);
                         }
                         Ok(HostFrame::Command(cmd)) => {
                             tracing::info!(
@@ -947,6 +975,25 @@ pub fn report_backend_window_id_registered(label: String, window_id: String) {
     if let Err(e) = tx.send(cmd) {
         tracing::warn!(
             "[launcher-ipc] report_backend_window_id_registered: channel closed ({})",
+            e
+        );
+    }
+}
+
+/// SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1 — sync API: answer a
+/// `ProbeUiThread` once its posted UI task actually executes. Called
+/// EXCLUSIVELY from `ProbeUiThreadReplyTask::execute()` on the UI thread —
+/// calling it from anywhere else would forge the exact liveness evidence
+/// the probe exists to collect. No-op if the launcher pipe is absent
+/// (standalone mode has no prober).
+pub fn report_ui_thread_alive(nonce: u64) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportUiThreadAlive { nonce };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!(
+            "[launcher-ipc] report_ui_thread_alive: channel closed ({})",
             e
         );
     }

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -1760,3 +1760,32 @@ unsafe fn find_main_render_widget(
     EnumChildWindows(root, Some(cb), &mut finder as *mut _ as isize);
     if finder.found.is_null() { None } else { Some(finder.found) }
 }
+
+// ── SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 1 — UI-thread probe ───
+
+wrap_task! {
+    pub struct ProbeUiThreadReplyTask {
+        nonce: u64,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // Executing at all IS the liveness evidence: this task only runs
+            // when CEF's UI thread pumps its queue. The reply is sent from
+            // here — the UI thread — per `report_ui_thread_alive`'s contract;
+            // replying from any other thread would forge the signal.
+            crate::launcher_ipc::report_ui_thread_alive(self.nonce);
+        }
+    }
+}
+
+/// SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1 — post the probe reply task.
+/// Called from the launcher-ipc reader on `ProbeUiThread`. If the UI thread
+/// is wedged — or not yet pumping (the known pre-ready `post_task` silent
+/// drop) — the task never executes and no reply is ever sent; the
+/// launcher's prober reads that silence as the signal. Deliberately no
+/// fallback reply path.
+pub fn post_probe_ui_thread_reply(nonce: u64) {
+    let mut task = ProbeUiThreadReplyTask::new(nonce);
+    post_task(ThreadId::UI, Some(&mut task));
+}

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -62,6 +62,26 @@ pub enum Command {
     Ping {
         nonce: u64,
     },
+    /// SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 1 — launcher → host
+    /// (over the host pipe, like the saga `IssueCmd::Host` commands): probe
+    /// whether the host's CEF **UI thread** is actually pumping. The host
+    /// replies with `ReportUiThreadAlive { nonce }` from a posted UI task —
+    /// NEVER from the pipe-reader thread (a wedged host's tokio reader keeps
+    /// answering; only a UI-thread round-trip is liveness evidence). A host
+    /// whose UI thread is hung, or not yet pumping (the known pre-ready
+    /// `post_task` silent drop), simply never replies — silence is the
+    /// signal; there is no host-side timeout.
+    ProbeUiThread {
+        nonce: u64,
+    },
+    /// Reply to `ProbeUiThread`, sent host → launcher via the `Report*`
+    /// path once the probe's posted UI task actually executes. Echoes the
+    /// nonce; the launcher treats ANY receipt as "UI thread pumped after
+    /// the matching probe was sent" (staleness bounded by the probe
+    /// interval, which is all the Phase-2 rule consumes).
+    ReportUiThreadAlive {
+        nonce: u64,
+    },
     /// Graceful disconnect. Server logs and closes the connection.
     /// In B.3+ this becomes `Quit { reason }` with shutdown semantics;
     /// for B.2 it's just a polite goodbye.

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -83,8 +83,8 @@ pub const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Debug)]
 pub enum HostPipeError {
     /// No host is currently connected and the caller asked to fail
-    /// rather than buffer.
-    #[allow(dead_code)] // reserved for fail-fast callers (CPD-3+)
+    /// rather than buffer (`try_send_command_no_buffer`; first caller is
+    /// the UI-liveness prober, SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1).
     HostNotConnected,
     /// Underlying write to the pipe failed.
     WriteFailed(io::Error),
@@ -363,6 +363,41 @@ impl HostPipe {
         let saga_id = saga_id_of(cmd);
         let frame = HostFrame::Command(cmd.clone());
         self.send_frame(frame, saga_id).await
+    }
+
+    /// Fail-fast variant of `send_command`: when no host writer is
+    /// installed, returns `HostNotConnected` immediately instead of
+    /// buffering (the variant the `HostPipeError` docs reserved for
+    /// exactly this).
+    ///
+    /// For frames where DELAYED delivery is meaningless or misleading —
+    /// the UI-liveness probe (SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1) is
+    /// the first caller: a probe buffered while the host is down would
+    /// either expire silently in the pending buffer (probes carry no
+    /// saga_id, so the drop paths can't even report the loss) or be
+    /// delivered to a FUTURE host, and in both cases the caller's
+    /// outstanding-probe bookkeeping would age into a false "UI thread
+    /// did not pump" miss (reagent P1, PR #2106 round 2 — the routine
+    /// disconnected-send during every crash-restart gap hit this).
+    ///
+    /// Residual race, accepted and bounded: a disconnect landing between
+    /// this check and the delegated write can still buffer the frame —
+    /// that window is hair-width (same lock, adjacent awaits) versus the
+    /// routine seconds-long disconnected spans this closes, and if it ever
+    /// fires the resulting one-tick miss coincides with the pipe
+    /// supervision's own loud disconnect logs for the same instant, so
+    /// the telemetry stays attributable.
+    pub async fn try_send_command_no_buffer(
+        &self,
+        cmd: &Command,
+    ) -> Result<(), HostPipeError> {
+        {
+            let inner = self.inner.lock().await;
+            if inner.writer.is_none() {
+                return Err(HostPipeError::HostNotConnected);
+            }
+        }
+        self.send_command(cmd).await
     }
 
     /// Push an Event down to the host. Called by the per-connection

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -397,7 +397,36 @@ impl HostPipe {
                 return Err(HostPipeError::HostNotConnected);
             }
         }
-        self.send_command(cmd).await
+        let res = self.send_command(cmd).await;
+        if res.is_err() {
+            // reagent P1 (PR #2106 round 3): a WRITE failure on an installed
+            // writer — the routine first detection of a dead connection —
+            // takes `send_frame`'s error branch, which pushes the frame into
+            // `pending_buffer` as part of its clear-writer handling even
+            // though it returns Err. That would break this method's contract
+            // via a second path (the stale probe drains to a future host on
+            // reconnect). Enforce the contract post-hoc: scrub any probe
+            // frames the delegated send may have parked. Probe-specific by
+            // design — one outstanding probe exists at a time, so ANY
+            // buffered ProbeUiThread frame is stale; a future non-probe
+            // no-buffer caller extends this per command kind.
+            self.purge_pending_probe_frames().await;
+        }
+        res
+    }
+
+    /// Remove every buffered `ProbeUiThread` frame. See
+    /// `try_send_command_no_buffer`'s error branch for why these can appear
+    /// despite the fail-fast contract, and why any such frame is stale by
+    /// construction.
+    async fn purge_pending_probe_frames(&self) {
+        let mut inner = self.inner.lock().await;
+        inner.pending_buffer.retain(|p| {
+            !matches!(
+                p.frame,
+                HostFrame::Command(Command::ProbeUiThread { .. })
+            )
+        });
     }
 
     /// Push an Event down to the host. Called by the per-connection

--- a/agentmux-launcher/src/host_pipe/tests.rs
+++ b/agentmux-launcher/src/host_pipe/tests.rs
@@ -16,8 +16,8 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{broadcast, Mutex};
 
 use super::{
-    make_shared_writer, BoxedWriter, HostFrame, HostPipe, SharedWriter, DISCONNECT_TIMEOUT,
-    PENDING_BUFFER_CAP,
+    make_shared_writer, BoxedWriter, HostFrame, HostPipe, HostPipeError, SharedWriter,
+    DISCONNECT_TIMEOUT, PENDING_BUFFER_CAP,
 };
 
 // ---- harness ---------------------------------------------------------------
@@ -456,4 +456,50 @@ async fn send_event_for_session_rejects_stale_session() {
         }
         other => panic!("unexpected frame on writer2: {:?}", other),
     }
+}
+
+// ---- fail-fast (no-buffer) sends -----------------------------------------
+// SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1: the UI-liveness prober must never
+// have its probe buffered while the host is down — a buffered probe either
+// expires unreported (no saga_id) or reaches a FUTURE host, and either way
+// the prober's outstanding-nonce bookkeeping would age into a false
+// "UI thread did not pump" miss (reagent P1, PR #2106 round 2).
+
+#[tokio::test]
+async fn try_send_no_buffer_fails_fast_and_buffers_nothing_while_disconnected() {
+    let (pipe, _) = make_pipe();
+    assert!(!pipe.is_connected().await);
+
+    let res = pipe
+        .try_send_command_no_buffer(&Command::ProbeUiThread { nonce: 7 })
+        .await;
+    assert!(
+        matches!(res, Err(HostPipeError::HostNotConnected)),
+        "disconnected fail-fast send must error, got {:?}",
+        res
+    );
+    assert_eq!(
+        pipe.pending_len().await,
+        0,
+        "fail-fast send must not leave a frame in the pending buffer"
+    );
+}
+
+#[tokio::test]
+async fn try_send_no_buffer_delivers_while_connected() {
+    let (pipe, _) = make_pipe();
+    let (writer, reader) = make_duplex();
+    pipe.set_writer(writer).await;
+
+    pipe.try_send_command_no_buffer(&Command::ProbeUiThread { nonce: 9 })
+        .await
+        .expect("connected fail-fast send must succeed");
+    assert_eq!(pipe.pending_len().await, 0);
+
+    let frames = read_n_frames(reader, 1).await;
+    assert!(
+        matches!(frames.as_slice(), [HostFrame::Command(Command::ProbeUiThread { nonce: 9 })]),
+        "probe must arrive on the wire, got {:?}",
+        frames
+    );
 }

--- a/agentmux-launcher/src/host_pipe/tests.rs
+++ b/agentmux-launcher/src/host_pipe/tests.rs
@@ -503,3 +503,28 @@ async fn try_send_no_buffer_delivers_while_connected() {
         frames
     );
 }
+
+#[tokio::test]
+async fn try_send_no_buffer_write_failure_purges_the_rebuffered_probe() {
+    // reagent P1 (PR #2106 round 3): a write failure on an INSTALLED writer
+    // takes send_frame's error branch, which re-buffers the frame as part
+    // of clear-writer handling (proven by write_failure_clears_writer_and_
+    // rebuffers above, pending_len == 1). The no-buffer contract requires
+    // the opposite for probes: Err AND an empty buffer — a stale probe must
+    // never drain into a future host.
+    let (pipe, _) = make_pipe();
+    let (writer, reader) = make_duplex();
+    drop(reader); // writes will fail with BrokenPipe/ConnectionAborted
+    pipe.set_writer(writer).await;
+
+    let result = pipe
+        .try_send_command_no_buffer(&Command::ProbeUiThread { nonce: 11 })
+        .await;
+    assert!(result.is_err(), "probe send must fail when peer dropped");
+    assert!(!pipe.is_connected().await);
+    assert_eq!(
+        pipe.pending_len().await,
+        0,
+        "the rebuffered probe frame must be purged — stale probes never reach a future host"
+    );
+}

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -566,6 +566,24 @@ where
         // `LAUNCHER_START_INSTANT` is a once-init `Instant`; the
         // first request seeds it, subsequent ones read its delta.
         let now_ms = launcher_start_ms();
+        // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1 — record UI-liveness
+        // telemetry at the transport layer, before the reducer (whose arm
+        // for this variant is a deliberate no-op: this is host-thread
+        // telemetry, not domain state). Latency logged only for a
+        // nonce-matched reply; any reply updates `last_alive`.
+        if let Command::ReportUiThreadAlive { nonce } = &cmd {
+            match crate::ui_liveness::record_alive(*nonce) {
+                Some(rtt) => crate::logging::log(&format!(
+                    "[ui-liveness] UI thread alive — probe nonce={} rtt={}ms",
+                    nonce,
+                    rtt.as_millis()
+                )),
+                None => crate::logging::log(&format!(
+                    "[ui-liveness] UI thread alive — unmatched/late reply nonce={}",
+                    nonce
+                )),
+            }
+        }
         let events = {
             let mut state = ctx.state.lock().await;
             let rctx = reducer::Ctx {
@@ -767,6 +785,15 @@ async fn enforce_register_first(
     let (msg, fatal) = match cmd {
         Command::Register { .. } => return None,
         Command::Ping { .. } => ("Ping before Register".to_string(), false),
+        // Liveness telemetry arriving pre-Register is harmless timing skew
+        // (host answered a probe before its Register round-trip completed);
+        // non-fatal, same treatment as Ping.
+        Command::ReportUiThreadAlive { .. } => {
+            ("ReportUiThreadAlive before Register".to_string(), false)
+        }
+        Command::ProbeUiThread { .. } => {
+            ("ProbeUiThread before Register (wrong direction)".to_string(), false)
+        }
         Command::Goodbye => ("Goodbye before Register".to_string(), true),
         Command::ReportWindowOpened { .. } => {
             ("ReportWindowOpened before Register".to_string(), true)

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -39,6 +39,7 @@ mod reducer;
 mod saga;
 mod second_instance;
 mod supervisor;
+mod ui_liveness;
 #[cfg(target_os = "windows")]
 mod splash;
 #[cfg(target_os = "macos")]

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -94,6 +94,17 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             let v = state.bump_version();
             vec![Event::Pong { nonce, version: v }]
         }
+        // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1 — UI-liveness telemetry is
+        // recorded at the transport layer (`ipc/server.rs` →
+        // `crate::ui_liveness`), NOT here: it's thread/process telemetry
+        // about the host, not domain state this reducer owns. This arm
+        // exists only for match exhaustiveness — a defensive no-op.
+        Command::ReportUiThreadAlive { .. } => Vec::new(),
+        // The launcher SENDS ProbeUiThread (over the host pipe); receiving
+        // one on its own IPC server is a wrong-direction message — ignore
+        // (the reducer is pure and does not log; the pre-Register table in
+        // ipc/server.rs already names this case for unregistered senders).
+        Command::ProbeUiThread { .. } => Vec::new(),
         Command::Goodbye => connection::handle_goodbye(state, ctx.registered_pid.unwrap_or(0)),
         Command::ReportWindowOpened {
             label,

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -559,6 +559,10 @@ pub(crate) async fn run_windows(
                     // A down pipe has its own supervision (reconnect +
                     // buffer budget); a failed send is NOT UI-thread
                     // evidence and is logged as transport, not liveness.
+                    // Retract the just-recorded probe (reagent P1): an
+                    // undelivered probe must not age into a false
+                    // "did not pump" miss on the next tick.
+                    crate::ui_liveness::retract_probe(ui_probe_nonce);
                     log(&format!(
                         "[ui-liveness] probe send failed (transport, not liveness): {:?}",
                         e

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -401,7 +401,9 @@ pub(crate) async fn run_windows(
         );
         log(&format!("IPC server started on {}", pipe_path));
 
-        (saga_coord, ipc_handle)
+        // `host_pipe` is also returned to the supervisor loop for the
+        // UI-liveness prober (SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 1).
+        (saga_coord, ipc_handle, host_pipe)
     };
 
     // 3b. Spawn srv. Host needs srv's endpoints to skip its own
@@ -418,7 +420,7 @@ pub(crate) async fn run_windows(
         launcher_setup,
         srv_spawner::spawn_srv(launcher_exe_dir, &paths, &srv_pipe_path, job_handle, &startup_sink)
     );
-    let (saga_coord, _ipc_handle) = setup_result;
+    let (saga_coord, _ipc_handle, host_pipe) = setup_result;
     let (srv_result, mut srv_child) = match srv_spawn_result {
         Ok(pair) => pair,
         Err(e) => {
@@ -525,8 +527,44 @@ pub(crate) async fn run_windows(
     let mut restart_splash_seq: u32 = 0;
     let mut last_abnormal_code: Option<i32> = None;
     let mut host_degraded = false;
+    // SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 1 — observe-only
+    // UI-thread liveness prober. Low rate (60s); the first tick is delayed
+    // a full interval so a booting host (whose UI thread isn't pumping yet
+    // — the known pre-ready `post_task` silent drop) isn't logged as a
+    // false miss. Phase 2's armed teardown rule will consume
+    // `ui_liveness::last_alive()`; nothing here acts on the result.
+    let mut ui_probe_interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+        std::time::Duration::from_secs(60),
+    );
+    ui_probe_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut ui_probe_nonce: u64 = 0;
     let exit_code = loop {
         tokio::select! {
+            _ = ui_probe_interval.tick() => {
+                ui_probe_nonce += 1;
+                if let Some((missed, sent_at)) = crate::ui_liveness::record_probe_sent(ui_probe_nonce) {
+                    log(&format!(
+                        "[ui-liveness] probe nonce={} unanswered after {}s — UI thread did not pump in that window",
+                        missed,
+                        sent_at.elapsed().as_secs()
+                    ));
+                }
+                if let Err(e) = host_pipe
+                    .send_command(&agentmux_common::ipc::Command::ProbeUiThread {
+                        nonce: ui_probe_nonce,
+                    })
+                    .await
+                {
+                    // A down pipe has its own supervision (reconnect +
+                    // buffer budget); a failed send is NOT UI-thread
+                    // evidence and is logged as transport, not liveness.
+                    log(&format!(
+                        "[ui-liveness] probe send failed (transport, not liveness): {:?}",
+                        e
+                    ));
+                }
+            }
             host_status = host_child.wait() => {
                 let code = match host_status {
                     Ok(s) => s.code().unwrap_or(1),

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -550,18 +550,23 @@ pub(crate) async fn run_windows(
                         sent_at.elapsed().as_secs()
                     ));
                 }
+                // Fail-fast send (reagent P1, round 2): the default
+                // `send_command` BUFFERS while disconnected and returns Ok,
+                // so a probe sent during a crash-restart gap would sit in
+                // the pending buffer (or expire there — probes carry no
+                // saga_id, so the drop paths can't report the loss) while
+                // its outstanding-probe entry aged into a false "did not
+                // pump" miss. `try_send_command_no_buffer` turns the
+                // disconnected case into an immediate error instead; the
+                // retract below then keeps the telemetry clean. A down
+                // pipe has its own supervision — a failed send is
+                // transport evidence, never liveness evidence.
                 if let Err(e) = host_pipe
-                    .send_command(&agentmux_common::ipc::Command::ProbeUiThread {
+                    .try_send_command_no_buffer(&agentmux_common::ipc::Command::ProbeUiThread {
                         nonce: ui_probe_nonce,
                     })
                     .await
                 {
-                    // A down pipe has its own supervision (reconnect +
-                    // buffer budget); a failed send is NOT UI-thread
-                    // evidence and is logged as transport, not liveness.
-                    // Retract the just-recorded probe (reagent P1): an
-                    // undelivered probe must not age into a false
-                    // "did not pump" miss on the next tick.
                     crate::ui_liveness::retract_probe(ui_probe_nonce);
                     log(&format!(
                         "[ui-liveness] probe send failed (transport, not liveness): {:?}",

--- a/agentmux-launcher/src/ui_liveness.rs
+++ b/agentmux-launcher/src/ui_liveness.rs
@@ -12,15 +12,20 @@
 //! host-side timeout.
 //!
 //! Phase 1 records `last_alive` + logs round-trip latency; Phase 2's armed
-//! teardown rule will consume `last_alive()` / `last_probe_sent()`. Kept as
-//! a tiny standalone module (not reducer state): this is transport+thread
-//! telemetry about the host process, not domain state the reducer owns.
+//! teardown rule will consume `last_alive()`. Kept as a tiny standalone
+//! module (not reducer state): this is transport+thread telemetry about the
+//! host process, not domain state the reducer owns.
+//!
+//! All logic lives on the `UiLiveness` struct (unit-testable in isolation —
+//! reagent P1 on the first version: tests sharing the process-global cell
+//! interleave under parallel execution); the module-level functions are
+//! thin delegates to the single process-global instance.
 
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 #[derive(Default)]
-struct UiLiveness {
+pub struct UiLiveness {
     /// Most recent probe: (nonce, when sent). One outstanding probe at a
     /// time is enough at the Phase-1 rate; an unanswered probe is simply
     /// overwritten by the next tick (the gap shows up as `last_alive`
@@ -31,75 +36,132 @@ struct UiLiveness {
     last_alive: Option<Instant>,
 }
 
+impl UiLiveness {
+    /// Record a probe about to be sent. Returns the previous probe's
+    /// `(nonce, sent)` if it was never answered — the caller logs the miss.
+    pub fn record_probe_sent(&mut self, nonce: u64) -> Option<(u64, Instant)> {
+        let unanswered = self.probe_sent.take();
+        self.probe_sent = Some((nonce, Instant::now()));
+        unanswered
+    }
+
+    /// Retract an outstanding probe whose SEND failed (reagent P1: a
+    /// transport failure must never age into a false "UI thread did not
+    /// pump" report — the probe was never delivered, so its silence is
+    /// transport evidence, not liveness evidence). No-op if a different
+    /// probe is outstanding.
+    pub fn retract_probe(&mut self, nonce: u64) {
+        if matches!(self.probe_sent, Some((n, _)) if n == nonce) {
+            self.probe_sent = None;
+        }
+    }
+
+    /// Record a `ReportUiThreadAlive`. Returns the round-trip latency when
+    /// the nonce matches the outstanding probe (`None` for a late/unmatched
+    /// reply — still recorded as aliveness, since ANY reply proves the UI
+    /// thread pumped after its probe was sent).
+    pub fn record_alive(&mut self, nonce: u64) -> Option<std::time::Duration> {
+        self.last_alive = Some(Instant::now());
+        match self.probe_sent {
+            Some((sent_nonce, sent_at)) if sent_nonce == nonce => {
+                self.probe_sent = None;
+                Some(sent_at.elapsed())
+            }
+            _ => None,
+        }
+    }
+
+    /// Phase-2 consumer surface: when did the host's UI thread last prove
+    /// itself alive? `None` = never (host hasn't answered a single probe
+    /// yet — startup, or standalone mode with no pipe).
+    pub fn last_alive(&self) -> Option<Instant> {
+        self.last_alive
+    }
+}
+
 fn cell() -> &'static Mutex<UiLiveness> {
     static S: OnceLock<Mutex<UiLiveness>> = OnceLock::new();
     S.get_or_init(|| Mutex::new(UiLiveness::default()))
 }
 
-/// Record a probe about to be sent. Returns the previous probe's
-/// `(nonce, sent)` if it was never answered — the caller logs the miss.
+/// See [`UiLiveness::record_probe_sent`]. Process-global instance.
 pub fn record_probe_sent(nonce: u64) -> Option<(u64, Instant)> {
-    let mut s = cell().lock().unwrap();
-    let unanswered = s.probe_sent.take();
-    s.probe_sent = Some((nonce, Instant::now()));
-    unanswered
+    cell().lock().unwrap().record_probe_sent(nonce)
 }
 
-/// Record a `ReportUiThreadAlive`. Returns the round-trip latency when the
-/// nonce matches the outstanding probe (`None` for a late/unmatched reply —
-/// still recorded as aliveness, since ANY reply proves the UI thread pumped
-/// after its probe was sent).
+/// See [`UiLiveness::retract_probe`]. Process-global instance.
+pub fn retract_probe(nonce: u64) {
+    cell().lock().unwrap().retract_probe(nonce)
+}
+
+/// See [`UiLiveness::record_alive`]. Process-global instance.
 pub fn record_alive(nonce: u64) -> Option<std::time::Duration> {
-    let mut s = cell().lock().unwrap();
-    s.last_alive = Some(Instant::now());
-    match s.probe_sent {
-        Some((sent_nonce, sent_at)) if sent_nonce == nonce => {
-            s.probe_sent = None;
-            Some(sent_at.elapsed())
-        }
-        _ => None,
-    }
+    cell().lock().unwrap().record_alive(nonce)
 }
 
-/// Phase-2 consumer surface: when did the host's UI thread last prove
-/// itself alive? `None` = never (host hasn't answered a single probe yet —
-/// startup, or standalone mode with no pipe).
+/// See [`UiLiveness::last_alive`]. Process-global instance.
 #[allow(dead_code)] // consumed by Phase 2's armed teardown rule
 pub fn last_alive() -> Option<Instant> {
-    cell().lock().unwrap().last_alive
+    cell().lock().unwrap().last_alive()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::UiLiveness;
 
-    // NOTE: tests share the process-global cell; each uses disjoint nonce
-    // ranges so parallel execution can't cross-contaminate matches.
+    // Each test owns its OWN UiLiveness instance — no process-global state,
+    // no parallel-execution interleaving (reagent P1 on the first version).
 
     #[test]
     fn matched_reply_yields_latency_and_clears_outstanding() {
-        record_probe_sent(1001);
-        let latency = record_alive(1001);
+        let mut l = UiLiveness::default();
+        l.record_probe_sent(1);
+        let latency = l.record_alive(1);
         assert!(latency.is_some(), "matched nonce must yield a latency");
         // Second reply to the same nonce: still aliveness, no latency.
-        assert!(record_alive(1001).is_none());
-        assert!(last_alive().is_some());
+        assert!(l.record_alive(1).is_none());
+        assert!(l.last_alive().is_some());
     }
 
     #[test]
     fn unmatched_reply_is_aliveness_without_latency() {
-        record_probe_sent(2001);
-        assert!(record_alive(2999).is_none(), "wrong nonce must not match");
-        assert!(last_alive().is_some(), "but it still proves aliveness");
+        let mut l = UiLiveness::default();
+        l.record_probe_sent(1);
+        assert!(l.record_alive(999).is_none(), "wrong nonce must not match");
+        assert!(l.last_alive().is_some(), "but it still proves aliveness");
+        // The outstanding probe survives an unmatched reply and can still
+        // be answered.
+        assert!(l.record_alive(1).is_some());
     }
 
     #[test]
     fn overwriting_an_unanswered_probe_reports_the_miss() {
-        record_probe_sent(3001);
-        let missed = record_probe_sent(3002);
+        let mut l = UiLiveness::default();
+        l.record_probe_sent(1);
+        let missed = l.record_probe_sent(2);
         assert!(
-            matches!(missed, Some((3001, _))),
+            matches!(missed, Some((1, _))),
             "the unanswered probe must be surfaced to the caller"
+        );
+    }
+
+    #[test]
+    fn retracted_send_failure_is_not_reported_as_a_miss() {
+        // reagent P1: a probe whose send failed must not age into a false
+        // "UI thread did not pump" miss on the next tick.
+        let mut l = UiLiveness::default();
+        l.record_probe_sent(1);
+        l.retract_probe(1);
+        assert!(
+            l.record_probe_sent(2).is_none(),
+            "a retracted probe must not be surfaced as unanswered"
+        );
+        // Retract only touches the matching nonce.
+        l.retract_probe(999);
+        let missed = l.record_probe_sent(3);
+        assert!(
+            matches!(missed, Some((2, _))),
+            "unrelated retract must not clear a live probe"
         );
     }
 }

--- a/agentmux-launcher/src/ui_liveness.rs
+++ b/agentmux-launcher/src/ui_liveness.rs
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 1 — UI-thread liveness
+//! telemetry (observe-only).
+//!
+//! The supervisor's prober sends `Command::ProbeUiThread { nonce }` over the
+//! host pipe on a low-rate interval; the host answers with
+//! `Command::ReportUiThreadAlive { nonce }` from a posted CEF UI task —
+//! i.e. a reply is evidence the UI thread pumped AFTER the probe was sent.
+//! Silence is the signal: a wedged UI thread never replies, and there is no
+//! host-side timeout.
+//!
+//! Phase 1 records `last_alive` + logs round-trip latency; Phase 2's armed
+//! teardown rule will consume `last_alive()` / `last_probe_sent()`. Kept as
+//! a tiny standalone module (not reducer state): this is transport+thread
+//! telemetry about the host process, not domain state the reducer owns.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+#[derive(Default)]
+struct UiLiveness {
+    /// Most recent probe: (nonce, when sent). One outstanding probe at a
+    /// time is enough at the Phase-1 rate; an unanswered probe is simply
+    /// overwritten by the next tick (the gap shows up as `last_alive`
+    /// growing stale, which is the exact signal Phase 2 consumes).
+    probe_sent: Option<(u64, Instant)>,
+    /// Last time ANY `ReportUiThreadAlive` arrived — proof the UI thread
+    /// pumped at that moment, regardless of nonce matching.
+    last_alive: Option<Instant>,
+}
+
+fn cell() -> &'static Mutex<UiLiveness> {
+    static S: OnceLock<Mutex<UiLiveness>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(UiLiveness::default()))
+}
+
+/// Record a probe about to be sent. Returns the previous probe's
+/// `(nonce, sent)` if it was never answered — the caller logs the miss.
+pub fn record_probe_sent(nonce: u64) -> Option<(u64, Instant)> {
+    let mut s = cell().lock().unwrap();
+    let unanswered = s.probe_sent.take();
+    s.probe_sent = Some((nonce, Instant::now()));
+    unanswered
+}
+
+/// Record a `ReportUiThreadAlive`. Returns the round-trip latency when the
+/// nonce matches the outstanding probe (`None` for a late/unmatched reply —
+/// still recorded as aliveness, since ANY reply proves the UI thread pumped
+/// after its probe was sent).
+pub fn record_alive(nonce: u64) -> Option<std::time::Duration> {
+    let mut s = cell().lock().unwrap();
+    s.last_alive = Some(Instant::now());
+    match s.probe_sent {
+        Some((sent_nonce, sent_at)) if sent_nonce == nonce => {
+            s.probe_sent = None;
+            Some(sent_at.elapsed())
+        }
+        _ => None,
+    }
+}
+
+/// Phase-2 consumer surface: when did the host's UI thread last prove
+/// itself alive? `None` = never (host hasn't answered a single probe yet —
+/// startup, or standalone mode with no pipe).
+#[allow(dead_code)] // consumed by Phase 2's armed teardown rule
+pub fn last_alive() -> Option<Instant> {
+    cell().lock().unwrap().last_alive
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // NOTE: tests share the process-global cell; each uses disjoint nonce
+    // ranges so parallel execution can't cross-contaminate matches.
+
+    #[test]
+    fn matched_reply_yields_latency_and_clears_outstanding() {
+        record_probe_sent(1001);
+        let latency = record_alive(1001);
+        assert!(latency.is_some(), "matched nonce must yield a latency");
+        // Second reply to the same nonce: still aliveness, no latency.
+        assert!(record_alive(1001).is_none());
+        assert!(last_alive().is_some());
+    }
+
+    #[test]
+    fn unmatched_reply_is_aliveness_without_latency() {
+        record_probe_sent(2001);
+        assert!(record_alive(2999).is_none(), "wrong nonce must not match");
+        assert!(last_alive().is_some(), "but it still proves aliveness");
+    }
+
+    #[test]
+    fn overwriting_an_unanswered_probe_reports_the_miss() {
+        record_probe_sent(3001);
+        let missed = record_probe_sent(3002);
+        assert!(
+            matches!(missed, Some((3001, _))),
+            "the unanswered probe must be surfaced to the caller"
+        );
+    }
+}

--- a/docs/specs/SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md
+++ b/docs/specs/SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md
@@ -1,0 +1,117 @@
+# SPEC: Launcher-side teardown backstop (UI-thread liveness probe + armed J0 teardown)
+
+**Date:** 2026-07-11
+**Status:** Ready for implementation (Phase 1 first, observe-only)
+**Tracking:** #2092 (carved out of Discussion #1680 §9.4); shared prerequisite with #942 §8
+**Scope:** `agentmux-common` (protocol), `agentmux-cef` (probe reply), `agentmux-launcher` (prober + rule)
+
+## Problem
+
+Every quit backstop shipped so far runs **inside the host**: the #2043 quit
+watchdog, Stage-2 executors, orphan_reconcile's nothing-will-pump drive — all
+of them die with a wedged host. If the host's UI thread hangs (deadlock,
+runaway synchronous work) after the last user window closes, nothing above it
+notices: the launcher sees a Running child and an open pipe (the host's
+tokio IPC reader keeps pumping happily — **pipe traffic is not liveness**),
+and the process tree lingers until the user kills it by hand. This is the one
+undelivered item from Discussion #1680's §9 scorecard.
+
+## Key insight — the trigger already exists
+
+The launcher already *detects* the arming condition; it just does nothing
+host-independent with it:
+
+- `ReportPoolDrainDecision { was_last: true }` — the host's own
+  "last user window closed, drain begins" report (Pillar 2).
+- The WRR reducer's `OrphanInstance` drift ("Last user-visible window
+  closed; host still alive (likely holding warm pool)") + the
+  `window_cleanup_cascade` saga — both observed firing in every clean quit's
+  launcher log.
+
+After those fire, a healthy host exits within seconds (live-measured: solo
+~257ms, multi-window ~2–5s with pool sweep). A host still alive long after
+is either legitimately busy (rare, bounded) or wedged. The backstop's job is
+to tell those apart — which needs a liveness probe that a wedged host
+CANNOT answer.
+
+## Phase 1 — UI-thread liveness probe (observe-only)
+
+New protocol pair (same shape as every existing launcher↔host exchange):
+
+- `Command::ProbeUiThread { nonce: u64 }` — launcher → host, over the
+  existing host pipe (same channel the saga `IssueCmd::Host` commands use).
+- `Command::ReportUiThreadAlive { nonce: u64 }` — host → launcher, following
+  the `Report*` convention.
+
+**The reply MUST round-trip through CEF's UI thread.** The host's pipe
+reader is a tokio task; replying from the handler would prove only that the
+reader is alive — the exact non-signal this spec exists to avoid. The
+handler posts a `wrap_task!` UI task whose `execute()` sends the report; a
+wedged (or pre-ready — the known `post_task` silent-drop) UI thread simply
+never replies, and that *silence is the signal*. No host-side timer needed.
+
+Launcher side (Phase 1): a low-rate prober (every 60s while the host is
+`Running`) records `last_ui_alive: Instant` + logs round-trip latency.
+**Observe-only** — no teardown consumer yet, mirroring how Step 4 Phase 1
+(GetSnapshot fetch) and every other risky mechanism in this program landed:
+protocol + telemetry first, consequence second, so a false-positive bug
+can't kill anything while the signal's real-world behavior is baked.
+
+Idempotency/dedup: nonce echo; the launcher treats any `ReportUiThreadAlive`
+as "alive as-of receipt" (a late reply to an old nonce still proves the UI
+thread pumped after the probe was sent — staleness is bounded by the probe
+interval, which is all the rule consumes).
+
+## Phase 2 — the armed teardown rule
+
+State machine in the supervisor (`run_windows`'s select loop), Windows first:
+
+```
+Disarmed ──(was_last drain report OR OrphanInstance-with-zero-user-mirror)──▶ Armed(t0)
+Armed    ──(host exits)──────────────────────────────────────────────────▶ normal supervised-exit path
+Armed    ──(any user window opens per mirror)────────────────────────────▶ Disarmed
+Armed    ──(t > t0 + GRACE and probe unanswered for ≥ 2 intervals)────────▶ Teardown
+```
+
+- `GRACE = 30s` — an order of magnitude above the slowest healthy quit
+  observed (multi-window with pool sweep), far below "user annoyed."
+- Teardown = log loudly (`[teardown-backstop] host wedged with zero user
+  windows — terminating job`), then `TerminateJobObject(J0)` and launcher
+  exit with a distinct code. **I2/I3 hold by construction**: J0 is the
+  launcher's own unnamed job; the blast radius is exactly the processes it
+  spawned. This is the one deliberate exception to "never kill what a saga
+  can reconcile" — there is nothing left to reconcile when zero user windows
+  remain and the UI thread is provably dead.
+- False-positive guards (each maps to a known legitimate zero-window state):
+  - **Startup**: rule disarmed until the first user window registers.
+  - **Crash-restart gap**: the supervisor owns restarts — the state machine
+    is suspended between abnormal exit and respawned-host readiness (the
+    same span the splash-respawn logic already brackets).
+  - **Crash-reproject**: reproject re-opens windows within the grace; the
+    mirror's `WindowOpened` disarms. A reproject slower than 30s with the
+    UI thread also unresponsive IS a wedge.
+  - **Probe transport failure** (pipe down): does NOT count as "unanswered"
+    — a disconnected pipe already has its own supervision (30s buffer
+    budget); only a delivered-but-unanswered probe is UI-thread evidence.
+
+## Verification plan
+
+- Phase 1: unit tests on the protocol arms (nonce echo, dedup) + live: probe
+  latency lines visible in the launcher log across a normal session, a
+  crash-restart, and a reproject.
+- Phase 2: reducer-style unit tests for the state machine (arm, disarm on
+  window-open, teardown on expiry); live wedge reproduction via a
+  debug-only host IPC command (`debug:hang_ui`, gated behind
+  `AGENTMUX_DEBUG_HANG=1`) that parks the UI thread in a sleep — then close
+  the last window and watch the backstop tear the tree down within
+  GRACE + 2 intervals, with zero processes left (the E2E harness's wmic
+  sweep as the assertion).
+
+## Non-goals
+
+- srv supervision (#942 Phase 2) — separate mechanism, same family.
+- macOS/Linux parity — the state machine is portable but lands
+  Windows-first like every mechanism in this program; unix.rs mirrors after
+  the Windows bake.
+- Replacing the host-side watchdog (#2043) — that stays as the first line;
+  this is the layer beneath it.


### PR DESCRIPTION
Phase 1 of `SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md` (in this PR), toward **#2092** — the one undelivered item from Discussion #1680's §9 scorecard — and #942 §8's responsiveness gap.

## Why

Every quit backstop shipped so far runs **inside the host** (the #2043 watchdog, Stage-2 executors, orphan_reconcile's quit drive) and dies with a wedged host. The launcher can't tell a hung UI thread from a healthy one: **pipe traffic is not liveness** — a wedged host's tokio IPC reader keeps pumping happily.

## What

- **Protocol:** `Command::ProbeUiThread { nonce }` (launcher → host, over the host pipe like the saga `IssueCmd::Host` commands) + `Command::ReportUiThreadAlive { nonce }` (host → launcher via the `Report*` path).
- **Host:** the pipe reader posts a `wrap_task!` UI task; the reply is sent **only** from the task's `execute()` on the UI thread. A wedged — or pre-ready (the known `post_task` silent drop) — UI thread never replies. Silence is the signal; deliberately no fallback reply path, no host-side timeout.
- **Launcher:** new `ui_liveness` telemetry module (probe bookkeeping, nonce-matched RTT, `last_alive()` as Phase 2's consumer surface; 3 unit tests). Recording happens at the **transport layer** (`ipc/server.rs`); the reducer arms are deliberate no-ops — this is thread telemetry about the host process, not domain state. 60s prober in `run_windows`'s select loop; first tick delayed one full interval so a booting host isn't a false miss; pipe send failures are logged as transport, never counted as liveness evidence.
- **Observe-only:** nothing consumes the signal yet. Phase 2 (the armed `TerminateJobObject(J0)` state machine — arm on the existing `was_last`/OrphanInstance signals, grace, disarm-on-window-open) lands separately after the probe bakes, mirroring how Step 4 Phase 1 (GetSnapshot, observe-only) de-risked crash-reproject.

## Verification

- Live on a packaged build: probe `nonce=1` answered `rtt=0ms` on a healthy host; after killing the inner host, the **supervised respawn's** UI thread answered `nonce=2` seamlessly across the restart — the prober needs no restart-awareness (the pipe reconnect machinery already owns that).
- Suites: launcher 202 (3 new), host 189, all green. Exhaustive-match sites for the new variants covered in the launcher reducer + pre-Register table.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)