### PR TITLE
fix(agent): reconcile TurnPhase down to Idle on backend turn-end (unsticks Working/Queued)

### DIFF
--- a/.changesets/1784228192-fix-agent-reconcile-turnphase-down-to-idle-when-the-backend--w2a1.md
+++ b/.changesets/1784228192-fix-agent-reconcile-turnphase-down-to-idle-when-the-backend--w2a1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): reconcile TurnPhase down to Idle when the backend reports the turn ended (unsticks Working/Queued)

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -101,6 +101,61 @@ describe("agent-pane-state reducer", () => {
             const r = update(start, { type: "ReconcileTurnActive", at: 100, active: true });
             expect(r.state.turnPhase.kind).toBe("Streaming");
         });
+
+        // active: false — downward reconciliation (completes #2005's symmetry).
+        // See docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md.
+        it("demotes a stuck Streaming phase to Idle when the backend reports the turn ended", () => {
+            const s = streaming(100);
+            expect(s.turnPhase.kind).toBe("Streaming");
+            const r = update(s, { type: "ReconcileTurnActive", at: 200, active: false });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.events[0]).toMatchObject({ type: "turn-inactive-reconciled", at: 200 });
+        });
+
+        it("clears currentTool and turnTokens when demoting a stuck Streaming turn", () => {
+            let s = streaming(100);
+            s = update(s, { type: "ToolStart", name: "Bash", arg: "ls" }).state;
+            s = update(s, { type: "TokensIn", input: 500, model: "claude-sonnet-5" }).state;
+            expect(s.currentTool).not.toBe(null);
+            const r = update(s, { type: "ReconcileTurnActive", at: 200, active: false });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.currentToolArg).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+        });
+
+        it("demotes Streaming even with a tool active — backend turn_active=false is authoritative (unlike the timeout watchdog)", () => {
+            let s = streaming(100);
+            s = update(s, { type: "ToolStart", name: "Bash", arg: "sleep 999" }).state;
+            // The liveness watchdog would REFUSE to recover a tool-active turn
+            // (a long tool legitimately keeps it alive); a backend result event
+            // is ground truth, so this demotes regardless.
+            const r = update(s, { type: "ReconcileTurnActive", at: 200, active: false });
+            expect(r.state.turnPhase.kind).toBe("Idle");
+        });
+
+        it("active: false leaves Submitting untouched — that's SUBMIT_TIMEOUT's job (and where the send-race lives)", () => {
+            const s = update(ready(100), { type: "TurnStart", at: 110 }).state;
+            expect(s.turnPhase.kind).toBe("Submitting");
+            const r = update(s, { type: "ReconcileTurnActive", at: 200, active: false });
+            expect(r.state).toBe(s);
+            expect(r.events).toEqual([]);
+        });
+
+        it("active: false leaves Done untouched (already terminal)", () => {
+            const s = update(streaming(100), { type: "TurnEnd", stats: null }).state;
+            expect(s.turnPhase.kind).toBe("Done");
+            const r = update(s, { type: "ReconcileTurnActive", at: 200, active: false });
+            expect(r.state).toBe(s);
+            expect(r.events).toEqual([]);
+        });
+
+        it("active: true still promotes from Idle after a prior demote (round-trip)", () => {
+            const demoted = update(streaming(100), { type: "ReconcileTurnActive", at: 200, active: false }).state;
+            expect(demoted.turnPhase.kind).toBe("Idle");
+            const r = update(demoted, { type: "ReconcileTurnActive", at: 300, active: true });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+        });
     });
 
     describe("ReconcileContextFromHistory (mount-time reconciliation)", () => {

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -343,28 +343,56 @@ export function update(
         }
 
         case "ReconcileTurnActive": {
-            // Only ever promotes the mount-default Idle — never overrides a
-            // phase a real stream/user event already produced. A `false`
-            // active flag is a no-op: Idle is already correct. Deliberately
-            // does NOT gate on `state.lastEventMs` the way TurnStart /
-            // StreamFlushObserved do — this seed is meant to cover exactly
-            // the window before the live stream has necessarily subscribed
-            // yet, which is the gap this command exists to close. See the
-            // type's doc comment in types.ts.
-            if (!command.active || state.turnPhase.kind !== "Idle") {
+            if (command.active) {
+                // Promote the mount-default Idle — never overrides a phase a
+                // real stream/user event already produced. Deliberately does
+                // NOT gate on `state.lastEventMs` the way TurnStart /
+                // StreamFlushObserved do — this seed is meant to cover exactly
+                // the window before the live stream has necessarily subscribed
+                // yet, which is the gap this command exists to close. See the
+                // type's doc comment in types.ts.
+                if (state.turnPhase.kind !== "Idle") {
+                    return { state, events: [] };
+                }
+                return {
+                    state: {
+                        ...state,
+                        turnPhase: {
+                            kind: "Streaming",
+                            bufferSize: 0,
+                            toolsActive: 0,
+                            lastEventMs: command.at,
+                        },
+                    },
+                    events: [{ type: "turn-active-reconciled-at-mount" }],
+                };
+            }
+            // active === false: the backend's authoritative turn_active (flipped
+            // false only on the CLI's `result` event = genuine turn-end) says
+            // the turn is over. Demote a STUCK Streaming phase to Idle. The
+            // frontend normally reaches Done itself via session_end; this only
+            // matters when it missed that event and would stay Streaming forever
+            // (Agent1 stuck-"Working" / Agent2 stuck-"Queued" — the latter's
+            // held-message flush is gated on the phase reaching Idle/Done, so a
+            // stuck Streaming strands the queue). ONLY Streaming: Submitting is
+            // left to SUBMIT_TIMEOUT (and is where the send-race lives — a local
+            // TurnStart racing a backend that hasn't marked the turn active yet,
+            // which would arrive here as a stale active:false), Interrupting to
+            // INTERRUPT_TIMEOUT, and Done/Idle/Disconnected are already correct.
+            // Clears currentTool/turnTokens exactly like the liveness watchdog's
+            // recovery, but on an authoritative signal rather than a timeout.
+            if (state.turnPhase.kind !== "Streaming") {
                 return { state, events: [] };
             }
             return {
                 state: {
                     ...state,
-                    turnPhase: {
-                        kind: "Streaming",
-                        bufferSize: 0,
-                        toolsActive: 0,
-                        lastEventMs: command.at,
-                    },
+                    currentTool: null,
+                    currentToolArg: null,
+                    turnTokens: null,
+                    turnPhase: { kind: "Idle" },
                 },
-                events: [{ type: "turn-active-reconciled-at-mount" }],
+                events: [{ type: "turn-inactive-reconciled", at: command.at }],
             };
         }
 

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -378,19 +378,30 @@ export type AgentPaneCommand =
     | { type: "StreamWatchdogTick"; nowMs: number }
 
     /**
-     * Mount-time reconciliation: `BlockControllerRuntimeStatus.turn_active`
+     * Reconciliation from `BlockControllerRuntimeStatus.turn_active`
      * (backend-verified, from the health monitor wired to the NDJSON
-     * stream — see `agentmux-srv/src/backend/blockcontroller/health.rs`)
-     * fetched once via `GetControllerStatus` during the launch flow's
-     * Phase 3. `registerPane()` always seeds `turnPhase: Idle` regardless
-     * of whether the agent is actually mid-turn; this command corrects
-     * that ONLY IF still `Idle` when it arrives — it never overrides a
-     * phase a real stream/user event already produced (TurnStart,
-     * StreamFlushObserved, etc. always win if they got there first). A
-     * `false` active flag is a no-op: `Idle` is already the right state
-     * and there is nothing to correct. See
-     * docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md
-     * Finding 1.
+     * stream — see `agentmux-srv/src/backend/blockcontroller/health.rs`),
+     * fetched via `GetControllerStatus` at mount AND dispatched on every
+     * live `controllerstatus` WPS event thereafter (useControllerStatusEvents).
+     * Bidirectional:
+     *   - `active: true`  — promote the mount-default `Idle` to `Streaming`
+     *     when the backend reports a turn already in flight. Corrects ONLY
+     *     an `Idle` phase; never overrides a phase a real stream/user event
+     *     already produced (TurnStart, StreamFlushObserved, etc. win if they
+     *     got there first). #2005 Finding 1.
+     *   - `active: false` — demote a stuck `Streaming` phase to `Idle`. The
+     *     backend flips `turn_active` false only on the CLI's `result` event
+     *     (genuine turn-end), so this is authoritative. Normally the frontend
+     *     reaches `Done` on its own via `session_end`; this covers the case
+     *     where it MISSED that event (pane backgrounded/unmounted across the
+     *     transition, or a dropped WPS event) and would otherwise stay
+     *     `Streaming` forever — the Agent1 stuck-"Working" / Agent2
+     *     stuck-"Queued" class. Only `Streaming` is demoted: `Submitting` is
+     *     covered by `SUBMIT_TIMEOUT` (and is where the send-race lives — a
+     *     just-dispatched local `TurnStart` racing a backend that hasn't yet
+     *     marked the turn active), `Interrupting` by `INTERRUPT_TIMEOUT`,
+     *     `Done`/`Idle`/`Disconnected` are already correct.
+     * See docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md.
      */
     | { type: "ReconcileTurnActive"; at: number; active: boolean }
     /**
@@ -571,6 +582,17 @@ export type AgentPaneEvent =
      * user-initiated `turn-started`.
      */
     | { type: "turn-active-reconciled-at-mount" }
+    /**
+     * `ReconcileTurnActive` demoted a stuck `Streaming` phase to `Idle`
+     * because the backend's authoritative `turn_active` reported the turn
+     * has ended (the `result` event fired) but the frontend never observed
+     * the terminal `session_end` — the class behind the Agent1 stuck-"Working"
+     * and Agent2 stuck-"Queued" incidents. Completes #2005's reconciliation
+     * symmetry (which only promoted Idle→Streaming). Surfaced for telemetry;
+     * the phase change is the real effect. See
+     * docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md.
+     */
+    | { type: "turn-inactive-reconciled"; at: number }
     /**
      * `ReconcileContextFromHistory` seeded `lastContextTokens` from a
      * historical `session_end` at mount. Surfaced for diagnostics only.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -483,8 +483,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         status.startLaunchFlow();
     });
 
-    // Log controllerstatus events as they stream in.
-    useControllerStatusEvents({ blockId: model.blockId, log });
+    // Log controllerstatus events as they stream in, and reconcile the pane's
+    // TurnPhase from the backend's live `turn_active` in both directions — the
+    // mount-time GetControllerStatus (onControllerStatus above) is one-shot, so
+    // without this a turn that ends while the pane is mounted but whose
+    // session_end the frontend missed would leave the phase stuck at Streaming
+    // (Agent1 stuck-"Working" / Agent2 stuck-"Queued"). Same dispatch as the
+    // mount reconcile, just fed by every live controllerstatus event.
+    useControllerStatusEvents({
+        blockId: model.blockId,
+        log,
+        onTurnActive: (active) => {
+            dispatchPaneIfRegistered(
+                model.blockId,
+                { type: "ReconcileTurnActive", at: Date.now(), active },
+                "system",
+            );
+        },
+    });
 
     // Subscribe to Claude Code OSC window-title extractions and write them
     // to term:osc_title block metadata (free fallback signal — see

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.test.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.test.ts
@@ -1,0 +1,41 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { deriveTurnActive } from "./useControllerStatusEvents";
+
+// Guards the exact wire contract that a P0 review caught: BlockControllerRuntime
+// Status.is_agent_pane and .turn_active are both serialized
+// `#[serde(skip_serializing_if = "is_false")]`, so a `false` is OMITTED rather
+// than sent. The turn-END event (the whole point of the demote path) therefore
+// arrives with turn_active ABSENT — it must read as false, never be dropped.
+describe("deriveTurnActive (controllerstatus wire-shape guard)", () => {
+    it("agent pane, turn in flight → true", () => {
+        expect(deriveTurnActive({ is_agent_pane: true, turn_active: true })).toBe(true);
+    });
+
+    it("agent pane, turn ENDED (turn_active omitted as false) → false, NOT null", () => {
+        // This is the case the demote path depends on and the one the old
+        // `typeof === "boolean"` guard silently dropped.
+        expect(deriveTurnActive({ is_agent_pane: true })).toBe(false);
+    });
+
+    it("agent pane, explicit turn_active:false (defensive — some deserializers rehydrate the default) → false", () => {
+        expect(deriveTurnActive({ is_agent_pane: true, turn_active: false })).toBe(false);
+    });
+
+    it("non-agent (shell/PTY) pane — both fields omitted → null (no signal, don't reconcile)", () => {
+        expect(deriveTurnActive({})).toBe(null);
+        expect(deriveTurnActive({ shellprocstatus: "running" })).toBe(null);
+    });
+
+    it("non-agent pane that explicitly serialized is_agent_pane:false → null", () => {
+        expect(deriveTurnActive({ is_agent_pane: false, turn_active: false })).toBe(null);
+    });
+
+    it("missing / non-object data → null", () => {
+        expect(deriveTurnActive(undefined)).toBe(null);
+        expect(deriveTurnActive(null)).toBe(null);
+        expect(deriveTurnActive("nope")).toBe(null);
+    });
+});

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
@@ -18,6 +18,17 @@ import type { LogFn } from "./useAgentControllerStatus";
 export interface UseControllerStatusEventsOptions {
     blockId: string;
     log: LogFn;
+    /**
+     * Live turn-active reconciliation. Called on every controllerstatus event
+     * that carries a boolean `turn_active` (agent panes only), so the pane's
+     * TurnPhase can follow the backend's authoritative turn state in BOTH
+     * directions while mounted — not just the one-shot GetControllerStatus at
+     * mount. This is what lets a stuck `Streaming` phase demote to `Idle` when
+     * the backend reports the turn ended but the frontend missed the terminal
+     * `session_end` (Agent1/Agent2 incidents). Consumer dispatches
+     * `ReconcileTurnActive`. See docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md.
+     */
+    onTurnActive?: (active: boolean) => void;
 }
 
 export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions): void {
@@ -26,16 +37,23 @@ export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions
             eventType: WpsEvent.ControllerStatus,
             scope: WOS.makeORef("block", opts.blockId),
             handler: (event) => {
-                const status = (event as any)?.data?.shellprocstatus;
+                const data = (event as any)?.data;
+                const status = data?.shellprocstatus;
                 if (status === "running") {
                     opts.log("subprocess", "spawned, waiting for response...");
                 } else if (status === "done") {
-                    const exitCode = (event as any)?.data?.shellprocexitcode;
+                    const exitCode = data?.shellprocexitcode;
                     if (exitCode != null && exitCode !== 0) {
                         opts.log("subprocess", `exited with code ${exitCode}`, "error");
                     } else {
                         opts.log("subprocess", "turn complete");
                     }
+                }
+                // `turn_active` is only meaningful for agent panes (shell/PTY
+                // controllers leave it absent); a non-boolean means "no signal",
+                // not "idle", so only forward a real boolean.
+                if (opts.onTurnActive && data?.is_agent_pane && typeof data.turn_active === "boolean") {
+                    opts.onTurnActive(data.turn_active);
                 }
             },
         });

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
@@ -15,6 +15,27 @@ import { WpsEvent } from "@/app/store/wps-events";
 import * as WOS from "@/app/store/wos";
 import type { LogFn } from "./useAgentControllerStatus";
 
