### PR TITLE
feat(mcp): default seed catalog for the Armory's MCP Servers tab

### DIFF
--- a/.changesets/1783994485-feat-mcp-seed-a-curated-set-of-credential-free-mcp-servers-i-tka4.md
+++ b/.changesets/1783994485-feat-mcp-seed-a-curated-set-of-credential-free-mcp-servers-i-tka4.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): seed a curated set of credential-free MCP servers into the Armory catalog

--- a/agentmux-srv/src/backend/mcp_seed.rs
+++ b/agentmux-srv/src/backend/mcp_seed.rs
@@ -1,0 +1,238 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Starter MCP Servers catalog seed: preloads a small set of curated global,
+//! credential-free MCP servers (`db_mcp_servers`, the v1 standalone catalog)
+//! on fresh install.
+//!
+//! Mirrors `skill_seed.rs` exactly, for the same reasons documented there:
+//! the actual "run exactly once, ever" gating lives in
+//! `migrations::m0016_seed_starter_mcp_servers`, tracked in the channel's
+//! `db_migrations` table — NOT in this module, and NOT gated on "is the
+//! catalog currently empty" (that gate can't distinguish "never seeded" from
+//! "seeded then the user deleted every starter server on purpose", which
+//! would silently resurrect the defaults on the next restart after a full
+//! deletion — see `m0015_seed_starter_skills.rs`'s history, reagent P2 on
+//! PR #2141 round 2, for why this shape was chosen over a simpler one). This
+//! module exposes only the pure insert logic; the migration owns invocation.
+//!
+//! Only credential-free, fully local servers belong in this manifest — see
+//! docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md §2:
+//! every `is_global` MCP server is auto-injected into every agent's
+//! `.mcp.json` at launch with no per-agent opt-in, so a seeded row needing an
+//! API key or OAuth token would break every agent's launch by default. The
+//! Filesystem reference server is deliberately NOT included despite being
+//! credential-free — it requires an allowlisted directory as a CLI arg with
+//! no environment-agnostic default (spec §9 open question 3); it can be
+//! added once that's resolved, either by computing a per-agent default at
+//! config-build time or shipping it with an explicit prereq the user fills
+//! in via the existing catalog-picker mechanism instead.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::storage::mcp_servers::McpServer;
+use super::storage::store::Store;
+use super::storage::StoreError;
+
+/// One entry in the embedded starter-mcp-servers manifest. `config` is a raw
+/// JSON object here (command/args/env) and gets re-serialized to a string to
+/// match `McpServer.config`'s storage shape.
+#[derive(Debug, Deserialize)]
+struct StarterMcpServer {
+    name: String,
+    transport: String,
+    config: serde_json::Value,
+}
+
+/// The embedded starter-mcp-servers manifest JSON. Content is authored
+/// externally and must not be edited here — see
+/// `agentmux-srv/src/config/starter-mcp-servers.json`.
+const STARTER_MCP_SERVERS_JSON: &str = include_str!("../config/starter-mcp-servers.json");
+
+/// Report returned after a seed attempt.
+pub struct McpServerSeedReport {
+    pub created: usize,
+}
+
+/// True if any global MCP server whose name matches a starter entry's name
+/// already exists — i.e. this channel already effectively has the starter
+/// set (or a name collision with it). The caller
+/// (`migrations::m0016_seed_starter_mcp_servers`) uses this to skip seeding
+/// entirely rather than attempting an insert that would collide on
+/// `mcp_server_upsert_unique_global`'s name-uniqueness check and permanently
+/// fail the migration on every subsequent boot — same self-heal
+/// `skill_seed.rs::any_starter_skill_name_exists` provides (reagent P1, PR
+/// #2144).
+pub(crate) fn any_starter_mcp_server_name_exists(wstore: &Arc<Store>) -> Result<bool, StoreError> {
+    let manifest: Vec<StarterMcpServer> = serde_json::from_str(STARTER_MCP_SERVERS_JSON)
+        .map_err(|e| StoreError::Other(format!("mcp server seed: parse manifest: {e}")))?;
+    let existing = wstore.mcp_server_list_global()?;
+    Ok(manifest
+        .iter()
+        .any(|entry| existing.iter().any(|item| item.server.name == entry.name)))
+}
+
+/// Parse the embedded manifest and insert every entry as a global MCP server
+/// via the validated `mcp_server_upsert_unique_global` path. Does NOT check
+/// whether the catalog is already populated — the caller
+/// (`migrations::m0016_seed_starter_mcp_servers`) owns run-once gating via
+/// `db_migrations` tracking, not catalog contents. Exposed at `pub(crate)`
+/// so the migration and tests can call it directly.
+///
+/// All-or-nothing: `mcp_server_upsert_unique_global` commits each insert in
+/// its own transaction, so a mid-loop failure can't be rolled back by the
+/// database itself. If any insert fails, this compensates by deleting every
+/// server already inserted in THIS call before returning the error —
+/// otherwise a retry (the migration framework re-runs `up()` on the next
+/// boot when a migration returns `Err`, since it's never marked applied)
+/// would hit the name-uniqueness rejection on the servers already stranded
+/// from the failed attempt. Mirrors `skill_seed::seed_starter_skills`
+/// exactly (reagent P2, PR #2141 round 1).
+pub(crate) fn seed_starter_mcp_servers(wstore: &Arc<Store>) -> Result<McpServerSeedReport, StoreError> {
+    let manifest: Vec<StarterMcpServer> = serde_json::from_str(STARTER_MCP_SERVERS_JSON)
+        .map_err(|e| StoreError::Other(format!("mcp server seed: parse manifest: {e}")))?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    let mut inserted_ids: Vec<String> = Vec::with_capacity(manifest.len());
+    for entry in &manifest {
+        let config = serde_json::to_string(&entry.config)
+            .map_err(|e| StoreError::Other(format!("mcp server seed: serialize config for '{}': {e}", entry.name)))?;
+        let server = McpServer {
+            id: Uuid::new_v4().to_string(),
+            name: entry.name.clone(),
+            transport: entry.transport.clone(),
+            config,
+            is_global: true,
+            created_at: now,
+            updated_at: now,
+        };
+        if let Err(e) = wstore.mcp_server_upsert_unique_global(&server) {
+            for id in &inserted_ids {
+                if let Err(cleanup_err) = wstore.mcp_server_delete(id) {
+                    tracing::error!(
+                        "mcp server seed: cleanup after partial failure could not remove {id}: {cleanup_err}"
+                    );
+                }
+            }
+            return Err(e);
+        }
+        inserted_ids.push(server.id);
+    }
+
+    Ok(McpServerSeedReport { created: inserted_ids.len() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeds_six_mcp_servers_into_an_empty_catalog() {
+        let wstore = Arc::new(Store::open_in_memory().unwrap());
+        assert!(wstore.mcp_server_list_global().unwrap().is_empty());
+
+        let report = seed_starter_mcp_servers(&wstore).unwrap();
+
+        assert_eq!(report.created, 6);
+        let after = wstore.mcp_server_list_global().unwrap();
+        assert_eq!(after.len(), 6, "all six starter MCP servers should be seeded");
+        assert!(after.iter().all(|item| item.server.is_global));
+        assert!(
+            after.iter().all(|item| item.server.transport == "stdio"),
+            "every Tier A entry is a local stdio process"
+        );
+    }
+
+    #[test]
+    fn seeded_config_round_trips_as_valid_json() {
+        let wstore = Arc::new(Store::open_in_memory().unwrap());
+        seed_starter_mcp_servers(&wstore).unwrap();
+
+        let after = wstore.mcp_server_list_global().unwrap();
+        let git = after
+            .iter()
+            .find(|item| item.server.name == "git")
+            .expect("git should be seeded");
+        let parsed: serde_json::Value = serde_json::from_str(&git.server.config).unwrap();
+        assert_eq!(parsed["command"], "uvx");
+        assert_eq!(parsed["args"][0], "mcp-server-git");
+    }
+
+    #[test]
+    fn a_failed_insert_rolls_back_the_ones_already_seeded_this_call() {
+        // Same failure mode as skill_seed.rs's equivalent test (reagent P2,
+        // PR #2141 round 1): mcp_server_upsert_unique_global commits each
+        // insert in its own transaction, so a mid-loop failure can't be
+        // rolled back by the database. Simulate it by pre-inserting a global
+        // server whose NAME collides with one of the starter entries — this
+        // forces seed_starter_mcp_servers to fail partway through the
+        // manifest, and the catalog must end up back at exactly the one
+        // pre-existing server, not a stranded partial starter set.
+        let wstore = Arc::new(Store::open_in_memory().unwrap());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        // "fetch" is the second entry in the manifest — colliding on it
+        // guarantees at least one successful insert ("git") precedes the
+        // failure, so the rollback path actually has something to clean up.
+        let colliding = McpServer {
+            id: "pre-existing-collision".to_string(),
+            name: "fetch".to_string(),
+            transport: "stdio".to_string(),
+            config: "{}".to_string(),
+            is_global: true,
+            created_at: now,
+            updated_at: now,
+        };
+        wstore.mcp_server_upsert_unique_global(&colliding).unwrap();
+
+        let result = seed_starter_mcp_servers(&wstore);
+        assert!(result.is_err(), "seeding must fail when a name collides");
+
+        let after = wstore.mcp_server_list_global().unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "a failed seed must roll back every server it inserted this call, leaving only the pre-existing one"
+        );
+        assert_eq!(after[0].server.id, "pre-existing-collision");
+    }
+
+    #[test]
+    fn any_starter_mcp_server_name_exists_detects_a_collision_without_inserting() {
+        let wstore = Arc::new(Store::open_in_memory().unwrap());
+        assert!(!any_starter_mcp_server_name_exists(&wstore).unwrap());
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let user_created = McpServer {
+            id: "user-server".to_string(),
+            name: "memory".to_string(),
+            transport: "stdio".to_string(),
+            config: "{}".to_string(),
+            is_global: true,
+            created_at: now,
+            updated_at: now,
+        };
+        wstore.mcp_server_upsert_unique_global(&user_created).unwrap();
+
+        assert!(any_starter_mcp_server_name_exists(&wstore).unwrap());
+        assert_eq!(
+            wstore.mcp_server_list_global().unwrap().len(),
+            1,
+            "the check itself must not insert anything"
+        );
+    }
+}

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -6,6 +6,7 @@ pub mod agent_config;
 pub mod agent_session;
 pub mod blockcontroller;
 pub mod mcp_probe;
+pub mod mcp_seed;
 /// Phase E.4.B Phase 4 — pure layout-tree helpers (Rust port of layoutTree.ts).
 pub mod layout;
 pub mod providers;

--- a/agentmux-srv/src/config/starter-mcp-servers.json
+++ b/agentmux-srv/src/config/starter-mcp-servers.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "git",
+        "transport": "stdio",
+        "config": { "command": "uvx", "args": ["mcp-server-git"] }
+    },
+    {
+        "name": "fetch",
+        "transport": "stdio",
+        "config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-fetch"] }
+    },
+    {
+        "name": "sequential-thinking",
+        "transport": "stdio",
+        "config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"] }
+    },
+    {
+        "name": "memory",
+        "transport": "stdio",
+        "config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-memory"] }
+    },
+    {
+        "name": "playwright",
+        "transport": "stdio",
+        "config": { "command": "npx", "args": ["@playwright/mcp@latest"] }
+    },
+    {
+        "name": "context7",
+        "transport": "stdio",
+        "config": { "command": "npx", "args": ["-y", "@upstash/context7-mcp"] }
+    }
+]

