### PR TITLE
feat(diags): muxlog auth subcommand + logout-path auth logging

### DIFF
--- a/.changesets/1784056916-feat-diags-muxlog-auth-subcommand-logout-path-auth-logging-8xb6.md
+++ b/.changesets/1784056916-feat-diags-muxlog-auth-subcommand-logout-path-auth-logging-8xb6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(diags): muxlog auth subcommand + logout-path auth logging

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -350,6 +350,7 @@ const HELP = `muxlog — AgentMux log viewer
   muxlog errors                      ERROR/WARN across host+srv (active instance)
   muxlog bridge                      startup-handshake trace (debug reconnect loops)
   muxlog swarm                       subagent/swarm lifecycle trace (spawn/name/status, debug duplicate groups)
+  muxlog auth                        provider auth/identity trace (login/OAuth wiring/unlink/account removal)
 
 Options (any position):
   -i <substr>   pick the instance whose log path/branch/version matches <substr>
@@ -391,6 +392,25 @@ function main() {
         opt.target = opt.target || "subagent_watcher";
         const f = resolveFile("srv", opt);
         console.log(`=== swarm trace: ${f} ===`);
+        printLastLines(f, opt.n, opt, true);
+        return;
+    }
+    if (cmd === "auth") {
+        // Provider auth / identity lifecycle trace. Unlike `swarm` (one module
+        // → one tracing target), auth events span several srv modules —
+        // server/identity_handlers.rs (auth.start/spawn/poll/cancel/submit*,
+        // "auth success (direct-account)" persistence, OAuth config-dir
+        // wiring), server/cli_handlers.rs (CheckCliAuth, "claude auth:"
+        // credential seeding), identity/auth_session.rs (cancel_session,
+        // session timeout), identity/resolver.rs ("oauth probe"), and the
+        // logout side in server/app_api/identity.rs + agent_handlers/
+        // identity.rs ("identity.unlink:", "identity.delete:") — so filter on
+        // the MESSAGE vocabulary, not a target (opt.grep matches the message
+        // field only, exactly what we want). A user --grep overrides the
+        // recipe's regex; --target/--level/--since/-n still combine.
+        opt.grep = opt.grep || /\bauth\.\w+|auth success|auth session|cancel_session|claude auth|CheckCliAuth|OAuth config dir|oauth probe|identity_upsert|identity\.(unlink|delete|self\.|account)|account\.oauth|keychain delete/i;
+        const f = resolveFile("srv", opt);
+        console.log(`=== auth trace: ${f} ===`);
         printLastLines(f, opt.n, opt, true);
         return;
     }

--- a/agentmux-srv/src/server/agent_handlers/identity.rs
+++ b/agentmux-srv/src/server/agent_handlers/identity.rs
@@ -409,7 +409,11 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // If this account stored its secret in the OS keychain, drop
                 // it too so no orphaned credential survives the DB row.
                 // `keyring` is blocking, so run it via spawn_blocking.
-                if let Ok(Some(acct)) = wstore.identity_get(&cmd.id) {
+                // Capture provider before the row is deleted so the logout-
+                // side log line (below) can carry it.
+                let acct = wstore.identity_get(&cmd.id).ok().flatten();
+                let provider = acct.as_ref().map(|a| a.provider.clone()).unwrap_or_default();
+                if let Some(acct) = &acct {
                     if matches!(acct.secret_ref, SecretRef::Keychain { .. }) {
                         let aid = cmd.id.clone();
                         let res = tokio::task::spawn_blocking(move || {
@@ -417,14 +421,28 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         })
                         .await
                         .unwrap_or_else(|je| Err(format!("join: {je}")));
-                        if let Err(e) = res {
-                            tracing::warn!(target: "identity", "keychain delete for {} failed: {e}", cmd.id);
+                        match res {
+                            // info!, not debug!: the production filter is
+                            // "agentmuxsrv=info,info" (reagent P1, PR #2143).
+                            // "identity.delete:" is `muxlog auth` vocabulary.
+                            Ok(()) => tracing::info!(
+                                account_id = %cmd.id,
+                                provider = %provider,
+                                "identity.delete: keychain secret removed"
+                            ),
+                            Err(e) => tracing::warn!(target: "identity", "keychain delete for {} failed: {e}", cmd.id),
                         }
                     }
                 }
                 let deleted = wstore
                     .identity_delete(&cmd.id)
                     .map_err(|e| format!("deleteidentityaccount: {e}"))?;
+                tracing::info!(
+                    account_id = %cmd.id,
+                    provider = %provider,
+                    deleted,
+                    "identity.delete: account removed (deleteidentityaccount)"
+                );
                 if deleted {
                     broker.publish(crate::backend::wps::WaveEvent {
                         event: "identityaccounts:changed".to_string(),
@@ -479,6 +497,15 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let removed = wstore
                     .agent_identity_unlink(&cmd.agent_id, &cmd.provider)
                     .map_err(|e| format!("unlinkagentidentity: {e}"))?;
+                // info!, not debug!: the production filter is
+                // "agentmuxsrv=info,info" (reagent P1, PR #2143).
+                // "identity.unlink:" is `muxlog auth` vocabulary.
+                tracing::info!(
+                    agent_id = %cmd.agent_id,
+                    provider = %cmd.provider,
+                    unlinked = removed,
+                    "identity.unlink: agent-identity link removed (unlinkagentidentity)"
+                );
                 if removed {
                     broker.publish(crate::backend::wps::WaveEvent {
                         event: format!("agentidentities:changed:{}", cmd.agent_id),

--- a/agentmux-srv/src/server/app_api/identity.rs
+++ b/agentmux-srv/src/server/app_api/identity.rs
@@ -274,9 +274,13 @@ fn register_identity_self_unlink(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // is part of the `muxlog auth` vocabulary — keep it stable.
                 // `unlinked == false` (no link row matched) is logged too:
                 // a silent no-op unlink is exactly what an auth stress run
-                // needs to see.
+                // needs to see. Both ids logged: link rows are keyed on
+                // def_id, not the S1 slug (the historical silent-no-op bug
+                // noted above) — a bad slug→def_id resolution is only
+                // visible if the log carries both.
                 tracing::info!(
                     agent_id = %req.agent_id,
+                    def_id = %def_id,
                     provider = %req.provider,
                     unlinked,
                     "identity.unlink: self-service provider unlink (identity.self.unlink)"

--- a/agentmux-srv/src/server/app_api/identity.rs
+++ b/agentmux-srv/src/server/app_api/identity.rs
@@ -268,6 +268,19 @@ fn register_identity_self_unlink(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let unlinked = id_store
                     .agent_identity_unlink(&def_id, &req.provider)
                     .map_err(|e| format!("identity.self.unlink: {e}"))?;
+                // info!, not debug!: the production filter is
+                // "agentmuxsrv=info,info" — debug lines never reach the log
+                // (reagent P1 on PR #2143). Message prefix "identity.unlink:"
+                // is part of the `muxlog auth` vocabulary — keep it stable.
+                // `unlinked == false` (no link row matched) is logged too:
+                // a silent no-op unlink is exactly what an auth stress run
+                // needs to see.
+                tracing::info!(
+                    agent_id = %req.agent_id,
+                    provider = %req.provider,
+                    unlinked,
+                    "identity.unlink: self-service provider unlink (identity.self.unlink)"
+                );
                 if unlinked {
                     broker.publish(crate::backend::wps::WaveEvent {
                         event: format!("agentidentities:changed:{}", req.agent_id),

--- a/docs/MUXLOG.md
+++ b/docs/MUXLOG.md
@@ -20,6 +20,7 @@ muxlog srv          # follow the active sidecar log
 muxlog bridge       # startup-handshake trace — debug "Can't reconnect" loops
 muxlog errors       # just the ERROR/WARN lines across host + sidecar
 muxlog swarm        # subagent/swarm lifecycle trace — spawn/name/status, debug duplicate groups
+muxlog auth         # provider auth/identity trace — login, OAuth dir wiring, unlink/logout
 muxlog help         # full usage
 ```
 
