### PR TITLE
fix(theme): darken primary text color across all 4 light themes

### DIFF
--- a/.changesets/1783975591-fix-theme-darken-primary-text-color-across-all-4-light-theme-4fcd.md
+++ b/.changesets/1783975591-fix-theme-darken-primary-text-color-across-all-4-light-theme-4fcd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(theme): darken primary text color across all 4 light themes for readability

--- a/frontend/app/themes/catppuccin-latte.scss
+++ b/frontend/app/themes/catppuccin-latte.scss
@@ -20,7 +20,10 @@
     --block-bg-solid-color: #ffffff;
     --modal-bg-color: #ffffff;
 
-    --main-text-color: #4c4f69;
+    // Darkened from Catppuccin's published "Text" (#4c4f69) — the
+    // canonical value read as too light for comfortable body-text
+    // reading in-app; still the same hue family, just more ink.
+    --main-text-color: #37394b;
     --secondary-text-color: #5c5f77;
     --grey-text-color: #8c8fa1;
 
@@ -58,7 +61,7 @@
     --scrollbar-thumb-hover-color: rgba(76, 79, 105, 0.4);
 
     --term-background: #eff1f5;
-    --term-foreground: #4c4f69;
+    --term-foreground: #37394b;
     --term-black: #5c5f77;
     --term-red: #d20f39;
     --term-green: #40a02b;

--- a/frontend/app/themes/gruvbox-light.scss
+++ b/frontend/app/themes/gruvbox-light.scss
@@ -15,7 +15,7 @@
     --block-bg-solid-color: #f9f5d7;
     --modal-bg-color: #ebdbb2;
 
-    --main-text-color: #3c3836;
+    --main-text-color: #2c2928;
     --secondary-text-color: #504945;
     --grey-text-color: #928374;
 
@@ -53,7 +53,7 @@
     --scrollbar-thumb-hover-color: rgba(60, 56, 54, 0.45);
 
     --term-background: #fbf1c7;
-    --term-foreground: #3c3836;
+    --term-foreground: #2c2928;
     --term-black: #504945;
     --term-red: #9d0006;
     --term-green: #79740e;

--- a/frontend/app/themes/light.scss
+++ b/frontend/app/themes/light.scss
@@ -22,7 +22,7 @@
     --block-bg-solid-color: #ffffff;
     --modal-bg-color: #ffffff;
 
-    --main-text-color: #1f2328;
+    --main-text-color: #0d0f11;
     --secondary-text-color: #4b535c;
     --grey-text-color: #6e7781;
 
@@ -83,7 +83,7 @@
     --scrollbar-thumb-hover-color: rgba(0, 0, 0, 0.4);
 
     --term-background: #ffffff;
-    --term-foreground: #1f2328;
+    --term-foreground: #0d0f11;
     --term-black: #1f2328;
     --term-red: #cf222e;
     --term-green: #116329;

--- a/frontend/app/themes/solarized-light.scss
+++ b/frontend/app/themes/solarized-light.scss
@@ -18,7 +18,12 @@
     --block-bg-solid-color: #fdf6e3;
     --modal-bg-color: #eee8d5;
 
-    --main-text-color: #657b83;
+    // Darkened from Solarized's canonical base00 (#657b83, still used
+    // verbatim below for --term-foreground) — base00 measures only
+    // ~4.1:1 against --main-bg-color, right at the edge of WCAG AA for
+    // UI body text. This token is app-chrome-only, so it doesn't affect
+    // the terminal's authentic Solarized rendering.
+    --main-text-color: #46555b;
     --secondary-text-color: #839496;
     --grey-text-color: #93a1a1;
 


### PR DESCRIPTION
## Summary
User feedback after testing the new light themes: body text read too light. WCAG contrast measurements against each theme's `--main-bg-color` confirmed a real, uneven issue:

| Theme | Old text | New text | Old contrast | New contrast |
|---|---|---|---|---|
| light | `#1f2328` | `#0d0f11` | 14.6:1 | 17.8:1 |
| catppuccin-latte | `#4c4f69` | `#37394b` | 7.1:1 | 10.0:1 |
| solarized-light | `#657b83` | `#46555b` | **4.1:1** | 7.2:1 |
| gruvbox-light | `#3c3836` | `#2c2928` | 10.2:1 | 12.7:1 |

Solarized Light's canonical `base00` was the real outlier — right at the edge of failing WCAG AA (needs 4.5:1) for normal text. The other three already passed comfortably but got a modest bump per the user's "bump it a bit across the board" request.

`--term-foreground` moves in lockstep with `--main-text-color` for light/catppuccin-latte/gruvbox-light (they were already kept identical). Left untouched for solarized-light, since that file's ANSI 16-color table is explicitly documented as Solarized's canonical mapping reproduced verbatim — only the app-chrome text token changed there, so terminal rendering stays authentic to the published Solarized palette.

## Test plan
- [x] `npx sass` compile — no errors.
- [x] `npx tsc --noEmit` clean (no TS touched, sanity check only).
- [ ] Manual: cycle through all 4 light themes in `task dev` and confirm body/UI text reads noticeably darker and easier to read, terminal text in Solarized Light still matches the classic palette.

<!-- agentmux:agent_id=agent1 -->