### PR TITLE
chore: release v0.53.4

### DIFF
--- a/.changesets/1783909839-fix-pane-hole-punch-mask-click-through-calayer-masking-doesn-folm.md
+++ b/.changesets/1783909839-fix-pane-hole-punch-mask-click-through-calayer-masking-doesn-folm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(pane): hole-punch mask click-through — CALayer masking doesn't affect AppKit hit testing

--- a/.changesets/1783913465-fix-tabs-active-tab-color-line-spans-the-full-tab-strip-not--lv00.md
+++ b/.changesets/1783913465-fix-tabs-active-tab-color-line-spans-the-full-tab-strip-not--lv00.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): active-tab color line spans the full tab strip, not just from the selected tab

--- a/.changesets/1783940748-fix-theme-body-background-used-a-hardcoded-dark-literal-inst-2fy5.md
+++ b/.changesets/1783940748-fix-theme-body-background-used-a-hardcoded-dark-literal-inst-2fy5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(theme): body background used a hardcoded dark literal instead of --main-bg-color, so light themes never fully reached the window chrome

--- a/.changesets/1783962377-feat-armory-fold-identities-tab-into-agent-pane-identity-ren-zdns.md
+++ b/.changesets/1783962377-feat-armory-fold-identities-tab-into-agent-pane-identity-ren-zdns.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): fold Identities tab into agent-pane Identity, rename Memory to Memories, reorder Armory rail

--- a/.changesets/1783962903-feat-srv-seed-a-starter-skills-catalog-on-fresh-install-fkm5.md
+++ b/.changesets/1783962903-feat-srv-seed-a-starter-skills-catalog-on-fresh-install-fkm5.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): seed a starter Skills catalog on fresh install

--- a/.changesets/1783975591-fix-theme-darken-primary-text-color-across-all-4-light-theme-4fcd.md
+++ b/.changesets/1783975591-fix-theme-darken-primary-text-color-across-all-4-light-theme-4fcd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(theme): darken primary text color across all 4 light themes for readability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.53.3"
+version = "0.53.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.53.3"
+version = "0.53.4"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.53.3"
+version = "0.53.4"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.53.3"
+version = "0.53.4"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.53.3"
+version = "0.53.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.53.3"
+version = "0.53.4"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.53.3"
+version = "0.53.4"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,15 @@
 # AgentMux Version History
 
+## 0.53.4 — 2026-07-13
+
+- fix(pane): hole-punch mask click-through — CALayer masking doesn't affect AppKit hit testing
+- fix(tabs): active-tab color line spans the full tab strip, not just from the selected tab
+- fix(theme): body background used a hardcoded dark literal instead of --main-bg-color, so light themes never fully reached the window chrome
+- feat(armory): fold Identities tab into agent-pane Identity, rename Memory to Memories, reorder Armory rail
+- feat(srv): seed a starter Skills catalog on fresh install
+- fix(theme): darken primary text color across all 4 light themes for readability
+
+
 ## 0.53.3 — 2026-07-13
 
 - fix(pane): flyout menus over browser panes on macOS — deterministic occlusion, click routing, and freeze-frame instead of black-out

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.53.3",
+      "version": "0.53.4",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release v0.53.4, consuming 6 pending changesets. Bump type forced to **patch** (override) even though the changeset set computed to `minor` (two `feat` entries present) — per explicit request.

Changes shipping in this release:
- fix(pane): hole-punch mask click-through — CALayer masking doesn't affect AppKit hit testing
- fix(tabs): active-tab color line spans the full tab strip, not just from the selected tab
- fix(theme): body background used a hardcoded dark literal instead of --main-bg-color, so light themes never fully reached the window chrome
- feat(armory): fold Identities tab into agent-pane Identity, rename Memory to Memories, reorder Armory rail
- feat(srv): seed a starter Skills catalog on fresh install
- fix(theme): darken primary text color across all 4 light themes for readability

All 5 version locations (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`) agree at 0.53.4.

## Test plan
- [x] `task release -- --as patch` completed with the release-consistency invariant satisfied (script re-reads all 5 locations and fails loudly on mismatch — it didn't).
- [x] Reviewed `git diff --staged` before committing.

<!-- agentmux:agent_id=agent1 -->