### PR TITLE
chore: release v0.53.2

### DIFF
--- a/.changesets/1783793263-fix-tabbar-cross-tab-drag-stability-stuck-overlay-cleanup-gh-2ab5.md
+++ b/.changesets/1783793263-fix-tabbar-cross-tab-drag-stability-stuck-overlay-cleanup-gh-2ab5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabbar): cross-tab drag stability (stuck-overlay cleanup, ghost/landing clamp, geometry refresh) + hover strobe

--- a/.changesets/1783796221-fix-instance-panel-floating-panes-focus-on-click-inline-opac-5poq.md
+++ b/.changesets/1783796221-fix-instance-panel-floating-panes-focus-on-click-inline-opac-5poq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(instance-panel): floating panes focus on click + inline opacity controls

--- a/.changesets/1783796274-feat-pool-adopt-foreign-window-uuid-labels-into-the-warm-poo-5fhv.md
+++ b/.changesets/1783796274-feat-pool-adopt-foreign-window-uuid-labels-into-the-warm-poo-5fhv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(pool): adopt foreign window-{uuid} labels into the warm pool on close (renderer reuse instead of park-and-blank)

--- a/.changesets/1783800650-fix-browser-show-the-loading-brain-instead-of-a-blank-pane-w-jner.md
+++ b/.changesets/1783800650-fix-browser-show-the-loading-brain-instead-of-a-blank-pane-w-jner.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser): show the loading brain instead of a blank pane while a page loads

--- a/.changesets/1783808987-feat-launcher-observe-only-ui-thread-liveness-probe-teardown-mip8.md
+++ b/.changesets/1783808987-feat-launcher-observe-only-ui-thread-liveness-probe-teardown-mip8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(launcher): observe-only UI-thread liveness probe (teardown backstop Phase 1)

--- a/.changesets/1783813107-feat-launcher-srv-supervision-via-host-recycle-an-srv-crash--kgxb.md
+++ b/.changesets/1783813107-feat-launcher-srv-supervision-via-host-recycle-an-srv-crash--kgxb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(launcher): srv supervision via host recycle — an srv crash no longer kills the session

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.53.1"
+version = "0.53.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.53.1"
+version = "0.53.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.53.1"
+version = "0.53.2"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.53.1"
+version = "0.53.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.53.1"
+version = "0.53.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.53.1"
+version = "0.53.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.53.1"
+version = "0.53.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,15 @@
 # AgentMux Version History
 
+## 0.53.2 — 2026-07-11
+
+- fix(tabbar): cross-tab drag stability (stuck-overlay cleanup, ghost/landing clamp, geometry refresh) + hover strobe
+- fix(instance-panel): floating panes focus on click + inline opacity controls
+- feat(pool): adopt foreign window-{uuid} labels into the warm pool on close (renderer reuse instead of park-and-blank)
+- fix(browser): show the loading brain instead of a blank pane while a page loads
+- feat(launcher): observe-only UI-thread liveness probe (teardown backstop Phase 1)
+- feat(launcher): srv supervision via host recycle — an srv crash no longer kills the session
+
+
 ## 0.53.1 — 2026-07-11
 
 - fix(tabbar): pane drag-to-tab reworked as spring-loaded tabs (real drop targets, switch-on-dwell, in-layout ghost)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.53.1",
+      "version": "0.53.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Patch release (explicit `--as patch` override) consuming the 6 pending changesets: pool adoption (#2102), the UI-thread liveness probe (#2106), srv supervision via host recycle (#2107), the browser-pane loading brain, and the tabbar cross-drag/instance-panel fixes.

Release-consistency invariant verified by `scripts/release.sh`: all 5 version locations agree at **0.53.2**.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)