### PR TITLE
fix(providers): consolidate Claude CLI pin to 2.1.198 + drift-guard test

### DIFF
--- a/.changesets/1784045174-fix-providers-consolidate-claude-cli-pin-to-2-1-198-across-a-o53k.md
+++ b/.changesets/1784045174-fix-providers-consolidate-claude-cli-pin-to-2-1-198-across-a-o53k.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(providers): consolidate Claude CLI pin to 2.1.198 across all four registries + drift-guard test

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -7,9 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       claude_version:
+        # Keep in sync with the Claude pin in agentmux-srv/src/backend/providers.rs,
+        # agentmux-cef/src/commands/providers.rs, and
+        # frontend/app/view/agent/providers/index.ts — enforced by
+        # frontend/app/view/agent/providers/pin-consistency.test.ts.
         description: 'Claude Code version to pin (empty = latest)'
         required: false
-        default: '2.1.197'
+        default: '2.1.198'
 
 env:
   REGISTRY: ghcr.io

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -197,7 +197,11 @@ fn detect_cli(name: &str) -> CliDetectionResult {
 // INV-X (SPEC_PROVIDER_ISOLATION): agents MUST run the AgentMux-installed,
 // version-pinned binary; "latest" is never acceptable here because it bypasses
 // the repeatable-install guarantee and could pull in a breaking CLI version.
-const CLAUDE_VERSION: &str = "2.1.185";
+// Keep in sync with agentmux-srv/src/backend/providers.rs `pinned_version`,
+// frontend/app/view/agent/providers/index.ts `pinnedVersion`, and
+// .github/workflows/container-image.yml `claude_version` default — enforced by
+// frontend/app/view/agent/providers/pin-consistency.test.ts.
+const CLAUDE_VERSION: &str = "2.1.198";
 const CODEX_VERSION: &str = "0.116.0";
 const GEMINI_VERSION: &str = "0.32.1";
 

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -157,7 +157,10 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &["CLAUDECODE"],
     npm_package: "@anthropic-ai/claude-code",
-    // Keep in sync with frontend/app/view/agent/providers/index.ts `pinnedVersion`.
+    // Keep in sync with frontend/app/view/agent/providers/index.ts `pinnedVersion`,
+    // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and
+    // .github/workflows/container-image.yml `claude_version` default — enforced by
+    // frontend/app/view/agent/providers/pin-consistency.test.ts.
     pinned_version: "2.1.198",
     icon: "sparkles",
     docs_url: "https://docs.anthropic.com/claude-code",

--- a/docs/analysis/ANALYSIS_SUBAGENT_SPAWN_TAXONOMY_2026_07_14.md
+++ b/docs/analysis/ANALYSIS_SUBAGENT_SPAWN_TAXONOMY_2026_07_14.md
@@ -1,0 +1,297 @@
+# Subagent spawn taxonomy: every way a subagent can come into existence
+
+**Date:** 2026-07-14
+**Status:** Reference doc — informs Swarm pane data-model design, not itself a spec
+**Scope:** Every distinct shape a Claude Code CLI subagent-spawn can take, as
+observed in AgentMux's own code (`agentmux-srv/src/backend/subagent_watcher.rs`,
+`frontend/app/view/swarm/swarm-model.ts`) and as documented/confirmed by
+Anthropic's official Claude Code docs (`code.claude.com/docs/en/*`) and
+CHANGELOG.
+**Related:** `docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`,
+`docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`,
+`docs/specs/SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md`, memory
+`agentmux-swarm-duplicate-subagent-groups.md`.
+
+---
+
+## 0. Direct answer
+
+> "Can subagents be launched without a workflow, and without a batch?"
+
+**Yes.** A subagent can be dispatched entirely solo — one `Task`/`Agent`-tool
+call, no sibling calls in the same turn, no `subagents/workflows/<run-id>/`
+directory anywhere on disk. That's the baseline case (Shape A, §2.1 below).
+
+But the question bundles two independent axes that need separating:
+
+- **"Batch"** — did the CLI dispatch *multiple* subagents together?
+- **"Workflow"** — did that dispatch go through Anthropic's own scripted
+  **Dynamic workflows** feature, or was it ad-hoc/turn-by-turn?
+
+Crossing those two axes gives four real cells, plus a fifth axis (recursion
+depth) that's orthogonal to both:
+
+| | Solo (1 subagent) | Batch (2+ subagents) |
+|---|---|---|
+| **Ad-hoc (turn-by-turn)** | Shape A — loose singleton | Shape B — ad-hoc parallel batch (shared `slug`, no workflow dir) |
+| **Dynamic workflow (scripted)** | Shape C, 1-agent run | Shape C — workflow-tool batch (`subagents/workflows/<run-id>/`) |
+
+...and independently, **any** cell above can additionally be nested one or
+more levels deep (§2.4) — a subagent spawned under any of the four cells can
+itself dispatch further subagents, confirmed officially supported up to 5
+levels as of Claude Code v2.1.172+.
+
+So: yes to "no workflow," yes to "no batch," and those are two separate yeses,
+not one.
+
+---
+
+## 1. Terminology: "workflow" means three things — but two of the three may be the same thing
+
+This codebase's biggest self-inflicted confusion risk. Resolve all three
+before writing anything that says "workflow" out loud.
+
+**Meaning 1 — Claude Code CLI's own official "Dynamic workflows" feature.**
+Confirmed via Anthropic's primary docs (`code.claude.com/docs/en/workflows`,
+`code.claude.com/docs/en/agents`), requires CLI v2.1.154+: *"A dynamic
+workflow is a JavaScript script that orchestrates subagents at scale. Claude
+writes the script for the task you describe, and a runtime executes it in the
+background."* Scripts use `agent()`/`parallel()`/`pipeline()` primitives
+(concurrency cap ~16, 1,000-agent total ceiling per run), and — this is the
+load-bearing detail — *"Every run writes its script to a file under your
+session's directory in `~/.claude/projects/`."* This is the exact mechanism
+the `deep-research` workflow used to produce the research this doc is built
+on, and the exact mechanism this Claude session's own `Workflow` tool wraps.
+
+**Meaning 2 — AgentMux's own pipeline/canvas feature.** RFC'd internally as
+"Workflows" (GitHub issues #753, #832) but shipped as **Drone** specifically
+to avoid colliding with Meaning 1. Explicit quote,
+`SPEC_DRONE_CANVAS_NODE_EDITOR_2026_06_05.md:15`: *"'Workflows' is unrelated —
+that term now refers strictly to Claude's own workflows feature."* Evidenced
+by the legacy `db_workflow_definitions`/`db_workflow_runs` tables, now dropped
+and migrated into `db_drone_*`.
+
+**Meaning 3 — `GitHubContext.workflow_run_id`** (`agents.rs:193`) — GitHub
+Actions CI run correlation. Unrelated to subagents entirely, but the string
+"workflow" shows up in logs/code near agent context regardless, so it's a
+real grep-confusion risk.
+
+**The open question this doc cannot fully close without a live trace:**
+`subagent_watcher.rs`'s `parse_workflow_id()` derives `Some(<id>)` from a
+`subagents/workflows/<run-id>/` directory segment it finds on disk — pure
+filesystem observation, AgentMux never creates this structure itself. Given
+Meaning 1's confirmed behavior (*"every run writes its script to a file under
+your session's directory"*) and the fact that this session's own `Workflow`
+tool calls emit a `journal.jsonl` with *"one `{"type":"result",...}` line per
+completed agent"* — a structural match to what `subagent_watcher.rs` already
+parses — **the best-supported hypothesis is that Meaning 1 and the
+`subagents/workflows/<run-id>/` directory shape are the same thing**: what
+`subagent_watcher.rs` calls a "workflow batch" is very likely literally
+Anthropic's Dynamic Workflows feature's own on-disk output, not a separate,
+coincidentally-named convention. This was assumed-but-unconfirmed prior to
+this doc; it is now well-supported by primary sources but still not
+byte-for-byte verified against a live Dynamic-workflow run's directory tree.
+**Recommended follow-up:** trigger a `Workflow()` call from within an
+AgentMux-hosted session and confirm the resulting `subagents/workflows/<id>/`
+directory's `journal.jsonl` shape matches what `subagent_watcher.rs` expects,
+closing this out definitively.
+
+---
+
+## 2. The five real shapes
+
+### 2.1 Shape A — Loose / ad-hoc solo subagent
+
+One `Task`/`Agent`-tool call (renamed from `Task` to `Agent` in CLI v2.1.63;
+`Task(...)` still works as an alias), dispatched turn-by-turn with no siblings
+in the same turn. On disk: `subagents/agent-<id>.jsonl` directly —
+`parse_workflow_id()` returns `None`. `workflow_id: Option<String> = None` in
+`SubagentInfo`. This is the base case; nothing else needs to be true for a
+subagent to exist.
+
+Anthropic's own docs (`code.claude.com/docs/en/agents`) explicitly contrast
+this mode against Dynamic workflows in a comparison table: ad-hoc/turn-by-turn
+delegation vs. *"Dynamic workflows — a script that runs many subagents and
+cross-checks their results, for work too big to coordinate one turn at a time
+or that needs more than a single pass."* Ad-hoc dispatch has no official name
+of its own beyond "the Task/Agent tool used directly" — it's the default,
+undocumented-because-it's-the-baseline mode.
+
+### 2.2 Shape B — Ad-hoc parallel batch (no workflow dir, shared slug)
+
+Multiple `Task`/`Agent`-tool calls issued within the **same turn**, still with
+no `subagents/workflows/<id>/` directory — each subagent gets its own loose
+`subagents/agent-<id>.jsonl` file (still Shape A structurally on disk) — but
+the CLI-generated `slug` (a human-readable per-batch codename, read once from
+the first JSONL line, `subagent_watcher.rs:1223`) is **identical across every
+member of the batch**.
+
+This is **not an officially-named Anthropic concept.** No primary source in
+this doc's research confirms a first-party term for "several ad-hoc Task
+calls issued in the same turn." (Note: `/batch` — see §3 below — is a
+*different*, officially documented mechanism and should not be conflated with
+this.) This shape is an **empirical AgentMux-side finding**, established via
+live traces this session: the historical "flood" reports (`Mazs`: 13
+subagents, one slug; `Loap`: 45 events, mostly one slug) and the duplicate-
+label bug just fixed this session (`Lzop`: 17 `agent_id`s, one slug, ~50ms
+spawn window — PR #2149). Because it's unofficial and only observationally
+confirmed, **it should not be assumed stable across CLI versions** — the slug
+generation/sharing behavior could change without a changelog entry, since it
+isn't a documented contract.
+
+Currently `subagent_watcher.rs`/`swarm-model.ts` do **not** structurally group
+this shape. It falls into the general "loose" bucket, and is only
+coincidentally caught by the frontend's `NameGroup` heuristic (grouping loose
+subagents that share a Haiku-generated `display_name`) — a mechanism designed
+for something else entirely (cosmetic name-collision grouping) and not
+guaranteed to catch every batch member, since `display_name` resolution is
+per-subagent, lazy, and not derived from the shared `slug` at all.
+
+### 2.3 Shape C — Dynamic-workflow batch
+
+`subagents/workflows/<run-id>/agent-<id>.jsonl` + a `journal.jsonl` in the
+same `<run-id>/` directory. `parse_workflow_id()` returns `Some(<run-id>)`.
+This is the shape produced by (per the current best hypothesis in §1)
+Anthropic's own Dynamic Workflows feature — a script using `agent()`,
+`parallel()`, `pipeline()`. `WorkflowGroup` in `swarm-model.ts` is keyed on
+this `workflow_id`, with no minimum-member gate (a workflow of exactly 1
+`agent()` call still produces this directory shape, so "workflow" and
+"batch-of-2+" are not synonymous either — a 1-member workflow run is
+structurally Shape C, not Shape A, even though it superficially looks solo).
+
+A **stray** file sitting two segments deep directly in `subagents/workflows/`
+(not inside a further `<run-id>/` subdirectory) is explicitly excluded from
+Shape C by the existing test suite
+(`workflow_id_none_for_stray_file_in_workflows_dir`) — treated as malformed/
+incomplete rather than a real workflow member.
+
+### 2.4 Recursive / nested subagents — confirmed real, NOT tracked by AgentMux
+
+**This is the most important actionable finding in this doc.** Prior
+internal-only investigation (this session, before this doc) flagged
+recursive/grandchild subagent spawning as "unconfirmed/undesigned — inferred
+from reading the algorithm, not backed by any test, comment, or live trace."
+External research **upgrades this from unconfirmed to confirmed-and-shipping**:
+
+- CHANGELOG (`github.com/anthropics/claude-code/blob/main/CHANGELOG.md`),
+  verified via direct `curl` of the raw file, `## 2.1.172`: *"Sub-agents can
+  now spawn their own sub-agents (up to 5 levels deep)."*
+- `## 2.1.181`: *"forked subagents now count toward the depth cap"* — i.e.
+  the cap isn't just "5 calls deep," it accounts for forked/resumed subagent
+  chains too.
+- `## 2.1.208`: *"Fixed foreground subagents spawning unbounded nested
+  chains; they now respect the same 5-level depth limit as background..."* —
+  confirms the 5-level cap applies uniformly to both foreground and
+  background subagents, and that this was itself a bug fix (foreground
+  subagents briefly had *no* cap before this release).
+- Anthropic's own subagent docs (`code.claude.com/docs/en/sub-agents`):
+  *"As of Claude Code v2.1.172, a subagent can spawn its own subagents...
+  Depth is counted as [distance from the top-level turn]."*
+
+**AgentMux has zero code path for this.** `watch_agent()` is only ever
+installed for a top-level, AgentMux-registered agent — never re-installed for
+a subagent's own discovered `agent_id`. No `parent_subagent_id` field exists
+anywhere in `SubagentInfo` or the frontend model. `SPEC_SUBAGENT_LIFECYCLE_
+RECONCILIATION_2026_07_12.md`'s §5 core assumption ("a subagent's lifetime is
+bounded by its parent's own turn") is written entirely in terms of top-level-
+pane parentage and never contemplates a subagent-of-a-subagent.
+
+Practical consequence: if a top-level subagent (in any of Shapes A/B/C) uses
+its own delegated Task/Agent-tool call, **AgentMux currently has no way to
+observe, attribute, or display that grandchild subagent at all** — it's
+either silently invisible (if nothing walks that far into the filesystem
+tree) or, worse, could be misattributed as a sibling of its parent if the
+scanning logic doesn't distinguish directory depth carefully. This has not
+been observed as a live bug yet (no confirmed live trace exists either way in
+this environment), but it is now a **known, real gap against a shipping CLI
+capability**, not a hypothetical.
+
+### 2.5 Abandoned — a status overlay, not a spawn shape
+
+`SubagentStatus::Abandoned` is not a fifth way to spawn — it's a
+runtime-computed liveness overlay on top of Shapes A/B/C, set only by
+`reconcile_stale_subagents()`, called only from `scan_session_subagents()` on
+pane-reopen. Explicitly documented as reopen-time-only, not real-time, per
+`SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md` §9 Open Question 1.
+Listed here only to make explicit that it doesn't belong in the same
+conceptual bucket as A/B/C/nesting — don't design a sixth "spawn shape" box
+for it.
+
+---
+
+## 3. Adjacent mechanisms (mentioned for completeness, not currently relevant to AgentMux's swarm model)
+
+- **`/batch` skill** — officially documented
+  (`code.claude.com/docs/en/agents`): *"a skill that has Claude split one
+  large change into 5 to 30 worktree-isolated subagents that each open a pull
+  request. It's a packaged use of subagents and worktrees, not a separate
+  coordination style."* Distinct from Shape B/C: worktree-isolated, one PR
+  per subagent, invoked as a named skill rather than an ambient batch. Not
+  currently observed or specially handled anywhere in AgentMux — would
+  presumably show up as either Shape B or Shape C on disk depending on how
+  `/batch` itself dispatches internally (not confirmed by this research).
+- **"Background agents"** (`background: true` in agent definitions, `Ctrl+F`
+  to kill, introduced v2.1.49 per one GitHub-issue-sourced claim) — **lower
+  confidence**: sourced from a single blog/issue reference, not among the
+  25 adversarially-verified claims in this research pass. Worth a follow-up
+  look if background-agent-shaped activity is ever seen live, but not
+  asserted as confirmed here.
+  and one bug source: `github.com/anthropics/claude-code/issues/64898`.
+- **Hooks cannot spawn subagents** — per one GitHub-issue source (also
+  below the adversarial-verification bar used elsewhere in this doc): hooks
+  can return `additionalContext`, a permission decision, or a block, but
+  cannot dispatch a Task/Agent-tool call themselves. Listed for completeness
+  as a confirmed *non*-mechanism, worth re-checking if hook-triggered
+  subagent activity is ever reported.
+
+---
+
+## 4. Risk callout: the on-disk JSONL format is explicitly undocumented-as-stable
+
+Anthropic's own docs (`code.claude.com/docs/en/sessions`), directly
+contradicting the assumption underlying `subagent_watcher.rs`'s entire
+approach: *"The entry format is internal to Claude Code and changes between
+versions, so scripts that parse these files directly can break on any
+release. To build on session data, use `/export` or the script interfaces
+instead."* `subagent_watcher.rs` does exactly the thing this warns against —
+raw JSONL parsing of `subagents/agent-<id>.jsonl` and
+`subagents/workflows/<run-id>/journal.jsonl`. This isn't a defect (there's no
+alternative — AgentMux has to observe subagents somehow, and it's explicitly
+100%-observational by design, never triggering spawns itself), but it means
+**any CLI upgrade is a standing risk of silently breaking Swarm pane
+data**, not just a one-time integration cost. Worth a lightweight canary (a
+smoke test against a real subagent JSONL sample, re-run on CLI version bumps)
+rather than only reactive bug reports when it breaks.
+
+---
+
+## 5. Summary table
+
+| Shape | Filesystem signature | `workflow_id` | Batched? | Officially named? | AgentMux support |
+|---|---|---|---|---|---|
+| A — loose/solo | `subagents/agent-<id>.jsonl` | `None` | No | No (baseline/default mode) | Full |
+| B — ad-hoc parallel batch | Same as A, ×N, shared `slug` | `None` | Yes | **No** — empirical only | None (coincidental `NameGroup` catch only) |
+| C — dynamic-workflow batch | `subagents/workflows/<run-id>/…` + `journal.jsonl` | `Some(<run-id>)` | Usually (1-member workflows exist too) | **Yes** — Anthropic's "Dynamic workflows" | Full (`WorkflowGroup`) |
+| D — recursive/nested | (same as A/B/C, one level deeper in spawn ancestry) | inherits parent's | orthogonal axis | **Yes** — confirmed, depth ≤ 5 | **None** — no `parent_subagent_id`, no re-`watch_agent()` |
+| Abandoned | n/a — status overlay only | n/a | n/a | n/a | Reopen-time only, not real-time |
+
+---
+
+## 6. Implications for Swarm pane design (not a spec — flagging for the next design pass)
+
+- Treat "batch" (B/C) and "nesting depth" (D) as **orthogonal axes**, not one
+  taxonomy. A batch member can itself be nested; nesting can occur inside a
+  solo dispatch too.
+- Shape B needs its own grouping key, distinct from both `WorkflowGroup`
+  (`workflow_id`) and `NameGroup` (Haiku `display_name`) — likely the shared
+  `slug` scoped to same-parent-same-turn, now that it's understood as a
+  real, load-bearing signal rather than noise. This directly extends the
+  user's own proposal earlier this session ("show the slug as a Batch at the
+  top level") — correct for Shape B specifically, where it's the *only*
+  grouping signal available, even though it would be wrong as a *general*
+  batching key for Shape C (workflow_id is authoritative there).
+- Shape D (nesting) needs a `parent_subagent_id` field and a
+  `watch_agent()`-equivalent re-install step per discovered subagent before
+  the Swarm pane can claim "easy visibility into these," per the user's own
+  stated purpose for the pane — right now a grandchild subagent is a blind
+  spot, not merely an edge case.

