### PR TITLE
fix(accounts): OAuth accounts crashed the Accounts detail modal (unmapped oauth_config_dir SecretRef)

### DIFF
--- a/.changesets/1784058517-fix-accounts-oauth-accounts-crashed-the-accounts-detail-moda-b8qp.md
+++ b/.changesets/1784058517-fix-accounts-oauth-accounts-crashed-the-accounts-detail-moda-b8qp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(accounts): OAuth accounts crashed the Accounts detail modal (unmapped oauth_config_dir SecretRef)

--- a/frontend/app/view/identity/identity-model.test.ts
+++ b/frontend/app/view/identity/identity-model.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 // shim. Keep them un-exported in the module so callers don't depend on
 // them, but expose for tests via `__internal__`.
 import * as identityModel from "./identity-model";
+import { __internal__ } from "./identity-model";
 import type { Account } from "./identity-model";
 
 // The helpers aren't re-exported; we round-trip through the public API
@@ -70,6 +71,40 @@ describe("identity-model SecretRef field-name translation", () => {
         // Different field name confirms why naked casts between the two
         // shapes are unsafe — caught by reagent in PR #480.
         expect((wireSecret as unknown as { value?: string }).value).toBeUndefined();
+    });
+
+    it("oauth_config_dir: maps to a defined SecretRef (regression: OAuth accounts crashed the Accounts detail modal)", () => {
+        // Live repro 2026-07-14: a Claude OAuth login persists a backend
+        // SecretRef::OAuthConfigDir, which secretRefFromBackend's switch
+        // didn't handle — it fell through and returned `undefined`, so
+        // opening the account in Armory → Accounts threw
+        // "Cannot read properties of undefined (reading 'backend')".
+        const wire = { backend: "oauth_config_dir", dir: "C:\\Users\\x\\.agentmux\\shared\\identities\\abc\\claude" } as const;
+        const fe = __internal__.secretRefFromBackend(wire);
+        expect(fe).toBeDefined();
+        expect(fe.backend).toBe("oauth_config_dir");
+        expect(fe.dir).toBe(wire.dir);
+
+        // Round-trip back to the wire shape.
+        const back = __internal__.secretRefToBackend(fe);
+        expect(back).toEqual(wire);
+    });
+
+    it("every backend SecretRef variant maps to a defined frontend SecretRef", () => {
+        // Exhaustiveness net: if the Rust enum grows another variant and
+        // gotypes/this module lag, the specific new variant can't be listed
+        // here yet — but every *known* variant must at minimum round-trip
+        // to a defined object, and the view additionally guards with `?.`.
+        const wires: Parameters<typeof __internal__.secretRefFromBackend>[0][] = [
+            { backend: "env", env_var: "X" },
+            { backend: "secrets_manager", sm_path: "p" },
+            { backend: "plaintext_dev", plaintext_dev: "v" },
+            { backend: "keychain", service: "s", account: "a" },
+            { backend: "oauth_config_dir", dir: "d" },
+        ];
+        for (const w of wires) {
+            expect(__internal__.secretRefFromBackend(w), `variant ${w.backend}`).toBeDefined();
+        }
     });
 
     it("module exports expected public surface", () => {

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -22,7 +22,7 @@ export type AccountStatus = "valid" | "expired" | "invalid" | "unknown" | "check
 export type IdentityTab = "accounts" | "assignments";
 
 export interface SecretRef {
-    backend: "env" | "secrets_manager" | "plaintext_dev" | "keychain";
+    backend: "env" | "secrets_manager" | "plaintext_dev" | "keychain" | "oauth_config_dir";
     env_var?: string;
     sm_path?: string;
     sm_json_path?: string;
@@ -32,6 +32,9 @@ export interface SecretRef {
     // specs/archive/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
     service?: string;
     account?: string;
+    // oauth_config_dir only — the provider CLI's per-account config dir.
+    // Tokens live in that dir (owned/refreshed by the CLI), never here.
+    dir?: string;
 }
 
 export interface AccountContext {
@@ -206,6 +209,8 @@ function secretRefFromBackend(s: IdentityAccount["secret_ref"]): SecretRef {
             return { backend: "plaintext_dev", value: s.plaintext_dev };
         case "keychain":
             return { backend: "keychain", service: s.service, account: s.account };
+        case "oauth_config_dir":
+            return { backend: "oauth_config_dir", dir: s.dir };
     }
 }
 
@@ -227,6 +232,8 @@ function secretRefToBackend(s: SecretRef): IdentityAccount["secret_ref"] {
             return { backend: "plaintext_dev", plaintext_dev: s.value ?? "" };
         case "keychain":
             return { backend: "keychain", service: s.service ?? "", account: s.account ?? "" };
+        case "oauth_config_dir":
+            return { backend: "oauth_config_dir", dir: s.dir ?? "" };
     }
 }
 
@@ -499,3 +506,8 @@ export class IdentityViewModel implements ViewModel {
         this._unsubAccounts = null;
     }
 }
+
+// Test-only hook for the (deliberately un-exported) SecretRef translators —
+// the pattern identity-model.test.ts's header asks for. Not part of the
+// public surface; do not import outside tests.
+export const __internal__ = { secretRefFromBackend, secretRefToBackend };

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -209,12 +209,12 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                     before `oauth_config_dir` was mapped). */}
                 <DetailField label="Backend" value={account.secret_ref?.backend ?? "unknown"} />
                 <Show when={account.secret_ref?.env_var}>
