### PR TITLE
fix(agent-pane): stop O(n) rebuilds on scroll and streamed chunks

### DIFF
--- a/.changesets/1783908843-fix-agent-pane-stop-o-n-rebuilds-on-scroll-and-streamed-chun-suba.md
+++ b/.changesets/1783908843-fix-agent-pane-stop-o-n-rebuilds-on-scroll-and-streamed-chun-suba.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): stop O(n) rebuilds on scroll and streamed chunks in agent-pane conversation rendering

--- a/.changesets/1783910275-chore-agent-pane-add-scroll-stream-dispatch-bench-suite-and--0d8b.md
+++ b/.changesets/1783910275-chore-agent-pane-add-scroll-stream-dispatch-bench-suite-and--0d8b.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(agent-pane): add scroll/stream dispatch bench suite and perf-probe dispatch timing (task #40)

--- a/frontend/app/devtools/agent-pane-perf-section.tsx
+++ b/frontend/app/devtools/agent-pane-perf-section.tsx
@@ -4,8 +4,10 @@
 /**
  * Agent-pane perf section for the diag panel — Phase 3 of the
  * virtualization redesign. Polls `agentPerfStore.snapshot()` at 1 Hz
- * and renders per-kind row mount times, estimator-miss rates, and
- * recent layout shifts.
+ * and renders per-kind row mount times, estimator-miss rates, recent
+ * layout shifts, and (task #40) layout/document store DISPATCH times —
+ * the reducer/store cost underneath the DOM that the original probe
+ * never covered.
  *
  * No-op in production: snapshot returns empty when probing is
  * disabled, so the section renders nothing.
@@ -28,6 +30,7 @@ const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
     estimatorMissRateByKind: new Map(),
     recentEstimatorMisses: [],
     recentLayoutShifts: [],
+    dispatchByKind: new Map(),
 };
 
 function formatMs(n: number | undefined): string {
@@ -67,7 +70,8 @@ export function AgentPanePerfSection(): JSX.Element {
         const s = snapshot();
         return s.rowMountByKind.size > 0
             || s.recentEstimatorMisses.length > 0
-            || s.recentLayoutShifts.length > 0;
+            || s.recentLayoutShifts.length > 0
+            || s.dispatchByKind.size > 0;
     };
 
     return (
@@ -138,6 +142,48 @@ export function AgentPanePerfSection(): JSX.Element {
                         <div style={{ color: "#666", "font-size": "9px", "margin-top": "2px" }}>
                             est-miss = pct measured outside ±{formatPct(ESTIMATOR_MISS_THRESHOLD)} of estimate
                         </div>
+                    </div>
+                </Show>
+
+                {/* Store dispatch durations (task #40) — the reducer/store cost
+                    underneath the DOM, not the row-mount cost above. "layout"
+                    is agent-pane-layout-store.ts (row positions/window),
+                    "document" is agent-document-store.ts (the message list). */}
+                <Show when={snapshot().dispatchByKind.size > 0}>
+                    <div style={{ "margin-bottom": "6px" }}>
+                        <div style={{ color: "#aaa", "font-size": "10px", "margin-bottom": "2px" }}>
+                            Store dispatch duration (last 64 per kind)
+                        </div>
+                        <table style={{ "font-size": "10px", "border-collapse": "collapse", width: "100%" }}>
+                            <thead>
+                                <tr style={{ color: "#888" }}>
+                                    <th style={{ "text-align": "left", padding: "1px 4px" }}>kind</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>p50</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>max</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>n</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <For each={[...snapshot().dispatchByKind.entries()].sort(
+                                    ([, a], [, b]) => (b.max ?? 0) - (a.max ?? 0),
+                                )}>
+                                    {([kind, q]) => (
+                                        <tr>
+                                            <td style={{ padding: "1px 4px" }}>{kind}</td>
+                                            <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                {formatMs(q.p50)}
+                                            </td>
+                                            <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                {formatMs(q.max)}
+                                            </td>
+                                            <td style={{ padding: "1px 4px", "text-align": "right", color: "#888" }}>
+                                                {q.count}
+                                            </td>
+                                        </tr>
+                                    )}
+                                </For>
+                            </tbody>
+                        </table>
                     </div>
                 </Show>
 

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -16,6 +16,7 @@
  */
 
 import type { DocumentNode } from "../view/agent/types";
+import { markDispatch } from "../view/agent/virtualization/perf-probe";
 import { update } from "./agent-document/reducer";
 import {
     AgentDocumentCommand,
@@ -124,6 +125,11 @@ export function dispatch(
             `[agent-document-store] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerPane must be called synchronously in the component body.`,
         );
     }
+    // Perf probe (task #40): times the FULL dispatch — reducer + the
+    // setter push below — the exact layer the original virtualization
+    // probe never measured (it only timed row DOM mount). No-op outside
+    // dev (see markDispatch / isProbingEnabled).
+    const stopDispatchTiming = markDispatch("document");
     const result = update(slot.state, command, Date.now(), opts);
     const prevNodes = slot.state.nodes;
     slot.state = result.state;
@@ -154,6 +160,7 @@ export function dispatch(
         source,
         at: Date.now(),
     });
+    stopDispatchTiming();
     return result.events;
 }
 

