### PR TITLE
fix(tabs): snap tab-separator slot to device pixel under fractional zoom

### DIFF
--- a/.changesets/1783915392-fix-tabs-snap-tab-separator-slot-width-to-device-pixel-under-ydy7.md
+++ b/.changesets/1783915392-fix-tabs-snap-tab-separator-slot-width-to-device-pixel-under-ydy7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): snap tab-separator slot width to device pixel under fractional zoom

--- a/frontend/app/mixins.scss
+++ b/frontend/app/mixins.scss
@@ -177,15 +177,27 @@
 /// participate in spec-defined pixel snapping (Patrick Brosset 2024)
 /// while a child <div> does not. Slot/line widths MUST share parity
 /// (both even or both odd) so the line centers on a device pixel.
+///
+/// The slot itself is run through `snap-chrome()` before being used as
+/// the flex-basis. Border-snapping only covers the `border-right` line;
+/// the slot's flex-basis and centering margins were still raw
+/// `--zoomfactor`-multiplied lengths, so at a non-integer zoom each
+/// separator's slot could independently round to a different device
+/// pixel, producing the "gap looks different between different tab
+/// pairs" symptom. Snapping the slot up front makes every slot land on
+/// the same sub-pixel decision. See RETRO_SUBPIXEL_RENDERING_RESEARCH_2026_04_26 §1.3/§4.2.
 @mixin v-separator($slot, $line, $color) {
-    flex: 0 0 #{$slot};
+    $slot-snapped: snap-chrome($slot);
+    flex: 0 0 #{$slot-snapped};
     display: block;
     border-right: #{$line} solid $color;
     // The slot is `border-box`, so the border occupies the rightmost
     // `line` px of the slot. To recenter the border in the gap, pull
     // the slot LEFT by half the leftover space (negative margin-left)
     // and push the next sibling RIGHT by the same amount (positive
-    // margin-right). Net visual gap stays exactly `slot` px.
-    margin-left:  calc((#{$line} - #{$slot}) / 2);
-    margin-right: calc((#{$slot} - #{$line}) / 2);
+    // margin-right). Net visual gap stays exactly `slot` px. Uses the
+    // snapped slot width so the centering math matches what actually
+    // got laid out.
+    margin-left:  calc((#{$line} - #{$slot-snapped}) / 2);
+    margin-right: calc((#{$slot-snapped} - #{$line}) / 2);
 }


### PR DESCRIPTION
## Summary
- The tab-separator's `border-right` line already opted into browser border-snapping, but the slot's `flex-basis` and centering margins were still raw `--zoomfactor`-multiplied lengths.
- At non-integer chrome zoom (anything other than 100%), each separator's slot could independently round to a different device pixel, producing visibly inconsistent gaps between different tab pairs.
- Wires the existing (previously unused) `snap-chrome()` helper into `v-separator()` so the slot width is explicitly rounded down to a device pixel before flex layout assigns it — closing the last unsnapped piece identified in `docs/retro/RETRO_SUBPIXEL_RENDERING_RESEARCH_2026_04_26.md` §1.3/§4.2.

## Test plan
- [x] `npx sass` compile of `tabbar.scss` confirms the mixin now emits `flex: 0 0 round(down, var(--tab-separator-width), var(--snap-chrome))` and matching margins.
- [x] `npm run lint:scss` on the touched files — no new errors introduced (pre-existing unrelated debt only).
- [ ] Manual: `task dev`, zoom the chrome (Ctrl+scroll) to a few non-integer levels (e.g. 110%, 90%, 133%) and confirm tab-separator gaps look uniform across the tab strip.

<!-- agentmux:agent_id=agent1 -->