### PR TITLE
docs: retro + universal identity gateway spec (PR #2164's gate doesn't gate what's actually running)

### DIFF
--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -20,6 +20,18 @@
 //! and it was never restored — today's gate only chooses between "block"
 //! and "true ambient" (`use_ambient_login=true`, zero isolation), not the
 //! isolated-auto-provision option that used to exist implicitly.
+//!
+//! **Second, read this too:** `inject_identity_env_with_broker`'s Steps 1/2
+//! (`instance_get_active_for_block` returning `None`; `identity_id` empty
+//! or `"blank"`) are UNCONDITIONAL early-returns that skip the Step 3/4
+//! gate entirely — and live verification on 2026-07-15 found this is not a
+//! rare edge case: every real running agent inspected hit one of these two
+//! paths. See `docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md`
+//! and `docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md` before
+//! assuming the Step 3/4 gate actually runs for the agent you're testing
+//! with — check whether its block has a `db_agents`/`db_agent_instances`
+//! row with a non-blank `identity_id` first, or it never reaches Step 3/4
+//! at all.
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md
+++ b/docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md
@@ -1,0 +1,170 @@
+# Retro — tonight's fail-closed spawn gate never runs for the agents actually running in production
+
+**Date:** 2026-07-15
+**Trigger:** Live user report, minutes after the previous auth-isolation retro
+merged: *"there are no logged in accounts in the armory, but I am still able
+to communicate to the Lzop agent."* Verified directly against the running
+databases — not reproduced from a synthetic test, found live.
+**Severity:** High. This is not a new bug — it means **PR #2164 (tonight's
+"fail spawn on missing oauth account" gate) does not gate the agents that
+are actually running right now**, in either of the two live AgentMux
+instances inspected. The gate is real code, correctly implemented for the
+data shape it assumes; that shape is not what real agents have.
+**Related:** `docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`
+(same resolver file, same failure pattern, written six hours earlier —
+its own closing line applies verbatim here too: *"a written invariant is
+worthless if nothing re-checks it when the ground moves."*)
+
+---
+
+## 1. What was verified live (not theoretical)
+
+Direct SQLite inspection of both currently-running AgentMux instances
+(dev:main channel at `~/.agentmux/dev/main/bdbef7b72912a6f3`, v0.53.5, built
+from tonight's `bf1b4e64` with PR #2164 included; and the v0.53.3 portable
+at `~/.agentmux/channels/local-main-b28b7a-5bc5caca/versions/0.53.3`):
+
+- **`db_accounts` is empty in the shared store** (`~/.agentmux/shared/store.db`)
+  — zero rows. This is the "no logged-in accounts in the Armory" the user
+  saw, and it's accurate; there really are none.
+- **Every agent-shaped block in both instances is still running.** A block
+  named "Lzop" (`f3b242ca-9a3a-47ba-a30d-c5836cc85068`, `agentProvider:
+  "claude"`) in the dev:main channel, and this very conversation's own pane
+  (`30e0638f-edd0-417a-9ea7-a744b31d8646`) in the v0.53.3 channel — **2 for
+  2** of the agent-shaped blocks actually observed running had **zero**
+  matching row in `db_agent_instances`, and for Lzop specifically, no
+  matching row in `db_agents` either (`SELECT ... FROM db_agents WHERE
+  id='9b1b8afe-447c-4461-9619-09c701c4fa86' AND is_template=0` → empty).
+- Lzop's block carries a **frozen** `cmd:env.CLAUDE_CONFIG_DIR` =
+  `C:\Users\area54\.agentmux\shared\providers\claude` — the old shared
+  isolated dir from the pre-Phase-4 Default-bundle era (see the prior
+  retro). That directory's `.credentials.json` is still being actively
+  refreshed (last write: this morning) by whatever else uses it — meaning
+  Lzop keeps working not because it was gated-and-passed, but because
+  nothing ever asked it to prove anything, and the directory it was frozen
+  to point at happens to still hold a live login for unrelated reasons.
+
+## 2. Root cause — two escape hatches inside the gate function itself, both untouched by tonight's PR #2164
+
+`agentmux-srv/src/identity/resolver.rs:596`,
+`inject_identity_env_with_broker`, runs in four steps. **PR #2164 only
+changed steps 3 and 4** (the `gate_oauth_failure` closure and its call
+sites). Steps 1 and 2 were left exactly as they were, and both are
+unconditional early-returns that skip the gate entirely:
+
+**Step 1** (`resolver.rs:592-604`, calling
+`backend/storage/agents.rs:1738` `instance_get_active_for_block`):
+
+```rust
+let instance = match wstore.instance_get_active_for_block(block_id) {
+    Ok(Some(i)) => i,
+    Ok(None) => {
+        // Block has no agent instance row — nothing to inject, and no
+        // gating either: quick-launch panes that never went through the
+        // launch modal are outside the managed-credentials contract.
+        return Ok(());
+    }
+    ...
+```
+
+`instance_get_active_for_block` itself has two tiers: it first tries
+`db_agents WHERE id = <block's agentId> AND is_template = 0` (the modern,
+consolidated table — Phase 3b.3), and only falls back to the legacy
+`db_agent_instances` table if that misses. **Lzop misses both tiers** — its
+`agentId` doesn't correspond to any row in either table — so Step 1 returns
+`None` and the whole function returns `Ok(())` before the layer-3 gate is
+ever reached.
+
+**Step 2** (`resolver.rs:606-624`), reached only when Step 1 *does* find a
+`db_agents` row:
+
+```rust
+if instance.identity_id.is_empty() || instance.identity_id == "blank" {
+    // Empty or legacy "blank" sentinel → ambient creds (no
+    // injection). ...
+    // Deliberately NOT gated by layer 3: this sentinel predates the
+    // managed-account model and was an explicit "ambient creds"
+    // choice at launch time, not a silent fallback.
+    ...
+    return Ok(());
+}
+```
+
+This is the same shape of bug, one level deeper: `db_agents.identity_id` is
+a real column, populated by exactly one write path
+(`agents_dual_write_instance_create`, `backend/storage/dual_write.rs:206-260`),
+which only fires when something calls `instance_create` — and that is
+**disconnected from** the account-linking system Steps 3/4 actually gate
+on (`db_agent_identity_links`, written by `LinkAgentIdentityCommand`,
+`agent_handlers/identity.rs:518-539`, which never touches `db_agents`).
+An agent can have a real, live, correctly-bound account in
+`db_agent_identity_links` and still sail past Step 2 ungated, because that
+table and the `identity_id` sentinel Step 2 checks are two different,
+never-reconciled signals.
+
+## 3. Why this wasn't caught before shipping PR #2164 tonight
+
+Every test added for PR #2164 (`spawn_blocked_when_bound_oauth_account_missing_and_flag_false`,
+`spawn_blocked_when_oauth_def_provider_has_no_binding_and_flag_false`, etc.)
+constructs its fixture by calling `store.instance_create(&inst)` /
+`store.agent_def_insert` directly in the test setup — i.e., every test
+*starts* from a state where Step 1 and Step 2 already pass, and only then
+exercises Steps 3/4. This is not a criticism of the tests' logic (they
+correctly prove what they set out to prove) — it's that **nothing in the
+test suite constructs the fixture shape real running agents actually have**:
+a block with agent-shaped meta and no instance/db_agents row at all, or one
+with a row but a blank `identity_id`. The two production call sites that
+create such blocks —
+
+- **App API `agent.open`** (`server/app_api/agent_open.rs`) — opens a pane
+  and sets meta; never calls `instance_create` at all. This is the path
+  external tools and orchestrators use, per `README.md:61`.
+- **The canonical frontend launch modal** (`frontend/app/view/agent/agent-model.ts:277-629`) —
+  *does* call `RpcApi.CreateAgentInstanceCommand`, but only **after** the
+  actual spawn (`ControllerResyncCommand`, line 541), wrapped in a
+  try/catch that logs and continues on failure (`:589-594`, "a failure here
+  doesn't abort the launch, the agent already started"). Best-effort,
+  not a precondition.
+
+— were never exercised by anything added tonight, so the gate's own
+internal escape hatches were invisible to the very PR that was supposed to
+close exactly this hole.
+
+## 4. What this means about "the norm," not "the edge case"
+
+Across the ~90 call sites referencing `instance_create`/`db_agent_instances`
+in the codebase, essentially all except two production call sites are test
+fixtures. Of the two real ones, one deliberately creates a bindingless stub
+(`agent_handlers/agent_define.rs`'s `make_stub_idempotent`, `block_id: ""`,
+`identity_id: ""`) and the other is the best-effort post-spawn call above.
+Combined with the live evidence (2 for 2 running agent-shaped blocks
+missing the row), the honest conclusion is: **the "managed-credentials
+contract" the Step-1 comment refers to is not a boundary most real agents
+are inside of — it's closer to the exception.** Tonight's gate is
+correctly built for a data shape that doesn't describe how agents actually
+come to exist in this system today.
+
+## 5. What needs to change (not implemented here — see the companion spec)
+
+This retro documents the finding; `docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md`
+proposes the fix. Summary of the direction: stop asking the gate to trust
+two disconnected identity signals (`db_agents.identity_id` sentinel vs.
+`db_agent_identity_links` rows) reached through a resolvability chain
+(block → agentId → db_agents-or-db_agent_instances) that real spawn paths
+don't reliably populate. Move the credential decision to a single point
+every spawn passes through unconditionally, keyed directly on the binding
+table Steps 3/4 already trust, not on an intermediate row that may or may
+not exist.
+
+## 6. The pattern, stated plainly, for whoever reads this next
+
+This is the **second** silent-orphaning finding on this exact file in one
+day. The first (`retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`)
+was about a *removed* isolation mechanism. This one is about a gate that
+was *added* correctly but only for a precondition that doesn't hold in
+production. Both are the same lesson from two different directions: this
+resolver function has accumulated enough independent, uncoordinated
+decision points (four steps, two of them unconditional early-exits) that
+no single PR touching it can reason about the whole thing at once anymore.
+That is itself the argument for collapsing it into one gateway rather than
+patching step 5.

--- a/docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md
+++ b/docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md
@@ -147,7 +147,7 @@ come to exist in this system today.
 ## 5. What needs to change (not implemented here — see the companion spec)
 
 This retro documents the finding; `docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md`
-proposes the fix. Summary of the direction: stop asking the gate to trust
+proposes the fix, tracked as agent task #50. Summary of the direction: stop asking the gate to trust
 two disconnected identity signals (`db_agents.identity_id` sentinel vs.
 `db_agent_identity_links` rows) reached through a resolvability chain
 (block → agentId → db_agents-or-db_agent_instances) that real spawn paths

--- a/docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md
+++ b/docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md
@@ -1,0 +1,166 @@
+# SPEC — universal identity gateway: close the gate's own internal bypasses
+
+**Date:** 2026-07-15
+**Status:** Proposed — investigation and live verification complete, design
+not yet implemented
+**Governing incident:** `docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md`
+**Related:** `docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`,
+`SPEC_PROVIDER_ISOLATION_2026_06_20.md` (INV-A), `SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md`
+(PR #2164, the gate this spec extends)
+
+---
+
+## 1. The good news first: there is already only one mechanical spawn gateway
+
+Before proposing changes, it's worth being precise about what's *not* broken.
+A full sweep of every place a provider CLI subprocess could plausibly be
+launched (`agentmux-srv/src/backend/blockcontroller/`,
+`agentmux-srv/src/server/agent_handlers/`, `agentmux-srv/src/server/app_api/`)
+found **exactly two call sites, ever**, that invoke credential injection:
+
+| Call site | File:line |
+|---|---|
+| `agentinput` RPC handler | `agentmux-srv/src/server/agent_handlers/input.rs:168` |
+| `agent.send` RPC handler | `agentmux-srv/src/server/app_api/agent_io.rs:165` |
+
+Both call `identity::resolver::inject_identity_env_async` and both correctly
+propagate a returned `SpawnGateError` as a blocking spawn failure (verified
+during tonight's PR #2164 work). The **container-agent spawn path**
+(`spawn_container_turn`, reached from inside `agentinput` at
+`input.rs:373-413`) is downstream of the *same* single call — it reuses the
+`env_vars` map `inject_identity_env_async` already produced, not a separate
+credential path. `agent.open` (`server/app_api/agent_open.rs`) never spawns
+a process directly at all — it opens the pane; the actual CLI process is
+lazily spawned on first `agentinput`/`agent.send`, which does gate. The MCP
+`Shell` tool spawns a *terminal* sub-block inside an already-open agent's
+own pane, not a new provider-CLI credential context.
+
+**So this is not a "scattered spawn paths" problem** — the architecture
+already funnels every real spawn through one function. The problem is
+entirely **inside that one function**: two unconditional early-returns that
+were correct when written and have since drifted out of sync with how
+agents actually get created.
+
+## 2. The two escape hatches (see the retro for full detail)
+
+`agentmux-srv/src/identity/resolver.rs:596`, `inject_identity_env_with_broker`:
+
+- **Step 1** (`:592-604`): if `instance_get_active_for_block(block_id)`
+  returns `None` — no matching row in `db_agents` (primary) or
+  `db_agent_instances` (legacy fallback) — return `Ok(())`, no gate.
+- **Step 2** (`:606-624`): if a row *is* found but its `identity_id` column
+  is empty or the literal string `"blank"` — return `Ok(())`, no gate.
+
+Both are reached in practice. Both are older than PR #2164's Steps 3/4 gate
+and were never revisited when that gate was added.
+
+## 3. Why patching Steps 1/2 in place is not enough
+
+The tempting fix — "make Step 1 also return `Err` instead of `Ok(())`" —
+would immediately break every agent in the system, including this
+session's own pane, since **2 of 2 live-observed running agents hit exactly
+this path today**. That's not a reason to leave it; it's a reason the fix
+has to also close the upstream gap (real spawns not reliably producing a
+`db_agents`/`identity_id` row), not just flip the downstream default.
+
+The deeper issue: Steps 1/2 and Steps 3/4 currently trust **two different,
+never-reconciled identity signals**:
+
+- Steps 1/2 trust `db_agents.identity_id`, populated by exactly one
+  production write path (`agents_dual_write_instance_create`,
+  `backend/storage/dual_write.rs:206-260`), itself only triggered by
+  `instance_create`, itself only called from two production sites — one a
+  deliberately-bindingless stub (`agent_handlers/agent_define.rs`'s
+  `make_stub_idempotent`), one a best-effort call **after** the spawn
+  already happened, swallowed on failure
+  (`frontend/app/view/agent/agent-model.ts:556-594`).
+- Steps 3/4 trust `db_agent_identity_links` (written by
+  `LinkAgentIdentityCommand`, `agent_handlers/identity.rs:518-539`) — the
+  table that's actually current, actually maintained, and actually what the
+  Armory UI reads and writes.
+
+An agent can be fully, correctly bound in `db_agent_identity_links` and
+still never reach the code that checks it, because Step 1/2 gatekeep on a
+different, effectively-vestigial signal first.
+
+## 4. Proposed fix
+
+### 4.1 Collapse to one identity signal
+
+Stop routing through `db_agents.identity_id` / `db_agent_instances` at all
+for the purpose of the credential gate. Resolve directly from the block's
+`agentId` (already read at `agents.rs:1747-1751`) against
+`db_agent_identity_links` / the agent definition's own provider — the same
+data Steps 3/4 already use. Concretely: merge what are currently four
+sequential steps with two different data sources into a single resolution
+that only ever asks "does this `agentId` have a definition, and does that
+definition have (or lack, with explicit opt-in) working credentials for the
+provider it needs" — one signal, one path, no intermediate row whose
+absence silently means "skip."
+
+### 4.2 Make the gate's default fail closed at every tier, not just tier 3/4
+
+Once 4.1 removes the two-signal split, "no instance row" stops being a
+meaningful state to special-case — there's no longer a `db_agents` row to
+be missing. What replaces Step 1's early-return should be: no agent
+definition for this block's `agentId` → that's the same shape as "unknown
+provider," which should log clearly and either block (if the block's own
+`agentProvider` meta names an oauth-class provider) or proceed (if it's
+provider-agnostic, e.g. a plain terminal block). The important change is
+that **there must be no code path where the answer to "does this spawn have
+provider X's credentials" is simply never computed.**
+
+### 4.3 A boot-time / CI invariant, not just a spawn-time one
+
+Per both retros' shared conclusion — a spec alone has already failed twice
+today to prevent a regression on this exact file — the fix needs a
+standing check, not just corrected logic:
+
+- **A live consistency check** (could run at srv startup, or as a periodic
+  background sweep, or exposed via `muxlog`/a diagnostics RPC): count
+  agent-shaped blocks (`meta.agentProvider` set) whose resolution produces
+  neither a bind nor an explicit ambient opt-in nor a blocked state — i.e.,
+  blocks that are *silently* running ungated right now. Tonight's
+  live numbers (2 for 2) should be **zero** once this ships; the check
+  makes "zero" an assertion instead of a hope.
+- **A test fixture shaped like production**, not like today's test setup.
+  Every current resolver test calls `instance_create`/`agent_def_insert`
+  directly, which is precisely the shape real agents *don't* reliably have.
+  Add a test that constructs a block the way `agent.open` + first
+  `agentinput` actually would (meta set, no instance row, no forced
+  identity_id) and asserts the gate still produces a real verdict — block,
+  ambient-with-opt-in, or resolved — never a silent, ungated pass-through.
+
+## 5. Full inventory — "every place login may happen," answered
+
+Per the user's request to identify all such places, for the record:
+
+| Surface | What it does | Gated by the spawn-time credential check? |
+|---|---|---|
+| `agentinput` RPC | Real per-turn spawn/resume | Yes (the one real gate; has the escape hatches above) |
+| `agent.send` RPC | Same, alternate entry point | Yes (same function) |
+| Container agent turn | Downstream of `agentinput`'s env | Yes, inherits `agentinput`'s outcome |
+| `agent.open` RPC | Opens the pane, no process yet | N/A — no spawn happens here |
+| Armory "Connect" (`auth.start`/`auth.spawn`) | Interactive OAuth login, **creates** an account row | N/A — this is account creation, not spawn-time credential use; out of scope for this gate |
+| `CheckCliAuth` | Validates whether the CLI reports a working login in a given dir | N/A — read-only status probe, not a spawn |
+| MCP `Shell` | Spawns a terminal sub-block inside an existing agent's pane | N/A — not a provider-CLI credential context |
+| MCP `SetName`/`WhoAmI` | Metadata only | N/A |
+
+The practical conclusion: there is nothing to "gather into" a new gateway —
+the gateway already exists and already receives every real spawn. The work
+is entirely in making that gateway's own decision tree honest about the
+data it actually has, per §4.
+
+## 6. Definition of done
+
+- Steps 1/2 of `inject_identity_env_with_broker` no longer read
+  `db_agents.identity_id` / `db_agent_instances` for gating purposes.
+- A block with agent-shaped meta and no `db_agents`/`db_agent_instances`
+  row (today's Lzop shape) produces a real gate verdict — blocked or
+  explicitly-ambient — never a silent `Ok(())`.
+- A resolver test constructs exactly this shape (not
+  `instance_create`-seeded) and asserts on it.
+- A live/diagnostic count of "agent-shaped blocks with no computed
+  credential verdict" is either exposed or added as a startup log line,
+  so this class of drift is visible going forward instead of requiring a
+  live incident to surface it.

--- a/docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md
+++ b/docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-15
 **Status:** Proposed — investigation and live verification complete, design
-not yet implemented
+not yet implemented. Implementation tracked as agent task #50.
 **Governing incident:** `docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md`
 **Related:** `docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`,
 `SPEC_PROVIDER_ISOLATION_2026_06_20.md` (INV-A), `SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md`


### PR DESCRIPTION
## What happened

Live user report, minutes after the previous auth-isolation retro (#2165) merged: Armory shows **zero** accounts, yet the "Lzop" agent kept responding.

Verified directly against both running instances' live SQLite databases — not a synthetic repro:
- `db_accounts` is genuinely empty in the shared store.
- **2 of 2** agent-shaped blocks actually observed running (Lzop in the dev:main channel; this very conversation's own pane in the v0.53.3 channel) have zero matching `db_agent_instances` row — and for Lzop, zero matching `db_agents` row either.
- Lzop's block carries a **frozen** `CLAUDE_CONFIG_DIR` pointing at the old shared isolated dir, whose credentials are still being actively refreshed by something else — it keeps working not because it passed a check, but because nothing ever asked it to prove anything.

## Root cause

`identity/resolver.rs`'s `inject_identity_env_with_broker` has **two unconditional early-returns that were never touched by tonight's PR #2164**:
- Step 1: no `db_agents`/`db_agent_instances` row for the block → `Ok(())`, no gate.
- Step 2: row exists but `identity_id` is blank → `Ok(())`, no gate.

Every PR #2164 test seeds its fixture via `instance_create`/`agent_def_insert` directly — exactly the shape real agents don't reliably have. The App API `agent.open` path never creates an instance row; the frontend launch modal's own attempt is best-effort, wrapped in try/catch, called *after* the spawn already happened.

## What this PR does (docs only — implementation is task #50)

- `docs/retro/retro-identity-gate-bypassed-by-missing-instance-binding-2026-07-15.md` — the incident, verified live, with exact citations.
- `docs/specs/SPEC_UNIVERSAL_IDENTITY_GATEWAY_2026_07_15.md` — the fix design, **plus the full inventory of every place a provider CLI could be spawned** (the user's "identify all the places login may happen" ask). Conclusion: this is NOT a scattered-spawn-paths problem — exactly two call sites ever invoke injection (`agentinput`, `agent.send`), both correctly wired. The bug is entirely inside the one shared function's own decision tree, which currently trusts two disconnected identity signals instead of one.
- Cross-link added to `identity/resolver.rs`'s module doc, matching the pattern from the prior same-day retro (#2165).

## Verification

- `cargo check -p agentmux-srv` clean (comment-only code change)
- All root-cause claims verified against live production data via direct SQLite queries, not assumed from code reading alone

<!-- agentmux:agent_id=agenta-07017 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)