--- a/agentmux-srv/src/config/starter-mcp-servers.json
+++ b/agentmux-srv/src/config/starter-mcp-servers.json
@@ -7,7 +7,7 @@
     {
         "name": "fetch",
         "transport": "stdio",
-        "config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-fetch"] }
+        "config": { "command": "uvx", "args": ["mcp-server-fetch"] }
     },
     {
         "name": "sequential-thinking",

--- a/agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs
+++ b/agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs
@@ -1,0 +1,142 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Seed the global MCP Servers catalog (`db_mcp_servers`, per-channel) with a
+//! curated, credential-free starter set on fresh install.
+//!
+//! Runs exactly once per channel, tracked in that channel's `db_migrations`
+//! table — NOT gated on "is the catalog currently empty," for the same
+//! reason `m0015_seed_starter_skills` isn't: that gate can't distinguish
+//! "never seeded" from "seeded then the user deleted every starter server on
+//! purpose," which would silently resurrect the defaults on the next restart
+//! after a full deletion. The migration framework's once-ever-per-channel
+//! tracking fixes this at the root: once `0016_seed_starter_mcp_servers` is
+//! marked applied, it never runs again for that channel regardless of what
+//! the user does to the catalog afterward.
+//!
+//! `up()` checks for an existing name collision first (same self-heal as
+//! m0015) and treats it as "already seeded" rather than inserting — guards
+//! against any future retired startup-seed path leaving the six starter
+//! names present before this migration ever ran.
+//!
+//! See docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
+//! for why only credential-free, fully local servers are in this manifest.
+
+use std::sync::Arc;
+
+use crate::backend::mcp_seed::{any_starter_mcp_server_name_exists, seed_starter_mcp_servers};
+use crate::backend::storage::store::Store;
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0016SeedStarterMcpServers;
+
+impl Migration for M0016SeedStarterMcpServers {
+    fn id(&self) -> &'static str { "0016_seed_starter_mcp_servers" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Channel }
+    fn description(&self) -> &'static str { "Seed the global MCP Servers catalog with a curated starter set" }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        let wstore = Arc::new(
+            Store::open(&ctx.channel_store_path)
+                .map_err(|e| MigrationError(format!("seed_starter_mcp_servers: open wstore: {}", e)))?,
+        );
+        if any_starter_mcp_server_name_exists(&wstore)
+            .map_err(|e| MigrationError(format!("seed_starter_mcp_servers: check existing: {}", e)))?
+        {
+            return Ok(());
+        }
+        seed_starter_mcp_servers(&wstore)
+            .map(|_| ())
+            .map_err(|e| MigrationError(format!("seed_starter_mcp_servers: {}", e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_for(path: &std::path::Path) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path: std::env::temp_dir().join("unused-store.db"),
+            channel_store_path: path.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn seeds_six_starter_mcp_servers_on_a_fresh_channel() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Create the channel store up front — `up()` no-ops when the path
+        // doesn't exist yet (mirrors m0007's guard).
+        Store::open(tmp.path()).unwrap();
+
+        M0016SeedStarterMcpServers.up(&ctx_for(tmp.path())).unwrap();
+
+        let wstore = Store::open(tmp.path()).unwrap();
+        assert_eq!(wstore.mcp_server_list_global().unwrap().len(), 6);
+    }
+
+    #[test]
+    fn once_marked_applied_a_full_catalog_deletion_is_never_resurrected() {
+        // This is the actual fix: the migration framework's db_migrations
+        // tracking (not mcp_seed's own logic) is what must prevent
+        // reseeding — reproduce that gate here rather than trusting it.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let wstore = Store::open(tmp.path()).unwrap();
+        let ctx = ctx_for(tmp.path());
+
+        M0016SeedStarterMcpServers.up(&ctx).unwrap();
+        wstore.migration_mark_applied("0016_seed_starter_mcp_servers", "channel", 0).unwrap();
+        assert_eq!(wstore.mcp_server_list_global().unwrap().len(), 6);
+
+        for item in wstore.mcp_server_list_global().unwrap() {
+            wstore.mcp_server_delete(&item.server.id).unwrap();
+        }
+        assert!(wstore.mcp_server_list_global().unwrap().is_empty());
+
+        // The real runner (runner.rs) never calls `up()` again once
+        // `migration_is_applied` is true — assert that precondition holds,
+        // matching the actual gate every real boot goes through.
+        assert!(
+            wstore.migration_is_applied("0016_seed_starter_mcp_servers"),
+            "once applied, the tracking row must persist regardless of catalog contents"
+        );
+    }
+
+    #[test]
+    fn self_heals_when_starter_servers_already_exist_from_a_prior_run() {
+        // Mirrors m0015's equivalent test: guards against any future
+        // retired startup-seed path leaving starter-server names present
+        // before this migration ever ran. Simulate that pre-existing state
+        // directly and confirm `up()` succeeds as a no-op instead of
+        // erroring on the name-uniqueness collision.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let wstore = Store::open(tmp.path()).unwrap();
+        let ctx = ctx_for(tmp.path());
+
+        let pre_existing = crate::backend::storage::mcp_servers::McpServer {
+            id: "pre-existing-from-old-path".to_string(),
+            name: "git".to_string(),
+            transport: "stdio".to_string(),
+            config: "{}".to_string(),
+            is_global: true,
+            created_at: 0,
+            updated_at: 0,
+        };
+        wstore.mcp_server_upsert_unique_global(&pre_existing).unwrap();
+
+        M0016SeedStarterMcpServers.up(&ctx).unwrap();
+
+        let after = wstore.mcp_server_list_global().unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "up() must skip seeding entirely on a name collision, not insert the other 5"
+        );
+        assert_eq!(after[0].server.id, "pre-existing-from-old-path");
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -31,6 +31,7 @@ mod m0012_dedup_identity_accounts;
 mod m0013_agent_direct_bindings;
 mod m0014_agent_direct_bindings_rerun;
 mod m0015_seed_starter_skills;
+mod m0016_seed_starter_mcp_servers;
 mod runner;
 
 pub use runner::count_pending_migrations;
@@ -122,4 +123,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0013_agent_direct_bindings::M0013AgentDirectBindings,
     &m0014_agent_direct_bindings_rerun::M0014AgentDirectBindingsRerun,
     &m0015_seed_starter_skills::M0015SeedStarterSkills,
+    &m0016_seed_starter_mcp_servers::M0016SeedStarterMcpServers,
 ];

--- a/docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
+++ b/docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
@@ -68,7 +68,7 @@ Because §2 established that global = auto-on-for-everyone, Tier A is deliberate
 | Server | Purpose | Command | Transport | Why safe to auto-enable |
 |---|---|---|---|---|
 | **Git** | Local repo read/search/diff/log operations | `uvx mcp-server-git` | stdio | No creds; operates on whatever repo the agent's cwd is in |
-| **Fetch** | Fetch + convert a web page to markdown | `npx -y @modelcontextprotocol/server-fetch` | stdio | No creds; outbound-only, no stored state |
+| **Fetch** | Fetch + convert a web page to markdown | `uvx mcp-server-fetch` | stdio | No creds; outbound-only, no stored state |
 | **Sequential Thinking** | Structured, revisable step-by-step reasoning scratchpad | `npx -y @modelcontextprotocol/server-sequential-thinking` | stdio | No creds, no I/O outside the process itself |
 | **Memory** | Cross-session knowledge-graph memory | `npx -y @modelcontextprotocol/server-memory` | stdio | No creds; local file-backed state |
 | **Playwright** | Browser automation via accessibility-tree snapshots (Microsoft-official) | `npx @playwright/mcp@latest` | stdio | No creds; downloads a browser binary on first use but needs no secret |

--- a/docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
+++ b/docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-13
 **Author:** AgentX
-**Type:** Research + proposal. No code shipped yet.
+**Type:** Research + proposal. Phase 1 (Tier A backend seed) implemented in this PR — see §5/§8 status note.
 **Purpose:** The Armory's **MCP Servers** tab is empty on every fresh install and stays empty until a user hand-types a server or clicks through the one-entry "Browse catalog" picker. This spec researches the current seeding gap, surveys the external MCP server ecosystem for what's worth seeding, and proposes a two-tier architecture — real DB-seeded rows for safe/local servers, catalog-picker entries for anything needing a credential — driven by a hard constraint discovered during this research: **every `is_global` MCP server is auto-injected into every agent's `.mcp.json` at launch, with no per-agent opt-in and no "disabled" flag.**
 
 ---
@@ -67,7 +67,6 @@ Because §2 established that global = auto-on-for-everyone, Tier A is deliberate
 
 | Server | Purpose | Command | Transport | Why safe to auto-enable |
 |---|---|---|---|---|
-| **Filesystem** | Sandboxed read/write/search within allowed dirs | `npx -y @modelcontextprotocol/server-filesystem <dir>` | stdio | No creds; dir allowlist is the only config, defaults to the agent's own working directory |
 | **Git** | Local repo read/search/diff/log operations | `uvx mcp-server-git` | stdio | No creds; operates on whatever repo the agent's cwd is in |
 | **Fetch** | Fetch + convert a web page to markdown | `npx -y @modelcontextprotocol/server-fetch` | stdio | No creds; outbound-only, no stored state |
 | **Sequential Thinking** | Structured, revisable step-by-step reasoning scratchpad | `npx -y @modelcontextprotocol/server-sequential-thinking` | stdio | No creds, no I/O outside the process itself |
@@ -75,9 +74,12 @@ Because §2 established that global = auto-on-for-everyone, Tier A is deliberate
 | **Playwright** | Browser automation via accessibility-tree snapshots (Microsoft-official) | `npx @playwright/mcp@latest` | stdio | No creds; downloads a browser binary on first use but needs no secret |
 | **Context7** | Live, version-specific library docs — reduces hallucinated APIs (Upstash) | `npx -y @upstash/context7-mcp` | stdio | No key required for the free tier; the closest thing to a de-facto standard for coding-agent doc lookup found in this research |
 
-All seven are `npx`/`uvx`-launched, meaning the *seed row* itself needs no network call — only the first real invocation triggers a package fetch, same cold-start cost every hand-typed stdio server already has today.
+All six are `npx`/`uvx`-launched, meaning the *seed row* itself needs no network call — only the first real invocation triggers a package fetch, same cold-start cost every hand-typed stdio server already has today.
+
+**Implemented in this PR:** `agentmux-srv/src/config/starter-mcp-servers.json` (the six-entry manifest above), `agentmux-srv/src/backend/mcp_seed.rs` (seed logic, mirrors `skill_seed.rs`), `agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs` (run-once-per-channel gating via the migration framework, mirrors `m0015_seed_starter_skills.rs`) — see §5 for why this shape was chosen over the schema-migration design this section originally proposed.
 
 **Explicitly excluded from Tier A, with reasons:**
+- **Filesystem** — credential-free, but requires an allowlisted directory as a CLI arg with no environment-agnostic default (§9 open question 3, still open) — deferred rather than shipped with a broken or overly-permissive default.
 - **SQLite** (reference server) — has a known, unpatched SQL-injection / prompt-injection vector; Anthropic declined to fix it and archived the server rather than patch it. Never seed this by default.
 - **Puppeteer** — archived/no-security-fixes; superseded by Playwright above. Don't seed a deprecated server when a maintained equivalent exists.
 - **Everything** / **Time** (reference servers) — real, maintained, but demo/utility-grade rather than "every coding session benefits from this." Left as easy manual adds, not seeded.
@@ -101,25 +103,25 @@ Six entries, matching the scale of Tier A. `Postgres` uses the actively-maintain
 
 ---
 
-## 5. Seed mechanism — revised to match the sibling Skills-seeding convention
+## 5. Seed mechanism — implemented, mirroring the shipped Skills-seeding precedent exactly
 
-**This section's first draft proposed a schema migration** (`is_seeded`/`user_hidden` columns on `db_mcp_servers`) plus a `reseed_if_needed`-style engine mirroring `agent_seed.rs` exactly. Revised after reading `SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` §4.3, which independently solved the identical "empty global Armory catalog" problem for Skills the same day and landed on something lighter — two independent research passes converging on avoiding the heavier design is itself a signal worth taking. This spec adopts that shape rather than the original draft:
+**This section's first draft proposed a schema migration** (`is_seeded`/`user_hidden` columns on `db_mcp_servers`) plus a `reseed_if_needed`-style engine mirroring `agent_seed.rs` exactly. By the time this spec's Phase 1 was implemented, `SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md`'s own Skills-seeding PR had already shipped (`skill_seed.rs`, `migrations/m0015_seed_starter_skills.rs`) — through two rounds of reagent findings that settled on a specific, battle-tested shape. This spec's implementation mirrors that shape exactly rather than the original draft above:
 
-- **No schema migration.** No new columns on `db_mcp_servers`. A seeded row is, after the one-time seed runs, indistinguishable from a user-created one — same as the Skills design. This sidesteps the entire "don't resurrect a user-deleted seeded row" problem `agent_seed.rs`'s `is_seeded`/`user_hidden` pair exists to solve (§3): if there's no recurring reseed trigger, there's nothing that could resurrect anything.
-- **A one-time seed, not a recurring reseed.** Gate on the same condition the Skills spec proposes: seed only if `db_mcp_servers WHERE is_global = 1` is empty **and** this is a fresh install (reuse whatever "fresh install" signal already exists elsewhere in the codebase — e.g. however first-run/default-channel state is detected today — rather than inventing a second one). A user who deletes a seeded server later just has one fewer server; nothing ever tries to put it back. This is a real behavior tradeoff versus the original draft's reseed-on-manifest-change (a future AgentMux release that improves the seeded `filesystem` command, say, won't retroactively reach existing installs) — accepted here for consistency with the sibling spec and because it's simpler and strictly safer; §9 keeps a path open to add versioned reseeding later if that tradeoff turns out to matter in practice.
-- **Reuse the `config/*.json` static-file convention**, not a Rust-`include_str!` manifest: new `agentmux-srv/src/config/starter-mcp-servers.json`, an array of `{name, transport, config}` objects (no `id`/`is_global`/timestamps — assigned at insert time, mirroring the Skills spec's §4.3 point 1 exactly).
-- **Insert via the existing validated path**, not hand-rolled SQL: `mcp_server_upsert_unique_global` (`mcp_servers.rs:255-282`) already enforces catalog-wide name uniqueness and sets `is_global = 1` — call it once per manifest entry, warn-and-skip on a name collision (the `seed_memories` precedent, `agent_seed.rs:278-291`) rather than aborting the whole batch, so a user who already hand-created a server named `filesystem` doesn't get it silently clobbered.
+- **No new columns on `db_mcp_servers`.** Run-once gating uses the migration framework's *existing* generic `db_migrations` tracking table (already used by every migration for exactly this purpose), not a bespoke `is_seeded` flag on this table. A seeded row is, after the seed runs, indistinguishable from a user-created one.
+- **A migration, not a "gate on empty" runtime check.** `agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs` — `MigrationScope::Channel`, runs at most once per channel, ever, tracked in `db_migrations`. This is *stronger* than "gate on `is_global` count == 0": that check can't distinguish "never seeded" from "seeded, then the user deleted every starter server on purpose" and would silently resurrect the defaults on a later restart — exactly the bug the Skills-seeding PR hit and fixed (reagent P2, PR #2141 round 2, documented in `skill_seed.rs`'s own doc comment). Once `0016_seed_starter_mcp_servers` is marked applied, it never runs again for that channel regardless of what the user does to the catalog afterward.
+- **Self-heals against a name collision instead of hard-failing.** `up()` calls `any_starter_mcp_server_name_exists` first (`mcp_seed.rs`) and treats a collision as "already seeded" rather than attempting an insert that would hit `mcp_server_upsert_unique_global`'s uniqueness check and permanently fail the migration on every subsequent boot (mirrors reagent P1, PR #2144, on the Skills equivalent).
+- **All-or-nothing insert with compensating rollback.** `mcp_server_upsert_unique_global` commits each row in its own transaction (not `StoreTx`-composable), so a mid-loop failure can't be rolled back by the database itself; `seed_starter_mcp_servers` deletes every row it inserted so far before propagating the error, so a failed migration (never marked applied, retried next boot) doesn't leave stranded rows that would then collide with themselves on retry (mirrors reagent P2, PR #2141 round 1).
+- **Reuses the `config/*.json` static-file convention**: `agentmux-srv/src/config/starter-mcp-servers.json`, an array of `{name, transport, config}` objects (no `id`/`is_global`/timestamps — assigned at insert time by `mcp_seed.rs`).
+- **Inserts via the existing validated path**, not hand-rolled SQL: `mcp_server_upsert_unique_global` (`mcp_servers.rs:255-282`).
 
 ```json
-[
-  { "name": "filesystem", "transport": "stdio",
-    "config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"] } }
-]
+{ "name": "git", "transport": "stdio",
+  "config": { "command": "uvx", "args": ["mcp-server-git"] } }
 ```
 
-**Open question, shared verbatim with the sibling spec's §4.3:** should this seed run unconditionally on every fresh install, or be opt-in (e.g. a "load starter servers" action in the Armory MCP tab's empty state)? Unconditional matches "pre-populate" and is simpler; an unconditional silent DB write on first launch is a bigger behavioral change than a button click. Flagging as a real product decision rather than assuming either default — and note this decision should almost certainly be made **once, for both catalogs together** (Skills and MCP servers), not independently per spec, since a user's expectation of "does the Armory auto-populate itself or not" should be consistent across tabs.
+This resolves the sibling spec's own open question ("unconditional on fresh install, or opt-in?") on the MCP side: **unconditional**, via the migration framework, consistent with whatever the Skills-seeding PR ultimately shipped for that same question — a user's expectation of "does the Armory auto-populate itself" is consistent across both tabs.
 
-**Frontend:** no new fields needed on `McpServer`/`McpServerListItem`/`McpServerCatalogItem` under this revised design — a seeded row uses the exact same edit/delete affordances `mcp-manager.tsx` already has for any global row.
+**Frontend:** no changes needed. A seeded row uses the exact same edit/delete affordances `mcp-manager.tsx` already has for any global row.
 
 ---
 
@@ -128,7 +130,7 @@ Six entries, matching the scale of Tier A. `Postgres` uses the actively-maintain
 - **No live catalog sync from an external registry.** The official MCP Registry (`registry.modelcontextprotocol.io`) is metadata-only and still preview/API-frozen; directories like Smithery/Glama/mcp.so trade curation for coverage and, in Smithery's case, add a hosting-infra trust surface (a real path-traversal incident occurred there in 2025, patched within days). A hardcoded, human-curated manifest — reviewed the same way `agent-seed.json` already is — is the right v1 shape; revisit only if the manifest becomes a maintenance burden at meaningfully larger scale.
 - **No cross-provider `.mcp.json` translation.** `build_mcp_config_from_refs` (`agentmux-srv/src/backend/agent_config.rs:320-395`) writes exactly one `.mcp.json` per agent regardless of `agent.provider` — this is Claude Code's native config format. `cli-catalog.ts` claims `mcpSupport` for Codex/Gemini/Qwen/etc., but those CLIs' real MCP config lives elsewhere (e.g. Codex CLI reads `~/.codex/config.toml`, not a project `.mcp.json`) and nothing in this codebase special-cases that today. Seeding more servers into `.mcp.json` doesn't make this gap worse, but it doesn't fix it either — flagged here so it isn't mistaken for in-scope.
 - **No secret-templating in `McpServer.config`.** Tier B staying catalog-only (§4) is a direct consequence of this — there is no mechanism today for a seeded row's `config` to reference an identity account's stored credential rather than a literal string. Building one is a real, separable feature (and would upgrade Tier B from "picker, user pastes a token" to "picker, user picks an already-connected account") but is out of scope for making the list non-empty.
-- **Version pinning is out of scope for Tier A.** Unlike the creative-connector spec's `uvx ableton-mcp@1.2.0`-style pinning recommendation (relevant there because those servers carry real code-exec risk against a user's creative-app state), Tier A's seven servers are Anthropic/Microsoft/Upstash-maintained references with a low-risk, well-scoped tool surface; `npx -y <pkg>@latest`-style resolution is consistent with how every other hand-typed stdio server in this codebase already works. Worth revisiting only if a Tier A server ever ships a breaking change that surprises users.
+- **Version pinning is out of scope for Tier A.** Unlike the creative-connector spec's `uvx ableton-mcp@1.2.0`-style pinning recommendation (relevant there because those servers carry real code-exec risk against a user's creative-app state), Tier A's servers are Anthropic/Microsoft/Upstash-maintained references with a low-risk, well-scoped tool surface; `npx -y <pkg>@latest`-style resolution is consistent with how every other hand-typed stdio server in this codebase already works. Worth revisiting only if a Tier A server ever ships a breaking change that surprises users.
 
 ---
 
