### PR TITLE
fix(identity): cascade links + remove OAuth token dir on account delete (auth-lifecycle gap, layer 1)

### DIFF
--- a/.changesets/1784060643-fix-identity-cascade-links-bindings-remove-oauth-token-dir-o-hdz2.md
+++ b/.changesets/1784060643-fix-identity-cascade-links-bindings-remove-oauth-token-dir-o-hdz2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): cascade links/bindings + remove OAuth token dir on account delete

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -119,6 +119,18 @@ pub struct AgentIdentityLink {
     pub provider: String,
 }
 
+/// What [`Store::identity_delete`] removed — the account row plus the
+/// cascaded `db_agent_identity_links` junction rows. Consumed by the
+/// `deleteidentityaccount` handler for `identity.delete:` logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IdentityDeleteOutcome {
+    /// True iff the `db_accounts` row existed and was deleted.
+    pub deleted: bool,
+    /// Number of `db_agent_identity_links` rows removed in the same
+    /// transaction.
+    pub links_cascaded: usize,
+}
+
 impl Store {
     // ---- Identity account CRUD ----
 
@@ -258,10 +270,35 @@ impl Store {
         Ok(())
     }
 
-    pub fn identity_delete(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute("DELETE FROM db_accounts WHERE id = ?1", params![id])?;
-        Ok(rows > 0)
+    /// Delete an identity account AND every `db_agent_identity_links`
+    /// row referencing it, atomically (single transaction under the
+    /// connection lock).
+    ///
+    /// The cascade is EXPLICIT even though the current DDL carries
+    /// `FOREIGN KEY (account_id) … ON DELETE CASCADE`: databases whose
+    /// links table arrived via legacy `ALTER TABLE … RENAME` (forge era)
+    /// never got the FK clause retrofitted — `CREATE TABLE IF NOT EXISTS`
+    /// can't alter an existing table — so on real user databases the
+    /// DDL-level cascade silently doesn't exist and dangling links
+    /// survive the account row (auth-lifecycle gap §2.4,
+    /// `docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md`).
+    /// `db_identity_bindings` (named by the report) was retired in Phase
+    /// 4c and no longer exists; links are the sole junction on accounts.
+    pub fn identity_delete(&self, id: &str) -> Result<IdentityDeleteOutcome, StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        // Links first, so the count is exact even on fresh databases
+        // where the FK cascade would otherwise race this delete.
+        let links_cascaded = tx.execute(
+            "DELETE FROM db_agent_identity_links WHERE account_id = ?1",
+            params![id],
+        )?;
+        let rows = tx.execute("DELETE FROM db_accounts WHERE id = ?1", params![id])?;
+        tx.commit()?;
+        Ok(IdentityDeleteOutcome {
+            deleted: rows > 0,
+            links_cascaded,
+        })
     }
 
     // ---- Agent ↔ Identity junction ----
@@ -347,4 +384,167 @@ impl Store {
         Ok(out)
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::super::store::{AgentDefinition, Store};
+    use super::*;
+
+    fn sample_account(id: &str, provider: &str) -> IdentityAccount {
+        IdentityAccount {
+            id: id.to_string(),
+            name: format!("asaf-{provider}"),
+            provider: provider.to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir {
+                dir: format!("/var/agentmux/identities/{id}/claude"),
+            },
+            context: serde_json::json!({}),
+            status: "ok".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    fn sample_agent(id: &str, slug: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: slug.to_string(),
+            name: id.to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+        }
+    }
+
+    fn count_links_for_account(store: &Store, account_id: &str) -> i64 {
+        let conn = store.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT count(*) FROM db_agent_identity_links WHERE account_id = ?1",
+            params![account_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    /// Recreate `db_agent_identity_links` in the LEGACY shape: no
+    /// `FOREIGN KEY (account_id) … ON DELETE CASCADE`. This is the shape a
+    /// production `store.db`/`objects.db` still has when the table arrived
+    /// via `ALTER TABLE … RENAME` from the forge era —
+    /// `CREATE TABLE IF NOT EXISTS` never retrofits FK clauses onto an
+    /// existing table, so the DDL-level cascade only exists on fresh
+    /// databases. `identity_delete` must therefore cascade EXPLICITLY
+    /// rather than lean on the FK (the account-delete auth-lifecycle gap,
+    /// docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md §2.4).
+    fn strip_links_fk(store: &Store) {
+        let conn = store.conn.lock().unwrap();
+        conn.execute_batch(
+            "DROP TABLE db_agent_identity_links;
+             CREATE TABLE db_agent_identity_links (
+                agent_id   TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                provider   TEXT NOT NULL,
+                PRIMARY KEY (agent_id, provider)
+             );",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn identity_delete_cascades_links_on_legacy_no_fk_schema() {
+        let store = Store::open_in_memory().unwrap();
+        strip_links_fk(&store);
+        store
+            .identity_upsert(&sample_account("acct-1", "anthropic"))
+            .unwrap();
+        store
+            .agent_identity_link("ag1", "acct-1", "anthropic")
+            .unwrap();
+        assert_eq!(count_links_for_account(&store, "acct-1"), 1);
+
+        let out = store.identity_delete("acct-1").unwrap();
+
+        assert!(store.identity_get("acct-1").unwrap().is_none());
+        assert_eq!(
+            count_links_for_account(&store, "acct-1"),
+            0,
+            "junction row must not survive the account row (dangling link)"
+        );
+        assert!(out.deleted);
+        assert_eq!(out.links_cascaded, 1, "explicit cascade must report the link row");
+
+        // Second delete is a no-op on both tables.
+        let again = store.identity_delete("acct-1").unwrap();
+        assert!(!again.deleted);
+        assert_eq!(again.links_cascaded, 0);
+    }
+
+    #[test]
+    fn identity_delete_cascades_links_on_current_schema() {
+        // Fresh schema — the DDL-level FK cascade also exists here; the
+        // explicit cascade must coexist with it (and still report the row).
+        let store = Store::open_in_memory().unwrap();
+        let mut agent = sample_agent("ag1", "agent-x");
+        store.agent_def_insert(&mut agent).unwrap();
+        store
+            .identity_upsert(&sample_account("acct-1", "anthropic"))
+            .unwrap();
+        store
+            .agent_identity_link("ag1", "acct-1", "anthropic")
+            .unwrap();
+
+        let out = store.identity_delete("acct-1").unwrap();
+
+        assert!(store.identity_get("acct-1").unwrap().is_none());
+        assert_eq!(count_links_for_account(&store, "acct-1"), 0);
+        assert!(out.deleted);
+        assert_eq!(
+            out.links_cascaded, 1,
+            "explicit cascade runs before the FK cascade, so the count is exact"
+        );
+    }
+
+    /// The analysis report (§2.4) names `db_identity_bindings` as a second
+    /// cascade target. That table was retired in Phase 4c of
+    /// SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md and is DROPPED by the
+    /// schema (`DEAD_TABLE_DROPS`) — `db_agent_identity_links` is the sole
+    /// junction referencing `db_accounts.id`. Pin that here so the cascade
+    /// in `identity_delete` is provably complete.
+    #[test]
+    fn identity_bindings_table_is_retired() {
+        let store = Store::open_in_memory().unwrap();
+        let conn = store.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master
+                 WHERE type='table' AND name IN ('db_identity_bindings', 'db_identity_bundles')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "retired bundle-binding tables must not exist");
+    }
 }

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -478,10 +478,10 @@
     fn test_identity_delete() {
         let store = v6_test_store();
         store.identity_upsert(&sample_account("id-gh", "github")).unwrap();
-        assert!(store.identity_delete("id-gh").unwrap());
+        assert!(store.identity_delete("id-gh").unwrap().deleted);
         assert!(store.identity_get("id-gh").unwrap().is_none());
         // Second delete is a no-op.
-        assert!(!store.identity_delete("id-gh").unwrap());
+        assert!(!store.identity_delete("id-gh").unwrap().deleted);
     }
 
     #[test]

--- a/agentmux-srv/src/identity/cleanup.rs
+++ b/agentmux-srv/src/identity/cleanup.rs
@@ -1,0 +1,333 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-disk / keychain credential cleanup for a deleted identity account.
+//!
+//! Layer 1 of the account-delete auth-lifecycle remediation
+//! (`docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md`
+//! §4 option 1): deleting an account row must not leave its credential
+//! material behind. Two secret backends carry on-host state:
+//!
+//! - `SecretRef::Keychain` — delete the OS-keychain entry (moved here
+//!   from the inline block in the `deleteidentityaccount` handler).
+//! - `SecretRef::OAuthConfigDir { dir }` — the CLI's live access +
+//!   refresh tokens sit in that directory; remove the tree. This is
+//!   best-effort and **containment-guarded**: the dir is only removed
+//!   when it resolves INSIDE the agentmux identities root
+//!   (`~/.agentmux/shared/identities/`). The legacy `~/.claude`
+//!   migration case (and any other ambient/global CLI dir) is the
+//!   user's own login — log and skip, never delete.
+//!
+//! Other variants (`Env`, `SecretsManager`, `PlaintextDev`) hold no
+//! agentmux-owned on-host state → no-op.
+//!
+//! All log lines use the `identity.delete:` prefix so they land in the
+//! `muxlog auth` vocabulary (regex `identity\.(unlink|delete|self\.|account)`),
+//! and use `info!`/`warn!` — the production filter is
+//! "agentmuxsrv=info,info", so `debug!` would be invisible (reagent P1,
+//! PR #2143). Provider-side token revocation (running the CLI's own
+//! `logout` against the dir before deleting) is an explicit follow-up —
+//! it needs per-provider subprocess plumbing this module doesn't have.
+
+use std::path::{Path, PathBuf};
+
+use crate::backend::storage::store::{IdentityAccount, SecretRef};
+
+/// What `cleanup_account_secrets` did, for callers/tests to assert on.
+/// Logging already happened inside the function.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SecretCleanup {
+    /// Keychain entry removed (or was already absent — idempotent).
+    KeychainRemoved,
+    /// Keychain delete failed (logged as warn; account delete proceeds).
+    KeychainFailed(String),
+    /// OAuth config dir tree removed.
+    OAuthDirRemoved(PathBuf),
+    /// OAuth config dir was already gone — nothing to remove.
+    OAuthDirAbsent(PathBuf),
+    /// OAuth config dir NOT removed: it does not resolve inside the
+    /// agentmux identities root (e.g. the legacy `~/.claude` migration
+    /// account), or the root itself could not be resolved/canonicalized.
+    OAuthDirSkipped { dir: PathBuf, reason: String },
+    /// OAuth config dir removal failed (fs error; logged as warn).
+    OAuthDirFailed { dir: PathBuf, error: String },
+    /// Secret backend holds no agentmux-owned on-host state.
+    NoOp,
+}
+
+/// Best-effort removal of the on-host credential material behind
+/// `acct.secret_ref`. Never returns `Err` — account deletion must not be
+/// blocked by cleanup trouble; every outcome is logged.
+///
+/// `identities_root` is the agentmux identities root
+/// (`DataPaths::identities_dir()`), `None` when `DataPaths::from_env()`
+/// could not resolve (CI / unusual envs) — OAuth dirs are then skipped,
+/// never guessed. Blocking (keyring + fs) — call via `spawn_blocking`
+/// from async contexts.
+pub fn cleanup_account_secrets(
+    acct: &IdentityAccount,
+    identities_root: Option<&Path>,
+) -> SecretCleanup {
+    match &acct.secret_ref {
+        SecretRef::Keychain { .. } => match crate::identity::secret_store::delete(&acct.id) {
+            Ok(()) => {
+                tracing::info!(
+                    account_id = %acct.id,
+                    provider = %acct.provider,
+                    "identity.delete: keychain secret removed"
+                );
+                SecretCleanup::KeychainRemoved
+            }
+            Err(e) => {
+                tracing::warn!(
+                    account_id = %acct.id,
+                    provider = %acct.provider,
+                    error = %e,
+                    "identity.delete: keychain secret delete failed"
+                );
+                SecretCleanup::KeychainFailed(e)
+            }
+        },
+        SecretRef::OAuthConfigDir { dir } => cleanup_oauth_dir(acct, Path::new(dir), identities_root),
+        SecretRef::Env { .. } | SecretRef::SecretsManager { .. } | SecretRef::PlaintextDev { .. } => {
+            SecretCleanup::NoOp
+        }
+    }
+}
+
+fn cleanup_oauth_dir(
+    acct: &IdentityAccount,
+    dir: &Path,
+    identities_root: Option<&Path>,
+) -> SecretCleanup {
+    let skip = |reason: String| -> SecretCleanup {
+        tracing::warn!(
+            account_id = %acct.id,
+            provider = %acct.provider,
+            dir = %dir.display(),
+            reason = %reason,
+            "identity.delete: oauth config dir outside data root — skipped"
+        );
+        SecretCleanup::OAuthDirSkipped { dir: dir.to_path_buf(), reason }
+    };
+
+    let root = match identities_root {
+        Some(r) => r,
+        None => return skip("identities root unresolved (DataPaths::from_env() = None)".into()),
+    };
+    if !dir.exists() {
+        // Nothing on disk — already clean (e.g. the CLI never wrote tokens).
+        tracing::info!(
+            account_id = %acct.id,
+            provider = %acct.provider,
+            dir = %dir.display(),
+            "identity.delete: oauth config dir already absent"
+        );
+        return SecretCleanup::OAuthDirAbsent(dir.to_path_buf());
+    }
+    // Canonicalize BOTH sides so `..` segments, symlinks, and Windows
+    // `\\?\` prefixes can't defeat the containment check.
+    let canon_root = match std::fs::canonicalize(root) {
+        Ok(p) => p,
+        Err(e) => return skip(format!("identities root not canonicalizable: {e}")),
+    };
+    let canon_dir = match std::fs::canonicalize(dir) {
+        Ok(p) => p,
+        Err(e) => return skip(format!("dir not canonicalizable: {e}")),
+    };
+    // Strictly inside the root — refuse the root itself and anything
+    // outside it (the legacy `~/.claude` migration dir lands here).
+    if canon_dir == canon_root || !canon_dir.starts_with(&canon_root) {
+        return skip(format!(
+            "resolved path {} is not strictly inside identities root {}",
+            canon_dir.display(),
+            canon_root.display()
+        ));
+    }
+    match std::fs::remove_dir_all(&canon_dir) {
+        Ok(()) => {
+            tracing::info!(
+                account_id = %acct.id,
+                provider = %acct.provider,
+                dir = %dir.display(),
+                "identity.delete: oauth config dir removed"
+            );
+            SecretCleanup::OAuthDirRemoved(dir.to_path_buf())
+        }
+        Err(e) => {
+            tracing::warn!(
+                account_id = %acct.id,
+                provider = %acct.provider,
+                dir = %dir.display(),
+                error = %e,
+                "identity.delete: oauth config dir removal failed"
+            );
+            SecretCleanup::OAuthDirFailed { dir: dir.to_path_buf(), error: e.to_string() }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acct_with(secret_ref: SecretRef) -> IdentityAccount {
+        IdentityAccount {
+            id: "acct-test".to_string(),
+            name: "asaf-anthropic".to_string(),
+            provider: "anthropic".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref,
+            context: serde_json::json!({}),
+            status: "ok".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    /// OAuthConfigDir inside the identities root → tree removed.
+    #[test]
+    fn oauth_dir_inside_data_root_is_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        let dir = root.join("acct-test").join("claude");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".credentials.json"), "{}").unwrap();
+
+        let acct = acct_with(SecretRef::OAuthConfigDir {
+            dir: dir.to_string_lossy().to_string(),
+        });
+        let out = cleanup_account_secrets(&acct, Some(&root));
+
+        assert!(matches!(out, SecretCleanup::OAuthDirRemoved(_)), "got {out:?}");
+        assert!(!dir.exists(), "token dir must be gone");
+        // The account's parent folder under the root may remain; only the
+        // configured dir tree is removed.
+        assert!(root.exists(), "identities root itself must survive");
+    }
+
+    /// OAuthConfigDir OUTSIDE the identities root (the legacy `~/.claude`
+    /// migration case) → NOT removed, skip outcome.
+    #[test]
+    fn oauth_dir_outside_data_root_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        std::fs::create_dir_all(&root).unwrap();
+        // A stand-in for the user's global ~/.claude dir.
+        let ambient = tmp.path().join("dot-claude");
+        std::fs::create_dir_all(&ambient).unwrap();
+        std::fs::write(ambient.join(".credentials.json"), "{}").unwrap();
+
+        let acct = acct_with(SecretRef::OAuthConfigDir {
+            dir: ambient.to_string_lossy().to_string(),
+        });
+        let out = cleanup_account_secrets(&acct, Some(&root));
+
+        assert!(
+            matches!(out, SecretCleanup::OAuthDirSkipped { .. }),
+            "must refuse to delete outside the identities root, got {out:?}"
+        );
+        assert!(ambient.exists(), "ambient CLI dir must be untouched");
+        assert!(ambient.join(".credentials.json").exists());
+    }
+
+    /// A `..`-laden path that textually starts under the root but resolves
+    /// outside it must also be skipped (canonicalization guard).
+    #[test]
+    fn oauth_dir_dotdot_escape_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        std::fs::create_dir_all(&root).unwrap();
+        let ambient = tmp.path().join("dot-claude");
+        std::fs::create_dir_all(&ambient).unwrap();
+
+        let sneaky = root.join("..").join("dot-claude");
+        let acct = acct_with(SecretRef::OAuthConfigDir {
+            dir: sneaky.to_string_lossy().to_string(),
+        });
+        let out = cleanup_account_secrets(&acct, Some(&root));
+
+        assert!(matches!(out, SecretCleanup::OAuthDirSkipped { .. }), "got {out:?}");
+        assert!(ambient.exists());
+    }
+
+    /// Unresolvable identities root (DataPaths::from_env() = None) → skip,
+    /// never guess.
+    #[test]
+    fn oauth_dir_with_no_root_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("identities").join("acct-test").join("claude");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let acct = acct_with(SecretRef::OAuthConfigDir {
+            dir: dir.to_string_lossy().to_string(),
+        });
+        let out = cleanup_account_secrets(&acct, None);
+
+        assert!(matches!(out, SecretCleanup::OAuthDirSkipped { .. }), "got {out:?}");
+        assert!(dir.exists(), "dir must be untouched when the root is unknown");
+    }
+
+    /// Already-absent dir → absent outcome, nothing created.
+    #[test]
+    fn oauth_dir_absent_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        std::fs::create_dir_all(&root).unwrap();
+        let dir = root.join("acct-test").join("claude");
+
+        let acct = acct_with(SecretRef::OAuthConfigDir {
+            dir: dir.to_string_lossy().to_string(),
+        });
+        let out = cleanup_account_secrets(&acct, Some(&root));
+
+        assert!(matches!(out, SecretCleanup::OAuthDirAbsent(_)), "got {out:?}");
+        assert!(!dir.exists());
+    }
+
+    /// Env / dev variants hold no on-host state → no-op, filesystem untouched.
+    #[test]
+    fn env_and_dev_variants_touch_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        let canary = root.join("acct-test").join("claude");
+        std::fs::create_dir_all(&canary).unwrap();
+
+        for secret_ref in [
+            SecretRef::Env { env_var: "ANTHROPIC_API_KEY".to_string() },
+            SecretRef::PlaintextDev { plaintext_dev: "sk-dev".to_string() },
+            SecretRef::SecretsManager { sm_path: "path/x".to_string(), sm_json_path: None },
+        ] {
+            let out = cleanup_account_secrets(&acct_with(secret_ref), Some(&root));
+            assert_eq!(out, SecretCleanup::NoOp);
+        }
+        assert!(canary.exists(), "no filesystem side effects for non-oauth variants");
+    }
+
+    /// Keychain variant must never touch the filesystem (outcome depends on
+    /// the host's keychain — absent entry deletes idempotently, headless CI
+    /// may fail — but both are non-filesystem outcomes).
+    #[test]
+    fn keychain_variant_touches_no_filesystem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        let canary = root.join("acct-test").join("claude");
+        std::fs::create_dir_all(&canary).unwrap();
+
+        // Deliberately unresolvable id so the delete is a guaranteed
+        // no-entry (idempotent Ok) on a dev machine's real keychain.
+        let mut acct = acct_with(SecretRef::Keychain {
+            service: "agentmux".to_string(),
+            account: "acct:zz-unit-test-never-provisioned".to_string(),
+        });
+        acct.id = "zz-unit-test-never-provisioned".to_string();
+        let out = cleanup_account_secrets(&acct, Some(&root));
+
+        assert!(
+            matches!(out, SecretCleanup::KeychainRemoved | SecretCleanup::KeychainFailed(_)),
+            "got {out:?}"
+        );
+        assert!(canary.exists(), "keychain cleanup must not touch the filesystem");
+    }
+}

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -31,6 +31,7 @@
 
 pub mod auth_patterns;
 pub mod auth_session;
