### PR TITLE
feat(swarm): three-way subagent status + interrupted chip + client-side downgrade guard

### DIFF
--- a/.changesets/1783912736-feat-swarm-three-way-subagent-status-active-completed-abando-z2sh.md
+++ b/.changesets/1783912736-feat-swarm-three-way-subagent-status-active-completed-abando-z2sh.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): three-way subagent status (active/completed/abandoned) with interrupted chip and client-side downgrade guard

--- a/frontend/app/view/agent/activity/subagent-adapter.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.ts
@@ -23,6 +23,10 @@ function subagentStatusToActivity(s: ActiveSubagent["status"]): ActivityStatus {
     switch (s) {
         case "active": return "running";
         case "completed": return "done";
+        // Terminated without a Result line (parent turn ended early) — same
+        // bucket as a shell's manual "stopped", not "error" (no failure
+        // signal, just cut off). See SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION.
+        case "abandoned": return "stopped";
     }
 }
 
@@ -36,10 +40,12 @@ export function subagentToActivity(s: ActiveSubagent): PinnedActivity {
         title: s.display_name || s.slug || s.agent_id,
         status: subagentStatusToActivity(s.status),
         startedAt: s.spawned_at,
-        // last_event_at at the moment a subagent completes is its own
-        // result event's timestamp — the closest thing to an "ended at"
-        // ActiveSubagent exposes (there is no dedicated field).
-        endedAt: s.status === "completed" ? s.last_event_at : undefined,
+        // last_event_at at the moment a subagent completes (or is reconciled
+        // to abandoned) is the closest thing to an "ended at" ActiveSubagent
+        // exposes (there is no dedicated field). Both are terminal — leaving
+        // abandoned out would tick the elapsed timer forever and never let
+        // D4 retention (RETENTION_MS.stopped) auto-dismiss the row.
+        endedAt: s.status === "completed" || s.status === "abandoned" ? s.last_event_at : undefined,
         canStop: false,
         subagent: s,
     };

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -108,6 +108,25 @@ describe("groupSubagentsByWorkflow", () => {
         }
     });
 