--- a/frontend/app/store/agent-document/reducer.bench.ts
+++ b/frontend/app/store/agent-document/reducer.bench.ts
@@ -1,0 +1,115 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Benchmarks for the agent-document reducer's `StreamFlush` — task #40,
+ * the empirical follow-up to the task #39 fix.
+ *
+ * Manual-only: NOT wired into `package.json`/CI. Run on demand with:
+ *
+ *   npx vitest bench frontend/app/store/agent-document/reducer.bench.ts
+ *
+ * Two scenarios, because `StreamFlush` has two different cost profiles
+ * and the task #39 fix only removed ONE O(n) pass from each — see the
+ * "what this does and doesn't prove" note below before reading numbers.
+ *
+ *  - "append" — `newNodes` contains a genuinely new id (the first chunk
+ *    of a new markdown/tool block). Before the fix: the reducer rebuilt
+ *    an id->index `Map` from scratch by scanning ALL of `state.nodes`
+ *    (`for (let i=0;i<state.nodes.length;i++) indexById.set(...)`) on
+ *    EVERY flush, unconditionally — one O(n) pass. After the fix: it
+ *    reuses `state.nodeIndexById` and only clones it
+ *    (`new Map(state.nodeIndexById)`) when an append actually happens —
+ *    still O(n) for the clone itself (a `Map` has no cheaper persistent
+ *    "add one entry" operation than a plain array does), so this
+ *    scenario is NOT expected to go flat. What it proves is the clone
+ *    (one pass, done by `Map`'s own copy constructor) is cheaper than
+ *    the old scan-and-insert loop (also one pass, but each iteration
+ *    pays for both a property read AND a hash-insert).
+ *
+ *  - "update-only" — `updatedNodes` targets an id that's ALREADY in
+ *    `state.nodes` (the dominant real-world case: every token AFTER the
+ *    first one in a streaming markdown block is a content-only update
+ *    to the SAME node, not a new node). Before the fix: same
+ *    unconditional O(n) map rebuild as above, PLUS the node-array copy.
+ *    After the fix: `nodeIndexById` is reused as-is (zero cost, not
+ *    even a clone) — the map rebuild is gone entirely for this case.
+ *
+ * What this does NOT prove: that `StreamFlush` overall is O(1)/O(k).
+ * It isn't, in EITHER scenario. `agent-document-store.ts` exposes
+ * `nodes` as a plain-array Solid *signal* (not a `createStore`), so a
+ * brand-new `DocumentNode[]` reference is structurally required on
+ * every change for the signal to fire — `ensureClone()`'s
+ * `state.nodes.slice()` is an O(n) full-array copy on every
+ * nodes-changing flush, append or update, before AND after this fix.
+ * That's the residual documented in PR #2127 / task #39: removing it
+ * too would mean switching to a store/`produce`-based document model,
+ * out of that task's scope. Expect BOTH scenarios below to still show
+ * cost growing with document size — the fix's win is a reduced constant
+ * factor (no more a SECOND O(n) pass stacked on top of the array copy),
+ * most pronounced in "update-only" where that second pass is now zero
+ * instead of one-map-insert-per-existing-node.
+ */
+
+import { bench, describe } from "vitest";
+import type { DocumentNode } from "../../view/agent/types";
+import { update } from "./reducer";
+import { initialState } from "./types";
+
+const DOC_SIZES = [100, 1_000, 10_000] as const;
+
+const md = (id: string, content = id): DocumentNode => ({
+    type: "markdown",
+    id,
+    content,
+    timestamp: 0,
+});
+
+/** Build a base state with `size` existing markdown nodes, via the
+ *  reducer itself (one real `StreamFlush`, not a hand-rolled object) so
+ *  `nodeIndexById` is populated exactly the way production traffic
+ *  populates it. This setup runs ONCE per size, outside the timed
+ *  `bench()` loop below. */
+function seedState(size: number) {
+    const nodes = Array.from({ length: size }, (_, i) => md(`existing-${i}`));
+    return update(initialState(), { type: "StreamFlush", newNodes: nodes, updatedNodes: [] })
+        .state;
+}
+
+describe("agent-document reducer update(): StreamFlush append (new node)", () => {
+    for (const size of DOC_SIZES) {
+        // `update()` is pure — `base` is never mutated or reassigned, so
+        // every iteration appends onto the SAME fixed-size document
+        // instead of letting the document grow across the bench run.
+        const base = seedState(size);
+        let counter = 0;
+        bench(`append 1 new node onto a ${size.toLocaleString()}-node document`, () => {
+            counter++;
+            update(base, {
+                type: "StreamFlush",
+                newNodes: [md(`new-${size}-${counter}`)],
+                updatedNodes: [],
+            });
+        });
+    }
+});
+
+describe("agent-document reducer update(): StreamFlush update-only (dominant streaming case)", () => {
+    for (const size of DOC_SIZES) {
+        const base = seedState(size);
+        // Target the LAST existing node each time — same node every
+        // call, mirroring "more tokens land on the in-progress tail
+        // block." A fresh `content` string per call avoids accidentally
+        // measuring any content-equality fast path.
+        const targetId = `existing-${size - 1}`;
+        let counter = 0;
+        bench(`update 1 existing node in a ${size.toLocaleString()}-node document`, () => {
+            counter++;
+            update(base, {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: [md(targetId, `updated content ${counter}`)],
+            });
+        });
+    }
+});

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import type { DocumentNode, ToolLogChunk, ToolNode } from "../../view/agent/types";
+import type { DocumentNode, ShellNode, ToolLogChunk, ToolNode } from "../../view/agent/types";
 import { update } from "./reducer";
-import { initialState, TRUNCATE_GRACE_MS } from "./types";
+import { AgentDocumentState, initialState, TRUNCATE_GRACE_MS } from "./types";
 
 const md = (id: string, content = id): DocumentNode => ({
     type: "markdown",
@@ -34,16 +34,31 @@ const chunk = (
     ...overrides,
 });
 
+const shell = (id: string, overrides: Partial<ShellNode> = {}): ShellNode => ({
+    type: "shell",
+    id,
+    cmd: "echo hi",
+    title: "echo hi",
+    status: "running",
+    spawnedAt: 0,
+    log: { chunks: [], open: true },
+    ...overrides,
+});
+
 /**
- * Build a state with `nodes` AND a matching `nodeIdSet`. Required since
- * issue #728 gap 4 made `nodeIdSet` part of `AgentDocumentState` — bare
- * `{ ...initialState(), nodes: [...] }` would leave the index empty
- * and break dedup invariants.
+ * Build a state with `nodes` AND matching `nodeIdSet` / `nodeIndexById`.
+ * Required since issue #728 gap 4 made `nodeIdSet` part of
+ * `AgentDocumentState` (bare `{ ...initialState(), nodes: [...] }` would
+ * leave the index empty and break dedup invariants), and task #39 added
+ * `nodeIndexById` as the O(1) position index `ToolChunkAppend` /
+ * `ShellChunkAppend` / `ShellStatusUpdate` / `StreamFlush` rely on instead
+ * of scanning `nodes` — same requirement, same reason.
  */
-const seed = (nodes: DocumentNode[]) => ({
+const seed = (nodes: DocumentNode[]): AgentDocumentState => ({
     ...initialState(),
     nodes,
     nodeIdSet: new Set(nodes.map((n) => n.id)),
+    nodeIndexById: new Map(nodes.map((n, i) => [n.id, i])),
 });
 
 describe("agent document reducer", () => {
@@ -1093,6 +1108,149 @@ describe("agent document reducer", () => {
             const oldTool = r.state.nodes.find((n) => n.id === "old-tool") as ToolNode;
             expect(oldTool.status).toBe("canceled");
             expect(r.events.some((e: any) => e.type === "orphans-scrubbed")).toBe(true);
+        });
+    });
+
+    describe("nodeIndexById invariant (task #39)", () => {
+        // The reducer keeps an id->index map in lockstep with `nodes` so
+        // ToolChunkAppend/ShellChunkAppend/ShellStatusUpdate/StreamFlush can
+        // resolve a target in O(1) instead of scanning the whole array on
+        // every streamed chunk. These tests pin the map's correctness across
+        // every command that touches it — a drift here would silently make
+        // chunk-append start dropping/misrouting chunks instead of erroring.
+
+        it("StreamFlush keeps nodeIndexById in sync with appended node positions", () => {
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a"), md("b"), md("c")],
+                updatedNodes: [],
+            });
+            expect(r.state.nodeIndexById.get("a")).toBe(0);
+            expect(r.state.nodeIndexById.get("b")).toBe(1);
+            expect(r.state.nodeIndexById.get("c")).toBe(2);
+            for (const [id, idx] of r.state.nodeIndexById) {
+                expect(r.state.nodes[idx]?.id).toBe(id);
+            }
+        });
+
+        it("StreamFlush collision (in-place update) does not change the index", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a"), md("b")],
+                updatedNodes: [],
+            }).state;
+            const r = update(s0, {
+                type: "StreamFlush",
+                newNodes: [md("a", "v2")], // collides with "a" → in-place update, not append
+                updatedNodes: [],
+            });
+            expect(r.state.nodeIndexById.get("a")).toBe(0);
+            expect(r.state.nodeIndexById.get("b")).toBe(1);
+            expect((r.state.nodes[0] as DocumentNode & { content: string }).content).toBe("v2");
+        });
+
+        it("HistoryLoaded shifts existing indices by the prepended page length", () => {
+            const s0 = seed([md("live-1"), md("live-2")]);
+            const r = update(s0, {
+                type: "HistoryLoaded",
+                nodes: [md("h1"), md("h2"), md("h3")],
+            });
+            expect(r.state.nodeIndexById.get("h1")).toBe(0);
+            expect(r.state.nodeIndexById.get("h2")).toBe(1);
+            expect(r.state.nodeIndexById.get("h3")).toBe(2);
+            expect(r.state.nodeIndexById.get("live-1")).toBe(3);
+            expect(r.state.nodeIndexById.get("live-2")).toBe(4);
+            for (const [id, idx] of r.state.nodeIndexById) {
+                expect(r.state.nodes[idx]?.id).toBe(id);
+            }
+        });
+
+        it("HistoryRestored (snapshot) shifts existing indices the same way", () => {
+            const s0 = seed([md("live-1")]);
+            const r = update(s0, {
+                type: "HistoryRestored",
+                nodes: [md("snap-1"), md("snap-2")],
+                fromSnapshot: true,
+            });
+            expect(r.state.nodeIndexById.get("snap-1")).toBe(0);
+            expect(r.state.nodeIndexById.get("snap-2")).toBe(1);
+            expect(r.state.nodeIndexById.get("live-1")).toBe(2);
+        });
+
+        it("UserClear and StreamTruncate reset nodeIndexById to empty", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a")],
+                updatedNodes: [],
+            }).state;
+            expect(update(s0, { type: "UserClear" }).state.nodeIndexById.size).toBe(0);
+            expect(
+                update(s0, { type: "StreamTruncate", reason: "fileop" }).state.nodeIndexById.size,
+            ).toBe(0);
+        });
+
+        it("ToolChunkAppend resolves the target via the index (O(1) path) and leaves siblings' indices untouched", () => {
+            const s0 = seed([md("before"), tool("t1"), md("after")]);
+            const r = update(s0, {
+                type: "ToolChunkAppend",
+                toolId: "t1",
+                chunk: chunk("hello"),
+            });
+            expect((r.state.nodes[1] as ToolNode).log?.chunks.map((c) => c.content)).toEqual([
+                "hello",
+            ]);
+            // Index map unchanged — only content at index 1 was replaced.
+            expect(r.state.nodeIndexById).toBe(s0.nodeIndexById);
+        });
+
+        it("ToolChunkAppend still drops a chunk whose id maps to a non-tool node", () => {
+            const s0 = seed([md("m1")]);
+            const r = update(s0, {
+                type: "ToolChunkAppend",
+                toolId: "m1",
+                chunk: chunk("x"),
+            });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([
+                { type: "tool-chunk-dropped", toolId: "m1", reason: "node-not-tool" },
+            ]);
+        });
+
+        it("ShellNodeCreate appends and records the new index", () => {
+            const s0 = seed([md("a")]);
+            const r = update(s0, { type: "ShellNodeCreate", node: shell("sh1") });
+            expect(r.state.nodeIndexById.get("sh1")).toBe(1);
+            expect(r.state.nodes[1]?.id).toBe("sh1");
+        });
+
+        it("ShellChunkAppend resolves via the index and drops for an unknown id", () => {
+            const s0 = seed([shell("sh1")]);
+            const r = update(s0, {
+                type: "ShellChunkAppend",
+                shellId: "sh1",
+                chunk: chunk("out"),
+            });
+            expect((r.state.nodes[0] as ShellNode).log.chunks.map((c) => c.content)).toEqual([
+                "out",
+            ]);
+            const dropped = update(s0, {
+                type: "ShellChunkAppend",
+                shellId: "nope",
+                chunk: chunk("out"),
+            });
+            expect(dropped.state).toBe(s0);
+        });
+
+        it("ShellStatusUpdate resolves via the index", () => {
+            const s0 = seed([shell("sh1")]);
+            const r = update(s0, {
+                type: "ShellStatusUpdate",
+                shellId: "sh1",
+                status: "exited-ok",
+                exitCode: 0,
+                exitedAt: 123,
+            });
+            expect((r.state.nodes[0] as ShellNode).status).toBe("exited-ok");
         });
     });
 });

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -218,6 +218,18 @@ export function update(
                     ],
                 };
             }