+pub mod cleanup;
 pub mod key_validator;
 pub mod oauth_client;
 pub mod resolver;

--- a/agentmux-srv/src/server/agent_handlers/identity.rs
+++ b/agentmux-srv/src/server/agent_handlers/identity.rs
@@ -406,37 +406,47 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let cmd: CommandDeleteIdentityAccountData = serde_json::from_value(data)
                     .map_err(|e| format!("deleteidentityaccount: {e}"))?;
-                // If this account stored its secret in the OS keychain, drop
-                // it too so no orphaned credential survives the DB row.
-                // `keyring` is blocking, so run it via spawn_blocking.
+                // Drop the credential material behind the row BEFORE the row
+                // itself: keychain entry for `SecretRef::Keychain`, on-disk
+                // OAuth token dir for `SecretRef::OAuthConfigDir` (layer 1 of
+                // ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md §4).
+                // Best-effort — cleanup trouble never blocks the delete; the
+                // cleanup fn logs every outcome under "identity.delete:".
+                // keyring + fs are blocking, so run via spawn_blocking.
                 // Capture provider before the row is deleted so the logout-
-                // side log line (below) can carry it.
+                // side log lines can carry it.
                 let acct = wstore.identity_get(&cmd.id).ok().flatten();
                 let provider = acct.as_ref().map(|a| a.provider.clone()).unwrap_or_default();
