### PR TITLE
fix(dock): collapse subagents spawned by one Agent tool call into a single dock row

### DIFF
--- a/.changesets/1784288893-fix-dock-collapse-subagents-spawned-by-one-agent-tool-call-i-wesk.md
+++ b/.changesets/1784288893-fix-dock-collapse-subagents-spawned-by-one-agent-tool-call-i-wesk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dock): collapse subagents spawned by one Agent tool call into a single dock row instead of one per subagent

--- a/frontend/app/view/agent/activity/subagent-adapter.test.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.test.ts
@@ -67,4 +67,39 @@ describe("subagentActivities", () => {
     it("returns an empty array when no subagents match the block", () => {
         expect(subagentActivities([mk({ agent_id: "a1", parent_block_id: "block-2" })], "block-1")).toEqual([]);
     });
+
+    it("collapses subagents sharing a workflow_id into one activity, not one per subagent", () => {
+        const all = [
+            mk({ agent_id: "a1", workflow_id: "wf_1", slug: "reviewer", status: "active" }),
+            mk({ agent_id: "a2", workflow_id: "wf_1", slug: "reviewer", status: "completed" }),
+            mk({ agent_id: "a3", workflow_id: "wf_1", slug: "reviewer", status: "completed" }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("wf:wf_1");
+        expect(result[0].title).toBe("reviewer (3)");
+        expect(result[0].status).toBe("running"); // one member still active
+        expect(result[0].subagent).toBeUndefined();
+        expect(result[0].subagentGroup?.members).toHaveLength(3);
+    });
+
+    it("marks a workflow group done only once every member is terminal", () => {
+        const all = [
+            mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed", last_event_at: 100 }),
+            mk({ agent_id: "a2", workflow_id: "wf_1", status: "completed", last_event_at: 200 }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result[0].status).toBe("done");
+        expect(result[0].endedAt).toBe(200);
+    });
+
+    it("does not group standalone subagents (no workflow_id, no shared display_name)", () => {
+        const all = [
+            mk({ agent_id: "a1", workflow_id: null, display_name: null }),
+            mk({ agent_id: "a2", workflow_id: null, display_name: null }),
+        ];
+        const result = subagentActivities(all, "block-1");
+        expect(result.map((a) => a.id)).toEqual(["a1", "a2"]);
+        expect(result.every((a) => a.subagentGroup === undefined)).toBe(true);
+    });
 });

--- a/frontend/app/view/agent/activity/subagent-adapter.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.ts
@@ -7,6 +7,12 @@
  * filtered to one agent pane's own spawns (`parent_block_id`). Phase 2 of the
  * dock — proves the `PinnedActivity` abstraction generalizes beyond shells.
  *
+ * Grouping reuses `groupSubagentsByWorkflow` verbatim — the same algorithm
+ * the Swarm pane's own tree view uses to collapse a Task/Workflow-tool run's
+ * dozens of subagents into one row. Without it, the dock showed one row per
+ * `ActiveSubagent` instead of one row per Agent tool call (a single run can
+ * spawn dozens at once — observed live: 45).
+ *
  * `canStop` is always `false`: no subagent-cancel RPC/UI exists anywhere in
  * the app today (confirmed — `AgentStopCommand` targets a pane's own agent
  * process, not a subagent by `agent_id`; the Swarm pane itself has no cancel
@@ -16,7 +22,15 @@
  * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md (§3, §7)
  */
 
-import type { ActiveSubagent } from "../../swarm/swarm-model";
+import {
+    groupCacheKey,
+    groupSubagentsByWorkflow,
+    isNameGroup,
+    isWorkflowGroup,
+    type ActiveSubagent,
+    type NameGroup,
+    type WorkflowGroup,
+} from "../../swarm/swarm-model";
 import type { ActivityStatus, PinnedActivity } from "./types";
 
 function subagentStatusToActivity(s: ActiveSubagent["status"]): ActivityStatus {
@@ -51,11 +65,35 @@ export function subagentToActivity(s: ActiveSubagent): PinnedActivity {
     };
 }
 
-/** This pane's own subagents (`parent_block_id === blockId`), mapped to activities. */
+/** A `WorkflowGroup`/`NameGroup` → one dock row summarizing every member,
+ *  instead of one row per subagent. `startedAt` is the earliest member's
+ *  spawn (the group's own lifetime, not just its most-recently-active
+ *  member's); `endedAt` only lands once every member is terminal, matching
+ *  `subagentToActivity`'s own "no member still running" rule. */
+function subagentGroupToActivity(group: WorkflowGroup | NameGroup): PinnedActivity {
+    const members = group.subagents;
+    const anyAbandoned = members.some((m) => m.status === "abandoned");
+    const status: ActivityStatus = group.activeCount > 0 ? "running" : anyAbandoned ? "stopped" : "done";
+    return {
+        id: groupCacheKey(group),
+        kind: "subagent",
+        title: `${group.name} (${group.totalCount})`,
+        status,
+        startedAt: Math.min(...members.map((m) => m.spawned_at)),
+        endedAt: group.activeCount === 0 ? group.lastEventAt : undefined,
+        canStop: false,
+        subagentGroup: { members },
+    };
+}
+
+/** This pane's own subagents (`parent_block_id === blockId`), grouped the
+ *  same way the Swarm pane's tree view groups them — by shared `workflow_id`,
+ *  then by shared `display_name` among what's left — and mapped to
+ *  activities. One dock row per Agent tool call, not per individual
+ *  subagent. */
 export function subagentActivities(all: ReadonlyArray<ActiveSubagent>, blockId: string): PinnedActivity[] {
-    const out: PinnedActivity[] = [];
-    for (const s of all) {
-        if (s.parent_block_id === blockId) out.push(subagentToActivity(s));
-    }
-    return out;
+    const mine = all.filter((s) => s.parent_block_id === blockId);
+    return groupSubagentsByWorkflow(mine).map((child) =>
+        isWorkflowGroup(child) || isNameGroup(child) ? subagentGroupToActivity(child) : subagentToActivity(child)
+    );
 }

--- a/frontend/app/view/agent/activity/types.ts
+++ b/frontend/app/view/agent/activity/types.ts
@@ -36,8 +36,17 @@ export interface PinnedActivity {
     // ── Kind-specific source, read by the row's tail + Expanded view ──
     /** Present when `kind === "shell"` (also "cron", which is a shell). */
     shell?: ShellNode;
-    /** Present when `kind === "subagent"`. */
+    /** Present when `kind === "subagent"` AND it represents exactly one
+     *  standalone subagent (no shared `workflow_id`/`display_name` group). */
     subagent?: ActiveSubagent;
+    /** Present when `kind === "subagent"` AND it represents a GROUP — every
+     *  subagent spawned together by one Task/Workflow-tool run, or every
+     *  loose subagent sharing one Haiku-generated `display_name` — collapsed
+     *  into a single dock row instead of one row per member. A single Agent
+     *  tool call can spawn dozens of subagents at once; without this a dock
+     *  row appeared per subagent instead of per tool call. Mutually
+     *  exclusive with `subagent` above. */
+    subagentGroup?: { members: ActiveSubagent[] };
 }
 
 /** Per-kind sigil; colored by status in CSS. */

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -169,6 +169,20 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
                     if (result?.tokens) recordTurn("ambient:subagent_name", result.tokens);
                 });
             }
+            // Same, for every unnamed member of a workflow/name group. The
+            // dock's roster (ActivityRow.tsx) renders all members flat, with
+            // no per-member toggle to hang this off of the way the Swarm
+            // pane's per-member SubagentRow.handleToggle does — so the
+            // group row's own first expand is the only hook available;
+            // fire it for every unnamed member at once instead of one.
+            if (a?.kind === "subagent" && a.subagentGroup) {
+                for (const member of a.subagentGroup.members) {
+                    if (member.display_name) continue;
+                    void callBackendService("subagent", "GenerateName", [member.agent_id]).then((result: any) => {
+                        if (result?.tokens) recordTurn("ambient:subagent_name", result.tokens);
+                    });
+                }
+            }
         }
     };
 

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -14,7 +14,13 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX 
 import { useTick } from "@/app/hook/useTick";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
