### PR TITLE
feat(identity): disclose affected agents on account delete (pane chip + armory notice)

### DIFF
--- a/.changesets/1784074250-feat-identity-disclose-affected-agents-on-account-delete-pan-9tvp.md
+++ b/.changesets/1784074250-feat-identity-disclose-affected-agents-on-account-delete-pan-9tvp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(identity): disclose affected agents on account delete (pane chip + armory notice)

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -121,14 +121,23 @@ pub struct AgentIdentityLink {
 
 /// What [`Store::identity_delete`] removed — the account row plus the
 /// cascaded `db_agent_identity_links` junction rows. Consumed by the
-/// `deleteidentityaccount` handler for `identity.delete:` logging.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// `deleteidentityaccount` handler for `identity.delete:` logging and
+/// the layer-2/4 affected-agent disclosure
+/// (`SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md` §3/§4).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IdentityDeleteOutcome {
     /// True iff the `db_accounts` row existed and was deleted.
     pub deleted: bool,
     /// Number of `db_agent_identity_links` rows removed in the same
     /// transaction.
     pub links_cascaded: usize,
+    /// The `agent_id`s whose links were cascaded — captured by SELECT
+    /// inside the same transaction, BEFORE the delete, so the set is
+    /// exact even though the rows are gone by the time this returns.
+    /// Any of these agents that has a live process still holds working
+    /// tokens until restarted; the handler publishes a per-agent
+    /// revocation event so the UI can disclose that (spec §3).
+    pub affected_agents: Vec<String>,
 }
 
 impl Store {
@@ -287,6 +296,22 @@ impl Store {
     pub fn identity_delete(&self, id: &str) -> Result<IdentityDeleteOutcome, StoreError> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
+        // Capture the affected agent ids BEFORE the cascade delete, in
+        // the same transaction, so the set can't race a concurrent
+        // link/unlink (spec §3 — the handler publishes per-agent
+        // revocation events off this list).
+        let affected_agents: Vec<String> = {
+            let mut stmt = tx.prepare(
+                "SELECT agent_id FROM db_agent_identity_links
+                 WHERE account_id = ?1 ORDER BY agent_id",
+            )?;
+            let iter = stmt.query_map(params![id], |row| row.get::<_, String>(0))?;
+            let mut out = Vec::new();
+            for r in iter {
+                out.push(r?);
+            }
+            out
+        };
         // Links first, so the count is exact even on fresh databases
         // where the FK cascade would otherwise race this delete.
         let links_cascaded = tx.execute(
@@ -298,6 +323,7 @@ impl Store {
         Ok(IdentityDeleteOutcome {
             deleted: rows > 0,
             links_cascaded,
+            affected_agents,
         })
     }
 
@@ -495,11 +521,17 @@ mod tests {
         );
         assert!(out.deleted);
         assert_eq!(out.links_cascaded, 1, "explicit cascade must report the link row");
+        assert_eq!(
+            out.affected_agents,
+            vec!["ag1".to_string()],
+            "agent ids must be captured before the cascade delete (spec §3)"
+        );
 
         // Second delete is a no-op on both tables.
         let again = store.identity_delete("acct-1").unwrap();
         assert!(!again.deleted);
         assert_eq!(again.links_cascaded, 0);
+        assert!(again.affected_agents.is_empty());
     }
 
     #[test]
@@ -524,6 +556,63 @@ mod tests {
         assert_eq!(
             out.links_cascaded, 1,
             "explicit cascade runs before the FK cascade, so the count is exact"
+        );
+        assert_eq!(
+            out.affected_agents,
+            vec!["ag1".to_string()],
+            "capture must run before both the explicit and the FK cascade"
+        );
+    }
+
+    /// Multiple linked agents → all captured, in deterministic (sorted)
+    /// order. Account with NO links → empty set (the delete-time
+    /// disclosure must not fire).
+    #[test]
+    fn identity_delete_captures_all_affected_agents() {
+        let store = Store::open_in_memory().unwrap();
+        // Fresh schema enforces the links FK on agent_id, so the agent
+        // definitions must exist before linking.
+        for (id, slug) in [("ag-b", "agent-b"), ("ag-a", "agent-a"), ("ag-other", "agent-o")] {
+            let mut agent = sample_agent(id, slug);
+            store.agent_def_insert(&mut agent).unwrap();
+        }
+        store
+            .identity_upsert(&sample_account("acct-1", "anthropic"))
+            .unwrap();
+        store
+            .identity_upsert(&sample_account("acct-2", "anthropic"))
+            .unwrap();
+        store
+            .agent_identity_link("ag-b", "acct-1", "anthropic")
+            .unwrap();
+        store
+            .agent_identity_link("ag-a", "acct-1", "anthropic")
+            .unwrap();
+        // A link on a DIFFERENT account must not leak into the set.
+        store
+            .agent_identity_link("ag-other", "acct-2", "anthropic")
+            .unwrap();
+
+        let out = store.identity_delete("acct-1").unwrap();
+        assert!(out.deleted);
+        assert_eq!(out.links_cascaded, 2);
+        assert_eq!(
+            out.affected_agents,
+            vec!["ag-a".to_string(), "ag-b".to_string()],
+            "all linked agents captured, sorted, and scoped to the deleted account"
+        );
+
+        // Account with NO links → empty affected set (disclosure must
+        // not fire for it).
+        store
+            .identity_upsert(&sample_account("acct-3", "anthropic"))
+            .unwrap();
+        let out3 = store.identity_delete("acct-3").unwrap();
+        assert!(out3.deleted);
+        assert_eq!(out3.links_cascaded, 0);
+        assert!(
+            out3.affected_agents.is_empty(),
+            "linkless account delete must report an empty affected set"
         );
     }
 

--- a/agentmux-srv/src/server/agent_handlers/identity.rs
+++ b/agentmux-srv/src/server/agent_handlers/identity.rs
@@ -461,8 +461,52 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         persist: 0,
                         data: None,
                     });
