### PR TITLE
fix(launcher): classify srv exits for system-OOM, not just CEF-host exits

### DIFF
--- a/.changesets/1784304147-fix-launcher-srv-oom-classify.md
+++ b/.changesets/1784304147-fix-launcher-srv-oom-classify.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): wire the existing commit-aware OOM retry into srv exits, not just CEF-host exits — a srv crash-loop under system OOM previously burned the fast restart budget and killed the whole launcher instead of waiting out the transient pressure

--- a/agentmux-launcher/src/mem_supervisor.rs
+++ b/agentmux-launcher/src/mem_supervisor.rs
@@ -146,23 +146,31 @@ pub fn commit_free_mb() -> u64 {
 /// recovered, or `false` if `OOM_RELAUNCH_DEADLINE` elapses first (the caller
 /// then gives up gracefully). `log` is the launcher's logger, threaded in so the
 /// wait is observable in the launcher log.
-pub async fn await_commit_recovery(log: impl Fn(&str)) -> bool {
+/// `subject` names whatever is being waited on for the two terminal log
+/// lines ("relaunching {subject}" / "giving up {subject} relaunch") — this
+/// function is shared by the host-OOM wait (`subject: "host"`) and the
+/// srv-OOM wait (`subject: "srv"`, `SPEC_MEMORY_PRESSURE_SUPERVISION`'s srv
+/// counterpart). Hardcoding "host" here made the srv-OOM wait's log
+/// misleadingly claim it was relaunching the host during an actual srv-OOM
+/// incident — reagent P1 on PR #2206.
+pub async fn await_commit_recovery(subject: &str, log: impl Fn(&str)) -> bool {
     let start = Instant::now();
     let mut backoff = BACKOFF_START;
     loop {
         let free = commit_free_mb();
         if free >= RESUME_FLOOR_MB {
             log(&format!(
-                "commit recovered: {} MB free (>= {} MB floor) — relaunching host",
-                free, RESUME_FLOOR_MB
+                "commit recovered: {} MB free (>= {} MB floor) — relaunching {}",
+                free, RESUME_FLOOR_MB, subject
             ));
             return true;
         }
         if start.elapsed() >= OOM_RELAUNCH_DEADLINE {
             log(&format!(
-                "commit still low ({} MB free) after {}s — giving up host relaunch",
+                "commit still low ({} MB free) after {}s — giving up {} relaunch",
                 free,
-                OOM_RELAUNCH_DEADLINE.as_secs()
+                OOM_RELAUNCH_DEADLINE.as_secs(),
+                subject
             ));
             return false;
         }

--- a/agentmux-launcher/src/mem_supervisor.rs
+++ b/agentmux-launcher/src/mem_supervisor.rs
@@ -215,6 +215,31 @@ mod tests {
     }
 
     #[test]
+    fn srv_fastfail_code_with_low_commit_is_system_oom() {
+        // docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md: srv is a
+        // plain Rust process, so an OOM there never emits
+        // CHROMIUM_OOM_EXIT_CODE — it surfaces as Windows' generic fail-fast
+        // abort, 0xC0000409 (STATUS_STACK_BUFFER_OVERRUN — the code name is
+        // misleading; the CRT overloads it for abort()/allocation-failure
+        // fast-fails too, not just real buffer overruns). The exact live exit
+        // code from the incident, reused here as a regression anchor:
+        // classify_host_exit is generic over which process died — only the
+        // low-commit fallback branch needs to catch it, not an exact-code
+        // match — so this is a straight application of the existing
+        // low-commit branch, now exercised by the launcher's srv-exit arm too.
+        const SRV_FASTFAIL_EXIT_CODE: i32 = -1_073_740_791;
+        assert_eq!(
+            classify_host_exit(SRV_FASTFAIL_EXIT_CODE, RESUME_FLOOR_MB - 1),
+            HostExitClass::SystemOom
+        );
+        // Same code with headroom present is just a genuine srv crash.
+        assert_eq!(
+            classify_host_exit(SRV_FASTFAIL_EXIT_CODE, RESUME_FLOOR_MB),
+            HostExitClass::Abnormal
+        );
+    }
+
+    #[test]
     fn backoff_doubles_then_caps() {
         assert_eq!(next_backoff(Duration::from_secs(2)), Duration::from_secs(4));
         assert_eq!(next_backoff(Duration::from_secs(4)), Duration::from_secs(8));

--- a/agentmux-launcher/src/supervisor/unix.rs
+++ b/agentmux-launcher/src/supervisor/unix.rs
@@ -462,7 +462,7 @@ pub(crate) async fn run_unix(
                         // SIGINT/SIGTERM + srv arms are starved for the whole
                         // wait (reagent P2). Mirrors the outer select! arms.
                         let recovered = tokio::select! {
-                            r = mem_supervisor::await_commit_recovery(log) => r,
+                            r = mem_supervisor::await_commit_recovery("host", log) => r,
                             srv_status = srv_child.wait() => {
                                 use std::os::unix::process::ExitStatusExt;
                                 match srv_status {

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -530,6 +530,10 @@ pub(crate) async fn run_windows(
     // a recycle must not step the retry ladder down to --disable-gpu),
     // while still counting against the host budget as runaway protection.
     let mut srv_restarts: Vec<std::time::Instant> = Vec::new();
+    // Separate budget for system-OOM srv exits, mirroring `oom_restarts`
+    // above — see the srv arm's classification comment
+    // (docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md).
+    let mut srv_oom_restarts: Vec<std::time::Instant> = Vec::new();
     let mut srv_recycle_kill = false;
     // SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11 Phase 1 — observe-only
     // UI-thread liveness prober. Low rate (60s); the first tick is delayed
@@ -852,26 +856,106 @@ pub(crate) async fn run_windows(
                         break 1;
                     }
                 };
-                if mem_supervisor::budget_exhausted(
-                    &mut srv_restarts,
-                    std::time::Instant::now(),
-                    SRV_RESTART_WINDOW,
-                    SRV_RESTART_BUDGET,
+                // Classify like the host arm above (SPEC_MEMORY_PRESSURE_
+                // SUPERVISION_2026_06_16 §5.B) instead of unconditionally
+                // burning the fast SRV_RESTART_BUDGET. srv is a plain Rust
+                // process, so it never emits Chromium's exact OOM code
+                // (`CHROMIUM_OOM_EXIT_CODE`) — but `classify_host_exit`'s
+                // low-commit-at-exit-time fallback still catches a genuine
+                // system-OOM srv abort (Rust's Windows fail-fast abort on
+                // allocation failure surfaces as the generic 0xC0000409, not
+                // 0xE0000008). Before this, EVERY srv exit — OOM or not —
+                // consumed the fixed, fast budget; a live incident hit that
+                // budget 3x in under 10 seconds (each respawned srv re-OOMing
+                // near-instantly into the still-starved system) and killed
+                // the whole launcher instead of waiting out a few seconds of
+                // transient commit pressure. See
+                // docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md.
+                let commit_free = mem_supervisor::commit_free_mb();
+                if matches!(
+                    mem_supervisor::classify_host_exit(code, commit_free),
+                    mem_supervisor::HostExitClass::SystemOom
                 ) {
+                    let now = std::time::Instant::now();
+                    if mem_supervisor::budget_exhausted(
+                        &mut srv_oom_restarts,
+                        now,
+                        mem_supervisor::OOM_RESTART_WINDOW,
+                        mem_supervisor::OOM_RESTART_BUDGET,
+                    ) {
+                        log(&format!(
+                            "srv hit system OOM (code {}, {} MB commit-free); srv OOM restart \
+                             budget exhausted ({} in {}s) — giving up",
+                            code,
+                            commit_free,
+                            mem_supervisor::OOM_RESTART_BUDGET,
+                            mem_supervisor::OOM_RESTART_WINDOW.as_secs()
+                        ));
+                        show_fatal_dialog(
+                            mem_supervisor::OOM_GIVEUP_TITLE,
+                            mem_supervisor::OOM_GIVEUP_BODY,
+                        );
+                        break code;
+                    }
                     log(&format!(
-                        "srv exited (code {}); srv restart budget exhausted ({} in {}s) — terminating launcher",
-                        code,
-                        SRV_RESTART_BUDGET,
-                        SRV_RESTART_WINDOW.as_secs()
+                        "srv hit system OOM (code {}, {} MB commit-free) — waiting for memory \
+                         to recover before respawning srv",
+                        code, commit_free
                     ));
-                    break 1;
+                    // Race the wait against the host dying too, same pattern
+                    // as the host arm's nested select above — without this,
+                    // a host crash during the (up to OOM_RELAUNCH_DEADLINE)
+                    // wait would go unnoticed until the wait finished.
+                    let recovered = tokio::select! {
+                        r = mem_supervisor::await_commit_recovery(log) => r,
+                        host_status = host_child.wait() => {
+                            match host_status {
+                                Ok(s) => log(&format!(
+                                    "CEF host exited UNEXPECTEDLY during srv-OOM wait with code {} — \
+                                     terminating launcher",
+                                    s.code().unwrap_or(1)
+                                )),
+                                Err(e) => log(&format!(
+                                    "FATAL: host wait failed during srv-OOM wait: {}", e
+                                )),
+                            }
+                            break 1;
+                        }
+                    };
+                    if !recovered {
+                        show_fatal_dialog(
+                            mem_supervisor::OOM_GIVEUP_TITLE,
+                            mem_supervisor::OOM_GIVEUP_BODY,
+                        );
+                        break code;
+                    }
+                    log(&format!(
+                        "commit recovered — respawning srv (OOM restart {}/{})",
+                        srv_oom_restarts.len(),
+                        mem_supervisor::OOM_RESTART_BUDGET
+                    ));
+                } else {
+                    if mem_supervisor::budget_exhausted(
+                        &mut srv_restarts,
+                        std::time::Instant::now(),
+                        SRV_RESTART_WINDOW,
+                        SRV_RESTART_BUDGET,
+                    ) {
+                        log(&format!(
+                            "srv exited (code {}); srv restart budget exhausted ({} in {}s) — terminating launcher",
+                            code,
+                            SRV_RESTART_BUDGET,
+                            SRV_RESTART_WINDOW.as_secs()
+                        ));
+                        break 1;
+                    }
+                    log(&format!(
+                        "srv exited UNEXPECTEDLY (code {}) — respawning srv + recycling host (restart {}/{})",
+                        code,
+                        srv_restarts.len(),
+                        SRV_RESTART_BUDGET
+                    ));
                 }
-                log(&format!(
-                    "srv exited UNEXPECTEDLY (code {}) — respawning srv + recycling host (restart {}/{})",
-                    code,
-                    srv_restarts.len(),
-                    SRV_RESTART_BUDGET
-                ));
                 match srv_spawner::spawn_srv(
                     launcher_exe_dir,
                     &paths,

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -702,7 +702,7 @@ pub(crate) async fn run_windows(
                         // run_windows has no signal arms (shutdown flows via the
                         // host/srv), so srv is the only concurrent event here.
                         let recovered = tokio::select! {
-                            r = mem_supervisor::await_commit_recovery(log) => r,
+                            r = mem_supervisor::await_commit_recovery("host", log) => r,
                             srv_status = srv_child.wait() => {
                                 match srv_status {
                                     Ok(s) => log(&format!(
@@ -907,7 +907,7 @@ pub(crate) async fn run_windows(
                     // a host crash during the (up to OOM_RELAUNCH_DEADLINE)
                     // wait would go unnoticed until the wait finished.
                     let recovered = tokio::select! {
-                        r = mem_supervisor::await_commit_recovery(log) => r,
+                        r = mem_supervisor::await_commit_recovery("srv", log) => r,
                         host_status = host_child.wait() => {
                             match host_status {
                                 Ok(s) => log(&format!(


### PR DESCRIPTION
Follow-up to #2205 — addresses the launcher-side half of the same incident (root cause: `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`, bundled in #2205).

## Gap

The launcher already has commit-aware "wait for memory to recover" handling for CEF-host exits (`mem_supervisor::classify_host_exit` / `HostExitClass::SystemOom`, `SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md`) — but it was only wired to the host-exit arm in `agentmux-launcher/src/supervisor/windows.rs`. The srv-exit arm treated every exit identically, burning the fixed, fast `SRV_RESTART_BUDGET` (3 restarts / 120s) regardless of cause.

In the incident, a srv crash-loop under system OOM (Windows fail-fast abort `0xC0000409` — not Chromium's `0xE0000008`, since srv is a plain Rust process, not Chromium) hit that fast budget 3x in under 10 seconds and terminated the **entire launcher** instead of waiting out what was likely a few seconds of transient commit pressure.

## Fix

`classify_host_exit` is already generic over which process died — its low-commit-at-exit-time fallback branch doesn't need an exact OOM code match, so it needed no changes. The srv-exit arm now calls it before deciding how to respond:

- **`SystemOom`**: waits for commit to recover (same backoff/deadline/give-up-dialog machinery already proven for the host arm, on its own `srv_oom_restarts` budget), racing against a concurrent host exit — mirrors the host arm's existing nested-select pattern.
- **`Abnormal`**: unchanged — existing fast `SRV_RESTART_BUDGET` behavior.

## Verification

- `cargo test -p agentmux-launcher`: 206/206 pass (205 pre-existing + 1 new — `srv_fastfail_code_with_low_commit_is_system_oom`, using the incident's actual exit code as a regression anchor).
- `cargo build -p agentmux-launcher` clean.

## Scope not covered

`agentmux-launcher/src/supervisor/unix.rs` has no retry budget for srv at all currently (any unexpected srv exit terminates immediately) — out of scope here since the incident was Windows-only; flagged in the retro as a follow-up for platform parity.

<!-- agentmux:agent_id=agenta-07017 -->