### PR TITLE
revert(cef): New Window color-flash fix (#2163) — introduced pool-promote failure on Windows

### DIFF
--- a/.changesets/1784143723-revert-cef-new-window-color-flash-fix-2163-introduced-pool-p-lt16.md
+++ b/.changesets/1784143723-revert-cef-new-window-color-flash-fix-2163-introduced-pool-p-lt16.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+revert(cef): New Window color-flash fix (#2163) — introduced pool-promote failure on Windows

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -13,21 +13,6 @@ use std::sync::Arc;
 use crate::client::*;
 use crate::state::AppState;
 
-/// CEF's own compositor backstop color for an opaque (non-transparent)
-/// window/browser — whatever paints before the page's own stylesheet has
-/// taken over. Must match `index.html`'s `#startup-loading`/`html` splash
-/// background (`rgb(34, 34, 34)`) so there is no visible color transition
-/// during the gap between "native window shown" and "page content painted."
-/// Previously `0xFF000000` (pure black), which didn't match the splash and
-/// produced a black-to-gray flash on every window open — see
-/// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md §4.1.
-/// Alpha stays `0xFF` (fully opaque) for the same reason the prior literal
-/// did: Chromium's compositor treats opaque layers more cheaply and enables
-/// subpixel LCD text. Shared with `ui_tasks::window::CreateWindowTask`
-/// (secondary/cold-path windows) so every non-transparent window/browser
-/// backstop agrees.
-pub(crate) const OPAQUE_BG_ARGB: u32 = 0xFF222222;
-
 // ---------------------------------------------------------------------------
 // Window & BrowserView delegates (CEF Views framework)
 // ---------------------------------------------------------------------------
@@ -1197,13 +1182,9 @@ wrap_browser_process_handler! {
                 windowless_frame_rate: 60,
                 // ARGB: alpha=0 → SK_AlphaTRANSPARENT → enables Views-framework
                 // transparency. Only set when window:transparent=true; opaque
-                // windows use OPAQUE_BG_ARGB (matches the startup splash's own
-                // background, see its doc comment) so Chromium's compositor
-                // treats layers as opaque (better performance, subpixel LCD
-                // text, no opacity flash) AND the color the compositor shows
-                // before real content paints agrees with the splash on top of
-                // it, instead of flashing black-to-gray.
-                background_color: if is_transparent { 0x00000000 } else { OPAQUE_BG_ARGB },
+                // windows use 0xFF000000 so Chromium's compositor treats layers as
+                // opaque (better performance, subpixel LCD text, no opacity flash).
+                background_color: if is_transparent { 0x00000000 } else { 0xFF000000 },
                 ..Default::default()
             };
 

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -9,25 +9,12 @@ use cef::*;
 
 use super::AgentMuxHandler;
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 use std::sync::Arc;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 use crate::state::AppState;
 
-/// Startup white-flash fix, originally Linux-only
-/// (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md), extended to
-/// Windows (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md
-/// §4.2) — the same underlying bug (`on_load_end` firing before the
-/// compositor has actually presented a frame) is unproven-but-structurally
-/// identical on Windows, and CEF's own `on_load_end` contract doesn't
-/// distinguish platforms. macOS is left ungated for now — no report of the
-/// symptom there yet; revisit if one surfaces. NOTE this gate only covers
-/// the cold-start/cold-path window-creation flow (main window's very first
-/// show, and secondary windows created via `CreateWindowTask` when the pool
-/// is empty) — pool windows skip this whole block (`is_pool_window` below)
-/// and are shown for the first time at promote, a separate, non-atomic
-/// sequence tracked in `window_pool.rs`/`ui_tasks::pool` (see the report's
-/// §4.3, the more common "New Window" case on a warm app).
+/// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
 ///
 /// Bound on how long the real window + native splash can stay hidden/up
 /// waiting for the frontend's first-paint signal before we show anyway.
@@ -43,18 +30,16 @@ use crate::state::AppState;
 /// immediate-show bug, but not the intended "wait for real paint" behavior.
 /// Set well above the observed worst case so the real signal wins in
 /// practice; this only matters as a backstop against a genuinely stalled
-/// renderer (crashed JS, rAF never firing at all). Kept the same value for
-/// Windows pending real measurements there — revisit if telemetry shows a
-/// different worst case.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+/// renderer (crashed JS, rAF never firing at all).
+#[cfg(target_os = "linux")]
 const PAINT_GATE_SAFETY_TIMEOUT_MS: i64 = 4000;
 
-/// Monotonic arm counter for the paint gate. Each `on_load_end` call
+/// Monotonic arm counter for the Linux paint gate. Each `on_load_end` call
 /// that (re-)arms a label's gate gets a fresh epoch; its safety-net timeout
 /// task captures that epoch and only acts if it's still current when the
 /// timeout fires (see `reveal_gated_window`). Mirrors the identical
 /// stale-timeout guard in `browser_pane::auth` (`NEXT_EPOCH`/`Entry::epoch`).
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 static PAINT_GATE_NEXT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Reveal (show + focus the real window, dismiss the native splash) once —
@@ -73,7 +58,7 @@ static PAINT_GATE_NEXT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::
 /// reagent PR #2151 review).
 ///
 /// Must run on the CEF UI thread.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 pub(crate) fn reveal_gated_window(
     state: &Arc<AppState>,
     label: &str,
@@ -110,12 +95,6 @@ pub(crate) fn reveal_gated_window(
             let _ = std::fs::write(&path, b"ready");
         }
     }
-    // Windows analogue of the ready-file write above — see
-    // signal_windows_splash_dismiss's doc comment for why this must fire
-    // here (gated on real paint) rather than unconditionally in
-    // `on_load_end` now that Windows's own window.show() is gated too.
-    #[cfg(target_os = "windows")]
-    signal_windows_splash_dismiss();
     let Some(mut browser) = state.get_browser(label) else { return };
     if let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) {
         if let Some(window) = bv.window() {
@@ -129,7 +108,7 @@ pub(crate) fn reveal_gated_window(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 wrap_task! {
     struct PaintGateRevealTask {
         state: Arc<AppState>,
@@ -155,7 +134,7 @@ wrap_task! {
 ///   to the slower safety timeout. Reagent PR #2151 second-round review.
 ///
 /// Must run on the CEF UI thread.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 pub(crate) fn handle_first_paint_signal(state: &Arc<AppState>, label: &str) {
     let already_armed = state.linux_paint_gate_pending.lock().contains_key(label);
     if already_armed {
@@ -165,7 +144,7 @@ pub(crate) fn handle_first_paint_signal(state: &Arc<AppState>, label: &str) {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 wrap_task! {
     struct FirstPaintSignalTask { state: Arc<AppState>, label: String }
     impl Task { fn execute(&self) {
@@ -178,41 +157,10 @@ wrap_task! {
 /// presented a frame. Posts to the UI thread to reveal the window if
 /// `on_load_end` already deferred it, or to record the signal for `on_load_end`
 /// to consume if it hasn't run yet (see `handle_first_paint_signal`).
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(target_os = "linux")]
 pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
     let mut task = FirstPaintSignalTask::new(state, label);
     post_task(ThreadId::UI, Some(&mut task));
-}
-
-/// Signal the launcher's native pre-splash to fade out. The launcher owns
-/// this splash and passes its event name via `AGENTMUX_SPLASH_EVENT`;
-/// `OpenEventW` + `SetEvent` is fire-and-forget — a missing env var means no
-/// launcher splash was running (e.g. `dev:standalone`).
-///
-/// Called from `reveal_gated_window` rather than unconditionally at the top
-/// of `on_load_end` (where this used to live) now that Windows's own
-/// `window.show()` is gated on real first paint (see this module's top-level
-/// doc comment) — firing it any earlier would dismiss the native splash
-/// before the CEF window it's meant to be masking has anything to show,
-/// which is a worse visible gap than the flash this whole gate exists to
-/// fix. Mirrors why the macOS/Linux ready-file write already only happens
-/// from `reveal_gated_window`, not from every `on_load_end` (including
-/// hidden pool-window prewarms) — see
-/// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md §4.2.
-#[cfg(target_os = "windows")]
-fn signal_windows_splash_dismiss() {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{OpenEventW, SetEvent, EVENT_MODIFY_STATE};
-    if let Ok(event_name) = std::env::var("AGENTMUX_SPLASH_EVENT") {
-        let nul: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
-        unsafe {
-            let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul.as_ptr());
-            if !ev.is_null() {
-                SetEvent(ev);
-                CloseHandle(ev);
-            }
-        }
-    }
 }
 
 impl AgentMuxHandler {
@@ -291,10 +239,27 @@ impl AgentMuxHandler {
             url_str
         );
 
-        // Windows splash-dismiss signal used to fire unconditionally here —
-        // moved to `signal_windows_splash_dismiss`, called from
-        // `reveal_gated_window` instead, now that Windows's window.show() is
-        // gated on real first paint below. See that function's doc comment.
+        // Signal the pre-splash to fade out the moment CEF's first frame
+        // is ready. The launcher created this named event and forwarded
+        // its name via AGENTMUX_SPLASH_EVENT. OpenEventW + SetEvent is
+        // fire-and-forget; missing env var means no splash was running.
+        #[cfg(target_os = "windows")]
+        {
+            use windows_sys::Win32::Foundation::CloseHandle;
+            use windows_sys::Win32::System::Threading::{
+                OpenEventW, SetEvent, EVENT_MODIFY_STATE,
+            };
+            if let Ok(event_name) = std::env::var("AGENTMUX_SPLASH_EVENT") {
+                let nul: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
+                unsafe {
+                    let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul.as_ptr());
+                    if !ev.is_null() {
+                        SetEvent(ev);
+                        CloseHandle(ev);
+                    }
+                }
+            }
+        }
 
         // macOS analogue of the Win32 splash signal: the launcher owns the native
         // splash (see agentmux-launcher/src/splash_mac.rs) and passes a ready-file
@@ -303,15 +268,13 @@ impl AgentMuxHandler {
         // tearing the splash down. Fire-and-forget; absent var => no launcher
         // splash (e.g. dev:standalone), so this is a no-op.
         //
-        // Linux and Windows do NOT write/signal it here. `on_load_end` fires
-        // per-browser on main-frame load-complete, including hidden
-        // pool-window prewarms — on either platform that could dismiss the
-        // splash before the real (visible) window has painted anything (the
-        // white-flash bug this gate fixes). Both instead signal from
-        // `reveal_gated_window`, gated on the same first-paint confirmation
-        // that unblocks the real window's show() below. See
-        // docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md and
-        // docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md §4.2.
+        // Linux does NOT write it here. `on_load_end` fires per-browser on
+        // main-frame load-complete, including hidden pool-window prewarms — on
+        // Linux that could dismiss the splash before the real (visible) window
+        // has painted anything (the white-flash bug this gate fixes). Linux
+        // writes the ready-file from `reveal_gated_window` instead, gated on the
+        // same first-paint confirmation that unblocks the real window's show()
+        // below. See docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md.
         #[cfg(target_os = "macos")]
         {
             if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
@@ -349,11 +312,11 @@ impl AgentMuxHandler {
                         // Falls back to the old immediate-show behavior if the
                         // window label can't be resolved (can't gate safely on
                         // an unknown label).
-                        #[cfg(any(target_os = "linux", target_os = "windows"))]
+                        #[cfg(target_os = "linux")]
                         let gate_label = browser_label.clone();
-                        #[cfg(any(target_os = "linux", target_os = "windows"))]
+                        #[cfg(target_os = "linux")]
                         let gated = gate_label.is_some();
-                        #[cfg(any(target_os = "linux", target_os = "windows"))]
+                        #[cfg(target_os = "linux")]
                         if let Some(label) = gate_label {
                             // The real paint signal can race ahead of this
                             // on_load_end call (see handle_first_paint_signal)
@@ -388,7 +351,7 @@ impl AgentMuxHandler {
                                 );
                             }
                         }
-                        #[cfg(any(target_os = "linux", target_os = "windows"))]
+                        #[cfg(target_os = "linux")]
                         if !gated {
                             window.show();
                             if let Some(ref mut b) = browser_cloned {
@@ -397,7 +360,7 @@ impl AgentMuxHandler {
                                 }
                             }
                         }
-                        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+                        #[cfg(not(target_os = "linux"))]
                         {
                             window.show();
                             if let Some(ref mut b) = browser_cloned {

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -387,18 +387,16 @@ pub fn set_window_init_status(state: &Arc<AppState>, args: &serde_json::Value) -
     serde_json::Value::Null
 }
 
-/// First-paint signal from the frontend (originally the Linux startup
-/// white-flash fix, docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md,
-/// extended to Windows —
-/// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md §4.2). Sent
-/// via a double-`requestAnimationFrame` at the very top of `bootstrap.ts` —
-/// the earliest reliable proxy for "the compositor actually presented a
-/// frame", as opposed to CEF's `on_load_end` which only means "main-frame
-/// HTML finished loading" and can fire before anything has visually painted.
+/// First-paint signal from the frontend (Linux startup white-flash fix, see
+/// docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md). Sent via a
+/// double-`requestAnimationFrame` at the very top of `bootstrap.ts` — the
+/// earliest reliable proxy for "the compositor actually presented a frame",
+/// as opposed to CEF's `on_load_end` which only means "main-frame HTML
+/// finished loading" and can fire before anything has visually painted.
 ///
-/// On Linux and Windows this unblocks the window `on_load_end` deferred (see
-/// `client::navigation::reveal_gated_window`). On macOS it's currently just
-/// logged for telemetry — no report of the white-flash symptom there yet.
+/// On Linux this unblocks the window `on_load_end` deferred (see
+/// `client::navigation::reveal_gated_window`). On other platforms it's
+/// currently just logged for telemetry — Windows/macOS aren't gated on it.
 pub fn report_first_paint(state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
     let label = args
         .get("label")
@@ -410,7 +408,7 @@ pub fn report_first_paint(state: &Arc<AppState>, args: &serde_json::Value) -> se
         label = %label,
         "[startup-paint] frontend reported first paint"
     );
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     crate::client::navigation::on_frontend_first_paint(state.clone(), label);
     serde_json::Value::Null
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -556,9 +556,7 @@ pub struct AppState {
     /// Window initialization status ("ready" or "wave-ready")
     pub window_init_status: Mutex<String>,
 
-    /// Startup white-flash fix, originally Linux-only
-    /// (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md), extended to
-    /// Windows (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md).
+    /// Linux startup white-flash fix (docs/specs/SPEC_LINUX_STARTUP_PAINT_GATING_2026_07_13.md).
     /// Window labels whose native `window.show()`/focus + splash-ready-file has
     /// been deferred by `on_load_end` pending a real first-paint confirmation
     /// from the frontend (`report_first_paint` IPC command) or a safety-net
@@ -568,24 +566,20 @@ pub struct AppState {
     /// gate) firing at its original, now-too-early deadline and revealing the
     /// window ahead of the *current* navigation's real paint. Mirrors the
     /// epoch pattern in `browser_pane::auth`. Only populated/consumed on
-    /// Linux and Windows (field name kept as-is rather than churning every
-    /// call site for a rename); the field exists unconditionally to keep
-    /// `AppState` un-cfg'd.
+    /// Linux; the field exists unconditionally to keep `AppState` un-cfg'd.
     pub linux_paint_gate_pending: Mutex<std::collections::HashMap<String, (std::time::Instant, u64)>>,
 
-    /// Startup white-flash fix, second-round race (reagent PR #2151
-    /// review), Linux-originated and extended to Windows alongside
-    /// `linux_paint_gate_pending` above: `report_first_paint` can reach the UI
-    /// thread before `on_load_end` arms `linux_paint_gate_pending` for the
-    /// same label — CEF's main-frame load-complete isn't guaranteed to fire
-    /// after the frontend's first compositor frame (render-blocking
-    /// stylesheets can resolve, and a frame can paint, before other
-    /// load-blocking resources finish and `on_load_end` runs). Labels land
-    /// here when the signal arrives too early; `on_load_end` checks this set
-    /// before arming so it can reveal immediately instead of falling through
-    /// to the slower safety timeout. Only populated/consumed on Linux and
-    /// Windows; unconditional field for the same reason as
-    /// `linux_paint_gate_pending` above.
+    /// Linux startup white-flash fix, second-round race (reagent PR #2151
+    /// review): `report_first_paint` can reach the UI thread before
+    /// `on_load_end` arms `linux_paint_gate_pending` for the same label — CEF's
+    /// main-frame load-complete isn't guaranteed to fire after the frontend's
+    /// first compositor frame (render-blocking stylesheets can resolve, and a
+    /// frame can paint, before other load-blocking resources finish and
+    /// `on_load_end` runs). Labels land here when the signal arrives too
+    /// early; `on_load_end` checks this set before arming so it can reveal
+    /// immediately instead of falling through to the slower safety timeout.
+    /// Only populated/consumed on Linux; unconditional field for the same
+    /// reason as `linux_paint_gate_pending` above.
     pub linux_first_paint_seen: Mutex<std::collections::HashSet<String>>,
 
     /// Phase B.5e — host's projection of the launcher's

--- a/agentmux-cef/src/ui_tasks/pool.rs
+++ b/agentmux-cef/src/ui_tasks/pool.rs
@@ -34,20 +34,6 @@ wrap_task! {
         y: i32,
         width: i32,
         height: i32,
-        // Signaled once execute() finishes (success or not) so the IPC-thread
-        // caller can block until CEF's own compositor visibility has actually
-        // flipped, instead of firing this task and immediately moving on to
-        // emit `pool:promote` to the frontend / start a pool refill — both of
-        // which used to race ahead of the real show with no ordering
-        // guarantee at all. See post_promote_pool_window_views_show below and
-        // docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md §4.3.
-        // Does NOT change the underlying Win32-then-CEF-Views show order
-        // (that ordering exists for its own documented reason above and this
-        // report did not find a safe way to verify a reorder without a real
-        // Windows GUI test session) — only makes the existing gap
-        // deterministic and measurable rather than leaving it to whatever the
-        // caller happened to do next.
-        done_tx: std::sync::mpsc::SyncSender<()>,
     }
 
     impl Task {
@@ -91,23 +77,10 @@ wrap_task! {
                     );
                 }
             }
-            let _ = self.done_tx.try_send(());
         }
     }
 }
 
-/// Blocking (bounded-wait) version of the previous fire-and-forget post — see
-/// `PromotePoolWindowViewsShowTask.done_tx`'s doc comment for why. Logs the
-/// actual IPC-thread-to-UI-thread elapsed time so a real run can measure this
-/// gap the same way the Linux paint-gate PR (#2151) measured its own
-/// first-paint latency before picking a safety timeout; 500ms here is a
-/// deliberately generous placeholder pending that measurement, not a tuned
-/// value — this is a same-process, same-machine cross-thread post with no
-/// GPU/EGL init or network I/O involved, so it should normally complete in
-/// low single-digit milliseconds. If the timeout is ever actually hit, the
-/// caller proceeds anyway (never blocks `promote_pool_window` — and by
-/// extension "New Window" — indefinitely on a wedged UI thread) and the
-/// warning log is the signal that something upstream is unexpectedly slow.
 #[cfg(target_os = "windows")]
 pub(crate) fn post_promote_pool_window_views_show(
     state: &Arc<AppState>,
@@ -117,7 +90,6 @@ pub(crate) fn post_promote_pool_window_views_show(
     width: i32,
     height: i32,
 ) {
-    let (done_tx, done_rx) = std::sync::mpsc::sync_channel::<()>(1);
     let mut task = PromotePoolWindowViewsShowTask::new(
         state.clone(),
         label.to_string(),
@@ -125,24 +97,8 @@ pub(crate) fn post_promote_pool_window_views_show(
         y,
         width,
         height,
-        done_tx,
     );
-    let posted_at = std::time::Instant::now();
     post_task(ThreadId::UI, Some(&mut task));
-    match done_rx.recv_timeout(std::time::Duration::from_millis(500)) {
-        Ok(()) => tracing::info!(
-            target: "pool:new-window",
-            label = %label,
-            elapsed_ms = posted_at.elapsed().as_millis() as u64,
-            "[pool] CEF Views show completed — safe to proceed"
-        ),
-        Err(_) => tracing::warn!(
-            target: "pool:new-window",
-            label = %label,
-            "[pool] CEF Views show did not complete within 500ms — proceeding anyway; \
-             pool:promote/frontend bootstrap may race ahead of the real compositor show"
-        ),
-    }
 }
 
 // ── Pool window promote (macOS / Linux) — Phase 7 ─────────────────────────

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -1368,36 +1368,22 @@ wrap_task! {
             let t0 = std::time::Instant::now();
             tracing::info!(label = %self.label, "[create-window] task entered UI thread");
 
-            // ARGB alpha=0 → transparent, mirroring the MAIN window (app.rs)
-            // and the global CefSettings.background_color (main.rs).
-            // CreateWindowTask builds every secondary window on Linux/macOS —
-            // additional windows AND floating-pane tear-offs
-            // (open_floating_pane_window routes here on non-Windows; the
-            // dedicated post_create_floating_window is Windows-only) — AND,
-            // on every platform including Windows, every pool window
-            // (`window_pool::spawn_pool_window` → `post_create_window` →
-            // this task), which is what a running app's "New Window"/tear-off
-            // actually promotes. Previously hard-coded 0xFF000000 (opaque
-            // black) here, which (a) overrode the transparent global default
-            // and (b) gated OFF the BrowserViewImpl transparency cascade (it
-            // only fires when default_background_color_ is transparent — see
-            // cef/libcef/browser/views/browser_view_impl.cc
-            // WebContentsCreated), making floaters/secondary windows fully
-            // opaque even when window:transparent=true — so it was changed to
-            // unconditional 0x00000000. That fixed the transparent case but
-            // broke the opaque one the other way: every non-transparent
-            // secondary/pool window's compositor backstop no longer matched
-            // the startup splash's background (`app::OPAQUE_BG_ARGB`,
-            // `rgb(34,34,34)`), producing a transparent/black-to-gray flash on
-            // every "New Window" — see
-            // docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md
-            // §4.1. Read the same transparency flag the main window already
-            // reads so both branches are covered: transparent stays
-            // 0x00000000 (preserves the cascade fix above), opaque now
-            // matches the splash instead of reverting to plain black.
-            let is_transparent = self.state.window_transparent.load(std::sync::atomic::Ordering::Relaxed);
             let settings = BrowserSettings {
-                background_color: if is_transparent { 0x00000000 } else { crate::app::OPAQUE_BG_ARGB },
+                // ARGB alpha=0 → transparent, mirroring the MAIN window
+                // (app.rs:679) and the global CefSettings.background_color
+                // (main.rs). CreateWindowTask builds every secondary window
+                // on Linux/macOS — additional windows AND floating-pane
+                // tear-offs (open_floating_pane_window routes here on
+                // non-Windows; the dedicated post_create_floating_window is
+                // Windows-only). Previously hard-coded 0xFF000000 (opaque
+                // black), which (a) overrode the transparent global default
+                // and (b) gated OFF the BrowserViewImpl transparency cascade
+                // (it only fires when default_background_color_ is
+                // transparent — see cef/libcef/browser/views/browser_view_impl.cc
+                // WebContentsCreated). Result: floaters/secondary windows were
+                // fully opaque even when window:transparent=true. 0x00000000
+                // lets them inherit the same transparency path as main.
+                background_color: 0x00000000,
                 ..Default::default()
             };
             let cef_url = CefString::from(self.url.as_str());


### PR DESCRIPTION
## Why

PR #2163 (color-flash fix) introduced a **functional regression**: "New Window" now fails ~2 of 3 times on Windows — the promoted pool window flashes an empty near-black surface, vanishes, and the frontend init never completes ("window.api still undefined after 5s — host API bridge failed to initialize").

**Live-captured evidence** (dev:main @ bf1b4e64, GDI burst-capture harness + CDP-triggered `openNewWindow()` + `pool:new-window` telemetry): two consecutive promote failures — the promoted window paints empty `rgb(12,12,12)` at +110ms for ~70ms, disappears, reappears ~1.2s for ~30-60ms, then gone; the CDP target keeps its un-promoted `pool=1` URL; no workspace window results. One earlier promote on the same build succeeded, i.e. it's a race, not deterministic.

**Confirmed sole cause:** `git log` over the window-show / pool-promote / navigation code (`navigation.rs`, `ui_tasks/pool.rs`, `window_pool.rs`, `ui_tasks/window.rs`) shows **#2163 is the only commit that touched any of it** in the relevant range. It worked before that merge; it fails after.

## What this reverts

The full #2163 change (widened the Linux window-show paint-gate to Windows §4.2, added a blocking `recv_timeout` to pool-promote §4.3, changed backstop colors §4.1). Verified the seven touched cef files are now byte-identical to their pre-#2163 state; `cargo check -p agentmux-cef` clean.

## What's kept

- `REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md` — the investigation report stays (the flash it documents is real and now un-fixed again; it's the basis for a careful re-fix).
- The cosmetic flash returns. That was the *pre-existing* behavior and is strictly preferable to a New Window that fails to open. The re-fix is tracked as tasks #51 (the cosmetic gap) and #52 (the promote failure this revert resolves) — both now have a live capture-harness acceptance test that #2163 shipped without.

## Follow-up discipline

The re-fix must not merge without the harness showing 5 consecutive successful promotes on a real Windows session — the exact verification #2163's own author flagged as missing and that this regression is the direct consequence of skipping.

<!-- agentmux:agent_id=agenta-07017 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)