### PR TITLE
feat(editor): file-tree Open to the Side / Open in New Tab

### DIFF
--- a/.changesets/1783907443-feat-editor-file-tree-open-to-the-side-open-in-new-tab-xmo4.md
+++ b/.changesets/1783907443-feat-editor-file-tree-open-to-the-side-open-in-new-tab-xmo4.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): file-tree Open to the Side / Open in New Tab

--- a/docs/specs/SPEC_EDITOR_FILE_TREE_OPEN_ACTIONS_2026_07_12.md
+++ b/docs/specs/SPEC_EDITOR_FILE_TREE_OPEN_ACTIONS_2026_07_12.md
@@ -1,0 +1,277 @@
+# SPEC: Editor File-Tree "Open" Actions (Open to the Side / Open in New Tab)
+
+Status: Draft
+Date: 2026-07-12
+Depends on: `SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md`, `SPEC_EDITOR_WIDGET_DEFAULT_UX_2026_06_14.md`
+Closes gap in: `SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md` §Menu Definitions (File node),
+§Phase 1
+
+---
+
+## Audit: current state of the editor pane's requested improvements
+
+Two improvements were requested for the editor pane: (1) finish the file-tree
+right-click menu, and (2) live markdown preview while editing. Auditing the
+code against `SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md` found:
+
+### 1. File-tree context menu — 90% done, one specific gap
+
+`buildContextMenuItems` (`frontend/app/view/editor/editor-view.tsx:559-630`)
+already implements everything in the original spec **except** two Phase-1
+items on the file-node menu:
+
+| Spec item (file node) | Implemented? | Where |
+|---|---|---|
+| Open | ✅ | `editor-view.tsx:605` |
+| **Open to the Side** | ❌ | — (this spec) |
+| **Open in New Tab** | ❌ | — (this spec) |
+| Copy Path | ✅ | `editor-view.tsx:607` |
+| Copy Relative Path | ✅ | `editor-view.tsx:608-612` |
+| Rename… (F2) | ✅ | `editor-view.tsx:616` |
+| Delete | ✅ | `editor-view.tsx:617-628` |
+| Reveal in Explorer | ✅ | `editor-view.tsx:614` |
+
+Folder-node menu (New File…, New Folder…, Rename…, Delete, Open in Terminal,
+Reveal in Explorer, Collapse Folder) and empty-space menu (New File…, New
+Folder…, Refresh) are complete — no gaps there. Phases 2–3 of the original
+spec (rename, create, delete flows, tab sync on rename/delete) all shipped as
+specified.
+
+The menu already uses the shared `ContextMenu` primitive
+(`frontend/app/components/context-menu.tsx`) the original spec introduced —
+this is the file tree's own primitive and is distinct from the codebase's
+other two right-click/dropdown mechanisms (`ContextMenuModel`, a native-OS
+menu used by tabs/blocks/action-widgets; `FlyoutMenu`, a click-triggered DOM
+dropdown used for the hamburger menu). This spec's new items stay on
+`ContextMenu` for consistency with the rest of this menu.
+
+**This spec covers only the two missing items.**
+
+### 2. Markdown live preview — already fully implemented, no gap found
+
+Live preview already exists as a complete, previously-shipped feature (fixed
+in PR #1743 after a regression documented in
+`docs/retro/retro-editor-markdown-preview-regression-2026-06-23.md`):
+
+- `.md` tabs default to `EditorMode = "preview"`
+  (`frontend/app/view/editor/editor-model.ts:845`); `"source"` and `"split"`
+  modes are also available via a toolbar and `Mod+Shift+V`
+  (`editor-view.tsx:746-770`, `editor-model.ts:855-857`).
+- CodeMirror's `updateListener` calls `setLiveDoc(content)` on every
+  keystroke (`editor-view.tsx:325-329`) — deliberately decoupled from the
+  persisted-content memo, which does not update per-keystroke
+  (see comment at `editor-view.tsx:99-104`).
+- The preview renders `<Markdown textAtom={() => liveDoc()} />`
+  (`editor-view.tsx:888`) — the same shared `frontend/app/element/markdown.tsx`
+  component used for agent chat rendering, built on a full
+  `unified`/`remark-gfm`/`rehype-*` pipeline (confirmed present in
+  `package.json`).
+
+**No implementation work is needed for live markdown preview** — it already
+updates on every edit in both `"preview"` (CodeMirror hidden, full preview)
+and `"split"` (side-by-side) modes. If there is a specific reproduction where
+this doesn't work as expected, that's a bug report against existing behavior,
+not a new feature — file it separately with repro steps rather than folding
+it into this spec.
+
+---
+
+## Problem (this spec's actual scope)
+
+Right-clicking a file in the editor tree offers no way to open it beside the
+current pane or in a fresh tab — both are one-click actions in every
+comparable IDE, and the original file-tree context-menu spec called for both
+in its very first implementation phase. Only "Open" (pinned tab in the
+*current* editor pane) exists today.
+
+---
+
+## Goals
+
+1. **Open to the Side**: opens the file in a new editor pane, split right of
+   the current editor pane, without disturbing the current pane's tabs.
+2. **Open in New Tab**: opens the file in a new editor pane inside a brand
+   new, otherwise-empty app tab (not the standard agent/sysinfo/swarm preset
+   tab).
+3. Both actions reuse existing backend/frontend primitives — no new RPCs.
+
+## Non-Goals
+
+- Multi-file selection ("open to the side" for N selected files at once) —
+  out of scope, same as the parent spec's multi-select non-goal.
+- Remembering per-file "preferred open mode" — every open via these two
+  actions is a one-shot user choice, not a persisted preference.
+
+---
+
+## Design
+
+Both actions are one RPC call each — `pane.open` (`agentmux-srv/src/backend/
+rpc_types/block.rs:336-367`) already accepts everything needed:
+
+```rust
+pub struct CommandPaneOpenData {
+    pub view: String,                          // "editor"
+    pub file: Option<String>,                  // the clicked file's path
+    pub tab_id: Option<String>,                 // target tab (Open in New Tab)
+    pub split_direction: Option<String>,        // "right" (Open to the Side)
+    pub split_reference_block_id: Option<String>, // this editor block's id
+    pub focus: Option<bool>,
+    // ...
+}
+```
+
+This is the exact mechanism the file tree's existing **Open in Terminal**
+action already uses (`editor-model.ts:804-816`, `pane.open` with
+`view: "term", split_direction: "right", split_reference_block_id:
+this.blockId`) — "Open to the Side" is that same call with `view: "editor",
+file: path` instead of `view: "term", cwd: path`.
+
+### Open to the Side
+
+```typescript
+// EditorViewModel (editor-model.ts), new method alongside openInTerminal():
+async openToTheSide(filePath: string): Promise<void> {
+    try {
+        await TabRpcClient.rpcCall("pane.open", {
+            view: "editor",
+            file: filePath,
+            split_direction: "right",
+            split_reference_block_id: this.blockId,
+        }, {});
+    } catch {
+        // pane.open might not be registered yet — fail silently, same as
+        // openInTerminal's existing error handling.
+    }
+}
+```
+
+No backend changes — `pane::build_pane_meta` (`agentmux-srv/src/server/
+app_api/pane.rs:208+`) already handles `view: "editor"` + `file` (it's how
+every `pane.open`-driven editor pane gets seeded, e.g. the existing "Open in
+Terminal" sibling action and widget-bar editor launches).
+
+### Open in New Tab
+
+There is no single RPC that creates a tab *and* opens a specific pane into it
+with no preset — `WorkspaceService.CreateTab` (used by `createTab()` in
+`frontend/app/store/global.ts:745-776`) is the primitive for creating a tab,
+but `createTab()` itself always layers on `applyTabPreset(tabId,
+DEFAULT_TAB_PRESET)` (agent + sysinfo + swarm), which is wrong for this
+action — the user asked for *this file*, not a fresh default workspace.
+
+**Revised during implementation** (the design below superseded the original
+draft, which called `pane.open` against the freshly created `tab_id` — that
+looked correct on paper and even matched the existing `openInTerminal` /
+`openToTheSide` pattern, but failed live testing: the backend created the
+block and updated the layout with zero errors every time, yet the block
+never rendered. Root cause: `pane.open`'s layout mutation goes through the
+*backend's* reducer-driven layout-queue + WaveObj broadcast, and a
+brand-new tab's *client-side* `layoutModel` — even once `waitForLayoutModel`
+confirms the object exists — isn't yet subscribed to receive that specific
+tab's `layout:update` broadcast. `openToTheSide` never hit this because it
+targets the *current*, long-subscribed tab. The fix: build the block through
+the same client-side path `applyTabPreset` itself uses —
+`ObjectService.CreateBlock` + `layoutModel.treeReducer(...)` — instead of
+the backend RPC.)
+
+```typescript
+// tab-presets.ts: export the two helpers applyTabPreset already uses
+// internally (waitForLayoutModel, createBlockOnModel) so other CreateTab
+// callers that need a NON-default block set can reuse them.
+
+// editor-model.ts:
+async openInNewTab(filePath: string): Promise<void> {
+    const ws = workspace(); // from @/store/global
+    if (!ws) return;
+    try {
+        const tabId = await WorkspaceService.CreateTab(ws.oid, "", true, false);
+        const layoutModel = await waitForLayoutModel(tabId);
+        if (!layoutModel) return; // tab never propagated
+        const isMarkdown = filePath.toLowerCase().endsWith(".md");
+        await createBlockOnModel(
+            tabId,
+            layoutModel,
+            {
+                meta: {
+                    view: "editor",
+                    file: filePath,
+                    // Mirrors build_pane_meta's markdown defaults
+                    // (agentmux-srv/src/server/app_api/pane.rs:208+) —
+                    // this path bypasses that function entirely, so its
+                    // per-view defaults have to be replicated here.
+                    ...(isMarkdown ? { "editor:tree_expanded": false, "editor:source_hidden": true } : {}),
+                },
+            },
+            null, // splitTargetId — none, this is the tab's only block
+            null,
+        );
+        await setActiveTab(tabId); // see note below
+    } catch {
+        // Fail silently, consistent with the file tree's other pane.open callers.
+    }
+}
+```
+
+**Also discovered live, unrelated to the render bug**: `WorkspaceService.
+CreateTab`'s `activate: bool` argument (3rd positional arg, `true` in both
+`createTab()` and the call above) is accepted by the `workspace.CreateTab`
+RPC handler but never forwarded into `Command::CreateTab` — the reducer
+only ever auto-activates a workspace's very *first* tab
+(`create_tab_second_tab_does_not_steal_active` in `reducer.rs`). Every
+`CreateTab` call for a workspace's 2nd+ tab silently fails to switch focus,
+`activate` argument notwithstanding. This affects the existing hamburger/
+titlebar "New Tab" action too — **out of scope for this spec**, worked
+around here with an explicit `setActiveTab(tabId)` call after the block
+exists, but worth a standalone bug report.
+
+### Menu wiring
+
+In `buildContextMenuItems` (`editor-view.tsx:604-606`), insert both items
+after "Open", before the "Copy Path" separator — matching the original
+spec's menu ordering exactly:
+
+```typescript
+return [
+    { type: "action", label: "Open", onSelect: () => void model.openFile(path) },
+    { type: "action", label: "Open to the Side", onSelect: () => void model.openToTheSide(path) },
+    { type: "action", label: "Open in New Tab", onSelect: () => void model.openInNewTab(path) },
+    { type: "separator" },
+    // ...unchanged
+];
+```
+
+---
+
+## Testing
+
+Verified live via CDP against a running `task dev` instance (right-click →
+click, not just unit-level):
+
+- "Open to the Side" on a file → a new editor pane appears split right of
+  the current one (2 distinct `editor-view` blocks under 2 distinct
+  `data-blockid`s, confirmed both belong to the same app tab), showing the
+  file; the original pane's tabs are untouched.
+- "Open in New Tab" on a file → a new, empty app tab is created, becomes
+  the active tab, and contains exactly one editor pane with the file open —
+  confirmed by checking the rendered markdown preview text, not just DOM
+  presence (early testing had a false-positive "it worked" read from
+  `data-blockid` existing in the DOM while the tab was actually still
+  blank — checking rendered file *content* is what caught the render bug
+  documented above).
+- Both actions on a file in a nested folder resolve the same absolute path
+  the tree already has (no relative-path resolution needed — the tree's
+  `path` values are already absolute, same as every other file-node action).
+- `pane.open` unavailable (very early startup race) → `openToTheSide` fails
+  silently, matching `openInTerminal`'s existing behavior. `openInNewTab`
+  no longer depends on `pane.open` at all (see above) — its equivalent
+  early-exit is `waitForLayoutModel` timing out and returning `null`.
+
+## Effort estimate (actual, not original estimate)
+
+The original "half a day, reuse pane.open for both" estimate held for
+`openToTheSide` but not for `openInNewTab`, which needed a different
+implementation strategy after live testing caught the client-side
+layout-model gap. Total: about a day including the debugging that found the
+two issues documented above (the render gap and the pre-existing
+`activate`-argument bug).

