### PR TITLE
fix(cef): closing "main" never notified srv — permanent window row leak

### DIFF
--- a/.changesets/1784230788-fix-cef-main-window-close-never-notified-srv.md
+++ b/.changesets/1784230788-fix-cef-main-window-close-never-notified-srv.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+fix(cef): closing the last window ("main") never notified srv, leaking its rows forever
+
+Closing "main" (the app's primary/last window) was structurally excluded from the srv-notify call every secondary window-* close already gets (CloseWindowTask, gated `self.label != "main"` on the incorrect assumption that process exit alone cleans up srv-side state). srv never heard about the close, so its window/workspace/tab rows leaked permanently and crash-reproject resurrected them as "ghost" windows on every subsequent launch. Fixed by notifying srv synchronously (not on a background thread, which lost the race against the host's own sidecar-kill on shutdown) before main's close completes. Live-verified: db_window drops to 0 after close, including cleanup of a pre-existing leaked row. A related but non-live gap in on_before_close's Stage 2 (real on macOS/Linux, dead code for this case on Windows) was fixed alongside as defense-in-depth.

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -574,6 +574,24 @@ impl AgentMuxHandler {
         true // cancel the top-level popup creation
     }
 
+    /// Post `quit_message_loop()` back to the UI thread from a background
+    /// thread, once that thread's `backend_close_window` notify work is
+    /// done. Never call `quit_message_loop()` directly off the UI thread —
+    /// see `ui_tasks::QuitMessageLoopTask`'s doc comment. Fixes the
+    /// last-window close race — docs/retro/retro-last-window-close-quit-race-2026-07-16.md.
+    fn quit_after_backend_notify() {
+        let mut task = crate::ui_tasks::QuitMessageLoopTask::new();
+        let posted = post_task(ThreadId::UI, Some(&mut task));
+        if posted == 0 {
+            // post_task can fail during teardown if the UI thread's message
+            // loop already tore down its task queue (see the doc note at
+            // lifecycle.rs:416 for the analogous close_browser case). Nothing
+            // recoverable to do — the process is already on its way out one
+            // way or another; log so a future investigation isn't blind.
+            tracing::warn!(target: "wrr", "[wrr] quit_after_backend_notify: post_task(UI) failed — process is likely already exiting");
+        }
+    }
+
     pub(crate) fn on_before_close(&mut self, browser: Option<&mut Browser>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
@@ -934,90 +952,105 @@ impl AgentMuxHandler {
         // Stage 2: every browser this handler ever managed is now
         // gone. Safe to call quit_message_loop — no other CEF
         // lifecycle is in flight that could deadlock with it.
-        if self.browser_list.is_empty() && !self.is_browser_pane {
-            tracing::warn!(
-                target: "wrr",
-                "[wrr] stage 2: self.browser_list.is_empty() — calling quit_message_loop"
-            );
-            quit_message_loop();
-            tracing::warn!(target: "wrr", "[wrr] quit_message_loop returned");
-        } else {
-            // Phase B.7.3.3 — `Event::WindowClosed` +
-            // `Event::WindowInstanceReleased` from the launcher
-            // drive remaining renderers' InstancePanel atoms via the
-            // CEF JS bridge; no sync emit here.
+        //
+        // 2026-07-16 fix (docs/retro/retro-last-window-close-quit-race-2026-07-16.md):
+        // this branch used to call quit_message_loop() and NOTHING ELSE —
+        // the backend-notify block below lived only in the `else` arm, so
+        // closing the LAST window never even attempted backend_close_window
+        // for it. srv never heard about the close, its window/workspace/tab
+        // row leaked permanently, and crash-reproject faithfully resurrected
+        // it as a "ghost" window on every subsequent launch. The notify
+        // logic below now runs UNCONDITIONALLY (last window or not); when
+        // this is the last window, quit_message_loop is deferred until that
+        // notify work finishes, posted back to the UI thread (it must run
+        // there — see the comment above about deadlocking on a nested call).
+        let is_last_window = self.browser_list.is_empty() && !self.is_browser_pane;
 
-            // Tell the backend to clean up this window's workspace/tabs/shells.
-            // This replaces the JavaScript `beforeunload` handler — running it here
-            // ensures shells die after the CEF browser is gone (not while it's still
-            // alive), so Task Manager keeps them grouped until they exit.
-            if let Some(window_id) = backend_window_id {
-                let web_endpoint = self.state.backend_endpoints.lock().web_endpoint.clone();
-                let auth_key = self.state.auth_key.lock().clone();
-                // Safe to report here (reagent P1 on PR #1965): we already
-                // resolved the window_id, so there's no pending retry left
-                // to race against.
-                let unregister_lbl = label.clone();
-                dlog(&format!("spawning backend_close_window thread for window_id={}", window_id));
-                std::thread::spawn(move || {
-                    backend_close_window(&web_endpoint, &auth_key, &window_id);
-                    if let Some(lbl) = unregister_lbl {
+        // Phase B.7.3.3 — `Event::WindowClosed` +
+        // `Event::WindowInstanceReleased` from the launcher
+        // drive remaining renderers' InstancePanel atoms via the
+        // CEF JS bridge; no sync emit here.
+
+        // Tell the backend to clean up this window's workspace/tabs/shells.
+        // This replaces the JavaScript `beforeunload` handler — running it here
+        // ensures shells die after the CEF browser is gone (not while it's still
+        // alive), so Task Manager keeps them grouped until they exit.
+        if let Some(window_id) = backend_window_id {
+            let web_endpoint = self.state.backend_endpoints.lock().web_endpoint.clone();
+            let auth_key = self.state.auth_key.lock().clone();
+            // Safe to report here (reagent P1 on PR #1965): we already
+            // resolved the window_id, so there's no pending retry left
+            // to race against.
+            let unregister_lbl = label.clone();
+            dlog(&format!("spawning backend_close_window thread for window_id={}", window_id));
+            std::thread::spawn(move || {
+                backend_close_window(&web_endpoint, &auth_key, &window_id);
+                if let Some(lbl) = unregister_lbl {
+                    crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
+                }
+                if is_last_window {
+                    tracing::warn!(target: "wrr", "[wrr] stage 2: backend notified — posting quit_message_loop to UI thread");
+                    Self::quit_after_backend_notify();
+                }
+            });
+        } else if let Some(lbl) = label.clone() {
+            // The immediate shadow lookup missed. This is expected and
+            // permanent for pre-promote pool-window churn (never had a
+            // backend_window_id, never will) — but it's also exactly
+            // what happens when a window is promoted and closed fast
+            // enough that the host->launcher->host register_backend_window
+            // round trip hasn't landed yet, confirmed in the 2026-07-04
+            // pagefile-test session (docs/retro/retro-window-lifecycle-leak-2026-07-04.md).
+            // Retry on this same background thread (never the UI thread)
+            // for a bounded window before giving up — closes that race
+            // without a larger reconciliation mechanism. See
+            // docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md.
+            let state = self.state.clone();
+            let web_endpoint = self.state.backend_endpoints.lock().web_endpoint.clone();
+            let auth_key = self.state.auth_key.lock().clone();
+            std::thread::spawn(move || {
+                let sleep_fn = |d: std::time::Duration| std::thread::sleep(d);
+                match retry_backend_window_id_lookup(
+                    BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
+                    BACKEND_WINDOW_ID_RETRY_DELAY,
+                    || state.backend_window_id(&lbl),
+                    sleep_fn,
+                ) {
+                    Some(window_id) => {
+                        dlog(&format!(
+                            "backend_window_id({:?}) resolved on retry — spawning backend_close_window",
+                            lbl
+                        ));
+                        backend_close_window(&web_endpoint, &auth_key, &window_id);
+                        // Report the unregister only now (reagent P1 on
+                        // PR #1965) — the retry just succeeded using
+                        // this mapping, so it's safe to tell the
+                        // launcher to drop it.
                         crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
                     }
-                });
-            } else if let Some(lbl) = label.clone() {
-                // The immediate shadow lookup missed. This is expected and
-                // permanent for pre-promote pool-window churn (never had a
-                // backend_window_id, never will) — but it's also exactly
-                // what happens when a window is promoted and closed fast
-                // enough that the host->launcher->host register_backend_window
-                // round trip hasn't landed yet, confirmed in the 2026-07-04
-                // pagefile-test session (docs/retro/retro-window-lifecycle-leak-2026-07-04.md).
-                // Retry on this same background thread (never the UI thread)
-                // for a bounded window before giving up — closes that race
-                // without a larger reconciliation mechanism. See
-                // docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md.
-                let state = self.state.clone();
-                let web_endpoint = self.state.backend_endpoints.lock().web_endpoint.clone();
-                let auth_key = self.state.auth_key.lock().clone();
-                std::thread::spawn(move || {
-                    let sleep_fn = |d: std::time::Duration| std::thread::sleep(d);
-                    match retry_backend_window_id_lookup(
-                        BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
-                        BACKEND_WINDOW_ID_RETRY_DELAY,
-                        || state.backend_window_id(&lbl),
-                        sleep_fn,
-                    ) {
-                        Some(window_id) => {
-                            dlog(&format!(
-                                "backend_window_id({:?}) resolved on retry — spawning backend_close_window",
-                                lbl
-                            ));
-                            backend_close_window(&web_endpoint, &auth_key, &window_id);
-                            // Report the unregister only now (reagent P1 on
-                            // PR #1965) — the retry just succeeded using
-                            // this mapping, so it's safe to tell the
-                            // launcher to drop it.
-                            crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
-                        }
-                        None => {
-                            let warn = format!(
-                                "[on_before_close] no backend window ID registered for label={:?} after {} retries ({}ms) — shells may orphan",
-                                lbl,
-                                BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
-                                BACKEND_WINDOW_ID_RETRY_ATTEMPTS * BACKEND_WINDOW_ID_RETRY_DELAY.as_millis() as u32
-                            );
-                            dlog(&warn);
-                            tracing::warn!("{}", warn);
-                            // Retries exhausted — nothing left to protect
-                            // against racing; report the unregister so the
-                            // launcher's bookkeeping doesn't keep a stale
-                            // entry for a label that's now definitely gone.
-                            crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
-                        }
+                    None => {
+                        let warn = format!(
+                            "[on_before_close] no backend window ID registered for label={:?} after {} retries ({}ms) — shells may orphan",
+                            lbl,
+                            BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
+                            BACKEND_WINDOW_ID_RETRY_ATTEMPTS * BACKEND_WINDOW_ID_RETRY_DELAY.as_millis() as u32
+                        );
+                        dlog(&warn);
+                        tracing::warn!("{}", warn);
+                        // Retries exhausted — nothing left to protect
+                        // against racing; report the unregister so the
+                        // launcher's bookkeeping doesn't keep a stale
+                        // entry for a label that's now definitely gone.
+                        crate::launcher_ipc::report_backend_window_id_unregistered(lbl);
                     }
-                });
-            } else if !self.is_browser_pane {
+                }
+                if is_last_window {
+                    tracing::warn!(target: "wrr", "[wrr] stage 2: backend notify attempt finished — posting quit_message_loop to UI thread");
+                    Self::quit_after_backend_notify();
+                }
+            });
+        } else {
+            if !self.is_browser_pane {
                 let warn = format!(
                     "[on_before_close] no backend window ID registered for label={:?} — shells may orphan",
                     label
@@ -1033,6 +1066,16 @@ impl AgentMuxHandler {
             // with. Warning here would fire once per pane close now that
             // the wrapper teardown actually runs CEF's close pipeline
             // (retro-browser-pane-renderer-leak-2026-07-07) — pure noise.
+            //
+            // No async work was started above (no backend_window_id, no
+            // label to retry against), so if this was the last window,
+            // quit_message_loop is safe to call directly, right here on
+            // the UI thread — no need to post it.
+            if is_last_window {
+                tracing::warn!(target: "wrr", "[wrr] stage 2: no backend notify possible (no label) — calling quit_message_loop directly");
+                quit_message_loop();
+                tracing::warn!(target: "wrr", "[wrr] quit_message_loop returned");
+            }
         }
 
         tracing::debug!(

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -471,6 +471,24 @@ pub(crate) fn unregister_after_parking_close(state: &Arc<AppState>, label: &str)
     // (QuitState finally transitions on this path) instead of the quit
     // resting solely on WRR's OS-signal gate.
     consume_request_drain(state, &out, "unregister_after_parking_close");
+    // 2026-07-16 fix (reagent P1 on PR #2186, docs/retro/retro-last-window-close-quit-race-2026-07-16.md):
+    // report_pool_drain_decision is the ONLY source of Event::PoolDrained /
+    // Event::PoolNotLast — the launcher's Phase F.6 window_cleanup saga
+    // (agentmux-launcher/src/saga/window_cleanup.rs) needs one of those to
+    // advance past its DrainingPool step. `on_before_close` reports this
+    // (lifecycle.rs, same request_drain.is_some() condition), but this
+    // function is the ACTUAL executor for every parking close on Windows —
+    // on_before_close never fires for any of them (this whole function
+    // exists because of that). Missing here meant every parking close's
+    // saga stalled in DrainingPool until its 30s timeout, main's included —
+    // silent because nothing else depended on the saga completing promptly,
+    // just wasted launcher-side saga slots. Same gate as on_before_close's:
+    // skip browser-pane-* (this function isn't reached for those anyway,
+    // but mirrors the source of truth exactly rather than assuming).
+    if !label.starts_with("browser-pane-") {
+        let was_last = out.request_drain.is_some();
+        crate::launcher_ipc::report_pool_drain_decision(label.to_string(), was_last);
+    }
     if label != "main" {
         // Mirror on_before_close's cache eviction (stale entries break
         // WM_CLOSE routing on label reuse). Main keeps its entry — the

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -37,6 +37,31 @@ wrap_task! {
     }
 }
 
+// ── Deferred quit_message_loop (last-window close fix, 2026-07-16) ────────
+//
+// `quit_message_loop()` must run on the UI thread (see the Stage-2 comment
+// in `client/lifecycle.rs::on_before_close`), but the last-window-close fix
+// (docs/retro/retro-last-window-close-quit-race-2026-07-16.md) needs to call
+// it AFTER a background thread finishes notifying srv via
+// `backend_close_window` — otherwise the process can exit before that
+// network call completes, leaking the closing window's srv-side row. This
+// task lets the background thread post the quit back to the UI thread once
+// its notify work is done, instead of calling it inline (from a background
+// thread `quit_message_loop()` is undefined behavior — it's not
+// thread-safe).
+
+wrap_task! {
+    pub struct QuitMessageLoopTask {}
+
+    impl Task {
+        fn execute(&self) {
+            tracing::warn!(target: "wrr", "[wrr] QuitMessageLoopTask: calling quit_message_loop");
+            quit_message_loop();
+            tracing::warn!(target: "wrr", "[wrr] QuitMessageLoopTask: quit_message_loop returned");
+        }
+    }
+}
+
 // ── Close ────────────────────────────────────────────────────────────────
 
 wrap_task! {
@@ -59,6 +84,66 @@ wrap_task! {
             // Widget::Close CHECKs !on_call_stack_ and aborts if the widget is
             // already being destroyed (e.g. macOS windowShouldClose racing this
             // queued IPC task) — is handled by the is_closed() guard below.
+            // 2026-07-16 fix (docs/retro/retro-last-window-close-quit-race-2026-07-16.md):
+            // "main" was the ONE label structurally excluded from ANY
+            // srv-notify call anywhere in this function — every branch below
+            // that calls `demote_srv_cleanup` (the actual `backend_close_window`
+            // → srv `CloseWindow` → delete_workspace cascade trigger) is
+            // explicitly gated on `self.label.starts_with("window-")` or
+            // `self.label != "main"`, on the documented assumption that "main's
+            // close feeds the tuned wrr last-window quit sequence and process
+            // exit reaps everything there." Process exit does NOT reap
+            // anything srv-side: srv is a separate process with its own
+            // persistent DB, and nothing else ever tells it main's window
+            // closed. Confirmed live: closing "main" left its srv window/
+            // workspace/tab rows permanently orphaned, resurrected by
+            // crash-reproject as a "ghost" window on every subsequent launch,
+            // while every OTHER label's close correctly reached srv.
+            //
+            // MUST be synchronous (block this UI-thread task), not fired on a
+            // background thread like `demote_srv_cleanup` does for window-*
+            // labels. First attempt used the async version and it lost the
+            // race every time: `lib.rs`'s shutdown sequence
+            // (`run_message_loop()` returning → "Killing backend sidecar")
+            // followed within ~50ms in live testing, killing the very srv
+            // process the background thread's HTTP call needed to reach,
+            // before it ever got there. CEF's message loop is single-threaded
+            // — this task, the WRR win-event callback that eventually calls
+            // `quit_message_loop()`, and everything else all run on the same
+            // UI thread, so blocking HERE transitively delays all of that
+            // until the notify finishes (or its own bounded ~1s retry +
+            // ~2s-capped HTTP timeouts are exhausted) — which is the point.
+            // Acceptable: this only affects the final moments of an
+            // already-closing app, and mirrors the small bounded quit delay
+            // the on_before_close-path fix (same retro doc) already accepts
+            // for the platforms where that path is the live one.
+            #[cfg(target_os = "windows")]
+            if self.label == "main" {
+                crate::launcher_ipc::report_panes_reaped(self.label.clone());
+                let web_endpoint = self.state.backend_endpoints.lock().web_endpoint.clone();
+                let auth_key = self.state.auth_key.lock().clone();
+                let sleep_fn = |d: std::time::Duration| std::thread::sleep(d);
+                match crate::client::retry_backend_window_id_lookup(
+                    crate::client::BACKEND_WINDOW_ID_RETRY_ATTEMPTS,
+                    crate::client::BACKEND_WINDOW_ID_RETRY_DELAY,
+                    || self.state.backend_window_id(&self.label),
+                    sleep_fn,
+                ) {
+                    Some(window_id) => {
+                        crate::client::backend_close_window(&web_endpoint, &auth_key, &window_id);
+                        crate::launcher_ipc::report_backend_window_id_unregistered(self.label.clone());
+                    }
+                    None => {
+                        tracing::warn!(
+                            target: "wrr",
+                            label = %self.label,
+                            "[close-window] main: no backend window ID after retries — srv state may orphan",
+                        );
+                        crate::launcher_ipc::report_backend_window_id_unregistered(self.label.clone());
+                    }
+                }
+            }
+
             if let Some(window) = get_window_on_ui(&self.state, &self.label) {
                 // CEF 148 Views: closing the WINDOW FIRST tears down the
                 // Window but leaves the hosted browser HIDDEN/RECYCLED —

--- a/docs/retro/retro-last-window-close-quit-race-2026-07-16.md
+++ b/docs/retro/retro-last-window-close-quit-race-2026-07-16.md
@@ -1,0 +1,77 @@
+# Retro: closing the LAST window ("main") never notified srv at all
+
+**Date:** 2026-07-16
+**Severity:** Medium — permanent srv-side `db_window`/`db_workspace` row leak, resurrected by crash-reproject on every subsequent launch
+**Tracking:** `docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md` §4c Round 3 (this fix)
+**Fix (confirmed, live-verified):** `agentmux-cef/src/ui_tasks/window.rs` (`CloseWindowTask::execute`, "main" branch)
+**Fix (defense-in-depth, not the live Windows path):** `agentmux-cef/src/client/lifecycle.rs` (`on_before_close`) — see §5
+
+---
+
+## 1. How it was found
+
+While smoke-testing a batch of merged PRs in a `task dev` instance, the user closed all open windows one at a time via the normal UI close button, then relaunched. Crash-reproject (Pillar 1) recreated a window titled "Starter workspace" that the user had explicitly closed — a "ghost" window reappearing after being deliberately closed.
+
+Live inspection of the instance's `objects.db` (`db_window` table) and `srv-events.log` confirmed:
+
+- `db_window` still contained a row for the closed "Starter workspace" window (`winsize: {width:0, height:0}`, stale placeholder geometry).
+- Tracing that specific `window_id` through the *entire* `srv-events.log` found **zero events of any kind** for it — not even an attempted-and-failed close. Every *other* window closed in the same session produced a full saga: `tab_deleted → active_tab_changed → workspace_deleted → saga_completed → srv_window_closed`.
+
+This ruled out a transient race (which would at least show a failed attempt) and pointed at a structural gap: this window's close never even tried to notify srv.
+
+## 2. First hypothesis (wrong location, right instinct)
+
+The first read of `AgentMuxHandler::on_before_close` (`client/lifecycle.rs`, Pillar 2's Phase B.9.3 two-stage close cascade) found what looked like the bug: its Stage 2 branched on whether the closing browser was the *last* one —
+
+```rust
+if self.browser_list.is_empty() && !self.is_browser_pane {
+    quit_message_loop();
+} else {
+    // ...notify srv via backend_close_window, with retry logic...
+}
+```
+
+— with the `backend_close_window` notify living **only** in the `else` arm, so the last window's close would skip it. This diagnosis was fixed (see §5) and is real, but **live testing (`getApi().closeWindow()` on the last window, then grepping the host's own `tracing::` log) proved `on_before_close` never actually runs for this case on this CEF build.** The Rust host log showed the real path taken:
+
+```
+[close-window] main close initiated — dispatching UnregisterBrowser (parked browser fires no on_before_close)
+```
+
+— a completely different function, `unregister_after_parking_close` (`ui_tasks/window.rs`), explicitly documented (`SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md`) as existing *because* CEF 148 Views parks (hides + recycles) the browser on `window.close()` instead of destroying it, so `on_before_close` never fires for the dominant Windows close path. `on_before_close`'s own fix is real and harmless to keep (see §5), but it was not the live bug.
+
+## 3. Actual root cause (confirmed via `tracing::` log, not `dlog()`)
+
+**Lesson learned mid-investigation:** this codebase has two logging sinks that look similar but aren't — `cef-debug.log` (forwarded JS `console.*` calls only) and the real Rust `tracing::` output (`agentmux-host-v*.log`, found via `muxlog ls`, one file per running instance). `dlog()` calls are a *third*, silent-by-default sink (`AGENTMUX_DEBUG_CLOSE=1` gated). Diagnosing this correctly required grepping the actual host log, not the CEF debug log.
+
+`getApi().closeWindow()` → the `close_window` IPC command → `CloseWindowTask` (`ui_tasks/window.rs`). That task has explicit, well-documented exclusions for the `"main"` label throughout — e.g.:
+
+```rust
+// Scope: NOT for "main" — main's close feeds the tuned wrr
+// last-window quit sequence and process exit reaps everything there.
+```
+
+and a `self.label != "main"` guard around the entire block that calls `demote_srv_cleanup` (the function that actually does `backend_close_window` → srv `CloseWindow` RPC → `delete_workspace` cascade) for every `window-*` label. **`"main"` was the one label that never reached `demote_srv_cleanup`, or any equivalent, anywhere in this function** — on the documented assumption that closing main is the same as quitting the app, and "process exit reaps everything." It doesn't: `agentmux-srv` is a *separate* process with its own persistent SQLite-backed object store. Nothing else ever tells it that main's window closed.
+
+## 4. The fix (confirmed, live-verified)
+
+Added a `self.label == "main"` branch at the top of `CloseWindowTask::execute` that runs the same backend-notify logic (`backend_window_id` lookup with bounded retry, then `backend_close_window`) every `window-*` label already gets via `demote_srv_cleanup`.
+
+**Critical detail — this call is synchronous, not fire-and-forget on a background thread** (unlike `demote_srv_cleanup`'s own pattern, which is fine for `window-*` labels since the process stays alive for them). First attempt used a background thread and it lost the race *every time*: the host's own shutdown sequence (`lib.rs`, right after `run_message_loop()` returns) logs `"Killing backend sidecar"` and kills the `agentmux-srv` child process — confirmed live to happen **within ~50ms** of the close starting, well before an async HTTP round-trip (even a fast localhost one) reliably completes.
+
+The fix instead blocks the UI thread. This works *because* CEF's message loop is single-threaded: this task, the WRR win-event callback that eventually calls `quit_message_loop()`, and everything else downstream all run on that same thread — so blocking here transitively delays the entire quit sequence (and the sidecar kill) until the notify finishes, capped by the existing bounded retry (~1s) and `backend_close_window`'s own timeouts (~2s). Acceptable: this only affects the final moments of an already-closing app.
+
+## 5. Defense-in-depth fix kept alongside (not the live Windows bug, but real)
+
+The original `on_before_close` fix from §2 was kept: the notify block there was *also* skip-on-last-window structured, and while CEF-148-Windows never reaches it for `"main"`'s own close, `on_before_close` **does** fire for other browsers in the same handler (confirmed live: floating-pool windows closing as part of the Stage-1 pool-drain cascade go through it normally), and per its own comment is the *correct, reliable* path on macOS/Linux (`window.close()` → `can_close` → `on_before_close` runs the full chain there, no parking). Leaving the old skip-on-last-window branch in place would still be a live bug on those platforms/paths. Implementation: the notify logic now runs unconditionally; `quit_message_loop()` (UI-thread-only) is deferred via a new `QuitMessageLoopTask` posted from the background notify thread once it completes, instead of firing immediately and racing ahead of it.
+
+## 6. What this doesn't fix
+
+- **A genuinely unreachable srv** (already dead, or slower than the bounded retry/timeout) still leaves the row orphaned — this fixes the *common* case, not every failure mode. The durable fix is the reconciliation-pass idea already tracked in `SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md` §2.3 (`SystemProcessInfo`-style periodic cross-check), still not implemented.
+- **macOS/Linux were not live-tested** — the `on_before_close` fix (§5) is reasoned from its own doc comments (`window.close()` → `can_close` → `on_before_close` runs the full chain there) but not empirically re-verified on those platforms this session.
+- Shutdown latency: closing the last window now briefly blocks the UI thread on the notify call before the process exits. Bounded (~1s retry + ~2s HTTP timeouts, worst case), judged acceptable for the final moment of an already-closing app.
+
+## 7. Verification
+
+- `cargo check -p agentmux-cef` — clean, both fixes.
+- Live repro (before fix): closing "main" (the last window) — zero events for its `window_id` anywhere in `srv-events.log`.
+- Live repro (after fix, synchronous branch): closing "main" now produces the full `srv_window_closed → saga_started(delete_workspace) → tab_deleted → active_tab_changed → workspace_deleted → saga_completed` sequence. `db_window` row count confirmed to drop to `0` afterward (was carrying a leaked row from before this fix — closing "main" with the fix in place cleaned up that pre-existing leak too, not just prevented new ones).

--- a/docs/retro/retro-last-window-close-quit-race-2026-07-16.md
+++ b/docs/retro/retro-last-window-close-quit-race-2026-07-16.md
@@ -70,6 +70,14 @@ The original `on_before_close` fix from §2 was kept: the notify block there was
 - **macOS/Linux were not live-tested** — the `on_before_close` fix (§5) is reasoned from its own doc comments (`window.close()` → `can_close` → `on_before_close` runs the full chain there) but not empirically re-verified on those platforms this session.
 - Shutdown latency: closing the last window now briefly blocks the UI thread on the notify call before the process exits. Bounded (~1s retry + ~2s HTTP timeouts, worst case), judged acceptable for the final moment of an already-closing app.
 
+## 6b. Follow-up (reagent P1, same day) — the notify fix left the launcher's saga stalling
+
+The §4 fix advances the launcher's Phase F.6 `window_cleanup` saga past its `PanesReaped` step (via `report_window_closed`, already firing) but reagent caught that nothing calls `report_pool_drain_decision` — the only source of `Event::PoolDrained`/`Event::PoolNotLast`, which the saga needs to advance past `DrainingPool`. That event was previously emitted only from `on_before_close` (itself dead code for every Windows parking close, not just main's — see §2/§3), so *every* parking close's saga was silently stalling to its 30s timeout, main's now included now that it reaches `PanesReaped` at all.
+
+Fixed in `unregister_after_parking_close` — the shared executor for *every* Windows parking close (main, `window-pool-*`, `window-*`), not just the new main-specific branch — using the exact same `request_drain.is_some()` signal `on_before_close` already had available via its own `UnregisterBrowser` dispatch output. This closes the gap for all parking closes, not only main's.
+
+Live-verified: launcher log shows `[saga] ... Done — emitting SagaCompleted` immediately after closing main, instead of stalling.
+
 ## 7. Verification
 
 - `cargo check -p agentmux-cef` — clean, both fixes.

--- a/docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md
+++ b/docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md
@@ -74,6 +74,18 @@ Verification protocol for round 2 (per §4, executed against a fresh isolated bu
 - srv `GET /api/v1/windows` returns to baseline count
 - instance-scoped renderer process count returns to baseline
 
+## 4c. Round 3 (2026-07-16) — "main" never notified srv on close, at all
+
+A third gap in the same close path: closing `"main"` (the app's last/primary window) left its `db_window`/`db_workspace` rows permanently orphaned, resurrected by crash-reproject on every subsequent launch. Found via: a user closed every window in a `task dev` session one at a time (clean UI closes), relaunched, and crash-reproject recreated the last-closed window ("Starter workspace") as a ghost. Tracing that window_id through the full `srv-events.log` found zero events for it, while every other close in the same session showed a complete `tab_deleted → workspace_deleted → saga_completed → srv_window_closed` saga — confirming a skip, not a failed attempt.
+
+Full analysis (including a wrong-location first hypothesis and the logging-sink confusion that caused it — `cef-debug.log` is JS-console-only, not the Rust `tracing::` output `muxlog` finds): `docs/retro/retro-last-window-close-quit-race-2026-07-16.md`.
+
+**Confirmed root cause, live-verified via the actual `tracing::` host log** (not the initial `on_before_close` hypothesis, which turned out to be dead code for this case on Windows — CEF 148 parks the browser on `"main"`'s close, so `on_before_close` never fires for it here, exactly as `SPEC_WRR_QUIT_FALSE_POSITIVE_2026_07_08.md` documents): the real close path, `CloseWindowTask::execute` (`ui_tasks/window.rs`), has an explicit `self.label != "main"` guard around the *entire* block that calls `demote_srv_cleanup` (the actual `backend_close_window` → srv `CloseWindow` → `delete_workspace` cascade trigger) for every `window-*` label — with the documented (and incorrect) assumption that "main's close feeds the tuned wrr last-window quit sequence and process exit reaps everything there." Process exit does not reap anything srv-side; `agentmux-srv` is a separate process.
+
+Fix: added a `self.label == "main"` branch running the same notify logic — but **synchronously** (blocking the UI thread), not on a background thread the way `demote_srv_cleanup` does it for `window-*` labels. A background-thread version was tried first and lost the race every time: the host's own shutdown sequence kills the `agentmux-srv` sidecar (`lib.rs`, "Killing backend sidecar") within ~50ms of the close starting, well before an async notify reliably completes. Blocking works because CEF's message loop is single-threaded — the notify call transitively delays `quit_message_loop()` and everything after it on the same thread. Live-verified: `db_window` count dropped to `0` after closing main with the fix in place (and cleaned up the pre-existing leaked row from before the fix, not just new ones).
+
+Kept alongside as defense-in-depth (real, but not the reported bug): the original `on_before_close` hypothesis — its Stage 2 also skipped the notify call on the last-window branch — was still fixed, since `on_before_close` **does** fire for other browsers in the same handler (e.g. floating-pool closes during the pool-drain cascade) and is the documented *correct* path on macOS/Linux (not re-verified live this session). Its notify logic now runs unconditionally; `quit_message_loop()` is deferred via a new `QuitMessageLoopTask` posted back to the UI thread once the background notify thread completes, instead of racing ahead of it.
+
 ## 5. Follow-ups tracked separately (not this PR)
 
 - Task #7 (this fix)
@@ -81,3 +93,4 @@ Verification protocol for round 2 (per §4, executed against a fresh isolated bu
 - Task #9 — window-level lifecycle test coverage (broader than the one regression test in §4)
 - Task #10 — cross-reference against the pagefile/OOM spec
 - Reconciliation pass / `SystemProcessInfo` (SPEC_AGENT_SYSTEM_MANAGEMENT_API_2026_07_04.md) — still undecided whether/when to implement
+- Round 3 (2026-07-16, this update) — last-window close never attempted the srv notify at all; fixed alongside this doc's update. A genuinely unreachable srv (or one slower than the notify's ~2s bounded timeout) still leaks the row — the reconciliation-pass idea above remains the durable fix for that residual case.


### PR DESCRIPTION
Fixes a permanent srv-side leak: closing the app's **last window** ("main") never told `srv` about it. The row stayed in `db_window`/`db_workspace` forever, and crash-reproject resurrected it as a "ghost" window on every subsequent launch — even after the user explicitly closed it.

## How this was found

Live smoke-testing: user closed all open windows via the normal UI close button, relaunched, and a window they'd just closed ("Starter workspace") reappeared. Tracing that window_id through the full `srv-events.log` found **zero events for it** — not a failed attempt, a structural skip. Every other window's close in the same session showed a complete `tab_deleted → workspace_deleted → saga_completed → srv_window_closed` saga.

## Root cause

`CloseWindowTask::execute` (`ui_tasks/window.rs`) gates its *entire* srv-notify block (`demote_srv_cleanup` → `backend_close_window` → srv `CloseWindow` RPC → `delete_workspace` cascade) on `self.label != "main"`, on the documented assumption that "main's close feeds the tuned wrr last-window quit sequence and process exit reaps everything there." **Process exit reaps nothing srv-side** — `agentmux-srv` is a separate process with its own persistent DB, and nothing else ever calls `CloseWindow` for main.

(First hypothesis targeted `on_before_close` instead — plausible from reading the code, but live testing against the host's actual `tracing::` log, not the JS-console-only `cef-debug.log`, proved that function is dead code for main's close on this CEF-148/Windows build. Full diagnostic trail, including that wrong turn, is in the retro doc.)

## The fix

Notify srv for `"main"` too — but **synchronously**, blocking the UI thread, unlike `demote_srv_cleanup`'s fire-and-forget background thread (fine for secondary windows, since the process stays alive for them). A background-thread version was tried first and **lost the race every time**: the host's own shutdown sequence kills the `agentmux-srv` sidecar within ~50ms of the close starting (confirmed via the host log), well before an async HTTP round-trip completes. Blocking works because CEF's message loop is single-threaded — the notify call transitively delays `quit_message_loop()` and everything downstream on that same thread.

Also fixed alongside as defense-in-depth (real bug, but not the one reported): `on_before_close`'s Stage 2 had a structurally identical skip-notify-on-last-window branch. It's dead code for main's close on Windows, but it's the documented *correct* path on macOS/Linux and does fire for other browsers in the same handler (e.g. floating-pool closes). Its notify now runs unconditionally; quit is deferred via a new `QuitMessageLoopTask`.

## Verification

- `cargo check -p agentmux-cef` — clean.
- `cargo test -p agentmux-cef --lib` — 189/189 pass.
- **Live, end-to-end, before/after**: closed the app's last window with the old code → zero srv events, `db_window` kept a stale row. Rebuilt with the fix, closed the last window again → full saga fires, `db_window` drops to `0` — including cleanup of the pre-existing leaked row that originally surfaced this bug.

Full writeup: `docs/retro/retro-last-window-close-quit-race-2026-07-16.md`. Tracking doc updated: `docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md` §4c (Round 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)