### PR TITLE
fix(cef): recover host bridge on reload for floating-pane/pool windows (#52)

### DIFF
--- a/.changesets/1784195930-fix-cef-reinject-ipc-creds-for-our-frontend-pool-windows.md
+++ b/.changesets/1784195930-fix-cef-reinject-ipc-creds-for-our-frontend-pool-windows.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+fix(cef): re-inject host IPC creds on every load of our-frontend windows (fixes floating-pane/pool bridge-init lock-out)
+
+on_load_end gated IPC-cred injection on `!is_browser_pane`, which starved floating-pane/pool windows (flagged is_browser_pane but hosting our own frontend). The frontend strips ipc_port/ipc_token from the URL after first read (token-leak fix), so after any reload (Vite HMR, WebGL context-loss reload, bridge auto-recover) those windows arrived cred-less and could never rebuild window.api — the permanent "window.api still undefined after 5s" blank + ~5s reload storm (#52). Now gate injection on frame ORIGIN: inject when the main frame is on our frontend origin (covers floating-pane/pool + main), never for a real remote browser pane (preserves the bearer-token leak protection).

--- a/.changesets/1784195930-fix-cef-reinject-ipc-creds-for-our-frontend-pool-windows.md
+++ b/.changesets/1784195930-fix-cef-reinject-ipc-creds-for-our-frontend-pool-windows.md
@@ -2,6 +2,6 @@
 type: patch
 ---
 
-fix(cef): re-inject host IPC creds on every load of our-frontend windows (fixes floating-pane/pool bridge-init lock-out)
+fix(cef): recover host bridge on reload for floating-pane/pool windows (#52)
 
-on_load_end gated IPC-cred injection on `!is_browser_pane`, which starved floating-pane/pool windows (flagged is_browser_pane but hosting our own frontend). The frontend strips ipc_port/ipc_token from the URL after first read (token-leak fix), so after any reload (Vite HMR, WebGL context-loss reload, bridge auto-recover) those windows arrived cred-less and could never rebuild window.api — the permanent "window.api still undefined after 5s" blank + ~5s reload storm (#52). Now gate injection on frame ORIGIN: inject when the main frame is on our frontend origin (covers floating-pane/pool + main), never for a real remote browser pane (preserves the bearer-token leak protection).
+Two-part fix for the "window.api still undefined after 5s" blank + ~5s reload storm on floating-pool windows. (1) Host: on_load_end gated IPC-cred injection on `!is_browser_pane`, starving floating-pane/pool windows (flagged is_browser_pane but hosting our own frontend). Now gate on frame ORIGIN so those windows get creds re-injected on every load, while a real remote browser pane still never receives the bearer token. (2) Frontend: setupCefApi strips ipc_port/ipc_token from the URL after first read, so on reload isCef() saw no creds and bailed before awaiting the re-injection. isCef() now remembers "we are CEF" in sessionStorage (set on first ipc_port sighting), surviving the strip and any reload so setupCefApi reaches waitForIpcCreds and picks up the host re-injection.

--- a/agentmux-cef/src/client/crash_recovery.rs
+++ b/agentmux-cef/src/client/crash_recovery.rs
@@ -99,7 +99,7 @@ impl AgentMuxHandler {
                     // memory-pause history untouched and fall through to the
                     // normal path, which has the assets-missing handling.
                     if let Ok(base_url) =
-                        crate::commands::window::resolve_frontend_base_url(self.ipc_port)
+                        crate::commands::window::resolve_frontend_base_url(self.resolved_ipc_port())
                     {
                         let now = Instant::now();
                         let hist = self.memory_pause_history.entry(bid).or_default();
@@ -217,12 +217,12 @@ impl AgentMuxHandler {
         // URL when possible. as_deref().cloned() borrows browser (a clone),
         // leaving the original intact for the load below. (codex P2 #1229.)
         let mut recovery_owned = browser.as_deref().cloned();
-        let app_url = match crate::commands::window::resolve_frontend_base_url(self.ipc_port) {
+        let app_url = match crate::commands::window::resolve_frontend_base_url(self.resolved_ipc_port()) {
             Ok(base_url) => match recovery_owned.as_mut() {
                 Some(owned) => self.recovery_target_url(owned, &base_url),
                 None => recovery_navigation_url(
                     &base_url,
-                    self.ipc_port,
+                    self.resolved_ipc_port(),
                     &self.state.ipc_token,
                     None,
                 ),

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -184,6 +184,21 @@ impl AgentMuxHandler {
         }))
     }
 
+    /// The authoritative IPC port for URL / cred construction.
+    ///
+    /// The handler's own `self.ipc_port` field is ZERO for floating-pane /
+    /// pool window handlers — they are built via
+    /// `new_with_browser_pane(state, 0, true)`. Any URL or cred built from
+    /// that 0 (bridge re-injection, crash-recovery navigation URL, base-URL
+    /// resolve) yields `…:0`, which the frontend's `invokeCommand` rejects
+    /// (`if (!port)`) → the backend-never-starts lock-out (#52). `AppState`
+    /// holds the real port (set at startup), so read it there. For non-pane
+    /// windows `self.ipc_port` already equals `state.ipc_port`, so this is a
+    /// no-op change for them.
+    fn resolved_ipc_port(&self) -> u16 {
+        *self.state.ipc_port.lock()
+    }
+
     /// Reverse-lookup this browser's window label from the reducer's browsers
     /// map (label → browser), by object identity. Mirrors the find-by-identity
     /// loop in `on_before_close`. Used by the crash-recovery navigation so a
@@ -225,6 +240,6 @@ impl AgentMuxHandler {
             return u;
         }
         let label = self.window_label_for(owned);
-        recovery_pages::recovery_navigation_url(base_url, self.ipc_port, &self.state.ipc_token, label.as_deref())
+        recovery_pages::recovery_navigation_url(base_url, self.resolved_ipc_port(), &self.state.ipc_token, label.as_deref())
     }
 }

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -231,16 +231,11 @@ impl AgentMuxHandler {
             .as_ref()
             .and_then(|b| b.main_frame().map(|f| CefString::from(&f.url()).to_string()))
             .unwrap_or_default();
-        // Use the AUTHORITATIVE port from AppState, not `self.ipc_port`.
-        // Floating-pane / pool window handlers are constructed with
-        // `new_with_browser_pane(state, 0, true)` — their `self.ipc_port` is
-        // ZERO. Injecting 0 makes the frontend's invokeCommand reject the
-        // creds (`if (!port)`) and time out on get_backend_endpoints, so the
-        // re-injection must carry the real IPC port that `state.ipc_port`
-        // holds. (The old code only injected for non-pane windows, whose
-        // `self.ipc_port` happens to be correct, which is why this never
-        // surfaced before.)
-        let ipc_port = *self.state.ipc_port.lock();
+        // Authoritative port (self.ipc_port is 0 for floating-pane/pool
+        // handlers — see resolved_ipc_port). Injecting 0 would make the
+        // frontend's invokeCommand reject the creds and time out on
+        // get_backend_endpoints (#52).
+        let ipc_port = self.resolved_ipc_port();
         // Non-pane windows (main + secondary app windows) always load our
         // frontend → inject unconditionally (unchanged behavior; `||`
         // short-circuits so the common path skips the origin resolve). Only

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -231,25 +231,35 @@ impl AgentMuxHandler {
             .as_ref()
             .and_then(|b| b.main_frame().map(|f| CefString::from(&f.url()).to_string()))
             .unwrap_or_default();
+        // Use the AUTHORITATIVE port from AppState, not `self.ipc_port`.
+        // Floating-pane / pool window handlers are constructed with
+        // `new_with_browser_pane(state, 0, true)` — their `self.ipc_port` is
+        // ZERO. Injecting 0 makes the frontend's invokeCommand reject the
+        // creds (`if (!port)`) and time out on get_backend_endpoints, so the
+        // re-injection must carry the real IPC port that `state.ipc_port`
+        // holds. (The old code only injected for non-pane windows, whose
+        // `self.ipc_port` happens to be correct, which is why this never
+        // surfaced before.)
+        let ipc_port = *self.state.ipc_port.lock();
         // Non-pane windows (main + secondary app windows) always load our
         // frontend → inject unconditionally (unchanged behavior; `||`
         // short-circuits so the common path skips the origin resolve). Only
         // `is_browser_pane` windows need the origin gate to separate our
         // floating-pane/pool windows from real remote browser panes.
         let should_inject = !self.is_browser_pane
-            || crate::commands::window::resolve_frontend_base_url(self.ipc_port)
+            || crate::commands::window::resolve_frontend_base_url(ipc_port)
                 .map(|base| super::recovery_pages::url_on_origin(&frame_url, &base))
                 .unwrap_or(false);
         if should_inject {
             let ipc_token = &self.state.ipc_token;
             let js = format!(
                 "window.__AGENTMUX_IPC_PORT__ = {}; window.__AGENTMUX_IPC_TOKEN__ = '{}';",
-                self.ipc_port, ipc_token
+                ipc_port, ipc_token
             );
             let code = CefString::from(js.as_str());
             let empty = CefString::from("");
             frame.execute_java_script(Some(&code), Some(&empty), 0);
-            tracing::info!("Injected IPC port {} into page: {}", self.ipc_port, frame_url);
+            tracing::info!("Injected IPC port {} into page: {}", ipc_port, frame_url);
         }
 
         // Pane-specific on_load_end work (focus subclass re-install after

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -209,35 +209,60 @@ impl AgentMuxHandler {
             return;
         }
 
+        // Re-inject the host IPC creds on EVERY main-frame load of OUR OWN
+        // frontend — crucially INCLUDING `is_browser_pane` floating-pane /
+        // pool windows, which host our frontend (on our localhost origin)
+        // but were starved of creds by the old `!is_browser_pane` gate.
+        //
+        // Why every load, not just the first: the frontend strips
+        // `ipc_port`/`ipc_token` from the URL after reading them once
+        // (cef-init.ts token-leak fix), so any reload (Vite HMR, WebGL
+        // context-loss reload, or the bridge auto-recover itself) arrives
+        // cred-less. Without re-injection, `setupCefApi` can't rebuild
+        // `window.api` → the permanent "window.api still undefined after 5s"
+        // blank + ~5s reload storm observed on floating-pool windows (#52).
+        //
+        // Gate on frame ORIGIN, not the pane flag: inject only when the
+        // loading main frame is on our frontend origin. A real browser pane
+        // rendering a remote site (example.com) is a different origin and
+        // still never receives the bearer token — preserving exactly the
+        // leak protection the `is_browser_pane` gate was meant to provide.
+        let frame_url = browser
+            .as_ref()
+            .and_then(|b| b.main_frame().map(|f| CefString::from(&f.url()).to_string()))
+            .unwrap_or_default();
+        // Non-pane windows (main + secondary app windows) always load our
+        // frontend → inject unconditionally (unchanged behavior; `||`
+        // short-circuits so the common path skips the origin resolve). Only
+        // `is_browser_pane` windows need the origin gate to separate our
+        // floating-pane/pool windows from real remote browser panes.
+        let should_inject = !self.is_browser_pane
+            || crate::commands::window::resolve_frontend_base_url(self.ipc_port)
+                .map(|base| super::recovery_pages::url_on_origin(&frame_url, &base))
+                .unwrap_or(false);
+        if should_inject {
+            let ipc_token = &self.state.ipc_token;
+            let js = format!(
+                "window.__AGENTMUX_IPC_PORT__ = {}; window.__AGENTMUX_IPC_TOKEN__ = '{}';",
+                self.ipc_port, ipc_token
+            );
+            let code = CefString::from(js.as_str());
+            let empty = CefString::from("");
+            frame.execute_java_script(Some(&code), Some(&empty), 0);
+            tracing::info!("Injected IPC port {} into page: {}", self.ipc_port, frame_url);
+        }
+
         // Pane-specific on_load_end work (focus subclass re-install after
-        // Chromium rebuilds Chrome_RenderWidgetHostHWND on navigation)
-        // lives in `crate::browser_pane::callbacks` after Phase 4. Returning early
-        // skips main-only IPC-port injection below.
+        // Chromium rebuilds Chrome_RenderWidgetHostHWND on navigation).
+        // Runs AFTER cred injection so a floating-pane window gets BOTH the
+        // bridge and its focus fix; a real remote browser pane falls through
+        // here having received no creds (origin didn't match above).
         if self.is_browser_pane {
             if let Some(b) = browser.as_deref() {
                 crate::browser_pane::callbacks::on_load_end_browser_pane(&self.state, b);
             }
             return;
         }
-
-        let ipc_token = &self.state.ipc_token;
-        let js = format!(
-            "window.__AGENTMUX_IPC_PORT__ = {}; window.__AGENTMUX_IPC_TOKEN__ = '{}';",
-            self.ipc_port, ipc_token
-        );
-        let code = CefString::from(js.as_str());
-        let url = CefString::from("");
-        frame.execute_java_script(Some(&code), Some(&url), 0);
-
-        let url_str = browser
-            .as_ref()
-            .and_then(|b| b.main_frame().map(|f| CefString::from(&f.url()).to_string()))
-            .unwrap_or_default();
-        tracing::info!(
-            "Injected IPC port {} into page: {}",
-            self.ipc_port,
-            url_str
-        );
 
         // Signal the pre-splash to fade out the moment CEF's first frame
         // is ready. The launcher created this named event and forwarded

--- a/frontend/util/cef-api.test.ts
+++ b/frontend/util/cef-api.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { isCef } from "./cef-api";
+
+// ── isCef — #52 reload lock-out fix ──────────────────────────────────────────
+//
+// setupCefApi strips ipc_port/ipc_token from the URL after first read
+// (token-leak fix). On a reload the URL has no ipc_port and the host global
+// hasn't been re-injected yet, so plain isCef() would return false and
+// setupCefApi would bail before awaiting the host's on_load_end re-injection —
+// the floating-pool "window.api still undefined after 5s" lock-out. The sticky
+// sessionStorage flag (set the moment we first see ipc_port) survives the strip
+// and any reload so isCef() stays true and setupCefApi reaches waitForIpcCreds.
+
+describe("isCef", () => {
+    const clear = () => {
+        try { sessionStorage.clear(); } catch { /* ignore */ }
+        delete (window as unknown as { __AGENTMUX_IPC_PORT__?: number }).__AGENTMUX_IPC_PORT__;
+        window.history.replaceState({}, "", "/");
+    };
+    beforeEach(clear);
+    afterEach(clear);
+
+    test("plain browser (no creds anywhere) → false", () => {
+        expect(isCef()).toBe(false);
+    });
+
+    test("first load with ipc_port in URL → true, and remembers it in sessionStorage", () => {
+        window.history.replaceState({}, "", "/?ipc_port=51234&windowLabel=main");
+        expect(isCef()).toBe(true);
+        expect(sessionStorage.getItem("amux:isCef")).toBe("1");
+    });
+
+    test("reload after cred-strip stays true via the sticky flag (the #52 fix)", () => {
+        // First load sees ipc_port → sets the flag.
+        window.history.replaceState({}, "", "/?ipc_port=51234");
+        expect(isCef()).toBe(true);
+        // Strip + reload: ipc_port gone from URL, host global not yet re-injected.
+        window.history.replaceState({}, "", "/?windowLabel=floating-pool-abc&pane-pool=1");
+        delete (window as unknown as { __AGENTMUX_IPC_PORT__?: number }).__AGENTMUX_IPC_PORT__;
+        // Without the sessionStorage flag this would be false → bail → lock-out.
+        expect(isCef()).toBe(true);
+    });
+
+    test("host-injected global present → true", () => {
+        (window as unknown as { __AGENTMUX_IPC_PORT__?: number }).__AGENTMUX_IPC_PORT__ = 51234;
+        expect(isCef()).toBe(true);
+    });
+});

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -748,9 +748,29 @@ export function buildCefApi(): AppApi {
 
 /**
  * Detect whether we're running inside a CEF host.
- * Checks URL query params first (available immediately), then window globals.
+ *
+ * Checks, in order: the `ipc_port` URL param (present only on first load),
+ * the injected window global, then a sticky `sessionStorage` flag.
+ *
+ * The sessionStorage flag closes the #52 reload lock-out: `setupCefApi`
+ * strips `ipc_port`/`ipc_token` from the URL after first read (token-leak
+ * fix), so after ANY reload (Vite HMR, WebGL context-loss reload, bridge
+ * auto-recover) neither the URL param nor the not-yet-re-injected global is
+ * present — plain `isCef()` would return false and `setupCefApi` would bail
+ * BEFORE `waitForIpcCreds`, so the host's `on_load_end` re-injection is
+ * never awaited and `window.api` never rebuilds. Remembering "we are CEF"
+ * in sessionStorage (set the moment we first see `ipc_port`) survives the
+ * strip and any `history.replaceState` (e.g. pool promote), and is
+ * per-browsing-context so it never leaks between windows or to a plain
+ * browser tab (which never sees `ipc_port`).
  */
 export function isCef(): boolean {
-    return new URLSearchParams(window.location.search).has("ipc_port")
-        || typeof window.__AGENTMUX_IPC_PORT__ !== "undefined";
+    if (new URLSearchParams(window.location.search).has("ipc_port")) {
+        try { sessionStorage.setItem("amux:isCef", "1"); } catch { /* storage disabled */ }
+        return true;
+    }
+    if (typeof window.__AGENTMUX_IPC_PORT__ !== "undefined") {
+        return true;
+    }
+    try { return sessionStorage.getItem("amux:isCef") === "1"; } catch { return false; }
 }


### PR DESCRIPTION
Fixes the floating-pane/pool **bridge-init lock-out** (#52): a warmed pool window that reloads (Vite HMR, WebGL context-loss reload, or the bridge auto-recover itself) comes back blank with `[initApp] window.api still undefined after 5s` and reload-storms every ~5s forever. The user hit this twice as "a window went blank."

## Root cause — three compounding layers

1. **Host skips cred injection for `is_browser_pane`** (`navigation.rs`). Floating-pane/pool windows are flagged `is_browser_pane` but host *our own frontend*. `on_load_end` injected `__AGENTMUX_IPC_PORT__`/token only when `!is_browser_pane`, so these windows never got creds re-injected.
2. **Frontend strips creds from the URL** after first read (`cef-init.ts`, token-leak fix), then on reload `isCef()` saw no `ipc_port` param and the not-yet-re-injected global → returned false → `setupCefApi` **bailed before `waitForIpcCreds`**, never awaiting the re-injection.
3. **Pool handlers carry `self.ipc_port = 0`** (`new_with_browser_pane(state, 0, true)`). Even once (1) injected, it injected port `0`, which `invokeCommand` rejects (`if (!port)`) → `get_backend_endpoints` fails → `initCefApi` falls into the one-time `backend-ready` wait → `Backend failed to start within 30s`.

## Fix

1. **`navigation.rs`**: gate injection on frame **origin** (`url_on_origin` + `resolve_frontend_base_url`) instead of the pane flag — inject for any main frame on our frontend origin (main + floating/pool), never for a real remote browser pane (preserves the bearer-token leak protection).
2. **`cef-api.ts` `isCef()`**: set a sticky `sessionStorage` flag on first `ipc_port` sighting and read it as a fallback — survives the strip + any reload/`replaceState`, so `setupCefApi` reaches `waitForIpcCreds`. Per-browsing-context (no cross-window/plain-browser leak). +4 unit tests.
3. **`navigation.rs`**: inject the authoritative `state.ipc_port` (Mutex, set at startup), not the handler's `self.ipc_port` which is `0` for pool windows.

## Verification (live, CDP-driven)

Rebuilt host + reproduced the exact failure on a `floating-pool&pane-pool=1` window: strip `ipc_port`/`ipc_token`, reload, check `window.api`.

- **Before fix**: `hasApi=false`, `globalPort=0`; host log `Backend failed to start within 30s`.
- **After fix**: `hasApi=true`; host log `[cef-api] Backend already ready` → `[cef-init] window.api installed`. Clean recovery on repeated reloads.

`cargo check -p agentmux-cef` clean, `tsc --noEmit` clean, 4/4 `isCef` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)