### PR TITLE
feat(layout): layout doctor diagnostics + last-expanded-pane minimize guard

### DIFF
--- a/.changesets/1784213298-feat-layout-layout-doctor-invariant-diagnostics-last-expande-hr8s.md
+++ b/.changesets/1784213298-feat-layout-layout-doctor-invariant-diagnostics-last-expande-hr8s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(layout): layout doctor invariant diagnostics + last-expanded-pane minimize guard

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -274,6 +274,122 @@ pub fn enforce_minimized_locks(root: &mut Option<LayoutNode>) -> usize {
     root.as_mut().map_or(0, walk)
 }
 
+/// Layout doctor — structural invariant validation, mirroring
+/// `validateLayoutInvariants` in `frontend/layout/lib/layoutInvariants.ts`
+/// (keep the check lists in sync). Returns human-readable violation strings;
+/// empty = healthy. Never mutates. Reducer choke points call this after
+/// prune/enforce and `tracing::error!` any findings, so a corrupted tree is
+/// attributed to the write that produced it instead of being reconstructed
+/// later from db_layout archaeology (issue #2179).
+pub fn validate_layout_invariants(root: &Option<LayoutNode>) -> Vec<String> {
+    let mut violations = Vec::new();
+    fn short(id: &str) -> &str {
+        &id[..id.len().min(8)]
+    }
+    fn walk(node: &LayoutNode, is_root: bool, violations: &mut Vec<String>) {
+        let is_branch = !node.children.is_empty();
+        let is_leaf = node.data.is_some();
+        let has = |k: &str| node.extra.contains_key(k);
+
+        // I1 — leaf XOR branch.
+        if is_branch == is_leaf {
+            violations.push(format!(
+                "LEAF_XOR_BRANCH @ {}: data {}, children {}",
+                short(&node.id),
+                if is_leaf { "present" } else { "absent" },
+                if is_branch { "present" } else { "absent" }
+            ));
+        }
+        // I2 — minimizedSize / slipMinimize are leaf-only markers.
+        if is_branch && (has("minimizedSize") || has("slipMinimize")) {
+            violations.push(format!(
+                "MIN_MARKER_ON_BRANCH @ {}: branch has {}",
+                short(&node.id),
+                if has("minimizedSize") { "minimizedSize" } else { "slipMinimize" }
+            ));
+        }
+        // I3 — columnDissolve is branch-only.
+        if !is_branch && has("columnDissolve") {
+            violations.push(format!("DISSOLVE_ON_LEAF @ {}", short(&node.id)));
+        }
+        // I4 — a dissolved column must stack vertically (#2176 signature).
+        if has("columnDissolve") && node.flex_direction != FlexDirection::Column {
+            violations.push(format!(
+                "DISSOLVED_NOT_COLUMN @ {}: flex_direction={:?}",
+                short(&node.id),
+                node.flex_direction
+            ));
+        }
+        // I5 — every child of a dissolved column is itself locked.
+        if has("columnDissolve") {
+            for c in &node.children {
+                if !is_node_locked(c) {
+                    violations.push(format!(
+                        "DISSOLVED_CHILD_UNLOCKED @ {}: inside dissolved column {}",
+                        short(&c.id),
+                        short(&node.id)
+                    ));
+                }
+            }
+        }
+        let locked_size = node.extra.get("minimizedLockedSize").and_then(|v| v.as_f64());
+        // I6 — a locked node's size honors its recorded lock (#2180).
+        if is_node_locked(node) {
+            if let Some(ls) = locked_size {
+                if (node.size - ls as f32).abs() > 1e-4 {
+                    violations.push(format!(
+                        "LOCK_SIZE_MISMATCH @ {}: size={} locked={}",
+                        short(&node.id),
+                        node.size,
+                        ls
+                    ));
+                }
+            }
+        } else if locked_size.is_some() {
+            // I7 — minimizedLockedSize must not outlive its lock marker.
+            violations.push(format!("ORPHAN_LOCKED_SIZE @ {}", short(&node.id)));
+        }
+        // I8 — sizes are positive.
+        if !is_root && !(node.size > 0.0) {
+            violations.push(format!("NONPOSITIVE_SIZE @ {}: size={}", short(&node.id), node.size));
+        }
+        for c in &node.children {
+            walk(c, false, violations);
+        }
+    }
+    if let Some(tree) = root {
+        walk(tree, true, &mut violations);
+        // I9 — at least one pane stays expanded. A tree whose every leaf is
+        // minimize-locked is an all-headers window with nothing restorable
+        // in view; the frontend's minimize toggle guards against producing
+        // this (`countExpandedLeaves` in layoutMinimize.ts).
+        fn count_leaves(node: &LayoutNode, leaves: &mut usize, expanded: &mut usize) {
+            if node.children.is_empty() {
+                if node.data.is_some() {
+                    *leaves += 1;
+                    if !is_node_locked(node) {
+                        *expanded += 1;
+                    }
+                }
+                return;
+            }
+            for c in &node.children {
+                count_leaves(c, leaves, expanded);
+            }
+        }
+        let (mut leaves, mut expanded) = (0usize, 0usize);
+        count_leaves(tree, &mut leaves, &mut expanded);
+        if leaves > 0 && expanded == 0 {
+            violations.push(format!(
+                "ALL_LEAVES_LOCKED @ {}: all {} leaves are minimize-locked; no expanded pane remains",
+                &tree.id[..tree.id.len().min(8)],
+                leaves
+            ));
+        }
+    }
+    violations
+}
+
 /// First leaf (depth-first) whose `data.block_id` is set but not present in
 /// `live_block_ids`. `data.block_id` is only ever non-empty on leaves —
 /// container/group nodes have `data: None` (see `ensure_group_node`).

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -451,6 +451,101 @@ fn insert_node_at_index_rejects_locked_resolution() {
 }
 
 #[test]