+/**
+ * Derive the reconciled `turn_active` from a raw controllerstatus event's
+ * `data`, or `null` when the event carries no turn signal (non-agent panes).
+ *
+ * Encodes the wire contract: `BlockControllerRuntimeStatus.is_agent_pane` and
+ * `.turn_active` are both `#[serde(skip_serializing_if = "is_false")]`
+ * (agentmux-srv/src/backend/blockcontroller/mod.rs), so a `false` value is
+ * OMITTED from the JSON rather than sent as `false`. A turn-END event for an
+ * agent pane therefore looks like `{ is_agent_pane: true }` with `turn_active`
+ * absent — which must read as `false`, not "no signal". Only a present
+ * `is_agent_pane: true` distinguishes an agent pane (idle or busy) from a
+ * shell/PTY pane (`{}`), so it is the gate; the turn state is then
+ * `turn_active === true` (absent → false).
+ */
+export function deriveTurnActive(data: unknown): boolean | null {
+    if (!data || typeof data !== "object") return null;
+    const d = data as { is_agent_pane?: unknown; turn_active?: unknown };
+    if (d.is_agent_pane !== true) return null;
+    return d.turn_active === true;
+}
+
 export interface UseControllerStatusEventsOptions {
     blockId: string;
     log: LogFn;
@@ -49,11 +70,12 @@ export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions
                         opts.log("subprocess", "turn complete");
                     }
                 }
