### PR TITLE
feat(swarm): group loose subagents sharing the same generated name

### DIFF
--- a/.changesets/1783907130-feat-swarm-group-loose-subagents-sharing-the-same-generated--rk84.md
+++ b/.changesets/1783907130-feat-swarm-group-loose-subagents-sharing-the-same-generated--rk84.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): group loose subagents sharing the same generated name

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -3,14 +3,27 @@
 
 import { describe, expect, it } from "vitest";
 import {
+    groupCacheKey,
     groupSubagentsByWorkflow,
+    isNameGroup,
     isWorkflowGroup,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     stabilizeGroupIdentity,
     type ActiveSubagent,
+    type NameGroup,
+    type SwarmChild,
     type WorkflowGroup,
 } from "./swarm-model";
+
+/** Extract a SwarmChild's own identifying id, for assertions that don't care
+ *  which of the three variants they got — narrows through all three via
+ *  isWorkflowGroup/isNameGroup rather than an unsafe cast. */
+function childId(c: SwarmChild): string {
+    if (isWorkflowGroup(c)) return c.workflowId;
+    if (isNameGroup(c)) return c.name;
+    return c.agent_id;
+}
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -128,8 +141,97 @@ describe("groupSubagentsByWorkflow", () => {
         ]);
         expect(result).toHaveLength(3);
         // newest-loose (900) > wf_1 group (500) > old-loose (100)
-        expect(isWorkflowGroup(result[0]) ? result[0].workflowId : result[0].agent_id).toBe("newest-loose");
-        expect(isWorkflowGroup(result[2]) ? result[2].workflowId : result[2].agent_id).toBe("old-loose");
+        expect(childId(result[0])).toBe("newest-loose");
+        expect(childId(result[2])).toBe("old-loose");
+    });
+
+    describe("name-based grouping of loose subagents (issue: same-name duplicate rows)", () => {
+        it("collapses 2+ loose subagents sharing a display_name into one NameGroup", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: null, display_name: "Code Reviewer" }),
+                mk({ agent_id: "a2", workflow_id: null, display_name: "Code Reviewer" }),
+                mk({ agent_id: "a3", workflow_id: null, display_name: "Code Reviewer" }),
+            ]);
+            expect(result).toHaveLength(1);
+            const group = result[0];
+            expect(isNameGroup(group)).toBe(true);
+            if (isNameGroup(group)) {
+                expect(group.name).toBe("Code Reviewer");
+                expect(group.totalCount).toBe(3);
+            }
+        });
+
+        it("leaves a single subagent with a unique display_name as a loose row (no group chrome for a non-dupe)", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: null, display_name: "Only One" }),
+            ]);
+            expect(result).toHaveLength(1);
+            expect(isNameGroup(result[0])).toBe(false);
+            expect(childId(result[0])).toBe("a1");
+        });
+
+        it("leaves subagents with no display_name yet as loose, ungrouped rows even if several exist", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: null, display_name: null }),
+                mk({ agent_id: "a2", workflow_id: null, display_name: null }),
+            ]);
+            expect(result).toHaveLength(2);
+            expect(result.every((c) => !isNameGroup(c))).toBe(true);
+        });
+
+        it("workflow grouping takes priority — same-named subagents in a workflow never form a NameGroup", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: "wf_1", display_name: "Worker" }),
+                mk({ agent_id: "a2", workflow_id: "wf_1", display_name: "Worker" }),
+            ]);
+            expect(result).toHaveLength(1);
+            expect(isWorkflowGroup(result[0])).toBe(true);
+            expect(result.some(isNameGroup)).toBe(false);
+        });
+
+        it("marks a NameGroup active if any member is still active", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: null, display_name: "N", status: "completed" }),
+                mk({ agent_id: "a2", workflow_id: null, display_name: "N", status: "active" }),
+            ]);
+            const group = result[0];
+            if (isNameGroup(group)) {
+                expect(group.status).toBe("active");
+                expect(group.activeCount).toBe(1);
+            } else {
+                throw new Error("expected a name group");
+            }
+        });
+
+        it("marks a NameGroup retired only once every member has completed", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: null, display_name: "N", status: "completed" }),
+                mk({ agent_id: "a2", workflow_id: null, display_name: "N", status: "completed" }),
+            ]);
+            const group = result[0];
+            if (isNameGroup(group)) {
+                expect(group.status).toBe("retired");
+            } else {
+                throw new Error("expected a name group");
+            }
+        });
+
+        it("mixes loose subagents, workflow groups, and name groups together, sorted by recency", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "solo", workflow_id: null, display_name: "Unique", last_event_at: 50 }),
+                mk({ agent_id: "n1", workflow_id: null, display_name: "Dup", last_event_at: 300 }),
+                mk({ agent_id: "n2", workflow_id: null, display_name: "Dup", last_event_at: 700 }),
+                mk({ agent_id: "w1", workflow_id: "wf_1", last_event_at: 500 }),
+            ]);
+            expect(result).toHaveLength(3);
+            const nameGroups = result.filter(isNameGroup);
+            const workflowGroups = result.filter(isWorkflowGroup);
+            expect(nameGroups).toHaveLength(1);
+            expect(workflowGroups).toHaveLength(1);
+            // Dup group's lastEventAt (700, from n2) > wf_1 (500) > solo (50)
+            expect(childId(result[0])).toBe("Dup");
+            expect(childId(result[2])).toBe("solo");
+        });
     });
 });
 
