### PR TITLE
fix(theme): native select dropdowns are white-on-white on dark themes

### DIFF
--- a/.changesets/1784146062-fix-theme-set-color-scheme-so-native-select-popups-aren-t-wh-pt9u.md
+++ b/.changesets/1784146062-fix-theme-set-color-scheme-so-native-select-popups-aren-t-wh-pt9u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(theme): set color-scheme so native select popups aren't white-on-white

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -7,6 +7,20 @@
    reference these tokens instead of their own hex. */
 
 :root {
+    // Tells the browser/CEF which palette to use for NATIVE form controls —
+    // <select> option popups, date pickers, etc. Without this, Chromium
+    // defaults every native popup to a light palette regardless of the
+    // app's own theme; a dark theme's `color: var(--main-text-color)`
+    // (near-white) then renders as white text on that default-white popup
+    // background — white-on-white, invisible. `color-scheme` is the one
+    // property Chromium actually honors for this (unlike arbitrary CSS on
+    // <option>, which it ignores). Default here is dark since 9 of 13
+    // themes are dark-family; the light-family override lives right below,
+    // gated on the same `[data-theme-polarity]` marker app.tsx already sets
+    // for exactly this dark/light branching (see base-menus.ts's
+    // LIGHT_THEME_IDS doc comment).
+    color-scheme: dark;
+
     --main-text-color: #f7f7f7;
     --title-font-size: 18px;
     // Default to a translucent value so the FIRST paint after page load has
@@ -380,4 +394,10 @@
     --z-modal:         9000;
     --z-flyout-menu:   9500;
     --z-context-menu:  10000;
+}
+
+// Light-family override for the `color-scheme` fix above — same marker
+// window-controls.win32.scss already uses for dark/light chrome decisions.
+[data-theme-polarity="light"] {
+    color-scheme: light;
 }


### PR DESCRIPTION
## Summary
- Reported: the Settings pane's theme dropdown shows white text on a white background when opened.
- Root cause: Chromium (agentmux-cef) renders native `<select>` option popups using its own default light palette unless the page sets `color-scheme`. Nothing in this codebase ever set it, so every dark theme's near-white `--main-text-color` (inherited via `color: inherit` on `.setting-select` etc.) rendered on that default-white popup — invisible.
- Fix is global, not Settings-scoped: `frontend/app/theme.scss` now sets `color-scheme: dark` on `:root`, with `color-scheme: light` under `[data-theme-polarity="light"]` — the same marker `window-controls.win32.scss` already uses for an analogous native-rendering decision. This fixes every native `<select>` in the app (Settings, Identity forms, Agent creation modals, etc.), not just the one reported.
- Audited every color declaration in `settings.scss` per the request to "scan through all items in settings" — no other contrast bugs found. Details in the commit message.

## Test plan
- [x] `tsc --noEmit` — passes
- [x] `stylelint` on `theme.scss` — no new violations
- [ ] Visual confirmation in a running build — not done in this session (no project skill exists for driving this native CEF desktop app from this environment; `color-scheme` is a standard, well-documented CSS mechanism so I'm confident in the fix, but flagging the gap rather than claiming a screenshot-verified fix)

<!-- agentmux:agent_id=agent2 -->