### PR TITLE
fix(auth): surface silent login-recovery failures instead of dead-ending

### DIFF
--- a/.changesets/1784252225-fix-auth-surface-silent-login-recovery-failures-instead-of-d-7khr.md
+++ b/.changesets/1784252225-fix-auth-surface-silent-login-recovery-failures-instead-of-d-7khr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): surface silent login-recovery failures instead of dead-ending

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .task
 frontend/dist
 dist/
+/log
 dist-dev/
 frontend/node_modules
 node_modules/

--- a/docs/specs/REPORT_AUTH_ARCHITECTURE_2026_06_25.md
+++ b/docs/specs/REPORT_AUTH_ARCHITECTURE_2026_06_25.md
@@ -1,0 +1,204 @@
+# Auth Architecture Report — AgentMux
+
+**Date:** 2026-06-25
+**Purpose:** Design-session input for making auth robust app-wide. Covers current state, the terminal-vs-agent gap, the "Login Again" crash, and gaps to fix.
+
+---
+
+## 1. How Credentials Are Stored
+
+Three independent storage layers co-exist today:
+
+### Provider OAuth tokens (per-bundle, on disk)
+
+- **Global (terminal ambient):** `~/.claude/.credentials.json` — what the terminal pane reads
+- **Isolated (per agent-identity bundle):** `~/.agentmux/identities/<bundle-id>/claude/.credentials.json`
+- Set via `CLAUDE_CONFIG_DIR` env var at spawn time
+- Same pattern for Codex (`CODEX_HOME`) and OpenClaw (`OPENCLAW_HOME`)
+
+### Identity account DB
+
+`agentmux-srv/src/backend/storage/identities.rs`
+- `db_identity_accounts` — each row: `provider`, `kind` ("oauth" | "api-key"), `secret_ref`, `status` ("valid" | "expired")
+- `db_identity_bindings` — joins `(bundle_id, provider) → account_id`
+- `db_identity_bundles` — named credential sets the user creates (e.g. "personal", "work")
+
+### MuxBus cloud credentials (singleton)
+
+`agentmux-srv/src/backend/storage/muxbus.rs`
+- One global row in `db_muxbus_credentials`: `access_token`, `refresh_token`, `user_email`, `cognito_domain`, `expires_at`
+- Not per-agent; injected into every agent env if valid
+
+---
+
+## 2. The Terminal-vs-Agent Auth Gap
+
+### Why terminal pane is authed
+
+The terminal pane spawns a shell with **no env override** for `CLAUDE_CONFIG_DIR`. The shell inherits whatever the user set up in `~/.claude/` — typically a valid credential from an earlier `claude setup-token` or OAuth login.
+
+### Why agent pane shows "Login again"
+
+At agent spawn, `inject_identity_env_async()` (`agentmux-srv/src/identity/resolver.rs:369–410`) always sets:
+
+```
+CLAUDE_CONFIG_DIR = ~/.agentmux/identities/<bundle-id>/claude/
+```
+
+If that directory has no `.credentials.json`, Claude CLI sees an empty credential store and reports `authenticated: false`. The frontend sees this and shows the "Login again" banner.
+
+**No credential copy happens by default.** The global `~/.claude/.credentials.json` is never automatically seeded into the bundle-specific dir. The user sees 401s even though their terminal is fully logged in.
+
+The disconnect between "my terminal works" and "my agent says login again" is the core UX problem.
+
+---
+
+## 3. The "Login Again" Button Does Nothing — Root Cause
+
+### Call chain
+
+```
+User clicks "Login Again"
+  → useAgentControllerStatus.ts:171 → forceProviderLogin()
+  → force-login.ts:43 → getApi().runCliLogin(cliPath, authLoginArgs, authEnv, requiresTty)
+  → CEF IPC: run_cli_login_pty (agentmux-cef/src/commands/platform.rs:656)
+  → portable_pty::CommandBuilder::spawn()
+  → claude auth login (Bun-compiled)
+  → CRASH: "FD ownership violation" before any output
+  → CEF sees child exit, no auth URL captured, nothing returned to frontend
+```
+
+### Why it crashes
+
+The Bun runtime enforces strict FD ownership at startup. When CEF's `portable_pty` spawns the Claude CLI, the ConPTY handle lifetime is violated — the `pair.master` is dropped too early, leaving the child process with dangling handles. Bun detects this and aborts before printing anything.
+
+Evidence: `SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md` §0–2 confirms zero `[login-pty]` output lines from the CEF spawn path. The backend's `auth.start()` PTY path (identity_handlers.rs) has the same underlying bug but was masked by earlier versions.
+
+### What "Use Existing Login" does (the working workaround)
+
+`useAgentControllerStatus.ts:212–236` offers a second button that calls `seed_provider_auth_from_global()` on the host — this copies `~/.claude/.credentials.json` into the bundle-specific dir without spawning the Bun CLI at all. This works reliably. The problem is it's hidden behind a secondary button and users never find it.
+
+---
+
+## 4. Recent Significant Auth Work
+
+| PR / Commit | What |
+|---|---|
+| #1775 (`19178949`) | Deduplicate identity accounts that share the same credential |
+| `d6341531` / `1752f5fa` | MuxBus cloud login chip in statusbar HostPopover |
+| `SPEC_HOST_CLI_LOGIN_CAPTURE` (Jun 20) | Investigated the Claude v2.1.x login capture failure; confirmed FD crash; added instrumentation |
+| `retro-claude-v2-1-auth-spawn-2026-06-23.md` | Post-mortem: headless CEF can't open browser for `setup-token` even if PTY works |
+| `SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md` | Token presence ≠ validity — the fast-path `CheckCliAuth` could return `authenticated: true` on an expired token |
+| `SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` | OAuth session lifecycle design (`auth.start` / `auth.poll` / `auth.cancel`) |
+
+---
+
+## 5. Frontend Auth State — No Central Reducer
+
+Auth state is **not centralized**. Each surface owns its own state:
+
+| Surface | State hook | What it holds |
+|---|---|---|
+| Agent pane | `useAgentControllerStatus.ts` | `authUrl`, `canRetry`, `loginWaiting`, `agentReady` |
+| Agent failure banner | `useAgentFailure.ts` | failure type, retry countdown, expanded |
+| Trust Center / HostPopover | `useMuxBusStatus()` | `{connected, email, expiresAt, valid}` — re-fetched on open |
+| Terminal pane | nothing | inherits ambient, never checks |
+
+**Problem:** Cross-pane auth events are invisible. If the user logs in via the Trust Center, agent panes don't re-check. If a MuxBus token expires, nothing tells the agent panes proactively.
+
+---
+
+## 6. MuxBus Cloud Login Flow (Works Today)
+
+1. User clicks "Connect" in HostPopover → frontend calls `muxbus.login(cognitoDomain, clientId)`
+2. Backend opens browser to Cognito PKCE URL, blocks up to 5 min for callback
+3. On callback, exchanges code → `access_token` + `refresh_token`; writes to `db_muxbus_credentials`
+4. Every subsequent agent spawn: `inject_muxbus_env()` (agent_handlers.rs:3156) injects `MUXBUS_TOKEN` if `current_time < expires_at`
+5. **No background refresh** — when the token expires, agents silently lose cloud auth until user manually reconnects
+
+---
+
+## 7. Auth Robustness Gaps (Priority Ordered)
+
+### P0 — "Login Again" crashes silently
+
+**Impact:** Auth recovery is broken for every user who hasn't discovered "Use Existing Login".
+**Fix:** Either:
+- Fix `portable_pty` usage in CEF — keep `pair.master` alive past `child.wait()` (matches how `agentmux-srv`'s auth.start already does it)
+- OR bypass PTY entirely for Claude CLI login: use pipes + `--print-default-system-prompt` style callback URL extraction
+- Short-term: **make "Use Existing Login" the primary button** and hide "Login Again" behind an "Advanced" expander
+
+### P1 — No credential seeding on agent launch
+
+**Impact:** Every agent pane launch requires manual intervention for new bundles.
+**Fix:** On first agent spawn against a bundle with no credentials, proactively check if a valid global `~/.claude/.credentials.json` exists. If yes, auto-seed it (same logic as "Use Existing Login"). Show a toast: "Using your global Claude login — manage in Trust Center."
+
+### P1 — No central auth reducer / cross-pane sync
+
+**Impact:** Trust Center login doesn't update agent pane banners; MuxBus token expiry is silent.
+**Fix:** Introduce a single SolidJS store atom (or Zustand-style slice) for app-wide auth state:
+```ts
+interface AppAuthState {
+  muxbus: { connected: boolean; email: string | null; expiresAt: number | null }
+  providers: Record<ProviderId, { authenticated: boolean; email: string | null }>
+  lastChecked: number
+}
+```
+Backend publishes a new WPS event `auth:changed` whenever any credential changes (login, logout, expiry). Frontend's central store subscribes and invalidates all panes.
+
+### P2 — MuxBus token no background refresh
+
+**Impact:** Agents silently lose cloud auth mid-session when the token expires.
+**Fix:** Backend timer job that calls Cognito token refresh endpoint before `expires_at`. Already have `refresh_token` in `db_muxbus_credentials`. Emit `auth:changed` event after refresh.
+
+### P2 — CheckCliAuth false positive
+
+**Impact:** Agent spawns, "seems authed", 401s on first real API call.
+**Fix:** `SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md` already specifies the fix — run `claude auth status --json` (slow path) rather than just checking file presence. Gate agent spawn on the slow-path result, with a spinner.
+
+### P3 — Terminal-vs-Agent mental model mismatch
+
+**Impact:** Confusing UX. Users think being logged in to the terminal means they're logged into the agent.
+**Fix:** Surface the distinction early: on first agent pane open, show a one-time "Your global Claude login is available — using it for this agent" message (if seeding) or "Agents use isolated logins — sign in below" (if no seed available).
+
+---
+
+## 8. Proposed Architecture — Robust App-Wide Auth
+
+```
+Backend                                          Frontend
+───────────────────────────────────────          ─────────────────────────────────
+AuthStateService (new)                           useAppAuth() store (new SolidJS atom)
+├─ watches db_muxbus_credentials                 ├─ subscribes to WPS auth:changed
+├─ watches db_identity_accounts                  ├─ exposes { muxbus, providers }
+├─ refreshes MuxBus token proactively            └─ invalidated on any auth event
+└─ emits WPS auth:changed on any change
+                                                 All panes read from useAppAuth():
+AgentSpawnService (extend)                       ├─ Agent pane 401 banner
+├─ pre-flight: seed global creds if bundle empty │  (no more per-pane polling)
+├─ post-launch: subscribe agent to auth:changed  ├─ HostPopover MuxBus chip
+└─ on auth:changed: update live agent env vars   └─ Trust Center panel
+
+CEF CliLogin (fix)
+├─ keep pair.master alive past child.wait()
+├─ pipes path as fallback if PTY fails
+└─ timeout + clean error propagated to frontend
+```
+
+---
+
+## 9. Key File Reference
+
+| File | What |
+|---|---|
+| `agentmux-srv/src/identity/resolver.rs:369` | `inject_identity_env_async` — sets `CLAUDE_CONFIG_DIR` per bundle |
+| `agentmux-srv/src/server/agent_handlers.rs:3148` | Agent spawn env assembly |
+| `agentmux-srv/src/server/muxbus_handlers.rs:50` | `muxbus.login` / `inject_muxbus_env` |
+| `agentmux-srv/src/muxbus/pkce.rs:26` | Cognito PKCE browser flow |
+| `agentmux-cef/src/commands/platform.rs:656` | `run_cli_login_pty` — the crashing PTY path |
+| `frontend/app/view/agent/hooks/useAgentControllerStatus.ts:171` | "Login Again" button handler |
+| `frontend/app/view/agent/hooks/useAgentControllerStatus.ts:212` | "Use Existing Login" (the working path) |
+| `frontend/app/view/accounts/AgentMuxConnectPanel.tsx:59` | `useMuxBusStatus` hook |
+| `docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md` | FD crash investigation |
+| `specs/SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md` | Token presence vs validity bug |
+| `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` | OAuth session lifecycle design |

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -928,6 +928,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 documentAtom={agentAtoms().documentAtom}
                 documentStateAtom={agentAtoms().documentStateAtom}
                 authUrl={status.authUrl}
+                authNotice={status.authNotice}
+                onDismissAuthNotice={() => status.setAuthNotice(null)}
                 authProviderId={provider()?.id ?? providerKey()}
                 onSubagentClick={handleSubagentClick}
                 onAgentErrorLogin={() => {

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -459,6 +459,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             });
         },
         onReady: () => onReadyFn?.(),
