### PR TITLE
fix(window): bind label->HWND at Views creation time, close reproject drag cross-wire

### DIFF
--- a/.changesets/1783884787-fix-window-bind-label-hwnd-at-views-creation-time-close-repr-jyyw.md
+++ b/.changesets/1783884787-fix-window-bind-label-hwnd-at-views-creation-time-close-repr-jyyw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): bind label->HWND at Views creation time, close reproject drag cross-wire

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -75,18 +75,48 @@ wrap_window_delegate! {
                 window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
             }
 
-            // Windows: hide pool windows from the taskbar at creation time.
-            // CefWindow::GetWindowHandle() is reliable here; BrowserHost::
-            // window_handle() (used in register_pool_window / on_after_created)
-            // can return null after the page loads — see window_pool.rs
-            // POOL_HWND_CACHE comment for the diagnosed CEF behaviour.
-            // This early call also pre-populates the HWND cache so
-            // promote_pool_window works even when on_after_created's
-            // BrowserHost lookup returns null.
+            // Windows: bind (label, HWND) into state.window_hwnds right here,
+            // at Views window-creation time — CefWindow::GetWindowHandle() is
+            // reliable at this exact synchronous callback (BrowserHost::
+            // window_handle(), used by capture_hwnd_for_label's fast path,
+            // frequently returns null in CEF Views mode and can go null again
+            // after the page loads — see window_pool.rs POOL_HWND_CACHE
+            // comment for the diagnosed CEF behaviour).
+            //
+            // This closes the crash-reproject HWND cross-wire race
+            // (docs/retro/retro-reproject-drag-hwnd-crosswire-2026-07-12.md):
+            // capture_hwnd_for_label's EnumWindows fallback picks "whichever
+            // of our own visible-but-unclaimed HWNDs comes first," which is
+            // only safe if windows are created one at a time — reproject's
+            // rapid back-to-back CreateWindowTask posts violate that, and two
+            // windows' fallbacks can cross-wire which label owns which HWND
+            // (a mis-binding that then latches permanently, since it passes
+            // the cache's own IsWindow liveness check on every later read).
+            // The CEF UI thread runs on_window_created for one window fully
+            // to completion before the next queued CreateWindowTask begins,
+            // so binding here — before either window's renderer has even
+            // started loading, let alone signalled "ready" — is race-free by
+            // construction. Mirrors the same pattern already proven for
+            // floating panes (floating_pane.rs's CreateFloatingWindowTask
+            // inserts into window_hwnds immediately after CreateWindowExW,
+            // before the browser is embedded).
+            //
+            // capture_hwnd_for_label's own "already registered" guard means
+            // it now becomes a no-op for every window that goes through this
+            // path; its EnumWindows fallback remains only as a defensive
+            // last resort for any exotic caller that doesn't carry a
+            // window_registration.
             #[cfg(target_os = "windows")]
