### PR TITLE
fix(tabbar): tab reorder drag never initiates

### DIFF
--- a/.changesets/1783993912-fix-tabbar-tab-reorder-drag-never-initiates-nested-draggable-8vce.md
+++ b/.changesets/1783993912-fix-tabbar-tab-reorder-drag-never-initiates-nested-draggable-8vce.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabbar): tab reorder drag never initiates — nested draggable=false blocked pragmatic-dnd

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -261,6 +261,13 @@ function Tab(props: TabProps): JSX.Element {
                         ref={editableRef!}
                         class={clsx("name", { focused: isEditable() })}
                         contentEditable={isEditable()}
+                        // Only block native drag while actively renaming — text
+                        // selection/caret placement over the auto-selected name
+                        // must win over pragmatic-dnd's wrapper draggable="true"
+                        // there (reagent P1, PR #2148). Unset otherwise so the
+                        // name area — the tab's largest surface — still starts
+                        // a reorder drag normally.
+                        draggable={isEditable() ? false : undefined}
                         onDblClick={() => handleRenameTab()}
                         onBlur={handleBlur}
                         onKeyDown={handleKeyDown}

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -251,7 +251,6 @@ function Tab(props: TabProps): JSX.Element {
                     "tab-colored": !!tabColor(),
                 })}
                 style={tabColor() ? ({ "--tab-color": tabColor() } as JSX.CSSProperties) : undefined}
-                draggable={false}
                 onClick={props.onSelect}
                 onContextMenu={handleContextMenu}
                 data-tab-id={props.id}

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -273,6 +273,7 @@ function Tab(props: TabProps): JSX.Element {
                         onClick={props.onClose}
                         onMouseDown={handleMouseDownOnClose}
                         title="Close Tab"
+                        draggable={false}
                     >
                         {/* VS Code's "close" codicon, inlined as SVG so we
                             don't pull in the codicons font. Path verbatim


### PR DESCRIPTION
## Summary

Fixes #2122 — dragging a tab within the strip showed a bounce-like animation
but the order never changed. Log evidence narrowed it to drag *initiation*:
zero `tab-drag started` lines and zero `ReorderTab` RPCs in any session.

## Root cause

`droppable-tab.tsx`'s `.tab-drop-wrapper` registers pragmatic-dnd's
`draggable()`, which sets `draggable="true"` on the wrapper element. `Tab`'s
own root `.tab` div (a direct child of that wrapper) explicitly set
`draggable={false}` — added in the commit that introduced pragmatic-dnd,
under the (incorrect) assumption that Tab should stop independently driving
its own drag now that the wrapper owns drag lifecycle.

Per the HTML5 Drag and Drop spec, the browser walks up from the mousedown
target to the nearest element with an *explicit* `draggable` attribute to
decide whether to initiate a drag. Since the user's mousedown lands on
`.tab` (or a descendant — the name text, close button), and `.tab` itself
sets `draggable="false"`, that wins over the ancestor wrapper's
`draggable="true"` — so the native `dragstart` event never fires, and
pragmatic-dnd's `onDragStart` (which logs `"tab-drag started"`) never runs.

## Fix

Remove the stray `draggable={false}` from `tab.tsx`. The wrapper's
pragmatic-dnd-managed `draggable="true"` now correctly governs drag
initiation for the whole subtree.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `frontend/app/tab/tabbar-dnd.test.ts` (30 tests, drop-side reorder
      math) — all passing, unaffected by this change
- [ ] Manual: drag a tab within the strip in `task dev` and confirm reorder
      commits (not run in this environment — no interactive browser
      available; jsdom does not implement the browser's native drag
      attribute-walking algorithm, so no automated test can exercise this
      specific regression)

<!-- agentmux:agent_id=agenty -->