### PR TITLE
fix(ui): ProviderLogo gradient-icon id collision made icons render blank when mounted twice

### DIFF
--- a/.changesets/1784260725-fix-ui-providerlogo-gradient-icon-id-collision-made-icons-re-1pln.md
+++ b/.changesets/1784260725-fix-ui-providerlogo-gradient-icon-id-collision-made-icons-re-1pln.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ui): ProviderLogo gradient-icon id collision made icons render blank when mounted twice

--- a/docs/specs/SPEC_ARMORY_ACCOUNTS_NO_MODALS_2026_07_16.md
+++ b/docs/specs/SPEC_ARMORY_ACCOUNTS_NO_MODALS_2026_07_16.md
@@ -1,0 +1,159 @@
+# SPEC — Armory Accounts: AgentMux icon (already correct) + remove modals, match single-pane page dynamics
+
+**Status:** Draft — spec only, no code written yet (per explicit request).
+**Trigger:** user request — "Inside of the armory accounts, use the Brain icon for the AgentMux .. also, we
+want to get rid of the modals, and use the page dynamics u see on the other sections of the armory."
+**Scope:** Armory's Accounts tab only (`AccountsManager`, `AccountsGallery`, `AccountsTab`/`AccountForm`/
+`AccountDetail` in `identity-view.tsx`, `AgentMuxConnectPanel`). Builds directly on
+`docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md` (PR #2170, merged) and
+`docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md`'s shared `PrimitiveListDetail`
+primitive — this spec is "finish the job" for the one Armory tab that primitive pass didn't touch.
+**Verify before acting:** all file:line citations checked against `main` @ `4cbf856b` on 2026-07-16.
+
+---
+
+## 1. AgentMux icon — already the brain, no change needed
+
+Checked every place "AgentMux" renders an icon inside Accounts:
+
+| Location | Code |
+|---|---|
+| Gallery tile (`AccountsGallery.tsx:69`) | `<ProviderLogo provider={tile.id} size={32} />`, `tile.id === "agentmux"` |
+| Connected-accounts row (`accounts-manager.tsx:98`) | `<ProviderLogo provider="agentmux" size={16} />` |
+| "Connect AgentMux" panel header (`AgentMuxConnectPanel.tsx:209`) | `<ProviderLogo provider="agentmux" size={20} />` |
+
+`ProviderLogo.tsx`'s provider-to-icon map (`p === "agentmux"`) already returns `brainSvg`
+(`@/app/asset/logo-brain.svg`, the "brain-alternate" brand mark — code comment confirms it's
+"byte-identical to the source `frontend/logos/agentmux-logo-brain-alternate.svg`"). This mapping
+predates this session entirely (introduced in `feaee26f`, PR #1504 — the original AgentMux Cloud
+tile feature) and every AgentMux-icon call site routes through it; there's no second, hardcoded, or
+stale icon anywhere in Accounts to fix.
+
+**If a running instance still shows something else, that's a stale build, not a code gap** — a
+fresh `task dev`/rebuild against current `main` should show the brain immediately.
+
+---
+
+## 2. Modals in the Accounts flow — the actual work
+
+Three distinct overlay/modal shells currently gate every Accounts action beyond the gallery+list
+that PR #2170 already unified into one scrolling page (`docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md`):
+
+| Flow | Trigger | Current shell |
+|---|---|---|
+| **Pick auth mode** (OAuth vs. Key) for a brand with no account yet | Click an empty gallery tile | `.accounts-chooser-overlay` (`AccountsGallery.tsx:82-123`) — small centered dialog, dimmed backdrop, click-outside-to-close |
+| **Connect AgentMux Cloud** | Click the AgentMux tile | Same `.accounts-chooser-overlay` shell, reused verbatim by `AgentMuxConnectPanel.tsx:202-220` |
+| **Add / Edit account form** | Pick a mode above, or click "Edit" on an existing account | `.identity-form-overlay` (`identity-view.tsx:642`) — full-screen dimmed backdrop wrapping `.identity-form`. Embeds `OAuthConnectPanel` inline when `mode === "oauth"` (`identity-view.tsx:733`) — not its own separate shell, moves with the form. |
+| **View an existing account's detail** | Click a connected-account row | `<Modal scope="window" size="md" showCloseButton>` (`identity-view.tsx:163-173`), wrapping `AccountDetail` (`:201-345` — provider/kind/secret-backend fields, linked-agents disclosure, Reauth/Validate/Edit/Delete footer actions) |
+
+Every other Armory tab (Bundles, Skills, MCP Servers) went through exactly this same
+overlay-on-top-of-a-list shape before PR #2170/#2178, and now uses the shared
+`PrimitiveListDetail` primitive (`frontend/app/element/primitive-list-detail.tsx`) instead: the
+list view and the detail/form view are two mutually-exclusive full-pane states, never an overlay
+floating on top of the list. Accounts is the one tab that pass didn't touch (it wasn't a
+side-by-side split to begin with — it was already single-column — so it fell outside that spec's
+literal "split-screen" trigger, even though it has the same "modal instead of page" issue in
+spirit).
+
+### 2.1 Proposed shape — reuse `PrimitiveListDetail`, one shared detail pane for three flows
+
+`AccountsManager` already renders gallery + connected-list as the **list** side of a
+`PrimitiveListDetail`. Add the **detail** side, populated by whichever of these three is active
+(mutually exclusive, exactly one at a time — same `inDetail()`-style derived boolean the other
+tabs use):
+
+1. **Connect flow** (empty tile clicked): today's two-step overlay chain (chooser → form) becomes
+   **one page**: auth-mode picker (OAuth / Key, when the brand offers both) at the top of the
+   detail pane, the actual form fields (from `AccountForm`) below it, updating in place as the
+   user picks a mode — no second overlay layer. AgentMux Cloud's connect flow (`AgentMuxConnectPanel`)
+   folds into the same detail-pane shape (it already has no mode choice — OAuth only — so it's just
+   the form-equivalent content, no picker step).
+2. **View existing account** (connected row clicked): `AccountDetail`'s content (provider/kind/
+   secret fields, linked-agents disclosure, footer actions) renders directly in the detail pane
+   instead of inside `<Modal>`. Same read-only-view-first pattern Bundles/Skills/MCP already use.
+3. **Edit existing account** (Edit clicked from #2): swaps the same detail pane into `AccountForm`'s
+   edit-mode content — mirrors how Bundles' `MemoryManagerBody` already toggles between its
+   read-only view and its edit form within one pane (`memory-manager.tsx`'s `model.draftAtom()` /
+   `model.selectedAtom()` two-step, `startEdit()`).
+
+Back affordation: the same `‹ Accounts` chevron-back convention `PrimitiveListDetail` already
+renders, reused as-is — no new component needed for this part.
+
+### 2.2 What changes in each file (shape only — implementer confirms exact diffs)
+
+- **`AccountsManager` (`accounts-manager.tsx`)**: becomes the actual `<PrimitiveListDetail>` host
+  (today it renders `AccountsGallery` + the connected-list section directly, with `AccountsTab`
+  producing its own internal `<Modal>` — that nesting goes away). `list` = today's gallery +
+  connected-accounts markup unchanged. `detail` = new content per §2.1, driven by a model-level
+  "what's active" signal (new state, or reuse/extend `IdentityViewModel`'s existing
+  `selectedAccountAtom`/`formOpenAtom`/`draftAtom`-shaped signals — they already model exactly
+  "nothing selected vs. viewing vs. editing," just currently rendered as overlay visibility instead
+  of pane content).
+- **`AccountsGallery.tsx`**: loses `.accounts-chooser-overlay`/`.accounts-chooser` (§2.1 point 1
+  replaces the popup with detail-pane content) but keeps the tile grid and `openTile`/`pick`
+  click-handling logic — those become "set the active detail flow," not "open an overlay."
+- **`identity-view.tsx`**: `AccountsTab`'s `<Modal>` wrapper around `AccountDetail` goes away
+  (§2.1 point 2) — `AccountDetail` itself (the actual field-rendering component) is reusable
+  as-is, just mounted directly in the detail pane instead of inside `ModalHeader`/`ModalBody`/
+  `ModalFooter`. `AccountForm`'s `.identity-form-overlay` wrapper goes away (§2.1 points 1 and 3)
+  — `.identity-form`'s inner content (the actual fields, including the embedded
+  `OAuthConnectPanel`) is reusable as-is.
+- **`AgentMuxConnectPanel.tsx`**: loses its `.accounts-chooser-overlay`/`.accounts-chooser` wrapper
+  (§2.1 point 1) — its inner content (the OAuth-only connect flow, config-missing fallback note)
+  is reusable as-is.
+- **`IdentityPanel`** (`identity-view.tsx:57-98`, the *other* consumer of `AccountsTab`/`AccountForm`
+  — the per-agent settings surface, distinct from Armory, per CLAUDE.md's "Identity" vs.
+  "Identities" table entry): **shares `AccountForm`'s `.identity-form-overlay` and
+  `AccountsTab`'s `<Modal>`-wrapped `AccountDetail`.** Same scope-boundary situation as
+  `SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md` §5 flagged for the Agent Setup Modal's
+  Skills/MCP tabs — removing the shared overlay/modal markup without also converting this
+  consumer would leave it broken. **Recommend the same resolution as that spec: convert this
+  consumer too** (no evidence its modal is intentionally different from Armory's), flagging
+  explicitly rather than assuming, per this codebase's established convention on scope decisions.
+
+### 2.3 What doesn't change
+
+- `AccountsGallery`'s tile grid, badge counts, `SERVICE_CATALOG` data, and click routing logic.
+- `AccountForm`'s and `AccountDetail`'s actual field content, validation, and RPC calls — pure
+  layout-shell change, no data-flow change (same principle as
+  `SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md` §4.4).
+- `OAuthConnectPanel` — already embedded inline, not its own shell; unaffected either way.
+- The shared `Modal`/`ModalHeader`/`ModalBody`/`ModalFooter` primitives themselves
+  (`@/app/element/modal`) — still used elsewhere in the app; this spec only stops *this* tab from
+  using them, doesn't touch the primitive.
+
+---
+
+## 3. Test coverage to add
+
+- Clicking an empty gallery tile shows the connect flow in the detail pane (not an overlay); the
+  list (gallery + connected accounts) is not visible at the same time.
+- Clicking a connected account row shows its read-only detail in the pane; clicking Edit swaps to
+  the form in the same pane without a page/overlay transition.
+- The back affordation returns to the list from any of the three detail states.
+- `IdentityPanel` (the per-agent, non-Armory consumer) still functions after the shared-component
+  change — confirm during implementation, not assumed by this spec (see §2.2's `IdentityPanel` note).
+
+---
+
+## 4. Suggested PR split
+
+1. **PR A** — `AccountsManager`/`AccountsGallery`/`identity-view.tsx` conversion to
+   `PrimitiveListDetail`, covering both the Armory Accounts tab and the `IdentityPanel` consumer
+   together (they share the exact same components being changed — splitting them would mean an
+   in-between commit where one consumer is broken).
+2. **PR B** (optional, only if PR A's diff is large) — `AgentMuxConnectPanel`'s overlay removal,
+   if not folded into PR A already.
+
+---
+
+## 5. Sources
+
+- `frontend/app/view/accounts/accounts-manager.tsx`, `AccountsGallery.tsx`, `AgentMuxConnectPanel.tsx`,
+  `OAuthConnectPanel.tsx`, `accounts-catalog.ts`
+- `frontend/app/view/identity/identity-view.tsx`, `identity-model.ts`
+- `frontend/app/element/ProviderLogo.tsx`, `frontend/app/asset/logo-brain.svg`
+- `frontend/app/element/primitive-list-detail.tsx`
+- `docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md` (the pattern this spec extends)
+- `frontend/app/element/modal.tsx` (`Modal`/`ModalHeader`/`ModalBody`/`ModalFooter` — shared
+  primitive, not modified by this spec)

--- a/frontend/app/element/ProviderLogo.tsx
+++ b/frontend/app/element/ProviderLogo.tsx
@@ -21,6 +21,52 @@ import plandexUrl from "@/app/element/icons/plandex.png?url";
 import brainSvg from "@/app/asset/logo-brain.svg?raw";
 import type { JSX } from "solid-js";
 
+// Several of the raw SVGs above (notably logo-brain.svg, whose 16-stop
+// gradient illustration renders AgentMux's brand mark) define internal
+// `<linearGradient id="...">`s with plain, non-unique ids and reference
+// them via `fill="url(#...)"`. `innerHTML`-mounting the SAME raw markup
+// more than once on one page (e.g. the Armory Accounts gallery tile AND
+// the connected-accounts row both showing the AgentMux icon at once)
+// creates duplicate ids — the browser resolves every `url(#id)` reference
+// to whichever element with that id appears FIRST in the document,
+// regardless of which copy defined it. Since these are userSpace-style
+// gradients positioned relative to their OWN originally-inlined copy's
+// geometry, every instance after the first paints with a gradient
+// positioned for a shape it doesn't belong to — in practice, invisible
+// (live-confirmed via CDP: a second inlined copy's path resolved its
+// gradient fill to the FIRST copy's element). Live symptom: the AgentMux
+// icon renders blank in Armory Accounts once both the tile and the
+// connected row are visible together (post-`SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT`,
+// both are now always in the same continuous scroll, not hidden in a
+// separate scroll region).
+//
+// Fix: give every mounted instance's internal ids a unique suffix before
+// setting innerHTML, so each copy's gradients/references only ever
+// resolve within itself. Scoped to actual defined ids only (collected
+// from `id="..."` attributes first) so this can't accidentally rewrite
+// unrelated `#` occurrences elsewhere in the markup (e.g. hex color
+// literals like `fill="#ff0000"`, which never match `id="..."`/`url(#...)`/
+// `href="#..."`).
+let nextSvgInstanceId = 0;
+
+function uniquifySvgIds(svg: string): string {
+    const ids = new Set<string>();
+    for (const m of svg.matchAll(/\bid="([\w-]+)"/g)) ids.add(m[1]);
+    if (ids.size === 0) return svg;
+    const suffix = `pl${nextSvgInstanceId++}`;
+    let out = svg;
+    for (const id of ids) {
+        const uniq = `${id}-${suffix}`;
+        // split/join instead of replaceAll — this codebase's TS lib target
+        // predates ES2021, and these are literal-string searches (no regex
+        // escaping needed).
+        out = out.split(`id="${id}"`).join(`id="${uniq}"`);
+        out = out.split(`url(#${id})`).join(`url(#${uniq})`);
+        out = out.split(`href="#${id}"`).join(`href="#${uniq}"`);
+    }
+    return out;
+}
+
 export interface ProviderLogoProps {
     provider: string;
     size?: number;
@@ -108,13 +154,15 @@ export const ProviderLogo = (props: ProviderLogoProps): JSX.Element => {
 
     if (r.html) {
         // SolidJS innerHTML mounts the raw SVG. font-size drives the
-        // 1em-based sizing inside lobehub's SVGs.
+        // 1em-based sizing inside lobehub's SVGs. uniquifySvgIds prevents
+        // gradient/id collisions when the same icon mounts more than once
+        // on one page — see its own doc comment above.
         return (
             <span
                 class={cls}
                 style={{ "font-size": `${size()}px`, "line-height": 0, display: "inline-flex" }}
                 aria-hidden="true"
-                innerHTML={r.html}
+                innerHTML={uniquifySvgIds(r.html)}
             />
         );
     }


### PR DESCRIPTION
## Summary

Reported: the AgentMux brain icon renders blank in Armory Accounts.

**Root cause:** several raw SVGs in `ProviderLogo.tsx` (notably `logo-brain.svg`, AgentMux's own brand mark — 16 `linearGradient` defs) use plain, non-unique internal ids and reference them via `fill="url(#id)")`. SolidJS mounts these via `innerHTML`; inlining the *same* raw markup more than once on one page creates duplicate ids. Live-confirmed via CDP: a second inlined copy's gradient-fill reference resolves to the **first** copy's element (browsers resolve id-fragment URLs to the first matching element in document order), not its own — since these are userSpace-positioned gradients tied to their originally-inlined copy's geometry, every instance after the first paints with a gradient positioned for a shape it doesn't belong to, rendering blank in practice.

This didn't need a rare edge case to hit: the AgentMux icon appears in both the gallery tile and the connected-accounts row simultaneously whenever an AgentMux Cloud session is connected, and both are now always in the same continuous scroll (post PR #2170/#2178's single-pane Armory work) rather than potentially hidden in a separate scroll region.

**Fix:** `uniquifySvgIds()` gives every mounted instance's internal ids (and their `url(#...)`/`href="#..."` references) a unique suffix before setting `innerHTML`, scoped to ids actually collected from the markup so it can't touch unrelated `#` occurrences (e.g. hex color literals). Fixes every gradient-based icon in `ProviderLogo`, not just the brain mark.

Also includes a design-only spec (`docs/specs/SPEC_ARMORY_ACCOUNTS_NO_MODALS_2026_07_16.md`, no code) proposing to remove the three modal/overlay shells in Armory Accounts (auth-mode chooser, add/edit form, account detail) in favor of the same `PrimitiveListDetail` single-pane pattern already used by Bundles/Skills/MCP Servers.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] Full frontend suite: `npx vitest run` — 1783 passed (1 unrelated flaky timeout in `tool-renderers/registry.test.ts`, confirmed flaky by re-running in isolation: passes in 2035ms, well under its 5000ms budget — not touched by this change).
- [x] Live-verified via CDP: injected the same raw SVG twice with the fix applied — 0 duplicate ids in the document, second instance's gradient fill resolves to its own element instead of the first instance's (was `wrap1` before the fix, `wrap2` after).

<!-- agentmux:agent_id=agent1 -->