### PR TITLE
feat(srv): subagent Abandoned status + reopen-time liveness reconciliation

### DIFF
--- a/.changesets/1783910207-feat-srv-subagent-abandoned-status-reopen-time-liveness-reco-y7ih.md
+++ b/.changesets/1783910207-feat-srv-subagent-abandoned-status-reopen-time-liveness-reco-y7ih.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(srv): subagent Abandoned status + reopen-time liveness reconciliation

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -66,6 +66,14 @@ pub struct SubagentInfo {
 pub enum SubagentStatus {
     Active,
     Completed,
+    /// The parent block's turn ended without a `Result` line ever appearing
+    /// for this subagent — it crashed, was killed, or was interrupted by an
+    /// app/srv restart mid-task. Distinct from `Completed`: the subagent
+    /// didn't finish, it was cut off. Set only by
+    /// `reconcile_stale_subagents`, never by `process_jsonl_change`'s
+    /// normal event processing. See
+    /// docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md.
+    Abandoned,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -561,7 +569,48 @@ impl SubagentWatcher {
             let subagents_dir = session_dir.join("subagents");
             if subagents_dir.is_dir() {
                 self.scan_subagents_dir(parent_agent, parent_block_id, &subagents_dir);
+                self.reconcile_stale_subagents(parent_block_id, session_id);
                 return; // session ids are unique — no need to keep scanning
+            }
+        }
+    }
+
+    /// After a full session backfill scan, downgrade any subagent that's
+    /// still `Active` to `Abandoned` if its parent block's turn is not
+    /// currently active. A subagent runs inside its parent's own CLI
+    /// process — a Task-tool call is synchronous within the parent's turn —
+    /// so once the parent's turn has ended, any subagent file lacking a
+    /// terminal `Result` line was interrupted (crashed, killed, or the
+    /// app/srv restarted mid-task), not still running. This call site is
+    /// reached from `scan_session_subagents`, itself only invoked when a
+    /// block re-registers with a pre-existing session id (`reactive.rs`) —
+    /// i.e. a freshly-spawned controller whose turn genuinely hasn't
+    /// started yet, so every subagent found on disk predates this process
+    /// and is unambiguously history, not in-flight.
+    ///
+    /// Only reconciles on a *confirmed-idle* read (`Some(false)`) —
+    /// `unwrap_or(true)` treats "no controller registered yet" or any
+    /// other uncertainty as "assume active, don't touch it," matching the
+    /// same conservative bias `ReconcileTurnActive` uses on the frontend
+    /// (only ever promote/correct on positive evidence, never guess).
+    /// Scoped to the reopen/backfill path only — see
+    /// docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md
+    /// Open Question 1 for why real-time (mid-session) reconciliation is a
+    /// deliberate fast-follow, not this pass.
+    fn reconcile_stale_subagents(&self, parent_block_id: &str, session_id: &str) {
+        let parent_turn_active =
+            crate::backend::blockcontroller::get_block_controller_status(parent_block_id)
+                .map(|s| s.turn_active)
+                .unwrap_or(true);
+        if parent_turn_active {
+            return;
+        }
+
+        let mut sessions = self.sessions.lock().unwrap();
+        let Some(session) = sessions.get_mut(session_id) else { return };
+        for state in session.subagents.values_mut() {
+            if state.info.status == SubagentStatus::Active {
+                state.info.status = SubagentStatus::Abandoned;
             }
         }
     }
@@ -1523,7 +1572,15 @@ mod tests {
 
     #[test]
     fn read_task_prompt_extracts_plain_string_content_from_first_line() {
-        let dir = std::env::temp_dir().join(format!("amx-test-{}", std::process::id()));
+        // Pre-existing bug fixed in passing: this and its two sibling tests
+        // below all shared one directory keyed on std::process::id() (constant
+        // for the whole test binary, not per-test) — under parallel test
+        // execution, one test's std::fs::remove_dir_all teardown could race
+        // another's still-in-progress create_dir_all/write/read, producing
+        // flaky failures unrelated to what each test actually exercises.
+        // now_millis() (already used elsewhere in this file for the same
+        // per-test-uniqueness purpose) gives each test its own directory.
+        let dir = std::env::temp_dir().join(format!("amx-test-{}", now_millis()));
         std::fs::create_dir_all(&dir).unwrap();
         let jsonl_path = dir.join("agent-prompt-string.jsonl");
         std::fs::write(
@@ -1541,7 +1598,7 @@ mod tests {
 
     #[test]
     fn read_task_prompt_extracts_joined_text_blocks_from_content_array() {
-        let dir = std::env::temp_dir().join(format!("amx-test-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("amx-test-{}", now_millis()));
         std::fs::create_dir_all(&dir).unwrap();
         let jsonl_path = dir.join("agent-prompt-array.jsonl");
         std::fs::write(
@@ -1558,7 +1615,7 @@ mod tests {
 
     #[test]
     fn read_task_prompt_returns_none_when_first_line_is_not_a_user_record() {
-        let dir = std::env::temp_dir().join(format!("amx-test-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("amx-test-{}", now_millis()));
         std::fs::create_dir_all(&dir).unwrap();
         let jsonl_path = dir.join("agent-prompt-none.jsonl");
         std::fs::write(
@@ -1906,6 +1963,180 @@ mod tests {
         watcher.scan_session_subagents("parent-1", "block-1", &config_dir, "never-existed");
 
         assert!(watcher.list_active().is_empty(), "unknown session id must not fall back to scanning everything");
+
+        std::fs::remove_dir_all(&config_dir).ok();
+    }
+
+    // ── reconcile_stale_subagents ─────────────────────────────────────────
+    //
+    // A stub `Controller` so these tests can control what
+    // `get_block_controller_status` reports without spinning up a real
+    // subprocess. `CONTROLLER_REGISTRY` is process-global (shared across
+    // every test in this binary) — each test below registers its stub
+    // under a unique, per-test block id (never a literal shared with any
+    // other test) so parallel test execution can't cross-contaminate.
+
+    struct StubController {
+        block_id: String,
+        turn_active: bool,
+    }
+
+    impl crate::backend::blockcontroller::Controller for StubController {
+        fn start(&self, _: crate::backend::obj::MetaMapType, _: Option<serde_json::Value>, _: bool) -> Result<(), String> {
+            Ok(())
+        }
+        fn stop(&self, _: bool, _: &str) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_runtime_status(&self) -> crate::backend::blockcontroller::BlockControllerRuntimeStatus {
+            crate::backend::blockcontroller::BlockControllerRuntimeStatus {
+                blockid: self.block_id.clone(),
+                turn_active: self.turn_active,
+                ..Default::default()
+            }
+        }
+        fn send_input(&self, _: crate::backend::blockcontroller::BlockInputUnion, _: Option<u64>) -> Result<(), String> {
+            Ok(())
+        }
+        fn controller_type(&self) -> &str {
+            "stub"
+        }
+        fn block_id(&self) -> &str {
+            &self.block_id
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn register_stub_controller(block_id: &str, turn_active: bool) {
+        crate::backend::blockcontroller::register_controller(
+            block_id,
+            Arc::new(StubController { block_id: block_id.to_string(), turn_active }),
+        );
+    }
+
+    #[test]
+    fn reconcile_stale_subagents_downgrades_active_to_abandoned_when_parent_turn_is_confirmed_idle() {
+        let block_id = format!("recon-idle-{}", now_millis());
+        register_stub_controller(&block_id, false);
+
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            let mut state = fixture_state("parent-1", "sub-a", "s1");
+            state.info.parent_block_id = block_id.clone();
+            s1.subagents.insert("sub-a".to_string(), state);
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        watcher.reconcile_stale_subagents(&block_id, "s1");
+
+        let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+        assert_eq!(info.status, SubagentStatus::Abandoned);
+    }
+
+    #[test]
+    fn reconcile_stale_subagents_leaves_active_alone_when_parent_turn_is_active() {
+        let block_id = format!("recon-active-{}", now_millis());
+        register_stub_controller(&block_id, true);
+
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            let mut state = fixture_state("parent-1", "sub-a", "s1");
+            state.info.parent_block_id = block_id.clone();
+            s1.subagents.insert("sub-a".to_string(), state);
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        watcher.reconcile_stale_subagents(&block_id, "s1");
+
+        let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+        assert_eq!(info.status, SubagentStatus::Active, "a genuinely active parent turn must never be reconciled away");
+    }
+
+    #[test]
+    fn reconcile_stale_subagents_leaves_active_alone_when_no_controller_is_registered() {
+        // No register_stub_controller call — block id is guaranteed unique
+        // (per-test suffix) so get_block_controller_status returns None.
+        // unwrap_or(true) means "uncertain" defaults to "assume active,
+        // don't touch it" — the same conservative bias as ReconcileTurnActive.
+        let block_id = format!("recon-unregistered-{}", now_millis());
+
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            let mut state = fixture_state("parent-1", "sub-a", "s1");
+            state.info.parent_block_id = block_id.clone();
+            s1.subagents.insert("sub-a".to_string(), state);
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        watcher.reconcile_stale_subagents(&block_id, "s1");
+
+        let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+        assert_eq!(info.status, SubagentStatus::Active);
+    }
+
+    #[test]
+    fn reconcile_stale_subagents_never_downgrades_an_already_completed_subagent() {
+        let block_id = format!("recon-completed-{}", now_millis());
+        register_stub_controller(&block_id, false);
+
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            let mut state = fixture_state("parent-1", "sub-a", "s1");
+            state.info.parent_block_id = block_id.clone();
+            state.info.status = SubagentStatus::Completed;
+            s1.subagents.insert("sub-a".to_string(), state);
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        watcher.reconcile_stale_subagents(&block_id, "s1");
+
+        let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+        assert_eq!(info.status, SubagentStatus::Completed, "a subagent that genuinely finished must stay Completed, not be downgraded");
+    }
+
+    /// End-to-end: a subagent JSONL with no terminal `result` line, backfilled
+    /// via a real `scan_session_subagents` call while the parent's turn is
+    /// confirmed idle, comes out `Abandoned` — not `Active` forever. This is
+    /// the exact user-reported symptom (SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md).
+    #[test]
+    fn scan_session_subagents_reconciles_an_unterminated_file_to_abandoned_when_parent_turn_is_idle() {
+        let block_id = format!("recon-scan-{}", now_millis());
+        register_stub_controller(&block_id, false);
+
+        let config_dir = std::env::temp_dir()
+            .join(format!("amx-scan-reconcile-test-{}", now_millis()));
+        let session_id = "target-session-uuid";
+        let target_dir = config_dir
+            .join("projects")
+            .join("ws-enc")
+            .join(session_id)
+            .join("subagents");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        // No "type":"result" line — this subagent never got a terminal event,
+        // simulating a crash/kill/interrupted-by-restart.
+        std::fs::write(
+            target_dir.join("agent-crashed.jsonl"),
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"working...\"}]}}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.scan_session_subagents("parent-1", &block_id, &config_dir, session_id);
+
+        let active = watcher.list_active();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].agent_id, "crashed");
+        assert_eq!(active[0].status, SubagentStatus::Abandoned);
 
         std::fs::remove_dir_all(&config_dir).ok();
     }

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -608,7 +608,20 @@ impl SubagentWatcher {
 
         let mut sessions = self.sessions.lock().unwrap();
         let Some(session) = sessions.get_mut(session_id) else { return };
+        // A session's subagent map can hold entries from a DIFFERENT block —
+        // the watcher dedupes purely by agent_id (see watch_agent's doc
+        // comment), so two blocks that both ran the same underlying Claude
+        // session id (e.g. one reattached to a session another block also
+        // touched) can have subagents from both mixed into one
+        // `SessionWatch`. We only have a confirmed-idle read for THIS one
+        // `parent_block_id` — a sibling block's subagent could easily still
+        // be genuinely active, so only reconcile entries this block itself
+        // owns (mirrors unwatch_agent's own parent-scoped filter). Reagent
+        // P1 on PR #2131.
         for state in session.subagents.values_mut() {
+            if state.info.parent_block_id != parent_block_id {
+                continue;
+            }
             if state.info.status == SubagentStatus::Active {
                 state.info.status = SubagentStatus::Abandoned;
             }
@@ -2102,6 +2115,40 @@ mod tests {
 
         let info = watcher.get_info("sub-a").expect("sub-a should still exist");
         assert_eq!(info.status, SubagentStatus::Completed, "a subagent that genuinely finished must stay Completed, not be downgraded");
+    }
+
+    #[test]
+    fn reconcile_stale_subagents_never_touches_a_sibling_blocks_subagent_in_the_same_session() {
+        // Two blocks can both have subagents recorded under the same
+        // session_id (the watcher dedupes purely by agent_id — see
+        // watch_agent's doc comment). reconcile_stale_subagents only has a
+        // confirmed-idle read for the ONE block it was called with; a
+        // sibling block sharing that session_id could still be genuinely
+        // active, so its subagent must be left alone. Reagent P1 on #2131.
+        let idle_block = format!("recon-sibling-idle-{}", now_millis());
+        let active_block = format!("recon-sibling-active-{}", now_millis());
+        register_stub_controller(&idle_block, false);
+        register_stub_controller(&active_block, true);
+
+        let watcher = fixture_watcher();
+        {
+            let mut sessions = watcher.sessions.lock().unwrap();
+            let mut s1 = SessionWatch { subagents: HashMap::new() };
+            let mut owned = fixture_state("parent-1", "sub-owned", "s1");
+            owned.info.parent_block_id = idle_block.clone();
+            let mut sibling = fixture_state("parent-2", "sub-sibling", "s1");
+            sibling.info.parent_block_id = active_block.clone();
+            s1.subagents.insert("sub-owned".to_string(), owned);
+            s1.subagents.insert("sub-sibling".to_string(), sibling);
+            sessions.insert("s1".to_string(), s1);
+        }
+
+        watcher.reconcile_stale_subagents(&idle_block, "s1");
+
+        let owned_info = watcher.get_info("sub-owned").expect("sub-owned should still exist");
+        assert_eq!(owned_info.status, SubagentStatus::Abandoned, "this block's own subagent should still be reconciled");
+        let sibling_info = watcher.get_info("sub-sibling").expect("sub-sibling should still exist");
+        assert_eq!(sibling_info.status, SubagentStatus::Active, "a sibling block's subagent must never be reconciled by an unrelated block's idle read");
     }
 
     /// End-to-end: a subagent JSONL with no terminal `result` line, backfilled


### PR DESCRIPTION
## Summary

Step 1 of #2126's spec (`docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`), addressing the root cause of the reported "subagents always show working, flood on pane open" bug.

`SubagentInfo.status` previously had **no liveness check anywhere** — a raw "have I seen a `Result` JSONL line yet" boolean, set once at file-discovery time. Every pane reopen (including the first restore after an app launch) replayed a session's full subagent history through that same logic, so anything without a terminal marker (crashed, killed, interrupted by an app/srv restart) came back "active" forever.

- Adds `SubagentStatus::Abandoned` and `reconcile_stale_subagents`, called at the end of `scan_session_subagents` (the reopen/backfill path).
- **Key insight (no new infrastructure needed):** a subagent runs inside its parent agent's own CLI process — a Task-tool call is synchronous within the parent's turn — so the parent block's `turn_active` (already tracked via `get_block_controller_status`, the exact signal the frontend's `ReconcileTurnActive` already uses to fix this same class of bug for the *parent* pane's own `TurnPhase`) is a valid liveness bound. Any subagent still `Active` once the parent's turn is confirmed idle was interrupted, not still running.
- Conservative by design: only reconciles on a *confirmed-idle* read. "No controller registered" or any other uncertainty defaults to leaving `Active` alone — same bias `ReconcileTurnActive` uses (only ever correct on positive evidence, never guess).
- Scoped to the reopen/backfill path only, per the spec's Open Question 1 — real-time (mid-session) reconciliation is a deliberate fast-follow, not this PR.
- **No wire-format break:** `Abandoned` is a new enum variant. The current frontend's `sub.status === "active" ? "working" : "idle"` already treats anything non-`"active"` as idle, so an unrecognized `"abandoned"` string renders as idle today, not a crash. Steps 2/3 (event-volume batching, dedicated frontend status) follow in separate PRs.

**Also fixes a pre-existing, unrelated test flake** discovered while verifying: three `read_task_prompt_*` tests shared one tempdir keyed on `std::process::id()` (constant for the whole test binary, not per-test), racing on teardown under parallel execution — confirmed via repeated runs that this flake pre-dates this PR (reproduced on unmodified `main`). Switched to `now_millis()`, matching the per-test-uniqueness convention already used elsewhere in this same file. Fixed here rather than filed separately since it's in the exact file this PR touches and would otherwise make this PR's own CI spuriously flaky.

## Test plan

- [x] `cargo build -p agentmux-srv --bin agentmux-srv` clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv subagent_watcher` — 35 tests passing, including 5 new ones covering: downgrade-to-Abandoned on confirmed-idle, no-downgrade when parent turn is active, no-downgrade when no controller is registered (the conservative default), no-downgrade of an already-`Completed` subagent, and an end-to-end `scan_session_subagents` test reproducing the exact user-reported symptom (unterminated JSONL → `Abandoned`, not stuck `Active`)
- [x] Re-ran `subagent_watcher` tests 8× back-to-back post-fix to confirm the flake is gone (was reproducing ~1-in-3 before the `now_millis()` fix)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` (full suite) — 1480/1481 passing; the one other observed flake (`agent_session::tests::archive_moves_content_and_clears_current`) is in an unrelated module, passes cleanly in isolation, and is out of scope here

<!-- agentmux:agent_id=agentx -->