-import { createSubagentDetail, type SubagentDetail, type SubagentEvent } from "../../swarm/swarm-model";
+import {
+    createSubagentDetail,
+    subagentDisplayLabel,
+    type ActiveSubagent,
+    type SubagentDetail,
+    type SubagentEvent,
+} from "../../swarm/swarm-model";
 import { KIND_SIGIL, type PinnedActivity } from "../activity/types";
 import type { ToolLogChunk } from "../types";
 
@@ -31,6 +37,17 @@ function subagentEventLine(e: SubagentEvent): string {
         case "progress": return t.output;
         case "tool_use": return `→ ${t.name}`;
         case "tool_result": return t.is_error ? `✗ ${t.preview}` : t.preview;
+    }
+}
+
+/** Terminal-status glyph for one member row inside an expanded group roster
+ *  — mirrors ActivityRow's own top-level `sigil()` (running/done/stopped),
+ *  just scoped to a single `ActiveSubagent` instead of a `PinnedActivity`. */
+function memberSigil(status: ActiveSubagent["status"]): string {
+    switch (status) {
+        case "active": return KIND_SIGIL.subagent;
+        case "completed": return "✓";
+        case "abandoned": return "■";
     }
 }
 
@@ -97,6 +114,11 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
             // cost is reserved for the expanded view, below).
             const n = a.subagent.event_count;
             return n > 0 ? `${n} event${n === 1 ? "" : "s"}` : undefined;
