### PR TITLE
fix(srv): move starter Skills seeding into migrations, stop resurrecting deleted skills

### DIFF
--- a/.changesets/1783977952-fix-srv-move-starter-skills-seeding-into-migrations-to-stop--lab7.md
+++ b/.changesets/1783977952-fix-srv-move-starter-skills-seeding-into-migrations-to-stop--lab7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): move starter Skills seeding into migrations to stop resurrecting deleted skills

--- a/agentmux-srv/src/backend/skill_seed.rs
+++ b/agentmux-srv/src/backend/skill_seed.rs
@@ -47,6 +47,27 @@ pub struct SkillSeedReport {
     pub created: usize,
 }
 
+/// True if any global skill whose name matches a starter-skill's name
+/// already exists — i.e. this channel already effectively has the starter
+/// set (or a name collision with it), whether from a prior run of this
+/// migration, the retired pre-migration startup-seed path (#2141, shipped
+/// before this migration existed — every channel that has already booted
+/// once has these names present), or the user coincidentally naming their
+/// own skill the same thing.
+///
+/// The caller (`migrations::m0015_seed_starter_skills`) uses this to skip
+/// seeding entirely rather than attempting an insert that would collide on
+/// `skill_upsert_unique_global`'s name-uniqueness check and permanently
+/// fail the migration on every subsequent boot (reagent P1, PR #2144).
+pub(crate) fn any_starter_skill_name_exists(wstore: &Arc<Store>) -> Result<bool, StoreError> {
+    let manifest: Vec<StarterSkill> = serde_json::from_str(STARTER_SKILLS_JSON)
+        .map_err(|e| StoreError::Other(format!("skill seed: parse manifest: {e}")))?;
+    let existing = wstore.skill_list_global()?;
+    Ok(manifest
+        .iter()
+        .any(|entry| existing.iter().any(|item| item.skill.name == entry.name)))
+}
+
 /// Parse the embedded manifest and insert every entry as a global skill via
 /// the validated `skill_upsert_unique_global` path. Does NOT check whether
 /// the catalog is already populated — the caller

--- a/agentmux-srv/src/backend/skill_seed.rs
+++ b/agentmux-srv/src/backend/skill_seed.rs
@@ -4,20 +4,17 @@
 //! Starter Skills catalog seed: preloads a small set of curated global
 //! skills (`db_skills`, the v1 standalone catalog) on fresh install.
 //!
-//! This is a **one-time, idempotent seed** — not a schema migration (which
-//! runs unconditionally every startup) and not a sync/upsert mechanism for
-//! the starter set going forward. It is gated on the global catalog being
-//! empty: if `skill_list_global()` returns any rows — including the case
-//! where the user seeded then deleted every starter skill on purpose — the
-//! seed step is a no-op. That gate can't distinguish "never seeded" from
-//! "seeded then fully cleared", and per the design that's fine: both states
-//! mean "the user should own an empty catalog from here," not "silently
-//! resurrect defaults."
+//! The actual "run exactly once, ever" gating lives in
+//! `migrations::m0015_seed_starter_skills`, tracked in the channel's
+//! `db_migrations` table — NOT in this module. An earlier version gated on
+//! "is the catalog currently empty," which couldn't distinguish "never
+//! seeded" from "seeded then the user deleted every starter skill on
+//! purpose," silently resurrecting the defaults on the next restart after a
+//! full deletion (reagent P2, PR #2141 round 2). This module now exposes
+//! only the pure insert logic; the migration owns once-ever invocation.
 //!
 //! Distinct from `agent_seed.rs`, which seeds legacy per-agent skills into
-//! `db_agent_skills` and re-seeds on every manifest version bump. This
-//! module seeds the newer standalone `db_skills` table exactly once and
-//! never re-seeds or updates existing rows.
+//! `db_agent_skills` and re-seeds on every manifest version bump.
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -50,51 +47,23 @@ pub struct SkillSeedReport {
     pub created: usize,
 }
 
