### PR TITLE
feat(launcher): srv supervision via host recycle (#942 Phase 2)

### DIFF
--- a/.changesets/1783813107-feat-launcher-srv-supervision-via-host-recycle-an-srv-crash--kgxb.md
+++ b/.changesets/1783813107-feat-launcher-srv-supervision-via-host-recycle-an-srv-crash--kgxb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launcher): srv supervision via host recycle — an srv crash no longer kills the session

--- a/agentmux-launcher/src/supervisor/mod.rs
+++ b/agentmux-launcher/src/supervisor/mod.rs
@@ -14,6 +14,17 @@
 pub(crate) const HOST_RESTART_BUDGET: usize = 3;
 pub(crate) const HOST_RESTART_WINDOW: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11 (#942 Phase 2) — srv gets its
+/// own crash budget: an unexpected srv exit respawns srv and recycles the
+/// host through the existing supervised-restart path (crash-reproject
+/// restores the session), at most this many times per window. A wider
+/// window than the host's: each srv recycle also costs a host restart, so
+/// a crash-looping srv burns both budgets and gives up loudly either way.
+#[cfg(target_os = "windows")]
+pub(crate) const SRV_RESTART_BUDGET: usize = 3;
+#[cfg(target_os = "windows")]
+pub(crate) const SRV_RESTART_WINDOW: std::time::Duration = std::time::Duration::from_secs(120);
+
 #[cfg(target_os = "windows")]
 mod windows;
 #[cfg(target_os = "windows")]

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -6,7 +6,9 @@ use crate::host_spawn::spawn_host_supervised;
 use crate::logging::log;
 use crate::second_instance::{forward_open_new_window, ForwardError};
 use crate::show_fatal_dialog;
-use crate::supervisor::{HOST_RESTART_BUDGET, HOST_RESTART_WINDOW};
+use crate::supervisor::{
+    HOST_RESTART_BUDGET, HOST_RESTART_WINDOW, SRV_RESTART_BUDGET, SRV_RESTART_WINDOW,
+};
 use crate::{
     config, data_dir, event_log, hash, host_pipe, ipc, mem_supervisor, saga, srv_spawner,
     startup_events, state,
@@ -421,7 +423,11 @@ pub(crate) async fn run_windows(
         srv_spawner::spawn_srv(launcher_exe_dir, &paths, &srv_pipe_path, job_handle, &startup_sink)
     );
     let (saga_coord, _ipc_handle, host_pipe) = setup_result;
-    let (srv_result, mut srv_child) = match srv_spawn_result {
+    // `mut`: SPEC_SRV_SUPERVISION_RECYCLE — an srv respawn rebinds this to
+    // the new endpoints; the subsequent (deliberate) host restart then picks
+    // them up through the existing `spawn_host_supervised(..., &srv_result,
+    // ...)` call sites with no further plumbing.
+    let (mut srv_result, mut srv_child) = match srv_spawn_result {
         Ok(pair) => pair,
         Err(e) => {
             log(&format!("FATAL: srv spawn failed: {}", e));
@@ -442,7 +448,12 @@ pub(crate) async fn run_windows(
     // of the Child into a launcher-scope binding so tokio can't see
     // it (its take() returns None) and the pipe stays open for the
     // launcher's lifetime. (Smoke test on v0.33.447 caught this.)
-    let _srv_stdin_keepalive = srv_child.stdin.take();
+    // `mut`: SPEC_SRV_SUPERVISION_RECYCLE — an srv respawn must park the NEW
+    // child's stdin here too, or the very next `srv_child.wait()` poll drops
+    // it and the fresh srv shuts down within milliseconds of starting
+    // (live-reproduced 2026-07-11: respawned srv logged "stdin closed,
+    // shutting down" 7ms after binding its listeners).
+    let mut srv_stdin_keepalive = srv_child.stdin.take();
 
     // 4-6. Spawn the host (suspended) → assign to J0 → resume, via
     // spawn_host_supervised(). The splash event is passed on every launch
@@ -508,8 +519,10 @@ pub(crate) async fn run_windows(
     // 7. Supervised wait loop (Phase 1 — host supervision). The host is
     // auto-restarted on abnormal exit, bounded by a crash budget so a
     // deterministic crash can't spin forever (spec §10-A). A clean host
-    // exit (code 0) ends the loop. srv is NOT yet supervised — an srv
-    // exit still terminates the launcher; srv supervision is Phase 2.
+    // exit (code 0) ends the loop. srv IS supervised too (#942 Phase 2,
+    // SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11): an unexpected srv exit
+    // respawns srv and recycles the host through this same restart path,
+    // bounded by its own SRV_RESTART_BUDGET.
     //
     // We don't manually kill the surviving child in the happy path:
     // dropping `job` below triggers KILL_ON_JOB_CLOSE which reaps the
@@ -527,6 +540,15 @@ pub(crate) async fn run_windows(
     let mut restart_splash_seq: u32 = 0;
     let mut last_abnormal_code: Option<i32> = None;
     let mut host_degraded = false;
+    // SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11 (#942 Phase 2) — srv crash
+    // budget + the recycle-kill flag. When srv dies unexpectedly, the srv
+    // arm respawns it, rebinds `srv_result`, sets this flag, and kills the
+    // host deliberately; the host arm (next iteration) consumes the flag to
+    // SKIP the deterministic-crash classification (the host didn't fault —
+    // a recycle must not step the retry ladder down to --disable-gpu),
+    // while still counting against the host budget as runaway protection.
+    let mut srv_restarts: Vec<std::time::Instant> = Vec::new();
+    let mut srv_recycle_kill = false;
     // SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 1 — observe-only
     // UI-thread liveness prober. Low rate (60s); the first tick is delayed
     // a full interval so a booting host (whose UI thread isn't pumping yet
@@ -710,10 +732,21 @@ pub(crate) async fn run_windows(
                         // step down to a degraded (--disable-gpu) relaunch so the retry
                         // isn't "the same thing again". Degraded is sticky; the ladder
                         // only steps down.
-                        if last_abnormal_code == Some(code) {
-                            host_degraded = true;
+                        //
+                        // SPEC_SRV_SUPERVISION_RECYCLE — a launcher-inflicted
+                        // recycle kill is NOT a host fault: skip the ladder
+                        // bookkeeping so an srv-driven recycle can never mark
+                        // the host deterministic-crashing or degrade it to
+                        // --disable-gpu. (It still counted against the budget
+                        // above — runaway protection stays.)
+                        if srv_recycle_kill {
+                            srv_recycle_kill = false;
+                        } else {
+                            if last_abnormal_code == Some(code) {
+                                host_degraded = true;
+                            }
+                            last_abnormal_code = Some(code);
                         }
-                        last_abnormal_code = Some(code);
                         log(&format!(
                             "CEF host exited abnormally (code {}) — relaunching (restart {}/{}{})",
                             code,
@@ -758,14 +791,80 @@ pub(crate) async fn run_windows(
                 }
             }
             srv_status = srv_child.wait() => {
-                match srv_status {
-                    Ok(s) => log(&format!(
-                        "srv exited UNEXPECTEDLY (host still running) with code {} — terminating launcher",
-                        s.code().unwrap_or(1)
-                    )),
-                    Err(e) => log(&format!("FATAL: srv wait failed: {}", e)),
+                // SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11 (#942 Phase 2) —
+                // recycle, don't rewire: srv's endpoints only reach the host
+                // via spawn-time env, and the host is DISPOSABLE (Pillar 1
+                // Step 4), so the supervision story is: respawn srv, rebind
+                // the endpoints, deliberately kill the host, and let the
+                // existing host-restart machinery (splash + crash-reproject)
+                // rebuild the session against the new srv. srv's SQLite
+                // state is durable (WAL) — reproject sees everything.
+                let code = match srv_status {
+                    Ok(s) => s.code().unwrap_or(1),
+                    Err(e) => {
+                        log(&format!("FATAL: srv wait failed: {}", e));
+                        break 1;
+                    }
+                };
+                if mem_supervisor::budget_exhausted(
+                    &mut srv_restarts,
+                    std::time::Instant::now(),
+                    SRV_RESTART_WINDOW,
+                    SRV_RESTART_BUDGET,
+                ) {
+                    log(&format!(
+                        "srv exited (code {}); srv restart budget exhausted ({} in {}s) — terminating launcher",
+                        code,
+                        SRV_RESTART_BUDGET,
+                        SRV_RESTART_WINDOW.as_secs()
+                    ));
+                    break 1;
                 }
-                break 1;
+                log(&format!(
+                    "srv exited UNEXPECTEDLY (code {}) — respawning srv + recycling host (restart {}/{})",
+                    code,
+                    srv_restarts.len(),
+                    SRV_RESTART_BUDGET
+                ));
+                match srv_spawner::spawn_srv(
+                    launcher_exe_dir,
+                    &paths,
+                    &srv_pipe_path,
+                    job_handle,
+                    &startup_sink,
+                )
+                .await
+                {
+                    Ok((new_result, new_child)) => {
+                        srv_result = new_result;
+                        srv_child = new_child;
+                        // Park the NEW srv's stdin exactly like cold boot does
+                        // (see `srv_stdin_keepalive`'s comment above): the next
+                        // `srv_child.wait()` poll would otherwise drop it, and
+                        // srv reads stdin-EOF as "parent died" and exits within
+                        // milliseconds — live-reproduced on the first version
+                        // of this arm.
+                        srv_stdin_keepalive = srv_child.stdin.take();
+                        log(&format!(
+                            "srv respawned (pid {}) — new endpoints ws={} web={}; recycling host",
+                            srv_result.pid, srv_result.ws_endpoint, srv_result.web_endpoint
+                        ));
+                        // The running host is wired to the DEAD srv's
+                        // endpoints — every backend connection it holds is
+                        // broken. Kill it deliberately; the host arm's
+                        // supervised restart (next select iteration) spawns
+                        // the replacement against the rebound `srv_result`.
+                        srv_recycle_kill = true;
+                        let _ = host_child.start_kill();
+                    }
+                    Err(e) => {
+                        log(&format!(
+                            "FATAL: srv respawn failed: {} — terminating launcher",
+                            e
+                        ));
+                        break 1;
+                    }
+                }
             }
         }
     };

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -615,8 +615,24 @@ pub(crate) async fn run_windows(
                 // (docs/retro/retro-oom-crash-2026-06-16.md,
                 // SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16 §5.B). A genuine
                 // host fault still takes the existing path below, unchanged.
+                //
+                // SPEC_SRV_SUPERVISION_RECYCLE (reagent P1, PR #2107) — a
+                // launcher-inflicted recycle kill is consumed BEFORE
+                // classification and forced onto the Abnormal path: we KNOW
+                // why the host died, so classifying its exit is meaningless
+                // and actively harmful — a recycle landing in a low-commit
+                // moment would otherwise route to the SystemOom branch,
+                // which always relaunches degraded (--disable-gpu) AND never
+                // resets the flag, leaving the NEXT genuine crash silently
+                // mistreated as a recycle.
+                let recycle_kill = std::mem::replace(&mut srv_recycle_kill, false);
                 let commit_free = mem_supervisor::commit_free_mb();
-                match mem_supervisor::classify_host_exit(code, commit_free) {
+                let exit_class = if recycle_kill {
+                    mem_supervisor::HostExitClass::Abnormal
+                } else {
+                    mem_supervisor::classify_host_exit(code, commit_free)
+                };
+                match exit_class {
                     mem_supervisor::HostExitClass::SystemOom => {
                         let now = std::time::Instant::now();
                         if mem_supervisor::budget_exhausted(
@@ -738,10 +754,9 @@ pub(crate) async fn run_windows(
                         // bookkeeping so an srv-driven recycle can never mark
                         // the host deterministic-crashing or degrade it to
                         // --disable-gpu. (It still counted against the budget
-                        // above — runaway protection stays.)
-                        if srv_recycle_kill {
-                            srv_recycle_kill = false;
-                        } else {
+                        // above — runaway protection stays. The flag itself
+                        // was consumed before classification — reagent P1.)
+                        if !recycle_kill {
                             if last_abnormal_code == Some(code) {
                                 host_degraded = true;
                             }

--- a/docs/specs/SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11.md
+++ b/docs/specs/SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11.md
@@ -1,0 +1,66 @@
+# SPEC: srv supervision via host recycle (#942 Phase 2)
+
+**Date:** 2026-07-11
+**Status:** Ready for implementation
+**Tracking:** #942 Phase 2 ("srv supervision"); supersedes that spec's
+`SrvManager` sketch for the srv case
+**Scope:** `agentmux-launcher/src/supervisor/windows.rs` (+ unix mirror later)
+
+## Problem
+
+An srv exit still terminates the entire launcher (`supervisor/windows.rs`'s
+srv-wait arm: log + `break 1`), taking the host — and the user's whole
+session — down with it. This is the explicitly-documented Phase-2 gap
+("srv is NOT yet supervised").
+
+## Design — recycle, don't rewire
+
+The original #942 sketch ("bespoke SrvManager; host tolerates srv
+reconnect") predates crash-reproject. Teaching a live host to re-resolve
+new srv endpoints means new IPC, new frontend reconnect states, and a
+consistency story for every in-flight RPC — a large surface. But the host
+is **disposable now** (Pillar 1 Step 4): killing and respawning it costs
+seconds and self-restores the window set with the restoring-session
+overlay. So srv supervision composes two baked mechanisms instead of
+building a third:
+
+1. **srv exits unexpectedly** (host still running) → check the srv restart
+   budget (`3 per 120s`; exhaustion = fatal dialog + today's behavior).
+2. **Respawn srv** via the same `srv_spawner::spawn_srv` call cold start
+   uses — same pipe name (keyed on dir_hash, freed by the dead srv), fresh
+   dynamic ports, durable SQLite state intact (WAL handles the crash).
+3. **Rebind `srv_result`** to the new endpoints. This is the entire
+   "rewire": host endpoints flow exclusively through
+   `spawn_host_supervised(..., &srv_result, ...)` env at spawn time.
+4. **Deliberately kill the host** (`start_kill`). It is unusable anyway —
+   every backend connection it holds points at a dead process. The next
+   select iteration's host-wait arm sees an abnormal exit and takes the
+   EXISTING supervised-restart path — splash with "Restoring session…",
+   new host spawned against the new endpoints, crash-reproject rebuilds
+   the windows from srv's durable topology.
+
+A launcher-inflicted recycle kill is flagged (`srv_recycle_kill`, consumed
+once) so the host-restart arm skips the deterministic-crash classification
+(`last_abnormal_code`/`host_degraded`): the host did not fault, and a
+recycle must not step the retry ladder down to `--disable-gpu`. It still
+COUNTS against the host restart budget — a crash-looping srv should
+exhaust budgets and give up loudly rather than churn forever (defense in
+depth on top of the srv budget).
+
+## Non-goals
+
+- Host tolerating srv reconnect in place (superseded — see above).
+- macOS/Linux parity in this PR (unix.rs mirrors after Windows bake, the
+  program's standard sequence).
+- srv hang-while-alive detection (this covers exits; liveness probing for
+  srv is a separate follow-up in the #942 family).
+
+## Verification
+
+- Budget unit-tested via the same helper the host budget uses.
+- Live: kill srv by PID mid-session with windows open → launcher log shows
+  srv respawn + deliberate host recycle; restoring-session splash; windows
+  reproject; frontend fully functional against the NEW srv (open/close a
+  window to prove RPC round-trips); `Client.windowids` intact. Second srv
+  kill within the window exercises the budget arithmetic; a third exhausts
+  it → fatal dialog, clean teardown, zero stray processes.


### PR DESCRIPTION
Implements `SPEC_SRV_SUPERVISION_RECYCLE_2026_07_11.md` (in this PR) — the "srv is NOT yet supervised" gap that #942's status map identified as the framework's first genuinely-remaining phase.

## Design — recycle, don't rewire

The original #942 sketch ("SrvManager; host tolerates srv reconnect") predates crash-reproject. The host is disposable now, so srv supervision composes two baked mechanisms: **respawn srv** (same path as cold boot; durable SQLite state intact) → **rebind `srv_result`** (host endpoints flow exclusively through spawn-time env — the rebind IS the rewire) → **deliberately kill the host** and let the existing supervised-restart machinery do the rest: restoring-session splash, new host against the new endpoints, crash-reproject rebuilds the windows.

- Bounded by `SRV_RESTART_BUDGET` (3 per 120s); exhaustion = loud give-up (today's behavior).
- A recycle kill is flagged (`srv_recycle_kill`, consumed once) so the host-restart arm **skips the deterministic-crash ladder** — an srv-driven recycle must never mark the host deterministic-crashing or degrade it to `--disable-gpu` — while still counting against the host budget as runaway protection.

## The bug live verification caught

The first respawned srv died **7ms** after starting (`stdin closed, shutting down`): tokio's `Child::wait()` proactively drops the child's stdin, and srv reads stdin-EOF as parent death. Cold boot parks srv's stdin in a keepalive binding for exactly this reason (the v0.33.447 lesson, documented at the binding); the respawn path now re-parks the new child's stdin identically.

## Verification (all live, packaged build)

- Kill srv mid-session with a second window open → `srv exited UNEXPECTEDLY … respawning srv + recycling host (restart 1/3)` → new endpoints → restoring splash → **main and "Window 2" fully reprojected and functional against the new srv** (RPC round-trip confirmed; `Client.windowids` intact at 2; the recycled frontend's `__WAVE_SERVER_WEB_ENDPOINT__` shows the new port).
- Two further kills exercised repeat recycles (each hit a freshly-respawned srv).
- A third kill inside the window: `srv restart budget exhausted (3 in 120s) — terminating launcher` → clean teardown, **zero** leftover processes.
- Launcher suite 206 passed.

Windows-first per the program convention; `unix.rs` mirrors after bake. srv hang-while-alive detection stays a separate follow-up in the #942 family.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)