--- a/docs/specs/SPEC_CLAUDE_CLI_PIN_CONTRACT_TESTS_2026_07_14.md
+++ b/docs/specs/SPEC_CLAUDE_CLI_PIN_CONTRACT_TESTS_2026_07_14.md
@@ -1,0 +1,122 @@
+# SPEC — CLI pin consolidation + contract tests against the pinned Claude CLI
+
+**Date:** 2026-07-14
+**Status:** Part A implemented (this PR); Parts B–D proposed
+**Motivation:** `docs/analysis/ANALYSIS_SUBAGENT_SPAWN_TAXONOMY_2026_07_14.md`
+§4 — Anthropic's own docs (`code.claude.com/docs/en/sessions`) state the JSONL
+transcript format "is internal to Claude Code and changes between versions, so
+scripts that parse these files directly can break on any release."
+`agentmux-srv/src/backend/subagent_watcher.rs` parses exactly those files, so
+**every CLI version bump is a standing risk of silently breaking the Swarm
+pane** (and anything else built on transcript observation). Today nothing
+verifies a new CLI version still emits what AgentMux expects — we find out
+from user-visible breakage.
+
+**Related:** `SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG_2026_07_02.md` (the pin
+bump whose "single-source-of-truth follow-up" Part A finally implements),
+`SPEC_PROVIDER_ISOLATION_2026_06_20.md` (INV-X: agents must run the pinned,
+AgentMux-installed binary).
+
+---
+
+## 1. Current state (pre-PR)
+
+The Claude CLI pin lived in **four places, already drifted three ways**:
+
+| Site | Pin (pre-PR) | Consumer |
+|---|---|---|
+| `agentmux-srv/src/backend/providers.rs` | 2.1.198 | srv-side npm install (`install_handlers.rs`) |
+| `frontend/app/view/agent/providers/index.ts` | 2.1.198 | install modal display + request |
+| `agentmux-cef/src/commands/providers.rs` | **2.1.185** (stale) | host-side installer |
+| `.github/workflows/container-image.yml` | **2.1.197** (stale) | Docker agent-image default |
+
+The 2026-07-02 bump updated the first two, missed the last two — exactly the
+drift trap that spec's follow-up item predicted. Additionally, the pin only
+governs the **install** flow; `agents/runner.rs` launches whatever `claude`
+resolves on PATH, so the pin is "the version we bless," not a runtime
+guarantee.
+
+## 2. Part A — pin consolidation (implemented in this PR)
+
+- Bump `agentmux-cef` `CLAUDE_VERSION` 2.1.185 → 2.1.198 and
+  `container-image.yml` default 2.1.197 → 2.1.198.
+- Cross-referencing keep-in-sync comments at all four sites.
+- **Drift guard:** `frontend/app/view/agent/providers/pin-consistency.test.ts`
+  — reads all four sites (TS registry by import, the two Rust registries and
+  the workflow YAML by source regex) and asserts equality for claude (all
+  four) and codex/gemini (the three registries). Also asserts pins are
+  concrete semvers, never `"latest"` (INV-X). Runs in the normal vitest suite
+  on every PR, so the next partial bump fails CI instead of shipping.
+
+A generated single-source file was considered and rejected for now: four sites
+span TS, two Rust crates, and workflow YAML; codegen plumbing costs more than
+the assertion test and the test fails equally loudly.
+
+## 3. Part B — recorded-fixture contract tests (proposed, offline, every PR)
+
+**Goal:** `subagent_watcher.rs`'s parsing assumptions are today encoded only as
+hand-built inline JSON in its test module — synthesized from memory of what
+the CLI emits, never validated against real output. Replace/augment with
+**recorded real transcripts** from the pinned CLI version.
+
+1. `scripts/record-cli-fixtures.sh` (dev-run, not CI): installs
+   `@anthropic-ai/claude-code@<pin>` into a temp prefix, runs it headless
+   (`--print`) in a scratch project with prompts crafted to produce each
+   taxonomy shape from `ANALYSIS_SUBAGENT_SPAWN_TAXONOMY_2026_07_14.md`:
+   - solo loose subagent (one Task/Agent call),
+   - ad-hoc parallel batch (2+ same-turn calls → shared `slug`, no workflow dir),
+   - dynamic-workflow run (`subagents/workflows/<id>/` + `journal.jsonl`),
+   - nested subagent (≥2 levels, supported since CLI 2.1.172).
+2. Sanitize (strip API-key-adjacent fields, normalize timestamps/ids where
+   they don't carry shape) and check in under
+   `agentmux-srv/tests/fixtures/cli/<version>/`.
+3. Rust contract tests feed the recorded files through the **real**
+   `subagent_watcher` parsing paths and assert the extracted
+   `SubagentInfo` fields (slug present, workflow_id Some/None per shape,
+   status transitions on `type:"result"`). These run in normal `cargo test` —
+   no network, no key, no flakiness.
+
+## 4. Part C — pin-bump-time live verification (proposed)
+
+The pin is the contract boundary, so the **PR that bumps the pin** must prove
+the new version. Process (documented in the bump checklist, enforced by
+review):
+
+1. Bump the pin (one logical change; drift test keeps the four sites honest).
+2. Re-run `scripts/record-cli-fixtures.sh` against the new version; commit the
+   regenerated fixtures alongside the bump.
+3. The Part B contract tests now run against the new recordings — a format
+   change surfaces as a red test **in the bump PR**, with the fixture diff
+   showing exactly what the CLI changed, before any user installs it.
+
+This is deliberately human-in-the-loop (like snapshot-test updates), because a
+shape change usually needs a code decision, not a mechanical accept.
+
+## 5. Part D — optional scheduled canary (proposed, alert-only)
+
+A nightly/weekly CI job installing `@anthropic-ai/claude-code@latest`,
+re-running the recording prompts with a real API key (CI secret), and diffing
+shapes against the pinned fixtures. Early warning that a *future* bump will
+hurt. Requirements that keep it honest: alert-only (never a merge gate — it's
+network-bound and nondeterministic), token budget cap, and normalization of
+known-nondeterministic fields (slugs, ids, timings) before diffing. Skip
+until Parts B/C exist; it's an optimization of lead time, not correctness.
+
+## 6. Non-goals
+
+- Runtime version enforcement (`runner.rs` refusing an unpinned PATH `claude`)
+  — a real gap but a product/UX decision (breaks users who intentionally
+  self-update), tracked separately from test infrastructure.
+- Contract tests for codex/gemini transcripts — same pattern applies later;
+  Claude is where the Swarm/subagent surface actually parses output today.
+
+## 7. Definition of done
+
+- **A (this PR):** four sites agree at 2.1.198; `pin-consistency.test.ts`
+  green; partial future bumps fail CI.
+- **B:** recorded fixtures for the four shapes checked in; `cargo test`
+  contract tests exercising real `subagent_watcher` parsing against them.
+- **C:** bump checklist documented; first pin bump after B lands regenerates
+  fixtures in the same PR.
+- **D (optional):** scheduled workflow with secret + budget cap, alerting via
+  GH issue on shape drift vs latest.

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -155,7 +155,10 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // stays alive for the paste. See docs / run_cli_login_pty.
         requiresLoginTty: true,
         npmPackage: "@anthropic-ai/claude-code",
-        // Keep in sync with agentmux-srv/src/backend/providers.rs `pinned_version`.
+        // Keep in sync with agentmux-srv/src/backend/providers.rs `pinned_version`,
+        // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and
+        // .github/workflows/container-image.yml `claude_version` default — enforced by
+        // ./pin-consistency.test.ts.
         pinnedVersion: "2.1.198",
         docsUrl: "https://docs.anthropic.com/claude-code",
         windowsInstallCommand: "irm https://claude.ai/install.ps1 | iex",

--- a/frontend/app/view/agent/providers/pin-consistency.test.ts
+++ b/frontend/app/view/agent/providers/pin-consistency.test.ts
@@ -1,0 +1,77 @@
+// Drift guard for CLI version pins duplicated across registries.
+//
+// The pinned CLI version for each npm-installed provider lives in FOUR
+// places that must agree (the follow-up SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG
+// §"Single-source-of-truth" recommended and this test implements):
+//
+//   1. frontend/app/view/agent/providers/index.ts   `pinnedVersion`
+//   2. agentmux-srv/src/backend/providers.rs        `pinned_version`
+//   3. agentmux-cef/src/commands/providers.rs       `CLAUDE_VERSION` etc.
+//   4. .github/workflows/container-image.yml        `claude_version` default
+//      (claude only — the container image is a Claude agent image)
+//
+// History: the 2026-07-02 pin bump (2.1.185 → 2.1.198) updated #1 and #2 but
+// missed #3 and #4, leaving the host-side installer 13 patch versions behind
+// the srv-side installer for the same provider. This test makes the next
+// missed site a CI failure instead of a silent drift.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PROVIDERS } from "./index";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+
+function read(rel: string): string {
+    return readFileSync(resolve(repoRoot, rel), "utf8");
+}
+
+/** Extract `pinned_version: "X"` from a named `static NAME: ProviderConfig` block. */
+function srvPin(source: string, staticName: string): string {
+    const m = source.match(
+        new RegExp(`static ${staticName}: ProviderConfig = ProviderConfig \\{[\\s\\S]*?pinned_version: "([^"]*)"`)
+    );
+    if (!m) throw new Error(`pinned_version not found for static ${staticName} in agentmux-srv providers.rs`);
+    return m[1];
+}
+
+/** Extract `const NAME: &str = "X";` from the cef host installer. */
+function cefPin(source: string, constName: string): string {
+    const m = source.match(new RegExp(`const ${constName}: &str = "([^"]+)";`));
+    if (!m) throw new Error(`const ${constName} not found in agentmux-cef providers.rs`);
+    return m[1];
+}
+
+describe("CLI pin consistency across registries", () => {
+    const srvSource = read("agentmux-srv/src/backend/providers.rs");
+    const cefSource = read("agentmux-cef/src/commands/providers.rs");
+
+    // provider key in PROVIDERS → [srv static name, cef const name]
+    const registries: Array<[keyof typeof PROVIDERS & string, string, string]> = [
+        ["claude", "CLAUDE", "CLAUDE_VERSION"],
+        ["codex", "CODEX", "CODEX_VERSION"],
+        ["gemini", "GEMINI", "GEMINI_VERSION"],
+    ];
+
+    for (const [key, srvStatic, cefConst] of registries) {
+        it(`${key}: frontend, srv, and cef installer pins agree`, () => {
+            const tsPin = PROVIDERS[key]?.pinnedVersion;
+            expect(tsPin, `PROVIDERS.${key}.pinnedVersion missing`).toBeTruthy();
+            expect(srvPin(srvSource, srvStatic), `srv pin for ${key}`).toBe(tsPin);
+            expect(cefPin(cefSource, cefConst), `cef host pin for ${key}`).toBe(tsPin);
+        });
+    }
+
+    it("claude: container-image.yml workflow default agrees", () => {
+        const yml = read(".github/workflows/container-image.yml");
+        const m = yml.match(/claude_version:[\s\S]*?default: '([^']+)'/);
+        if (!m) throw new Error("claude_version default not found in container-image.yml");
+        expect(m[1]).toBe(PROVIDERS.claude.pinnedVersion);
+    });
+
+    it("pins are concrete versions, not 'latest' (repeatable-install invariant)", () => {
+        for (const [key] of registries) {
+            expect(PROVIDERS[key].pinnedVersion, `${key} must be a concrete semver pin`).toMatch(/^\d+\.\d+\.\d+$/);
+        }
+    });
+});


