### PR TITLE
fix(win): suppress console flashes from host/launcher/common/bashwrap spawns

### DIFF
--- a/.changesets/1784147960-fix-win-suppress-console-flashes-from-launcher-splash-git-br-m2kh.md
+++ b/.changesets/1784147960-fix-win-suppress-console-flashes-from-launcher-splash-git-br-m2kh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(win): suppress console flashes from launcher splash / git-branch / taskkill / migrate spawns

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -139,10 +139,17 @@ fn idle_kill_timeout() -> Duration {
 fn kill_process_tree(pid: u32) {
     #[cfg(windows)]
     {
-        match std::process::Command::new("taskkill")
-            .args(["/T", "/F", "/PID", &pid.to_string()])
-            .output()
+        let mut cmd = std::process::Command::new("taskkill");
+        cmd.args(["/T", "/F", "/PID", &pid.to_string()]);
         {
+            // CREATE_NO_WINDOW: console-flash suppression — bashwrap is a
+            // GUI-subsystem parent, so spawning taskkill without this pops a
+            // visible console window. std::process::Command needs CommandExt.
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+        match cmd.output() {
             Ok(out) if out.status.success() => {
                 tracing::info!(target: "bashwrap", pid, "kill_process_tree: taskkill succeeded");
             }

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -237,12 +237,21 @@ async fn run_migrations_inner(
     use tokio::process::Command;
     use tokio::io::BufReader;
 
-    let mut child = Command::new(&srv_path)
+    let mut command = Command::new(&srv_path);
+    command
         .arg("--wavedata")
         .arg(&data_dir)
         .arg("migrate")
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    #[cfg(windows)]
+    {
+        // CREATE_NO_WINDOW: console-flash suppression — host (GUI) spawning the
+        // srv migrate child; tokio::process::Command has creation_flags inherent.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    let mut child = command
         .spawn()
         .map_err(|e| format!("Failed to spawn agentmux-srv migrate: {}", e))?;
 

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -420,11 +420,18 @@ fn detect_branch(exe_dir: &Path) -> String {
 }
 
 fn run_git_branch(repo_dir: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(repo_dir)
-        .output()
-        .ok()?;
+    let mut cmd = Command::new("git");
+    cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(repo_dir);
+    #[cfg(windows)]
+    {
+        // CREATE_NO_WINDOW: console-flash suppression — std::process::Command
+        // needs the CommandExt trait to call creation_flags.
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = cmd.output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/agentmux-launcher/src/splash_info.rs
+++ b/agentmux-launcher/src/splash_info.rs
@@ -95,7 +95,17 @@ fn dev_label() -> Option<String> {
 
 /// First non-empty stdout line of `cmd args`, trimmed. `None` on any failure.
 fn cmd_first_line(cmd: &str, args: &[&str]) -> Option<String> {
-    let out = Command::new(cmd).args(args).output().ok()?;
+    let mut command = Command::new(cmd);
+    command.args(args);
+    #[cfg(windows)]
+    {
+        // CREATE_NO_WINDOW: console-flash suppression — std::process::Command
+        // needs the CommandExt trait to call creation_flags.
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    let out = command.output().ok()?;
     if !out.status.success() {
         return None;
     }


### PR DESCRIPTION
Add `CREATE_NO_WINDOW` (0x0800_0000) to four Windows GUI-subsystem parents that spawn a console child without the flag and therefore pop a visible console window.

Follow-up to #2171 (highest-frequency srv spawns); parallel to the `fix/console-flash-srv-sites` PR covering the remaining agentmux-srv sites. This PR deliberately does **not** touch agentmux-srv.

## Sites fixed

- `agentmux-common/src/runtime_mode.rs:422` — `run_git_branch` → `git rev-parse --abbrev-ref HEAD` (std::process::Command). Dev-only branch-keying path, fires at startup.
- `agentmux-launcher/src/splash_info.rs:97` — `cmd_first_line` helper backing `whoami`/`hostname` (std::process::Command). GUI launcher splash footer; one fix covers both callers.
- `agentmux-cef/src/commands/backend.rs:240` — `run_migrations_inner` → host spawns `agentmux-srv … migrate` (tokio::process::Command, inherent `creation_flags`). Fires only when a DB migration is pending at startup.
- `agentmux-bashwrap/src/bash_wrap.rs:142` — `kill_process_tree` → `taskkill /T /F /PID` (std::process::Command). bashwrap is GUI-subsystem.

Sites #1/#2/#4 are startup/dev-only-ish; site #3 (taskkill) is the one that fires during **normal Bash-tool operation** (idle-kill / cleanup of wrapped commands), so it is the most user-visible of the four.

std vs tokio handled correctly: the three std sites use `use std::os::windows::process::CommandExt;` (scoped inside the `cfg(windows)` block); the tokio site uses the inherent method. Each guarded by `#[cfg(windows)]` with a one-line `CREATE_NO_WINDOW: console-flash suppression` comment.

## Verify

`cargo check -p agentmux-common -p agentmux-launcher -p agentmux-bashwrap -p agentmux-cef` clean (all four exit 0).

<!-- agentmux:agent_id=agenta-07017 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)