### PR TITLE
fix(launcher): rotate/cap agentmux-launcher.log, demote 5 firehose INFO sites (task #34)

### DIFF
--- a/.changesets/1783904947-fix-launcher-rotate-cap-agentmux-launcher-log-demote-5-high--6pgg.md
+++ b/.changesets/1783904947-fix-launcher-rotate-cap-agentmux-launcher-log-demote-5-high--6pgg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): rotate/cap agentmux-launcher.log, demote 5 high-volume INFO log sites to debug

--- a/agentmux-launcher/src/logging.rs
+++ b/agentmux-launcher/src/logging.rs
@@ -1,12 +1,22 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Rotation cap for `agentmux-launcher.log` (SPEC_WIN10_PAGEFILE_OOM_CRASH_
+/// 2026_06_29 P1). This file mirrors the srv subprocess's entire stderr
+/// stream verbatim, forever, with no rotation of its own — left unbounded
+/// it grew to 406 MB across 69 days on a real machine, directly tightening
+/// the page-file ceiling the pagefile-OOM spec is about. 50 MB per file ×
+/// 3 rotated files + the live file ≈ 200 MB worst case, versus unbounded.
+const MAX_LOG_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_ROTATED_FILES: u32 = 3;
+
 /// Append a timestamped line to ~/.agentmux/logs/agentmux-launcher.log.
 /// Best-effort — silently no-ops if the log dir doesn't exist yet.
 pub(crate) fn log(msg: &str) {
     let log_dir = dirs_fallback_home().join(".agentmux").join("logs");
     let _ = std::fs::create_dir_all(&log_dir);
     let path = log_dir.join("agentmux-launcher.log");
+    rotate_if_oversized(&path);
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -21,6 +31,31 @@ pub(crate) fn log(msg: &str) {
     }
 }
 
+fn rotated_path(path: &std::path::Path, n: u32) -> std::path::PathBuf {
+    path.with_extension(format!("log.{n}"))
+}
+
+/// Size-based rotation: `agentmux-launcher.log` -> `.log.1` -> `.log.2` ->
+/// `.log.3` (oldest dropped), run once per `log()` call before appending.
+/// A `metadata()` stat per call is cheap relative to the disk write that
+/// follows; simplicity here matters more than shaving a syscall. Best-effort
+/// like `log()` itself — any failure (permissions, concurrent access) just
+/// leaves the current file growing past the cap rather than losing log data
+/// or panicking.
+fn rotate_if_oversized(path: &std::path::Path) {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return;
+    };
+    if meta.len() < MAX_LOG_BYTES {
+        return;
+    }
+    let _ = std::fs::remove_file(rotated_path(path, MAX_ROTATED_FILES));
+    for i in (1..MAX_ROTATED_FILES).rev() {
+        let _ = std::fs::rename(rotated_path(path, i), rotated_path(path, i + 1));
+    }
+    let _ = std::fs::rename(path, rotated_path(path, 1));
+}
+
 /// Home dir without depending on `dirs` for THIS specific lookup.
 /// Kept to avoid a dirs dep cycle from log() — log() is called from
 /// data_dir::resolve_paths via failure paths, and we want it to work