-                if let Some(acct) = &acct {
-                    if matches!(acct.secret_ref, SecretRef::Keychain { .. }) {
-                        let aid = cmd.id.clone();
-                        let res = tokio::task::spawn_blocking(move || {
-                            crate::identity::secret_store::delete(&aid)
-                        })
-                        .await
-                        .unwrap_or_else(|je| Err(format!("join: {je}")));
-                        match res {
-                            // info!, not debug!: the production filter is
-                            // "agentmuxsrv=info,info" (reagent P1, PR #2143).
-                            // "identity.delete:" is `muxlog auth` vocabulary.
-                            Ok(()) => tracing::info!(
-                                account_id = %cmd.id,
-                                provider = %provider,
-                                "identity.delete: keychain secret removed"
-                            ),
-                            Err(e) => tracing::warn!(target: "identity", "keychain delete for {} failed: {e}", cmd.id),
-                        }
-                    }
+                if let Some(acct) = acct {
+                    // Containment root for OAuth dirs: only paths inside
+                    // ~/.agentmux/shared/identities/ are ever removed (the
+                    // legacy ~/.claude migration dir is the user's global
+                    // CLI login — never ours to delete).
+                    let identities_root = agentmux_common::DataPaths::from_env()
+                        .map(|p| p.identities_dir());
+                    let _ = tokio::task::spawn_blocking(move || {
+                        crate::identity::cleanup::cleanup_account_secrets(
+                            &acct,
+                            identities_root.as_deref(),
+                        )
+                    })
+                    .await;
                 }
-                let deleted = wstore
+                let outcome = wstore
                     .identity_delete(&cmd.id)
                     .map_err(|e| format!("deleteidentityaccount: {e}"))?;
+                let deleted = outcome.deleted;
+                if outcome.links_cascaded > 0 {
+                    // info!, not debug!: the production filter is
+                    // "agentmuxsrv=info,info" (reagent P1, PR #2143).
+                    // "identity.delete:" is `muxlog auth` vocabulary.
+                    tracing::info!(
+                        account_id = %cmd.id,
+                        provider = %provider,
+                        links = outcome.links_cascaded,
+                        "identity.delete: links cascaded"
+                    );
+                }
                 tracing::info!(
                     account_id = %cmd.id,
                     provider = %provider,

--- a/docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md
+++ b/docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md
@@ -1,0 +1,125 @@
+# Account deletion does not deauthenticate anything — auth lifecycle gap
+
+**Date:** 2026-07-14
+**Status:** Report — live-reproduced, not yet fixed
+**Repro:** During auth stress-testing on a fresh `task dev` (v0.53.5, main
+`1d5fa3f5`): user deleted the Anthropic account(s) in **Armory → Accounts**;
+a running Claude agent **kept responding**, still fully authenticated.
+**Related:** `SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md` (the injection
+design), `SPEC_PROVIDER_ISOLATION_2026_06_20.md`, PR #2157 (logout-side
+diagnostics that made this gap observable), PR #2158 (OAuth account UI crash
+found the same session).
+
+---
+
+## 1. Expectation vs. reality
+
+The natural user model: *deleting an account in the Armory revokes that
+identity — agents using it stop being authenticated.* The actual behavior:
+deletion is **pure bookkeeping**. `deleteidentityaccount`
+(`agentmux-srv/src/server/agent_handlers/identity.rs:400-460`) does exactly
+three things:
+
+1. If the secret lives in the OS keychain (`SecretRef::Keychain`), delete it.
+2. `DELETE FROM db_accounts WHERE id = ?1`
+   (`backend/storage/identities.rs:261-265` — single-row delete, no cascade).
+3. Publish `identityaccounts:changed` (a UI-refresh event, nothing more).
+
+Nothing else in the system reacts. Four distinct layers keep the agent
+authenticated:
+
+## 2. The four layers of the gap
+
+### 2.1 Running agent processes are untouched
+
+No code path connects account deletion to live agents. The CLI process was
+spawned with its credentials already injected (env vars for api-key class,
+`CLAUDE_CONFIG_DIR` pointer for OAuth class, `identity/resolver.rs:600-650`)
+and holds working tokens for its lifetime. There is no kill, no restart, no
+notification, not even a UI chip on affected agent panes. **This alone fully
+explains the repro** — the responding agent simply already had its creds.
+
+### 2.2 OAuth tokens survive on disk (and are never revoked upstream)
+
+For OAuth accounts the "secret" is `SecretRef::OAuthConfigDir { dir }` — a
+pointer to a config dir (e.g. `~/.agentmux/shared/identities/<id>/claude/`)
+holding the CLI's **live access + refresh tokens**. The delete handler's
+keychain cleanup explicitly matches only `SecretRef::Keychain`; the
+OAuthConfigDir variant falls through, so **the token directory survives the
+account row**. Nothing calls the provider's revocation endpoint (or
+`claude logout`) either — the tokens aren't just present, they're *valid*.
+Anyone (or any later spawn) pointing at that dir is still authenticated.
+Note the irony: the handler's own comment says the keychain cleanup exists
+"so no orphaned credential survives the DB row" — for OAuth accounts an
+orphaned credential is exactly what survives.
+
+### 2.3 Next spawn silently falls back to ambient credentials
+
+At spawn, per-binding resolution treats a missing account row as a
+log-and-skip (`resolver.rs:577-590`: "account … bound to identity … but row
+not found — skipping"). With no injection performed, the spawned Claude CLI
+does its default thing: read `~/.claude` — the user's **global, ambient
+login**. So even after a restart, the agent typically *still* authenticates,
+now on a different (unmanaged, invisible-to-Armory) identity, with only a
+WARN in the srv log to show for it. The "deleted the account" and "agent
+still works" states are indistinguishable in the UI.
+
+### 2.4 Orphaned junction rows
+
+`identity_delete` doesn't cascade `db_agent_identity_links` /
+`db_identity_bindings` rows that reference the deleted `account_id`. They
+persist as dangling references, discovered only as per-spawn WARNs (§2.3).
+Harmless individually, but they mean the system's own picture of "which
+agents use which accounts" contains links to accounts that no longer exist.
+
+## 3. Severity
+
+**High for the product's own promise.** The Armory is pitched as the control
+surface for agent credentials; a delete that doesn't deauthenticate breaks
+the core mental model, and the ambient-fallback layer (2.3) makes it worse
+than a no-op — the agent silently migrates to the user's personal login.
+For a machine shared or used for demos, "I deleted the account" ≠ "the agent
+lost access" is a genuine security-expectation violation, though not an
+external vulnerability (everything stays on the local machine, under the
+same OS user).
+
+## 4. Remediation options (roughly in dependency order)
+
+1. **Cascade + cleanup at delete time** (smallest, clearly correct):
+   - Delete `db_agent_identity_links`/`db_identity_bindings` rows referencing
+     the account (fixes 2.4).
+   - For `OAuthConfigDir` accounts, delete the config dir (fixes 2.2's
+     on-disk half). Best-effort provider-side revocation (running the CLI's
+     own `logout` against that dir first) fixes the other half.
+2. **Reconcile running agents**: on account delete, look up agents linked to
+   it (the reverse index exists — `agentsAssignedToAccount`) and either
+   (a) hard-stop their blocks, or (b) surface a "credentials revoked —
+   restart required" state on the pane. (a) is the honest semantics;
+   (b) is less disruptive but leaves 2.1 half-open until the process ends.
+3. **Kill the silent ambient fallback**: when a binding exists but the
+   account row is gone (or the binding was cascaded away in #1 and the agent
+   has no account for an oauth-class provider), spawn should either fail
+   loudly ("no credentials for provider anthropic") or require an explicit
+   per-agent "use ambient/global login" opt-in. Silent fallback to `~/.claude`
+   is the layer that turns every other fix into a no-op.
+4. **UI truthfulness**: while any agent still holds credentials from a
+   deleted account (2.1b chosen over 2.1a), the Armory should show it —
+   e.g. a "revoked, N agents still hold tokens" row state instead of the row
+   simply vanishing.
+
+Option 3 is the load-bearing one: as long as ambient fallback exists, delete
+semantics can never be made honest for oauth-class providers on a machine
+where the user is also logged in globally.
+
+## 5. Diagnostics note
+
+This gap was only cleanly observable because of PR #2157 (logout-side
+`identity.delete:`/`identity.unlink:` info logging + `muxlog auth`). The
+delete itself now logs; what's missing is everything that *should* happen
+after it. The resolver's "row not found — skipping" WARN at next spawn is
+target `identity`, so it also surfaces in `muxlog auth` — the full lifecycle
+of the bug is now traceable end to end:
+`identity.delete: account removed` → (agent keeps responding, no log at all —
+layer 2.1) → next spawn: `account … bound … but row not found — skipping` →
+CLI silently uses `~/.claude` (no AgentMux log line at all — the fallback is
+invisible even to the srv, which is itself part of the gap).