-                    <DetailField label="Env var" value={account.secret_ref.env_var!} />
+                    <DetailField label="Env var" value={account.secret_ref?.env_var ?? ""} />
                 </Show>
                 <Show when={account.secret_ref?.sm_path}>
                     <DetailField
                         label="Secrets Manager"
-                        value={`${account.secret_ref.sm_path}${account.secret_ref.sm_json_path ? ` → ${account.secret_ref.sm_json_path}` : ""}`}
+                        value={`${account.secret_ref?.sm_path ?? ""}${account.secret_ref?.sm_json_path ? ` → ${account.secret_ref.sm_json_path}` : ""}`}
                     />
                 </Show>
                 <Show when={account.secret_ref?.backend === "plaintext_dev"}>
@@ -227,7 +227,7 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                 <Show when={account.secret_ref?.backend === "oauth_config_dir"}>
                     <DetailField label="Stored in" value="Provider CLI config dir (tokens owned by the CLI)" />
                     <Show when={account.secret_ref?.dir}>
-                        <DetailField label="Config dir" value={account.secret_ref.dir!} />
+                        <DetailField label="Config dir" value={account.secret_ref?.dir ?? ""} />
                     </Show>
                 </Show>
 
@@ -269,7 +269,7 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                         Reauth
                     </button>
                 </Show>
-                <Show when={account.status === "unknown" && account.secret_ref.backend === "keychain"}>
+                <Show when={account.status === "unknown" && account.secret_ref?.backend === "keychain"}>
                     <button class="identity-btn identity-btn-primary" onClick={() => model.openEditForm(account)}>
                         Validate…
                     </button>
@@ -410,11 +410,11 @@ export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Elemen
     const [provider, setProvider] = createSignal<AccountProvider>(editing()?.provider ?? preset?.provider ?? "github");
     const [kind, setKind] = createSignal<AccountKind>(editing()?.kind ?? preset?.kind ?? "pat");
     const [displayName, setDisplayName] = createSignal(editing()?.display_name ?? "");
-    const [secretBackend, setSecretBackend] = createSignal<SecretRef["backend"]>(editing()?.secret_ref.backend ?? "keychain");
-    const [secretEnvVar, setSecretEnvVar] = createSignal(editing()?.secret_ref.env_var ?? "");
-    const [secretSmPath, setSecretSmPath] = createSignal(editing()?.secret_ref.sm_path ?? "");
-    const [secretSmJsonPath, setSecretSmJsonPath] = createSignal(editing()?.secret_ref.sm_json_path ?? "");
-    const [secretValue, setSecretValue] = createSignal(editing()?.secret_ref.value ?? "");
+    const [secretBackend, setSecretBackend] = createSignal<SecretRef["backend"]>(editing()?.secret_ref?.backend ?? "keychain");
+    const [secretEnvVar, setSecretEnvVar] = createSignal(editing()?.secret_ref?.env_var ?? "");
+    const [secretSmPath, setSecretSmPath] = createSignal(editing()?.secret_ref?.sm_path ?? "");
+    const [secretSmJsonPath, setSecretSmJsonPath] = createSignal(editing()?.secret_ref?.sm_json_path ?? "");
+    const [secretValue, setSecretValue] = createSignal(editing()?.secret_ref?.value ?? "");
     // Context
     const [ghUsername, setGhUsername] = createSignal(editing()?.context.github_username ?? "");
     const [ghScopes, setGhScopes] = createSignal(editing()?.context.github_scopes?.join(", ") ?? "");
@@ -432,7 +432,7 @@ export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Elemen
     // in the OS keychain and returns only a masked tail + metadata — it is
     // never read back into the UI. Existing keychain accounts render locked
     // (masked) and require Replace to re-enter.
-    const editingIsKeychain = editing()?.secret_ref.backend === "keychain";
+    const editingIsKeychain = editing()?.secret_ref?.backend === "keychain";
     const [keychainKey, setKeychainKey] = createSignal("");
     const [keyBusy, setKeyBusy] = createSignal(false);
     const [keyError, setKeyError] = createSignal<string | null>(null);
@@ -498,8 +498,8 @@ export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Elemen
             // Preserve the existing keychain pointer (service/account) so a
             // metadata-only Save on a locked account doesn't drop it. New
             // keychain accounts go through the key flow, not this path.