-                // `turn_active` is only meaningful for agent panes (shell/PTY
-                // controllers leave it absent); a non-boolean means "no signal",
-                // not "idle", so only forward a real boolean.
-                if (opts.onTurnActive && data?.is_agent_pane && typeof data.turn_active === "boolean") {
-                    opts.onTurnActive(data.turn_active);
+                // Reconcile turn_active for agent panes only — see
+                // deriveTurnActive for the omitted-false wire contract that
+                // makes a turn-END event's `turn_active` ABSENT (not `false`).
+                const active = deriveTurnActive(data);
+                if (opts.onTurnActive && active !== null) {
+                    opts.onTurnActive(active);
                 }
             },
         });


### PR DESCRIPTION
## Summary
Completes the reconciliation symmetry PR #2005 started. #2005 reconciled the pane's `TurnPhase` **up** from backend truth (`Idle → Streaming` when the backend reports a turn in flight) but never **down**. So when a turn ends but the frontend misses the terminal `session_end` (pane backgrounded/unmounted across the transition, or a dropped WPS event), the phase stays `Streaming` forever.

**Two live incidents, one bug** — both diagnosed this week:
- **Agent1** — stuck "Working…" indicator (`docs/retro/retro-persistent-agent-working-status-stuck-2026-07-16.md`).
- **Agent2** — stuck "Queued" held message. For persistent agents "Queued" is a pure *frontend* state (`send_message` writes straight to stdin + emits accepted immediately), and the held-message auto-flush (`agent-view.tsx:704-713`) is gated on the phase reaching `Idle`/`Done` — so a stuck `Streaming` strands the queue indefinitely (`docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md`).

