### PR TITLE
feat(theme): light theme reaches header/status-bar chrome + 3 more light themes

### DIFF
--- a/.changesets/1783909383-feat-theme-light-theme-reaches-header-status-bar-chrome-add--yt8v.md
+++ b/.changesets/1783909383-feat-theme-light-theme-reaches-header-status-bar-chrome-add--yt8v.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(theme): light theme reaches header/status-bar chrome + add Catppuccin Latte, Solarized Light, Gruvbox Light

--- a/docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md
+++ b/docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md
@@ -1,0 +1,89 @@
+# Spec: Light Theme — Header/Status-Bar Depth Fixes + 3 New Light Themes
+
+**Date:** 2026-07-13
+**Status:** Implemented (this spec documents the change; code is in the same PR)
+**Follows:** `docs/specs/SPEC_LIGHT_THEME_AND_DEPTH_FIXES_2026_07_11.md` (the original light theme), the PR #2104 review cycle that fixed `--input-bg-color` and the `*-text-color` triad.
+
+**Trigger:** manual verification of PR #2104 on `task dev` surfaced that the window header (top bar, holding tabs + widgets) and the status bar (bottom) stayed dark under the Light theme, even though every other surface had correctly gone light.
+
+---
+
+## 1. Does the theme system reach the header and status bar? — Answer
+
+**The plumbing does; three specific things didn't wire into it correctly.** Every rule in these areas is written against `var(--token)`, not hardcoded colors, and most tokens resolve correctly via alias (`--widget-icon-color` → `--secondary-text-color`, `--tab-separator-color` → `--border-color`, etc. — both already overridden by `light.scss`). Five concrete gaps were found and fixed, three of them exactly explaining the reported symptom:
+
+| # | Where | Bug | Why it looked "still dark" |
+|---|---|---|---|
+| 1 | `.window-header` (`window-header.{win32,darwin,linux}.scss`) | `background: var(--tab-strip-bg)` — token exists, but `--tab-strip-bg: rgba(255, 255, 255, 0.03)` at `:root` is a **white** tint (meant to lighten a dark surface). `light.scss` never overrode it. | A white tint over an already-near-white background is invisible; the header rendered at its literal dark-theme value with no light override to fall back to — **this is the top bar staying dark.** |
+| 2 | `.status-bar` (`StatusBar.scss`) | `background: rgba(0, 0, 0, 0.35)` — a **hardcoded literal**, not a token at all. | Never participated in the theme system in the first place — **this is the status bar staying dark, on every theme, not just Light.** |
+| 3 | `.action-widget-more-btn` hover/open, `.action-widget[.context-active]` (`action-widgets.scss`) | `var(--hoverbg-color, ...)` — missing hyphen; the real token is `--hover-bg-color`. `--hoverbg-color` is never defined anywhere. | Every widget-bar hover, on every theme, silently used the hardcoded white-tint fallback — theme-inert since the day it was written. Same rule also hardcoded `color: white` for the hover/open text color. |
+| 4 | Windows caption buttons (min/max hover/press), `window-controls.win32.scss` | Gated on `@media (prefers-color-scheme: light)` — the **OS** setting — not AgentMux's own `data-theme` attribute. | If the OS is in dark mode (common) while AgentMux's own theme is set to Light, the caption buttons kept the dark-tuned tint. Wrong signal entirely, not a missing value. |
+| 5 | (adjacent, found during the sweep) `.status-bar-restart-btn`, `.close-btn` hover in `window-controls.win32.scss` | Hardcoded `color: #fff`/`color: white` | **Not bugs** — both are already correctly documented as intentional (white-on-solid-red is universally readable; the Win11 close-button red is an OS brand color, not theme-relative). Left as-is. |
+| — | `.config-error-button` in `system-status.scss` | Hardcoded `color: black` | Dead CSS — no component renders this class (only the similarly-named `.config-error-message` is used). Confirmed via `grep`; left untouched, out of scope. |
+
+---
+
+## 2. Fixes
+
+### 2.1 New/fixed tokens (`theme.scss`, `light.scss`)
+
+- **New `--status-bar-bg` token** at `:root` (`theme.scss`), default value = the exact literal it replaces (`rgba(0, 0, 0, 0.35)`) — **zero visual change on any existing dark theme.** `StatusBar.scss` now reads `background: var(--status-bar-bg)`.
+- **`light.scss` gains two overrides it was missing**: `--tab-strip-bg: rgba(0, 0, 0, 0.03)` and `--status-bar-bg: rgba(0, 0, 0, 0.06)`. Same polarity-flip reasoning as the PR #2104 `--input-bg-color` fix: black tints darken regardless of what's underneath (no vanish-toward-invisibility risk), so they're the correct direction for every light-family theme's recessed chrome strips — mirrored for both new tokens.
+
+### 2.2 `--hoverbg-color` → `--hover-bg-color` typo fix
+`action-widgets.scss`, both call sites (widget hover, "More" button hover/open). Also fixed the hardcoded `color: white` on the same rule → `var(--widget-icon-hover-color)`, matching the equivalent icon-hover treatment three lines above it in the same file.
+
+### 2.3 Caption-button light detection: OS media query → app theme signal
+Introduced a generic **light/dark polarity marker**, independent of which specific theme is active:
+
+- `frontend/app/menu/base-menus.ts` — new `LIGHT_THEME_IDS: ReadonlySet<string>`, alongside the existing `THEME_OPTIONS` list (single source of truth for both).
+- `app.tsx` — alongside the existing `data-theme="<id>"` attribute, now also sets `data-theme-polarity="light"` on `<html>` when the active theme id is in `LIGHT_THEME_IDS` (removed otherwise).
+- `window-controls.win32.scss` — the caption-button hover/press override moves from `@media (prefers-color-scheme: light)` to `[data-theme-polarity="light"] &` (SCSS nesting → `[data-theme-polarity="light"] .window-action-buttons`). Same values, correct gate.
+
+**Why a separate polarity marker instead of one `[data-theme="light"]` check**, given the header/status-bar fixes (§2.1) just needed a plain per-theme override: this specific bug is in a *chrome* file that shouldn't need to know about individual theme ids or be edited every time a new light theme is added — one selector now correctly covers Light **and** the three new themes below, and whatever light theme is added next, for free. (The header/status-bar tokens don't need this: each theme file, dark or light, already declares its own value or inherits a shared default — that pattern doesn't require a polarity concept, only genuinely theme-agnostic *logic* like this one does.)
+
+---
+
+## 3. Three more light themes
+
+Added, matching this codebase's existing "borrow the real palette's well-known colors, apply them through the established structural token pattern" convention (every existing dark theme — Nord, Dracula, Catppuccin, Gruvbox, Tokyo Night — already does this; `light.scss` itself is recognizably GitHub's light palette under a generic name). Selection: two are the official light flavor of an *already-present* dark theme (giving users a light/dark pair within the same family), one is a well-known standalone classic.
+
+| Theme id | Label | Pairs with | Palette source |
+|---|---|---|---|
+| `catppuccin-latte` | Catppuccin Latte | existing `catppuccin` (Mocha) | Catppuccin's official Latte flavor — Base/Mantle/Text/Subtext + named accents (Blue, Red, Green, Yellow, Peach, Mauve, Teal, Pink) |
+| `solarized-light` | Solarized Light | — (standalone classic) | Ethan Schoonover's Solarized — base3/base2/base01/base00 + the 8 accent hues shared with Solarized Dark |
+| `gruvbox-light` | Gruvbox Light | existing `gruvbox` (Dark) | Gruvbox's official light variant, using the palette's own "faded" accent set (its documented choice for light backgrounds, vs. the "neutral/bright" set the existing dark Gruvbox theme uses) |
+
+Each new file (`frontend/app/themes/{catppuccin-latte,solarized-light,gruvbox-light}.scss`) follows `light.scss`'s exact token surface and light-polarity conventions (§2.1's black-tint direction for hover/highlight/input-bg/tab-strip/status-bar), but tints hover/highlight with the theme's own accent color rather than plain black — mirroring how the existing dark Catppuccin/Gruvbox themes tint *their* hover/highlight with their own accent instead of plain white. `--error-text-color`/`--success-text-color`/`--warning-text-color` alias to the theme's own `--error-color`/`--success-color`/`--warning-color`, same pattern `light.scss` established in the PR #2104 review (avoids the dark-tuned defaults' contrast failure on a light surface).
+
+**Solarized Light's `--term-*` table is Solarized's own canonical, widely-published 16-color ANSI mapping**, reproduced as-is rather than derived — unlike every other theme file (including this one's own UI tokens), that specific mapping is the palette's unchanged-for-over-a-decade signature. Catppuccin Latte's and Gruvbox Light's `--term-*` tables are derived from each theme's own core semantic colors (same approach `light.scss` itself uses), not a claimed reproduction of any one tool's exact ANSI export.
+
+### 3.1 Registration (4 touchpoints, all existing themes already require these)
+- `frontend/app/themes/index.scss` — `@use` the 3 new files.
+- `frontend/app/menu/base-menus.ts` — 3 new `THEME_OPTIONS` entries + `LIGHT_THEME_IDS` (§2.3).
+- `schema/settings.json` — `window:theme` enum + description gain the 3 new ids.
+- `frontend/types/gotypes.d.ts` — no change needed; `window:theme` is typed as plain `string` there, no enum duplication to update.
+
+---
+
+## 4. Verification
+
+- `npx tsc --noEmit` — clean.
+- `npm run build` — clean (SCSS compiles, no errors).
+- `npx vitest run` — 1688 passed, 2 skipped (pre-existing, unrelated), 0 failures. No test hardcodes the theme count or enumerates `THEME_OPTIONS`, so the 3 additions needed no test updates.
+- Not independently re-verified visually beyond the original manual `task dev` check that surfaced the header/status-bar symptom — recommend a follow-up look at all 4 light themes (original + 3 new) once this lands, same as the note on the original light theme spec.
+
+## 5. Files touched
+
+| File | Change |
+|---|---|
+| `frontend/app/theme.scss` | new `--status-bar-bg` token at `:root` |
+| `frontend/app/statusbar/StatusBar.scss` | hardcoded status-bar background → `var(--status-bar-bg)` |
+| `frontend/app/window/action-widgets.scss` | `--hoverbg-color` typo → `--hover-bg-color` (×2); hardcoded `color: white` → `var(--widget-icon-hover-color)` |
+| `frontend/app/window/window-controls.win32.scss` | `@media (prefers-color-scheme: light)` → `[data-theme-polarity="light"] &` |
+| `frontend/app/menu/base-menus.ts` | new `LIGHT_THEME_IDS`; 3 new `THEME_OPTIONS` entries |
+| `frontend/app/app.tsx` | sets/clears `data-theme-polarity` alongside `data-theme` |
+| `frontend/app/themes/light.scss` | adds `--tab-strip-bg` / `--status-bar-bg` overrides |
+| `frontend/app/themes/{catppuccin-latte,solarized-light,gruvbox-light}.scss` | new |
+| `frontend/app/themes/index.scss` | `@use` the 3 new files |
+| `schema/settings.json` | `window:theme` enum + description |

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -9,6 +9,7 @@ import "./diag/replace-child-diagnostic";
 import { Workspace } from "@/app/workspace/workspace";
 import { FloatingPaneWorkspace } from "@/app/workspace/floating-pane-workspace";
 import { ContextMenuModel } from "@/store/contextmenu";
+import { LIGHT_THEME_IDS } from "@/app/menu/base-menus";
 import { atoms, getApi, getSettingsPrefixAtom, isDev, openLink, removeFlashError, flashErrors } from "@/store/global";
 import { appHandleKeyDown, keyboardMouseDownHandler } from "@/store/keymodel";
 import { chromeZoomIn, chromeZoomOut, zoomBlockIn, zoomBlockOut, WHEEL_STEP } from "@/store/zoom.platform";
@@ -194,6 +195,13 @@ function AppSettingsUpdater() {
             document.documentElement.setAttribute("data-theme", theme);
         } else {
             document.documentElement.removeAttribute("data-theme");
+        }
+        // Generic light/dark polarity marker, independent of which specific
+        // theme is active — see LIGHT_THEME_IDS for why this exists.
+        if (theme && LIGHT_THEME_IDS.has(theme)) {
+            document.documentElement.setAttribute("data-theme-polarity", "light");
+        } else {
+            document.documentElement.removeAttribute("data-theme-polarity");
         }
     });
     return null;

