### PR TITLE
fix(browser-pane): clip the pane-wrapper HWND too so overlay menus over panes accept hover/click on Windows

### DIFF
--- a/.changesets/1783994468-fix-browser-pane-clip-the-pane-wrapper-hwnd-too-so-overlay-m-js3q.md
+++ b/.changesets/1783994468-fix-browser-pane-clip-the-pane-wrapper-hwnd-too-so-overlay-m-js3q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): clip the pane-wrapper HWND too so overlay menus over panes accept hover/click on Windows

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -722,6 +722,34 @@ impl BrowserPaneManager {
                 }
             }
 
+            // App-owned wrapper HWND (browser_pane::wrapper — see its module
+            // doc and SPEC_BROWSER_PANE_WINDOWS_TEARDOWN_SPIKE_2026_07_03.md)
+            // sits directly between `pane_hwnd` and its host window and is
+            // kept congruent with it (same origin, same size — its own
+            // `WM_SIZE` handler resizes CEF's child to exactly fill it, see
+            // `wrapper.rs`). `SetWindowRgn` only changes hit-testing for the
+            // HWND it's called on: clipping `pane_hwnd` alone stops IT from
+            // painting/claiming the hole, but Win32 hit-testing for a point
+            // inside that hole then resolves to `pane_hwnd`'s own parent —
+            // the wrapper — which still claims its full, unclipped
+            // rectangle there. The wrapper's window class paints nothing of
+            // its own (`hbrBackground: null`) so the DOM underneath still
+            // shows through visually (matches "renders fine"), but its
+            // `WM_LBUTTONDOWN`/`WM_MOUSEMOVE` fall through to
+            // `DefWindowProcW` unhandled — the input is silently absorbed
+            // there instead of reaching the DOM (matches "hover/click
+            // no-op"). See docs/analysis/ANALYSIS_WINDOWS_PANE_OVERLAY_WRAPPER_HITTEST_GAP_2026_07_13.md.
+            // Every region applied to `pane_hwnd` below must therefore also
+            // be applied to the wrapper, in the same wrapper-local
+            // coordinates (congruent, so no separate coordinate math is
+            // needed). `None` only if the wrapper hasn't been created yet /
+            // already torn down (a real race, not the common case — every
+            // embedded pane creation on Windows creates one unconditionally,
+            // `browser_pane/creation.rs`); degrade gracefully by clipping
+            // just the pane in that case rather than failing the whole call.
+            let wrapper_hwnd = crate::browser_pane::wrapper::peek_wrapper_hwnd(label)
+                .map(|h| h as *mut std::ffi::c_void);
+
             unsafe {
                 // Empty overlay list = restore full visibility (region=NULL).
                 // bRedraw=FALSE (0) — see #1097 fix #5. With bRedraw=TRUE
@@ -756,6 +784,14 @@ impl BrowserPaneManager {
                     // invalidate the entire pane; CEF will paint only
                     // dirty regions on the next pump.
                     InvalidateRect(pane_hwnd as _, std::ptr::null(), 0);
+                    // Restore the wrapper's region too — see the wrapper_hwnd
+                    // comment above. Not gated on `applied`/cached separately:
+                    // the wrapper and pane_hwnd always change in lockstep, so
+                    // the pane's own sig is the correct gate for both.
+                    if let Some(wrapper_hwnd) = wrapper_hwnd {
+                        SetWindowRgn(wrapper_hwnd as _, std::ptr::null_mut(), 0);
+                        InvalidateRect(wrapper_hwnd as _, std::ptr::null(), 0);
+                    }
                     // Only record the sig if the region actually applied; on a
                     // (rare) SetWindowRgn failure leave the entry unset so the
                     // next call retries instead of skipping a clip that never
@@ -821,28 +857,44 @@ impl BrowserPaneManager {
                     continue;
                 }
 
-                // Build region in pane-local coords: start with full pane,
-                // subtract every overlay rect that intersects it.
-                let region = CreateRectRgn(0, 0, pane_w, pane_h);
+                // Build a region in pane-local coords: start with full pane,
+                // subtract every overlay rect that intersects it. Factored
+                // into a closure because it must run TWICE — once per
+                // target HWND — since `SetWindowRgn` takes ownership of the
+                // region handle it's given on success, so the same GDI
+                // region object can't be handed to two different windows.
+                // The wrapper is congruent with `pane_hwnd` (same origin,
+                // same size — see the wrapper_hwnd comment above), so the
+                // exact same `pane_w`/`pane_h`/`pane_rect` inputs apply to
+                // both without any extra coordinate math.
+                let build_region = || -> *mut std::ffi::c_void {
+                    let region = CreateRectRgn(0, 0, pane_w, pane_h);
+                    if region.is_null() {
+                        return region;
+                    }
+                    for (ox, oy, ow, oh) in overlay_rects {
+                        // Translate overlay rect (window client coords) →
+                        // pane-local coords by subtracting pane's window pos.
+                        let left = ox - pane_rect.left;
+                        let top = oy - pane_rect.top;
+                        let right = left + ow;
+                        let bottom = top + oh;
+                        // Skip if no intersection with the pane's local bounds.
+                        if right <= 0 || bottom <= 0 || left >= pane_w || top >= pane_h {
+                            continue;
+                        }
+                        let overlay_rgn = CreateRectRgn(left, top, right, bottom);
+                        if !overlay_rgn.is_null() {
+                            CombineRgn(region, region, overlay_rgn, RGN_DIFF);
+                            DeleteObject(overlay_rgn as _);
+                        }
+                    }
+                    region
+                };
+
+                let region = build_region();
                 if region.is_null() {
                     continue;
-                }
-                for (ox, oy, ow, oh) in overlay_rects {
-                    // Translate overlay rect (window client coords) →
-                    // pane-local coords by subtracting pane's window pos.
-                    let left = ox - pane_rect.left;
-                    let top = oy - pane_rect.top;
-                    let right = left + ow;
-                    let bottom = top + oh;
-                    // Skip if no intersection with the pane's local bounds.
-                    if right <= 0 || bottom <= 0 || left >= pane_w || top >= pane_h {
-                        continue;
-                    }
-                    let overlay_rgn = CreateRectRgn(left, top, right, bottom);
-                    if !overlay_rgn.is_null() {
-                        CombineRgn(region, region, overlay_rgn, RGN_DIFF);
-                        DeleteObject(overlay_rgn as _);
-                    }
                 }
                 // SetWindowRgn takes ownership of the region handle on
                 // success; the system frees it when the window is destroyed
@@ -856,6 +908,24 @@ impl BrowserPaneManager {
                 // invalidate the whole pane. CEF dirty-region painting
                 // keeps the actual GPU work proportional to the change.
                 InvalidateRect(pane_hwnd as _, std::ptr::null(), 0);
+                // Same clip on the wrapper — see the wrapper_hwnd comment
+                // above for why this is required, not optional, for
+                // hover/click to reach the DOM inside the punched hole. A
+                // second, independently-created region handle (never the
+                // same handle passed to pane_hwnd above — see the ownership
+                // note). Best-effort: a wrapper-side failure here doesn't
+                // block the pane's own clip from being recorded, matching
+                // the "degrade gracefully" stance for a missing wrapper_hwnd
+                // above.
+                if let Some(wrapper_hwnd) = wrapper_hwnd {
+                    let wrapper_region = build_region();
+                    if !wrapper_region.is_null() {
+                        if SetWindowRgn(wrapper_hwnd as _, wrapper_region as _, 0) == 0 {
+                            DeleteObject(wrapper_region as _);
+                        }
+                        InvalidateRect(wrapper_hwnd as _, std::ptr::null(), 0);
+                    }
+                }
                 // Only record the sig when the region actually applied (matches
                 // the whole-visibility branch); on failure free the orphaned
                 // region and leave the entry unset so the next call retries.

--- a/docs/analysis/ANALYSIS_WINDOWS_PANE_OVERLAY_WRAPPER_HITTEST_GAP_2026_07_13.md
+++ b/docs/analysis/ANALYSIS_WINDOWS_PANE_OVERLAY_WRAPPER_HITTEST_GAP_2026_07_13.md
@@ -1,0 +1,219 @@
+# Windows: widget "More" menu / hamburger menu render over panes but don't accept hover/click
+
+**Date:** 2026-07-13 · **Author:** Agent1 · **Trigger:** user report — AgentO's
+flyout-menu-over-browser-pane work (verified working on macOS) renders
+correctly on the `local-main-b28b7a-577e65c6` Windows instance, but hovering
+over an item in the widget bar's "More" dropdown or the hamburger menu does
+nothing, and clicking an item is a no-op, whenever the menu is positioned
+over a browser or messenger pane.
+
+> **Verdict (one line):** Almost certainly a **hit-testing gap, not a
+> rendering gap** — `SetWindowRgn` (the Win32 "punch a hole so DOM shows
+> through a native pane" mechanism) is applied only to CEF's own pane HWND,
+> never to the **app-owned wrapper HWND** introduced five weeks later
+> (2026-07-03, PR #1957) for an unrelated bug. The wrapper fully covers the
+> same rect, was never given a matching region, and silently swallows every
+> mouse message in the "hole." This is Windows-only and would not reproduce
+> on macOS/Linux, which don't have this wrapper (or `SetWindowRgn`) at all.
+
+---
+
+## 1. Reproduction context
+
+Checked the reported instance's own logs (it isn't currently running, so
+this is post-hoc log analysis, not a live CDP session):
+
+```
+C:\Users\asafe\.agentmux\channels\local-main-b28b7a-577e65c6\versions\0.53.4\logs\agentmux-host-v0.53.4.log.2026-07-14
+```
+
+- 1× `[pane-wrapper] created` — confirms this session did create at least
+  one embedded browser pane on Windows, going through the app-owned wrapper
+  HWND path described below.
+- 15× `[pane-airspace] applied overlay clip to pane HWNDs` with
+  `overlay_count` toggling between 0/2/4 — confirms the overlay-clip
+  mechanism *was* firing repeatedly, consistent with a menu being
+  opened/closed/hovered several times while a pane was open. So the
+  frontend→backend clip pipeline is running end-to-end; the failure is not
+  "the mechanism never engaged," it's "the mechanism engages but only half
+  of what needs clipping gets clipped" (see §4).
+
+No crash, panic, or error-level log line near these events — this is a
+silent behavioral gap, not a fault.
+
+## 2. Background: how the airspace hole-punch works (unchanged since May)
+
+Fully described in `docs/analysis/ANALYSIS_BROWSER_PANE_AIRSPACE_ARCHITECTURE_2026_05_30.md`
+(read in full before this doc); short version:
+
+On Windows, an embedded browser pane is a **native child HWND**, which always
+composites *above* DOM regardless of CSS z-index (the "airspace" problem).
+Any DOM element that must show through a pane tags itself `data-pane-overlay`
++ calls `usePaneOverlay()` (`frontend/app/platform/pane-overlay.ts`). Both
+`FlyoutMenu` (hamburger + its submenus, `frontend/app/element/flyoutmenu.tsx:253,378`)
+and the widget bar's `MoreDropdown` (`frontend/app/window/action-widgets.tsx:159,221`)
+do this — **same primitive, same code path**, which is why the user sees the
+identical symptom on both surfaces; this is one bug, not two.
+
+The rect is sent to the host over `browser_panes_set_overlay_clip`. The
+Rust handler, `BrowserPanes::set_pane_overlay_clip`
+(`agentmux-cef/src/browser_panes.rs:659-880`, Windows branch), calls Win32
+`SetWindowRgn` on the pane's HWND to **subtract** the overlay rect from the
+pane's own paintable/hit-testable region. Outside the hole, the pane covers
+the DOM as before; inside it, the pane no longer claims that area, so
+whatever's underneath is what the user sees *and interacts with* — normally.
+
+## 3. What changed five weeks later: the app-owned wrapper HWND
+
+`docs/specs/SPEC_BROWSER_PANE_WINDOWS_TEARDOWN_SPIKE_2026_07_03.md` (2026-07-03)
+and its implementation, PR #1957 (`fix(browser-pane): app-owned wrapper HWND
+fixes Windows renderer leak on pane close`), inserted a **new HWND** into the
+parent chain, for a completely unrelated bug (closing a pane never tore down
+its CEF renderer process — issue #1936). The fix: an app-owned, app-defined
+window class (`AgentMuxPaneWrapper[-hash]`, `agentmux-cef/src/browser_pane/wrapper.rs`)
+now sits **between** the pane's host window and CEF's own browser HWND:
+
+```
+main (or wherever the pane lives)
+ └─ wrapper HWND   (WS_CHILD, our own class, agentmux-cef/src/browser_pane/wrapper.rs)
+     └─ pane HWND  (WS_CHILD, CEF's own — this is what host.window_handle() returns)
+```
+
+The wrapper fills exactly the pane's rect; CEF's own HWND fills the
+wrapper's entire client area as its sole child (`wrapper_wndproc`'s `WM_SIZE`
+handler keeps them congruent — `wrapper.rs:98-114`). The wrapper's window
+class registers with **`hbrBackground: null`** (`wrapper.rs:159`, "the CEF
+child fills the client area before any WM_ERASEBKGND would matter") and
+handles only `WM_SIZE`/`WM_DESTROY` — every other message, including every
+mouse message, falls through to `DefWindowProcW` untouched (`wrapper.rs:126-129`).
+
+**`set_pane_overlay_clip` was never updated to account for this new window.**
+It resolves the pane via `browser.host()` → CEF's `BrowserHost::window_handle()`
+(`browser_panes.rs:709`) — which is, and has always been, CEF's *own* inner
+HWND — and calls `SetWindowRgn` on **that**, exclusively
+(`browser_panes.rs:752`, `:853`). The wrapper's region is never touched
+anywhere in this function or in `wrapper.rs`. `git log` on `browser_panes.rs`
+since the wrapper landed shows exactly one touch (#2098, the macOS flyout
+fix, unrelated) — the region-punch logic itself hasn't been revisited since
+before the wrapper existed.
+
+One detail worth flagging precisely: the author of `set_pane_overlay_clip`
+clearly *knew* the wrapper existed by the time this code was last touched —
+the function already walks `GA_ROOT` instead of a single `GetParent` hop
+specifically because "`pane_hwnd` is a `WS_CHILD` of our own wrapper HWND,
+not directly of main" (`browser_panes.rs:774-783`, comment). So this isn't a
+case of the wrapper being invisible to this code — the *positioning* math was
+correctly adjusted for it, but the *region* was not also propagated to it.
+An easy thing to miss: `GetAncestor(..., GA_ROOT)` silently walks past the
+wrapper for the "which top-level window is this" question, which reads as
+"the wrapper is handled" — but `SetWindowRgn` doesn't walk anything; it has
+to be called on each HWND individually, and the wrapper's own call was never
+added.
+
+## 4. Why this produces exactly "renders, but hover/click no-op" — not a visual glitch too
+
+This is the detail that makes the symptom look confusing at first (why isn't
+there *also* a black spot or offset, per the older DPI-mismatch bug class?)
+but it falls out cleanly once painting and hit-testing are considered
+separately, which is exactly how Win32 treats them:
+
+- **Painting:** the wrapper's class has `hbrBackground: null` and no
+  `WM_PAINT`/`WM_ERASEBKGND` handler. A window that paints *nothing itself*
+  simply leaves whatever was already composited underneath at the DWM/GDI
+  level, at that surface, untouched — no `WS_EX_TRANSPARENT` or
+  `WS_EX_LAYERED` needed for that. So once `SetWindowRgn` excludes the
+  overlay rect from *CEF's own HWND* (the innermost window, which is the
+  only one that ever actually draws anything there), nothing in the whole
+  wrapper→pane chain paints over that pixel region — the DOM menu underneath
+  shows through correctly. This matches the user's "it renders."
+- **Hit-testing:** Win32 mouse hit-testing walks the child-window tree by
+  **rectangle-or-region**, independent of what actually got painted. A
+  `SetWindowRgn`-excluded point on the pane HWND makes Windows skip *that
+  HWND* as a candidate — but the search doesn't fall through past the pane's
+  own immediate parent. It resolves to the **wrapper**, because the wrapper
+  still claims its full, un-clipped rectangular region there (no
+  `SetWindowRgn` call was ever made on it). The wrapper has no mouse-message
+  handling of its own, so `WM_LBUTTONDOWN`/`WM_MOUSEMOVE` land on
+  `DefWindowProcW` and are silently absorbed — no click fires, no `:hover`
+  reaches the DOM (the OS never delivered the input event to the browser
+  process hosting that DOM at all). This matches "hover not working, click
+  is a no-op" precisely, including that it's a *silent* no-op with nothing
+  in the console — there's nothing to catch, because the DOM's event
+  listeners are never invoked in the first place.
+
+## 5. Why macOS was clean (and why AgentO's verification didn't catch this)
+
+macOS/Linux don't use child HWNDs for panes at all — `docs/analysis/ANALYSIS_BROWSER_PANE_AIRSPACE_ARCHITECTURE_2026_05_30.md`
+§1: panes there are `CefBrowserView`s, and the "hide the whole pane instead
+of punching a hole" workaround is architecturally different (no
+`SetWindowRgn` equivalent, no wrapper window, no region-vs-rectangle
+hit-testing split — see `browser_panes.rs:883-` for the non-Windows path).
+The wrapper HWND is behind `#![cfg(target_os = "windows")]`
+(`wrapper.rs:41`) and doesn't exist as a concept on the other platforms.
+AgentO's PR #2098 (macOS flyout-over-pane occlusion/click-routing fix) and
+its live verification were entirely correct for that platform — this is a
+distinct, Windows-specific gap that opened up independently, five weeks
+after the airspace mechanism was last validated there, as a side effect of
+an unrelated Windows-only bug fix.
+
+## 6. Confidence and what would nail it down further
+
+**High confidence** in the mechanism (§3-4) from static code reading — the
+absence of any `SetWindowRgn` call on `wrapper_hwnd` anywhere in the
+codebase is a clean, structural fact, not an inference, and it fully
+explains every part of the reported symptom (renders / no hover / no click /
+silent / Windows-only / post-dates the working macOS verification). What
+this analysis has **not** done, and what would make it certain rather than
+"almost certainly":
+
+1. **Live repro with Spy++ / Window Detective** — hover over a More-dropdown
+   item positioned over a pane, confirm the HWND actually receiving
+   `WM_MOUSEMOVE` at that screen point is the `AgentMuxPaneWrapper[-hash]`
+   class, not the DOM/main window. This is the single most direct
+   confirmation available and doesn't require a code change.
+2. Alternatively, a temporary `tracing::debug!` in `wrapper_wndproc`'s
+   fallthrough arm, logging any mouse message it receives with its
+   screen-point — reproduce, then check whether it fires while hovering a
+   "dead" menu item.
+
+## 7. Proposed fix (not yet implemented — flagging shape, not shipping)
+
+Mechanically small: apply the **same region**, in the **same wrapper-local
+coordinates** (the wrapper and CEF's own HWND are kept congruent — same
+origin, same size — by `wrapper_wndproc`'s `WM_SIZE` handler, so no new
+coordinate math is needed) to `wrapper_hwnd` right alongside the existing
+`SetWindowRgn(pane_hwnd, ...)` calls in both branches of
+`set_pane_overlay_clip` (`browser_panes.rs:752` restore-to-full-visibility,
+and `:853` apply-clip). `peek_wrapper_hwnd(label)` (`wrapper.rs:66-68`,
+already used elsewhere in this same file for resize) is the lookup this
+would use. `CreateRectRgn`/`CombineRgn` already build one region object per
+call — either apply it to both HWNDs (regions are not shared handles once
+`SetWindowRgn` takes ownership, so a second, separately-created region would
+be needed for the wrapper) or restructure slightly to build it once and use
+`SetWindowRgn`'s "system takes ownership" semantics correctly for two
+targets. Left as a follow-up, not attempted here per the ask to investigate
+and report first.
+
+---
+
+### File references
+
+- `agentmux-cef/src/browser_panes.rs` — `set_pane_overlay_clip` (`:659-880`,
+  Windows branch); the two `SetWindowRgn(pane_hwnd, ...)` call sites
+  (`:752`, `:853`) that would need a wrapper-HWND counterpart
+- `agentmux-cef/src/browser_pane/wrapper.rs` — wrapper HWND module; class
+  registration (`hbrBackground: null`, `:159`), `wrapper_wndproc` (`:81-130`,
+  only handles `WM_SIZE`/`WM_DESTROY`), `peek_wrapper_hwnd` (`:66-68`)
+- `docs/specs/SPEC_BROWSER_PANE_WINDOWS_TEARDOWN_SPIKE_2026_07_03.md` — why
+  the wrapper exists (renderer-teardown leak, unrelated to airspace)
+- `docs/analysis/ANALYSIS_BROWSER_PANE_AIRSPACE_ARCHITECTURE_2026_05_30.md` —
+  the airspace/overlay-clip mechanism this gap sits inside; predates the
+  wrapper by 5 weeks
+- `frontend/app/platform/pane-overlay.ts` — `usePaneOverlay`, frontend side
+  of the clip pipeline (unaffected — the frontend's contract is honored
+  correctly; the gap is entirely on the Rust/Win32 side)
+- `frontend/app/element/flyoutmenu.tsx` (`:253`, `:378`) and
+  `frontend/app/window/action-widgets.tsx` (`:159`, `:221`) — the two
+  reported-affected surfaces, both going through the identical
+  `usePaneOverlay` primitive
+- Instance logs analyzed: `C:\Users\asafe\.agentmux\channels\local-main-b28b7a-577e65c6\versions\0.53.4\logs\agentmux-host-v0.53.4.log.2026-07-14`


### PR DESCRIPTION
## Summary

Reported: AgentO's flyout-menu-over-browser-pane work (verified working on macOS) renders correctly on Windows, but hovering an item in the widget bar's "More" dropdown or the hamburger menu (and its submenus) does nothing, and clicking is a silent no-op, whenever the menu sits over a browser/messenger pane.

**Root cause:** the airspace hole-punch (`SetWindowRgn`, which subtracts a DOM overlay's rect from a native pane's region so the pane stops claiming that area) was only ever applied to CEF's own inner pane HWND. PR #1957 (2026-07-03) inserted an app-owned **wrapper HWND** between the pane and its host window, for an unrelated bug (renderer teardown leak on pane close). The wrapper is congruent with the pane HWND (same rect, kept in sync by its own `WM_SIZE` handler) but was never given a matching clipped region.

Win32 hit-testing resolves by rectangle/region, independent of what's actually painted: excluding a point from the pane HWND's region only removes *that* window as a hit-test candidate — resolution then falls to its own parent, the wrapper, which still claimed the full unclipped rect. The wrapper's window class paints nothing of its own (`NULL` background brush), so the DOM underneath stays visible ("renders fine"), but its mouse messages fall through to `DefWindowProcW` unhandled — silently absorbed before ever reaching the DOM ("hover/click no-op"). Confirmed via the actual reported instance's logs (`local-main-b28b7a-577e65c6`): the overlay-clip pipeline was firing correctly (15× applied, 1× wrapper created) — this was never a "mechanism didn't engage" bug, just "only half of what needed clipping got clipped."

Full root-cause writeup: `docs/analysis/ANALYSIS_WINDOWS_PANE_OVERLAY_WRAPPER_HITTEST_GAP_2026_07_13.md`

**Fix:** apply the same region, in the same wrapper-local coordinates, to the wrapper HWND alongside every existing `SetWindowRgn` call on the pane HWND (both the restore-full-visibility and apply-clip branches, `agentmux-cef/src/browser_panes.rs::set_pane_overlay_clip`). Reuses the existing per-pane cache signature as the gate for both HWNDs (they always change in lockstep). Degrades gracefully — clips only the pane — if the wrapper HWND isn't found (a real but rare race, not the common case).

Why macOS was unaffected: it doesn't use child HWNDs, `SetWindowRgn`, or this wrapper concept at all (`#![cfg(target_os = "windows")]`) — a distinct, Windows-only regression that opened up independently, five weeks after the airspace mechanism was last touched there.

## Test plan
- [x] `cargo check -p agentmux-cef` — clean, no new warnings.
- [x] `cargo test -p agentmux-cef --lib browser_panes` — 2/2 pass.
- [x] `cargo build -p agentmux-cef` — clean full build.
- [x] `task dev` smoke test — app launches cleanly, no crashes, no new errors in the host log.
- [ ] **Manual, on a real Windows desktop:** open a browser/messenger pane, open the widget bar's More dropdown (or hamburger menu) positioned over it, hover and click an item — should now work. I could not verify this specific part myself: CDP-injected synthetic mouse events bypass the real Win32 hit-testing path entirely (they wouldn't exercise this bug either way), and I didn't want to drive the real OS cursor/click on a live shared desktop session from here. Flagging explicitly rather than claiming it's confirmed.

<!-- agentmux:agent_id=agent1 -->