### PR TITLE
fix(swarm): disambiguate subagent row labels when slug is shared across a batch

### DIFF
--- a/.changesets/1783993847-fix-swarm-disambiguate-subagent-row-labels-when-slug-is-shar-ldwc.md
+++ b/.changesets/1783993847-fix-swarm-disambiguate-subagent-row-labels-when-slug-is-shar-ldwc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): disambiguate subagent row labels when slug is shared across a batch

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -10,6 +10,7 @@ import {
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     stabilizeGroupIdentity,
+    subagentDisplayLabel,
     type ActiveSubagent,
     type NameGroup,
     type SwarmChild,
@@ -451,5 +452,56 @@ describe("pruneGroupIdentityCache", () => {
         expect(cache.size).toBe(1);
         expect(cache.has("name:block-1:A")).toBe(true);
         expect(cache.has("name:block-1:B")).toBe(false);
+    });
+});
+
+describe("subagentDisplayLabel", () => {
+    it("prefers display_name over everything else", () => {
+        expect(
+            subagentDisplayLabel({ display_name: "Refactor shell module", slug: "cheerful-enchanting-sketch", agent_id: "abc1234def" })
+        ).toBe("Refactor shell module");
+    });
+
+    it("falls back to agent_id short prefix when there is no slug either", () => {
+        expect(subagentDisplayLabel({ display_name: null, slug: "", agent_id: "abc1234def" })).toBe("abc1234");
+    });
+
+    // Regression for task #44's live repro: 17 structurally distinct
+    // agent_ids spawned within ~50ms of one another under one parent all
+    // resolved the identical literal slug "magical-enchanting-diffie" —
+    // confirmed (see subagentDisplayLabel's doc comment) to be a shared
+    // Claude Code per-session/per-batch codename, not a per-subagent unique
+    // value, so a bare `slug` fallback rendered all 17 as visually
+    // identical rows before any per-agent display_name had resolved.
+    it("disambiguates same-slug siblings with a short agent_id suffix instead of returning a bare, non-unique slug", () => {
+        const shared = "magical-enchanting-diffie";
+        // The short-id disambiguator is `agent_id.substring(0, 7)` — pad the
+        // index so it lands within the first 7 characters, otherwise every
+        // id would collide on the same "agent-0" prefix and this test would
+        // fail to exercise the actual disambiguation.
+        const subagents = Array.from({ length: 17 }, (_, i) => ({
+            display_name: null as string | null,
+            slug: shared,
+            agent_id: `${i.toString().padStart(7, "0")}-agent-${"x".repeat(10)}`,
+        }));
+
+        const labels = subagents.map((s) => subagentDisplayLabel(s));
+
+        // Every label still surfaces the shared slug (it's real, useful
+        // context — this batch legitimately shares a codename)...
+        expect(labels.every((l) => l.startsWith(`${shared} · `))).toBe(true);
+        // ...but all 17 labels are nonetheless pairwise distinct, since each
+        // subagent's own agent_id is genuinely unique.
+        expect(new Set(labels).size).toBe(17);
+    });
+
+    it("still includes the short agent_id suffix even when slug looks unique in isolation", () => {
+        // subagentDisplayLabel can't know whether a slug collides with a
+        // sibling's without seeing the whole list, so it always
+        // disambiguates when falling back to slug rather than only on
+        // detected collision — cheap, consistent, and never wrong.
+        expect(subagentDisplayLabel({ display_name: null, slug: "solo-run", agent_id: "zzzz999yyyy" })).toBe(
+            "solo-run · zzzz999"
+        );
     });
 });

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -215,6 +215,45 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
     return [...stillLoose, ...groups, ...nameGroups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
 }
 
