### PR TITLE
feat(layout): minimize is a display mode (i3 pattern) — geometry derived, slip/dissolve deleted

### DIFF
--- a/.changesets/1784269908-feat-layout-minimize-is-a-display-mode-derived-geometry-slip-5x81.md
+++ b/.changesets/1784269908-feat-layout-minimize-is-a-display-mode-derived-geometry-slip-5x81.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(layout): minimize is a display mode — derived geometry, slip/dissolve machinery deleted

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -219,7 +219,15 @@ pub fn prune_dangling_block_refs(
 /// through the untyped `extra` catch-all on this side. Mirrors
 /// `isNodeLocked` in `frontend/layout/lib/layoutMinimize.ts`.
 pub fn is_node_locked(node: &LayoutNode) -> bool {
-    node.extra.contains_key("minimizedSize")
+    // Current model: the `minimized` display-mode flag (geometry derived at
+    // render on the frontend; stored sizes never touched). The remaining keys
+    // are legacy markers from the pre-display-mode model, recognized until
+    // persisted trees are migrated by the frontend's `rebuildMinimizedSet`.
+    node.extra
+        .get("minimized")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+        || node.extra.contains_key("minimizedSize")
         || node.extra.contains_key("slipMinimize")
         || node.extra.contains_key("columnDissolve")
 }
@@ -300,12 +308,19 @@ pub fn validate_layout_invariants(root: &Option<LayoutNode>) -> Vec<String> {
                 if is_branch { "present" } else { "absent" }
             ));
         }
