### PR TITLE
chore: release v0.53.5

### DIFF
--- a/.changesets/1783977814-feat-srv-swarm-subagent-lifecycle-diagnostics-muxlog-swarm-6hv2.md
+++ b/.changesets/1783977814-feat-srv-swarm-subagent-lifecycle-diagnostics-muxlog-swarm-6hv2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): swarm/subagent lifecycle diagnostics (muxlog swarm)

--- a/.changesets/1783977952-fix-srv-move-starter-skills-seeding-into-migrations-to-stop--lab7.md
+++ b/.changesets/1783977952-fix-srv-move-starter-skills-seeding-into-migrations-to-stop--lab7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): move starter Skills seeding into migrations to stop resurrecting deleted skills

--- a/.changesets/1783993847-fix-swarm-disambiguate-subagent-row-labels-when-slug-is-shar-ldwc.md
+++ b/.changesets/1783993847-fix-swarm-disambiguate-subagent-row-labels-when-slug-is-shar-ldwc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): disambiguate subagent row labels when slug is shared across a batch

--- a/.changesets/1783993912-fix-tabbar-tab-reorder-drag-never-initiates-nested-draggable-8vce.md
+++ b/.changesets/1783993912-fix-tabbar-tab-reorder-drag-never-initiates-nested-draggable-8vce.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabbar): tab reorder drag never initiates — nested draggable=false blocked pragmatic-dnd

--- a/.changesets/1783994468-fix-browser-pane-clip-the-pane-wrapper-hwnd-too-so-overlay-m-js3q.md
+++ b/.changesets/1783994468-fix-browser-pane-clip-the-pane-wrapper-hwnd-too-so-overlay-m-js3q.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): clip the pane-wrapper HWND too so overlay menus over panes accept hover/click on Windows

--- a/.changesets/1783994485-feat-mcp-seed-a-curated-set-of-credential-free-mcp-servers-i-tka4.md
+++ b/.changesets/1783994485-feat-mcp-seed-a-curated-set-of-credential-free-mcp-servers-i-tka4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): seed a curated set of credential-free MCP servers into the Armory catalog

--- a/.changesets/1783994551-fix-linux-gate-startup-window-show-splash-dismiss-on-real-fi-oy1y.md
+++ b/.changesets/1783994551-fix-linux-gate-startup-window-show-splash-dismiss-on-real-fi-oy1y.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(linux): gate startup window-show/splash-dismiss on real first paint, not load-complete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.53.4"
+version = "0.53.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.53.4"
+version = "0.53.5"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.53.4"
+version = "0.53.5"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.53.4"
+version = "0.53.5"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.53.4"
+version = "0.53.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.53.4"
+version = "0.53.5"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.53.4"
+version = "0.53.5"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,16 @@
 # AgentMux Version History
 
+## 0.53.5 — 2026-07-14
+
+- feat(srv): swarm/subagent lifecycle diagnostics (muxlog swarm)
+- fix(srv): move starter Skills seeding into migrations to stop resurrecting deleted skills
+- fix(swarm): disambiguate subagent row labels when slug is shared across a batch
+- fix(tabbar): tab reorder drag never initiates — nested draggable=false blocked pragmatic-dnd
+- fix(browser-pane): clip the pane-wrapper HWND too so overlay menus over panes accept hover/click on Windows
+- feat(mcp): seed a curated set of credential-free MCP servers into the Armory catalog
+- fix(linux): gate startup window-show/splash-dismiss on real first paint, not load-complete
+
+
 ## 0.53.4 — 2026-07-13
 
 - fix(pane): hole-punch mask click-through — CALayer masking doesn't affect AppKit hit testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.53.4",
+      "version": "0.53.5",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 7 pending changesets. **Forced patch bump** (`--as patch`)
per request, overriding the auto-computed `minor` (one queued changeset was
`feat`) — the mcp-seed feature ships under this patch version.

0.53.4 → 0.53.5

## Changes shipping

- feat(srv): swarm/subagent lifecycle diagnostics (muxlog swarm)
- fix(srv): move starter Skills seeding into migrations to stop resurrecting deleted skills
- fix(swarm): disambiguate subagent row labels when slug is shared across a batch
- fix(tabbar): tab reorder drag never initiates — nested draggable=false blocked pragmatic-dnd
- fix(browser-pane): clip the pane-wrapper HWND too so overlay menus over panes accept hover/click on Windows
- feat(mcp): seed a curated set of credential-free MCP servers into the Armory catalog
- fix(linux): gate startup window-show/splash-dismiss on real first paint, not load-complete

## Test plan

- [x] Release-consistency invariant verified: package.json, Cargo.toml,
      Cargo.lock, package-lock.json, and VERSION_HISTORY.md all agree at 0.53.5
- [x] All 7 changesets consumed and deleted

<!-- agentmux:agent_id=agenty -->