-            if let Some((_, label)) = self.window_registration.as_ref() {
+            if let Some((state, label)) = self.window_registration.as_ref() {
+                let raw_hwnd = window.window_handle().0 as *mut std::ffi::c_void;
+                if !raw_hwnd.is_null() {
+                    state.window_hwnds.lock().insert(label.clone(), raw_hwnd as isize);
+                }
+
+                // Pool windows additionally need the taskbar-hiding /
+                // promote-time bookkeeping below — unrelated to the
+                // window_hwnds bind above, kept as its own branch.
                 if label.starts_with("window-pool-") {
-                    let raw_hwnd = window.window_handle().0 as *mut std::ffi::c_void;
                     if !raw_hwnd.is_null() {
                         crate::commands::window_pool::init_pool_window_hwnd(label, raw_hwnd);
                     }

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -393,8 +393,11 @@ pub fn resolve_window_at_cursor(
                             //
                             // window_hwnds maps this HWND to a `window-pool-*`
                             // label (inserted at Views window-creation time,
-                            // in on_window_created — before promote, and
-                            // never rewritten by promote itself). Two different windows
+                            // in on_window_created, well before promote;
+                            // promote's own window_hwnds insert in
+                            // window_pool.rs re-affirms the SAME (label,
+                            // hwnd) pair rather than repointing the label at
+                            // a different window). Two different windows
                             // wear a pool label, and they need OPPOSITE answers:
                             //
                             //  - A genuine promoted SECONDARY keeps its pool label

--- a/agentmux-cef/src/commands/window/motion.rs
+++ b/agentmux-cef/src/commands/window/motion.rs
@@ -392,7 +392,9 @@ pub fn resolve_window_at_cursor(
                             // uses for this HWND.
                             //
                             // window_hwnds maps this HWND to a `window-pool-*`
-                            // label (inserted at promote). Two different windows
+                            // label (inserted at Views window-creation time,
+                            // in on_window_created — before promote, and
+                            // never rewritten by promote itself). Two different windows
                             // wear a pool label, and they need OPPOSITE answers:
                             //
                             //  - A genuine promoted SECONDARY keeps its pool label

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -1155,14 +1155,17 @@ pub fn promote_pool_window(
     // Register the promoted window's outer top-level HWND under its label in the
     // chrome-resolution cache (`window_hwnds`) so the new window's title-bar
     // DRAG / CLOSE / MINIMIZE / MAXIMIZE act on THIS window. Pool windows
-    // otherwise never land in `window_hwnds`: `capture_hwnd_for_label` reads
-    // `host.window_handle()`, which is null for pool windows
-    // (SPEC_POOL_WINDOW_HWND_NULL), so `resolve_window_hwnd` fell back to
-    // `find_own_top_level_window()` (the MAIN window) — which is why dragging the
-    // new window's header moved the original, and close/maximize would hit the
-    // wrong window. `raw_hwnd` is the CefWindow top-level handle (already the
-    // outer HWND), so store it directly; this also overwrites any stale entry
-    // pointing at the off-screen pre-promote pool window.
+    // already land in `window_hwnds` at Views window-creation time
+    // (`AgentMuxWindowDelegate::on_window_created`, widened in the
+    // reproject-drag-hwnd-crosswire fix to cover every registered label,
+    // not just non-pool ones) — this insert is a defensive re-affirmation,
+    // not the sole source of truth it once was. It still matters: it's what
+    // keeps this path correct if that entry was ever evicted between
+    // creation and promote (e.g. a stale-HWND eviction from
+    // `resolve_window_hwnd`'s `IsWindow` liveness check), and it overwrites
+    // any leftover entry pointing at the off-screen pre-promote pool window.
+    // `raw_hwnd` is the CefWindow top-level handle (already the outer HWND),
+    // so store it directly.
     state
         .window_hwnds
         .lock()

--- a/docs/retro/retro-reproject-drag-hwnd-crosswire-2026-07-12.md
+++ b/docs/retro/retro-reproject-drag-hwnd-crosswire-2026-07-12.md
@@ -1,0 +1,162 @@
+# Retro: dragging Window 2 moves Window 3 (HWND cross-wire after crash-reproject)
+
+2026-07-12. Reported live, mid-session, on v0.53.2: 3 windows open at start
+(main + 2 recreated windows). Dragging the second window by its title bar
+visibly moved the third window instead.
+
+## Investigation (read-only, against the live instance — nothing killed or modified)
+
+- `tasklist` found the live host, PID 1896, single process for all 3 windows.
+- CDP target list (`node .verify_step4p2_cdp.mjs 9222 --list`) showed **both**
+  non-main windows' boot URLs carry `&restoring=1` — i.e. both came from
+  **crash-reproject**, not a cold boot. This immediately narrowed the search
+  to the reproject code path (`SPEC_PILLAR1_HOST_REPROJECT_DESIGN`).
+- `window.api.listWindowInstances()` gave the host's own label↔windowId
+  bookkeeping for the two extra windows.
+- Ground truth via an inline PowerShell/C# `EnumWindows` probe (real HWND,
+  PID, rect, title) confirmed all 3 windows share one process and gave the
+  authoritative title↔label↔HWND table:
+
+  | Title | Label | HWND |
+  |---|---|---|
+  | Window 2 | `window-cc3cae59856d426c94057731952c8fa7` | `66866` |
+  | Window 3 | `window-fbc0dc2faa5a4dd2bc52b0fd78a09bcf` | `66870` |
+
+- Read `frontend/app/hook/useWindowDrag.win32.ts` in full. The native drag
+  path (default) is a single fire-and-forget `start_window_drag` IPC per
+  drag gesture, carrying `label: ownWindowLabel()` — and `ownWindowLabel()`
+  reads `windowLabel` from **that renderer's own URL**. Each renderer can
+  only ever report its own, correct label. **The frontend cannot be the
+  source of a cross-window mixup here** — this pointed the investigation
+  entirely at the host's label→HWND resolution.
+- Read the host handler, `commands::window::motion::start_window_drag`
+  (`agentmux-cef/src/commands/window/motion.rs:220`): resolves
+  `resolve_window_hwnd(state, label)`, falls back to
+  `find_own_top_level_window()` if that's null, then drives a manual
+  Win32 move loop on whatever HWND it got.
+- Read `resolve_window_hwnd` (`agentmux-cef/src/commands/window/lifecycle.rs:311`):
+  step 1 is a `state.window_hwnds` cache lookup (label → HWND) — this is
+  the authoritative source when populated correctly.
+- Read `capture_hwnd_for_label` (`lifecycle.rs:493`), the function that
+  populates that cache. This is where the bug lives.
+
+## Root cause
+
+`capture_hwnd_for_label(state, label)` runs once per window, triggered by
+that window's own `set_window_init_status { status: "ready", label }` IPC
+call (`commands/backend.rs:369`) — i.e. independently, per-renderer, with
+**no ordering barrier between windows**.
+
+Its fast path (`browser.host().window_handle()`) is frequently NULL in CEF
+Views mode at this point (the function's own doc comment: *"may be non-NULL
+by this point even in CEF Views mode"* — an admission it often isn't). When
+the fast path misses, it falls back to:
+
+```rust
+// Fallback: pick the first eligible visible HWND not already mapped.
+let known: HashSet<isize> = state.window_hwnds.lock().values().cloned().collect();
+for hwnd_raw in find_all_own_windows() {
+    if known.contains(&raw) { continue; }
+    ...
+    state.window_hwnds.lock().insert(label.to_string(), raw);
+    return;
+}
+```
+
+This picks **whichever visible top-level HWND of this process isn't yet
+claimed**, in `EnumWindows` (Z-order) enumeration order — not the HWND that
+actually belongs to `label`. The function's own comment states the
+correctness assumption plainly: *"Reliable because windows are opened
+sequentially (pool windows are hidden before promotion)."* That assumption
+holds for ordinary, one-at-a-time window creation. It does **not** hold when
+two windows are created back-to-back and both reach their fallback path
+before either has registered.
+
+Crash-reproject is exactly that scenario. `reproject_from_snapshot`
+(`agentmux-cef/src/commands/window/creation.rs:503`) loops over every
+snapshotted window and calls `open_window_with_kind` synchronously in a
+tight `for` loop; each call does nothing but **post** a `CreateWindowTask`
+to the UI thread (fire-and-forget — the surrounding code's own comment: *"Ok
+here means only that a CreateWindowTask was successfully POSTED... not that
+the window actually exists yet"*). So for a 2-window reproject, both
+`CreateWindowTask`s land on the UI thread's queue within the same tight
+loop, both windows come into existence within milliseconds of each other,
+and both renderers can plausibly finish loading and fire their own
+`ready` IPC within the same short window. When that happens:
+
+1. Window 2's `capture_hwnd_for_label` fast path misses, calls
+   `find_all_own_windows()`. At that instant window 3's HWND may already be
+   visible but not yet claimed. It picks *whichever HWND `EnumWindows`
+   yields first* — which, by Z-order, has no guaranteed relationship to
+   "the window whose renderer just signalled ready."
+2. Window 3's `capture_hwnd_for_label` runs moments later, same fallback,
+   and claims whatever's left.
+3. Depending on timing, label↔HWND gets crossed: `window_hwnds["window-cc..."]`
+   (Window 2's label) ends up holding Window 3's real HWND, or vice versa.
+4. Every subsequent `resolve_window_hwnd(state, "window-cc...")` call
+   returns the wrong (cached, "validated" via `IsWindow`) HWND forever —
+   this isn't a one-off glitch, it latches. Dragging "Window 2" from then on
+   moves Window 3, consistently, exactly as reported.
+
+This is the *same bug class* the codebase has already named and partially
+defended against elsewhere — `find_own_top_level_window`'s own doc comment
+calls it *"the root of the recurring 'wrong window' bug class (#1165, #1166,
+the 2026-05-30 browser-pane parent bug)"*, and `resolve_window_hwnd_strict`
+exists specifically because the EnumWindows-fallback family is unsafe
+whenever more than one top-level window can plausibly match. `capture_hwnd_for_label`'s
+fallback is a sibling of that same family, exercised at window-creation time
+instead of window-action time — and it wasn't hardened the same way,
+because until crash-reproject existed, multiple windows being created
+close enough together to race it was rare (normal multi-window sessions are
+opened one drag/click at a time, by a human, seconds apart).
+
+## Would tonight's architecture work have fixed this?
+
+**No.** Everything shipped tonight — the crash-reproject fast/slow-path
+mechanism itself (Pillar 1 Step 4), the `Client.windowids` leak-class fixes,
+pool adoption, srv recycle-on-crash, the UI-thread liveness probe — operates
+on **backend window-id bookkeeping** (srv rows, `Client.windowids`,
+label_remap for parent/child relationships) or **process-level supervision**
+(host/srv liveness). None of it touches `window_hwnds`/`capture_hwnd_for_label`,
+which is purely an **in-process, host-local Win32 concern**: which physical
+HWND does a given frontend label correspond to. Reproject's `label_remap`
+guarantees the *backend* identity of a recreated window is correct
+(new srv row correctly superseding the old one); it says nothing about,
+and never touches, the *native HWND* binding.
+
+If anything, tonight's work is what made this bug **easy to hit**: crash-reproject
+is precisely the mechanism that creates multiple windows in rapid,
+back-to-back succession from a single driver loop — the one precondition
+`capture_hwnd_for_label`'s fallback comment assumed wouldn't happen ("windows
+are opened sequentially"). This is a **latent bug the reproject feature
+newly exposes at meaningfully higher frequency**, not a bug reproject
+introduced or a bug reproject's own correctness logic would have caught —
+they're orthogonal subsystems that happen to compose badly under load.
+
+## Fix direction (not implemented — investigation/retro only, per this session's scope)
+
+Not attempted yet; flagging the shape of the fix for a follow-up:
+
+- `capture_hwnd_for_label`'s fallback needs a way to attribute a *specific*
+  newly-created HWND to a *specific* label, not "first unclaimed one in
+  Z-order." The natural fix is to thread the actual HWND through from
+  `CreateWindowTask`'s own `CreateWindowExW` return value (the UI thread
+  already knows exactly which HWND it just created for which label — this
+  is available at creation time, not resolved after the fact) rather than
+  reconstructing the mapping later via `set_window_init_status`'s fallback.
+- Failing that, at minimum the fallback should serialize: hold a lock (or
+  process reproject creations one at a time with a completion barrier)
+  across the "enumerate → claim" section so two windows' fallbacks can never
+  interleave.
+
+## Related
+
+- `agentmux-cef/src/commands/window/lifecycle.rs` — `capture_hwnd_for_label`,
+  `resolve_window_hwnd`, `resolve_window_hwnd_strict`, `find_own_top_level_window`
+  (all read this session).
+- `agentmux-cef/src/commands/window/motion.rs` — `start_window_drag`.
+- `agentmux-cef/src/commands/window/creation.rs` — `reproject_from_snapshot`.
+- `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` §P1 —
+  prior documentation of the same EnumWindows-fallback hazard class.
+- `SPEC_PILLAR1_HOST_REPROJECT_DESIGN` / `SPEC_PILLAR1_STEP4` — the
+  crash-reproject mechanism whose window-creation loop is the trigger.

--- a/docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_12.md
+++ b/docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_12.md
@@ -1,0 +1,132 @@
+# Status & Roadmap — Lifecycle & Crash Architecture Program (as of 2026-07-12)
+
+> **Supersedes** `STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_07.md` (and its 2026-07-11
+> addendum) in full. That doc's addendum already noted Pillar 1 Step 4 and Pillar 2 landing;
+> this snapshot covers everything since, including one newly discovered, **not yet fixed**
+> lifecycle bug found live tonight.
+
+**Type:** Status snapshot + forward roadmap, not a plan doc — a point-in-time picture of the
+three-pillar disposability program (`docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md`)
+plus everything adjacent to it that's shipped or been found since 2026-07-07.
+**Verify before acting:** re-check file:line references if read more than a few days after
+2026-07-12 — this subsystem moves fast (see the historical-audit trend in §5 of the discussion doc:
+~45-55% of PRs touch memory/lifecycle/crash).
+
+---
+
+## 0. The one-sentence picture
+
+**All three pillars are functionally complete** (Pillar 1 through Step 5, Step 6 gated on bake
+time; Pillars 2 and 3 fully done) and the whole `Client.windowids` leak class is closed — but
+tonight's live use surfaced a **new, distinct, not-yet-fixed lifecycle bug**: a native-HWND
+label cross-wire that crash-reproject's multi-window creation triggers, causing one window's
+title-bar drag to move a *different* window.
+
+---
+
+## 1. Pillar 1 — disposable host
+
+**Goal:** host death (OOM, crash) becomes a visible, bounded reproject instead of a catastrophe.
+
+| Step | What | Status |
+|---|---|---|
+| 1 | Layout single-writer collapse (`#864`) | ✅ Done, merged. |
+| 2 | Persist per-window opacity + floating-pane placement/restore-rect | ✅ Done, merged, live-verified. |
+| 3 | Persist window `kind` + parent linkage | ✅ Done, merged, live-verified. |
+| 4 | Crash-reproject: fast-path from launcher snapshot, slow-path from srv, restoring-session overlay, splash respawn | ✅ **Done, all 5 phases** (#2014, #2015, #2017, #2032). |
+| 5 | E2E test: "host OOM ⇒ session reprojects" | ✅ Done. |
+| 6 | Collapse graceful-flush-vs-crash incoherence; shrink saga layer to an in-memory registry | ⬜ **Gated on bake period** — reproject needs ~3-4 weeks of real usage before it's safe to delete the durable-saga fallback it's replacing. Started ~2026-07-11, so roughly early-to-mid August before this can start. |
+
+Reproject's own bake period is *itself* how tonight's new bug (§4) got found — it's exactly the
+kind of thing that only surfaces under real multi-window crash/restart cycles, not synthetic
+single-window tests.
+
+## 2. Pillar 2 — single lifecycle authority (`reconcile_quit`)
+
+✅ **Done, all 4 phases** (#2080, #2081, #2084, #2083). `reconcile_quit` is the sole quit
+decision-maker; the WRR last-user-window path (previously the dominant *unwired* gap) is now the
+Draining-gated Stage-2 executor; `orphan_reconcile` is a sanitizer/executor, not a decision-maker.
+No open items.
+
+## 3. Pillar 3 — admission control
+
+✅ Shipped independently before this program (#1853). `available_commit_gb()` +
+`admit_spawn()` gate refuses agent spawn under commit pressure. Follow-ons (queue-and-drain,
+per-agent working-set cap, frontend "memory full" badge) remain open but low-priority and
+independent of everything else here.
+
+---
+
+## 4. Lifecycle bugs — found and fixed since 2026-07-07
+
+Bugs adjacent to (not formally inside) the three-pillar program, surfaced by the same
+investigative/live-usage pressure the program exists to relieve. Each has its own retro.
+
+| Bug | Status | Retro |
+|---|---|---|
+| Browser-pane renderer leak (`DestroyWindow` off owner-thread → silent no-op on every pane close) | ✅ Fixed, merged (PR #2000) | `retro-browser-pane-renderer-leak-2026-07-07.md` |
+| `Client.windowids` leak, IPC close path | ✅ Fixed (#2087) | — |
+| `Client.windowids` leak, registration race | ✅ Fixed (#2088) + `test/e2e/window-close-baseline.e2e.test.ts` | — |
+| `Client.windowids` leak, OS-level WM_CLOSE (Alt+F4/taskbar) bypassing IPC entirely | ✅ Fixed (#2089), wndproc subclass hook | — |
+| Pool-warmup window `backend_window_id` leak into `Client.windowids` | ✅ Fixed (#2102-era) | — |
+| Launcher teardown backstop, UI-thread liveness probe (observe-only) | ✅ Phase 1 merged | — |
+| srv crash → host recycle (`SRV_RESTART_BUDGET`) | ✅ Merged (#2107) | — |
+| Pagefile/disk: track free space on pagefile volume, warn below threshold | ✅ Merged (#2109) | — |
+| **Drag-HWND cross-wire: dragging window N can move a *different* window after a multi-window crash-reproject** | 🆕 **Root-caused tonight, NOT yet fixed.** Task #36. | `retro-reproject-drag-hwnd-crosswire-2026-07-12.md` |
+
+### 4.1 — The new bug, in one paragraph
+
+`capture_hwnd_for_label` (`agentmux-cef/src/commands/window/lifecycle.rs:493`) binds a window's
+label to its real Win32 HWND the first time that window's renderer signals "ready" — independently,
+per window, with no ordering barrier between windows. When its fast path misses (common in CEF
+Views mode), it falls back to "claim whichever of our own visible-but-unclaimed HWNDs `EnumWindows`
+returns first" — correct only if windows are created one at a time, an assumption its own comment
+states outright. Crash-reproject creates multiple windows back-to-back from a single driver loop,
+so two windows' fallbacks can race and cross-wire which label owns which HWND. Once cached, it's
+validated (`IsWindow`) and **latches permanently** — not a one-off glitch, a durable mis-binding
+for the rest of that session. **This is orthogonal to everything shipped this session**: reproject's
+`label_remap` machinery (Step 4) guarantees the *backend/srv* identity of a recreated window is
+correct; it never touches the *native HWND* binding, which is where this bug actually lives. If
+anything, Step 4 is what makes the bug easy to hit — it's the one mechanism that creates multiple
+windows in rapid succession, the precondition the vulnerable fallback assumed away.
+
+Fix direction (not yet implemented, scoped as task #36): thread the actual HWND through from
+`CreateWindowTask`'s own `CreateWindowExW` return value at creation time (the UI thread already
+knows exactly which HWND belongs to which label the moment it creates it) instead of reconstructing
+the mapping later via EnumWindows; or, failing that, serialize the fallback so two windows'
+claim-a-HWND sections can never interleave.
+
+---
+
+## 5. Roadmap — open items, ranked
+
+1. **Task #36 — fix the drag-HWND cross-wire (§4.1).** Newest, live-reported, has a confirmed
+   root cause and a scoped fix direction. Reasonable next pick given it's a direct, reproducible
+   user-facing correctness bug (not a resource leak) and reproject's ongoing bake period will keep
+   generating exactly the multi-window-reproject conditions that trigger it.
+2. **Task #32 — teardown backstop Phase 2** (armed J0 state machine). Gated on the Phase 1
+   liveness probe accumulating a few more days of bake time; probe merged 2026-07-11, so likely
+   ready to resume within the next few days.
+3. **Task #33 — pagefile P0 item 3**: re-derive the commit-aware scheduler reserve from
+   `PrivateUsage` instead of `VirtualMemorySize64`. Last open P0 from `SPEC_WIN10_PAGEFILE_OOM_CRASH`.
+4. **Task #34 / #35 — pagefile P1s**: throttle the SetMeta log firehose + rotate/cap
+   `agentmux-launcher.log`; prompt (opt-in, never automatic) to shut down an old AgentMux version
+   on upgrade. Lower urgency than the P0s.
+5. **Task #15 — Residual C**: non-Windows close-path verification. Blocked on macOS/Linux
+   hardware access, not on any decision here.
+6. **Task #4 — `SPEC_AGENT_SYSTEM_MANAGEMENT_API`**: still awaiting a go/no-go call: not a
+   lifecycle-program item, listed here only because it's the other standing open task.
+7. **Pillar 1 Step 6**: not startable until the bake period completes (~early-to-mid August 2026),
+   tracked for awareness, not action.
+
+---
+
+## 6. Sources
+
+- `docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_07.md` (superseded by this doc)
+- `docs/architecture/DISCUSSION_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_06_29.md` (program index)
+- `docs/specs/SPEC_PILLAR1_HOST_REPROJECT_DESIGN_2026_06_30.md`, `SPEC_PILLAR1_STEP4` phases
+- `docs/specs/SPEC_PILLAR2_SANITIZE_THEN_DECIDE_2026_07_11.md`
+- `docs/retro/retro-browser-pane-renderer-leak-2026-07-07.md`
+- `docs/retro/retro-reproject-drag-hwnd-crosswire-2026-07-12.md` (new)
+- `docs/specs/SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md`


### PR DESCRIPTION
## Summary
- Root cause (task #36, retro `docs/retro/retro-reproject-drag-hwnd-crosswire-2026-07-12.md`): `capture_hwnd_for_label`'s EnumWindows fallback binds a window's label to "whichever of our own visible-but-unclaimed HWNDs comes first" — correct only if windows are created one at a time. Crash-reproject creates multiple windows back-to-back, so two windows' fallback calls can race and cross-wire which label owns which HWND. Once cached it passes the `IsWindow` liveness check on every later read, so the mis-binding **latches permanently** — dragging window 2's title bar visibly moves window 3 instead, exactly as reported live tonight.
- Fix: bind `(label, HWND)` into `state.window_hwnds` directly inside `AgentMuxWindowDelegate::on_window_created`, at Views window-creation time — `CefWindow::GetWindowHandle()` is reliable at this exact synchronous, per-window-serialized callback (the CEF UI thread runs one window's `on_window_created` fully to completion before the next queued `CreateWindowTask` even begins), so the race window never opens. This widens the existing Windows-only HWND capture in that callback (previously gated to `window-pool-*` labels only) to cover every registered label, mirroring the already-proven `floating_pane.rs` pattern (bind into `window_hwnds` immediately after native creation, before anything that could race).
- `capture_hwnd_for_label`'s own "already registered" guard means it's now a no-op for every window created this way; its EnumWindows fallback remains only as a defensive last resort for any caller that doesn't carry a `window_registration` (DevTools/popup delegates, which intentionally pass `None`).
- Also includes a superseding lifecycle/crash-architecture status + roadmap doc (`docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_12.md`), tracking this fix alongside the rest of the disposability-pillar program.

## Test plan
- [x] `cargo check -p agentmux-cef` — clean (only pre-existing dead-code warnings, unrelated).
- [ ] Live smoke test: cold-boot 3+ windows via crash-reproject (kill host mid-session with 2+ non-main windows open), confirm each window drags independently and none cross-wire.
- [ ] Confirm pool-window taskbar-hiding / promote behavior unaffected (the pool-specific branch is untouched, just reads the already-computed `raw_hwnd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)