--- a/frontend/app/tab/tab-presets.ts
+++ b/frontend/app/tab/tab-presets.ts
@@ -73,7 +73,15 @@ function resolveBlockDef(widgetKey: WidgetKey): BlockDef | null {
 // The new tab's WaveObj + LayoutState propagate via subscription after
 // CreateTab returns. Poll briefly for the layout model to be ready
 // rather than racing against the WaveObj queue.
-async function waitForLayoutModel(tabId: string, timeoutMs = 2000): Promise<any | null> {
+//
+// Exported: any caller that creates a block in a freshly-created tab via
+// a raw pane.open (bypassing applyTabPreset's own createBlockOnModel path)
+// needs this same wait first — the backend can create+layout the block
+// successfully with zero errors while the frontend's reactive layout
+// subscription for that tab still isn't wired up yet, so the block never
+// renders. See EditorViewModel.openInNewTab in
+// frontend/view/editor/editor-model.ts.
+export async function waitForLayoutModel(tabId: string, timeoutMs = 2000): Promise<any | null> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
         const tab = WOS.getObjectValue(WOS.makeORef("tab", tabId));
@@ -152,7 +160,21 @@ async function applyNode(
 // to ObjectService.CreateBlock so the server routes it correctly
 // regardless of which tab is currently active (the user can click
 // freely during preset application without scrambling the layout).
-async function createBlockOnModel(
+//
+// Exported: this is the client-side layout-tree mutation path (direct
+// ObjectService.CreateBlock + layoutModel.treeReducer), NOT the backend
+// pane.open RPC's server-driven layout-queue path. The two are NOT
+// equivalent for a brand-new tab — confirmed live: pane.open against a
+// freshly created tab_id succeeds server-side with zero errors ("block
+// created + layout updated" in the srv log) and STILL never renders,
+// because the tab's client-side layoutModel — even once
+// waitForLayoutModel() confirms the object exists — isn't yet
+// subscribed to receive the backend's layout:update WaveObj broadcast
+// for that specific brand-new tab. Going through treeReducer() directly
+// sidesteps that gap entirely (same reactive path applyTabPreset already
+// relies on). See EditorViewModel.openInNewTab in
+// frontend/view/editor/editor-model.ts.
+export async function createBlockOnModel(
     expectedTabId: string,
     layoutModel: any,
     blockDef: BlockDef,

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -18,7 +18,7 @@
 // Earlier specs: SPEC_EDITOR_FILE_TREE_2026-05-26.md, SPEC_EDITOR_LSP_AND_THEMES_2026-05-26.md.
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
-import { useBlockAtom } from "@/app/store/global";
+import { setActiveTab, useBlockAtom, workspace } from "@/app/store/global";
 import {
     EditorPaneEvent,
     EditorTab,
@@ -32,6 +32,8 @@ import {
 } from "@/app/store/editor-pane-state-store";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { WorkspaceService } from "@/app/store/services";
+import { createBlockOnModel, waitForLayoutModel } from "@/app/tab/tab-presets";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { FileTreeModel } from "./file-tree-model";
@@ -812,6 +814,89 @@ export class EditorViewModel implements ViewModel {
             }, {});
         } catch {
             // pane.open might not be registered yet — fail silently.
+        }
+    }
+
+    /** Open a file in a new editor pane, split right of the current one.
+     *  Same pane.open mechanism as openInTerminal above, just view:"editor" +
+     *  file instead of view:"term" + cwd. See
+     *  docs/specs/SPEC_EDITOR_FILE_TREE_OPEN_ACTIONS_2026_07_12.md. */
+    async openToTheSide(filePath: string): Promise<void> {
+        try {
+            await TabRpcClient.rpcCall("pane.open", {
+                view: "editor",
+                file: filePath,
+                split_direction: "right",
+                split_reference_block_id: this.blockId,
+            }, {});
+        } catch {
+            // pane.open might not be registered yet — fail silently, same as openInTerminal.
+        }
+    }
+
+    /** Open a file in a new editor pane inside a brand-new, otherwise-empty
+     *  app tab. Deliberately bypasses createTab() in store/global.ts, which
+     *  always layers on the agent/sysinfo/swarm default preset — wrong here,
+     *  the user asked for THIS file, not a fresh default workspace.
+     *
+     *  Three things every other CreateTab caller in this codebase gets for
+     *  free via applyTabPreset() (tab-presets.ts), which this method can't
+     *  call directly since it always adds the default widget set — so each
+     *  is replicated individually here:
+     *
+     *  1. waitForLayoutModel(tabId) before touching the new tab at all. The
+     *     tab's WaveObj + LayoutState propagate via subscription some time
+     *     after CreateTab returns, not synchronously with it.
+     *  2. createBlockOnModel(...) — NOT the pane.open RPC used for
+     *     openToTheSide above. Confirmed live: pane.open against a freshly
+     *     created tab_id succeeds server-side with zero errors ("block
+     *     created + layout updated" in the srv log) and the block STILL
+     *     never renders — the tab's client-side layoutModel, even once
+     *     waitForLayoutModel() confirms the object exists, isn't yet
+     *     subscribed to receive the backend's layout:update broadcast for
+     *     that specific brand-new tab. createBlockOnModel goes through
+     *     ObjectService.CreateBlock + layoutModel.treeReducer(...) directly
+     *     — the same client-side path applyTabPreset uses for every preset
+     *     widget — which sidesteps the gap entirely. The constructed
+     *     BlockDef mirrors exactly what the backend's build_pane_meta
+     *     (agentmux-srv/src/server/app_api/pane.rs) would have produced for
+     *     `pane.open { view: "editor", file }` on the openToTheSide path.
+     *  3. Explicit setActiveTab() AFTER the block exists. CreateTab's own
+     *     `activate` arg looks like it should switch focus to the new tab,
+     *     but the reducer only auto-activates a workspace's very FIRST tab
+     *     ever (see create_tab_second_tab_does_not_steal_active in
+     *     reducer.rs) — `activate` is accepted by the RPC and silently
+     *     dropped before it reaches the reducer for every tab after the
+     *     first. This looks like a latent bug in createTab()'s own
+     *     hamburger/titlebar "New Tab" action too (same activate=true, same
+     *     silent no-op past the first tab) — out of scope here, flagging
+     *     for a separate fix. Called last so the destination tab already
+     *     has its content when the switch's reveal-gate opens — avoids a
+     *     flash of an empty tab. */
+    async openInNewTab(filePath: string): Promise<void> {
+        const ws = workspace();
+        if (!ws) return;
+        try {
+            const tabId = await WorkspaceService.CreateTab(ws.oid, "", true, false);
+            const layoutModel = await waitForLayoutModel(tabId);
+            if (!layoutModel) return; // Tab never propagated — nothing safe to do.
+            const isMarkdown = filePath.toLowerCase().endsWith(".md");
+            await createBlockOnModel(
+                tabId,
+                layoutModel,
+                {
+                    meta: {
+                        view: "editor",
+                        file: filePath,
+                        ...(isMarkdown ? { "editor:tree_expanded": false, "editor:source_hidden": true } : {}),
+                    },
+                },
+                null,
+                null,
+            );
+            await setActiveTab(tabId);
+        } catch {
+            // Fail silently, consistent with the file tree's other pane.open callers.
         }
     }
 

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -603,6 +603,8 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         }
         return [
             { type: "action", label: "Open", onSelect: () => void model.openFile(path) },
+            { type: "action", label: "Open to the Side", onSelect: () => void model.openToTheSide(path) },
+            { type: "action", label: "Open in New Tab", onSelect: () => void model.openInNewTab(path) },
             { type: "separator" },
             { type: "action", label: "Copy Path", onSelect: () => void copyToClipboard(path) },
             { type: "action", label: "Copy Relative Path", onSelect: () => {


### PR DESCRIPTION
## Context

Audit request: finish the editor's file-tree right-click menu, and confirm live markdown preview works. Full findings in `docs/specs/SPEC_EDITOR_FILE_TREE_OPEN_ACTIONS_2026_07_12.md`.

**Markdown live preview**: already fully shipped, no gap found — `.md` tabs default to a live preview mode, CodeMirror pushes every keystroke to the preview via a dedicated `liveDoc` signal (deliberately decoupled from the debounced content memo), rendered through the same remark/rehype pipeline used for agent chat. Nothing to build there.

**File-tree context menu**: 90% done already (Copy Path, Copy Relative Path, Rename, Delete, Reveal in Explorer, New File/Folder, Open in Terminal, Collapse Folder — all shipped per the original spec). Exactly two Phase-1 items from `SPEC_FILE_TREE_CONTEXT_MENU_2026_06_14.md` were spec'd but never implemented: **Open to the Side** and **Open in New Tab**. This PR closes that gap.

## What shipped

- **`openToTheSide(filePath)`**: `pane.open` with `split_direction:"right"` against the current pane's `blockId` — the exact mechanism the existing "Open in Terminal" action already uses. No backend changes.
- **`openInNewTab(filePath)`**: creates a raw, preset-free tab (bypassing `createTab()`'s always-on agent/sysinfo/swarm default), then adds the editor block via the same client-side path `applyTabPreset()` uses internally.

## Two bugs found and fixed along the way (both via live CDP testing, not guessed)

1. **`pane.open` doesn't work against a brand-new tab.** The original design (mirroring `openToTheSide`) called `pane.open` with the new `tab_id`. It looked right and even succeeded server-side every time (confirmed in the srv log: `"block created + layout updated"`, zero errors) — but the block never rendered. Root cause: a freshly created tab's client-side `layoutModel` isn't yet subscribed to the backend's `layout:update` broadcast for that tab, even after `waitForLayoutModel()` confirms the model object exists. `openToTheSide` never hits this because it targets the *current*, already-subscribed tab. Fix: route through `ObjectService.CreateBlock` + `layoutModel.treeReducer(...)` directly — the exact client-side path `applyTabPreset` already uses for every preset widget. Exported `waitForLayoutModel`/`createBlockOnModel` from `tab-presets.ts` (both already existed, just module-private) for reuse.

2. **`WorkspaceService.CreateTab`'s `activate` argument is a no-op past the first tab.** The RPC handler parses it but never forwards it into the reducer command — the reducer only auto-activates a workspace's very first tab ever (`create_tab_second_tab_does_not_steal_active` in `reducer.rs`). This affects the existing hamburger/titlebar "New Tab" action too, not just this new code. **Out of scope for this PR** — worked around here with an explicit `setActiveTab()` call, flagging separately for a standalone fix.

## Testing

- `tsc --noEmit` clean.
- Live CDP verification on `task dev`, right-click-driven (not unit-level): confirmed `openToTheSide` produces two distinct rendered blocks under the same app tab; confirmed `openInNewTab` by checking the new tab's *rendered file content* (checking only for `data-blockid` presence gave a false positive during debugging — the block existed in the data layer without ever painting).

<!-- agentmux:agent_id=agento -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)