+/**
+ * Compute the label `SubagentRow`/`SubagentDetailPane` show for a subagent,
+ * in the same priority order both call sites use: `display_name` (once
+ * Haiku resolves it) > `slug` > a short prefix of `agent_id`.
+ *
+ * `slug` is NOT a per-subagent-unique identifier — it's read straight
+ * through from whatever the Claude Code CLI happened to write into the
+ * first line of the subagent's own JSONL file (`subagent_watcher.rs`'s
+ * `read_jsonl_from_offset`), which in practice is that CLI's own
+ * per-session/per-batch codename. A whole Task/Workflow-tool batch of
+ * genuinely distinct, unrelated subagents legitimately shares one slug —
+ * already established as an expected, non-buggy signature in
+ * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md Finding 3
+ * ("one shared slug = one legitimate concurrent spawn") and relied on by
+ * `groupSubagentsByWorkflow`'s `WorkflowGroup.name` derivation above.
+ *
+ * Falling back to a bare `slug` as a ROW LABEL, though, silently assumed
+ * the opposite — that it WAS subagent-unique — so every member of such a
+ * batch rendered as a visually identical `SubagentRow` until its own
+ * `display_name` resolved. Live-reproduced in task #44: 17 structurally
+ * distinct `agent_id`s, one shared literal slug, spawned within ~50ms of
+ * each other under one parent, rendered as 17 apparently-duplicate rows —
+ * not a slug-generation bug or a spawn-dedup bug (all 17 were genuinely
+ * separate, correctly-ungrouped subagents; `workflow_id`/`display_name`
+ * grouping never entered the picture since neither had resolved yet).
+ * Appending a short, always-unique `agent_id` suffix keeps same-slug
+ * siblings visually distinct without claiming a uniqueness `slug` never
+ * had — mirrors the existing pattern in `SubagentDetailPane`, which
+ * already shows `agent_id.substring(0, 7)` as a separate meta chip next to
+ * the name for exactly this reason.
+ */
+export function subagentDisplayLabel(
+    sub: Pick<ActiveSubagent, "display_name" | "slug" | "agent_id">
+): string {
+    if (sub.display_name) return sub.display_name;
+    const shortId = sub.agent_id.substring(0, 7);
+    return sub.slug ? `${sub.slug} · ${shortId}` : shortId;
+}
+
 function shallowEqualSubagent(a: ActiveSubagent, b: ActiveSubagent): boolean {
     return (
         a.slug === b.slug &&

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -3,7 +3,7 @@
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowGroup, NameGroup, SubagentDetail, SubagentEvent } from "./swarm-model";
-import { isWorkflowGroup, isNameGroup, groupCacheKey } from "./swarm-model";
+import { isWorkflowGroup, isNameGroup, groupCacheKey, subagentDisplayLabel } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -387,7 +387,11 @@ function SubagentRow({
     parentAgentStatus: "running" | "idle";
 }): JSX.Element {
     const expanded = createMemo(() => model.isExpanded(sub.agent_id));
-    const displayLabel = createMemo(() => sub.display_name || sub.slug || sub.agent_id.substring(0, 7));
+    // See subagentDisplayLabel's doc comment (swarm-model.ts) — slug is a
+    // shared per-batch codename, not a per-subagent identifier, so this
+    // disambiguates same-slug siblings with a short agent_id suffix instead
+    // of assuming slug alone is unique (task #44).
+    const displayLabel = createMemo(() => subagentDisplayLabel(sub));
 
     const handleToggle = () => {
         const wasExpanded = expanded();
@@ -438,8 +442,15 @@ function SubagentDetailPane({ sub, detail }: { sub: ActiveSubagent; detail: Suba
     const events = detail.eventsAtom;
     const status = detail.statusAtom;
 
+    // Same slug-is-not-unique reasoning as SubagentRow's displayLabel (see
+    // subagentDisplayLabel's doc comment in swarm-model.ts) — prefer the
+    // freshest info() read, falling back to the row's own `sub` fields.
     const name = createMemo(() =>
-        info()?.display_name || sub.display_name || info()?.slug || sub.slug || sub.agent_id.substring(0, 7)
+        subagentDisplayLabel({
+            display_name: info()?.display_name ?? sub.display_name,
+            slug: info()?.slug ?? sub.slug,
+            agent_id: sub.agent_id,
+        })
     );
     const modelName = createMemo(() => info()?.model ?? sub.model);
     const eventCount = createMemo(() => info()?.event_count ?? sub.event_count);


### PR DESCRIPTION
## Summary

Task #44: live-reproduced tonight in a `task dev` instance under agent "Lzop" — the Swarm pane rendered **17 structurally distinct subagents (17 different agent_ids) all showing the identical literal slug `"magical-enchanting-diffie"`** within ~50ms of each other, appearing as duplicate-looking rows.

## Root cause

Neither of the two hypothesized mechanisms (slug-generation collision, or an upstream spawn-dedup bug producing 17 entities that should've been fewer) is what's actually happening.

`SubagentInfo.slug` (`agentmux-srv/src/backend/subagent_watcher.rs`'s `read_jsonl_from_offset`) is read straight through from the Claude Code CLI's own JSONL `"slug"` field — which is a **per-session/per-batch codename**, not a per-subagent-unique value. This is already documented and treated as *expected, correct* behavior in `docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md` Finding 3 ("one shared slug = one legitimate concurrent spawn"), and `WorkflowGroup`'s own name derivation (`swarm-model.ts`) already relies on exactly this fact.

The actual bug was in the frontend: `SubagentRow`'s/`SubagentDetailPane`'s label fallback chain (`display_name || slug || agent_id.substring(0,7)`) silently assumed `slug` *was* subagent-unique. All 17 subagents were correctly spawned as 17 separate entities and correctly left ungrouped — no shared `workflow_id`, no `display_name` resolved yet. This is confirmed by the DOM class actually observed live, `swarm-subagent-group`, which (per `swarm-view.tsx`/`swarm-view.scss`) only `SubagentRow` ever uses — `WorkflowGroupRow`/`NameGroupRow` use the visually-similar but structurally distinct `swarm-workflow-group` class. That rules out the "17 singleton WorkflowGroups" hypothesis from the original investigation notes. They were just 17 ordinary, correctly-ungrouped rows all rendering the same bare-slug label text.

## Fix

Extracted the label computation into a shared, testable `subagentDisplayLabel()` (`frontend/app/view/swarm/swarm-model.ts`), used by both `SubagentRow` and `SubagentDetailPane` in `swarm-view.tsx`. It appends a short, always-unique `agent_id` suffix whenever falling back to `slug`, so same-slug siblings stay visually distinct without claiming a uniqueness `slug` never had.

Backend (`subagent_watcher.rs`) and grouping logic (`NameGroup`/`WorkflowGroup` in `swarm-model.ts`) are untouched — investigation found neither is implicated, and forcing per-subagent slug uniqueness upstream would actually break `WorkflowGroup`'s existing shared-slug-based name derivation.

## Test plan

- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv subagent` — 36 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/swarm/swarm-model.test.ts` — 34 passed, including new `subagentDisplayLabel` regression tests reproducing the 17-subagent/one-slug scenario from the live repro
- [x] `task changeset -- patch "..."` added

## Residual risk / judgment calls

- This fix is based on thorough code reading (confirmed via the exact CSS class the live repro actually rendered) rather than a fresh live re-repro of this specific fix — I did not re-launch `task dev` to visually confirm the disambiguated labels render correctly in the running app, so it's worth a quick visual sanity check before merge.
- `WorkflowGroup.name` (the group *header* label, derived the same way from `sorted.find(m => m.slug)?.slug`) can still theoretically collide across two *different* `workflow_id`s that happen to share a session-level slug — lower impact (group headers show a count/status badge, and this wasn't the mechanism actually observed live) but flagging it as a known adjacent case, deliberately left out of scope here.
- The second lead from the original task #44 investigation ("same agent_id spawned twice under two different parents ~100 microseconds apart") was flagged as likely investigator-tooling contamination, not a real bug — not re-investigated here per the task's explicit guidance.

<!-- agentmux:agent_id=agenta -->