+fn validate_invariants_clean_on_healthy_locked_tree() {
+    let root = Some(group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![locked_leaf("l1", "b1", 33.0), leaf("l2", "b2", 367.0)],
+    ));
+    assert!(validate_layout_invariants(&root).is_empty());
+    assert!(validate_layout_invariants(&None).is_empty());
+}
+
+#[test]
+fn validate_invariants_flags_the_recovered_0_53_6_corruption() {
+    // Fixture: the exact corrupted shape recovered from a live v0.53.6
+    // instance's db_layout (issue #2179) — a BRANCH carrying the leaf-only
+    // `minimizedSize` marker, with a slipped leaf trapped inside it.
+    let mut term = leaf("term", "b-term", 2.2);
+    term.extra
+        .insert("slipMinimize".into(), serde_json::json!({"targetColumnId": "x"}));
+    let agent = leaf("agent", "b-agent", 4.4);
+    let mut mid = group("mid", FlexDirection::Row, 6.8, vec![term, agent]);
+    mid.extra.insert("minimizedSize".into(), serde_json::json!(9.0));
+    let mut outer = group("outer", FlexDirection::Column, 30.0, vec![mid]);
+    outer.extra.insert("_slipAnchor".into(), serde_json::Value::Bool(true));
+    let root = Some(group(
+        "root",
+        FlexDirection::Row,
+        10.0,
+        vec![outer, leaf("armory", "b-armory", 10.0)],
+    ));
+
+    let violations = validate_layout_invariants(&root);
+    assert!(
+        violations.iter().any(|v| v.starts_with("MIN_MARKER_ON_BRANCH")),
+        "expected MIN_MARKER_ON_BRANCH, got: {:?}",
+        violations
+    );
+}
+
+#[test]
+fn validate_invariants_flags_all_leaves_locked() {
+    // Every leaf minimize-locked = an all-headers window with nothing
+    // restorable in view (the frontend's last-expanded-pane guard exists to
+    // prevent exactly this).
+    let root = Some(group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![locked_leaf("l1", "b1", 33.0), locked_leaf("l2", "b2", 33.0)],
+    ));
+    let violations = validate_layout_invariants(&root);
+    assert!(
+        violations.iter().any(|v| v.starts_with("ALL_LEAVES_LOCKED")),
+        "expected ALL_LEAVES_LOCKED, got: {:?}",
+        violations
+    );
+    // A healthy mixed tree does not trip it (covered by
+    // validate_invariants_clean_on_healthy_locked_tree).
+}
+
+#[test]
+fn validate_invariants_flags_flipped_dissolve_lock_mismatch_and_intruder() {
+    // A dissolved column with Row direction (#2176 signature), a tampered
+    // locked size, and an unlocked zero-size intruder child.
+    let mut tampered = locked_leaf("l1", "b1", 33.0);
+    tampered.size = 120.0;
+    let intruder = leaf("l9", "b9", 0.0);
+    let mut dissolved = group("colA", FlexDirection::Row, 66.0, vec![tampered, intruder]);
+    dissolved
+        .extra
+        .insert("columnDissolve".into(), serde_json::json!({"targetColumnId": "host"}));
+    let root = Some(group(
+        "host",
+        FlexDirection::Column,
+        400.0,
+        vec![dissolved, leaf("content", "b3", 300.0)],
+    ));
+
+    let violations = validate_layout_invariants(&root);
+    for expected in [
+        "DISSOLVED_NOT_COLUMN",
+        "LOCK_SIZE_MISMATCH",
+        "DISSOLVED_CHILD_UNLOCKED",
+        "NONPOSITIVE_SIZE",
+    ] {
+        assert!(
+            violations.iter().any(|v| v.starts_with(expected)),
+            "expected {}, got: {:?}",
+            expected,
+            violations
+        );
+    }
+}
+
+#[test]
 fn balance_drops_empty_branch_child() {
     // Row[ leaf1, leaf2, empty-branch ] → empty branch dropped, 2 remain.
     let mut node = group(

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -148,6 +148,16 @@ pub(super) fn handle_layout_set_tree(
             "reducer: LayoutSetTree snapped minimize-locked node size(s) back to their locked values"
         );
     }
+    // Layout doctor (issue #2179): loudly attribute any surviving structural
+    // corruption to this write instead of letting it persist silently.
+    let violations = crate::backend::layout::validate_layout_invariants(&tab.rootnode);
+    if !violations.is_empty() {
+        tracing::error!(
+            tab_id = %tab_id,
+            violations = ?violations,
+            "layout-doctor: invariant violation(s) in tree persisted by LayoutSetTree"
+        );
+    }
     let new_tree = tab.rootnode.clone();
     let v = state.bump_version();
     vec![Event::LayoutTreeReplaced {
@@ -761,6 +771,15 @@ pub(super) fn handle_layout_insert_node_at_index(
             "reducer: LayoutInsertNodeAtIndex snapped minimize-locked node size(s) back to their locked values"
         );
     }
+    // Layout doctor (issue #2179), same rationale as handle_layout_set_tree.
+    let violations = crate::backend::layout::validate_layout_invariants(&tab.rootnode);
+    if !violations.is_empty() {
+        tracing::error!(
+            tab_id = %tab_id,
+            violations = ?violations,
+            "layout-doctor: invariant violation(s) in tree persisted by LayoutInsertNodeAtIndex"
+        );
+    }
     reconcile_focus_magnify(tab);
     let new_tree = tab.rootnode.clone();
     let v = state.bump_version();
@@ -839,6 +858,16 @@ where
             op,
             snapped,
             "reducer: snapped minimize-locked node size(s) back to their locked values"
+        );
+    }
+    // Layout doctor (issue #2179), same rationale as handle_layout_set_tree.
+    let violations = crate::backend::layout::validate_layout_invariants(&tab.rootnode);
+    if !violations.is_empty() {
+        tracing::error!(
+            tab_id = %tab_id,
+            op,
+            violations = ?violations,
+            "layout-doctor: invariant violation(s) in tree persisted by structural op"
         );
     }
     Ok(())

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -272,7 +272,14 @@ function EndIcons(props: {
                 />
             </Show>
 
-            <Show when={!ephemeral() && !magnified() && numLeafs() > 1}>
+            {/* canMinimize: the last expanded pane loses its minimize button —
+                the window must always keep at least one expanded pane, so
+                another pane has to be restored before this one can collapse.
+                Optional call: NodeModels are cached on the LayoutModel, so a
+                hot-reload can pair this (new) header with a pre-canMinimize
+                cached model — degrade to showing the button (the toggle's own
+                countExpandedLeaves guard still enforces the policy). */}
+            <Show when={!ephemeral() && !magnified() && numLeafs() > 1 && (props.nodeModel.canMinimize?.() ?? true)}>
                 <OptMinimizeButton
                     minimized={minimized()}
                     toggleMinimize={props.nodeModel.toggleMinimize}

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -4,6 +4,7 @@
 import { batch } from "solid-js";
 import { balanceNode, walkNodes } from "./layoutNode";
 import { enforceMinimizedLocks, isNodeLocked } from "./layoutMinimize";
+import { reportLayoutViolations } from "./layoutInvariants";
 import {
     FlexDirection,
     LayoutNode,
@@ -54,6 +55,11 @@ export function updateTree(model: LayoutModel, balanceTree = true) {
             // is corrected here rather than trusted to have known about the lock.
             enforceMinimizedLocks(model.treeState.rootNode);
             model.treeState.rootNode = balanceNode(model.treeState.rootNode, callback);
+            // Layout doctor (issue #2179): observe the post-normalization tree
+            // and log loudly if any structural invariant is broken, so a
+            // corruption is attributed at the pass that produced it instead of
+            // reconstructed later from db_layout archaeology.
+            reportLayoutViolations(model.treeState.rootNode, "updateTree");
         } else walkNodes(model.treeState.rootNode, callback);
 
         // Process ephemeral node, if present.

--- a/frontend/layout/lib/layoutInvariants.ts
+++ b/frontend/layout/lib/layoutInvariants.ts
@@ -1,0 +1,223 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Layout doctor — pure invariant validation for the layout tree, plus a
+// compact tree dumper for logs. Mirrored by `validate_layout_invariants` in
+// `agentmux-srv/src/backend/layout/mod.rs`; keep the two check lists in sync.
+//
+// Motivation (issue #2179): pane-minimize corruption kept shipping because
+// nothing ever *observed* an illegal tree — each bug was reconstructed after
+// the fact from db_layout archaeology. These checks run at the same choke
+// points as `balanceNode`/`enforceMinimizedLocks` and turn a silent
+// corruption into a loud, attributable log line at the moment it appears.
+
+import type { LayoutNode } from "./types";
+import { FlexDirection } from "./types";
+
+export interface LayoutViolation {
+    code: string;
+    nodeId: string;
+    detail: string;
+}
+
+const SIZE_EPS = 1e-4;
+
+/**
+ * A locked node is one whose size is owned by the minimize subsystem: a minimized
+ * leaf (`minimizedSize`), a slipped header (`slipMinimize`), or a dissolved column
+ * (`columnDissolve`). No other writer may resize, move, swap, or split it, and no
+ * resize handle is rendered on its edges. See
+ * `docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`.
+ *
+ * Canonical home is here (the invariant module) so `layoutMinimize` can import
+ * the doctor without an import cycle; `layoutMinimize` re-exports it for its
+ * existing importers.
+ */
+export function isNodeLocked(node: LayoutNode | undefined): boolean {
+    if (!node) return false;
+    return node.minimizedSize !== undefined || node.slipMinimize !== undefined || node.columnDissolve !== undefined;
+}
+
+/**
+ * Validate structural invariants of a layout tree. Returns an empty array on
+ * a healthy tree. Never throws and never mutates.
+ */
+export function validateLayoutInvariants(root: LayoutNode | undefined): LayoutViolation[] {
+    const violations: LayoutViolation[] = [];
+    if (!root) return violations;
+
+    function walk(node: LayoutNode, isRoot: boolean) {
+        const isBranch = !!node.children?.length;
+        const isLeaf = node.data !== undefined;
+
+        // I1 — leaf XOR branch (matches validateNode / balance's own check,
+        // but reported instead of thrown).
+        if (isBranch === isLeaf) {
+            violations.push({
+                code: "LEAF_XOR_BRANCH",
+                nodeId: node.id,
+                detail: `data ${isLeaf ? "present" : "absent"}, children ${isBranch ? "present" : "absent"}`,
+            });
+        }
+
+        // I2 — minimizedSize / slipMinimize are leaf-only markers. A branch
+        // carrying one means a minimized leaf was promoted to a group without
+        // migrating its minimize fields (e.g. addIntermediateNode, or the
+        // leaf→Column conversions in _slipMinimize/_dissolveColumn).
+        if (isBranch && (node.minimizedSize !== undefined || node.slipMinimize !== undefined)) {
+            violations.push({
+                code: "MIN_MARKER_ON_BRANCH",
+                nodeId: node.id,
+                detail: `branch has ${node.minimizedSize !== undefined ? "minimizedSize" : "slipMinimize"}`,
+            });
+        }
+
+        // I3 — columnDissolve is branch-only.
+        if (!isBranch && node.columnDissolve !== undefined) {
+            violations.push({ code: "DISSOLVE_ON_LEAF", nodeId: node.id, detail: "leaf has columnDissolve" });
+        }
+
+        // I4 — a dissolved column must stack its headers vertically. A Row
+        // direction here is the "narrow instead of short" signature (#2176).
+        if (node.columnDissolve !== undefined && node.flexDirection !== FlexDirection.Column) {
+            violations.push({
+                code: "DISSOLVED_NOT_COLUMN",
+                nodeId: node.id,
+                detail: `dissolved column has flexDirection=${node.flexDirection}`,
+            });
+        }
+
+        // I5 — every child of a dissolved column is itself locked (dissolve
+        // fires only when allCollapsed; an unlocked child means something was
+        // inserted into the header strip).
+        if (node.columnDissolve !== undefined && node.children) {
+            for (const c of node.children) {
+                if (!isNodeLocked(c)) {
+                    violations.push({
+                        code: "DISSOLVED_CHILD_UNLOCKED",
+                        nodeId: c.id,
+                        detail: `unlocked child inside dissolved column ${node.id}`,
+                    });
+                }
+            }
+        }
+
+        // I6 — a locked node's size honors its recorded lock (#2180).
+        if (isNodeLocked(node) && node.minimizedLockedSize !== undefined) {
+            if (Math.abs(node.size - node.minimizedLockedSize) > SIZE_EPS) {
+                violations.push({
+                    code: "LOCK_SIZE_MISMATCH",
+                    nodeId: node.id,
+                    detail: `size=${node.size} locked=${node.minimizedLockedSize}`,
+                });
+            }
+        }
+
+        // I7 — minimizedLockedSize must not outlive its lock marker.
+        if (!isNodeLocked(node) && node.minimizedLockedSize !== undefined) {
+            violations.push({
+                code: "ORPHAN_LOCKED_SIZE",
+                nodeId: node.id,
+                detail: `minimizedLockedSize=${node.minimizedLockedSize} with no lock marker`,
+            });
+        }
+
+        // I8 — sizes are positive (a zero/negative flex size renders as dead
+        // or inverted space).
+        if (!isRoot && !(node.size > 0)) {
+            violations.push({ code: "NONPOSITIVE_SIZE", nodeId: node.id, detail: `size=${node.size}` });
+        }
+
+        node.children?.forEach((c) => walk(c, false));
+    }
+
+    walk(root, true);
+
+    // I9 — at least one pane stays expanded. A tree whose every leaf is
+    // minimize-locked is an all-headers window with nothing restorable in
+    // view; `minimizeNodeToggle` guards against producing this.
+    let leafCount = 0;
+    let expandedCount = 0;
+    (function countLeaves(node: LayoutNode) {
+        if (!node.children?.length) {
+            if (node.data !== undefined) {
+                leafCount++;
+                if (
+                    node.minimizedSize === undefined &&
+                    node.slipMinimize === undefined &&
+                    node.columnDissolve === undefined
+                ) {
+                    expandedCount++;
+                }
+            }
+            return;
+        }
+        node.children.forEach(countLeaves);
+    })(root);
+    if (leafCount > 0 && expandedCount === 0) {
+        violations.push({
+            code: "ALL_LEAVES_LOCKED",
+            nodeId: root.id,
+            detail: `all ${leafCount} leaves are minimize-locked; no expanded pane remains`,
+        });
+    }
+
+    return violations;
+}
+
+/**
+ * Compact one-line-per-node dump of a layout tree for violation logs —
+ * enough to reconstruct the shape without a full JSON blob.
+ */
+export function describeLayoutTree(root: LayoutNode | undefined): string {
+    if (!root) return "(empty tree)";
+    const lines: string[] = [];
+    function walk(node: LayoutNode, depth: number) {
+        const flags = [
+            node.minimizedSize !== undefined ? `MIN(orig=${node.minimizedSize})` : "",
+            node.minimizedLockedSize !== undefined ? `LOCK=${node.minimizedLockedSize}` : "",
+            node.slipMinimize !== undefined ? "SLIP" : "",
+            node.columnDissolve !== undefined ? "DISSOLVED" : "",
+            node._slipAnchor ? "anchor" : "",
+        ]
+            .filter(Boolean)
+            .join(" ");
+        const kind = node.data?.blockId ? `leaf ${String(node.data.blockId).slice(0, 8)}` : "branch";
+        lines.push(
+            `${"  ".repeat(depth)}${kind} id=${node.id.slice(0, 8)} dir=${node.flexDirection} size=${node.size}${flags ? " " + flags : ""}`
+        );
+        node.children?.forEach((c) => walk(c, depth + 1));
+    }
+    walk(root, 0);
+    return lines.join("\n");
+}
+
+// Dedupe repeated identical violation reports (updateTree runs on every
+// geometry pass; one corrupted tree would otherwise spam the console).
+let lastReportSignature: string | undefined;
+
+/**
+ * Validate and report violations to the console. `context` says which choke
+ * point observed the tree (e.g. "updateTree", "minimizeToggle:restore").
+ * Returns the violations so callers can react programmatically.
+ */
+export function reportLayoutViolations(
+    root: LayoutNode | undefined,
+    context: string
+): LayoutViolation[] {
+    const violations = validateLayoutInvariants(root);
+    if (violations.length === 0) {
+        lastReportSignature = undefined;
+        return violations;
+    }
+    const signature = JSON.stringify(violations);
+    if (signature !== lastReportSignature) {
+        lastReportSignature = signature;
+        console.error(
+            `[layout-doctor] ${violations.length} invariant violation(s) after ${context}:\n` +
+                violations.map((v) => `  ${v.code} @ ${v.nodeId.slice(0, 8)}: ${v.detail}`).join("\n") +
+                `\ntree:\n${describeLayoutTree(root)}`
+        );
+    }
+    return violations;
+}

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -4,22 +4,36 @@
 
 import { newLayoutNode } from "./layoutNode";
 import { findNode, findParent } from "./layoutNode";
+import { isNodeLocked, reportLayoutViolations } from "./layoutInvariants";
 import type { LayoutModel } from "./layoutModel";
 import { DefaultNodeSize, FlexDirection, type LayoutNodeAdditionalProps, type LayoutNode } from "./types";
 
 /** Height of the block header in CSS pixels (matches --header-height in theme.scss). */
 export const HeaderHeightPx = 33;
 
+// Canonical definition lives in layoutInvariants (the doctor validates lock
+// invariants, and importing from here would be an import cycle); re-exported
+// so existing importers keep working.
+export { isNodeLocked };
+
 /**
- * A locked node is one whose size is owned by the minimize subsystem: a minimized
- * leaf (`minimizedSize`), a slipped header (`slipMinimize`), or a dissolved column
- * (`columnDissolve`). No other writer may resize, move, swap, or split it, and no
- * resize handle is rendered on its edges. See
- * `docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`.
+ * Count leaves that are NOT minimize-locked — i.e. panes still showing
+ * content. The window must always keep at least one: `minimizeNodeToggle`
+ * no-ops when asked to collapse the last expanded pane, and the header hides
+ * that pane's minimize button (`NodeModel.canMinimize`).
  */
-export function isNodeLocked(node: LayoutNode | undefined): boolean {
-    if (!node) return false;
-    return node.minimizedSize !== undefined || node.slipMinimize !== undefined || node.columnDissolve !== undefined;
+export function countExpandedLeaves(root: LayoutNode | undefined): number {
+    if (!root) return 0;
+    let count = 0;
+    function walk(node: LayoutNode) {
+        if (!node.children?.length) {
+            if (node.data !== undefined && !isNodeLocked(node)) count++;
+            return;
+        }
+        node.children.forEach(walk);
+    }
+    walk(root);
+    return count;
 }
 
 /**
@@ -217,6 +231,13 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
 
     // ── Minimize ──────────────────────────────────────────────────────────────
     if (!sibling) return;
+
+    // The last expanded pane cannot be collapsed — the window must always keep
+    // at least one pane showing content (an all-headers window is dead space
+    // with nothing restorable in view). The header already hides the minimize
+    // button in this state (NodeModel.canMinimize); this is the authoritative
+    // guard for programmatic callers.
+    if (countExpandedLeaves(model.treeState.rootNode) <= 1) return;
 
     if (parentNode.flexDirection === FlexDirection.Row) {
         // Slip path: pane occupies a Row slot — slip header into adjacent column instead
@@ -532,6 +553,14 @@ function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
         return next;
     });
     model.updateTree();
+    // Layout doctor (issue #2179): a minimize/restore toggle is the highest-
+    // risk mutation in the layout system (slip / dissolve / undissolve all
+    // restructure the tree). Validate immediately with toggle attribution —
+    // updateTree above also validates, but this context names the culprit.
+    reportLayoutViolations(
+        model.treeState.rootNode,
+        `minimizeToggle:${minimized ? "minimize" : "restore"}:${nodeId.slice(0, 8)}`
+    );
     model.localTreeStateAtom._set({ ...model.treeState });
     model.persistToBackend();
 }

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -59,6 +59,14 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                     const minimizedIds = model.minimizedNodeIds();
                     return minimizedIds.has(nodeid);
                 }),
+                canMinimize: createMemo(() => {
+                    const minimizedIds = model.minimizedNodeIds();
+                    // Restoring is always allowed; minimizing requires at
+                    // least one OTHER expanded pane to remain (the window
+                    // must never become all-headers).
+                    if (minimizedIds.has(nodeid)) return true;
+                    return model.numLeafs() - minimizedIds.size > 1;
+                }),
                 isEphemeral: createMemo(() => {
                     const ephemeralNode = model.ephemeralNode();
                     return ephemeralNode?.id === nodeid;

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -335,6 +335,13 @@ export interface NodeModel {
     isFocused: Accessor<boolean>;
     isMagnified: Accessor<boolean>;
     isMinimized: Accessor<boolean>;
+    /**
+     * False when this pane is the LAST expanded (non-minimized) pane in the
+     * layout — the window must always keep at least one expanded pane, so the
+     * minimize button is hidden and `minimizeNodeToggle` no-ops. Restore is
+     * always allowed (true whenever the pane is currently minimized).
+     */
+    canMinimize: Accessor<boolean>;
     isEphemeral: Accessor<boolean>;
     ready: Accessor<boolean>;
     disablePointerEvents: Accessor<boolean>;

--- a/frontend/layout/tests/layoutInvariants.test.ts
+++ b/frontend/layout/tests/layoutInvariants.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { newLayoutNode } from "../lib/layoutNode";
+import { validateLayoutInvariants, describeLayoutTree } from "../lib/layoutInvariants";
+import { minimizeNodeToggle } from "../lib/layoutMinimize";
+import { FlexDirection, type LayoutNode, type LayoutNodeAdditionalProps } from "../lib/types";
+
+function makeMockModel(rootNode: LayoutNode, addlProps: Record<string, Partial<LayoutNodeAdditionalProps>> = {}) {
+    let minimizedSet = new Set<string>();
+    return {
+        treeState: { rootNode, pendingBackendActions: [] },
+        getter: (_sig: unknown) => addlProps as Record<string, LayoutNodeAdditionalProps>,
+        additionalProps: {} as any,
+        gapSizePx: () => 0,
+        minimizedNodeIds: {
+            _set: (u: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+                minimizedSet = typeof u === "function" ? u(minimizedSet) : u;
+            },
+        },
+        updateTree: () => {},
+        localTreeStateAtom: { _set: () => {} },
+        persistToBackend: () => {},
+    };
+}
+
+describe("validateLayoutInvariants", () => {
+    it("returns no violations for a healthy tree produced by a real minimize", () => {
+        const pane1 = newLayoutNode(FlexDirection.Row, 200, undefined, { blockId: "p1" });
+        const pane2 = newLayoutNode(FlexDirection.Row, 200, undefined, { blockId: "p2" });
+        const col = newLayoutNode(FlexDirection.Column, 200, [pane1, pane2]);
+        const other = newLayoutNode(FlexDirection.Column, 200, [
+            newLayoutNode(FlexDirection.Row, 200, undefined, { blockId: "p3" }),
+        ]);
+        const root = newLayoutNode(FlexDirection.Row, 200, [col, other]);
+        const model = makeMockModel(root, { [col.id]: { pixelToSizeRatio: 1 } });
+
+        minimizeNodeToggle(model as any, pane1.id);
+
+        expect(validateLayoutInvariants(root)).toEqual([]);
+    });
+
+    // Regression fixture: the exact corrupted shape recovered from a live
+    // v0.53.6 instance's db_layout after the user's "minimized 2 panes and it
+    // distorted" repro (issue #2179) — a BRANCH carrying the leaf-only
+    // `minimizedSize` marker, with a slipped leaf trapped inside it:
+    //
+    //   root (Row)
+    //   ├── branch (Column, _slipAnchor)
+    //   │   └── branch (Row, minimizedSize=9)   ← illegal: MIN marker on branch
+    //   │       ├── leaf term  (slipMinimize)
+    //   │       └── leaf agent
+    //   └── leaf armory
+    it("flags the corrupted tree recovered from the live 0.53.6 instance", () => {
+        const term = newLayoutNode(FlexDirection.Column, 2.2, undefined, { blockId: "term" });
+        term.slipMinimize = { targetColumnId: "x", originalRowSize: 10, originalRowIndex: 0, targetWasLeaf: true };
+        const agent = newLayoutNode(FlexDirection.Column, 4.4, undefined, { blockId: "agent" });
+        const midBranch = newLayoutNode(FlexDirection.Row, 6.8, [term, agent]);
+        midBranch.minimizedSize = 9;
+        const outerCol = newLayoutNode(FlexDirection.Column, 30, [midBranch]);
+        outerCol._slipAnchor = true;
+        const armory = newLayoutNode(FlexDirection.Column, 10, undefined, { blockId: "armory" });
+        const root = newLayoutNode(FlexDirection.Row, 10, [outerCol, armory]);
+
+        const violations = validateLayoutInvariants(root);
+        expect(violations.map((v) => v.code)).toContain("MIN_MARKER_ON_BRANCH");
+    });
+
+    it("flags a dissolved column whose direction was flipped (the #2176 signature)", () => {
+        const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
+        l1.minimizedSize = 200;
+        l1.minimizedLockedSize = 33;
+        const l2 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b2" });
+        l2.minimizedSize = 200;
+        l2.minimizedLockedSize = 33;
+        const dissolved = newLayoutNode(FlexDirection.Row, 66, [l1, l2]); // Row = wrong
+        dissolved.columnDissolve = {
+            targetColumnId: "host",
+            originalRowSize: 200,
+            originalRowIndex: 0,
+            targetWasLeaf: true,
+        };
+        const content = newLayoutNode(FlexDirection.Row, 300, undefined, { blockId: "b3" });
+        const host = newLayoutNode(FlexDirection.Column, 400, [dissolved, content]);
+
+        const codes = validateLayoutInvariants(host).map((v) => v.code);
+        expect(codes).toContain("DISSOLVED_NOT_COLUMN");
+    });
+
+    it("flags a locked node whose size was tampered with, and an orphaned lock", () => {
+        const locked = newLayoutNode(FlexDirection.Row, 120, undefined, { blockId: "b1" });
+        locked.minimizedSize = 200;
+        locked.minimizedLockedSize = 33; // size 120 ≠ locked 33
+        const orphan = newLayoutNode(FlexDirection.Row, 200, undefined, { blockId: "b2" });
+        orphan.minimizedLockedSize = 33; // no lock marker
+        const root = newLayoutNode(FlexDirection.Column, 400, [locked, orphan]);
+
+        const codes = validateLayoutInvariants(root).map((v) => v.code);
+        expect(codes).toContain("LOCK_SIZE_MISMATCH");
+        expect(codes).toContain("ORPHAN_LOCKED_SIZE");
+    });
+
+    it("flags an unlocked child inside a dissolved column and nonpositive sizes", () => {
+        const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
+        l1.minimizedSize = 200;
+        const intruder = newLayoutNode(FlexDirection.Row, 0, undefined, { blockId: "b9" }); // also size 0
+        const dissolved = newLayoutNode(FlexDirection.Column, 66, [l1, intruder]);
+        dissolved.columnDissolve = {
+            targetColumnId: "host",
+            originalRowSize: 200,
+            originalRowIndex: 0,
+            targetWasLeaf: true,
+        };
+        const content = newLayoutNode(FlexDirection.Row, 300, undefined, { blockId: "b3" });
+        const host = newLayoutNode(FlexDirection.Column, 400, [dissolved, content]);
+
+        const codes = validateLayoutInvariants(host).map((v) => v.code);
+        expect(codes).toContain("DISSOLVED_CHILD_UNLOCKED");
+        expect(codes).toContain("NONPOSITIVE_SIZE");
+    });
+
+    it("flags a tree where every leaf is minimize-locked (all-headers window)", () => {
+        const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
+        l1.minimizedSize = 200;
+        const l2 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b2" });
+        l2.minimizedSize = 200;
+        const root = newLayoutNode(FlexDirection.Column, 400, [l1, l2]);
+
+        const codes = validateLayoutInvariants(root).map((v) => v.code);
+        expect(codes).toContain("ALL_LEAVES_LOCKED");
+    });
+
+    it("describeLayoutTree renders the lock flags", () => {
+        const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
+        l1.minimizedSize = 200;
+        l1.minimizedLockedSize = 33;
+        const root = newLayoutNode(FlexDirection.Column, 400, [
+            l1,
+            newLayoutNode(FlexDirection.Row, 367, undefined, { blockId: "b2" }),
+        ]);
+        const desc = describeLayoutTree(root);
+        expect(desc).toContain("MIN(orig=200)");
+        expect(desc).toContain("LOCK=33");
+    });
+});

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -317,10 +317,11 @@ describe("cascade dissolve — multiple columns collapse into one", () => {
         // colB (inside colC) still contains colA-dissolved
         expect(colB.children!.some(c => c.id === colA.id)).toBe(true);
 
-        // paneC can still be minimized (colB-dissolved is its sibling)
+        // paneC is now the LAST expanded pane — minimizing it is a no-op
+        // (the window must always keep one expanded pane).
         minimizeNodeToggle(model as any, paneC.id);
-        expect(paneC.minimizedSize).toBeDefined();
-        expect(root.children).toHaveLength(1); // dissolve bails (no Row sibling) — correct
+        expect(paneC.minimizedSize).toBeUndefined();
+        expect(root.children).toHaveLength(1);
     });
 
     it("restores pane from 3-deep cascade (A→B→C → restore colA pane)", () => {
@@ -397,7 +398,7 @@ describe("cascade dissolve — multiple columns collapse into one", () => {
 // ── Bail case — no adjacent sibling ─────────────────────────────────────────
 
 describe("dissolve bail cases", () => {
-    it("does not dissolve when the column is the only child in the Row", () => {
+    it("refuses to minimize the last expanded pane (no-op), so a lone column never fully collapses", () => {
         const pane1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "p1" });
         const pane2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "p2" });
         const col   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [pane1, pane2]);
@@ -406,14 +407,53 @@ describe("dissolve bail cases", () => {
         const model = makeMockModel(root, { [col.id]: { pixelToSizeRatio: 1 } });
 
         minimizeNodeToggle(model as any, pane1.id);
+        // pane2 is now the LAST expanded pane — this toggle must no-op.
+        // (Previously it minimized and dissolve bailed, leaving an
+        // all-headers window with nothing restorable in view.)
         minimizeNodeToggle(model as any, pane2.id);
 
-        // col stays in root Row — dissolve bailed (no Row sibling)
         expect(root.children).toHaveLength(1);
         expect(col.columnDissolve).toBeUndefined();
-        // Both panes are still individually minimized
         expect(pane1.minimizedSize).toBeDefined();
+        expect(pane2.minimizedSize).toBeUndefined();
+        expect(pane2.size).toBeGreaterThan(HeaderHeightPx);
+
+        // Restoring pane1 re-enables minimizing pane2.
+        minimizeNodeToggle(model as any, pane1.id);
+        expect(pane1.minimizedSize).toBeUndefined();
+        minimizeNodeToggle(model as any, pane2.id);
         expect(pane2.minimizedSize).toBeDefined();
+        expect(pane1.minimizedSize).toBeUndefined();
+    });
+});
+
+// ── Last expanded pane cannot be minimized ───────────────────────────────────
+
+describe("last expanded pane guard", () => {
+    it("no-ops when the only remaining expanded pane (after a dissolve) is toggled", () => {
+        const { root, colA, paneA1, paneA2, colB, paneB } = buildTwoColumnLayout();
+        const model = makeMockModel(root, {
+            [colA.id]: { pixelToSizeRatio: 1 },
+            [colB.id]: { pixelToSizeRatio: 1 },
+        });
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id); // colA dissolves into colB
+        expect(colA.columnDissolve).toBeDefined();
+
+        // paneB is the last expanded pane — toggle must not collapse it.
+        const sizeBefore = paneB.size;
+        minimizeNodeToggle(model as any, paneB.id);
+        expect(paneB.minimizedSize).toBeUndefined();
+        expect(paneB.size).toBe(sizeBefore);
+        expect(model.getMinimizedSet().has(paneB.id)).toBe(false);
+
+        // Restoring one pane (undissolves colA) re-enables minimizing: with
+        // paneA1 and paneB both expanded, paneA1 can collapse again.
+        minimizeNodeToggle(model as any, paneA1.id);
+        expect(paneA1.minimizedSize).toBeUndefined();
+        minimizeNodeToggle(model as any, paneA1.id);
+        expect(paneA1.minimizedSize).toBeDefined();
     });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #2180, tracked in #2179. Two additions driven by live smoke testing:

### 1. Layout doctor (solid diagnostics)

Every prior minimize bug (dead space, narrow-vs-short, resize-through-lock) shipped **silently** and was root-caused afterwards from `db_layout` archaeology. This adds always-on invariant validation at the choke points every mutation already flows through:

- **Validators:** `validateLayoutInvariants` (TS, `frontend/layout/lib/layoutInvariants.ts`) / `validate_layout_invariants` (Rust) — kept in sync, 9 checks:

| # | Code | Catches |
|---|---|---|
| I1 | `LEAF_XOR_BRANCH` | node with both/neither of data+children |
| I2 | `MIN_MARKER_ON_BRANCH` | leaf-only minimize markers on a branch (the recovered 0.53.6 corruption) |
| I3 | `DISSOLVE_ON_LEAF` | `columnDissolve` on a leaf |
| I4 | `DISSOLVED_NOT_COLUMN` | dissolved column direction flipped (the #2176 signature) |
| I5 | `DISSOLVED_CHILD_UNLOCKED` | intruder inside a header strip |
| I6 | `LOCK_SIZE_MISMATCH` | locked size tampered (the #2180 signature) |
| I7 | `ORPHAN_LOCKED_SIZE` | lock bookkeeping outliving the lock |
| I8 | `NONPOSITIVE_SIZE` | dead/inverted flex space |
| I9 | `ALL_LEAVES_LOCKED` | all-headers window, nothing restorable |

- **Reporting:** frontend — every `updateTree` pass + every minimize toggle (`console.error` with violation list + compact tree dump, deduped against spam, toggle-attributed context strings). Backend — all three reducer write sites (`tracing::error` → srv logs).
- **Regression fixture:** the corrupted tree recovered from a live v0.53.6 instance (`branch carrying minimizedSize` with a slipped header trapped inside) is now a test fixture on both sides.
- `isNodeLocked`'s canonical home moves to `layoutInvariants` (re-exported from `layoutMinimize`) to avoid an import cycle.

### 2. Last-expanded-pane guard

The window must always keep at least one pane showing content:

- The last non-minimized pane **loses its minimize button** (`NodeModel.canMinimize` → blockframe `Show` condition; restore is always allowed). Defensive optional-call so a hot-reload pairing new header code with a cached pre-`canMinimize` NodeModel degrades gracefully.
- `minimizeNodeToggle` **no-ops** via `countExpandedLeaves` — the authoritative guard for programmatic callers.
- The old dissolve-bail dead end (lone column fully collapsed into unrestorable headers) is now unreachable by construction; the two tests encoding it are updated to the new policy, with dedicated guard tests added (no-op on last pane, re-enable after restore).

## Test plan

- [x] 6 new TS invariant tests (incl. the 0.53.6 corruption fixture) + last-pane guard tests — `npx vitest run frontend/layout`: 98 passed
- [x] 4 new Rust invariant tests — full `cargo test --bin agentmux-srv`: 1505 passed
- [x] Live smoke test on a fresh `task dev` instance

**Do not merge without explicit approval from @asafebgi** (smoke-testing in progress).

Refs #2179.