### PR DESCRIPTION
## Problem

The Claude CLI version pin lived in **four places that had drifted three ways**:

| Site | Pin (before) |
|---|---|
| `agentmux-srv/src/backend/providers.rs` | 2.1.198 |
| `frontend/app/view/agent/providers/index.ts` | 2.1.198 |
| `agentmux-cef/src/commands/providers.rs` | **2.1.185 (stale)** |
| `.github/workflows/container-image.yml` default | **2.1.197 (stale)** |

The 2026-07-02 bump (SPEC_AGENT_MODEL_DROPDOWN_CLI_PIN_LOG) updated the first two and missed the last two — the exact drift trap that spec's own "single-source-of-truth follow-up" item predicted and recommended a sync test for. That follow-up was never done; this PR does it.

## Changes

- Bump `agentmux-cef` `CLAUDE_VERSION` 2.1.185 → 2.1.198; `container-image.yml` default 2.1.197 → 2.1.198
- **New drift guard** `frontend/app/view/agent/providers/pin-consistency.test.ts` (runs in the normal vitest suite): asserts all four sites agree for claude, the three registries agree for codex/gemini, and that pins are concrete semvers (never `"latest"` — INV-X repeatable-install invariant). A future partial bump fails CI instead of shipping.
- Cross-referencing keep-in-sync comments at all four sites
- `docs/specs/SPEC_CLAUDE_CLI_PIN_CONTRACT_TESTS_2026_07_14.md` — Part A is this PR; Parts B–D propose recorded-fixture contract tests for `subagent_watcher.rs`'s JSONL parsing (Anthropic's docs explicitly state the transcript format can break on any release) and pin-bump-time live verification
- `docs/analysis/ANALYSIS_SUBAGENT_SPAWN_TAXONOMY_2026_07_14.md` — the motivating taxonomy of subagent spawn shapes (solo / ad-hoc shared-slug batch / dynamic-workflow / nested), cross-referenced from the swarm duplicate-label work (#2149)

## Verification

- `npx vitest run frontend/app/view/agent/providers/pin-consistency.test.ts` — 5/5 pass
- Rust changes are a const string bump + comments only

<!-- agentmux:agent_id=agenta-07017 -->