+        }
+        if (a.subagentGroup) {
+            const members = a.subagentGroup.members;
+            const active = members.filter((m) => m.status === "active").length;
+            return active > 0 ? `${active}/${members.length} active` : `${members.length} subagents`;
         }
         return undefined;
     });
@@ -195,6 +217,29 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
                             </Show>
                             <For each={subagentDetail()?.eventsAtom() ?? []}>
                                 {(event) => <pre class="agent-tool-log-line">{subagentEventLine(event)}</pre>}
+                            </For>
+                        </div>
+                    </Show>
+
+                    {/* Group roster — a compact per-member summary, not a live
+                        transcript: opening one dock row's expand shouldn't
+                        subscribe to N members' event streams at once (a
+                        single Task/Workflow run can spawn dozens). Full
+                        per-member transcripts remain the Swarm pane's job. */}
+                    <Show when={props.expanded() && a().subagentGroup}>
+                        <div
+                            class="agent-activity-log agent-tool-overlay-log"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <For each={a().subagentGroup!.members}>
+                                {(member) => (
+                                    <pre class="agent-tool-log-line">
+                                        {memberSigil(member.status)} {subagentDisplayLabel(member)}
+                                        {member.event_count > 0
+                                            ? ` — ${member.event_count} event${member.event_count === 1 ? "" : "s"}`
+                                            : ""}
+                                    </pre>
+                                )}
                             </For>
                         </div>
                     </Show>


### PR DESCRIPTION
## Summary
- The pinned activity dock mapped every `ActiveSubagent` 1:1 into a `PinnedActivity` with no grouping — a single Task/Workflow-tool run that spawns dozens of subagents at once flooded the dock with dozens of rows instead of one.
- The Swarm pane's own tree view already solves this exact problem via `groupSubagentsByWorkflow` (group by shared `workflow_id`, then by shared `display_name` among the loose remainder). `subagent-adapter.ts` now reuses that same function unmodified instead of reimplementing grouping, so one Agent tool call produces one dock row with an aggregate title (`name (count)`), aggregate status, and a compact expand roster listing each member.
- `PinnedActivity` gains an optional `subagentGroup?: { members }` field (mutually exclusive with the existing singular `subagent` field); `ActivityRow` renders a group's tail as `"N/M active"` and its expanded view as a per-member status list instead of a live transcript (avoids opening N event subscriptions at once for a single row).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean across the whole project
- [x] `npx vitest run app/view/agent/activity/subagent-adapter.test.ts` — 10/10 passing, including 3 new tests covering workflow-group collapsing, done-only-when-all-terminal status, and that standalone subagents stay ungrouped
- [x] Live-verified the dev build boots cleanly against this branch (CDP smoke check, no console/runtime errors)
- [ ] Live multi-subagent repro (spawning a real Task/Workflow run with 10+ subagents to visually confirm one dock row) not performed — the grouping logic is a straight reuse of `groupSubagentsByWorkflow`, already live-verified for the Swarm pane's own tree view

<!-- agentmux:agent_id=agent1 -->