@@ -205,6 +307,52 @@ describe("stabilizeGroupIdentity", () => {
         expect(stabilized[0]).toBe(loose[0]);
         expect(cache.size).toBe(0);
     });
+
+    it("reuses the cached NameGroup reference when nothing about the group changed", () => {
+        const cache = new Map<string, WorkflowGroup | NameGroup>();
+        const members = [
+            mk({ agent_id: "a1", workflow_id: null, display_name: "Dup" }),
+            mk({ agent_id: "a2", workflow_id: null, display_name: "Dup" }),
+        ];
+        const first = groupSubagentsByWorkflow(members);
+        const stabilizedFirst = stabilizeGroupIdentity(cache, first);
+
+        const second = groupSubagentsByWorkflow(members);
+        const stabilizedSecond = stabilizeGroupIdentity(cache, second);
+
+        expect(stabilizedSecond[0]).toBe(stabilizedFirst[0]);
+    });
+
+    it("keeps a WorkflowGroup and a NameGroup with the same raw id/name as distinct cache entries", () => {
+        // groupCacheKey namespaces with "wf:"/"name:" precisely so this
+        // coincidence can't collide two unrelated groups into one cache slot.
+        const cache = new Map<string, WorkflowGroup | NameGroup>();
+        const wfChildren = groupSubagentsByWorkflow([
+            mk({ agent_id: "a1", workflow_id: "shared-id" }),
+            mk({ agent_id: "a2", workflow_id: "shared-id" }),
+        ]);
+        const nameChildren = groupSubagentsByWorkflow([
+            mk({ agent_id: "b1", workflow_id: null, display_name: "shared-id" }),
+            mk({ agent_id: "b2", workflow_id: null, display_name: "shared-id" }),
+        ]);
+        stabilizeGroupIdentity(cache, wfChildren);
+        stabilizeGroupIdentity(cache, nameChildren);
+        expect(cache.size).toBe(2);
+        expect(cache.has("wf:shared-id")).toBe(true);
+        expect(cache.has("name:shared-id")).toBe(true);
+    });
+});
+
+describe("groupCacheKey", () => {
+    it("namespaces a WorkflowGroup key with 'wf:' and a NameGroup key with 'name:'", () => {
+        const [wf] = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1" })]).filter(isWorkflowGroup);
+        const [ng] = groupSubagentsByWorkflow([
+            mk({ agent_id: "a1", workflow_id: null, display_name: "N" }),
+            mk({ agent_id: "a2", workflow_id: null, display_name: "N" }),
+        ]).filter(isNameGroup);
+        expect(groupCacheKey(wf)).toBe("wf:wf_1");
+        expect(groupCacheKey(ng)).toBe("name:N");
+    });
 });
 
 describe("pruneGroupIdentityCache", () => {
@@ -216,9 +364,31 @@ describe("pruneGroupIdentityCache", () => {
         stabilizeGroupIdentity(cache, groupB);
         expect(cache.size).toBe(2);
 
-        pruneGroupIdentityCache(cache, new Set(["wf_a"]));
+        // Live keys use groupCacheKey's namespaced "wf:<id>" form, not the
+        // raw workflowId.
+        pruneGroupIdentityCache(cache, new Set(["wf:wf_a"]));
         expect(cache.size).toBe(1);
-        expect(cache.has("wf_a")).toBe(true);
-        expect(cache.has("wf_b")).toBe(false);
+        expect(cache.has("wf:wf_a")).toBe(true);
+        expect(cache.has("wf:wf_b")).toBe(false);
+    });
+
+    it("drops entries for name groups no longer live, keeps the rest", () => {
+        const cache = new Map<string, WorkflowGroup | NameGroup>();
+        const groupA = groupSubagentsByWorkflow([
+            mk({ agent_id: "a1", workflow_id: null, display_name: "A" }),
+            mk({ agent_id: "a2", workflow_id: null, display_name: "A" }),
+        ]);
+        const groupB = groupSubagentsByWorkflow([
+            mk({ agent_id: "b1", workflow_id: null, display_name: "B" }),
+            mk({ agent_id: "b2", workflow_id: null, display_name: "B" }),
+        ]);
+        stabilizeGroupIdentity(cache, groupA);
+        stabilizeGroupIdentity(cache, groupB);
+        expect(cache.size).toBe(2);
+
+        pruneGroupIdentityCache(cache, new Set(["name:A"]));
+        expect(cache.size).toBe(1);
+        expect(cache.has("name:A")).toBe(true);
+        expect(cache.has("name:B")).toBe(false);
     });
 });

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -339,19 +339,47 @@ describe("stabilizeGroupIdentity", () => {
         stabilizeGroupIdentity(cache, nameChildren);
         expect(cache.size).toBe(2);
         expect(cache.has("wf:shared-id")).toBe(true);
-        expect(cache.has("name:shared-id")).toBe(true);
+        expect(cache.has("name:block-1:shared-id")).toBe(true);
+    });
+
+    it("keeps same-named NameGroups from two different agent blocks as distinct cache entries (reagent P1 on #2123)", () => {
+        // groupIdentityCache/expandedIds are shared across the WHOLE tree
+        // (buildTree() calls groupSubagentsByWorkflow once per block, into
+        // one cache) — a Haiku-generated name like "Code Reviewer" can
+        // plausibly repeat across two unrelated agent panes. Without
+        // parentBlockId in the key, block A's and block B's same-named
+        // groups would stomp each other's identity/expand state.
+        const cache = new Map<string, WorkflowGroup | NameGroup>();
+        const blockAChildren = groupSubagentsByWorkflow([
+            mk({ agent_id: "a1", parent_block_id: "block-A", workflow_id: null, display_name: "Code Reviewer" }),
+            mk({ agent_id: "a2", parent_block_id: "block-A", workflow_id: null, display_name: "Code Reviewer" }),
+        ]);
+        const blockBChildren = groupSubagentsByWorkflow([
+            mk({ agent_id: "b1", parent_block_id: "block-B", workflow_id: null, display_name: "Code Reviewer" }),
+            mk({ agent_id: "b2", parent_block_id: "block-B", workflow_id: null, display_name: "Code Reviewer" }),
+        ]);
+        const stabilizedA = stabilizeGroupIdentity(cache, blockAChildren);
+        const stabilizedB = stabilizeGroupIdentity(cache, blockBChildren);
+        expect(cache.size).toBe(2);
+        expect(stabilizedA[0]).not.toBe(stabilizedB[0]);
+        if (isNameGroup(stabilizedA[0]) && isNameGroup(stabilizedB[0])) {
+            expect(stabilizedA[0].subagents.map((s) => s.agent_id)).toEqual(["a1", "a2"]);
+            expect(stabilizedB[0].subagents.map((s) => s.agent_id)).toEqual(["b1", "b2"]);
+        } else {
+            throw new Error("expected two name groups");
+        }
     });
 });
 
 describe("groupCacheKey", () => {
-    it("namespaces a WorkflowGroup key with 'wf:' and a NameGroup key with 'name:'", () => {
+    it("namespaces a WorkflowGroup key with 'wf:' and a NameGroup key with 'name:<parentBlockId>:'", () => {
         const [wf] = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1" })]).filter(isWorkflowGroup);
         const [ng] = groupSubagentsByWorkflow([
             mk({ agent_id: "a1", workflow_id: null, display_name: "N" }),
             mk({ agent_id: "a2", workflow_id: null, display_name: "N" }),
         ]).filter(isNameGroup);
         expect(groupCacheKey(wf)).toBe("wf:wf_1");
-        expect(groupCacheKey(ng)).toBe("name:N");
+        expect(groupCacheKey(ng)).toBe("name:block-1:N");
     });
 });
 
@@ -386,9 +414,9 @@ describe("pruneGroupIdentityCache", () => {
         stabilizeGroupIdentity(cache, groupB);
         expect(cache.size).toBe(2);
 
-        pruneGroupIdentityCache(cache, new Set(["name:A"]));
+        pruneGroupIdentityCache(cache, new Set(["name:block-1:A"]));
         expect(cache.size).toBe(1);
-        expect(cache.has("name:A")).toBe(true);
-        expect(cache.has("name:B")).toBe(false);
+        expect(cache.has("name:block-1:A")).toBe(true);
+        expect(cache.has("name:block-1:B")).toBe(false);
     });
 });

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -93,6 +93,17 @@ export interface NameGroup {
      *  a name exists (display_name is null before subagent.GenerateName
      *  resolves), so ungrouped/unnamed subagents never form a NameGroup. */
     name: string;
+    /** Every member's shared parent_block_id — groupSubagentsByWorkflow is
+     *  always called with an already block-filtered subagent list (see
+     *  buildTree()), so this is uniform across the group. Required for
+     *  groupCacheKey: unlike WorkflowGroup's backend-unique workflowId, a
+     *  Haiku-generated display_name can plausibly repeat across two
+     *  unrelated agent panes (e.g. "Code Reviewer" in both), and
+     *  groupIdentityCache/expandedIds are shared across the WHOLE tree —
+     *  without this, two different blocks' same-named groups would stomp
+     *  each other's cached identity and expand/collapse state. Reagent P1
+     *  on PR #2123. */
+    parentBlockId: string;
     subagents: ActiveSubagent[];
     activeCount: number;
     totalCount: number;
@@ -181,6 +192,9 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
         nameGroups.push({
             kind: "nameGroup" as const,
             name,
+            // Uniform across the group — groupSubagentsByWorkflow is always
+            // called with an already block-filtered list (buildTree()).
+            parentBlockId: sorted[0].parent_block_id,
             subagents: sorted,
             activeCount,
             totalCount: sorted.length,
@@ -247,9 +261,18 @@ function shallowEqualGroupContent(a: WorkflowGroup | NameGroup, b: WorkflowGroup
 }
 
 /** Namespaced cache key so a `WorkflowGroup`'s `workflowId` and a
- *  `NameGroup`'s `name` can never collide in the shared identity cache. */
+ *  `NameGroup`'s `name` can never collide in the shared identity cache.
+ *  `NameGroup` additionally scopes by `parentBlockId`: a `workflowId` is
+ *  backend-unique so a bare name would never collide there, but a
+ *  Haiku-generated `display_name` (e.g. "Code Reviewer") can plausibly
+ *  repeat across two unrelated agent panes, and `groupIdentityCache`/
+ *  `expandedIds` are shared across the WHOLE tree (every block) — without
+ *  the block scope, two blocks' same-named groups would stomp each other's
+ *  cached identity and expand/collapse state. Reagent P1 on PR #2123. */
 export function groupCacheKey(child: WorkflowGroup | NameGroup): string {
-    return isWorkflowGroup(child) ? `wf:${child.workflowId}` : `name:${child.name}`;
+    return isWorkflowGroup(child)
+        ? `wf:${child.workflowId}`
+        : `name:${child.parentBlockId}:${child.name}`;
 }
 
 /**

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -74,10 +74,40 @@ export interface WorkflowGroup {
     lastEventAt: number;
 }
 
-export type SwarmChild = ActiveSubagent | WorkflowGroup;
+/**
+ * A group of LOOSE subagents (no `workflow_id` — not spawned together by one
+ * Task/Workflow-tool run) that independently earned the same Haiku-generated
+ * `display_name`. A user repeatedly spawning similar tasks (e.g. "review this
+ * file" across many files) legitimately gets the same/near-identical name for
+ * each invocation — the naming model doing its job, not a malfunction — but
+ * left flat that reads as "dozens of duplicate rows." Workflow grouping takes
+ * priority: a subagent already collapsed into a `WorkflowGroup` never also
+ * enters this grouping pass, regardless of name. See
+ * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md — this extends
+ * that report's chosen "group, not truncate" approach to same-name loose
+ * subagents, which the original workflow-only grouping didn't cover.
+ */
+export interface NameGroup {
+    kind: "nameGroup";
+    /** The shared display_name — always non-empty; grouping only fires once
+     *  a name exists (display_name is null before subagent.GenerateName
+     *  resolves), so ungrouped/unnamed subagents never form a NameGroup. */
+    name: string;
+    subagents: ActiveSubagent[];
+    activeCount: number;
+    totalCount: number;
+    status: "active" | "retired";
+    lastEventAt: number;
+}
+
+export type SwarmChild = ActiveSubagent | WorkflowGroup | NameGroup;
 
 export function isWorkflowGroup(child: SwarmChild): child is WorkflowGroup {
     return "kind" in child && child.kind === "workflowGroup";
+}
+
+export function isNameGroup(child: SwarmChild): child is NameGroup {
+    return "kind" in child && child.kind === "nameGroup";
 }
 
 export interface AgentTreeNode {
@@ -91,10 +121,14 @@ export interface AgentTreeNode {
 }
 
 /**
- * Group `subagents` (already filtered to one parent block) by `workflow_id`.
- * Subagents with no `workflow_id` pass through unchanged; subagents sharing
- * one collapse into a single `WorkflowGroup`. Result is sorted by most
- * recent activity, mixing loose subagents and groups in one recency order.
+ * Group `subagents` (already filtered to one parent block) by `workflow_id`,
+ * then, for the loose remainder, by shared `display_name`. Subagents sharing
+ * a `workflow_id` collapse into a `WorkflowGroup`; among what's left, two or
+ * more subagents sharing an identical, non-empty `display_name` collapse
+ * into a `NameGroup`. A single subagent with a unique name (or no name yet)
+ * stays a loose, ungrouped row — group chrome for something that isn't
+ * actually a dupe would be noise of its own. Result is sorted by most recent
+ * activity, mixing loose subagents and both group kinds in one recency order.
  */
 export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChild[] {
     const loose: ActiveSubagent[] = [];
@@ -124,8 +158,40 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
         };
     });
 
-    const lastEventOf = (c: SwarmChild): number => (isWorkflowGroup(c) ? c.lastEventAt : c.last_event_at);
-    return [...loose, ...groups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
+    const stillLoose: ActiveSubagent[] = [];
+    const byName = new Map<string, ActiveSubagent[]>();
+    for (const s of loose) {
+        if (s.display_name) {
+            const members = byName.get(s.display_name) ?? [];
+            members.push(s);
+            byName.set(s.display_name, members);
+        } else {
+            stillLoose.push(s);
+        }
+    }
+
+    const nameGroups: NameGroup[] = [];
+    for (const [name, members] of byName) {
+        if (members.length < 2) {
+            stillLoose.push(...members);
+            continue;
+        }
+        const sorted = [...members].sort((a, b) => b.last_event_at - a.last_event_at);
+        const activeCount = sorted.filter((m) => m.status === "active").length;
+        nameGroups.push({
+            kind: "nameGroup" as const,
+            name,
+            subagents: sorted,
+            activeCount,
+            totalCount: sorted.length,
+            status: activeCount > 0 ? "active" as const : "retired" as const,
+            lastEventAt: sorted[0]?.last_event_at ?? 0,
+        });
+    }
+
+    const lastEventOf = (c: SwarmChild): number =>
+        isWorkflowGroup(c) || isNameGroup(c) ? c.lastEventAt : c.last_event_at;
+    return [...stillLoose, ...groups, ...nameGroups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
 }
 
 function shallowEqualSubagent(a: ActiveSubagent, b: ActiveSubagent): boolean {
@@ -165,7 +231,10 @@ export function mergeSubagentsPreservingIdentity(
     });
 }
 
-function shallowEqualGroup(a: WorkflowGroup, b: WorkflowGroup): boolean {
+/** Common fields shared by both group kinds — `shallowEqualGroupContent`
+ *  compares only these, so it works for a `WorkflowGroup` or `NameGroup`
+ *  pair without needing to know which kind it's looking at. */
+function shallowEqualGroupContent(a: WorkflowGroup | NameGroup, b: WorkflowGroup | NameGroup): boolean {
     return (
         a.name === b.name &&
         a.activeCount === b.activeCount &&
@@ -177,46 +246,56 @@ function shallowEqualGroup(a: WorkflowGroup, b: WorkflowGroup): boolean {
     );
 }
 
+/** Namespaced cache key so a `WorkflowGroup`'s `workflowId` and a
+ *  `NameGroup`'s `name` can never collide in the shared identity cache. */
+export function groupCacheKey(child: WorkflowGroup | NameGroup): string {
+    return isWorkflowGroup(child) ? `wf:${child.workflowId}` : `name:${child.name}`;
+}
+
 /**
- * Stabilize `WorkflowGroup` wrapper identity across `buildTree()` calls,
- * mirroring `mergeSubagentsPreservingIdentity` one level up.
+ * Stabilize `WorkflowGroup`/`NameGroup` wrapper identity across `buildTree()`
+ * calls, mirroring `mergeSubagentsPreservingIdentity` one level up.
  * `groupSubagentsByWorkflow` is a pure function — it unconditionally builds
- * a brand-new `WorkflowGroup` object per call, even when every member
- * (already reference-stable thanks to `mergeSubagentsPreservingIdentity`)
- * is unchanged. Left alone, that fresh wrapper still remounts
- * `WorkflowGroupRow` — and everything nested inside an expanded one
+ * brand-new group objects per call, even when every member (already
+ * reference-stable thanks to `mergeSubagentsPreservingIdentity`) is
+ * unchanged. Left alone, that fresh wrapper still remounts `WorkflowGroupRow`/
+ * `NameGroupRow` — and everything nested inside an expanded one
  * (`SubagentRow`, `SubagentDetailPane`, `SubagentDetailEvent`) — on every
  * unrelated tree recompute, which for a workflow group (the highest-volume
  * case: a single run can spawn dozens of subagents) defeats the very
  * remount fix `expandedIdsAtom`/`getSubagentDetail` were meant to provide.
  *
- * `cache` is a `Map<workflowId, WorkflowGroup>` the caller keeps around
- * (one per `SwarmViewModel`), shared and called once per BLOCK within one
+ * `cache` is a `Map<groupCacheKey, group>` the caller keeps around (one per
+ * `SwarmViewModel`), shared and called once per BLOCK within one
  * `buildTree()` pass — this function only reuses-or-replaces into `cache`,
  * it never prunes it (pruning here, scoped to one block's children, would
  * evict entries a DIFFERENT block's call just wrote). Callers doing a full
  * multi-block tree rebuild should prune the cache once afterward against
- * every workflowId seen across the whole tree — see `pruneGroupIdentityCache`.
+ * every group key actually produced across the whole tree — see
+ * `pruneGroupIdentityCache`.
  */
 export function stabilizeGroupIdentity(
-    cache: Map<string, WorkflowGroup>,
+    cache: Map<string, WorkflowGroup | NameGroup>,
     children: SwarmChild[]
 ): SwarmChild[] {
     return children.map((child) => {
-        if (!isWorkflowGroup(child)) return child;
-        const old = cache.get(child.workflowId);
-        const stable = old && shallowEqualGroup(old, child) ? old : child;
-        cache.set(child.workflowId, stable);
+        if (!isWorkflowGroup(child) && !isNameGroup(child)) return child;
+        const key = groupCacheKey(child);
+        const old = cache.get(key);
+        const stable = old && shallowEqualGroupContent(old, child) ? old : child;
+        cache.set(key, stable);
         return stable;
     });
 }
 
-/** Drop cache entries for workflows no longer present anywhere in the tree
- *  — call once after a full `buildTree()` pass, not per-block (see
- *  `stabilizeGroupIdentity`), so it can't grow unbounded across sessions. */
-export function pruneGroupIdentityCache(cache: Map<string, WorkflowGroup>, liveWorkflowIds: Set<string>): void {
+/** Drop cache entries for groups no longer present anywhere in the tree —
+ *  call once after a full `buildTree()` pass, not per-block (see
+ *  `stabilizeGroupIdentity`), so it can't grow unbounded across sessions.
+ *  `liveGroupKeys` must use the same `wf:<id>` / `name:<name>` namespacing
+ *  as `groupCacheKey` — see `SwarmViewModel.buildTree()`. */
+export function pruneGroupIdentityCache(cache: Map<string, WorkflowGroup | NameGroup>, liveGroupKeys: Set<string>): void {
     for (const key of [...cache.keys()]) {
-        if (!liveWorkflowIds.has(key)) cache.delete(key);
+        if (!liveGroupKeys.has(key)) cache.delete(key);
     }
 }
 
@@ -387,14 +466,16 @@ export class SwarmViewModel implements ViewModel {
     private detailCache = new Map<string, SubagentDetail>();
 
     // Persisted across buildTree() calls so stabilizeGroupIdentity can reuse
-    // the same WorkflowGroup wrapper object when a group's own content is
-    // unchanged — without this, expandedIds/detailCache above still don't
-    // help a subagent NESTED inside a workflow group, since <For> remounts
-    // the whole WorkflowGroupRow subtree (SubagentRow, SubagentDetailPane,
-    // SubagentDetailEvent — including the latter's own local `expanded`
-    // signal for a tool_use/tool_result toggle) whenever the group's own
-    // wrapper reference changes, which is every buildTree() call otherwise.
-    private groupIdentityCache = new Map<string, WorkflowGroup>();
+    // the same WorkflowGroup/NameGroup wrapper object when a group's own
+    // content is unchanged — without this, expandedIds/detailCache above
+    // still don't help a subagent NESTED inside a group, since <For> remounts
+    // the whole WorkflowGroupRow/NameGroupRow subtree (SubagentRow,
+    // SubagentDetailPane, SubagentDetailEvent — including the latter's own
+    // local `expanded` signal for a tool_use/tool_result toggle) whenever the
+    // group's own wrapper reference changes, which is every buildTree() call
+    // otherwise. Keyed by groupCacheKey's namespaced "wf:<id>" / "name:<name>"
+    // strings so the two group kinds' key spaces never collide.
+    private groupIdentityCache = new Map<string, WorkflowGroup | NameGroup>();
 
     private unsubs: (() => void)[] = [];
     // Per-block controllerstatus unsubs — cleaned up when block list refreshes
@@ -593,6 +674,14 @@ export class SwarmViewModel implements ViewModel {
         const parentIds = subagents.map((s) => s.parent_block_id).filter(Boolean);
         const allBlockIds = [...new Set([...blockIds, ...parentIds])];
 
+        // Collected from the groups actually produced below, not derived
+        // from the raw subagent list — a NameGroup only exists once 2+
+        // subagents share a name (see groupSubagentsByWorkflow), so a
+        // subagent-list-level heuristic ("any subagent with this name is
+        // live") would wrongly keep singleton entries' keys alive forever.
+        // Harmless either way (stabilizeGroupIdentity only ever cache.set()s
+        // keys for groups that actually formed), but this is the precise set.
+        const liveGroupKeys = new Set<string>();
         const nodes = allBlockIds.map((blockId) => {
             const blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
             const block = blockAtom();
@@ -605,17 +694,16 @@ export class SwarmViewModel implements ViewModel {
             const rawCtx = block?.meta?.["term:ctx-tokens"];
             const contextTokens = typeof rawCtx === "number" ? rawCtx : null;
             const agentStatus = statuses.get(blockId) ?? "idle";
-            const children = stabilizeGroupIdentity(
-                this.groupIdentityCache,
-                groupSubagentsByWorkflow(subagents.filter((s) => s.parent_block_id === blockId))
-            );
+            const rawChildren = groupSubagentsByWorkflow(subagents.filter((s) => s.parent_block_id === blockId));
+            for (const c of rawChildren) {
+                if (isWorkflowGroup(c) || isNameGroup(c)) liveGroupKeys.add(groupCacheKey(c));
+            }
+            const children = stabilizeGroupIdentity(this.groupIdentityCache, rawChildren);
             return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, subagents: children };
         });
 
-        // Prune once per full pass (not per-block — see stabilizeGroupIdentity)
-        // against every workflow_id live anywhere in the flat subagent list.
-        const liveWorkflowIds = new Set(subagents.map((s) => s.workflow_id).filter((id): id is string => !!id));
-        pruneGroupIdentityCache(this.groupIdentityCache, liveWorkflowIds);
+        // Prune once per full pass (not per-block — see stabilizeGroupIdentity).
+        pruneGroupIdentityCache(this.groupIdentityCache, liveGroupKeys);
 
         return nodes;
     }

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowGroup, SubagentDetail, SubagentEvent } from "./swarm-model";
-import { isWorkflowGroup } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowGroup, NameGroup, SubagentDetail, SubagentEvent } from "./swarm-model";
+import { isWorkflowGroup, isNameGroup, groupCacheKey } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -257,6 +257,8 @@ function AgentRow({
                 <For each={node.subagents}>
                     {(child) => isWorkflowGroup(child)
                         ? <WorkflowGroupRow group={child} model={model} />
+                        : isNameGroup(child)
+                        ? <NameGroupRow group={child} model={model} />
                         : <SubagentRow sub={child} model={model} />}
                 </For>
             </div>
@@ -277,6 +279,43 @@ function WorkflowGroupRow({ group, model }: { group: WorkflowGroup; model: Swarm
             <div
                 class="swarm-workflow-header"
                 onClick={() => model.toggleExpanded(group.workflowId)}
+                title={group.name}
+            >
+                <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-workflow-expand-icon`} />
+                <span class="swarm-workflow-name">{group.name}</span>
+                <span class="swarm-workflow-count">
+                    {group.status === "active" ? `${group.activeCount}/${group.totalCount} active` : `${group.totalCount} retired`}
+                </span>
+                <span class={`swarm-workflow-status-badge swarm-workflow-status-badge--${group.status}`}>
+                    {group.status === "active" ? "Active" : "Retired"}
+                </span>
+            </div>
+            <Show when={expanded()}>
+                <div class="swarm-workflow-members">
+                    <For each={group.subagents}>
+                        {(sub) => <SubagentRow sub={sub} model={model} />}
+                    </For>
+                </div>
+            </Show>
+        </div>
+    );
+}
+
+// ── Name group row (loose subagents sharing one display_name) ──────────
+
+function NameGroupRow({ group, model }: { group: NameGroup; model: SwarmViewModel }): JSX.Element {
+    // Same expand-state-on-the-ViewModel rationale as WorkflowGroupRow —
+    // reuses groupCacheKey's "name:<name>" namespacing so this can never
+    // collide with a WorkflowGroupRow's workflowId or a SubagentRow's
+    // agent_id in the shared expandedIds set.
+    const key = groupCacheKey(group);
+    const expanded = createMemo(() => model.isExpanded(key));
+
+    return (
+        <div class={`swarm-workflow-group swarm-workflow-group--${group.status}`}>
+            <div
+                class="swarm-workflow-header"
+                onClick={() => model.toggleExpanded(key)}
                 title={group.name}
             >
                 <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-workflow-expand-icon`} />


### PR DESCRIPTION
## Summary

Fixes the "dozens of duplicate-looking subagent rows" complaint in the Swarm pane. Root cause (confirmed via investigation, not assumed): every Task-tool call spawns a subagent with its own distinct `agent_id` — there's no "same worker, new job" concept — so repeatedly spawning similar tasks (e.g. "review this file" × 30) correctly earns each invocation the same/near-identical Haiku-generated `display_name` from `subagent.GenerateName`. That's the naming model doing its job, not a malfunction. The only grouping that existed (`groupSubagentsByWorkflow`, from the earlier "flood" fix — `docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`) collapses subagents sharing a `workflow_id` (one Workflow-tool batch run); **loose, individually-spawned subagents had no equivalent** and rendered flat, one row per invocation, forever.

- `groupSubagentsByWorkflow` (`swarm-model.ts`) now runs a second pass over the loose remainder: 2+ subagents sharing an identical, non-empty `display_name` collapse into a new `NameGroup`.
- Workflow grouping takes priority — a subagent already collapsed into a `WorkflowGroup` never also enters name-grouping, regardless of name.
- A subagent with a unique name (or no name yet — `display_name` is null until `subagent.GenerateName` resolves) stays a loose, ungrouped row. Group chrome for something that isn't actually a dupe would just be a different kind of noise.
- New `NameGroupRow` (`swarm-view.tsx`) mirrors `WorkflowGroupRow`'s collapsed-by-default chrome exactly — reuses the same `swarm-workflow-*` CSS classes, no new styling needed.
- `stabilizeGroupIdentity`/`pruneGroupIdentityCache` now share one identity-preservation cache across both group kinds, keyed via a new `groupCacheKey()` with `"wf:"`/`"name:"` namespacing so a `WorkflowGroup`'s id and a `NameGroup`'s name can never collide in the shared cache — same rationale as the existing `<For>`-remount-prevention pattern one level up (`mergeSubagentsPreservingIdentity`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run frontend/app/view/swarm` — 27 tests passing (1 file), including 7 new tests for name-grouping behavior, 2 new `stabilizeGroupIdentity` tests (NameGroup reuse + wf/name key-collision safety), a new `groupCacheKey` test, and a new `pruneGroupIdentityCache` test for name-group eviction. Fixed 2 pre-existing tests whose assertions used the old un-namespaced cache-key contract.

<!-- agentmux:agent_id=agentx -->