-/// Seed the global Skills catalog (`db_skills WHERE is_global = 1`) from the
-/// embedded starter set, but only if that catalog is currently empty.
-///
-/// Called once at startup, alongside `agent_seed::auto_seed_on_startup`.
-/// Failures are logged and non-fatal — a broken seed should never block
-/// server startup.
-pub fn seed_starter_skills_if_empty(wstore: &Arc<Store>) {
-    match wstore.skill_list_global() {
-        Ok(existing) if !existing.is_empty() => {
-            tracing::debug!(
-                count = existing.len(),
-                "skill seed: global catalog already has skills, skipping starter seed"
-            );
-        }
-        Ok(_) => match seed_starter_skills(wstore) {
-            Ok(report) => {
-                if report.created > 0 {
-                    tracing::info!(
-                        "skill seed: seeded {} starter skills into the global catalog",
-                        report.created
-                    );
-                }
-            }
-            Err(e) => tracing::error!("skill seed: failed: {e}"),
-        },
-        Err(e) => tracing::error!("skill seed: failed to check global catalog: {e}"),
-    }
-}
-
 /// Parse the embedded manifest and insert every entry as a global skill via
 /// the validated `skill_upsert_unique_global` path. Does NOT check whether
-/// the catalog is already populated — callers (namely
-/// `seed_starter_skills_if_empty`) own that gate. Exposed separately so
-/// tests can exercise idempotency directly.
+/// the catalog is already populated — the caller
+/// (`migrations::m0015_seed_starter_skills`) owns run-once gating via
+/// `db_migrations` tracking, not catalog contents. Exposed at `pub(crate)`
+/// so the migration and tests can call it directly.
 ///
 /// All-or-nothing: `skill_upsert_unique_global` commits each insert in its
 /// own transaction (it isn't `StoreTx`-composable — see its own doc
 /// comment), so a mid-loop failure can't be rolled back by the database
 /// itself. If any insert fails, this compensates by deleting every skill
