### PR TITLE
fix(menu): route pane context-menu submenus through the paintable-area framework

### DIFF
--- a/.changesets/1784285080-fix-menu-context-submenu-offscreen.md
+++ b/.changesets/1784285080-fix-menu-context-submenu-offscreen.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(menu): route pane context-menu submenus through the paintable-area framework — "Replace With..."/"Pane Color" no longer cut off at the window edge; menus taller than the free space now scroll internally

--- a/docs/analysis/submenu-offscreen-second-level-2026-07-16.md
+++ b/docs/analysis/submenu-offscreen-second-level-2026-07-16.md
@@ -1,0 +1,132 @@
+# Second-level submenus escape the paintable-area framework
+
+**Date:** 2026-07-16
+**Symptom (user report):** right-click a pane header → hover **"Replace With..."** — the
+second-level submenu gets cut off at the window edge. The top-level menu is always
+placed correctly.
+**Verdict:** the paintable-area framework is working as designed; the pane
+context-menu renderer's **second level never calls it**. The submenu is positioned by
+two lines of hand-rolled CSS from before the framework existed.
+
+---
+
+## 1. What the framework guarantees (and to whom)
+
+`frontend/app/util/menu-position.ts` (SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20) is
+opt-in per call site. A surface that calls `computeMenuPosition(request, el)` gets the
+floating-ui pipeline — `offset → flip → shift → size` against an explicit boundary
+(paintable area or viewport) — and can call `assertMenuInPaintableArea(el, label)` to
+get the dev-only `[menu-guard]` console error if it still lands outside. A surface
+that doesn't call it gets nothing: there is no global observer sweeping the DOM for
+off-screen menus.
+
+Surface inventory as of today:
+
+| Surface | Level 1 | Level 2 | Dev guard |
+|---|---|---|---|
+| `FlyoutMenu` (`element/flyoutmenu.tsx`) | ✅ `computeMenuPosition` (:77–81) | ✅ `right-start`/`left-start` compute (:395–403) | ✅ (:92, :414) |
+| `Popover`, `Tooltip` | ✅ (Phase 2/3 migrations) | n/a | ✅ |
+| `components/context-menu.tsx` | ✅ | n/a — "Single-level only" by contract | ✅ |
+| **`showJsContextMenu`** (`util/cef-api.ts` — ALL pane right-click menus) | ✅ (:244–260) | ❌ **hand-rolled CSS, no framework call** | ❌ never called for submenus |
+
+`showJsContextMenu` is the renderer behind `showContextMenu` (`cef-api.ts:306–309`),
+which is what `store/contextmenu.ts` drives. Every pane right-click menu goes through
+it — so every submenu built via `type: "submenu"` is affected: **"Replace With..."**
+(`block/pane-actions.ts:101–136`), **"Pane Color"** (`block/blockframe.tsx`), and any
+future menu def with a `submenu` array.
+
+## 2. Root cause — `cef-api.ts:199–220`
+
+When `renderItems` meets an item with a submenu it does this:
+
+```ts
+row.style.position = "relative";          // :205
+const sub = document.createElement("div");
+sub.className = "menu sub-menu";
+sub.style.display = "none";
+sub.style.left = "100%";                  // :215 — anchor at row's right edge
+sub.style.top = "0";                      // :216 — align with row's top
+renderItems(sub, item.submenu);
+row.appendChild(sub);
+row.addEventListener("mouseenter", () => { sub.style.display = ""; });
+row.addEventListener("mouseleave", () => { sub.style.display = "none"; });
+```
+
+`position: absolute; left: 100%; top: 0` inside the hovered row
+(`.menu` is `position: absolute` from `flyoutmenu.scss:9`), unconditionally. There is:
+
+- **no `computeMenuPosition` call** — no flip to `left-start` when the right side has
+  no room, no shift, no size clamp;
+- **no `assertMenuInPaintableArea` call** — so the framework's own dev alarm is
+  structurally blind here. This is why the regression survived the Phase 4 guard:
+  the guard only covers surfaces that opt in;
+- **no vertical handling** — a tall submenu near the bottom edge overflows downward
+  the same way (`top: 0` pins it to the row).
+
+Because the parent menu is placed at the cursor and is up to 400px wide
+(`flyoutmenu.scss:12`), right-clicking anywhere in the right ~half of the window puts
+the row's right edge close enough to the window edge that the submenu (width:
+`max-content`, `flyoutmenu.scss:20–23`) extends past it. DOM content cannot paint
+outside the window, so it's clipped — exactly the reported "Replace With... gets cut
+off".
+
+Contrast with the compliant implementation in the same codebase:
+`FlyoutMenu`'s `SubMenu` (`flyoutmenu.tsx:395–414`) computes
+`computeMenuPosition({ anchor: anchorRect, placement: mirrored ? "left-start" :
+"right-start", avoidNativePanes: false })` with `autoUpdate`, then asserts the guard.
+That is the pattern the context-menu submenu was supposed to follow and didn't —
+`showJsContextMenu`'s **top level** was migrated to the framework (with careful
+visibility:hidden-until-placed handling, `cef-api.ts:244–260`), but the submenu branch
+kept its pre-framework CSS.
+
+## 3. Secondary gap (both renderers): `maxWidth`/`maxHeight` are computed and dropped
+
+`computeMenuPosition` returns `{ style, placement, maxHeight, maxWidth }` — the `size`
+middleware's clamp for when even a flipped placement can't fully fit. Neither consumer
+applies it:
+
+- `flyoutmenu.tsx:22` `styleToString` serializes only `position/left/top`;
+- `cef-api.ts:253–254` copies only `pos.style.left` / `pos.style.top`.
+
+So even framework-routed menus can overflow when they're taller than the paintable
+area (they flip and shift, but never shrink/scroll). Low severity — it needs an
+unusually tall menu — but it's the same class of bug and the fix should thread it
+through (`max-height` + `overflow-y: auto`).
+
+## 4. Fix direction
+
+In `showJsContextMenu`'s submenu branch, replace the static CSS with the FlyoutMenu
+pattern, adapted to the imperative DOM style of this function:
+
+1. Keep the DOM nesting (it's what makes the `mouseenter`/`mouseleave` hover logic
+   work), but position the submenu with **`position: fixed`** viewport coordinates
+   instead of `left:100%` — `computeMenuPosition` already returns
+   `position: fixed` styles. (Caveat: fixed coords resolve against the viewport only
+   if no ancestor creates a containing block via `transform`/`filter`; the overlay
+   chain here — plain `.menu` inside a `position:fixed` overlay — is clean today.)
+2. On `mouseenter`: show it `visibility: hidden`, call
+   `computeMenuPosition({ anchor: row.getBoundingClientRect(), placement:
+   "right-start", avoidNativePanes: false }, sub)`, apply `left/top` **and**
+   `maxHeight/maxWidth` (with `overflow-y: auto`), then reveal — same
+   hidden-until-placed discipline the top level already uses (it also keeps the
+   `data-pane-overlay` clip rect from registering a stale position).
+3. Call `assertMenuInPaintableArea(sub, "context-submenu")` after placement so the
+   dev guard covers this surface from now on.
+4. flip handles the left-mirroring automatically (`right-start` → `left-start`), same
+   as FlyoutMenu's `mirrored` case.
+
+Optionally, apply the returned `maxHeight`/`maxWidth` in `flyoutmenu.tsx`'s
+`styleToString` too (§3) — same PR, few lines.
+
+**Repro to verify against:** move a window so its right edge is near the screen's
+right, right-click a pane header in the window's right half, hover "Replace With..."
+(long list — every pane widget) and "Pane Color". Both must flip to the left of the
+parent menu and stay fully visible; in dev, no `[menu-guard]` console errors.
+
+## 5. Sources
+
+- `frontend/util/cef-api.ts` :199–220 (broken submenu branch), :244–260 (compliant top level)
+- `frontend/app/element/flyoutmenu.tsx` :77–92 (L1), :395–414 (compliant SubMenu pattern)
+- `frontend/app/util/menu-position.ts` (framework), `flyoutmenu.scss` :7–23 (`.menu`, `.sub-menu`)
+- `frontend/app/block/pane-actions.ts` :101–136 ("Replace With..." def), `store/contextmenu.ts` :45–46 (submenu conversion)
+- `docs/specs/SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20.md` (framework spec; Phase 3 "manual-math surfaces" is where this site was missed)

