### PR TITLE
fix(cef): macOS build broken by openpty winsize mutability (#2193 regression)

### DIFF
--- a/.changesets/1784285459-fix-cef-macos-build-broken-by-openpty-winsize-mutability-219-hzr6.md
+++ b/.changesets/1784285459-fix-cef-macos-build-broken-by-openpty-winsize-mutability-219-hzr6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): macOS build broken by openpty winsize mutability (#2193 regression)

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -754,7 +754,11 @@ fn spawn_login_pty_unix(
             &mut slave_fd,
             std::ptr::null_mut(),
             std::ptr::null_mut(),
-            &ws,
+            // `&mut` coerces to both platform bindings: Apple libc declares
+            // `winp: *mut winsize`, Linux `*const winsize`. A plain `&ws`
+            // only satisfies Linux — breaking macOS builds, which CI never
+            // compiles (no macOS runner).
+            &mut ws,
         )
     };
     if rc != 0 {


### PR DESCRIPTION
## Summary

Every macOS build has been failing with E0308 since #2193 merged this morning: `spawn_login_pty_unix` passes `&ws` to `libc::openpty`, whose `winp` parameter is declared `*mut winsize` in Apple's libc binding but `*const winsize` on Linux — so Linux/Windows CI compiled green while macOS broke. `&mut ws` coerces to both signatures (with a comment explaining the platform divergence so it doesn't regress).

Found because `task dev` on a Mac stopped building; verified with `cargo check -p agentmux-cef` on darwin.

## Test plan
- [x] `cargo check -p agentmux-cef` on macOS: compiles (was E0308)
- [x] No behavior change — pointer mutability coercion only