### PR TITLE
fix(activity-dock): group subagent rows by workflow, one dock row per Agent-tool call

### DIFF
--- a/.changesets/1784287906-fix-activity-dock-group-subagent-rows-by-workflow-one-dock-r-ih5r.md
+++ b/.changesets/1784287906-fix-activity-dock-group-subagent-rows-by-workflow-one-dock-r-ih5r.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(activity-dock): group subagent rows by workflow, one dock row per Agent-tool call

--- a/frontend/app/view/agent/activity/subagent-adapter.test.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.test.ts
@@ -67,4 +67,52 @@ describe("subagentActivities", () => {
     it("returns an empty array when no subagents match the block", () => {
         expect(subagentActivities([mk({ agent_id: "a1", parent_block_id: "block-2" })], "block-1")).toEqual([]);
     });
+
+    it("collapses a Workflow-tool batch (shared workflow_id) into one row, not one per subagent", () => {
+        // Regression for the live-reported "dozens of subagents in the dock
+        // for 1-2 tool calls" bug — a single Workflow-tool call spawning many
+        // subagents must render as one dock row, matching the Swarm tree's
+        // own WorkflowGroup collapse.
+        const all = [
+            mk({ agent_id: "a1", workflow_id: "wf_1", slug: "batch", spawned_at: 100, last_event_at: 300, status: "active" }),
+            mk({ agent_id: "a2", workflow_id: "wf_1", slug: "batch", spawned_at: 150, last_event_at: 400, status: "active" }),
+            mk({ agent_id: "a3", workflow_id: "wf_1", slug: "batch", spawned_at: 200, last_event_at: 500, status: "completed" }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("wf:wf_1");
+        expect(result[0].title).toBe("batch (3)");
+        expect(result[0].status).toBe("running"); // ≥1 member still active
+        expect(result[0].startedAt).toBe(100); // earliest member
+        expect(result[0].canStop).toBe(false);
+    });
+
+    it("marks a workflow group done once every member is terminal", () => {
+        const all = [
+            mk({ agent_id: "a1", workflow_id: "wf_1", slug: "batch", status: "completed", last_event_at: 300 }),
+            mk({ agent_id: "a2", workflow_id: "wf_1", slug: "batch", status: "abandoned", last_event_at: 400 }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result).toHaveLength(1);
+        expect(result[0].status).toBe("done");
+        expect(result[0].endedAt).toBe(400);
+    });
+
+    it("collapses same-name loose subagents (no workflow_id) into one row", () => {
+        const all = [
+            mk({ agent_id: "a1", display_name: "Code Reviewer", spawned_at: 100 }),
+            mk({ agent_id: "a2", display_name: "Code Reviewer", spawned_at: 200 }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result).toHaveLength(1);
+        expect(result[0].title).toBe("Code Reviewer (2)");
+    });
+
+    it("leaves a lone, uniquely-named subagent as its own row", () => {
+        const all = [mk({ agent_id: "a1", display_name: "One-off task" })];
+        const result = subagentActivities(all, "block-1");
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("a1");
+        expect(result[0].title).toBe("One-off task");
+    });
 });

--- a/frontend/app/view/agent/activity/subagent-adapter.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.ts
@@ -13,10 +13,35 @@
  * action either). Wiring a real cancel is its own follow-up, not invented
  * here just because the dock's row chrome has a stop button slot.
  *
+ * Grouping: a single Workflow-tool call can spawn dozens of subagents at once
+ * (the Swarm pane's own docs cite 45 observed live —
+ * REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md Finding 4). Left flat,
+ * one dock row per `ActiveSubagent` reads as "dozens of subagents" for what
+ * was really one Agent-tool call from this pane's perspective — reported
+ * live 2026-07-16. Reuses the Swarm pane's own `groupSubagentsByWorkflow`
+ * (shared `workflow_id` → one `WorkflowGroup`; same-name loose subagents →
+ * one `NameGroup`) instead of re-deriving the grouping rules, so the dock and
+ * the Swarm tree always agree on what counts as "one call".
+ *
+ * Known simplification: a grouped row's expanded view and tail text show
+ * only the group's most-recently-active member (`representative`), not every
+ * member's transcript — the dock's row chrome (ActivityRow.tsx) renders one
+ * `subagent` per row today; teaching it a real multi-member expanded view is
+ * a follow-up, not required to fix the row-count explosion this addresses.
+ *
  * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md (§3, §7)
  */
 
-import type { ActiveSubagent } from "../../swarm/swarm-model";
+import {
+    groupCacheKey,
+    groupSubagentsByWorkflow,
+    isNameGroup,
+    isWorkflowGroup,
+    type ActiveSubagent,
+    type NameGroup,
+    type SwarmChild,
+    type WorkflowGroup,
+} from "../../swarm/swarm-model";
 import type { ActivityStatus, PinnedActivity } from "./types";
 
 function subagentStatusToActivity(s: ActiveSubagent["status"]): ActivityStatus {
@@ -51,11 +76,36 @@ export function subagentToActivity(s: ActiveSubagent): PinnedActivity {
     };
 }
 
-/** This pane's own subagents (`parent_block_id === blockId`), mapped to activities. */
+/** One dock row for a whole `WorkflowGroup`/`NameGroup` batch — see the
+ *  module comment's "Known simplification" for why `subagent` is a single
+ *  representative member rather than the full group. `id` reuses the Swarm
+ *  pane's own `groupCacheKey` (`wf:<id>` / `name:<blockId>:<name>`) so the
+ *  dock and the Swarm tree never invent two different identity schemes for
+ *  the same group. */
+function groupToActivity(g: WorkflowGroup | NameGroup): PinnedActivity {
+    const representative = g.subagents[0]; // groupSubagentsByWorkflow sorts newest-first
+    return {
+        id: groupCacheKey(g),
+        kind: "subagent",
+        title: `${g.name} (${g.totalCount})`,
+        status: g.status === "active" ? "running" : "done",
+        startedAt: Math.min(...g.subagents.map((s) => s.spawned_at)),
+        endedAt: g.status === "retired" ? g.lastEventAt : undefined,
+        canStop: false,
+        subagent: representative,
+    };
+}
+
+function swarmChildToActivity(c: SwarmChild): PinnedActivity {
+    if (isWorkflowGroup(c) || isNameGroup(c)) return groupToActivity(c);
+    return subagentToActivity(c);
+}
+
+/** This pane's own subagents (`parent_block_id === blockId`), grouped by
+ *  `workflow_id`/shared name exactly as the Swarm tree groups them, then
+ *  mapped to activities — one dock row per Agent-tool call, not per
+ *  subagent. */
 export function subagentActivities(all: ReadonlyArray<ActiveSubagent>, blockId: string): PinnedActivity[] {
-    const out: PinnedActivity[] = [];
-    for (const s of all) {
-        if (s.parent_block_id === blockId) out.push(subagentToActivity(s));
-    }
-    return out;
+    const mine = all.filter((s) => s.parent_block_id === blockId);
+    return groupSubagentsByWorkflow(mine).map(swarmChildToActivity);
 }


### PR DESCRIPTION
## Summary
- Live-reported: the pinned activity dock showed dozens of subagent rows for what was actually 1-2 Agent-tool calls.
- Root cause: `subagent-adapter.ts` mapped every `ActiveSubagent` to its own `PinnedActivity`, regardless of whether it was a standalone Task-tool subagent or one member of a Workflow-tool batch spawning dozens at once (the Swarm docs cite 45 observed live in one run).
- The Swarm pane already solved exactly this with `groupSubagentsByWorkflow` (shared `workflow_id` → one `WorkflowGroup`; same-name loose subagents → one `NameGroup`) — the dock adapter never adopted it. This PR reuses that grouping and its `groupCacheKey` identity scheme directly instead of re-deriving the rules, so the dock and the Swarm tree always agree on what counts as "one call".
- Known simplification (documented in a code comment): a grouped row's expanded view and tail text show only the most-recently-active member, not every member's transcript — `ActivityRow.tsx` renders one `subagent` per row today; a real multi-member expanded view is a follow-up, not required to fix the row-count explosion.

## Test plan
- [x] `tsc --noEmit` — passes
- [x] New tests: workflow-batch collapse, workflow-group-done-once-all-terminal, same-name loose-subagent collapse, lone-subagent-stays-ungrouped — all pass
- [x] Existing `subagent-adapter.test.ts` (unchanged behavior for all-loose input) — passes
- [x] `swarm-model.test.ts` (shared grouping logic, unmodified) — 34/34 pass

<!-- agentmux:agent_id=agent2 -->