--- a/docs/analysis/submenu-offscreen-second-level-2026-07-16.md
+++ b/docs/analysis/submenu-offscreen-second-level-2026-07-16.md
@@ -91,7 +91,9 @@ applies it:
 So even framework-routed menus can overflow when they're taller than the paintable
 area (they flip and shift, but never shrink/scroll). Low severity — it needs an
 unusually tall menu — but it's the same class of bug and the fix should thread it
-through (`max-height` + `overflow-y: auto`).
+through (`max-height` + `overflow-y: auto`). `maxWidth` is deliberately left
+unapplied: an inline max-width overrides (and can loosen) the `.menu` 400px CSS cap,
+and flip+shift already guarantee horizontal fit for menus at or under that cap.
 
 ## 4. Fix direction
 
@@ -107,7 +109,8 @@ pattern, adapted to the imperative DOM style of this function:
 2. On `mouseenter`: show it `visibility: hidden`, call
    `computeMenuPosition({ anchor: row.getBoundingClientRect(), placement:
    "right-start", avoidNativePanes: false }, sub)`, apply `left/top` **and**
-   `maxHeight/maxWidth` (with `overflow-y: auto`), then reveal — same
+   `maxHeight` (with `overflow-y: auto`; see §3 for why not `maxWidth`), then
+   reveal — same
    hidden-until-placed discipline the top level already uses (it also keeps the
    `data-pane-overlay` clip rect from registering a stale position).
 3. Call `assertMenuInPaintableArea(sub, "context-submenu")` after placement so the

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -18,9 +18,22 @@ import {
 
 import "./flyoutmenu.scss";
 
-/** Serialize a MenuPositionResult.style (position:fixed + left/top) to a CSS string. */
-function styleToString(s: MenuPositionResult["style"]): string {
-    return `position:${s.position};left:${s.left};top:${s.top}`;
+/**
+ * Serialize a MenuPositionResult (position:fixed + left/top + size cap) to a
+ * CSS string. The size() max-height cap makes a menu taller than the free
+ * space scroll internally instead of overflowing the window. max-width is
+ * deliberately NOT applied — an inline max-width would override (and can
+ * loosen) the .menu 400px CSS cap, and horizontal fit is already guaranteed
+ * by flip+shift for menus at or under that cap. justify-content is forced to
+ * flex-start because the .menu rule's flex-end makes overflow unreachable in
+ * a scroll container (a no-op when the menu fits).
+ */
+function styleToString(pos: MenuPositionResult): string {
+    const s = pos.style;
+    return (
+        `position:${s.position};left:${s.left};top:${s.top};` +
+        `max-height:${pos.maxHeight}px;overflow-y:auto;justify-content:flex-start`
+    );
 }
 
 type MenuProps = {
@@ -78,7 +91,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
             { anchor: referenceEl, placement: props.placement ?? "bottom-start", avoidNativePanes: false },
             floatingEl,
         );
-        setFloatingStyle(styleToString(pos.style));
+        setFloatingStyle(styleToString(pos));
     };
 
     const registerFloating = (el: HTMLElement) => {
@@ -400,7 +413,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                     },
                     el,
                 );