@@ -30,4 +65,56 @@ pub(crate) fn dirs_fallback_home() -> std::path::PathBuf {
         .or_else(|_| std::env::var("HOME"))
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::path::PathBuf::from("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rotate_if_oversized_is_a_noop_below_the_cap() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("agentmux-launcher.log");
+        std::fs::write(&path, vec![b'x'; 1024]).unwrap();
+
+        rotate_if_oversized(&path);
+
+        assert!(path.exists());
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 1024);
+        assert!(!rotated_path(&path, 1).exists());
+    }
+
+    #[test]
+    fn rotate_if_oversized_rotates_the_live_file_to_dot_1() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("agentmux-launcher.log");
+        std::fs::write(&path, vec![b'x'; MAX_LOG_BYTES as usize]).unwrap();
+
+        rotate_if_oversized(&path);
+
+        assert!(!path.exists(), "oversized live file should be rotated away");
+        assert!(rotated_path(&path, 1).exists());
+        assert_eq!(
+            std::fs::metadata(rotated_path(&path, 1)).unwrap().len(),
+            MAX_LOG_BYTES
+        );
+    }
+
+    #[test]
+    fn rotate_if_oversized_shifts_the_whole_chain_and_drops_the_oldest() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("agentmux-launcher.log");
+        std::fs::write(&path, vec![b'x'; MAX_LOG_BYTES as usize]).unwrap();
+        std::fs::write(rotated_path(&path, 1), b"gen1").unwrap();
+        std::fs::write(rotated_path(&path, 2), b"gen2").unwrap();
+        std::fs::write(rotated_path(&path, 3), b"gen3-oldest-should-be-dropped").unwrap();
+
+        rotate_if_oversized(&path);
+
+        assert!(!path.exists());
+        assert_eq!(std::fs::read(rotated_path(&path, 1)).unwrap(), vec![b'x'; MAX_LOG_BYTES as usize]);
+        assert_eq!(std::fs::read(rotated_path(&path, 2)).unwrap(), b"gen1");
+        assert_eq!(std::fs::read(rotated_path(&path, 3)).unwrap(), b"gen2");
+    }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -884,7 +884,14 @@ impl PersistentSubprocessController {
 
                 // Publish line as WPS blockfile event and write-through to FileStore
                 // for persistent history (Phase 1.3).
-                tracing::info!(
+                //
+                // debug, not info: fires on EVERY output line a streaming agent
+                // produces — the single largest contributor (~27%) to an
+                // unrotated 406 MB launcher-log mirror on a real machine
+                // (SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 P1). Default
+                // production filter is info, so this is now suppressed unless
+                // RUST_LOG=debug is set.
+                tracing::debug!(
                     block_id = %block_id_read,
                     line_len = line.len(),
                     "persistent stdout → blockfile"

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -613,7 +613,17 @@ impl SubprocessController {
                         // Publish the NDJSON line as a WPS blockfile event on the "output" subject
                         // and write-through to FileStore for persistent history (Phase 1.3).
                         if let Some(ref broker) = broker_read {
-                            tracing::info!(block_id = %block_id_read, line = %trimmed, "subprocess stdout → blockfile");
+                            // debug, not info: fires on every NDJSON line, and
+                            // logs the FULL line content (not just length like
+                            // persistent.rs's sibling) — a real contributor
+                            // (~6%) to an unrotated 406 MB launcher-log mirror
+                            // on a real machine (SPEC_WIN10_PAGEFILE_OOM_CRASH_
+                            // 2026_06_29 P1). muxlog.mjs already treats this
+                            // exact line as noise-to-drop-by-default when
+                            // tailing, independent corroboration. Default
+                            // production filter is info, so this is now
+                            // suppressed unless RUST_LOG=debug is set.
+                            tracing::debug!(block_id = %block_id_read, line = %trimmed, "subprocess stdout → blockfile");
                             // Include the newline so the frontend line splitter works correctly
                             let line_with_newline = format!("{}\n", trimmed);
                             super::shell::handle_append_block_file(

--- a/agentmux-srv/src/backend/rpc/engine.rs
+++ b/agentmux-srv/src/backend/rpc/engine.rs
@@ -452,7 +452,12 @@ impl WshRpcEngine {
             let handler_elapsed = handler_start.elapsed();
             let total_elapsed = request_start.elapsed();
 
-            tracing::info!(
+            // debug, not info: fires on every websocket RPC call, of any kind
+            // — ~27% of an unrotated 406 MB launcher-log mirror on a real
+            // machine (SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 P1). Default
+            // production filter is info, so this is now suppressed unless
+            // RUST_LOG=debug is set; still there for perf debugging on demand.
+            tracing::debug!(
                 "[rpc-perf] command={} dispatch={:.2}ms handler={:.2}ms total={:.2}ms",
                 command,
                 dispatch_elapsed.as_secs_f64() * 1000.0,

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -64,7 +64,12 @@ pub(crate) async fn run_service_call(state: &AppState, call: &WebCallType) -> We
     let service_start = std::time::Instant::now();
     let result = dispatch_service(state, call).await;
     let elapsed = service_start.elapsed();
-    tracing::info!(
+    // debug, not info: fires on every HTTP /agentmux/service call — a
+    // meaningful slice (~10%+) of an unrotated 406 MB launcher-log mirror on
+    // a real machine (SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29 P1). Default
+    // production filter is info, so this is now suppressed unless
+    // RUST_LOG=debug is set; still there for perf debugging on demand.
+    tracing::debug!(
         "[http-perf] {}.{}: {:.2}ms",
         call.service,
         call.method,

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -664,7 +664,12 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     serde_json::from_value(data).map_err(|e| format!("setmeta: {e}"))?;
                 let oref_str = cmd.oref.to_string();
                 let meta_keys: Vec<&String> = cmd.meta.keys().collect();
-                tracing::info!(oref = %oref_str, keys = ?meta_keys, "SetMeta");
+                // debug, not info: fires on every metadata write (zoom, title,
+                // view-state edits); at info this became a meaningful slice of
+                // an unrotated launcher-log mirror (SPEC_WIN10_PAGEFILE_OOM_
+                // CRASH_2026_06_29 P1). Default production filter is info, so
+                // this is now suppressed unless RUST_LOG=debug is set.
+                tracing::debug!(oref = %oref_str, keys = ?meta_keys, "SetMeta");
                 update_object_meta(&wstore, &oref_str, &cmd.meta)?;
                 // Per-agent zoom persistence (SPEC_AGENT_ZOOM_PERSISTENCE): the
                 // frontend writes term:zoom via this WebSocket path, not the HTTP


### PR DESCRIPTION
## Summary
`SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29` P1 (task #34): `agentmux-launcher.log` mirrors the srv subprocess's entire stderr stream verbatim, forever, with no rotation. Confirmed live: **406 MB across 69 days** on a real machine (bigger than the 244 MB the spec originally cited — this was actively getting worse, not already mitigated).

**Investigation found the spec's own diagnosis was stale.** Sampling the real file showed `SetMeta` (the line literally named in the P1) is only 0.77% of it. Four other unconditional `tracing::info!` sites dominate instead:

| Site | % of file | Trigger |
|---|---|---|
| `persistent stdout → blockfile` | ~27% | every output line a streaming agent produces |
| `[rpc-perf]` | ~27% | every websocket RPC call, of any kind |
| `[http-perf]` | ~10%+ | every HTTP `/agentmux/service` call |
| `subprocess stdout → blockfile` | ~6% | logs full line content; `muxlog.mjs` already treats this exact line as noise-to-drop-by-default when tailing, independent corroboration |
| `SetMeta` | 0.77% | the originally-named line — included for completeness |

All five demoted `info!` → `debug!`. Default production filter (`RUST_LOG` unset → effectively global `info`) now suppresses them at the subscriber level, before either srv's own file sink or its stderr (which the launcher mirrors verbatim) ever sees the event — still available via `RUST_LOG=debug` on demand for perf debugging.

**Rotation** (the unconditional fix regardless of log-level tuning): `agentmux-launcher/src/logging.rs::rotate_if_oversized` — a size check before each append, `.log` → `.log.1` → `.log.2` → `.log.3` (oldest dropped) once the live file crosses 50 MB. No rotation precedent existed in this repo for this file (`tracing-appender`, used elsewhere, only rotates by time; the launcher has no `tracing` dependency at all by design, so this is a small hand-rolled check rather than a new dependency).

## Test plan
- [x] `cargo check -p agentmux-srv -p agentmux-launcher` — clean.
- [x] 3 new unit tests for `rotate_if_oversized` (noop below cap, rotates live file to `.1`, shifts the whole chain and drops the oldest) — all passing.
- [ ] Live: confirm `agentmux-launcher.log` growth is bounded over the next few days of normal usage.