### PR TITLE
chore: release v0.53.6

### DIFF
--- a/.changesets/1784045174-fix-providers-consolidate-claude-cli-pin-to-2-1-198-across-a-o53k.md
+++ b/.changesets/1784045174-fix-providers-consolidate-claude-cli-pin-to-2-1-198-across-a-o53k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(providers): consolidate Claude CLI pin to 2.1.198 across all four registries + drift-guard test

--- a/.changesets/1784056916-feat-diags-muxlog-auth-subcommand-logout-path-auth-logging-8xb6.md
+++ b/.changesets/1784056916-feat-diags-muxlog-auth-subcommand-logout-path-auth-logging-8xb6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(diags): muxlog auth subcommand + logout-path auth logging

--- a/.changesets/1784058153-fix-bashwrap-disable-git-pager-and-kill-idle-hung-children-i-rxgn.md
+++ b/.changesets/1784058153-fix-bashwrap-disable-git-pager-and-kill-idle-hung-children-i-rxgn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(bashwrap): disable git pager and kill idle-hung children instead of leaking the wrapper process

--- a/.changesets/1784058517-fix-accounts-oauth-accounts-crashed-the-accounts-detail-moda-b8qp.md
+++ b/.changesets/1784058517-fix-accounts-oauth-accounts-crashed-the-accounts-detail-moda-b8qp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(accounts): OAuth accounts crashed the Accounts detail modal (unmapped oauth_config_dir SecretRef)

--- a/.changesets/1784060643-fix-identity-cascade-links-bindings-remove-oauth-token-dir-o-hdz2.md
+++ b/.changesets/1784060643-fix-identity-cascade-links-bindings-remove-oauth-token-dir-o-hdz2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): cascade links/bindings + remove OAuth token dir on account delete

--- a/.changesets/1784074250-feat-identity-disclose-affected-agents-on-account-delete-pan-9tvp.md
+++ b/.changesets/1784074250-feat-identity-disclose-affected-agents-on-account-delete-pan-9tvp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(identity): disclose affected agents on account delete (pane chip + armory notice)

--- a/.changesets/1784075745-feat-identity-fail-spawn-on-missing-oauth-account-explicit-p-vgj8.md
+++ b/.changesets/1784075745-feat-identity-fail-spawn-on-missing-oauth-account-explicit-p-vgj8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(identity): fail spawn on missing oauth account, explicit per-agent global-login opt-in

--- a/.changesets/1784076438-feat-settings-fill-out-window-panes-sounds-and-advanced-4x4z.md
+++ b/.changesets/1784076438-feat-settings-fill-out-window-panes-sounds-and-advanced-4x4z.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(settings): fill out Window & Panes, Sounds, and Advanced sections

--- a/.changesets/1784077788-fix-cef-reduce-new-window-startup-color-flash-on-windows-z1a2.md
+++ b/.changesets/1784077788-fix-cef-reduce-new-window-startup-color-flash-on-windows-z1a2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): reduce New Window startup color flash on Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.53.5"
+version = "0.53.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.53.5"
+version = "0.53.6"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.53.5"
+version = "0.53.6"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.53.5"
+version = "0.53.6"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.53.5"
+version = "0.53.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.53.5"
+version = "0.53.6"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.53.5"
+version = "0.53.6"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,18 @@
 # AgentMux Version History
 
+## 0.53.6 — 2026-07-15
+
+- fix(providers): consolidate Claude CLI pin to 2.1.198 across all four registries + drift-guard test
+- feat(diags): muxlog auth subcommand + logout-path auth logging
+- fix(bashwrap): disable git pager and kill idle-hung children instead of leaking the wrapper process
+- fix(accounts): OAuth accounts crashed the Accounts detail modal (unmapped oauth_config_dir SecretRef)
+- fix(identity): cascade links/bindings + remove OAuth token dir on account delete
+- feat(identity): disclose affected agents on account delete (pane chip + armory notice)
+- feat(identity): fail spawn on missing oauth account, explicit per-agent global-login opt-in
+- feat(settings): fill out Window & Panes, Sounds, and Advanced sections
+- fix(cef): reduce New Window startup color flash on Windows
+
+
 ## 0.53.5 — 2026-07-14
 
 - feat(srv): swarm/subagent lifecycle diagnostics (muxlog swarm)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.53.5",
+  "version": "0.53.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.53.5",
+      "version": "0.53.6",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.53.5",
+  "version": "0.53.6",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 9 pending changesets. **Forced patch bump**
(`--as patch`) per request, overriding the auto-computed `minor` (three
queued changesets were `feat`) — those features ship under this patch
version.

0.53.5 → 0.53.6

## Changes shipping

- fix(providers): consolidate Claude CLI pin to 2.1.198 across all four registries + drift-guard test
- feat(diags): muxlog auth subcommand + logout-path auth logging
- fix(bashwrap): disable git pager and kill idle-hung children instead of leaking the wrapper process
- fix(accounts): OAuth accounts crashed the Accounts detail modal (unmapped oauth_config_dir SecretRef)
- fix(identity): cascade links/bindings + remove OAuth token dir on account delete
- feat(identity): disclose affected agents on account delete (pane chip + armory notice)
- feat(identity): fail spawn on missing oauth account, explicit per-agent global-login opt-in
- feat(settings): fill out Window & Panes, Sounds, and Advanced sections
- fix(cef): reduce New Window startup color flash on Windows

## Test plan

- [x] Release-consistency invariant verified: package.json, Cargo.toml,
      Cargo.lock, package-lock.json, and VERSION_HISTORY.md all agree at 0.53.6
- [x] All 9 changesets consumed and deleted

<!-- agentmux:agent_id=agenty -->