### PR TITLE
feat(launcher): teardown backstop Phase 2 — armed J0 teardown for a wedged host (#2092)

### DIFF
--- a/.changesets/1784244179-feat-launcher-teardown-backstop-phase2-armed-j0-teardown.md
+++ b/.changesets/1784244179-feat-launcher-teardown-backstop-phase2-armed-j0-teardown.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+feat(launcher): teardown backstop Phase 2 — armed J0 teardown for a wedged host
+
+Completes SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 (#2092), the last undelivered item from Discussion #1680's §9 scorecard. Phase 1's observe-only UI-thread liveness probe now feeds an armed state machine: arm on PoolDrained / OrphanInstance drift (last user window closed, host still alive), disarm on any WindowOpened or host exit, and — once armed past a 30s grace with ≥2 consecutive delivered-but-unanswered UI-thread probes — TerminateJobObject(J0) with a distinct launcher exit code (86). A host whose UI thread wedges after the last window closes no longer lingers as an orphaned process tree. Includes the spec's debug:hang_ui verification hook (double-gated behind AGENTMUX_DEBUG_HANG=1), a consecutive-miss counter in ui_liveness (any pump since a probe's send disqualifies it as wedge evidence), and reducer-style unit tests for the state machine. Docs riding along: 2026-07-16 lifecycle program status snapshot, SPEC_BRIDGE_INIT_RECOVERY correction (its reload-preserves-creds premise was proven false by #2181), and tracking-doc updates.

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -251,6 +251,22 @@ async fn route_command(
             // before/after every tear-off to surface intermittent failures.
             Ok(commands::floating_pane::get_pane_debug_state(state))
         }
+        "debug:hang_ui" => {
+            // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 2 verification hook —
+            // deliberately wedge the CEF UI thread so the launcher's armed
+            // J0 teardown can be reproduced live (close the last window,
+            // watch the backstop terminate the tree within GRACE + 2 probe
+            // intervals). Double-gated: the env var must be explicitly set
+            // AND the command explicitly invoked — never reachable in
+            // normal operation.
+            if std::env::var("AGENTMUX_DEBUG_HANG").as_deref() != Ok("1") {
+                Err("debug:hang_ui refused — set AGENTMUX_DEBUG_HANG=1 to enable".to_string())
+            } else {
+                tracing::warn!("[debug:hang_ui] parking the CEF UI thread in a 1h sleep — teardown-backstop verification only");
+                crate::ui_tasks::post_hang_ui_thread(state);
+                Ok(serde_json::Value::Null)
+            }
+        }
         "get_instance_number" => Ok(commands::window::get_instance_number(state, args)),
         "register_backend_window" => Ok(commands::window::register_backend_window(state, args)),
         "get_env" => Ok(commands::platform::get_env(args)),

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -1892,3 +1892,29 @@ pub fn post_probe_ui_thread_reply(nonce: u64) {
     let mut task = ProbeUiThreadReplyTask::new(nonce);
     post_task(ThreadId::UI, Some(&mut task));
 }
+
+// ── SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 2 — debug wedge (verification) ──
+
+wrap_task! {
+    pub struct HangUiThreadTask {}
+
+    impl Task {
+        fn execute(&self) {
+            // Park the UI thread. The message loop stops pumping: probe
+            // reply tasks queue but never execute, so the launcher's
+            // consecutive-miss counter climbs and — once the last user
+            // window is closed and the machine arms — the backstop tears
+            // the tree down. 1h is effectively forever for the test while
+            // still self-recovering if the backstop somehow doesn't fire.
+            tracing::warn!("[debug:hang_ui] UI thread parked (1h sleep) — the teardown backstop should reap this process");
+            std::thread::sleep(std::time::Duration::from_secs(3600));
+        }
+    }
+}
+
+/// SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 2 — verification-only UI-thread
+/// wedge. Caller (`ipc.rs "debug:hang_ui"`) gates on `AGENTMUX_DEBUG_HANG=1`.
+pub fn post_hang_ui_thread(_state: &Arc<AppState>) {
+    let mut task = HangUiThreadTask::new();
+    post_task(ThreadId::UI, Some(&mut task));
+}

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -595,6 +595,53 @@ where
             reducer::update(&mut state, cmd.clone(), &rctx)
         };
 
+        // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 2 — arm/disarm the J0
+        // teardown state machine from the VALIDATED reducer output (same
+        // layering as the Phase-1 `ReportUiThreadAlive` intercept above:
+        // process-supervision state about the host, not domain state the
+        // reducer owns — hooking the emitted events keeps the reducer pure
+        // while still only reacting to reports the reducer accepted).
+        //
+        // Arm: `PoolDrained` (host's own "last user window closed, drain
+        // begins" report) or `OrphanInstance` drift (mirror saw the last
+        // user window close with the host still Running). Disarm: any
+        // `WindowOpened` (covers crash-reproject re-opening windows within
+        // the grace, and ordinary re-opens). The supervisor additionally
+        // disarms on every host exit (the crash-restart-gap guard).
+        for ev in &events {
+            match ev {
+                Event::PoolDrained { label, .. } => {
+                    if crate::teardown_backstop::arm() {
+                        crate::logging::log(&format!(
+                            "[teardown-backstop] ARMED (PoolDrained, label={}) — grace {}s, then ≥{} unanswered probes ⇒ teardown",
+                            label,
+                            crate::teardown_backstop::TEARDOWN_GRACE.as_secs(),
+                            crate::teardown_backstop::TEARDOWN_REQUIRED_MISSES,
+                        ));
+                    }
+                }
+                Event::HwndDriftDetected {
+                    kind: agentmux_common::ipc::HwndDriftKind::OrphanInstance,
+                    ..
+                } => {
+                    if crate::teardown_backstop::arm() {
+                        crate::logging::log(
+                            "[teardown-backstop] ARMED (OrphanInstance drift — last user window closed, host still alive)",
+                        );
+                    }
+                }
+                Event::WindowOpened { label, .. } => {
+                    if crate::teardown_backstop::disarm() {
+                        crate::logging::log(&format!(
+                            "[teardown-backstop] disarmed — user window opened (label={})",
+                            label
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+
         // If the reducer accepted the Register (no AlreadyRegistered
         // error in the output), commit the local connection state.
         if let Some((kind, pid)) = pre_register {

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -40,6 +40,7 @@ mod reducer;
 mod saga;
 mod second_instance;
 mod supervisor;
+mod teardown_backstop;
 mod ui_liveness;
 #[cfg(target_os = "windows")]
 mod splash;

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -590,8 +590,47 @@ pub(crate) async fn run_windows(
     );
     ui_probe_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut ui_probe_nonce: u64 = 0;
+    // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 2 — armed J0 teardown check.
+    // Low-rate poll of the state machine (armed by the IPC server's
+    // post-reducer event hook on PoolDrained / OrphanInstance, disarmed on
+    // WindowOpened and on every host exit below). The teardown decision
+    // itself lives in `teardown_backstop::should_teardown` (grace elapsed
+    // AND ≥2 consecutive unanswered UI-thread probes); this tick only
+    // evaluates and executes. 5s granularity is plenty against a 30s grace.
+    let mut teardown_check_interval =
+        tokio::time::interval(std::time::Duration::from_secs(5));
+    teardown_check_interval
+        .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Distinct exit code so the wedged-host teardown is unambiguous in any
+    // log/exit-code triage (spec: "launcher exit with a distinct code").
+    const TEARDOWN_BACKSTOP_EXIT_CODE: i32 = 86;
     let exit_code = loop {
         tokio::select! {
+            _ = teardown_check_interval.tick() => {
+                let misses = crate::ui_liveness::consecutive_misses();
+                if crate::teardown_backstop::should_teardown(misses) {
+                    log(&format!(
+                        "[teardown-backstop] host wedged with zero user windows — terminating job \
+                         (armed > {}s grace, {} consecutive unanswered UI-thread probes)",
+                        crate::teardown_backstop::TEARDOWN_GRACE.as_secs(),
+                        misses,
+                    ));
+                    // I2/I3 hold by construction: J0 is this launcher's own
+                    // unnamed job; the blast radius is exactly the processes
+                    // it spawned (host + srv + their descendants — the
+                    // launcher itself is never assigned to J0). The one
+                    // deliberate exception to "never kill what a saga can
+                    // reconcile": zero user windows remain and the UI thread
+                    // is provably dead, so there is nothing to reconcile.
+                    unsafe {
+                        windows_sys::Win32::System::JobObjects::TerminateJobObject(
+                            job_handle,
+                            TEARDOWN_BACKSTOP_EXIT_CODE as u32,
+                        );
+                    }
+                    break TEARDOWN_BACKSTOP_EXIT_CODE;
+                }
+            }
             _ = ui_probe_interval.tick() => {
                 ui_probe_nonce += 1;
                 if let Some((missed, sent_at)) = crate::ui_liveness::record_probe_sent(ui_probe_nonce) {
@@ -626,6 +665,16 @@ pub(crate) async fn run_windows(
                 }
             }
             host_status = host_child.wait() => {
+                // SPEC_LAUNCHER_TEARDOWN_BACKSTOP Phase 2 — the host exiting
+                // (cleanly, crashing, or recycled) always stands the armed
+                // teardown down: an Armed machine's whole premise is "the
+                // host is alive but wedged", and this is the crash-restart-gap
+                // false-positive guard — the machine stays suspended across
+                // the restart and can only re-arm from a fresh drain report
+                // by the NEW host.
+                if crate::teardown_backstop::disarm() {
+                    log("[teardown-backstop] disarmed — host exited (supervised-exit path owns it now)");
+                }
                 let code = match host_status {
                     Ok(s) => s.code().unwrap_or(1),
                     Err(e) => {

--- a/agentmux-launcher/src/teardown_backstop.rs
+++ b/agentmux-launcher/src/teardown_backstop.rs
@@ -1,0 +1,193 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 2 — the armed J0
+//! teardown state machine.
+//!
+//! ```text
+//! Disarmed ──(PoolDrained / OrphanInstance drift)──▶ Armed(t0)
+//! Armed    ──(host exits — supervisor disarms)─────▶ Disarmed
+//! Armed    ──(any WindowOpened event)──────────────▶ Disarmed
+//! Armed    ──(t > t0+GRACE and ≥2 unanswered probes)▶ Teardown
+//! ```
+//!
+//! Consumes Phase 1's `ui_liveness` telemetry: the *decision* to tear down
+//! requires BOTH the grace period elapsing since arming AND the UI-thread
+//! prober reporting ≥ N consecutive unanswered probes — a wedged UI thread
+//! cannot answer, and transport failures never count as misses (the prober
+//! retracts probes whose SEND failed, so silence here is genuinely
+//! UI-thread evidence, not pipe evidence).
+//!
+//! Arm/disarm are driven from `ipc::server`'s post-reducer event hook
+//! (validated events only — same layering as the Phase 1 transport-side
+//! `ReportUiThreadAlive` intercept: this is process-supervision state about
+//! the host, not domain state the reducer owns). The supervisor's select
+//! loop polls `should_teardown` on a low-rate tick and, on `true`,
+//! `TerminateJobObject(J0)`s the tree — the one deliberate exception to
+//! "never kill what a saga can reconcile": zero user windows remain and the
+//! UI thread is provably dead, so there is nothing left to reconcile.
+//!
+//! False-positive guards (spec §Phase 2), and where each lives:
+//! - Startup: nothing arms until a drain/orphan event, which requires a
+//!   registered host that already opened (and closed) a user window.
+//! - Crash-restart gap: the supervisor disarms on every host exit; the
+//!   machine can only re-arm from a fresh drain report by the NEW host.
+//! - Crash-reproject: reproject re-opens windows within the grace; the
+//!   mirror's `WindowOpened` event disarms.
+//! - Probe transport failure: `ui_liveness::retract_probe` keeps failed
+//!   sends out of the consecutive-miss count entirely.
+//!
+//! Like `ui_liveness`, all logic lives on the struct (unit-testable with an
+//! injected clock); the module-level functions delegate to one
+//! process-global instance.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Grace period between arming and the earliest possible teardown. An
+/// order of magnitude above the slowest healthy quit observed
+/// (multi-window with pool sweep: ~2-5s), far below "user annoyed".
+pub const TEARDOWN_GRACE: Duration = Duration::from_secs(30);
+
+/// Consecutive unanswered UI-thread probes required (on top of the grace)
+/// before the host counts as wedged. At the Phase-1 probe rate (60s) this
+/// bounds worst-case wedge→teardown latency to roughly GRACE + 2 probe
+/// intervals — the spec's stated verification envelope.
+pub const TEARDOWN_REQUIRED_MISSES: u32 = 2;
+
+#[derive(Debug, Default)]
+pub struct TeardownBackstop {
+    /// `Some(t0)` = armed since `t0`. Re-arming while armed keeps the
+    /// ORIGINAL `t0` — a second drain report means the host has been
+    /// failing to exit since the first one, not that the clock restarts.
+    armed_since: Option<Instant>,
+}
+
+impl TeardownBackstop {
+    /// Arm the machine. Returns `true` when this call newly armed it
+    /// (callers log the transition); `false` when it was already armed
+    /// (the original arm time is kept).
+    pub fn arm(&mut self, now: Instant) -> bool {
+        if self.armed_since.is_some() {
+            return false;
+        }
+        self.armed_since = Some(now);
+        true
+    }
+
+    /// Disarm. Returns `true` when this call newly disarmed it.
+    pub fn disarm(&mut self) -> bool {
+        self.armed_since.take().is_some()
+    }
+
+    pub fn is_armed(&self) -> bool {
+        self.armed_since.is_some()
+    }
+
+    /// The teardown decision: armed for longer than `grace`, AND the
+    /// UI-thread prober has accumulated at least `required_misses`
+    /// consecutive unanswered probes. Pure read — the caller executes.
+    pub fn should_teardown(
+        &self,
+        now: Instant,
+        grace: Duration,
+        consecutive_misses: u32,
+        required_misses: u32,
+    ) -> bool {
+        match self.armed_since {
+            Some(t0) => {
+                now.saturating_duration_since(t0) > grace && consecutive_misses >= required_misses
+            }
+            None => false,
+        }
+    }
+}
+
+fn cell() -> &'static Mutex<TeardownBackstop> {
+    static S: OnceLock<Mutex<TeardownBackstop>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(TeardownBackstop::default()))
+}
+
+/// See [`TeardownBackstop::arm`]. Process-global instance.
+pub fn arm() -> bool {
+    cell().lock().unwrap().arm(Instant::now())
+}
+
+/// See [`TeardownBackstop::disarm`]. Process-global instance.
+pub fn disarm() -> bool {
+    cell().lock().unwrap().disarm()
+}
+
+/// See [`TeardownBackstop::should_teardown`]. Process-global instance,
+/// evaluated against the spec constants and the live probe-miss count.
+pub fn should_teardown(consecutive_misses: u32) -> bool {
+    cell().lock().unwrap().should_teardown(
+        Instant::now(),
+        TEARDOWN_GRACE,
+        consecutive_misses,
+        TEARDOWN_REQUIRED_MISSES,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn disarmed_never_tears_down() {
+        let b = TeardownBackstop::default();
+        let now = Instant::now();
+        assert!(!b.should_teardown(now, TEARDOWN_GRACE, 99, TEARDOWN_REQUIRED_MISSES));
+    }
+
+    #[test]
+    fn armed_within_grace_never_tears_down_even_with_misses() {
+        let mut b = TeardownBackstop::default();
+        let base = Instant::now();
+        assert!(b.arm(base), "first arm is a transition");
+        assert!(!b.should_teardown(t(base, 29), TEARDOWN_GRACE, 99, TEARDOWN_REQUIRED_MISSES));
+    }
+
+    #[test]
+    fn armed_past_grace_without_misses_never_tears_down() {
+        // A host answering probes is alive-but-slow — the host-side quit
+        // watchdog owns that case, not this backstop.
+        let mut b = TeardownBackstop::default();
+        let base = Instant::now();
+        b.arm(base);
+        assert!(!b.should_teardown(t(base, 300), TEARDOWN_GRACE, 1, TEARDOWN_REQUIRED_MISSES));
+    }
+
+    #[test]
+    fn armed_past_grace_with_required_misses_tears_down() {
+        let mut b = TeardownBackstop::default();
+        let base = Instant::now();
+        b.arm(base);
+        assert!(b.should_teardown(t(base, 31), TEARDOWN_GRACE, 2, TEARDOWN_REQUIRED_MISSES));
+    }
+
+    #[test]
+    fn disarm_cancels_a_pending_teardown() {
+        let mut b = TeardownBackstop::default();
+        let base = Instant::now();
+        b.arm(base);
+        assert!(b.disarm(), "disarm of an armed machine is a transition");
+        assert!(!b.disarm(), "second disarm is a no-op");
+        assert!(!b.should_teardown(t(base, 300), TEARDOWN_GRACE, 99, TEARDOWN_REQUIRED_MISSES));
+    }
+
+    #[test]
+    fn rearming_keeps_the_original_arm_time() {
+        let mut b = TeardownBackstop::default();
+        let base = Instant::now();
+        b.arm(base);
+        // A second arm 29s in must NOT restart the grace clock…
+        assert!(!b.arm(t(base, 29)), "re-arm while armed is not a transition");
+        // …so at t=31 the ORIGINAL t0 has aged past the 30s grace.
+        assert!(b.should_teardown(t(base, 31), TEARDOWN_GRACE, 2, TEARDOWN_REQUIRED_MISSES));
+    }
+}

--- a/agentmux-launcher/src/ui_liveness.rs
+++ b/agentmux-launcher/src/ui_liveness.rs
@@ -34,6 +34,13 @@ pub struct UiLiveness {
     /// Last time ANY `ReportUiThreadAlive` arrived — proof the UI thread
     /// pumped at that moment, regardless of nonce matching.
     last_alive: Option<Instant>,
+    /// Phase 2 — consecutive DELIVERED-but-unanswered probes. Incremented
+    /// when a new probe overwrites an unanswered one; reset by any reply.
+    /// Retracted probes (send failed — transport evidence, not liveness
+    /// evidence) never reach the overwrite path, so they can't inflate
+    /// this. Consumed by the armed teardown rule
+    /// (`teardown_backstop::should_teardown`).
+    consecutive_misses: u32,
 }
 
 impl UiLiveness {
@@ -41,6 +48,18 @@ impl UiLiveness {
     /// `(nonce, sent)` if it was never answered — the caller logs the miss.
     pub fn record_probe_sent(&mut self, nonce: u64) -> Option<(u64, Instant)> {
         let unanswered = self.probe_sent.take();
+        if let Some((_, sent_at)) = unanswered {
+            // Wedge evidence only if the UI thread has NOT pumped since this
+            // probe was sent. A nonce-unmatched (late) reply doesn't clear
+            // the outstanding probe (Phase-1 semantics: it can still be
+            // answered for latency), but it DOES prove the thread pumped
+            // after `sent_at` — so the probe aging out is telemetry noise,
+            // not a wedge signal.
+            let pumped_since = self.last_alive.is_some_and(|la| la >= sent_at);
+            if !pumped_since {
+                self.consecutive_misses = self.consecutive_misses.saturating_add(1);
+            }
+        }
         self.probe_sent = Some((nonce, Instant::now()));
         unanswered
     }
@@ -62,6 +81,10 @@ impl UiLiveness {
     /// thread pumped after its probe was sent).
     pub fn record_alive(&mut self, nonce: u64) -> Option<std::time::Duration> {
         self.last_alive = Some(Instant::now());
+        // ANY reply proves the UI thread pumped — the wedge streak is over
+        // regardless of nonce matching (a late reply to an old probe is
+        // still a pump that happened after that probe was sent).
+        self.consecutive_misses = 0;
         match self.probe_sent {
             Some((sent_nonce, sent_at)) if sent_nonce == nonce => {
                 self.probe_sent = None;
@@ -76,6 +99,12 @@ impl UiLiveness {
     /// yet — startup, or standalone mode with no pipe).
     pub fn last_alive(&self) -> Option<Instant> {
         self.last_alive
+    }
+
+    /// Phase-2 consumer surface: consecutive delivered-but-unanswered
+    /// probes. See the field doc for what does (and doesn't) count.
+    pub fn consecutive_misses(&self) -> u32 {
+        self.consecutive_misses
     }
 }
 
@@ -100,9 +129,14 @@ pub fn record_alive(nonce: u64) -> Option<std::time::Duration> {
 }
 
 /// See [`UiLiveness::last_alive`]. Process-global instance.
-#[allow(dead_code)] // consumed by Phase 2's armed teardown rule
+#[allow(dead_code)] // kept as telemetry surface; Phase 2 consumes consecutive_misses
 pub fn last_alive() -> Option<Instant> {
     cell().lock().unwrap().last_alive()
+}
+
+/// See [`UiLiveness::consecutive_misses`]. Process-global instance.
+pub fn consecutive_misses() -> u32 {
+    cell().lock().unwrap().consecutive_misses()
 }
 
 #[cfg(test)]
@@ -143,6 +177,28 @@ mod tests {
             matches!(missed, Some((1, _))),
             "the unanswered probe must be surfaced to the caller"
         );
+    }
+
+    #[test]
+    fn consecutive_misses_count_and_reset() {
+        let mut l = UiLiveness::default();
+        assert_eq!(l.consecutive_misses(), 0);
+        // Two unanswered probes overwritten in sequence → 2 misses.
+        l.record_probe_sent(1);
+        l.record_probe_sent(2);
+        assert_eq!(l.consecutive_misses(), 1);
+        l.record_probe_sent(3);
+        assert_eq!(l.consecutive_misses(), 2);
+        // ANY reply — even nonce-unmatched — resets the streak, AND marks
+        // the still-outstanding probe (3) as pumped-since, so its later
+        // overwrite is telemetry noise, not a new miss.
+        l.record_alive(999);
+        assert_eq!(l.consecutive_misses(), 0);
+        // A retracted (send-failed) probe never inflates the count.
+        l.record_probe_sent(4);
+        l.retract_probe(4);
+        l.record_probe_sent(5);
+        assert_eq!(l.consecutive_misses(), 0);
     }
 
     #[test]

--- a/docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
+++ b/docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md
@@ -1,7 +1,8 @@
 # SPEC: Host-Bridge Init Failure — Self-Heal + Recovery UI
 
 **Date:** 2026-06-15
-**Status:** Draft
+**Status:** Implemented (self-heal loop, recovery UI, Ctrl+R/F5 keybinding all shipped)
+**Correction (2026-07-16):** §3.5's premise that *"the document is a real `http://…` URL, so `location.reload()` does work and preserves the `__AGENTMUX_IPC_PORT__`/token query params"* was **proven false** by the #52 investigation (PR #2181): `setupCefApi` strips `ipc_port`/`ipc_token` from the URL after first read (the 2026-06-12 token-leak fix), so a reload arrives cred-less and — for `is_browser_pane`-flagged floating-pane/pool windows, which the host's `on_load_end` skipped — could never reacquire them. The self-heal reload loop this spec designed was re-entering an identical, deterministic failure every ~5s. Fixed in #2181 by (a) origin-gating the host's cred re-injection instead of gating on the pane flag, (b) making `isCef()` sticky via sessionStorage across the strip, and (c) injecting the authoritative `state.ipc_port` (pool handlers carry `self.ipc_port = 0`). With those in place, the reload-based self-heal below works as designed for all windows.
 **Scope:** `frontend/app/init/error-display.ts` + `frontend/app-init.ts` startup-error path
 
 ---

--- a/docs/specs/SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md
+++ b/docs/specs/SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md
@@ -1,7 +1,7 @@
 # SPEC: Launcher-side teardown backstop (UI-thread liveness probe + armed J0 teardown)
 
 **Date:** 2026-07-11
-**Status:** Ready for implementation (Phase 1 first, observe-only)
+**Status:** Phase 1 merged 2026-07-11 (observe-only probe). Phase 2 implemented 2026-07-16 — armed state machine in `agentmux-launcher/src/teardown_backstop.rs`, arm/disarm hooks in `ipc/server.rs`'s post-reducer event pass (PoolDrained / OrphanInstance arm; WindowOpened disarms; supervisor disarms on every host exit), teardown execution in the supervisor's 5s check tick (`TerminateJobObject(J0)`, launcher exit code 86), `consecutive_misses` counter added to `ui_liveness` (any pump since a probe's send disqualifies it as wedge evidence), and the §Verification `debug:hang_ui` host command (double-gated: `AGENTMUX_DEBUG_HANG=1` + explicit invoke).
 **Tracking:** #2092 (carved out of Discussion #1680 §9.4); shared prerequisite with #942 §8
 **Scope:** `agentmux-common` (protocol), `agentmux-cef` (probe reply), `agentmux-launcher` (prober + rule)
 

--- a/docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_16.md
+++ b/docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_16.md
@@ -1,0 +1,94 @@
+# Status & Roadmap — Lifecycle & Crash Architecture Program (as of 2026-07-16)
+
+> **Supersedes** `STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_12.md` in full. That
+> snapshot's #1-ranked open item (drag-HWND cross-wire) and its pagefile P0/P1 stack have
+> all shipped since; two NEW lifecycle bugs were found and fixed live (both in the
+> window-close → srv notify chain), and the teardown backstop's Phase 2 landed — closing
+> the last open item from Discussion #1680's §9 scorecard.
+
+**Type:** Status snapshot + forward roadmap, not a plan doc.
+**Verify before acting:** re-check file:line references if read more than a few days after
+2026-07-16 — this subsystem moves fast.
+
+---
+
+## 0. The one-sentence picture
+
+**All three pillars are functionally complete** (Pillar 1 through Step 5, Step 6 gated on
+bake time; Pillars 2 and 3 fully done), the entire `Client.windowids` leak class is closed,
+the window-close → srv notify chain is now correct for **every** close path including the
+app's last window, and the launcher can now reap a wedged host on its own (teardown
+backstop Phase 2) — leaving Step 6, one gated task, and one hardware-blocked verification
+as the only open program items.
+
+## 1. Pillar 1 — disposable host
+
+| Step | What | Status |
+|---|---|---|
+| 1 | Layout single-writer collapse (`#864`) | ✅ Done, merged. |
+| 2 | Persist per-window opacity + floating-pane placement/restore-rect | ✅ Done, merged, live-verified. |
+| 3 | Persist window `kind` + parent linkage | ✅ Done, merged, live-verified. |
+| 4 | Crash-reproject: fast-path from launcher snapshot, slow-path from srv, restoring-session overlay, splash respawn | ✅ Done, all 5 phases (#2014, #2015, #2017, #2032). |
+| 5 | E2E test: "host OOM ⇒ session reprojects" | ✅ Done. |
+| 6 | Collapse graceful-flush-vs-crash incoherence; shrink saga layer to an in-memory registry | ⬜ **Gated on bake period** (started ~2026-07-11; startable early-to-mid August 2026). Task #37. |
+
+Bake-period yield so far: the drag-HWND cross-wire (fixed, #2111) and the ghost-window
+resurrection below — both found precisely because reproject keeps running under real use.
+
+## 2. Pillar 2 — single lifecycle authority (`reconcile_quit`)
+
+✅ Done, all 4 phases (#2080, #2081, #2084, #2083). No open items. Two adjacent gaps found
+and fixed since 07-12 (see §4) — both in the close-path *notify* chain, not in the quit
+decision authority itself.
+
+## 3. Pillar 3 — admission control
+
+✅ Shipped (#1853). Follow-ons (queue-and-drain, per-agent working-set cap, "memory full"
+badge) remain open, low-priority, independent.
+
+## 4. Lifecycle bugs — found and fixed since 2026-07-12
+
+| Bug | Status | Doc |
+|---|---|---|
+| Drag-HWND cross-wire (multi-window reproject binds a label to the wrong HWND; dragging window N moves a different window) | ✅ Fixed (#2111) — label→HWND bound at Views creation time | `retro-reproject-drag-hwnd-crosswire-2026-07-12.md` |
+| Pagefile P0 item 3: commit-aware scheduler reserve re-derived from `PrivateUsage` | ✅ Done (task #33) | `SPEC_WIN10_PAGEFILE_OOM_CRASH_2026_06_29.md` |
+| Pagefile P1s: SetMeta log-firehose throttle + launcher-log rotation; old-version shutdown prompt on upgrade | ✅ Done (tasks #34, #35) | same |
+| **Floating-pane/pool bridge-init lock-out** — reload of a warmed pool window could never rebuild `window.api` (3 compounding layers: pane-flag-gated cred injection, cred-strip vs `isCef()`, `self.ipc_port = 0`); blank window + ~5s reload storm | ✅ Fixed (#2181), live-verified | `SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md` (2026-07-16 correction header) |
+| **Last-window close never notified srv** — closing "main" left its `db_window`/workspace rows orphaned forever; crash-reproject resurrected them as ghost windows on every launch. Plus (reagent catch): NO Windows parking close ever reported `PoolDrained`/`PoolNotLast`, so every close's launcher saga silently stalled to its 30s timeout | ✅ Fixed (#2186), live-verified both halves | `retro-last-window-close-quit-race-2026-07-16.md`, `SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md` §4c |
+
+## 5. Teardown backstop (#2092) — Phase 2 shipped 2026-07-16
+
+Phase 1 (observe-only UI-thread liveness probe) merged 07-11 and baked. Phase 2 — the armed
+J0 teardown state machine — is now implemented (`agentmux-launcher/src/teardown_backstop.rs`):
+arm on `PoolDrained`/`OrphanInstance`, disarm on `WindowOpened` or any host exit, teardown
+(`TerminateJobObject(J0)`, exit code 86) when armed past the 30s grace with ≥2 consecutive
+delivered-but-unanswered UI-thread probes. This closes the one undelivered item from
+Discussion #1680's §9 scorecard: a host whose UI thread wedges after the last window closes
+no longer lingers as an orphaned tree — the launcher reaps it within roughly
+GRACE + 2 probe intervals. Verification hook: `debug:hang_ui` (double-gated behind
+`AGENTMUX_DEBUG_HANG=1`). Spec: `SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md`.
+
+## 6. Roadmap — open items, ranked
+
+1. **Pillar 1 Step 6** — startable early-to-mid August once the reproject bake completes
+   (task #37). The remaining structural item.
+2. **Task #15 — non-Windows close-path verification.** Blocked on macOS/Linux hardware.
+   Scope has GROWN since 07-12: #2186's `on_before_close` defense-in-depth fix (the notify
+   + deferred-quit path that IS live on those platforms) needs verifying there too.
+3. **Reconciliation pass** (srv cross-checks `state.windows` against host/launcher reality)
+   — the durable fix for the residual "srv unreachable at close time still orphans the row"
+   failure mode both #2186 and the 07-04 spec explicitly leave open. Ties into the
+   still-undecided task #4 (`SPEC_AGENT_SYSTEM_MANAGEMENT_API`).
+4. **Task #51 — pool-promote color flash** (adjacent, cosmetic). Any re-fix must pass the
+   capture-harness gate (5 consecutive clean promotes) before merging — #2163's revert is
+   the cautionary tale.
+5. Pillar 3 follow-ons — open, low-priority, independent.
+
+## 7. Sources
+
+- `docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_12.md` (superseded)
+- `docs/specs/SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md`
+- `docs/specs/SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md` (§4c added 07-16)
+- `docs/retro/retro-last-window-close-quit-race-2026-07-16.md`
+- `docs/specs/SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md` (07-16 correction header)
+- `docs/retro/retro-reproject-drag-hwnd-crosswire-2026-07-12.md`


### PR DESCRIPTION
Completes **SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11** (#2092) — the last undelivered item from Discussion #1680's §9 scorecard. Every quit backstop shipped so far runs *inside* the host and dies with a wedged host; this is the launcher-side layer beneath them: a host whose UI thread wedges after the last user window closes no longer lingers as an orphaned process tree.

## The state machine (`teardown_backstop.rs`, new)

```
Disarmed ──(PoolDrained / OrphanInstance drift)──▶ Armed(t0)
Armed    ──(host exits — supervisor disarms)─────▶ Disarmed   (crash-restart-gap guard)
Armed    ──(any WindowOpened event)──────────────▶ Disarmed   (crash-reproject guard)
Armed    ──(t > t0+30s AND ≥2 unanswered probes)─▶ Teardown: TerminateJobObject(J0), exit 86
```

- **Arm/disarm** driven from `ipc/server.rs`'s post-reducer **validated-event** pass (same layering as Phase 1's transport-side `ReportUiThreadAlive` intercept — supervision state, reducer stays pure).
- **Teardown** in the supervisor's 5s check tick. I2/I3 hold by construction: J0 is the launcher's own unnamed job, and the launcher is never assigned to it.
- **`ui_liveness`** gains the `consecutive_misses` Phase-2 consumer surface, with a subtlety its own test caught: a nonce-unmatched late reply proves the UI thread pumped *after* the outstanding probe was sent — so that probe aging out is telemetry noise, not wedge evidence. Send-failed (retracted) probes never count.
- **`debug:hang_ui`** verification hook (spec §Verification), double-gated: `AGENTMUX_DEBUG_HANG=1` + explicit invoke.

## Live verification (Windows, end to end)

Wedged the UI thread via `debug:hang_ui` — probes went unanswered while the tokio IPC side kept answering (the exact *"pipe traffic is not liveness"* premise the spec is built on) — then closed the last window via direct IPC. Launcher log:

```
[teardown-backstop] ARMED (OrphanInstance drift — last user window closed, host still alive)
[teardown-backstop] host wedged with zero user windows — terminating job (armed > 30s grace, 14 consecutive unanswered UI-thread probes)
```

31 seconds arm-to-teardown; entire process tree reaped, ports freed.

An amusing meta-note: the first verification attempt drove the close over CDP, which silently deadlocked — **CDP's own response routing needs the UI thread the test had just parked**. Re-driven over direct HTTP IPC.

## Tests

`cargo test -p agentmux-launcher`: **225/225** (6 new — state-machine transitions + miss-counter semantics). `cargo check` clean on both crates.

## Docs riding along (no-standalone-docs-PR convention)

- `docs/status/STATUS_LIFECYCLE_AND_CRASH_ARCHITECTURE_2026_07_16.md` — new program snapshot superseding 07-12 (stale: its #1 open item #2111 had shipped, plus tasks #33–35, #2181, #2186).
- `SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11.md` — status → Phase 2 done.
- `SPEC_BRIDGE_INIT_RECOVERY_2026_06_15.md` — correction header: its §3.5 "reload preserves creds" premise was proven false by the #52/#2181 investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)