### PR TITLE
feat(sysinfo): track pagefile-volume free disk + warn on a stuck page file

### DIFF
--- a/.changesets/1783865214-feat-sysinfo-track-pagefile-volume-free-disk-warn-when-a-sys-4cch.md
+++ b/.changesets/1783865214-feat-sysinfo-track-pagefile-volume-free-disk-warn-when-a-sys-4cch.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(sysinfo): track pagefile-volume free disk + warn when a system-managed page file can't grow

--- a/.changesets/1783865214-feat-sysinfo-track-pagefile-volume-free-disk-warn-when-a-sys-4cch.md
+++ b/.changesets/1783865214-feat-sysinfo-track-pagefile-volume-free-disk-warn-when-a-sys-4cch.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(sysinfo): track pagefile-volume free disk + warn when a system-managed page file can't grow

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -80,6 +80,8 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
     "Win32_System_ProcessStatus",
     "Win32_System_SystemInformation",
+    "Win32_System_Registry",
+    "Win32_Storage_FileSystem",
 ] }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -88,6 +88,282 @@ pub fn available_commit_gb() -> Option<f64> {
     None
 }
 
+// ── SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 ────────────────────────
+// "Track free disk on the pagefile volume, not just avail_page_gb. Warn when
+// free disk < ~15% and page file is system-managed." The existing commit
+// gauge above only sees the SYMPTOM (commit near limit); it is blind to the
+// CAUSE this spec found: a system-managed page file wants to grow toward
+// min(3×RAM, ⅛ volume) but silently cannot if the volume it lives on doesn't
+// have the free space, pinning the commit ceiling well below what every
+// other gauge assumes. This makes the cause itself visible.
+
+/// One `PagingFiles` registry entry
+/// (`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management`),
+/// parsed from its `"<path> <initial_mb> <maximum_mb>"` string form. Per
+/// [Microsoft's documented format](https://learn.microsoft.com/en-us/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size-for-64-bit-versions-of-windows):
+/// `initial_mb == 0 && maximum_mb == 0` means "system managed" (auto-grow)
+/// for that specific pagefile.
+#[derive(Debug, Clone, PartialEq)]
+struct PagingFileEntry {
+    /// Drive letter the pagefile lives on, uppercased, e.g. `"C"`. `None` if
+    /// the path couldn't be parsed as `<letter>:\...` (UNC path, malformed).
+    drive_letter: Option<char>,
+    system_managed: bool,
+}
+
+/// Parse one raw `"<path> <initial_mb> <maximum_mb>"` line from the
+/// `PagingFiles` REG_MULTI_SZ value. Tolerant of the format's use of `??`
+/// instead of a drive letter for some `\\?\Volume{guid}\` forms — those
+/// yield `drive_letter: None` rather than erroring, since a pure parser
+/// should never fail on a value the OS itself produced.
+fn parse_paging_file_entry(line: &str) -> Option<PagingFileEntry> {
+    let mut parts = line.split_whitespace();
+    let path = parts.next()?;
+    let initial: u64 = parts.next()?.parse().ok()?;
+    let maximum: u64 = parts.next()?.parse().ok()?;
+    let drive_letter = path
+        .chars()
+        .next()
+        .filter(|c| c.is_ascii_alphabetic())
+        .map(|c| c.to_ascii_uppercase());
+    Some(PagingFileEntry {
+        drive_letter,
+        system_managed: initial == 0 && maximum == 0,
+    })
+}
+
+/// Decide which volume to watch and whether it's at risk of a stuck
+/// (non-growing) page file, from the parsed `PagingFiles` entries.
+///
+/// - **Empty list** (the common default): Windows fully automatically
+///   manages a single pagefile's size AND location — not expressed as any
+///   registry entry at all. Falls back to `system_drive` as the practical
+///   answer (where CEF/the OS itself lives; the overwhelmingly likely
+///   pagefile location in this configuration) — `system_managed: true`.
+/// - **Has entries**: watch the first volume with a `system_managed: true`
+///   entry (the volume that can actually run out of the growth room this
+///   spec is about). If every entry is fixed-size, no volume is at growth
+///   risk from disk space — report `system_managed: false` on
+///   `system_drive` for visibility, but the frontend must not apply the
+///   "can't grow" risk framing to a fixed-size pagefile.
+fn resolve_pagefile_watch_target(entries: &[PagingFileEntry], system_drive: char) -> (char, bool) {
+    if entries.is_empty() {
+        return (system_drive, true);
+    }
+    for e in entries {
+        if e.system_managed {
+            return (e.drive_letter.unwrap_or(system_drive), true);
+        }
+    }
+    (system_drive, false)
+}
+
+/// Read `PagingFiles` and split it into entries. Non-Windows / read failure
+/// returns an empty vec (caller's `resolve_pagefile_watch_target` then
+/// degrades to "watch the system drive as if system-managed" — the correct
+/// fail-open default: assume the common case rather than silently reporting
+/// nothing).
+#[cfg(target_os = "windows")]
+fn read_paging_files_registry() -> Vec<PagingFileEntry> {
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ,
+        REG_MULTI_SZ,
+    };
+
+    let subkey: Vec<u16> =
+        "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\0"
+            .encode_utf16()
+            .collect();
+    let value_name: Vec<u16> = "PagingFiles\0".encode_utf16().collect();
+
+    unsafe {
+        let mut hkey: HKEY = std::ptr::null_mut();
+        if RegOpenKeyExW(HKEY_LOCAL_MACHINE, subkey.as_ptr(), 0, KEY_READ, &mut hkey) as u32
+            != ERROR_SUCCESS
+        {
+            return Vec::new();
+        }
+
+        let mut buf_bytes: u32 = 0;
+        let mut value_type: u32 = 0;
+        let query1 = RegQueryValueExW(
+            hkey,
+            value_name.as_ptr(),
+            std::ptr::null(),
+            &mut value_type,
+            std::ptr::null_mut(),
+            &mut buf_bytes,
+        );
+        if query1 as u32 != ERROR_SUCCESS || value_type != REG_MULTI_SZ || buf_bytes == 0 {
+            RegCloseKey(hkey);
+            return Vec::new();
+        }
+
+        let mut buf: Vec<u16> = vec![0u16; buf_bytes as usize / 2];
+        let query2 = RegQueryValueExW(
+            hkey,
+            value_name.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            buf.as_mut_ptr() as *mut u8,
+            &mut buf_bytes,
+        );
+        RegCloseKey(hkey);
+        if query2 as u32 != ERROR_SUCCESS {
+            return Vec::new();
+        }
+
+        // REG_MULTI_SZ: NUL-separated strings, terminated by a double NUL.
+        buf.split(|&c| c == 0)
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| parse_paging_file_entry(&String::from_utf16_lossy(s)))
+            .collect()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn read_paging_files_registry() -> Vec<PagingFileEntry> {
+    Vec::new()
+}
+
+/// Free/total space (GB) for a drive letter, e.g. `'C'`. Windows-only;
+/// returns `None` on any failure (drive not found, API error) so callers
+/// degrade to "no data" rather than a wrong number.
+#[cfg(target_os = "windows")]
+fn drive_free_total_gb(drive_letter: char) -> Option<(f64, f64)> {
+    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+    let root: Vec<u16> = format!("{}:\\\0", drive_letter).encode_utf16().collect();
+    let mut free_available: u64 = 0;
+    let mut total: u64 = 0;
+    let ok = unsafe {
+        GetDiskFreeSpaceExW(
+            root.as_ptr(),
+            &mut free_available,
+            &mut total,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    Some((
+        free_available as f64 / BYTES_PER_GB,
+        total as f64 / BYTES_PER_GB,
+    ))
+}
+
+/// The `(drive_letter, system_managed)` pagefile watch target, resolved
+/// once per process lifetime. `PagingFiles` is machine configuration that
+/// requires a reboot to take effect — re-reading the registry every
+/// sysinfo tick (default 1 Hz) would be pure waste. Free disk space, by
+/// contrast, genuinely changes during a session and is re-read every tick
+/// in `get_pagefile_volume_data`.
+#[cfg(target_os = "windows")]
+fn pagefile_watch_target() -> (char, bool) {
+    static TARGET: std::sync::OnceLock<(char, bool)> = std::sync::OnceLock::new();
+    *TARGET.get_or_init(|| {
+        let system_drive = std::env::var("SystemDrive")
+            .ok()
+            .and_then(|s| s.chars().next())
+            .map(|c| c.to_ascii_uppercase())
+            .unwrap_or('C');
+        let entries = read_paging_files_registry();
+        resolve_pagefile_watch_target(&entries, system_drive)
+    })
+}
+
+/// Collect pagefile-volume disk tracking: `disk:pagefile_volume:free_gb`,
+/// `:total_gb`, `:free_pct`, and `disk:pagefile_system_managed` (1.0/0.0).
+/// No-op (keys absent) on non-Windows or any read failure — matches
+/// `get_commit_data`'s fail-open convention.
+fn get_pagefile_volume_data(_values: &mut HashMap<String, f64>) {
+    #[cfg(target_os = "windows")]
+    {
+        let (drive, system_managed) = pagefile_watch_target();
+        if let Some((free_gb, total_gb)) = drive_free_total_gb(drive) {
+            _values.insert("disk:pagefile_volume:free_gb".to_string(), free_gb);
+            _values.insert("disk:pagefile_volume:total_gb".to_string(), total_gb);
+            if total_gb > 0.0 {
+                _values.insert(
+                    "disk:pagefile_volume:free_pct".to_string(),
+                    (free_gb / total_gb) * 100.0,
+                );
+            }
+            _values.insert(
+                "disk:pagefile_system_managed".to_string(),
+                if system_managed { 1.0 } else { 0.0 },
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod pagefile_volume_tests {
+    use super::*;
+
+    #[test]
+    fn parses_system_managed_entry() {
+        let e = parse_paging_file_entry("C:\\pagefile.sys 0 0").unwrap();
+        assert_eq!(e.drive_letter, Some('C'));
+        assert!(e.system_managed);
+    }
+
+    #[test]
+    fn parses_fixed_size_entry() {
+        let e = parse_paging_file_entry("D:\\pagefile.sys 4096 8192").unwrap();
+        assert_eq!(e.drive_letter, Some('D'));
+        assert!(!e.system_managed);
+    }
+
+    #[test]
+    fn lowercases_drive_letter_normalized_to_upper() {
+        // Windows can report either case; the registry doesn't enforce one.
+        let e = parse_paging_file_entry("c:\\pagefile.sys 0 0").unwrap();
+        assert_eq!(e.drive_letter, Some('C'));
+    }
+
+    #[test]
+    fn malformed_line_returns_none() {
+        assert!(parse_paging_file_entry("").is_none());
+        assert!(parse_paging_file_entry("C:\\pagefile.sys").is_none());
+        assert!(parse_paging_file_entry("C:\\pagefile.sys notanumber 0").is_none());
+    }
+
+    #[test]
+    fn empty_entries_falls_back_to_system_drive_as_managed() {
+        // The common default: no explicit PagingFiles entries at all means
+        // Windows fully auto-manages a single pagefile — not expressed as a
+        // registry entry, so an empty list must NOT be read as "no pagefile
+        // risk" (the opposite of the truth).
+        let (drive, managed) = resolve_pagefile_watch_target(&[], 'C');
+        assert_eq!(drive, 'C');
+        assert!(managed);
+    }
+
+    #[test]
+    fn watches_the_first_system_managed_volume() {
+        let entries = vec![
+            PagingFileEntry { drive_letter: Some('D'), system_managed: false },
+            PagingFileEntry { drive_letter: Some('E'), system_managed: true },
+        ];
+        let (drive, managed) = resolve_pagefile_watch_target(&entries, 'C');
+        assert_eq!(drive, 'E');
+        assert!(managed);
+    }
+
+    #[test]
+    fn all_fixed_size_reports_not_managed_on_system_drive() {
+        // No volume is at "can't grow" risk — but we still surface a
+        // number (system drive) for visibility, correctly flagged as not
+        // subject to this specific risk.
+        let entries = vec![PagingFileEntry { drive_letter: Some('D'), system_managed: false }];
+        let (drive, managed) = resolve_pagefile_watch_target(&entries, 'C');
+        assert_eq!(drive, 'C');
+        assert!(!managed);
+    }
+}
+
 /// Network I/O tracking state for rate calculations.
 struct NetState {
     prev_sent: u64,
@@ -209,6 +485,7 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
         get_cpu_data(&sys, &mut values);
         get_mem_data(&sys, &mut values);
         get_commit_data(&mut values);
+        get_pagefile_volume_data(&mut values);
         net_state.get_net_data(&networks, &mut values);
         get_disk_data(&disks, elapsed_secs, &mut values);
 

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -470,22 +470,30 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
         // /proc reads; block_in_place signals the Tokio runtime to keep
         // other tasks (including terminal echo) running on other threads
         // while this thread is occupied — preventing 1Hz echo starvation.
+        //
+        // `get_pagefile_volume_data`'s `GetDiskFreeSpaceExW` call (reagent
+        // P1, PR #2109) is a synchronous Win32 disk I/O syscall — the exact
+        // hazard this block exists to isolate, unlike `get_commit_data`'s
+        // `GlobalMemoryStatusEx` (pure in-memory, no filesystem driver
+        // involved) — so its result is computed here too, alongside the
+        // other blocking OS reads, not in the async section below.
+        let mut pagefile_values = HashMap::new();
         tokio::task::block_in_place(|| {
             sys.refresh_cpu_usage();
             sys.refresh_memory();
             networks.refresh(true);
             disks.refresh(true);
+            get_pagefile_volume_data(&mut pagefile_values);
         });
 
         let now_instant = Instant::now();
         let elapsed_secs = now_instant.duration_since(last_tick).as_secs_f64();
         last_tick = now_instant;
 
-        let mut values = HashMap::new();
+        let mut values = pagefile_values;
         get_cpu_data(&sys, &mut values);
         get_mem_data(&sys, &mut values);
         get_commit_data(&mut values);
-        get_pagefile_volume_data(&mut values);
         net_state.get_net_data(&networks, &mut values);
         get_disk_data(&disks, elapsed_secs, &mut values);
 

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -122,6 +122,10 @@
         min-width: 16ch; // fits "PF 99.9G/99.9G"
     }
 
+    .stat-pagefile-disk {
+        min-width: 8ch; // fits "Disk 99%"
+    }
+
     .stat-disk {
         min-width: 12ch; // fits "R999M W999M"
     }

--- a/frontend/app/statusbar/SystemStats.tsx
+++ b/frontend/app/statusbar/SystemStats.tsx
@@ -19,6 +19,9 @@ type SysStats = {
     diskWrite: number;
     netSent: number;
     netRecv: number;
+    pagefileVolumeFreeGb: number | null;
+    pagefileVolumeFreePct: number | null;
+    pagefileSystemManaged: boolean;
 };
 
 function formatMemBytes(gb: number): string {
@@ -46,6 +49,25 @@ function commitColor(used: number, total: number): string {
     const ratio = used / total;
     if (ratio > 0.95) return "var(--error-color)";
     if (ratio > 0.85) return "var(--warning-color)";
+    return "var(--secondary-text-color)";
+}
+
+// SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 — the commit gauge above
+// only sees the SYMPTOM (commit near limit); it's blind to the CAUSE this
+// spec found: a system-managed page file wants to auto-grow toward
+// min(3×RAM, ⅛ volume) but silently can't if the volume it lives on is low
+// on free space, pinning the commit ceiling below what every other gauge
+// assumes. Thresholds match the spec's own numbers: <15% free is its
+// documented "crash risk" line; <8% is the free-space level the spec's
+// source incident actually crashed at (20.1 GB / 446 GB ≈ 4.5%, but 8% is
+// used here as a slightly less alarmist error line — the spec's own
+// worked example put "safe again" at ≥60-80 GB free on a ~450 GB volume,
+// i.e. ~13-18%, so 15%/8% brackets warning vs. already-in-the-danger-zone).
+// A FIXED-size page file isn't gated by free disk this way — never colored.
+function pagefileDiskColor(freePct: number | null, systemManaged: boolean): string {
+    if (freePct == null || !systemManaged) return "var(--secondary-text-color)";
+    if (freePct < 8) return "var(--error-color)";
+    if (freePct < 15) return "var(--warning-color)";
     return "var(--secondary-text-color)";
 }
 
@@ -108,6 +130,9 @@ const SystemStats = (): JSX.Element => {
                     diskWrite: vals["disk:write"] ?? 0,
                     netSent: vals["net:bytessent"] ?? 0,
                     netRecv: vals["net:bytesrecv"] ?? 0,
+                    pagefileVolumeFreeGb: vals["disk:pagefile_volume:free_gb"] ?? null,
+                    pagefileVolumeFreePct: vals["disk:pagefile_volume:free_pct"] ?? null,
+                    pagefileSystemManaged: (vals["disk:pagefile_system_managed"] ?? 0) > 0,
                 });
             },
         });
@@ -168,6 +193,27 @@ const SystemStats = (): JSX.Element => {
                             aria-label="Commit charge"
                         >
                             PF {formatMemBytes(s().commitUsed)}/{formatMemBytes(s().commitTotal)}
+                        </span>
+                    </Show>
+                    {/* SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 §5.2 P0 — surfaces the
+                        CAUSE the PF gauge above can't see: a system-managed page file
+                        that wants to grow but can't because its volume is low on free
+                        space. Only rendered once the backend has a reading (Windows-only
+                        gauge; absent elsewhere). */}
+                    <Show when={s().pagefileVolumeFreePct != null}>
+                        <span class="stat-separator">|</span>
+                        <span
+                            class="stat-mono stat-pagefile-disk"
+                            style={{ color: pagefileDiskColor(s().pagefileVolumeFreePct, s().pagefileSystemManaged) }}
+                            data-tip={
+                                (s().pagefileSystemManaged
+                                    ? "Free space on the page-file volume. Low free space can silently cap how large Windows lets the page file (and therefore the commit limit above) grow. "
+                                    : "Free space on the page-file volume. The page file here is a fixed size, so this isn't a growth-ceiling risk. ") +
+                                (s().pagefileVolumeFreeGb != null ? `${formatMemBytes(s().pagefileVolumeFreeGb!)} free.` : "")
+                            }
+                            aria-label="Page-file volume free disk space"
+                        >
+                            Disk {Math.round(s().pagefileVolumeFreePct!)}%
                         </span>
                     </Show>
                     {/* Network indicator stays mounted even at 0/0 so the user


### PR DESCRIPTION
Implements P0 item 1 of `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md` §5.2 (task #10's cross-reference).

## The gap

The existing commit gauge (`mem:commit:used/total`, StatusBar `PF x/y`) only sees the **symptom** the spec's regression produces: commit near its limit. It's blind to the **cause**: a system-managed page file wants to auto-grow toward `min(3×RAM, ⅛ volume)` but silently can't if the volume it lives on doesn't have the free space, pinning the real commit ceiling well below what the RAM figure alone suggests — invisible to every existing gauge.

## What

- **`agentmux-srv/src/backend/sysinfo.rs`**: new `get_pagefile_volume_data`, emitting `disk:pagefile_volume:{free_gb,total_gb,free_pct}` and `disk:pagefile_system_managed`. Resolves which volume to watch by parsing the `PagingFiles` registry value — `initial=0 && maximum=0` means "system managed" per Microsoft's documented format; an **empty** value (the common default) means Windows fully auto-manages a single pagefile on the system drive, so that case is correctly treated as system-managed rather than "no data" (a naive reading would get this backwards). Registry read is memoized for the process lifetime (machine config, needs a reboot to change); free disk space is re-read every tick since it genuinely moves during a session. 7 unit tests on the pure parsing/resolution logic.
- **`frontend/app/statusbar/SystemStats.tsx`**: new `"Disk NN%"` stat beside the existing `PF` gauge. Colored using the spec's own numbers (**<15% free = warning, <8% = error**) **only** when the page file is system-managed — a fixed-size page file isn't gated by free disk this way, so it's never flagged as at-risk. Tooltip explains the mechanism and shows the free-space figure in GB.

## Verification

Live on a packaged build, against **this machine's actual current disk state**: `df` showed 20G/447G free (~4.5%); the UI rendered **"Disk 4%" in error-red**, tooltip `"...19.4G free"` — matching exactly, and correctly surfacing the live risk condition the spec set out to make visible. Neighboring `PF`/`Mem` gauges unaffected (no regression). `cargo test -p agentmux-srv`: 1487 passed (7 new). `npx vitest run`: 1684 passed.

## Scope note

This is P0 item 1 of the spec's 3-item P0 list. Item 2 (confirm `0xE0000008` is caught by gated recovery) turned out to already be fully covered by existing code on inspection — both the renderer-level path (`crash_recovery.rs`'s dedicated `PROCESS_OOM` → memory-paused page, #1229) and the host-level path (`mem_supervisor::classify_host_exit` explicitly matching `CHROMIUM_OOM_EXIT_CODE = 0xE000_0008`) — no code change needed there. Item 3 (commit-aware turn scheduler re-derived from `PrivateUsage`) and the P1 items (log rotation, shut-down-old-version-on-upgrade) remain open follow-ups.

<!-- agentmux:agent_id=agenta -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)