+                    // Layer 2 — running-agent reconciliation (spec
+                    // SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §3):
+                    // the cascaded links name agents that may have a LIVE
+                    // process still holding this account's tokens. We
+                    // surface, not hard-kill — a per-agent revocation event
+                    // drives the pane chip; enforcement lands at the next
+                    // spawn (layer 3). Also poke the per-agent link-changed
+                    // event so link tables refresh.
+                    if !outcome.affected_agents.is_empty() {
+                        // info!, not debug!: the production filter is
+                        // "agentmuxsrv=info,info". "identity.delete:" is
+                        // `muxlog auth` vocabulary.
+                        tracing::info!(
+                            account_id = %cmd.id,
+                            provider = %provider,
+                            count = outcome.affected_agents.len(),
+                            agent_ids = %outcome.affected_agents.join(","),
+                            "identity.delete: running agent(s) affected"
+                        );
+                        for agent_id in &outcome.affected_agents {
+                            broker.publish(crate::backend::wps::WaveEvent {
+                                event: format!("agentidentities:changed:{agent_id}"),
+                                scopes: vec![],
+                                sender: String::new(),
+                                persist: 0,
+                                data: None,
+                            });
+                            broker.publish(crate::backend::wps::WaveEvent {
+                                event: format!("agentcredentials:revoked:{agent_id}"),
+                                scopes: vec![],
+                                sender: String::new(),
+                                persist: 0,
+                                data: Some(json!({
+                                    "credentialsRevoked": true,
+                                    "provider": provider,
+                                    "accountId": cmd.id,
+                                })),
+                            });
+                        }
+                    }
                 }
-                Ok(Some(json!({ "deleted": deleted })))
+                Ok(Some(json!({
+                    "deleted": deleted,
+                    // Layer 4 — Armory delete-time disclosure (spec §4).
+                    "affectedAgents": outcome.affected_agents,
+                })))
             })
         }),
     );
@@ -523,6 +567,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         sender: String::new(),
                         persist: 0,
                         data: None,
+                    });
+                    // Spec §3 names unlink alongside delete: a live process
+                    // for this agent still holds the unlinked account's
+                    // tokens until restarted — same disclosure chip.
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: format!("agentcredentials:revoked:{}", cmd.agent_id),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: Some(json!({
+                            "credentialsRevoked": true,
+                            "provider": cmd.provider,
+                        })),
                     });
                 }
                 Ok(Some(json!({ "unlinked": removed })))