-/// already inserted in THIS call before returning the error — otherwise
-/// the catalog would be left non-empty-but-incomplete, and the
-/// empty-catalog gate in `seed_starter_skills_if_empty` would treat that
-/// partial state as "already seeded," permanently stranding it with no
-/// retry path (reagent P2, PR #2141 round 1).
-fn seed_starter_skills(wstore: &Arc<Store>) -> Result<SkillSeedReport, StoreError> {
+/// already inserted in THIS call before returning the error — otherwise a
+/// retry (the migration framework re-runs `up()` on the next boot when a
+/// migration returns `Err`, since it's never marked applied) would hit
+/// `skill_upsert_unique_global`'s name-uniqueness rejection on the skills
+/// already stranded from the failed attempt (reagent P2, PR #2141 round 1).
+pub(crate) fn seed_starter_skills(wstore: &Arc<Store>) -> Result<SkillSeedReport, StoreError> {
     let manifest: Vec<StarterSkill> = serde_json::from_str(STARTER_SKILLS_JSON)
         .map_err(|e| StoreError::Other(format!("skill seed: parse manifest: {e}")))?;
 
@@ -137,94 +106,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn seeds_into_empty_catalog() {
+    fn seeds_six_skills_into_an_empty_catalog() {
         let wstore = Arc::new(Store::open_in_memory().unwrap());
         assert!(wstore.skill_list_global().unwrap().is_empty());
 
-        seed_starter_skills_if_empty(&wstore);
+        let report = seed_starter_skills(&wstore).unwrap();
 
+        assert_eq!(report.created, 6);
         let after = wstore.skill_list_global().unwrap();
         assert_eq!(after.len(), 6, "all six starter skills should be seeded");
         assert!(after.iter().all(|item| item.skill.is_global));
-    }
-
-    #[test]
-    fn seeding_is_idempotent() {
-        let wstore = Arc::new(Store::open_in_memory().unwrap());
-
-        seed_starter_skills_if_empty(&wstore);
-        let first_count = wstore.skill_list_global().unwrap().len();
-        assert_eq!(first_count, 6);
-
-        // Running the gated entry point again must not duplicate rows —
-        // the catalog is no longer empty, so this is a no-op.
-        seed_starter_skills_if_empty(&wstore);
-        let second_count = wstore.skill_list_global().unwrap().len();
-        assert_eq!(second_count, first_count, "re-running the seed step must not duplicate rows");
-    }
-
-    #[test]
-    fn skips_seeding_when_a_global_skill_already_exists() {
-        let wstore = Arc::new(Store::open_in_memory().unwrap());
-
-        // Simulate a pre-existing global skill (e.g. user-created, or a
-        // starter skill that survived from a previous partial state).
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        let pre_existing = Skill {
-            id: "user-skill-1".to_string(),
-            name: "My Own Skill".to_string(),
-            trigger: "my-own-skill".to_string(),
-            skill_type: "prompt".to_string(),
-            description: "A user-authored skill.".to_string(),
-            content: "Do the thing.".to_string(),
-            is_global: true,
-            created_at: now,
-            updated_at: now,
-        };
-        wstore.skill_upsert_unique_global(&pre_existing).unwrap();
-
-        seed_starter_skills_if_empty(&wstore);
-
-        let after = wstore.skill_list_global().unwrap();
-        assert_eq!(
-            after.len(),
-            1,
-            "seed step must not run when the global catalog is non-empty"
-        );
-        assert_eq!(after[0].skill.id, "user-skill-1");
-    }
-
-    #[test]
-    fn deleting_all_seeded_skills_then_calling_again_does_reseed() {
-        // Per the design: an empty-catalog gate can't distinguish "never
-        // seeded" from "seeded then the user deleted everything on
-        // purpose" — that's intentional (see the module doc comment). This
-        // test verifies the actual consequence, not just the intermediate
-        // state: once seeded-then-cleared, the catalog looks identical to
-        // fresh, so a second call to `seed_starter_skills_if_empty` DOES
-        // reseed. In production this never happens — the call site is
-        // startup-only — but this proves the function-level behavior the
-        // module comment claims, rather than asserting only the emptiness
-        // in between and leaving the "would reseed" half unverified
-        // (reagent P2, PR #2141 round 1).
-        let wstore = Arc::new(Store::open_in_memory().unwrap());
-        seed_starter_skills_if_empty(&wstore);
-        assert_eq!(wstore.skill_list_global().unwrap().len(), 6);
-
-        for item in wstore.skill_list_global().unwrap() {
-            wstore.skill_delete(&item.skill.id).unwrap();
-        }
-        assert!(wstore.skill_list_global().unwrap().is_empty());
-
-        seed_starter_skills_if_empty(&wstore);
-        assert_eq!(
-            wstore.skill_list_global().unwrap().len(),
-            6,
-            "an empty catalog is indistinguishable from fresh, so calling the gated entry point again reseeds"
-        );
     }
 
     #[test]

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -650,11 +650,10 @@ async fn main() {
     // Auto-seed agent definitions on first launch (or empty DB)
     backend::agent_seed::auto_seed_on_startup(&wstore);
 
-    // Seed the global Skills catalog (db_skills) with a curated starter set
-    // on fresh install. One-time, idempotent: only runs if the catalog is
-    // currently empty. See backend::skill_seed for the empty-catalog
-    // rationale (also covers "seeded then user deleted everything").
-    backend::skill_seed::seed_starter_skills_if_empty(&wstore);
+    // The starter Skills catalog is seeded by migrations::m0015_seed_starter_skills
+    // (run once ever per channel, tracked in db_migrations) — not here. See
+    // that migration's doc comment for why catalog-emptiness was dropped as
+    // the gate.
 
     // Gap-repair: backfill definitions written after the Phase 3a marker
     // but before Phase 3b dual-write (they exist in db_agent_definitions

--- a/agentmux-srv/src/migrations/m0015_seed_starter_skills.rs
+++ b/agentmux-srv/src/migrations/m0015_seed_starter_skills.rs
@@ -1,0 +1,97 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Seed the global Skills catalog (`db_skills`, per-channel) with a curated
+//! starter set on fresh install.
+//!
+//! Runs exactly once per channel, tracked in that channel's `db_migrations`
+//! table — NOT gated on "is the catalog currently empty." The prior
+//! `seed_starter_skills_if_empty` gate (removed) couldn't distinguish "never
+//! seeded" from "seeded then the user deleted every starter skill on
+//! purpose," so a normal srv restart after a full deletion silently
+//! resurrected the defaults (reagent P2, PR #2141 round 2 — confirmed by
+//! `skill_seed.rs`'s own former test). The migration framework's
+//! once-ever-per-channel tracking fixes this at the root: once
+//! `0015_seed_starter_skills` is marked applied, it never runs again for
+//! that channel regardless of what the user does to the catalog afterward.
+
+use std::sync::Arc;
+
+use crate::backend::skill_seed::seed_starter_skills;
+use crate::backend::storage::store::Store;
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0015SeedStarterSkills;
+
+impl Migration for M0015SeedStarterSkills {
+    fn id(&self) -> &'static str { "0015_seed_starter_skills" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Channel }
+    fn description(&self) -> &'static str { "Seed the global Skills catalog with a curated starter set" }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        let wstore = Arc::new(
+            Store::open(&ctx.channel_store_path)
+                .map_err(|e| MigrationError(format!("seed_starter_skills: open wstore: {}", e)))?,
+        );
+        seed_starter_skills(&wstore)
+            .map(|_| ())
+            .map_err(|e| MigrationError(format!("seed_starter_skills: {}", e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_for(path: &std::path::Path) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path: std::env::temp_dir().join("unused-store.db"),
+            channel_store_path: path.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn seeds_six_starter_skills_on_a_fresh_channel() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Create the channel store up front — `up()` no-ops when the path
+        // doesn't exist yet (mirrors m0007's guard).
+        Store::open(tmp.path()).unwrap();
+
+        M0015SeedStarterSkills.up(&ctx_for(tmp.path())).unwrap();
+
+        let wstore = Store::open(tmp.path()).unwrap();
+        assert_eq!(wstore.skill_list_global().unwrap().len(), 6);
+    }
+
+    #[test]
+    fn once_marked_applied_a_full_catalog_deletion_is_never_resurrected() {
+        // This is the actual fix: the migration framework's db_migrations
+        // tracking (not skill_seed's own logic) is what must prevent
+        // reseeding — reproduce that gate here rather than trusting it.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let wstore = Store::open(tmp.path()).unwrap();
+        let ctx = ctx_for(tmp.path());
+
+        M0015SeedStarterSkills.up(&ctx).unwrap();
+        wstore.migration_mark_applied("0015_seed_starter_skills", "channel", 0).unwrap();
+        assert_eq!(wstore.skill_list_global().unwrap().len(), 6);
+
+        for item in wstore.skill_list_global().unwrap() {
+            wstore.skill_delete(&item.skill.id).unwrap();
+        }
+        assert!(wstore.skill_list_global().unwrap().is_empty());
+
+        // The real runner (runner.rs) never calls `up()` again once
+        // `migration_is_applied` is true — assert that precondition holds,
+        // matching the actual gate every real boot goes through.
+        assert!(
+            wstore.migration_is_applied("0015_seed_starter_skills"),
+            "once applied, the tracking row must persist regardless of catalog contents"
+        );
+    }
+}

--- a/agentmux-srv/src/migrations/m0015_seed_starter_skills.rs
+++ b/agentmux-srv/src/migrations/m0015_seed_starter_skills.rs
@@ -14,10 +14,19 @@
 //! once-ever-per-channel tracking fixes this at the root: once
 //! `0015_seed_starter_skills` is marked applied, it never runs again for
 //! that channel regardless of what the user does to the catalog afterward.
+//!
+//! Self-heals against installs that already ran the retired pre-migration
+//! startup-seed path (#2141) before this migration existed — every such
+//! channel already has the 6 starter-skill names present, which would
+//! collide with `skill_upsert_unique_global`'s name-uniqueness check and
+//! permanently fail this migration on every boot if seeding were attempted
+//! unconditionally (reagent P1, PR #2144). `up()` checks for an existing
+//! name collision first and treats it as "already seeded" rather than
+//! inserting.
 
 use std::sync::Arc;
 
-use crate::backend::skill_seed::seed_starter_skills;
+use crate::backend::skill_seed::{any_starter_skill_name_exists, seed_starter_skills};
 use crate::backend::storage::store::Store;
 use super::{Migration, MigrationContext, MigrationError, MigrationScope};
 
@@ -36,6 +45,11 @@ impl Migration for M0015SeedStarterSkills {
             Store::open(&ctx.channel_store_path)
                 .map_err(|e| MigrationError(format!("seed_starter_skills: open wstore: {}", e)))?,
         );
+        if any_starter_skill_name_exists(&wstore)
+            .map_err(|e| MigrationError(format!("seed_starter_skills: check existing: {}", e)))?
+        {
+            return Ok(());
+        }
         seed_starter_skills(&wstore)
             .map(|_| ())
             .map_err(|e| MigrationError(format!("seed_starter_skills: {}", e)))
@@ -93,5 +107,44 @@ mod tests {
             wstore.migration_is_applied("0015_seed_starter_skills"),
             "once applied, the tracking row must persist regardless of catalog contents"
         );
+    }
+
+    #[test]
+    fn self_heals_when_starter_skills_already_exist_from_the_retired_startup_path() {
+        // Reagent P1 (PR #2144): every channel that already booted once
+        // under the retired pre-migration startup-seed path (#2141) already
+        // has the 6 starter-skill names present. Without this self-heal,
+        // `up()` would call seed_starter_skills unconditionally, collide on
+        // skill_upsert_unique_global's name-uniqueness check on the very
+        // first insert, return Err, never get marked applied, and retry-fail
+        // on every subsequent boot. Simulate that pre-existing state
+        // directly (not via the removed startup path) and confirm `up()`
+        // succeeds as a no-op instead of erroring.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let wstore = Store::open(tmp.path()).unwrap();
+        let ctx = ctx_for(tmp.path());
+
+        let pre_existing = crate::backend::storage::skills::Skill {
+            id: "pre-existing-from-old-startup-path".to_string(),
+            name: "Systematic Debugging".to_string(),
+            trigger: "systematic-debugging".to_string(),
+            skill_type: "prompt".to_string(),
+            description: "Seeded by the retired startup path.".to_string(),
+            content: "n/a".to_string(),
+            is_global: true,
+            created_at: 0,
+            updated_at: 0,
+        };
+        wstore.skill_upsert_unique_global(&pre_existing).unwrap();
+
+        M0015SeedStarterSkills.up(&ctx).unwrap();
+
+        let after = wstore.skill_list_global().unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "up() must skip seeding entirely on a name collision, not insert the other 5"
+        );
+        assert_eq!(after[0].skill.id, "pre-existing-from-old-startup-path");
     }
 }

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -30,6 +30,7 @@ mod m0011_shared_store_backfill;
 mod m0012_dedup_identity_accounts;
 mod m0013_agent_direct_bindings;
 mod m0014_agent_direct_bindings_rerun;
+mod m0015_seed_starter_skills;
 mod runner;
 
 pub use runner::count_pending_migrations;
@@ -120,4 +121,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0012_dedup_identity_accounts::M0012DedupIdentityAccounts,
     &m0013_agent_direct_bindings::M0013AgentDirectBindings,
     &m0014_agent_direct_bindings_rerun::M0014AgentDirectBindingsRerun,
+    &m0015_seed_starter_skills::M0015SeedStarterSkills,
 ];


### PR DESCRIPTION
## Summary

Fixes a bug in the starter Skills catalog seeding shipped in #2141 (part of Armory Phase 5, `docs/specs/SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md`).

`skill_seed::seed_starter_skills_if_empty` gated seeding on "is `db_skills WHERE is_global=1` currently empty" — that check can't distinguish "never seeded" from "seeded then the user deleted every starter skill on purpose," so a normal srv restart after a full deletion silently reseeded the defaults. The spec explicitly required "don't resurrect it" (§4.4), and PR #2141's own test (`deleting_all_seeded_skills_then_calling_again_does_reseed`) proved the shipped code violated that — it was flagged in review and "fixed" by renaming the test to describe the resurrection rather than fixing the behavior.

Root cause: seeding ran as an ad-hoc call in `main.rs` at startup, not through the migrations framework — so there was no persistent "already seeded" record independent of the table's current contents.

**Fix:** moved seeding into `migrations::m0015_seed_starter_skills` (`MigrationScope::Channel`), tracked once-ever per channel in `db_migrations` — the same mechanism every other one-time backend seed in this codebase already uses. Once applied, the migration framework never re-invokes `up()` regardless of what the user does to the catalog afterward, fixing the bug at the root instead of trying to infer intent from an emptiness check.

`skill_seed.rs` now exposes only the pure insert-with-rollback logic (`seed_starter_skills`, `pub(crate)`); the removed `seed_starter_skills_if_empty` gate and its `main.rs` call site are gone. Tests updated accordingly — the migration has its own test proving a full catalog deletion post-apply is never resurrected.

## Test plan

- [x] `cargo check -p agentmux-srv --tests` — clean
- [x] `cargo test -p agentmux-srv` — 1461 passed, 0 failed
- [x] New migration test `once_marked_applied_a_full_catalog_deletion_is_never_resurrected` directly proves the fix

<!-- agentmux:agent_id=agenty -->