### PR TITLE
fix(linux): gate startup window-show/splash-dismiss on real first paint

### DIFF
--- a/.changesets/1783994551-fix-linux-gate-startup-window-show-splash-dismiss-on-real-fi-oy1y.md
+++ b/.changesets/1783994551-fix-linux-gate-startup-window-show-splash-dismiss-on-real-fi-oy1y.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(linux): gate startup window-show/splash-dismiss on real first paint, not load-complete

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -53,7 +53,7 @@ mod handlers;
 pub(crate) mod helpers;
 mod lifecycle;
 mod display;
-mod navigation;
+pub(crate) mod navigation;
 mod crash_recovery;
 mod recovery_pages;
 #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -34,16 +34,50 @@ use crate::state::AppState;
 #[cfg(target_os = "linux")]
 const PAINT_GATE_SAFETY_TIMEOUT_MS: i64 = 4000;
 
+/// Monotonic arm counter for the Linux paint gate. Each `on_load_end` call
+/// that (re-)arms a label's gate gets a fresh epoch; its safety-net timeout
+/// task captures that epoch and only acts if it's still current when the
+/// timeout fires (see `reveal_gated_window`). Mirrors the identical
+/// stale-timeout guard in `browser_pane::auth` (`NEXT_EPOCH`/`Entry::epoch`).
+#[cfg(target_os = "linux")]
+static PAINT_GATE_NEXT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Reveal (show + focus the real window, dismiss the native splash) once —
 /// whichever of the real `report_first_paint` IPC signal or the safety-net
 /// timeout fires first wins; the other becomes a no-op via the
-/// `linux_paint_gate_pending` membership check. Must run on the CEF UI thread.
+/// `linux_paint_gate_pending` membership check.
+///
+/// `expected_epoch`: `None` for the real-signal path (always reveal whatever
+/// is currently armed for `label` — a stale signal from a torn-down document
+/// can't fire; CEF cancels pending rAF/timers on navigation). `Some(epoch)`
+/// for the safety-timeout path — reveals only if `label`'s current arm is
+/// still the one this specific timeout was scheduled for; if `on_load_end`
+/// re-armed the gate since (reload/retry mid-startup), this stale timeout is
+/// a no-op instead of revealing the window ahead of the *current*
+/// navigation's real paint (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md,
+/// reagent PR #2151 review).
+///
+/// Must run on the CEF UI thread.
 #[cfg(target_os = "linux")]
