### PR TITLE
fix(srv): cap cold-backfill subagent replay to the most recent files

### DIFF
--- a/.changesets/1784304035-fix-srv-subagent-backfill-cap.md
+++ b/.changesets/1784304035-fix-srv-subagent-backfill-cap.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): cap cold-backfill subagent replay to the 200 most-recent files — an unbounded full-history replay on every pane reopen/srv restart was a live contributor to a launcher-killing crash loop

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -1481,6 +1481,15 @@ fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEventType> {
     }
 }
 
+/// Modification time of `path`, or `UNIX_EPOCH` if it can't be read (a
+/// vanished/permission-denied file sorts oldest — excluded first by
+/// `scan_subagents_dir`'s recency cap rather than crashing the scan).
+fn file_mtime(path: &Path) -> std::time::SystemTime {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
 /// Walk up `path`'s ancestors (parent, grandparent, ...) and return the
 /// first one that already exists on disk. Used by `watch_agent` when the
 /// target directory doesn't exist yet — `notify::Watcher::watch` fails
@@ -1500,15 +1509,6 @@ fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEventType> {
 /// (giving up on watching rather than risking an unbounded walk) if `path`
 /// isn't under the home directory at all, or if no existing ancestor is
 /// found within that bound.
-/// Modification time of `path`, or `UNIX_EPOCH` if it can't be read (a
-/// vanished/permission-denied file sorts oldest — excluded first by
-/// `scan_subagents_dir`'s recency cap rather than crashing the scan).
-fn file_mtime(path: &Path) -> std::time::SystemTime {
-    std::fs::metadata(path)
-        .and_then(|m| m.modified())
-        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
-}
-
 fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
     let floor = dirs::home_dir()?;
     path.ancestors()

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -133,6 +133,13 @@ struct SessionWatch {
 /// the hard ceiling on what's retained to serve it from.
 const MAX_SUBAGENT_EVENTS: usize = 2048;
 
+/// Cap on how many `agent-*.jsonl` files `scan_subagents_dir` will replay in
+/// one cold backfill (pane reopen / srv restart) — see that function's doc
+/// comment. 200 comfortably covers a real reopen's "what happened recently"
+/// use case while bounding the worst case to a fixed, small cost regardless
+/// of how many workflow runs a long-lived session has accumulated.
+const BACKFILL_MAX_FILES: usize = 200;
+
 struct SubagentState {
     info: SubagentInfo,
     file_offset: u64,
@@ -703,18 +710,45 @@ impl SubagentWatcher {
 
     /// Process agent-*.jsonl directly in `dir`, plus workflow runs under
     /// `dir/workflows/<wf>/` (member agent files + journal).
+    ///
+    /// A pane's `subagents/` directory accumulates forever — every Task-tool
+    /// and Workflow-tool run this session has ever made leaves its
+    /// `agent-*.jsonl` files behind. Because `is_new` (`process_jsonl_change`)
+    /// is keyed off the in-memory `sessions` map, which starts empty on every
+    /// srv process (restart or fresh start), an unbounded scan here replays
+    /// the session's ENTIRE history — full-file read + parse + WS broadcast
+    /// per file — on every pane reopen or srv restart. On a heavily-used pane
+    /// this is a genuine crash trigger, not just wasted work: a live incident
+    /// (see docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md) hit
+    /// 1,000+ replayed files across three back-to-back srv restarts in under
+    /// 10 seconds, on a machine already near its commit ceiling — the
+    /// resulting allocation/broadcast storm is a plausible contributor to
+    /// each restart re-crashing before the launcher's 3-strikes budget gave
+    /// up and killed the whole app.
+    ///
+    /// Bound the replay to the `BACKFILL_MAX_FILES` most-recently-modified
+    /// agent files (by mtime) — recent activity is what the Swarm pane's
+    /// reopen backfill exists to show; a months-old workflow run replaying on
+    /// every restart serves no one. Skipped files are still on disk and
+    /// still show up via `list_active`'s normal file-count telemetry if
+    /// something later reads them directly — this only bounds the *push*
+    /// (broadcast) side of a cold backfill.
     fn scan_subagents_dir(&self, parent_agent: &str, parent_block_id: &str, dir: &Path) {
+        let mut candidates: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+
         if let Ok(files) = std::fs::read_dir(dir) {
             for file in files.flatten() {
                 let path = file.path();
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                     if name.starts_with("agent-") && name.ends_with(".jsonl") {
-                        self.process_jsonl_change(parent_agent, parent_block_id, &path);
+                        candidates.push((file_mtime(&path), path));
                     }
                 }
             }
         }
+
         let workflows_dir = dir.join("workflows");
+        let mut journals: Vec<PathBuf> = Vec::new();
         if let Ok(runs) = std::fs::read_dir(&workflows_dir) {
             for run in runs.flatten() {
                 if let Ok(files) = std::fs::read_dir(run.path()) {
@@ -724,16 +758,39 @@ impl SubagentWatcher {
                             Some(name)
                                 if name.starts_with("agent-") && name.ends_with(".jsonl") =>
                             {
-                                self.process_jsonl_change(parent_agent, parent_block_id, &path);
+                                candidates.push((file_mtime(&path), path));
                             }
-                            Some("journal.jsonl") => {
-                                self.process_journal_change(parent_agent, parent_block_id, &path);
-                            }
+                            // Journals are one small file per run (not one per
+                            // member agent) — always process them so
+                            // `workflow:updated`/run status stay accurate
+                            // regardless of the member-file cap below.
+                            Some("journal.jsonl") => journals.push(path),
                             _ => {}
                         }
                     }
                 }
             }
+        }
+
+        let total = candidates.len();
+        candidates.sort_by(|a, b| b.0.cmp(&a.0)); // newest mtime first
+        let skipped = total.saturating_sub(BACKFILL_MAX_FILES);
+        if skipped > 0 {
+            tracing::info!(
+                agent = %parent_agent,
+                parent_block_id = %parent_block_id,
+                dir = %dir.display(),
+                total,
+                skipped,
+                cap = BACKFILL_MAX_FILES,
+                "scan_subagents_dir: capping cold-backfill replay to the most recent files"
+            );
+        }
+        for (_, path) in candidates.into_iter().take(BACKFILL_MAX_FILES) {
+            self.process_jsonl_change(parent_agent, parent_block_id, &path);
+        }
+        for path in journals {
+            self.process_journal_change(parent_agent, parent_block_id, &path);
         }
     }
 
@@ -1443,6 +1500,15 @@ fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEventType> {
 /// (giving up on watching rather than risking an unbounded walk) if `path`
 /// isn't under the home directory at all, or if no existing ancestor is
 /// found within that bound.
+/// Modification time of `path`, or `UNIX_EPOCH` if it can't be read (a
+/// vanished/permission-denied file sorts oldest — excluded first by
+/// `scan_subagents_dir`'s recency cap rather than crashing the scan).
+fn file_mtime(path: &Path) -> std::time::SystemTime {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
 fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
     let floor = dirs::home_dir()?;
     path.ancestors()
@@ -1596,6 +1662,17 @@ mod tests {
 
     fn fixture_watcher() -> SubagentWatcher {
         SubagentWatcher::new(Arc::new(EventBus::new()))
+    }
+
+    /// Write a minimal terminated subagent JSONL file with an explicit mtime
+    /// (`UNIX_EPOCH + offset_secs`), so backfill-ordering tests don't depend
+    /// on real wall-clock write speed / filesystem timestamp resolution.
+    fn write_agent_file_with_mtime(path: &Path, offset_secs: u64) {
+        use std::io::Write;
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(b"{\"type\":\"result\",\"result\":\"done\"}\n").unwrap();
+        f.set_modified(std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(offset_secs))
+            .unwrap();
     }
 
     fn fixture_state(parent_agent: &str, agent_id: &str, session_id: &str) -> SubagentState {
@@ -2081,6 +2158,103 @@ mod tests {
         watcher.scan_session_subagents("parent-1", "block-1", &config_dir, "never-existed");
 
         assert!(watcher.list_active().is_empty(), "unknown session id must not fall back to scanning everything");
+
+        std::fs::remove_dir_all(&config_dir).ok();
+    }
+
+    // ── scan_subagents_dir backfill cap (docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md) ──
+    //
+    // A long-lived pane's subagents/ directory accumulates forever; without a
+    // cap, every cold backfill (pane reopen, srv restart) replays the WHOLE
+    // history — a live incident hit 1,000+ replayed files across three
+    // back-to-back srv crash-restarts in under 10 seconds. These tests lock
+    // in the fix: the cap applies regardless of corpus size, and it always
+    // keeps the most RECENT files, not an arbitrary subset.
+
+    #[test]
+    fn scan_subagents_dir_caps_cold_backfill_to_the_most_recent_files() {
+        let config_dir = std::env::temp_dir()
+            .join(format!("amx-scan-backfill-cap-test-{}", now_millis()));
+        let session_id = "backfill-cap-session";
+        let subagents_dir = config_dir
+            .join("projects")
+            .join("ws-enc")
+            .join(session_id)
+            .join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+
+        // One more file than the cap, mtimes strictly increasing by index —
+        // "newest BACKFILL_MAX_FILES" is unambiguous regardless of directory
+        // enumeration order.
+        let total = BACKFILL_MAX_FILES + 1;
+        for i in 0..total {
+            let path = subagents_dir.join(format!("agent-id{i:04}.jsonl"));
+            write_agent_file_with_mtime(&path, i as u64);
+        }
+
+        let watcher = fixture_watcher();
+        watcher.scan_session_subagents("parent-1", "block-1", &config_dir, session_id);
+
+        let active = watcher.list_active();
+        assert_eq!(
+            active.len(),
+            BACKFILL_MAX_FILES,
+            "cold backfill must not replay more than the cap regardless of corpus size"
+        );
+        assert!(
+            !active.iter().any(|a| a.agent_id == "id0000"),
+            "the single oldest file must be the one dropped"
+        );
+        assert!(
+            active
+                .iter()
+                .any(|a| a.agent_id == format!("id{:04}", total - 1)),
+            "the newest file must always survive the cap"
+        );
+
+        std::fs::remove_dir_all(&config_dir).ok();
+    }
+
+    #[test]
+    fn scan_subagents_dir_processes_workflow_journal_even_beyond_the_member_cap() {
+        let config_dir = std::env::temp_dir()
+            .join(format!("amx-scan-backfill-journal-test-{}", now_millis()));
+        let session_id = "backfill-journal-session";
+        let run_dir = config_dir
+            .join("projects")
+            .join("ws-enc")
+            .join(session_id)
+            .join("subagents")
+            .join("workflows")
+            .join("wf_test-run");
+        std::fs::create_dir_all(&run_dir).unwrap();
+
+        // More member files than the cap — the cap must still apply here...
+        let total = BACKFILL_MAX_FILES + 5;
+        for i in 0..total {
+            let path = run_dir.join(format!("agent-id{i:04}.jsonl"));
+            write_agent_file_with_mtime(&path, i as u64);
+        }
+        // ...but the run's journal (one small file, not one per member) is
+        // always processed regardless — it drives `workflow:updated`/run
+        // status, which must stay accurate even when membership is capped.
+        std::fs::write(
+            run_dir.join("journal.jsonl"),
+            "{\"type\":\"started\",\"agent_id\":\"id0000\"}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.scan_session_subagents("parent-1", "block-1", &config_dir, session_id);
+
+        assert_eq!(
+            watcher.list_active().len(),
+            BACKFILL_MAX_FILES,
+            "member files are still capped inside a workflow run"
+        );
+        let workflows = watcher.list_workflows();
+        assert_eq!(workflows.len(), 1, "the run's journal must still be processed");
+        assert_eq!(workflows[0].workflow_id, "wf_test-run");
 
         std::fs::remove_dir_all(&config_dir).ok();
     }

--- a/docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md
+++ b/docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md
@@ -1,0 +1,63 @@
+# Retro: subagent-backfill replay storm crashed the launcher via srv OOM (2026-07-17)
+
+**Date:** 2026-07-17
+**Severity:** High — the entire app (not just a window) died and stayed dead until manually relaunched.
+**Status:** Root-caused; two fixes implemented (this PR + a companion launcher PR).
+
+## 1. What the user saw
+
+The "shared" (portable) v0.53.5 instance went unresponsive and had to be manually relaunched. No in-app error — the whole process tree was gone.
+
+## 2. Timeline (from `~/.agentmux/logs/agentmux-launcher.log` and the srv log)
+
+All times below are 2026-07-17, UTC (log timestamps) with local PDT in parens.
+
+| Time (UTC) | Event |
+|---|---|
+| 15:06:00–15:06:09 | `agentmux-srv` logs a burst of **~1,030 "subagent spawned" events in ~10s**, all for one logical subagent (slug `quizzical-tumbling-valiant`, parent block `7142b72e-...` — this session's own agent pane), each broadcasting a WebSocket event to every connected window. |
+| 15:06:01 (08:06:01) | srv exits, code `-1073740791` (`0xC0000409` — Windows' generic fail-fast/abort code; **not** a literal stack-buffer overrun despite the status name — this is what a Rust allocation failure looks like on Windows). Launcher logs "srv exited UNEXPECTEDLY ... respawning srv + recycling host (restart 1/3)". |
+| 15:06:04 | Respawned srv (new PID) crashes again, same code, ~3s after spawn. Restart 2/3. |
+| 15:06:07 | Third respawn crashes again, ~3s after spawn. Restart 3/3. |
+| 15:06:10 | `srv restart budget exhausted (3 in 120s) — terminating launcher`. **The whole app exits.** |
+
+Every one of the three respawned srv processes crashed within ~3 seconds of starting, and the "subagent spawned" burst (15:06:00–15:06:09) is co-extensive with the entire cascade — each fresh srv immediately re-hit the same trigger on startup.
+
+Corroborating, live, at investigation time: this machine's system commit charge was measured at 87.5/87.7 GB (~99.8%, ~200 MB headroom) — a `tsc --noEmit` run OOM'd twice needing a bumped Node heap, and a bare PowerShell `Get-Counter` call itself threw `System.OutOfMemoryException`. The system has essentially zero commit slack; a sharp allocation spike is enough to tip any process over.
+
+## 3. Root cause: unbounded historical replay on every cold backfill
+
+`agentmux-srv/src/backend/subagent_watcher.rs`'s `scan_session_subagents` → `scan_subagents_dir` runs whenever a pane (re)opens or a block re-registers with a pre-existing session id (`agentmux-srv/src/server/reactive.rs:350`) — including every srv restart, since a fresh process's block controllers re-register on startup. It walks:
+
+- every `agent-*.jsonl` directly under `subagents/`, **plus**
+- every `agent-*.jsonl` under **every workflow run directory this session has ever produced**, under `subagents/workflows/<run-id>/`.
+
+There is no bound on directory age or count — it replays the session's **entire lifetime** of subagent activity, every time. `process_jsonl_change`'s `is_new` check (`!session.subagents.contains_key(&agent_id)`, line ~791) is keyed off an in-memory `HashMap` that starts empty on every fresh srv process, so a restart can never tell "already told a client about this" from "genuinely new" — every historical file reads as new again, each one doing a full-file read + JSON parse + `tracing::info!` + WebSocket broadcast to every connected window.
+
+This session's pane has accumulated a large `subagents/` corpus from real Task/Workflow-tool usage over many days of debugging work (including the swarm/subagent-diagnostics work in tasks #43/#44). On a cold restart, replaying that whole corpus is expensive enough — and, on a machine already near its commit ceiling, fast enough — to itself trigger the next OOM, which is why all three respawns died identically within ~3 seconds: each one hit the same full-history replay on startup and re-crashed before finishing it.
+
+This is the same duplicate-subagent-slug class of bug tracked in tasks #43/#44 (`[[agentmux-swarm-duplicate-subagent-groups]]`), but at roughly 100x the previously-observed scale (8+ duplicates → 1,000+) — a cold-restart replay storm, not just a display-dedup glitch.
+
+## 4. Contributing gap: no OOM-aware retry for srv exits
+
+The launcher already has commit-aware "wait for memory to recover" handling for the **CEF host** process (`agentmux-launcher/src/mem_supervisor.rs`'s `classify_host_exit`/`SystemOom`, wired in `agentmux-launcher/src/supervisor/windows.rs`'s host-exit arm) — built for exactly this class of transient system-OOM crash (`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`). But it was only wired to the host-exit branch; the **srv**-exit branch treated every exit identically, burning the fixed, fast `SRV_RESTART_BUDGET` (3 restarts / 120s) regardless of cause. Since srv is a plain Rust process (not Chromium), it never emits `CHROMIUM_OOM_EXIT_CODE` (`0xE0000008`) — but `classify_host_exit`'s low-commit-at-exit-time fallback branch is generic and already catches this case once wired up; it doesn't need a Rust-specific OOM code. Without that wiring, three fast identical crashes (all really the same transient condition) looked indistinguishable from three genuine bugs and burned the budget to zero, killing the launcher instead of waiting out what was likely a recoverable few seconds of commit pressure.
+
+## 5. Fixes
+
+**Fix A (this PR) — bound the cold-backfill replay** (`agentmux-srv/src/backend/subagent_watcher.rs`): `scan_subagents_dir` now caps replay to the `BACKFILL_MAX_FILES` (200) most-recently-modified `agent-*.jsonl` files, by mtime, regardless of how large the session's total historical corpus has grown. Workflow run journals (one small file per run, not per member) are still always processed so `workflow:updated`/run-status telemetry stays accurate even when membership replay is capped. This directly bounds the worst-case cost of every future pane reopen / srv restart to a fixed, small amount of work.
+
+**Fix B (companion launcher PR) — wire srv exits through the existing OOM classifier** (`agentmux-launcher/src/supervisor/windows.rs`): the srv-exit arm now calls `mem_supervisor::classify_host_exit(code, commit_free)` before deciding how to respond. A `SystemOom`-classified exit waits for commit to recover (same backoff/deadline/give-up-dialog machinery already proven for the host arm, on its own `srv_oom_restarts` budget) instead of consuming the fast crash budget; a genuine `Abnormal` exit keeps the existing fast-budget behavior unchanged.
+
+## 6. Scope not covered by these fixes
+
+- **Why the corpus got this large in the first place** — not investigated here. `subagents/` directories are never pruned/archived; a long-lived, heavily-used pane will keep accumulating them. Worth a follow-up if backfill cost (even bounded) becomes noticeable.
+- **Unix/macOS srv supervision** (`agentmux-launcher/src/supervisor/unix.rs`) has no retry budget for srv at all currently — any unexpected srv exit terminates the launcher immediately (no OOM classification, no respawn). Out of scope here (this incident was Windows-only); flagged for future parity work.
+- **Whether the pre-existing duplicate-slug bug (tasks #43/#44) also has a live, non-restart-triggered trigger** — this incident's storm was specifically a cold-restart replay; whether the same slug can still collide during a single live session wasn't re-verified here.
+
+## 7. Sources
+
+- `~/.agentmux/logs/agentmux-launcher.log` (crash-loop timeline)
+- `~/.agentmux/logs/agentmuxsrv-v0.53.5.log.2026-07-17` (subagent-spawn burst)
+- `agentmux-srv/src/backend/subagent_watcher.rs` (`scan_session_subagents`, `scan_subagents_dir`, `process_jsonl_change`)
+- `agentmux-launcher/src/mem_supervisor.rs`, `agentmux-launcher/src/supervisor/windows.rs`
+- `docs/specs/SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`, `docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`
+- `[[agentmux-swarm-duplicate-subagent-groups]]`, `[[agentmux-pagefile-oom-crash-crossref]]`, `[[agentmux-memory-commit-vs-virtual]]` (memory)


### PR DESCRIPTION
## Incident

This "shared" v0.53.5 instance crashed and stayed dead — the whole launcher terminated, not just a window. Full root-cause writeup: `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md` (bundled in this PR).

## Root cause

`agentmux-srv/src/backend/subagent_watcher.rs`'s `scan_subagents_dir` — run on every pane (re)open **and every srv restart** (a fresh process's blocks re-register on startup) — walked every `agent-*.jsonl` file this session has EVER produced, including every historical workflow run, with no bound on age or count. `process_jsonl_change`'s `is_new` check is keyed off an in-memory map that starts empty on every fresh srv process, so a restart can't tell "already told a client" from "genuinely new" — every historical file replays as new again: full-file read + parse + `tracing::info!` + WebSocket broadcast, per file.

This session's pane has a large accumulated `subagents/` corpus from real Task/Workflow-tool usage over many days. On a cold restart that's expensive enough — and on a machine already near its commit ceiling, fast enough — to itself trigger the next OOM: the log shows a ~1,030-event replay burst across three back-to-back srv crash-restarts in under 10 seconds, each respawn re-hitting the identical trigger on startup before the launcher's 3-strikes budget gave up and killed the whole app.

## Fix

`scan_subagents_dir` now caps replay to the `BACKFILL_MAX_FILES` (200) most-recently-modified `agent-*.jsonl` files, by mtime, regardless of how large the session's total historical corpus has grown. Workflow run journals (one small file per run, not per member) are still always processed so `workflow:updated`/run-status telemetry stays accurate even when membership replay is capped.

A companion PR wires the launcher's existing commit-aware OOM retry (`mem_supervisor::classify_host_exit`, already used for CEF-host exits) into srv exits too — before this, any srv crash (OOM or not) burned a fixed fast budget with no "wait for memory to recover" grace, unlike the host. That's the other half of why this incident escalated to a full launcher kill instead of a brief hiccup.

## Verification

- `cargo test -p agentmux-srv subagent_watcher`: 38/38 pass (36 pre-existing + 2 new — cap applies regardless of corpus size and always keeps the newest files; workflow journal still processed beyond the member cap).

<!-- agentmux:agent_id=agenta-07017 -->