@@ -82,6 +83,7 @@ muxlog srv --since 2026-06-15T23:30 cat        # a time window
 | `muxlog errors` | ERROR + WARN across the active host and sidecar |
 | `muxlog bridge` | the startup handshake — `Loading URL`, `Injected IPC …`, `backend-ready`, `window.api`, `Bootstrap failed` — correlated in time, so a reconnect loop is obvious at a glance |
 | `muxlog swarm` | subagent/swarm lifecycle — spawn, `display_name` resolution (`subagent.GenerateName`), status transitions (`reconcile_stale_subagents`' active→abandoned pass), and the `parent_block_id`/`session_id`/`workflow_id` each event carries — filters the sidecar log to `subagent_watcher.rs`'s tracing target so a duplicate-group or stuck-status report is diagnosable from logs alone (srv-side only; there's no host-side subagent logging to combine in) |
+| `muxlog auth` | provider auth / identity lifecycle — the login flow (`auth.start` / `auth.spawn` child start+exit / `auth.cancel`), OAuth config-dir wiring, `auth success (direct-account)` persistence, `CheckCliAuth` + the one-time `claude auth:` credential import, and the logout side (`identity.unlink:` provider unlinks, `identity.delete:` account + keychain removal). Auth events span multiple srv modules, so this filters on the **message** vocabulary rather than a tracing target — pass your own `--grep` to override, or combine `--since`/`--level`/`-i` as usual. Ideal for repeated login/logout stress runs |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a one-command diagnostic trace for provider auth ahead of repeated Claude Code login/logout stress testing, and closes the logout-side auth logging gap.

Mirrors the `muxlog swarm` pattern from PR #2143 — including its reagent P1 lesson: all new lifecycle logging uses `tracing::info!`, **not** `debug!`, because the default production filter (`agentmuxsrv=info,info`) makes debug lines invisible.

### Part 1 — `muxlog auth` recipe

- New subcommand in `agentmux-srv/src/backend/shellintegration/muxlog.mjs`, following the `swarm`/`bridge` recipe shape (`=== auth trace: <file> ===` header, `printLastLines(..., whole=true)`).
- Key difference from `swarm`: swarm filters by a single tracing target (`subagent_watcher`); auth events span multiple srv modules (`server/identity_handlers.rs`, `server/cli_handlers.rs`, `server/app_api/identity.rs`, `server/agent_handlers/identity.rs`, `identity/auth_session.rs`, `identity/resolver.rs`), so the recipe filters on the **message** vocabulary via `opt.grep` (which matches the message field only):

  ```
  /\bauth\.\w+|auth success|auth session|cancel_session|claude auth|CheckCliAuth|OAuth config dir|oauth probe|identity_upsert|identity\.(unlink|delete|self\.|account)|account\.oauth|keychain delete/i
  ```

  Regex built from the vocabulary that actually exists in the Rust sources (`auth.start`/`auth.spawn`/`auth.cancel`, `auth success (direct-account)`, OAuth config-dir wiring, `CheckCliAuth`, the `claude auth:` one-time credential import, `oauth probe`/`identity_upsert` persistence failures) plus the new logout prefixes below. A user `--grep` overrides the recipe regex; `--since`/`--level`/`--target`/`-i`/`-n` still combine.
- Documented in the muxlog HELP text and `docs/MUXLOG.md` (quick start + recipes table), same as #2143 did for swarm.

### Part 2 — logout/unlink logging gap

The login side logged richly; the logout side logged only `identity.self.unlink: {e}` errors. Added `tracing::info!` with structured fields (provider, agent_id, account_id — identifiers and outcomes only, never tokens/keys) at each logout-side success path, with stable message prefixes (`identity.unlink:` / `identity.delete:`) covered by the filter regex:

| Path | Log line |
|---|---|
| `identity.self.unlink` (`server/app_api/identity.rs`) | `identity.unlink: self-service provider unlink (identity.self.unlink)` — logs `unlinked` true/false so silent no-op unlinks are visible |
| `unlinkagentidentity` (`server/agent_handlers/identity.rs`) | `identity.unlink: agent-identity link removed (unlinkagentidentity)` |
| `deleteidentityaccount` (`server/agent_handlers/identity.rs`) | `identity.delete: account removed (deleteidentityaccount)` + `identity.delete: keychain secret removed`; provider is captured before the row is deleted |

## Verification

- `cargo check -p agentmux-srv` passes (pre-existing warnings only)
- `node agentmux-srv/src/backend/shellintegration/muxlog.mjs help` prints the new `auth` line; `muxlog auth` runs clean against the live srv log
- Regex unit-verified against the full known message vocabulary (all 20 known auth/logout messages match; no false positives on e.g. "author"/"unauthorized"/transcript noise)
- No muxlog tests exist to break (`tools/**` is vitest-excluded; muxlog has no test file)

Follow-up to #2143 — same recipe pattern, applied to the auth domain.

<!-- agentmux:agent_id=agenta-07017 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)