### PR TITLE
fix(layout): minimize is a locked state (Option B of the locked-state redesign)

### DIFF
--- a/.changesets/1784196051-fix-layout-minimize-is-a-locked-state-reject-snap-back-resiz-uk7s.md
+++ b/.changesets/1784196051-fix-layout-minimize-is-a-locked-state-reject-snap-back-resiz-uk7s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): minimize is a locked state — reject/snap-back resize and structural ops on minimized panes

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -255,7 +255,12 @@ pub fn enforce_minimized_locks(root: &mut Option<LayoutNode>) -> usize {
                         .find(|&j| !locked_flags[j])
                         .or_else(|| (0..i).rev().find(|&j| !locked_flags[j]));
                     if let Some(j) = beneficiary {
-                        node.children[j].size += delta;
+                        // Floor at 1 flex unit (same floor as the slip/
+                        // undissolve restore paths): a tampered size BELOW
+                        // the lock makes the delta negative, and the
+                        // repayment must not drive the beneficiary's size
+                        // to zero or negative.
+                        node.children[j].size = (node.children[j].size + delta).max(1.0);
                     }
                     snapped += 1;
                 }
@@ -402,6 +407,12 @@ pub fn insert_node_at_index(
     }
 
     let parent = unsafe { &mut *current };
+    // Minimized is a locked state: an `index_arr` that resolves into a
+    // dissolved column (locked container) or onto a minimized leaf (which
+    // `ensure_group_node` would otherwise promote into a group) is rejected.
+    if is_node_locked(parent) {
+        return Err(LayoutError::NodeLocked { id: parent.id.clone() });
+    }
     ensure_group_node(parent);
     let insert_at = (clamped_idx + 1).min(parent.children.len());
     parent.children.insert(insert_at, node);

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -33,6 +33,10 @@ pub enum LayoutError {
     /// both `data` and `children`, or neither. The TS oracle (`validateNode`
     /// in `layoutNode.ts`) throws "Invalid node" here.
     InvalidNode { id: String },
+    /// The op targets a minimize-locked node (minimized leaf, slipped header,
+    /// or dissolved column). Minimized is a locked state — see
+    /// `docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`.
+    NodeLocked { id: String },
 }
 
 impl std::fmt::Display for LayoutError {
@@ -44,6 +48,7 @@ impl std::fmt::Display for LayoutError {
             Self::InvalidSize { node_id, size } => write!(f, "invalid size {:.2} for node {}", size, node_id),
             Self::InvalidIndexPath => write!(f, "index_arr is empty or points to a non-existent location"),
             Self::InvalidNode { id } => write!(f, "invalid node (leaf-XOR-branch violated): {}", id),
+            Self::NodeLocked { id } => write!(f, "node is minimize-locked: {}", id),
         }
     }
 }
@@ -206,6 +211,62 @@ pub fn prune_dangling_block_refs(
         }
     }
     pruned
+}
+
+/// A minimize-locked node: a minimized leaf (`minimizedSize`), a slipped
+/// header (`slipMinimize`), or a dissolved column (`columnDissolve`). The
+/// fields are written by the frontend minimize subsystem and round-trip
+/// through the untyped `extra` catch-all on this side. Mirrors
+/// `isNodeLocked` in `frontend/layout/lib/layoutMinimize.ts`.
+pub fn is_node_locked(node: &LayoutNode) -> bool {
+    node.extra.contains_key("minimizedSize")
+        || node.extra.contains_key("slipMinimize")
+        || node.extra.contains_key("columnDissolve")
+}
+
+/// Write-point enforcement of the minimize lock (the invariant-at-the-write
+/// companion to `prune_dangling_block_refs`, per
+/// `SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`): snap every
+/// locked node's `size` back to its recorded `minimizedLockedSize`,
+/// returning the delta to the nearest unlocked sibling (next preferred,
+/// then previous) so the parent's flex-unit budget is conserved. Mirrors
+/// `enforceMinimizedLocks` in `frontend/layout/lib/layoutMinimize.ts`.
+/// Returns the number of snapped nodes (0 = tree already honored the locks
+/// — the common case, cheap to call unconditionally on every write).
+///
+/// If every sibling is locked (inside a dissolved column) the delta is
+/// dropped: flex sizes are relative within the parent, so the locked
+/// nodes' shares stay proportionally correct.
+pub fn enforce_minimized_locks(root: &mut Option<LayoutNode>) -> usize {
+    fn walk(node: &mut LayoutNode) -> usize {
+        let mut snapped = 0;
+        let locked_flags: Vec<bool> = node.children.iter().map(is_node_locked).collect();
+        for i in 0..node.children.len() {
+            let locked_size = node.children[i]
+                .extra
+                .get("minimizedLockedSize")
+                .and_then(|v| v.as_f64())
+                .map(|v| v as f32);
+            if let (true, Some(locked_size)) = (locked_flags[i], locked_size) {
+                let delta = node.children[i].size - locked_size;
+                if delta.abs() > 1e-4 {
+                    node.children[i].size = locked_size;
+                    let beneficiary = (i + 1..node.children.len())
+                        .find(|&j| !locked_flags[j])
+                        .or_else(|| (0..i).rev().find(|&j| !locked_flags[j]));
+                    if let Some(j) = beneficiary {
+                        node.children[j].size += delta;
+                    }
+                    snapped += 1;
+                }
+            }
+        }
+        for child in &mut node.children {
+            snapped += walk(child);
+        }
+        snapped
+    }
+    root.as_mut().map_or(0, walk)
 }
 
 /// First leaf (depth-first) whose `data.block_id` is set but not present in
@@ -412,9 +473,18 @@ pub fn move_node(
     let node_to_move = find_node_by_id(root, node_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: node_id.to_string() })?
         .clone();
+    // Minimized is a locked state: a locked node can't be moved (restore it
+    // first), and nothing may be inserted into a dissolved column.
+    if is_node_locked(&node_to_move) {
+        return Err(LayoutError::NodeLocked { id: node_id.to_string() });
+    }
     // Confirm destination exists while tree is still intact.
-    if find_node_by_id(root, new_parent_id).is_none() {
-        return Err(LayoutError::NodeNotFound { id: new_parent_id.to_string() });
+    match find_node_by_id(root, new_parent_id) {
+        None => return Err(LayoutError::NodeNotFound { id: new_parent_id.to_string() }),
+        Some(p) if is_node_locked(p) => {
+            return Err(LayoutError::NodeLocked { id: new_parent_id.to_string() });
+        }
+        Some(_) => {}
     }
     // Confirm destination is NOT a descendant of the node being moved.
     if find_node_by_id(&node_to_move, new_parent_id).is_some() {
@@ -507,6 +577,13 @@ pub fn swap_nodes(
     let n2 = find_node_by_id(root, node2_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: node2_id.to_string() })?
         .clone();
+    // Minimized is a locked state: locked nodes don't swap.
+    if is_node_locked(&n1) {
+        return Err(LayoutError::NodeLocked { id: node1_id.to_string() });
+    }
+    if is_node_locked(&n2) {
+        return Err(LayoutError::NodeLocked { id: node2_id.to_string() });
+    }
     let p1_id = find_parent_id(root, node1_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: format!("parent of {}", node1_id) })?;
     let p2_id = find_parent_id(root, node2_id)
@@ -558,10 +635,18 @@ pub fn resize_nodes(root: &mut LayoutNode, ops: &[ResizeOp]) -> Result<(), Layou
             });
         }
     }