--- a/docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md
+++ b/docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md
@@ -66,11 +66,17 @@ still works" states are indistinguishable in the UI.
 
 ### 2.4 Orphaned junction rows
 
-`identity_delete` doesn't cascade `db_agent_identity_links` /
-`db_identity_bindings` rows that reference the deleted `account_id`. They
-persist as dangling references, discovered only as per-spawn WARNs (§2.3).
-Harmless individually, but they mean the system's own picture of "which
-agents use which accounts" contains links to accounts that no longer exist.
+`identity_delete` doesn't cascade `db_agent_identity_links` rows that
+reference the deleted `account_id`. (This report originally also named
+`db_identity_bindings` — that table was retired in migration Phase 4c and no
+longer exists; links are the sole junction on accounts, and a test now pins
+that.) Orphans persist as dangling references, discovered only as per-spawn
+WARNs (§2.3). Subtlety found during remediation: the *current* DDL does carry
+`FOREIGN KEY … ON DELETE CASCADE` with `PRAGMA foreign_keys=ON`, but legacy
+user databases got the links table via forge-era `ALTER TABLE … RENAME`,
+which never retrofits FK clauses — so on real installs the DDL-level cascade
+silently doesn't exist and the orphans are real (proven by a red test against
+a legacy-shaped schema).
 
 ## 3. Severity
 