+    it("treats an abandoned member the same as a completed one for grouping purposes (both terminal)", () => {
+        // SubagentStatus::Abandoned (SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md)
+        // — a subagent whose parent turn ended without a Result line. Like
+        // "completed", it must NOT count toward activeCount and must let the
+        // group retire.
+        const result = groupSubagentsByWorkflow([
+            mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed" }),
+            mk({ agent_id: "a2", workflow_id: "wf_1", status: "abandoned" }),
+        ]);
+        const group = result[0];
+        if (isWorkflowGroup(group)) {
+            expect(group.status).toBe("retired");
+            expect(group.activeCount).toBe(0);
+            expect(group.totalCount).toBe(2);
+        } else {
+            throw new Error("expected a workflow group");
+        }
+    });
+
     it("derives the group name from the first member with a non-empty slug", () => {
         const result = groupSubagentsByWorkflow([
             mk({ agent_id: "a1", workflow_id: "wf_1", slug: "", last_event_at: 200 }),
@@ -211,6 +230,20 @@ describe("groupSubagentsByWorkflow", () => {
             const group = result[0];
             if (isNameGroup(group)) {
                 expect(group.status).toBe("retired");
+            } else {
+                throw new Error("expected a name group");
+            }
+        });
+
+        it("treats an abandoned NameGroup member the same as a completed one (both terminal)", () => {
+            const result = groupSubagentsByWorkflow([
+                mk({ agent_id: "a1", workflow_id: null, display_name: "N", status: "completed" }),
+                mk({ agent_id: "a2", workflow_id: null, display_name: "N", status: "abandoned" }),
+            ]);
+            const group = result[0];
+            if (isNameGroup(group)) {
+                expect(group.status).toBe("retired");
+                expect(group.activeCount).toBe(0);
             } else {
                 throw new Error("expected a name group");
             }

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -20,7 +20,14 @@ export interface ActiveSubagent {
     parent_agent: string;
     parent_block_id: string;
     session_id: string;
-    status: "active" | "completed";
+    /** `"abandoned"` (SubagentStatus::Abandoned, Rust) — the parent block's
+     *  turn ended without a Result line ever appearing for this subagent
+     *  (crashed, killed, or interrupted by an app/srv restart). Distinct
+     *  from `"completed"`: it didn't finish, it was cut off. Set by the
+     *  backend's `reconcile_stale_subagents`, currently only on pane
+     *  reopen/backfill — see
+     *  docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md. */
+    status: "active" | "completed" | "abandoned";
     /** Unix ms when this subagent was first observed — set once, immutable.
      *  Distinct from `last_event_at`, which advances on every journal read. */
     spawned_at: number;
@@ -327,7 +334,7 @@ export function pruneGroupIdentityCache(cache: Map<string, WorkflowGroup | NameG
 export interface SubagentDetail {
     eventsAtom: Accessor<SubagentEvent[]>;
     infoAtom: Accessor<ActiveSubagent | null>;
-    statusAtom: Accessor<"active" | "completed" | "loading">;
+    statusAtom: Accessor<"active" | "completed" | "abandoned" | "loading">;
     dispose: () => void;
 }
 
@@ -346,7 +353,7 @@ export interface SubagentDetail {
 export function createSubagentDetail(subagentId: string): SubagentDetail {
     const [events, setEvents] = createSignal<SubagentEvent[]>([]);
     const [info, setInfo] = createSignal<ActiveSubagent | null>(null);
-    const [status, setStatus] = createSignal<"active" | "completed" | "loading">("loading");
+    const [status, setStatus] = createSignal<"active" | "completed" | "abandoned" | "loading">("loading");
 
     const unsubs: (() => void)[] = [];
 

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -223,6 +223,12 @@
     &--completed {
         opacity: 0.85;
     }
+    // Interrupted (crashed/killed/cut off by a restart), not simply
+    // finished — same dimming as --completed since it's equally terminal,
+    // but the status chip's label/dot carries the actual distinction.
+    &--abandoned {
+        opacity: 0.85;
+    }
 }
 
 .swarm-subagent-row {
@@ -240,6 +246,9 @@
     }
 
     &--completed {
+        opacity: 0.55;
+    }
+    &--abandoned {
         opacity: 0.55;
     }
 
@@ -429,6 +438,15 @@
     &--disconnected {
         background: var(--secondary-text-color);
         opacity: 0.25;
+    }
+    // A subagent that got cut off (crashed/killed/interrupted by a
+    // restart, or a client-side inference that its parent's turn already
+    // ended — see subagentDisplayStatus) rather than genuinely finishing.
+    // Distinct from both --working (no pulse — nothing is happening) and
+    // --error (this isn't necessarily a failure, just incomplete).
+    &--interrupted {
+        background: var(--warning-color, #f5a623);
+        opacity: 0.5;
     }
     // Distinct from --idle: this block has no registered TurnPhase in this
     // renderer (unmounted pane / other workspace) — we genuinely don't know

--- a/frontend/app/view/swarm/swarm-view.test.ts
+++ b/frontend/app/view/swarm/swarm-view.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { subagentDisplayStatus } from "./swarm-view";
+import type { ActiveSubagent } from "./swarm-model";
+
+function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
+    return {
+        slug: "",
+        parent_agent: "parent",
+        parent_block_id: "block-1",
+        session_id: "session-1",
+        status: "active",
+        spawned_at: 0,
+        last_event_at: 0,
+        event_count: 1,
+        model: null,
+        workflow_id: null,
+        display_name: null,
+        ...overrides,
+    };
+}
+
+describe("subagentDisplayStatus", () => {
+    it("shows 'working' for an active subagent whose parent is running", () => {
+        const sub = mk({ agent_id: "a1", status: "active" });
+        expect(subagentDisplayStatus(sub, "running")).toBe("working");
+    });
+
+    it("shows 'idle' for a completed subagent, regardless of parent status", () => {
+        const sub = mk({ agent_id: "a1", status: "completed" });
+        expect(subagentDisplayStatus(sub, "running")).toBe("idle");
+        expect(subagentDisplayStatus(sub, "idle")).toBe("idle");
+    });
+
+    it("shows 'interrupted' for a backend-confirmed abandoned subagent, regardless of parent status", () => {
+        const sub = mk({ agent_id: "a1", status: "abandoned" });
+        expect(subagentDisplayStatus(sub, "running")).toBe("interrupted");
+        expect(subagentDisplayStatus(sub, "idle")).toBe("interrupted");
+    });
+
+    it("client-side backstop: shows 'interrupted' (not 'working') for a still-active subagent whose parent has already gone idle", () => {
+        // A subagent cannot genuinely still be active once its parent's own
+        // turn has ended (Task-tool calls are synchronous within the
+        // parent's turn) — the backend hasn't reconciled this one yet
+        // (still reports "active"), but the frontend has the same
+        // parent-idle signal available for free and shouldn't keep
+        // rendering it as "working".
+        const sub = mk({ agent_id: "a1", status: "active" });
+        expect(subagentDisplayStatus(sub, "idle")).toBe("interrupted");
+    });
+
+    it("never mutates the underlying subagent — it's a pure display projection", () => {
+        const sub = mk({ agent_id: "a1", status: "active" });
+        const before = { ...sub };
+        subagentDisplayStatus(sub, "idle");
+        expect(sub).toEqual(before);
+    });
+});

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -160,7 +160,7 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
 
 // ── Status derived from TurnPhase ────────────────────────────────────────
 
-type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected" | "unknown";
+export type AgentDisplayStatus = "working" | "tools" | "stopping" | "idle" | "error" | "disconnected" | "unknown" | "interrupted";
 
 function phaseToDisplayStatus(blockId: string, fallback: "running" | "idle"): AgentDisplayStatus {
     const phaseAccessor = getBlockTurnPhase(blockId);
@@ -191,6 +191,27 @@ function phaseToDisplayStatus(blockId: string, fallback: "running" | "idle"): Ag
         case "Disconnected":  return "disconnected";
         default:              return "idle";
     }
+}
+
+/**
+ * A subagent runs inside its parent agent's own CLI process — a Task-tool
+ * call is synchronous within the parent's turn — so it cannot genuinely
+ * still be active once the parent's own turn has ended. The backend already
+ * reconciles this (SubagentStatus::Abandoned), but currently only at pane
+ * reopen (see docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md
+ * Open Question 1) — this is a client-side backstop using the exact same
+ * signal (`parentAgentStatus`, fed by GetControllerStatus/controllerstatus,
+ * the same turn_active the backend's reconcile_stale_subagents reads) for
+ * the mid-session gap until real-time backend reconciliation ships. Purely
+ * a DISPLAY decision — never mutates the underlying ActiveSubagent, so
+ * grouping (activeCount/retired) keeps reading the real backend status.
+ */
+export function subagentDisplayStatus(sub: ActiveSubagent, parentAgentStatus: "running" | "idle"): AgentDisplayStatus {
+    if (sub.status === "abandoned") return "interrupted";
+    if (sub.status === "active") {
+        return parentAgentStatus === "idle" ? "interrupted" : "working";
+    }
+    return "idle"; // completed
 }
 
 // ── Agent root row ───────────────────────────────────────────────────────
@@ -256,10 +277,10 @@ function AgentRow({
             <div class="swarm-children">
                 <For each={node.subagents}>
                     {(child) => isWorkflowGroup(child)
-                        ? <WorkflowGroupRow group={child} model={model} />
+                        ? <WorkflowGroupRow group={child} model={model} parentAgentStatus={node.agentStatus} />
                         : isNameGroup(child)
-                        ? <NameGroupRow group={child} model={model} />
-                        : <SubagentRow sub={child} model={model} />}
+                        ? <NameGroupRow group={child} model={model} parentAgentStatus={node.agentStatus} />
+                        : <SubagentRow sub={child} model={model} parentAgentStatus={node.agentStatus} />}
                 </For>
             </div>
         </div>
@@ -268,7 +289,15 @@ function AgentRow({
 
 // ── Workflow group row (collapsed by default) ───────────────────────────
 
-function WorkflowGroupRow({ group, model }: { group: WorkflowGroup; model: SwarmViewModel }): JSX.Element {
+function WorkflowGroupRow({
+    group,
+    model,
+    parentAgentStatus,
+}: {
+    group: WorkflowGroup;
+    model: SwarmViewModel;
+    parentAgentStatus: "running" | "idle";
+}): JSX.Element {
     // Expand state lives on the ViewModel, not a local signal — see
     // SwarmViewModel._expandedIds for why a local signal here silently
     // collapses on unrelated tree refreshes.
@@ -293,7 +322,7 @@ function WorkflowGroupRow({ group, model }: { group: WorkflowGroup; model: Swarm
             <Show when={expanded()}>
                 <div class="swarm-workflow-members">
                     <For each={group.subagents}>
-                        {(sub) => <SubagentRow sub={sub} model={model} />}
+                        {(sub) => <SubagentRow sub={sub} model={model} parentAgentStatus={parentAgentStatus} />}
                     </For>
                 </div>
             </Show>
@@ -303,7 +332,15 @@ function WorkflowGroupRow({ group, model }: { group: WorkflowGroup; model: Swarm
 
 // ── Name group row (loose subagents sharing one display_name) ──────────
 
-function NameGroupRow({ group, model }: { group: NameGroup; model: SwarmViewModel }): JSX.Element {
+function NameGroupRow({
+    group,
+    model,
+    parentAgentStatus,
+}: {
+    group: NameGroup;
+    model: SwarmViewModel;
+    parentAgentStatus: "running" | "idle";
+}): JSX.Element {
     // Same expand-state-on-the-ViewModel rationale as WorkflowGroupRow —
     // reuses groupCacheKey's "name:<name>" namespacing so this can never
     // collide with a WorkflowGroupRow's workflowId or a SubagentRow's
@@ -330,7 +367,7 @@ function NameGroupRow({ group, model }: { group: NameGroup; model: SwarmViewMode
             <Show when={expanded()}>
                 <div class="swarm-workflow-members">
                     <For each={group.subagents}>
-                        {(sub) => <SubagentRow sub={sub} model={model} />}
+                        {(sub) => <SubagentRow sub={sub} model={model} parentAgentStatus={parentAgentStatus} />}
                     </For>
                 </div>
             </Show>
@@ -340,7 +377,15 @@ function NameGroupRow({ group, model }: { group: NameGroup; model: SwarmViewMode
 
 // ── Subagent child row ───────────────────────────────────────────────────
 
-function SubagentRow({ sub, model }: { sub: ActiveSubagent; model: SwarmViewModel }): JSX.Element {
+function SubagentRow({
+    sub,
+    model,
+    parentAgentStatus,
+}: {
+    sub: ActiveSubagent;
+    model: SwarmViewModel;
+    parentAgentStatus: "running" | "idle";
+}): JSX.Element {
     const expanded = createMemo(() => model.isExpanded(sub.agent_id));
     const displayLabel = createMemo(() => sub.display_name || sub.slug || sub.agent_id.substring(0, 7));
 
@@ -366,7 +411,7 @@ function SubagentRow({ sub, model }: { sub: ActiveSubagent; model: SwarmViewMode
             >
                 <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-expand-icon`} />
                 <span class="swarm-subagent-slug">{displayLabel()}</span>
-                <AgentStatusChip status={sub.status === "active" ? "working" : "idle"} />
+                <AgentStatusChip status={subagentDisplayStatus(sub, parentAgentStatus)} />
             </div>
             <Show when={expanded()}>
                 <SubagentDetailPane sub={sub} detail={model.getSubagentDetail(sub.agent_id)} />
@@ -471,6 +516,7 @@ const STATUS_LABEL: Record<AgentDisplayStatus, string> = {
     error:        "error",
     disconnected: "offline",
     unknown:      "unknown",
+    interrupted:  "interrupted",
 };
 
 function AgentStatusChip({ status }: { status: AgentDisplayStatus }): JSX.Element {

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -402,10 +402,21 @@ function SubagentRow({
         }
     };
 
+    // Row/group dimming must track the same effective status as the chip
+    // (reagent P2 on #2134) — otherwise a client-side "interrupted" backstop
+    // shows the new chip/dot but the row stays full-opacity, since only a
+    // backend-confirmed sub.status === "abandoned" would dim it directly.
+    const dimVariant = createMemo(() => {
+        const displayStatus = subagentDisplayStatus(sub, parentAgentStatus);
+        if (displayStatus === "interrupted") return "abandoned";
+        if (displayStatus === "idle") return "completed";
+        return "active";
+    });
+
     return (
-        <div class={`swarm-subagent-group swarm-subagent-group--${sub.status}`}>
+        <div class={`swarm-subagent-group swarm-subagent-group--${dimVariant()}`}>
             <div
-                class={`swarm-subagent-row swarm-subagent-row--${sub.status}`}
+                class={`swarm-subagent-row swarm-subagent-row--${dimVariant()}`}
                 onClick={handleToggle}
                 title={displayLabel()}
             >


### PR DESCRIPTION
## Summary

Step 3 of #2126's spec (`docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`) — consumes step 1's backend `Abandoned` status (#2131, already merged to `main`).

- `ActiveSubagent.status` / `SubagentDetail.statusAtom` extended from `"active" | "completed"` to `"active" | "completed" | "abandoned"`, matching the wire type shipped in #2131.
- New pure `subagentDisplayStatus(sub, parentAgentStatus)` in `swarm-view.tsx`: `"interrupted"` if the backend confirms `abandoned`, OR (client-side backstop) if `sub.status === "active"` but the parent block has already gone idle — using the same `turn_active`-derived `agentStatus` signal the parent pane's own reducer already relies on for this exact class of bug. Otherwise `"working"` (active + parent running) or `"idle"` (completed). Never mutates the input — a display-only projection; grouping/counting logic (`groupSubagentsByWorkflow`) keeps reading the real backend status untouched.
- `parentAgentStatus: "running" | "idle"` threaded from `AgentRow` down through `WorkflowGroupRow`/`NameGroupRow` to `SubagentRow`, replacing the old `sub.status === "active" ? "working" : "idle"` two-way ternary at the chip render site.
- New `AgentDisplayStatus` value `"interrupted"` + `STATUS_LABEL` entry + `.swarm-status-dot--interrupted` (warning-color, 0.5 opacity, no pulse — visually distinct from both `--working` and `--error`) and `--abandoned` group/row dimming (same values as `--completed`).

This is what closes the loop the user originally reported: a subagent whose parent turn ended without a terminal Result event previously stayed stuck showing "working" forever in the UI. Step 1 fixes it at rest (reopen-time backend reconciliation); this step also fixes it live, in the same session, via the client-side backstop — no reopen needed to see it stop pulsing.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run app/view/swarm/` — 35/35 passing:
  - `swarm-model.test.ts`: 2 new tests confirming an `abandoned` member is treated identically to `completed` for grouping purposes (both terminal) in both `WorkflowGroup` and `NameGroup` — zero changes needed to `groupSubagentsByWorkflow` itself, confirming the 3-way status generalizes cleanly.
  - `swarm-view.test.ts` (new file): 5 tests for `subagentDisplayStatus` — working-when-parent-running, idle-for-completed-regardless-of-parent, interrupted-for-backend-abandoned-regardless-of-parent, the key client-side-backstop case (active + parent idle → interrupted), and a purity check (never mutates the input).

<!-- agentmux:agent_id=agentx -->