+        // A successful recovery (seed-from-global / terminal login) refreshed
+        // the credential — retry the failed turn so the agent recovers in one
+        // click. Lazy arrow: retryLastTurn is defined below but only invoked at
+        // runtime (post-click), by which point it's initialized.
+        onRecovered: () => retryLastTurn(),
         getInitialTermSize: () => computeTermSizeFromEl(rootRef),
         // Mount-time TurnPhase reconciliation — see
         // docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -41,13 +41,23 @@ export const loginCommand: SlashCommand = {
             // Shared with the failure-banner / inline-error "Login Again" action
             // (useAgentControllerStatus.relogin) — opens the OAuth in an in-app
             // browser pane and surfaces the URL box. See force-login.ts.
-            await forceProviderLogin({
+            const outcome = await forceProviderLogin({
                 provider: prov,
                 cliPath,
                 authEnv,
                 setAuthUrl: ctx.setAuthUrl,
                 log: ctx.log,
             });
+            if (outcome === "no-url") {
+                // Never report success for a login that opened nothing
+                // (retro-agent-auth-relogin-noop-2026-07-01 §5.1).
+                return {
+                    kind: "error",
+                    message:
+                        "/login: the CLI didn't produce a login URL, so no browser was opened. " +
+                        "Use the “Login via terminal” or “Use existing login” actions instead.",
+                };
+            }
             ctx.log("auth", "run /cost to verify authentication once logged in");
             return { kind: "ok" };
         } catch (err: any) {

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -31,6 +31,15 @@ interface AgentDocumentViewProps {
     documentAtom: SignalPair<DocumentNode[]>;
     documentStateAtom: SignalPair<DocumentState>;
     authUrl?: Accessor<string | null>;
+    /**
+     * User-visible auth-recovery error (e.g. "Login Again" couldn't open a
+     * browser). Rendered as an error box in the same header slot as the
+     * auth-URL box, with a dismiss button. Never fail silently — see
+     * retro-agent-auth-relogin-noop-2026-07-01 §5.1.
+     */
+    authNotice?: Accessor<string | null>;
+    /** Dismiss handler for the auth notice (clears the signal). */
+    onDismissAuthNotice?: () => void;
     /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
     authProviderId?: string;
     onSubagentClick?: (node: SubagentLinkNode) => void;
@@ -155,6 +164,20 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
             </Show>
             <Show when={props.authUrl?.()}>
                 {(url) => <AuthUrlBox url={url()} authProviderId={props.authProviderId} />}
+            </Show>
+            <Show when={props.authNotice?.()}>
+                {(notice) => (
+                    <div class="agent-auth-notice" role="alert">
+                        <span class="agent-auth-notice-text">{notice()}</span>
+                        <button
+                            class="agent-auth-notice-dismiss"
+                            title="Dismiss"
+                            onClick={() => props.onDismissAuthNotice?.()}
+                        >
+                            ✕
+                        </button>
+                    </div>
+                )}
             </Show>
         </>
     );

--- a/frontend/app/view/agent/flows/force-login.test.ts
+++ b/frontend/app/view/agent/flows/force-login.test.ts
@@ -7,8 +7,10 @@
  * The whole point of this helper is that it NEVER consults CheckCliAuth — it
  * unconditionally runs the provider login. These tests pin:
  *   - runCliLogin is called with the provider's login command + auth env;
- *   - a captured URL is pushed to setAuthUrl AND opened via openOAuthBrowserPane;
- *   - a null URL surfaces a warning and does not call setAuthUrl;
+ *   - a captured URL is pushed to setAuthUrl AND opened via openOAuthBrowserPane,
+ *     and the call resolves "opened";
+ *   - a null URL resolves "no-url" (the CALLER surfaces the visible error —
+ *     retro-agent-auth-relogin-noop-2026-07-01 §5.1) and does not call setAuthUrl;
  *   - CheckCliAuth is never invoked (no auth-status gate).
  */
 
@@ -43,7 +45,7 @@ describe("forceProviderLogin", () => {
         const setAuthUrl = vi.fn();
         const log = vi.fn();
 
-        await forceProviderLogin({
+        const outcome = await forceProviderLogin({
             provider,
             cliPath: "C:/cli/claude.cmd",
             authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
@@ -59,6 +61,7 @@ describe("forceProviderLogin", () => {
         );
         expect(setAuthUrl).toHaveBeenCalledWith(URL);
         expect(hub.openPane).toHaveBeenCalledWith(URL);
+        expect(outcome).toBe("opened");
     });
 
     it("NEVER consults the auth-status check (the whole point of forcing)", async () => {
@@ -67,16 +70,19 @@ describe("forceProviderLogin", () => {
         expect(hub.checkCliAuth).not.toHaveBeenCalled();
     });
 
-    it("warns and does not set an auth URL when no URL is captured", async () => {
+    it("resolves 'no-url' and does not set an auth URL when no URL is captured", async () => {
         hub.runCliLogin.mockResolvedValue(null);
         const setAuthUrl = vi.fn();
         const log = vi.fn();
 
-        await forceProviderLogin({ provider, cliPath: "x", authEnv: {}, setAuthUrl, log });
+        const outcome = await forceProviderLogin({ provider, cliPath: "x", authEnv: {}, setAuthUrl, log });
 
         expect(setAuthUrl).not.toHaveBeenCalled();
         expect(hub.openPane).not.toHaveBeenCalled();
-        expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/browser window should have opened/i), "warn");
+        expect(outcome).toBe("no-url");
+        // The helper still logs, but must NOT pretend a browser opened — the
+        // caller owns the user-visible error (never fail silently, retro §5.1).
+        expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/no login URL captured/i), "warn");
     });
 
     it("still resolves (URL set) even when the pane falls back to the system browser", async () => {

--- a/frontend/app/view/agent/flows/force-login.ts
+++ b/frontend/app/view/agent/flows/force-login.ts
@@ -40,7 +40,16 @@ export interface ForceLoginParams {
     log: LogFn;
 }
 
-export async function forceProviderLogin(p: ForceLoginParams): Promise<void> {
+/**
+ * Outcome of a forced login attempt. "no-url" means the CLI produced no
+ * scrapeable OAuth URL — nothing was opened, and the CALLER must surface a
+ * user-visible error pointing at the reliable recovery paths (the silent
+ * warn-only branch here is how "Login Again" became a dead button —
+ * retro-agent-auth-relogin-noop-2026-07-01 §5.1).
+ */
+export type ForceLoginOutcome = "opened" | "no-url";
+
+export async function forceProviderLogin(p: ForceLoginParams): Promise<ForceLoginOutcome> {
     const { provider, cliPath, authEnv, setAuthUrl, log } = p;
     log("auth", "re-login: forcing a fresh OAuth (bypassing the auth-status check)…");
 
@@ -62,9 +71,10 @@ export async function forceProviderLogin(p: ForceLoginParams): Promise<void> {
             log("auth", "could not open a browser; copy the URL from the box above and open it manually", "warn");
         }
         log("auth", "after you finish, just send your message again — the agent will use the new token");
-    } else {
-        // No URL captured (some providers don't print one); the CLI may have
-        // opened its own browser. Leave the user to complete it manually.
-        log("auth", "a browser window should have opened — complete login there", "warn");
+        return "opened";
     }
+    // No URL captured — the CLI either crashed at spawn or runs a login TUI
+    // that prints no parseable URL (Claude Code v2.1.x). Nothing opened.
+    log("auth", "no login URL captured from the CLI — nothing was opened", "warn");
+    return "no-url";
 }

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -36,6 +36,7 @@
 import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
 import { getApi, getBlockMetaKeyAtom } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
+import * as WOS from "@/app/store/wos";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
 import { forceProviderLogin } from "../flows/force-login";
@@ -52,6 +53,15 @@ export interface UseAgentControllerStatusOptions {
     onLoginSuccess?: (email: string | null) => void;
     /** Called once when the launch flow completes successfully and the agent is ready to receive messages. */
     onReady?: () => void;
+    /**
+     * Called when a recovery action (seed-from-global / terminal login) has
+     * successfully refreshed the credential. The pane wires this to retry the
+     * failed turn, so a single "Use existing login" click both fixes the
+     * credential AND drives the agent back to a working state — without it, the
+     * seed succeeds silently and the 401 failure row lingers (the "Login Again
+     * does nothing" symptom).
+     */
+    onRecovered?: () => void;
     /**
      * Returns the pane's current `{rows, cols}` (or undefined if not laid out
      * yet). Forwarded to the launch flow to seed the PTY size at spawn.
@@ -210,6 +220,14 @@ export function useAgentControllerStatus(
                 unix_install_command: prov.unixInstallCommand,
                 block_id: opts.blockId,
             }, { timeout: 300000 });
+            // Persist the resolved path back to block meta (mirrors
+            // launch-flow.ts) so a subsequent recovery click reuses it instead
+            // of re-running the full resolution RPC. Best-effort — a failed
+            // write just means the next click re-resolves.
+            try {
+                const oref = WOS.makeORef("block", opts.blockId);
+                await RpcApi.SetMetaCommand(TabRpcClient, { oref, meta: { cmd: r.cli_path } });
+            } catch { /* non-fatal: next click re-resolves */ }
             return r.cli_path;
         } catch (err: any) {
             const msg = `Couldn't find the ${prov.cliCommand} CLI to run the login: ${err?.message ?? String(err)}`;
@@ -301,7 +319,20 @@ export function useAgentControllerStatus(
                 const v = (envMeta as Record<string, unknown>)[prov.authConfigDirEnvVar];
                 if (typeof v === "string") configDir = v;
             }
-            await seedGlobalLogin(prov.id, opts.log, configDir);
+            const seeded = await seedGlobalLogin(prov.id, opts.log, configDir);
+            if (seeded) {
+                // Credential is now valid on disk — but the agent spawns fresh
+                // per turn and the failure row only clears on the next turn, so
+                // a successful seed looks like it "did nothing". Drive the
+                // recovery: retry the failed turn (fresh spawn picks up the new
+                // token and TurnStart clears the row).
+                opts.log("auth", "Signed in from your global login — retrying…");
+                opts.onRecovered?.();
+            } else {
+                const msg = "Couldn't use your global login — no valid global Claude credential was found. Try “Login via terminal”.";
+                opts.log("auth", msg, "warn");
+                setAuthNotice(msg);
+            }
         } catch (err: any) {
             const msg = `Use existing login failed: ${err?.message ?? String(err)}`;
             opts.log("auth", msg, "error");
@@ -364,8 +395,9 @@ export function useAgentControllerStatus(
                 seeded = await seedGlobalLogin(prov.id, silentLog, configDir);
             }
             if (seeded) {
-                opts.log("auth", "Login successful — your next message will use the new token.");
+                opts.log("auth", "Login successful — retrying…");
                 setAuthNotice(null);
+                opts.onRecovered?.();
             } else if (!loginCancelled) {
                 const msg = "No login detected after 5 minutes. Complete the login in the terminal, then click “Use existing login”.";
                 opts.log("auth", msg, "warn");

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -317,27 +317,33 @@ export function useAgentControllerStatus(
             return;
         }
         setAuthNotice(null);
-        let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
-        if (!cliPath) {
-            // Same H2 trap as relogin: the gated launch flow would trust the
-            // auth check and skip the login the user explicitly asked for.
-            cliPath = (await resolveCliForRecovery(prov, "login via terminal")) ?? undefined;
-            if (!cliPath) return;
-        }
-        const authEnv = await recoveryAuthEnv(prov);
-        const configDir = prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined;
-
-        // Strip CLAUDE_CONFIG_DIR (and equivalents) from the terminal env so the
-        // login writes to the user's global ~/.claude instead of the isolated dir.
-        // seedGlobalLogin polls the global dir and copies on success — if we kept
-        // the isolated dir key the poll would look in global but the creds would
-        // land in isolated, and a terminal-fresh login would never be detected.
-        const terminalEnv: Record<string, string> = { ...authEnv };
-        if (prov.authConfigDirEnvVar) delete terminalEnv[prov.authConfigDirEnvVar];
-
+        // Claim the in-flight guard BEFORE any await. The CLI resolve below
+        // can take up to 300 s, and the recovery buttons have no disabled
+        // binding — so setting the flag only after the awaits (the previous
+        // bug) let a rapid double-click pass the top guard twice and open two
+        // terminal windows with overlapping poll loops. Mirror relogin: flag
+        // first, reset in finally.
         reloginInFlight = true;
         setLoginWaiting(true);
         try {
+            let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
+            if (!cliPath) {
+                // Same H2 trap as relogin: the gated launch flow would trust the
+                // auth check and skip the login the user explicitly asked for.
+                cliPath = (await resolveCliForRecovery(prov, "login via terminal")) ?? undefined;
+                if (!cliPath) return;
+            }
+            const authEnv = await recoveryAuthEnv(prov);
+            const configDir = prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined;
+
+            // Strip CLAUDE_CONFIG_DIR (and equivalents) from the terminal env so the
+            // login writes to the user's global ~/.claude instead of the isolated dir.
+            // seedGlobalLogin polls the global dir and copies on success — if we kept
+            // the isolated dir key the poll would look in global but the creds would
+            // land in isolated, and a terminal-fresh login would never be detected.
+            const terminalEnv: Record<string, string> = { ...authEnv };
+            if (prov.authConfigDirEnvVar) delete terminalEnv[prov.authConfigDirEnvVar];
+
             await getApi().openLoginTerminal(cliPath, prov.authLoginCommand, terminalEnv);
             opts.log("auth", "A terminal window opened — complete the login there, then come back.");
 

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -149,6 +149,11 @@ export function useAgentControllerStatus(
         loginCancelled = false;
         setFlowRunning(true);
         setCanRetry(false);
+        // Any fresh launch/retry supersedes a prior recovery attempt — clear a
+        // stale authNotice (e.g. "no login URL captured" from an earlier
+        // relogin) so it can't linger past a "Retry Login" the user just
+        // clicked and mislead them about this attempt's outcome.
+        setAuthNotice(null);
         const prov = opts.provider();
         try {
             const authEnv = await buildAuthEnv(prov);

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -261,6 +261,10 @@ export function useAgentControllerStatus(
             return;
         }
         setAuthNotice(null);
+        // Clear any OAuth URL box left by a PRIOR attempt before starting a
+        // fresh one — otherwise a subsequent "no-url" outcome would stack the
+        // error notice below a stale, contradictory URL box (reagent P2).
+        setAuthUrl(null);
         // The CLI path + auth env are written to block meta at launch; reuse
         // them instead of re-resolving (the agent is already running, so the
         // CLI is installed). If `cmd` is missing, resolve it directly — see

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -35,6 +35,8 @@
 
 import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
 import { getApi, getBlockMetaKeyAtom } from "@/app/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
 import { forceProviderLogin } from "../flows/force-login";
 import { seedGlobalLogin } from "../flows/seed-global-login";
@@ -62,6 +64,15 @@ export interface UseAgentControllerStatusOptions {
 export interface UseAgentControllerStatus {
     authUrl: Accessor<string | null>;
     setAuthUrl: (url: string | null) => void;
+    /**
+     * User-visible auth-recovery notice, rendered as an error box above the
+     * composer (same surface as the auth-URL box). Set when a recovery action
+     * fails in a way the user must react to — e.g. "Login Again" captured no
+     * OAuth URL so nothing opened (retro-agent-auth-relogin-noop-2026-07-01
+     * §5.1: never fail silently). Cleared on the next recovery attempt.
+     */
+    authNotice: Accessor<string | null>;
+    setAuthNotice: (notice: string | null) => void;
     canRetry: Accessor<boolean>;
     flowRunning: Accessor<boolean>;
     agentReady: Accessor<boolean>;
@@ -120,6 +131,7 @@ export function useAgentControllerStatus(
     opts: UseAgentControllerStatusOptions,
 ): UseAgentControllerStatus {
     const [authUrl, setAuthUrl] = createSignal<string | null>(null);
+    const [authNotice, setAuthNotice] = createSignal<string | null>(null);
     const [canRetry, setCanRetry] = createSignal(false);
     const [flowRunning, setFlowRunning] = createSignal(false);
     const [agentReady, setAgentReady] = createSignal(false);
@@ -171,23 +183,39 @@ export function useAgentControllerStatus(
     // flight (the user double-clicks "Login Again"). Separate from flowRunning
     // — relogin must work even when the gated flow believes it already finished.
     let reloginInFlight = false;
-    const relogin = async () => {
-        if (reloginInFlight) return;
-        const prov = opts.provider();
-        if (!prov) {
-            opts.log("auth", "re-login: no active provider", "warn");
-            return;
+
+    /**
+     * Resolve the provider CLI directly when block meta has no `cmd` yet.
+     * The old fallback here ran the GATED launch flow — which trusts
+     * `CheckCliAuth`'s expired-but-present false positive and skips login,
+     * degrading "Login Again" into exactly the no-op it exists to bypass
+     * (retro-agent-auth-relogin-noop-2026-07-01 H2). Resolving the CLI and
+     * proceeding with the forced login keeps the user's explicit intent.
+     * Returns null (with a visible notice) if resolution fails.
+     */
+    const resolveCliForRecovery = async (prov: ProviderDefinition, action: string): Promise<string | null> => {
+        opts.log("auth", `${action}: CLI path not in block meta — resolving it directly`, "warn");
+        try {
+            const r = await RpcApi.ResolveCliCommand(TabRpcClient, {
+                provider_id: prov.id,
+                cli_command: prov.cliCommand,
+                npm_package: prov.npmPackage,
+                pinned_version: prov.pinnedVersion,
+                windows_install_command: prov.windowsInstallCommand,
+                unix_install_command: prov.unixInstallCommand,
+                block_id: opts.blockId,
+            }, { timeout: 300000 });
+            return r.cli_path;
+        } catch (err: any) {
+            const msg = `Couldn't find the ${prov.cliCommand} CLI to run the login: ${err?.message ?? String(err)}`;
+            opts.log("auth", msg, "error");
+            setAuthNotice(msg);
+            return null;
         }
-        // The CLI path + auth env are written to block meta at launch; reuse
-        // them instead of re-resolving (the agent is already running, so the
-        // CLI is installed). If `cmd` is missing the agent never launched —
-        // fall back to the full launch flow.
-        const cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
-        if (!cliPath) {
-            opts.log("auth", "re-login: CLI not resolved yet — running the full launch flow instead", "warn");
-            void startLaunchFlow();
-            return;
-        }
+    };
+
+    /** Auth env for recovery actions: block meta `cmd:env` when present, else rebuilt. */
+    const recoveryAuthEnv = async (prov: ProviderDefinition): Promise<Record<string, string>> => {
         const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
         const authEnv: Record<string, string> = {};
         if (envMeta && typeof envMeta === "object") {
@@ -195,12 +223,49 @@ export function useAgentControllerStatus(
                 if (typeof v === "string") authEnv[k] = v;
             }
         }
+        if (Object.keys(authEnv).length > 0) return authEnv;
+        // Meta env missing (agent never launched) — rebuild the isolated-dir
+        // env the launch flow would have used, so the login lands in the same
+        // store the agent will read.
+        return (await buildAuthEnv(prov)) ?? {};
+    };
+
+    const relogin = async () => {
+        if (reloginInFlight) return;
+        const prov = opts.provider();
+        if (!prov) {
+            opts.log("auth", "re-login: no active provider", "warn");
+            return;
+        }
+        setAuthNotice(null);
+        // The CLI path + auth env are written to block meta at launch; reuse
+        // them instead of re-resolving (the agent is already running, so the
+        // CLI is installed). If `cmd` is missing, resolve it directly — see
+        // resolveCliForRecovery for why this must NOT fall back to the gated
+        // launch flow.
+        let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
         reloginInFlight = true;
         setLoginWaiting(true);
         try {
-            await forceProviderLogin({ provider: prov, cliPath, authEnv, setAuthUrl, log: opts.log });
+            if (!cliPath) {
+                cliPath = (await resolveCliForRecovery(prov, "re-login")) ?? undefined;
+                if (!cliPath) return;
+            }
+            const authEnv = await recoveryAuthEnv(prov);
+            const outcome = await forceProviderLogin({ provider: prov, cliPath, authEnv, setAuthUrl, log: opts.log });
+            if (outcome === "no-url") {
+                // Never fail silently (retro §5.1): tell the user nothing
+                // opened and point at the recovery paths that do work.
+                setAuthNotice(
+                    "Couldn't start a browser login — the CLI didn't produce a login URL, so nothing was opened. " +
+                    "Use “Login via terminal” to complete the login in a real terminal window" +
+                    (prov.id === "claude" ? ", or “Use existing login” to copy your global Claude login into this agent." : "."),
+                );
+            }
         } catch (err: any) {
-            opts.log("auth", `re-login failed: ${err?.message ?? String(err)}`, "error");
+            const msg = `Re-login failed: ${err?.message ?? String(err)}`;
+            opts.log("auth", msg, "error");
+            setAuthNotice(msg);
         } finally {
             reloginInFlight = false;
             setLoginWaiting(false);
@@ -219,6 +284,7 @@ export function useAgentControllerStatus(
             opts.log("auth", "use existing login: no active provider", "warn");
             return;
         }
+        setAuthNotice(null);
         seedInFlight = true;
         try {
             // Seed into the agent's RESOLVED auth dir (from cmd:env), not a
@@ -232,7 +298,9 @@ export function useAgentControllerStatus(
             }
             await seedGlobalLogin(prov.id, opts.log, configDir);
         } catch (err: any) {
-            opts.log("auth", `use existing login failed: ${err?.message ?? String(err)}`, "error");
+            const msg = `Use existing login failed: ${err?.message ?? String(err)}`;
+            opts.log("auth", msg, "error");
+            setAuthNotice(msg);
         } finally {
             seedInFlight = false;
         }
@@ -248,19 +316,15 @@ export function useAgentControllerStatus(
             opts.log("auth", "login via terminal: no active provider", "warn");
             return;
         }
-        const cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
+        setAuthNotice(null);
+        let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
         if (!cliPath) {
-            opts.log("auth", "login via terminal: CLI not resolved — running launch flow instead", "warn");
-            void startLaunchFlow();
-            return;
+            // Same H2 trap as relogin: the gated launch flow would trust the
+            // auth check and skip the login the user explicitly asked for.
+            cliPath = (await resolveCliForRecovery(prov, "login via terminal")) ?? undefined;
+            if (!cliPath) return;
         }
-        const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
-        const authEnv: Record<string, string> = {};
-        if (envMeta && typeof envMeta === "object") {
-            for (const [k, v] of Object.entries(envMeta as Record<string, unknown>)) {
-                if (typeof v === "string") authEnv[k] = v;
-            }
-        }
+        const authEnv = await recoveryAuthEnv(prov);
         const configDir = prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined;
 
         // Strip CLAUDE_CONFIG_DIR (and equivalents) from the terminal env so the
@@ -290,11 +354,16 @@ export function useAgentControllerStatus(
             }
             if (seeded) {
                 opts.log("auth", "Login successful — your next message will use the new token.");
+                setAuthNotice(null);
             } else if (!loginCancelled) {
-                opts.log("auth", "No login detected after 5 minutes. Complete the login in the terminal, then click 'Use existing login'.", "warn");
+                const msg = "No login detected after 5 minutes. Complete the login in the terminal, then click “Use existing login”.";
+                opts.log("auth", msg, "warn");
+                setAuthNotice(msg);
             }
         } catch (err: any) {
-            opts.log("auth", `terminal login failed: ${err?.message ?? String(err)}`, "error");
+            const msg = `Terminal login failed: ${err?.message ?? String(err)}`;
+            opts.log("auth", msg, "error");
+            setAuthNotice(msg);
         } finally {
             reloginInFlight = false;
             setLoginWaiting(false);
@@ -324,6 +393,8 @@ export function useAgentControllerStatus(
     return {
         authUrl,
         setAuthUrl,
+        authNotice,
+        setAuthNotice,
         canRetry,
         flowRunning,
         agentReady,

--- a/frontend/app/view/agent/styles/_activity-log.scss
+++ b/frontend/app/view/agent/styles/_activity-log.scss
@@ -114,6 +114,40 @@
         box-shadow: 0 0 12px rgba(74, 158, 255, 0.15);
     }
 
+    // Auth-recovery error notice — same header slot as the auth-URL box, but
+    // error-accented: shown when a login action failed visibly (e.g. no OAuth
+    // URL could be captured, so no browser opened).
+    .agent-auth-notice {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-2);
+        margin-top: var(--space-2);
+        padding: 10px var(--space-3);
+        background: color-mix(in srgb, var(--error-color) 10%, transparent);
+        border: 1px solid var(--error-color);
+        color: var(--main-text-color);
+        font-size: 12px;
+        line-height: 1.5;
+
+        .agent-auth-notice-text {
+            flex: 1;
+        }
+
+        .agent-auth-notice-dismiss {
+            flex: none;
+            background: none;
+            border: none;
+            color: var(--secondary-text-color);
+            cursor: pointer;
+            font-size: 12px;
+            padding: 0 2px;
+
+            &:hover {
+                color: var(--main-text-color);
+            }
+        }
+    }
+
     .agent-auth-title {
         font-size: 12px;
         font-weight: 700;


### PR DESCRIPTION
## What

Implements the ranked fixes from `docs/retros/retro-agent-auth-relogin-noop-2026-07-01.md` (status was "root-caused; fix not yet implemented"):

1. **Never fail silently (retro §5.1).** `forceProviderLogin` now returns `"opened" | "no-url"`. On `no-url` (Claude Code v2.1.x un-scrapeable login TUI, or the CLI dying at spawn), the user gets an error-styled, dismissable notice box — rendered in the same header slot as the auth-URL box — pointing at the recovery paths that do work ("Login via terminal", and "Use existing login" for Claude). `/login` now returns a slash **error** instead of `ok` when nothing opened.

2. **Fix the H2 fallback trap (retro §5.3).** `relogin()` and `loginViaTerminal()` no longer degrade to the *gated* launch flow when block meta has no `cmd` — that flow trusts `CheckCliAuth`'s expired-but-present false positive and skips the login the user explicitly clicked for. They now resolve the CLI directly via `ResolveCliCommand` (and rebuild the isolated auth env via `buildAuthEnv` when `cmd:env` is absent), with a visible notice if resolution fails.

3. **Visible outcomes everywhere:** `useGlobalLogin` failures, terminal-login failures, and the 5-minute terminal-login poll timeout all set the notice now.

Also commits the previously-untracked `docs/specs/REPORT_AUTH_ARCHITECTURE_2026_06_25.md` (design-session input this work draws on) and gitignores `/log` (the documented `task package:linux 2>&1 | tee log` convention).

## Why

"Login Again" was a structurally dead button: the no-URL branch logged a console-only warn, so a broken recovery path was indistinguishable from a dead one — the primary auth-recovery affordance could not recover (retro severity: High).

## Tests

- `force-login.test.ts` updated to pin the new outcome contract (`opened`/`no-url`, no silent "browser should have opened" claim).
- `useAgentFailure.test.ts` still green; `tsc --noEmit` clean.

## Not in this PR (follow-ups)

- Host-side fd hygiene in `run_cli_login_pty` so Bun-compiled CLIs survive the CEF host spawn at all (the keystone for fresh-OAuth capture; branch coming next).
- Central `auth:changed` cross-pane sync (REPORT_AUTH_ARCHITECTURE §7-P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)