@@ -146,7 +148,7 @@ Researched mid-2026 state of the MCP ecosystem, for anyone extending either tier
 
 ## 8. Phased plan
 
-**Phase 1 — Tier A backend seed.** `agentmux-srv/src/config/starter-mcp-servers.json` with the 7 Tier A entries, a one-time seed step gated on "no global MCP servers exist yet + fresh install" per §5, inserting via `mcp_server_upsert_unique_global`. No schema change, no new frontend fields. This alone makes the Armory non-empty by default and every new agent launch immediately capable of local file/git/fetch/reasoning/memory/browser/doc-lookup tool use with zero user setup. Should land alongside (or immediately after) the sibling spec's Skills-seeding PR B, sharing whatever "fresh install" gate and unconditional-vs-opt-in decision (§5) that PR settles on, rather than each spec answering it independently.
+**Phase 1 — Tier A backend seed. Implemented in this PR.** `agentmux-srv/src/config/starter-mcp-servers.json` with the 6 Tier A entries, a migration (`m0016_seed_starter_mcp_servers`, run-once-per-channel via `db_migrations`) inserting via `mcp_server_upsert_unique_global`. No schema change, no new frontend fields — see §5. This alone makes the Armory non-empty by default and every new agent launch immediately capable of local git/fetch/reasoning/memory/browser/doc-lookup tool use with zero user setup.
 
 **Phase 2 — Tier B catalog expansion.** Add the six §4 entries to `MCP_PRELOAD_CATALOG`, following the exact shape the Ableton entry already established (`prereqNote` explaining what credential is needed and where to get it, `docsUrl` pointing at the upstream project). No schema change needed for this phase — it's purely additive to an existing, already-shipped mechanism.
 