-        // I2 — minimizedSize / slipMinimize are leaf-only markers.
-        if is_branch && (has("minimizedSize") || has("slipMinimize")) {
+        // I2 — the `minimized` flag and the legacy minimizedSize/slipMinimize
+        // markers are leaf-only.
+        if is_branch && (has("minimized") || has("minimizedSize") || has("slipMinimize")) {
             violations.push(format!(
                 "MIN_MARKER_ON_BRANCH @ {}: branch has {}",
                 short(&node.id),
-                if has("minimizedSize") { "minimizedSize" } else { "slipMinimize" }
+                if has("minimized") {
+                    "minimized"
+                } else if has("minimizedSize") {
+                    "minimizedSize"
+                } else {
+                    "slipMinimize"
+                }
             ));
         }
         // I3 — columnDissolve is branch-only.

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -232,6 +232,20 @@ pub fn is_node_locked(node: &LayoutNode) -> bool {
         || node.extra.contains_key("columnDissolve")
 }
 
+/// True when a node renders as minimized: a locked leaf, or a branch whose
+/// every child is effectively minimized (a stacked chip strip). Mirrors
+/// `isEffectivelyMinimized` in `frontend/layout/lib/layoutInvariants.ts`.
+/// Reducer guards use THIS (not `is_node_locked`): a fully-collapsed branch
+/// has no branch-level marker in the display-mode model, but its stored size
+/// becomes load-bearing again the moment a child restores — so it must be
+/// just as untargetable as a minimized leaf.
+pub fn is_effectively_minimized(node: &LayoutNode) -> bool {
+    if node.children.is_empty() {
+        return is_node_locked(node);
+    }
+    node.children.iter().all(is_effectively_minimized)
+}
+
 /// Write-point enforcement of the minimize lock (the invariant-at-the-write
 /// companion to `prune_dangling_block_refs`, per
 /// `SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`): snap every
@@ -541,7 +555,7 @@ pub fn insert_node_at_index(
     // Minimized is a locked state: an `index_arr` that resolves into a
     // dissolved column (locked container) or onto a minimized leaf (which
     // `ensure_group_node` would otherwise promote into a group) is rejected.
-    if is_node_locked(parent) {
+    if is_effectively_minimized(parent) {
         return Err(LayoutError::NodeLocked { id: parent.id.clone() });
     }
     ensure_group_node(parent);
@@ -617,13 +631,13 @@ pub fn move_node(
         .clone();
     // Minimized is a locked state: a locked node can't be moved (restore it
     // first), and nothing may be inserted into a dissolved column.
-    if is_node_locked(&node_to_move) {
+    if is_effectively_minimized(&node_to_move) {
         return Err(LayoutError::NodeLocked { id: node_id.to_string() });
     }
     // Confirm destination exists while tree is still intact.
     match find_node_by_id(root, new_parent_id) {
         None => return Err(LayoutError::NodeNotFound { id: new_parent_id.to_string() }),
-        Some(p) if is_node_locked(p) => {
+        Some(p) if is_effectively_minimized(p) => {
             return Err(LayoutError::NodeLocked { id: new_parent_id.to_string() });
         }
         Some(_) => {}
@@ -720,10 +734,10 @@ pub fn swap_nodes(
         .ok_or_else(|| LayoutError::NodeNotFound { id: node2_id.to_string() })?
         .clone();
     // Minimized is a locked state: locked nodes don't swap.
-    if is_node_locked(&n1) {
+    if is_effectively_minimized(&n1) {
         return Err(LayoutError::NodeLocked { id: node1_id.to_string() });
     }
-    if is_node_locked(&n2) {
+    if is_effectively_minimized(&n2) {
         return Err(LayoutError::NodeLocked { id: node2_id.to_string() });
     }
     let p1_id = find_parent_id(root, node1_id)
@@ -785,7 +799,7 @@ pub fn resize_nodes(root: &mut LayoutNode, ops: &[ResizeOp]) -> Result<(), Layou
     for op in ops {
         match find_node_by_id(root, &op.node_id) {
             None => return Err(LayoutError::NodeNotFound { id: op.node_id.clone() }),
-            Some(node) if is_node_locked(node) => {
+            Some(node) if is_effectively_minimized(node) => {
                 return Err(LayoutError::NodeLocked { id: op.node_id.clone() });
             }
             Some(_) => {}
@@ -860,7 +874,7 @@ fn split_impl(
     // a locked node would spawn a full pane inside a header strip).
     let target = find_node_by_id(root, target_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: target_id.to_string() })?;
-    if is_node_locked(target) {
+    if is_effectively_minimized(target) {
         return Err(LayoutError::NodeLocked { id: target_id.to_string() });
     }
 

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -293,6 +293,61 @@ fn resize_nodes_rejects_display_mode_minimized_target() {
 }
 
 #[test]
+fn resize_nodes_rejects_fully_minimized_branch() {
+    // A collapsed column has no branch-level marker in the display-mode
+    // model, but its stored size becomes load-bearing again when any child
+    // restores — guards use is_effectively_minimized, not is_node_locked.
+    let stack = group(
+        "colA",
+        FlexDirection::Column,
+        200.0,
+        vec![minimized_leaf("l1", "b1", 200.0), minimized_leaf("l2", "b2", 200.0)],
+    );
+    let mut root = group(
+        "root",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![stack, leaf("colB", "b3", 200.0)],
+    );
+    let ops = vec![
+        ResizeOp { node_id: "colA".into(), size: 1.0 },
+        ResizeOp { node_id: "colB".into(), size: 99.0 },
+    ];
+    assert!(matches!(
+        resize_nodes(&mut root, &ops),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    assert_eq!(root.children[0].size, 200.0);
+    assert_eq!(root.children[1].size, 200.0);
+}
+
+#[test]
+fn move_node_rejects_fully_minimized_branch_endpoints() {
+    let stack = group(
+        "colA",
+        FlexDirection::Column,
+        200.0,
+        vec![minimized_leaf("l1", "b1", 200.0), minimized_leaf("l2", "b2", 200.0)],
+    );
+    let mut root = group(
+        "root",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![stack, leaf("other", "b3", 200.0)],
+    );
+    // Moving a fully-minimized branch is rejected.
+    assert!(matches!(
+        move_node(&mut root, "colA", "root", 1),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    // Moving anything INTO a fully-minimized branch is rejected.
+    assert!(matches!(
+        move_node(&mut root, "other", "colA", 0),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+}
+
+#[test]
 fn validate_invariants_flags_display_mode_flag_on_branch() {
     let mut branch = group(
         "br",

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -263,9 +263,79 @@ fn balance_column_dissolve_suppresses_direction_flip() {
 
 // ── Minimize lock (locked-state spec, 2026-07-16) ───────────────────────────
 
-/// Leaf carrying the minimize-lock fields the frontend writes (round-tripped
-/// through `extra`): `minimizedSize` (original size) + `minimizedLockedSize`
-/// (the size the node is locked to while minimized).
+/// Leaf carrying the display-mode minimize flag (current model — geometry
+/// derived at render, stored size untouched).
+fn minimized_leaf(id: &str, block_id: &str, size: f32) -> LayoutNode {
+    let mut node = leaf(id, block_id, size);
+    node.extra.insert("minimized".into(), serde_json::Value::Bool(true));
+    node
+}
+
+#[test]
+fn resize_nodes_rejects_display_mode_minimized_target() {
+    let mut root = group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![minimized_leaf("l1", "b1", 200.0), leaf("l2", "b2", 200.0)],
+    );
+    let ops = vec![
+        ResizeOp { node_id: "l1".into(), size: 90.0 },
+        ResizeOp { node_id: "l2".into(), size: 10.0 },
+    ];
+    assert!(matches!(
+        resize_nodes(&mut root, &ops),
+        Err(LayoutError::NodeLocked { .. })
+    ));
+    // Atomic reject: stored sizes untouched (minimize never wrote them either).
+    assert_eq!(root.children[0].size, 200.0);
+    assert_eq!(root.children[1].size, 200.0);
+}
+
+#[test]
+fn validate_invariants_flags_display_mode_flag_on_branch() {
+    let mut branch = group(
+        "br",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![leaf("l1", "b1", 100.0), leaf("l2", "b2", 100.0)],
+    );
+    branch.extra.insert("minimized".into(), serde_json::Value::Bool(true));
+    let root = Some(group(
+        "root",
+        FlexDirection::Row,
+        DEFAULT_NODE_SIZE,
+        vec![branch, leaf("l3", "b3", 100.0)],
+    ));
+    let violations = validate_layout_invariants(&root);
+    assert!(
+        violations.iter().any(|v| v.starts_with("MIN_MARKER_ON_BRANCH")),
+        "expected MIN_MARKER_ON_BRANCH, got: {:?}",
+        violations
+    );
+}
+
+#[test]
+fn validate_invariants_flags_all_leaves_locked_via_display_flag() {
+    let root = Some(group(
+        "root",
+        FlexDirection::Column,
+        DEFAULT_NODE_SIZE,
+        vec![minimized_leaf("l1", "b1", 200.0), minimized_leaf("l2", "b2", 200.0)],
+    ));
+    let violations = validate_layout_invariants(&root);
+    assert!(
+        violations.iter().any(|v| v.starts_with("ALL_LEAVES_LOCKED")),
+        "expected ALL_LEAVES_LOCKED, got: {:?}",
+        violations
+    );
+}
+
+/// LEGACY MODEL — leaf carrying the pre-display-mode minimize-lock fields
+/// (round-tripped through `extra`): `minimizedSize` (original size) +
+/// `minimizedLockedSize` (the size the node was locked to while minimized).
+/// These markers remain recognized until persisted trees are migrated by the
+/// frontend's `rebuildMinimizedSet`.
 fn locked_leaf(id: &str, block_id: &str, locked_size: f32) -> LayoutNode {
     let mut node = leaf(id, block_id, locked_size);
     node.extra

--- a/agentmux-srv/src/reducer/layout.rs
+++ b/agentmux-srv/src/reducer/layout.rs
@@ -229,7 +229,7 @@ pub(super) fn handle_layout_insert_node(
             // so it would otherwise satisfy the group-node arm below) cannot
             // host inserts — minimized is a locked state
             // (SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md).
-            Some(parent_node) if crate::backend::layout::is_node_locked(parent_node) => {
+            Some(parent_node) if crate::backend::layout::is_effectively_minimized(parent_node) => {
                 let v = state.bump_version();
                 return vec![Event::Error {
                     code: ErrorCode::InvalidCommand,

--- a/docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md
+++ b/docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md
@@ -1,0 +1,203 @@
+# Research — Pane Minimize/Collapse Best Practices in Tiling Layout Systems
+
+**Date:** 2026-07-16
+**Type:** External research report (deep-research harness: 5 search angles, 21 sources
+fetched, 96 claims extracted, top 25 adversarially verified by 3 independent votes each —
+23 confirmed 3-0, 2 refuted 0-3, 0 unverified)
+**Trigger:** Four distinct bug classes in two weeks from AgentMux's in-tree pane-minimize
+design, culminating in the layout doctor capturing a live cascade producing **negative
+sizes** (issue #2179). This report surveys how mature systems solve the same problem and
+maps the findings 1:1 against what we already attempted.
+**Companion docs:** `SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md` (Option B/C),
+`INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`.
+
+---
+
+## 1. Verdict (TL;DR)
+
+**Across every surveyed mature system, minimize/collapse is never modeled as size
+arithmetic inside the flex/ratio tree.** Verified 3-0 per system, panes either:
+
+1. **leave the tree entirely** into a dedicated dock structure (FlexLayout top-level
+   `borders`, AvalonDock edge-anchored `LayoutAnchorGroup`s, Eclipse Trim Stacks,
+   IntelliJ tool-window bars, i3 scratchpad), or
+2. **collapse via a discrete container display mode** whose geometry is derived fresh at
+   render time and never stored (i3 stacked/tabbed, FlexLayout/Dockview maximize,
+   IntelliJ view modes).
+
+The single strongest precedent: **tmux's maintainer rejected — in writing — the exact
+design we built.** Asked for in-layout hidden panes, nicm warned that a "halfway" design
+where panes are flagged inside the live layout so "every loop skips it *is* adding a
+special kind of pane… no better than just using a special session" (i.e. out-of-tree
+relocation), and tmux enforces the hard invariant that *every pane in a window's layout
+is visible* — its zoom is a whole-layout snapshot swap that is forcibly undone before any
+structural operation (15+ call sites).
+
+**Our Option C (out-of-tree per-column dock) is the established pattern.** The only
+in-tree collapse mature systems make work is the i3 model: a `displayMode: "stack"`
+container flag whose header-stack geometry the renderer computes every pass, leaving
+stored flex weights untouched. Our "slip" mechanism has **no analog in any surveyed
+system**.
+
+## 2. What we attempted (the failure history this is measured against)
+
+| Attempt | Mechanism | Outcome |
+|---|---|---|
+| In-tree minimize | Squeeze `size` to header height; store `minimizedSize` for restore; "slip" (header migrates into adjacent column); "column dissolve" (fully-minimized column nests into a neighbor, converting leaves into columns) | Four bug classes below |
+| Bug class 1 | `balanceNode` direction-alternation flipped a dissolved column's orientation | Point-guard (#2176) |
+| Bug class 2 | Resize handles freely resized minimized panes (min-size guard was even inverted for them) | Write-point locks: `minimizedLockedSize`, reducer rejections, handle suppression (#2180) |
+| Bug class 3 | Leaf→group promotions stranded leaf-only marker fields on branches (TS/Rust port divergence) | Found via live 0.53.6 DB archaeology; doctor invariant I2 |
+| Bug class 4 | Cascading dissolves computed **negative** sizes (steal-from-neighbor arithmetic clamps the neighbor at a floor → `actualStolen < 0`), and the #2180 locks then *faithfully preserved the garbage* | Caught live by the layout doctor (`NONPOSITIVE_SIZE`, tree dump in dev log) |
+| Diagnostics | 9-invariant layout doctor at every write choke point, both TS and Rust (PR #2184, unmerged) | Works — attributed bug class 4 in real time |
+
+## 3. Survey: how mature systems model minimize
+
+| System | Model | Where minimized panes live | Verified |
+|---|---|---|---|
+| **FlexLayout** | Out-of-tree | Top-level `borders` element — border nodes *"can only be used within the `borders` top-level element"*, structurally impossible inside the main row/tabset tree | 3-0 |
+| **AvalonDock** | Out-of-tree | `ToggleAutoHide()` moves the pane out of `RootPanel` into a `LayoutAnchorGroup` on `LayoutRoot.{Left,Right,Top,Bottom}Side` | 3-0 |
+| **Eclipse** | Out-of-tree (presentation) | Minimized view stacks move to **Trim Stacks** at the workbench-window edges (E4 nuance: the `MPartStack` stays in the E4 model, tagged `Minimized` and un-rendered — the *presentation* is out-of-tree) | 3-0 |
+| **IntelliJ** | Out-of-tree | Tool windows attach to edge **tool-window bars** outside the editor split tree, managed by a separate `ToolWindowManager` layer; collapse behavior is one of 5 discrete view modes | 3-0 |
+| **i3/sway (scratchpad)** | Out-of-tree | Minimize-equivalent moves the window to an invisible scratchpad workspace, entirely off the tiling layout | 3-0 |
+| **i3/sway (stacked/tabbed)** | In-tree **display mode** | Per-container `layout` mode; non-focused children stay in the tree at full size (`percent` untouched), hidden purely by render-time stacking order; IPC tree schema has **no minimized-state or saved-size field at all** | 3-0 |
+| **tmux (zoom)** | Whole-layout snapshot swap | `window_zoom()` saves `saved_layout_root`, builds a one-pane layout; unzoom swaps the snapshot back; forced unzoom before every structural op | 3-0 |
+| **Dockview / FlexLayout (maximize)** | In-tree **discrete flag** | `maximizeGroup`/`MAXIMIZE_TOGGLE` store a dedicated reference (`_maximizedNode` / `maximizedTabSet`) and toggle *other views' visibility* — **no weights mutated**; Dockview `serialize()` deliberately exits maximize first so persisted dimensions stay uncorrupted | 3-0 |
+| **DockPanel Suite** | Out-of-tree | Auto-hide moves content to edge strips with a dedicated overlay for temporary display | (secondary source) |
+
+Coverage gaps (see §8): no claims about VS Code internals, Golden Layout, rc-dock,
+Lumino, Qt QDockWidget, or macOS Dock survived verification — conclusions rest on the
+seven systems above, all confirmed against primary docs plus source code.
+
+## 4. The i3 insight: our "column dissolve" as a display mode
+
+i3's stacked container is **visually identical to what column dissolve tries to build**
+(a vertical stack of title bars with one/zero panes showing) — but implemented the
+opposite way:
+
+- The header stack is **recomputed by the renderer on every pass**: focused child gets
+  container size minus the decoration heights of all children. Computed geometry
+  (`rect`, `window_rect`, `deco_rect`) is documented as *"temporary, meaning they will be
+  overwritten by calling render_con"* — rendered sizes are never a source of truth any
+  operation could corrupt.
+- **Orientation is not stored** — i3 deliberately removed the stored orientation field in
+  2012; `con_orientation()` is a pure switch on the layout mode (vertical for
+  splitv/stacking, horizontal for splith/tabbed). **Our bug class 1 is structurally
+  impossible in i3**: no normalization pass can flip what is derived, not stored.
+- Because the state is derived, i3 needs **no locks, no rejection rules, no
+  `minimizedSize` bookkeeping** — the invariant-bearing state simply is not writable.
+
+## 5. State-model patterns that keep these trees consistent
+
+1. **One tree as sole source of truth.** i3 abandoned an earlier multiple-lists design as
+   *"complicated to use (snapping), understand and implement."*
+2. **A single command/reducer choke point.** FlexLayout: after model load, *all* changes
+   go through `model.doAction()` (~19 typed actions); direct mutators are `@internal`.
+   (AgentMux already has this — SPEC_864.)
+3. **Computed geometry is throwaway derived state**, never read back as authoritative.
+   Persistent size lives only in relative `percent`/weight fields that transient modes
+   never touch. Dockview and tmux both **exit maximize/zoom before serializing** so
+   display state cannot leak into stored sizes — the exact inverse of our bug class 4,
+   where dissolve arithmetic leaked garbage into stored sizes and the locks preserved it.
+
+Notably: **none of these systems relies on write-point locks or reducer rejections to
+protect a size invariant.** Our #2180 lock layer is a defensible hardening of a design no
+mature system uses; it treats a symptom the surveyed architectures remove at the root.
+
+## 6. Restore semantics
+
+- **AvalonDock** (the direct model for Option C): auto-hide stores
+  `PreviousContainer = parentPane` (serialized as `PreviousContainerId`,
+  `ILayoutPreviousContainer` pattern); un-hide re-docks into that stored container and
+  falls back to creating a fresh pane via the layout engine only when the reference is
+  null or detached (`previousContainer.Root == null`) — the documented answer to the
+  **anchor-disappeared** problem.
+- **Eclipse** tracks provenance: un-maximize restores only trim stacks created *by that
+  maximize* (`MINIMIZED_BY_ZOOM` tag); independently minimized stacks stay minimized.
+- **tmux** restores by whole-snapshot swap; any structural change invalidates the
+  snapshot wholesale (forced unzoom) rather than attempting partial reconciliation.
+- **i3 scratchpad** sidesteps restore entirely: the window returns *floating, centered* —
+  never to its prior tree position.
+
+Common thread: **explicit provenance references with defined fallbacks — never
+reconstruction from residual size state left in the tree.** Our `minimizedSize`/
+`slipMinimize.targetColumnId`/`columnDissolve.originalRowIndex` bookkeeping is a partial
+reinvention of this, but stored *inside* the mutable tree where every structural op must
+preserve it (bug class 3: they don't).
+
+## 7. Recommendation for AgentMux
+
+**Adopt Option C — it is the industry pattern, not an experiment.** Composed entirely
+from verified precedents:
+
+1. **Minimized panes leave the flex tree** into a per-column dock list of
+   `{paneId, previousContainerId, savedRelativeSize}` — the AvalonDock
+   `ILayoutPreviousContainer` pattern — with an explicit fallback (re-insert via the
+   layout engine at a default position) when the anchor container is gone. If
+   maximize-by-minimizing-others is ever added, tag dock entries Eclipse-style
+   (`MINIMIZED_BY_ZOOM`) so bulk restore is scoped.
+2. **All mutations stay on the reducer choke point** (we already have this). Dock
+   membership becomes reducer-owned state under SPEC_864, so backend enforcement is
+   structural, not arithmetic.
+3. **If any in-tree collapse is retained, make it a display mode, not surgery:** replace
+   "column dissolve" with `displayMode: "stack"` on the column — the renderer derives the
+   header-stack geometry each pass from header count; stored flex weights are never
+   touched. This deletes dissolve/undissolve structural surgery, the negative-size
+   arithmetic, and the orientation coupling **simultaneously** (i3 pattern).
+4. **Drop "slip".** No surveyed system implements anything comparable; its job (a lone
+   Row pane collapsing sideways) is subsumed by dock placement rules.
+5. **Keep the layout doctor** as the regression net during migration; note that
+   invariants I2/I4/I6/I7 become *unnecessary by construction* once minimize state is
+   unwritable — which is the measure of success: the doctor should end up with nothing
+   to say about minimize.
+
+What gets deleted: `_slipMinimize`, `_dissolveColumn`, `_undissolveColumn`,
+`slipMinimize`/`columnDissolve`/`_slipAnchor` fields, both `balanceNode` carve-outs, the
+`minimizedLockedSize` lock layer and its reducer rejections (~all of #2180's mechanism,
+kept only as generic hardening if desired), and the steal-from-neighbor arithmetic.
+
+**Bug-class → pattern map (why this can't regress):**
+
+| Our bug class | Preventing pattern (verified) |
+|---|---|
+| 1 — direction flip | Orientation/geometry derived, not stored (i3) |
+| 2 — resize-through-lock | Minimized panes aren't in the tree; there is no edge to resize (all dock systems) |
+| 3 — stranded markers | No leaf-only marker fields in the tree; dock entry is the record (AvalonDock) |
+| 4 — cascade negatives | No steal arithmetic; header strip geometry derived per render (i3); display state never serialized into sizes (Dockview/tmux) |
+
+## 8. Caveats and open questions (from verification)
+
+- **Coverage gaps:** VS Code internals, Golden Layout, rc-dock, Lumino, Qt QDockWidget,
+  macOS Dock — no claims survived verification; conclusions rest on i3, tmux, FlexLayout,
+  Dockview, AvalonDock, Eclipse, IntelliJ. Two Dockview claims (that it *lacks*
+  collapse-to-edge per issue #765) were refuted 0-3 — draw no conclusion there.
+- **Precision nuances:** Eclipse's E4 model keeps the minimized `MPartStack` in the model
+  (tagged, un-rendered) — "out-of-tree" is strictly true of the presentation. IntelliJ
+  does persist a per-window size "weight" for restore, but as memory separate from the
+  collapse mechanism. FlexLayout's choke point is TS `@internal` visibility, not runtime
+  immutability.
+- **Open questions for the Option C spec:**
+  1. When the host column itself closes: promote its dock to a neighbor column, escalate
+     to a window-level tray (Eclipse/IntelliJ style), or force-restore? (AvalonDock's
+     null/detached fallback answers the per-pane case, not the dock-container-vanishes
+     case.)
+  2. VS Code's grid/serializable-view internals remain the highest-profile unexamined
+     web-tech analog — worth a targeted follow-up before finalizing the spec.
+  3. Whether any "slip"-like affordance is worth re-adding as a dock placement rule.
+
+## 9. Primary sources
+
+- i3: userguide, hacking-howto, ipc docs; src/render.c, src/con.c, include/data.h;
+  commit de94f6da1a (orientation field removal) — https://i3wm.org/docs/
+- tmux: issue #3047 (maintainer quotes verified verbatim via GitHub API); window.c
+  zoom/unzoom on master — https://github.com/tmux/tmux/issues/3047
+- FlexLayout: README/Model.ts — https://github.com/caplin/FlexLayout
+- AvalonDock: LayoutAnchorGroup wiki; LayoutAnchorable.cs:413-506 —
+  https://github.com/Dirkster99/AvalonDock/wiki/LayoutAnchorGroup
+- Eclipse: Workbench User Guide (min/max); MinMaxAddon.java —
+  https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.user/gettingStarted/qs-39g.htm
+- IntelliJ: viewing-modes, manipulating-tool-windows —
+  https://www.jetbrains.com/help/idea/viewing-modes.html
+- Dockview: maximized-groups docs; gridview.ts —
+  https://dockview.dev/docs/core/groups/maxmizedGroups/
+- Adjacent practitioner failure logs: react-resizable-panels CHANGELOG (multi-year
+  in-tree `collapsedSize` bug log), react-mosaic, pixeleuphoria docking-splitter notes.

--- a/docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md
+++ b/docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md
@@ -2,7 +2,13 @@
 
 **Date:** 2026-07-16
 **Type:** Investigation + redesign proposal
-**Status:** Option B implemented 2026-07-16 (see §6); Option C remains a proposal
+**Status:** SUPERSEDED by the display-mode model, implemented 2026-07-16 (see §8).
+Option B (locks, §6) shipped in #2180, then was retired the same day after the layout
+doctor caught cascade arithmetic producing negative sizes live — Option B's locks
+faithfully preserved the garbage. External research
+(`docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md`) confirmed no mature
+system stores minimize as in-tree size state; the implemented design is the research's
+recommendation §7.3 (i3 pattern: display-mode flag + render-derived geometry).
 **Trigger:** User report: a minimized pane can still be resized by dragging the adjacent
 resize handle. Minimize is supposed to be a *locked* state; today it is not.
 **Prior related work:** `INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`
@@ -234,3 +240,39 @@ Merged history this consolidates:
 - PR #2039 — `prune_dangling_block_refs` write-path invariant ("WRR-style").
 - PR #2176 — dissolved-column direction-flip guard in `balanceNode`/`balance_node`.
 - `docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`.
+
+## 8. Final design (implemented 2026-07-16): minimize is a display mode
+
+After the layout doctor (#2184) caught a live cascade computing **negative sizes** —
+which Option B's locks then preserved — external research
+(`RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md`; i3, tmux, Eclipse, IntelliJ,
+FlexLayout, AvalonDock, Dockview, all source-verified) established that no mature system
+stores minimize as in-tree size state. The implemented model is the research's
+recommendation §7.3, the i3 pattern:
+
+- **State:** one leaf-only flag, `minimized: true`. Nothing else. Stored flex sizes are
+  **never touched** by minimize; restore = clear the flag, original geometry intact by
+  construction.
+- **Geometry is derived, per render pass** (`computeMainAxisAllocation` in
+  `layoutGeometry.ts`): a minimized leaf renders as a header chip (header height in a
+  Column parent; fixed `MinimizedRowSlotWidthPx` chip in a Row parent, cross-axis clamped
+  to header height); a fully-minimized subtree renders as a stacked chip strip (one
+  header height per leaf), with expanded siblings absorbing the remainder proportionally
+  to their untouched flex sizes. Chips scale down when the container is too small.
+- **Deleted wholesale:** `_slipMinimize`, `_dissolveColumn`, `_undissolveColumn`, the
+  `slipMinimize`/`columnDissolve`/`_slipAnchor` bookkeeping, `minimizedSize` restore
+  arithmetic, `minimizedLockedSize` + `enforceMinimizedLocks` on the frontend, and all
+  steal-from-neighbor math. `balanceNode`'s two carve-outs remain as inert pre-migration
+  protection; backend `enforce_minimized_locks` remains for unmigrated legacy trees.
+- **Kept:** the reducer guards both sides (`isNodeLocked`/`is_node_locked` now keyed on
+  the flag + legacy markers) — minimized panes stay untargetable by resize/move/swap/
+  split/insert; the last-expanded-pane guard; the collapsed-header reduction; the layout
+  doctor (I2 extended to the flag; I4/I5/I6/I7 now legacy-detection).
+- **Migration:** `rebuildMinimizedSet` converts legacy state in place at load
+  (`minimizedSize` → size restored + flag; `slipMinimize` → flag in place;
+  `columnDissolve`/`minimizedLockedSize`/`_slipAnchor` → dropped).
+- **Why each historical bug class is now structurally impossible:** direction flips
+  can't corrupt what geometry derives (bug 1); there is no squeezed size to resize and no
+  handle on chip edges (bug 2); one leaf-only flag instead of four marker fields
+  (bug 3, doctor I2 still watches promotions); no arithmetic exists to compute a negative
+  size (bug 4).

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -38,10 +38,16 @@ function countLeafPanes(node: LayoutNode): number {
  * Fixed main-axis pixels for a minimized child: a header-height strip per
  * stacked chip in a Column parent, a compact fixed-width chip in a Row parent.
  * Derived fresh every pass — minimize never writes sizes (see layoutMinimize).
+ *
+ * Gap compensation: each tile's rendered box is inset by `gapSizePx`
+ * downstream (`innerRect` computes `calc(size - gapSizePx)` in
+ * layoutNodeModels.ts), and the header has a FIXED --header-height in
+ * block.scss — so the slot allocation must be header + gap for the visible
+ * box to come out exactly header-sized instead of clipping.
  */
-function minimizedFixedPx(node: LayoutNode, parentIsRow: boolean): number {
-    if (parentIsRow) return MinimizedRowSlotWidthPx;
-    return countLeafPanes(node) * HeaderHeightPx;
+function minimizedFixedPx(node: LayoutNode, parentIsRow: boolean, gapPx: number): number {
+    if (parentIsRow) return MinimizedRowSlotWidthPx + gapPx;
+    return countLeafPanes(node) * (HeaderHeightPx + gapPx);
 }
 
 /**
@@ -55,9 +61,10 @@ export function computeMainAxisAllocation(
     children: LayoutNode[],
     nodeIsRow: boolean,
     nodePixels: number,
-    getSize: (n: LayoutNode) => number
+    getSize: (n: LayoutNode) => number,
+    gapPx = 0
 ): MainAxisAllocation {
-    const fixed = children.map((c) => (isEffectivelyMinimized(c) ? minimizedFixedPx(c, nodeIsRow) : 0));
+    const fixed = children.map((c) => (isEffectivelyMinimized(c) ? minimizedFixedPx(c, nodeIsRow, gapPx) : 0));
     const fixedTotal = fixed.reduce((a, b) => a + b, 0);
     const scale = fixedTotal > nodePixels && fixedTotal > 0 ? nodePixels / fixedTotal : 1;
     const remainingPx = Math.max(nodePixels - fixedTotal * scale, 0);
@@ -204,7 +211,8 @@ function updateTreeHelper(
     const nodeRect: Dimensions = node.id === model.treeState.rootNode.id ? boundingRect : additionalProps.rect;
     const nodeIsRow = node.flexDirection === FlexDirection.Row;
     const nodePixels = nodeIsRow ? nodeRect.width : nodeRect.height;
-    const alloc = computeMainAxisAllocation(node.children, nodeIsRow, nodePixels, getNodeSize);
+    const gapPx = model.gapSizePx();
+    const alloc = computeMainAxisAllocation(node.children, nodeIsRow, nodePixels, getNodeSize, gapPx);
     const pixelToSizeRatio = alloc.pixelToSizeRatio;
 
     let lastChildRect: Dimensions;
@@ -220,7 +228,11 @@ function updateTreeHelper(
             top: !nodeIsRow && lastChildRect ? lastChildRect.top + lastChildRect.height : nodeRect.top,
             left: nodeIsRow && lastChildRect ? lastChildRect.left + lastChildRect.width : nodeRect.left,
             width: nodeIsRow ? alloc.px[i] : nodeRect.width,
-            height: nodeIsRow ? (chipLeaf ? Math.min(HeaderHeightPx, nodeRect.height) : nodeRect.height) : alloc.px[i],
+            height: nodeIsRow
+                ? chipLeaf
+                    ? Math.min(HeaderHeightPx + gapPx, nodeRect.height)
+                    : nodeRect.height
+                : alloc.px[i],
         };
         const transform = setTransform(rect);
         additionalPropsMap[child.id] = {

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -3,8 +3,8 @@
 
 import { batch } from "solid-js";
 import { balanceNode, walkNodes } from "./layoutNode";
-import { enforceMinimizedLocks, isNodeLocked } from "./layoutMinimize";
-import { reportLayoutViolations } from "./layoutInvariants";
+import { HeaderHeightPx, MinimizedRowSlotWidthPx } from "./layoutMinimize";
+import { isEffectivelyMinimized, reportLayoutViolations } from "./layoutInvariants";
 import {
     FlexDirection,
     LayoutNode,
@@ -15,6 +15,62 @@ import {
 } from "./types";
 import { setTransform } from "./utils";
 import type { LayoutModel } from "./layoutModel";
+
+export interface MainAxisAllocation {
+    /** Main-axis pixels per child, index-aligned with the children array. */
+    px: number[];
+    /**
+     * Flex-units-per-pixel for the EXPANDED children (minimized chips take
+     * fixed pixels off the top first). This is what resize-drag math uses to
+     * convert pointer deltas into flex units, so it must describe only the
+     * space the flex solver actually distributes.
+     */
+    pixelToSizeRatio: number;
+}
+
+/** Leaf count of a subtree — one header chip per leaf when fully minimized. */
+function countLeafPanes(node: LayoutNode): number {
+    if (!node.children?.length) return 1;
+    return node.children.reduce((s, c) => s + countLeafPanes(c), 0);
+}
+
+/**
+ * Fixed main-axis pixels for a minimized child: a header-height strip per
+ * stacked chip in a Column parent, a compact fixed-width chip in a Row parent.
+ * Derived fresh every pass — minimize never writes sizes (see layoutMinimize).
+ */
+function minimizedFixedPx(node: LayoutNode, parentIsRow: boolean): number {
+    if (parentIsRow) return MinimizedRowSlotWidthPx;
+    return countLeafPanes(node) * HeaderHeightPx;
+}
+
+/**
+ * Derive each child's main-axis pixels: minimized children get fixed
+ * chip-sized allocations (scaled down proportionally if the container is too
+ * small to fit them all), and the remaining pixels are split among expanded
+ * children proportionally to their stored flex sizes — which are never
+ * mutated by minimize. Pure; exported for unit tests.
+ */
+export function computeMainAxisAllocation(
+    children: LayoutNode[],
+    nodeIsRow: boolean,
+    nodePixels: number,
+    getSize: (n: LayoutNode) => number
+): MainAxisAllocation {
+    const fixed = children.map((c) => (isEffectivelyMinimized(c) ? minimizedFixedPx(c, nodeIsRow) : 0));
+    const fixedTotal = fixed.reduce((a, b) => a + b, 0);
+    const scale = fixedTotal > nodePixels && fixedTotal > 0 ? nodePixels / fixedTotal : 1;
+    const remainingPx = Math.max(nodePixels - fixedTotal * scale, 0);
+    const flexTotal = children.reduce((s, c, i) => (fixed[i] ? s : s + getSize(c)), 0);
+    const pixelToSizeRatio =
+        flexTotal > 0 && remainingPx > 0
+            ? flexTotal / remainingPx
+            : children.reduce((s, c) => s + getSize(c), 0) / Math.max(nodePixels, 1);
+    const px = children.map((c, i) =>
+        fixed[i] ? fixed[i] * scale : flexTotal > 0 ? getSize(c) / pixelToSizeRatio : 0
+    );
+    return { px, pixelToSizeRatio };
+}
 
 /**
  * Recursively walks the tree to find leaf nodes, update the resize handles, and compute additional properties for each node.
@@ -49,11 +105,10 @@ export function updateTree(model: LayoutModel, balanceTree = true) {
                 resizeAction
             );
         if (balanceTree) {
-            // Enforce minimize locks before balancing — same choke point, same
-            // rationale as the backend's prune/enforce pair: any writer that
-            // changed a locked node's size (stale tree push, unguarded mutation)
-            // is corrected here rather than trusted to have known about the lock.
-            enforceMinimizedLocks(model.treeState.rootNode);
+            // Minimize is a display mode: geometry for minimized panes is
+            // derived inside updateTreeHelper each pass, and stored sizes are
+            // never touched — so there are no size locks to enforce here
+            // anymore (see layoutMinimize.ts header).
             model.treeState.rootNode = balanceNode(model.treeState.rootNode, callback);
             // Layout doctor (issue #2179): observe the post-normalization tree
             // and log loudly if any structural invariant is broken, so a
@@ -149,19 +204,23 @@ function updateTreeHelper(
     const nodeRect: Dimensions = node.id === model.treeState.rootNode.id ? boundingRect : additionalProps.rect;
     const nodeIsRow = node.flexDirection === FlexDirection.Row;
     const nodePixels = nodeIsRow ? nodeRect.width : nodeRect.height;
-    const totalChildrenSize = node.children.reduce((acc, child) => acc + getNodeSize(child), 0);
-    const pixelToSizeRatio = totalChildrenSize / nodePixels;
+    const alloc = computeMainAxisAllocation(node.children, nodeIsRow, nodePixels, getNodeSize);
+    const pixelToSizeRatio = alloc.pixelToSizeRatio;
 
     let lastChildRect: Dimensions;
     const resizeHandles: ResizeHandleProps[] = [];
 
     node.children.forEach((child, i) => {
-        const childSize = getNodeSize(child);
+        // A minimized LEAF renders as a header chip: in a Row parent its
+        // cross-axis (height) is clamped to the header, top-aligned in the
+        // slot. Fully-minimized branches keep the full cross-axis — their own
+        // children are chips via recursion.
+        const chipLeaf = isEffectivelyMinimized(child) && !child.children?.length;
         const rect: Dimensions = {
             top: !nodeIsRow && lastChildRect ? lastChildRect.top + lastChildRect.height : nodeRect.top,
             left: nodeIsRow && lastChildRect ? lastChildRect.left + lastChildRect.width : nodeRect.left,
-            width: nodeIsRow ? childSize / pixelToSizeRatio : nodeRect.width,
-            height: nodeIsRow ? nodeRect.height : childSize / pixelToSizeRatio,
+            width: nodeIsRow ? alloc.px[i] : nodeRect.width,
+            height: nodeIsRow ? (chipLeaf ? Math.min(HeaderHeightPx, nodeRect.height) : nodeRect.height) : alloc.px[i],
         };
         const transform = setTransform(rect);
         additionalPropsMap[child.id] = {
@@ -171,12 +230,11 @@ function updateTreeHelper(
         };
 
         // We only want the resize handles in between nodes, this ensures we have at most
-        // n-1 handles. A locked edge (either flanking child minimized/slipped/dissolved)
-        // gets no handle at all — minimized is a locked state, so there is nothing for
-        // the user to resize there (I3 in the minimize locked-state spec). Because gaps
-        // can now be skipped, parentIndex must be the child-array index (i - 1), NOT
-        // resizeHandles.length — onResizeMove uses it to look up the flanking children.
-        if (lastChildRect && !isNodeLocked(node.children[i - 1]) && !isNodeLocked(child)) {
+        // n-1 handles. A minimized edge (either flanking child renders as a chip) gets
+        // no handle at all — chip geometry is derived, there is nothing to resize.
+        // Because gaps can be skipped, parentIndex must be the child-array index (i - 1),
+        // NOT resizeHandles.length — onResizeMove uses it to look up flanking children.
+        if (lastChildRect && !isEffectivelyMinimized(node.children[i - 1]) && !isEffectivelyMinimized(child)) {
             const resizeHandleIndex = i - 1;
             const halfResizeHandleSizePx = resizeHandleSizePx / 2;
             const resizeHandleDimensions: Dimensions = {

--- a/frontend/layout/lib/layoutInvariants.ts
+++ b/frontend/layout/lib/layoutInvariants.ts
@@ -23,11 +23,15 @@ export interface LayoutViolation {
 const SIZE_EPS = 1e-4;
 
 /**
- * A locked node is one whose size is owned by the minimize subsystem: a minimized
- * leaf (`minimizedSize`), a slipped header (`slipMinimize`), or a dissolved column
- * (`columnDissolve`). No other writer may resize, move, swap, or split it, and no
- * resize handle is rendered on its edges. See
- * `docs/specs/SPEC_LAYOUT_MINIMIZE_LOCKED_STATE_REDESIGN_2026_07_16.md`.
+ * A locked node is one owned by the minimize subsystem. Current model: the
+ * `minimized` display-mode flag (geometry derived at render, stored size never
+ * touched — see `RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md` §7).
+ * The legacy markers (`minimizedSize`/`slipMinimize`/`columnDissolve`) are
+ * still recognized so unmigrated persisted trees stay guarded until
+ * `rebuildMinimizedSet` migrates them at load.
+ *
+ * No other writer may resize, move, swap, or split a locked node, and no
+ * resize handle is rendered on its edges.
  *
  * Canonical home is here (the invariant module) so `layoutMinimize` can import
  * the doctor without an import cycle; `layoutMinimize` re-exports it for its
@@ -35,7 +39,25 @@ const SIZE_EPS = 1e-4;
  */
 export function isNodeLocked(node: LayoutNode | undefined): boolean {
     if (!node) return false;
-    return node.minimizedSize !== undefined || node.slipMinimize !== undefined || node.columnDissolve !== undefined;
+    return (
+        node.minimized === true ||
+        node.minimizedSize !== undefined ||
+        node.slipMinimize !== undefined ||
+        node.columnDissolve !== undefined
+    );
+}
+
+/**
+ * True when a node renders as minimized: a leaf with the `minimized` flag, or
+ * a branch whose every child is effectively minimized (a column of header
+ * chips). Drives render-time geometry derivation (`updateTreeHelper`) and
+ * resize-handle suppression. Legacy markers count so unmigrated trees render
+ * sanely before migration runs.
+ */
+export function isEffectivelyMinimized(node: LayoutNode | undefined): boolean {
+    if (!node) return false;
+    if (!node.children?.length) return isNodeLocked(node);
+    return node.children.every((c) => isEffectivelyMinimized(c));
 }
 
 /**
@@ -60,15 +82,16 @@ export function validateLayoutInvariants(root: LayoutNode | undefined): LayoutVi
             });
         }
 
-        // I2 — minimizedSize / slipMinimize are leaf-only markers. A branch
-        // carrying one means a minimized leaf was promoted to a group without
-        // migrating its minimize fields (e.g. addIntermediateNode, or the
-        // leaf→Column conversions in _slipMinimize/_dissolveColumn).
-        if (isBranch && (node.minimizedSize !== undefined || node.slipMinimize !== undefined)) {
+        // I2 — the `minimized` flag and the legacy minimizedSize/slipMinimize
+        // markers are leaf-only. A branch carrying one means a minimized leaf
+        // was promoted to a group without migrating its minimize fields.
+        if (isBranch && (node.minimized !== undefined || node.minimizedSize !== undefined || node.slipMinimize !== undefined)) {
             violations.push({
                 code: "MIN_MARKER_ON_BRANCH",
                 nodeId: node.id,
-                detail: `branch has ${node.minimizedSize !== undefined ? "minimizedSize" : "slipMinimize"}`,
+                detail: `branch has ${
+                    node.minimized !== undefined ? "minimized" : node.minimizedSize !== undefined ? "minimizedSize" : "slipMinimize"
+                }`,
             });
         }
 
@@ -142,11 +165,7 @@ export function validateLayoutInvariants(root: LayoutNode | undefined): LayoutVi
         if (!node.children?.length) {
             if (node.data !== undefined) {
                 leafCount++;
-                if (
-                    node.minimizedSize === undefined &&
-                    node.slipMinimize === undefined &&
-                    node.columnDissolve === undefined
-                ) {
+                if (!isNodeLocked(node)) {
                     expandedCount++;
                 }
             }
@@ -174,11 +193,12 @@ export function describeLayoutTree(root: LayoutNode | undefined): string {
     const lines: string[] = [];
     function walk(node: LayoutNode, depth: number) {
         const flags = [
-            node.minimizedSize !== undefined ? `MIN(orig=${node.minimizedSize})` : "",
-            node.minimizedLockedSize !== undefined ? `LOCK=${node.minimizedLockedSize}` : "",
-            node.slipMinimize !== undefined ? "SLIP" : "",
-            node.columnDissolve !== undefined ? "DISSOLVED" : "",
-            node._slipAnchor ? "anchor" : "",
+            node.minimized ? "MIN" : "",
+            node.minimizedSize !== undefined ? `legacyMIN(orig=${node.minimizedSize})` : "",
+            node.minimizedLockedSize !== undefined ? `legacyLOCK=${node.minimizedLockedSize}` : "",
+            node.slipMinimize !== undefined ? "legacySLIP" : "",
+            node.columnDissolve !== undefined ? "legacyDISSOLVED" : "",
+            node._slipAnchor ? "legacyAnchor" : "",
         ]
             .filter(Boolean)
             .join(" ");

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -4,7 +4,7 @@
 import { findNode } from "./layoutNode";
 import { isNodeLocked, isEffectivelyMinimized, reportLayoutViolations } from "./layoutInvariants";
 import type { LayoutModel } from "./layoutModel";
-import type { LayoutNode } from "./types";
+import { DefaultNodeSize, type LayoutNode } from "./types";
 
 /** Height of the block header in CSS pixels (matches --header-height in theme.scss). */
 export const HeaderHeightPx = 33;
@@ -140,10 +140,22 @@ export function rebuildMinimizedSet(model: LayoutModel) {
     const ids = new Set<string>();
     let migrated = 0;
     const root = model.treeState.rootNode;
-    function walk(node: LayoutNode) {
+    // Flex sizes are relative WITHIN a parent. A slipped/dissolved node lives
+    // nested in its slip/dissolve TARGET — a different unit space from where
+    // its `originalRowSize` was recorded — so restoring that raw number would
+    // give it a wildly wrong proportion among its current siblings. Instead,
+    // heal its size to a sane share of the parent it actually sits in: the
+    // mean of its positive-sized siblings, falling back to DefaultNodeSize.
+    const saneShare = (node: LayoutNode, parent: LayoutNode | undefined): number => {
+        const sibs = parent?.children?.filter((c) => c !== node && c.size > 0) ?? [];
+        if (!sibs.length) return DefaultNodeSize;
+        return sibs.reduce((s, c) => s + c.size, 0) / sibs.length;
+    };
+    function walk(node: LayoutNode, parent: LayoutNode | undefined) {
         if (!node) return;
         const isLeaf = !node.children?.length;
         if (node.minimizedSize !== undefined) {
+            // Same parent, same unit space — the recorded original is exact.
             if (isLeaf) {
                 node.size = node.minimizedSize;
                 node.minimized = true;
@@ -152,26 +164,20 @@ export function rebuildMinimizedSet(model: LayoutModel) {
             migrated++;
         }
         if (node.slipMinimize !== undefined) {
-            // The slip squeezed the leaf's size to header units in its host
-            // column — restore the recorded pre-slip size so a later restore
-            // doesn't render a permanent sliver (same rule as the
-            // minimizedSize path above). Unit spaces are per-parent, so the
-            // original Row-slot size is the best available record.
-            if (node.slipMinimize.originalRowSize > 0) {
-                node.size = node.slipMinimize.originalRowSize;
-            }
+            // Slip squeezed the leaf to header units inside its TARGET column;
+            // heal to a sane share of the column it now sits in.
+            node.size = saneShare(node, parent);
             if (isLeaf) node.minimized = true;
             node.slipMinimize = undefined;
             migrated++;
         }
         if (node.columnDissolve !== undefined) {
-            // The dissolve set the branch's size to the stolen header total —
+            // Dissolve set the branch's size to the stolen header total —
             // possibly tiny or even negative (the cascade bug this redesign
-            // kills). Restore the recorded pre-dissolve size: it becomes
-            // load-bearing again the moment any child leaf is restored.
-            if (node.columnDissolve.originalRowSize > 0) {
-                node.size = node.columnDissolve.originalRowSize;
-            }
+            // kills). The size becomes load-bearing again the moment any
+            // child leaf restores; heal it to a sane share of its CURRENT
+            // (nested) parent.
+            node.size = saneShare(node, parent);
             node.columnDissolve = undefined;
             migrated++;
         }
@@ -184,9 +190,9 @@ export function rebuildMinimizedSet(model: LayoutModel) {
             migrated++;
         }
         if (node.minimized && isLeaf) ids.add(node.id);
-        node.children?.forEach(walk);
+        node.children?.forEach((c) => walk(c, node));
     }
-    if (root) walk(root);
+    if (root) walk(root, undefined);
     if (migrated > 0) {
         console.warn(`[layoutMinimize] migrated ${migrated} legacy minimize field(s) to the display-mode flag`);
     }

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -1,26 +1,55 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-
-import { newLayoutNode } from "./layoutNode";
-import { findNode, findParent } from "./layoutNode";
-import { isNodeLocked, reportLayoutViolations } from "./layoutInvariants";
+import { findNode } from "./layoutNode";
+import { isNodeLocked, isEffectivelyMinimized, reportLayoutViolations } from "./layoutInvariants";
 import type { LayoutModel } from "./layoutModel";
-import { DefaultNodeSize, FlexDirection, type LayoutNodeAdditionalProps, type LayoutNode } from "./types";
+import type { LayoutNode } from "./types";
 
 /** Height of the block header in CSS pixels (matches --header-height in theme.scss). */
 export const HeaderHeightPx = 33;
 
-// Canonical definition lives in layoutInvariants (the doctor validates lock
+/**
+ * Main-axis width (px) of a minimized pane whose parent is a Row: the pane
+ * renders as a compact header chip instead of a full-height narrow strip.
+ */
+export const MinimizedRowSlotWidthPx = 180;
+
+// Canonical definitions live in layoutInvariants (the doctor validates lock
 // invariants, and importing from here would be an import cycle); re-exported
 // so existing importers keep working.
-export { isNodeLocked };
+export { isNodeLocked, isEffectivelyMinimized };
 
 /**
- * Count leaves that are NOT minimize-locked — i.e. panes still showing
- * content. The window must always keep at least one: `minimizeNodeToggle`
- * no-ops when asked to collapse the last expanded pane, and the header hides
- * that pane's minimize button (`NodeModel.canMinimize`).
+ * # Minimize is a display mode
+ *
+ * A minimized pane is a leaf with `minimized: true` — nothing else. Its stored
+ * flex `size` is NEVER touched: the renderer (`updateTreeHelper`) derives the
+ * header-chip geometry fresh on every pass (header height in a Column parent,
+ * a fixed-width chip in a Row parent, and a fully-minimized subtree renders as
+ * a stacked strip of chips). Restore is just clearing the flag — the pane's
+ * original size is intact by construction, because it never changed.
+ *
+ * This replaces the previous size-arithmetic model (squeeze `size` to header
+ * height + `minimizedSize` restore bookkeeping + "slip" and "column dissolve"
+ * structural surgery), which produced four distinct bug classes in two weeks
+ * (see `docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md` §2).
+ * The research verdict: every mature system models collapse as either
+ * out-of-tree docking or a render-derived display mode (i3 stacked/tabbed,
+ * maximize toggles); none stores squeezed sizes in the layout tree. Derived
+ * state cannot drift, so this model needs no size locks, no snap-back
+ * enforcement, and no restore arithmetic.
+ *
+ * Legacy trees (with `minimizedSize`/`slipMinimize`/`columnDissolve`/
+ * `minimizedLockedSize`/`_slipAnchor`) are migrated in place by
+ * `rebuildMinimizedSet` at load.
+ */
+
+/**
+ * Count leaves that are NOT minimized — i.e. panes still showing content. The
+ * window must always keep at least one: `minimizeNodeToggle` no-ops when asked
+ * to collapse the last expanded pane, and the header hides that pane's
+ * minimize button (`NodeModel.canMinimize`).
  */
 export function countExpandedLeaves(root: LayoutNode | undefined): number {
     if (!root) return 0;
@@ -37,508 +66,36 @@ export function countExpandedLeaves(root: LayoutNode | undefined): number {
 }
 
 /**
- * Write-point enforcement of the minimize lock: snap every locked node's `size`
- * back to its recorded `minimizedLockedSize`, returning the delta to the nearest
- * unlocked sibling (next preferred, then previous) so the parent's unit budget is
- * conserved. Runs on every `updateTree` pass — the same choke point as
- * `balanceNode` — so a locked size survives any writer that bypasses the reducer
- * guards (stale tree pushes, direct mutations). Returns the number of snapped nodes.
- *
- * If every sibling is locked (inside a dissolved column) the delta is dropped:
- * flex sizes are relative within the parent, so the locked nodes' shares stay
- * proportionally correct.
- */
-export function enforceMinimizedLocks(root: LayoutNode | undefined): number {
-    let snapped = 0;
-    function walk(node: LayoutNode) {
-        if (!node.children) return;
-        node.children.forEach((child, i) => {
-            if (isNodeLocked(child) && child.minimizedLockedSize !== undefined) {
-                const delta = child.size - child.minimizedLockedSize;
-                if (Math.abs(delta) > 1e-4) {
-                    child.size = child.minimizedLockedSize;
-                    const beneficiary =
-                        node.children!.slice(i + 1).find((c) => !isNodeLocked(c)) ??
-                        node.children!.slice(0, i).reverse().find((c) => !isNodeLocked(c));
-                    // Floor at 1 flex unit (same floor as the slip/undissolve
-                    // restore paths): a tampered size BELOW the lock makes the
-                    // delta negative, and the repayment must not drive the
-                    // beneficiary's size to zero or negative.
-                    if (beneficiary) beneficiary.size = Math.max(beneficiary.size + delta, 1);
-                    snapped++;
-                }
-            }
-            walk(child);
-        });
-    }
-    if (root) walk(root);
-    return snapped;
-}
-
-/**
- * Toggle minimize for a given leaf node.
- *
- * There are three minimize paths:
- *
- * **Column parent (normal path):** The node collapses vertically to its header bar.
- * Freed space is given to the adjacent sibling. `node.minimizedSize` stores the
- * original height for restore. After collapsing, if ALL children of the parent
- * column are now minimized, the column itself dissolves (see below).
- *
- * **Row parent (slip path):** Shrinking the node's Row-slot size would make it
- * horizontally narrow (thin strip) rather than vertically collapsed. Instead the
- * pane "slips" its header to the top of the nearest adjacent column, giving its
- * full width to that column. `node.slipMinimize` stores restore context.
- *
- * **Column dissolve:** When every leaf in a Column is minimized, the column is
- * pulled out of the root Row and re-inserted as a branch at the top of the adjacent
- * column. The column's Row-slot width is given to that adjacent column. On restore,
- * clicking any child's minimize button undissolves the column first, returning it to
- * its original Row position with all children still minimized. `colNode.columnDissolve`
- * stores restore context.
- *
- * ### balanceNode and the _slipAnchor invariant
- *
- * After a slip or dissolve, the parentRow may have exactly one child. Normally
- * `balanceNode` would hoist that column's children into the grandparent (single-
- * child-branch flatMap rule), scattering them and losing `targetColumnId`. We
- * prevent this by setting `parentRow._slipAnchor = true`, which `balanceNode`
- * checks before applying the hoist. The Row(→Column) direction alternation is
- * preserved, and the tree is stable through serialise/reload cycles.
+ * Toggle minimize for a leaf node. Minimize sets the display-mode flag;
+ * restore clears it. No sizes are read or written.
  */
 export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
     const node = findNode(model.treeState.rootNode, nodeId);
     if (!node) return;
 
-    const addlProps = model.getter(model.additionalProps);
-    const gapSizePx = model.gapSizePx();
-
-    // ── Restore: slip path ────────────────────────────────────────────────────
-    if (node.slipMinimize !== undefined) {
-        const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = node.slipMinimize;
-
-        const targetCol = findNode(model.treeState.rootNode, targetColumnId);
-        if (targetCol?.children) {
-            // Remove the slipped header from the column; give its size back to the neighbor.
-            const slipIdx = targetCol.children.findIndex((c) => c.id === nodeId);
-            if (slipIdx !== -1) {
-                const reclaimUnits = node.size;
-                targetCol.children.splice(slipIdx, 1);
-                const neighbor = targetCol.children[slipIdx] ?? targetCol.children[slipIdx - 1];
-                if (neighbor) neighbor.size += reclaimUnits;
-            }
-
-            // If the column was converted from a leaf during slip, unwrap it back.
-            if (targetWasLeaf && targetCol.children.length === 1) {
-                const only = targetCol.children[0];
-                if (only.data && !only.children) {
-                    targetCol.data = only.data;
-                    targetCol.children = undefined;
-                    targetCol.flexDirection = FlexDirection.Row;
-                }
-            }
-
-            // Shrink column back to its original width.
-            targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
-
-            // Re-insert node in the Row and clear the slip anchor.
-            const rowNode = findParent(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
-            if (rowNode.children) {
-                node.size = originalRowSize;
-                node.slipMinimize = undefined;
-                node.minimizedLockedSize = undefined;
-                rowNode._slipAnchor = undefined;
-                const idx = Math.min(originalRowIndex, rowNode.children.length);
-                rowNode.children.splice(idx, 0, node);
-            }
-        } else {
-            console.warn(`[layoutMinimize] slip restore: target column ${targetColumnId} not found; dropping slip state`);
-            node.slipMinimize = undefined;
-            node.minimizedLockedSize = undefined;
-        }
-
-        _finishToggle(model, nodeId, false);
+    // Only leaves minimize — a branch reaching here indicates a caller bug
+    // (and the doctor's I2 would flag the resulting tree).
+    if (node.children?.length) {
+        console.warn(`[layoutMinimize] toggle on branch ${nodeId} ignored — minimize is leaf-only`);
         return;
     }
 
-    // ── Pre-check: parent column dissolved — undissolve before toggling ───────
-    // A node inside a dissolved column has `minimizedSize` set and lives inside a
-    // column that itself has `columnDissolve`. Clicking restore on that node first
-    // undissolves the parent column (returns it to its Row slot), then falls through
-    // to the normal restore path so both the undissolve and the individual pane
-    // restore happen in a single click.
-    //
-    // In a cascade (A→B→C, 3-deep): colA dissolves into colB, then colB dissolves
-    // into colC. When the user restores a pane in colA, the immediate parent (colA)
-    // has columnDissolve set, but colA's targetColumnId (colB) is itself still
-    // dissolved inside colC. We must undissolve ancestor columns from outermost to
-    // innermost before undissolving the immediate parent, otherwise _undissolveColumn
-    // cannot find the correct Row insertion point and colB.size underflows.
-    const parentForDissolveCheck = findParent(model.treeState.rootNode, nodeId);
-    if (parentForDissolveCheck?.columnDissolve !== undefined) {
-        // Collect all dissolved ancestors of parentForDissolveCheck from innermost
-        // to outermost by walking up via the columnDissolve.targetColumnId chain.
-        const dissolvedAncestors: LayoutNode[] = [];
-        let cursor: LayoutNode | undefined = parentForDissolveCheck;
-        while (cursor?.columnDissolve !== undefined) {
-            const targetCol = findNode(model.treeState.rootNode, cursor.columnDissolve.targetColumnId);
-            if (targetCol?.columnDissolve !== undefined) {
-                dissolvedAncestors.push(targetCol);
-            }
-            cursor = targetCol;
-        }
-        // Undissolve from outermost to innermost so each column is returned to its
-        // Row slot before its inner neighbour tries to use it as an insertion target.
-        for (const ancestor of dissolvedAncestors.reverse()) {
-            _undissolveColumn(model, ancestor);
-        }
-        // Now undissolve the immediate parent of the clicked pane.
-        _undissolveColumn(model, parentForDissolveCheck);
-        // Fall through — node still has minimizedSize set; normal restore runs below.
-    }
-
-    // ── Need parent for minimize and normal restore ───────────────────────────
-    const parentNode = findParent(model.treeState.rootNode, nodeId);
-    if (!parentNode?.children?.length) return;
-
-    const pixelToSizeRatio = addlProps[parentNode.id]?.pixelToSizeRatio;
-    if (!pixelToSizeRatio) return;
-
-    const siblings = parentNode.children;
-    const nodeIdx = siblings.findIndex((c) => c.id === nodeId);
-    const sibling = siblings[nodeIdx + 1] ?? siblings[nodeIdx - 1];
-
-    // ── Restore: normal path ──────────────────────────────────────────────────
-    if (node.minimizedSize !== undefined) {
-        if (!sibling) return;
-        const headerSizeUnits = (HeaderHeightPx + gapSizePx) * pixelToSizeRatio;
-        const reclaimUnits = node.minimizedSize - headerSizeUnits;
-        const siblingAfterReclaim = sibling.size - reclaimUnits;
-        const minSiblingUnits = HeaderHeightPx * pixelToSizeRatio;
-        if (siblingAfterReclaim < minSiblingUnits) {
-            const available = sibling.size - minSiblingUnits;
-            node.size += available;
-            sibling.size = minSiblingUnits;
-        } else {
-            node.size = node.minimizedSize;
-            sibling.size = siblingAfterReclaim;
-        }
-        node.minimizedSize = undefined;
-        node.minimizedLockedSize = undefined;
+    // ── Restore ───────────────────────────────────────────────────────────────
+    if (node.minimized) {
+        node.minimized = undefined;
         _finishToggle(model, nodeId, false);
         return;
     }
 
     // ── Minimize ──────────────────────────────────────────────────────────────
-    if (!sibling) return;
-
     // The last expanded pane cannot be collapsed — the window must always keep
-    // at least one pane showing content (an all-headers window is dead space
-    // with nothing restorable in view). The header already hides the minimize
+    // at least one pane showing content. The header already hides the minimize
     // button in this state (NodeModel.canMinimize); this is the authoritative
     // guard for programmatic callers.
     if (countExpandedLeaves(model.treeState.rootNode) <= 1) return;
 
-    if (parentNode.flexDirection === FlexDirection.Row) {
-        // Slip path: pane occupies a Row slot — slip header into adjacent column instead
-        // of making the pane horizontally narrow.
-        if (!_slipMinimize(model, node, nodeIdx, parentNode, sibling, addlProps, gapSizePx)) return;
-    } else {
-        // Normal path: pane is in a Column — collapse it vertically within the column.
-        const headerSizeUnits = (HeaderHeightPx + gapSizePx) * pixelToSizeRatio;
-        const freedUnits = node.size - headerSizeUnits;
-        if (freedUnits <= 0) return; // already tiny — no-op
-        node.minimizedSize = node.size;
-        node.size = headerSizeUnits;
-        node.minimizedLockedSize = headerSizeUnits;
-        sibling.size += freedUnits;
-
-        // If all children of the column are now minimized (leaves via minimizedSize/
-        // slipMinimize, or previously dissolved sub-columns via columnDissolve),
-        // dissolve this column into the adjacent Row sibling.
-        const allCollapsed = parentNode.children.every(
-            (c) => c.minimizedSize !== undefined || c.slipMinimize !== undefined || c.columnDissolve !== undefined
-        );
-        if (allCollapsed) {
-            _dissolveColumn(model, parentNode, addlProps, gapSizePx);
-        }
-    }
-
+    node.minimized = true;
     _finishToggle(model, nodeId, true);
-}
-
-/**
- * Slip a pane from its Row slot into the top of an adjacent column.
- * Returns true on success, false if the tree was not mutated (caller should bail).
- *
- * Sets `_slipAnchor = true` on the parentRow so `balanceNode` skips the
- * single-child-branch hoist rule, keeping the Row(→Column) direction alternation
- * intact while the pane is in the slipped state.
- */
-function _slipMinimize(
-    model: LayoutModel,
-    node: LayoutNode,
-    nodeIdx: number,
-    parentRow: LayoutNode,
-    sibling: LayoutNode,
-    addlProps: Record<string, LayoutNodeAdditionalProps>,
-    gapSizePx: number,
-): boolean {
-    const siblingProps = addlProps[sibling.id];
-    let targetWasLeaf = false;
-
-    // Convert a plain leaf sibling into a Column container so we can prepend the header.
-    if (!sibling.children) {
-        targetWasLeaf = true;
-        const heightPx = siblingProps?.rect?.height;
-        const totalUnits = DefaultNodeSize;
-        const headerUnitsEst = heightPx
-            ? ((HeaderHeightPx + gapSizePx) * totalUnits) / heightPx
-            : totalUnits * 0.05;
-        const contentUnits = Math.max(totalUnits - headerUnitsEst, headerUnitsEst);
-        const contentNode = newLayoutNode(FlexDirection.Row, contentUnits, undefined, sibling.data);
-        sibling.data = undefined;
-        sibling.flexDirection = FlexDirection.Column;
-        sibling.children = [contentNode];
-    }
-
-    // Compute header height in the column's flex-units.
-    const colRatio: number | undefined = siblingProps?.pixelToSizeRatio
-        ?? (siblingProps?.rect?.height && sibling.children
-            ? sibling.children.reduce((s, c) => s + c.size, 0) / siblingProps.rect.height
-            : undefined);
-
-    if (colRatio == null) {
-        console.warn("[layoutMinimize] slip: cannot determine column ratio, skipping");
-        if (targetWasLeaf) {
-            const only = sibling.children?.[0];
-            if (only?.data) {
-                sibling.data = only.data;
-                sibling.children = undefined;
-                sibling.flexDirection = FlexDirection.Row;
-            }
-        }
-        return false;
-    }
-
-    const headerInColUnits = (HeaderHeightPx + gapSizePx) * colRatio;
-
-    // Steal header height from the first column child to keep total column size constant.
-    const firstChild = sibling.children![0];
-    if (firstChild) {
-        firstChild.size = Math.max(firstChild.size - headerInColUnits, headerInColUnits);
-    }
-
-    // Record slip state before modifying node.size.
-    node.slipMinimize = {
-        targetColumnId: sibling.id,
-        originalRowSize: node.size,
-        originalRowIndex: nodeIdx,
-        targetWasLeaf,
-    };
-
-    // Remove from Row, give its width to the sibling.
-    sibling.size += node.size;
-    parentRow.children!.splice(nodeIdx, 1);
-
-    // Mark the Row so balanceNode skips the single-child hoist for this subtree.
-    // Without this, balanceNode's flatMap rule would see parentRow(1 child = B branch)
-    // and hoist B's children directly into grandparent, scattering them and losing
-    // targetColumnId. The Row(→Column) direction alternation stays correct.
-    parentRow._slipAnchor = true;
-
-    // Insert at top of the column.
-    node.size = headerInColUnits;
-    node.minimizedLockedSize = headerInColUnits;
-    sibling.children!.unshift(node);
-    return true;
-}
-
-/**
- * Dissolve a fully-collapsed column into an adjacent column.
- *
- * Called after the last leaf in `colNode` is minimized. Removes `colNode` from its
- * Row slot, gives its width to the adjacent sibling column, and re-inserts `colNode`
- * as a branch at the top of that sibling. The column's leaf children retain their
- * individual `minimizedSize` values.
- *
- * Returns true on success; false if bailing without mutating the tree (no Row parent,
- * no adjacent sibling, or column-ratio unavailable).
- */
-function _dissolveColumn(
-    model: LayoutModel,
-    colNode: LayoutNode,
-    addlProps: Record<string, LayoutNodeAdditionalProps>,
-    gapSizePx: number,
-): boolean {
-    const rowNode = findParent(model.treeState.rootNode, colNode.id);
-    if (!rowNode?.children?.length || rowNode.flexDirection !== FlexDirection.Row) return false;
-
-    const nodeIdx = rowNode.children.findIndex((c) => c.id === colNode.id);
-    const sibling = rowNode.children[nodeIdx + 1] ?? rowNode.children[nodeIdx - 1];
-    if (!sibling) return false;
-
-    // Don't dissolve into a column that is itself dissolved (it's nested elsewhere).
-    if (sibling.columnDissolve !== undefined) return false;
-
-    const siblingProps = addlProps[sibling.id];
-    let targetWasLeaf = false;
-
-    // Convert a plain leaf sibling into a Column container so we can prepend the branch.
-    if (!sibling.children) {
-        targetWasLeaf = true;
-        const heightPx = siblingProps?.rect?.height;
-        const totalUnits = DefaultNodeSize;
-        const headerUnitsEst = heightPx
-            ? ((HeaderHeightPx + gapSizePx) * totalUnits) / heightPx
-            : totalUnits * 0.05;
-        const contentUnits = Math.max(totalUnits - headerUnitsEst, headerUnitsEst);
-        const contentNode = newLayoutNode(FlexDirection.Row, contentUnits, undefined, sibling.data);
-        sibling.data = undefined;
-        sibling.flexDirection = FlexDirection.Column;
-        sibling.children = [contentNode];
-    }
-
-    // Compute dissolved column's height in the sibling column's flex-unit space.
-    const colRatio: number | undefined = siblingProps?.pixelToSizeRatio
-        ?? (siblingProps?.rect?.height && sibling.children
-            ? sibling.children.reduce((s, c) => s + c.size, 0) / siblingProps.rect.height
-            : undefined);
-
-    if (colRatio == null) {
-        console.warn("[layoutMinimize] dissolve: cannot determine column ratio, skipping");
-        if (targetWasLeaf) {
-            const only = sibling.children?.[0];
-            if (only) {
-                sibling.data = only.data;
-                sibling.children = undefined;
-                sibling.flexDirection = FlexDirection.Row;
-            }
-        }
-        return false;
-    }
-
-    // One header per leaf child — count recursively: a dissolved sub-column
-    // (with columnDissolve set) represents multiple collapsed headers and should
-    // count as its children.length, not 1, so cascade dissolve heights are correct.
-    const leafCount = colNode.children!.reduce((sum, c) =>
-        sum + (c.columnDissolve !== undefined && c.children ? c.children.length : 1), 0);
-    const totalHeaderUnits = leafCount * (HeaderHeightPx + gapSizePx) * colRatio;
-
-    // Steal from sibling's first child so sibling's total flex-size stays constant.
-    // Track actualStolen separately: if firstChild.size is clamped to the floor,
-    // less than totalHeaderUnits is stolen, so colNode.size must reflect that.
-    const firstChild = sibling.children![0];
-    let actualStolen = totalHeaderUnits;
-    if (firstChild) {
-        const floorUnits = (HeaderHeightPx + gapSizePx) * colRatio;
-        const prevSize = firstChild.size;
-        firstChild.size = Math.max(firstChild.size - totalHeaderUnits, floorUnits);
-        actualStolen = prevSize - firstChild.size;
-    }
-
-    // Record dissolve context.
-    colNode.columnDissolve = {
-        targetColumnId: sibling.id,
-        originalRowSize: colNode.size,
-        originalRowIndex: nodeIdx,
-        targetWasLeaf,
-    };
-
-    // Give the dissolved column's Row-slot width to the sibling; remove from Row.
-    sibling.size += colNode.size;
-    rowNode.children.splice(nodeIdx, 1);
-    rowNode._slipAnchor = true;
-
-    // Insert the dissolved column branch at the top of the sibling column.
-    // Use actualStolen (not totalHeaderUnits) to keep the size budget honest
-    // when firstChild.size was clamped to the floor value.
-    colNode.size = actualStolen;
-    colNode.minimizedLockedSize = actualStolen;
-    sibling.children!.unshift(colNode);
-
-    return true;
-}
-
-/**
- * Walk up the ancestor chain from `nodeId` and return the first ancestor whose
- * `flexDirection` is `FlexDirection.Row`.  Returns `undefined` if none is found
- * (e.g. the node is already at the root level with no Row ancestor).
- *
- * Used by `_undissolveColumn` to locate the correct Row insertion point in
- * cascade-dissolve scenarios where the host column is itself nested inside
- * another dissolved column.
- */
-function _findRowAncestor(root: LayoutNode, nodeId: string): LayoutNode | undefined {
-    const parent = findParent(root, nodeId);
-    if (!parent) return undefined;
-    if (parent.flexDirection === FlexDirection.Row) return parent;
-    return _findRowAncestor(root, parent.id);
-}
-
-/**
- * Restore a dissolved column to its original Row slot.
- *
- * Removes `colNode` from its host column, shrinks the host back by the original
- * width, and re-inserts `colNode` into the root Row at its original index. The
- * column's children retain their `minimizedSize` values — they remain visually
- * collapsed within the restored column.
- */
-function _undissolveColumn(model: LayoutModel, colNode: LayoutNode): void {
-    const { targetColumnId, originalRowSize, originalRowIndex, targetWasLeaf } = colNode.columnDissolve!;
-
-    const targetCol = findNode(model.treeState.rootNode, targetColumnId);
-    if (!targetCol?.children) {
-        console.warn(`[layoutMinimize] undissolve: target column ${targetColumnId} not found`);
-        return;
-    }
-    // Clear dissolve context only after confirming targetCol exists — clearing
-    // it before the check would permanently lose restore context on a missing target.
-    colNode.columnDissolve = undefined;
-    colNode.minimizedLockedSize = undefined;
-
-    // Remove colNode from the host column; give its height back to the neighbor.
-    const slipIdx = targetCol.children.findIndex((c) => c.id === colNode.id);
-    if (slipIdx !== -1) {
-        const reclaimUnits = colNode.size;
-        targetCol.children.splice(slipIdx, 1);
-        const neighbor = targetCol.children[slipIdx] ?? targetCol.children[slipIdx - 1];
-        if (neighbor) neighbor.size += reclaimUnits;
-    }
-
-    // If the target was originally a leaf that got wrapped, unwrap it.
-    if (targetWasLeaf && targetCol.children.length === 1) {
-        const only = targetCol.children[0];
-        if (!only.children) {
-            targetCol.data = only.data;
-            targetCol.children = undefined;
-            targetCol.flexDirection = FlexDirection.Row;
-        }
-    }
-
-    // Shrink the host column back to its pre-dissolve width.
-    targetCol.size = Math.max(targetCol.size - originalRowSize, 1);
-
-    // Re-insert colNode into the Row at its original index.
-    // IMPORTANT: In a cascade-dissolve scenario, targetCol may itself be
-    // nested inside another column (dissolved into a third column).
-    // findParent(root, targetColumnId) would return that outer column rather
-    // than the Row — causing colNode to be spliced in as a Column-in-Column
-    // instead of going back to its Row slot. We must walk up the ancestor
-    // chain from targetCol until we reach a Row-direction node.
-    const rowNode = _findRowAncestor(model.treeState.rootNode, targetColumnId) ?? model.treeState.rootNode;
-    if (rowNode.children) {
-        colNode.size = originalRowSize;
-        // Only clear _slipAnchor if no remaining sibling has a concurrent slipMinimize
-        // that also depends on it — undissolving one column must not remove an anchor
-        // that a slip-minimized pane on the same row still needs.
-        const stillNeedsAnchor = rowNode.children.some((c) => c.slipMinimize !== undefined);
-        if (!stillNeedsAnchor) {
-            rowNode._slipAnchor = undefined;
-        }
-        const idx = Math.min(originalRowIndex, rowNode.children.length);
-        rowNode.children.splice(idx, 0, colNode);
-    }
 }
 
 /** Commit tree changes and update the minimized-node-id reactive set. */
@@ -553,10 +110,7 @@ function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
         return next;
     });
     model.updateTree();
-    // Layout doctor (issue #2179): a minimize/restore toggle is the highest-
-    // risk mutation in the layout system (slip / dissolve / undissolve all
-    // restructure the tree). Validate immediately with toggle attribution —
-    // updateTree above also validates, but this context names the culprit.
+    // Layout doctor (issue #2179): validate immediately with toggle attribution.
     reportLayoutViolations(
         model.treeState.rootNode,
         `minimizeToggle:${minimized ? "minimize" : "restore"}:${nodeId.slice(0, 8)}`
@@ -566,24 +120,60 @@ function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
 }
 
 /**
- * Scan the loaded tree for nodes that carry a `minimizedSize` or `slipMinimize`
- * field and rebuild the in-memory `minimizedNodeIds` set. Also restores `_slipAnchor`
- * on any Row that owns the host column of a dissolved branch.
- * Called once during `initializeFromWaveObject`.
+ * Scan the loaded tree, migrate any legacy minimize state to the display-mode
+ * flag, and rebuild the in-memory `minimizedNodeIds` set. Called once during
+ * `initializeFromWaveObject`.
+ *
+ * Migration rules (one-way, in place):
+ * - `minimizedSize` (leaf was size-squeezed): restore `size` to the recorded
+ *   original, set `minimized`, drop the marker. (Siblings that received the
+ *   freed units keep them — a one-time proportional drift, acceptable.)
+ * - `slipMinimize` (header slipped into a neighbor column): set `minimized`,
+ *   drop the marker. The pane stays where the slip left it — restorable in
+ *   place; the original Row-slot context is intentionally not reconstructed.
+ * - `columnDissolve` (branch nested into a neighbor): drop the marker. The
+ *   structure it built is a valid tree; its children migrate individually.
+ * - `minimizedLockedSize` / `_slipAnchor`: dropped (lock layer and balance
+ *   carve-out bookkeeping of the legacy model).
  */
 export function rebuildMinimizedSet(model: LayoutModel) {
     const ids = new Set<string>();
+    let migrated = 0;
     const root = model.treeState.rootNode;
-    function walk(node: typeof root) {
+    function walk(node: LayoutNode) {
         if (!node) return;
-        if (node.minimizedSize !== undefined || node.slipMinimize !== undefined) ids.add(node.id);
-        if (node.columnDissolve !== undefined) {
-            // Restore _slipAnchor on the Row that owns the dissolved column's host.
-            const targetRow = findParent(root, node.columnDissolve.targetColumnId);
-            if (targetRow) targetRow._slipAnchor = true;
+        const isLeaf = !node.children?.length;
+        if (node.minimizedSize !== undefined) {
+            if (isLeaf) {
+                node.size = node.minimizedSize;
+                node.minimized = true;
+            }
+            node.minimizedSize = undefined;
+            migrated++;
         }
+        if (node.slipMinimize !== undefined) {
+            if (isLeaf) node.minimized = true;
+            node.slipMinimize = undefined;
+            migrated++;
+        }
+        if (node.columnDissolve !== undefined) {
+            node.columnDissolve = undefined;
+            migrated++;
+        }
+        if (node.minimizedLockedSize !== undefined) {
+            node.minimizedLockedSize = undefined;
+            migrated++;
+        }
+        if (node._slipAnchor) {
+            node._slipAnchor = undefined;
+            migrated++;
+        }
+        if (node.minimized && isLeaf) ids.add(node.id);
         node.children?.forEach(walk);
     }
-    walk(root);
+    if (root) walk(root);
+    if (migrated > 0) {
+        console.warn(`[layoutMinimize] migrated ${migrated} legacy minimize field(s) to the display-mode flag`);
+    }
     model.minimizedNodeIds._set(ids);
 }

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -152,11 +152,26 @@ export function rebuildMinimizedSet(model: LayoutModel) {
             migrated++;
         }
         if (node.slipMinimize !== undefined) {
+            // The slip squeezed the leaf's size to header units in its host
+            // column — restore the recorded pre-slip size so a later restore
+            // doesn't render a permanent sliver (same rule as the
+            // minimizedSize path above). Unit spaces are per-parent, so the
+            // original Row-slot size is the best available record.
+            if (node.slipMinimize.originalRowSize > 0) {
+                node.size = node.slipMinimize.originalRowSize;
+            }
             if (isLeaf) node.minimized = true;
             node.slipMinimize = undefined;
             migrated++;
         }
         if (node.columnDissolve !== undefined) {
+            // The dissolve set the branch's size to the stolen header total —
+            // possibly tiny or even negative (the cascade bug this redesign
+            // kills). Restore the recorded pre-dissolve size: it becomes
+            // load-bearing again the moment any child leaf is restored.
+            if (node.columnDissolve.originalRowSize > 0) {
+                node.size = node.columnDissolve.originalRowSize;
+            }
             node.columnDissolve = undefined;
             migrated++;
         }

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -293,7 +293,7 @@ export class LayoutModel {
 
     /**
      * Set of node IDs that are currently minimized (collapsed to header bar).
-     * Kept in sync with `node.minimizedSize` on each LayoutNode in the tree.
+     * Kept in sync with the `node.minimized` display-mode flag on each leaf.
      */
     minimizedNodeIds: SignalAtom<Set<string>>;
 

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -3,7 +3,7 @@
 
 import { debounce } from "throttle-debounce";
 import { findNode } from "./layoutNode";
-import { isNodeLocked } from "./layoutMinimize";
+import { isEffectivelyMinimized } from "./layoutMinimize";
 import {
     FlexDirection,
     LayoutTreeActionType,
@@ -73,7 +73,7 @@ export function onResizeMove(model: LayoutModel, resizeHandle: ResizeHandleProps
         // Minimized is a locked state: locked edges get no handle (layoutGeometry),
         // but a stale handle from a pre-suppression frame could still deliver a drag
         // here — refuse to build a resize context that flanks a locked node.
-        if (isNodeLocked(beforeNode) || isNodeLocked(afterNode)) return;
+        if (isEffectivelyMinimized(beforeNode) || isEffectivelyMinimized(afterNode)) return;
 
         const addlProps = model.getter(model.additionalProps);
         const pixelToSizeRatio = addlProps[resizeHandle.parentNodeId]?.pixelToSizeRatio;

--- a/frontend/layout/lib/layoutTree.ts
+++ b/frontend/layout/lib/layoutTree.ts
@@ -32,7 +32,7 @@ import {
 } from "./types";
 
 import { newLayoutNode } from "./layoutNode";
-import { isNodeLocked } from "./layoutMinimize";
+import { isEffectivelyMinimized } from "./layoutMinimize";
 import { LayoutTreeReplaceNodeAction, LayoutTreeSplitHorizontalAction, LayoutTreeSplitVerticalAction } from "./types";
 
 export const DEFAULT_MAX_CHILDREN = 5;
@@ -255,7 +255,7 @@ export function moveNode(layoutState: LayoutTreeState, action: LayoutTreeMoveNod
 
     // Minimized is a locked state: a locked node can't be moved (restore it first),
     // and nothing may be inserted into a dissolved column.
-    if (isNodeLocked(node) || isNodeLocked(parent)) {
+    if (isEffectivelyMinimized(node) || isEffectivelyMinimized(parent)) {
         console.warn("moveNode rejected: source or destination is minimize-locked");
         return;
     }
@@ -357,8 +357,8 @@ export function swapNode(layoutState: LayoutTreeState, action: LayoutTreeSwapNod
 
     // Minimized is a locked state: locked nodes don't swap.
     if (
-        isNodeLocked(findNode(layoutState.rootNode, action.node1Id)) ||
-        isNodeLocked(findNode(layoutState.rootNode, action.node2Id))
+        isEffectivelyMinimized(findNode(layoutState.rootNode, action.node1Id)) ||
+        isEffectivelyMinimized(findNode(layoutState.rootNode, action.node2Id))
     ) {
         console.warn("swapNode rejected: a swap endpoint is minimize-locked");
         return;
@@ -416,7 +416,7 @@ export function resizeNode(layoutState: LayoutTreeState, action: LayoutTreeResiz
     // Resize ops come in before/after pairs whose unit sum is conserved — applying
     // only the unlocked half would leak flex units, so it's all-or-nothing.
     for (const resize of action.resizeOperations) {
-        if (isNodeLocked(findNode(layoutState.rootNode, resize.nodeId))) {
+        if (isEffectivelyMinimized(findNode(layoutState.rootNode, resize.nodeId))) {
             console.warn(`resizeNode rejected: node ${resize.nodeId} is minimize-locked`);
             return;
         }
@@ -529,7 +529,7 @@ export function splitHorizontal(layoutState: LayoutTreeState, action: LayoutTree
         return;
     }
     // Minimized is a locked state: splitting would spawn a full pane inside a header strip.
-    if (isNodeLocked(targetNode)) {
+    if (isEffectivelyMinimized(targetNode)) {
         console.warn("splitHorizontal rejected: target is minimize-locked", targetNodeId);
         return;
     }
@@ -581,7 +581,7 @@ export function splitVertical(layoutState: LayoutTreeState, action: LayoutTreeSp
         return;
     }
     // Minimized is a locked state: splitting would spawn a full pane inside a header strip.
-    if (isNodeLocked(targetNode)) {
+    if (isEffectivelyMinimized(targetNode)) {
         console.warn("splitVertical rejected: target is minimize-locked", targetNodeId);
         return;
     }

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -220,11 +220,11 @@ export interface LayoutNode {
      */
     minimizedSize?: number;
     /**
-     * The flex-unit size this node is locked to while minimized (header height in the
-     * parent's unit space at minimize time; for a dissolved column, the stacked-headers
-     * total). Written by the minimize subsystem alongside `minimizedSize`/`slipMinimize`/
-     * `columnDissolve`; `enforceMinimizedLocks` snaps `size` back to this value if any
-     * other writer changes it. Cleared on restore.
+     * LEGACY (pre display-mode model) — the flex-unit size a node was locked to
+     * while minimized under the size-squeeze model. No new writes; the frontend
+     * migrates it away in `rebuildMinimizedSet`, and only the Rust-side
+     * `enforce_minimized_locks` still reads it (protection for unmigrated
+     * persisted trees).
      */
     minimizedLockedSize?: number;
     /**

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -206,7 +206,18 @@ export interface LayoutNode {
     children?: LayoutNode[];
     flexDirection: FlexDirection;
     size: number;
-    /** Original size before minimization. Presence indicates the node is minimized. */
+    /**
+     * Display-mode flag: the pane renders as a header chip; geometry is derived
+     * at render time (`updateTreeHelper`) and this node's stored `size` is NEVER
+     * touched by minimize — restore is just clearing the flag. The i3 pattern,
+     * per `RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md` §7. Leaf-only.
+     */
+    minimized?: true;
+    /**
+     * LEGACY (pre display-mode model) — original size before minimization;
+     * presence indicated the node was minimized via size-squeezing. Migrated to
+     * the `minimized` flag by `rebuildMinimizedSet` at load; no new writes.
+     */
     minimizedSize?: number;
     /**
      * The flex-unit size this node is locked to while minimized (header height in the

--- a/frontend/layout/tests/layoutInvariants.test.ts
+++ b/frontend/layout/tests/layoutInvariants.test.ts
@@ -120,27 +120,41 @@ describe("validateLayoutInvariants", () => {
         expect(codes).toContain("NONPOSITIVE_SIZE");
     });
 
-    it("flags a tree where every leaf is minimize-locked (all-headers window)", () => {
+    it("flags a tree where every leaf is minimize-locked (all-headers window) — legacy and flag models", () => {
         const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
-        l1.minimizedSize = 200;
+        l1.minimizedSize = 200; // legacy marker
         const l2 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b2" });
-        l2.minimizedSize = 200;
+        l2.minimized = true; // display-mode flag
         const root = newLayoutNode(FlexDirection.Column, 400, [l1, l2]);
 
         const codes = validateLayoutInvariants(root).map((v) => v.code);
         expect(codes).toContain("ALL_LEAVES_LOCKED");
     });
 
-    it("describeLayoutTree renders the lock flags", () => {
+    it("flags the minimized display-mode flag on a branch (leaf-only)", () => {
+        const l1 = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "b1" });
+        const l2 = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "b2" });
+        const branch = newLayoutNode(FlexDirection.Column, 200, [l1, l2]);
+        branch.minimized = true; // illegal: flag is leaf-only
+        const root = newLayoutNode(FlexDirection.Row, 200, [
+            branch,
+            newLayoutNode(FlexDirection.Column, 200, undefined, { blockId: "b3" }),
+        ]);
+
+        const codes = validateLayoutInvariants(root).map((v) => v.code);
+        expect(codes).toContain("MIN_MARKER_ON_BRANCH");
+    });
+
+    it("describeLayoutTree renders flag and legacy lock markers distinctly", () => {
         const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
         l1.minimizedSize = 200;
         l1.minimizedLockedSize = 33;
-        const root = newLayoutNode(FlexDirection.Column, 400, [
-            l1,
-            newLayoutNode(FlexDirection.Row, 367, undefined, { blockId: "b2" }),
-        ]);
+        const l2 = newLayoutNode(FlexDirection.Row, 367, undefined, { blockId: "b2" });
+        l2.minimized = true;
+        const root = newLayoutNode(FlexDirection.Column, 400, [l1, l2]);
         const desc = describeLayoutTree(root);
-        expect(desc).toContain("MIN(orig=200)");
-        expect(desc).toContain("LOCK=33");
+        expect(desc).toContain("legacyMIN(orig=200)");
+        expect(desc).toContain("legacyLOCK=33");
+        expect(desc).toContain(" MIN");
     });
 });

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -267,10 +267,12 @@ describe("legacy state migration (rebuildMinimizedSet)", () => {
         expect(model.getMinimizedSet().has(paneA2.id)).toBe(false);
     });
 
-    it("migrates slip/dissolve/anchor bookkeeping: markers cleared, slipped leaf flagged in place", () => {
+    it("migrates slip/dissolve/anchor bookkeeping: markers cleared, sizes restored from originalRowSize", () => {
         const { root, colA, paneA1 } = buildTwoColumnLayout();
-        paneA1.slipMinimize = { targetColumnId: colA.id, originalRowSize: 10, originalRowIndex: 0, targetWasLeaf: true };
-        colA.columnDissolve = { targetColumnId: "x", originalRowSize: 10, originalRowIndex: 0, targetWasLeaf: false };
+        paneA1.slipMinimize = { targetColumnId: colA.id, originalRowSize: 150, originalRowIndex: 0, targetWasLeaf: true };
+        paneA1.size = 2.2; // slip-era squeezed size
+        colA.columnDissolve = { targetColumnId: "x", originalRowSize: 120, originalRowIndex: 0, targetWasLeaf: false };
+        colA.size = -0.0039; // the cascade-bug corruption: stolen-total gone negative
         root._slipAnchor = true;
         const model = makeMockModel(root);
 
@@ -278,7 +280,9 @@ describe("legacy state migration (rebuildMinimizedSet)", () => {
 
         expect(paneA1.minimized).toBe(true);
         expect(paneA1.slipMinimize).toBeUndefined();
+        expect(paneA1.size).toBe(150); // pre-slip size restored, not a permanent sliver
         expect(colA.columnDissolve).toBeUndefined();
+        expect(colA.size).toBe(120); // pre-dissolve size restored — heals the negative
         expect(colA.minimized).toBeUndefined(); // branch never gets the flag
         expect(root._slipAnchor).toBeUndefined();
         expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -2,38 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { newLayoutNode } from "../lib/layoutNode";
+import { newLayoutNode, balanceNode } from "../lib/layoutNode";
 import {
     minimizeNodeToggle,
     rebuildMinimizedSet,
-    enforceMinimizedLocks,
+    countExpandedLeaves,
     isNodeLocked,
+    isEffectivelyMinimized,
     HeaderHeightPx,
+    MinimizedRowSlotWidthPx,
 } from "../lib/layoutMinimize";
+import { computeMainAxisAllocation } from "../lib/layoutGeometry";
 import { resizeNode, splitVertical } from "../lib/layoutTree";
-import { balanceNode } from "../lib/layoutNode";
-import { FlexDirection, type LayoutNode, type LayoutNodeAdditionalProps } from "../lib/types";
+import { FlexDirection, type LayoutNode } from "../lib/types";
 
 // ── Minimal LayoutModel mock ─────────────────────────────────────────────────
+// The display-mode toggle needs no geometry (no addlProps, no gap, no ratios).
 
-function makeMockModel(
-    rootNode: LayoutNode,
-    addlProps: Record<string, Partial<LayoutNodeAdditionalProps>> = {},
-    gapSizePx = 0,
-) {
+function makeMockModel(rootNode: LayoutNode) {
     let minimizedSet = new Set<string>();
-    const treeState = { rootNode, pendingBackendActions: [] };
-    const model = {
-        treeState,
-        getter: (_sig: unknown) => addlProps as Record<string, LayoutNodeAdditionalProps>,
-        additionalProps: {} as any,
-        gapSizePx: () => gapSizePx,
+    return {
+        treeState: { rootNode, pendingBackendActions: [] },
         minimizedNodeIds: {
-            // Real SignalAtom._set accepts both a value and an updater function.
-            _set: (updaterOrValue: Set<string> | ((prev: Set<string>) => Set<string>)) => {
-                minimizedSet = typeof updaterOrValue === "function"
-                    ? updaterOrValue(minimizedSet)
-                    : updaterOrValue;
+            _set: (u: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+                minimizedSet = typeof u === "function" ? u(minimizedSet) : u;
             },
         },
         updateTree: () => {},
@@ -41,463 +33,174 @@ function makeMockModel(
         persistToBackend: () => {},
         getMinimizedSet: () => minimizedSet,
     };
-    return model;
 }
 
-// Sizes must exceed HeaderHeightPx (33) so freedUnits > 0 and minimize doesn't no-op.
 const PANE_SIZE = 200;
 
-// ── Helper: build a 2-column layout ─────────────────────────────────────────
-//
 //   root (Row)
-//   ├── colA (Column, size=200)
-//   │   ├── paneA1 (leaf, size=200)
-//   │   └── paneA2 (leaf, size=200)
-//   └── colB (Column, size=200)
-//       └── paneB  (leaf, size=200)
-
+//   ├── colA (Column) → paneA1, paneA2
+//   └── colB (Column) → paneB
 function buildTwoColumnLayout() {
     const paneA1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA1" });
     const paneA2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA2" });
-    const colA   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
-
-    const paneB  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
-    const colB   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
-
-    const root   = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB]);
+    const colA = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
+    const paneB = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
+    const colB = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
+    const root = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB]);
     return { root, colA, paneA1, paneA2, colB, paneB };
 }
 
-// ── Normal column-collapse (no dissolve) ─────────────────────────────────────
+// ── Display-mode toggle ──────────────────────────────────────────────────────
 
-describe("normal column collapse (partial — dissolve not triggered)", () => {
-    it("collapses the pane to header height, gives freed space to sibling", () => {
-        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-
-        expect(paneA1.minimizedSize).toBe(PANE_SIZE);
-        expect(paneA1.size).toBe(HeaderHeightPx);
-        expect(paneA2.size).toBe(PANE_SIZE + (PANE_SIZE - HeaderHeightPx));
-        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
-        // colA stays in root Row — paneA2 still expanded
-        expect(root.children).toHaveLength(2);
-    });
-
-    it("restores pane to its original size", () => {
-        const { root, colA, paneA1 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+describe("minimize as a display mode", () => {
+    it("sets only the flag — stored sizes of the pane AND its siblings never change", () => {
+        const { root, paneA1, paneA2, colA, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root);
 
         minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA1.id);
 
-        expect(paneA1.minimizedSize).toBeUndefined();
+        expect(paneA1.minimized).toBe(true);
+        expect(isNodeLocked(paneA1)).toBe(true);
         expect(paneA1.size).toBe(PANE_SIZE);
-        expect(model.getMinimizedSet().has(paneA1.id)).toBe(false);
-        void root;
-    });
-});
-
-// ── Column dissolve ───────────────────────────────────────────────────────────
-
-describe("column dissolve — all panes minimized triggers dissolve into adjacent column", () => {
-    it("dissolves colA into colB when both panes in colA are minimized", () => {
-        const { root, colA, paneA1, paneA2, colB, paneB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        expect(root.children).toHaveLength(2); // no dissolve yet
-
-        minimizeNodeToggle(model as any, paneA2.id); // triggers dissolve
-
-        // Root Row now holds only colB
-        expect(root.children).toHaveLength(1);
-        expect(root.children![0].id).toBe(colB.id);
-        expect(root._slipAnchor).toBe(true);
-
-        // colA is now the first child of colB
-        expect(colB.children![0].id).toBe(colA.id);
-        expect(colA.columnDissolve).toBeDefined();
-        expect(colA.columnDissolve!.targetColumnId).toBe(colB.id);
-        expect(colA.columnDissolve!.originalRowSize).toBe(PANE_SIZE);
-        expect(colA.columnDissolve!.originalRowIndex).toBe(0);
-
-        // colB absorbed colA's Row-slot width
-        expect(colB.size).toBe(PANE_SIZE * 2);
-
-        // paneB is still in colB (after dissolved colA)
-        expect(colB.children![1].id).toBe(paneB.id);
-
-        // Both panes inside colA retain their minimizedSize
-        expect(paneA1.minimizedSize).toBeDefined();
-        expect(paneA2.minimizedSize).toBeDefined();
-        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
-        expect(model.getMinimizedSet().has(paneA2.id)).toBe(true);
-    });
-
-    it("colA occupies 2 × HeaderHeightPx flex-units inside colB after dissolve", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-
-        expect(colA.size).toBe(2 * HeaderHeightPx);
-        void colB;
-    });
-
-    // Regression: production calls balanceNode(root) on every geometry pass
-    // (layoutGeometry.ts's updateTree), which this test suite otherwise never
-    // exercises since makeMockModel's updateTree is a no-op stub. A dissolved
-    // column is nested inside a same-direction Column sibling by design, so
-    // balanceNode's direction-alternation rule used to flip colA's own
-    // flexDirection to Row, laying its two minimized headers out side-by-side
-    // ("narrow") instead of stacked ("short").
-    it("keeps the dissolved column's own flexDirection stacked after balanceNode runs", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id); // triggers dissolve: colA nests inside colB
-
-        expect(colB.children![0].id).toBe(colA.id);
-        expect(colA.flexDirection).toBe(FlexDirection.Column);
-        expect(colB.flexDirection).toBe(FlexDirection.Column);
-
-        balanceNode(root);
-
-        // colA is still nested first inside colB and still stacks vertically.
-        expect(colB.children![0].id).toBe(colA.id);
-        expect(colA.flexDirection).toBe(FlexDirection.Column);
-    });
-});
-
-// ── Undissolve on restore ─────────────────────────────────────────────────────
-
-describe("undissolve — clicking a pane in a dissolved column restores the column", () => {
-    it("undissolves colA and restores the clicked pane in a single toggle", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-        expect(root.children).toHaveLength(1);
-
-        // One toggle on paneA2: undissolves colA AND restores paneA2
-        minimizeNodeToggle(model as any, paneA2.id);
-
-        // colA is back in the root Row at its original index
-        expect(root.children).toHaveLength(2);
-        expect(root.children![0].id).toBe(colA.id);
-        expect(colA.columnDissolve).toBeUndefined();
-        expect(root._slipAnchor).toBeUndefined();
-
-        // colB width is restored
-        expect(colB.size).toBe(PANE_SIZE);
-
-        // paneA2 is restored
-        expect(paneA2.minimizedSize).toBeUndefined();
-        expect(model.getMinimizedSet().has(paneA2.id)).toBe(false);
-
-        // paneA1 remains minimized inside colA
-        expect(paneA1.minimizedSize).toBeDefined();
-        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
-    });
-
-    it("undissolves via paneA1 as well", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-
-        minimizeNodeToggle(model as any, paneA1.id);
-
-        expect(root.children).toHaveLength(2);
-        expect(colA.columnDissolve).toBeUndefined();
-        expect(paneA1.minimizedSize).toBeUndefined();
-        expect(model.getMinimizedSet().has(paneA1.id)).toBe(false);
-        expect(paneA2.minimizedSize).toBeDefined();
-        void colB;
-    });
-});
-
-// ── rebuildMinimizedSet ───────────────────────────────────────────────────────
-
-describe("rebuildMinimizedSet", () => {
-    it("rebuilds minimizedNodeIds from minimizedSize fields after tree load", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-
-        // Simulate fresh load: clear the set, then rebuild
-        model.minimizedNodeIds._set(new Set<string>());
-        rebuildMinimizedSet(model as any);
-
-        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
-        expect(model.getMinimizedSet().has(paneA2.id)).toBe(true);
-    });
-
-    it("restores _slipAnchor on the owning Row for a dissolved column", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-
-        root._slipAnchor = undefined; // simulate stale serialised state
-        rebuildMinimizedSet(model as any);
-
-        expect(root._slipAnchor).toBe(true);
-    });
-});
-
-// ── Cascade dissolve — 3 columns → 2 → 1 ────────────────────────────────────
-
-describe("cascade dissolve — multiple columns collapse into one", () => {
-    it("colA dissolves into colB, then colB dissolves into colC when all minimized", () => {
-        // root (Row)
-        // ├── colA (Column) → paneA1, paneA2
-        // ├── colB (Column) → paneB
-        // └── colC (Column) → paneC
-        const paneA1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA1" });
-        const paneA2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA2" });
-        const colA   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
-        const paneB  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
-        const colB   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
-        const paneC  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneC" });
-        const colC   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneC]);
-        const root   = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB, colC]);
-
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-            [colC.id]: { pixelToSizeRatio: 1 },
-        });
-
-        // Minimize colA's panes → colA dissolves into colB
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-        expect(root.children).toHaveLength(2); // colA gone, root has colB + colC
-        expect(colA.columnDissolve).toBeDefined();
-        expect(colB.children![0].id).toBe(colA.id);
-
-        // Minimize colB's pane (colB now has [colA-dissolved, paneB]) →
-        // allCollapsed includes columnDissolve, so colB dissolves into colC
-        minimizeNodeToggle(model as any, paneB.id);
-        expect(root.children).toHaveLength(1); // only colC remains
-        expect(root.children![0].id).toBe(colC.id);
-        expect(colB.columnDissolve).toBeDefined();
-        expect(colC.children![0].id).toBe(colB.id);
-
-        // colB (inside colC) still contains colA-dissolved
-        expect(colB.children!.some(c => c.id === colA.id)).toBe(true);
-
-        // paneC is now the LAST expanded pane — minimizing it is a no-op
-        // (the window must always keep one expanded pane).
-        minimizeNodeToggle(model as any, paneC.id);
-        expect(paneC.minimizedSize).toBeUndefined();
-        expect(root.children).toHaveLength(1);
-    });
-
-    it("restores pane from 3-deep cascade (A→B→C → restore colA pane)", () => {
-        // root (Row)
-        // ├── colA (Column) → paneA1, paneA2
-        // ├── colB (Column) → paneB
-        // └── colC (Column) → paneC
-        const paneA1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA1" });
-        const paneA2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneA2" });
-        const colA   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneA1, paneA2]);
-        const paneB  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneB" });
-        const colB   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneB]);
-        const paneC  = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "paneC" });
-        const colC   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [paneC]);
-        const root   = newLayoutNode(FlexDirection.Row, PANE_SIZE, [colA, colB, colC]);
-
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-            [colC.id]: { pixelToSizeRatio: 1 },
-        });
-
-        // Step 1: Dissolve colA into colB (minimize all panes in colA)
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id);
-        expect(colA.columnDissolve).toBeDefined();
-        expect(root.children).toHaveLength(2); // colB + colC remain
-
-        // Step 2: Dissolve colB into colC (colB now has [colA-dissolved, paneB]; minimizing paneB collapses it)
-        minimizeNodeToggle(model as any, paneB.id);
-        expect(colB.columnDissolve).toBeDefined();
-        expect(root.children).toHaveLength(1); // only colC remains
-        expect(root.children![0].id).toBe(colC.id);
-
-        // Step 3: Restore paneA1 from the deeply dissolved colA.
-        // The recursive-undissolve-ancestors path must undissolve colB (outermost) then colA
-        // (immediate parent) before restoring paneA1 — exercising the path added in commit 360dd82.
-        minimizeNodeToggle(model as any, paneA1.id);
-
-        // All three columns must be back in the root Row
-        expect(root.children).toHaveLength(3);
-        const rootIds = root.children!.map((c) => c.id);
-        expect(rootIds).toContain(colA.id);
-        expect(rootIds).toContain(colB.id);
-        expect(rootIds).toContain(colC.id);
-
-        // No column retains a columnDissolve marker
-        expect(colA.columnDissolve).toBeUndefined();
-        expect(colB.columnDissolve).toBeUndefined();
-        expect(colC.columnDissolve).toBeUndefined();
-
-        // Each column is restored to its original Row-slot size
+        expect(paneA2.size).toBe(PANE_SIZE);
         expect(colA.size).toBe(PANE_SIZE);
         expect(colB.size).toBe(PANE_SIZE);
-        expect(colC.size).toBe(PANE_SIZE);
-
-        // root Row no longer needs the slip anchor
-        expect(root._slipAnchor).toBeUndefined();
-
-        // paneA1 is restored (the pane we clicked)
         expect(paneA1.minimizedSize).toBeUndefined();
+        expect(paneA1.minimizedLockedSize).toBeUndefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+    });
+
+    it("restore clears the flag — original geometry is intact by construction", () => {
+        const { root, paneA1 } = buildTwoColumnLayout();
+        const model = makeMockModel(root);
+
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA1.id);
+
+        expect(paneA1.minimized).toBeUndefined();
+        expect(paneA1.size).toBe(PANE_SIZE);
         expect(model.getMinimizedSet().has(paneA1.id)).toBe(false);
+    });
 
-        // paneA2 remains minimized inside colA
-        expect(paneA2.minimizedSize).toBeDefined();
-        expect(model.getMinimizedSet().has(paneA2.id)).toBe(true);
+    it("no structural surgery: minimizing every pane of a column leaves the tree shape untouched", () => {
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        const model = makeMockModel(root);
 
-        // paneB remains minimized inside colB
-        expect(paneB.minimizedSize).toBeDefined();
-        expect(model.getMinimizedSet().has(paneB.id)).toBe(true);
+        minimizeNodeToggle(model as any, paneA1.id);
+        minimizeNodeToggle(model as any, paneA2.id);
+
+        // No dissolve: colA stays in the root Row with both children.
+        expect(root.children).toHaveLength(2);
+        expect(root.children![0].id).toBe(colA.id);
+        expect(colA.children).toHaveLength(2);
+        expect(colA.columnDissolve).toBeUndefined();
+        expect(root._slipAnchor).toBeUndefined();
+        // colA is now effectively minimized (renders as a chip stack).
+        expect(isEffectivelyMinimized(colA)).toBe(true);
+        expect(isEffectivelyMinimized(colB)).toBe(false);
+    });
+
+    it("toggle on a branch is a no-op", () => {
+        const { root, colA } = buildTwoColumnLayout();
+        const model = makeMockModel(root);
+        minimizeNodeToggle(model as any, colA.id);
+        expect(colA.minimized).toBeUndefined();
     });
 });
 
-// ── Bail case — no adjacent sibling ─────────────────────────────────────────
-
-describe("dissolve bail cases", () => {
-    it("refuses to minimize the last expanded pane (no-op), so a lone column never fully collapses", () => {
-        const pane1 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "p1" });
-        const pane2 = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "p2" });
-        const col   = newLayoutNode(FlexDirection.Column, PANE_SIZE, [pane1, pane2]);
-        const root  = newLayoutNode(FlexDirection.Row, PANE_SIZE, [col]);
-
-        const model = makeMockModel(root, { [col.id]: { pixelToSizeRatio: 1 } });
-
-        minimizeNodeToggle(model as any, pane1.id);
-        // pane2 is now the LAST expanded pane — this toggle must no-op.
-        // (Previously it minimized and dissolve bailed, leaving an
-        // all-headers window with nothing restorable in view.)
-        minimizeNodeToggle(model as any, pane2.id);
-
-        expect(root.children).toHaveLength(1);
-        expect(col.columnDissolve).toBeUndefined();
-        expect(pane1.minimizedSize).toBeDefined();
-        expect(pane2.minimizedSize).toBeUndefined();
-        expect(pane2.size).toBeGreaterThan(HeaderHeightPx);
-
-        // Restoring pane1 re-enables minimizing pane2.
-        minimizeNodeToggle(model as any, pane1.id);
-        expect(pane1.minimizedSize).toBeUndefined();
-        minimizeNodeToggle(model as any, pane2.id);
-        expect(pane2.minimizedSize).toBeDefined();
-        expect(pane1.minimizedSize).toBeUndefined();
-    });
-});
-
-// ── Last expanded pane cannot be minimized ───────────────────────────────────
+// ── Last expanded pane guard ─────────────────────────────────────────────────
 
 describe("last expanded pane guard", () => {
-    it("no-ops when the only remaining expanded pane (after a dissolve) is toggled", () => {
-        const { root, colA, paneA1, paneA2, colB, paneB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
+    it("refuses to minimize the last expanded pane; restore re-enables", () => {
+        const { root, paneA1, paneA2, paneB } = buildTwoColumnLayout();
+        const model = makeMockModel(root);
 
         minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id); // colA dissolves into colB
-        expect(colA.columnDissolve).toBeDefined();
+        minimizeNodeToggle(model as any, paneA2.id);
+        expect(countExpandedLeaves(root)).toBe(1);
 
-        // paneB is the last expanded pane — toggle must not collapse it.
-        const sizeBefore = paneB.size;
-        minimizeNodeToggle(model as any, paneB.id);
-        expect(paneB.minimizedSize).toBeUndefined();
-        expect(paneB.size).toBe(sizeBefore);
-        expect(model.getMinimizedSet().has(paneB.id)).toBe(false);
+        minimizeNodeToggle(model as any, paneB.id); // last expanded — no-op
+        expect(paneB.minimized).toBeUndefined();
 
-        // Restoring one pane (undissolves colA) re-enables minimizing: with
-        // paneA1 and paneB both expanded, paneA1 can collapse again.
-        minimizeNodeToggle(model as any, paneA1.id);
-        expect(paneA1.minimizedSize).toBeUndefined();
-        minimizeNodeToggle(model as any, paneA1.id);
-        expect(paneA1.minimizedSize).toBeDefined();
+        minimizeNodeToggle(model as any, paneA1.id); // restore one
+        minimizeNodeToggle(model as any, paneB.id); // now allowed
+        expect(paneB.minimized).toBe(true);
+        expect(paneA1.minimized).toBeUndefined();
     });
 });
 
-// ── Minimize lock (locked-state spec, 2026-07-16) ───────────────────────────
+// ── Derived geometry (computeMainAxisAllocation) ─────────────────────────────
 
-describe("minimize lock — minimized is a locked state", () => {
-    it("records minimizedLockedSize on minimize and clears it on restore", () => {
-        const { root, colA, paneA1 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+describe("derived chip geometry", () => {
+    const size = (n: LayoutNode) => n.size;
 
-        minimizeNodeToggle(model as any, paneA1.id);
-        expect(paneA1.minimizedLockedSize).toBe(HeaderHeightPx);
-        expect(paneA1.size).toBe(HeaderHeightPx);
-        expect(isNodeLocked(paneA1)).toBe(true);
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        expect(paneA1.minimizedLockedSize).toBeUndefined();
-        expect(isNodeLocked(paneA1)).toBe(false);
+    it("Column parent: minimized leaf gets exactly header height; sibling gets the rest", () => {
+        const { colA, paneA1, paneA2 } = buildTwoColumnLayout();
+        paneA1.minimized = true;
+        const { px, pixelToSizeRatio } = computeMainAxisAllocation(colA.children!, false, 800, size);
+        expect(px[0]).toBe(HeaderHeightPx);
+        expect(px[1]).toBe(800 - HeaderHeightPx);
+        // Ratio describes only the flex-distributed space.
+        expect(pixelToSizeRatio).toBeCloseTo(PANE_SIZE / (800 - HeaderHeightPx));
     });
 
-    it("records minimizedLockedSize on the dissolved column and clears it on undissolve", () => {
-        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
-        const model = makeMockModel(root, {
-            [colA.id]: { pixelToSizeRatio: 1 },
-            [colB.id]: { pixelToSizeRatio: 1 },
-        });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        minimizeNodeToggle(model as any, paneA2.id); // triggers dissolve
-        expect(colA.minimizedLockedSize).toBe(colA.size);
-        expect(isNodeLocked(colA)).toBe(true);
-
-        minimizeNodeToggle(model as any, paneA2.id); // undissolves + restores
-        expect(colA.minimizedLockedSize).toBeUndefined();
-        expect(isNodeLocked(colA)).toBe(false);
+    it("Row parent: minimized leaf gets the fixed chip width", () => {
+        const a = newLayoutNode(FlexDirection.Column, 10, undefined, { blockId: "a" });
+        const b = newLayoutNode(FlexDirection.Column, 10, undefined, { blockId: "b" });
+        a.minimized = true;
+        const { px } = computeMainAxisAllocation([a, b], true, 1000, size);
+        expect(px[0]).toBe(MinimizedRowSlotWidthPx);
+        expect(px[1]).toBe(1000 - MinimizedRowSlotWidthPx);
     });
 
-    it("resizeNode rejects the whole action when any target is locked (the reported bug)", () => {
+    it("fully-minimized column in a Row parent renders as one fixed-width chip stack", () => {
         const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
+        paneA1.minimized = true;
+        paneA2.minimized = true;
+        const { px } = computeMainAxisAllocation(root.children!, true, 1000, size);
+        expect(px[0]).toBe(MinimizedRowSlotWidthPx); // colA: chip stack slot
+        expect(px[1]).toBe(1000 - MinimizedRowSlotWidthPx); // colB absorbs the rest
+    });
 
-        minimizeNodeToggle(model as any, paneA1.id);
-        const lockedSize = paneA1.size;
-        const siblingSize = paneA2.size;
+    it("fully-minimized column in a Column parent gets one header height per leaf", () => {
+        const inner1 = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "i1" });
+        const inner2 = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "i2" });
+        inner1.minimized = true;
+        inner2.minimized = true;
+        const stack = newLayoutNode(FlexDirection.Column, 10, [inner1, inner2]);
+        const other = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "o" });
+        const { px } = computeMainAxisAllocation([stack, other], false, 600, size);
+        expect(px[0]).toBe(2 * HeaderHeightPx);
+        expect(px[1]).toBe(600 - 2 * HeaderHeightPx);
+    });
+
+    it("chips scale down proportionally when the container is too small for them", () => {
+        const a = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "a" });
+        const b = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "b" });
+        a.minimized = true;
+        b.minimized = true;
+        const { px } = computeMainAxisAllocation([a, b], false, 40, size);
+        expect(px[0]).toBeCloseTo(20);
+        expect(px[1]).toBeCloseTo(20);
+        expect(px[0] + px[1]).toBeCloseTo(40);
+    });
+
+    it("no minimized children: identical to plain proportional split", () => {
+        const a = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "a" });
+        const b = newLayoutNode(FlexDirection.Row, 300, undefined, { blockId: "b" });
+        const { px, pixelToSizeRatio } = computeMainAxisAllocation([a, b], false, 800, size);
+        expect(px[0]).toBeCloseTo(200);
+        expect(px[1]).toBeCloseTo(600);
+        expect(pixelToSizeRatio).toBeCloseTo(400 / 800);
+    });
+});
+
+// ── Reducer guards (minimized = locked) ──────────────────────────────────────
+
+describe("minimized panes are untargetable by tree mutations", () => {
+    it("resizeNode rejects the whole action when any target is minimized", () => {
+        const { root, paneA1, paneA2 } = buildTwoColumnLayout();
+        paneA1.minimized = true;
 
         resizeNode({ rootNode: root, pendingBackendActions: [] } as any, {
             type: "resize" as any,
@@ -507,16 +210,13 @@ describe("minimize lock — minimized is a locked state", () => {
             ],
         } as any);
 
-        // Atomic reject: neither side of the pair applied.
-        expect(paneA1.size).toBe(lockedSize);
-        expect(paneA2.size).toBe(siblingSize);
+        expect(paneA1.size).toBe(PANE_SIZE);
+        expect(paneA2.size).toBe(PANE_SIZE);
     });
 
-    it("splitVertical rejects a locked target", () => {
+    it("splitVertical rejects a minimized target", () => {
         const { root, colA, paneA1 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
-
-        minimizeNodeToggle(model as any, paneA1.id);
+        paneA1.minimized = true;
         const newNode = newLayoutNode(FlexDirection.Row, PANE_SIZE, undefined, { blockId: "newPane" });
         splitVertical({ rootNode: root, pendingBackendActions: [] } as any, {
             type: "splitvertical" as any,
@@ -524,49 +224,72 @@ describe("minimize lock — minimized is a locked state", () => {
             newNode,
             position: "after",
         } as any);
-
-        // Tree unchanged: colA still has exactly its two original panes.
         expect(colA.children).toHaveLength(2);
-        expect(paneA1.size).toBe(HeaderHeightPx);
-    });
-
-    it("enforceMinimizedLocks snaps a tampered minimized size back and repays the sibling", () => {
-        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
-
-        minimizeNodeToggle(model as any, paneA1.id);
-        const siblingSize = paneA2.size;
-
-        // Simulate a writer that bypassed the reducer guards (stale tree push).
-        paneA1.size = 120;
-        paneA2.size = siblingSize - (120 - HeaderHeightPx);
-
-        const snapped = enforceMinimizedLocks(root);
-        expect(snapped).toBe(1);
-        expect(paneA1.size).toBe(HeaderHeightPx);
-        expect(paneA2.size).toBe(siblingSize);
-    });
-
-    it("enforceMinimizedLocks is a no-op on a tree that honors its locks", () => {
-        const { root, colA, paneA1 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
-        minimizeNodeToggle(model as any, paneA1.id);
-        expect(enforceMinimizedLocks(root)).toBe(0);
-    });
-
-    it("enforceMinimizedLocks clamps a negative-delta repayment at the 1-unit floor", () => {
-        const { root, colA, paneA1, paneA2 } = buildTwoColumnLayout();
-        const model = makeMockModel(root, { [colA.id]: { pixelToSizeRatio: 1 } });
-        minimizeNodeToggle(model as any, paneA1.id);
-
-        // Tampered BELOW the lock: delta is negative, and the beneficiary is
-        // too small to absorb it — the repayment must clamp, not go negative.
-        paneA1.size = 5;
-        paneA2.size = 10;
-
-        expect(enforceMinimizedLocks(root)).toBe(1);
-        expect(paneA1.size).toBe(HeaderHeightPx);
-        expect(paneA2.size).toBe(1);
     });
 });
 
+// ── Legacy migration ─────────────────────────────────────────────────────────
+
+describe("legacy state migration (rebuildMinimizedSet)", () => {
+    it("migrates a size-squeezed legacy pane: size restored, flag set, markers cleared", () => {
+        const { root, paneA1, paneA2 } = buildTwoColumnLayout();
+        paneA1.minimizedSize = PANE_SIZE; // legacy: original size recorded...
+        paneA1.size = HeaderHeightPx; // ...while size was squeezed
+        paneA1.minimizedLockedSize = HeaderHeightPx;
+        const model = makeMockModel(root);
+
+        rebuildMinimizedSet(model as any);
+
+        expect(paneA1.minimized).toBe(true);
+        expect(paneA1.size).toBe(PANE_SIZE);
+        expect(paneA1.minimizedSize).toBeUndefined();
+        expect(paneA1.minimizedLockedSize).toBeUndefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+        expect(model.getMinimizedSet().has(paneA2.id)).toBe(false);
+    });
+
+    it("migrates slip/dissolve/anchor bookkeeping: markers cleared, slipped leaf flagged in place", () => {
+        const { root, colA, paneA1 } = buildTwoColumnLayout();
+        paneA1.slipMinimize = { targetColumnId: colA.id, originalRowSize: 10, originalRowIndex: 0, targetWasLeaf: true };
+        colA.columnDissolve = { targetColumnId: "x", originalRowSize: 10, originalRowIndex: 0, targetWasLeaf: false };
+        root._slipAnchor = true;
+        const model = makeMockModel(root);
+
+        rebuildMinimizedSet(model as any);
+
+        expect(paneA1.minimized).toBe(true);
+        expect(paneA1.slipMinimize).toBeUndefined();
+        expect(colA.columnDissolve).toBeUndefined();
+        expect(colA.minimized).toBeUndefined(); // branch never gets the flag
+        expect(root._slipAnchor).toBeUndefined();
+        expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);
+    });
+
+    it("rebuilds the set from existing flags without touching anything", () => {
+        const { root, paneA2 } = buildTwoColumnLayout();
+        paneA2.minimized = true;
+        const model = makeMockModel(root);
+        rebuildMinimizedSet(model as any);
+        expect(model.getMinimizedSet()).toEqual(new Set([paneA2.id]));
+        expect(paneA2.size).toBe(PANE_SIZE);
+    });
+});
+
+// ── Legacy balance carve-outs stay inert but protective pre-migration ────────
+
+describe("balanceNode legacy carve-outs", () => {
+    it("still refuses to flip a legacy dissolved column's direction before migration runs", () => {
+        const l1 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b1" });
+        l1.minimizedSize = 200;
+        const l2 = newLayoutNode(FlexDirection.Row, 33, undefined, { blockId: "b2" });
+        l2.minimizedSize = 200;
+        const dissolved = newLayoutNode(FlexDirection.Column, 66, [l1, l2]);
+        dissolved.columnDissolve = { targetColumnId: "host", originalRowSize: 200, originalRowIndex: 0, targetWasLeaf: true };
+        const content = newLayoutNode(FlexDirection.Row, 300, undefined, { blockId: "b3" });
+        const host = newLayoutNode(FlexDirection.Column, 400, [dissolved, content]);
+
+        balanceNode(host);
+
+        expect(host.children![0].flexDirection).toBe(FlexDirection.Column);
+    });
+});

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -233,6 +233,27 @@ describe("minimized panes are untargetable by tree mutations", () => {
         expect(paneA2.size).toBe(PANE_SIZE);
     });
 
+    it("resizeNode rejects a fully-minimized BRANCH — its stored size becomes load-bearing on restore", () => {
+        // A collapsed column has no branch-level marker in the display-mode
+        // model, but mutating its stored size while collapsed would corrupt
+        // the proportion that reappears when any child restores (reagent P1,
+        // round 3).
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        paneA1.minimized = true;
+        paneA2.minimized = true; // colA is now effectively minimized
+
+        resizeNode({ rootNode: root, pendingBackendActions: [] } as any, {
+            type: "resize" as any,
+            resizeOperations: [
+                { nodeId: colA.id, size: 1 },
+                { nodeId: colB.id, size: 399 },
+            ],
+        } as any);
+
+        expect(colA.size).toBe(PANE_SIZE);
+        expect(colB.size).toBe(PANE_SIZE);
+    });
+
     it("splitVertical rejects a minimized target", () => {
         const { root, colA, paneA1 } = buildTwoColumnLayout();
         paneA1.minimized = true;
@@ -267,11 +288,17 @@ describe("legacy state migration (rebuildMinimizedSet)", () => {
         expect(model.getMinimizedSet().has(paneA2.id)).toBe(false);
     });
 
-    it("migrates slip/dissolve/anchor bookkeeping: markers cleared, sizes restored from originalRowSize", () => {
-        const { root, colA, paneA1 } = buildTwoColumnLayout();
-        paneA1.slipMinimize = { targetColumnId: colA.id, originalRowSize: 150, originalRowIndex: 0, targetWasLeaf: true };
+    it("migrates slip/dissolve bookkeeping: sizes healed to a sane share of the CURRENT parent", () => {
+        // Flex sizes are relative within a parent. A slipped/dissolved node
+        // lives nested in its slip/dissolve TARGET — restoring the recorded
+        // originalRowSize (a weight from a DIFFERENT unit space) would give it
+        // a wildly wrong proportion; the migration heals to the mean of its
+        // current siblings instead (reagent P1, round 3).
+        const { root, colA, paneA1, paneA2, colB } = buildTwoColumnLayout();
+        paneA1.slipMinimize = { targetColumnId: colA.id, originalRowSize: 9999, originalRowIndex: 0, targetWasLeaf: true };
         paneA1.size = 2.2; // slip-era squeezed size
-        colA.columnDissolve = { targetColumnId: "x", originalRowSize: 120, originalRowIndex: 0, targetWasLeaf: false };
+        paneA2.size = 300; // paneA1's current sibling in colA
+        colA.columnDissolve = { targetColumnId: "x", originalRowSize: 9999, originalRowIndex: 0, targetWasLeaf: false };
         colA.size = -0.0039; // the cascade-bug corruption: stolen-total gone negative
         root._slipAnchor = true;
         const model = makeMockModel(root);
@@ -280,9 +307,9 @@ describe("legacy state migration (rebuildMinimizedSet)", () => {
 
         expect(paneA1.minimized).toBe(true);
         expect(paneA1.slipMinimize).toBeUndefined();
-        expect(paneA1.size).toBe(150); // pre-slip size restored, not a permanent sliver
+        expect(paneA1.size).toBe(300); // mean of current siblings, NOT the alien 9999
         expect(colA.columnDissolve).toBeUndefined();
-        expect(colA.size).toBe(120); // pre-dissolve size restored — heals the negative
+        expect(colA.size).toBe(colB.size); // sane share among root siblings — heals the negative
         expect(colA.minimized).toBeUndefined(); // branch never gets the flag
         expect(root._slipAnchor).toBeUndefined();
         expect(model.getMinimizedSet().has(paneA1.id)).toBe(true);

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -185,6 +185,25 @@ describe("derived chip geometry", () => {
         expect(px[0] + px[1]).toBeCloseTo(40);
     });
 
+    it("gap compensation: chip slot = header + gap so the inset inner box is exactly header-sized", () => {
+        // innerRect renders each tile at calc(size - gapSizePx); the header has
+        // a FIXED --header-height, so allocating raw HeaderHeightPx would clip
+        // it by the gap (reagent P1 on PR #2197).
+        const gap = 3;
+        const { colA, paneA1 } = buildTwoColumnLayout();
+        paneA1.minimized = true;
+        const { px } = computeMainAxisAllocation(colA.children!, false, 800, size, gap);
+        expect(px[0]).toBe(HeaderHeightPx + gap);
+        expect(px[1]).toBe(800 - HeaderHeightPx - gap);
+
+        // Row parent: chip width also carries the gap.
+        const a = newLayoutNode(FlexDirection.Column, 10, undefined, { blockId: "a" });
+        const b = newLayoutNode(FlexDirection.Column, 10, undefined, { blockId: "b" });
+        a.minimized = true;
+        const row = computeMainAxisAllocation([a, b], true, 1000, size, gap);
+        expect(row.px[0]).toBe(MinimizedRowSlotWidthPx + gap);
+    });
+
     it("no minimized children: identical to plain proportional split", () => {
         const a = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "a" });
         const b = newLayoutNode(FlexDirection.Row, 300, undefined, { blockId: "b" });


### PR DESCRIPTION
## Summary

Research-backed redesign of pane minimize, tracked in #2179. The prior in-tree size-arithmetic model produced four bug classes in two weeks (direction flip #2176, resize-through-lock #2180, marker fields stranded on branches, cascading dissolves computing **negative sizes** — caught live by the layout doctor from #2184). Deep research across i3, tmux, Eclipse, IntelliJ, FlexLayout, AvalonDock, and Dockview — 21 sources, top 25 claims adversarially verified 3-0, report included in this PR (`docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md`) — found **no mature system stores minimize as in-tree size state**. tmux's maintainer rejected exactly our prior design in writing; i3 derives collapse geometry per render pass so drift is structurally impossible. This PR implements the research's recommendation (§7.3, the i3 pattern).

## The model

- **State:** one leaf-only flag, `minimized: true`. Stored flex sizes are **never touched** by minimize; restore = clear the flag — original geometry intact by construction.
- **Geometry derived per render pass** (`computeMainAxisAllocation`, pure + unit-tested): header-height strip in a Column parent; fixed-width chip (`MinimizedRowSlotWidthPx`, cross-axis clamped to header height) in a Row parent; a fully-minimized subtree renders as a stacked chip strip (one header height per leaf); chips scale down proportionally in tiny containers. Expanded siblings absorb the remainder proportionally to their untouched flex sizes; `pixelToSizeRatio` now describes only the flex-distributed space so resize-drag math stays exact.
- **Deleted wholesale:** slip/dissolve/undissolve structural surgery, `minimizedSize` restore arithmetic, `slipMinimize`/`columnDissolve`/`_slipAnchor` bookkeeping, and the frontend `enforceMinimizedLocks` lock layer (~450 lines of the machinery that generated every bug).
- **Kept:** reducer guards on both sides (`isNodeLocked`/`is_node_locked` keyed on the flag + legacy markers — minimized panes remain untargetable by resize/move/swap/split/insert), the last-expanded-pane guard, the collapsed-header reduction, and the layout doctor (I2 extended to the flag; I4–I7 now legacy detection). `balanceNode`'s carve-outs and Rust `enforce_minimized_locks` remain as inert protection for unmigrated trees.
- **Migration:** `rebuildMinimizedSet` converts legacy persisted state in place at load (`minimizedSize` → size restored + flag; `slipMinimize` → flag in place; `columnDissolve`/`minimizedLockedSize`/`_slipAnchor` → dropped), with a one-line log of the migrated count.

## Why each historical bug class is now structurally impossible

| Bug class | Why it can't recur |
|---|---|
| 1 — direction flip renders headers sideways | Chip geometry is derived; there is no stored orientation-coupled state to flip |
| 2 — resize through the header-height invariant | There is no squeezed size to resize and no handle generated on chip edges |
| 3 — marker fields stranded on branches | One leaf-only flag instead of four marker fields (doctor I2 still watches promotions) |
| 4 — cascade computes negative sizes | No steal-from-neighbor arithmetic exists; allocation is a pure function clamped ≥ 0 |

## Test plan

- [x] Full rewrite of `layoutMinimize.test.ts`: display-mode toggle (sizes untouched), no-structural-surgery assertion, last-expanded guard, 6 derived-geometry cases (Column/Row chips, stacked strips, scale-down clamp, no-minimize parity with plain proportional split), reducer-guard rejections, 3 legacy-migration cases, legacy balance carve-out
- [x] `layoutInvariants.test.ts`: flag-on-branch I2, flag-based ALL_LEAVES_LOCKED, distinct legacy/flag describe output; 0.53.6 corruption fixture unchanged
- [x] Rust: flag-based lock rejection + flag-on-branch + flag ALL_LEAVES_LOCKED; all legacy-marker tests still pass unchanged
- [x] `cargo test --bin agentmux-srv`: **1515 passed** · `npx vitest run frontend/layout`: **96 passed**

Also includes the research report and the spec update (§8, status superseded) per "no separate PRs for docs."

Refs #2179.