### PR TITLE
fix(layout): stop balanceNode from flipping a dissolved column's own direction

### DIFF
--- a/.changesets/1784192592-fix-layout-stop-balancenode-from-flipping-a-dissolved-column-souq.md
+++ b/.changesets/1784192592-fix-layout-stop-balancenode-from-flipping-a-dissolved-column-souq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): stop balanceNode from flipping a dissolved column's own direction

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -729,6 +729,8 @@ fn validate_node(node: &LayoutNode) -> bool {
 ///   matches the TS `flatMap`.
 /// - `_slipAnchor` (read from the untyped `extra` catch-all, where the
 ///   frontend stores it) suppresses the single-child-branch hoist.
+/// - `columnDissolve` (same `extra` catch-all) suppresses the direction-flip
+///   alternation, so a dissolved column's own children stay stacked.
 /// - The single-leaf collapse copies the child's `data` + `id` only; the node
 ///   keeps its own `size` / `flex_direction` / `extra` — exactly as TS does.
 pub fn balance_node(node: &mut LayoutNode) -> Result<(), LayoutError> {
@@ -739,7 +741,14 @@ pub fn balance_node(node: &mut LayoutNode) -> Result<(), LayoutError> {
     let parent_flex = node.flex_direction;
     let mut rebuilt: Vec<LayoutNode> = Vec::with_capacity(node.children.len());
     for mut child in std::mem::take(&mut node.children) {
-        if child.flex_direction == parent_flex {
+        // A dissolved column (`columnDissolve` set, in `extra`) must keep the
+        // flexDirection it had when its leaf children were minimized — that's
+        // what stacks them vertically inside the header strip. It's nested
+        // under a sibling column of the same direction by design (see
+        // `_dissolveColumn` in layoutMinimize.ts), so the alternation rule
+        // below would otherwise flip it and lay the headers out sideways.
+        let column_dissolve = child.extra.contains_key("columnDissolve");
+        if child.flex_direction == parent_flex && !column_dissolve {
             child.flex_direction = reverse_flex_direction(parent_flex);
         }
         let slip_anchor = child

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -228,6 +228,40 @@ fn balance_slip_anchor_suppresses_hoist() {
 }
 
 #[test]
+fn balance_column_dissolve_suppresses_direction_flip() {
+    // Sibling(Column)[ dissolved-colA(Column, columnDissolve)[ leaf1, leaf2 ], leaf3 ]
+    // — mirrors what layoutMinimize's `_dissolveColumn` produces: a dissolved
+    // column nested as the first child of a same-direction Column sibling.
+    // Without the columnDissolve guard, the unconditional direction-alternation
+    // rule would flip colA to Row, laying leaf1/leaf2 out side-by-side instead
+    // of stacked.
+    let mut dissolved_col = group(
+        "colA",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![
+            leaf_dir("l1", "b1", FlexDirection::Row),
+            leaf_dir("l2", "b2", FlexDirection::Row),
+        ],
+    );
+    dissolved_col
+        .extra
+        .insert("columnDissolve".into(), serde_json::json!({"targetColumnId": "sibling"}));
+    let mut sibling = group(
+        "sibling",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![dissolved_col, leaf_dir("l3", "b3", FlexDirection::Row)],
+    );
+    balance_node(&mut sibling).unwrap();
+    assert_eq!(
+        sibling.children[0].flex_direction,
+        FlexDirection::Column,
+        "dissolved column must stay Column so its stacked minimized panes render vertically"
+    );
+}
+
+#[test]
 fn balance_drops_empty_branch_child() {
     // Row[ leaf1, leaf2, empty-branch ] → empty branch dropped, 2 remain.
     let mut node = group(

--- a/frontend/layout/lib/layoutNode.ts
+++ b/frontend/layout/lib/layoutNode.ts
@@ -207,7 +207,13 @@ export function balanceNode(
         (node) => {
             if (!validateNode(node)) throw new Error("Invalid node");
             node.children = node.children?.flatMap((child) => {
-                if (child.flexDirection === node.flexDirection) {
+                // A dissolved column (`columnDissolve` set) must keep the
+                // flexDirection it had when its leaf children were minimized —
+                // that's what stacks them vertically inside the header strip.
+                // It's nested under a sibling column of the same direction by
+                // design (see _dissolveColumn), so the alternation rule below
+                // would otherwise flip it and lay the headers out sideways.
+                if (child.flexDirection === node.flexDirection && child.columnDissolve === undefined) {
                     child.flexDirection = reverseFlexDirection(node.flexDirection);
                 }
                 if (child.children?.length == 1 && child.children[0].children && !child._slipAnchor) {

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import { newLayoutNode } from "../lib/layoutNode";
 import { minimizeNodeToggle, rebuildMinimizedSet, HeaderHeightPx } from "../lib/layoutMinimize";
+import { balanceNode } from "../lib/layoutNode";
 import { FlexDirection, type LayoutNode, type LayoutNodeAdditionalProps } from "../lib/types";
 
 // ── Minimal LayoutModel mock ─────────────────────────────────────────────────
@@ -143,6 +144,34 @@ describe("column dissolve — all panes minimized triggers dissolve into adjacen
 
         expect(colA.size).toBe(2 * HeaderHeightPx);
         void colB;
+    });
+
+    // Regression: production calls balanceNode(root) on every geometry pass
+    // (layoutGeometry.ts's updateTree), which this test suite otherwise never
+    // exercises since makeMockModel's updateTree is a no-op stub. A dissolved
+    // column is nested inside a same-direction Column sibling by design, so
+    // balanceNode's direction-alternation rule used to flip colA's own
+    // flexDirection to Row, laying its two minimized headers out side-by-side
+    // ("narrow") instead of stacked ("short").
+    it("keeps the dissolved column's own flexDirection stacked after balanceNode runs", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id); // triggers dissolve: colA nests inside colB
+
+        expect(colB.children![0].id).toBe(colA.id);
+        expect(colA.flexDirection).toBe(FlexDirection.Column);
+        expect(colB.flexDirection).toBe(FlexDirection.Column);
+
+        balanceNode(root);
+
+        // colA is still nested first inside colB and still stacks vertically.
+        expect(colB.children![0].id).toBe(colA.id);
+        expect(colA.flexDirection).toBe(FlexDirection.Column);
     });
 });
 


### PR DESCRIPTION
## Summary

Fixes the "pane collapse becomes narrow instead of short" bug: minimizing the
last non-minimized pane in a Column (e.g. minimizing `cpu` then `swarm` in the
default agent/cpu/swarm layout) triggers `_dissolveColumn()`, which nests the
dissolved column — still needing `Column` direction to stack its minimized
headers vertically — as the first child of an adjacent sibling that gets
converted into a same-direction `Column`.

`balanceNode` (TS) / `balance_node` (Rust) run their direction-alternation
rule **unconditionally** on every child, so the dissolved column's own
`flexDirection` got flipped to `Row`, turning the two stacked minimized
headers into a side-by-side split ("narrow") instead of a vertical stack
("short") — exactly the reported repro.

Root-caused by directly inspecting a live dev instance's persisted
`db_layout` tree, where the dissolved branch node had
`"flexDirection": "row"` despite needing to stay `"column"`.

## Fix

Mirrors the existing `_slipAnchor` guard, which already protects the
separate single-child-hoist rule from this same class of problem: skip the
direction flip when the child has `columnDissolve` set.

- TS: `frontend/layout/lib/layoutNode.ts` — `child.columnDissolve === undefined` guard
- Rust: `agentmux-srv/src/backend/layout/mod.rs` — `child.extra.get("columnDissolve")` guard

## Test plan

- [x] New regression test in `frontend/layout/tests/layoutMinimize.test.ts`
      (calls `balanceNode` after a real dissolve, as production's
      `updateTree` does on every geometry pass — confirmed it fails without
      the fix: `"row"` received, `"column"` expected)
- [x] New regression test in `agentmux-srv/src/backend/layout/tests.rs`
      (confirmed it fails without the fix the same way)
- [x] Full `cargo test --bin agentmux-srv` — 1491 passed
- [x] `npx vitest run frontend/layout` — 83 passed