-    // Validation pass 2: all target nodes exist.
+    // Validation pass 2: all target nodes exist and none is minimize-locked.
+    // Ops come in before/after pairs whose unit sum is conserved — applying
+    // only the unlocked half would leak flex units, so it's all-or-nothing
+    // (same atomic-reject semantics as the passes above, and the same guard
+    // as the frontend's `resizeNode`).
     for op in ops {
-        if find_node_by_id(root, &op.node_id).is_none() {
-            return Err(LayoutError::NodeNotFound { id: op.node_id.clone() });
+        match find_node_by_id(root, &op.node_id) {
+            None => return Err(LayoutError::NodeNotFound { id: op.node_id.clone() }),
+            Some(node) if is_node_locked(node) => {
+                return Err(LayoutError::NodeLocked { id: op.node_id.clone() });
+            }
+            Some(_) => {}
         }
     }
     // Apply pass (all valid).
@@ -629,9 +714,13 @@ fn split_impl(
     position: SplitPosition,
     direction: FlexDirection,
 ) -> Result<(), LayoutError> {
-    // Find target; it must exist.
-    let _ = find_node_by_id(root, target_id)
+    // Find target; it must exist and must not be minimize-locked (splitting
+    // a locked node would spawn a full pane inside a header strip).
+    let target = find_node_by_id(root, target_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: target_id.to_string() })?;
+    if is_node_locked(target) {
+        return Err(LayoutError::NodeLocked { id: target_id.to_string() });
+    }
 
     let parent_id = find_parent_id(root, target_id);
 

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -261,6 +261,141 @@ fn balance_column_dissolve_suppresses_direction_flip() {
     );
 }
 