@@ -156,7 +158,7 @@ Researched mid-2026 state of the MCP ecosystem, for anyone extending either tier
 
 ## 9. Open questions
 
-1. **Is one-time-only seeding (§5) the right call long-term?** It's simpler and strictly safer than reseed-on-manifest-change today, but it also means a future fix to a Tier A entry's command/args never reaches an install that seeded before the fix shipped. If that turns out to matter in practice, the `is_seeded`/`user_hidden` + versioned-reseed design in §3 is still there to adopt later — not proposed for v1, but not thrown away either.
+1. **Is run-once-forever seeding (§5) the right call long-term?** It's simpler and strictly safer than reseed-on-manifest-change, but it also means a future fix to a Tier A entry's command/args never reaches a channel that already ran `m0016`. If that turns out to matter in practice, the `is_seeded`/`user_hidden` + versioned-reseed design in §3 is still there to adopt later as a new migration — not proposed for v1, but not thrown away either.
 2. **Should Tier A's seed be skippable at first-run** (e.g. for a locked-down/offline environment where even `npx -y <pkg>` package resolution on first invocation is undesirable)? `agent_seed.rs` has no such escape hatch for agent templates today, so the precedent is "no," but MCP servers do outbound network I/O on first real use in a way agent templates don't — worth a explicit product decision rather than silently inheriting the agent-seed precedent.
 3. **Filesystem server's default allowed-directory.** `@modelcontextprotocol/server-filesystem` takes an allowlisted directory as a CLI arg (§4's table shows `<dir>` unfilled) — seeding a literal path is environment-specific and can't be baked into a static manifest the way the other six Tier A commands can. Needs either a per-agent-cwd default computed at config-build time (extending `build_mcp_config_from_refs` to substitute a placeholder) or shipping this one entry with an empty/unset arg and a `prereqNote`-equivalent nudging the user to fill it in — decide before Phase 1 ships this specific entry.
 4. **Filesystem's directory arg is the one Tier A entry that can't ship as a static manifest value without answering question 3 first** — the other six need no per-install customization, this one does. If question 3 lands on "ship it anyway with an empty arg," confirm the resulting server fails safely (a probe error the user can see, not a silent no-op) rather than, worse, defaulting to some unexpectedly broad directory.