--- a/frontend/app/menu/base-menus.ts
+++ b/frontend/app/menu/base-menus.ts
@@ -4,7 +4,8 @@
 /**
  * Theme list shown in the hamburger menu Theme submenu. Order matters
  * for muscle memory — don't reshuffle. Ids must match the schema enum
- * at schema/settings.json `window:theme`.
+ * at schema/settings.json `window:theme`, and each theme's SCSS file
+ * at frontend/app/themes/<id>.scss.
  */
 export const THEME_OPTIONS: ReadonlyArray<{ id: string; label: string }> = [
     { id: "default", label: "Default" },
@@ -17,5 +18,29 @@ export const THEME_OPTIONS: ReadonlyArray<{ id: string; label: string }> = [
     { id: "tokyo-night", label: "Tokyo Night" },
     { id: "gruvbox", label: "Gruvbox" },
     { id: "light", label: "Light" },
+    { id: "catppuccin-latte", label: "Catppuccin Latte" },
+    { id: "solarized-light", label: "Solarized Light" },
+    { id: "gruvbox-light", label: "Gruvbox Light" },
 ];
+
+/**
+ * Theme ids that are light-background (the inverse of every other theme's
+ * dark-background convention). Consumed by app.tsx to additionally set
+ * `data-theme-polarity="light"` on <html> alongside `data-theme="<id>"`.
+ *
+ * Why a separate polarity marker instead of gating CSS on the specific
+ * theme id: a handful of chrome elements (e.g. the Windows caption-button
+ * hover/press tint, window-controls.win32.scss) need a light-vs-dark
+ * decision but don't have (and shouldn't need) per-theme tuning — one
+ * `[data-theme-polarity="light"]` selector covers every light theme
+ * without hardcoding N theme ids into N call sites, and covers whatever
+ * light theme is added next for free.
+ * See docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md.
+ */
+export const LIGHT_THEME_IDS: ReadonlySet<string> = new Set([
+    "light",
+    "catppuccin-latte",
+    "solarized-light",
+    "gruvbox-light",
+]);
 

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -22,7 +22,7 @@
     flex-shrink: 0;
     font-size: 11px;
     zoom: var(--zoomfactor);
-    background: rgba(0, 0, 0, 0.35);
+    background: var(--status-bar-bg);
     border-top: 1px solid var(--border-color);
     color: var(--secondary-text-color);
     user-select: none;

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -83,6 +83,17 @@
     // recessed tab-strip behind it.
     --workspace-surface: var(--block-bg-color);
     --tab-strip-bg: rgba(255, 255, 255, 0.03);
+    // The bottom status bar's own recessed strip — same concept as
+    // --tab-strip-bg (Layer A) but a separate token: StatusBar.scss used to
+    // hardcode this as a bare `rgba(0, 0, 0, 0.35)` literal, which is why it
+    // stayed dark under every theme including Light (a hardcoded literal
+    // doesn't participate in the theme system at all — unlike --tab-strip-bg,
+    // which WAS a real token but simply had no light.scss override, letting
+    // it fall through to this file's white-tint default and go invisible on
+    // a light surface). This value is the exact literal it replaces, so
+    // every existing dark theme is visually unchanged; only Light (and any
+    // other light-polarity theme) needs its own override.
+    --status-bar-bg: rgba(0, 0, 0, 0.35);
     --block-border-radius: 0;
 
     --keybinding-color: #e0e0e0;

--- a/frontend/app/themes/catppuccin-latte.scss
+++ b/frontend/app/themes/catppuccin-latte.scss
@@ -1,0 +1,94 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Catppuccin Latte — the official light flavor of Catppuccin (pairs with
+// the existing dark "Catppuccin" theme, which is the Mocha flavor). Soft
+// pastel light, warm mauve/blue accent. Colors are Catppuccin's published
+// palette (Base/Mantle/Crust, Text/Subtext, and the named accent hues).
+// See docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md.
+//
+// Same light-polarity conventions as themes/light.scss (black tints for
+// hover/highlight/input-bg, not white — see that file's header comment)
+// but tinted with this theme's own accent (Blue) rather than plain black,
+// mirroring how the dark Catppuccin theme tints its hover/highlight with
+// its own accent (Mauve) instead of plain white.
+
+[data-theme="catppuccin-latte"] {
+    --main-bg-color: #eff1f5;
+    --panel-bg-color: rgba(76, 79, 105, 0.04);
+    --block-bg-color: rgba(255, 255, 255, 0.6);
+    --block-bg-solid-color: #ffffff;
+    --modal-bg-color: #ffffff;
+
+    --main-text-color: #4c4f69;
+    --secondary-text-color: #5c5f77;
+    --grey-text-color: #8c8fa1;
+
+    --accent-color: #1e66f5;
+    --accent-color-rgb: 30, 102, 245;
+    --link-color: #1e66f5;
+
+    --border-color: rgba(76, 79, 105, 0.14);
+    --form-element-border-color: rgba(76, 79, 105, 0.18);
+    --keybinding-border-color: rgba(30, 102, 245, 0.28);
+
+    --hover-bg-color: rgba(30, 102, 245, 0.06);
+    --highlight-bg-color: rgba(30, 102, 245, 0.12);
+    --input-bg-color: rgba(76, 79, 105, 0.07);
+
+    --tab-strip-bg: rgba(76, 79, 105, 0.035);
+    --status-bar-bg: rgba(76, 79, 105, 0.07);
+
+    --error-color: #d20f39;
+    --warning-color: #df8e1d;
+    --success-color: #40a02b;
+
+    --error-text-color: var(--error-color);
+    --success-text-color: var(--success-color);
+    --warning-text-color: var(--warning-color);
+
+    --button-grey-bg: rgba(76, 79, 105, 0.05);
+    --button-grey-hover-bg: rgba(30, 102, 245, 0.09);
+    --button-grey-border-color: rgba(76, 79, 105, 0.18);
+    --button-green-bg: #40a02b;
+    --button-red-bg: #d20f39;
+    --button-yellow-bg: #df8e1d;
+
+    --scrollbar-thumb-color: rgba(76, 79, 105, 0.25);
+    --scrollbar-thumb-hover-color: rgba(76, 79, 105, 0.4);
+
+    --term-background: #eff1f5;
+    --term-foreground: #4c4f69;
+    --term-black: #5c5f77;
+    --term-red: #d20f39;
+    --term-green: #40a02b;
+    --term-yellow: #df8e1d;
+    --term-blue: #1e66f5;
+    --term-magenta: #ea76cb;
+    --term-cyan: #179299;
+    --term-white: #acb0be;
+    --term-bright-black: #6c6f85;
+    --term-bright-red: #e64553;
+    --term-bright-green: #40a02b;
+    --term-bright-yellow: #df8e1d;
+    --term-bright-blue: #1e66f5;
+    --term-bright-magenta: #8839ef;
+    --term-bright-cyan: #179299;
+    --term-bright-white: #bcc0cc;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
+}

--- a/frontend/app/themes/gruvbox-light.scss
+++ b/frontend/app/themes/gruvbox-light.scss
@@ -1,0 +1,89 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Gruvbox Light — the official light variant of Gruvbox (pairs with the
+// existing dark "Gruvbox" theme). Retro warm cream background; uses
+// Gruvbox's own "faded" accent set, which is the palette's documented
+// choice for light backgrounds (its "neutral/bright" set — used by the
+// dark Gruvbox theme here — is tuned for dark backgrounds instead).
+// See docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md.
+
+[data-theme="gruvbox-light"] {
+    --main-bg-color: #fbf1c7;
+    --panel-bg-color: rgba(60, 56, 54, 0.05);
+    --block-bg-color: rgba(255, 255, 255, 0.45);
+    --block-bg-solid-color: #f9f5d7;
+    --modal-bg-color: #ebdbb2;
+
+    --main-text-color: #3c3836;
+    --secondary-text-color: #504945;
+    --grey-text-color: #928374;
+
+    --accent-color: #af3a03;
+    --accent-color-rgb: 175, 58, 3;
+    --link-color: #076678;
+
+    --border-color: rgba(60, 56, 54, 0.16);
+    --form-element-border-color: rgba(60, 56, 54, 0.2);
+    --keybinding-border-color: rgba(175, 58, 3, 0.28);
+
+    --hover-bg-color: rgba(175, 58, 3, 0.07);
+    --highlight-bg-color: rgba(175, 58, 3, 0.14);
+    --input-bg-color: rgba(60, 56, 54, 0.08);
+
+    --tab-strip-bg: rgba(60, 56, 54, 0.04);
+    --status-bar-bg: rgba(60, 56, 54, 0.08);
+
+    --error-color: #9d0006;
+    --warning-color: #b57614;
+    --success-color: #79740e;
+
+    --error-text-color: var(--error-color);
+    --success-text-color: var(--success-color);
+    --warning-text-color: var(--warning-color);
+
+    --button-grey-bg: rgba(60, 56, 54, 0.05);
+    --button-grey-hover-bg: rgba(175, 58, 3, 0.1);
+    --button-grey-border-color: rgba(60, 56, 54, 0.2);
+    --button-green-bg: #79740e;
+    --button-red-bg: #9d0006;
+    --button-yellow-bg: #b57614;
+
+    --scrollbar-thumb-color: rgba(60, 56, 54, 0.28);
+    --scrollbar-thumb-hover-color: rgba(60, 56, 54, 0.45);
+
+    --term-background: #fbf1c7;
+    --term-foreground: #3c3836;
+    --term-black: #504945;
+    --term-red: #9d0006;
+    --term-green: #79740e;
+    --term-yellow: #b57614;
+    --term-blue: #076678;
+    --term-magenta: #8f3f71;
+    --term-cyan: #427b58;
+    --term-white: #a89984;
+    --term-bright-black: #665c54;
+    --term-bright-red: #af3a03;
+    --term-bright-green: #928374;
+    --term-bright-yellow: #7c6f64;
+    --term-bright-blue: #427b58;
+    --term-bright-magenta: #af3a03;
+    --term-bright-cyan: #076678;
+    --term-bright-white: #282828;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
+}

--- a/frontend/app/themes/index.scss
+++ b/frontend/app/themes/index.scss
@@ -12,3 +12,6 @@
 @use "tokyo-night";
 @use "gruvbox";
 @use "light";
+@use "catppuccin-latte";
+@use "solarized-light";
+@use "gruvbox-light";

--- a/frontend/app/themes/light.scss
+++ b/frontend/app/themes/light.scss
@@ -46,6 +46,18 @@
     // tuned for transient/interactive states, not a static field boundary.
     --input-bg-color: rgba(0, 0, 0, 0.06);
 
+    // Header (tab strip) and status bar recessed-chrome strips — both were
+    // missing here (SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md):
+    // --tab-strip-bg's :root default is a WHITE tint (lightens a dark
+    // surface) and was invisible over this theme's already-light chrome;
+    // --status-bar-bg didn't exist as a token at all until this fix — the
+    // status bar was a hardcoded literal that never reached the theme
+    // system. Same polarity flip as --hover-bg-color/--input-bg-color
+    // above: black tints darken regardless of theme, so they're the
+    // correct direction for every light-family theme's recessed strips.
+    --tab-strip-bg: rgba(0, 0, 0, 0.03);
+    --status-bar-bg: rgba(0, 0, 0, 0.06);
+
     --error-color: #d1242f;
     --warning-color: #9a6700;
     --success-color: #1a7f37;

--- a/frontend/app/themes/solarized-light.scss
+++ b/frontend/app/themes/solarized-light.scss
@@ -1,0 +1,93 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Solarized Light — Ethan Schoonover's Solarized palette, light mode.
+// One of the most widely-ported terminal/editor color schemes; the base
+// tones (base01-base3) and the 8 accent hues are its well-known published
+// values. The --term-* table below is Solarized's own canonical 16-color
+// ANSI mapping (base03/base02/base2/base3 for black/bright-black/white/
+// bright-white, the 8 accents for the rest) — unlike this file's UI tokens,
+// that exact mapping is Solarized's defining, unchanged-for-over-a-decade
+// signature, so it's reproduced verbatim rather than derived.
+// See docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md.
+
+[data-theme="solarized-light"] {
+    --main-bg-color: #fdf6e3;
+    --panel-bg-color: rgba(88, 110, 117, 0.05);
+    --block-bg-color: rgba(255, 255, 255, 0.5);
+    --block-bg-solid-color: #fdf6e3;
+    --modal-bg-color: #eee8d5;
+
+    --main-text-color: #657b83;
+    --secondary-text-color: #839496;
+    --grey-text-color: #93a1a1;
+
+    --accent-color: #268bd2;
+    --accent-color-rgb: 38, 139, 210;
+    --link-color: #268bd2;
+
+    --border-color: rgba(101, 123, 131, 0.16);
+    --form-element-border-color: rgba(101, 123, 131, 0.2);
+    --keybinding-border-color: rgba(38, 139, 210, 0.28);
+
+    --hover-bg-color: rgba(38, 139, 210, 0.07);
+    --highlight-bg-color: rgba(38, 139, 210, 0.14);
+    --input-bg-color: rgba(101, 123, 131, 0.09);
+
+    --tab-strip-bg: rgba(101, 123, 131, 0.045);
+    --status-bar-bg: rgba(101, 123, 131, 0.09);
+
+    --error-color: #dc322f;
+    --warning-color: #b58900;
+    --success-color: #859900;
+
+    --error-text-color: var(--error-color);
+    --success-text-color: var(--success-color);
+    --warning-text-color: var(--warning-color);
+
+    --button-grey-bg: rgba(101, 123, 131, 0.06);
+    --button-grey-hover-bg: rgba(38, 139, 210, 0.1);
+    --button-grey-border-color: rgba(101, 123, 131, 0.2);
+    --button-green-bg: #859900;
+    --button-red-bg: #dc322f;
+    --button-yellow-bg: #b58900;
+
+    --scrollbar-thumb-color: rgba(101, 123, 131, 0.28);
+    --scrollbar-thumb-hover-color: rgba(101, 123, 131, 0.45);
+
+    // Solarized's canonical ANSI 16-color table (verbatim — see header).
+    --term-background: #fdf6e3;
+    --term-foreground: #657b83;
+    --term-black: #073642;
+    --term-red: #dc322f;
+    --term-green: #859900;
+    --term-yellow: #b58900;
+    --term-blue: #268bd2;
+    --term-magenta: #d33682;
+    --term-cyan: #2aa198;
+    --term-white: #eee8d5;
+    --term-bright-black: #002b36;
+    --term-bright-red: #cb4b16;
+    --term-bright-green: #586e75;
+    --term-bright-yellow: #657b83;
+    --term-bright-blue: #839496;
+    --term-bright-magenta: #6c71c4;
+    --term-bright-cyan: #93a1a1;
+    --term-bright-white: #fdf6e3;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
+}

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -62,7 +62,7 @@
     }
 
     &.context-active {
-        background: var(--hoverbg-color, rgba(255, 255, 255, 0.08));
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
     }
 
     &.dragging {
@@ -102,8 +102,11 @@
 
     &:hover,
     &.open {
-        background: var(--hoverbg-color, rgba(255, 255, 255, 0.08));
-        color: white;
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
+        // Was a hardcoded `white` — invisible against a light theme's
+        // hover background. Matches the icon-hover treatment above
+        // (line 20) for the same "this control is active" state.
+        color: var(--widget-icon-hover-color);
     }
 
     i {

--- a/frontend/app/window/window-controls.win32.scss
+++ b/frontend/app/window/window-controls.win32.scss
@@ -55,7 +55,14 @@
     --win-caption-hover-bg: rgba(255, 255, 255, 0.13);
     --win-caption-press-bg: rgba(255, 255, 255, 0.09);
 
-    @media (prefers-color-scheme: light) {
+    // Was `@media (prefers-color-scheme: light)` — the OS-level dark/light
+    // setting, which is a different signal from AgentMux's own theme
+    // switcher (`data-theme`/`data-theme-polarity`, set in app.tsx). If the
+    // OS was in dark mode but the user picked a light AgentMux theme (or
+    // vice versa), the caption buttons used the wrong tint. Gate on the
+    // app's own polarity marker instead — covers every light theme, not
+    // just this one condition.
+    [data-theme-polarity="light"] & {
         --win-caption-hover-bg: rgba(0, 0, 0, 0.09);
         --win-caption-press-bg: rgba(0, 0, 0, 0.065);
     }

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -154,8 +154,8 @@
         },
         "window:theme": {
           "type": "string",
-          "enum": ["default", "midnight", "high-contrast", "monokai", "nord", "dracula", "catppuccin", "tokyo-night", "gruvbox", "light"],
-          "description": "UI color theme. Options: default (dark grey + blue), midnight (deep navy), high-contrast (black + cyan), monokai (warm dark + green), nord (arctic blue-grey), dracula (purple dark), catppuccin (pastel dark + mauve), tokyo-night (blue-purple), gruvbox (retro warm + yellow), light (white + blue)"
+          "enum": ["default", "midnight", "high-contrast", "monokai", "nord", "dracula", "catppuccin", "tokyo-night", "gruvbox", "light", "catppuccin-latte", "solarized-light", "gruvbox-light"],
+          "description": "UI color theme. Options: default (dark grey + blue), midnight (deep navy), high-contrast (black + cyan), monokai (warm dark + green), nord (arctic blue-grey), dracula (purple dark), catppuccin (pastel dark + mauve), tokyo-night (blue-purple), gruvbox (retro warm + yellow), light (white + blue), catppuccin-latte (pastel light + blue), solarized-light (cream + cyan/blue), gruvbox-light (retro warm cream + orange)"
         },
         "telemetry:*": {
           "type": "boolean"


### PR DESCRIPTION
## Summary
Follow-up to #2104 (the original Light theme). Manual verification on `task dev` found the window header and status bar still dark under Light theme — traced to 3 real bugs, plus 2 more found in the same sweep:

1. **`--tab-strip-bg`** (window header bg) — real token, but its `:root` default is a *white* tint (meant to lighten a dark surface); `light.scss` never overrode it, so it went invisible on an already-light background.
2. **Status bar background was a hardcoded literal** (`rgba(0,0,0,0.35)`), never a token at all — introduced `--status-bar-bg`, default = the exact literal it replaces (zero change on every existing dark theme).
3. **`--hoverbg-color` typo** (missing hyphen) in `action-widgets.scss` — the widget-bar hover has been theme-inert on *every* theme since it was written, not just Light. Also fixed a hardcoded `color: white` on the same rule.
4. **Caption-button hover/press gated on the OS's `prefers-color-scheme`**, not AgentMux's own theme switcher — wrong signal, would misfire whenever OS and app theme disagree. Introduced a generic `data-theme-polarity` attribute (`LIGHT_THEME_IDS` in `base-menus.ts`) so this and any future light-only chrome logic scale to N light themes for free.
5. Swept for other hardcoded white/black colors in the same files — 2 more found and confirmed **intentional** (OS-brand close-button red, white-on-solid-red restart button), left as-is; 1 found **dead** (unused `.config-error-button` class), left untouched.

**Plus 3 new light themes**, pairing with existing dark families where one exists:
- **Catppuccin Latte** (pairs with existing Catppuccin/Mocha)
- **Solarized Light** (standalone classic — canonical ANSI term-* table reproduced verbatim)
- **Gruvbox Light** (pairs with existing Gruvbox; uses the palette's documented light-background accent set)

Full detail: `docs/specs/SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — 1688 passed, 0 failures
- [ ] Visual check on `task dev`: header + status bar now light under all 4 light themes; caption-button hover/press correct regardless of OS theme setting; widget-bar hover visible

<!-- agentmux:agent_id=agent1 -->