+            // `fresh` prepends onto `state.nodes`, so every existing index
+            // shifts by `fresh.length` and the new nodes take 0..fresh.length-1.
+            // This is an O(existing-index-size) rebuild — unlike StreamFlush's
+            // per-chunk hot path, HistoryLoaded fires only on paginated
+            // older-history loads, and the merge below is already O(n) work.
+            const nextIndexById = new Map<string, number>();
+            for (const [id, idx] of state.nodeIndexById) {
+                nextIndexById.set(id, idx + fresh.length);
+            }
+            for (let i = 0; i < fresh.length; i++) {
+                nextIndexById.set(fresh[i].id, i);
+            }
             // Scrub orphans in the freshly-loaded replay. Same reason
             // as HistoryRestored: the legacy/NDJSON fallback path
             // (useHistoryPagination, no-snapshot path) can replay a
@@ -259,6 +271,7 @@ export function update(
                     ...state,
                     nodes: [...scrubbedFresh, ...state.nodes],
                     nodeIdSet: nextIdSet,
+                    nodeIndexById: nextIndexById,
                 },
                 events: loadEvents,
             };
@@ -309,6 +322,15 @@ export function update(
             const scrubResult = scrubOrphanedInProgress(fresh, nowMs);
             const scrubbedFresh = scrubResult ? scrubResult.nodes : fresh;
             const mergedNodes = [...scrubbedFresh, ...state.nodes];
+            // Same prepend-shift as HistoryLoaded above — `fresh` lands at
+            // the front, so every existing index moves by `fresh.length`.
+            const nextIndexById = new Map<string, number>();
+            for (const [id, idx] of state.nodeIndexById) {
+                nextIndexById.set(id, idx + fresh.length);
+            }
+            for (let i = 0; i < fresh.length; i++) {
+                nextIndexById.set(fresh[i].id, i);
+            }
             const restoreEvents: ReducerResult["events"] = [
                 {
                     type: "history-restored",
@@ -328,6 +350,7 @@ export function update(
                     ...state,
                     nodes: mergedNodes,
                     nodeIdSet: nextIdSet,
+                    nodeIndexById: nextIndexById,
                     sessionPhase: "active",
                 },
                 events: restoreEvents,
@@ -338,10 +361,18 @@ export function update(
             const noWork = command.newNodes.length === 0 && command.updatedNodes.length === 0;
             if (noWork) return { state, events: [] };
 
-            const indexById = new Map<string, number>();
-            for (let i = 0; i < state.nodes.length; i++) {
-                indexById.set(state.nodes[i].id, i);
-            }
+            // Reuse the incrementally-maintained id->index map instead of
+            // rebuilding it by scanning the full `nodes` array on every
+            // flush — this ran on EVERY streamed chunk (several times per
+            // RAF frame during active streaming) and was O(total document
+            // length) regardless of how much actually changed. task #39.
+            // Cloned lazily, only if this flush appends a node (the only
+            // case that adds an entry).
+            let indexById = state.nodeIndexById;
+            const ensureIndexClone = () => {
+                if (indexById === state.nodeIndexById) indexById = new Map(state.nodeIndexById);
+                return indexById;
+            };
             // Lazy-clone: only allocate a new array if something changes.
             let next: DocumentNode[] | null = null;
             const ensureClone = () => {
@@ -379,7 +410,7 @@ export function update(
                 }
                 const arr = ensureClone();
                 arr.push(n);
-                indexById.set(n.id, arr.length - 1);
+                ensureIndexClone().set(n.id, arr.length - 1);
                 if (!nextIdSet) nextIdSet = new Set(state.nodeIdSet);
                 nextIdSet.add(n.id);
                 appendedNew++;
@@ -414,6 +445,7 @@ export function update(
                     ...state,
                     nodes: next,
                     nodeIdSet: nextIdSet ?? state.nodeIdSet,
+                    nodeIndexById: indexById,
                 },
                 events: [
                     {
@@ -501,7 +533,12 @@ export function update(
                 return { state, events: [] };
             }
             return {
-                state: { ...state, nodes: [], nodeIdSet: new Set<string>() },
+                state: {
+                    ...state,
+                    nodes: [],
+                    nodeIdSet: new Set<string>(),
+                    nodeIndexById: new Map<string, number>(),
+                },
                 events: [
                     { type: "truncate-applied", reason: command.reason, clearedCount: cleared },
                 ],
@@ -514,14 +551,21 @@ export function update(
             }
             const nextSet = new Set(state.nodeIdSet);
             nextSet.add(command.node.id);
+            const nextIndexById = new Map(state.nodeIndexById);
+            nextIndexById.set(command.node.id, state.nodes.length);
             return {
-                state: { ...state, nodes: [...state.nodes, command.node], nodeIdSet: nextSet },
+                state: {
+                    ...state,
+                    nodes: [...state.nodes, command.node],
+                    nodeIdSet: nextSet,
+                    nodeIndexById: nextIndexById,
+                },
                 events: [{ type: "stream-flushed", appendedNew: 1, collidedAndUpdated: 0, updateApplied: 0, updateDropped: 0 }],
             };
         }
 
         case "ShellChunkAppend": {
-            const idx = state.nodes.findIndex((n) => n.type === "shell" && n.id === command.shellId);
+            const idx = findNodeIndex(state, command.shellId, "shell");
             if (idx === -1) return { state, events: [] };
             const shell = state.nodes[idx] as ShellNode;
             const existingChunks = shell.log.chunks;
@@ -536,7 +580,7 @@ export function update(
         }
 
         case "ShellStatusUpdate": {
-            const idx = state.nodes.findIndex((n) => n.type === "shell" && n.id === command.shellId);
+            const idx = findNodeIndex(state, command.shellId, "shell");
             if (idx === -1) return { state, events: [] };
             const shell = state.nodes[idx] as ShellNode;
             const nextNodes = state.nodes.slice();
@@ -556,7 +600,12 @@ export function update(
                 state:
                     cleared === 0
                         ? state
-                        : { ...state, nodes: [], nodeIdSet: new Set<string>() },
+                        : {
+                              ...state,
+                              nodes: [],
+                              nodeIdSet: new Set<string>(),
+                              nodeIndexById: new Map<string, number>(),
+                          },
                 events: [{ type: "user-cleared", clearedCount: cleared }],
             };
         }
@@ -610,28 +659,41 @@ function shouldSuppressTruncate(
 }
 
 /**
+ * Locate the index of a node by id + expected type via the reducer's
+ * incrementally-maintained `nodeIndexById` — O(1) instead of the O(n) linear
+ * scan this used to be (`state.nodes.findIndex(...)`), which ran on every
+ * single streamed chunk. task #39. Returns -1 if the id is unknown or the
+ * matching node isn't of `expectedType`.
+ */
+function findNodeIndex(
+    state: AgentDocumentState,
+    id: string,
+    expectedType: DocumentNode["type"],
+): number {
+    const idx = state.nodeIndexById.get(id);
+    if (idx == null) return -1;
+    const node = state.nodes[idx];
+    return node != null && node.id === id && node.type === expectedType ? idx : -1;
+}
+
+/**
  * Locate the index of a ToolNode by id, or -1 if either the id is
  * unknown or the matching node is not a tool. The two failure modes
- * map to distinct audit-event reasons.
+ * map to distinct audit-event reasons. O(1) via `nodeIndexById` — see
+ * `findNodeIndex`.
  */
 function findToolIndex(state: AgentDocumentState, toolId: string): number {
-    if (!state.nodeIdSet.has(toolId)) return -1;
-    for (let i = 0; i < state.nodes.length; i++) {
-        if (state.nodes[i].id === toolId) {
-            return state.nodes[i].type === "tool" ? i : -1;
-        }
-    }
-    return -1;
+    return findNodeIndex(state, toolId, "tool");
 }
 
 function nodeReasonFor(
     state: AgentDocumentState,
     toolId: string,
 ): "unknown-tool-id" | "node-not-tool" {
-    if (!state.nodeIdSet.has(toolId)) return "unknown-tool-id";
-    for (const n of state.nodes) {
-        if (n.id === toolId && n.type !== "tool") return "node-not-tool";
-    }
+    const idx = state.nodeIndexById.get(toolId);
+    if (idx == null) return "unknown-tool-id";
+    const node = state.nodes[idx];
+    if (node != null && node.id === toolId && node.type !== "tool") return "node-not-tool";
     return "unknown-tool-id";
 }
 

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -27,6 +27,18 @@ export interface AgentDocumentState {
      * from this set rather than rebuilt. Issue #728 gap 4.
      */
     nodeIdSet: Set<string>;
+    /**
+     * id -> current index in `nodes`, kept in lockstep with `nodes`
+     * (same lifecycle as `nodeIdSet`). Lets `StreamFlush` resolve
+     * collisions/updates and `ToolChunkAppend` / `ShellChunkAppend` /
+     * `ShellStatusUpdate` locate their target node in O(1) instead of
+     * scanning the full array on every streamed chunk — task #39. Any
+     * command that reorders or prepends `nodes` (`HistoryLoaded`,
+     * `HistoryRestored`) must rebuild this map to match; a command that
+     * only mutates node CONTENT in place (scrub, truncate-status flips)
+     * leaves indices untouched and can pass the same map through.
+     */
+    nodeIndexById: Map<string, number>;
 }
 
 export const initialState = (): AgentDocumentState => ({
@@ -34,6 +46,7 @@ export const initialState = (): AgentDocumentState => ({
     sessionPhase: "loading-history",
     sessionStartedAt: null,
     nodeIdSet: new Set<string>(),
+    nodeIndexById: new Map<string, number>(),
 });
 
 /** Optional knobs the dispatcher can pass through to the reducer. */

--- a/frontend/app/store/agent-pane-layout-store.bench.ts
+++ b/frontend/app/store/agent-pane-layout-store.bench.ts
@@ -1,0 +1,79 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Benchmarks for `agent-pane-layout-store.ts` dispatch — task #40, the
+ * empirical follow-up to the task #39 fix.
+ *
+ * Manual-only: NOT wired into `package.json`/CI. Run on demand with:
+ *
+ *   npx vitest bench frontend/app/store/agent-pane-layout-store.bench.ts
+ *
+ * This is the first `.bench.ts` file in this repo — establishing the
+ * convention (Vitest's `bench()`/`describe()` from the `vitest` package,
+ * one `describe` per scenario, one `bench` per input size, run via
+ * `vitest bench` rather than `vitest run`).
+ *
+ * What this measures: `dispatch()` cost for a SCROLL-ONLY update
+ * (`scrollTop` changes, nothing else) against a pane whose row positions
+ * are already built and cached, at 100 / 1,000 / 10,000 rows.
+ *
+ * Before task #39's fix, `layoutInputsChanged` gated the full
+ * `computeLayoutView()` — which rebuilds the O(n) prefix-sum
+ * `positions()` array — on ANY of `orderedIds/heights/estimates/
+ * scrollTop/viewportPx/scrollMarginPx/overscan` changing. A pure scroll
+ * event re-walked the ENTIRE historical row-position array every time,
+ * so this benchmark's cost would have scaled ~linearly with row count
+ * (100 → 1,000 → 10,000 roughly 10x → 100x baseline). We don't maintain
+ * that old code path here to compare against directly (git history has
+ * it, and `positions()`'s own doc comment still says "O(n)") — this
+ * bench exists to prove the CURRENT code doesn't regress back into that
+ * shape, and to give a concrete "is a scroll-only dispatch cheap"
+ * number for future changes to check themselves against.
+ *
+ * After the fix: a scroll-only dispatch reuses the cached `rows` array
+ * and only re-derives the visible window via `windowRangeOf`'s O(log n)
+ * binary search (see `positionInputsChanged` / `windowInputsChanged` in
+ * `agent-pane-layout-store.ts`). Expect near-flat timing across row
+ * counts — any noticeable growth with row count here is a regression
+ * signal (the O(n) rebuild came back).
+ */
+
+import { bench, describe } from "vitest";
+import { dispatch, registerPane } from "./agent-pane-layout-store";
+
+const ROW_COUNTS = [100, 1_000, 10_000] as const;
+
+/** Register a pane with `rowCount` rows already positioned (one
+ *  `NodesChanged` dispatch — the only O(n) work this setup needs, and
+ *  it happens ONCE, outside the timed `bench()` loop below). Default
+ *  row heights are fine: this benchmark is about the SCROLL path, not
+ *  measurement/estimation. */
+function setupPane(rowCount: number): string {
+    const blockId = `bench-scroll-${rowCount}`;
+    registerPane(blockId, {
+        layout: () => { /* no-op projection — bench doesn't render */ },
+        zoom: () => { /* no-op projection */ },
+    });
+    const orderedIds = Array.from({ length: rowCount }, (_, i) => `n${i}`);
+    dispatch(blockId, { type: "NodesChanged", orderedIds });
+    dispatch(blockId, { type: "Scrolled", scrollTop: 0, viewportPx: 600 });
+    return blockId;
+}
+
+describe("agent-pane-layout-store dispatch: scroll-only update", () => {
+    for (const rowCount of ROW_COUNTS) {
+        const blockId = setupPane(rowCount);
+        // Every call uses a DIFFERENT scrollTop. If we sent the same value
+        // twice, the reducer's own `Scrolled` no-op short-circuit
+        // (`state.scrollTop === command.scrollTop`) would return the
+        // identical state ref and the store would skip its window-changed
+        // branch entirely — cheating the benchmark by measuring the no-op
+        // path instead of the real "recompute the window" path.
+        let scrollTop = 0;
+        bench(`${rowCount.toLocaleString()} rows`, () => {
+            scrollTop = (scrollTop + 17) % 1_000_000;
+            dispatch(blockId, { type: "Scrolled", scrollTop, viewportPx: 600 });
+        });
+    }
+});

--- a/frontend/app/store/agent-pane-layout-store.test.ts
+++ b/frontend/app/store/agent-pane-layout-store.test.ts
@@ -101,4 +101,63 @@ describe("agent-pane-layout store", () => {
         unregisterPane(BID);
         expect(snapshot(BID)).toBeNull();
     });
+
+    describe("scroll-only updates reuse the cached prefix sum (task #39)", () => {
+        it("a scroll-only dispatch does NOT recompute positions — same `rows` array reference", () => {
+            const { layout } = mkPane();
+            dispatch(BID, { type: "NodesChanged", orderedIds: ["a", "b", "c"] });
+            dispatch(BID, { type: "RowMeasured", nodeId: "a", state: "collapsed", cssPx: 40 });
+            const afterData = layout.mock.calls.at(-1)![0];
+
+            dispatch(BID, { type: "Scrolled", scrollTop: 10, viewportPx: 200 });
+            const afterScroll = layout.mock.calls.at(-1)![0];
+
+            // `computeLayoutView`/`positions()` allocate a fresh `rows` array
+            // on every REAL recompute (documented on `positions()`), so
+            // referential equality here proves the scroll-only dispatch
+            // reused the cached prefix sum instead of rebuilding it — the
+            // O(n)-per-scroll-event bug this fixes.
+            expect(afterScroll.rows).toBe(afterData.rows);
+            expect(afterScroll.totalSize).toBe(afterData.totalSize);
+            // The window itself must still be recomputed (that's the whole
+            // point of a scroll) — just via the cheap O(log n) path.
+            expect(afterScroll.window).not.toBe(afterData.window);
+        });
+
+        it("a data-changing dispatch after a scroll-only one still rebuilds `rows`", () => {
+            const { layout } = mkPane();
+            dispatch(BID, { type: "NodesChanged", orderedIds: ["a", "b", "c"] });
+            dispatch(BID, { type: "Scrolled", scrollTop: 10, viewportPx: 200 });
+            const afterScroll = layout.mock.calls.at(-1)![0];
+
+            dispatch(BID, { type: "RowMeasured", nodeId: "b", state: "collapsed", cssPx: 55 });
+            const afterMeasure = layout.mock.calls.at(-1)![0];
+
+            expect(afterMeasure.rows).not.toBe(afterScroll.rows);
+            expect(afterMeasure.rows[1].height).toBe(55);
+        });
+
+        it("the reused-positions window is still correct (not stale) after scrolling", () => {
+            const { layout } = mkPane();
+            const ids = Array.from({ length: 20 }, (_, i) => `n${i}`);
+            dispatch(BID, { type: "NodesChanged", orderedIds: ids });
+            for (const id of ids) {
+                dispatch(BID, { type: "RowMeasured", nodeId: id, state: "collapsed", cssPx: 20 });
+            }
+            // Rows are 20px each (0..400 total). viewportPx=40 shows 2 rows;
+            // scrollTop=200 puts rows n10/n11 in view, padded by the default
+            // overscan (5) on each side.
+            dispatch(BID, { type: "Scrolled", scrollTop: 200, viewportPx: 40 });
+            const view = layout.mock.calls.at(-1)![0];
+            expect(view.window).toEqual({ startIndex: 5, endIndex: 16 });
+
+            // Scroll again (still no data change) — window must track the
+            // NEW scrollTop, not the stale cached one.
+            dispatch(BID, { type: "Scrolled", scrollTop: 0, viewportPx: 40 });
+            const view2 = layout.mock.calls.at(-1)![0];
+            expect(view2.window).toEqual({ startIndex: 0, endIndex: 6 });
+            // Positions array itself is still the same cached reference.
+            expect(view2.rows).toBe(view.rows);
+        });
+    });
 });

--- a/frontend/app/store/agent-pane-layout-store.ts
+++ b/frontend/app/store/agent-pane-layout-store.ts
@@ -20,6 +20,7 @@
  */
 
 import { type CommandSource, recordDispatch } from "./command-source";
+import { markDispatch } from "../view/agent/virtualization/perf-probe";
 import {
     computeLayoutView,
     update,
@@ -160,6 +161,12 @@ export function dispatch(
         );
     }
 
+    // Perf probe (task #40): times the FULL dispatch — reducer + the
+    // positions/window recompute below — the exact layer the original
+    // virtualization probe never measured (it only timed row DOM mount).
+    // No-op outside dev (see markDispatch / isProbingEnabled).
+    const stopDispatchTiming = markDispatch("layout");
+
     const prev = slot.state;
     const result = update(prev, command);
     slot.state = result.state;
@@ -210,6 +217,7 @@ export function dispatch(
         at: Date.now(),
     });
 
+    stopDispatchTiming();
     return result.events;
 }
 

--- a/frontend/app/store/agent-pane-layout-store.ts
+++ b/frontend/app/store/agent-pane-layout-store.ts
@@ -75,6 +75,14 @@ function viewsEqual(a: LayoutView, b: LayoutView): boolean {
     if (a.window.startIndex !== b.window.startIndex) return false;
     if (a.window.endIndex !== b.window.endIndex) return false;
     if (a.rows.length !== b.rows.length) return false;
+    // reagent (PR #2127): on a scroll-only dispatch whose window happens not
+    // to move (common during smooth/momentum scrolling — scrollTop changes
+    // every RAF tick, the visible index range often doesn't), `a.rows`/
+    // `b.rows` are the SAME cached array reference (see `cachedRows` in
+    // `dispatch()` above) — the elementwise walk below is redundant work on
+    // exactly the long-conversation scroll path task #39 targeted. Short-
+    // circuit on reference equality before paying for it.
+    if (a.rows === b.rows) return true;
     for (let i = 0; i < a.rows.length; i++) {
         const ra = a.rows[i];
         const rb = b.rows[i];

--- a/frontend/app/store/agent-pane-layout-store.ts
+++ b/frontend/app/store/agent-pane-layout-store.ts
@@ -23,6 +23,7 @@ import { type CommandSource, recordDispatch } from "./command-source";
 import {
     computeLayoutView,
     update,
+    windowRangeOf,
     type LayoutView,
     type RowPosition,
     type WindowRange,
@@ -54,6 +55,14 @@ interface Slot {
      *  (e.g. an off-flow measurement: writing the non-current expansion slot
      *  changes the `heights` map ref but not any position). codex P2 on #1236. */
     lastView: LayoutView | null;
+    /** Cached prefix-sum positions + total from the last position recompute
+     *  (`positionInputsChanged` was true, or this is the pane's first
+     *  dispatch). Reused as-is across scroll-only dispatches — see
+     *  `windowInputsChanged` — so a pure scroll/viewport/overscan change
+     *  re-derives just the window (O(log n)) instead of rebuilding the whole
+     *  prefix sum (O(n)). `null` only before the first recompute. */
+    cachedRows: RowPosition[] | null;
+    cachedTotalSize: number;
 }
 
 const slots = new Map<string, Slot>();
@@ -75,10 +84,14 @@ function viewsEqual(a: LayoutView, b: LayoutView): boolean {
     return true;
 }
 
-/** Fields whose change requires recomputing the projected layout view.
- *  `zoom` is deliberately excluded (INV-2). All of these are replaced by a
- *  fresh reference on change, so referential inequality is exact. */
-function layoutInputsChanged(
+/** Fields whose change moves row POSITIONS (the prefix-sum `positions()`
+ *  array itself) — order, heights/estimates, or the leading scrollMargin
+ *  offset that every row's `start` is measured from. A change here requires
+ *  a full O(n) recompute; there's no way to patch the prefix sum locally
+ *  without re-walking everything after the first changed row. All of these
+ *  are replaced by a fresh reference on change, so referential inequality is
+ *  exact. */
+function positionInputsChanged(
     a: AgentPaneLayoutState,
     b: AgentPaneLayoutState,
 ): boolean {
@@ -87,9 +100,24 @@ function layoutInputsChanged(
         a.expansion !== b.expansion ||
         a.heights !== b.heights ||
         a.estimates !== b.estimates ||
+        a.scrollMarginPx !== b.scrollMarginPx
+    );
+}
+
+/** Fields whose change moves only the visible WINDOW over an otherwise
+ *  unchanged `positions()` array — scroll offset, viewport size, overscan
+ *  padding. None of these can change any row's start/height, so when only
+ *  these change (and `positionInputsChanged` is false), the store reuses the
+ *  last-computed positions array and re-derives the window via the O(log n)
+ *  `windowRangeOf` binary search instead of re-walking the whole prefix sum.
+ *  This is the fix for the scroll-triggered O(n) rebuild (task #39). */
+function windowInputsChanged(
+    a: AgentPaneLayoutState,
+    b: AgentPaneLayoutState,
+): boolean {
+    return (
         a.scrollTop !== b.scrollTop ||
         a.viewportPx !== b.viewportPx ||
-        a.scrollMarginPx !== b.scrollMarginPx ||
         a.overscan !== b.overscan
     );
 }
@@ -103,7 +131,13 @@ export function registerPane(
     blockId: string,
     proj: AgentPaneLayoutProjections,
 ): void {
-    slots.set(blockId, { state: initialState(), proj, lastView: null });
+    slots.set(blockId, {
+        state: initialState(),
+        proj,
+        lastView: null,
+        cachedRows: null,
+        cachedTotalSize: 0,
+    });
 }
 
 export function unregisterPane(blockId: string): void {
@@ -130,11 +164,34 @@ export function dispatch(
     const result = update(prev, command);
     slot.state = result.state;
 
-    if (layoutInputsChanged(prev, slot.state)) {
-        // The ref-level gate above is cheap but coarse: an off-flow measurement
-        // changes the `heights` ref without moving any position. Recompute the
-        // view and project only if it actually differs (codex P2 on #1236).
-        const view = computeLayoutView(slot.state);
+    const positionsChanged = positionInputsChanged(prev, slot.state);
+    const windowChanged = windowInputsChanged(prev, slot.state);
+    if (positionsChanged || windowChanged) {
+        let view: LayoutView;
+        if (positionsChanged || slot.cachedRows === null) {
+            // Data actually moved (or this is the pane's first recompute) —
+            // full O(n) prefix-sum rebuild. The ref-level gate above is cheap
+            // but coarse: an off-flow measurement changes the `heights` ref
+            // without moving any position. Project only if the resulting view
+            // actually differs (codex P2 on #1236).
+            view = computeLayoutView(slot.state);
+            slot.cachedRows = view.rows;
+            slot.cachedTotalSize = view.totalSize;
+        } else {
+            // Scroll-only update (scrollTop/viewportPx/overscan changed,
+            // nothing that moves a row). Positions are provably unchanged, so
+            // reuse the cached prefix-sum array and re-derive just the window
+            // via the existing O(log n) binary search instead of re-walking
+            // the whole historical positions array on every scroll event
+            // (task #39).
+            const window = windowRangeOf(
+                slot.cachedRows,
+                slot.state.scrollTop,
+                slot.state.viewportPx,
+                slot.state.overscan,
+            );
+            view = { rows: slot.cachedRows, totalSize: slot.cachedTotalSize, window };
+        }
         if (slot.lastView === null || !viewsEqual(view, slot.lastView)) {
             slot.lastView = view;
             slot.proj.layout(view);

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -118,6 +118,16 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     let virtualContainerRef: HTMLDivElement | undefined;
     // Guard against concurrent older-history fetches triggered by scroll.
     let loadingOlderInFlight = false;
+    // RAF-coalesced scroll handling (task #39): native `scroll` events can
+    // fire dozens of times per drag/wheel gesture; without coalescing, each
+    // one dispatches a layout `Scrolled` command and re-derives the window.
+    // Mirrors the `scheduleFlush`/`flushRafId` idiom useAgentStream.ts uses to
+    // batch stream chunks into one dispatch per animation frame — same
+    // "guard with a nullable rAF handle" pattern, applied to scroll here.
+    // `handleScrollNow` reads scrollRef's LIVE values (not anything captured
+    // from the event), so it's safe to defer to the next frame: whichever
+    // scroll position is current when the frame runs is the one applied.
+    let scrollRafId: number | null = null;
 
     // Sticky frontier id — set once when the document first crosses
     // STREAMING_BUFFER_SIZE; advanced whenever the buffer exceeds the
@@ -489,7 +499,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         }
     };
 
-    const handleScroll = (): void => {
+    const handleScrollNow = (): void => {
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
 
@@ -620,6 +630,23 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             });
         }
     };
+
+    // Coalesce native `scroll` events to at most one `handleScrollNow` call
+    // per animation frame. `onScroll` below wires this, not `handleScrollNow`
+    // directly.
+    const handleScroll = (): void => {
+        if (scrollRafId != null) return;
+        scrollRafId = requestAnimationFrame(() => {
+            scrollRafId = null;
+            handleScrollNow();
+        });
+    };
+    onCleanup(() => {
+        if (scrollRafId != null) {
+            cancelAnimationFrame(scrollRafId);
+            scrollRafId = null;
+        }
+    });
 
     // ── Phase 3 Step 3+4: render from the slice + a standalone measure RO ──
     // Rows render from the slice's prefix-sum positions (computeLayoutView →

--- a/frontend/app/view/agent/virtualization/perf-probe.test.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
     agentPerfStore,
     ESTIMATOR_MISS_THRESHOLD,
+    markDispatch,
     markRowMount,
 } from "./perf-probe";
 
@@ -120,11 +121,35 @@ describe("agentPerfStore", () => {
         });
     });
 
+    describe("recordDispatchTiming", () => {
+        // task #40 — the store-dispatch timing probe, added to close the
+        // blind spot from the original investigation: row-mount timing
+        // never measured the reducer/store cost underneath the DOM.
+        it("aggregates per-kind dispatch durations into a snapshot", () => {
+            agentPerfStore.recordDispatchTiming("layout", 1);
+            agentPerfStore.recordDispatchTiming("layout", 3);
+            agentPerfStore.recordDispatchTiming("document", 2);
+
+            const snap = agentPerfStore.snapshot();
+            expect(snap.dispatchByKind.get("layout")!.count).toBe(2);
+            expect(snap.dispatchByKind.get("document")!.count).toBe(1);
+        });
+
+        it("keeps layout and document timings independent", () => {
+            for (let i = 0; i < 5; i++) agentPerfStore.recordDispatchTiming("layout", 1);
+            for (let i = 0; i < 3; i++) agentPerfStore.recordDispatchTiming("document", 1);
+            const snap = agentPerfStore.snapshot();
+            expect(snap.dispatchByKind.get("layout")!.count).toBe(5);
+            expect(snap.dispatchByKind.get("document")!.count).toBe(3);
+        });
+    });
+
     describe("reset", () => {
         it("clears all recorded data", () => {
             agentPerfStore.recordRowMount("markdown", 5);
             agentPerfStore.recordEstimatorMeasurement("tool", 100, 200);
             agentPerfStore.recordLayoutShift(0.05);
+            agentPerfStore.recordDispatchTiming("layout", 4);
 
             agentPerfStore.reset();
 
@@ -133,6 +158,7 @@ describe("agentPerfStore", () => {
             expect(snap.recentEstimatorMisses).toHaveLength(0);
             expect(snap.recentLayoutShifts).toHaveLength(0);
             expect(snap.estimatorMissRateByKind.size).toBe(0);
+            expect(snap.dispatchByKind.size).toBe(0);
         });
     });
 });
@@ -159,5 +185,30 @@ describe("markRowMount", () => {
         const snap = agentPerfStore.snapshot();
         expect(snap.rowMountByKind.get("agent_message")!.count).toBe(2);
         expect(snap.rowMountByKind.get("tool")!.count).toBe(1);
+    });
+});
+
+describe("markDispatch", () => {
+    beforeEach(() => agentPerfStore.reset());
+
+    it("returns a closer that records duration on call", async () => {
+        const close = markDispatch("layout");
+        await new Promise<void>((r) => setTimeout(r, 5));
+        close();
+        const snap = agentPerfStore.snapshot();
+        const q = snap.dispatchByKind.get("layout");
+        expect(q).toBeDefined();
+        expect(q!.count).toBe(1);
+        // Should be at least 5ms (with timer slop, allow 2ms floor).
+        expect(q!.max).toBeGreaterThanOrEqual(2);
+    });
+
+    it("multiple calls accumulate independently per kind", () => {
+        markDispatch("layout")();
+        markDispatch("layout")();
+        markDispatch("document")();
+        const snap = agentPerfStore.snapshot();
+        expect(snap.dispatchByKind.get("layout")!.count).toBe(2);
+        expect(snap.dispatchByKind.get("document")!.count).toBe(1);
     });
 });

--- a/frontend/app/view/agent/virtualization/perf-probe.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.ts
@@ -42,6 +42,17 @@ export interface LayoutShiftSample {
     timestamp: number;
 }
 
+/**
+ * Which store's `dispatch()` a timing sample came from. `layout` is
+ * `agent-pane-layout-store.ts` (row positions/window); `document` is
+ * `agent-document-store.ts` (the message list — StreamFlush/chunk
+ * appends). Task #39/#40: this is the exact blind spot the original
+ * virtualization perf probe never covered — it measured row MOUNT
+ * cost, not the reducer/store DISPATCH cost underneath, which is what
+ * was actually growing with conversation length.
+ */
+export type DispatchKind = "layout" | "document";
+
 /** Threshold above which an estimator is considered a miss. */
 export const ESTIMATOR_MISS_THRESHOLD = 0.30;
 
@@ -68,10 +79,18 @@ class AgentPerfStore {
     private kindMissCount = new Map<NodeKind, { misses: number; total: number }>();
     /** Layout-shift events scoped to agent pane. */
     private layoutShifts: LayoutShiftSample[] = [];
+    /** Per-kind store `dispatch()` duration (ms) — layout vs document
+     *  store. p50/p95/max surface in HUD, same shape as `rowMountAgg`. */
+    private dispatchAgg = new KeyedAggregator(SAMPLE_RING_SIZE);
 
     recordRowMount(kind: NodeKind, durationMs: number): void {
         if (!isProbingEnabled()) return;
         this.rowMountAgg.record(kind, durationMs);
+    }
+
+    recordDispatchTiming(kind: DispatchKind, durationMs: number): void {
+        if (!isProbingEnabled()) return;
+        this.dispatchAgg.record(kind, durationMs);
     }
 
     recordEstimatorMeasurement(kind: NodeKind, estimated: number, actual: number): void {
@@ -116,6 +135,7 @@ class AgentPerfStore {
             estimatorMissRateByKind: missRates,
             recentEstimatorMisses: [...this.estimatorMisses],
             recentLayoutShifts: [...this.layoutShifts],
+            dispatchByKind: this.dispatchAgg.snapshot() as Map<DispatchKind, QuantileSnapshot>,
         };
     }
 
@@ -125,6 +145,7 @@ class AgentPerfStore {
         this.estimatorMisses = [];
         this.kindMissCount.clear();
         this.layoutShifts = [];
+        this.dispatchAgg = new KeyedAggregator(SAMPLE_RING_SIZE);
     }
 }
 
@@ -133,6 +154,8 @@ export interface AgentPerfSnapshot {
     estimatorMissRateByKind: ReadonlyMap<NodeKind, number>;
     recentEstimatorMisses: readonly EstimatorMissSample[];
     recentLayoutShifts: readonly LayoutShiftSample[];
+    /** Store `dispatch()` duration (ms), keyed by `layout`/`document`. */
+    dispatchByKind: ReadonlyMap<DispatchKind, QuantileSnapshot>;
 }
 
 const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
@@ -140,6 +163,7 @@ const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
     estimatorMissRateByKind: new Map(),
     recentEstimatorMisses: [],
     recentLayoutShifts: [],
+    dispatchByKind: new Map(),
 };
 
 export const agentPerfStore = new AgentPerfStore();
@@ -200,6 +224,25 @@ export function markRowMount(kind: NodeKind): () => void {
     const start = performance.now();
     return () => {
         agentPerfStore.recordRowMount(kind, performance.now() - start);
+    };
+}
+
+/**
+ * Time a store `dispatch()` call. Returns a function the caller invokes
+ * once the dispatch (reducer + projection) has fully settled — same
+ * start/stop shape as `markRowMount`, applied to the layer underneath
+ * the DOM: `agent-pane-layout-store.ts` and `agent-document-store.ts`
+ * call this around their `dispatch()` bodies so the HUD can show the
+ * cost this task's fix (task #39) targeted, which the row-mount probe
+ * above never covered.
+ *
+ * Production: returns a no-op.
+ */
+export function markDispatch(kind: DispatchKind): () => void {
+    if (!isProbingEnabled()) return NOOP;
+    const start = performance.now();
+    return () => {
+        agentPerfStore.recordDispatchTiming(kind, performance.now() - start);
     };
 }
 


### PR DESCRIPTION
## Summary

Task #39. A prior investigation found that the agent pane's DOM windowing (visible rows + a 50-node streaming buffer) works correctly, but the **data layer underneath** did O(total-conversation-length) work on every streamed chunk AND on every scroll event — making the pane get measurably slower as a session's conversation grows, independent of any LLM/API context-size cost.

This PR is the fix, in priority order from the task brief:

1. **Scroll no longer triggers a full O(n) layout recompute.** `agent-pane-layout-store.ts`'s `dispatch` used to gate the full `computeLayoutView()` (which rebuilds the O(n) prefix-sum `positions()` array) on ANY of `orderedIds/heights/estimates/scrollTop/viewportPx/scrollMarginPx/overscan` changing. Split into `positionInputsChanged` (order/heights/estimates/scrollMargin — real position-affecting changes, needs full O(n) rebuild) vs `windowInputsChanged` (scrollTop/viewportPx/overscan — reuses the cached positions array, just re-derives the visible window via the already-existing O(log n) `windowRangeOf` binary search). A pure scroll now costs O(log n), not O(n).

2. **Scroll handler is now RAF-coalesced.** `AgentDocumentVirtualList.tsx`'s `handleScroll` used to dispatch on every native `scroll` event (which can fire dozens of times per drag/wheel gesture). Now coalesced to at most one dispatch per animation frame, mirroring the `scheduleFlush`/`flushRafId` idiom `useAgentStream.ts` already uses for stream-chunk batching.

3. **Streamed chunks no longer rebuild an id→index Map or linear-scan `nodes` on every chunk.** Added an incrementally-maintained `nodeIndexById: Map<string, number>` to `AgentDocumentState`, kept in lockstep with `nodes` the same way `nodeIdSet` already is (issue #728 gap 4 pattern). `StreamFlush`, `ToolChunkAppend`, `ShellChunkAppend`, `ShellStatusUpdate` all resolve their target node in O(1)/O(k) now, instead of an O(n) Map rebuild (`StreamFlush`) or O(n) linear scan (the others) on every single chunk.

## Residual / known limitation

`state.nodes.slice()` itself is still O(n) per chunk. `nodes` is exposed to the reactive layer as a plain-array **signal** (`agent-document-store.ts`'s `DocumentSetter`), not a SolidJS `createStore` — so a brand-new array reference is structurally required for the signal to fire. Eliminating that too would mean switching the document state to a store-based `produce`/`reconcile` model for fine-grained in-place updates, which is a bigger architectural change than this task's scope (the task explicitly said not to touch the virtualization architecture). Flagging this as a legitimate follow-up rather than forcing it into this PR.

## Test plan

- [x] Verified all cited file:line locations against current code (mostly matched; `StreamFlush` had already grown a lazy-clone guard since the investigation, but still rebuilt the O(n) `indexById` Map every flush)
- [x] Added tests pinning the new behaviors:
  - `agent-pane-layout-store.test.ts`: scroll-only dispatch reuses the cached `rows` array reference (proves no O(n) recompute); a subsequent data-changing dispatch still rebuilds `rows`; the reused-positions window is still correct (not stale) across repeated scrolls
  - `reducer.test.ts`: `nodeIndexById` stays correct across every command that touches `nodes` (StreamFlush append/collision, HistoryLoaded/HistoryRestored prepend-shift, UserClear/StreamTruncate reset, ShellNodeCreate/ShellChunkAppend/ShellStatusUpdate, and the non-tool-node drop path)
- [x] Full frontend suite: `npx vitest run` → 1701 passed, 3 skipped (unrelated e2e tests needing a build dir), 0 failures
- [x] `npx tsc --noEmit` clean

<!-- agentmux:agent_id=agenta -->