### PR TITLE
fix(ui): unify nested scroll areas in Accounts and the agent picker into one continuous list

### DIFF
--- a/.changesets/1784193699-fix-ui-unify-nested-scroll-areas-in-accounts-and-the-agent-p-zzga.md
+++ b/.changesets/1784193699-fix-ui-unify-nested-scroll-areas-in-accounts-and-the-agent-p-zzga.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): unify nested scroll areas in Accounts and the agent picker into one continuous list

--- a/frontend/app/view/accounts/accounts-gallery.scss
+++ b/frontend/app/view/accounts/accounts-gallery.scss
@@ -94,20 +94,17 @@
     color: var(--secondary-text-color);
 }
 
-// ── AccountsManager layout (gallery + scrollable accounts list) ───────────────
-// Makes identity-body a flex column so the gallery takes its natural height
-// and the connected-accounts section fills the remaining space.
+// ── AccountsManager layout (gallery + connected accounts, one scroll) ─────────
+// Both sections flow at their natural height; `.identity-body` (the parent)
+// is the single scroll boundary for the whole tab — see its own comment.
 .accounts-manager-body {
     display: flex;
     flex-direction: column;
 }
 
 .accounts-manager-list-section {
-    flex: 1;
-    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 // ── Tile-click chooser (OAuth / Key) ──────────────────────────────────────────

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -76,8 +76,9 @@ export function AccountsManager(): JSX.Element {
                 />
                 {/* Connected accounts (manage existing). Shown when there is any
                     stored account OR an AgentMux Cloud session is connected.
-                    accounts-manager-list-section is flex:1 so it fills remaining
-                    height below the gallery. */}
+                    Flows at natural height below the gallery — .identity-body
+                    (the shared parent) is the single scroll boundary for the
+                    whole tab, not this section on its own. */}
                 <Show when={model.accountsAtom().length > 0 || agentMuxConnected()}>
                     <div class="accounts-manager-list-section">
                         <div class="accounts-connected-heading">Connected accounts</div>

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -5,12 +5,18 @@
 // the pre-split file (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
 .agent-view {
     // === Agent Picker ===
+    // The single scroll boundary for the whole picker — My Agents and
+    // + New from template used to each own an independent scroll area
+    // (agent-recent-sessions-list and agent-picker-list respectively);
+    // now they flow at their natural height and this is the only thing
+    // that scrolls, so the picker reads as one continuous list.
     .agent-picker {
         display: flex;
         flex-direction: column;
         height: 100%;
         padding: var(--space-4);
         gap: var(--space-3);
+        overflow-y: auto;
         // Min tile width for the My Agents / Templates grids. The grids
         // auto-fill across the full pane width, so column count scales with
         // the pane ("maximize screen room"). Tunable in one place.
@@ -45,8 +51,8 @@
         grid-template-columns: repeat(auto-fill, minmax(min(var(--agent-tile-min), 100%), 1fr));
         gap: var(--space-3);
         align-content: start;
-        flex: 1;
-        overflow-y: auto;
+        // Natural height, no independent scroll — `.agent-picker` (above)
+        // is the single scroll boundary for the whole picker now.
         width: 100%;
     }
 

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -12,10 +12,12 @@
         flex-direction: column;
         gap: var(--space-2);
         width: 100%;
-        // Hard cap so the list doesn't swallow the picker when the
-        // user has 20 active sessions. Internal scroll instead.
-        max-height: 40vh;
-        overflow: hidden;
+        // Natural height — was capped to 40vh with its own internal
+        // scroll (to keep a large session count from pushing the
+        // templates tier off-screen), but that made My Agents and
+        // New-from-template two independent scroll areas instead of
+        // one continuous list. `.agent-picker` is now the single
+        // scroll boundary for the whole picker.
     }
 
     .agent-recent-sessions-header {
@@ -62,10 +64,8 @@
         grid-template-columns: repeat(auto-fill, minmax(min(var(--agent-tile-min, 240px), 100%), 1fr));
         gap: var(--space-2);
         align-content: start;
-        overflow-y: auto;
-        // Scroll containment so wheeling inside the list doesn't
-        // spill into the picker-list below once we hit the boundary.
-        overscroll-behavior: contain;
+        // Natural height, no independent scroll — `.agent-picker` is the
+        // single scroll boundary for the whole picker now.
     }
 
     .agent-recent-sessions-row {

--- a/frontend/app/view/identity/styles/_accounts.scss
+++ b/frontend/app/view/identity/styles/_accounts.scss
@@ -46,26 +46,18 @@
 }
 
 // ── Accounts layout (list + detail) ──────────────────────────────────────────
+// Natural height — `.identity-body` (the shared parent, see its own comment
+// in styles/_header.scss) is the single scroll boundary now, not this list
+// on its own.
 
 .identity-accounts-layout {
-    flex: 1;
-    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .identity-accounts-list {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
     padding: var(--space-2);
     min-width: 0;
-
-    &::-webkit-scrollbar-thumb {
-        background: var(--scrollbar-thumb-color);
-        border-radius: 0;
-    }
 }
 
 // ── Group ─────────────────────────────────────────────────────────────────────

--- a/frontend/app/view/identity/styles/_assignments.scss
+++ b/frontend/app/view/identity/styles/_assignments.scss
@@ -5,9 +5,9 @@
 
 // ── Assignments matrix ────────────────────────────────────────────────────────
 
+// Natural height — `.identity-body` (styles/_header.scss) is the single
+// scroll boundary, not this section on its own.
 .identity-assignments {
-    height: 100%;
-    overflow: auto;
     padding: var(--space-3);
 }
 

--- a/frontend/app/view/identity/styles/_header.scss
+++ b/frontend/app/view/identity/styles/_header.scss
@@ -63,12 +63,25 @@
 }
 
 // ── Body ─────────────────────────────────────────────────────────────────────
+//
+// The single scroll boundary for everything under the header — the
+// gallery + connected-accounts list in AccountsManager, and the
+// accounts/assignments lists in IdentityPanel, all flow as one
+// continuous region instead of each owning its own independent
+// scroll area. See docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md's
+// single-pane principle, extended here from list/detail split-screens
+// to nested-scroll-area sprawl — same "one thing, one scroll" idea.
 
 .identity-body {
     flex: 1;
     min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow-y: auto;
+
+    &::-webkit-scrollbar-thumb {
+        background: var(--scrollbar-thumb-color);
+        border-radius: 0;
+    }
 }
 


### PR DESCRIPTION
## Summary

Both surfaces had two independently-scrolling sections stacked instead of one continuous scroll:

- **Armory's Accounts tab**: the brand-tile gallery (natural height) sat above a connected-accounts list that was its own clipped, independently scrolling region (`.accounts-manager-list-section` / `.identity-body` both had `overflow: hidden`, with `.identity-accounts-list` doing the actual scrolling inside that bounded box).
- **The agent picker (My Agents / + New from template)**: "My Agents" was hard-capped to `40vh` with its own internal scroll (deliberately — see the removed comment, to keep a large session count from pushing the templates tier off-screen), and "+ New from template" had a second, separate scroll area below it, with `overscroll-behavior: contain` explicitly preventing scroll-chaining between them.

**Fix:** made `.identity-body` (shared by Armory's Accounts tab and the per-agent Identity panel's Accounts/Assignments tabs) and `.agent-picker` the single scroll boundary in each case. Removed every inner section's own `overflow`/`max-height` clip so they flow at natural height as one list.

Accepts the tradeoff the old `40vh` cap was avoiding: a user with many active sessions now scrolls past all of them to reach the templates tier, rather than each section getting a bounded, independently-scrolling slot. That's the explicit ask — one long list, not two scroll areas.

## Test plan
- [x] `npx sass` compile of `app.scss` — no errors.
- [x] `npx stylelint` on all touched files — no new violations (pre-existing hex-color debt in untouched lines only).
- [x] Full frontend suite: `npx vitest run` — 1744 passed, 3 skipped (pre-existing), 0 failures.
- [ ] Manual: open Armory → Accounts with several connected accounts across providers — should be one continuous scroll from the gallery through the connected-accounts list. Open the agent picker with several active sessions and several templates — same, one continuous scroll from My Agents through + New from template.

<!-- agentmux:agent_id=agent1 -->