### PR TITLE
chore: release v0.53.3

### DIFF
--- a/.changesets/1783794700-fix-pane-flyout-menus-over-browser-panes-on-macos-occlusion--7xrb.md
+++ b/.changesets/1783794700-fix-pane-flyout-menus-over-browser-panes-on-macos-occlusion--7xrb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(pane): flyout menus over browser panes on macOS — deterministic occlusion, click routing, and freeze-frame instead of black-out

--- a/.changesets/1783796014-fix-tabbar-invert-strobe-at-500ms-remove-reduced-motion-resp-j0vv.md
+++ b/.changesets/1783796014-fix-tabbar-invert-strobe-at-500ms-remove-reduced-motion-resp-j0vv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabbar): invert strobe at 500ms, remove reduced-motion respect app-wide, source pane no longer lingers after cross-tab move

--- a/.changesets/1783800919-feat-theme-add-a-light-theme-fix-phantom-tokens-context-menu-8y91.md
+++ b/.changesets/1783800919-feat-theme-add-a-light-theme-fix-phantom-tokens-context-menu-8y91.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(theme): add a light theme + fix phantom tokens, context menu, and pane title bar theming

--- a/.changesets/1783810085-fix-layout-drag-stabilization-registry-owner-check-prune-de--th86.md
+++ b/.changesets/1783810085-fix-layout-drag-stabilization-registry-owner-check-prune-de--th86.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(layout): drag stabilization — registry owner-check, prune de-fang, persistence Phase A

--- a/.changesets/1783865214-feat-sysinfo-track-pagefile-volume-free-disk-warn-when-a-sys-4cch.md
+++ b/.changesets/1783865214-feat-sysinfo-track-pagefile-volume-free-disk-warn-when-a-sys-4cch.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(sysinfo): track pagefile-volume free disk + warn when a system-managed page file can't grow

--- a/.changesets/1783865355-fix-ui-pane-minimize-icon-uses-horizontal-bar-convention-arm-ycin.md
+++ b/.changesets/1783865355-fix-ui-pane-minimize-icon-uses-horizontal-bar-convention-arm-ycin.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ui): pane minimize icon uses horizontal-bar convention, Armory action uses vault icon

--- a/.changesets/1783881559-fix-agent-remove-noisy-blue-focus-outline-on-conversation-ro-tffr.md
+++ b/.changesets/1783881559-fix-agent-remove-noisy-blue-focus-outline-on-conversation-ro-tffr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove noisy blue focus outline on conversation rows

--- a/.changesets/1783884787-fix-window-bind-label-hwnd-at-views-creation-time-close-repr-jyyw.md
+++ b/.changesets/1783884787-fix-window-bind-label-hwnd-at-views-creation-time-close-repr-jyyw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): bind label->HWND at Views creation time, close reproject drag cross-wire

--- a/.changesets/1783904947-fix-launcher-rotate-cap-agentmux-launcher-log-demote-5-high--6pgg.md
+++ b/.changesets/1783904947-fix-launcher-rotate-cap-agentmux-launcher-log-demote-5-high--6pgg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher): rotate/cap agentmux-launcher.log, demote 5 high-volume INFO log sites to debug

--- a/.changesets/1783906330-fix-launcher-detect-and-log-other-running-agentmux-versions--l0im.md
+++ b/.changesets/1783906330-fix-launcher-detect-and-log-other-running-agentmux-versions--l0im.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher): detect and log other running AgentMux versions on startup

--- a/.changesets/1783906330-fix-srv-extend-commit-aware-admission-gate-to-the-interactiv-o0fv.md
+++ b/.changesets/1783906330-fix-srv-extend-commit-aware-admission-gate-to-the-interactiv-o0fv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): extend commit-aware admission gate to the interactive agent pane spawn path

--- a/.changesets/1783906369-fix-editor-file-tree-rename-create-delete-silently-failed-ou-728v.md
+++ b/.changesets/1783906369-fix-editor-file-tree-rename-create-delete-silently-failed-ou-728v.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(editor): file-tree rename/create/delete silently failed outside $HOME

--- a/.changesets/1783906796-fix-storage-rename-db-identity-accounts-db-accounts-db-memor-odb2.md
+++ b/.changesets/1783906796-fix-storage-rename-db-identity-accounts-db-accounts-db-memor-odb2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(storage): rename db_identity_accounts -> db_accounts, db_memory_bundles -> db_bundles (Armory Phase 4a)

