### PR TITLE
feat(srv): log commit (pagefile) attribution — who's inflating it

### DIFF
--- a/.changesets/1784305307-feat-srv-commit-attribution-diagnostics.md
+++ b/.changesets/1784305307-feat-srv-commit-attribution-diagnostics.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(srv): log periodic + urgent-on-pressure commit (pagefile) attribution — buckets every process into AgentMux's own family, pane process trees (Claude CLI etc.), and other apps, so a future OOM crash leaves a forensic trail of who was consuming commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ single pointer; run `muxlog ls` first when several instances are up.
 | Frontend `[fe]` lines | `muxlog fe` |
 | Search sidecar (agent transcript excluded) | `muxlog srv grep <regex>` |
 | Memory heartbeat | `muxlog host grep mem_heartbeat` |
+| Commit (pagefile) attribution — who's inflating commit: AgentMux itself, panes' process trees (Claude CLI etc.), or other apps | `muxlog srv grep mem_attribution` |
 | Errors + warnings (host & sidecar) | `muxlog errors` |
 | Startup-handshake / reconnect-loop trace | `muxlog bridge` |
 | Target a specific instance | `muxlog host -i <branch\|version>` |

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -118,11 +118,21 @@ fn classify_commit_attribution(
 /// pressure), classify, and log one line. Independent of the per-tick
 /// block-stats pass above — it does its own PID-tree collection so it
 /// can't be affected by that pass's ordering.
-fn log_memory_attribution(sys: &mut sysinfo::System) {
+///
+/// `commit_used_gb`/`commit_total_gb` come from the caller's already-computed
+/// `get_commit_data` values rather than re-querying `GlobalMemoryStatusEx`
+/// here — this function is on the same tick as that call.
+fn log_memory_attribution(sys: &mut sysinfo::System, commit_used_gb: f64, commit_total_gb: f64) {
+    // Only name()/parent()/virtual_memory() are read below — parent() and
+    // name() are always populated regardless of refresh kind, so only
+    // memory needs to be requested. The per-pane pass a few lines below
+    // (targeted `ProcessesToUpdate::Some`) uses the same restraint; this is
+    // the whole-machine equivalent, so it's the one call where skipping
+    // CPU deltas/disk I/O/exe/cmdline/environ actually matters.
     sys.refresh_processes_specifics(
         ProcessesToUpdate::All,
         true, // remove dead processes — keep this bounded to what's live
-        ProcessRefreshKind::everything(),
+        ProcessRefreshKind::nothing().with_memory(),
     );
 
     let mut pane_pids: HashSet<u32> = HashSet::new();
@@ -154,27 +164,6 @@ fn log_memory_attribution(sys: &mut sysinfo::System) {
         .collect();
 
     let result = classify_commit_attribution(&samples, &pane_pids, ATTRIBUTION_OTHER_TOP_N);
-    let (commit_used_gb, commit_total_gb) = {
-        #[cfg(target_os = "windows")]
-        {
-            use windows_sys::Win32::System::SystemInformation::{
-                GlobalMemoryStatusEx, MEMORYSTATUSEX,
-            };
-            let mut mem: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
-            mem.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
-            if unsafe { GlobalMemoryStatusEx(&mut mem) } != 0 {
-                let total_gb = mem.ullTotalPageFile as f64 / BYTES_PER_GB;
-                let avail_gb = mem.ullAvailPageFile as f64 / BYTES_PER_GB;
-                (total_gb - avail_gb, total_gb)
-            } else {
-                (0.0, 0.0)
-            }
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            (0.0, 0.0)
-        }
-    };
 
     let other_top_str = result
         .other_top
@@ -613,7 +602,7 @@ mod commit_attribution_tests {
     #[test]
     fn log_memory_attribution_runs_against_the_real_process_table_without_panicking() {
         let mut sys = sysinfo::System::new_all();
-        log_memory_attribution(&mut sys); // must not panic
+        log_memory_attribution(&mut sys, 0.0, 0.0); // must not panic
         assert!(
             sys.processes().len() > 1,
             "expected the real process table to have picked up more than just this test binary"
@@ -774,7 +763,11 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
             && last_urgent_attribution
                 .is_none_or(|t| now_instant.duration_since(t) >= ATTRIBUTION_URGENT_COOLDOWN);
         if due_periodic || due_urgent {
-            tokio::task::block_in_place(|| log_memory_attribution(&mut sys));
+            let commit_used_gb = *values.get("mem:commit:used").unwrap_or(&0.0);
+            let commit_total_gb = *values.get("mem:commit:total").unwrap_or(&0.0);
+            tokio::task::block_in_place(|| {
+                log_memory_attribution(&mut sys, commit_used_gb, commit_total_gb)
+            });
             last_attribution = now_instant;
             if due_urgent {
                 last_urgent_attribution = Some(now_instant);

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -5,7 +5,9 @@
 //! and publishes them via the WPS broker. Sampling interval is configurable
 //! via the `telemetry:interval` setting (0.1s–2.0s, default 1.0s).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+#[cfg(target_os = "windows")]
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -38,15 +40,19 @@ const MAX_INTERVAL_SECS: f64 = 2.0;
 // visibility — Chrome, VS Code, Docker, Windows itself, ...).
 
 /// How often to log a full attribution snapshot in the steady state.
+#[cfg(target_os = "windows")]
 const ATTRIBUTION_INTERVAL: Duration = Duration::from_secs(30);
 /// Re-snapshot immediately (bypassing `ATTRIBUTION_INTERVAL`) once available
 /// commit drops below this — a snapshot taken seconds before a crash is far
 /// more useful than one from up to 30s earlier.
+#[cfg(target_os = "windows")]
 const ATTRIBUTION_URGENT_THRESHOLD_GB: f64 = 2.0;
 /// Debounce for the urgent trigger so a sustained low-commit period doesn't
 /// log every single tick.
+#[cfg(target_os = "windows")]
 const ATTRIBUTION_URGENT_COOLDOWN: Duration = Duration::from_secs(10);
 /// How many "other" processes to name individually in the log line.
+#[cfg(target_os = "windows")]
 const ATTRIBUTION_OTHER_TOP_N: usize = 5;
 /// Per-block descendant-PID cap for the attribution walk — deliberately its
 /// OWN, much larger constant, not `process_tree::MAX_PIDS_PER_BLOCK` (64).
@@ -58,6 +64,7 @@ const ATTRIBUTION_OTHER_TOP_N: usize = 5;
 /// beyond "returned exactly `max_pids` results," so that's what
 /// `log_memory_attribution` checks to log a truncation warning rather than
 /// silently under-counting (no silent caps).
+#[cfg(target_os = "windows")]
 const ATTRIBUTION_MAX_PIDS_PER_BLOCK: usize = 4096;
 
 /// One process's classification input — commit charge, not working set:
@@ -65,12 +72,14 @@ const ATTRIBUTION_MAX_PIDS_PER_BLOCK: usize = 4096;
 /// Windows is `PROCESS_MEMORY_COUNTERS_EX::PrivateUsage` — a misleading
 /// name from sysinfo's cross-platform API, but the right number: the
 /// process's private/committed bytes.)
+#[cfg(target_os = "windows")]
 struct ProcSample {
     pid: u32,
     name: String,
     commit_mb: f64,
 }
 
+#[cfg(target_os = "windows")]
 struct AttributionResult {
     agentmux_mb: f64,
     panes_mb: f64,
@@ -83,7 +92,12 @@ struct AttributionResult {
 /// process table (mirrors `resolve_pagefile_watch_target` above).
 /// `pane_pids` is the exact PID set `pidregistry`'s block trees computed —
 /// membership, not a name guess, so this bucket can never miscount a
-/// same-named-but-unrelated process.
+/// same-named-but-unrelated process. Aggregates "other" by process name
+/// before ranking the top-N — a multi-process app (Chrome, VS Code) would
+/// otherwise get split across many small per-PID entries that individually
+/// miss the cutoff while collectively dominating `other_mb`, hiding the
+/// true top contributor (reagent P1 on PR #2207).
+#[cfg(target_os = "windows")]
 fn classify_commit_attribution(
     samples: &[ProcSample],
     pane_pids: &HashSet<u32>,
@@ -91,16 +105,17 @@ fn classify_commit_attribution(
 ) -> AttributionResult {
     let mut agentmux_mb = 0.0;
     let mut panes_mb = 0.0;
-    let mut other: Vec<(String, f64)> = Vec::new();
+    let mut other_by_name: HashMap<String, f64> = HashMap::new();
     for s in samples {
         if s.name.to_ascii_lowercase().starts_with("agentmux") {
             agentmux_mb += s.commit_mb;
         } else if pane_pids.contains(&s.pid) {
             panes_mb += s.commit_mb;
         } else {
-            other.push((s.name.clone(), s.commit_mb));
+            *other_by_name.entry(s.name.clone()).or_insert(0.0) += s.commit_mb;
         }
     }
+    let mut other: Vec<(String, f64)> = other_by_name.into_iter().collect();
     other.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     let other_mb: f64 = other.iter().map(|(_, mb)| mb).sum();
     other.truncate(top_n);
@@ -122,6 +137,7 @@ fn classify_commit_attribution(
 /// `commit_used_gb`/`commit_total_gb` come from the caller's already-computed
 /// `get_commit_data` values rather than re-querying `GlobalMemoryStatusEx`
 /// here — this function is on the same tick as that call.
+#[cfg(target_os = "windows")]
 fn log_memory_attribution(sys: &mut sysinfo::System, commit_used_gb: f64, commit_total_gb: f64) {
     // Only name()/parent()/virtual_memory() are read below — parent() and
     // name() are always populated regardless of refresh kind, so only
@@ -524,7 +540,7 @@ mod pagefile_volume_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "windows"))]
 mod commit_attribution_tests {
     use super::*;
 
@@ -577,6 +593,27 @@ mod commit_attribution_tests {
     }
 
     #[test]
+    fn aggregates_other_by_name_before_ranking_so_a_multi_process_app_is_not_split_below_the_cutoff() {
+        // A multi-process app (Chrome, VS Code) spread across many small
+        // per-PID entries must still rank by its TOTAL commit, not have each
+        // PID compete individually against single-process apps — otherwise
+        // the true top contributor can be missing from other_top even
+        // though other_mb (the sum) correctly reflects it. reagent P1 on
+        // PR #2207.
+        let samples = vec![
+            sample(1, "chrome.exe", 100.0),
+            sample(2, "chrome.exe", 100.0),
+            sample(3, "chrome.exe", 100.0),
+            sample(4, "chrome.exe", 100.0),
+            sample(5, "single_app.exe", 250.0),
+        ];
+        let result = classify_commit_attribution(&samples, &HashSet::new(), 1);
+        assert_eq!(result.other_mb, 650.0);
+        assert_eq!(result.other_top.len(), 1);
+        assert_eq!(result.other_top[0], ("chrome.exe".to_string(), 400.0));
+    }
+
+    #[test]
     fn name_match_is_case_insensitive() {
         let samples = vec![sample(1, "AgentMux-Srv.exe", 42.0)];
         let result = classify_commit_attribution(&samples, &HashSet::new(), 5);
@@ -592,13 +629,13 @@ mod commit_attribution_tests {
         assert!(result.other_top.is_empty());
     }
 
-    /// Runs the real Win32 process-enumeration + `GlobalMemoryStatusEx` path
-    /// against this machine's actual process table — the synthetic-data
-    /// tests above cover classification logic but can't catch a bad
-    /// Win32 API call, an access-denied edge case, or a panic on a real
-    /// process's field values. This test's own process is guaranteed to
-    /// exist in the table with a real name and non-zero commit, so a
-    /// classification bucket is exercised end-to-end for real.
+    /// Runs the real Win32 process-enumeration path against this machine's
+    /// actual process table — the synthetic-data tests above cover
+    /// classification logic but can't catch a bad Win32 API call, an
+    /// access-denied edge case, or a panic on a real process's field
+    /// values. This test's own process is guaranteed to exist in the table
+    /// with a real name and non-zero commit, so a classification bucket is
+    /// exercised end-to-end for real.
     #[test]
     fn log_memory_attribution_runs_against_the_real_process_table_without_panicking() {
         let mut sys = sysinfo::System::new_all();
@@ -693,9 +730,12 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
     // Commit-attribution cadence — see the "Commit (pagefile) attribution"
     // section above. Starts due-now-minus-interval so the first snapshot
     // establishes a baseline shortly after startup, not 30s of silence.
+    // Windows-only — see the matching #[cfg] on the loop body below.
+    #[cfg(target_os = "windows")]
     let mut last_attribution = Instant::now()
         .checked_sub(ATTRIBUTION_INTERVAL)
         .unwrap_or_else(Instant::now);
+    #[cfg(target_os = "windows")]
     let mut last_urgent_attribution: Option<Instant> = None;
 
     let mut current_interval = get_interval_secs(&config_watcher);
@@ -754,23 +794,32 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
         // (debounced) when commit heads toward exhaustion — see
         // docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md. Reuses
         // the commit numbers just computed above rather than re-querying.
-        let commit_avail_gb = match (values.get("mem:commit:total"), values.get("mem:commit:used")) {
-            (Some(total), Some(used)) => Some(total - used),
-            _ => None,
-        };
-        let due_periodic = now_instant.duration_since(last_attribution) >= ATTRIBUTION_INTERVAL;
-        let due_urgent = commit_avail_gb.is_some_and(|gb| gb < ATTRIBUTION_URGENT_THRESHOLD_GB)
-            && last_urgent_attribution
-                .is_none_or(|t| now_instant.duration_since(t) >= ATTRIBUTION_URGENT_COOLDOWN);
-        if due_periodic || due_urgent {
-            let commit_used_gb = *values.get("mem:commit:used").unwrap_or(&0.0);
-            let commit_total_gb = *values.get("mem:commit:total").unwrap_or(&0.0);
-            tokio::task::block_in_place(|| {
-                log_memory_attribution(&mut sys, commit_used_gb, commit_total_gb)
-            });
-            last_attribution = now_instant;
-            if due_urgent {
-                last_urgent_attribution = Some(now_instant);
+        // Windows-only like every other commit/pagefile helper in this file
+        // (get_commit_data, available_commit_gb, get_pagefile_volume_data) —
+        // its rationale (pagefile/commit exhaustion) doesn't apply elsewhere,
+        // and off-Windows `mem:commit:*` are never populated, so this would
+        // otherwise pay a full process-table refresh every tick just to log
+        // a permanently-zero commit_used_gb/commit_total_gb.
+        #[cfg(target_os = "windows")]
+        {
+            let commit_avail_gb = match (values.get("mem:commit:total"), values.get("mem:commit:used")) {
+                (Some(total), Some(used)) => Some(total - used),
+                _ => None,
+            };
+            let due_periodic = now_instant.duration_since(last_attribution) >= ATTRIBUTION_INTERVAL;
+            let due_urgent = commit_avail_gb.is_some_and(|gb| gb < ATTRIBUTION_URGENT_THRESHOLD_GB)
+                && last_urgent_attribution
+                    .is_none_or(|t| now_instant.duration_since(t) >= ATTRIBUTION_URGENT_COOLDOWN);
+            if due_periodic || due_urgent {
+                let commit_used_gb = *values.get("mem:commit:used").unwrap_or(&0.0);
+                let commit_total_gb = *values.get("mem:commit:total").unwrap_or(&0.0);
+                tokio::task::block_in_place(|| {
+                    log_memory_attribution(&mut sys, commit_used_gb, commit_total_gb)
+                });
+                last_attribution = now_instant;
+                if due_urgent {
+                    last_urgent_attribution = Some(now_instant);
+                }
             }
         }
 

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -585,6 +585,23 @@ mod commit_attribution_tests {
         assert_eq!(result.other_mb, 0.0);
         assert!(result.other_top.is_empty());
     }
+
+    /// Runs the real Win32 process-enumeration + `GlobalMemoryStatusEx` path
+    /// against this machine's actual process table — the synthetic-data
+    /// tests above cover classification logic but can't catch a bad
+    /// Win32 API call, an access-denied edge case, or a panic on a real
+    /// process's field values. This test's own process is guaranteed to
+    /// exist in the table with a real name and non-zero commit, so a
+    /// classification bucket is exercised end-to-end for real.
+    #[test]
+    fn log_memory_attribution_runs_against_the_real_process_table_without_panicking() {
+        let mut sys = sysinfo::System::new_all();
+        log_memory_attribution(&mut sys); // must not panic
+        assert!(
+            sys.processes().len() > 1,
+            "expected the real process table to have picked up more than just this test binary"
+        );
+    }
 }
 
 /// Network I/O tracking state for rate calculations.

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -5,7 +5,7 @@
 //! and publishes them via the WPS broker. Sampling interval is configurable
 //! via the `telemetry:interval` setting (0.1s–2.0s, default 1.0s).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -24,6 +24,160 @@ const PERSIST_COUNT: usize = 1024;
 const DEFAULT_INTERVAL_SECS: f64 = 1.0;
 const MIN_INTERVAL_SECS: f64 = 0.2;
 const MAX_INTERVAL_SECS: f64 = 2.0;
+
+// ── Commit (pagefile) attribution ────────────────────────────────────────
+// docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md: a live OOM
+// crash left no forensic trail of WHICH processes were consuming commit —
+// only the system-wide total (`get_commit_data`) was ever logged. This
+// section adds periodic + urgent-on-pressure attribution, bucketing every
+// process on the machine into "agentmux" (this app's own process family —
+// host, srv, launcher, CEF helper processes), "panes" (every registered
+// block's shell process tree — agent CLI subprocesses, terminal shells,
+// etc.; exact PID-tree membership via `pidregistry` + `process_tree`, not
+// name-guessing), and "other" (everything else, top-N by commit kept for
+// visibility — Chrome, VS Code, Docker, Windows itself, ...).
+
+/// How often to log a full attribution snapshot in the steady state.
+const ATTRIBUTION_INTERVAL: Duration = Duration::from_secs(30);
+/// Re-snapshot immediately (bypassing `ATTRIBUTION_INTERVAL`) once available
+/// commit drops below this — a snapshot taken seconds before a crash is far
+/// more useful than one from up to 30s earlier.
+const ATTRIBUTION_URGENT_THRESHOLD_GB: f64 = 2.0;
+/// Debounce for the urgent trigger so a sustained low-commit period doesn't
+/// log every single tick.
+const ATTRIBUTION_URGENT_COOLDOWN: Duration = Duration::from_secs(10);
+/// How many "other" processes to name individually in the log line.
+const ATTRIBUTION_OTHER_TOP_N: usize = 5;
+
+/// One process's classification input — commit charge, not working set:
+/// what actually exhausts the pagefile. (sysinfo's `virtual_memory()` on
+/// Windows is `PROCESS_MEMORY_COUNTERS_EX::PrivateUsage` — a misleading
+/// name from sysinfo's cross-platform API, but the right number: the
+/// process's private/committed bytes.)
+struct ProcSample {
+    pid: u32,
+    name: String,
+    commit_mb: f64,
+}
+
+struct AttributionResult {
+    agentmux_mb: f64,
+    panes_mb: f64,
+    other_mb: f64,
+    /// Top `top_n` "other" processes by commit, descending.
+    other_top: Vec<(String, f64)>,
+}
+
+/// Pure classification, factored out for unit testing without a real
+/// process table (mirrors `resolve_pagefile_watch_target` above).
+/// `pane_pids` is the exact PID set `pidregistry`'s block trees computed —
+/// membership, not a name guess, so this bucket can never miscount a
+/// same-named-but-unrelated process.
+fn classify_commit_attribution(
+    samples: &[ProcSample],
+    pane_pids: &HashSet<u32>,
+    top_n: usize,
+) -> AttributionResult {
+    let mut agentmux_mb = 0.0;
+    let mut panes_mb = 0.0;
+    let mut other: Vec<(String, f64)> = Vec::new();
+    for s in samples {
+        if s.name.to_ascii_lowercase().starts_with("agentmux") {
+            agentmux_mb += s.commit_mb;
+        } else if pane_pids.contains(&s.pid) {
+            panes_mb += s.commit_mb;
+        } else {
+            other.push((s.name.clone(), s.commit_mb));
+        }
+    }
+    other.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let other_mb: f64 = other.iter().map(|(_, mb)| mb).sum();
+    other.truncate(top_n);
+    AttributionResult {
+        agentmux_mb,
+        panes_mb,
+        other_mb,
+        other_top: other,
+    }
+}
+
+/// Full-system commit snapshot: refresh every process (heavier than the
+/// per-block passes above, but only ever called on the attribution
+/// cadence — every 30s in steady state, or debounced-urgent under
+/// pressure), classify, and log one line. Independent of the per-tick
+/// block-stats pass above — it does its own PID-tree collection so it
+/// can't be affected by that pass's ordering.
+fn log_memory_attribution(sys: &mut sysinfo::System) {
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true, // remove dead processes — keep this bounded to what's live
+        ProcessRefreshKind::everything(),
+    );
+
+    let pane_pids: HashSet<u32> = pidregistry::get_all()
+        .iter()
+        .flat_map(|(_, pid)| {
+            process_tree::collect_descendants(
+                sys,
+                Pid::from(*pid as usize),
+                process_tree::MAX_PIDS_PER_BLOCK,
+            )
+        })
+        .map(|pid| pid.as_u32())
+        .collect();
+
+    let samples: Vec<ProcSample> = sys
+        .processes()
+        .iter()
+        .map(|(pid, proc)| ProcSample {
+            pid: pid.as_u32(),
+            name: proc.name().to_string_lossy().into_owned(),
+            commit_mb: proc.virtual_memory() as f64 / BYTES_PER_MB,
+        })
+        .collect();
+
+    let result = classify_commit_attribution(&samples, &pane_pids, ATTRIBUTION_OTHER_TOP_N);
+    let (commit_used_gb, commit_total_gb) = {
+        #[cfg(target_os = "windows")]
+        {
+            use windows_sys::Win32::System::SystemInformation::{
+                GlobalMemoryStatusEx, MEMORYSTATUSEX,
+            };
+            let mut mem: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+            mem.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+            if unsafe { GlobalMemoryStatusEx(&mut mem) } != 0 {
+                let total_gb = mem.ullTotalPageFile as f64 / BYTES_PER_GB;
+                let avail_gb = mem.ullAvailPageFile as f64 / BYTES_PER_GB;
+                (total_gb - avail_gb, total_gb)
+            } else {
+                (0.0, 0.0)
+            }
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            (0.0, 0.0)
+        }
+    };
+
+    let other_top_str = result
+        .other_top
+        .iter()
+        .map(|(name, mb)| format!("{}:{:.0}MB", name, mb))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    tracing::info!(
+        target: "mem_attribution",
+        commit_used_gb = format!("{:.2}", commit_used_gb),
+        commit_total_gb = format!("{:.2}", commit_total_gb),
+        agentmux_mb = format!("{:.0}", result.agentmux_mb),
+        panes_mb = format!("{:.0}", result.panes_mb),
+        other_mb = format!("{:.0}", result.other_mb),
+        other_top = %other_top_str,
+        process_count = samples.len(),
+        "commit attribution"
+    );
+}
 
 /// Collect CPU usage (total + per-core).
 fn get_cpu_data(sys: &sysinfo::System, values: &mut HashMap<String, f64>) {
@@ -364,6 +518,75 @@ mod pagefile_volume_tests {
     }
 }
 
+#[cfg(test)]
+mod commit_attribution_tests {
+    use super::*;
+
+    fn sample(pid: u32, name: &str, commit_mb: f64) -> ProcSample {
+        ProcSample { pid, name: name.to_string(), commit_mb }
+    }
+
+    #[test]
+    fn buckets_agentmux_by_name_regardless_of_pane_membership() {
+        // Name match wins even if (hypothetically) a PID also showed up in
+        // a pane's descendant tree — AgentMux's own processes are never
+        // "pane" work, no matter how the tree walk found them.
+        let samples = vec![sample(100, "agentmux-cef.exe", 500.0)];
+        let mut pane_pids = HashSet::new();
+        pane_pids.insert(100);
+        let result = classify_commit_attribution(&samples, &pane_pids, 5);
+        assert_eq!(result.agentmux_mb, 500.0);
+        assert_eq!(result.panes_mb, 0.0);
+    }
+
+    #[test]
+    fn buckets_pane_pids_by_membership_not_name() {
+        // A pane's process tree (e.g. node.exe running Claude Code) is
+        // classified by exact PID membership, not by guessing its name.
+        let samples = vec![sample(200, "node.exe", 300.0), sample(201, "conhost.exe", 10.0)];
+        let mut pane_pids = HashSet::new();
+        pane_pids.insert(200);
+        pane_pids.insert(201);
+        let result = classify_commit_attribution(&samples, &pane_pids, 5);
+        assert_eq!(result.panes_mb, 310.0);
+        assert_eq!(result.agentmux_mb, 0.0);
+        assert!(result.other_top.is_empty());
+    }
+
+    #[test]
+    fn everything_else_falls_to_other_ranked_and_capped() {
+        let samples = vec![
+            sample(1, "chrome.exe", 800.0),
+            sample(2, "Code.exe", 600.0),
+            sample(3, "Docker Desktop.exe", 1200.0),
+            sample(4, "explorer.exe", 150.0),
+        ];
+        let result = classify_commit_attribution(&samples, &HashSet::new(), 2);
+        // Total is preserved even though the printed list is capped.
+        assert_eq!(result.other_mb, 800.0 + 600.0 + 1200.0 + 150.0);
+        // Only the top 2 (by commit) are kept for the log line, descending.
+        assert_eq!(result.other_top.len(), 2);
+        assert_eq!(result.other_top[0].0, "Docker Desktop.exe");
+        assert_eq!(result.other_top[1].0, "chrome.exe");
+    }
+
+    #[test]
+    fn name_match_is_case_insensitive() {
+        let samples = vec![sample(1, "AgentMux-Srv.exe", 42.0)];
+        let result = classify_commit_attribution(&samples, &HashSet::new(), 5);
+        assert_eq!(result.agentmux_mb, 42.0);
+    }
+
+    #[test]
+    fn empty_process_list_yields_zeroed_result() {
+        let result = classify_commit_attribution(&[], &HashSet::new(), 5);
+        assert_eq!(result.agentmux_mb, 0.0);
+        assert_eq!(result.panes_mb, 0.0);
+        assert_eq!(result.other_mb, 0.0);
+        assert!(result.other_top.is_empty());
+    }
+}
+
 /// Network I/O tracking state for rate calculations.
 struct NetState {
     prev_sent: u64,
@@ -444,6 +667,13 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
     let mut net_state = NetState::new();
     let mut disks = Disks::new_with_refreshed_list();
     let mut last_tick = Instant::now();
+    // Commit-attribution cadence — see the "Commit (pagefile) attribution"
+    // section above. Starts due-now-minus-interval so the first snapshot
+    // establishes a baseline shortly after startup, not 30s of silence.
+    let mut last_attribution = Instant::now()
+        .checked_sub(ATTRIBUTION_INTERVAL)
+        .unwrap_or_else(Instant::now);
+    let mut last_urgent_attribution: Option<Instant> = None;
 
     let mut current_interval = get_interval_secs(&config_watcher);
     let mut ticker = tokio::time::interval(Duration::from_secs_f64(current_interval));
@@ -496,6 +726,26 @@ pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWat
         get_commit_data(&mut values);
         net_state.get_net_data(&networks, &mut values);
         get_disk_data(&disks, elapsed_secs, &mut values);
+
+        // Commit attribution: periodic in the steady state, or immediately
+        // (debounced) when commit heads toward exhaustion — see
+        // docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md. Reuses
+        // the commit numbers just computed above rather than re-querying.
+        let commit_avail_gb = match (values.get("mem:commit:total"), values.get("mem:commit:used")) {
+            (Some(total), Some(used)) => Some(total - used),
+            _ => None,
+        };
+        let due_periodic = now_instant.duration_since(last_attribution) >= ATTRIBUTION_INTERVAL;
+        let due_urgent = commit_avail_gb.is_some_and(|gb| gb < ATTRIBUTION_URGENT_THRESHOLD_GB)
+            && last_urgent_attribution
+                .is_none_or(|t| now_instant.duration_since(t) >= ATTRIBUTION_URGENT_COOLDOWN);
+        if due_periodic || due_urgent {
+            tokio::task::block_in_place(|| log_memory_attribution(&mut sys));
+            last_attribution = now_instant;
+            if due_urgent {
+                last_urgent_attribution = Some(now_instant);
+            }
+        }
 
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -48,6 +48,17 @@ const ATTRIBUTION_URGENT_THRESHOLD_GB: f64 = 2.0;
 const ATTRIBUTION_URGENT_COOLDOWN: Duration = Duration::from_secs(10);
 /// How many "other" processes to name individually in the log line.
 const ATTRIBUTION_OTHER_TOP_N: usize = 5;
+/// Per-block descendant-PID cap for the attribution walk — deliberately its
+/// OWN, much larger constant, not `process_tree::MAX_PIDS_PER_BLOCK` (64).
+/// That cap is sized for the Sysinfo pane's small per-block CPU/mem display;
+/// reusing it here silently dropped overflow into the "other" bucket
+/// instead of "panes" in exactly the storm scenario this feature exists to
+/// diagnose (a single block's descendant tree exceeding 64 processes) —
+/// reagent P1 on PR #2207. `collect_descendants` gives no truncation signal
+/// beyond "returned exactly `max_pids` results," so that's what
+/// `log_memory_attribution` checks to log a truncation warning rather than
+/// silently under-counting (no silent caps).
+const ATTRIBUTION_MAX_PIDS_PER_BLOCK: usize = 4096;
 
 /// One process's classification input — commit charge, not working set:
 /// what actually exhausts the pagefile. (sysinfo's `virtual_memory()` on
@@ -114,17 +125,23 @@ fn log_memory_attribution(sys: &mut sysinfo::System) {
         ProcessRefreshKind::everything(),
     );
 
-    let pane_pids: HashSet<u32> = pidregistry::get_all()
-        .iter()
-        .flat_map(|(_, pid)| {
-            process_tree::collect_descendants(
-                sys,
-                Pid::from(*pid as usize),
-                process_tree::MAX_PIDS_PER_BLOCK,
-            )
-        })
-        .map(|pid| pid.as_u32())
-        .collect();
+    let mut pane_pids: HashSet<u32> = HashSet::new();
+    for (block_id, pid) in pidregistry::get_all() {
+        let tree = process_tree::collect_descendants(
+            sys,
+            Pid::from(pid as usize),
+            ATTRIBUTION_MAX_PIDS_PER_BLOCK,
+        );
+        if tree.len() == ATTRIBUTION_MAX_PIDS_PER_BLOCK {
+            tracing::warn!(
+                block_id = %block_id,
+                cap = ATTRIBUTION_MAX_PIDS_PER_BLOCK,
+                "log_memory_attribution: block's descendant PID tree hit the cap — \
+                 some processes may be misclassified into \"other\" instead of \"panes\""
+            );
+        }
+        pane_pids.extend(tree.into_iter().map(|pid| pid.as_u32()));
+    }
 
     let samples: Vec<ProcSample> = sys
         .processes()


### PR DESCRIPTION
Follow-up to #2205 / #2206 — closes the observability gap those PRs' incident hit: **no log ever recorded which process was actually consuming commit**, only the system-wide total. That incident got root-caused anyway through careful cross-log correlation, but the next OOM crash might not leave as clean a trail. The user asked directly: "we need to get to the bottom of it, even if it means adding granular diagnostics to figure out who is inflating the page file. it could be agentmux or claude, we need to figure it out."

## What this adds

Extends the existing sysinfo loop (`agentmux-srv/src/backend/sysinfo.rs`, already running at ~1Hz for the Sysinfo pane) with a periodic (30s) + urgent-on-pressure (commit-available <2GB, debounced to every 10s while sustained) full-process-table snapshot, logged at `target: "mem_attribution"` (`muxlog srv grep mem_attribution`). Every process on the machine is bucketed:

- **`agentmux`** — this app's own process family (host, srv, launcher, CEF helper processes — name-matched, `starts_with("agentmux")`)
- **`panes`** — every registered block's shell process tree (agent CLI subprocesses — including Claude Code — terminal shells, etc.), by **exact PID-tree membership** via the existing `pidregistry` + `process_tree::collect_descendants` (the same primitive that already powers per-pane CPU/mem in the Sysinfo pane), not name-guessing
- **`other`** — everything else on the machine, with the top 5 by commit named individually in the log line, so it's never a black box even when the answer is neither AgentMux nor a pane (Chrome, VS Code, Docker, Windows itself, ...)

Uses **commit charge**, not working set: sysinfo's `virtual_memory()` on Windows is `PROCESS_MEMORY_COUNTERS_EX::PrivateUsage` under the hood (a misleading name from sysinfo's cross-platform API) — that's the number that actually exhausts the pagefile; working set (physical RAM residency) is a related but distinct metric.

## Why this shape

- Reuses infrastructure that already exists in this file (the per-block process-tree BFS, the `GlobalMemoryStatusEx` commit read) rather than adding a new subsystem.
- The urgent trigger means a snapshot lands close to an actual crash, not just up to 30s stale.
- Classification logic is a pure function (`classify_commit_attribution`), unit-tested without needing a real process table — mirrors this file's existing `resolve_pagefile_watch_target` pattern.

## Verification

- `cargo test -p agentmux-srv commit_attribution`: 5/5 new tests pass (bucket-by-name, bucket-by-PID-membership regardless of name, other-ranked-and-capped-but-total-preserved, case-insensitive name match, empty-table edge case).
- `cargo test -p agentmux-srv`: full suite green (one `subagent_watcher` test flaked once under parallel load, confirmed pre-existing/unrelated — passes in isolation and on a clean rerun of the full suite).
- `cargo build -p agentmux-srv` clean, no new warnings.

<!-- agentmux:agent_id=agenta-07017 -->