### PR TITLE
fix(srv): extend commit-aware admission gate to the interactive agent pane

### DIFF
--- a/.changesets/1783906330-fix-srv-extend-commit-aware-admission-gate-to-the-interactiv-o0fv.md
+++ b/.changesets/1783906330-fix-srv-extend-commit-aware-admission-gate-to-the-interactiv-o0fv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): extend commit-aware admission gate to the interactive agent pane spawn path

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -13,10 +13,16 @@
 //! Headless and one-shot by design — the drone Agent block's
 //! contract is "send task, wait for done, return result." The
 //! interactive agent pane has its own PTY-based controller in
-//! `blockcontroller/shell.rs`; that path is NOT routed through
-//! this runner (see `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md`
-//! §4.2 — what's shared is the translator + event shape, not the
-//! spawn function).
+//! `blockcontroller/shell/lifecycle.rs`; that path is NOT routed
+//! through this runner's spawn (see
+//! `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` §4.2 — what's
+//! shared is the translator + event shape, not the spawn function).
+//! It DOES reuse this module's commit-aware admission gate
+//! (`admit_spawn` / `agent_commit_reserve_gb`, `pub(crate)`) — see
+//! `blockcontroller::shell::lifecycle::ShellController::start`,
+//! which calls them right before spawning a `claude`/`codex`/
+//! `gemini`/`qwen` interactive pane, mirroring this file's
+//! `run_agent` gate.
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -90,7 +96,7 @@ pub enum AgentError {
 /// gate on a host with a huge page file; higher on a constrained box).
 const DEFAULT_AGENT_COMMIT_RESERVE_GB: f64 = 2.0;
 
-fn agent_commit_reserve_gb() -> f64 {
+pub(crate) fn agent_commit_reserve_gb() -> f64 {
     std::env::var("AGENTMUX_AGENT_COMMIT_RESERVE_GB")
         .ok()
         .and_then(|s| s.parse::<f64>().ok())
@@ -102,7 +108,7 @@ fn agent_commit_reserve_gb() -> f64 {
 /// agent? `None` available (non-Windows, or the read failed) ⇒ admit — there's no
 /// cheap commit limit to enforce. Strict `<` so a value exactly at the reserve is
 /// admitted. CEF-free / OS-free so it is fully unit-testable.
-fn admit_spawn(avail_commit_gb: Option<f64>, reserve_gb: f64) -> Result<(), AgentError> {
+pub(crate) fn admit_spawn(avail_commit_gb: Option<f64>, reserve_gb: f64) -> Result<(), AgentError> {
     match avail_commit_gb {
         Some(avail) if avail < reserve_gb => {
             Err(AgentError::CommitPressure { avail_gb: avail, reserve_gb })

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -181,6 +181,48 @@ impl Controller for ShellController {
             })
             .or_else(|| std::env::var("WAVEMUX_AGENT_ID").ok());
 
+        // Detect agent pane: cmd contains a known agent CLI or has AGENTMUX_AGENT_ID set.
+        // Computed here (before spawn) rather than after so the commit-aware admission
+        // gate below can use it; also reused post-spawn to set `inner.is_agent_pane`.
+        let is_agent = agent_id_for_jekt.is_some()
+            || cmd_str.to_lowercase().contains("claude")
+            || cmd_str.to_lowercase().contains("codex")
+            || cmd_str.to_lowercase().contains("gemini")
+            || cmd_str.to_lowercase().contains("qwen");
+
+        // Pillar 3 — commit-aware admission control, extended to the interactive
+        // agent pane. The drone Agent block's one-shot spawn (`agents::runner::
+        // run_agent`) already refuses to start another `claude.exe` when system
+        // commit headroom is below the reserve, to avoid tipping the box into a
+        // Chromium OOM abort (0xE0000008). That gate covered only the drone path;
+        // this interactive PTY spawn is the OTHER (likely more common) place a
+        // fresh agent CLI process gets started, and previously had no protection
+        // at all. Reuse the same pure decision + reserve lookup here, gated on
+        // `is_agent` so plain shell/cmd panes are unaffected — only a new
+        // claude/codex/gemini/qwen process is refused under commit pressure.
+        // See SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md, PR #1853.
+        if is_agent {
+            if let Err(e) = crate::agents::runner::admit_spawn(
+                crate::backend::sysinfo::available_commit_gb(),
+                crate::agents::runner::agent_commit_reserve_gb(),
+            ) {
+                tracing::warn!(
+                    block_id = %self.block_id,
+                    cmd = %cmd_str,
+                    error = %e,
+                    "admission gate: refusing interactive agent spawn under commit pressure"
+                );
+                let mut inner = self.inner.lock().unwrap();
+                Self::set_status(&mut inner, STATUS_DONE);
+                inner.proc_exit_code = -1;
+                inner.input_tx = None;
+                self.unlock_run();
+                return Err(format!(
+                    "memory full — not enough memory to start a new agent right now, free up memory and try again ({e})"
+                ));
+            }
+        }
+
         let mut cmd = if !cmd_str.is_empty() && (!cmd_args.is_empty() || interactive) {
             // Direct spawn: cmd:args provided or cmd:interactive set.
             // Spawn the CLI directly (no sh -c wrapper) so args are passed correctly.
@@ -411,13 +453,6 @@ impl Controller for ShellController {
             format!("failed to spawn command: {e}")
         })?;
         tracing::info!(block_id = %self.block_id, "process spawned successfully");
-
-        // Detect agent pane: cmd contains a known agent CLI or has AGENTMUX_AGENT_ID set.
-        let is_agent = agent_id_for_jekt.is_some()
-            || cmd_str.to_lowercase().contains("claude")
-            || cmd_str.to_lowercase().contains("codex")
-            || cmd_str.to_lowercase().contains("gemini")
-            || cmd_str.to_lowercase().contains("qwen");
 
         // Register PID and record spawn metadata.
         let spawn_ts_ms = SystemTime::now()

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -323,8 +323,12 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             log("agent", "previous turn complete — send a message to continue");
         }
     } catch (err: any) {
-        log("controller", `resync failed: ${err?.message ?? String(err)}`, "warn");
-        log("agent", "ready — type a message below to start");
+        // Don't follow a real resync failure with the generic "ready" message —
+        // that previously masked every resync error (including the commit-
+        // pressure admission gate's "memory full" refusal) with a misleading
+        // all-clear a line later. Surface the actual failure at "error" so it's
+        // the last, most visible line in the panel.
+        log("controller", `resync failed: ${err?.message ?? String(err)}`, "error");
     }
 
     return "success";


### PR DESCRIPTION
## Summary

Pillar 3's commit-aware admission gate (#1853) refuses a new agent spawn when Windows system commit headroom is too low, protecting against a Chromium OOM abort (`0xE0000008`). It only covered the drone Agent block's one-shot `claude --print` spawn (`agents::runner::run_agent`) — the **interactive agent pane**, the other (likely more common) path a fresh `claude`/`codex`/`gemini`/`qwen` process gets started, had zero protection. This PR closes that gap.

- Reuses the existing pure decision functions from `agents::runner` (`admit_spawn`, `agent_commit_reserve_gb`, now `pub(crate)`) rather than duplicating logic.
- Calls them in `blockcontroller/shell/lifecycle.rs::ShellController::start`, right before the real PTY spawn (`pair.slave.spawn_command(cmd)`), gated on the same agent-CLI detection already used to set `is_agent_pane` (hoisted earlier in the function so both uses share one computation) — plain shell/cmd panes are unaffected, only claude/codex/gemini/qwen spawns are gated.
- On refusal, returns the same `Err(String)` shape as sibling failures in this function (PTY-open failure, spawn failure), which `resync_controller` already propagates through the RPC layer (`controllerresync` command) back to the caller.
- Also fixes a frontend bug found while tracing the error path: `launch-flow.ts`'s `catch` on `ControllerResyncCommand` logged `resync failed: ...` at `warn` immediately followed by a hardcoded `"ready — type a message below to start"` — masking every resync failure (not just this new one) behind a false all-clear. Now the catch logs only the real failure, at `error` level, so the "memory full" message (and any other resync failure) is actually visible in the pane's activity log.

## Why this scope

Investigated whether the interactive-pane spawn was cleanly gateable: it is — the PTY spawn happens synchronously inside `ShellController::start`, which already returns `Result<(), String>` through `resync_controller` to the `controllerresync` RPC handler, exactly mirroring the drone block's error path. No architecture change needed; this reuses the exact mechanism already used for the two sibling failures a few lines below (PTY-open failure, spawn-command failure).

## Test plan
- [x] `cargo check -p agentmux-srv` — clean (pre-existing warnings only, no new ones)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv blockcontroller::shell` — 37/37 pass
- [x] `cargo test -p agentmux-srv --bin agentmux-srv agents::runner` — 15/15 pass (existing `admit_spawn`/`agent_commit_reserve_gb` pure-function tests already cover the reused decision logic; no new call-site test added — the codebase has no infra for exercising the real (non-mock) PTY spawn path in tests, and `run_agent`'s own wiring follows the same precedent of testing only the pure function, not the call site)
- [ ] Manual: trigger low commit headroom (`AGENTMUX_AGENT_COMMIT_RESERVE_GB` set very high) and confirm an interactive agent pane launch shows the "memory full" message instead of silently failing

## Residual risk / judgment calls
- The frontend fix in `launch-flow.ts` is a small, pre-existing-bug fix that was necessary to make this gate's error UX actually visible (without it, the "memory full" message would flash and then be immediately overwritten by "ready"). It affects the error display for *all* resync failures, not just the new commit-pressure case, but the change itself is narrow (2 log calls in one catch block) and does not alter control flow/return semantics.
- `launch-flow.ts`'s `launchAgent` still returns `"success"` even when the resync failed (a separate pre-existing bug — the return-value contract ("success" | "auth_failed" | "fatal") has no "retryable resync failure" category). Left untouched — fixing it would ripple into every caller's switch statement and is out of scope for a surgical admission-gate fix.
- No new Rust unit test was added at the `ShellController::start` call-site level for the gate itself, since (a) the pure decision logic is already fully tested via `admit_spawn`'s existing tests, (b) the codebase's own `run_agent` gate follows the identical "test the pure function only" pattern, and (c) `agent_commit_reserve_gb` reads an env var that Rust 1.81+ flags as unsound to mutate under concurrent test execution (a constraint already called out in a comment in `runner.rs`) — so a call-site test would either be non-deterministic (real system commit) or require the same unsound env mutation the codebase already avoids elsewhere.

Task #38. Follow-up to #1853 (which shipped Pillar 3's gate for the drone path only).

<!-- agentmux:agent_id=agenta -->