-                setSubStyle(styleToString(computed.style));
+                setSubStyle(styleToString(computed));
             };
             cleanupAutoUpdate?.();
             // anchorRect is a static DOMRect, so autoUpdate's reference is a

--- a/frontend/util/cef-api.test.ts
+++ b/frontend/util/cef-api.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { isCef } from "./cef-api";
+import { isCef, showJsContextMenu } from "./cef-api";
 
 // ── isCef — #52 reload lock-out fix ──────────────────────────────────────────
 //
@@ -47,5 +47,99 @@ describe("isCef", () => {
     test("host-injected global present → true", () => {
         (window as unknown as { __AGENTMUX_IPC_PORT__?: number }).__AGENTMUX_IPC_PORT__ = 51234;
         expect(isCef()).toBe(true);
+    });
+});
+
+// ── showJsContextMenu — submenu placement (PR #2198) ─────────────────────────
+//
+// The second level historically used static `left:100%;top:0` CSS only and was
+// cut off at the window edge. It now routes through computeMenuPosition on
+// hover (fixed viewport coords, flip/shift/size), held visibility:hidden until
+// placed. The static CSS remains as the degraded fallback if the async
+// placement rejects, so a submenu is never revealed unpositioned.
+
+
+describe("showJsContextMenu — submenu placement", () => {
+    const removeOverlay = () => {
+        document.getElementById("cef-context-menu-overlay")?.remove();
+    };
+    beforeEach(removeOverlay);
+    afterEach(removeOverlay);
+
+    const menuWithSub: NativeContextMenuItem[] = [
+        {
+            id: "replace-with",
+            label: "Replace With...",
+            type: "submenu",
+            submenu: [
+                { label: "Terminal", id: "term" },
+                { label: "Browser", id: "web" },
+            ],
+        },
+    ];
+
+    const open = () => {
+        showJsContextMenu(menuWithSub, { x: 40, y: 40 }, null);
+        const overlay = document.getElementById("cef-context-menu-overlay")!;
+        const row = overlay.querySelector<HTMLElement>(".menu-item")!;
+        const sub = overlay.querySelector<HTMLElement>(".sub-menu")!;
+        return { overlay, row, sub };
+    };
+
+    const waitFor = async (cond: () => boolean, ms = 500) => {
+        const start = Date.now();
+        while (!cond()) {
+            if (Date.now() - start > ms) throw new Error("waitFor timed out");
+            await new Promise((r) => setTimeout(r, 5));
+        }
+    };
+
+    test("submenu starts hidden with the static edge-anchored fallback", () => {
+        const { row, sub } = open();
+        expect(sub.style.display).toBe("none");
+        // Degraded fallback: if framework placement ever rejects, these CSS
+        // values still anchor the submenu at the row's right edge.
+        expect(sub.style.left).toBe("100%");
+        expect(sub.style.top).toBe("0px");
+        expect(row.style.position).toBe("relative");
+    });
+
+    test("hover reveals it only after framework placement (fixed px coords + size cap)", async () => {
+        const { row, sub } = open();
+        row.dispatchEvent(new MouseEvent("mouseenter"));
+        // Shown immediately for measurement, but not yet visible — the
+        // pane-overlay clip must register the final rect only.
+        expect(sub.style.display).toBe("");
+        expect(sub.style.visibility).toBe("hidden");
+
+        await waitFor(() => sub.style.visibility === "");
+        expect(sub.style.position).toBe("fixed");
+        expect(sub.style.left).toMatch(/^-?\d+px$/);
+        expect(sub.style.top).toMatch(/^-?\d+px$/);
+        // size() cap applied: taller-than-free-space menus scroll internally.
+        expect(sub.style.maxHeight).toMatch(/^\d+px$/);
+        expect(sub.style.overflowY).toBe("auto");
+    });
+
+    test("mouseleave before placement resolves keeps it hidden (stale-promise guard)", async () => {
+        const { row, sub } = open();
+        row.dispatchEvent(new MouseEvent("mouseenter"));
+        row.dispatchEvent(new MouseEvent("mouseleave"));
+        expect(sub.style.display).toBe("none");
+        // Give the in-flight computeMenuPosition promise time to settle; the
+        // guard must not reveal a submenu whose hover already ended.
+        await new Promise((r) => setTimeout(r, 50));
+        expect(sub.style.display).toBe("none");
+        expect(sub.style.visibility).toBe("hidden");
+    });
+
+    test("top-level menu is framework-placed too (fixed coords, then revealed)", async () => {
+        const { overlay } = open();
+        const menuEl = overlay.querySelector<HTMLElement>(".menu")!;
+        expect(menuEl.style.visibility).toBe("hidden");
+        await waitFor(() => menuEl.style.visibility === "");
+        expect(menuEl.style.position).toBe("fixed");
+        expect(menuEl.style.left).toMatch(/^-?\d+px$/);
+        expect(menuEl.style.maxHeight).toMatch(/^\d+px$/);
     });
 });

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -8,7 +8,11 @@
 // the React app bootstraps.
 
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
-import { computeMenuPosition } from "@/app/util/menu-position";
+import {
+    assertMenuInPaintableArea,
+    computeMenuPosition,
+    type MenuPositionResult,
+} from "@/app/util/menu-position";
 import { benchMark } from "@/util/startup-bench";
 
 // Cache for "synchronous" values that are fetched once at startup.
