### PR TITLE
fix(ui): pane minimize icon uses horizontal-bar convention, Armory action uses vault icon

### DIFF
--- a/.changesets/1783865355-fix-ui-pane-minimize-icon-uses-horizontal-bar-convention-arm-ycin.md
+++ b/.changesets/1783865355-fix-ui-pane-minimize-icon-uses-horizontal-bar-convention-arm-ycin.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): pane minimize icon uses horizontal-bar convention, Armory action uses vault icon

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -166,9 +166,13 @@ function getViewIconElem(viewIconUnion: string | IconButtonDecl, blockData: Bloc
 }
 
 function OptMinimizeButton(props: { minimized: boolean; toggleMinimize: () => void }): JSX.Element {
+    // OS-window minimize convention (a horizontal bar), matching the sibling
+    // OptMagnifyButton's window-maximize/window-restore pairing just below —
+    // the previous chevron-up/chevron-down pair read as a dropdown toggle
+    // rather than a minimize control.
     const decl = createMemo<IconButtonDecl>(() => ({
         elemtype: "iconbutton",
-        icon: props.minimized ? "chevron-up" : "chevron-down",
+        icon: props.minimized ? "window-restore" : "window-minimize",
         title: props.minimized ? "Restore" : "Minimize",
         click: props.toggleMinimize,
     }));

--- a/frontend/app/view/agent/components/PaneRow.tsx
+++ b/frontend/app/view/agent/components/PaneRow.tsx
@@ -17,6 +17,7 @@
 
 import clsx from "clsx";
 import { For, Show, type JSX } from "solid-js";
+import { makeIconClass } from "@/util/util";
 import "./PaneRow.scss";
 
 /** Status accent — drives the 3px left-border colour (and dim for terminal). */
@@ -30,8 +31,13 @@ export type PaneRowAccent =
     | "neutral";
 
 export interface PaneRowAction {
-    /** Single-glyph button label (e.g. "■" stop, "×" dismiss, "⌫" close). */
-    glyph: string;
+    /** Single-glyph button label (e.g. "■" stop, "×" dismiss, "⌫" close).
+     *  Ignored when `icon` is set. */
+    glyph?: string;
+    /** FontAwesome icon key (e.g. "vault") — takes precedence over `glyph`
+     *  when set, for actions that need to visually match an icon used
+     *  elsewhere (e.g. the widget bar) rather than an emoji approximation. */
+    icon?: string;
     /** Optional text rendered after the glyph (e.g. "Retry now", "Login Again").
      *  Turns the icon button into a labelled button for action-heavy rows like
      *  the failure-recovery row. */
@@ -99,7 +105,12 @@ export const PaneRow = (props: PaneRowProps): JSX.Element => {
                             // stopPropagation so an action never also fires onActivate.
                             onClick={(e) => { e.stopPropagation(); action.onClick(); }}
                         >
-                            <span aria-hidden="true">{action.glyph}</span>
+                            <Show
+                                when={action.icon}
+                                fallback={<span aria-hidden="true">{action.glyph}</span>}
+                            >
+                                {(icon) => <i class={makeIconClass(icon(), true)} aria-hidden="true" />}
+                            </Show>
                             <Show when={action.label}>
                                 <span class="pane-row-action-text">{action.label}</span>
                             </Show>

--- a/frontend/app/view/agent/failure/failure-accessory.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.ts
@@ -101,7 +101,10 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
         disabled: view.retrying, onClick: on.retry,
     };
     const trustCenter: PaneRowAction = {
-        glyph: "⚙", label: "Armory → Accounts", title: "Open Armory → Accounts", onClick: on.trustCenter,
+        // Same "vault" FontAwesome icon as the widget bar's Armory entry
+        // (agentmux-srv/src/config/widgets.json) and the hamburger menu's
+        // Armory item, instead of a generic gear emoji.
+        icon: "vault", label: "Armory → Accounts", title: "Open Armory → Accounts", onClick: on.trustCenter,
     };
 
     const actions: PaneRowAction[] = [];
@@ -128,7 +131,10 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
             actions.push({ ...trustCenter, label: "Armory (switch / upgrade)", primary: true });
             break;
         case "spawn_failure":
-            actions.push({ ...trustCenter, glyph: "🧩", label: "Provider setup", title: "Fix the provider install", primary: true });
+            // Clear `icon` — this isn't an Armory action, so it must NOT
+            // inherit trustCenter's vault icon (icon takes precedence over
+            // glyph in PaneRow's render).
+            actions.push({ ...trustCenter, icon: undefined, glyph: "🧩", label: "Provider setup", title: "Fix the provider install", primary: true });
             break;
         case "rate_limited":
         case "overloaded":


### PR DESCRIPTION
## Summary

Two small pane-header icon fixes:

1. **Minimize button** (`frontend/app/block/blockframe.tsx`'s `OptMinimizeButton`) used `chevron-up`/`chevron-down`, which reads as a dropdown toggle rather than a minimize control. Switched to `window-minimize`/`window-restore` — the OS-window horizontal-bar convention, and a direct mirror of the sibling `OptMagnifyButton`'s `window-maximize`/`window-restore` pairing right below it.

2. **Agent pane's "Armory → Accounts" failure-recovery action** (`frontend/app/view/agent/failure/failure-accessory.ts`) used a generic ⚙ gear emoji. `PaneRowAction` (`PaneRow.tsx`) now supports an optional FontAwesome `icon` field that takes precedence over the emoji `glyph` when set, so this action can use the same `"vault"` icon as the widget bar's Armory entry (`agentmux-srv/src/config/widgets.json`) and the hamburger menu's Armory item, instead of an emoji approximation. Every other `PaneRowAction` in the codebase is untouched (still glyph-only); the `spawn_failure` case that spreads `trustCenter` and overrides to a different glyph explicitly clears `icon` so it doesn't silently inherit the vault icon.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run frontend/app/view/agent frontend/app/block` — 56 test files / 704 tests passing
- [x] Confirmed `fa-window-minimize`/`fa-window-restore`/`fa-window-maximize` exist in the bundled `public/fontawesome/css/fontawesome.min.css`

<!-- agentmux:agent_id=agentx -->