-            secretRef.service = editing()?.secret_ref.service;
-            secretRef.account = editing()?.secret_ref.account;
+            secretRef.service = editing()?.secret_ref?.service;
+            secretRef.account = editing()?.secret_ref?.account;
         }
 
         const context = buildContext();

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -203,22 +203,32 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                 <DetailField label="Kind" value={KIND_LABELS[account.kind]} />
 
                 <div class="identity-detail-section">Secret</div>
-                <DetailField label="Backend" value={account.secret_ref.backend} />
-                <Show when={account.secret_ref.env_var}>
+                {/* `?.` guards throughout: an account whose secret_ref shape the
+                    frontend doesn't know yet must degrade to "unknown", not crash
+                    the pane (live repro 2026-07-14: OAuth accounts crashed here
+                    before `oauth_config_dir` was mapped). */}
+                <DetailField label="Backend" value={account.secret_ref?.backend ?? "unknown"} />
+                <Show when={account.secret_ref?.env_var}>
                     <DetailField label="Env var" value={account.secret_ref.env_var!} />
                 </Show>
-                <Show when={account.secret_ref.sm_path}>
+                <Show when={account.secret_ref?.sm_path}>
                     <DetailField
                         label="Secrets Manager"
                         value={`${account.secret_ref.sm_path}${account.secret_ref.sm_json_path ? ` → ${account.secret_ref.sm_json_path}` : ""}`}
                     />
                 </Show>
-                <Show when={account.secret_ref.backend === "plaintext_dev"}>
+                <Show when={account.secret_ref?.backend === "plaintext_dev"}>
                     <DetailField label="Value" value="••••••••••••" />
                 </Show>
-                <Show when={account.secret_ref.backend === "keychain"}>
+                <Show when={account.secret_ref?.backend === "keychain"}>
                     <DetailField label="Stored in" value="OS keychain" />
                     <DetailField label="Key" value={account.context.masked_tail ?? "••••••••"} />
+                </Show>
+                <Show when={account.secret_ref?.backend === "oauth_config_dir"}>
+                    <DetailField label="Stored in" value="Provider CLI config dir (tokens owned by the CLI)" />
+                    <Show when={account.secret_ref?.dir}>
+                        <DetailField label="Config dir" value={account.secret_ref.dir!} />
+                    </Show>
                 </Show>
 
                 <Show when={account.context.github_username}>

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -320,7 +320,12 @@ declare global {
         | { backend: "plaintext_dev"; plaintext_dev: string }
         // Armory API keys: pointer into the OS keychain. Plaintext is
         // never carried here. See specs/archive/SPEC_TRUST_CENTER_2026_06_15.md §7/§12.2.
-        | { backend: "keychain"; service: string; account: string };
+        | { backend: "keychain"; service: string; account: string }
+        // OAuth credentials as a filesystem pointer: the provider CLI reads
+        // its tokens from this dir at spawn time; agentmux holds only the
+        // path. See SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md and the Rust
+        // SecretRef::OAuthConfigDir variant (storage/identities.rs).
+        | { backend: "oauth_config_dir"; dir: string };
 
     type IdentityAccount = {
         id: string;


### PR DESCRIPTION
## Bug (live repro during auth stress-testing)

Logging in to Claude Code via OAuth persists an account whose `secret_ref` is the Rust `SecretRef::OAuthConfigDir` variant (`storage/identities.rs` — a filesystem pointer to the per-account CLI config dir; tokens are owned by the CLI, never stored). The frontend's `secretRefFromBackend()` switch (identity-model.ts) only mapped the four api-key-style backends (`env`/`secrets_manager`/`plaintext_dev`/`keychain`), so an OAuth account's `secret_ref` mapped to `undefined` — and clicking the account in **Armory → Accounts** threw:

```
TypeError: Cannot read properties of undefined (reading 'backend')
    at identity-view.tsx DetailField
```

killing the pane. Side effect visible in srv logs: the crashed renderer's WS consumer stalls → `eventbus` "ws egress lane full … dropping event" bursts.

## Fix

- `oauth_config_dir` added to both frontend `SecretRef` types (`gotypes.d.ts` union + `identity-model.ts` loose shape) and both translators (`secretRefFromBackend`/`secretRefToBackend`)
- Detail modal renders it: "Stored in: Provider CLI config dir (tokens owned by the CLI)" + the dir path
- All `secret_ref` reads in the modal guarded with `?.` — a future unmapped variant degrades to Backend: "unknown" instead of crashing the Accounts pane
- `__internal__` test hook added (the pattern identity-model.test.ts's own header asks for) + regression tests: the exact oauth_config_dir round-trip, plus an all-known-variants-map-to-defined net

## Verification

- `npx vitest run frontend/app/view/identity/identity-model.test.ts` — 5/5 pass (2 new)
- `npx tsc --noEmit` clean
- Hot-reloaded into the live dev instance where the crash reproduced

<!-- agentmux:agent_id=agenta-07017 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)