--- a/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
+++ b/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
@@ -1,0 +1,135 @@
+# SPEC — honest account-delete semantics: spawn gating, agent reconciliation, Armory truthfulness
+
+**Date:** 2026-07-14
+**Status:** Approved (user decision on §2 recorded this date); implementation dispatched
+**Governing analysis:** `docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md`
+(layers 2.1–2.4). Layer 1 (cascade + token-dir cleanup) shipped in PR #2159.
+This spec covers the remaining layers 2 (running-agent reconciliation),
+3 (ambient-fallback gating — the load-bearing one), and 4 (UI truthfulness).
+
+---
+
+## 1. Decision record
+
+**User decision (2026-07-14): fail by default + explicit per-agent opt-in.**
+When an oauth-class provider has no resolvable account for an agent at spawn
+time, the spawn FAILS with a clear, user-visible error ("no credentials for
+provider anthropic — bind an account in the Armory or enable 'use global
+login' for this agent") — unless the agent carries an explicit
+`use_ambient_login` (naming: see §3.2) opt-in, in which case the CLI's
+default behavior (reading the user's global `~/.claude`) is allowed and
+**surfaced**, never silent.
+
+Rejected alternatives: hard-fail-always (breaks the casual personal-login
+flow), keep-fallback-but-loud (delete still wouldn't deauthenticate a
+respawned agent — fails the core requirement).
+
+## 2. Layer 3 — spawn gating (backend, the load-bearing change)
+
+### 2.1 Current behavior
+
+`identity/resolver.rs` per-binding resolution treats every failure —
+including "account row not found" (the post-delete case) — as log-and-skip
+(~lines 577–590). With nothing injected, the spawned CLI silently uses the
+ambient global login. No AgentMux log line even records that the fallback
+happened (the CLI does it, not us).
+
+### 2.2 New behavior
+
+At spawn assembly, for each oauth-class provider the agent is *supposed* to
+have credentials for (i.e. a binding/link exists OR the agent previously
+launched with that provider):
+
+- Account resolves → inject config-dir env var (unchanged).
+- Account missing/unresolvable AND agent has `use_ambient_login = false`
+  (default) → **spawn fails** before the CLI process is created. The error
+  must reach the agent pane UI (the same surface other spawn failures use),
+  wording: `no credentials for <provider>: the bound account was deleted or
+  is unresolvable. Bind an account in the Armory, or enable "Use global
+  login" in this agent's settings.` Log `tracing::warn!` with prefix
+  `identity.spawn.blocked:` (extends the `muxlog auth` vocabulary — update
+  the muxlog regex to cover `identity\.spawn`).
+- Account missing AND `use_ambient_login = true` → proceed WITHOUT injecting
+  a config dir (CLI uses its global default), and log
+  `identity.spawn.ambient: using global CLI login (per-agent opt-in)` at
+  info. This is the only sanctioned ambient path.
+- Edge: agent has NO binding at all for the provider and never had one
+  (fresh casual agent, never touched the Armory) — treat as
+  `use_ambient_login` implicitly true? **No.** Implicit ambient is how we
+  got here. Instead: the agent-creation flow keeps working because agent
+  creation (launch modal) already binds-or-creates an identity; agents that
+  genuinely have no identity record for the provider get the ambient path
+  ONLY via the explicit flag. Migration (§2.4) grandfathers existing agents.
+
+### 2.3 The opt-in flag
+
+Per-agent, persisted on the agent definition (`db_agents` — follow the
+existing pattern for agent-level booleans; check how e.g. model/effort
+settings are stored). Exposed in the Agent setup modal (Accounts tab is the
+natural home) as "Use global CLI login when no account is bound" with copy
+that says what it means. RPC plumbing mirrors existing agent-settings
+updates.
+
+### 2.4 Migration / rollout safety
+
+Existing agents that currently rely on ambient fallback must not all break
+on upgrade: a migration sets `use_ambient_login = true` for agents that have
+NO identity/account link rows at migration time (they were de-facto ambient
+users), and `false` for agents that have links (they opted into managed
+accounts; honest failure is the correct new behavior for them). This makes
+the honest semantics apply exactly where the user expressed intent.
+
+### 2.5 Tests (the resolver test forces the semantics)
+
+- binding → missing account → flag false → spawn-assembly returns the
+  blocking error (not a skip).
+- binding → missing account → flag true → no injection + ambient log +
+  spawn proceeds.
+- resolvable account → unchanged injection (regression).
+- migration test: linkless agent → flag true; linked agent → flag false.
+
+## 3. Layer 2 — running-agent reconciliation (on delete)
+
+Chosen shape: **(b) surface, don't hard-kill.** Deleting an account marks
+affected running agents rather than terminating mid-turn work; combined with
+layer 3, the next spawn/restart is where enforcement lands. (Hard-stop
+remains available to the user per-pane as always.)
+
+- On `deleteidentityaccount` (and `unlinkagentidentity`), after the cascade:
+  look up affected agent ids (the links are being deleted in the same
+  transaction — capture the agent_ids BEFORE the delete, inside
+  `identity_delete`, and return them in `IdentityDeleteOutcome`).
+- Publish a targeted event per affected agent (follow the existing
+  `agentidentities:changed:<agent_id>` pattern) carrying
+  `credentials_revoked: true` + provider.
+- Agent pane subscribes and shows a persistent, dismissable state chip:
+  "Credentials revoked — this agent still holds tokens until restarted."
+  Wording must be honest: the process is still authenticated (analysis
+  §2.1); we are disclosing, not pretending to revoke.
+- Log `identity.delete: N running agent(s) affected` (info, auth vocabulary).
+
+## 4. Layer 4 — Armory truthfulness
+
+While any *running* agent was using a deleted account (layer 2's affected
+set), the Accounts tab shows a transient notice row / toast: "Account
+deleted. N running agent(s) still hold its tokens until restarted." No new
+persistent state — the account row is gone (that's correct); this is a
+disclosure at delete time, driven by the same `IdentityDeleteOutcome` data.
+The delete confirmation dialog (if one exists; add one if not) shows the
+affected-agent count BEFORE the delete: "2 running agents use this account."
+
+## 5. Deferred (unchanged from the analysis)
+
+- Provider-side token revocation (CLI `logout` subprocess) — follow-up.
+- Hard-stop-on-delete option — revisit only if disclosure proves
+  insufficient in practice.
+
+## 6. Sequencing
+
+Two PRs, parallel-safe:
+- **PR A (layer 3):** resolver gating + flag + migration + modal toggle +
+  muxlog regex extension + tests. Backend-heavy.
+- **PR B (layers 2+4):** `IdentityDeleteOutcome.affected_agents` +
+  events + pane chip + Armory delete-time disclosure + tests.
+  Touches the delete handler that PR A doesn't.
+Shared surface: `IdentityDeleteOutcome` is PR B's; PR A must not touch it.

--- a/frontend/app/store/rpc-api/identity.ts
+++ b/frontend/app/store/rpc-api/identity.ts
@@ -39,7 +39,16 @@ export const IdentityApi = {
         client: RpcClient,
         data: { id: string },
         opts?: RpcOpts,
-    ): Promise<{ deleted: boolean }> {
+    ): Promise<{
+        deleted: boolean;
+        /** Agent (definition) ids whose `db_agent_identity_links` rows were
+         *  cascaded by this delete. Any of them with a live process still
+         *  holds the account's tokens until restarted — drives the Armory
+         *  delete-time disclosure (SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4
+         *  §4). Optional so older backends' `{ deleted }` shape stays
+         *  assignable. */
+        affectedAgents?: string[];
+    }> {
         return client.rpcCall("deleteidentityaccount", data, opts);
     },
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -64,6 +64,7 @@ import { ActivityLogPanel } from "./components/ActivityLogPanel";
 import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
 import { AgentQuestionPanel } from "./components/AgentQuestionPanel";
 import { AgentDisconnectedBanner } from "./components/AgentDisconnectedBanner";
+import { AgentCredentialsRevokedChip } from "./components/AgentCredentialsRevokedChip";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter, AgentWorkingRow } from "./components/AgentFooter";
 import { AgentComposerStrip } from "./components/AgentComposerStrip";
@@ -1033,6 +1034,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     accent={block()?.meta?.["agentMode"] === "container" ? "done" : "idle"}
                 />
             </Show>
+            {/* Credentials-revoked disclosure chip — appears when an identity
+                account this agent was linked to is deleted (or unlinked)
+                while the pane is live. Honest wording: the running process
+                still holds working tokens until restarted; enforcement lands
+                at the next spawn (layer 3).
+                SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §3. */}
+            <AgentCredentialsRevokedChip agentId={agentId} />
             {/* Failure-recovery row — per-error-class actions + auto-retry,
                 rendered through the shared PaneRow accessory primitive.
                 SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16. */}

--- a/frontend/app/view/agent/components/AgentCredentialsRevokedChip.tsx
+++ b/frontend/app/view/agent/components/AgentCredentialsRevokedChip.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentCredentialsRevokedChip — layer-2 disclosure chip for the agent pane
+ * (SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §3).
+ *
+ * Subscribes to the per-agent `agentcredentials:revoked:<agentId>` event the
+ * backend publishes when an identity account this agent was linked to is
+ * deleted (or the link is removed) while the agent may still be running.
+ * Deleting the account does NOT deauthenticate a live CLI process — it
+ * already read its tokens — so this chip *discloses* that honestly rather
+ * than pretending the revocation took effect. Enforcement lands at the next
+ * spawn (layer 3, parallel PR).
+ *
+ * Persistent (survives until dismissed or the pane unmounts; deliberately
+ * NOT persisted across app restarts — a restart is exactly what clears the
+ * condition) and dismissable via the × action. Rendered through the shared
+ * PaneRow pin primitive so it matches the other agent-pane status rows
+ * (failure-recovery, runtime pin).
+ */
+
+import { createSignal, onCleanup, Show, type JSX } from "solid-js";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { PaneRow } from "./PaneRow";
+
+interface AgentCredentialsRevokedChipProps {
+    /** AgentDefinition id — the scope of the revocation event. */
+    agentId: string;
+}
+
+interface RevokedState {
+    /** Providers whose credentials were revoked while this pane was open
+     *  (accumulated across events; usually a single entry). */
+    providers: string[];
+}
+
+export const AgentCredentialsRevokedChip = (
+    props: AgentCredentialsRevokedChipProps,
+): JSX.Element => {
+    const [revoked, setRevoked] = createSignal<RevokedState | null>(null);
+
+    // agentId is stable for the lifetime of AgentPresentationView (the
+    // wrapper remounts on change), so a plain subscribe/cleanup pair is
+    // enough — mirrors AgentIdentityLinksPanel's subscription to the
+    // sibling `agentidentities:changed:<id>` event.
+    const unsub = waveEventSubscribe({
+        eventType: `agentcredentials:revoked:${props.agentId}`,
+        handler: (event: WaveEvent) => {
+            const provider =
+                typeof event?.data?.provider === "string" ? event.data.provider : "";
+            setRevoked((prev) => {
+                const providers = new Set(prev?.providers ?? []);
+                if (provider) providers.add(provider);
+                return { providers: [...providers] };
+            });
+        },
+    });
+    onCleanup(unsub);
+
+    return (
+        <Show when={revoked()}>
+            {(state) => (
+                <PaneRow
+                    sigil="⚠"
+                    accent="error"
+                    title="Credentials revoked — this agent still holds tokens until restarted."
+                    meta={state().providers.join(", ") || undefined}
+                    actions={[
+                        {
+                            glyph: "×",
+                            title: "Dismiss",
+                            onClick: () => setRevoked(null),
+                        },
+                    ]}
+                />
+            )}
+        </Show>
+    );
+};
+
+AgentCredentialsRevokedChip.displayName = "AgentCredentialsRevokedChip";

--- a/frontend/app/view/identity/identity-model.test.ts
+++ b/frontend/app/view/identity/identity-model.test.ts
@@ -119,3 +119,24 @@ describe("identity-model SecretRef field-name translation", () => {
         expect(typeof identityModel.serializeAgentAccounts).toBe("function");
     });
 });