-pub(crate) fn reveal_gated_window(state: &Arc<AppState>, label: &str, reason: &'static str) {
+pub(crate) fn reveal_gated_window(
+    state: &Arc<AppState>,
+    label: &str,
+    reason: &'static str,
+    expected_epoch: Option<u64>,
+) {
     let armed_at = {
         let mut pending = state.linux_paint_gate_pending.lock();
-        match pending.remove(label) {
-            Some(armed_at) => armed_at,
+        match pending.get(label) {
+            Some(&(armed_at, epoch)) => {
+                if expected_epoch.is_some_and(|expected| expected != epoch) {
+                    // A newer on_load_end call re-armed this label after this
+                    // timeout was scheduled — the newer arm's own timeout (or
+                    // the real signal) owns the reveal now.
+                    return;
+                }
+                pending.remove(label);
+                armed_at
+            }
             // Already revealed by the other path, or never armed (e.g. a pool
             // window — those don't go through this gate at all).
             None => return,
@@ -76,9 +110,14 @@ pub(crate) fn reveal_gated_window(state: &Arc<AppState>, label: &str, reason: &'
 
 #[cfg(target_os = "linux")]
 wrap_task! {
-    struct PaintGateRevealTask { state: Arc<AppState>, label: String, reason: &'static str }
+    struct PaintGateRevealTask {
+        state: Arc<AppState>,
+        label: String,
+        reason: &'static str,
+        expected_epoch: Option<u64>,
+    }
     impl Task { fn execute(&self) {
-        reveal_gated_window(&self.state, &self.label, self.reason);
+        reveal_gated_window(&self.state, &self.label, self.reason, self.expected_epoch);
     }}
 }
 
@@ -88,7 +127,7 @@ wrap_task! {
 /// `on_load_end` deferred it.
 #[cfg(target_os = "linux")]
 pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
-    let mut task = PaintGateRevealTask::new(state, label, "signal");
+    let mut task = PaintGateRevealTask::new(state, label, "signal", None);
     post_task(ThreadId::UI, Some(&mut task));
 }
 
@@ -247,14 +286,21 @@ impl AgentMuxHandler {
                         let gated = gate_label.is_some();
                         #[cfg(target_os = "linux")]
                         if let Some(label) = gate_label {
+                            // Fresh epoch per arm — see PAINT_GATE_NEXT_EPOCH
+                            // and reveal_gated_window's doc comment. Guards
+                            // against a reload/retry re-arming this same
+                            // label before this timeout fires.
+                            let epoch = PAINT_GATE_NEXT_EPOCH
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             self.state
                                 .linux_paint_gate_pending
                                 .lock()
-                                .insert(label.clone(), std::time::Instant::now());
+                                .insert(label.clone(), (std::time::Instant::now(), epoch));
                             let mut timeout_task = PaintGateRevealTask::new(
                                 self.state.clone(),
                                 label,
                                 "timeout",
+                                Some(epoch),
                             );
                             post_delayed_task(
                                 ThreadId::UI,

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -17,28 +17,45 @@ use crate::state::AppState;
 /// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
 ///
 /// Bound on how long the real window + native splash can stay hidden/up
-/// waiting for the frontend's first-paint signal before we show anyway. Chosen
-/// generously relative to the one-shot `MAX_GATE_MS` (800ms) reveal-gate
-/// pattern in `frontend/app/store/tab-reveal.ts` — this gate covers a coarser
-/// event (compositor's first frame) than that one (post-mount settle), so a
-/// slower budget avoids false-triggering on a merely-slow-but-healthy start.
+/// waiting for the frontend's first-paint signal before we show anyway.
+///
+/// Empirically (2026-07-14, verification run on the dev machine, a
+/// resource-shared sandbox running several concurrent CEF instances) the real
+/// double-rAF signal for the main window landed ~2.08s after `on_load_end`,
+/// and pool-window prewarms (unaffected by this gate, so this is a baseline
+/// reading of the environment's compositor-first-frame latency, not an
+/// artifact of the gate itself) landed 1.36-1.84s out. An earlier 1500ms cap
+/// fired *before* that real signal, silently degrading this fix to "always
+/// show after a fixed 1.5s delay" — strictly better than the original
+/// immediate-show bug, but not the intended "wait for real paint" behavior.
+/// Set well above the observed worst case so the real signal wins in
+/// practice; this only matters as a backstop against a genuinely stalled
+/// renderer (crashed JS, rAF never firing at all).
 #[cfg(target_os = "linux")]
-const PAINT_GATE_SAFETY_TIMEOUT_MS: i64 = 1500;
+const PAINT_GATE_SAFETY_TIMEOUT_MS: i64 = 4000;
 
 /// Reveal (show + focus the real window, dismiss the native splash) once —
 /// whichever of the real `report_first_paint` IPC signal or the safety-net
 /// timeout fires first wins; the other becomes a no-op via the
 /// `linux_paint_gate_pending` membership check. Must run on the CEF UI thread.
 #[cfg(target_os = "linux")]
-pub(crate) fn reveal_gated_window(state: &Arc<AppState>, label: &str) {
-    {
+pub(crate) fn reveal_gated_window(state: &Arc<AppState>, label: &str, reason: &'static str) {
+    let armed_at = {
         let mut pending = state.linux_paint_gate_pending.lock();
-        if !pending.remove(label) {
+        match pending.remove(label) {
+            Some(armed_at) => armed_at,
             // Already revealed by the other path, or never armed (e.g. a pool
             // window — those don't go through this gate at all).
-            return;
+            None => return,
         }
-    }
+    };
+    tracing::info!(
+        target: "startup-paint",
+        label = %label,
+        reason,
+        elapsed_ms = armed_at.elapsed().as_millis() as u64,
+        "[startup-paint] revealing gated window"
+    );
     if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
         if !path.is_empty() {
             let _ = std::fs::write(&path, b"ready");
@@ -59,9 +76,9 @@ pub(crate) fn reveal_gated_window(state: &Arc<AppState>, label: &str) {
 
 #[cfg(target_os = "linux")]
 wrap_task! {
-    struct PaintGateRevealTask { state: Arc<AppState>, label: String }
+    struct PaintGateRevealTask { state: Arc<AppState>, label: String, reason: &'static str }
     impl Task { fn execute(&self) {
-        reveal_gated_window(&self.state, &self.label);
+        reveal_gated_window(&self.state, &self.label, self.reason);
     }}
 }
 
@@ -71,7 +88,7 @@ wrap_task! {
 /// `on_load_end` deferred it.
 #[cfg(target_os = "linux")]
 pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
-    let mut task = PaintGateRevealTask::new(state, label);
+    let mut task = PaintGateRevealTask::new(state, label, "signal");
     post_task(ThreadId::UI, Some(&mut task));
 }
 
@@ -230,9 +247,15 @@ impl AgentMuxHandler {
                         let gated = gate_label.is_some();
                         #[cfg(target_os = "linux")]
                         if let Some(label) = gate_label {
-                            self.state.linux_paint_gate_pending.lock().insert(label.clone());
-                            let mut timeout_task =
-                                PaintGateRevealTask::new(self.state.clone(), label);
+                            self.state
+                                .linux_paint_gate_pending
+                                .lock()
+                                .insert(label.clone(), std::time::Instant::now());
+                            let mut timeout_task = PaintGateRevealTask::new(
+                                self.state.clone(),
+                                label,
+                                "timeout",
+                            );
                             post_delayed_task(
                                 ThreadId::UI,
                                 Some(&mut timeout_task),

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -9,6 +9,72 @@ use cef::*;
 
 use super::AgentMuxHandler;
 
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use crate::state::AppState;
+
+/// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
+///
+/// Bound on how long the real window + native splash can stay hidden/up
+/// waiting for the frontend's first-paint signal before we show anyway. Chosen
+/// generously relative to the one-shot `MAX_GATE_MS` (800ms) reveal-gate
+/// pattern in `frontend/app/store/tab-reveal.ts` — this gate covers a coarser
+/// event (compositor's first frame) than that one (post-mount settle), so a
+/// slower budget avoids false-triggering on a merely-slow-but-healthy start.
+#[cfg(target_os = "linux")]
+const PAINT_GATE_SAFETY_TIMEOUT_MS: i64 = 1500;
+
+/// Reveal (show + focus the real window, dismiss the native splash) once —
+/// whichever of the real `report_first_paint` IPC signal or the safety-net
+/// timeout fires first wins; the other becomes a no-op via the
+/// `linux_paint_gate_pending` membership check. Must run on the CEF UI thread.
+#[cfg(target_os = "linux")]
+pub(crate) fn reveal_gated_window(state: &Arc<AppState>, label: &str) {
+    {
+        let mut pending = state.linux_paint_gate_pending.lock();
+        if !pending.remove(label) {
+            // Already revealed by the other path, or never armed (e.g. a pool
+            // window — those don't go through this gate at all).
+            return;
+        }
+    }
+    if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
+        if !path.is_empty() {
+            let _ = std::fs::write(&path, b"ready");
+        }
+    }
+    let Some(mut browser) = state.get_browser(label) else { return };
+    if let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) {
+        if let Some(window) = bv.window() {
+            if window.is_visible() == 0 {
+                window.show();
+                if let Some(host) = browser.host() {
+                    host.set_focus(1);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+wrap_task! {
+    struct PaintGateRevealTask { state: Arc<AppState>, label: String }
+    impl Task { fn execute(&self) {
+        reveal_gated_window(&self.state, &self.label);
+    }}
+}
+
+/// Called off the UI thread (IPC handler for `report_first_paint`) once the
+/// frontend's double-`requestAnimationFrame` confirms the compositor actually
+/// presented a frame. Posts to the UI thread to reveal the window if
+/// `on_load_end` deferred it.
+#[cfg(target_os = "linux")]
+pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
+    let mut task = PaintGateRevealTask::new(state, label);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 impl AgentMuxHandler {
     /// CEF fires this whenever the browser's loading/history state changes
     /// (navigation started, navigation committed, back/forward enabled).
@@ -107,13 +173,21 @@ impl AgentMuxHandler {
             }
         }
 
-        // macOS/Linux analogue of the Win32 splash signal: the launcher owns the
-        // native splash (see agentmux-launcher/src/splash_mac.rs and splash_linux/)
-        // and passes a ready-file path via AGENTMUX_SPLASH_READY_FILE. Creating the
-        // file is the cross-process "first frame painted" signal the launcher polls
-        // for before tearing the splash down. Fire-and-forget; absent var => no
-        // launcher splash (e.g. dev:standalone), so this is a no-op.
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        // macOS analogue of the Win32 splash signal: the launcher owns the native
+        // splash (see agentmux-launcher/src/splash_mac.rs) and passes a ready-file
+        // path via AGENTMUX_SPLASH_READY_FILE. Creating the file is the
+        // cross-process "first frame painted" signal the launcher polls for before
+        // tearing the splash down. Fire-and-forget; absent var => no launcher
+        // splash (e.g. dev:standalone), so this is a no-op.
+        //
+        // Linux does NOT write it here. `on_load_end` fires per-browser on
+        // main-frame load-complete, including hidden pool-window prewarms — on
+        // Linux that could dismiss the splash before the real (visible) window
+        // has painted anything (the white-flash bug this gate fixes). Linux
+        // writes the ready-file from `reveal_gated_window` instead, gated on the
+        // same first-paint confirmation that unblocks the real window's show()
+        // below. See docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
+        #[cfg(target_os = "macos")]
         {
             if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
                 if !path.is_empty() {
@@ -142,10 +216,45 @@ impl AgentMuxHandler {
             if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {
                 if let Some(window) = bv.window() {
                     if window.is_visible() == 0 {
-                        window.show();
-                        if let Some(ref mut b) = browser_cloned {
-                            if let Some(host) = b.host() {
-                                host.set_focus(1);
+                        // Linux: defer the actual show()/focus (and the splash
+                        // dismiss above) until the frontend confirms a real
+                        // compositor paint, instead of doing it here on mere
+                        // load-complete — see reveal_gated_window and
+                        // docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
+                        // Falls back to the old immediate-show behavior if the
+                        // window label can't be resolved (can't gate safely on
+                        // an unknown label).
+                        #[cfg(target_os = "linux")]
+                        let gate_label = browser_label.clone();
+                        #[cfg(target_os = "linux")]
+                        let gated = gate_label.is_some();
+                        #[cfg(target_os = "linux")]
+                        if let Some(label) = gate_label {
+                            self.state.linux_paint_gate_pending.lock().insert(label.clone());
+                            let mut timeout_task =
+                                PaintGateRevealTask::new(self.state.clone(), label);
+                            post_delayed_task(
+                                ThreadId::UI,
+                                Some(&mut timeout_task),
+                                PAINT_GATE_SAFETY_TIMEOUT_MS,
+                            );
+                        }
+                        #[cfg(target_os = "linux")]
+                        if !gated {
+                            window.show();
+                            if let Some(ref mut b) = browser_cloned {
+                                if let Some(host) = b.host() {
+                                    host.set_focus(1);
+                                }
+                            }
+                        }
+                        #[cfg(not(target_os = "linux"))]
+                        {
+                            window.show();
+                            if let Some(ref mut b) = browser_cloned {
+                                if let Some(host) = b.host() {
+                                    host.set_focus(1);
+                                }
                             }
                         }
                     }

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -121,13 +121,45 @@ wrap_task! {
     }}
 }
 
+/// Handle the real `report_first_paint` signal on the UI thread. Two possible
+/// orderings against `on_load_end`, both handled:
+///
+/// - `on_load_end` already armed the gate (the common case) — reveal now.
+/// - `on_load_end` hasn't run yet for this label — CEF's main-frame
+///   load-complete isn't guaranteed to fire after first paint (render-blocking
+///   stylesheets can resolve, and a frame can be presented, before other
+///   load-blocking resources finish). Record the label in
+///   `linux_first_paint_seen` so `on_load_end` reveals immediately when it
+///   does arm, instead of silently dropping this signal and falling through
+///   to the slower safety timeout. Reagent PR #2151 second-round review.
+///
+/// Must run on the CEF UI thread.
+#[cfg(target_os = "linux")]
+pub(crate) fn handle_first_paint_signal(state: &Arc<AppState>, label: &str) {
+    let already_armed = state.linux_paint_gate_pending.lock().contains_key(label);
+    if already_armed {
+        reveal_gated_window(state, label, "signal", None);
+    } else {
+        state.linux_first_paint_seen.lock().insert(label.to_string());
+    }
+}
+
+#[cfg(target_os = "linux")]
+wrap_task! {
+    struct FirstPaintSignalTask { state: Arc<AppState>, label: String }
+    impl Task { fn execute(&self) {
+        handle_first_paint_signal(&self.state, &self.label);
+    }}
+}
+
 /// Called off the UI thread (IPC handler for `report_first_paint`) once the
 /// frontend's double-`requestAnimationFrame` confirms the compositor actually
 /// presented a frame. Posts to the UI thread to reveal the window if
-/// `on_load_end` deferred it.
+/// `on_load_end` already deferred it, or to record the signal for `on_load_end`
+/// to consume if it hasn't run yet (see `handle_first_paint_signal`).
 #[cfg(target_os = "linux")]
 pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
-    let mut task = PaintGateRevealTask::new(state, label, "signal", None);
+    let mut task = FirstPaintSignalTask::new(state, label);
     post_task(ThreadId::UI, Some(&mut task));
 }
 
@@ -286,27 +318,38 @@ impl AgentMuxHandler {
                         let gated = gate_label.is_some();
                         #[cfg(target_os = "linux")]
                         if let Some(label) = gate_label {
+                            // The real paint signal can race ahead of this
+                            // on_load_end call (see handle_first_paint_signal)
+                            // — if it already arrived, reveal immediately
+                            // instead of arming a gate + safety timeout for a
+                            // paint that already happened.
+                            let already_painted =
+                                self.state.linux_first_paint_seen.lock().remove(&label);
                             // Fresh epoch per arm — see PAINT_GATE_NEXT_EPOCH
                             // and reveal_gated_window's doc comment. Guards
                             // against a reload/retry re-arming this same
-                            // label before this timeout fires.
+                            // label before a timeout fires.
                             let epoch = PAINT_GATE_NEXT_EPOCH
                                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             self.state
                                 .linux_paint_gate_pending
                                 .lock()
                                 .insert(label.clone(), (std::time::Instant::now(), epoch));
-                            let mut timeout_task = PaintGateRevealTask::new(
-                                self.state.clone(),
-                                label,
-                                "timeout",
-                                Some(epoch),
-                            );
-                            post_delayed_task(
-                                ThreadId::UI,
-                                Some(&mut timeout_task),
-                                PAINT_GATE_SAFETY_TIMEOUT_MS,
-                            );
+                            if already_painted {
+                                reveal_gated_window(&self.state, &label, "signal-early", None);
+                            } else {
+                                let mut timeout_task = PaintGateRevealTask::new(
+                                    self.state.clone(),
+                                    label,
+                                    "timeout",
+                                    Some(epoch),
+                                );
+                                post_delayed_task(
+                                    ThreadId::UI,
+                                    Some(&mut timeout_task),
+                                    PAINT_GATE_SAFETY_TIMEOUT_MS,
+                                );
+                            }
                         }
                         #[cfg(target_os = "linux")]
                         if !gated {

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -386,3 +386,29 @@ pub fn set_window_init_status(state: &Arc<AppState>, args: &serde_json::Value) -
     }
     serde_json::Value::Null
 }
+
+/// First-paint signal from the frontend (Linux startup white-flash fix, see
+/// docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md). Sent via a
+/// double-`requestAnimationFrame` at the very top of `bootstrap.ts` — the
+/// earliest reliable proxy for "the compositor actually presented a frame",
+/// as opposed to CEF's `on_load_end` which only means "main-frame HTML
+/// finished loading" and can fire before anything has visually painted.
+///
+/// On Linux this unblocks the window `on_load_end` deferred (see
+/// `client::navigation::reveal_gated_window`). On other platforms it's
+/// currently just logged for telemetry — Windows/macOS aren't gated on it.
+pub fn report_first_paint(state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .unwrap_or("main")
+        .to_string();
+    tracing::info!(
+        target: "startup-paint",
+        label = %label,
+        "[startup-paint] frontend reported first paint"
+    );
+    #[cfg(target_os = "linux")]
+    crate::client::navigation::on_frontend_first_paint(state.clone(), label);
+    serde_json::Value::Null
+}

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -209,6 +209,7 @@ async fn route_command(
         "get_backend_endpoints" => commands::backend::get_backend_endpoints(state),
         "get_wave_init_opts" => commands::backend::get_wave_init_opts(state),
         "set_window_init_status" => Ok(commands::backend::set_window_init_status(state, args)),
+        "report_first_paint" => Ok(commands::backend::report_first_paint(state, args)),
         "fe_log" => Ok(commands::backend::fe_log(args)),
         "fe_log_structured" => Ok(commands::backend::fe_log_structured(args)),
 

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -560,9 +560,11 @@ pub struct AppState {
     /// Window labels whose native `window.show()`/focus + splash-ready-file has
     /// been deferred by `on_load_end` pending a real first-paint confirmation
     /// from the frontend (`report_first_paint` IPC command) or a safety-net
-    /// timeout, whichever fires first. Only populated/consumed on Linux; the
-    /// field exists unconditionally to keep `AppState` un-cfg'd.
-    pub linux_paint_gate_pending: Mutex<std::collections::HashSet<String>>,
+    /// timeout, whichever fires first. Value is when the gate was armed, so
+    /// `reveal_gated_window` can log how long the window actually stayed
+    /// hidden and via which path. Only populated/consumed on Linux; the field
+    /// exists unconditionally to keep `AppState` un-cfg'd.
+    pub linux_paint_gate_pending: Mutex<std::collections::HashMap<String, std::time::Instant>>,
 
     /// Phase B.5e — host's projection of the launcher's
     /// authoritative `state.instance_registry`. Fed by
@@ -1273,7 +1275,7 @@ impl Default for AppState {
             window_id: Mutex::new(None),
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
-            linux_paint_gate_pending: Mutex::new(std::collections::HashSet::new()),
+            linux_paint_gate_pending: Mutex::new(std::collections::HashMap::new()),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -560,11 +560,14 @@ pub struct AppState {
     /// Window labels whose native `window.show()`/focus + splash-ready-file has
     /// been deferred by `on_load_end` pending a real first-paint confirmation
     /// from the frontend (`report_first_paint` IPC command) or a safety-net
-    /// timeout, whichever fires first. Value is when the gate was armed, so
-    /// `reveal_gated_window` can log how long the window actually stayed
-    /// hidden and via which path. Only populated/consumed on Linux; the field
-    /// exists unconditionally to keep `AppState` un-cfg'd.
-    pub linux_paint_gate_pending: Mutex<std::collections::HashMap<String, std::time::Instant>>,
+    /// timeout, whichever fires first. Value is `(armed_at, epoch)` — `epoch`
+    /// guards against a stale safety-net timeout from an earlier `on_load_end`
+    /// call for the same label (e.g. a reload/retry mid-startup re-arms the
+    /// gate) firing at its original, now-too-early deadline and revealing the
+    /// window ahead of the *current* navigation's real paint. Mirrors the
+    /// epoch pattern in `browser_pane::auth`. Only populated/consumed on
+    /// Linux; the field exists unconditionally to keep `AppState` un-cfg'd.
+    pub linux_paint_gate_pending: Mutex<std::collections::HashMap<String, (std::time::Instant, u64)>>,
 
     /// Phase B.5e — host's projection of the launcher's
     /// authoritative `state.instance_registry`. Fed by

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -569,6 +569,19 @@ pub struct AppState {
     /// Linux; the field exists unconditionally to keep `AppState` un-cfg'd.
     pub linux_paint_gate_pending: Mutex<std::collections::HashMap<String, (std::time::Instant, u64)>>,
 
+    /// Linux startup white-flash fix, second-round race (reagent PR #2151
+    /// review): `report_first_paint` can reach the UI thread before
+    /// `on_load_end` arms `linux_paint_gate_pending` for the same label — CEF's
+    /// main-frame load-complete isn't guaranteed to fire after the frontend's
+    /// first compositor frame (render-blocking stylesheets can resolve, and a
+    /// frame can paint, before other load-blocking resources finish and
+    /// `on_load_end` runs). Labels land here when the signal arrives too
+    /// early; `on_load_end` checks this set before arming so it can reveal
+    /// immediately instead of falling through to the slower safety timeout.
+    /// Only populated/consumed on Linux; unconditional field for the same
+    /// reason as `linux_paint_gate_pending` above.
+    pub linux_first_paint_seen: Mutex<std::collections::HashSet<String>>,
+
     /// Phase B.5e — host's projection of the launcher's
     /// authoritative `state.instance_registry`. Fed by
     /// `Event::WindowInstanceAssigned` /
@@ -1279,6 +1292,7 @@ impl Default for AppState {
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
             linux_paint_gate_pending: Mutex::new(std::collections::HashMap::new()),
+            linux_first_paint_seen: Mutex::new(std::collections::HashSet::new()),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -556,6 +556,14 @@ pub struct AppState {
     /// Window initialization status ("ready" or "wave-ready")
     pub window_init_status: Mutex<String>,
 
+    /// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
+    /// Window labels whose native `window.show()`/focus + splash-ready-file has
+    /// been deferred by `on_load_end` pending a real first-paint confirmation
+    /// from the frontend (`report_first_paint` IPC command) or a safety-net
+    /// timeout, whichever fires first. Only populated/consumed on Linux; the
+    /// field exists unconditionally to keep `AppState` un-cfg'd.
+    pub linux_paint_gate_pending: Mutex<std::collections::HashSet<String>>,
+
     /// Phase B.5e — host's projection of the launcher's
     /// authoritative `state.instance_registry`. Fed by
     /// `Event::WindowInstanceAssigned` /
@@ -1265,6 +1273,7 @@ impl Default for AppState {
             window_id: Mutex::new(None),
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
+            linux_paint_gate_pending: Mutex::new(std::collections::HashSet::new()),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -12,10 +12,38 @@ import { initApp } from "./app-init";
 import { tryAutoRecover, clearStartupReloadCount } from "./app/init/error-display";
 import { benchMark } from "@/util/startup-bench";
 import { initPerf } from "@/perf";
+import { invokeCommand } from "@/app/platform/ipc";
 
 // Pipe all console.log/warn/error to the Rust host log file.
 // Must run before any other code so early messages are captured.
 initLogPipe();
+
+// ── First-paint signal (Linux startup white-flash fix) ──────────────────────
+// docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
+//
+// Tell the host the moment the browser has actually composited a frame — not
+// "main-frame load complete" (CEF's `on_load_end`, which can fire before
+// anything has visually painted and is what the host used to gate the native
+// window's show() on). Double rAF is the standard proxy for "a frame was
+// presented": the first callback runs before this frame is drawn, the second
+// only after it has been.
+//
+// Fired directly via invokeCommand() rather than getApi() — getApi() isn't
+// installed until setupCefApi()'s full IPC batch resolves, which can take
+// seconds on a slow start (see the spec's profiling numbers) and would be far
+// too late to gate the window's first show(). invokeCommand() only needs
+// `window.__AGENTMUX_IPC_PORT__`/`__AGENTMUX_IPC_TOKEN__`, which on a normal
+// (non-reload) launch are already present from the boot URL's query params —
+// no wait required. Harmless no-op outside CEF (invokeCommand rejects; caught
+// and ignored) and on platforms that don't gate on this signal (Windows/macOS
+// currently just log it).
+requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+        benchMark("frontend-painted");
+        const label = new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+        invokeCommand("report_first_paint", { label }).catch(() => {});
+    });
+});
 
 // Capture uncaught errors + unhandled promise rejections and forward
 // them via the same fe_log_structured IPC channel as the console pipe.


### PR DESCRIPTION
## Summary

Fixes #2146 — on Linux, the native window and launcher splash were shown/dismissed from `on_load_end` (CEF's main-frame *load-complete* event), not from an actual compositor paint. Windows/macOS got away with this; Linux's slower GPU/EGL init path exposed it as a blank/transparent window, a white flash, then the loading brain, then a brief blank moment again before settling.

- `frontend/bootstrap.ts`: fires a new `report_first_paint` IPC call on the second `requestAnimationFrame` after script start (the standard "a frame was actually presented" proxy), sent directly via `invokeCommand` rather than waiting on the slower `setupCefApi()` bridge.
- `agentmux-cef/src/client/navigation.rs`: on Linux only, `on_load_end` no longer shows/focuses the window or writes the splash-ready-file immediately. It arms a pending-gate entry + a safety-net timeout; the real reveal happens in `reveal_gated_window`, triggered by whichever of the paint signal or timeout fires first. Windows/macOS behavior is unchanged.
- `agentmux-cef/src/commands/backend.rs` / `ipc.rs` / `state.rs`: new `report_first_paint` command + `linux_paint_gate_pending` state (keyed by arm-time, so reveals log which path won and how long the window was gated).

Full diagnosis + profiling data: `docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md` (on the `docs/linux-startup-white-flash-spec` branch, not yet merged).

## Verification

Built + ran a fresh `task package:linux` AppImage twice:

1. First pass used a 1500ms safety timeout. Cross-referencing `on_load_end` and `report_first_paint` timestamps showed the real signal for the main window landing ~2.08s out (pool-window prewarms, unaffected by this gate, landed 1.36–1.84s out — confirming this is real compositor-first-frame latency in this environment, not an artifact of the change). The 1500ms cap fired *before* the real signal, silently degrading the fix to "always show after 1.5s" instead of waiting for real paint.
2. Widened the timeout to 4000ms and added reveal-path logging. Rebuilt, killed the stale same-version instance (single-instance pipe would've otherwise forwarded to it), relaunched fresh:

   ```
   [startup-paint] revealing gated window label=main reason=signal elapsed_ms=1487
   ```

   Confirms the window is now revealed by the real paint signal, not the timeout fallback. No errors in the host log; `startup-bench` shows `frontend-painted` firing before `isMainWindow-done`, i.e. the window reveals as soon as there's real content to show rather than waiting for full app boot.

`cargo check -p agentmux-cef` and `tsc --noEmit` both clean.

## Test plan

- [x] `cargo check -p agentmux-cef`
- [x] `tsc --noEmit`
- [x] Built `task package:linux`, verified via host log that `main` reveals via `reason=signal` not `reason=timeout`
- [ ] Manual visual confirmation on a real Linux desktop (this sandbox's screenshot tooling wasn't reliable for a before/after visual — log-based verification only)
- [ ] Windows/macOS smoke test to confirm no behavior change (code is `#[cfg(target_os = "linux")]`-gated, but worth a sanity check)

<!-- agentmux:agent_id=agentu -->