@@ -120,6 +124,25 @@ export async function initCefApi(): Promise<void> {
 let contextMenuClickCallback: ((id: string) => void) | null = null;
 
 /**
+ * Apply a computed MenuPositionResult to a menu element: fixed left/top plus
+ * the size() max-height cap so a menu taller than the free space scrolls
+ * internally instead of being placed partly outside. max-width is deliberately
+ * NOT applied — an inline max-width would override (and can loosen) the .menu
+ * 400px CSS cap, and horizontal fit is already guaranteed by flip+shift for
+ * menus at or under that cap. justify-content is forced to flex-start because
+ * the .menu rule's flex-end makes overflow unreachable in a scroll container
+ * (it is a no-op when the menu fits, so this only matters when capped).
+ */
+function applyMenuPosition(el: HTMLElement, pos: MenuPositionResult) {
+    el.style.position = "fixed";
+    if (pos.style.left != null) el.style.left = String(pos.style.left);
+    if (pos.style.top != null) el.style.top = String(pos.style.top);
+    el.style.maxHeight = `${pos.maxHeight}px`;
+    el.style.overflowY = "auto";
+    el.style.justifyContent = "flex-start";
+}
+
+/**
  * Render a context menu as a positioned HTML overlay.
  * Fires the callback with the clicked item's id, then removes the overlay.
  */
@@ -197,13 +220,6 @@ function showJsContextMenu(
             row.appendChild(label);
 
             if (item.submenu && item.submenu.length > 0) {
-                // The submenu uses `position: absolute; left: 100%` to
-                // anchor at the row's right edge. That requires the
-                // row to be a positioned ancestor; otherwise `left:
-                // 100%` resolves against the outer .menu and every
-                // submenu opens at the same vertical position.
-                row.style.position = "relative";
-
                 const arrow = document.createElement("i");
                 arrow.className = "fa-sharp fa-solid fa-chevron-right";
                 row.appendChild(arrow);
@@ -212,11 +228,38 @@ function showJsContextMenu(
                 sub.className = "menu sub-menu";
                 sub.setAttribute("data-pane-overlay", "");
                 sub.style.display = "none";
-                sub.style.left = "100%";
-                sub.style.top = "0";
                 renderItems(sub, item.submenu);
                 row.appendChild(sub);
-                row.addEventListener("mouseenter", () => { sub.style.display = ""; });
+                // Positioned through the shared framework, like the top-level
+                // menu: anchored to the row, preferring right-start — flip()
+                // sends it left of the parent near the right edge, shift()
+                // pulls it up near the bottom, size() caps it when taller than
+                // the free space. The computed coords are position:fixed, so
+                // staying nested inside the row (which the hover logic needs)
+                // doesn't affect placement. Held visibility:hidden until
+                // placed for the same reason as the parent menu: the
+                // pane-overlay clip must register the final rect only.
+                row.addEventListener("mouseenter", () => {
+                    sub.style.visibility = "hidden";
+                    sub.style.display = "";
+                    void computeMenuPosition(
+                        {
+                            anchor: row.getBoundingClientRect(),
+                            placement: "right-start",
+                            avoidNativePanes: false,
+                        },
+                        sub,
+                    ).then((pos) => {
+                        // Hover may have left (or the whole menu closed)
+                        // before the async placement resolved.
+                        if (!sub.isConnected || sub.style.display === "none") return;
+                        applyMenuPosition(sub, pos);
+                        sub.style.visibility = "";
+                        assertMenuInPaintableArea(sub, "context-submenu");
+                    }).catch(() => {
+                        if (sub.isConnected) sub.style.visibility = "";
+                    });
+                });
                 row.addEventListener("mouseleave", () => { sub.style.display = "none"; });
             } else if (item.enabled !== false) {
                 row.addEventListener("click", () => {
@@ -250,9 +293,9 @@ function showJsContextMenu(
         menuEl,
     ).then((pos) => {
         if (!menuEl.isConnected) return;
-        if (pos.style.left != null) menuEl.style.left = String(pos.style.left);
-        if (pos.style.top != null) menuEl.style.top = String(pos.style.top);
+        applyMenuPosition(menuEl, pos);
         menuEl.style.visibility = "";
+        assertMenuInPaintableArea(menuEl, "context-menu");
     }).catch(() => {
         // computeMenuPosition should not throw; if it does, fall back to the
         // raw cursor position rather than leaving the menu invisible.

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -145,8 +145,9 @@ function applyMenuPosition(el: HTMLElement, pos: MenuPositionResult) {
 /**
  * Render a context menu as a positioned HTML overlay.
  * Fires the callback with the clicked item's id, then removes the overlay.
+ * Exported for tests only — production callers go through showContextMenu.
  */
-function showJsContextMenu(
+export function showJsContextMenu(
     items: NativeContextMenuItem[],
     position: { x: number; y: number },
     onClick: ((id: string) => void) | null
@@ -220,6 +221,13 @@ function showJsContextMenu(
             row.appendChild(label);
 
             if (item.submenu && item.submenu.length > 0) {
+                // Static CSS fallback (the pre-framework behavior): anchor at
+                // the row's right edge, which needs the row as positioned
+                // ancestor. Kept so a computeMenuPosition rejection still
+                // yields a positioned submenu; the framework placement below
+                // overrides it with fixed viewport coords on success.
+                row.style.position = "relative";
+
                 const arrow = document.createElement("i");
                 arrow.className = "fa-sharp fa-solid fa-chevron-right";
                 row.appendChild(arrow);
@@ -228,6 +236,8 @@ function showJsContextMenu(
                 sub.className = "menu sub-menu";
                 sub.setAttribute("data-pane-overlay", "");
                 sub.style.display = "none";
+                sub.style.left = "100%";
+                sub.style.top = "0";
                 renderItems(sub, item.submenu);
                 row.appendChild(sub);
                 // Positioned through the shared framework, like the top-level


### PR DESCRIPTION
## Problem

Right-click a pane header near the window's right edge and hover **"Replace With..."** — the second-level submenu paints off-window and is cut off. Same for "Pane Color" and any `type: "submenu"` item.

## Root cause

`showJsContextMenu` (`frontend/util/cef-api.ts`) — the renderer behind every pane right-click menu — routes its **top-level** menu through `computeMenuPosition`, but its **submenu branch** kept pre-framework CSS: `position:absolute; left:100%; top:0` inside the hovered row. No flip, no shift, no size cap, and no `assertMenuInPaintableArea` call, so the framework's dev guard was structurally blind to it (the guard is opt-in per call site). This is the SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20 Phase 3 ("manual-math surfaces") site that was missed.

Full analysis: `docs/analysis/submenu-offscreen-second-level-2026-07-16.md` (bundled).

## Fix

- On row hover, the submenu is placed via `computeMenuPosition({anchor: row.getBoundingClientRect(), placement: "right-start", avoidNativePanes: false})` — flip sends it left of the parent near the right edge, shift pulls it up near the bottom. Coordinates are `position:fixed`, so the DOM nesting the hover logic needs doesn't affect placement. Held `visibility:hidden` until placed (same pane-overlay-clip rationale as the top level) and guarded with `assertMenuInPaintableArea(sub, "context-submenu")`.
- Secondary gap fixed in the same pass: `computeMenuPosition`'s `maxHeight` cap was returned but dropped by every consumer. Both `showJsContextMenu` levels and `FlyoutMenu`'s `styleToString` now apply `max-height` + `overflow-y:auto` (+ `justify-content:flex-start`, since `.menu`'s `flex-end` makes overflow unreachable in a scroll container — a no-op when the menu fits). `maxWidth` is deliberately **not** applied: an inline max-width would override, and can loosen, the `.menu` 400px CSS cap; horizontal fit is already guaranteed by flip+shift for menus at or under that cap.

## Verification

- `tsc --noEmit` clean; `vitest run` on `cef-api.test.ts` + `menu-position.test.ts`: 21/21 pass.
- Manual repro to check on a live build: window near the screen's right edge → right-click a pane header in the window's right half → hover "Replace With..." and "Pane Color" — both must open to the LEFT of the parent and stay fully visible; dev console shows no `[menu-guard]` errors.

<!-- agentmux:agent_id=agenta-07017 -->