### PR TITLE
feat(srv): swarm/subagent lifecycle diagnostics (muxlog swarm)

### DIFF
--- a/.changesets/1783977814-feat-srv-swarm-subagent-lifecycle-diagnostics-muxlog-swarm-6hv2.md
+++ b/.changesets/1783977814-feat-srv-swarm-subagent-lifecycle-diagnostics-muxlog-swarm-6hv2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): swarm/subagent lifecycle diagnostics (muxlog swarm)

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -349,6 +349,7 @@ const HELP = `muxlog — AgentMux log viewer
   muxlog mem                         system commit-free + pressure + live AgentMux procs
   muxlog errors                      ERROR/WARN across host+srv (active instance)
   muxlog bridge                      startup-handshake trace (debug reconnect loops)
+  muxlog swarm                       subagent/swarm lifecycle trace (spawn/name/status, debug duplicate groups)
 
 Options (any position):
   -i <substr>   pick the instance whose log path/branch/version matches <substr>
@@ -374,6 +375,23 @@ function main() {
             const f = discover(tgt).filter((e) => !opt.instance || e.file.toLowerCase().includes(opt.instance.toLowerCase()))[0];
             if (f) { console.log(`\n=== ${tgt}: ${f.file} ===`); printLastLines(f.file, opt.n, opt, true); }
         }
+        return;
+    }
+    if (cmd === "swarm") {
+        // Subagent/swarm lifecycle trace: spawn, display_name resolution
+        // (subagent.GenerateName), status transitions (including
+        // reconcile_stale_subagents' active->abandoned pass), and the
+        // parent_block_id a subagent is bound to on backfill — the fields a
+        // NAME-based grouping/dedup bug in the Swarm view needs, without
+        // wading through the (usually much larger) agent-transcript log.
+        // All emitted srv-side from subagent_watcher.rs's tracing target
+        // (`agentmux_srv::backend::subagent_watcher`, rendered as
+        // `srv:subagent_watcher` by shortTarget) — there is no host-side
+        // subagent logging to combine in (checked: agentmux-cef has none).
+        opt.target = opt.target || "subagent_watcher";
+        const f = resolveFile("srv", opt);
+        console.log(`=== swarm trace: ${f} ===`);
+        printLastLines(f, opt.n, opt, true);
         return;
     }
     if (cmd === "bridge") {

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -596,7 +596,13 @@ impl SubagentWatcher {
                 // parent_block_ids" (a subagent's parent_block_id is fixed at
                 // first discovery, see process_jsonl_change; a mismatch here is
                 // the mechanism a NAME/grouping-dedup bug would leave a trail in).
-                tracing::debug!(
+                //
+                // reagent (PR #2143 round 1): info!, not debug! — the default
+                // production EnvFilter (agentmux-srv/src/main.rs, "agentmuxsrv=
+                // info,info") drops debug-level lines unless RUST_LOG=debug is
+                // already set, which would make this diagnostic invisible in a
+                // normally-running srv, defeating the point of adding it.
+                tracing::info!(
                     agent = %parent_agent,
                     parent_block_id = %parent_block_id,
                     session_id = %session_id,
@@ -638,7 +644,11 @@ impl SubagentWatcher {
                 .map(|s| s.turn_active)
                 .unwrap_or(true);
         if parent_turn_active {
-            tracing::debug!(
+            // reagent (PR #2143 round 1): info!, not debug! — see the note on
+            // the backfill log above; the default production filter drops
+            // debug-level lines, which would make this and the pass-summary
+            // log below invisible in a normally-running srv.
+            tracing::info!(
                 parent_block_id = %parent_block_id,
                 session_id = %session_id,
                 "reconcile_stale_subagents: parent turn active (or unknown) — nothing to reconcile"
@@ -682,7 +692,7 @@ impl SubagentWatcher {
             }
         }
         if reconciled > 0 {
-            tracing::debug!(
+            tracing::info!(
                 parent_block_id = %parent_block_id,
                 session_id = %session_id,
                 reconciled,
@@ -791,7 +801,12 @@ impl SubagentWatcher {
             // under — log it so it's visible without needing to reproduce.
             if let Some(existing) = session.subagents.get(&agent_id) {
                 if existing.info.parent_block_id != parent_block_id {
-                    tracing::debug!(
+                    // reagent (PR #2143 round 1, P1): info!, not debug! — this
+                    // is the single most likely diagnostic trail for the
+                    // duplication bug this PR exists to help find; at debug!
+                    // it would be silently dropped by the default production
+                    // filter and never actually appear when it matters.
+                    tracing::info!(
                         agent_id = %agent_id,
                         session_id = %session_id,
                         existing_parent_block_id = %existing.info.parent_block_id,

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -502,12 +502,23 @@ impl SubagentWatcher {
     /// RPC firing and resolving) — the caller should treat that as a no-op,
     /// not an error.
     pub fn set_display_name(&self, agent_id: &str, display_name: &str) -> bool {
+        // Captured alongside the mutation itself (not re-looked-up after
+        // unlocking) — this is the exact moment a NAME-based grouping key is
+        // born, so the fields that decide which group it lands in
+        // (workflow_id, parent_block_id) need to be logged from the same
+        // locked read that set it, not a racy re-fetch.
+        let mut found_context: Option<(String, String, Option<String>)> = None;
         let found = {
             let mut sessions = self.sessions.lock().unwrap();
             let mut found = false;
             for session in sessions.values_mut() {
                 if let Some(state) = session.subagents.get_mut(agent_id) {
                     state.info.display_name = Some(display_name.to_string());
+                    found_context = Some((
+                        state.info.parent_block_id.clone(),
+                        state.info.session_id.clone(),
+                        state.info.workflow_id.clone(),
+                    ));
                     found = true;
                     break;
                 }
@@ -515,6 +526,17 @@ impl SubagentWatcher {
             found
         };
         // Mutex released here — broadcast outside the lock
+
+        if let Some((parent_block_id, session_id, workflow_id)) = &found_context {
+            tracing::info!(
+                agent_id = %agent_id,
+                display_name = %display_name,
+                parent_block_id = %parent_block_id,
+                session_id = %session_id,
+                workflow_id = ?workflow_id,
+                "subagent display_name resolved"
+            );
+        }
 
         if found {
             let named_event = WSEventType {
@@ -568,6 +590,19 @@ impl SubagentWatcher {
             let session_dir = entry.path().join(session_id);
             let subagents_dir = session_dir.join("subagents");
             if subagents_dir.is_dir() {
+                // Correlates a pane (re)open with the session it's backfilling —
+                // needed to tell "this session was backfilled once" apart from
+                // "this session was backfilled repeatedly under different
+                // parent_block_ids" (a subagent's parent_block_id is fixed at
+                // first discovery, see process_jsonl_change; a mismatch here is
+                // the mechanism a NAME/grouping-dedup bug would leave a trail in).
+                tracing::debug!(
+                    agent = %parent_agent,
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    dir = %subagents_dir.display(),
+                    "backfilling session subagents on pane (re)open"
+                );
                 self.scan_subagents_dir(parent_agent, parent_block_id, &subagents_dir);
                 self.reconcile_stale_subagents(parent_block_id, session_id);
                 return; // session ids are unique — no need to keep scanning
@@ -603,6 +638,11 @@ impl SubagentWatcher {
                 .map(|s| s.turn_active)
                 .unwrap_or(true);
         if parent_turn_active {
+            tracing::debug!(
+                parent_block_id = %parent_block_id,
+                session_id = %session_id,
+                "reconcile_stale_subagents: parent turn active (or unknown) — nothing to reconcile"
+            );
             return;
         }
 
@@ -618,13 +658,36 @@ impl SubagentWatcher {
         // be genuinely active, so only reconcile entries this block itself
         // owns (mirrors unwatch_agent's own parent-scoped filter). Reagent
         // P1 on PR #2131.
+        let mut reconciled = 0usize;
         for state in session.subagents.values_mut() {
             if state.info.parent_block_id != parent_block_id {
                 continue;
             }
             if state.info.status == SubagentStatus::Active {
                 state.info.status = SubagentStatus::Abandoned;
+                reconciled += 1;
+                // Every field a NAME-based grouping/dedup bug needs to
+                // reconstruct offline: which subagent, which workflow (if
+                // any), which display_name it had already resolved (grouping
+                // is keyed on this), and which block/session it's bound to.
+                tracing::info!(
+                    agent_id = %state.info.agent_id,
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    workflow_id = ?state.info.workflow_id,
+                    display_name = ?state.info.display_name,
+                    slug = %state.info.slug,
+                    "subagent reconciled: active -> abandoned (parent turn ended)"
+                );
             }
+        }
+        if reconciled > 0 {
+            tracing::debug!(
+                parent_block_id = %parent_block_id,
+                session_id = %session_id,
+                reconciled,
+                "reconcile_stale_subagents: pass complete"
+            );
         }
     }
 
@@ -716,6 +779,27 @@ impl SubagentWatcher {
                 });
 
             let is_new = !session.subagents.contains_key(&agent_id);
+            // A subagent's parent_block_id is stamped once, at first
+            // discovery (below), and never updated on later re-scans of the
+            // same session — see the entry's doc comment. If this session is
+            // being (re)scanned under a DIFFERENT block_id than the one this
+            // subagent was originally bound to (e.g. the pane was reopened
+            // under a new block), the subagent stays attributed to its
+            // original, now possibly-stale parent_block_id. That's a direct
+            // candidate mechanism for a subagent silently falling outside
+            // the block reconcile_stale_subagents/buildTree() expect it
+            // under — log it so it's visible without needing to reproduce.
+            if let Some(existing) = session.subagents.get(&agent_id) {
+                if existing.info.parent_block_id != parent_block_id {
+                    tracing::debug!(
+                        agent_id = %agent_id,
+                        session_id = %session_id,
+                        existing_parent_block_id = %existing.info.parent_block_id,
+                        rescanned_parent_block_id = %parent_block_id,
+                        "subagent re-observed under a different parent_block_id than its original — parent_block_id NOT updated"
+                    );
+                }
+            }
             let state = session.subagents.entry(agent_id.clone()).or_insert_with(|| {
                 SubagentState {
                     info: SubagentInfo {
@@ -812,6 +896,9 @@ impl SubagentWatcher {
                 agent_id = %agent_id,
                 slug = %info_snapshot.slug,
                 parent = %parent_agent,
+                parent_block_id = %parent_block_id,
+                session_id = %session_id,
+                workflow_id = ?info_snapshot.workflow_id,
                 "subagent spawned"
             );
         }
@@ -861,6 +948,9 @@ impl SubagentWatcher {
             tracing::info!(
                 agent_id = %agent_id,
                 total_events = info_snapshot.event_count,
+                parent_block_id = %parent_block_id,
+                session_id = %session_id,
+                workflow_id = ?info_snapshot.workflow_id,
                 "subagent completed"
             );
         }

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -19,6 +19,7 @@ muxlog              # follow the most-recently-active host log
 muxlog srv          # follow the active sidecar log
 muxlog bridge       # startup-handshake trace — debug "Can't reconnect" loops
 muxlog errors       # just the ERROR/WARN lines across host + sidecar
+muxlog swarm        # subagent/swarm lifecycle trace — spawn/name/status, debug duplicate groups
 muxlog help         # full usage
 ```
 