--- a/.changesets/1783907130-feat-swarm-group-loose-subagents-sharing-the-same-generated--rk84.md
+++ b/.changesets/1783907130-feat-swarm-group-loose-subagents-sharing-the-same-generated--rk84.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): group loose subagents sharing the same generated name

--- a/.changesets/1783907294-fix-agent-disable-native-spellcheck-on-the-conversation-comp-btgd.md
+++ b/.changesets/1783907294-fix-agent-disable-native-spellcheck-on-the-conversation-comp-btgd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): disable native spellcheck on the conversation composer

--- a/.changesets/1783907443-feat-editor-file-tree-open-to-the-side-open-in-new-tab-xmo4.md
+++ b/.changesets/1783907443-feat-editor-file-tree-open-to-the-side-open-in-new-tab-xmo4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): file-tree Open to the Side / Open in New Tab

--- a/.changesets/1783908843-fix-agent-pane-stop-o-n-rebuilds-on-scroll-and-streamed-chun-suba.md
+++ b/.changesets/1783908843-fix-agent-pane-stop-o-n-rebuilds-on-scroll-and-streamed-chun-suba.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): stop O(n) rebuilds on scroll and streamed chunks in agent-pane conversation rendering

--- a/.changesets/1783909362-fix-tabs-active-tab-color-line-stops-at-the-tab-strip-not-th-mfgz.md
+++ b/.changesets/1783909362-fix-tabs-active-tab-color-line-stops-at-the-tab-strip-not-th-mfgz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): active-tab color line stops at the tab strip, not the window edge

--- a/.changesets/1783909383-feat-theme-light-theme-reaches-header-status-bar-chrome-add--yt8v.md
+++ b/.changesets/1783909383-feat-theme-light-theme-reaches-header-status-bar-chrome-add--yt8v.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(theme): light theme reaches header/status-bar chrome + add Catppuccin Latte, Solarized Light, Gruvbox Light

--- a/.changesets/1783910207-feat-srv-subagent-abandoned-status-reopen-time-liveness-reco-y7ih.md
+++ b/.changesets/1783910207-feat-srv-subagent-abandoned-status-reopen-time-liveness-reco-y7ih.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): subagent Abandoned status + reopen-time liveness reconciliation

--- a/.changesets/1783910275-chore-agent-pane-add-scroll-stream-dispatch-bench-suite-and--0d8b.md
+++ b/.changesets/1783910275-chore-agent-pane-add-scroll-stream-dispatch-bench-suite-and--0d8b.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(agent-pane): add scroll/stream dispatch bench suite and perf-probe dispatch timing (task #40)

--- a/.changesets/1783911469-feat-identity-armory-phase-4b-4c-retire-identity-bundle-laye-pjkj.md
+++ b/.changesets/1783911469-feat-identity-armory-phase-4b-4c-retire-identity-bundle-laye-pjkj.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(identity): Armory Phase 4b/4c — retire Identity bundle layer, drop db_identity_bundles/db_identity_bindings

--- a/.changesets/1783912577-fix-swarm-debounce-subagent-list-refresh-instead-of-batching-lsgu.md
+++ b/.changesets/1783912577-fix-swarm-debounce-subagent-list-refresh-instead-of-batching-lsgu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): debounce subagent list refresh instead of batching backend broadcasts

--- a/.changesets/1783912736-feat-swarm-three-way-subagent-status-active-completed-abando-z2sh.md
+++ b/.changesets/1783912736-feat-swarm-three-way-subagent-status-active-completed-abando-z2sh.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): three-way subagent status (active/completed/abandoned) with interrupted chip and client-side downgrade guard

--- a/.changesets/1783915392-fix-tabs-snap-tab-separator-slot-width-to-device-pixel-under-ydy7.md
+++ b/.changesets/1783915392-fix-tabs-snap-tab-separator-slot-width-to-device-pixel-under-ydy7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): snap tab-separator slot width to device pixel under fractional zoom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.53.2"
+version = "0.53.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.53.2"
+version = "0.53.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.53.2"
+version = "0.53.3"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.53.2"
+version = "0.53.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.53.2"
+version = "0.53.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.53.2"
+version = "0.53.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.53.2"
+version = "0.53.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -28,7 +28,6 @@
 - feat(swarm): three-way subagent status (active/completed/abandoned) with interrupted chip and client-side downgrade guard
 - fix(tabs): snap tab-separator slot width to device pixel under fractional zoom
 
