### PR TITLE
fix(agent): remove noisy blue focus outline on conversation rows

### DIFF
--- a/.changesets/1783881559-fix-agent-remove-noisy-blue-focus-outline-on-conversation-ro-tffr.md
+++ b/.changesets/1783881559-fix-agent-remove-noisy-blue-focus-outline-on-conversation-ro-tffr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): remove noisy blue focus outline on conversation rows

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -87,11 +87,6 @@
         // rows lose their layout context and tables break.
         width: 100%;
 
-        &:focus {
-            outline: 1px solid var(--accent-color);
-            outline-offset: -1px;
-        }
-
         // Force tables to constrain their layout to the row width.
         // Spec: SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
         //       §"Tables and rich content"
@@ -134,11 +129,6 @@
         content-visibility: auto;
         contain-intrinsic-size: auto 80px;
         contain: layout style;
-
-        &:focus {
-            outline: 1px solid var(--accent-color);
-            outline-offset: -1px;
-        }
     }
 
     // === New-message enter animation ===


### PR DESCRIPTION
## Summary

Removes the thin blue `:focus` outline that appeared around a conversation row (user turn, assistant turn, tool call) whenever it was clicked.

Every row (`frontend/app/view/agent/virtualization/DocumentRow.tsx`) has `tabindex="0"` so it can receive keyboard-navigation focus, but the `:focus` outline rule fired on a plain mouse click too — drawing a visible `1px solid var(--accent-color)` border around whichever row was last clicked, with no corresponding "focused row" behavior to justify it. Pure visual noise.

Removed both:
- `.agent-document-row:focus` — the live rule, targets the current virtualized row wrapper
- `.agent-document-node-wrapper:focus` — an already-marked-`// Legacy class`, identical duplicate kept only for non-virtualized callers

`frontend/app/view/agent/styles/_document.scss` only.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Verified no other `outline` rule remains in `_document.scss`; confirmed the other `outline` rules elsewhere in the agent pane's stylesheets (composer input, control-bar buttons, recent-sessions picker rows, decision panel) are unrelated interactive elements, out of scope for "conversation items"

<!-- agentmux:agent_id=agentx -->