--- a/docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
+++ b/docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md
@@ -1,0 +1,184 @@
+# Spec: Default Seed Catalog for the Armory's MCP Servers Tab
+
+**Date:** 2026-07-13
+**Author:** AgentX
+**Type:** Research + proposal. No code shipped yet.
+**Purpose:** The Armory's **MCP Servers** tab is empty on every fresh install and stays empty until a user hand-types a server or clicks through the one-entry "Browse catalog" picker. This spec researches the current seeding gap, surveys the external MCP server ecosystem for what's worth seeding, and proposes a two-tier architecture — real DB-seeded rows for safe/local servers, catalog-picker entries for anything needing a credential — driven by a hard constraint discovered during this research: **every `is_global` MCP server is auto-injected into every agent's `.mcp.json` at launch, with no per-agent opt-in and no "disabled" flag.**
+
+---
+
+## 1. Problem statement
+
+`frontend/app/view/mcp/mcp-manager.tsx:70` renders `"No MCP servers yet"` on a fresh install, and stays that way indefinitely — `db_mcp_servers` (`agentmux-srv/src/backend/storage/migrations.rs:437-446`) is created empty by the v10 migration and **no code path anywhere in the backend ever inserts a seed row into it.** Confirmed by grep: no `INSERT INTO db_mcp_servers` exists outside the user-driven `mcp_server_upsert*` methods (`agentmux-srv/src/backend/storage/mcp_servers.rs:149-282`), and none of `agent_seed.rs`, `identity/migration.rs`, or any `m00XX_*.rs` migration touches this table.
+
+The one thing in the codebase that looks like a seed list is not one:
+
+- `frontend/app/view/mcp/mcp-preload-catalog.ts` — `MCP_PRELOAD_CATALOG: McpPreloadEntry[]`, currently **one entry** (Ableton Live, `:40-51`). This is a UI picker: selecting a tile calls `McpCatalogModel.startFromCatalog()` (`mcp-model.ts:140`), which only **pre-fills the add-server draft form** — the user still has to review and click Save (`mcp.catalog.upsert`) before anything is written. Its own doc comment is explicit that this is deliberately a frontend-only source of truth, not a DB seed (`mcp-preload-catalog.ts:11-18`).
+- A sibling proposal, `docs/specs/SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS_2026_07_10.md`, expands this exact picker with niche creative-software connectors (Ableton, TouchDesigner, ComfyUI, REAPER…) and is explicit that "no backend/schema change is required" for that work (§3, line 97) — by design, it never makes the list non-empty by default; a user who wants none of those tools still opens the Armory to a blank page.
+
+**What this spec adds that neither of those covers:** a small, curated set of general-purpose, credential-free, local dev-productivity servers (filesystem, git, fetch, sequential-thinking) that are useful to essentially every coding-agent user, seeded as real rows so the Armory is non-empty and agents are immediately more capable on first launch — the same "get productive immediately" bar the seeded agent-definition manifest (`agent-seed.json`) already sets for agent templates.
+
+**Sibling work, same day:** `docs/specs/SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` §4 independently researched the identical problem shape for the Armory's **Skills** tab (`db_skills WHERE is_global=1` is also empty on every fresh install, also has no seed path) and reached a simpler implementation shape than this spec's first draft did — see §5's revision below, which adopts it.
+
+---
+
+## 2. The constraint that shapes everything else: `is_global` means "on for every agent, unconditionally"
+
+This was the single most important fact surfaced during codebase research, and it rules out the naive "just seed everything as global rows" approach.
+
+`Store::mcp_server_list(agent_id)` (`agentmux-srv/src/backend/storage/mcp_servers.rs:54-83`) is the query every agent's `.mcp.json` is built from:
+
+```sql
+SELECT ... FROM db_mcp_servers s
+WHERE s.is_global = 1
+   OR s.id IN (SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?1)
+```
+
+Its own doc comment says it plainly: *"A global server is always visible to every agent"* (`:30`). And the call site that actually builds the launch-time `.mcp.json`, `agentmux-srv/src/server/app_api/agent_open.rs:583-593`, confirms there is no filtering step in between:
+
+> "v1 MCP: same rule. **Globals + synthetic `agentmux` are always emitted**; the legacy blob's user servers are merged in ONLY when the agent has no own ref-bound servers."
+
+There is no `enabled`/`disabled` column on `db_mcp_servers`, and no per-agent "I haven't bound this yet, don't start it" gate for global rows — `is_global = true` and "every agent tries to spawn/probe this at every launch" are the same thing today. This is fine for the servers this spec calls **Tier A** (stdio, fully local, no credentials — a missing/misconfigured env var can't happen because there are no env vars to misconfigure). It is actively harmful for anything needing an API key or OAuth token: seeding, say, a GitHub or Postgres server as a global row would mean **every agent on every launch** attempts to start a process or reach a URL that fails immediately for lack of a credential, on every single agent — a novel error introduced at seed time, not something the user opted into.
+
+This isn't an MCP-specific quirk — it's a shared property of every `is_global`-flagged Armory primitive. `SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` §4.1 independently found the identical mechanism for `db_skills`: *"Global skills need no per-agent bind step to take effect... unions every agent's own `db_agent_skills_ref` rows with all `is_global = 1` rows automatically."* The difference is consequence, not mechanism: a global Skill is inert prompt text with no credential and no execution surface, so "on for everyone, unconditionally" is exactly what that spec wants and ships without a tiering split. A global MCP server can be an arbitrary local process or a networked call requiring a secret, so the same mechanism that's harmless for Skills is the reason this spec needs one.
+
+This is why §4 below is a two-tier design rather than one seed list.
+
+---
+
+## 3. A seed idiom already in the codebase — and why this spec doesn't fully reuse it
+
+`agentmux-srv/src/backend/agent_seed.rs` already solves "ship a curated default set, on first launch, without clobbering user edits" for agent definitions and memory bundles. It's worth understanding in full because it's the natural first instinct for this problem — this spec's own first draft proposed extending it directly — even though §5 ultimately adopts a lighter mechanism instead, for consistency with the sibling Skills-seeding spec written the same day. Understanding what `agent_seed.rs` does (and which parts of its complexity are and aren't earned) is what makes that simplification a deliberate choice rather than an oversight:
+
+- **Embedded manifest:** `const SEED_MANIFEST: &str = include_str!("../../agent-seed.json")` (`:138`) — parsed once at startup, not a runtime fetch.
+- **First-launch seed:** `auto_seed_on_startup` (`:299`) calls `seed_agents` when `agent_def_count() == 0` — a one-shot bulk insert, skipping any id already present (`:159-162`).
+- **Reseed-on-manifest-change:** `reseed_if_needed` (`:359`) runs on every subsequent startup, but only actually mutates anything if it detects a real difference (new manifest id, or an identity field like `description` changed, `:374-386`). When it does mutate, it **preserves user-editable fields** on existing rows — provider, agent_type, environment, shell, auto_start, hide-state — updating only the seed-owned identity fields (`:445-467`). New ids always start visible (`user_hidden = 0`, `:439`); ids dropped from the manifest get deleted (`:475-482`).
+- **Known, accepted tradeoff in that design:** deletion isn't tracked as a tombstone. If a user hard-deletes a seeded row and the manifest's identity fields later change for an unrelated reason, `reseed_if_needed`'s loop treats the (now-absent) id as "not yet created" and re-inserts it (`:469-472`, the `None => insert` branch). The codebase's answer for agent templates is `user_hidden` — a soft-hide the user can set instead of a hard delete, which *is* preserved across reseeds (`:466`, and both regression tests at `agent_seed.rs:553-606`).
+
+The `is_seeded`/`user_hidden`/reseed-on-change machinery exists in `agent_seed.rs` because agent templates genuinely need it: templates get added and removed across releases, users customize provider/shell/environment on top of a seeded identity, and losing that customization on every restart would be a real regression. MCP servers don't have the equivalent "user customizes on top of a seed" case (§5) — a seeded Tier A row's command/args aren't something a user meaningfully tweaks in place, they either keep it, delete it, or replace it with their own. That's the concrete reason §5 lands on a lighter mechanism instead of porting this one wholesale: the extra machinery here is solving a problem MCP seeding doesn't actually have.
+
+---
+
+## 4. Design: two tiers, two different mechanisms
+
+### Tier A — no credential, fully local, safe to seed as real `is_global = true` DB rows
+
+Because §2 established that global = auto-on-for-everyone, Tier A is deliberately restricted to servers where "on for everyone, always" has no failure mode: no API key, no OAuth, no network dependency beyond `npx`/`uvx` resolving a package the first time. These become real `db_mcp_servers` rows via a new seed pass — mechanism detailed in §5.
+
+| Server | Purpose | Command | Transport | Why safe to auto-enable |
+|---|---|---|---|---|
+| **Filesystem** | Sandboxed read/write/search within allowed dirs | `npx -y @modelcontextprotocol/server-filesystem <dir>` | stdio | No creds; dir allowlist is the only config, defaults to the agent's own working directory |
+| **Git** | Local repo read/search/diff/log operations | `uvx mcp-server-git` | stdio | No creds; operates on whatever repo the agent's cwd is in |
+| **Fetch** | Fetch + convert a web page to markdown | `npx -y @modelcontextprotocol/server-fetch` | stdio | No creds; outbound-only, no stored state |
+| **Sequential Thinking** | Structured, revisable step-by-step reasoning scratchpad | `npx -y @modelcontextprotocol/server-sequential-thinking` | stdio | No creds, no I/O outside the process itself |
+| **Memory** | Cross-session knowledge-graph memory | `npx -y @modelcontextprotocol/server-memory` | stdio | No creds; local file-backed state |
+| **Playwright** | Browser automation via accessibility-tree snapshots (Microsoft-official) | `npx @playwright/mcp@latest` | stdio | No creds; downloads a browser binary on first use but needs no secret |
+| **Context7** | Live, version-specific library docs — reduces hallucinated APIs (Upstash) | `npx -y @upstash/context7-mcp` | stdio | No key required for the free tier; the closest thing to a de-facto standard for coding-agent doc lookup found in this research |
+
+All seven are `npx`/`uvx`-launched, meaning the *seed row* itself needs no network call — only the first real invocation triggers a package fetch, same cold-start cost every hand-typed stdio server already has today.
+
+**Explicitly excluded from Tier A, with reasons:**
+- **SQLite** (reference server) — has a known, unpatched SQL-injection / prompt-injection vector; Anthropic declined to fix it and archived the server rather than patch it. Never seed this by default.
+- **Puppeteer** — archived/no-security-fixes; superseded by Playwright above. Don't seed a deprecated server when a maintained equivalent exists.
+- **Everything** / **Time** (reference servers) — real, maintained, but demo/utility-grade rather than "every coding session benefits from this." Left as easy manual adds, not seeded.
+
+### Tier B — needs an API key or OAuth: catalog-picker entries only, never auto-seeded as global rows
+
+GitHub, Postgres, Brave Search, Linear, Sentry, and Notion are all high-value for a coding agent, and all need a secret this spec cannot supply at seed time (there is no account/credential-templating mechanism in `McpServer.config` today — confirmed by grep, the config field is a literal JSON blob, not a template referencing an identity account). Per §2, seeding these as `is_global = true` would break every agent's launch with a missing-credential error the user never asked for.
+
+Instead, these are added to the **existing** `MCP_PRELOAD_CATALOG` picker (`mcp-preload-catalog.ts`) — the same one-click-prefill, user-reviews-and-saves flow already shipped for Ableton Live. No schema change, no seed engine involvement; the user pastes their own token into the pre-filled config before clicking Save, at which point it becomes a real (and, at that point, correctly configured) global row.
+
+| Server | Purpose | Package / endpoint | Transport | Credential |
+|---|---|---|---|---|
+| **GitHub** | Repos, issues, PRs, code search | `ghcr.io/github/github-mcp-server` (Docker) or remote `https://api.githubcopilot.com/mcp/` | local stdio or remote http | `GITHUB_PERSONAL_ACCESS_TOKEN`, or OAuth for the remote endpoint |
+| **Postgres MCP Pro** | Read/write Postgres, index tuning, explain plans | `crystaldba/postgres-mcp` (Docker) | stdio | `DATABASE_URI` connection string |
+| **Brave Search** | Web/image/video/news search | `npx -y @brave/brave-search-mcp-server --transport http` | stdio or http | `BRAVE_API_KEY` (free tier: 2,000 queries/mo) |
+| **Linear** | Issue creation/update, sprint search | remote `https://mcp.linear.app/mcp` via `npx -y mcp-remote ...` | streamable HTTP | OAuth 2.1 + PKCE |
+| **Sentry** | Query/triage errors from the agent | `npx @sentry/mcp-server@latest --access-token=...` | remote-first, stdio supported | Access token or OAuth |
+| **Notion** | Read/write pages and databases | `npx @notionhq/notion-mcp-server` (local) or OAuth remote | stdio or OAuth remote | `NOTION_TOKEN` or OAuth |
+
+Six entries, matching the scale of Tier A. `Postgres` uses the actively-maintained `crystaldba/postgres-mcp` rather than Anthropic's own archived `server-postgres` (which is read-only and unmaintained). This list is deliberately smaller than the ~15-server survey in §7 — the full survey exists so a future pass can extend either tier without re-researching from scratch, not because every surveyed server belongs in v1.
+
+---
+
+## 5. Seed mechanism — revised to match the sibling Skills-seeding convention
+
+**This section's first draft proposed a schema migration** (`is_seeded`/`user_hidden` columns on `db_mcp_servers`) plus a `reseed_if_needed`-style engine mirroring `agent_seed.rs` exactly. Revised after reading `SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` §4.3, which independently solved the identical "empty global Armory catalog" problem for Skills the same day and landed on something lighter — two independent research passes converging on avoiding the heavier design is itself a signal worth taking. This spec adopts that shape rather than the original draft:
+
+- **No schema migration.** No new columns on `db_mcp_servers`. A seeded row is, after the one-time seed runs, indistinguishable from a user-created one — same as the Skills design. This sidesteps the entire "don't resurrect a user-deleted seeded row" problem `agent_seed.rs`'s `is_seeded`/`user_hidden` pair exists to solve (§3): if there's no recurring reseed trigger, there's nothing that could resurrect anything.
+- **A one-time seed, not a recurring reseed.** Gate on the same condition the Skills spec proposes: seed only if `db_mcp_servers WHERE is_global = 1` is empty **and** this is a fresh install (reuse whatever "fresh install" signal already exists elsewhere in the codebase — e.g. however first-run/default-channel state is detected today — rather than inventing a second one). A user who deletes a seeded server later just has one fewer server; nothing ever tries to put it back. This is a real behavior tradeoff versus the original draft's reseed-on-manifest-change (a future AgentMux release that improves the seeded `filesystem` command, say, won't retroactively reach existing installs) — accepted here for consistency with the sibling spec and because it's simpler and strictly safer; §9 keeps a path open to add versioned reseeding later if that tradeoff turns out to matter in practice.
+- **Reuse the `config/*.json` static-file convention**, not a Rust-`include_str!` manifest: new `agentmux-srv/src/config/starter-mcp-servers.json`, an array of `{name, transport, config}` objects (no `id`/`is_global`/timestamps — assigned at insert time, mirroring the Skills spec's §4.3 point 1 exactly).
+- **Insert via the existing validated path**, not hand-rolled SQL: `mcp_server_upsert_unique_global` (`mcp_servers.rs:255-282`) already enforces catalog-wide name uniqueness and sets `is_global = 1` — call it once per manifest entry, warn-and-skip on a name collision (the `seed_memories` precedent, `agent_seed.rs:278-291`) rather than aborting the whole batch, so a user who already hand-created a server named `filesystem` doesn't get it silently clobbered.
+
+```json
+[
+  { "name": "filesystem", "transport": "stdio",
+    "config": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"] } }
+]
+```
+
+**Open question, shared verbatim with the sibling spec's §4.3:** should this seed run unconditionally on every fresh install, or be opt-in (e.g. a "load starter servers" action in the Armory MCP tab's empty state)? Unconditional matches "pre-populate" and is simpler; an unconditional silent DB write on first launch is a bigger behavioral change than a button click. Flagging as a real product decision rather than assuming either default — and note this decision should almost certainly be made **once, for both catalogs together** (Skills and MCP servers), not independently per spec, since a user's expectation of "does the Armory auto-populate itself or not" should be consistent across tabs.
+
+**Frontend:** no new fields needed on `McpServer`/`McpServerListItem`/`McpServerCatalogItem` under this revised design — a seeded row uses the exact same edit/delete affordances `mcp-manager.tsx` already has for any global row.
+
+---
+
+## 6. Explicit non-goals
+
+- **No live catalog sync from an external registry.** The official MCP Registry (`registry.modelcontextprotocol.io`) is metadata-only and still preview/API-frozen; directories like Smithery/Glama/mcp.so trade curation for coverage and, in Smithery's case, add a hosting-infra trust surface (a real path-traversal incident occurred there in 2025, patched within days). A hardcoded, human-curated manifest — reviewed the same way `agent-seed.json` already is — is the right v1 shape; revisit only if the manifest becomes a maintenance burden at meaningfully larger scale.
+- **No cross-provider `.mcp.json` translation.** `build_mcp_config_from_refs` (`agentmux-srv/src/backend/agent_config.rs:320-395`) writes exactly one `.mcp.json` per agent regardless of `agent.provider` — this is Claude Code's native config format. `cli-catalog.ts` claims `mcpSupport` for Codex/Gemini/Qwen/etc., but those CLIs' real MCP config lives elsewhere (e.g. Codex CLI reads `~/.codex/config.toml`, not a project `.mcp.json`) and nothing in this codebase special-cases that today. Seeding more servers into `.mcp.json` doesn't make this gap worse, but it doesn't fix it either — flagged here so it isn't mistaken for in-scope.
+- **No secret-templating in `McpServer.config`.** Tier B staying catalog-only (§4) is a direct consequence of this — there is no mechanism today for a seeded row's `config` to reference an identity account's stored credential rather than a literal string. Building one is a real, separable feature (and would upgrade Tier B from "picker, user pastes a token" to "picker, user picks an already-connected account") but is out of scope for making the list non-empty.
+- **Version pinning is out of scope for Tier A.** Unlike the creative-connector spec's `uvx ableton-mcp@1.2.0`-style pinning recommendation (relevant there because those servers carry real code-exec risk against a user's creative-app state), Tier A's seven servers are Anthropic/Microsoft/Upstash-maintained references with a low-risk, well-scoped tool surface; `npx -y <pkg>@latest`-style resolution is consistent with how every other hand-typed stdio server in this codebase already works. Worth revisiting only if a Tier A server ever ships a breaking change that surprises users.
+
+---
+
+## 7. Full ecosystem survey (reference for future tier expansion, not all shipped in v1)
+
+Researched mid-2026 state of the MCP ecosystem, for anyone extending either tier later:
+
+- **`modelcontextprotocol/servers`** now holds only steering-group-maintained reference servers: Everything, Fetch, Filesystem, Git, Memory, Sequential Thinking, Time. Latest tag `2026.7.4`.
+- **`modelcontextprotocol/servers-archived`** — no-security-fixes archive of servers Anthropic no longer maintains as references: AWS KB Retrieval, (old) Brave Search, EverArt, (old) Git dup, (old) GitHub, GitLab, Google Drive, Google Maps, (old) PostgreSQL, Puppeteer, Redis, (old) Sentry, (old) Slack, **SQLite (unpatched SQLi vuln)**. The general pattern: most SaaS-integration categories were superseded by vendor-official servers outside Anthropic's monorepo (GitHub → `github/github-mcp-server`, Brave → `brave/brave-search-mcp-server`, Notion → `makenotion/notion-mcp-server`, Linear → `mcp.linear.app`, Sentry → `mcp.sentry.dev`).
+- **Registries/directories surveyed** (see §6 for why none is used directly): official Registry (~9,652 servers, metadata-only), PulseMCP (11,840+, human-curated), Smithery (7,000+, hosted execution, had a patched security incident), Glama (21,000+, largest but least curated), mcp.so (19,700+, unvetted), Docker MCP Catalog (200+, strongest security posture — signed SBOMs, sandboxing, credential manager — worth a second look if AgentMux ever containerizes agent MCP execution by default).
+- **Security baseline worth remembering when extending either tier:** a scan of 8,000+ public registry servers found 36.7% with SSRF issues, 43% with unsafe command-execution paths, 41% with zero authentication. Popularity alone isn't a safety signal — prefer official/vendor-maintained servers over community forks where one exists (the Ableton-connector spec's §2.1 "five competing forks, no obvious winner" problem is the cautionary example of what happens when no official option exists).
+- Additional servers noted as high-value but deliberately left out of both tiers for now: **Supabase MCP** (official, OAuth-remote, strong candidate for a future Tier B slot if Supabase usage among AgentMux's users turns out to be common), **Slack** (comms-oriented rather than "get productive immediately" for a coding loop — good Tier B candidate on a later pass), **Google Drive** (archived reference, no confirmed current official replacement identified in this research pass — needs its own verification before it's trustworthy enough to catalog).
+
+---
+
+## 8. Phased plan
+
+**Phase 1 — Tier A backend seed.** `agentmux-srv/src/config/starter-mcp-servers.json` with the 7 Tier A entries, a one-time seed step gated on "no global MCP servers exist yet + fresh install" per §5, inserting via `mcp_server_upsert_unique_global`. No schema change, no new frontend fields. This alone makes the Armory non-empty by default and every new agent launch immediately capable of local file/git/fetch/reasoning/memory/browser/doc-lookup tool use with zero user setup. Should land alongside (or immediately after) the sibling spec's Skills-seeding PR B, sharing whatever "fresh install" gate and unconditional-vs-opt-in decision (§5) that PR settles on, rather than each spec answering it independently.
+
+**Phase 2 — Tier B catalog expansion.** Add the six §4 entries to `MCP_PRELOAD_CATALOG`, following the exact shape the Ableton entry already established (`prereqNote` explaining what credential is needed and where to get it, `docsUrl` pointing at the upstream project). No schema change needed for this phase — it's purely additive to an existing, already-shipped mechanism.
+
+**Phase 3 — not committed scope.** Secret-templating for `McpServer.config` (§6) to let Tier B servers reference an already-connected identity account instead of a hand-pasted token; revisit registry/directory sync (§6) only if manual manifest maintenance becomes a real bottleneck at a meaningfully larger catalog size.
+
+---
+
+## 9. Open questions
+
+1. **Is one-time-only seeding (§5) the right call long-term?** It's simpler and strictly safer than reseed-on-manifest-change today, but it also means a future fix to a Tier A entry's command/args never reaches an install that seeded before the fix shipped. If that turns out to matter in practice, the `is_seeded`/`user_hidden` + versioned-reseed design in §3 is still there to adopt later — not proposed for v1, but not thrown away either.
+2. **Should Tier A's seed be skippable at first-run** (e.g. for a locked-down/offline environment where even `npx -y <pkg>` package resolution on first invocation is undesirable)? `agent_seed.rs` has no such escape hatch for agent templates today, so the precedent is "no," but MCP servers do outbound network I/O on first real use in a way agent templates don't — worth a explicit product decision rather than silently inheriting the agent-seed precedent.
+3. **Filesystem server's default allowed-directory.** `@modelcontextprotocol/server-filesystem` takes an allowlisted directory as a CLI arg (§4's table shows `<dir>` unfilled) — seeding a literal path is environment-specific and can't be baked into a static manifest the way the other six Tier A commands can. Needs either a per-agent-cwd default computed at config-build time (extending `build_mcp_config_from_refs` to substitute a placeholder) or shipping this one entry with an empty/unset arg and a `prereqNote`-equivalent nudging the user to fill it in — decide before Phase 1 ships this specific entry.
+4. **Filesystem's directory arg is the one Tier A entry that can't ship as a static manifest value without answering question 3 first** — the other six need no per-install customization, this one does. If question 3 lands on "ship it anyway with an empty arg," confirm the resulting server fails safely (a probe error the user can see, not a silent no-op) rather than, worse, defaulting to some unexpectedly broad directory.
+
+---
+
+## 10. References
+
+- Internal: `agentmux-srv/src/backend/storage/mcp_servers.rs`, `agentmux-srv/src/backend/storage/migrations.rs:437-462`, `agentmux-srv/src/server/app_api/mcp.rs`, `agentmux-srv/src/backend/mcp_probe.rs`, `agentmux-srv/src/backend/agent_config.rs:252-395`, `agentmux-srv/src/server/app_api/agent_open.rs:575-615`, `agentmux-srv/src/backend/agent_seed.rs` (the seed idiom §3 evaluates and §5 partially departs from), `frontend/app/view/mcp/mcp-manager.tsx`, `frontend/app/view/mcp/mcp-model.ts`, `frontend/app/view/mcp/mcp-preload-catalog.ts`, `frontend/app/view/mcp/McpCatalogPicker.tsx`, `specs/SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md` (governing schema spec), `docs/specs/SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md` (probe + one-click-install groundwork this spec builds on), `docs/specs/SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS_2026_07_10.md` (sibling proposal — niche creative connectors via the same picker mechanism Tier B reuses here), `docs/specs/SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` (independent same-day sibling spec — identical problem shape for Skills, source of the lighter §5 seed mechanism and the shared §2 `is_global`-auto-inject finding), `docs/specs/archive/REPORT_ARMORY_FEATURE_STATUS_2026_07_07.md` (confirms seeding was not among the six tracked Armory/MCP gaps as of #1960 — genuinely unaddressed territory).
+- [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers)
+- [modelcontextprotocol/servers-archived](https://github.com/modelcontextprotocol/servers-archived)
+- [Official MCP Registry](https://registry.modelcontextprotocol.io/) / [registry preview announcement](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)
+- [github/github-mcp-server](https://github.com/github/github-mcp-server)
+- [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
+- [upstash/context7](https://github.com/upstash/context7)
+- [brave/brave-search-mcp-server](https://github.com/brave/brave-search-mcp-server)
+- [crystaldba/postgres-mcp](https://github.com/crystaldba/postgres-mcp)
+- [makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server)
+- [Linear MCP docs](https://linear.app/docs/mcp)
+- [Sentry MCP docs](https://docs.sentry.io/) (`mcp.sentry.dev`, `@sentry/mcp-server`)
+- [Supabase MCP docs](https://supabase.com/docs/guides/ai-tools/mcp)
+- [Docker MCP Catalog & Toolkit](https://docs.docker.com/ai/mcp-catalog-and-toolkit/)
+- [WorkOS: Everything your team needs to know about MCP in 2026](https://workos.com/blog/everything-your-team-needs-to-know-about-mcp-in-2026)
+- [SSOJet: Best MCP Servers 2026](https://ssojet.com/blog/best-mcp-servers-2026)
+- [TrueFoundry: MCP registries comparison](https://www.truefoundry.com/blog/best-mcp-registries)


### PR DESCRIPTION
## Summary

Research + proposal spec, **plus Phase 1 implementation** (both in this PR). The Armory's MCP Servers tab ships empty on every install — `db_mcp_servers` has no seed mechanism, and the only thing that looked like a seed list (`mcp-preload-catalog.ts`) is a manual one-click-prefill picker with a single entry, not real seed data.

**Spec** (`docs/specs/SPEC_ARMORY_MCP_SERVER_DEFAULT_SEED_CATALOG_2026_07_13.md`): researched the current codebase state and the external MCP server ecosystem (popular vs. archived/deprecated as of mid-2026), then designed a two-tier seed catalog:
- **Tier A** (credential-free, fully local, seeded as real DB rows): Git, Fetch, Sequential Thinking, Memory, Playwright, Context7.
- **Tier B** (needs an API key/OAuth, stays in the opt-in catalog picker): GitHub, Postgres, Brave Search, Linear, Sentry, Notion.

The tiering is a direct consequence of a hard constraint this research surfaced: `is_global = true` MCP servers are auto-injected into **every** agent's `.mcp.json` at launch, with no per-agent opt-in and no disabled flag — seeding a credential-needing server globally would break every agent's launch by default.

While writing the spec, found `SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` — an independent, same-day sibling spec that solved the identical "empty global Armory catalog" problem for Skills, and by the time Phase 1 here was implemented, its PR had already shipped (`skill_seed.rs`, `migrations/m0015_seed_starter_skills.rs`) through two rounds of reagent findings. This PR's implementation mirrors that shipped shape exactly rather than the spec's own first draft (which had proposed a schema migration + `agent_seed.rs`-style reseed engine):

**Implementation** (Phase 1 — Tier A backend seed):
- `agentmux-srv/src/config/starter-mcp-servers.json` — the 6-entry manifest.
- `agentmux-srv/src/backend/mcp_seed.rs` — seed logic, mirrors `skill_seed.rs`: all-or-nothing insert via `mcp_server_upsert_unique_global` with compensating rollback on partial failure, and a name-collision self-heal so a colliding install can't hard-fail the migration forever.
- `agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs` — run-once-per-channel via the migration framework's `db_migrations` tracking (not a "seed if empty" runtime check, which can't distinguish "never seeded" from "user deleted everything on purpose" and would silently resurrect deleted defaults).
- No schema changes, no new frontend fields — a seeded row is indistinguishable from a user-created one.
- Filesystem, SQLite, and Puppeteer are deliberately excluded from the seed (directory-arg ambiguity, unpatched SQLi vuln, and deprecated-in-favor-of-Playwright, respectively — see spec §4).

**Size impact:** no new crate dependencies (`uuid`/`serde_json` already used throughout). Diff is 7 files / +440 lines (mostly tests and doc comments — the actual seed logic is ~120 lines). The embedded JSON manifest is 948 bytes. Nothing is bundled into the AgentMux binary/install beyond that — the six servers are `npx`/`uvx`-launched and download lazily into the user's own global npm/uv cache only the first time each is actually invoked by an agent, exactly like every hand-typed MCP server already works today; this PR doesn't change that model, it just pre-populates 6 catalog rows that reference existing public packages.

Tier B (catalog-picker additions) is left as a documented follow-up (§8 Phase 2), not shipped here.

## Test plan

- [x] `cargo build -p agentmux-srv --bin agentmux-srv --tests` clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv mcp_seed` — 4/4 passing (empty-catalog seed, config round-trips as valid JSON, partial-failure rollback, name-collision self-heal check)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv m0016` — 3/3 passing (fresh-channel seed, once-applied survives full deletion, self-heals on pre-existing name collision)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` (full suite) — 1469/1469 passing, 0 failed

<!-- agentmux:agent_id=agentx -->