### PR TITLE
feat(identity): fail spawn on missing oauth account, explicit per-agent global-login opt-in (layer 3)

### DIFF
--- a/.changesets/1784075745-feat-identity-fail-spawn-on-missing-oauth-account-explicit-p-vgj8.md
+++ b/.changesets/1784075745-feat-identity-fail-spawn-on-missing-oauth-account-explicit-p-vgj8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(identity): fail spawn on missing oauth account, explicit per-agent global-login opt-in

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -195,6 +195,7 @@ pub fn seed_agents(wstore: &Arc<Store>) -> Result<SeedReport, StoreError> {
             container_image: agent_def.container_image.clone(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -440,6 +441,7 @@ fn reseed_if_needed(
             container_image: agent_def.container_image.clone(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {
@@ -546,6 +548,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         wstore.agent_def_insert(&mut def).unwrap();
     }

--- a/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
+++ b/agentmux-srv/src/backend/agent_session/migrations/v1_templates.rs
@@ -283,6 +283,7 @@ pub fn migrate_promote_template_sessions_v1(
                 container_image: template.container_image.clone(),
                 container_volumes: template.container_volumes.clone(),
                 container_name: String::new(),
+                use_ambient_login: 0,
             };
             if let Err(e) = wstore.agent_def_insert(&mut new_def) {
                 tracing::warn!(

--- a/agentmux-srv/src/backend/agent_session/tests.rs
+++ b/agentmux-srv/src/backend/agent_session/tests.rs
@@ -465,6 +465,7 @@ fn insert_template(
         container_image: String::new(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut def).unwrap();
     def
@@ -697,6 +698,7 @@ fn template_promote_does_not_reuse_clone_with_active_zone() {
         container_image: template.container_image.clone(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut user_clone).unwrap();
     // The user's clone has its OWN active conversation.
@@ -803,6 +805,7 @@ fn template_promote_preserves_user_continuation_on_clone() {
         container_image: template.container_image.clone(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
     // Seeded `:current` has the OLDER stale snapshot the prior
@@ -901,6 +904,7 @@ fn template_promote_recovers_partial_copy_at_zone() {
         container_image: template.container_image.clone(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
 
@@ -1001,6 +1005,7 @@ fn template_promote_promotes_newer_source_over_stale_destination() {
         container_image: template.container_image.clone(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
 
@@ -1120,6 +1125,7 @@ fn template_promote_idempotent_under_partial_failure_at_archive_move() {
         container_image: template.container_image.clone(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut prior_target).unwrap();
     // Realistic partial-failure shape: run 1 copied :current
@@ -1256,6 +1262,7 @@ fn template_promote_skips_already_user_owned_definitions() {
         container_image: String::new(),
         container_volumes: "[]".to_string(),
         container_name: String::new(),
+        use_ambient_login: 0,
     };
     wstore.agent_def_insert(&mut user_def).unwrap();
     write_session_state(&filestore, &user_def.id, br#"{"nodes":[]}"#).unwrap();

--- a/agentmux-srv/src/backend/rpc_types/agent.rs
+++ b/agentmux-srv/src/backend/rpc_types/agent.rs
@@ -415,6 +415,12 @@ pub struct CommandUpdateAgentDefinitionData {
     /// JSON array of volume mount specs. Empty array (`"[]"`) for host agents.
     #[serde(default = "default_container_volumes")]
     pub container_volumes: String,
+    /// Explicit per-agent opt-in to the CLI's global (ambient) login when no
+    /// oauth-class account resolves at spawn (0/1). `None` (omitted) preserves
+    /// the stored value — callers that only edit name/icon/accounts don't
+    /// carry it. SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3.
+    #[serde(default)]
+    pub use_ambient_login: Option<i64>,
 }
 
 /// Input for deleteagent

--- a/agentmux-srv/src/backend/shellintegration/muxlog.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxlog.mjs
@@ -404,11 +404,13 @@ function main() {
         // credential seeding), identity/auth_session.rs (cancel_session,
         // session timeout), identity/resolver.rs ("oauth probe"), and the
         // logout side in server/app_api/identity.rs + agent_handlers/
-        // identity.rs ("identity.unlink:", "identity.delete:") — so filter on
-        // the MESSAGE vocabulary, not a target (opt.grep matches the message
-        // field only, exactly what we want). A user --grep overrides the
-        // recipe's regex; --target/--level/--since/-n still combine.
-        opt.grep = opt.grep || /\bauth\.\w+|auth success|auth session|cancel_session|claude auth|CheckCliAuth|OAuth config dir|oauth probe|identity_upsert|identity\.(unlink|delete|self\.|account)|account\.oauth|keychain delete/i;
+        // identity.rs ("identity.unlink:", "identity.delete:"), plus the
+        // layer-3 spawn gate in identity/resolver.rs
+        // ("identity.spawn.blocked:", "identity.spawn.ambient:") — so filter
+        // on the MESSAGE vocabulary, not a target (opt.grep matches the
+        // message field only, exactly what we want). A user --grep overrides
+        // the recipe's regex; --target/--level/--since/-n still combine.
+        opt.grep = opt.grep || /\bauth\.\w+|auth success|auth session|cancel_session|claude auth|CheckCliAuth|OAuth config dir|oauth probe|identity_upsert|identity\.(unlink|delete|self\.|account|spawn)|account\.oauth|keychain delete/i;
         const f = resolveFile("srv", opt);
         console.log(`=== auth trace: ${f} ===`);
         printLastLines(f, opt.n, opt, true);

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -105,6 +105,18 @@ pub struct AgentDefinition {
     /// empty for host agents. Schema v6.
     #[serde(default)]
     pub container_name: String,
+    /// Explicit per-agent opt-in to the CLI's global (ambient) login when no
+    /// oauth-class account resolves at spawn time. `0` (default) = spawn
+    /// FAILS when an oauth-class provider the agent is supposed to have
+    /// credentials for is missing/unresolvable ("fail by default"); `1` =
+    /// the spawn proceeds WITHOUT injecting a config dir so the CLI reads
+    /// the user's global login (e.g. `~/.claude`) — surfaced via the
+    /// `identity.spawn.ambient:` log line, never silent. Toggled from the
+    /// Agent setup modal's Accounts tab. Schema v12; the m0017 migration
+    /// grandfathers pre-existing linkless agents to `1`. Layer 3 of
+    /// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md (§2.2-§2.4).
+    #[serde(default)]
+    pub use_ambient_login: i64,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -302,7 +314,8 @@ impl Store {
                     restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
-                    user_hidden, container_image, container_volumes, container_name
+                    user_hidden, container_image, container_volumes, container_name,
+                    use_ambient_login
              FROM db_agent_definitions
              WHERE is_seeded = 0 AND parent_id = ?1
              ORDER BY updated_at DESC, created_at DESC",
@@ -336,7 +349,8 @@ impl Store {
                         restart_on_crash, idle_timeout_minutes, created_at,
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_id, branch_label, updated_at,
-                        user_hidden, container_image, container_volumes, container_name
+                        user_hidden, container_image, container_volumes, container_name,
+                        use_ambient_login
                  FROM db_agent_definitions
                  WHERE id = ?1",
             )?;
@@ -374,7 +388,8 @@ impl Store {
                         restart_on_crash, idle_timeout_minutes, created_at,
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_template_id, branch_label, updated_at,
-                        user_hidden, container_image, container_volumes, container_name
+                        user_hidden, container_image, container_volumes, container_name,
+                        use_ambient_login
                  FROM db_agents
                  ORDER BY updated_at DESC, created_at ASC",
             )?;
@@ -514,9 +529,9 @@ impl Store {
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
              is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
-             container_image, container_volumes, container_name)
+             container_image, container_volumes, container_name, use_ambient_login)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
+                     ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
             params![
                 agent.id,
                 agent.slug,
@@ -550,6 +565,7 @@ impl Store {
                 agent.container_image,
                 agent.container_volumes,
                 agent.container_name,
+                agent.use_ambient_login,
             ],
         )?;
         // Persist the stamped updated_at before we leave the lock so the
@@ -604,7 +620,8 @@ impl Store {
                         restart_on_crash, idle_timeout_minutes, created_at,
                         agent_type, environment, agent_bus_id, is_seeded,
                         accounts, parent_id, branch_label, updated_at,
-                        user_hidden, container_image, container_volumes, container_name
+                        user_hidden, container_image, container_volumes, container_name,
+                        use_ambient_login
                  FROM db_agent_definitions
                  WHERE (lower(trim(name)) = ?1 OR slug = ?2)
                    AND is_seeded = 0
@@ -653,10 +670,10 @@ impl Store {
                     working_directory, shell, provider_flags, auto_start, restart_on_crash,
                     idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
                     is_seeded, accounts, parent_id, branch_label, updated_at, user_hidden,
-                    container_image, container_volumes, container_name)
+                    container_image, container_volumes, container_name, use_ambient_login)
                  VALUES
                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
+                    ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
                 params![
                     agent.id, agent.slug, agent.name, agent.icon, agent.provider,
                     agent.description, agent.working_directory, agent.shell,
@@ -667,6 +684,7 @@ impl Store {
                     agent.created_at, // updated_at = created_at for new rows
                     agent.user_hidden,
                     agent.container_image, agent.container_volumes, agent.container_name,
+                    agent.use_ambient_login,
                 ],
             )?;
             agent.created_at
@@ -764,7 +782,8 @@ impl Store {
                  working_directory=?5, shell=?6, provider_flags=?7, auto_start=?8,
                  restart_on_crash=?9, idle_timeout_minutes=?10,
                  agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15,
-                 container_image=?17, container_volumes=?18, container_name=?19
+                 container_image=?17, container_volumes=?18, container_name=?19,
+                 use_ambient_login=?20
                  WHERE id=?16",
                 params![
                     agent.name,
@@ -786,6 +805,7 @@ impl Store {
                     agent.container_image,
                     agent.container_volumes,
                     agent.container_name,
+                    agent.use_ambient_login,
                 ],
             )?
         };
@@ -860,6 +880,43 @@ impl Store {
         // on the next agent_def_list. (P0.2b + codex P1 on #1385.)
         let global_retired = self.registry_def_retire(id);
         Ok(rows > 0 || global_retired)
+    }
+
+    /// One-shot grandfather pass for the layer-3 ambient-login opt-in
+    /// (m0017, spec §2.4 of SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md).
+    ///
+    /// Agents WITHOUT any `db_agent_identity_links` row at migration time
+    /// were de-facto ambient users → `use_ambient_login = 1`; agents WITH
+    /// links opted into managed accounts → `0` (honest failure is the new
+    /// behavior for them). `linked_agent_ids` comes from the SHARED store
+    /// (the live links table); this method writes both the legacy
+    /// `db_agent_definitions` and the consolidated `db_agents` projections
+    /// of the CURRENT channel store. Returns (rows set to 1, rows set to 0)
+    /// across `db_agent_definitions`.
+    pub fn agents_grandfather_ambient_login(
+        &self,
+        linked_agent_ids: &std::collections::HashSet<String>,
+    ) -> Result<(usize, usize), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        // Set everyone ambient first, then flip the linked set back to the
+        // fail-by-default 0 — two passes instead of a dynamic IN() list.
+        let ambient_defs = conn.execute(
+            "UPDATE db_agent_definitions SET use_ambient_login = 1",
+            [],
+        )?;
+        conn.execute("UPDATE db_agents SET use_ambient_login = 1", [])?;
+        let mut linked_rows = 0usize;
+        for id in linked_agent_ids {
+            linked_rows += conn.execute(
+                "UPDATE db_agent_definitions SET use_ambient_login = 0 WHERE id = ?1",
+                params![id],
+            )?;
+            conn.execute(
+                "UPDATE db_agents SET use_ambient_login = 0 WHERE id = ?1",
+                params![id],
+            )?;
+        }
+        Ok((ambient_defs.saturating_sub(linked_rows), linked_rows))
     }
 
     // AgentContent / AgentSkill / AgentHistory CRUD live in
@@ -1806,5 +1863,6 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
         container_image: row.get(22)?,
         container_volumes: row.get(23)?,
         container_name: row.get(24)?,
+        use_ambient_login: row.get(25)?,
     })
 }

--- a/agentmux-srv/src/backend/storage/def_registry_mirror.rs
+++ b/agentmux-srv/src/backend/storage/def_registry_mirror.rs
@@ -58,6 +58,7 @@ pub(super) fn agent_definition_to_record(
         container_image: def.container_image.clone(),
         container_volumes: def.container_volumes.clone(),
         container_name: def.container_name.clone(),
+        use_ambient_login: def.use_ambient_login,
         content: content
             .iter()
             .map(|c| DefContentBlob {
@@ -116,6 +117,7 @@ pub(super) fn record_to_agent_definition(rec: &DefinitionRecord) -> AgentDefinit
         container_image: d.container_image.clone(),
         container_volumes: d.container_volumes.clone(),
         container_name: d.container_name.clone(),
+        use_ambient_login: d.use_ambient_login,
     }
 }
 
@@ -336,6 +338,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         }
     }
 

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -66,7 +66,8 @@ impl Store {
                 auto_start, restart_on_crash, idle_timeout_minutes,
                 slug, branch_label, working_directory,
                 created_at, updated_at, is_seeded, user_hidden,
-                container_image, container_volumes, container_name
+                container_image, container_volumes, container_name,
+                use_ambient_login
              ) VALUES (
                 ?1, ?2, ?3, ?4,
                 ?5, ?6,
@@ -75,7 +76,8 @@ impl Store {
                 ?14, ?15, ?16,
                 ?17, ?18, ?19,
                 ?20, ?21, ?22, ?23,
-                ?24, ?25, ?26
+                ?24, ?25, ?26,
+                ?27
              )
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
@@ -100,7 +102,8 @@ impl Store {
                 is_seeded = excluded.is_seeded,
                 container_image = excluded.container_image,
                 container_volumes = excluded.container_volumes,
-                container_name = excluded.container_name",
+                container_name = excluded.container_name,
+                use_ambient_login = excluded.use_ambient_login",
             params![
                 def.id,
                 def.name,
@@ -128,6 +131,7 @@ impl Store {
                 def.container_image,
                 def.container_volumes,
                 def.container_name,
+                def.use_ambient_login,
             ],
         )?;
         Ok(())
@@ -350,7 +354,8 @@ impl Store {
                     instance_name,
                     created_at, updated_at, is_seeded, user_hidden,
                     last_block_id,
-                    container_image, container_volumes, container_name
+                    container_image, container_volumes, container_name,
+                    use_ambient_login
                  ) VALUES (
                     ?1, ?2, ?3, ?4,
                     0, ?5,
@@ -362,7 +367,8 @@ impl Store {
                     ?22,
                     ?23, ?24, 0, ?25,
                     ?26,
-                    ?27, ?28, ?29
+                    ?27, ?28, ?29,
+                    ?30
                  )
                  ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
@@ -404,6 +410,7 @@ impl Store {
                     def.container_image,
                     def.container_volumes,
                     def.container_name,
+                    def.use_ambient_login,
                 ],
             )
         };
@@ -621,7 +628,8 @@ impl Store {
                     restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded,
                     accounts, parent_id, branch_label, updated_at,
-                    user_hidden, container_image, container_volumes, container_name
+                    user_hidden, container_image, container_volumes, container_name,
+                    use_ambient_login
              FROM db_agent_definitions WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], |row| {
@@ -651,6 +659,7 @@ impl Store {
                 container_image: row.get(22)?,
                 container_volumes: row.get(23)?,
                 container_name: row.get(24)?,
+                use_ambient_login: row.get(25)?,
             })
         });
         match result {

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -384,6 +384,24 @@ impl Store {
         Ok(out)
     }
 
+    /// Distinct agent ids that have at least one `db_agent_identity_links`
+    /// row. Used by the m0017 ambient-login grandfather migration to decide
+    /// which agents "opted into managed accounts" (flag stays 0) versus
+    /// de-facto ambient users (flag set to 1) — spec §2.4 of
+    /// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md.
+    pub fn agent_ids_with_identity_links(&self) -> Result<Vec<String>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT agent_id FROM db_agent_identity_links",
+        )?;
+        let iter = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
 }
 
 #[cfg(test)]
@@ -437,6 +455,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         }
     }
 

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -384,17 +384,24 @@ impl Store {
         Ok(out)
     }
 
-    /// Distinct agent ids that have at least one `db_agent_identity_links`
-    /// row. Used by the m0017 ambient-login grandfather migration to decide
-    /// which agents "opted into managed accounts" (flag stays 0) versus
-    /// de-facto ambient users (flag set to 1) — spec §2.4 of
-    /// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md.
-    pub fn agent_ids_with_identity_links(&self) -> Result<Vec<String>, StoreError> {
+    /// Every distinct `(agent_id, provider)` link pair. Used by the
+    /// m0017/m0018 ambient-login grandfather migrations, which must reason
+    /// about provider CLASS: only oauth-class links mean an agent "opted
+    /// into managed CLI login" (flag stays 0) — an api-key link (e.g. a
+    /// github PAT) is never spawn-gated, so it must not forfeit
+    /// grandfathering (spec §2.4 of
+    /// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md). Class
+    /// filtering happens at the caller via
+    /// `identity::resolver::provider_class`; the storage layer stays
+    /// class-agnostic.
+    pub fn agent_identity_link_provider_pairs(&self) -> Result<Vec<(String, String)>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT DISTINCT agent_id FROM db_agent_identity_links",
+            "SELECT DISTINCT agent_id, provider FROM db_agent_identity_links",
         )?;
-        let iter = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        let iter = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
         let mut out = Vec::new();
         for r in iter {
             out.push(r?);

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -60,7 +60,13 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 3;
 ///   v11 — Phase 4a of SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md: rename
 ///        db_identity_accounts -> db_accounts, db_memory_bundles -> db_bundles
 ///        (SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md).
-pub const OBJECT_SCHEMA_VERSION: i64 = 11;
+///   v12 — use_ambient_login on both db_agent_definitions and db_agents:
+///        explicit per-agent opt-in to the CLI's global (ambient) login when
+///        no oauth-class account resolves at spawn (layer 3 of
+///        SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3). Defaults
+///        to 0 (fail-by-default); the m0017 data migration grandfathers
+///        pre-existing linkless agents to 1.
+pub const OBJECT_SCHEMA_VERSION: i64 = 12;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -195,7 +201,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             user_hidden          INTEGER NOT NULL DEFAULT 0,
             container_image      TEXT NOT NULL DEFAULT '',
             container_volumes    TEXT NOT NULL DEFAULT '[]',
-            container_name       TEXT NOT NULL DEFAULT ''
+            container_name       TEXT NOT NULL DEFAULT '',
+            use_ambient_login    INTEGER NOT NULL DEFAULT 0
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_slug
             ON db_agent_definitions(slug);
@@ -370,7 +377,12 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             -- Empty for host agents; populated by ContainerManager.
             container_image      TEXT NOT NULL DEFAULT '',
             container_volumes    TEXT NOT NULL DEFAULT '[]',
-            container_name       TEXT NOT NULL DEFAULT ''
+            container_name       TEXT NOT NULL DEFAULT '',
+
+            -- Explicit per-agent opt-in to the CLI's global (ambient) login
+            -- when no oauth-class account resolves at spawn (schema v12,
+            -- SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3).
+            use_ambient_login    INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_agents_is_template
             ON db_agents(is_template);
@@ -516,6 +528,10 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         // rename. See SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md.
         "ALTER TABLE db_bundles ADD COLUMN is_global INTEGER NOT NULL DEFAULT 0",
         "ALTER TABLE db_bundles ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
+        // v12: explicit per-agent ambient-login opt-in (fail-by-default spawn
+        // gating — SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3).
+        "ALTER TABLE db_agent_definitions ADD COLUMN use_ambient_login INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE db_agents ADD COLUMN use_ambient_login INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -317,6 +317,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -383,6 +384,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");
@@ -444,6 +446,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         }
     }
 
@@ -2291,6 +2294,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
         // db_agents row exists, projected as template.
@@ -2330,6 +2334,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
         // User-cloned def has is_seeded=0 + parent_id pointing at template.
@@ -2375,6 +2380,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
         def.name = "New Name".to_string();
@@ -2414,6 +2420,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
         assert_eq!(count_agents(&store, "id = 'tpl-del'"), 1);
@@ -2451,6 +2458,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
 
@@ -2536,6 +2544,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
 
@@ -2630,6 +2639,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let inst = AgentInstance {
@@ -2686,6 +2696,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let inst = AgentInstance {
@@ -2740,6 +2751,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl_a).unwrap();
         let mut tpl_b = tpl_a.clone();
@@ -2806,6 +2818,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
             };
             store.agent_def_insert(&mut d).unwrap();
         }
@@ -2847,6 +2860,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
         // User-clone DEF of that template (Phase 1 created this).
@@ -2920,6 +2934,7 @@
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut tpl).unwrap();
         let mut clone = AgentDefinition {

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -196,19 +196,37 @@ pub fn probe_oauth_status(
 /// CLI would read the user's global login (`~/.claude`) after an account
 /// was deleted.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SpawnGateError {
-    pub provider: String,
+pub enum SpawnGateError {
+    /// The gate's credentials verdict: no resolvable account, no opt-in.
+    MissingCredentials { provider: String },
+    /// The injection task itself could not run to completion (task-join
+    /// failure — e.g. a panic inside the blocking closure, which also
+    /// poisons the `Store` mutex for every later call). The gate FAILS
+    /// CLOSED on this: an open fallback would silently convert one panic
+    /// anywhere in the store into a permanent, systemic bypass of
+    /// `use_ambient_login = false` (reagent P1, PR #2164 round 1). A
+    /// blocked spawn is retryable and visible; a silent ambient launch
+    /// is neither.
+    InjectionUnavailable { detail: String },
 }
 
 impl std::fmt::Display for SpawnGateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "no credentials for {}: the bound account was deleted or is \
-             unresolvable. Bind an account in the Armory, or enable \
-             \"Use global login\" in this agent's settings.",
-            self.provider,
-        )
+        match self {
+            SpawnGateError::MissingCredentials { provider } => write!(
+                f,
+                "no credentials for {}: the bound account was deleted or is \
+                 unresolvable. Bind an account in the Armory, or enable \
+                 \"Use global login\" in this agent's settings.",
+                provider,
+            ),
+            SpawnGateError::InjectionUnavailable { detail } => write!(
+                f,
+                "credential injection could not run ({detail}); the spawn was \
+                 refused rather than falling back to the global CLI login. \
+                 Retry, and check `muxlog auth` if it persists.",
+            ),
+        }
     }
 }
 
@@ -447,7 +465,6 @@ pub async fn inject_identity_env_async(
     block_id: String,
     env_vars: HashMap<String, String>,
 ) -> Result<HashMap<String, String>, SpawnGateError> {
-    let fallback = env_vars.clone();
     match tokio::task::spawn_blocking(move || {
         let mut env = env_vars;
         inject_identity_env_with_broker(wstore, id_store, broker, &block_id, &mut env)
@@ -457,11 +474,18 @@ pub async fn inject_identity_env_async(
     {
         Ok(result) => result,
         Err(e) => {
-            // Join failure is an infrastructure fault, not a credentials
-            // verdict — fail open with the un-merged map (pre-gate
-            // behavior) rather than blocking the spawn on a runtime hiccup.
-            tracing::warn!(target: "identity", "identity injection task join failed: {e}");
-            Ok(fallback)
+            // Fail CLOSED. A join failure means the closure panicked (or
+            // was cancelled) — the gate never rendered a verdict, and the
+            // panic has likely poisoned the Store mutex, so failing open
+            // here would bypass use_ambient_login=false for every later
+            // spawn too (reagent P1, PR #2164 round 1). See
+            // SpawnGateError::InjectionUnavailable.
+            tracing::warn!(
+                target: "identity",
+                error = %e,
+                "identity.spawn.blocked: injection task join failed — failing closed"
+            );
+            Err(SpawnGateError::InjectionUnavailable { detail: e.to_string() })
         }
     }
 }
@@ -666,7 +690,7 @@ pub fn inject_identity_env_with_broker(
                 instance.identity_id,
                 detail,
             );
-            Err(SpawnGateError {
+            Err(SpawnGateError::MissingCredentials {
                 provider: provider.to_string(),
             })
         }
@@ -1134,7 +1158,7 @@ mod tests {
         // Blocking spawn-gate error — and nothing injected.
         assert_eq!(
             res,
-            Err(SpawnGateError { provider: "claude".to_string() }),
+            Err(SpawnGateError::MissingCredentials { provider: "claude".to_string() }),
         );
         assert!(env.get("CLAUDE_CONFIG_DIR").is_none());
         assert!(env.is_empty());
@@ -1224,7 +1248,7 @@ mod tests {
 
         assert_eq!(
             res,
-            Err(SpawnGateError { provider: "claude".to_string() }),
+            Err(SpawnGateError::MissingCredentials { provider: "claude".to_string() }),
         );
         // Nothing was injected — the CLI process must never be created.
         assert!(env.is_empty());
@@ -1294,7 +1318,7 @@ mod tests {
 
         assert_eq!(
             res,
-            Err(SpawnGateError { provider: "claude".to_string() }),
+            Err(SpawnGateError::MissingCredentials { provider: "claude".to_string() }),
         );
         assert!(env.is_empty());
     }

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -213,11 +213,15 @@ pub enum SpawnGateError {
 impl std::fmt::Display for SpawnGateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            // The quoted toggle name must match AgentIdentityModal.tsx's
+            // label VERBATIM so users can find it (reagent P2, PR #2164
+            // round 2).
             SpawnGateError::MissingCredentials { provider } => write!(
                 f,
                 "no credentials for {}: the bound account was deleted or is \
                  unresolvable. Bind an account in the Armory, or enable \
-                 \"Use global login\" in this agent's settings.",
+                 \"Use global CLI login when no account is bound\" in this \
+                 agent's settings.",
                 provider,
             ),
             SpawnGateError::InjectionUnavailable { detail } => write!(
@@ -452,12 +456,13 @@ pub fn inject_identity_env(
 /// `keyring` (D-Bus Secret Service on Linux) read — so it runs on a blocking
 /// thread via `spawn_blocking` rather than stalling an async runtime worker.
 /// Takes ownership of `env_vars` and returns it with identity vars merged in.
-/// On the rare task-join failure the original map is returned unchanged so
-/// the static `cmd:env` vars are never lost. See spec §12.2.
 ///
 /// `Err(SpawnGateError)` is the layer-3 spawn gate (see
 /// [`inject_identity_env`]): the caller must NOT spawn the CLI and must
-/// surface the error on the agent pane like any other spawn failure.
+/// surface the error on the agent pane like any other spawn failure. A
+/// task-join failure also fails CLOSED (`InjectionUnavailable`, blocking
+/// the spawn) — see that variant's doc for why an open fallback would
+/// systemically bypass the gate after any store panic.
 pub async fn inject_identity_env_async(
     wstore: Arc<Store>,
     id_store: Arc<Store>,
@@ -1257,7 +1262,7 @@ mod tests {
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("no credentials for claude"), "got: {msg}");
         assert!(msg.contains("Armory"), "got: {msg}");
-        assert!(msg.contains("Use global login"), "got: {msg}");
+        assert!(msg.contains("Use global CLI login when no account is bound"), "got: {msg}");
     }
 
     #[test]

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -180,6 +180,40 @@ pub fn probe_oauth_status(
     }
 }
 
+/// Blocking spawn-gate error — layer 3 of
+/// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md (§2.2).
+///
+/// Returned by the injection entry points when an **oauth-class** provider
+/// the agent is supposed to have credentials for (a binding exists, or the
+/// provider is the agent definition's own CLI provider) has no resolvable
+/// account AND the agent has not opted into ambient login
+/// (`use_ambient_login = 0`, the default). The spawn callers surface
+/// `Display` verbatim in the agent pane (same `error_during_execution`
+/// frame other spawn failures use) — the wording is the spec's.
+///
+/// Api-key-class bindings keep the historical log-and-skip behavior; this
+/// error exists only for the oauth class, where silent fallback meant the
+/// CLI would read the user's global login (`~/.claude`) after an account
+/// was deleted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnGateError {
+    pub provider: String,
+}
+
+impl std::fmt::Display for SpawnGateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "no credentials for {}: the bound account was deleted or is \
+             unresolvable. Bind an account in the Armory, or enable \
+             \"Use global login\" in this agent's settings.",
+            self.provider,
+        )
+    }
+}
+
+impl std::error::Error for SpawnGateError {}
+
 /// Errors specific to the resolver. Every variant is recoverable
 /// (the spawn proceeds with whatever env vars resolved successfully)
 /// — they exist for tracing visibility, not control flow.
@@ -357,22 +391,33 @@ pub fn resolve_secret(secret_ref: &SecretRef) -> Result<String, ResolverError> {
 /// 3. Read the `db_agent_identity_links` rows for the instance's definition.
 /// 4. For each binding: fetch the account, resolve its `SecretRef`,
 ///    look up the provider's env-var matrix, write each var into
-///    `env_vars`. Any per-binding failure is logged and skipped —
-///    other bindings still inject. The agent CLI launches with
-///    whatever resolved cleanly plus whatever ambient env was already
-///    in the spawn map.
+///    `env_vars`.
+///    - **Api-key-class** per-binding failures are logged and skipped —
+///      other bindings still inject (historical behavior).
+///    - **Oauth-class** failures (account row missing, lookup error,
+///      non-OAuthConfigDir secret_ref) are BLOCKING unless the agent
+///      definition carries `use_ambient_login = 1`: the function returns
+///      [`SpawnGateError`] before the CLI process is created. With the
+///      opt-in set, the binding is skipped WITHOUT injecting a config dir
+///      (the CLI uses its global login) and `identity.spawn.ambient:` is
+///      logged at info — the only sanctioned ambient path (spec §2.2).
+/// 5. If the agent definition's own provider is oauth-class and no binding
+///    for it exists at all (fresh/never-bound or post-delete-cascade), the
+///    same gate applies — implicit ambient fallback is how the
+///    delete-doesn't-deauthenticate gap happened (spec §2.2 edge case).
 ///
-/// This function is intentionally infallible at the top level. It
-/// has no `Result`, just side-effects on `env_vars` and `tracing::warn`
-/// for every per-binding error. The spawn never aborts because a
-/// secret didn't resolve.
+/// Layer 3 of SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md. Before
+/// it, this function was intentionally infallible ("the spawn never aborts
+/// because a secret didn't resolve") — that is still true for api-key-class
+/// bindings, but oauth-class resolution failures now fail the spawn by
+/// default so account deletion is honest at the next spawn.
 pub fn inject_identity_env(
     wstore: Arc<Store>,
     id_store: Arc<Store>,
     block_id: &str,
     env_vars: &mut HashMap<String, String>,
-) {
-    inject_identity_env_with_broker(wstore, id_store, None, block_id, env_vars);
+) -> Result<(), SpawnGateError> {
+    inject_identity_env_with_broker(wstore, id_store, None, block_id, env_vars)
 }
 
 /// `inject_identity_env` + optional broker handle so the OAuth-class
@@ -391,25 +436,32 @@ pub fn inject_identity_env(
 /// Takes ownership of `env_vars` and returns it with identity vars merged in.
 /// On the rare task-join failure the original map is returned unchanged so
 /// the static `cmd:env` vars are never lost. See spec §12.2.
+///
+/// `Err(SpawnGateError)` is the layer-3 spawn gate (see
+/// [`inject_identity_env`]): the caller must NOT spawn the CLI and must
+/// surface the error on the agent pane like any other spawn failure.
 pub async fn inject_identity_env_async(
     wstore: Arc<Store>,
     id_store: Arc<Store>,
     broker: Option<Arc<Broker>>,
     block_id: String,
     env_vars: HashMap<String, String>,
-) -> HashMap<String, String> {
+) -> Result<HashMap<String, String>, SpawnGateError> {
     let fallback = env_vars.clone();
     match tokio::task::spawn_blocking(move || {
         let mut env = env_vars;
-        inject_identity_env_with_broker(wstore, id_store, broker, &block_id, &mut env);
-        env
+        inject_identity_env_with_broker(wstore, id_store, broker, &block_id, &mut env)
+            .map(|()| env)
     })
     .await
     {
-        Ok(merged) => merged,
+        Ok(result) => result,
         Err(e) => {
+            // Join failure is an infrastructure fault, not a credentials
+            // verdict — fail open with the un-merged map (pre-gate
+            // behavior) rather than blocking the spawn on a runtime hiccup.
             tracing::warn!(target: "identity", "identity injection task join failed: {e}");
-            fallback
+            Ok(fallback)
         }
     }
 }
@@ -459,12 +511,12 @@ fn resolve_bindings_for_instance(
         });
 
     if direct.is_empty() {
-        // Non-fatal — the spawn proceeds with no identity env injected,
-        // same as "identity has no accounts bound" below. Distinct log
-        // line + event so a non-sentinel identity resolving to zero
-        // links (e.g. an agent that was never linked to an account) is
-        // visible, not silently indistinguishable from routine
-        // "no accounts configured."
+        // Distinct log line + event so a non-sentinel identity resolving
+        // to zero links (e.g. an agent that was never linked to an
+        // account) is visible, not silently indistinguishable from
+        // routine "no accounts configured." Whether the spawn proceeds
+        // is decided by the caller's layer-3 definition-provider gate
+        // (oauth-class CLI provider + no ambient opt-in → blocked).
         tracing::warn!(
             target: "identity",
             "no direct account links for definition {} (identity {}) — \
@@ -506,17 +558,19 @@ pub fn inject_identity_env_with_broker(
     broker: Option<Arc<Broker>>,
     block_id: &str,
     env_vars: &mut HashMap<String, String>,
-) {
+) -> Result<(), SpawnGateError> {
     // Step 1: instance lookup — per-channel, always reads from wstore.
     let instance = match wstore.instance_get_active_for_block(block_id) {
         Ok(Some(i)) => i,
         Ok(None) => {
-            // Block has no agent instance row — nothing to inject.
-            return;
+            // Block has no agent instance row — nothing to inject, and no
+            // gating either: quick-launch panes that never went through the
+            // launch modal are outside the managed-credentials contract.
+            return Ok(());
         }
         Err(e) => {
             tracing::warn!(target: "identity", "instance lookup failed for block {}: {}", block_id, e);
-            return;
+            return Ok(());
         }
     };
 
@@ -528,25 +582,48 @@ pub fn inject_identity_env_with_broker(
         // SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md), so seeing
         // one here means either a legacy continuation row or a UI
         // regression. Warn so the regression is visible in logs.
+        // Deliberately NOT gated by layer 3: this sentinel predates the
+        // managed-account model and was an explicit "ambient creds"
+        // choice at launch time, not a silent fallback.
         tracing::warn!(
             target: "identity",
             "instance {} has empty/blank identity_id — falling back to ambient creds. \
              Legacy row or UI regression?",
             block_id
         );
-        return;
+        return Ok(());
     }
+
+    // Layer-3 gate inputs: the agent definition's ambient opt-in flag and
+    // its own CLI provider (the oauth-class provider every launch of this
+    // agent uses, whether or not a binding row exists for it). A missing
+    // definition row reads as flag=false / no expected provider — the
+    // per-binding gate still applies to whatever links exist.
+    let (use_ambient, def_provider) = match wstore.agent_def_get(&instance.definition_id) {
+        Ok(Some(d)) => (d.use_ambient_login != 0, Some(d.provider)),
+        Ok(None) => (false, None),
+        Err(e) => {
+            tracing::warn!(
+                target: "identity",
+                "definition lookup failed for {} (layer-3 gate reads use_ambient_login=false): {}",
+                instance.definition_id,
+                e,
+            );
+            (false, None)
+        }
+    };
 
     // Step 3: bindings — global, reads from id_store. Direct-links-only
     // as of Phase 3 slice 2 PR-B (the flip) — see resolve_bindings_for_instance's
     // doc comment for the transitional gap this closes and the one it
     // doesn't (#1624 PR-C).
+    //
+    // NOTE: an empty set no longer short-circuits — it falls through to the
+    // definition-provider gate below (spec §2.2 edge case: an agent whose
+    // oauth-class CLI provider has no binding at all is blocked unless the
+    // ambient opt-in is set; the m0017 migration grandfathers pre-existing
+    // linkless agents).
     let bindings = resolve_bindings_for_instance(&id_store, &instance, broker.as_ref());
-
-    if bindings.is_empty() {
-        // Identity exists but has no accounts bound. Nothing to inject.
-        return;
-    }
 
     // Step 4: per-binding resolution + env injection.
     //
@@ -556,9 +633,45 @@ pub fn inject_identity_env_with_broker(
     //   - OAuth   — expect SecretRef::OAuthConfigDir, inject its dir
     //               as the provider's config-dir env var.
     //
-    // Per-binding failures (unknown provider, account row missing,
-    // mismatched secret_ref, secret resolution failed) are logged and
-    // skipped — other bindings still inject.
+    // Api-key-class per-binding failures (unknown provider, account row
+    // missing, mismatched secret_ref, secret resolution failed) are logged
+    // and skipped — other bindings still inject. Oauth-class failures go
+    // through the layer-3 gate: blocking by default, skip-with-
+    // `identity.spawn.ambient:` when the agent opted in (spec §2.2).
+    let mut injected_oauth: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    // Gate helper for an unresolvable oauth-class binding/provider.
+    // Returns Ok(()) when the agent opted into ambient (caller skips the
+    // binding), Err(SpawnGateError) otherwise (caller aborts the spawn).
+    let gate_oauth_failure = |provider: &str, detail: &str| -> Result<(), SpawnGateError> {
+        if use_ambient {
+            tracing::info!(
+                target: "identity",
+                "identity.spawn.ambient: using global CLI login (per-agent opt-in) — \
+                 provider {}, definition {} ({})",
+                provider,
+                instance.definition_id,
+                detail,
+            );
+            Ok(())
+        } else {
+            tracing::warn!(
+                target: "identity",
+                "identity.spawn.blocked: no credentials for provider {} \
+                 (definition {}, identity {}) — {}; spawn refused \
+                 (use_ambient_login=false)",
+                provider,
+                instance.definition_id,
+                instance.identity_id,
+                detail,
+            );
+            Err(SpawnGateError {
+                provider: provider.to_string(),
+            })
+        }
+    };
+
     for binding in &bindings {
         let class = match provider_class(&binding.provider) {
             Some(c) => c,
@@ -572,10 +685,23 @@ pub fn inject_identity_env_with_broker(
                 continue;
             }
         };
+        let is_oauth_class = matches!(class, ProviderClass::OAuth { .. });
 
         let account = match id_store.identity_get(&binding.account_id) {
             Ok(Some(a)) => a,
             Ok(None) => {
+                // The post-delete case (analysis §2.3): the link survived
+                // (or was cascaded and re-created stale) but the account
+                // row is gone. For oauth-class providers this is the
+                // load-bearing layer-3 gate — no more silent fallback to
+                // the user's global login.
+                if is_oauth_class {
+                    gate_oauth_failure(
+                        &binding.provider,
+                        &format!("account {} row not found", binding.account_id),
+                    )?;
+                    continue;
+                }
                 tracing::warn!(
                     target: "identity",
                     "account {} bound to identity {} but row not found — skipping",
@@ -585,6 +711,13 @@ pub fn inject_identity_env_with_broker(
                 continue;
             }
             Err(e) => {
+                if is_oauth_class {
+                    gate_oauth_failure(
+                        &binding.provider,
+                        &format!("account lookup failed for {}: {}", binding.account_id, e),
+                    )?;
+                    continue;
+                }
                 tracing::warn!(
                     target: "identity",
                     "account lookup failed for {}: {}",
@@ -625,23 +758,25 @@ pub fn inject_identity_env_with_broker(
             }
             ProviderClass::OAuth { config_dir_env_var } => {
                 // OAuth-class bindings expect SecretRef::OAuthConfigDir.
-                // Any other variant is a misconfiguration — log and
-                // skip rather than mis-inject the wrong secret.
+                // Any other variant is a misconfiguration — the account is
+                // unresolvable for this provider, so it goes through the
+                // layer-3 gate rather than silently leaving the CLI on the
+                // user's global login.
                 let dir = match &account.secret_ref {
                     SecretRef::OAuthConfigDir { dir } => dir.clone(),
                     other => {
-                        tracing::warn!(
-                            target: "identity",
-                            "oauth-class provider {} has non-OAuthConfigDir secret_ref \
-                             ({:?}) on account {} — skipping",
-                            binding.provider,
-                            other,
-                            binding.account_id,
-                        );
+                        gate_oauth_failure(
+                            &binding.provider,
+                            &format!(
+                                "non-OAuthConfigDir secret_ref ({:?}) on account {}",
+                                other, binding.account_id,
+                            ),
+                        )?;
                         continue;
                     }
                 };
                 env_vars.insert(config_dir_env_var.to_string(), dir.clone());
+                injected_oauth.insert(binding.provider.clone());
                 tracing::info!(
                     target: "identity",
                     "injected {} for oauth provider {} (identity={}, account={})",
@@ -709,6 +844,24 @@ pub fn inject_identity_env_with_broker(
             }
         }
     }
+
+    // Step 5: definition-provider gate (spec §2.2 edge case). The agent's
+    // own CLI provider is an oauth-class provider it is "supposed to have
+    // credentials for" whether or not a binding row exists — an agent with
+    // NO binding for it (never bound, or the link was cascaded away by an
+    // account delete) must not silently launch on the user's global login.
+    // Bindings that existed but failed were already gated inside the loop,
+    // so this only fires for the genuinely-unbound case (no double logs).
+    if let Some(p) = def_provider {
+        if matches!(provider_class(&p), Some(ProviderClass::OAuth { .. }))
+            && !injected_oauth.contains(&p)
+            && !bindings.iter().any(|b| b.provider == p)
+        {
+            gate_oauth_failure(&p, "no account bound for the agent's provider")?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -882,6 +1035,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -902,7 +1056,10 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-oauth", &mut env);
+        // Spec §2.5 regression: a resolvable oauth account injects
+        // unchanged — the layer-3 gate never fires (Ok even with
+        // use_ambient_login=0).
+        inject_identity_env(store.clone(), store, "block-oauth", &mut env).unwrap();
 
         // OAuth dispatch sets the provider's config-dir env var.
         assert_eq!(
@@ -916,11 +1073,13 @@ mod tests {
 
     #[cfg(debug_assertions)]
     #[test]
-    fn inject_oauth_class_skips_account_with_non_oauth_secret_ref() {
+    fn inject_oauth_class_blocks_account_with_non_oauth_secret_ref() {
         // An oauth-class provider (claude) bound to an account whose
         // SecretRef is the API-key shape (Env) is a misconfiguration:
-        // the resolver logs + skips rather than mis-injecting the
-        // wrong secret as if it were a config-dir.
+        // the account is unresolvable for the provider, so the layer-3
+        // gate blocks the spawn (use_ambient_login=0) instead of
+        // mis-injecting the wrong secret or silently launching on the
+        // user's global login.
         let store = make_store();
 
         let mut def = crate::backend::storage::store::AgentDefinition {
@@ -949,6 +1108,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -969,10 +1129,173 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-bad", &mut env);
+        let res = inject_identity_env(store.clone(), store, "block-bad", &mut env);
 
-        // Nothing injected — the binding was skipped.
+        // Blocking spawn-gate error — and nothing injected.
+        assert_eq!(
+            res,
+            Err(SpawnGateError { provider: "claude".to_string() }),
+        );
         assert!(env.get("CLAUDE_CONFIG_DIR").is_none());
+        assert!(env.is_empty());
+    }
+
+    // ── Layer 3 — spawn gating (SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4
+    //    _2026_07_14.md §2.2/§2.5) ────────────────────────────────────
+
+    /// Fixture def for the gating tests — oauth-class CLI provider
+    /// (claude) with a configurable ambient opt-in.
+    fn gate_def(use_ambient_login: i64) -> crate::backend::storage::store::AgentDefinition {
+        crate::backend::storage::store::AgentDefinition {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login,
+        }
+    }
+
+    /// Delete an account row while KEEPING its link — the post-delete
+    /// shape on a legacy DB (analysis §2.4: real installs got the links
+    /// table via ALTER RENAME with no FK cascade clause, so orphan links
+    /// are real). FKs are toggled off for the surgical delete so the
+    /// test store's DDL-level cascade doesn't fire.
+    fn delete_account_row_keep_link(store: &Store, account_id: &str) {
+        let conn = store.conn().lock().unwrap();
+        conn.execute_batch(&format!(
+            "PRAGMA foreign_keys=OFF;
+             DELETE FROM db_accounts WHERE id = '{account_id}';
+             PRAGMA foreign_keys=ON;"
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn spawn_blocked_when_bound_oauth_account_missing_and_flag_false() {
+        // Spec §2.5 test 1: binding → missing account → flag false →
+        // spawn-assembly returns the blocking error (not a skip).
+        let store = make_store();
+        let mut def = gate_def(0);
+        store.agent_def_insert(&mut def).unwrap();
+
+        let claude = make_account(
+            "acct-gone",
+            "claude",
+            SecretRef::OAuthConfigDir {
+                dir: "/var/agentmux/identities/id-x/claude".to_string(),
+            },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store
+            .agent_identity_link("def-1", "acct-gone", "claude")
+            .unwrap();
+        // Delete the account row out from under the link — the exact
+        // post-`deleteidentityaccount` shape the resolver used to
+        // log-and-skip ("row not found — skipping", analysis §2.3).
+        delete_account_row_keep_link(&store, "acct-gone");
+
+        insert_block_for_agent(&store, "block-gate-1", "def-1");
+        let inst = make_instance("block-gate-1", "id-x");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        let res = inject_identity_env(store.clone(), store, "block-gate-1", &mut env);
+
+        assert_eq!(
+            res,
+            Err(SpawnGateError { provider: "claude".to_string() }),
+        );
+        // Nothing was injected — the CLI process must never be created.
+        assert!(env.is_empty());
+        // The error's Display is the user-facing pane message (spec §2.2
+        // wording) — pin the load-bearing pieces.
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("no credentials for claude"), "got: {msg}");
+        assert!(msg.contains("Armory"), "got: {msg}");
+        assert!(msg.contains("Use global login"), "got: {msg}");
+    }
+
+    #[test]
+    fn spawn_proceeds_ambient_when_bound_oauth_account_missing_and_flag_true() {
+        // Spec §2.5 test 2: binding → missing account → flag true → no
+        // injection + spawn proceeds (the sanctioned ambient path; the
+        // `identity.spawn.ambient:` info line is asserted-by-return-value
+        // here since this codebase has no tracing capture).
+        let store = make_store();
+        let mut def = gate_def(1);
+        store.agent_def_insert(&mut def).unwrap();
+
+        let claude = make_account(
+            "acct-gone-2",
+            "claude",
+            SecretRef::OAuthConfigDir {
+                dir: "/var/agentmux/identities/id-y/claude".to_string(),
+            },
+        );
+        store.identity_upsert(&claude).unwrap();
+        store
+            .agent_identity_link("def-1", "acct-gone-2", "claude")
+            .unwrap();
+        delete_account_row_keep_link(&store, "acct-gone-2");
+
+        insert_block_for_agent(&store, "block-gate-2", "def-1");
+        let inst = make_instance("block-gate-2", "id-y");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store.clone(), store, "block-gate-2", &mut env).unwrap();
+
+        // No config dir injected — the CLI uses its global login, by
+        // explicit opt-in, never silently.
+        assert!(env.get("CLAUDE_CONFIG_DIR").is_none());
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn spawn_blocked_when_oauth_def_provider_has_no_binding_and_flag_false() {
+        // Spec §2.2 edge case: an agent whose oauth-class CLI provider has
+        // NO binding at all (never bound, or the link was cascaded away by
+        // an account delete) is blocked without the opt-in — implicit
+        // ambient is how the delete-doesn't-deauthenticate gap happened.
+        // (The m0017 migration grandfathers pre-existing linkless agents
+        // to flag=1; `inject_no_direct_links_injects_nothing` covers that
+        // side.)
+        let store = make_store();
+        let mut def = gate_def(0);
+        store.agent_def_insert(&mut def).unwrap();
+
+        insert_block_for_agent(&store, "block-gate-3", "def-1");
+        let inst = make_instance("block-gate-3", "id-z");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        let res = inject_identity_env(store.clone(), store, "block-gate-3", &mut env);
+
+        assert_eq!(
+            res,
+            Err(SpawnGateError { provider: "claude".to_string() }),
+        );
         assert!(env.is_empty());
     }
 
@@ -995,7 +1318,7 @@ mod tests {
     fn inject_no_instance_does_nothing() {
         let store = make_store();
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-no-instance", &mut env);
+        inject_identity_env(store.clone(), store, "block-no-instance", &mut env).unwrap();
         assert!(env.is_empty());
     }
 
@@ -1029,6 +1352,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1038,7 +1362,10 @@ mod tests {
         let _ = inst; // keep clippy happy
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-blank", &mut env);
+        // The blank sentinel is the pre-managed-accounts explicit "ambient
+        // creds" launch choice — NOT gated by layer 3 (Ok even with
+        // use_ambient_login=0).
+        inject_identity_env(store.clone(), store, "block-blank", &mut env).unwrap();
         assert!(env.is_empty());
     }
 
@@ -1074,6 +1401,11 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            // Ambient opt-in: this test exercises api-key / zero-link behavior,
+            // not the layer-3 oauth gate. The def provider (claude) has no
+            // oauth binding here, so without the opt-in the gate would
+            // block the spawn (covered by the spawn_blocked_* tests).
+            use_ambient_login: 1,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1109,7 +1441,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-1", &mut env);
+        inject_identity_env(store.clone(), store, "block-1", &mut env).unwrap();
 
         // GitHub writes both standard env-var names from one secret.
         assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_round_trip"));
@@ -1154,6 +1486,11 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            // Ambient opt-in: this test exercises api-key / zero-link behavior,
+            // not the layer-3 oauth gate. The def provider (claude) has no
+            // oauth binding here, so without the opt-in the gate would
+            // block the spawn (covered by the spawn_blocked_* tests).
+            use_ambient_login: 1,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1174,7 +1511,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-direct", &mut env);
+        inject_identity_env(store.clone(), store, "block-direct", &mut env).unwrap();
 
         assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_direct"));
         assert_eq!(env.get("GH_TOKEN").map(String::as_str), Some("ghp_direct"));
@@ -1214,6 +1551,11 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            // Ambient opt-in: this test exercises api-key / zero-link behavior,
+            // not the layer-3 oauth gate. The def provider (claude) has no
+            // oauth binding here, so without the opt-in the gate would
+            // block the spawn (covered by the spawn_blocked_* tests).
+            use_ambient_login: 1,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1231,7 +1573,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-unlinked", &mut env);
+        inject_identity_env(store.clone(), store, "block-unlinked", &mut env).unwrap();
 
         // Nothing injected — an account with no direct link is invisible
         // to the resolver.
@@ -1274,6 +1616,11 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            // Ambient opt-in: this test exercises api-key / zero-link behavior,
+            // not the layer-3 oauth gate. The def provider (claude) has no
+            // oauth binding here, so without the opt-in the gate would
+            // block the spawn (covered by the spawn_blocked_* tests).
+            use_ambient_login: 1,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1298,7 +1645,8 @@ mod tests {
             Some(broker.clone()),
             "block-unlinked-2",
             &mut env,
-        );
+        )
+        .unwrap();
 
         // The event is persisted (see resolve_bindings_for_instance's
         // publish) precisely so it's readable here without needing a live
@@ -1342,6 +1690,11 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            // Ambient opt-in: this test exercises api-key / zero-link behavior,
+            // not the layer-3 oauth gate. The def provider (claude) has no
+            // oauth binding here, so without the opt-in the gate would
+            // block the spawn (covered by the spawn_blocked_* tests).
+            use_ambient_login: 1,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1376,7 +1729,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-mixed", &mut env);
+        inject_identity_env(store.clone(), store, "block-mixed", &mut env).unwrap();
 
         // GitHub injection succeeded.
         assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_good"));
@@ -1416,6 +1769,11 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            // Ambient opt-in: this test exercises api-key / zero-link behavior,
+            // not the layer-3 oauth gate. The def provider (claude) has no
+            // oauth binding here, so without the opt-in the gate would
+            // block the spawn (covered by the spawn_blocked_* tests).
+            use_ambient_login: 1,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1436,7 +1794,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-future", &mut env);
+        inject_identity_env(store.clone(), store, "block-future", &mut env).unwrap();
         // No env-var matrix for "custom" — nothing injected, no panic.
         assert!(env.is_empty());
     }
@@ -1574,6 +1932,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1606,7 +1965,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store.clone(), "block-probe", &mut env);
+        inject_identity_env(store.clone(), store.clone(), "block-probe", &mut env).unwrap();
 
         // Env injection still happened (resolver doesn't block on
         // probe outcome — the CLI launches with the dir env var set
@@ -1653,6 +2012,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1687,7 +2047,7 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store.clone(), "block-ok", &mut env);
+        inject_identity_env(store.clone(), store.clone(), "block-ok", &mut env).unwrap();
 
         let after = store.identity_get("acct-ok").unwrap().unwrap();
         assert_eq!(after.status, oauth_status::VALID);

--- a/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
+++ b/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
@@ -1,0 +1,223 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Grandfather the layer-3 `use_ambient_login` opt-in for pre-existing
+//! agents (spec §2.4 of SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md).
+//!
+//! The spawn gate (identity/resolver.rs) now FAILS a spawn when an
+//! oauth-class provider the agent is supposed to have credentials for has
+//! no resolvable account — unless the agent carries an explicit
+//! `use_ambient_login = 1`. Existing agents that relied on the (previously
+//! silent) ambient fallback must not all break on upgrade:
+//!
+//! - agents with NO `db_agent_identity_links` rows at migration time were
+//!   de-facto ambient users → `use_ambient_login = 1`;
+//! - agents WITH links opted into managed accounts → `0` (honest failure
+//!   is the correct new behavior for them).
+//!
+//! Channel-scoped: each pre-existing channel's `db_agent_definitions` /
+//! `db_agents` rows get the pass exactly once (fresh channels have no
+//! agent rows, so re-running on a new channel is a no-op — it can never
+//! flip an agent created after the upgrade). The live links table is the
+//! SHARED store's; the channel store's legacy copy is not consulted.
+//! Cross-channel registry records are handled by the Global-scoped
+//! `m0018_ambient_login_registry`.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::backend::storage::store::Store;
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0017AmbientLoginGrandfather;
+
+impl Migration for M0017AmbientLoginGrandfather {
+    fn id(&self) -> &'static str { "0017_ambient_login_grandfather" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Channel }
+    fn description(&self) -> &'static str {
+        "Grandfather use_ambient_login=1 for agents without identity links (layer-3 spawn gating)"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        let wstore = Arc::new(
+            Store::open(&ctx.channel_store_path)
+                .map_err(|e| MigrationError(format!("ambient_login_grandfather: open wstore: {}", e)))?,
+        );
+        // The live links live in the shared store. A missing shared store
+        // (fresh install racing the bootstrap) means no links exist —
+        // every agent row (if any) is a de-facto ambient user.
+        let linked: HashSet<String> = if ctx.shared_store_path.exists() {
+            Store::open_shared(&ctx.shared_store_path)
+                .map_err(|e| MigrationError(format!("ambient_login_grandfather: open shared store: {}", e)))?
+                .agent_ids_with_identity_links()
+                .map_err(|e| MigrationError(format!("ambient_login_grandfather: read links: {}", e)))?
+                .into_iter()
+                .collect()
+        } else {
+            HashSet::new()
+        };
+        let (ambient, managed) = wstore
+            .agents_grandfather_ambient_login(&linked)
+            .map_err(|e| MigrationError(format!("ambient_login_grandfather: {}", e)))?;
+        tracing::info!(
+            target: "identity",
+            ambient,
+            managed,
+            "identity.spawn: ambient-login grandfather — {} linkless agent(s) set to ambient, {} linked agent(s) kept fail-by-default",
+            ambient,
+            managed,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::store::AgentDefinition;
+
+    fn ctx_for(channel: &std::path::Path, shared: &std::path::Path) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path: shared.to_path_buf(),
+            channel_store_path: channel.to_path_buf(),
+        }
+    }
+
+    fn make_def(id: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: id.to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        }
+    }
+
+    /// Spec §2.5 migration test: linkless agent → flag true; linked agent →
+    /// flag false. Links live in the SHARED store; the flag lands on the
+    /// channel store's rows (both tables).
+    #[test]
+    fn linkless_agent_gets_ambient_linked_agent_stays_fail_by_default() {
+        let channel = tempfile::NamedTempFile::new().unwrap();
+        let shared = tempfile::NamedTempFile::new().unwrap();
+
+        // Channel store: two user agents.
+        let wstore = Store::open(channel.path()).unwrap();
+        let mut linkless = make_def("agent-linkless");
+        wstore.agent_def_insert(&mut linkless).unwrap();
+        let mut linked = make_def("agent-linked");
+        wstore.agent_def_insert(&mut linked).unwrap();
+
+        // Shared store: one link for agent-linked. The account row is not
+        // required for the grandfather decision (only the link's presence),
+        // and links-without-accounts are exactly the post-delete shape.
+        let shared_store = Store::open_shared(shared.path()).unwrap();
+        let acct = crate::backend::storage::store::IdentityAccount {
+            id: "acct-1".to_string(),
+            name: "claude-acct-1".to_string(),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: crate::backend::storage::store::SecretRef::OAuthConfigDir {
+                dir: "/tmp/nowhere".to_string(),
+            },
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        shared_store.identity_upsert(&acct).unwrap();
+        shared_store
+            .agent_identity_link("agent-linked", "acct-1", "claude")
+            .unwrap();
+        drop(shared_store);
+        drop(wstore);
+
+        M0017AmbientLoginGrandfather
+            .up(&ctx_for(channel.path(), shared.path()))
+            .unwrap();
+
+        let wstore = Store::open(channel.path()).unwrap();
+        let after_linkless = wstore.agent_def_get("agent-linkless").unwrap().unwrap();
+        assert_eq!(
+            after_linkless.use_ambient_login, 1,
+            "linkless agent must be grandfathered to ambient"
+        );
+        let after_linked = wstore.agent_def_get("agent-linked").unwrap().unwrap();
+        assert_eq!(
+            after_linked.use_ambient_login, 0,
+            "linked agent must keep fail-by-default"
+        );
+        // The consolidated db_agents projection agrees (it's what the
+        // roster/modal read).
+        let listed = wstore.agent_def_list().unwrap();
+        assert_eq!(
+            listed.iter().find(|a| a.id == "agent-linkless").unwrap().use_ambient_login,
+            1,
+        );
+        assert_eq!(
+            listed.iter().find(|a| a.id == "agent-linked").unwrap().use_ambient_login,
+            0,
+        );
+    }
+
+    #[test]
+    fn missing_shared_store_treats_every_agent_as_linkless() {
+        let channel = tempfile::NamedTempFile::new().unwrap();
+        let wstore = Store::open(channel.path()).unwrap();
+        let mut def = make_def("agent-solo");
+        wstore.agent_def_insert(&mut def).unwrap();
+        drop(wstore);
+
+        let missing_shared = std::env::temp_dir()
+            .join("agentmux-test-shared-store-definitely-missing-x9q.db");
+        let _ = std::fs::remove_file(&missing_shared);
+        M0017AmbientLoginGrandfather
+            .up(&ctx_for(channel.path(), &missing_shared))
+            .unwrap();
+
+        let wstore = Store::open(channel.path()).unwrap();
+        assert_eq!(
+            wstore.agent_def_get("agent-solo").unwrap().unwrap().use_ambient_login,
+            1,
+        );
+    }
+
+    #[test]
+    fn missing_channel_store_is_a_noop() {
+        let shared = tempfile::NamedTempFile::new().unwrap();
+        let missing_channel = std::env::temp_dir()
+            .join("agentmux-test-channel-store-definitely-missing-x9q.db");
+        let _ = std::fs::remove_file(&missing_channel);
+        M0017AmbientLoginGrandfather
+            .up(&ctx_for(&missing_channel, shared.path()))
+            .unwrap();
+        assert!(!missing_channel.exists(), "up() must not create the store");
+    }
+}

--- a/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
+++ b/agentmux-srv/src/migrations/m0017_ambient_login_grandfather.rs
@@ -10,10 +10,15 @@
 //! `use_ambient_login = 1`. Existing agents that relied on the (previously
 //! silent) ambient fallback must not all break on upgrade:
 //!
-//! - agents with NO `db_agent_identity_links` rows at migration time were
-//!   de-facto ambient users → `use_ambient_login = 1`;
-//! - agents WITH links opted into managed accounts → `0` (honest failure
-//!   is the correct new behavior for them).
+//! - agents with NO **oauth-class** `db_agent_identity_links` rows at
+//!   migration time were de-facto ambient users for their CLI login →
+//!   `use_ambient_login = 1`. Api-key-class links (e.g. a github PAT) do
+//!   NOT count: they are never spawn-gated, so an agent whose only link is
+//!   a PAT was still relying on the ambient CLI login and must be
+//!   grandfathered, not broken (spec §2.4's rationale — "grandfather
+//!   de-facto ambient users" — keyed on the spawn-relevant provider class);
+//! - agents WITH an oauth-class link opted into managed CLI accounts →
+//!   `0` (honest failure is the correct new behavior for them).
 //!
 //! Channel-scoped: each pre-existing channel's `db_agent_definitions` /
 //! `db_agents` rows get the pass exactly once (fresh channels have no
@@ -28,6 +33,22 @@ use std::sync::Arc;
 
 use crate::backend::storage::store::Store;
 use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+/// Agent ids whose links include at least one **oauth-class** provider —
+/// the only class the layer-3 spawn gate blocks on. Shared by m0017
+/// (channel rows) and m0018 (registry records) so the two passes can never
+/// disagree on the rule.
+pub(crate) fn oauth_linked_agent_ids(
+    shared: &Store,
+) -> Result<HashSet<String>, crate::backend::storage::error::StoreError> {
+    use crate::identity::resolver::{provider_class, ProviderClass};
+    Ok(shared
+        .agent_identity_link_provider_pairs()?
+        .into_iter()
+        .filter(|(_, provider)| matches!(provider_class(provider), Some(ProviderClass::OAuth { .. })))
+        .map(|(agent_id, _)| agent_id)
+        .collect())
+}
 
 pub struct M0017AmbientLoginGrandfather;
 
@@ -50,12 +71,10 @@ impl Migration for M0017AmbientLoginGrandfather {
         // (fresh install racing the bootstrap) means no links exist —
         // every agent row (if any) is a de-facto ambient user.
         let linked: HashSet<String> = if ctx.shared_store_path.exists() {
-            Store::open_shared(&ctx.shared_store_path)
-                .map_err(|e| MigrationError(format!("ambient_login_grandfather: open shared store: {}", e)))?
-                .agent_ids_with_identity_links()
+            let shared = Store::open_shared(&ctx.shared_store_path)
+                .map_err(|e| MigrationError(format!("ambient_login_grandfather: open shared store: {}", e)))?;
+            oauth_linked_agent_ids(&shared)
                 .map_err(|e| MigrationError(format!("ambient_login_grandfather: read links: {}", e)))?
-                .into_iter()
-                .collect()
         } else {
             HashSet::new()
         };
@@ -184,6 +203,56 @@ mod tests {
         assert_eq!(
             listed.iter().find(|a| a.id == "agent-linked").unwrap().use_ambient_login,
             0,
+        );
+    }
+
+    /// Spec §2.4 (as clarified): only OAUTH-CLASS links forfeit
+    /// grandfathering. An agent whose only link is an api-key-class github
+    /// PAT was still a de-facto ambient user for its CLI login — the spawn
+    /// gate never blocks on api-key providers, so counting that link would
+    /// break exactly the users grandfathering exists to protect.
+    #[test]
+    fn api_key_only_links_do_not_forfeit_grandfathering() {
+        let channel = tempfile::NamedTempFile::new().unwrap();
+        let shared = tempfile::NamedTempFile::new().unwrap();
+
+        let wstore = Store::open(channel.path()).unwrap();
+        let mut pat_only = make_def("agent-pat-only");
+        wstore.agent_def_insert(&mut pat_only).unwrap();
+        drop(wstore);
+
+        // Shared store: a github (api-key-class) link and nothing else.
+        let shared_store = Store::open_shared(shared.path()).unwrap();
+        let acct = crate::backend::storage::store::IdentityAccount {
+            id: "acct-gh".to_string(),
+            name: "asaf-github".to_string(),
+            provider: "github".to_string(),
+            kind: "pat".to_string(),
+            display_name: String::new(),
+            secret_ref: crate::backend::storage::store::SecretRef::Keychain {
+                service: "agentmux".to_string(),
+                account: "acct-gh".to_string(),
+            },
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        shared_store.identity_upsert(&acct).unwrap();
+        shared_store
+            .agent_identity_link("agent-pat-only", "acct-gh", "github")
+            .unwrap();
+        drop(shared_store);
+
+        M0017AmbientLoginGrandfather
+            .up(&ctx_for(channel.path(), shared.path()))
+            .unwrap();
+
+        let wstore = Store::open(channel.path()).unwrap();
+        assert_eq!(
+            wstore.agent_def_get("agent-pat-only").unwrap().unwrap().use_ambient_login,
+            1,
+            "a PAT-only agent is a de-facto ambient CLI user and must be grandfathered"
         );
     }
 

--- a/agentmux-srv/src/migrations/m0018_ambient_login_registry.rs
+++ b/agentmux-srv/src/migrations/m0018_ambient_login_registry.rs
@@ -40,13 +40,14 @@ impl Migration for M0018AmbientLoginRegistry {
         let def_store = registry::DefinitionStore::open(def_dir)
             .map_err(|e| MigrationError(format!("ambient_login_registry: open def store: {}", e)))?;
 
+        // Same oauth-class-only rule as m0017 (shared helper — the two
+        // passes must never disagree): api-key links don't forfeit
+        // grandfathering.
         let linked: HashSet<String> = if ctx.shared_store_path.exists() {
-            Store::open_shared(&ctx.shared_store_path)
-                .map_err(|e| MigrationError(format!("ambient_login_registry: open shared store: {}", e)))?
-                .agent_ids_with_identity_links()
+            let shared = Store::open_shared(&ctx.shared_store_path)
+                .map_err(|e| MigrationError(format!("ambient_login_registry: open shared store: {}", e)))?;
+            super::m0017_ambient_login_grandfather::oauth_linked_agent_ids(&shared)
                 .map_err(|e| MigrationError(format!("ambient_login_registry: read links: {}", e)))?
-                .into_iter()
-                .collect()
         } else {
             HashSet::new()
         };

--- a/agentmux-srv/src/migrations/m0018_ambient_login_registry.rs
+++ b/agentmux-srv/src/migrations/m0018_ambient_login_registry.rs
@@ -1,0 +1,160 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Grandfather `use_ambient_login` on the GLOBAL cross-channel definition
+//! registry (`~/.agentmux/shared/agents/definitions/`) — the sibling of
+//! `m0017_ambient_login_grandfather`, which handles the per-channel SQLite
+//! projections.
+//!
+//! Why a separate, Global-scoped step: an agent created in channel A is
+//! surfaced in channel B only via its registry record (`agent_def_get`'s
+//! registry fallback), so a record left at the serde-default `0` would
+//! block that agent's spawns in every OTHER channel even after m0017
+//! grandfathered channel A's SQLite rows. Global scope also means this
+//! runs exactly once ever — a Channel-scoped registry pass would re-run
+//! when a NEW channel is created later and wrongly flip agents that were
+//! deliberately created fail-by-default after the upgrade.
+//!
+//! Spec §2.4 of SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md.
+
+use std::collections::HashSet;
+
+use crate::backend::storage::store::Store;
+use crate::registry;
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0018AmbientLoginRegistry;
+
+impl Migration for M0018AmbientLoginRegistry {
+    fn id(&self) -> &'static str { "0018_ambient_login_registry" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Global }
+    fn description(&self) -> &'static str {
+        "Grandfather use_ambient_login=1 on linkless cross-channel definition records"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        let def_dir = ctx.home.join("shared").join("agents").join("definitions");
+        if !def_dir.exists() {
+            return Ok(());
+        }
+        let def_store = registry::DefinitionStore::open(def_dir)
+            .map_err(|e| MigrationError(format!("ambient_login_registry: open def store: {}", e)))?;
+
+        let linked: HashSet<String> = if ctx.shared_store_path.exists() {
+            Store::open_shared(&ctx.shared_store_path)
+                .map_err(|e| MigrationError(format!("ambient_login_registry: open shared store: {}", e)))?
+                .agent_ids_with_identity_links()
+                .map_err(|e| MigrationError(format!("ambient_login_registry: read links: {}", e)))?
+                .into_iter()
+                .collect()
+        } else {
+            HashSet::new()
+        };
+
+        let records = def_store
+            .list_active()
+            .map_err(|e| MigrationError(format!("ambient_login_registry: list records: {}", e)))?;
+        let mut flipped = 0usize;
+        for mut rec in records {
+            let id = rec.data.id.clone();
+            let want = if linked.contains(&id) { 0 } else { 1 };
+            if rec.data.use_ambient_login != want {
+                rec.data.use_ambient_login = want;
+                def_store
+                    .upsert(&rec)
+                    .map_err(|e| MigrationError(format!("ambient_login_registry: upsert {}: {}", id, e)))?;
+                flipped += 1;
+            }
+        }
+        tracing::info!(
+            target: "identity",
+            flipped,
+            "identity.spawn: ambient-login registry grandfather — {} record(s) updated",
+            flipped,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::{DefinitionRecord, DefinitionRecordV1, DEF_MAX_SUPPORTED_SCHEMA};
+
+    fn record(id: &str) -> DefinitionRecord {
+        DefinitionRecord {
+            schema_version: DEF_MAX_SUPPORTED_SCHEMA,
+            data: DefinitionRecordV1 {
+                id: id.to_string(),
+                name: id.to_string(),
+                provider: "claude".to_string(),
+                is_seeded: 0,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn linkless_record_flips_to_ambient_linked_record_stays() {
+        let home = tempfile::tempdir().unwrap();
+        let def_dir = home.path().join("shared").join("agents").join("definitions");
+        let def_store = registry::DefinitionStore::open(def_dir.clone()).unwrap();
+        def_store.upsert(&record("remote-linkless")).unwrap();
+        def_store.upsert(&record("remote-linked")).unwrap();
+
+        let shared = home.path().join("shared").join("store.db");
+        std::fs::create_dir_all(shared.parent().unwrap()).unwrap();
+        let shared_store = Store::open_shared(&shared).unwrap();
+        let acct = crate::backend::storage::store::IdentityAccount {
+            id: "acct-1".to_string(),
+            name: "claude-acct-1".to_string(),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: crate::backend::storage::store::SecretRef::OAuthConfigDir {
+                dir: "/tmp/nowhere".to_string(),
+            },
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        shared_store.identity_upsert(&acct).unwrap();
+        shared_store
+            .agent_identity_link("remote-linked", "acct-1", "claude")
+            .unwrap();
+        drop(shared_store);
+
+        let ctx = MigrationContext {
+            home: home.path().to_path_buf(),
+            data_dir: home.path().to_path_buf(),
+            shared_store_path: shared,
+            channel_store_path: home.path().join("unused-objects.db"),
+        };
+        M0018AmbientLoginRegistry.up(&ctx).unwrap();
+
+        let reopened = registry::DefinitionStore::open(def_dir).unwrap();
+        assert_eq!(
+            reopened.get("remote-linkless").unwrap().unwrap().data.use_ambient_login,
+            1,
+            "linkless registry record must be grandfathered to ambient"
+        );
+        assert_eq!(
+            reopened.get("remote-linked").unwrap().unwrap().data.use_ambient_login,
+            0,
+            "linked registry record must keep fail-by-default"
+        );
+    }
+
+    #[test]
+    fn missing_registry_dir_is_a_noop() {
+        let home = tempfile::tempdir().unwrap();
+        let ctx = MigrationContext {
+            home: home.path().to_path_buf(),
+            data_dir: home.path().to_path_buf(),
+            shared_store_path: home.path().join("shared").join("store.db"),
+            channel_store_path: home.path().join("unused-objects.db"),
+        };
+        M0018AmbientLoginRegistry.up(&ctx).unwrap();
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -32,6 +32,8 @@ mod m0013_agent_direct_bindings;
 mod m0014_agent_direct_bindings_rerun;
 mod m0015_seed_starter_skills;
 mod m0016_seed_starter_mcp_servers;
+mod m0017_ambient_login_grandfather;
+mod m0018_ambient_login_registry;
 mod runner;
 
 pub use runner::count_pending_migrations;
@@ -124,4 +126,6 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0014_agent_direct_bindings_rerun::M0014AgentDirectBindingsRerun,
     &m0015_seed_starter_skills::M0015SeedStarterSkills,
     &m0016_seed_starter_mcp_servers::M0016SeedStarterMcpServers,
+    &m0017_ambient_login_grandfather::M0017AmbientLoginGrandfather,
+    &m0018_ambient_login_registry::M0018AmbientLoginRegistry,
 ];

--- a/agentmux-srv/src/registry/def_migrate.rs
+++ b/agentmux-srv/src/registry/def_migrate.rs
@@ -85,6 +85,7 @@ const DEF_COLUMNS: &[(&str, &str)] = &[
     ("container_image", "''"),
     ("container_volumes", "'[]'"),
     ("container_name", "''"),
+    ("use_ambient_login", "0"),
 ];
 
 /// Outcome stats — surfaced in the srv log.
@@ -293,6 +294,7 @@ fn read_user_definitions(db: &Path) -> Result<Vec<(DefinitionRecord, i64)>, rusq
                 container_image: row.get(22)?,
                 container_volumes: row.get(23)?,
                 container_name: row.get(24)?,
+                use_ambient_login: row.get(25)?,
                 content: Vec::new(),
                 skills: Vec::new(),
             })

--- a/agentmux-srv/src/registry/def_schema.rs
+++ b/agentmux-srv/src/registry/def_schema.rs
@@ -121,6 +121,14 @@ pub struct DefinitionRecordV1 {
     pub container_volumes: String,
     #[serde(default)]
     pub container_name: String,
+    /// Explicit per-agent opt-in to the CLI's global (ambient) login when
+    /// no oauth-class account resolves at spawn (mirrors the SQLite v12
+    /// column — SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3).
+    /// Additive under `#[serde(default)]` (older files read as 0 =
+    /// fail-by-default; older binaries ignore the extra field), same as
+    /// the container_* fields — no envelope bump.
+    #[serde(default)]
+    pub use_ambient_login: i64,
     /// System-prompt / mcp / env / soul / startup blobs (db_agent_content),
     /// embedded so a cross-channel agent launches with its instructions.
     #[serde(default)]
@@ -205,6 +213,7 @@ mod tests {
                 container_image: String::new(),
                 container_volumes: "[]".to_string(),
                 container_name: String::new(),
+                use_ambient_login: 0,
                 content: Vec::new(),
                 skills: Vec::new(),
             },

--- a/agentmux-srv/src/registry/def_store.rs
+++ b/agentmux-srv/src/registry/def_store.rs
@@ -304,6 +304,7 @@ mod tests {
                 container_image: String::new(),
                 container_volumes: "[]".to_string(),
                 container_name: String::new(),
+                use_ambient_login: 0,
                 content: Vec::new(),
                 skills: Vec::new(),
             },

--- a/agentmux-srv/src/server/agent_handlers/core.rs
+++ b/agentmux-srv/src/server/agent_handlers/core.rs
@@ -123,6 +123,10 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_image: String::new(),
                     container_volumes: "[]".to_string(),
                     container_name: String::new(),
+                    // New agents fail-by-default on missing oauth creds; the
+                    // ambient opt-in is an explicit per-agent toggle (spec
+                    // §2.2 edge case — no implicit ambient for fresh agents).
+                    use_ambient_login: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -203,6 +207,11 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_volumes: if cmd.container_volumes == "[]" { old.container_volumes.clone() } else { cmd.container_volumes },
                     // container_name is server-managed; preserve the existing value.
                     container_name: old.container_name.clone(),
+                    // Preserve the ambient-login opt-in when the caller omits
+                    // the field (Option — most callers only edit name/icon/
+                    // accounts). The Agent setup modal's Accounts tab sends
+                    // Some(0|1) to flip it. Spec §2.3.
+                    use_ambient_login: cmd.use_ambient_login.unwrap_or(old.use_ambient_login),
                 };
                 let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -398,6 +407,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_image: String::new(),
                     container_volumes: "[]".to_string(),
                     container_name: String::new(),
+                    use_ambient_login: 0,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
 
@@ -533,6 +543,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         container_image: String::new(),
                         container_volumes: "[]".to_string(),
                         container_name: String::new(),
+                        use_ambient_login: 0,
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -98,6 +98,9 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
     // Container manager — None on hosts without Docker; container agents
     // return an error to the caller rather than crashing the server.
     let container_manager_ai = state.container_manager.clone();
+    // Filestore — the spawn-gate error frame must be PERSISTED to the
+    // block file, not just live-broadcast (reagent P1, PR #2164 round 2).
+    let filestore_ai = state.filestore.clone();
     engine.register_handler(
         COMMAND_AGENT_INPUT,
         Box::new(move |data, _ctx| {
@@ -106,6 +109,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
             let auth_key = auth_key_ai.clone();
             let broker = broker_ai.clone();
             let container_manager = container_manager_ai.clone();
+            let filestore_gate = filestore_ai.clone();
             Box::pin(async move {
                 let cmd: CommandAgentInputData = serde_json::from_value(data)
                     .map_err(|e| format!("agentinput: {e}"))?;
@@ -179,12 +183,16 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                             "error": {"message": format!("[AgentMux] {gate}")}
                         })
                         .to_string();
+                        // Some(&filestore_gate): the frame must be PERSISTED
+                        // to the block file, not just live-broadcast —
+                        // otherwise the error vanishes on pane
+                        // reload/reconnect (reagent P1, PR #2164 round 2).
                         crate::backend::blockcontroller::shell::handle_append_block_file(
                             &broker,
                             &cmd.blockid,
                             crate::backend::blockcontroller::subprocess::SUBPROCESS_OUTPUT_SUBJECT,
                             format!("{error_frame}\n").as_bytes(),
-                            None,
+                            Some(&filestore_gate),
                             None,
                         );
                         return Err(format!("identity spawn gate: {gate}"));

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -148,21 +148,48 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                 };
                 // Identity injection: look up the active AgentInstance for
                 // this block, resolve its identity_id's bindings, and merge
-                // each per-provider env var into the spawn map. Failures
-                // are logged and skipped — the agent CLI launches with
-                // whatever resolved cleanly plus the static cmd:env block.
+                // each per-provider env var into the spawn map. Api-key-class
+                // failures are logged and skipped — the agent CLI launches
+                // with whatever resolved cleanly plus the static cmd:env
+                // block. Oauth-class resolution failures are BLOCKING unless
+                // the agent opted into ambient login (layer-3 spawn gate,
+                // SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.2):
+                // surface the error in the agent pane (same
+                // `error_during_execution` frame the container spawn-failure
+                // path uses below) and abort before the CLI is created.
                 // See agentmux-srv/src/identity/resolver.rs. Broker
                 // hand-in lets the OAuth expiry probe (PR D, spec §4.4)
                 // publish `identitybundlebindings:changed:<bundle_id>`
                 // when it flips a token's status valid→expired etc.
-                env_vars = crate::identity::resolver::inject_identity_env_async(
+                env_vars = match crate::identity::resolver::inject_identity_env_async(
                     wstore.clone(),
                     id_store.clone(),
                     Some(broker.clone()),
                     cmd.blockid.clone(),
                     env_vars,
                 )
-                .await;
+                .await
+                {
+                    Ok(env) => env,
+                    Err(gate) => {
+                        let error_frame = serde_json::json!({
+                            "type": "result",
+                            "is_error": true,
+                            "subtype": "error_during_execution",
+                            "error": {"message": format!("[AgentMux] {gate}")}
+                        })
+                        .to_string();
+                        crate::backend::blockcontroller::shell::handle_append_block_file(
+                            &broker,
+                            &cmd.blockid,
+                            crate::backend::blockcontroller::subprocess::SUBPROCESS_OUTPUT_SUBJECT,
+                            format!("{error_frame}\n").as_bytes(),
+                            None,
+                            None,
+                        );
+                        return Err(format!("identity spawn gate: {gate}"));
+                    }
+                };
                 // MuxBus cloud token — injects MUXBUS_TOKEN + MUXBUS_COGNITO_DOMAIN
                 // if the user has authenticated via muxbus.login. No-op if no
                 // credentials are stored. Auto-refreshes if token is nearly expired.

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -398,6 +398,7 @@ mod recent_sessions_tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         let mut def_mut = def.clone();
         wstore.agent_def_insert(&mut def_mut).unwrap();
@@ -695,6 +696,7 @@ mod recent_sessions_tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         wstore.agent_def_insert(&mut tpl).unwrap();
 
@@ -724,6 +726,7 @@ mod recent_sessions_tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
+            use_ambient_login: 0,
         };
         wstore.agent_def_insert(&mut user_a).unwrap();
 

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -141,6 +141,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_image: template.container_image.clone(),
                     container_volumes: template.container_volumes.clone(),
                     container_name: String::new(),
+                    use_ambient_login: 0,
                 };
                 wstore
                     .agent_def_insert(&mut new_def)
@@ -348,6 +349,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     container_image: source.container_image.clone(),
                     container_volumes: source.container_volumes.clone(),
                     container_name: String::new(),
+                    use_ambient_login: 0,
                 };
                 wstore
                     .agent_def_insert(&mut fork)

--- a/agentmux-srv/src/server/app_api/agent_io.rs
+++ b/agentmux-srv/src/server/app_api/agent_io.rs
@@ -149,20 +149,46 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         .collect(),
                     _ => std::collections::HashMap::new(),
                 };
-                // Identity injection — same path as websocket.rs's
-                // AgentInputCommand. See identity/resolver.rs. Passes
+                // Identity injection — same path as the `agentinput`
+                // handler. See identity/resolver.rs. Passes
                 // the broker so the OAuth-class branch can publish a
                 // `identitybundlebindings:changed:<bundle_id>` event
                 // when the expiry probe updates an account's status
-                // (PR D — spec §4.4).
-                env_vars = crate::identity::resolver::inject_identity_env_async(
+                // (PR D — spec §4.4). Oauth-class resolution failures are
+                // BLOCKING unless the agent opted into ambient login
+                // (layer-3 spawn gate, SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4
+                // _2026_07_14.md §2.2): surface the error in the agent pane
+                // via the `error_during_execution` frame (rendered as an
+                // agent_error node) and abort before the CLI is created.
+                env_vars = match crate::identity::resolver::inject_identity_env_async(
                     wstore.clone(),
                     id_store.clone(),
                     Some(broker.clone()),
                     cmd.block_id.clone(),
                     env_vars,
                 )
-                .await;
+                .await
+                {
+                    Ok(env) => env,
+                    Err(gate) => {
+                        let error_frame = serde_json::json!({
+                            "type": "result",
+                            "is_error": true,
+                            "subtype": "error_during_execution",
+                            "error": {"message": format!("[AgentMux] {gate}")}
+                        })
+                        .to_string();
+                        crate::backend::blockcontroller::shell::handle_append_block_file(
+                            &broker,
+                            &cmd.block_id,
+                            crate::backend::blockcontroller::subprocess::SUBPROCESS_OUTPUT_SUBJECT,
+                            format!("{error_frame}\n").as_bytes(),
+                            None,
+                            None,
+                        );
+                        return Err(format!("identity spawn gate: {gate}"));
+                    }
+                };
                 let session_id_field = obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/agentmux-srv/src/server/app_api/agent_io.rs
+++ b/agentmux-srv/src/server/app_api/agent_io.rs
@@ -110,6 +110,7 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
     let broker = state.broker.clone();
     let container_manager = state.container_manager.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_AGENT_SEND,
@@ -118,6 +119,7 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let id_store = id_store.clone();
             let broker = broker.clone();
             let container_manager = container_manager.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandAgentSendData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.send: {e}"))?;
@@ -178,12 +180,16 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             "error": {"message": format!("[AgentMux] {gate}")}
                         })
                         .to_string();
+                        // Some(filestore): the frame must be PERSISTED to the
+                        // block file, not just live-broadcast — otherwise the
+                        // error vanishes on pane reload/reconnect (reagent P1,
+                        // PR #2164 round 2).
                         crate::backend::blockcontroller::shell::handle_append_block_file(
                             &broker,
                             &cmd.block_id,
                             crate::backend::blockcontroller::subprocess::SUBPROCESS_OUTPUT_SUBJECT,
                             format!("{error_frame}\n").as_bytes(),
-                            None,
+                            Some(&filestore),
                             None,
                         );
                         return Err(format!("identity spawn gate: {gate}"));

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -334,6 +334,7 @@ pub(crate) async fn agent_define_core(
         container_image: cmd.container_image.clone(),
         container_volumes: cmd.container_volumes.clone(),
         container_name: String::new(), // assigned by ContainerManager on first spawn
+        use_ambient_login: 0,
     };
 
     // Atomic check-then-insert.

--- a/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
+++ b/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
@@ -74,10 +74,17 @@ updates.
 
 Existing agents that currently rely on ambient fallback must not all break
 on upgrade: a migration sets `use_ambient_login = true` for agents that have
-NO identity/account link rows at migration time (they were de-facto ambient
-users), and `false` for agents that have links (they opted into managed
-accounts; honest failure is the correct new behavior for them). This makes
-the honest semantics apply exactly where the user expressed intent.
+NO **oauth-class** identity link rows at migration time (they were de-facto
+ambient users for their CLI login), and `false` for agents that have an
+oauth-class link (they opted into managed CLI accounts; honest failure is
+the correct new behavior for them). Api-key-class links (e.g. a github PAT)
+do NOT count against grandfathering — they are never spawn-gated, so an
+agent whose only link is a PAT was still an ambient CLI user, and blocking
+it would break exactly the users this section exists to protect.
+(Clarified 2026-07-14 during implementation review: the original wording
+said "no link rows" of any kind, which contradicted this section's own
+rationale.) This makes the honest semantics apply exactly where the user
+expressed intent.
 
 ### 2.5 Tests (the resolver test forces the semantics)
 

--- a/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
+++ b/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
@@ -45,8 +45,8 @@ launched with that provider):
   (default) → **spawn fails** before the CLI process is created. The error
   must reach the agent pane UI (the same surface other spawn failures use),
   wording: `no credentials for <provider>: the bound account was deleted or
-  is unresolvable. Bind an account in the Armory, or enable "Use global
-  login" in this agent's settings.` Log `tracing::warn!` with prefix
+  is unresolvable. Bind an account in the Armory, or enable "Use global CLI
+  login when no account is bound" in this agent's settings.` Log `tracing::warn!` with prefix
   `identity.spawn.blocked:` (extends the `muxlog auth` vocabulary — update
   the muxlog regex to cover `identity\.spawn`).
 - Account missing AND `use_ambient_login = true` → proceed WITHOUT injecting

--- a/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
+++ b/docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md
@@ -1,0 +1,135 @@
+# SPEC — honest account-delete semantics: spawn gating, agent reconciliation, Armory truthfulness
+
+**Date:** 2026-07-14
+**Status:** Approved (user decision on §2 recorded this date); implementation dispatched
+**Governing analysis:** `docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md`
+(layers 2.1–2.4). Layer 1 (cascade + token-dir cleanup) shipped in PR #2159.
+This spec covers the remaining layers 2 (running-agent reconciliation),
+3 (ambient-fallback gating — the load-bearing one), and 4 (UI truthfulness).
+
+---
+
+## 1. Decision record
+
+**User decision (2026-07-14): fail by default + explicit per-agent opt-in.**
+When an oauth-class provider has no resolvable account for an agent at spawn
+time, the spawn FAILS with a clear, user-visible error ("no credentials for
+provider anthropic — bind an account in the Armory or enable 'use global
+login' for this agent") — unless the agent carries an explicit
+`use_ambient_login` (naming: see §3.2) opt-in, in which case the CLI's
+default behavior (reading the user's global `~/.claude`) is allowed and
+**surfaced**, never silent.
+
+Rejected alternatives: hard-fail-always (breaks the casual personal-login
+flow), keep-fallback-but-loud (delete still wouldn't deauthenticate a
+respawned agent — fails the core requirement).
+
+## 2. Layer 3 — spawn gating (backend, the load-bearing change)
+
+### 2.1 Current behavior
+
+`identity/resolver.rs` per-binding resolution treats every failure —
+including "account row not found" (the post-delete case) — as log-and-skip
+(~lines 577–590). With nothing injected, the spawned CLI silently uses the
+ambient global login. No AgentMux log line even records that the fallback
+happened (the CLI does it, not us).
+
+### 2.2 New behavior
+
+At spawn assembly, for each oauth-class provider the agent is *supposed* to
+have credentials for (i.e. a binding/link exists OR the agent previously
+launched with that provider):
+
+- Account resolves → inject config-dir env var (unchanged).
+- Account missing/unresolvable AND agent has `use_ambient_login = false`
+  (default) → **spawn fails** before the CLI process is created. The error
+  must reach the agent pane UI (the same surface other spawn failures use),
+  wording: `no credentials for <provider>: the bound account was deleted or
+  is unresolvable. Bind an account in the Armory, or enable "Use global
+  login" in this agent's settings.` Log `tracing::warn!` with prefix
+  `identity.spawn.blocked:` (extends the `muxlog auth` vocabulary — update
+  the muxlog regex to cover `identity\.spawn`).
+- Account missing AND `use_ambient_login = true` → proceed WITHOUT injecting
+  a config dir (CLI uses its global default), and log
+  `identity.spawn.ambient: using global CLI login (per-agent opt-in)` at
+  info. This is the only sanctioned ambient path.
+- Edge: agent has NO binding at all for the provider and never had one
+  (fresh casual agent, never touched the Armory) — treat as
+  `use_ambient_login` implicitly true? **No.** Implicit ambient is how we
+  got here. Instead: the agent-creation flow keeps working because agent
+  creation (launch modal) already binds-or-creates an identity; agents that
+  genuinely have no identity record for the provider get the ambient path
+  ONLY via the explicit flag. Migration (§2.4) grandfathers existing agents.
+
+### 2.3 The opt-in flag
+
+Per-agent, persisted on the agent definition (`db_agents` — follow the
+existing pattern for agent-level booleans; check how e.g. model/effort
+settings are stored). Exposed in the Agent setup modal (Accounts tab is the
+natural home) as "Use global CLI login when no account is bound" with copy
+that says what it means. RPC plumbing mirrors existing agent-settings
+updates.
+
+### 2.4 Migration / rollout safety
+
+Existing agents that currently rely on ambient fallback must not all break
+on upgrade: a migration sets `use_ambient_login = true` for agents that have
+NO identity/account link rows at migration time (they were de-facto ambient
+users), and `false` for agents that have links (they opted into managed
+accounts; honest failure is the correct new behavior for them). This makes
+the honest semantics apply exactly where the user expressed intent.
+
+### 2.5 Tests (the resolver test forces the semantics)
+
+- binding → missing account → flag false → spawn-assembly returns the
+  blocking error (not a skip).
+- binding → missing account → flag true → no injection + ambient log +
+  spawn proceeds.
+- resolvable account → unchanged injection (regression).
+- migration test: linkless agent → flag true; linked agent → flag false.
+
+## 3. Layer 2 — running-agent reconciliation (on delete)
+
+Chosen shape: **(b) surface, don't hard-kill.** Deleting an account marks
+affected running agents rather than terminating mid-turn work; combined with
+layer 3, the next spawn/restart is where enforcement lands. (Hard-stop
+remains available to the user per-pane as always.)
+
+- On `deleteidentityaccount` (and `unlinkagentidentity`), after the cascade:
+  look up affected agent ids (the links are being deleted in the same
+  transaction — capture the agent_ids BEFORE the delete, inside
+  `identity_delete`, and return them in `IdentityDeleteOutcome`).
+- Publish a targeted event per affected agent (follow the existing
+  `agentidentities:changed:<agent_id>` pattern) carrying
+  `credentials_revoked: true` + provider.
+- Agent pane subscribes and shows a persistent, dismissable state chip:
+  "Credentials revoked — this agent still holds tokens until restarted."
+  Wording must be honest: the process is still authenticated (analysis
+  §2.1); we are disclosing, not pretending to revoke.
+- Log `identity.delete: N running agent(s) affected` (info, auth vocabulary).
+
+## 4. Layer 4 — Armory truthfulness
+
+While any *running* agent was using a deleted account (layer 2's affected
+set), the Accounts tab shows a transient notice row / toast: "Account
+deleted. N running agent(s) still hold its tokens until restarted." No new
+persistent state — the account row is gone (that's correct); this is a
+disclosure at delete time, driven by the same `IdentityDeleteOutcome` data.
+The delete confirmation dialog (if one exists; add one if not) shows the
+affected-agent count BEFORE the delete: "2 running agents use this account."
+
+## 5. Deferred (unchanged from the analysis)
+
+- Provider-side token revocation (CLI `logout` subprocess) — follow-up.
+- Hard-stop-on-delete option — revisit only if disclosure proves
+  insufficient in practice.
+
+## 6. Sequencing
+
+Two PRs, parallel-safe:
+- **PR A (layer 3):** resolver gating + flag + migration + modal toggle +
+  muxlog regex extension + tests. Backend-heavy.
+- **PR B (layers 2+4):** `IdentityDeleteOutcome.affected_agents` +
+  events + pane chip + Armory delete-time disclosure + tests.
+  Touches the delete handler that PR A doesn't.
+Shared surface: `IdentityDeleteOutcome` is PR B's; PR A must not touch it.

--- a/frontend/app/view/agent/components/AgentIdentityModal.scss
+++ b/frontend/app/view/agent/components/AgentIdentityModal.scss
@@ -13,6 +13,91 @@
     max-width: 560px;
 }
 
+// Layer-3 ambient-login opt-in row (spec §2.3 —
+// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md). Local switch
+// styling mirrors the settings pane's .setting-toggle (that stylesheet
+// isn't loaded in the agent-pane modal context).
+.agent-ambient-login-section {
+    padding: var(--space-3) var(--space-5);
+    border-top: 1px solid var(--border-color);
+}
+
+.agent-ambient-login-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.agent-ambient-login-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    flex: 1;
+    min-width: 0;
+}
+
+.agent-ambient-login-label {
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--main-text-color);
+}
+
+.agent-ambient-login-help {
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+    line-height: 1.4;
+}
+
+.agent-ambient-login-toggle {
+    flex: none;
+    position: relative;
+    width: 34px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 9px;
+    background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+    cursor: default;
+
+    &:disabled {
+        opacity: 0.6;
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--shadow-focus-ring);
+    }
+
+    .agent-ambient-login-toggle-thumb {
+        position: absolute;
+        top: 1px;
+        left: 1px;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: var(--main-text-color);
+        opacity: 0.7;
+        transition: transform 120ms ease;
+    }
+
+    &--on {
+        background: var(--accent-color);
+        border-color: var(--accent-color);
+
+        .agent-ambient-login-toggle-thumb {
+            transform: translateX(16px);
+            background: var(--button-text-color);
+            opacity: 1;
+        }
+    }
+}
+
+.agent-ambient-login-error {
+    margin-top: var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--error-color);
+}
+
 .agent-modal-footer {
     display: flex;
     justify-content: flex-end;

--- a/frontend/app/view/agent/components/AgentIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityModal.tsx
@@ -15,10 +15,16 @@
  * the snapshot so the next assignment builds on the latest state rather
  * than the snapshot from when the modal opened (Codex P2 on PR #1587).
  *
+ * Also hosts the per-agent "Use global CLI login" toggle
+ * (`use_ambient_login`) — the explicit opt-in that lets a spawn proceed
+ * on the CLI's global login when no oauth-class account resolves.
+ * Without it, such spawns fail with a visible error (layer-3 spawn
+ * gating, SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.2-§2.3).
+ *
  * Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md §4.
  */
 
-import { createSignal, onCleanup, type JSX } from "solid-js";
+import { createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import {
@@ -44,28 +50,56 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
     // memo keeps reading the original snapshot and the second assignment
     // overwrites the first.
     const [liveAgent, setLiveAgent] = createSignal<AgentDefinition>(props.agent);
+    const [ambientSaving, setAmbientSaving] = createSignal(false);
+    const [ambientError, setAmbientError] = createSignal<string | null>(null);
+
+    /** Common UpdateAgentDefinitionCommand payload from the live snapshot.
+     *  `accounts` / `use_ambient_login` are layered on by the callers. */
+    const basePayload = (a: AgentDefinition): CommandUpdateAgentDefinitionData => ({
+        id: a.id,
+        name: a.name,
+        icon: a.icon,
+        provider: a.provider,
+        description: a.description,
+        working_directory: a.working_directory,
+        shell: a.shell,
+        provider_flags: a.provider_flags,
+        auto_start: a.auto_start,
+        restart_on_crash: a.restart_on_crash,
+        idle_timeout_minutes: a.idle_timeout_minutes,
+        agent_type: a.agent_type,
+        environment: a.environment,
+        agent_bus_id: a.agent_bus_id,
+    });
 
     const handleUpdate = async (newAccounts: AgentAccounts): Promise<void> => {
         const a = liveAgent();
         const serialized = serializeAgentAccounts(newAccounts);
         await RpcApi.UpdateAgentDefinitionCommand(TabRpcClient, {
-            id: a.id,
-            name: a.name,
-            icon: a.icon,
-            provider: a.provider,
-            description: a.description,
-            working_directory: a.working_directory,
-            shell: a.shell,
-            provider_flags: a.provider_flags,
-            auto_start: a.auto_start,
-            restart_on_crash: a.restart_on_crash,
-            idle_timeout_minutes: a.idle_timeout_minutes,
-            agent_type: a.agent_type,
-            environment: a.environment,
-            agent_bus_id: a.agent_bus_id,
+            ...basePayload(a),
             accounts: serialized,
         });
         setLiveAgent({ ...a, accounts: serialized });
+    };
+
+    const ambientOn = () => (liveAgent().use_ambient_login ?? 0) !== 0;
+
+    const handleAmbientToggle = async (): Promise<void> => {
+        const a = liveAgent();
+        const next = ambientOn() ? 0 : 1;
+        setAmbientError(null);
+        setAmbientSaving(true);
+        try {
+            await RpcApi.UpdateAgentDefinitionCommand(TabRpcClient, {
+                ...basePayload(a),
+                use_ambient_login: next,
+            });
+            setLiveAgent({ ...a, use_ambient_login: next });
+        } catch (e) {
+            setAmbientError(String(e));
+        } finally {
+            setAmbientSaving(false);
+        }
     };
 
     return (
@@ -75,6 +109,38 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
                 model={model}
                 onUpdate={handleUpdate}
             />
+            {/* Layer-3 ambient-login opt-in (spec §2.3). Immediate RPC on
+                change — same convention as the account dropdowns above. */}
+            <div class="agent-ambient-login-section">
+                <div class="agent-ambient-login-row">
+                    <div class="agent-ambient-login-text">
+                        <span class="agent-ambient-login-label">
+                            Use global CLI login when no account is bound
+                        </span>
+                        <span class="agent-ambient-login-help">
+                            When on, this agent may launch with your machine-wide CLI
+                            login (e.g. ~/.claude) if no managed account resolves.
+                            When off, launching fails instead — deleting an account in
+                            the Armory reliably deauthenticates this agent's next start.
+                        </span>
+                    </div>
+                    <button
+                        type="button"
+                        role="switch"
+                        aria-checked={ambientOn()}
+                        aria-label="Use global CLI login when no account is bound"
+                        class="agent-ambient-login-toggle"
+                        classList={{ "agent-ambient-login-toggle--on": ambientOn() }}
+                        disabled={ambientSaving()}
+                        onClick={() => void handleAmbientToggle()}
+                    >
+                        <span class="agent-ambient-login-toggle-thumb" />
+                    </button>
+                </div>
+                <Show when={ambientError()}>
+                    <div class="agent-ambient-login-error">{ambientError()}</div>
+                </Show>
+            </div>
             <div class="agent-modal-footer">
                 <button
                     class="agent-modal-done-btn"

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -305,6 +305,15 @@ declare global {
          * Empty string for host-only agents.
          */
         container_image?: string;
+        /**
+         * Explicit per-agent opt-in (0/1) to the CLI's global (ambient)
+         * login when no oauth-class account resolves at spawn. 0 (default)
+         * = spawn fails with a visible error instead of silently falling
+         * back to ~/.claude. Toggled from the Agent setup modal's Accounts
+         * tab. Schema v12 — layer 3 of
+         * SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3.
+         */
+        use_ambient_login?: number;
     };
 
     // ── v6: identity, instance, junction ────────────────────────────────────
@@ -688,6 +697,12 @@ declare global {
         agent_bus_id?: string;
         /** JSON-encoded per-provider account refs. See AgentDefinition.accounts. */
         accounts?: string;
+        /**
+         * Explicit ambient-login opt-in (0/1). Omit to preserve the stored
+         * value — the backend treats absence as "no change". See
+         * AgentDefinition.use_ambient_login.
+         */
+        use_ambient_login?: number;
     };
 
     // CommandDeleteAgentDefinitionData


### PR DESCRIPTION
## What

PR A (layer 3 — spawn gating) of `docs/specs/SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md` (§2), committed with this PR. Implements the decision record (§1): **fail by default + explicit per-agent opt-in**. Background: `docs/analysis/ANALYSIS_ACCOUNT_DELETE_AUTH_LIFECYCLE_GAP_2026_07_14.md` — layer 2.3, the load-bearing one ("as long as ambient fallback exists, delete semantics can never be made honest"). Layer 1 (cascade + token-dir cleanup) shipped in #2159; layers 2+4 are the parallel PR B (this PR does not touch `IdentityDeleteOutcome` or the delete/unlink handlers).

## How

**Resolver gating** (`agentmux-srv/src/identity/resolver.rs`): `inject_identity_env*` is now fallible (`SpawnGateError`). For **oauth-class** providers:
- bound account resolves → inject config-dir env var (unchanged, regression-tested);
- account missing/unresolvable (post-delete "row not found", lookup error, mismatched secret_ref) AND `use_ambient_login=0` (default) → **spawn fails before the CLI process is created**, wording per spec §2.2; logs `identity.spawn.blocked:` (warn);
- same but flag=1 → proceed WITHOUT injecting a config dir (CLI uses its global login), logs `identity.spawn.ambient: using global CLI login (per-agent opt-in)` (info) — the only sanctioned ambient path;
- spec §2.2 edge: an agent whose own oauth-class CLI provider has **no binding at all** is gated identically (no implicit ambient).

Api-key-class bindings keep the historical log-and-skip behavior (per spec scope).

**Error surface**: both spawn call sites (`agentinput` in `server/agent_handlers/input.rs`, `agent.send` in `server/app_api/agent_io.rs`) append an `error_during_execution` result frame to the block file — the exact mechanism existing container spawn failures use — which the frontend renders as an `agent_error` transcript node in the agent pane (claude-translator → stream-parser), plus the RPC returns the error.

**Flag storage**: `use_ambient_login INTEGER NOT NULL DEFAULT 0` on `db_agent_definitions` + `db_agents` (object schema v11→v12, additive idempotent ALTERs), threaded through `AgentDefinition`, dual-write, the cross-channel `DefinitionRecordV1` (additive `#[serde(default)]`, no envelope bump — same as the container_* fields), and `def_migrate`'s schema-resilient column list. `updateagent` takes an optional `use_ambient_login` (omitted = preserve stored value).

**Migration** (spec §2.4, migration-tracking framework):
- `m0017` (Channel): agents with zero `db_agent_identity_links` rows (read from the shared store) → flag=1 (grandfathered de-facto ambient users); agents with links → 0 (honest failure is the new behavior they opted into). Fresh channels no-op, so post-upgrade agents can never be flipped retroactively.
- `m0018` (Global, runs once ever): same rule applied to the cross-channel definition registry records, so an agent surfaced in another channel via the registry fallback agrees with its grandfathered state.

**UI**: "Use global CLI login when no account is bound" toggle in the Agent setup modal's **Accounts** tab (`AgentIdentityModal.tsx`), immediate RPC on change with explanatory copy.

**muxlog**: the `muxlog auth` recipe regex now also matches `identity\.spawn` (blocked/ambient lines join the auth-lifecycle trace end-to-end).

## Tests (spec §2.5)

- `spawn_blocked_when_bound_oauth_account_missing_and_flag_false` — binding → missing account → flag false → blocking error (message pins the spec wording), no injection.
- `spawn_proceeds_ambient_when_bound_oauth_account_missing_and_flag_true` — flag true → Ok, no config-dir injection.
- `inject_oauth_class_sets_config_dir_env_var` — resolvable account injects unchanged (regression).
- `spawn_blocked_when_oauth_def_provider_has_no_binding_and_flag_false` — the §2.2 edge.
- `inject_oauth_class_blocks_account_with_non_oauth_secret_ref` — misconfigured secret_ref now gates instead of skipping.
- `m0017`: `linkless_agent_gets_ambient_linked_agent_stays_fail_by_default` (+ missing-store no-ops); `m0018`: `linkless_record_flips_to_ambient_linked_record_stays`.
- Assertions are on return values / DB state (no tracing capture exists in this codebase).

`cargo test -p agentmux-srv`: **1498 passed, 0 failed**. `cargo check` clean. `npx tsc --noEmit` + stylelint clean.

<!-- agentmux:agent_id=agenta-07017 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)