-
 ## 0.53.2 — 2026-07-11
 
 - fix(tabbar): cross-tab drag stability (stuck-overlay cleanup, ghost/landing clamp, geometry refresh) + hover strobe

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,34 @@
 # AgentMux Version History
 
+## 0.53.3 — 2026-07-13
+
+- fix(pane): flyout menus over browser panes on macOS — deterministic occlusion, click routing, and freeze-frame instead of black-out
+- fix(tabbar): invert strobe at 500ms, remove reduced-motion respect app-wide, source pane no longer lingers after cross-tab move
+- feat(theme): add a light theme + fix phantom tokens, context menu, and pane title bar theming
+- fix(layout): drag stabilization — registry owner-check, prune de-fang, persistence Phase A
+- feat(sysinfo): track pagefile-volume free disk + warn when a system-managed page file can't grow
+- fix(ui): pane minimize icon uses horizontal-bar convention, Armory action uses vault icon
+- fix(agent): remove noisy blue focus outline on conversation rows
+- fix(window): bind label->HWND at Views creation time, close reproject drag cross-wire
+- fix(launcher): rotate/cap agentmux-launcher.log, demote 5 high-volume INFO log sites to debug
+- fix(launcher): detect and log other running AgentMux versions on startup
+- fix(srv): extend commit-aware admission gate to the interactive agent pane spawn path
+- fix(editor): file-tree rename/create/delete silently failed outside $HOME
+- fix(storage): rename db_identity_accounts -> db_accounts, db_memory_bundles -> db_bundles (Armory Phase 4a)
+- feat(swarm): group loose subagents sharing the same generated name
+- fix(agent): disable native spellcheck on the conversation composer
+- feat(editor): file-tree Open to the Side / Open in New Tab
+- fix(agent-pane): stop O(n) rebuilds on scroll and streamed chunks in agent-pane conversation rendering
+- fix(tabs): active-tab color line stops at the tab strip, not the window edge
+- feat(theme): light theme reaches header/status-bar chrome + add Catppuccin Latte, Solarized Light, Gruvbox Light
+- feat(srv): subagent Abandoned status + reopen-time liveness reconciliation
+- chore(agent-pane): add scroll/stream dispatch bench suite and perf-probe dispatch timing (task #40)
+- feat(identity): Armory Phase 4b/4c — retire Identity bundle layer, drop db_identity_bundles/db_identity_bindings
+- fix(swarm): debounce subagent list refresh instead of batching backend broadcasts
+- feat(swarm): three-way subagent status (active/completed/abandoned) with interrupted chip and client-side downgrade guard
+- fix(tabs): snap tab-separator slot width to device pixel under fractional zoom
+
+
 ## 0.53.2 — 2026-07-11
 
 - fix(tabbar): cross-tab drag stability (stuck-overlay cleanup, ghost/landing clamp, geometry refresh) + hover strobe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.53.2",
+      "version": "0.53.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Patch release consuming 25 pending changesets (forced patch bump — 8 of them were `minor`-tier; per the changesets workflow's documented `--as patch` override, that queued minor work ships under the patch label rather than blocking on a minor release).

Notable items in this release:
- fix(window): bind label->HWND at Views creation time, close reproject drag cross-wire (#2111)
- fix(launcher): rotate/cap agentmux-launcher.log, demote 5 firehose INFO sites (#2116)
- fix(launcher): detect and log other running AgentMux versions on startup (#2117)
- fix(srv): extend commit-aware admission gate to the interactive agent pane (#2119)
- fix(agent-pane): stop O(n) rebuilds on scroll and streamed chunks + bench suite/perf-probe dispatch timing (#2127)
- feat(sysinfo): track pagefile-volume free disk + warn on a stuck page file (#2109)
- feat(identity): Armory Phase 4b/4c — retire Identity bundle layer
- feat(swarm): three-way subagent status + group loose subagents + debounced refresh
- feat(theme): light theme + 3 more light themes (Catppuccin Latte, Solarized Light, Gruvbox Light)
- feat(editor): file-tree Open to the Side / Open in New Tab
- Several smaller UI fixes (tabbar, pane minimize icon, agent focus outline, spellcheck)

All 5 version locations verified in agreement at 0.53.3 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md).

## Test plan
- [x] `scripts/release.sh` self-verified all 5 version locations agree post-bump.
- CI will run the standard build/test/vitest checks on this PR.