+// ── Minimize lock (locked-state spec, 2026-07-16) ───────────────────────────
+
+/// Leaf carrying the minimize-lock fields the frontend writes (round-tripped
+/// through `extra`): `minimizedSize` (original size) + `minimizedLockedSize`
+/// (the size the node is locked to while minimized).
+fn locked_leaf(id: &str, block_id: &str, locked_size: f32) -> LayoutNode {
+    let mut node = leaf(id, block_id, locked_size);
+    node.extra
+        .insert("minimizedSize".into(), serde_json::json!(200.0));
+    node.extra
+        .insert("minimizedLockedSize".into(), serde_json::json!(locked_size));
+    node
+}
+
+#[test]
+fn resize_nodes_rejects_minimize_locked_target() {
+    let mut root = group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![locked_leaf("l1", "b1", 33.0), leaf("l2", "b2", 367.0)],
+    );
+    let ops = vec![
+        ResizeOp { node_id: "l1".into(), size: 90.0 },
+        ResizeOp { node_id: "l2".into(), size: 10.0 },
+    ];
+    assert!(matches!(
+        resize_nodes(&mut root, &ops),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    // Atomic reject: neither op applied.
+    assert_eq!(root.children[0].size, 33.0);
+    assert_eq!(root.children[1].size, 367.0);
+}
+
+#[test]
+fn move_node_rejects_locked_source_and_locked_destination() {
+    let mut dissolved = group(
+        "colA",
+        FlexDirection::Column,
+        66.0,
+        vec![locked_leaf("l1", "b1", 33.0), locked_leaf("l2", "b2", 33.0)],
+    );
+    dissolved
+        .extra
+        .insert("columnDissolve".into(), serde_json::json!({"targetColumnId": "host"}));
+    let mut root = group(
+        "root",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![
+            group("host", FlexDirection::Column, 200.0, vec![dissolved, leaf("content", "b3", 300.0)]),
+            leaf("other", "b4", 200.0),
+        ],
+    );
+    // Moving a locked node out is rejected.
+    assert!(matches!(
+        move_node(&mut root, "l1", "root", 0),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    // Moving anything INTO a dissolved column is rejected.
+    assert!(matches!(
+        move_node(&mut root, "other", "colA", 0),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+}
+
+#[test]
+fn swap_nodes_rejects_locked_endpoint() {
+    let mut root = group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![locked_leaf("l1", "b1", 33.0), leaf("l2", "b2", 367.0)],
+    );
+    assert!(matches!(
+        swap_nodes(&mut root, "l1", "l2"),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    assert!(matches!(
+        swap_nodes(&mut root, "l2", "l1"),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+}
+
+#[test]
+fn split_rejects_locked_target() {
+    let mut root = group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![locked_leaf("l1", "b1", 33.0), leaf("l2", "b2", 367.0)],
+    );
+    assert!(matches!(
+        split_vertical(&mut root, "l1", leaf("new", "b9", 100.0), SplitPosition::After),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    assert!(matches!(
+        split_horizontal(&mut root, "l1", leaf("new", "b9", 100.0), SplitPosition::Before),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+}
+
+#[test]
+fn enforce_locks_snaps_tampered_size_and_redistributes() {
+    // A minimized leaf whose size was dragged from its locked 33.0 up to 120.0
+    // (the reported bug). Enforcement snaps it back and returns the 87.0 delta
+    // to the unlocked sibling so the column's unit budget is conserved.
+    let mut tampered = locked_leaf("l1", "b1", 33.0);
+    tampered.size = 120.0;
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![tampered, leaf("l2", "b2", 280.0)],
+    ));
+    let snapped = enforce_minimized_locks(&mut root);
+    assert_eq!(snapped, 1);
+    let root = root.unwrap();
+    assert_eq!(root.children[0].size, 33.0);
+    assert_eq!(root.children[1].size, 367.0);
+}
+
+#[test]
+fn enforce_locks_noop_when_sizes_honored() {
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![locked_leaf("l1", "b1", 33.0), leaf("l2", "b2", 367.0)],
+    ));
+    assert_eq!(enforce_minimized_locks(&mut root), 0);
+    assert_eq!(enforce_minimized_locks(&mut None), 0);
+}
+
 #[test]
 fn balance_drops_empty_branch_child() {
     // Row[ leaf1, leaf2, empty-branch ] → empty branch dropped, 2 remain.

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -397,6 +397,60 @@ fn enforce_locks_noop_when_sizes_honored() {
 }
 
 #[test]
+fn enforce_locks_clamps_negative_delta_repayment() {
+    // Tampered BELOW the lock: size 5.0 vs locked 33.0 → delta = -28.0. The
+    // beneficiary sibling only has 10.0 units; the repayment must clamp at
+    // the 1.0 floor instead of driving it negative (reagent P2, PR #2180).
+    let mut tampered = locked_leaf("l1", "b1", 33.0);
+    tampered.size = 5.0;
+    let mut root = Some(group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![tampered, leaf("l2", "b2", 10.0)],
+    ));
+    let snapped = enforce_minimized_locks(&mut root);
+    assert_eq!(snapped, 1);
+    let root = root.unwrap();
+    assert_eq!(root.children[0].size, 33.0);
+    assert_eq!(root.children[1].size, 1.0, "beneficiary clamped at the floor, not negative");
+}
+
+#[test]
+fn insert_node_at_index_rejects_locked_resolution() {
+    // index_arr resolving INTO a dissolved column (locked container) is
+    // rejected (reagent P1, PR #2180).
+    let mut dissolved = group(
+        "colA",
+        FlexDirection::Column,
+        66.0,
+        vec![locked_leaf("l1", "b1", 33.0), locked_leaf("l2", "b2", 33.0)],
+    );
+    dissolved
+        .extra
+        .insert("columnDissolve".into(), serde_json::json!({"targetColumnId": "root"}));
+    let mut root = group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![dissolved, leaf("content", "b3", 300.0)],
+    );
+    assert!(matches!(
+        insert_node_at_index(&mut root, leaf("new", "b9", 10.0), &[0, 0]),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    // index_arr resolving ONTO a minimized leaf (which ensure_group_node
+    // would otherwise promote into a group) is rejected too.
+    assert!(matches!(
+        insert_node_at_index(&mut root, leaf("new", "b9", 10.0), &[0, 0, 0]),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    // Tree untouched by either rejection.
+    assert_eq!(root.children.len(), 2);
+    assert_eq!(root.children[0].children.len(), 2);
+}
+
+#[test]
 fn balance_drops_empty_branch_child() {
     // Row[ leaf1, leaf2, empty-branch ] → empty branch dropped, 2 remain.
     let mut node = group(

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -2813,6 +2813,56 @@ mod tests {
         }
     }
 
+    /// Minimize-lock guard on the explicit-parent insert path (reagent P1,
+    /// PR #2180): a dissolved column has `data: None`, so without its own
+    /// locked check it would satisfy the "is a group node" arm and accept
+    /// the insert — letting an agent/API caller seed a full pane inside a
+    /// header strip.
+    #[test]
+    fn layout_insert_node_rejects_minimize_locked_parent() {
+        let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "b1");
+        seed_block(&mut state, &tab_id, "b2");
+        seed_block(&mut state, &tab_id, "b3");
+
+        let mut l1 = leaf_node("l1", "b1");
+        l1.extra.insert("minimizedSize".into(), serde_json::json!(200.0));
+        let mut l2 = leaf_node("l2", "b2");
+        l2.extra.insert("minimizedSize".into(), serde_json::json!(200.0));
+        let mut dissolved = agentmux_common::LayoutNode {
+            id: "colA".into(),
+            children: vec![l1, l2],
+            ..Default::default()
+        };
+        dissolved
+            .extra
+            .insert("columnDissolve".into(), serde_json::json!({"targetColumnId": "root"}));
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(agentmux_common::LayoutNode {
+            id: "root".into(),
+            children: vec![dissolved, leaf_node("content", "b3")],
+            ..Default::default()
+        });
+
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("new", "b3"),
+                parent_id: Some("colA".into()),
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr-locked".into(),
+            },
+            &ctx(1),
+        );
+
+        assert!(matches!(&events[0], Event::Error { code: ErrorCode::InvalidCommand, .. }));
+        // Dissolved column untouched.
+        let root = state.tabs[&tab_id].rootnode.as_ref().unwrap();
+        assert_eq!(root.children[0].children.len(), 2);
+    }
+
     /// SPEC_864 Phase 2 — a slice-carrying full-row push applies focus/
     /// magnify to the TabRecord (empty = clear) and echoes the slices on
     /// the emitted event for the persist subscriber.

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -2763,6 +2763,56 @@ mod tests {
         }
     }
 
+    /// Minimize-lock enforcement at the set-tree choke point
+    /// (SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md): a pushed
+    /// tree in which a minimized node's size was tampered with (e.g. a
+    /// resize that slipped past a stale frontend's guards) must be snapped
+    /// back to its recorded locked size, with the delta repaid to the
+    /// unlocked sibling, before the tree is persisted.
+    #[test]
+    fn layout_set_tree_snaps_tampered_minimized_size_back_to_its_lock() {
+        let (mut state, tab_id) = fresh_tab();
+        seed_block(&mut state, &tab_id, "b1");
+        seed_block(&mut state, &tab_id, "b2");
+
+        let mut minimized = leaf_node("min", "b1");
+        minimized.size = 120.0; // tampered: locked value is 33.0
+        minimized
+            .extra
+            .insert("minimizedSize".into(), serde_json::json!(200.0));
+        minimized
+            .extra
+            .insert("minimizedLockedSize".into(), serde_json::json!(33.0));
+        let mut sibling = leaf_node("sib", "b2");
+        sibling.size = 280.0;
+        let pushed_tree = agentmux_common::LayoutNode {
+            id: "root".into(),
+            children: vec![minimized, sibling],
+            ..Default::default()
+        };
+
+        let events = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: Some(pushed_tree),
+                correlation_id: "corr".into(),
+                slices: None,
+            },
+            &ctx(1),
+        );
+
+        assert!(matches!(&events[0], Event::LayoutTreeReplaced { .. }));
+        let root = state.tabs[&tab_id].rootnode.as_ref().unwrap();
+        assert_eq!(root.children[0].size, 33.0, "tampered size snapped back to lock");
+        assert_eq!(root.children[1].size, 367.0, "delta repaid to the unlocked sibling");
+        // The emitted event's tree must reflect the healed sizes too — it is
+        // what the persist subscriber writes to db_layout.
+        if let Event::LayoutTreeReplaced { new_tree, .. } = &events[0] {
+            assert_eq!(new_tree.as_ref().unwrap().children[0].size, 33.0);
+        }
+    }
+
     /// SPEC_864 Phase 2 — a slice-carrying full-row push applies focus/
     /// magnify to the TabRecord (empty = clear) and echoes the slices on
     /// the emitted event for the persist subscriber.

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -215,6 +215,22 @@ pub(super) fn handle_layout_insert_node(
     } else if let Some(pid) = parent_id.as_deref() {
         let root = tab.rootnode.as_mut().expect("non-empty checked above");
         match crate::backend::layout::find_node_by_id_mut(root, pid) {
+            // Minimize-locked parents (a dissolved column has `data: None`,
+            // so it would otherwise satisfy the group-node arm below) cannot
+            // host inserts — minimized is a locked state
+            // (SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md).
+            Some(parent_node) if crate::backend::layout::is_node_locked(parent_node) => {
+                let v = state.bump_version();
+                return vec![Event::Error {
+                    code: ErrorCode::InvalidCommand,
+                    message: format!(
+                        "LayoutInsertNode: parent_id {:?} is minimize-locked, cannot host inserts (tab {})",
+                        pid, tab_id
+                    ),
+                    fatal: false,
+                    version: v,
+                }];
+            }
             Some(parent_node) if parent_node.data.is_none() => {
                 let len = parent_node.children.len();
                 let target = index.map(|i| i.min(len)).unwrap_or(len);

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -137,6 +137,17 @@ pub(super) fn handle_layout_set_tree(
             "reducer: LayoutSetTree pruned dangling layout leaf/leaves referencing since-deleted blocks"
         );
     }
+    // Minimize-lock enforcement (same write-point-invariant shape as the
+    // prune above; SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md):
+    // a pushed tree that resized a minimized node gets snapped back here.
+    let snapped = crate::backend::layout::enforce_minimized_locks(&mut tab.rootnode);
+    if snapped > 0 {
+        tracing::warn!(
+            tab_id = %tab_id,
+            snapped,
+            "reducer: LayoutSetTree snapped minimize-locked node size(s) back to their locked values"
+        );
+    }
     let new_tree = tab.rootnode.clone();
     let v = state.bump_version();
     vec![Event::LayoutTreeReplaced {
@@ -725,6 +736,15 @@ pub(super) fn handle_layout_insert_node_at_index(
             "reducer: LayoutInsertNodeAtIndex pruned dangling layout leaf/leaves referencing since-deleted blocks"
         );
     }
+    // Minimize-lock enforcement, same choke point (see handle_layout_set_tree).
+    let snapped = crate::backend::layout::enforce_minimized_locks(&mut tab.rootnode);
+    if snapped > 0 {
+        tracing::warn!(
+            tab_id = %tab_id,
+            snapped,
+            "reducer: LayoutInsertNodeAtIndex snapped minimize-locked node size(s) back to their locked values"
+        );
+    }
     reconcile_focus_magnify(tab);
     let new_tree = tab.rootnode.clone();
     let v = state.bump_version();
@@ -789,6 +809,20 @@ where
             op,
             pruned,
             "reducer: pruned dangling layout leaf/leaves referencing since-deleted blocks"
+        );
+    }
+    // Minimize-lock enforcement, same choke point (see handle_layout_set_tree).
+    // The per-op guards (`LayoutError::NodeLocked`) reject ops that *target* a
+    // locked node; this pass additionally corrects indirect damage — e.g. a
+    // legitimate resize pair whose unit redistribution squeezed a locked
+    // sibling through `balance_node`'s rebuild.
+    let snapped = crate::backend::layout::enforce_minimized_locks(&mut tab.rootnode);
+    if snapped > 0 {
+        tracing::warn!(
+            tab_id = %tab_id,
+            op,
+            snapped,
+            "reducer: snapped minimize-locked node size(s) back to their locked values"
         );
     }
     Ok(())

--- a/docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md
+++ b/docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md
@@ -1,0 +1,236 @@
+# Spec — Pane Minimize as a Locked State (redesign)
+
+**Date:** 2026-07-16
+**Type:** Investigation + redesign proposal
+**Status:** Option B implemented 2026-07-16 (see §6); Option C remains a proposal
+**Trigger:** User report: a minimized pane can still be resized by dragging the adjacent
+resize handle. Minimize is supposed to be a *locked* state; today it is not.
+**Prior related work:** `INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`
+(dead-space, PRs #2036/#2039), PR #2176 (dissolved-column direction flip).
+
+---
+
+## 1. TL;DR
+
+Minimize is currently implemented as *advisory data inside the flex tree* — marker fields
+(`minimizedSize`, `slipMinimize`, `columnDissolve`, `_slipAnchor`) that every other layout
+mutation path is individually expected to notice and respect. Almost none of them do. An
+audit of every mutation surface (§4) found exactly **two** paths with any minimize
+awareness, and one of them (`layoutResize.ts`) is aware **backwards**: it explicitly
+*exempts* minimized nodes from the minimum-size guard so drags keep working next to them —
+which is precisely what makes a minimized pane freely resizable.
+
+This is the third bug in a row with the same root shape (after the dead-space resurrection
+and the dissolved-column direction flip): a "cooperating writers" invariant that every
+writer must remember, and doesn't. The fix pattern that already worked twice in this
+codebase — enforce the invariant at the write choke point, not in each caller
+(`prune_dangling_block_refs`, WRR) — applies directly. §5 proposes:
+
+- **Near term (Option B):** make "minimized ⇒ size is locked and untargetable" an
+  enforced write-path invariant on both the TS and Rust sides, plus suppress the resize
+  affordance (handle + cursor) on locked edges.
+- **Longer term (Option C):** the "more sophisticated algorithm" — take minimized panes
+  *out of the flex tree entirely* (a per-column header dock). This eliminates the entire
+  slip/dissolve special-case machinery, whose existence is itself a symptom of forcing
+  locked panes through a solver built for free ones.
+
+## 2. Reported symptom
+
+With a pane minimized (header-height only), the resize handle on its edge still renders,
+still shows a resize affordance, and dragging it resizes the minimized pane like any other.
+Consequences:
+
+- The header-height invariant is silently broken: the pane can be stretched to reveal a
+  strip of stale content, or crushed below header height (clipping the header), while the
+  minimize toggle still reports "minimized" (`minimizedSize` remains set, the node stays in
+  `minimizedNodeIds`). UI state and visual state disagree.
+- Restore math corrupts: `minimizeNodeToggle`'s restore path returns
+  `minimizedSize − currentSize` worth of flex units to siblings. If a drag changed
+  `currentSize` in between, the redistribution is wrong and sibling sizes drift on every
+  minimize/resize/restore cycle.
+- The drag is persisted through the normal resize commit (`CommitPendingAction` →
+  backend `ResizeNodes`), so the broken state round-trips through `db_layout` and survives
+  restart — same persistence shape as the dead-space bug.
+
+## 3. How minimize works today (current design)
+
+State lives in the layout tree itself (`frontend/layout/lib/types.ts`), mirrored untyped on
+the Rust side through `LayoutNode.extra`:
+
+| Field | On | Meaning |
+|---|---|---|
+| `minimizedSize` | leaf | Set ⇒ node is minimized; stores the *original* size for restore. Current `size` is squeezed to header height. |
+| `slipMinimize` | leaf | Row-parent variant: the header "slips" into an adjacent column. |
+| `columnDissolve` | column | Whole column dissolved into an adjacent sibling after all its leaves minimized; stores restore context (`targetColumnId`, original row slot). |
+| `_slipAnchor` | row | Guard flag telling `balanceNode` to skip its single-child hoist for this subtree. |
+
+Every geometry pass runs `balanceNode` over the whole tree
+(`layoutGeometry.ts:49`), and the backend runs the ported `balance_node` +
+`prune_dangling_block_refs` at each reducer write. The minimize marker fields survive those
+passes only because of targeted carve-outs (`_slipAnchor` for the hoist rule; the
+`columnDissolve` direction-flip guard added in PR #2176).
+
+The key property: **a minimized pane is still an ordinary flex node** with an ordinary
+`size`, sitting in the ordinary tree, reachable by every ordinary mutation.
+
+## 4. Audit: which mutation surfaces know minimize exists
+
+Grep basis: `minimizedSize|slipMinimize|columnDissolve|minimizedNodeIds` across
+`frontend/` and `agentmux-srv/`. Only `layoutMinimize.ts`, `layoutModel.ts`,
+`layoutNode.ts`, `layoutResize.ts`, `types.ts` (TS) and `balance_node` (Rust) reference
+any of it.
+
+| Surface | File | Minimize-aware? | What can go wrong |
+|---|---|---|---|
+| Resize handle **generation** | `layoutGeometry.ts:145-189` | ❌ No | Handles render between every sibling pair, including edges of minimized panes. The affordance itself is the bug's front door. |
+| Resize handle **drag** | `layoutResize.ts:101-108` | ⚠️ **Backwards** | Explicit exemption: *"Minimized nodes can legitimately be smaller than MinNodeSizePx — skip the guard for them."* Added so drags adjacent to a sub-40px minimized pane aren't rejected — side effect: the minimized pane itself resizes freely. |
+| Resize **apply** (frontend reducer) | `layoutTree.ts:394-401` | ❌ No | Applies any `resizeOperations` to any node. |
+| Resize **apply** (backend reducer) | `backend/layout/mod.rs:551-571` (`resize_nodes`) | ❌ No | Validates only 0–100 range and node existence; blindly writes `size` onto minimized nodes. Agent/API-driven resizes bypass the frontend entirely. |
+| Move / insert / swap / split / delete | `layoutTree.ts` (all handlers), Rust ports | ❌ No | A split can target a minimized pane (spawning a full-size sibling inside a header strip); a move can drop an arbitrary node *into* a dissolved column; swap can teleport a minimized node under a Row where its squeezed size means something else. |
+| Cross-tab / floating DnD | `crossTabDrag.ts`, `dragInFlight.ts` | ❌ No | Same class as move. |
+| Magnify | `layoutMagnify.ts` | ❌ No | Magnifying a minimized pane shows full content while state says minimized (benign-ish, but same disagreement). |
+| Tree normalization | `balanceNode` / `balance_node` | ⚠️ Two carve-outs | `_slipAnchor` (hoist) + `columnDissolve` (direction flip, PR #2176). Each was added *after* a corruption shipped. |
+| Backend-driven inserts (agents creating panes) | `handle_layout_insert_node*` | ❌ No | New panes can be seeded into a dissolved column's slot. |
+
+Two structural observations:
+
+1. **The one aware path is aware in the wrong direction.** The `layoutResize.ts` exemption
+   exists because a minimized pane's size (~header height ≈ 33px) is below `MinNodeSizePx`
+   (40px), so *without* the exemption every drag on an adjacent handle computes a
+   below-minimum size for the minimized node and gets rejected — the handle would be dead.
+   The patch chose "keep the handle alive" over "keep the lock", because there was no
+   concept of a lock to keep. It's a faithful record of what happens when each writer
+   improvises its own minimize policy.
+2. **The slip/dissolve machinery exists to work around the same absence.** Slip-minimize
+   and column-dissolve are both answers to "a minimized pane still occupies a flex slot,
+   and the solver will do something ugly with it." They add restore-context bookkeeping,
+   two `balanceNode` carve-outs, and an `_undissolveColumn` inverse — all of which are
+   themselves new invariants that other writers can (and do) violate.
+
+## 5. Redesign: minimize is a locked state
+
+Target invariant, stated once:
+
+> **I1.** A minimized node's `size` is owned exclusively by the minimize subsystem. No
+> other writer may change it, on either side of the wire.
+> **I2.** No generic tree mutation (resize / move / swap / split / magnify-restore
+> shuffle) may target a minimized node or a dissolved column, nor insert into one.
+> **I3.** A locked edge presents no affordance: no resize handle, no resize cursor.
+
+### Option A — point-guards in every caller (rejected as the strategy)
+
+Patch each row of the §4 table individually. This is the "cooperating writers" model that
+produced the last three bugs; each new mutation path (there were four new ones added in the
+last two months) re-opens the hole. Elements of A that are UX-necessary (handle
+suppression, I3) are kept, but as *presentation* of the lock, not as its enforcement.
+
+### Option B — write-point enforcement (recommended now)
+
+Same shape as `prune_dangling_block_refs` (PR #2039): enforce at the reducer/model choke
+points every mutation already flows through, so individual callers don't need to know.
+
+1. **Reject locked-target ops at both reducers.**
+   - Frontend: `layoutTree.ts::resizeNode` drops any `ResizeNodeOperation` whose target
+     has `minimizedSize`/`columnDissolve` set (drop the *pair* — a resize op always comes
+     as a before/after pair whose sum is conserved; dropping one side would leak units).
+     Same rejection in move/swap/split handlers when the target or destination parent is
+     locked.
+   - Backend: `resize_nodes` (`backend/layout/mod.rs`) gains the same check via
+     `extra` (`minimizedSize`/`columnDissolve` keys), returning a new
+     `LayoutError::NodeLocked` — closing the agent/API path the frontend never sees.
+2. **Snap-back normalization pass** (belt-and-braces, catches writers that bypass the
+   reducers, e.g. a full `SetTree` push of a stale tree — the dead-space lesson): a
+   `enforceMinimizedLocks(root)` / `enforce_minimized_locks(root)` pass run exactly where
+   `balanceNode`/`prune_dangling_block_refs` already run. For every node with
+   `minimizedSize` set, force `size` back to the recorded locked size. This requires
+   persisting the *locked* size at minimize time (new field `minimizedLockedSize`,
+   set by `minimizeNodeToggle` alongside `minimizedSize`), because header height in flex
+   units depends on the column's pixel ratio at minimize time and cannot be recomputed
+   from the tree alone. Delta from a snap-back is returned to the nearest unlocked
+   sibling, mirroring `_dissolveColumn`'s existing "steal from first child" arithmetic.
+3. **Affordance suppression (I3).** `layoutGeometry.ts` handle loop: skip emitting a
+   handle when either flanking child is locked (`minimizedSize`/`columnDissolve`).
+   This also deletes the backwards exemption in `layoutResize.ts:101-108` — with no
+   handle on locked edges, the exemption has nothing left to serve and the
+   `MinNodeSizePx` guard becomes unconditional again.
+4. **Tests.** Mirror the established pattern: pure oracle tests in
+   `frontend/layout/tests/` (resize op on a minimized node is a no-op; handle list
+   contains no locked edges; SetTree with a tampered minimized size snaps back), ported
+   Rust tests in `backend/layout/tests.rs`, reducer-level tests for the `NodeLocked`
+   rejection, red/green verified against reverted guards.
+
+Estimated scope: ~1 day. No persistence migration (new field is additive; old trees
+without `minimizedLockedSize` fall back to current behavior until next minimize).
+
+### Option C — structural separation: minimized panes leave the flex tree
+
+The deeper redesign the current glitchiness is pointing at. A minimized pane stops being a
+flex node at all:
+
+- Each column (or tab) owns a **minimized dock**: an ordered list of block IDs rendered as
+  a fixed-height header strip *outside* the flex solver's domain (a sibling DOM region,
+  not a tree node). Minimize = remove leaf from tree (existing `delete_node` collapse
+  semantics — already battle-tested by `prune_dangling_block_refs`) + append to dock.
+  Restore = re-insert (existing insert-at-index machinery) + remove from dock.
+- **Everything in §4 becomes correct by construction.** The solver never sees a locked
+  node, so resize *cannot* touch one; there is no edge to suppress; move/split/swap
+  cannot target what isn't in the tree. I1–I3 stop being enforced invariants and become
+  type-level facts.
+- **The entire slip/dissolve apparatus is deleted:** `slipMinimize`, `columnDissolve`,
+  `_slipAnchor`, `_dissolveColumn`/`_undissolveColumn`, both `balanceNode` carve-outs,
+  and their restore-context bookkeeping. Column-dissolve behavior (headers migrating to a
+  neighbor when a column fully collapses) falls out naturally: an empty column's dock
+  docks onto the adjacent one.
+- Costs: a persisted-schema addition (`dock` list per tab/column) with a one-time
+  migration for trees currently containing minimize markers; frontend render work for the
+  dock strip; SPEC_864 single-writer treatment of dock membership in the Rust reducer.
+  Estimated scope: ~1–2 weeks including migration and both-sides tests.
+
+### Recommendation
+
+Do **B now** — it closes the reported hole and every adjacent one in the §4 table with the
+already-proven enforcement pattern, and it is not throwaway: the reducer-level rejection
+and affordance suppression survive into C unchanged. Then decide on **C** as its own
+spec'd effort; it is the honest fix for the glitchiness class (this is the "more
+sophisticated algorithm"), and every future minimize bug that B's snap-back absorbs is
+additional evidence for prioritizing it.
+
+## 6. Option B implementation notes (as shipped)
+
+- **"Locked"** = `minimizedSize` (minimized leaf) ∪ `slipMinimize` (slipped header) ∪
+  `columnDissolve` (dissolved column) — `isNodeLocked` (TS) / `is_node_locked` (Rust).
+- **Lock recording:** `minimizedLockedSize` written at all three squeeze sites (normal
+  minimize, slip, dissolve) and cleared at all three restore sites.
+- **Guards:** frontend `resizeNode`/`moveNode`/`swapNode`/`splitHorizontal`/`splitVertical`
+  reject locked targets (resize rejects the whole before/after pair — applying half would
+  leak flex units); Rust `resize_nodes`/`move_node`/`swap_nodes`/`split_impl` return the
+  new `LayoutError::NodeLocked`. `move` also rejects a locked *destination* (insertion
+  into a dissolved column).
+- **Snap-back:** `enforceMinimizedLocks` runs in `updateTree` before `balanceNode`;
+  `enforce_minimized_locks` runs at the same three reducer choke points as
+  `prune_dangling_block_refs`. Delta repaid to the nearest unlocked sibling.
+- **Affordance:** handle generation skips locked edges. This forced a latent-bug fix:
+  handle `parentIndex` was `resizeHandles.length`, correct only while every gap got a
+  handle — it is now the child-array index. The backwards `MinNodeSizePx` exemption in
+  `layoutResize.ts` is deleted (nothing left for it to serve) and a stale-handle guard
+  added at resize-context creation.
+- **Known limitations (deliberately out of B's scope, motivate C):**
+  - The lock is in flex units, so a minimized pane's *pixel* height still scales with
+    container resizes (pre-existing behavior). Pixel-true headers require either a
+    ratio-aware enforcement pass or Option C's dock.
+  - `findNextInsertLocation` (both sides) can still choose an insertion slot inside a
+    dissolved column for blind inserts; reducer-guarded paths reject it, but the
+    heuristic itself is not minimize-aware.
+
+## 7. Tracking
+
+Consolidated GitHub tracking issue: agentmuxai/agentmux#2179 (created 2026-07-16, this
+report attached). Supersedes stale issue #247 (macOS resize-cursor — root-caused against
+the pre-CEF WKWebView/tao stack, already flagged stale in triage 2026-06-15, confirmed
+working in 0.50.3).
+
+Merged history this consolidates:
+- PR #2036 — dead-space point fix (delete-saga frontend notification).
+- PR #2039 — `prune_dangling_block_refs` write-path invariant ("WRR-style").
+- PR #2176 — dissolved-column direction-flip guard in `balanceNode`/`balance_node`.
+- `docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`.

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -3,6 +3,7 @@
 
 import { batch } from "solid-js";
 import { balanceNode, walkNodes } from "./layoutNode";
+import { enforceMinimizedLocks, isNodeLocked } from "./layoutMinimize";
 import {
     FlexDirection,
     LayoutNode,
@@ -46,8 +47,14 @@ export function updateTree(model: LayoutModel, balanceTree = true) {
                 boundingRect,
                 resizeAction
             );
-        if (balanceTree) model.treeState.rootNode = balanceNode(model.treeState.rootNode, callback);
-        else walkNodes(model.treeState.rootNode, callback);
+        if (balanceTree) {
+            // Enforce minimize locks before balancing — same choke point, same
+            // rationale as the backend's prune/enforce pair: any writer that
+            // changed a locked node's size (stale tree push, unguarded mutation)
+            // is corrected here rather than trusted to have known about the lock.
+            enforceMinimizedLocks(model.treeState.rootNode);
+            model.treeState.rootNode = balanceNode(model.treeState.rootNode, callback);
+        } else walkNodes(model.treeState.rootNode, callback);
 
         // Process ephemeral node, if present.
         const ephemeralNode = model.getter(model.ephemeralNode);
@@ -157,9 +164,14 @@ function updateTreeHelper(
             treeKey: additionalProps.treeKey + i,
         };
 
-        // We only want the resize handles in between nodes, this ensures we have n-1 handles.
-        if (lastChildRect) {
-            const resizeHandleIndex = resizeHandles.length;
+        // We only want the resize handles in between nodes, this ensures we have at most
+        // n-1 handles. A locked edge (either flanking child minimized/slipped/dissolved)
+        // gets no handle at all — minimized is a locked state, so there is nothing for
+        // the user to resize there (I3 in the minimize locked-state spec). Because gaps
+        // can now be skipped, parentIndex must be the child-array index (i - 1), NOT
+        // resizeHandles.length — onResizeMove uses it to look up the flanking children.
+        if (lastChildRect && !isNodeLocked(node.children[i - 1]) && !isNodeLocked(child)) {
+            const resizeHandleIndex = i - 1;
             const halfResizeHandleSizePx = resizeHandleSizePx / 2;
             const resizeHandleDimensions: Dimensions = {
                 top: nodeIsRow

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -34,7 +34,7 @@ export function isNodeLocked(node: LayoutNode | undefined): boolean {
  * flex sizes are relative within the parent, so the locked nodes' shares stay
  * proportionally correct.
  */
-export function enforceMinimizedLocks(root: LayoutNode): number {
+export function enforceMinimizedLocks(root: LayoutNode | undefined): number {
     let snapped = 0;
     function walk(node: LayoutNode) {
         if (!node.children) return;
@@ -46,7 +46,11 @@ export function enforceMinimizedLocks(root: LayoutNode): number {
                     const beneficiary =
                         node.children!.slice(i + 1).find((c) => !isNodeLocked(c)) ??
                         node.children!.slice(0, i).reverse().find((c) => !isNodeLocked(c));
-                    if (beneficiary) beneficiary.size += delta;
+                    // Floor at 1 flex unit (same floor as the slip/undissolve
+                    // restore paths): a tampered size BELOW the lock makes the
+                    // delta negative, and the repayment must not drive the
+                    // beneficiary's size to zero or negative.
+                    if (beneficiary) beneficiary.size = Math.max(beneficiary.size + delta, 1);
                     snapped++;
                 }
             }

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -11,6 +11,53 @@ import { DefaultNodeSize, FlexDirection, type LayoutNodeAdditionalProps, type La
 export const HeaderHeightPx = 33;
 
 /**
+ * A locked node is one whose size is owned by the minimize subsystem: a minimized
+ * leaf (`minimizedSize`), a slipped header (`slipMinimize`), or a dissolved column
+ * (`columnDissolve`). No other writer may resize, move, swap, or split it, and no
+ * resize handle is rendered on its edges. See
+ * `docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`.
+ */
+export function isNodeLocked(node: LayoutNode | undefined): boolean {
+    if (!node) return false;
+    return node.minimizedSize !== undefined || node.slipMinimize !== undefined || node.columnDissolve !== undefined;
+}
+
+/**
+ * Write-point enforcement of the minimize lock: snap every locked node's `size`
+ * back to its recorded `minimizedLockedSize`, returning the delta to the nearest
+ * unlocked sibling (next preferred, then previous) so the parent's unit budget is
+ * conserved. Runs on every `updateTree` pass — the same choke point as
+ * `balanceNode` — so a locked size survives any writer that bypasses the reducer
+ * guards (stale tree pushes, direct mutations). Returns the number of snapped nodes.
+ *
+ * If every sibling is locked (inside a dissolved column) the delta is dropped:
+ * flex sizes are relative within the parent, so the locked nodes' shares stay
+ * proportionally correct.
+ */
+export function enforceMinimizedLocks(root: LayoutNode): number {
+    let snapped = 0;
+    function walk(node: LayoutNode) {
+        if (!node.children) return;
+        node.children.forEach((child, i) => {
+            if (isNodeLocked(child) && child.minimizedLockedSize !== undefined) {
+                const delta = child.size - child.minimizedLockedSize;
+                if (Math.abs(delta) > 1e-4) {
+                    child.size = child.minimizedLockedSize;
+                    const beneficiary =
+                        node.children!.slice(i + 1).find((c) => !isNodeLocked(c)) ??
+                        node.children!.slice(0, i).reverse().find((c) => !isNodeLocked(c));
+                    if (beneficiary) beneficiary.size += delta;
+                    snapped++;
+                }
+            }
+            walk(child);
+        });
+    }
+    if (root) walk(root);
+    return snapped;
+}
+
+/**
  * Toggle minimize for a given leaf node.
  *
  * There are three minimize paths:
@@ -81,6 +128,7 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
             if (rowNode.children) {
                 node.size = originalRowSize;
                 node.slipMinimize = undefined;
+                node.minimizedLockedSize = undefined;
                 rowNode._slipAnchor = undefined;
                 const idx = Math.min(originalRowIndex, rowNode.children.length);
                 rowNode.children.splice(idx, 0, node);
@@ -88,6 +136,7 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
         } else {
             console.warn(`[layoutMinimize] slip restore: target column ${targetColumnId} not found; dropping slip state`);
             node.slipMinimize = undefined;
+            node.minimizedLockedSize = undefined;
         }
 
         _finishToggle(model, nodeId, false);
@@ -157,6 +206,7 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
             sibling.size = siblingAfterReclaim;
         }
         node.minimizedSize = undefined;
+        node.minimizedLockedSize = undefined;
         _finishToggle(model, nodeId, false);
         return;
     }
@@ -175,6 +225,7 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
         if (freedUnits <= 0) return; // already tiny — no-op
         node.minimizedSize = node.size;
         node.size = headerSizeUnits;
+        node.minimizedLockedSize = headerSizeUnits;
         sibling.size += freedUnits;
 
         // If all children of the column are now minimized (leaves via minimizedSize/
@@ -273,6 +324,7 @@ function _slipMinimize(
 
     // Insert at top of the column.
     node.size = headerInColUnits;
+    node.minimizedLockedSize = headerInColUnits;
     sibling.children!.unshift(node);
     return true;
 }
@@ -377,6 +429,7 @@ function _dissolveColumn(
     // Use actualStolen (not totalHeaderUnits) to keep the size budget honest
     // when firstChild.size was clamped to the floor value.
     colNode.size = actualStolen;
+    colNode.minimizedLockedSize = actualStolen;
     sibling.children!.unshift(colNode);
 
     return true;
@@ -417,6 +470,7 @@ function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
     // Clear dissolve context only after confirming targetCol exists — clearing
     // it before the check would permanently lose restore context on a missing target.
     colNode.columnDissolve = undefined;
+    colNode.minimizedLockedSize = undefined;
 
     // Remove colNode from the host column; give its height back to the neighbor.
     const slipIdx = targetCol.children.findIndex((c) => c.id === colNode.id);

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -3,6 +3,7 @@
 
 import { debounce } from "throttle-debounce";
 import { findNode } from "./layoutNode";
+import { isNodeLocked } from "./layoutMinimize";
 import {
     FlexDirection,
     LayoutTreeActionType,
@@ -69,6 +70,11 @@ export function onResizeMove(model: LayoutModel, resizeHandle: ResizeHandleProps
         const beforeNode = parentNode.children![resizeHandle.parentIndex];
         const afterNode = parentNode.children![resizeHandle.parentIndex + 1];
 
+        // Minimized is a locked state: locked edges get no handle (layoutGeometry),
+        // but a stale handle from a pre-suppression frame could still deliver a drag
+        // here — refuse to build a resize context that flanks a locked node.
+        if (isNodeLocked(beforeNode) || isNodeLocked(afterNode)) return;
+
         const addlProps = model.getter(model.additionalProps);
         const pixelToSizeRatio = addlProps[resizeHandle.parentNodeId]?.pixelToSizeRatio;
         if (beforeNode && afterNode && pixelToSizeRatio) {
@@ -98,12 +104,7 @@ export function onResizeMove(model: LayoutModel, resizeHandle: ResizeHandleProps
     const beforeNodeSize = model.resizeContext.beforeNodeStartSize - clientDiff;
     const afterNodeSize = model.resizeContext.afterNodeStartSize + clientDiff;
 
-    // Minimized nodes can legitimately be smaller than MinNodeSizePx — skip the guard for them.
-    const beforeNode = findNode(model.treeState.rootNode, model.resizeContext.beforeNodeId);
-    const afterNode = findNode(model.treeState.rootNode, model.resizeContext.afterNodeId);
-    const beforeMinimized = beforeNode?.minimizedSize !== undefined;
-    const afterMinimized = afterNode?.minimizedSize !== undefined;
-    if ((!beforeMinimized && beforeNodeSize < minNodeSize) || (!afterMinimized && afterNodeSize < minNodeSize)) {
+    if (beforeNodeSize < minNodeSize || afterNodeSize < minNodeSize) {
         return;
     }
 

--- a/frontend/layout/lib/layoutTree.ts
+++ b/frontend/layout/lib/layoutTree.ts
@@ -32,6 +32,7 @@ import {
 } from "./types";
 
 import { newLayoutNode } from "./layoutNode";
+import { isNodeLocked } from "./layoutMinimize";
 import { LayoutTreeReplaceNodeAction, LayoutTreeSplitHorizontalAction, LayoutTreeSplitVerticalAction } from "./types";
 
 export const DEFAULT_MAX_CHILDREN = 5;
@@ -252,6 +253,13 @@ export function moveNode(layoutState: LayoutTreeState, action: LayoutTreeMoveNod
     const parent = findNode(rootNode, action.parentId);
     const oldParent = findParent(rootNode, action.node.id);
 
+    // Minimized is a locked state: a locked node can't be moved (restore it first),
+    // and nothing may be inserted into a dissolved column.
+    if (isNodeLocked(node) || isNodeLocked(parent)) {
+        console.warn("moveNode rejected: source or destination is minimize-locked");
+        return;
+    }
+
     let startingIndex = 0;
 
     // If moving under the same parent, we need to make sure that we are removing the child from its old position, not its new one.
@@ -347,6 +355,15 @@ export function swapNode(layoutState: LayoutTreeState, action: LayoutTreeSwapNod
         return;
     }
 
+    // Minimized is a locked state: locked nodes don't swap.
+    if (
+        isNodeLocked(findNode(layoutState.rootNode, action.node1Id)) ||
+        isNodeLocked(findNode(layoutState.rootNode, action.node2Id))
+    ) {
+        console.warn("swapNode rejected: a swap endpoint is minimize-locked");
+        return;
+    }
+
     const parentNode1 = findParent(layoutState.rootNode, action.node1Id);
     const parentNode2 = findParent(layoutState.rootNode, action.node2Id);
     const parentNode1Index = parentNode1.children!.findIndex((child) => child.id === action.node1Id);
@@ -395,6 +412,15 @@ export function resizeNode(layoutState: LayoutTreeState, action: LayoutTreeResiz
     if (!action.resizeOperations) {
         console.error("invalid resizeNode operation. nodeSizes array must be defined.");
     }
+    // Minimized is a locked state: reject the whole action if any target is locked.
+    // Resize ops come in before/after pairs whose unit sum is conserved — applying
+    // only the unlocked half would leak flex units, so it's all-or-nothing.
+    for (const resize of action.resizeOperations) {
+        if (isNodeLocked(findNode(layoutState.rootNode, resize.nodeId))) {
+            console.warn(`resizeNode rejected: node ${resize.nodeId} is minimize-locked`);
+            return;
+        }
+    }
     for (const resize of action.resizeOperations) {
         if (!resize.nodeId || resize.size < 0 || resize.size > 100) {
             console.error("invalid resizeNode operation. nodeId must be defined and size must be between 0 and 100");
@@ -403,7 +429,7 @@ export function resizeNode(layoutState: LayoutTreeState, action: LayoutTreeResiz
         const node = findNode(layoutState.rootNode, resize.nodeId);
         node.size = resize.size;
     }
-    
+
 }
 
 export function focusNode(layoutState: LayoutTreeState, action: LayoutTreeFocusNodeAction) {
@@ -502,6 +528,11 @@ export function splitHorizontal(layoutState: LayoutTreeState, action: LayoutTree
         console.error("splitHorizontal: Target node not found", targetNodeId);
         return;
     }
+    // Minimized is a locked state: splitting would spawn a full pane inside a header strip.
+    if (isNodeLocked(targetNode)) {
+        console.warn("splitHorizontal rejected: target is minimize-locked", targetNodeId);
+        return;
+    }
     const originalTargetSize = applySizeFraction(targetNode, newNode, sizeFraction);
 
     const parent = findParent(layoutState.rootNode, targetNodeId);
@@ -547,6 +578,11 @@ export function splitVertical(layoutState: LayoutTreeState, action: LayoutTreeSp
     const targetNode = findNode(layoutState.rootNode, targetNodeId);
     if (!targetNode) {
         console.error("splitVertical: Target node not found", targetNodeId);
+        return;
+    }
+    // Minimized is a locked state: splitting would spawn a full pane inside a header strip.
+    if (isNodeLocked(targetNode)) {
+        console.warn("splitVertical rejected: target is minimize-locked", targetNodeId);
         return;
     }
     const originalTargetSize = applySizeFraction(targetNode, newNode, sizeFraction);

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -209,6 +209,14 @@ export interface LayoutNode {
     /** Original size before minimization. Presence indicates the node is minimized. */
     minimizedSize?: number;
     /**
+     * The flex-unit size this node is locked to while minimized (header height in the
+     * parent's unit space at minimize time; for a dissolved column, the stacked-headers
+     * total). Written by the minimize subsystem alongside `minimizedSize`/`slipMinimize`/
+     * `columnDissolve`; `enforceMinimizedLocks` snaps `size` back to this value if any
+     * other writer changes it. Cleared on restore.
+     */
+    minimizedLockedSize?: number;
+    /**
      * Set when a pane was minimized from a solo Row slot (parent flex-direction = Row).
      * Instead of shrinking horizontally, the pane slips its header into the adjacent
      * column. Stores restore context so the operation is fully reversible.

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -513,5 +513,20 @@ describe("minimize lock — minimized is a locked state", () => {
         minimizeNodeToggle(model as any, paneA1.id);
         expect(enforceMinimizedLocks(root)).toBe(0);
     });
+
+    it("enforceMinimizedLocks clamps a negative-delta repayment at the 1-unit floor", () => {
+        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+        minimizeNodeToggle(model as any, paneA1.id);
+
+        // Tampered BELOW the lock: delta is negative, and the beneficiary is
+        // too small to absorb it — the repayment must clamp, not go negative.
+        paneA1.size = 5;
+        paneA2.size = 10;
+
+        expect(enforceMinimizedLocks(root)).toBe(1);
+        expect(paneA1.size).toBe(HeaderHeightPx);
+        expect(paneA2.size).toBe(1);
+    });
 });
 

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -3,7 +3,14 @@
 
 import { describe, expect, it } from "vitest";
 import { newLayoutNode } from "../lib/layoutNode";
-import { minimizeNodeToggle, rebuildMinimizedSet, HeaderHeightPx } from "../lib/layoutMinimize";
+import {
+    minimizeNodeToggle,
+    rebuildMinimizedSet,
+    enforceMinimizedLocks,
+    isNodeLocked,
+    HeaderHeightPx,
+} from "../lib/layoutMinimize";
+import { resizeNode, splitVertical } from "../lib/layoutTree";
 import { balanceNode } from "../lib/layoutNode";
 import { FlexDirection, type LayoutNode, type LayoutNodeAdditionalProps } from "../lib/types";
 
@@ -407,6 +414,104 @@ describe("dissolve bail cases", () => {
         // Both panes are still individually minimized
         expect(pane1.minimizedSize).toBeDefined();
         expect(pane2.minimizedSize).toBeDefined();
+    });
+});
+
+// ── Minimize lock (locked-state spec, 2026-07-16) ───────────────────────────
+
+describe("minimize lock — minimized is a locked state", () => {
+    it("records minimizedLockedSize on minimize and clears it on restore", () => {
+        const { root, colA, paneA1 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        expect(paneA1.minimizedLockedSize).toBe(HeaderHeightPx);
+        expect(paneA1.size).toBe(HeaderHeightPx);
+        expect(isNodeLocked(paneA1)).toBe(true);
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        expect(paneA1.minimizedLockedSize).toBeUndefined();
+        expect(isNodeLocked(paneA1)).toBe(false);
+    });
+
+    it("records minimizedLockedSize on the dissolved column and clears it on undissolve", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id); // triggers dissolve
+        expect(colA.minimizedLockedSize).toBe(colA.size);
+        expect(isNodeLocked(colA)).toBe(true);
+
+        minimizeNodeToggle(model as any, paneA2.id); // undissolves + restores
+        expect(colA.minimizedLockedSize).toBeUndefined();
+        expect(isNodeLocked(colA)).toBe(false);
+    });
+
+    it("resizeNode rejects the whole action when any target is locked (the reported bug)", () => {
+        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        const lockedSize = paneA1.size;
+        const siblingSize = paneA2.size;
+
+        resizeNode({ rootNode: root, pendingBackendActions: [] } as any, {
+            type: "resize" as any,
+            resizeOperations: [
+                { nodeId: paneA1.id, size: 90 },
+                { nodeId: paneA2.id, size: 10 },
+            ],
+        } as any);
+
+        // Atomic reject: neither side of the pair applied.
+        expect(paneA1.size).toBe(lockedSize);
+        expect(paneA2.size).toBe(siblingSize);
+    });
+
+    it("splitVertical rejects a locked target", () => {
+        const { root, colA, paneA1 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        const newNode = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "newPane" });
+        splitVertical({ rootNode: root, pendingBackendActions: [] } as any, {
+            type: "splitvertical" as any,
+            targetNodeId: paneA1.id,
+            newNode,
+            position: "after",
+        } as any);
+
+        // Tree unchanged: colA still has exactly its two original panes.
+        expect(colA.children).toHaveLength(2);
+        expect(paneA1.size).toBe(HeaderHeightPx);
+    });
+
+    it("enforceMinimizedLocks snaps a tampered minimized size back and repays the sibling", () => {
+        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        const siblingSize = paneA2.size;
+
+        // Simulate a writer that bypassed the reducer guards (stale tree push).
+        paneA1.size = 120;
+        paneA2.size = siblingSize - (120 - HeaderHeightPx);
+
+        const snapped = enforceMinimizedLocks(root);
+        expect(snapped).toBe(1);
+        expect(paneA1.size).toBe(HeaderHeightPx);
+        expect(paneA2.size).toBe(siblingSize);
+    });
+
+    it("enforceMinimizedLocks is a no-op on a tree that honors its locks", () => {
+        const { root, colA, paneA1 } = buildTwoColumnLayout();
+        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+        minimizeNodeToggle(model as any, paneA1.id);
+        expect(enforceMinimizedLocks(root)).toBe(0);
     });
 });
 


### PR DESCRIPTION
## Summary

A minimized pane was freely resizable — dragging the adjacent handle overwrote its header-height size while the minimize state still said "minimized," corrupting the restore arithmetic and persisting the broken state through `db_layout`. The one minimize-aware line in the resize path was aware **backwards**: `layoutResize.ts` exempted minimized nodes from the `MinNodeSizePx` guard so adjacent handles would keep working, which is exactly what made the lock draggable. An audit (spec §4) found every other mutation surface — move/swap/split/DnD on the frontend, `resize_nodes`/`move_node`/`swap_nodes`/`split_impl` on the backend — entirely minimize-blind.

Implements **Option B** of `docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md` (included in this PR), tracked in #2179. Same enforcement shape as `prune_dangling_block_refs` (#2039): the invariant lives at the write choke points, not in each caller.

## Changes

- **Lock definition:** `isNodeLocked` (TS) / `is_node_locked` (Rust) — locked = `minimizedSize` (minimized leaf) ∪ `slipMinimize` (slipped header) ∪ `columnDissolve` (dissolved column).
- **Lock recording:** new `minimizedLockedSize` field written at all three squeeze sites (normal minimize, slip, dissolve), cleared at all three restore sites. Additive — old persisted trees simply lack it until the next minimize.
- **Reducer guards (both sides):** frontend `resizeNode`/`moveNode`/`swapNode`/`splitHorizontal`/`splitVertical` reject locked targets; resize rejects the whole before/after pair (applying half would leak flex units). Rust `resize_nodes`/`move_node`/`swap_nodes`/`split_impl` return the new `LayoutError::NodeLocked`; `move_node` also rejects a locked *destination* (insertion into a dissolved column). This closes the agent/API path that never touches the frontend.
- **Snap-back enforcement:** `enforceMinimizedLocks` runs in `updateTree` before `balanceNode`; `enforce_minimized_locks` runs at the reducer's set-tree / insert-at-index / `apply_atomic` sites right after the prune. A tampered locked size is snapped back and the delta repaid to the nearest unlocked sibling, so the parent's flex budget is conserved.
- **Affordance suppression:** resize handles are no longer generated on locked edges. This surfaced a latent bug: handle `parentIndex` was `resizeHandles.length`, correct only while every gap got a handle — now it's the child-array index (its only consumer, `onResizeMove`, looks up flanking children by it). The backwards `MinNodeSizePx` exemption is deleted (nothing left for it to serve — the guard is unconditional again) and a stale-handle guard added at resize-context creation.

## Known limitations (spec §6, deliberate)

- Lock is in flex units: minimized pixel height still scales with container resizes (pre-existing). Pixel-true headers need Option C's dock (or a ratio-aware pass).
- `findNextInsertLocation`'s heuristic is still not minimize-aware for blind inserts.

## Test plan

- [x] 7 new Rust tests: guard rejections for resize/move (source + destination)/swap/split, snap-back + redistribution, no-op on clean trees, and a reducer-level end-to-end (`layout_set_tree_snaps_tampered_minimized_size_back_to_its_lock`) proving the choke-point wiring and that the emitted event carries the healed tree.
- [x] 6 new vitest tests: lock recording/clearing (leaf + dissolved column), atomic resize rejection (the reported bug), split rejection, snap-back + sibling repayment, no-op.
- [x] Full `cargo test --bin agentmux-srv`: 1498 passed.
- [x] Full `npx vitest run frontend/layout`: 89 passed.

Refs #2179.