### PR TITLE
fix(win): suppress console-window flashes from CLI probe spawns

### DIFF
--- a/.changesets/1784145647-fix-win-suppress-console-window-flashes-from-cli-probe-spawn-bm88.md
+++ b/.changesets/1784145647-fix-win-suppress-console-window-flashes-from-cli-probe-spawn-bm88.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(win): suppress console-window flashes from CLI probe spawns (make_cli_cmd + where + auth-poll)

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -20,6 +20,29 @@ enum ResolvedShim {
 /// extract the real entry point and invoke it directly (either `node <script>`
 /// for JS shims or the target `.exe` directly for native-binary shims).
 pub fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
+    let mut cmd = build_cli_cmd(cli_path);
+    // CREATE_NO_WINDOW: the host + launcher are GUI-subsystem and srv is
+    // launched windowless, so a console-subsystem child (node, claude.exe,
+    // cmd.exe) spawned without this flag forces Windows to allocate a fresh
+    // console window — the "terminal flash" seen during dev, most visibly
+    // from the ambient Haiku calls that fire as the user types
+    // (server/app_api/session.rs) and the per-check `--version`/auth probes.
+    // Applied at this single chokepoint so every `make_cli_cmd` caller is
+    // covered; idempotent for the agent-CLI callers (persistent/subprocess/
+    // acp) that already set it manually. `tokio::process::Command` exposes
+    // `creation_flags` as an inherent method on Windows — no `CommandExt`
+    // import needed (see agentmux-bashwrap/src/bash_wrap.rs's note).
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
+/// Resolve `cli_path` to a runnable `Command` (the `.cmd`/`.bat` shim parsing
+/// on Windows). `make_cli_cmd` wraps this to apply `CREATE_NO_WINDOW`.
+fn build_cli_cmd(cli_path: &str) -> tokio::process::Command {
     #[cfg(windows)]
     if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
         match parse_cmd_wrapper(cli_path) {

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -1308,16 +1308,21 @@ async fn confirm_authenticated(
 ) -> bool {
     use std::process::Stdio;
     use tokio::process::Command;
-    match Command::new(cli_path)
-        .args(args)
+    let mut c = Command::new(cli_path);
+    c.args(args)
         .envs(env)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .kill_on_drop(true)
-        .status()
-        .await
+        .kill_on_drop(true);
+    // CREATE_NO_WINDOW: this status probe is polled in a drain loop during an
+    // auth flow — without the flag each poll flashes a console. See cli.rs.
+    #[cfg(windows)]
     {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        c.creation_flags(CREATE_NO_WINDOW);
+    }
+    match c.status().await {
         Ok(s) => s.success(),
         Err(_) => false,
     }

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -155,11 +155,16 @@ fn provider_install_dir(provider_id: &str) -> Option<std::path::PathBuf> {
 /// See SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
 async fn resolve_tool_path(tool: &str) -> Option<String> {
     let cmd = if cfg!(windows) { "where" } else { "which" };
-    let output = tokio::process::Command::new(cmd)
-        .arg(tool)
-        .output()
-        .await
-        .ok()?;
+    let mut c = tokio::process::Command::new(cmd);
+    c.arg(tool);
+    // CREATE_NO_WINDOW: `where` is console-subsystem; without this it flashes
+    // a console window on every pre-launch prereq check. See cli.rs's note.
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        c.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = c.output().await.ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
## Symptom

Windows **console/terminal windows flash** on screen constantly during `task dev`, making the app hard to test. Classic signature of a console-subsystem child spawned without `CREATE_NO_WINDOW`: the host + launcher are GUI-subsystem and srv runs windowless, so any un-flagged console child forces the OS to pop a fresh console window.

## Root cause (audited across the whole Rust workspace)

`agentmux_common::make_cli_cmd` — the shared CLI `Command` builder — never set the flag, leaving each of its 7 callers to remember. The agent-process callers (`persistent`/`subprocess`/`acp`) do; the **probe** callers didn't, so the highest-*frequency* spawns flashed:

- **ambient Haiku calls** (`server/app_api/session.rs:540`) — fire continuously as the user types (activity summaries + next-prompt ghost text). This is the dominant flash.
- `<cli> --version` and auth-check probes (`cli_handlers.rs:404,738`)

## Fix

- Set `CREATE_NO_WINDOW` inside `make_cli_cmd` at the single chokepoint (refactored to `build_cli_cmd` + one flag application). Covers all 7 callers; idempotent for the ones that already set it manually.
- Plus the two raw `Command` sites that fire during dev/test and route *around* `make_cli_cmd`:
  - `resolve_tool_path`'s `where` (per-launch prereq check)
  - `confirm_authenticated`'s status poll (polled in a drain loop during login)

## Scope / follow-up

The audit found ~10 other un-suppressed sites, all lower-frequency / user-initiated / dev-only (dev git branch-key, launcher `whoami`/`hostname` splash, `migrate` spawn, whisper, browser-open, bashwrap `taskkill`, mcp probe). Left for a follow-up sweep — this PR targets the constant flashing that blocks testing. Note the two already-correct precedents this follows: the bashwrap subsystem fix and `shell_node.rs`'s `CREATE_NO_WINDOW` (SPEC_ELIMINATE_BASHWRAP_CONSOLE_WINDOWS_2026_06_20, which explicitly scoped out these srv probe sites).

## Verification

- `cargo check -p agentmux-common -p agentmux-srv` clean (`creation_flags` resolves as the inherent method on `tokio::process::Command`, no `CommandExt` import needed)
- Fix is a spawn-flag-only change; no behavior change beyond window suppression

<!-- agentmux:agent_id=agenta-07017 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)