@@ -80,6 +81,7 @@ muxlog srv --since 2026-06-15T23:30 cat        # a time window
 | `muxlog mem` (alias `doctor`) | system **commit-free** + derived pressure level (the OOM-relevant ceiling, not physical RAM) + the count and footprint of live AgentMux processes — makes multi-instance commit pressure visible before the cliff (`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16` §5.G) |
 | `muxlog errors` | ERROR + WARN across the active host and sidecar |
 | `muxlog bridge` | the startup handshake — `Loading URL`, `Injected IPC …`, `backend-ready`, `window.api`, `Bootstrap failed` — correlated in time, so a reconnect loop is obvious at a glance |
+| `muxlog swarm` | subagent/swarm lifecycle — spawn, `display_name` resolution (`subagent.GenerateName`), status transitions (`reconcile_stale_subagents`' active→abandoned pass), and the `parent_block_id`/`session_id`/`workflow_id` each event carries — filters the sidecar log to `subagent_watcher.rs`'s tracing target so a duplicate-group or stuck-status report is diagnosable from logs alone (srv-side only; there's no host-side subagent logging to combine in) |
 
 ---
 


### PR DESCRIPTION
## Summary

Task #43: tonight a real bug was live-repro'd under an agent named "Lzop" — the Swarm pane rendered 8+ separate duplicate `swarm-subagent-group` DOM entries, all named `magical-enchanting-diffie`, all status `abandoned`, that should have collapsed into ONE `NameGroup` per the recently-merged "group loose subagents sharing the same generated name" feature (`frontend/app/view/swarm/swarm-model.ts`).

Diagnosing it hit a real gap: `grep magical-enchanting-diffie` across the live srv log returned **nothing**, despite `subagent_watcher.rs` already having ~15 tracing call sites — none of them covered the specific step that assigns/resolves a subagent's display name, or the abandon-reconciliation path shipped in `docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`.

**This PR is diagnostics only** — no behavior change to subagent lifecycle logic, no attempt to fix the duplication itself (that's an explicit follow-up).

## What changed

- **`agentmux-srv/src/backend/subagent_watcher.rs`** — added `tracing::debug!`/`tracing::info!` at the points a NAME-based grouping/dedup bug needs to reconstruct a decision from logs alone:
  - `process_jsonl_change`'s existing "subagent spawned"/"subagent completed" logs now also carry `parent_block_id`, `session_id`, `workflow_id`.
  - New: a mismatch log when a session is re-scanned and finds a subagent whose `parent_block_id` differs from the one it was originally bound to (a subagent's `parent_block_id` is frozen at first discovery and never updated — a direct candidate mechanism for a subagent silently falling outside the block a later `reconcile_stale_subagents`/frontend `buildTree()` pass expects it under).
  - New: `set_display_name` now logs `agent_id`, `display_name`, `parent_block_id`, `session_id`, `workflow_id` at the exact moment a NAME-based grouping key is born (the `subagent.GenerateName` resolution step).
  - New: `reconcile_stale_subagents` now logs each `Active -> Abandoned` transition (with `workflow_id`, `display_name`, `slug`) plus a pass summary, and a debug line when it's a no-op because the parent turn is still active/unknown.
  - New: `scan_session_subagents` logs each backfill-on-reopen entry point (`parent_block_id`, `session_id`, `dir`) — needed to tell "backfilled once" apart from "backfilled repeatedly under different `parent_block_id`s across reopens."

- **`agentmux-srv/src/backend/shellintegration/muxlog.mjs`** — new `muxlog swarm` subcommand, mirroring the existing `errors`/`bridge` shape. Filters the sidecar log to `subagent_watcher.rs`'s tracing target (`agentmux_srv::backend::subagent_watcher`, rendered `srv:subagent_watcher`). Confirmed no host-side subagent logging exists to combine in (`agentmux-cef` has zero `subagent` references).

- **`docs/MUXLOG.md`** — documented `muxlog swarm` alongside the other recipes/quick-start commands.

## Verification

- `cargo check -p agentmux-srv` — clean (no new warnings; only pre-existing dead-code warnings elsewhere).
- `node -c muxlog.mjs` — parses; `muxlog swarm` reachable and tested end-to-end against this environment's real srv log.

## A concrete lead for the follow-up duplication-fix task

Running the new `muxlog swarm` tool against this environment's own (pre-existing) srv log surfaced two things worth flagging even though this PR doesn't act on them:

1. **The duplicated text is almost certainly the `slug`, not a Haiku `display_name`.** At `21:02:19`, 17 *structurally distinct* subagents (17 different `agent_id`s) were spawned within ~50ms under parent `Lzop`, all sharing the literal identical `slug: "magical-enchanting-diffie"`. `display_name` is null until a user expands a row (`subagent.GenerateName`) — so this collision predates any Haiku naming step. If the duplicate groups the user saw are actually `WorkflowGroup`s (which, unlike `NameGroup`, have **no minimum-member-count gate** and fall back to `sorted.find(m => m.slug)?.slug` for their name), then N *different* `workflow_id`s each producing a singleton group with a coincidentally-identical slug-derived name would look exactly like this bug — and the recently-merged `NameGroup` feature would be entirely uninvolved. Worth checking: is `swarm-subagent-group` shared CSS between `WorkflowGroupRow` and `NameGroupRow` (it is, per `swarm-view.tsx:417`) — so DOM inspection alone can't tell which kind actually rendered; check `workflow_id` on the underlying subagents first.

2. **A same-`agent_id`-different-parent race.** At `21:13:43`, `agent_id=adefeb4956788f5d4` was logged as newly spawned twice, ~100 microseconds apart, on two different threads, under two different parents (`AgentA` and `Lzop`). Both hit the `is_new` branch, meaning both calls independently computed `is_new = true` — i.e. they landed in two different `SessionWatch` entries (different `derive_session_id` results) despite representing what looks like the same subagent file. This is a genuine, log-confirmed duplication mechanism, separate from (but possibly compounding) the grouping question above.

<!-- agentmux:agent_id=agenta -->