@@ -85,9 +91,10 @@ same OS user).
 
 ## 4. Remediation options (roughly in dependency order)
 
-1. **Cascade + cleanup at delete time** (smallest, clearly correct):
-   - Delete `db_agent_identity_links`/`db_identity_bindings` rows referencing
-     the account (fixes 2.4).
+1. **Cascade + cleanup at delete time** (smallest, clearly correct) —
+   **implemented, PR #2159**:
+   - Delete `db_agent_identity_links` rows referencing the account, in the
+     same transaction as the account row (fixes 2.4).
    - For `OAuthConfigDir` accounts, delete the config dir (fixes 2.2's
      on-disk half). Best-effort provider-side revocation (running the CLI's
      own `logout` against that dir first) fixes the other half.


### PR DESCRIPTION
## What

Layer 1 (§4 option 1) of [`docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md`](../blob/fix/account-delete-cascade-cleanup/docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md) (shipped in this PR): deleting an account in the Armory now cascades its junction rows and removes its on-disk OAuth token directory, instead of being pure bookkeeping.

### 1. Explicit link cascade (`Store::identity_delete`)

- Deletes `db_agent_identity_links` rows `WHERE account_id = ?` atomically with the `db_accounts` row (single transaction under the connection lock), returning a new `IdentityDeleteOutcome { deleted, links_cascaded }`.
- Why explicit, when the current DDL has `FOREIGN KEY (account_id) REFERENCES db_accounts(id) ON DELETE CASCADE`: `CREATE TABLE IF NOT EXISTS` never retrofits FK clauses. The forge-era `db_forge_agent_identities` table (commit `2abada85`) had **no** `account_id` FK at all, and it was renamed forward into `db_agent_identity_links` on real user databases — on those, the DDL-level cascade silently doesn't exist (report §2.4's dangling links).
- **Table-name correction vs. the report:** `db_identity_bindings` no longer exists — it was dropped in Phase 4c of `SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md` (`DEAD_TABLE_DROPS`). `db_agent_identity_links(account_id)` is the sole junction referencing `db_accounts(id)`; a test (`identity_bindings_table_is_retired`) pins that so the cascade is provably complete.