## Changes
- **reducer** (`agent-pane-state/reducer.ts`): `ReconcileTurnActive` with `active:false` now demotes a stuck **`Streaming`** phase to `Idle`, clearing `currentTool`/`turnTokens` like the liveness watchdog — but on the backend's *authoritative* `result`-event signal rather than a timeout guess. Only `Streaming` is demoted: `Submitting` is left to `SUBMIT_TIMEOUT` (and is where the send-race lives — a local `TurnStart` racing a backend that hasn't marked the turn active yet), `Interrupting` to `INTERRUPT_TIMEOUT`, `Done`/`Idle`/`Disconnected` already correct. `active:true` behavior unchanged.
- **live wiring** (`useControllerStatusEvents.ts` + `agent-view.tsx`): forward live `turn_active` from every `controllerstatus` WPS event via a new `onTurnActive` callback (guarded to agent panes carrying a boolean flag), so reconciliation runs continuously while mounted — not just the one-shot `GetControllerStatus` at mount. `agent-view` dispatches `ReconcileTurnActive`.

Once the phase reaches `Idle`, the existing flush effect fires, so Agent2's held message delivers with no separate backstop needed.

## Test plan
- 7 new reducer cases: demote from `Streaming`; clears tool/tokens; demotes even with a tool active (backend signal is authoritative, unlike the timeout watchdog); leaves `Submitting`/`Done` untouched; promote→demote→promote round-trip.
- `npx tsc --noEmit` clean.
- `npx vitest run` — 150/150 reducer, 701/701 agent + swarm tests pass.

Note: this fixes the class behind the "I don't see my messages / stuck Working" reports; it lands in the reducer + live-status wiring, no backend change.

<!-- agentmux:agent_id=agent3 -->