### PR TITLE
docs(srv): close the loop on the commit-reserve VirtualMemorySize64 P0 (task #33)

### DIFF
--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -69,12 +69,25 @@ pub enum AgentError {
 }
 
 /// Minimum free system commit (GB) required to admit a new agent spawn. Below
-/// this, launching another `claude.exe` (~0.5–0.7 GB private commit plus tooling
-/// overhead) risks pushing the system commit charge to its limit, where a failed
-/// allocation aborts the CEF host (Chromium OOM). Conservative floor; tune from
-/// measured per-agent `PrivateUsage`. Overridable via
-/// `AGENTMUX_AGENT_COMMIT_RESERVE_GB` (e.g. 0 disables the gate on a host with a
-/// huge page file; higher on a constrained box).
+/// this, launching another `claude.exe` risks pushing the system commit charge
+/// to its limit, where a failed allocation aborts the CEF host (Chromium OOM).
+///
+/// SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29's original P0 called for
+/// re-deriving this reserve from real per-agent `PrivateUsage`, not
+/// `VirtualMemorySize64` — the 6/26 estimate (`SPEC_MEMORY_ANALYSIS_2026_06_26`)
+/// had mistakenly attributed ~10.5 GB of commit to each `claude.exe`, read off
+/// `VirtualMemorySize64` (reserved address space, not commit charge). That
+/// number was never wired into this constant — this file has measured
+/// `2.0 GB` since Pillar 3 shipped (#1853) — but the measurement trail behind
+/// it is worth stating explicitly now that it exists:
+/// `SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02.md` re-measured a
+/// live `claude.exe`'s actual `PrivateUsage` (Windows' real per-process commit
+/// counter) at ~1.05 GB, corroborated independently by
+/// Resource-Exhaustion-Detector telemetry (0.49–0.67 GB) in the 6/29 spec.
+/// `2.0` GB is ~2x that per-agent figure, a reasonable safety margin for one
+/// additional spawn — no VirtualMemorySize64-derived inflation to correct.
+/// Overridable via `AGENTMUX_AGENT_COMMIT_RESERVE_GB` (e.g. 0 disables the
+/// gate on a host with a huge page file; higher on a constrained box).
 const DEFAULT_AGENT_COMMIT_RESERVE_GB: f64 = 2.0;
 
 fn agent_commit_reserve_gb() -> f64 {


### PR DESCRIPTION
## Summary
`SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29`'s P0 item 3 asked to re-derive the commit-aware admission gate's reserve (`agentmux-srv/src/agents/runner.rs::DEFAULT_AGENT_COMMIT_RESERVE_GB`) from real per-agent `PrivateUsage` instead of `VirtualMemorySize64`.

**Investigation finding**: no code in this repo ever read `VirtualMemorySize64` for this purpose. The inflated ~10.5 GB/agent figure was a narrative estimate in an older, since-corrected spec (`SPEC_MEMORY_ANALYSIS_2026_06_26`), never wired into this constant. The shipped reserve has been `2.0` GB since Pillar 3 landed (#1853) — already in the right ballpark against the real measured `PrivateUsage` (~1.05 GB/agent, per `SPEC_MEMORY_COMMIT_ATTRIBUTION_CORRECTION_2026_07_02.md`, corroborated by independent Resource-Exhaustion-Detector telemetry in the 6/29 spec: 0.49–0.67 GB).

**No functional change** — this closes the P0 item by making the measurement trail explicit in the doc comment, so it stops looking like an open bug it isn't.

**Separately flagged, not fixed here** (filed as its own follow-up, task #38): the admission gate only covers the drone Agent block's one-shot spawn path (`agents::runner::run_agent`) — the interactive Agent pane's PTY spawn (`blockcontroller/shell.rs`) is not routed through it at all, by existing design (`runner.rs`'s own module doc). Real coverage gap, worth its own decision on whether/how to extend, out of scope for this P0 item.

## Test plan
- [x] `cargo check -p agentmux-srv` — clean (pre-existing warnings only, unrelated).
- Comment-only change to an existing constant; no behavior change, no new tests needed.