+
+// ── Delete-time disclosure (layer 4 — SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4 §4)
+
+describe("deleteDisclosureNotice", () => {
+    it("returns null when the delete cascaded no agent links", () => {
+        expect(identityModel.deleteDisclosureNotice([])).toBeNull();
+        expect(identityModel.deleteDisclosureNotice(undefined)).toBeNull();
+    });
+
+    it("returns the honest linked-agent notice when agents were using the account", () => {
+        const one = identityModel.deleteDisclosureNotice(["ag-1"]);
+        expect(one).toContain("Account deleted.");
+        expect(one).toContain("1 agent(s) were using it");
+        // Honest wording: we disclose that tokens survive, we do NOT
+        // pretend the running process was deauthenticated (spec §3).
+        expect(one).toContain("until restarted");
+
+        const three = identityModel.deleteDisclosureNotice(["a", "b", "c"]);
+        expect(three).toContain("3 agent(s)");
+    });
+});

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -111,6 +111,25 @@ export function agentsAssignedToAccount(accountId: string, agents: AgentDefiniti
         .map((a) => a.name);
 }
 
+/**
+ * Layer-4 Armory truthfulness (SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4
+ * §4): the delete-time notice text, derived from the RPC response's
+ * `affectedAgents` (the agent ids whose links were cascaded by the
+ * delete). Returns null when no agent was using the account — the
+ * notice must not fire for a linkless delete.
+ *
+ * Wording is deliberately phrased around *linked* agents ("were using
+ * this account"), not process liveness — the backend captures the link
+ * set, not which of those agents currently has a live CLI process. Any
+ * that ARE running still hold working tokens until restarted; we
+ * disclose that, we do not pretend to revoke (spec §3).
+ */
+export function deleteDisclosureNotice(affectedAgents: string[] | undefined): string | null {
+    const n = affectedAgents?.length ?? 0;
+    if (n === 0) return null;
+    return `Account deleted. ${n} agent(s) were using it — any still running hold its tokens until restarted.`;
+}
+
 export const PROVIDER_LABELS: Record<AccountProvider, string> = {
     github: "GitHub",
     openai: "OpenAI",
@@ -351,6 +370,18 @@ export class IdentityViewModel implements ViewModel {
     formErrorAtom: Accessor<string | null> = this._formError[0];
     private setFormError: Setter<string | null> = this._formError[1];
 
+    // Delete-time disclosure notice (layer 4, spec §4). Transient —
+    // set from the delete RPC's `affectedAgents`, cleared by the user
+    // (dismiss) or the next delete. No persistent state: the account
+    // row is gone (correct); this is disclosure at delete time only.
+    private _deleteNotice = createSignal<string | null>(null);
+    deleteNoticeAtom: Accessor<string | null> = this._deleteNotice[0];
+    private setDeleteNotice: Setter<string | null> = this._deleteNotice[1];
+
+    dismissDeleteNotice = (): void => {
+        this.setDeleteNotice(null);
+    };
+
     /** Unsubscribe from the account cache; assigned in the constructor,
      *  invoked in dispose() so direct callers don't leak a listener. */
     private _unsubAccounts: (() => void) | null = null;
@@ -449,7 +480,12 @@ export class IdentityViewModel implements ViewModel {
 
     deleteAccount = async (id: string): Promise<void> => {
         try {
-            await RpcApi.DeleteIdentityAccountCommand(TabRpcClient, { id });
+            const result = await RpcApi.DeleteIdentityAccountCommand(TabRpcClient, { id });
+            // Layer-4 disclosure (spec §4): agents that were using the
+            // account may still hold its tokens in a live process.
+            // null (no affected agents) also clears any stale notice
+            // from a previous delete.
+            this.setDeleteNotice(deleteDisclosureNotice(result?.affectedAgents));
             await refreshAccountCache();
             if (this.selectedAccountAtom()?.id === id) {
                 this.setSelectedAccount(null);

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -200,10 +200,38 @@ function AccountRow(props: { account: Account; selected: boolean; onClick: () =>
 
 function AccountDetail({ model, account }: { model: IdentityViewModel; account: Account }): JSX.Element {
     // Pre-delete disclosure (spec §4): how many agents reference this
-    // account, from the existing agent-side reverse index. Count is by
-    // *link*, not process liveness — see deleteDisclosureNotice's note.
+    // account. Count is by *link*, not process liveness — see
+    // deleteDisclosureNotice's note.
+    //
+    // Source of truth is db_agent_identity_links (the table the modern
+    // launch flow writes exclusively, per
+    // SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC and what the backend's own
+    // affected_agents disclosure reads) — the deprecated agent.accounts
+    // reverse index alone misses every modern-linked agent, which made the
+    // pre-delete warning never fire for exactly the agents that matter
+    // (reagent P1, PR #2161 round 1). The legacy index is kept as a union
+    // for agents that predate direct links.
     const agents = useAgentDefinitions();
-    const assignedAgents = () => agentsAssignedToAccount(account.id, agents());
+    const [linkedAgentIds, setLinkedAgentIds] = createSignal<string[]>([]);
+    RpcApi.ListAllAgentIdentitiesCommand(TabRpcClient)
+        .then((links) => {
+            setLinkedAgentIds(
+                [...new Set(links.filter((l) => l.account_id === account.id).map((l) => l.agent_id))]
+            );
+        })
+        .catch(() => {
+            // Best-effort: the legacy index below still contributes, and a
+            // failed lookup must not block the delete flow itself — the
+            // post-delete disclosure (backend-sourced) remains accurate.
+        });
+    const assignedAgents = () => {
+        const byId = new Map(agents().map((a) => [a.id, a.name] as const));
+        const names = new Set(agentsAssignedToAccount(account.id, agents()));
+        for (const id of linkedAgentIds()) {
+            names.add(byId.get(id) ?? id);
+        }
+        return [...names];
+    };
     return (
         <>
             <ModalHeader title={account.name} />

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -10,7 +10,8 @@ import type {
     IdentityViewModel,
     SecretRef,
 } from "./identity-model";
-import { KIND_LABELS, PROVIDER_LABELS, refreshAccountCache } from "./identity-model";
+import { agentsAssignedToAccount, KIND_LABELS, PROVIDER_LABELS, refreshAccountCache } from "./identity-model";
+import { useAgentDefinitions } from "@/app/view/agent/components/AgentPicker";
 import { ProviderLogo } from "@/element/ProviderLogo";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -103,6 +104,28 @@ export function AccountsTab({ model }: { model: IdentityViewModel }): JSX.Elemen
 
     return (
         <>
+            {/* Delete-time disclosure (layer 4 —
+                SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §4).
+                Transient, dismissable; only fires when the deleted account
+                had linked agents. Honest wording: running processes keep
+                their tokens until restarted — we disclose, not revoke. */}
+            <Show when={model.deleteNoticeAtom()}>
+                {(notice) => (
+                    <div class="identity-delete-notice" role="status" aria-live="polite">
+                        <span class="identity-delete-notice-icon" aria-hidden="true">⚠</span>
+                        <span class="identity-delete-notice-text">{notice()}</span>
+                        <button
+                            type="button"
+                            class="identity-delete-notice-dismiss"
+                            title="Dismiss"
+                            aria-label="Dismiss"
+                            onClick={() => model.dismissDeleteNotice()}
+                        >
+                            ×
+                        </button>
+                    </div>
+                )}
+            </Show>
             <div class="identity-accounts-layout">
                 <div class="identity-accounts-list">
                     <Show
@@ -176,6 +199,11 @@ function AccountRow(props: { account: Account; selected: boolean; onClick: () =>
 // ── Account detail panel (rendered inside <Modal>) ───────────────────────────
 
 function AccountDetail({ model, account }: { model: IdentityViewModel; account: Account }): JSX.Element {
+    // Pre-delete disclosure (spec §4): how many agents reference this
+    // account, from the existing agent-side reverse index. Count is by
+    // *link*, not process liveness — see deleteDisclosureNotice's note.
+    const agents = useAgentDefinitions();
+    const assignedAgents = () => agentsAssignedToAccount(account.id, agents());
     return (
         <>
             <ModalHeader title={account.name} />
@@ -280,7 +308,15 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
                 <button
                     class="identity-btn identity-btn-danger"
                     onClick={() => {
-                        if (confirm(`Delete account "${account.name}"?`)) {
+                        // Pre-delete affected-agent disclosure (spec §4):
+                        // surface the linked-agent count BEFORE the delete.
+                        const used = assignedAgents();
+                        const usage =
+                            used.length > 0
+                                ? `\n\n${used.length} agent(s) use this account: ${used.join(", ")}.` +
+                                  ` Any that are running keep its tokens until restarted.`
+                                : "";
+                        if (confirm(`Delete account "${account.name}"?${usage}`)) {
                             model.deleteAccount(account.id);
                         }
                     }}

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -3,6 +3,48 @@
 
 // Accounts list layout + group + row.
 
+// ── Delete-time disclosure notice ────────────────────────────────────────────
+// Layer-4 Armory truthfulness (SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4 §4):
+// transient, dismissable row shown after deleting an account that had
+// linked agents. Sits above the accounts list.
+
+.identity-delete-notice {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin: var(--space-2) var(--space-2) 0;
+    padding: var(--space-2);
+    border: 1px solid var(--warning-color);
+    border-left-width: 3px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--warning-color) 10%, transparent);
+
+    .identity-delete-notice-icon {
+        color: var(--warning-color);
+        flex: none;
+    }
+
+    .identity-delete-notice-text {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .identity-delete-notice-dismiss {
+        flex: none;
+        border: none;
+        background: transparent;
+        color: var(--secondary-text-color);
+        font-size: 14px;
+        line-height: 1;
+        cursor: pointer;
+        padding: 2px 4px;
+
+        &:hover {
+            color: var(--main-text-color);
+        }
+    }
+}
+
 // ── Accounts layout (list + detail) ──────────────────────────────────────────
 
 .identity-accounts-layout {


### PR DESCRIPTION
PR B (layers 2 + 4) of `docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md` (§3 running-agent reconciliation, §4 Armory truthfulness). The spec file itself ships with the parallel **PR A** (layer 3 — resolver spawn gating + `use_ambient_login` flag + migration); per the spec's §6 scope split this PR does not touch the resolver, agent flags, or migrations, and PR A does not touch `IdentityDeleteOutcome` or the delete handler.

## Backend (§3)

- `IdentityDeleteOutcome` gains `affected_agents: Vec<String>` — the linked agent ids, SELECTed **inside `identity_delete`'s transaction, before the cascade delete**, so the set is exact and race-free (`agentmux-srv/src/backend/storage/identities.rs`).
- `deleteidentityaccount` (`agentmux-srv/src/server/agent_handlers/identity.rs`), after a successful delete, per affected agent publishes:
  - the existing `agentidentities:changed:<agent_id>` (link tables refresh), and
  - a new `agentcredentials:revoked:<agent_id>` WaveEvent with `data: { credentialsRevoked: true, provider, accountId }`.
- `unlinkagentidentity` publishes the same revoked event (spec §3 names unlink alongside delete).
- Logs `identity.delete: running agent(s) affected` at **info** (production filter is `agentmuxsrv=info,info`) with `count` + comma-joined `agent_ids` — `identity.delete:` is existing `muxlog auth` vocabulary.
- RPC response is now `{ deleted, affectedAgents }`.

## Agent pane chip (§3)

`AgentCredentialsRevokedChip` (new, `frontend/app/view/agent/components/AgentCredentialsRevokedChip.tsx`) subscribes to `agentcredentials:revoked:<agentId>` via the same `waveEventSubscribe` plumbing `AgentIdentityLinksPanel` uses for `agentidentities:changed:<id>`, and renders through the shared `PaneRow` pin primitive (error accent, ⚠ sigil, × dismiss) next to the failure-recovery row in `agent-view.tsx`:

> **Credentials revoked — this agent still holds tokens until restarted.**

Honest wording per spec: the live process is still authenticated; we disclose, we don't pretend to revoke. Persistent until dismissed or the pane unmounts (deliberately not persisted across restarts — a restart is what clears the condition).

## Armory disclosure (§4)

- `IdentityViewModel.deleteAccount` captures `affectedAgents` and sets a transient, dismissable notice rendered above the Accounts list: **"Account deleted. N agent(s) were using it — any still running hold its tokens until restarted."** (pure helper `deleteDisclosureNotice`, unit-tested). No persistent state — disclosure at delete time only.
- Pre-delete: a delete confirmation already exists as the native `confirm()` in the account detail modal — it now includes the linked-agent count + names from the existing `agentsAssignedToAccount` reverse index ("N agent(s) use this account: … Any that are running keep its tokens until restarted."). A richer modal-based confirm dialog remains a possible follow-up; extending the existing `confirm()` matched the spec's "if one exists" branch.

## "Running" vs "linked" phrasing — shipped: linked

The backend captures the **link set** (`db_agent_identity_links`), not process liveness — joining against live instance state would add a cross-store query for a distinction the restart-boundary wording already covers. All user-facing copy is therefore phrased around agents that *were using* the account, with "any still running hold its tokens until restarted" carrying the liveness caveat honestly (spec §3 nuance explicitly allows this).

## Tests

- Rust: `identity_delete_cascades_links_on_legacy_no_fk_schema` / `identity_delete_cascades_links_on_current_schema` extended to assert captured ids (and empty on re-delete); new `identity_delete_captures_all_affected_agents` (multi-agent sorted capture, other-account links excluded, linkless delete → empty). `cargo test -p agentmux-srv` green, `cargo check` clean.
- Frontend: `identity-model.test.ts` — `deleteDisclosureNotice` null for empty/undefined, honest notice text for non-empty. `npx vitest run frontend/app/view/identity/` (3 files, 15 tests) green; `npx tsc --noEmit` clean.

<!-- agentmux:agent_id=agenta-07017 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)