### 2. OAuth token-dir cleanup (`identity::cleanup::cleanup_account_secrets`)

New plain, unit-testable function called from the `deleteidentityaccount` handler (replacing the inline keychain block):

- `SecretRef::Keychain` → existing keychain delete behavior, moved here.
- `SecretRef::OAuthConfigDir { dir }` → best-effort `remove_dir_all`, **containment-guarded**: both the dir and the identities root (`DataPaths::identities_dir()` = `~/.agentmux/shared/identities/`) are canonicalized, and removal happens only when the dir resolves *strictly inside* the root. The legacy `~/.claude` migration case (user's global CLI login) is logged and skipped, never deleted. Unresolvable root (`DataPaths::from_env()` = None) → skip, never guess.
- `Env` / `SecretsManager` / `PlaintextDev` → no-op.

### 3. Logging

Every cascade/cleanup action logs at `info!`/`warn!` (production filter is `agentmuxsrv=info,info`) with `identity.delete:` prefixes, already matched by the `muxlog auth` regex (`identity\.(unlink|delete|self\.|account)`): `links cascaded` (count), `oauth config dir removed`, `oauth config dir outside data root — skipped`, `oauth config dir already absent`, `keychain secret removed`. All carry `account_id` + `provider` fields.

## Red-test-first evidence

`identity_delete_cascades_links_on_legacy_no_fk_schema` (recreates the legacy FK-less table shape) was run against the unmodified `identity_delete` and **failed** as predicted — the link row survived the account delete:

```
assertion `left == right` failed: junction row must not survive the account row (dangling link)
  left: 1
 right: 0
```

It passes with the explicit cascade. (`identity_delete_cascades_links_on_current_schema` passed even before the fix, via the fresh-DDL FK — kept to guard the fresh-schema path and the exact `links_cascaded` count.)

## Tests added

- `backend::storage::identities::tests::identity_delete_cascades_links_on_legacy_no_fk_schema` (red → green)
- `backend::storage::identities::tests::identity_delete_cascades_links_on_current_schema`
- `backend::storage::identities::tests::identity_bindings_table_is_retired`
- `identity::cleanup::tests::{oauth_dir_inside_data_root_is_removed, oauth_dir_outside_data_root_is_skipped, oauth_dir_dotdot_escape_is_skipped, oauth_dir_with_no_root_is_skipped, oauth_dir_absent_is_noop, env_and_dev_variants_touch_nothing, keychain_variant_touches_no_filesystem}`

Full `cargo test -p agentmux-srv`: 1479 + 4 + 7 passed, 0 failed. `cargo check -p agentmux-srv` clean (no new warnings).

## Deferred / out of scope

- **Provider-side token revocation** (running the CLI's own `logout` against the dir before deleting): skipped — needs per-provider subprocess plumbing (CLI path resolution, `CLAUDE_CONFIG_DIR` injection, timeout handling). Explicit follow-up; the dir removal already invalidates the *local* copy of the tokens.
- **Log-fields regression test** (structured `account_id`/`provider`/`deleted` assertion): skipped — the codebase has no tracing-capture test infrastructure (only the global subscriber in `main.rs`); adding a capture layer or `tracing-test` dev-dep is new infra beyond this PR. The cleanup outcomes are asserted via the returned `SecretCleanup` enum instead.
- **Layers 2–4** of the report: running-agent reconciliation, resolver ambient-fallback removal, UI truthfulness.

<!-- agentmux:agent_id=agenta-07017 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)