### PR TITLE
fix(win): suppress remaining srv-side console flashes (follow-up to #2171)

### DIFF
--- a/.changesets/1784148092-fix-win-suppress-console-flashes-from-srv-mcp-probe-whisper--758m.md
+++ b/.changesets/1784148092-fix-win-suppress-console-flashes-from-srv-mcp-probe-whisper--758m.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(win): suppress console flashes from srv mcp-probe / whisper / browser-open spawns

--- a/agentmux-srv/src/backend/mcp_probe.rs
+++ b/agentmux-srv/src/backend/mcp_probe.rs
@@ -135,6 +135,12 @@ async fn probe_stdio(config: &Value) -> ProbeResult {
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .kill_on_drop(true);
+    // CREATE_NO_WINDOW: console-flash suppression, see agentmux-common/src/cli.rs
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -395,14 +395,20 @@ fn spawn_auth_cli(
 
         // Spawn the CLI. kill_on_drop guarantees cleanup if our
         // task is aborted (cancel path).
-        let mut child = match Command::new(&cli_path)
-            .args(&auth_login_args)
+        let mut cmd = Command::new(&cli_path);
+        cmd.args(&auth_login_args)
             .envs(&auth_env)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
+            .kill_on_drop(true);
+        // CREATE_NO_WINDOW: console-flash suppression, see agentmux-common/src/cli.rs
+        #[cfg(windows)]
+        {
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+        let mut child = match cmd.spawn()
         {
             Ok(c) => {
                 tracing::info!(

--- a/agentmux-srv/src/server/shell_handlers.rs
+++ b/agentmux-srv/src/server/shell_handlers.rs
@@ -227,6 +227,17 @@ pub fn register_shell_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let mut proc = {
                     let mut c = tokio::process::Command::new("sh");
                     c.args(["-c", &cmd.command]);
+                    // CREATE_NO_WINDOW: console-flash suppression — on Windows
+                    // this `sh` is Git Bash (console-subsystem), and srv is
+                    // launched windowless, so without the flag every shellexec
+                    // pops a console window. This is the highest-frequency
+                    // console-flash site (fires on every MCP Shell tool call).
+                    // See agentmux-common/src/cli.rs.
+                    #[cfg(windows)]
+                    {
+                        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                        c.creation_flags(CREATE_NO_WINDOW);
+                    }
                     c
                 };
                 proc.stdout(std::process::Stdio::piped());

--- a/agentmux-srv/src/server/voice.rs
+++ b/agentmux-srv/src/server/voice.rs
@@ -355,6 +355,12 @@ async fn transcribe_local_whisper(
     // block the HTTP handler forever. kill_on_drop ensures the timed-out child
     // is reaped when the timeout future drops it.
     cmd.kill_on_drop(true);
+    // CREATE_NO_WINDOW: console-flash suppression, see agentmux-common/src/cli.rs
+    #[cfg(windows)]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
     const WHISPER_TIMEOUT_SECS: u64 = 120;
 
     let output = tokio::time::timeout(

--- a/agentmux-srv/src/util.rs
+++ b/agentmux-srv/src/util.rs
@@ -20,10 +20,12 @@ pub fn open_browser(url: &str) {
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
-        let _ = std::process::Command::new("cmd")
-            .arg("/C")
-            .raw_arg(format!("start \"\" \"{url}\""))
-            .spawn();
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.arg("/C").raw_arg(format!("start \"\" \"{url}\""));
+        // CREATE_NO_WINDOW: console-flash suppression, see agentmux-common/src/cli.rs
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        let _ = cmd.spawn();
     }
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
Follow-up to #2171, covering the remaining Windows console-window flashes from `agentmux-srv` subprocess spawns. On Windows the host/launcher are GUI-subsystem and srv runs windowless, so any console-subsystem child spawned via std/tokio `Command` **without** `CREATE_NO_WINDOW` (0x0800_0000) pops a visible console window. #2171 fixed the highest-frequency chokepoints (`make_cli_cmd`, `where` prereq, auth-poll); this adds the same idiom to the remaining srv-side spawns.

## Sites fixed
- **agentmux-srv/src/backend/mcp_probe.rs:138** — MCP stdio server probe spawn (npx/node). Fires when a user adds/tests an MCP server. `tokio::process::Command`, inherent `creation_flags`.
- **agentmux-srv/src/server/voice.rs:358** — whisper-cli spawn (push-to-talk). `tokio::process::Command`, inherent `creation_flags`.
- **agentmux-srv/src/util.rs:25** — `cmd /C start "" "<url>"` browser-open. Windows-only `#[cfg(target_os = "windows")]` path; `std::process::Command` via `CommandExt` (already imported for `raw_arg`). Adding the flag to a `cmd /C start` correctly suppresses the transient `cmd.exe` console.
- **agentmux-srv/src/server/identity_handlers.rs:405** — `auth.spawn` provider-CLI login spawn (pipe path, `spawn_auth_cli`).

## auth.spawn determination
**It needed a fix — real srv-side spawn, not a pure forward.** The doc comment near `requires_tty` (line 84) says the flag is "forwarded down to the CEF host's `run_cli_login`", but that only describes the `requires_tty` flag's semantics; the actual `Command::spawn` happens in srv. `auth.start` → `spawn_auth_cli` (called at identity_handlers.rs:188) does a live `tokio::process::Command::new(&cli_path)...spawn()` on the non-TTY pipe path, which lacked the flag — now fixed. The PTY branch (`spawn_auth_cli_pty`, portable_pty `CommandBuilder`) is left as-is: it runs under a ConPTY pseudoconsole and does not pop a visible window. The existing status-probe spawn in the same file (identity_handlers.rs ~1320) already had the flag and served as the reference idiom.

## Verify
- `cargo check -p agentmux-srv` clean (exit 0; only pre-existing unrelated warnings).

Each site carries a one-line comment referencing `agentmux-common/src/cli.rs`. Did **not** touch `make_cli_cmd`, `install_handlers`, or the auth-poll (already done in #2171), and nothing outside `agentmux-srv`.

<!-- agentmux:agent_id=agenta-07017 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)