### PR TITLE
fix(armory): eliminate split-screen list+detail layouts, single pane at every width

### DIFF
--- a/.changesets/1784144966-fix-armory-eliminate-split-screen-list-detail-layouts-single-zciy.md
+++ b/.changesets/1784144966-fix-armory-eliminate-split-screen-list-detail-layouts-single-zciy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): eliminate split-screen list+detail layouts, single pane at every width

--- a/docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md
+++ b/docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md
@@ -1,0 +1,232 @@
+# SPEC — Armory: eliminate split-screen list+detail layouts, single-pane at every width
+
+**Status:** Draft — spec only, no code written yet (per explicit request).
+**Trigger:** user report — Armory panes are frequently used narrow (AgentMux panes are
+user-resizable/tileable, not fixed-width dialogs), and the current list+detail split-screen
+layouts either stay side-by-side (unusable when narrow) or collapse into a stacked
+list-above-detail layout that still shows both at once, cramped. Explicit constraint: no split
+screen, and no tree-of-selections either.
+**Scope:** Armory only (hamburger → Armory), all 5 tabs. Two of the three affected components
+(`AgentPrimitiveModal.scss`, used by the Skills/MCP Servers tabs) are also shared with the
+per-agent Agent Setup Modal outside Armory — see §5 for why that's flagged as a separate
+decision, not silently included.
+**Verify before acting:** all file:line citations checked against `main` @ `b2e78754`
+(v0.53.6) on 2026-07-15.
+
+---
+
+## 1. Current state, tab by tab
+
+Checked all 5 `RAIL` entries in `frontend/app/view/armory/armory-view.tsx:16-21`
+(Accounts / Memories / Skills / MCP Servers / Bundles) for split-screen usage:
+
+| Tab | Component | Layout | Split-screen? |
+|---|---|---|---|
+| **Accounts** | `AccountsManager` → `AccountsGallery.tsx` | `.accounts-gallery-grid` — a wrapping tile grid, connect flow opens as an overlay/modal | **No.** Already fine. |
+| **Memories** (native "brain") | `GlobalBrainManager` | `.global-brain-sections` — single vertical list; clicking a row expands it **in place** into an edit form (`SectionEditor`), replacing the row's own content | **No.** Already fine — and the best in-house precedent (§3). |
+| **Skills** | `SkillManager` → `.agent-primitive-modal` (shared, `AgentPrimitiveModal.scss`) | Fixed `220px` list + `flex: 1` detail, side by side | **Yes — no responsive fallback at any width.** |
+| **MCP Servers** | `McpManager` → `.agent-primitive-modal` (same shared component) | Same as Skills | **Yes — same gap.** |
+| **Bundles** | `MemoryManager` → `MemoryManagerBody` (`memory-view.scss`) | `.memory-view { display: flex; flex-direction: row }` — `240px` list + `flex: 1` detail | **Yes**, and it *does* have a `@container memory-pane (max-width: 767px)` fallback (`memory-view.scss:277-292`) — but that fallback only changes `flex-direction` to `column`: the list caps to `max-height: 40%` and stays visible **above** the detail, which now has `60%` of a narrow pane to work with. **Still two things visible at once in a thin pane** — this is very likely exactly what triggered the report; it looks like a responsive fix but doesn't remove the split, it just re-orients it. |
+
+**Net: 3 of 5 tabs (Bundles, Skills, MCP Servers) show a list and a detail simultaneously, one
+of them even after its "responsive" breakpoint fires.** Accounts and Memories don't have this
+problem today and aren't touched by this spec except as the precedent that shaped §3's design.
+
+---
+
+## 2. Why the current "responsive" attempt for Bundles doesn't solve it
+
+`memory-view.scss:277-292`'s narrow-width fallback is a real, deliberate attempt at
+responsiveness (it uses the `@container memory-pane` query the whole app already relies on for
+pane-width breakpoints — this isn't an oversight, someone tried). The gap is conceptual, not a
+bug: **stacking two panes vertically is still splitting the available space between two
+simultaneously-visible surfaces.** In a genuinely thin pane (which is the normal case this
+spec is written for, not an edge case), 40% height for a scrollable list leaves room for maybe
+2-3 rows before it scrolls, and the remaining 60% squeezes a form with a name field, a
+description field, and an `8`-row textarea. Neither half is comfortably usable. The fix isn't a
+better split ratio — it's not splitting at all.
+
+---
+
+## 3. Proposed pattern: single-pane, one view at a time, always
+
+**No split, at any width.** Not "split above some breakpoint, stack below it" — never show the
+list and the detail simultaneously. This is a deliberate simplification versus trying to tune
+a responsive split further, and it directly satisfies the "no split screen" constraint without
+a width threshold to get wrong.
+
+### 3.1 Two shapes already exist in this codebase; pick per tab, don't force one pattern everywhere
+
+**Shape A — inline accordion (GlobalBrainManager's existing pattern, unchanged).** Already
+proven in Armory today (`global-brain-manager.tsx:93-167`): the list stays single-column, and
+selecting a row expands it in place into its edit form, replacing the row's collapsed content.
+No navigation, no "back" button — the row *is* the detail. Works well when: content per item is
+short (name + one paragraph), so an expanded row doesn't dominate the whole scroll.
+
+**Shape B — single-pane push navigation (new, for Bundles/Skills/MCP).** List view shows only
+the list (full width, full height) + the existing "New" button. Selecting an item — or clicking
+"New" — **replaces** the list view with a full-width, full-height detail view (the exact same
+read-only/edit-form content each of these three already renders today, just no longer squeezed
+into a side column). A back affordation at the top of the detail view (`‹ Bundles` /
+`‹ Skills` / `‹ MCP Servers`) returns to the list. This is a flat two-state stack (list ⇄
+detail), never more than one level — **not** a tree: there's no nested category/folder
+structure, no drill-down through groups, just "am I looking at the list, or one item."
+
+**Recommendation:** Shape B for Bundles, Skills, and MCP Servers. Their detail views are full
+CRUD forms (name/description/instructions-or-content/bind-row, some with an 8+ row textarea) —
+meaningfully bigger than GlobalBrainManager's name+textarea pair, and benefit from the full
+pane rather than competing for space inside a scrolling list of siblings. GlobalBrainManager
+itself is explicitly **out of scope** — it already does the right thing, don't touch it.
+
+### 3.2 Why not push navigation for everything, replacing Shape A too?
+
+Considered and rejected: `GlobalBrainManager`'s accordion is small, well-tested (existing
+coverage), and genuinely the better fit for its content size — converting it to push
+navigation would be redundant churn with no user-visible upside and a mechanical diff for its
+own sake. "Consistent code shape" isn't a strong enough reason to touch a component that isn't
+broken; matching *content shape to interaction shape* is the actual design principle here, not
+uniformity for its own sake.
+
+### 3.3 Why not a tree / grouped-category browser?
+
+Explicitly ruled out by the request. Worth stating why it would've been tempting and why it's
+wrong here anyway: Skills and MCP Servers could theoretically be grouped (by provider, by
+bound/unbound status), and a collapsible tree is a common way to keep a long flat list
+manageable in a narrow space. But a tree adds a *third* navigational state (which group is
+expanded) on top of list/detail, and for the realistic list sizes here (a handful to a few
+dozen skills/MCP servers/bundles per workspace — these are hand-curated primitives, not an
+auto-discovered catalog) a plain scrolling list is already fully manageable without grouping.
+Grouping is a solution to a list-length problem this feature doesn't have.
+
+---
+
+## 4. Implementation shape
+
+### 4.1 Shared primitive, not three parallel implementations
+
+Skills, MCP Servers, and Bundles all want the identical list↔detail state machine (`view:
+"list" | "detail"`, `selectedId`, transitions on select/new/save/cancel/delete/back). Bundles
+already has this exact shape today (`MemoryViewModel`'s `selectedIdAtom`/`draftAtom`,
+`memory-model.ts`) — Skills/MCP's models (`SkillViewModel`/`McpViewModel`, presumed similarly
+shaped given they render through the same `AgentPrimitiveModal` markup) very likely already
+have equivalent selection/draft state too, since the *data* flow doesn't change here — only
+whether list and detail render simultaneously or as two mutually-exclusive views.
+
+**Recommend:** extract a small shared layout component (e.g. `<PrimitiveListDetail>` or
+similar — naming is the implementer's call) that takes `{ view: Accessor<"list" | "detail">,
+list: JSX.Element, detail: JSX.Element, backLabel: string, onBack: () => void }` and renders
+the mutually-exclusive single-pane layout with the back affordation. `MemoryManagerBody`,
+`SkillManager`, and `McpManager` each keep their own existing list-item markup and
+read-only/edit-form markup exactly as-is (no changes needed to what's *inside* each pane) —
+only the outer "are both visible at once" wrapper changes. This avoids three near-duplicate
+implementations of the same back-button-and-visibility logic, which is exactly the kind of
+divergence that made `memory-view.scss`'s attempted fix and `AgentPrimitiveModal.scss`'s
+complete absence-of-a-fix two different half-solutions to one problem in the first place.
+
+### 4.2 CSS
+
+Both `memory-view.scss` and `AgentPrimitiveModal.scss` currently define the list/detail split
+as `display: flex` on a shared row parent with a fixed-width list child. The single-pane
+version is simpler, not just different: the parent shows exactly one child
+(`.is-active`/`display: none` on the other, same toggle mechanism `armory-view.tsx` already
+uses for its own tab panes at `bundle-manager-pane.is-hidden`, or a plain `<Show>`), each child
+at `width: 100%; height: 100%`. **This can delete code**, not just add a breakpoint:
+`memory-view.scss:277-292`'s stacking fallback becomes entirely unnecessary once there's
+nothing to stack — the single-pane behavior is now correct at every width, so the container
+query that used to switch between "row" and "column" split goes away.
+
+### 4.3 Back affordation
+
+A single shared small component/class for the "‹ Back to X" control at the top of every detail
+view, consistent styling across all three tabs (currently there isn't one anywhere in Armory to
+copy, since nothing needs one today). Suggest reusing whatever chevron/back-icon convention
+already exists elsewhere in the app's settings/modal chrome, rather than inventing new iconography.
+
+### 4.4 What doesn't change
+
+- Every existing RPC call, model method, and validation rule in `MemoryViewModel` /
+  `SkillViewModel` / `McpViewModel` — this is a pure layout change, no data-flow change.
+- The read-only-view → edit-form → save/cancel state machine each tab already has internally
+  (e.g. Bundles' `selectedAtom`/`draftAtom` two-step) stays exactly as-is; it just now renders
+  in a full-width single pane instead of a `flex: 1` side column.
+- GlobalBrainManager and AccountsManager — out of scope, already correct (§3.2, §1).
+
+---
+
+## 5. Scope decision the implementer/user should confirm before starting
+
+`AgentPrimitiveModal.scss` (and its `.agent-primitive-modal` markup) is **shared** between
+Armory's Skills/MCP Servers tabs and the per-agent **Agent Setup Modal**'s own Skills/MCP tabs
+(`AgentSkillsModal.tsx`/`AgentMcpModal.tsx`, outside Armory — CLAUDE.md's "Not widgets" table).
+This spec's ask was scoped to "all screens in the Armory," but fixing the shared component
+necessarily also changes those non-Armory surfaces, since there's only one
+`AgentPrimitiveModal.scss` today.
+
+Two ways to handle this, implementer's call:
+1. **Let it ride** — the Agent Setup Modal is also frequently opened at a modest width and
+   would very plausibly benefit from the identical fix; sharing the component was presumably
+   intentional for exactly this kind of consistency. Simplest, no extra work.
+2. **Fork before changing** — duplicate the component so Armory gets the new single-pane
+   layout and the Agent Setup Modal keeps its current split, if there's a reason (not identified
+   in this investigation) the modal specifically wants the split kept. Extra code, no known
+   justification found — recommend against this unless the user has one.
+
+**Recommendation: option 1.** No spec or code found suggesting the Agent Setup Modal's split
+is intentional-and-load-bearing; it looks like the same unaddressed gap in a shared component,
+not a considered difference. Flagging explicitly rather than silently expanding scope, per this
+codebase's own convention (see `SPEC_LIGHT_THEME_DEPTH_AND_MORE_THEMES_2026_07_13.md` for the
+same "confirm the scope boundary rather than assume" pattern on a different feature).
+
+`AgentNativeMemoryModal.scss` (referenced in `AgentPrimitiveModal.scss:7`'s own comment as
+sharing "the same list+detail shape") is a **different** component (per-agent native-memory
+file browser, also outside Armory) — not touched by this spec, not verified against this
+investigation. Flagging only so a future pass doesn't assume it's already covered.
+
+---
+
+## 6. Test coverage to add
+
+- Selecting a Bundle/Skill/MCP server from the list shows only the detail view (list not
+  present in the DOM, or `display: none`/hidden — whichever mechanism is chosen).
+- "New" from the list view opens the detail view in create mode.
+- The back affordation returns to the list view with the list's scroll position and content
+  intact (no refetch needed — data doesn't change, only which view is shown).
+- Save / Cancel / Delete from the detail view all return to the list view afterward, matching
+  each tab's current post-save/cancel/delete behavior (verify none of the three currently do
+  something list-view-specific on save that a full navigation-back would break — e.g. does
+  Bundles currently re-select the saved item and show its read-only detail rather than
+  returning to the list? If so, decide whether that behavior is preserved in the new shape or
+  intentionally simplified to "always return to list," and note that in the actual PR, since
+  this spec inspected the *layout* code, not every save-completion code path in each model).
+- No `@container` layout test still asserts the old stacked-at-narrow behavior for Bundles
+  (`memory-view.scss:277`'s removed breakpoint) — delete/update any existing test coupled to it.
+- Manual: resize an Armory-hosting pane down to a genuinely thin width (a few hundred px) for
+  each of the three tabs — list should be fully readable, detail should be fully usable, at no
+  point should both be visible or either be cramped.
+
+---
+
+## 7. Suggested PR split
+
+1. **PR A** — shared `<PrimitiveListDetail>`-style layout primitive + Bundles migration (single
+   tab, proves the pattern, smallest blast radius — Bundles' own model is already closest to
+   this shape).
+2. **PR B** — Skills + MCP Servers migration onto the same shared primitive (both share
+   `AgentPrimitiveModal.scss` today, so naturally land together). Confirms the §5 scope decision
+   before touching the Agent Setup Modal's shared usage.
+
+---
+
+## 8. Sources
+
+- `frontend/app/view/armory/armory-view.tsx`, `armory-view.scss`
+- `frontend/app/view/memory/memory-manager.tsx`, `memory-model.ts`, `memory-view.scss`
+- `frontend/app/view/skill/skill-manager.tsx`
+- `frontend/app/view/mcp/mcp-manager.tsx`
+- `frontend/app/view/agent/components/AgentPrimitiveModal.scss`
+- `frontend/app/view/brain/global-brain-manager.tsx`, `global-brain.scss`
+- `frontend/app/view/accounts/AccountsGallery.tsx`, `accounts-manager.tsx`
+- `docs/specs/SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md` (current Armory
+  tab set/order this spec assumes)
+- GitHub issue #2024 (Armory consolidation tracker — confirmed no open item covers this;
+  independent scope)

--- a/frontend/app/element/primitive-list-detail.scss
+++ b/frontend/app/element/primitive-list-detail.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.primitive-list-detail {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.primitive-list-detail-list {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.primitive-list-detail-detail {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.primitive-list-detail-back-btn {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    margin: 8px;
+    padding: 5px 10px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--main-text-color);
+    font-size: 12px;
+    cursor: default;
+
+    i {
+        font-size: 10px;
+        opacity: 0.8;
+    }
+
+    &:hover {
+        background: var(--hover-bg-color);
+    }
+}
+
+.primitive-list-detail-detail-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}

--- a/frontend/app/element/primitive-list-detail.tsx
+++ b/frontend/app/element/primitive-list-detail.tsx
@@ -1,0 +1,48 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// PrimitiveListDetail — shared single-pane list/detail layout for Armory's
+// Bundles/Skills/MCP Servers tabs (and any future list+CRUD-form primitive
+// with the same shape). Renders exactly ONE of {list, detail} at a time —
+// never both, at any pane width. Replaces the previous fixed-width
+// side-by-side split (and, for Bundles, a stacked-but-still-both-visible
+// narrow-width fallback) that didn't hold up in a thin pane. See
+// docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md.
+//
+// Not a tree: this is a flat two-state stack (list, or one item's detail),
+// never a nested category/group drill-down.
+
+import { Show, type JSX } from "solid-js";
+
+import "./primitive-list-detail.scss";
+
+export function PrimitiveListDetail(props: {
+    /** True when the detail view (read-only or edit form) should show instead of the list. */
+    showDetail: boolean;
+    /** Label after the back chevron, e.g. "Bundles", "Skills", "MCP Servers". */
+    backLabel: string;
+    onBack: () => void;
+    list: JSX.Element;
+    detail: JSX.Element;
+}): JSX.Element {
+    return (
+        <div class="primitive-list-detail">
+            <Show when={!props.showDetail}>
+                <div class="primitive-list-detail-list">{props.list}</div>
+            </Show>
+            <Show when={props.showDetail}>
+                <div class="primitive-list-detail-detail">
+                    <button
+                        type="button"
+                        class="primitive-list-detail-back-btn"
+                        onClick={() => props.onBack()}
+                    >
+                        <i class="fa-sharp fa-solid fa-chevron-left" aria-hidden="true" />
+                        <span>{props.backLabel}</span>
+                    </button>
+                    <div class="primitive-list-detail-detail-body">{props.detail}</div>
+                </div>
+            </Show>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -9,6 +9,7 @@
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
+import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { openOrFocusPaneByView } from "@/app/store/global";
 import { AgentMcpModel } from "../agent-mcp-model";
 import "./AgentPrimitiveModal.scss";
@@ -21,66 +22,67 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
     const model = new AgentMcpModel(props.agentId);
     onCleanup(() => model.dispose());
 
-    return (
-        <div class="agent-primitive-modal">
+    // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md §5.
+    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+    const handleBack = () => {
+        model.setError(null);
+        model.setSelectedId(null);
+        model.setDraft(null);
+    };
+
+    const listView = (
+        <div class="agent-primitive-modal-list">
             <Show when={model.errorAtom()}>
                 <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
             </Show>
-
-            <div class="agent-primitive-modal-body">
-                <div class="agent-primitive-modal-list">
-                    <Show
-                        when={model.serversAtom().length > 0}
-                        fallback={<div class="agent-primitive-modal-list-empty">No MCP servers yet</div>}
-                    >
-                        <For each={model.serversAtom()}>
-                            {(server) => (
-                                <button
-                                    class="agent-primitive-modal-list-item"
-                                    classList={{ "is-selected": model.selectedIdAtom() === server.id }}
-                                    onClick={() => model.handleSelect(server)}
+            <Show
+                when={model.serversAtom().length > 0}
+                fallback={<div class="agent-primitive-modal-list-empty">No MCP servers yet</div>}
+            >
+                <For each={model.serversAtom()}>
+                    {(server) => (
+                        <button
+                            class="agent-primitive-modal-list-item"
+                            classList={{ "is-selected": model.selectedIdAtom() === server.id }}
+                            onClick={() => model.handleSelect(server)}
+                        >
+                            <span class="agent-primitive-modal-list-item-name">{server.name}</span>
+                            <Show when={server.is_global}>
+                                <span class="agent-primitive-modal-list-item-badge">global</span>
+                                <span
+                                    class="agent-primitive-modal-list-item-badge"
+                                    classList={{ "is-bound": server.bound_to_agent }}
                                 >
-                                    <span class="agent-primitive-modal-list-item-name">{server.name}</span>
-                                    <Show when={server.is_global}>
-                                        <span class="agent-primitive-modal-list-item-badge">global</span>
-                                        <span
-                                            class="agent-primitive-modal-list-item-badge"
-                                            classList={{ "is-bound": server.bound_to_agent }}
-                                        >
-                                            {server.bound_to_agent ? "bound" : "not bound"}
-                                        </span>
-                                    </Show>
-                                </button>
-                            )}
-                        </For>
-                    </Show>
+                                    {server.bound_to_agent ? "bound" : "not bound"}
+                                </span>
+                            </Show>
+                        </button>
+                    )}
+                </For>
+            </Show>
 
-                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
-                        + New MCP server
-                    </button>
-                    <button
-                        class="agent-primitive-modal-new-btn"
-                        onClick={() => void openOrFocusPaneByView("armory")}
-                    >
-                        Browse the Armory catalog →
-                    </button>
-                </div>
+            <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                + New MCP server
+            </button>
+            <button
+                class="agent-primitive-modal-new-btn"
+                onClick={() => void openOrFocusPaneByView("armory")}
+            >
+                Browse the Armory catalog →
+            </button>
+        </div>
+    );
 
-                <div class="agent-primitive-modal-detail">
-                    <Show
-                        when={model.draftAtom()}
-                        fallback={
-                            <Show
-                                when={model.selectedAtom()}
-                                fallback={
-                                    <div class="agent-primitive-modal-empty">
-                                        Select a server from the list, or create a new one. Servers
-                                        created here are private to this agent — for one shared across
-                                        every agent, create it in the Armory catalog instead.
-                                    </div>
-                                }
-                            >
-                                {(server) => (
+    const detailView = (
+        <div class="agent-primitive-modal-detail">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+            <Show
+                when={model.draftAtom()}
+                fallback={
+                    <Show when={model.selectedAtom()}>
+                        {(server) => (
                                     <div class="agent-primitive-modal-readonly">
                                         <h3 class="agent-primitive-modal-name">{server().name}</h3>
                                         <Show when={server().is_global}>
@@ -193,10 +195,18 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                                 </div>
                             </form>
                         )}
-                    </Show>
-                </div>
-            </div>
+            </Show>
         </div>
+    );
+
+    return (
+        <PrimitiveListDetail
+            showDetail={inDetail()}
+            backLabel="MCP Servers"
+            onBack={handleBack}
+            list={listView}
+            detail={detailView}
+        />
     );
 };
 

--- a/frontend/app/view/agent/components/AgentPrimitiveModal.scss
+++ b/frontend/app/view/agent/components/AgentPrimitiveModal.scss
@@ -2,17 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Shared styles for the agent-scoped primitive list/detail tabs (MCP
-// Servers, Skills) hosted inside AgentSetupModal. Same list+detail shape as
-// AgentNativeMemoryModal.scss, generalized to a form-editor detail pane
-// instead of a file browser — see AgentMcpModal.tsx / AgentSkillsModal.tsx.
-
-.agent-primitive-modal {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    height: 100%;
-    min-height: 0;
-}
+// Servers, Skills) hosted inside AgentSetupModal, and reused by Armory's
+// own Skills/MCP Servers tabs (skill-manager.tsx / mcp-manager.tsx). Content
+// styling only — the outer list/detail layout and the list-vs-detail toggle
+// live in PrimitiveListDetail (frontend/app/element/primitive-list-detail.tsx).
+// This used to be a fixed-width side-by-side split with no narrow-pane
+// fallback; see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md.
 
 .agent-primitive-modal-error {
     flex-shrink: 0;
@@ -24,19 +19,11 @@
     font-size: var(--text-sm);
 }
 
-.agent-primitive-modal-body {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    border: 1px solid var(--border-color);
-}
-
 .agent-primitive-modal-list {
-    flex-shrink: 0;
-    width: 220px;
+    width: 100%;
+    height: 100%;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--border-color);
     overflow-y: auto;
 }
 
@@ -110,22 +97,11 @@
 }
 
 .agent-primitive-modal-detail {
-    flex: 1;
-    min-width: 0;
+    width: 100%;
+    height: 100%;
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-}
-
-.agent-primitive-modal-empty {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--space-4);
-    text-align: center;
-    color: var(--secondary-text-color);
-    font-size: var(--text-sm);
 }
 
 .agent-primitive-modal-readonly {

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -12,6 +12,7 @@
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
+import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { openOrFocusPaneByView } from "@/app/store/global";
 import { AgentSkillModel } from "../agent-skill-model";
 import "./AgentPrimitiveModal.scss";
@@ -24,66 +25,69 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
     const model = new AgentSkillModel(props.agentId);
     onCleanup(() => model.dispose());
 
-    return (
-        <div class="agent-primitive-modal">
+    // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md
+    // §5 (shared with Armory's Skills/MCP Servers tabs; applied here too since
+    // there's no evidence the split was intentional in this modal specifically).
+    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+    const handleBack = () => {
+        model.setError(null);
+        model.setSelectedId(null);
+        model.setDraft(null);
+    };
+
+    const listView = (
+        <div class="agent-primitive-modal-list">
             <Show when={model.errorAtom()}>
                 <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
             </Show>
-
-            <div class="agent-primitive-modal-body">
-                <div class="agent-primitive-modal-list">
-                    <Show
-                        when={model.skillsAtom().length > 0}
-                        fallback={<div class="agent-primitive-modal-list-empty">No skills yet</div>}
-                    >
-                        <For each={model.skillsAtom()}>
-                            {(skill) => (
-                                <button
-                                    class="agent-primitive-modal-list-item"
-                                    classList={{ "is-selected": model.selectedIdAtom() === skill.id }}
-                                    onClick={() => model.handleSelect(skill)}
+            <Show
+                when={model.skillsAtom().length > 0}
+                fallback={<div class="agent-primitive-modal-list-empty">No skills yet</div>}
+            >
+                <For each={model.skillsAtom()}>
+                    {(skill) => (
+                        <button
+                            class="agent-primitive-modal-list-item"
+                            classList={{ "is-selected": model.selectedIdAtom() === skill.id }}
+                            onClick={() => model.handleSelect(skill)}
+                        >
+                            <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
+                            <Show when={skill.is_global}>
+                                <span class="agent-primitive-modal-list-item-badge">global</span>
+                                <span
+                                    class="agent-primitive-modal-list-item-badge"
+                                    classList={{ "is-bound": skill.bound_to_agent }}
                                 >
-                                    <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
-                                    <Show when={skill.is_global}>
-                                        <span class="agent-primitive-modal-list-item-badge">global</span>
-                                        <span
-                                            class="agent-primitive-modal-list-item-badge"
-                                            classList={{ "is-bound": skill.bound_to_agent }}
-                                        >
-                                            {skill.bound_to_agent ? "bound" : "not bound"}
-                                        </span>
-                                    </Show>
-                                </button>
-                            )}
-                        </For>
-                    </Show>
+                                    {skill.bound_to_agent ? "bound" : "not bound"}
+                                </span>
+                            </Show>
+                        </button>
+                    )}
+                </For>
+            </Show>
 
-                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
-                        + New skill
-                    </button>
-                    <button
-                        class="agent-primitive-modal-new-btn"
-                        onClick={() => void openOrFocusPaneByView("armory")}
-                    >
-                        Browse the Armory catalog →
-                    </button>
-                </div>
+            <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                + New skill
+            </button>
+            <button
+                class="agent-primitive-modal-new-btn"
+                onClick={() => void openOrFocusPaneByView("armory")}
+            >
+                Browse the Armory catalog →
+            </button>
+        </div>
+    );
 
-                <div class="agent-primitive-modal-detail">
-                    <Show
-                        when={model.draftAtom()}
-                        fallback={
-                            <Show
-                                when={model.selectedAtom()}
-                                fallback={
-                                    <div class="agent-primitive-modal-empty">
-                                        Select a skill from the list, or create a new one. Skills
-                                        created here are private to this agent — for one shared across
-                                        every agent, create it in the Armory catalog instead.
-                                    </div>
-                                }
-                            >
-                                {(skill) => (
+    const detailView = (
+        <div class="agent-primitive-modal-detail">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+            <Show
+                when={model.draftAtom()}
+                fallback={
+                    <Show when={model.selectedAtom()}>
+                        {(skill) => (
                                     <div class="agent-primitive-modal-readonly">
                                         <h3 class="agent-primitive-modal-name">{skill().name}</h3>
                                         <Show when={skill().is_global}>
@@ -209,10 +213,18 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                 </div>
                             </form>
                         )}
-                    </Show>
-                </div>
-            </div>
+            </Show>
         </div>
+    );
+
+    return (
+        <PrimitiveListDetail
+            showDetail={inDetail()}
+            backLabel="Skills"
+            onBack={handleBack}
+            list={listView}
+            detail={detailView}
+        />
     );
 };
 

--- a/frontend/app/view/armory/armory-view.scss
+++ b/frontend/app/view/armory/armory-view.scss
@@ -86,18 +86,6 @@
     }
 }
 
-// Modifier class gives the memory (Bundles) pane its own container
-// context so its child elements can respond to pane-width queries.
-// (The .memory-view root is a descendant of this container and can
-// therefore be targeted by @container queries on it. The former
-// `.bundle-manager-pane--identity` modifier for the Armory "Identities"
-// tab was removed along with that tab — see
-// docs/specs/SPEC_ARMORY_PHASE5_CONSOLIDATION_AND_SKILL_SEEDING_2026_07_13.md §1.)
-.bundle-manager-pane--memories {
-    container-type: inline-size;
-    container-name: memory-pane;
-}
-
 // ── Bottom tab bar (xs only) ─────────────────────────────────────────────────
 
 .bundle-manager-tab-bar {

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -64,7 +64,7 @@ export function ArmoryView(_props: ViewComponentProps<ArmoryViewModel>): JSX.Ele
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "mcp" }}>
                         <McpManager />
                     </div>
-                    <div class="bundle-manager-pane bundle-manager-pane--memories" classList={{ "is-hidden": section() !== "memories" }}>
+                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "memories" }}>
                         <MemoryManager />
                     </div>
                 </div>

--- a/frontend/app/view/mcp/mcp-manager.tsx
+++ b/frontend/app/view/mcp/mcp-manager.tsx
@@ -10,6 +10,7 @@
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
+import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { McpCatalogModel } from "./mcp-model";
 import { McpCatalogPicker } from "./McpCatalogPicker";
 import { findPreloadEntryByName } from "./mcp-preload-catalog";
@@ -57,56 +58,58 @@ export const McpManager = (): JSX.Element => {
     const model = new McpCatalogModel();
     onCleanup(() => model.dispose());
 
-    return (
-        <div class="agent-primitive-modal">
+    // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md.
+    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+    const handleBack = () => {
+        model.setError(null);
+        model.setSelectedId(null);
+        model.setDraft(null);
+    };
+
+    const listView = (
+        <div class="agent-primitive-modal-list">
             <Show when={model.errorAtom()}>
                 <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
             </Show>
+            <Show
+                when={model.serversAtom().length > 0}
+                fallback={<div class="agent-primitive-modal-list-empty">No MCP servers yet</div>}
+            >
+                <For each={model.serversAtom()}>
+                    {(server) => (
+                        <button
+                            class="agent-primitive-modal-list-item"
+                            classList={{ "is-selected": model.selectedIdAtom() === server.id }}
+                            onClick={() => model.handleSelect(server)}
+                        >
+                            <span class="agent-primitive-modal-list-item-name">{server.name}</span>
+                            <span class="agent-primitive-modal-list-item-badge">
+                                {server.bound_count} {server.bound_count === 1 ? "agent" : "agents"}
+                            </span>
+                        </button>
+                    )}
+                </For>
+            </Show>
 
-            <div class="agent-primitive-modal-body">
-                <div class="agent-primitive-modal-list">
-                    <Show
-                        when={model.serversAtom().length > 0}
-                        fallback={<div class="agent-primitive-modal-list-empty">No MCP servers yet</div>}
-                    >
-                        <For each={model.serversAtom()}>
-                            {(server) => (
-                                <button
-                                    class="agent-primitive-modal-list-item"
-                                    classList={{ "is-selected": model.selectedIdAtom() === server.id }}
-                                    onClick={() => model.handleSelect(server)}
-                                >
-                                    <span class="agent-primitive-modal-list-item-name">{server.name}</span>
-                                    <span class="agent-primitive-modal-list-item-badge">
-                                        {server.bound_count} {server.bound_count === 1 ? "agent" : "agents"}
-                                    </span>
-                                </button>
-                            )}
-                        </For>
-                    </Show>
+            <button class="agent-primitive-modal-new-btn" onClick={() => model.openCatalogPicker()}>
+                + Browse catalog
+            </button>
+            <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                + New MCP server
+            </button>
+        </div>
+    );
 
-                    <button class="agent-primitive-modal-new-btn" onClick={() => model.openCatalogPicker()}>
-                        + Browse catalog
-                    </button>
-                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
-                        + New MCP server
-                    </button>
-                </div>
-
-                <div class="agent-primitive-modal-detail">
-                    <Show
-                        when={model.draftAtom()}
-                        fallback={
-                            <Show
-                                when={model.selectedAtom()}
-                                fallback={
-                                    <div class="agent-primitive-modal-empty">
-                                        Select a server from the list, or create a new one. Servers
-                                        created here are global — visible to every agent.
-                                    </div>
-                                }
-                            >
-                                {(server) => (
+    const detailView = (
+        <div class="agent-primitive-modal-detail">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+            <Show
+                when={model.draftAtom()}
+                fallback={
+                    <Show when={model.selectedAtom()}>
+                        {(server) => (
                                     <div class="agent-primitive-modal-readonly">
                                         <h3 class="agent-primitive-modal-name">{server().name}</h3>
                                         <p class="agent-primitive-modal-global-note">
@@ -212,14 +215,23 @@ export const McpManager = (): JSX.Element => {
                                 </div>
                             </form>
                         )}
-                    </Show>
-                </div>
-            </div>
+            </Show>
+        </div>
+    );
 
+    return (
+        <>
+            <PrimitiveListDetail
+                showDetail={inDetail()}
+                backLabel="MCP Servers"
+                onBack={handleBack}
+                list={listView}
+                detail={detailView}
+            />
             <Show when={model.catalogPickerOpenAtom()}>
                 <McpCatalogPicker model={model} />
             </Show>
-        </div>
+        </>
     );
 };
 

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -19,6 +19,7 @@
 
 import { For, onCleanup, Show, type JSX } from "solid-js";
 
+import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { type MemoryDraft, MemoryViewModel } from "./memory-model";
 
 import "./memory-view.scss";
@@ -77,111 +78,115 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
         model.setDraft({ ...current, [key]: value });
     };
 
-    return (
-        <div class="memory-view">
-            <div class="memory-view-rail">
-                <div class="memory-view-rail-header">
-                    <button class="memory-view-new-btn" onClick={handleNew}>
-                        + New Preset
-                    </button>
-                </div>
-                <ul class="memory-view-list">
-                    <For each={model.memoriesAtom()}>
-                        {(memory) => (
-                            <li
-                                class="memory-view-list-item"
-                                classList={{
-                                    "is-selected": model.selectedIdAtom() === memory.id,
-                                    "is-blank": !!memory.is_blank,
-                                    "is-global": !!memory.is_global,
-                                }}
-                                onClick={() => handleSelect(memory)}
-                            >
-                                <div class="memory-view-list-item-name">
-                                    <span class="memory-view-list-item-name-text">
-                                        {memory.is_blank ? "— Blank (vanilla CLI) —" : memory.name}
-                                    </span>
-                                    <Show when={memory.is_global}>
-                                        <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
-                                    </Show>
+    // Single-pane: the detail view (read-only or edit form) shows instead of
+    // the list, never alongside it — see
+    // docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md.
+    // "In detail" whenever something is selected OR a draft (new or
+    // editing-existing) is open; otherwise the list shows. The old
+    // no-selection empty-state message ("Select a preset...") is gone — with
+    // nothing selected you're just looking at the list, there's no third
+    // empty detail state to explain.
+    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+
+    const handleBack = () => {
+        model.setError(null);
+        model.setSelectedId(null);
+        model.setDraft(null);
+    };
+
+    const listView = (
+        <div class="memory-view-rail">
+            <div class="memory-view-rail-header">
+                <button class="memory-view-new-btn" onClick={handleNew}>
+                    + New Preset
+                </button>
+            </div>
+            <ul class="memory-view-list">
+                <For each={model.memoriesAtom()}>
+                    {(memory) => (
+                        <li
+                            class="memory-view-list-item"
+                            classList={{
+                                "is-selected": model.selectedIdAtom() === memory.id,
+                                "is-blank": !!memory.is_blank,
+                                "is-global": !!memory.is_global,
+                            }}
+                            onClick={() => handleSelect(memory)}
+                        >
+                            <div class="memory-view-list-item-name">
+                                <span class="memory-view-list-item-name-text">
+                                    {memory.is_blank ? "— Blank (vanilla CLI) —" : memory.name}
+                                </span>
+                                <Show when={memory.is_global}>
+                                    <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
+                                </Show>
+                            </div>
+                            {/* Subtitle shows the description now that presets
+                                are provider-agnostic (§4.1a). Class name kept
+                                to avoid CSS churn. */}
+                            <Show when={!memory.is_blank && memory.description}>
+                                <div class="memory-view-list-item-provider">
+                                    {memory.description}
                                 </div>
-                                {/* Subtitle shows the description now that presets
-                                    are provider-agnostic (§4.1a). Class name kept
-                                    to avoid CSS churn. */}
-                                <Show when={!memory.is_blank && memory.description}>
-                                    <div class="memory-view-list-item-provider">
-                                        {memory.description}
+                            </Show>
+                        </li>
+                    )}
+                </For>
+            </ul>
+        </div>
+    );
+
+    const detailView = (
+        <div class="memory-view-detail">
+            <Show when={model.errorAtom()}>
+                <div class="memory-view-error">{model.errorAtom()}</div>
+            </Show>
+
+            <Show
+                when={model.draftAtom()}
+                fallback={
+                    <Show when={model.selectedAtom()}>
+                        {(memory) => (
+                            <div class="memory-view-readonly">
+                                <h2 class="memory-view-name">{memory().name}</h2>
+                                <Show when={memory().description}>
+                                    <p class="memory-view-description">{memory().description}</p>
+                                </Show>
+                                <dl class="memory-view-fields">
+                                    <Show when={memory().is_global}>
+                                        <dt>Scope</dt>
+                                        <dd>
+                                            <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
+                                            {" "}— injected into every agent at launch
+                                        </dd>
+                                    </Show>
+                                    <dt>Instructions</dt>
+                                    <dd class="memory-view-instructions-readonly">
+                                        <pre>{memory().instructions || "(none)"}</pre>
+                                    </dd>
+                                </dl>
+                                <Show when={!memory().is_blank}>
+                                    <div class="memory-view-actions">
+                                        <button
+                                            class="memory-view-edit-btn"
+                                            onClick={() => model.startEdit(memory())}
+                                        >
+                                            Edit
+                                        </button>
+                                        <button
+                                            class="memory-view-delete-btn"
+                                            onClick={() => handleDelete(memory().id)}
+                                        >
+                                            Delete
+                                        </button>
                                     </div>
                                 </Show>
-                            </li>
+                            </div>
                         )}
-                    </For>
-                </ul>
-            </div>
-
-            <div class="memory-view-detail">
-                <Show when={model.errorAtom()}>
-                    <div class="memory-view-error">{model.errorAtom()}</div>
-                </Show>
-
-                <Show
-                    when={model.draftAtom()}
-                    fallback={
-                        <Show
-                            when={model.selectedAtom()}
-                            fallback={
-                                <div class="memory-view-empty">
-                                    <p>Select a preset from the list, or create a new one.</p>
-                                    <p class="memory-view-empty-hint">
-                                        A preset holds an agent's system instructions, context
-                                        files, MCP servers, and skills. It is provider-agnostic —
-                                        the CLI and model belong to the agent. Pick one at launch
-                                        time alongside an Identity to compose an agent instance.
-                                    </p>
-                                </div>
-                            }
-                        >
-                            {(memory) => (
-                                <div class="memory-view-readonly">
-                                    <h2 class="memory-view-name">{memory().name}</h2>
-                                    <Show when={memory().description}>
-                                        <p class="memory-view-description">{memory().description}</p>
-                                    </Show>
-                                    <dl class="memory-view-fields">
-                                        <Show when={memory().is_global}>
-                                            <dt>Scope</dt>
-                                            <dd>
-                                                <span class="memory-view-global-badge" title="Injected into all agents at launch">Global</span>
-                                                {" "}— injected into every agent at launch
-                                            </dd>
-                                        </Show>
-                                        <dt>Instructions</dt>
-                                        <dd class="memory-view-instructions-readonly">
-                                            <pre>{memory().instructions || "(none)"}</pre>
-                                        </dd>
-                                    </dl>
-                                    <Show when={!memory().is_blank}>
-                                        <div class="memory-view-actions">
-                                            <button
-                                                class="memory-view-edit-btn"
-                                                onClick={() => model.startEdit(memory())}
-                                            >
-                                                Edit
-                                            </button>
-                                            <button
-                                                class="memory-view-delete-btn"
-                                                onClick={() => handleDelete(memory().id)}
-                                            >
-                                                Delete
-                                            </button>
-                                        </div>
-                                    </Show>
-                                </div>
-                            )}
-                        </Show>
-                    }
-                >
-                    {(draft) => (
+                    </Show>
+                }
+            >
+                {(draft) => (
                         <form
                             class="memory-view-form"
                             onSubmit={(e) => {
@@ -259,9 +264,18 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
                             </p>
                         </form>
                     )}
-                </Show>
-            </div>
+            </Show>
         </div>
+    );
+
+    return (
+        <PrimitiveListDetail
+            showDetail={inDetail()}
+            backLabel="Bundles"
+            onBack={handleBack}
+            list={listView}
+            detail={detailView}
+        />
     );
 };
 

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -96,6 +96,9 @@ export const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element =>
 
     const listView = (
         <div class="memory-view-rail">
+            <Show when={model.errorAtom()}>
+                <div class="memory-view-error">{model.errorAtom()}</div>
+            </Show>
             <div class="memory-view-rail-header">
                 <button class="memory-view-new-btn" onClick={handleNew}>
                     + New Preset

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -1,292 +1,259 @@
-// Memory pane — matches the swarm/forge SCSS conventions for layout
-// (left rail + right detail). Colors come from the global theme tokens.
+// Memory pane — single-pane list/detail (PrimitiveListDetail owns the
+// outer layout and the list-vs-detail toggle; these rules style the
+// content of each). Colors come from the global theme tokens. See
+// docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md —
+// this used to be a row-split (list beside detail) with a narrow-width
+// fallback that stacked them instead of removing the split; both are
+// gone now that only one of the two ever renders at a time.
 
-.memory-view {
+.memory-view-rail {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     height: 100%;
     overflow: hidden;
     background: var(--main-bg-color);
     color: var(--main-text-color);
+}
 
-    .memory-view-rail {
-        flex: 0 0 240px;
-        display: flex;
-        flex-direction: column;
-        border-right: 1px solid var(--border-color);
-        overflow: hidden;
-    }
+.memory-view-rail-header {
+    padding: 8px;
+    border-bottom: 1px solid var(--border-color);
+}
 
-    .memory-view-rail-header {
-        padding: 8px;
-        border-bottom: 1px solid var(--border-color);
-    }
+.memory-view-new-btn {
+    width: 100%;
+    padding: 6px 10px;
+    background: var(--accent-color);
+    color: var(--accent-text-color, #fff);
+    border: none;
+    border-radius: 0;
+    cursor: default;
+    font-size: 13px;
 
-    .memory-view-new-btn {
-        width: 100%;
-        padding: 6px 10px;
-        background: var(--accent-color);
-        color: var(--accent-text-color, #fff);
-        border: none;
-        border-radius: 0;
-        cursor: default;
-        font-size: 13px;
-
-        &:hover {
-            filter: brightness(1.1);
-        }
-    }
-
-    .memory-view-list {
-        flex: 1 1 auto;
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        overflow-y: auto;
-    }
-
-    .memory-view-list-item {
-        padding: 10px 12px;
-        cursor: default;
-        border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.06));
-
-        &:hover {
-            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
-        }
-
-        &.is-selected {
-            background: var(--selected-bg-color, rgba(255, 255, 255, 0.08));
-        }
-
-        &.is-blank {
-            font-style: italic;
-            color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
-        }
-    }
-
-    .memory-view-list-item-name {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 13px;
-        font-weight: 500;
-        min-width: 0;
-    }
-
-    .memory-view-list-item-name-text {
-        flex: 1 1 0;
-        min-width: 0;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-    .memory-view-global-badge {
-        flex: 0 0 auto;
-        font-size: 10px;
-        font-weight: 600;
-        letter-spacing: 0.04em;
-        padding: 1px 5px;
-        border-radius: 3px;
-        background: var(--accent-color);
-        color: var(--accent-text-color, #fff);
-        text-transform: uppercase;
-        opacity: 0.85;
-    }
-
-    .memory-view-list-item-provider {
-        font-size: 11px;
-        color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
-        margin-top: 2px;
-    }
-
-    .memory-view-detail {
-        flex: 1 1 auto;
-        padding: 16px 24px;
-        overflow-y: auto;
-    }
-
-    .memory-view-error {
-        padding: 8px 12px;
-        margin-bottom: 12px;
-        background: var(--error-bg-color, rgba(255, 80, 80, 0.15));
-        color: var(--error-text-color, #ff8080);
-        border-radius: 0;
-        font-size: 13px;
-    }
-
-    .memory-view-empty {
-        max-width: 460px;
-        color: var(--secondary-text-color, rgba(255, 255, 255, 0.7));
-        line-height: 1.5;
-    }
-
-    .memory-view-empty-hint {
-        font-size: 13px;
-        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
-        margin-top: 8px;
-    }
-
-    // ── Read-only detail ────────────────────────────────────────────
-    .memory-view-readonly {
-        max-width: 720px;
-    }
-
-    .memory-view-name {
-        font-size: 20px;
-        margin: 0 0 4px;
-    }
-
-    .memory-view-description {
-        margin: 0 0 16px;
-        color: var(--secondary-text-color);
-    }
-
-    .memory-view-fields {
-        display: grid;
-        grid-template-columns: 140px 1fr;
-        column-gap: 16px;
-        row-gap: 8px;
-        margin: 0 0 16px;
-
-        dt {
-            color: var(--secondary-text-color);
-            font-size: 13px;
-        }
-
-        dd {
-            margin: 0;
-            font-size: 13px;
-        }
-    }
-
-    .memory-view-instructions-readonly pre {
-        margin: 0;
-        padding: 8px;
-        background: var(--code-bg-color, rgba(0, 0, 0, 0.2));
-        border-radius: 0;
-        white-space: pre-wrap;
-        font-family: var(--mono-font, "JetBrains Mono", monospace);
-        font-size: 12px;
-        max-height: 240px;
-        overflow-y: auto;
-    }
-
-    .memory-view-actions {
-        display: flex;
-        gap: 8px;
-        margin-top: 16px;
-    }
-
-    .memory-view-edit-btn,
-    .memory-view-delete-btn,
-    .memory-view-cancel-btn,
-    .memory-view-save-btn {
-        padding: 6px 14px;
-        border: 1px solid var(--border-color);
-        border-radius: 0;
-        background: transparent;
-        color: var(--main-text-color);
-        cursor: default;
-        font-size: 13px;
-
-        &:hover:not(:disabled) {
-            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
-        }
-
-        &:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-        }
-    }
-
-    .memory-view-save-btn {
-        background: var(--accent-color);
-        color: var(--accent-text-color, #fff);
-        border-color: transparent;
-    }
-
-    .memory-view-delete-btn {
-        color: var(--error-text-color, #ff8080);
-        border-color: var(--error-text-color, #ff8080);
-    }
-
-    // ── Edit form ───────────────────────────────────────────────────
-    .memory-view-form {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        max-width: 720px;
-    }
-
-    .memory-view-form-title {
-        font-size: 18px;
-        margin: 0 0 4px;
-    }
-
-    .memory-view-field {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-    }
-
-    .memory-view-field-label {
-        font-size: 12px;
-        color: var(--secondary-text-color);
-    }
-
-    .memory-view-input,
-    .memory-view-textarea {
-        padding: 6px 10px;
-        background: var(--input-bg-color, rgba(0, 0, 0, 0.2));
-        color: var(--main-text-color);
-        border: 1px solid var(--border-color);
-        border-radius: 0;
-        font-size: 13px;
-        font-family: inherit;
-
-        &:focus {
-            outline: none;
-            border-color: var(--accent-color);
-        }
-    }
-
-    .memory-view-textarea {
-        font-family: var(--mono-font, "JetBrains Mono", monospace);
-        font-size: 12px;
-        resize: vertical;
-        min-height: 120px;
-    }
-
-    .memory-view-form-actions {
-        display: flex;
-        gap: 8px;
-        justify-content: flex-end;
-        margin-top: 8px;
-    }
-
-    .memory-view-form-hint {
-        font-size: 11px;
-        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
-        margin: 4px 0 0;
-        font-style: italic;
+    &:hover {
+        filter: brightness(1.1);
     }
 }
 
-// sm and below: stack list above detail
-@container memory-pane (max-width: 767px) {
-    .memory-view {
-        flex-direction: column;
+.memory-view-list {
+    flex: 1 1 auto;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+}
+
+.memory-view-list-item {
+    padding: 10px 12px;
+    cursor: default;
+    border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.06));
+
+    &:hover {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
     }
 
-    .memory-view-rail {
-        flex: 0 0 auto;
-        max-height: 40%;
-        border-right: none;
-        border-bottom: 1px solid var(--border-color);
+    &.is-selected {
+        background: var(--selected-bg-color, rgba(255, 255, 255, 0.08));
     }
 
-    .memory-view-detail {
-        padding: 12px 16px;
+    &.is-blank {
+        font-style: italic;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
     }
+}
+
+.memory-view-list-item-name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    min-width: 0;
+}
+
+.memory-view-list-item-name-text {
+    flex: 1 1 0;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.memory-view-global-badge {
+    flex: 0 0 auto;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: var(--accent-color);
+    color: var(--accent-text-color, #fff);
+    text-transform: uppercase;
+    opacity: 0.85;
+}
+
+.memory-view-list-item-provider {
+    font-size: 11px;
+    color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+    margin-top: 2px;
+}
+
+.memory-view-detail {
+    padding: 16px 24px;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+}
+
+.memory-view-error {
+    padding: 8px 12px;
+    margin-bottom: 12px;
+    background: var(--error-bg-color, rgba(255, 80, 80, 0.15));
+    color: var(--error-text-color, #ff8080);
+    border-radius: 0;
+    font-size: 13px;
+}
+
+// ── Read-only detail ────────────────────────────────────────────
+.memory-view-readonly {
+    max-width: 720px;
+}
+
+.memory-view-name {
+    font-size: 20px;
+    margin: 0 0 4px;
+}
+
+.memory-view-description {
+    margin: 0 0 16px;
+    color: var(--secondary-text-color);
+}
+
+.memory-view-fields {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    column-gap: 16px;
+    row-gap: 8px;
+    margin: 0 0 16px;
+
+    dt {
+        color: var(--secondary-text-color);
+        font-size: 13px;
+    }
+
+    dd {
+        margin: 0;
+        font-size: 13px;
+    }
+}
+
+.memory-view-instructions-readonly pre {
+    margin: 0;
+    padding: 8px;
+    background: var(--code-bg-color, rgba(0, 0, 0, 0.2));
+    border-radius: 0;
+    white-space: pre-wrap;
+    font-family: var(--mono-font, "JetBrains Mono", monospace);
+    font-size: 12px;
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.memory-view-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.memory-view-edit-btn,
+.memory-view-delete-btn,
+.memory-view-cancel-btn,
+.memory-view-save-btn {
+    padding: 6px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    background: transparent;
+    color: var(--main-text-color);
+    cursor: default;
+    font-size: 13px;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+.memory-view-save-btn {
+    background: var(--accent-color);
+    color: var(--accent-text-color, #fff);
+    border-color: transparent;
+}
+
+.memory-view-delete-btn {
+    color: var(--error-text-color, #ff8080);
+    border-color: var(--error-text-color, #ff8080);
+}
+
+// ── Edit form ───────────────────────────────────────────────────
+.memory-view-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 720px;
+}
+
+.memory-view-form-title {
+    font-size: 18px;
+    margin: 0 0 4px;
+}
+
+.memory-view-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.memory-view-field-label {
+    font-size: 12px;
+    color: var(--secondary-text-color);
+}
+
+.memory-view-input,
+.memory-view-textarea {
+    padding: 6px 10px;
+    background: var(--input-bg-color, rgba(0, 0, 0, 0.2));
+    color: var(--main-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    font-size: 13px;
+    font-family: inherit;
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color);
+    }
+}
+
+.memory-view-textarea {
+    font-family: var(--mono-font, "JetBrains Mono", monospace);
+    font-size: 12px;
+    resize: vertical;
+    min-height: 120px;
+}
+
+.memory-view-form-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
+}
+
+.memory-view-form-hint {
+    font-size: 11px;
+    color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
+    margin: 4px 0 0;
+    font-style: italic;
 }

--- a/frontend/app/view/skill/skill-manager.tsx
+++ b/frontend/app/view/skill/skill-manager.tsx
@@ -10,6 +10,7 @@
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
+import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { SkillCatalogModel } from "./skill-model";
 import "../agent/components/AgentPrimitiveModal.scss";
 
@@ -17,53 +18,55 @@ export const SkillManager = (): JSX.Element => {
     const model = new SkillCatalogModel();
     onCleanup(() => model.dispose());
 
-    return (
-        <div class="agent-primitive-modal">
+    // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md.
+    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+    const handleBack = () => {
+        model.setError(null);
+        model.setSelectedId(null);
+        model.setDraft(null);
+    };
+
+    const listView = (
+        <div class="agent-primitive-modal-list">
             <Show when={model.errorAtom()}>
                 <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
             </Show>
+            <Show
+                when={model.skillsAtom().length > 0}
+                fallback={<div class="agent-primitive-modal-list-empty">No skills yet</div>}
+            >
+                <For each={model.skillsAtom()}>
+                    {(skill) => (
+                        <button
+                            class="agent-primitive-modal-list-item"
+                            classList={{ "is-selected": model.selectedIdAtom() === skill.id }}
+                            onClick={() => model.handleSelect(skill)}
+                        >
+                            <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
+                            <span class="agent-primitive-modal-list-item-badge">
+                                {skill.bound_count} {skill.bound_count === 1 ? "agent" : "agents"}
+                            </span>
+                        </button>
+                    )}
+                </For>
+            </Show>
 
-            <div class="agent-primitive-modal-body">
-                <div class="agent-primitive-modal-list">
-                    <Show
-                        when={model.skillsAtom().length > 0}
-                        fallback={<div class="agent-primitive-modal-list-empty">No skills yet</div>}
-                    >
-                        <For each={model.skillsAtom()}>
-                            {(skill) => (
-                                <button
-                                    class="agent-primitive-modal-list-item"
-                                    classList={{ "is-selected": model.selectedIdAtom() === skill.id }}
-                                    onClick={() => model.handleSelect(skill)}
-                                >
-                                    <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
-                                    <span class="agent-primitive-modal-list-item-badge">
-                                        {skill.bound_count} {skill.bound_count === 1 ? "agent" : "agents"}
-                                    </span>
-                                </button>
-                            )}
-                        </For>
-                    </Show>
+            <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
+                + New skill
+            </button>
+        </div>
+    );
 
-                    <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
-                        + New skill
-                    </button>
-                </div>
-
-                <div class="agent-primitive-modal-detail">
-                    <Show
-                        when={model.draftAtom()}
-                        fallback={
-                            <Show
-                                when={model.selectedAtom()}
-                                fallback={
-                                    <div class="agent-primitive-modal-empty">
-                                        Select a skill from the list, or create a new one. Skills
-                                        created here are global — visible to every agent.
-                                    </div>
-                                }
-                            >
-                                {(skill) => (
+    const detailView = (
+        <div class="agent-primitive-modal-detail">
+            <Show when={model.errorAtom()}>
+                <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
+            </Show>
+            <Show
+                when={model.draftAtom()}
+                fallback={
+                    <Show when={model.selectedAtom()}>
+                        {(skill) => (
                                     <div class="agent-primitive-modal-readonly">
                                         <h3 class="agent-primitive-modal-name">{skill().name}</h3>
                                         <p class="agent-primitive-modal-global-note">
@@ -174,10 +177,18 @@ export const SkillManager = (): JSX.Element => {
                                 </div>
                             </form>
                         )}
-                    </Show>
-                </div>
-            </div>
+            </Show>
         </div>
+    );
+
+    return (
+        <PrimitiveListDetail
+            showDetail={inDetail()}
+            backLabel="Skills"
+            onBack={handleBack}
+            list={listView}
+            detail={detailView}
+        />
     );
 };
 


### PR DESCRIPTION
## Summary

Three of the Armory's five tabs (Bundles, Skills, MCP Servers) showed a list and a detail pane simultaneously:
- **Skills / MCP Servers**: fixed `220px` list + `flex: 1` detail, side by side, no responsive fallback at any width.
- **Bundles**: same side-by-side split, with a `@container` fallback at ≤767px that *stacked* list above detail instead of removing the split — still both visible at once, just reoriented (list capped to 40% height, detail squeezed into the remaining 60%).

Neither holds up in a genuinely thin pane, which is the normal case for AgentMux panes (user-resizable/tileable), not an edge case.

**Fix:** a shared single-pane layout primitive, `PrimitiveListDetail` (`frontend/app/element/primitive-list-detail.tsx`), that renders exactly one of `{list, detail}` at a time, at any width, with a small back affordation to return to the list. Not a tree — a flat two-state stack, never more than one level.

**Migrated:**
- `MemoryManagerBody` (Armory's Bundles tab)
- `SkillManager` + `McpManager` (Armory's Skills / MCP Servers tabs)
- `AgentSkillsModal` / `AgentMcpModal` (the Agent Setup Modal's own Skills/MCP tabs) — these share the exact same `AgentPrimitiveModal.scss`/markup shape as the Armory tabs; fixing the shared CSS without migrating these too would have broken them. No evidence found that their split layout was intentionally different from Armory's.

**Untouched (already fine):** `GlobalBrainManager` (Memories tab) already uses an inline-accordion pattern — single column, expand-in-place, no split. `AccountsManager` uses a tile grid. Both were the precedent this design follows for the migrated tabs' content-size-dependent shape.

**Deleted dead code, not just added a breakpoint:** the old narrow-width stacking fallback for Bundles (`@container memory-pane`), its now-unused container-type modifier class on the Armory pane wrapper, the fixed `220px` list width + side-by-side flex row for Skills/MCP, and the "select an item from the list" empty-state messages that no longer have anywhere to render (with nothing selected you're just looking at the list now — there's no third empty-detail state to explain).

Full design writeup: `docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md`

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npx sass` compile of `app.scss` — no errors.
- [x] `npx stylelint` on all touched/new SCSS — no new violations (pre-existing hex-color debt in untouched lines of `memory-view.scss`/`armory-view.scss` only).
- [x] Full frontend suite: `npx vitest run` — 1744 passed, 3 skipped (pre-existing), 0 failures.
- [ ] Manual: resize an Armory-hosting pane down to a thin width for Bundles/Skills/MCP Servers — list should be fully readable, detail should be fully usable, at no point should both be visible or either be cramped. Same for the Agent Setup Modal's Skills/MCP tabs.

<!-- agentmux:agent_id=agent1 -->