### PR TITLE
feat(swarm): AgentDispatch/SubAgent two-level schema for subagents/workflows

### DIFF
--- a/.changesets/1784332937-feat-agent-dispatch-subagent-schema.md
+++ b/.changesets/1784332937-feat-agent-dispatch-subagent-schema.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): AgentDispatch/SubAgent two-level schema — one row per Agent-tool-or-Workflow-tool call in the Swarm pane, with a concatenated live activity feed for large workflow dispatches instead of one row per member

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -15,10 +15,14 @@
 //!
 //! This module watches those directories and emits:
 //!   - `subagent:spawned`   — new subagent JSONL file detected
-//!   - `subagent:activity`  — new events appended to a subagent file
+//!   - `subagent:activity`  — new events for a Solo dispatch's one member
+//!     (Workflow-dispatch member activity is coalesced into
+//!     `dispatch:activity` instead — see `PendingDispatchActivity`)
 //!   - `subagent:completed` — subagent finished (result event seen)
-//!   - `workflow:updated`   — a workflow run's member count or journal
-//!     `started`/`result` tally changed (see `WorkflowInfo`)
+//!   - `dispatch:updated`   — an `AgentDispatch`'s member count or status
+//!     changed (both Solo and Workflow kinds; see `AgentDispatch`)
+//!   - `dispatch:activity`  — coalesced new events across a Workflow
+//!     dispatch's members, flushed every `DISPATCH_ACTIVITY_FLUSH_INTERVAL`
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
@@ -35,8 +39,12 @@ use super::eventbus::{EventBus, WSEventType, WS_EVENT_RPC};
 
 // ── Public types ──────────────────────────────────────────────────────────
 
+// SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17: `SubAgent` is the
+// member-level entity (one spawned Claude Code agent instance) — renamed
+// in place from `SubagentInfo`. Its container, `AgentDispatch` (below), is
+// the new entity: one per Agent-tool-or-Workflow-tool call.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SubagentInfo {
+pub struct SubAgent {
     pub agent_id: String,
     pub slug: String,
     pub jsonl_path: String,
@@ -49,21 +57,34 @@ pub struct SubagentInfo {
     /// dock to render an elapsed timer / sort by spawn recency.
     pub spawned_at: u64,
     pub last_event_at: u64,
-    pub status: SubagentStatus,
+    pub status: SubAgentStatus,
     pub event_count: usize,
     pub model: Option<String>,
-    /// Some("wf_<id>") when this subagent runs inside a Workflow tool run
-    /// (JSONL under `subagents/workflows/<id>/`); None for direct subagents.
-    pub workflow_id: Option<String>,
+    /// The owning `AgentDispatch.dispatch_id` — mandatory, unlike the old
+    /// `workflow_id: Option<String>` it replaces. A Workflow-tool member
+    /// carries the run-id Claude Code already assigns
+    /// (`subagents/workflows/<run-id>/`); a solo Task-tool call gets a
+    /// synthesized `format!("solo:{agent_id}")` (see `solo_dispatch_id`) —
+    /// every SubAgent now has a real container, not just workflow members.
+    pub dispatch_id: String,
     /// Concise Haiku-generated name, set once on-demand when a client first
     /// expands this subagent (see `subagent.GenerateName`). None until then
     /// — callers fall back to `slug`/`agent_id` themselves.
     pub display_name: Option<String>,
+    /// The transcript's own `"parentUuid"` field, parsed verbatim (SPEC
+    /// §9.2). `None` in every real transcript checked so far — nested
+    /// subagent spawning is permitted for unrestricted-tool subagent types
+    /// (`general-purpose`/`claude`) but has never been observed in
+    /// practice. Captured defensively since the first JSONL line is
+    /// already read for `slug`/`model`; if ever `Some`, this SubAgent is a
+    /// grandchild of another SubAgent, not a direct member of its nominal
+    /// `dispatch_id`.
+    pub spawned_from_agent_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
-pub enum SubagentStatus {
+pub enum SubAgentStatus {
     Active,
     Completed,
     /// The parent block's turn ended without a `Result` line ever appearing
@@ -71,8 +92,7 @@ pub enum SubagentStatus {
     /// app/srv restart mid-task. Distinct from `Completed`: the subagent
     /// didn't finish, it was cut off. Set only by
     /// `reconcile_stale_subagents`, never by `process_jsonl_change`'s
-    /// normal event processing. See
-    /// docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md.
+    /// normal event processing.
     Abandoned,
 }
 
@@ -97,26 +117,58 @@ pub enum SubagentEventType {
     Result { content: String },
 }
 
+/// The container-level entity: one per Agent-tool (Task tool) call or
+/// Workflow-tool call. "What got kicked off," not "what ran" — a `Solo`
+/// dispatch always has exactly one `SubAgent`; a `Workflow` dispatch has
+/// however many the run has spawned so far (may still be growing).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WorkflowInfo {
-    pub workflow_id: String,
+pub struct AgentDispatch {
+    /// Workflow kind: the run-id Claude Code already assigns
+    /// (`subagents/workflows/<run-id>/`) — stable across srv restarts,
+    /// unlike an agent_id. Solo kind: `format!("solo:{agent_id}")` (see
+    /// `solo_dispatch_id`) — a solo dispatch is 1:1 with its one member, so
+    /// no separate ID-minting is needed.
+    pub dispatch_id: String,
+    pub kind: DispatchKind,
     pub parent_agent: String,
     pub parent_block_id: String,
     pub session_id: String,
-    /// Agents launched, per the run's journal `started` records (falls back
-    /// to the count of member JSONL files seen when the journal lags).
-    pub agents_total: usize,
-    /// Agents finished, per the journal's `result` records.
-    pub agents_done: usize,
-    pub status: WorkflowStatus,
+    /// Members launched. Workflow kind: per the run's journal `started`
+    /// records (falls back to the count of member JSONL files seen when the
+    /// journal lags). Solo kind: always 1.
+    pub member_count: usize,
+    /// Members finished. Workflow kind: per the journal's `result` records.
+    /// Solo kind: 1 once its one SubAgent is Completed, else 0.
+    pub members_done: usize,
+    pub status: DispatchStatus,
     pub last_event_at: u64,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum DispatchKind {
+    Solo,
+    Workflow,
+}
+
+// SPEC §9.3 (open): an Abandoned aggregation rule for DispatchStatus,
+// mirroring SubAgentStatus::Abandoned one level up, is proposed but not yet
+// implemented — this enum matches today's WorkflowStatus behavior (no
+// abandoned tracking at the dispatch level) rather than half-implementing
+// an undecided rule.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
-pub enum WorkflowStatus {
+pub enum DispatchStatus {
     Running,
     Completed,
+}
+
+/// Solo dispatch identity — a solo Task-tool call has no run-id from Claude
+/// Code (it's a flat file directly under `subagents/`, not nested under
+/// `workflows/<run-id>/`), so it needs a synthesized-but-deterministic ID.
+/// Prefixed so it can never collide with a real workflow run-id.
+fn solo_dispatch_id(agent_id: &str) -> String {
+    format!("solo:{agent_id}")
 }
 
 // ── Internal state ────────────────────────────────────────────────────────
@@ -141,15 +193,19 @@ const MAX_SUBAGENT_EVENTS: usize = 2048;
 const BACKFILL_MAX_FILES: usize = 200;
 
 struct SubagentState {
-    info: SubagentInfo,
+    info: SubAgent,
     file_offset: u64,
     events: Vec<SubagentEvent>,
 }
 
-struct WorkflowState {
-    info: WorkflowInfo,
+/// Tracked state for a Workflow-kind `AgentDispatch`. Solo-kind dispatches
+/// have no equivalent persistent state — they're synthesized on demand
+/// (`list_dispatches`) directly from their one `SubAgent`, since there's
+/// nothing to aggregate across members when there's only ever one.
+struct DispatchState {
+    info: AgentDispatch,
     journal_offset: u64,
-    /// Journal-sourced counters. `agents_total` in the public info is
+    /// Journal-sourced counters. `member_count` in the public info is
     /// max(journal_started, member files seen) since either side can lag.
     journal_started: usize,
     journal_results: usize,
@@ -166,11 +222,33 @@ struct WatchedAgent {
 
 // ── SubagentWatcher ───────────────────────────────────────────────────────
 
+/// Buffered `subagent:activity` events for one Workflow-kind dispatch,
+/// coalesced into a single `dispatch:activity` broadcast on the next flush
+/// tick instead of one WS message per member-event (SPEC §7 — the exact
+/// mechanism behind the 1,030-events-in-10-seconds broadcast storm in
+/// docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md). Solo-kind
+/// dispatches are never buffered here — one member has no coalescing
+/// benefit, and immediate feedback matters more when it's the only thing
+/// running.
+struct PendingDispatchActivity {
+    parent_agent: String,
+    parent_block_id: String,
+    session_id: String,
+    /// One entry per member that had new events since the last flush.
+    members: Vec<(String /* agent_id */, Vec<SubagentEvent>)>,
+}
+
+/// Flush cadence for buffered dispatch activity (SPEC §9.5 — 250ms-1s was
+/// floated as a plausible range, not measured; 500ms is the midpoint,
+/// picked as a reasonable default pending real usage data).
+const DISPATCH_ACTIVITY_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
+
 pub struct SubagentWatcher {
     event_bus: Arc<EventBus>,
     sessions: Mutex<HashMap<String, SessionWatch>>,
     watched_agents: Mutex<Vec<WatchedAgent>>,
-    workflows: Mutex<HashMap<String, WorkflowState>>,
+    dispatches: Mutex<HashMap<String, DispatchState>>,
+    pending_activity: Mutex<HashMap<String, PendingDispatchActivity>>,
 }
 
 impl SubagentWatcher {
@@ -179,14 +257,26 @@ impl SubagentWatcher {
             event_bus,
             sessions: Mutex::new(HashMap::new()),
             watched_agents: Mutex::new(Vec::new()),
-            workflows: Mutex::new(HashMap::new()),
+            dispatches: Mutex::new(HashMap::new()),
+            pending_activity: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Create a new SubagentWatcher and return it wrapped in Arc.
+    /// Create a new SubagentWatcher and return it wrapped in Arc. Also
+    /// starts the background flush loop for coalesced dispatch activity
+    /// (SPEC §7) — runs for the lifetime of the process, mirroring
+    /// `watch_agent`'s existing `tokio::spawn` pattern.
     pub fn spawn(event_bus: Arc<EventBus>) -> Arc<Self> {
         let watcher = Arc::new(Self::new(event_bus));
         tracing::info!("subagent watcher initialized");
+        let flusher = Arc::clone(&watcher);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(DISPATCH_ACTIVITY_FLUSH_INTERVAL);
+            loop {
+                interval.tick().await;
+                flusher.flush_pending_dispatch_activity();
+            }
+        });
         watcher
     }
 
@@ -448,7 +538,7 @@ impl SubagentWatcher {
     }
 
     /// List all subagents across all sessions (sync — safe to call from RPC dispatch).
-    pub fn list_active(&self) -> Vec<SubagentInfo> {
+    pub fn list_active(&self) -> Vec<SubAgent> {
         let sessions = self.sessions.lock().unwrap();
         let mut result = Vec::new();
         for session in sessions.values() {
@@ -460,18 +550,54 @@ impl SubagentWatcher {
         result
     }
 
-    /// List all tracked workflow runs (sync — safe to call from RPC dispatch).
-    pub fn list_workflows(&self) -> Vec<WorkflowInfo> {
-        let mut workflows = self.workflows.lock().unwrap();
-        let mut result: Vec<WorkflowInfo> = workflows
-            .values_mut()
-            .map(|state| {
-                Self::refresh_workflow_status(state);
-                state.info.clone()
-            })
-            .collect();
+    /// List all tracked dispatches — both kinds (sync — safe to call from
+    /// RPC dispatch). Workflow-kind dispatches come from tracked
+    /// `DispatchState`; Solo-kind dispatches have no persistent state of
+    /// their own and are synthesized 1:1 from every loose `SubAgent` (SPEC
+    /// §5/§8) — this is what gives every solo Task-tool call a real,
+    /// backend-issued container it never had before.
+    pub fn list_dispatches(&self) -> Vec<AgentDispatch> {
+        let mut result: Vec<AgentDispatch> = {
+            let mut dispatches = self.dispatches.lock().unwrap();
+            dispatches
+                .values_mut()
+                .map(|state| {
+                    Self::refresh_dispatch_status(state);
+                    state.info.clone()
+                })
+                .collect()
+        };
+        let sessions = self.sessions.lock().unwrap();
+        for session in sessions.values() {
+            for state in session.subagents.values() {
+                if let Some(solo) = Self::solo_dispatch(&state.info) {
+                    result.push(solo);
+                }
+            }
+        }
         result.sort_by(|a, b| b.last_event_at.cmp(&a.last_event_at));
         result
+    }
+
+    /// Synthesize the `AgentDispatch` for a loose (non-workflow) `SubAgent`.
+    /// `None` for a workflow member — those are represented by their
+    /// tracked `DispatchState` instead, not synthesized per-call.
+    fn solo_dispatch(sub: &SubAgent) -> Option<AgentDispatch> {
+        if !sub.dispatch_id.starts_with("solo:") {
+            return None;
+        }
+        let done = matches!(sub.status, SubAgentStatus::Completed | SubAgentStatus::Abandoned);
+        Some(AgentDispatch {
+            dispatch_id: sub.dispatch_id.clone(),
+            kind: DispatchKind::Solo,
+            parent_agent: sub.parent_agent.clone(),
+            parent_block_id: sub.parent_block_id.clone(),
+            session_id: sub.session_id.clone(),
+            member_count: 1,
+            members_done: done as usize,
+            status: if done { DispatchStatus::Completed } else { DispatchStatus::Running },
+            last_event_at: sub.last_event_at,
+        })
     }
 
     /// Get recent events for a specific subagent (sync — safe to call from RPC dispatch).
@@ -492,7 +618,7 @@ impl SubagentWatcher {
     /// after its `subagent:spawned` event already fired needs its info once,
     /// at mount; scanning + cloning every active subagent across every
     /// session for that is wasteful when the caller already knows the id.
-    pub fn get_info(&self, agent_id: &str) -> Option<SubagentInfo> {
+    pub fn get_info(&self, agent_id: &str) -> Option<SubAgent> {
         let sessions = self.sessions.lock().unwrap();
         for session in sessions.values() {
             if let Some(state) = session.subagents.get(agent_id) {
@@ -512,9 +638,9 @@ impl SubagentWatcher {
         // Captured alongside the mutation itself (not re-looked-up after
         // unlocking) — this is the exact moment a NAME-based grouping key is
         // born, so the fields that decide which group it lands in
-        // (workflow_id, parent_block_id) need to be logged from the same
+        // (dispatch_id, parent_block_id) need to be logged from the same
         // locked read that set it, not a racy re-fetch.
-        let mut found_context: Option<(String, String, Option<String>)> = None;
+        let mut found_context: Option<(String, String, String)> = None;
         let found = {
             let mut sessions = self.sessions.lock().unwrap();
             let mut found = false;
@@ -524,7 +650,7 @@ impl SubagentWatcher {
                     found_context = Some((
                         state.info.parent_block_id.clone(),
                         state.info.session_id.clone(),
-                        state.info.workflow_id.clone(),
+                        state.info.dispatch_id.clone(),
                     ));
                     found = true;
                     break;
@@ -534,13 +660,13 @@ impl SubagentWatcher {
         };
         // Mutex released here — broadcast outside the lock
 
-        if let Some((parent_block_id, session_id, workflow_id)) = &found_context {
+        if let Some((parent_block_id, session_id, dispatch_id)) = &found_context {
             tracing::info!(
                 agent_id = %agent_id,
                 display_name = %display_name,
                 parent_block_id = %parent_block_id,
                 session_id = %session_id,
-                workflow_id = ?workflow_id,
+                dispatch_id = %dispatch_id,
                 "subagent display_name resolved"
             );
         }
@@ -680,18 +806,18 @@ impl SubagentWatcher {
             if state.info.parent_block_id != parent_block_id {
                 continue;
             }
-            if state.info.status == SubagentStatus::Active {
-                state.info.status = SubagentStatus::Abandoned;
+            if state.info.status == SubAgentStatus::Active {
+                state.info.status = SubAgentStatus::Abandoned;
                 reconciled += 1;
                 // Every field a NAME-based grouping/dedup bug needs to
-                // reconstruct offline: which subagent, which workflow (if
-                // any), which display_name it had already resolved (grouping
-                // is keyed on this), and which block/session it's bound to.
+                // reconstruct offline: which subagent, which dispatch,
+                // which display_name it had already resolved (grouping is
+                // keyed on this), and which block/session it's bound to.
                 tracing::info!(
                     agent_id = %state.info.agent_id,
                     parent_block_id = %parent_block_id,
                     session_id = %session_id,
-                    workflow_id = ?state.info.workflow_id,
+                    dispatch_id = %state.info.dispatch_id,
                     display_name = ?state.info.display_name,
                     slug = %state.info.slug,
                     "subagent reconciled: active -> abandoned (parent turn ended)"
@@ -812,6 +938,9 @@ impl SubagentWatcher {
         // so walk ancestors instead of assuming a fixed depth.
         let session_id = derive_session_id(jsonl_path);
         let workflow_id = parse_workflow_id(jsonl_path);
+        // Every SubAgent has a real dispatch_id now — a solo Task-tool call
+        // gets a synthesized one (SPEC §5), not just workflow members.
+        let dispatch_id = workflow_id.clone().unwrap_or_else(|| solo_dispatch_id(&agent_id));
 
         // Read the current offset before locking (so file I/O is outside the lock)
         let current_offset = {
@@ -874,7 +1003,7 @@ impl SubagentWatcher {
             }
             let state = session.subagents.entry(agent_id.clone()).or_insert_with(|| {
                 SubagentState {
-                    info: SubagentInfo {
+                    info: SubAgent {
                         agent_id: agent_id.clone(),
                         slug: String::new(),
                         jsonl_path: jsonl_path.to_string_lossy().to_string(),
@@ -883,11 +1012,12 @@ impl SubagentWatcher {
                         session_id: session_id.clone(),
                         spawned_at: now_millis(),
                         last_event_at: now_millis(),
-                        status: SubagentStatus::Active,
+                        status: SubAgentStatus::Active,
                         event_count: 0,
                         model: None,
-                        workflow_id: None,
+                        dispatch_id: dispatch_id.clone(),
                         display_name: None,
+                        spawned_from_agent_id: None,
                     },
                     file_offset: 0,
                     events: Vec::new(),
@@ -895,7 +1025,7 @@ impl SubagentWatcher {
             });
 
             state.file_offset = new_offset;
-            state.info.workflow_id = workflow_id.clone();
+            state.info.dispatch_id = dispatch_id.clone();
 
             // Update metadata from first line if we got it
             if let Some(m) = meta {
@@ -904,6 +1034,9 @@ impl SubagentWatcher {
                 }
                 if let Some(model) = m.model {
                     state.info.model = Some(model);
+                }
+                if m.parent_uuid.is_some() {
+                    state.info.spawned_from_agent_id = m.parent_uuid;
                 }
             }
 
@@ -934,7 +1067,7 @@ impl SubagentWatcher {
             if let Some(last) = new_events.last() {
                 if matches!(&last.event_type, SubagentEventType::Result { .. }) {
                     completed = true;
-                    state.info.status = SubagentStatus::Completed;
+                    state.info.status = SubAgentStatus::Completed;
                 }
             }
 
@@ -958,7 +1091,7 @@ impl SubagentWatcher {
                             "parentBlockId": parent_block_id,
                             "sessionId": session_id,
                             "model": info_snapshot.model,
-                            "workflowId": info_snapshot.workflow_id,
+                            "dispatchId": info_snapshot.dispatch_id,
                         }
                     }
                 })),
@@ -970,32 +1103,52 @@ impl SubagentWatcher {
                 parent = %parent_agent,
                 parent_block_id = %parent_block_id,
                 session_id = %session_id,
-                workflow_id = ?info_snapshot.workflow_id,
+                dispatch_id = %info_snapshot.dispatch_id,
                 "subagent spawned"
             );
         }
 
         if !new_events.is_empty() {
-            let activity_event = WSEventType {
-                eventtype: WS_EVENT_RPC.to_string(),
-                oref: String::new(),
-                data: Some(json!({
-                    "command": "eventrecv",
-                    "data": {
-                        "event": "subagent:activity",
+            if workflow_id.is_some() {
+                // Workflow-kind member: buffer for the next coalesced
+                // dispatch:activity flush instead of broadcasting per-member
+                // (SPEC §7) — a large dispatch's activity ticks are the
+                // exact mechanism behind the crash-storm broadcast volume in
+                // docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md.
+                let mut pending = self.pending_activity.lock().unwrap();
+                let entry = pending
+                    .entry(dispatch_id.clone())
+                    .or_insert_with(|| PendingDispatchActivity {
+                        parent_agent: parent_agent.to_string(),
+                        parent_block_id: parent_block_id.to_string(),
+                        session_id: session_id.clone(),
+                        members: Vec::new(),
+                    });
+                entry.members.push((agent_id.clone(), new_events.clone()));
+            } else {
+                // Solo dispatch: exactly one member, no coalescing benefit —
+                // broadcast immediately, same as before the redesign.
+                let activity_event = WSEventType {
+                    eventtype: WS_EVENT_RPC.to_string(),
+                    oref: String::new(),
+                    data: Some(json!({
+                        "command": "eventrecv",
                         "data": {
-                            "agentId": agent_id,
-                            "parentAgent": parent_agent,
-                            "parentBlockId": parent_block_id,
-                            "newEvents": new_events.len(),
-                            "totalEvents": info_snapshot.event_count,
-                            "events": new_events,
-                            "workflowId": info_snapshot.workflow_id,
+                            "event": "subagent:activity",
+                            "data": {
+                                "agentId": agent_id,
+                                "parentAgent": parent_agent,
+                                "parentBlockId": parent_block_id,
+                                "newEvents": new_events.len(),
+                                "totalEvents": info_snapshot.event_count,
+                                "events": new_events,
+                                "dispatchId": info_snapshot.dispatch_id,
+                            }
                         }
-                    }
-                })),
-            };
-            self.event_bus.broadcast_event(&activity_event);
+                    })),
+                };
+                self.event_bus.broadcast_event(&activity_event);
+            }
         }
 
         if completed {
@@ -1011,7 +1164,7 @@ impl SubagentWatcher {
                             "parentAgent": parent_agent,
                             "parentBlockId": parent_block_id,
                             "totalEvents": info_snapshot.event_count,
-                            "workflowId": info_snapshot.workflow_id,
+                            "dispatchId": info_snapshot.dispatch_id,
                         }
                     }
                 })),
@@ -1022,13 +1175,13 @@ impl SubagentWatcher {
                 total_events = info_snapshot.event_count,
                 parent_block_id = %parent_block_id,
                 session_id = %session_id,
-                workflow_id = ?info_snapshot.workflow_id,
+                dispatch_id = %info_snapshot.dispatch_id,
                 "subagent completed"
             );
         }
 
         if let Some(wf_id) = workflow_id {
-            self.update_workflow_membership(
+            self.update_dispatch_membership(
                 &wf_id,
                 parent_agent,
                 parent_block_id,
@@ -1036,19 +1189,66 @@ impl SubagentWatcher {
                 is_new,
                 completed,
             );
+        } else if is_new || completed {
+            // Solo dispatch: no tracked DispatchState to update — just
+            // broadcast the freshly-synthesized AgentDispatch so dispatch:
+            // updated fires for both kinds (SPEC §5), not just Workflow.
+            if let Some(dispatch) = Self::solo_dispatch(&info_snapshot) {
+                self.broadcast_dispatch_updated(&dispatch);
+            }
         }
     }
 
-    /// Fold a member subagent's lifecycle into its workflow aggregate and
-    /// broadcast `workflow:updated` — but only when membership actually
+    /// Flush every dispatch with buffered activity as one coalesced
+    /// `dispatch:activity` broadcast (SPEC §7). Called on
+    /// `DISPATCH_ACTIVITY_FLUSH_INTERVAL` by the background task
+    /// `spawn` starts. A quiet dispatch (nothing buffered) costs nothing —
+    /// the map only ever holds entries for dispatches with real pending
+    /// activity, drained on every flush.
+    fn flush_pending_dispatch_activity(&self) {
+        let batch: HashMap<String, PendingDispatchActivity> = {
+            let mut pending = self.pending_activity.lock().unwrap();
+            std::mem::take(&mut *pending)
+        };
+        for (dispatch_id, pending) in batch {
+            if pending.members.is_empty() {
+                continue;
+            }
+            let new_events: usize = pending.members.iter().map(|(_, evs)| evs.len()).sum();
+            let event = WSEventType {
+                eventtype: WS_EVENT_RPC.to_string(),
+                oref: String::new(),
+                data: Some(json!({
+                    "command": "eventrecv",
+                    "data": {
+                        "event": "dispatch:activity",
+                        "data": {
+                            "dispatchId": dispatch_id,
+                            "parentAgent": pending.parent_agent,
+                            "parentBlockId": pending.parent_block_id,
+                            "sessionId": pending.session_id,
+                            "newEvents": new_events,
+                            "members": pending.members.iter().map(|(agent_id, events)| {
+                                json!({ "agentId": agent_id, "events": events })
+                            }).collect::<Vec<_>>(),
+                        }
+                    }
+                })),
+            };
+            self.event_bus.broadcast_event(&event);
+        }
+    }
+
+    /// Fold a member subagent's lifecycle into its dispatch aggregate and
+    /// broadcast `dispatch:updated` — but only when membership actually
     /// changed (a spawn or a completion). `process_jsonl_change` calls this
     /// unconditionally for every workflow member, including plain
     /// text/tool_use/tool_result activity ticks that carry neither flag; a
-    /// workflow with several active members would otherwise broadcast a WS
-    /// event on every one of those ticks even though `agentsTotal`/
-    /// `agentsDone` never moved. Mirrors the `has_new_records` gate in
+    /// dispatch with several active members would otherwise broadcast a WS
+    /// event on every one of those ticks even though `memberCount`/
+    /// `membersDone` never moved. Mirrors the `has_new_records` gate in
     /// `process_journal_change`.
-    fn update_workflow_membership(
+    fn update_dispatch_membership(
         &self,
         workflow_id: &str,
         parent_agent: &str,
@@ -1062,9 +1262,9 @@ impl SubagentWatcher {
         }
 
         let info = {
-            let mut workflows = self.workflows.lock().unwrap();
-            let state = Self::workflow_entry(
-                &mut workflows,
+            let mut dispatches = self.dispatches.lock().unwrap();
+            let state = Self::dispatch_entry(
+                &mut dispatches,
                 workflow_id,
                 parent_agent,
                 parent_block_id,
@@ -1076,14 +1276,14 @@ impl SubagentWatcher {
             if member_completed {
                 state.members_completed += 1;
             }
-            Self::refresh_workflow_info(state);
+            Self::refresh_dispatch_info(state);
             state.info.clone()
         };
-        self.broadcast_workflow_updated(&info);
+        self.broadcast_dispatch_updated(&info);
     }
 
     /// Process a changed workflow journal (subagents/workflows/<wf>/journal.jsonl):
-    /// tally new `started`/`result` records and broadcast `workflow:updated`.
+    /// tally new `started`/`result` records and broadcast `dispatch:updated`.
     fn process_journal_change(
         &self,
         parent_agent: &str,
@@ -1098,8 +1298,8 @@ impl SubagentWatcher {
 
         // Read the current offset before locking (file I/O outside the lock).
         let offset = {
-            let workflows = self.workflows.lock().unwrap();
-            workflows
+            let dispatches = self.dispatches.lock().unwrap();
+            dispatches
                 .get(&workflow_id)
                 .map(|w| w.journal_offset)
                 .unwrap_or(0)
@@ -1124,9 +1324,9 @@ impl SubagentWatcher {
 
         let has_new_records = started > 0 || results > 0;
         let info = {
-            let mut workflows = self.workflows.lock().unwrap();
-            let state = Self::workflow_entry(
-                &mut workflows,
+            let mut dispatches = self.dispatches.lock().unwrap();
+            let state = Self::dispatch_entry(
+                &mut dispatches,
                 &workflow_id,
                 parent_agent,
                 parent_block_id,
@@ -1140,36 +1340,37 @@ impl SubagentWatcher {
             if has_new_records {
                 state.journal_started += started;
                 state.journal_results += results;
-                Self::refresh_workflow_info(state);
+                Self::refresh_dispatch_info(state);
             }
             state.info.clone()
         };
         // Only broadcast when the counters actually moved — an offset-only
         // advance (non-started/result lines) has no observable effect on
-        // WorkflowInfo, so a broadcast would just be noise.
+        // AgentDispatch, so a broadcast would just be noise.
         if has_new_records {
-            self.broadcast_workflow_updated(&info);
+            self.broadcast_dispatch_updated(&info);
         }
     }
 
-    fn workflow_entry<'a>(
-        workflows: &'a mut HashMap<String, WorkflowState>,
+    fn dispatch_entry<'a>(
+        dispatches: &'a mut HashMap<String, DispatchState>,
         workflow_id: &str,
         parent_agent: &str,
         parent_block_id: &str,
         session_id: &str,
-    ) -> &'a mut WorkflowState {
-        workflows
+    ) -> &'a mut DispatchState {
+        dispatches
             .entry(workflow_id.to_string())
-            .or_insert_with(|| WorkflowState {
-                info: WorkflowInfo {
-                    workflow_id: workflow_id.to_string(),
+            .or_insert_with(|| DispatchState {
+                info: AgentDispatch {
+                    dispatch_id: workflow_id.to_string(),
+                    kind: DispatchKind::Workflow,
                     parent_agent: parent_agent.to_string(),
                     parent_block_id: parent_block_id.to_string(),
                     session_id: session_id.to_string(),
-                    agents_total: 0,
-                    agents_done: 0,
-                    status: WorkflowStatus::Running,
+                    member_count: 0,
+                    members_done: 0,
+                    status: DispatchStatus::Running,
                     last_event_at: now_millis(),
                 },
                 journal_offset: 0,
@@ -1183,43 +1384,44 @@ impl SubagentWatcher {
     /// Recompute public counters from raw journal/member counters. Either
     /// source can lag the other (journal writes vs member file creation), so
     /// take the max of each pair.
-    fn refresh_workflow_info(state: &mut WorkflowState) {
-        state.info.agents_total = state.journal_started.max(state.member_files);
-        state.info.agents_done = state.journal_results.max(state.members_completed);
+    fn refresh_dispatch_info(state: &mut DispatchState) {
+        state.info.member_count = state.journal_started.max(state.member_files);
+        state.info.members_done = state.journal_results.max(state.members_completed);
         state.info.last_event_at = now_millis();
-        Self::refresh_workflow_status(state);
+        Self::refresh_dispatch_status(state);
     }
 
     /// Counts-complete + 60s quiet ⇒ Completed. There is no timer: the flip
-    /// happens lazily at the next event or ListWorkflows read. `started ==
+    /// happens lazily at the next event or ListDispatches read. `started ==
     /// results` alone is not terminal — it also holds between phases of a
     /// still-running workflow, hence the quiet window.
-    fn refresh_workflow_status(state: &mut WorkflowState) {
-        let counts_complete = state.info.agents_total > 0
-            && state.info.agents_done >= state.info.agents_total;
+    fn refresh_dispatch_status(state: &mut DispatchState) {
+        let counts_complete = state.info.member_count > 0
+            && state.info.members_done >= state.info.member_count;
         let quiet = now_millis().saturating_sub(state.info.last_event_at) > 60_000;
         state.info.status = if counts_complete && quiet {
-            WorkflowStatus::Completed
+            DispatchStatus::Completed
         } else {
-            WorkflowStatus::Running
+            DispatchStatus::Running
         };
     }
 
-    fn broadcast_workflow_updated(&self, info: &WorkflowInfo) {
+    fn broadcast_dispatch_updated(&self, info: &AgentDispatch) {
         let event = WSEventType {
             eventtype: WS_EVENT_RPC.to_string(),
             oref: String::new(),
             data: Some(json!({
                 "command": "eventrecv",
                 "data": {
-                    "event": "workflow:updated",
+                    "event": "dispatch:updated",
                     "data": {
-                        "workflowId": info.workflow_id,
+                        "dispatchId": info.dispatch_id,
+                        "kind": info.kind,
                         "parentAgent": info.parent_agent,
                         "parentBlockId": info.parent_block_id,
                         "sessionId": info.session_id,
-                        "agentsTotal": info.agents_total,
-                        "agentsDone": info.agents_done,
+                        "memberCount": info.member_count,
+                        "membersDone": info.members_done,
                         "status": info.status,
                     }
                 }
@@ -1235,6 +1437,10 @@ impl SubagentWatcher {
 struct JsonlMeta {
     slug: String,
     model: Option<String>,
+    /// The line's own `"parentUuid"` field, verbatim (SPEC §9.2 — `SubAgent.
+    /// spawned_from_agent_id`). `None` in every real transcript checked so
+    /// far; captured defensively since this line is already parsed.
+    parent_uuid: Option<String>,
 }
 
 /// Read a JSONL file from a byte offset, parsing new subagent events.
@@ -1277,6 +1483,10 @@ fn read_jsonl_from_offset(
 
         // Extract metadata from init/config lines
         if offset == 0 && meta.is_none() {
+            let parent_uuid = value
+                .get("parentUuid")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             if let Some(slug) = value.get("slug").and_then(|v| v.as_str()) {
                 meta = Some(JsonlMeta {
                     slug: slug.to_string(),
@@ -1284,6 +1494,7 @@ fn read_jsonl_from_offset(
                         .get("model")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string()),
+                    parent_uuid: parent_uuid.clone(),
                 });
             }
             if meta.is_none() {
@@ -1298,6 +1509,7 @@ fn read_jsonl_from_offset(
                             .get("model")
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string()),
+                        parent_uuid,
                     });
                 }
             }
@@ -1677,7 +1889,7 @@ mod tests {
 
     fn fixture_state(parent_agent: &str, agent_id: &str, session_id: &str) -> SubagentState {
         SubagentState {
-            info: SubagentInfo {
+            info: SubAgent {
                 agent_id: agent_id.to_string(),
                 slug: String::new(),
                 jsonl_path: String::new(),
@@ -1686,11 +1898,12 @@ mod tests {
                 session_id: session_id.to_string(),
                 spawned_at: 0,
                 last_event_at: 0,
-                status: SubagentStatus::Active,
+                status: SubAgentStatus::Active,
                 event_count: 0,
                 model: None,
-                workflow_id: None,
+                dispatch_id: solo_dispatch_id(agent_id),
                 display_name: None,
+                spawned_from_agent_id: None,
             },
             file_offset: 0,
             events: Vec::new(),
@@ -1912,7 +2125,7 @@ mod tests {
             let sessions = watcher.sessions.lock().unwrap();
             let session = sessions.values().next().expect("session recorded");
             let state = session.subagents.get("sub-a").expect("subagent recorded");
-            assert_eq!(state.info.status, SubagentStatus::Completed);
+            assert_eq!(state.info.status, SubAgentStatus::Completed);
             assert!(matches!(
                 state.events.last().unwrap().event_type,
                 SubagentEventType::Result { .. }
@@ -1940,7 +2153,174 @@ mod tests {
             let sessions = watcher.sessions.lock().unwrap();
             let session = sessions.values().next().expect("session recorded");
             let state = session.subagents.get("sub-b").expect("subagent recorded");
-            assert_eq!(state.info.status, SubagentStatus::Active);
+            assert_eq!(state.info.status, SubAgentStatus::Active);
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── AgentDispatch (SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17) ──
+
+    #[test]
+    fn process_jsonl_change_parses_spawned_from_agent_id_from_parent_uuid() {
+        // Empirically null in every real transcript checked (SPEC §9.2), but
+        // the field is captured defensively — verify it round-trips when
+        // present so a future real occurrence isn't silently dropped.
+        let dir = std::env::temp_dir().join(format!("amx-subagent-parentuuid-{}", now_millis()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-child-a.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"parentUuid\":\"parent-turn-uuid-123\",\"agentId\":\"child-a\",\"type\":\"user\"}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+
+        let sessions = watcher.sessions.lock().unwrap();
+        let session = sessions.values().next().expect("session recorded");
+        let state = session.subagents.get("child-a").expect("subagent recorded");
+        assert_eq!(
+            state.info.spawned_from_agent_id.as_deref(),
+            Some("parent-turn-uuid-123")
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn process_jsonl_change_leaves_spawned_from_agent_id_none_when_parent_uuid_is_null() {
+        let dir = std::env::temp_dir().join(format!("amx-subagent-parentuuid-null-{}", now_millis()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-child-b.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"parentUuid\":null,\"agentId\":\"child-b\",\"type\":\"user\"}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+
+        let sessions = watcher.sessions.lock().unwrap();
+        let session = sessions.values().next().expect("session recorded");
+        let state = session.subagents.get("child-b").expect("subagent recorded");
+        assert_eq!(state.info.spawned_from_agent_id, None);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_dispatches_synthesizes_a_solo_dispatch_for_a_loose_subagent() {
+        let dir = std::env::temp_dir().join(format!("amx-solo-dispatch-{}", now_millis()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-solo-a.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+
+        let dispatches = watcher.list_dispatches();
+        assert_eq!(dispatches.len(), 1, "one solo dispatch, synthesized on demand");
+        let d = &dispatches[0];
+        assert_eq!(d.dispatch_id, "solo:solo-a");
+        assert_eq!(d.kind, DispatchKind::Solo);
+        assert_eq!(d.member_count, 1);
+        assert_eq!(d.members_done, 0, "still active, not yet completed");
+        assert_eq!(d.status, DispatchStatus::Running);
+
+        // The same dispatch_id is stamped on the member itself.
+        let active = watcher.list_active();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].dispatch_id, "solo:solo-a");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_dispatches_marks_solo_dispatch_done_once_its_member_completes() {
+        let dir = std::env::temp_dir().join(format!("amx-solo-dispatch-done-{}", now_millis()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let jsonl_path = dir.join("agent-solo-b.jsonl");
+        std::fs::write(&jsonl_path, "{\"type\":\"result\",\"result\":\"done\"}\n").unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+
+        let dispatches = watcher.list_dispatches();
+        assert_eq!(dispatches.len(), 1);
+        assert_eq!(dispatches[0].members_done, 1);
+        assert_eq!(dispatches[0].status, DispatchStatus::Completed);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_dispatches_includes_a_tracked_workflow_dispatch_from_its_journal() {
+        let dir = std::env::temp_dir().join(format!("amx-workflow-dispatch-{}", now_millis()));
+        let run_dir = dir.join("subagents").join("workflows").join("wf_xyz789");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        let journal_path = run_dir.join("journal.jsonl");
+        std::fs::write(
+            &journal_path,
+            concat!(
+                "{\"type\":\"started\",\"agent_id\":\"m1\"}\n",
+                "{\"type\":\"started\",\"agent_id\":\"m2\"}\n",
+            ),
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_journal_change("parent-1", "block-1", &journal_path);
+
+        let dispatches = watcher.list_dispatches();
+        assert_eq!(dispatches.len(), 1);
+        let d = &dispatches[0];
+        assert_eq!(d.dispatch_id, "wf_xyz789");
+        assert_eq!(d.kind, DispatchKind::Workflow);
+        assert_eq!(d.member_count, 2);
+        assert_eq!(d.members_done, 0);
+        assert_eq!(d.status, DispatchStatus::Running);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn workflow_member_activity_is_buffered_not_broadcast_immediately() {
+        // SPEC §7: a Workflow-kind member's new events are coalesced into
+        // pending_activity, not broadcast per-member — the direct fix for
+        // the crash-storm mechanism in
+        // docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md.
+        let dir = std::env::temp_dir().join(format!("amx-coalesce-{}", now_millis()));
+        let run_dir = dir.join("subagents").join("workflows").join("wf_coalesce1");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        let jsonl_path = run_dir.join("agent-member-a.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"working\"}]}}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+
+        {
+            let pending = watcher.pending_activity.lock().unwrap();
+            let buffered = pending.get("wf_coalesce1").expect("activity buffered for this dispatch");
+            assert_eq!(buffered.members.len(), 1);
+            assert_eq!(buffered.members[0].0, "member-a");
+        }
+
+        // Flushing drains the buffer.
+        watcher.flush_pending_dispatch_activity();
+        {
+            let pending = watcher.pending_activity.lock().unwrap();
+            assert!(pending.is_empty(), "flush must drain every dispatch's buffer");
         }
 
         std::fs::remove_dir_all(&dir).ok();
@@ -2326,7 +2706,7 @@ mod tests {
         watcher.reconcile_stale_subagents(&block_id, "s1");
 
         let info = watcher.get_info("sub-a").expect("sub-a should still exist");
-        assert_eq!(info.status, SubagentStatus::Abandoned);
+        assert_eq!(info.status, SubAgentStatus::Abandoned);
     }
 
     #[test]
@@ -2347,7 +2727,7 @@ mod tests {
         watcher.reconcile_stale_subagents(&block_id, "s1");
 
         let info = watcher.get_info("sub-a").expect("sub-a should still exist");
-        assert_eq!(info.status, SubagentStatus::Active, "a genuinely active parent turn must never be reconciled away");
+        assert_eq!(info.status, SubAgentStatus::Active, "a genuinely active parent turn must never be reconciled away");
     }
 
     #[test]
@@ -2371,7 +2751,7 @@ mod tests {
         watcher.reconcile_stale_subagents(&block_id, "s1");
 
         let info = watcher.get_info("sub-a").expect("sub-a should still exist");
-        assert_eq!(info.status, SubagentStatus::Active);
+        assert_eq!(info.status, SubAgentStatus::Active);
     }
 
     #[test]
@@ -2385,7 +2765,7 @@ mod tests {
             let mut s1 = SessionWatch { subagents: HashMap::new() };
             let mut state = fixture_state("parent-1", "sub-a", "s1");
             state.info.parent_block_id = block_id.clone();
-            state.info.status = SubagentStatus::Completed;
+            state.info.status = SubAgentStatus::Completed;
             s1.subagents.insert("sub-a".to_string(), state);
             sessions.insert("s1".to_string(), s1);
         }
@@ -2393,7 +2773,7 @@ mod tests {
         watcher.reconcile_stale_subagents(&block_id, "s1");
 
         let info = watcher.get_info("sub-a").expect("sub-a should still exist");
-        assert_eq!(info.status, SubagentStatus::Completed, "a subagent that genuinely finished must stay Completed, not be downgraded");
+        assert_eq!(info.status, SubAgentStatus::Completed, "a subagent that genuinely finished must stay Completed, not be downgraded");
     }
 
     #[test]
@@ -2425,9 +2805,9 @@ mod tests {
         watcher.reconcile_stale_subagents(&idle_block, "s1");
 
         let owned_info = watcher.get_info("sub-owned").expect("sub-owned should still exist");
-        assert_eq!(owned_info.status, SubagentStatus::Abandoned, "this block's own subagent should still be reconciled");
+        assert_eq!(owned_info.status, SubAgentStatus::Abandoned, "this block's own subagent should still be reconciled");
         let sibling_info = watcher.get_info("sub-sibling").expect("sub-sibling should still exist");
-        assert_eq!(sibling_info.status, SubagentStatus::Active, "a sibling block's subagent must never be reconciled by an unrelated block's idle read");
+        assert_eq!(sibling_info.status, SubAgentStatus::Active, "a sibling block's subagent must never be reconciled by an unrelated block's idle read");
     }
 
     /// End-to-end: a subagent JSONL with no terminal `result` line, backfilled
@@ -2462,7 +2842,7 @@ mod tests {
         let active = watcher.list_active();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].agent_id, "crashed");
-        assert_eq!(active[0].status, SubagentStatus::Abandoned);
+        assert_eq!(active[0].status, SubAgentStatus::Abandoned);
 
         std::fs::remove_dir_all(&config_dir).ok();
     }

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -236,6 +236,38 @@ struct PendingDispatchActivity {
     session_id: String,
     /// One entry per member that had new events since the last flush.
     members: Vec<(String /* agent_id */, Vec<SubagentEvent>)>,
+    /// Members newly discovered since the last flush — buffered so a cold
+    /// backfill's `subagent:spawned` broadcasts are smoothed onto the flush
+    /// cadence too, not just activity ticks (reagent P1 on the coalescing
+    /// PR: `spawned`/`completed` were still unconditional-and-immediate,
+    /// undiminished by the activity coalescing above).
+    spawned: Vec<PendingSpawn>,
+    /// Members that finished since the last flush.
+    completed: Vec<PendingCompletion>,
+}
+
+struct PendingSpawn {
+    agent_id: String,
+    slug: String,
+    model: Option<String>,
+}
+
+struct PendingCompletion {
+    agent_id: String,
+    total_events: usize,
+}
+
+impl PendingDispatchActivity {
+    fn new(parent_agent: &str, parent_block_id: &str, session_id: &str) -> Self {
+        Self {
+            parent_agent: parent_agent.to_string(),
+            parent_block_id: parent_block_id.to_string(),
+            session_id: session_id.to_string(),
+            members: Vec::new(),
+            spawned: Vec::new(),
+            completed: Vec::new(),
+        }
+    }
 }
 
 /// Flush cadence for buffered dispatch activity (SPEC §9.5 — 250ms-1s was
@@ -1077,35 +1109,47 @@ impl SubagentWatcher {
         // Mutex released here — broadcast outside the lock
 
         if is_new {
-            let spawned_event = WSEventType {
-                eventtype: WS_EVENT_RPC.to_string(),
-                oref: String::new(),
-                data: Some(json!({
-                    "command": "eventrecv",
-                    "data": {
-                        "event": "subagent:spawned",
+            if workflow_id.is_some() {
+                let mut pending = self.pending_activity.lock().unwrap();
+                let entry = pending
+                    .entry(dispatch_id.clone())
+                    .or_insert_with(|| PendingDispatchActivity::new(parent_agent, parent_block_id, &session_id));
+                entry.spawned.push(PendingSpawn {
+                    agent_id: info_snapshot.agent_id.clone(),
+                    slug: info_snapshot.slug.clone(),
+                    model: info_snapshot.model.clone(),
+                });
+            } else {
+                let spawned_event = WSEventType {
+                    eventtype: WS_EVENT_RPC.to_string(),
+                    oref: String::new(),
+                    data: Some(json!({
+                        "command": "eventrecv",
                         "data": {
-                            "agentId": info_snapshot.agent_id,
-                            "slug": info_snapshot.slug,
-                            "parentAgent": parent_agent,
-                            "parentBlockId": parent_block_id,
-                            "sessionId": session_id,
-                            "model": info_snapshot.model,
-                            "dispatchId": info_snapshot.dispatch_id,
+                            "event": "subagent:spawned",
+                            "data": {
+                                "agentId": info_snapshot.agent_id,
+                                "slug": info_snapshot.slug,
+                                "parentAgent": parent_agent,
+                                "parentBlockId": parent_block_id,
+                                "sessionId": session_id,
+                                "model": info_snapshot.model,
+                                "dispatchId": info_snapshot.dispatch_id,
+                            }
                         }
-                    }
-                })),
-            };
-            self.event_bus.broadcast_event(&spawned_event);
-            tracing::info!(
-                agent_id = %agent_id,
-                slug = %info_snapshot.slug,
-                parent = %parent_agent,
-                parent_block_id = %parent_block_id,
-                session_id = %session_id,
-                dispatch_id = %info_snapshot.dispatch_id,
-                "subagent spawned"
-            );
+                    })),
+                };
+                self.event_bus.broadcast_event(&spawned_event);
+                tracing::info!(
+                    agent_id = %agent_id,
+                    slug = %info_snapshot.slug,
+                    parent = %parent_agent,
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    dispatch_id = %info_snapshot.dispatch_id,
+                    "subagent spawned"
+                );
+            }
         }
 
         if !new_events.is_empty() {
@@ -1118,12 +1162,7 @@ impl SubagentWatcher {
                 let mut pending = self.pending_activity.lock().unwrap();
                 let entry = pending
                     .entry(dispatch_id.clone())
-                    .or_insert_with(|| PendingDispatchActivity {
-                        parent_agent: parent_agent.to_string(),
-                        parent_block_id: parent_block_id.to_string(),
-                        session_id: session_id.clone(),
-                        members: Vec::new(),
-                    });
+                    .or_insert_with(|| PendingDispatchActivity::new(parent_agent, parent_block_id, &session_id));
                 entry.members.push((agent_id.clone(), new_events.clone()));
             } else {
                 // Solo dispatch: exactly one member, no coalescing benefit —
@@ -1152,32 +1191,43 @@ impl SubagentWatcher {
         }
 
         if completed {
-            let completed_event = WSEventType {
-                eventtype: WS_EVENT_RPC.to_string(),
-                oref: String::new(),
-                data: Some(json!({
-                    "command": "eventrecv",
-                    "data": {
-                        "event": "subagent:completed",
+            if workflow_id.is_some() {
+                let mut pending = self.pending_activity.lock().unwrap();
+                let entry = pending
+                    .entry(dispatch_id.clone())
+                    .or_insert_with(|| PendingDispatchActivity::new(parent_agent, parent_block_id, &session_id));
+                entry.completed.push(PendingCompletion {
+                    agent_id: agent_id.clone(),
+                    total_events: info_snapshot.event_count,
+                });
+            } else {
+                let completed_event = WSEventType {
+                    eventtype: WS_EVENT_RPC.to_string(),
+                    oref: String::new(),
+                    data: Some(json!({
+                        "command": "eventrecv",
                         "data": {
-                            "agentId": agent_id,
-                            "parentAgent": parent_agent,
-                            "parentBlockId": parent_block_id,
-                            "totalEvents": info_snapshot.event_count,
-                            "dispatchId": info_snapshot.dispatch_id,
+                            "event": "subagent:completed",
+                            "data": {
+                                "agentId": agent_id,
+                                "parentAgent": parent_agent,
+                                "parentBlockId": parent_block_id,
+                                "totalEvents": info_snapshot.event_count,
+                                "dispatchId": info_snapshot.dispatch_id,
+                            }
                         }
-                    }
-                })),
-            };
-            self.event_bus.broadcast_event(&completed_event);
-            tracing::info!(
-                agent_id = %agent_id,
-                total_events = info_snapshot.event_count,
-                parent_block_id = %parent_block_id,
-                session_id = %session_id,
-                dispatch_id = %info_snapshot.dispatch_id,
-                "subagent completed"
-            );
+                    })),
+                };
+                self.event_bus.broadcast_event(&completed_event);
+                tracing::info!(
+                    agent_id = %agent_id,
+                    total_events = info_snapshot.event_count,
+                    parent_block_id = %parent_block_id,
+                    session_id = %session_id,
+                    dispatch_id = %info_snapshot.dispatch_id,
+                    "subagent completed"
+                );
+            }
         }
 
         if let Some(wf_id) = workflow_id {
@@ -1211,31 +1261,91 @@ impl SubagentWatcher {
             std::mem::take(&mut *pending)
         };
         for (dispatch_id, pending) in batch {
-            if pending.members.is_empty() {
-                continue;
-            }
-            let new_events: usize = pending.members.iter().map(|(_, evs)| evs.len()).sum();
-            let event = WSEventType {
-                eventtype: WS_EVENT_RPC.to_string(),
-                oref: String::new(),
-                data: Some(json!({
-                    "command": "eventrecv",
-                    "data": {
-                        "event": "dispatch:activity",
+            for spawn in &pending.spawned {
+                let spawned_event = WSEventType {
+                    eventtype: WS_EVENT_RPC.to_string(),
+                    oref: String::new(),
+                    data: Some(json!({
+                        "command": "eventrecv",
                         "data": {
-                            "dispatchId": dispatch_id,
-                            "parentAgent": pending.parent_agent,
-                            "parentBlockId": pending.parent_block_id,
-                            "sessionId": pending.session_id,
-                            "newEvents": new_events,
-                            "members": pending.members.iter().map(|(agent_id, events)| {
-                                json!({ "agentId": agent_id, "events": events })
-                            }).collect::<Vec<_>>(),
+                            "event": "subagent:spawned",
+                            "data": {
+                                "agentId": spawn.agent_id,
+                                "slug": spawn.slug,
+                                "parentAgent": pending.parent_agent,
+                                "parentBlockId": pending.parent_block_id,
+                                "sessionId": pending.session_id,
+                                "model": spawn.model,
+                                "dispatchId": dispatch_id,
+                            }
                         }
-                    }
-                })),
-            };
-            self.event_bus.broadcast_event(&event);
+                    })),
+                };
+                self.event_bus.broadcast_event(&spawned_event);
+                tracing::info!(
+                    agent_id = %spawn.agent_id,
+                    slug = %spawn.slug,
+                    parent = %pending.parent_agent,
+                    parent_block_id = %pending.parent_block_id,
+                    session_id = %pending.session_id,
+                    dispatch_id = %dispatch_id,
+                    "subagent spawned"
+                );
+            }
+
+            if !pending.members.is_empty() {
+                let new_events: usize = pending.members.iter().map(|(_, evs)| evs.len()).sum();
+                let event = WSEventType {
+                    eventtype: WS_EVENT_RPC.to_string(),
+                    oref: String::new(),
+                    data: Some(json!({
+                        "command": "eventrecv",
+                        "data": {
+                            "event": "dispatch:activity",
+                            "data": {
+                                "dispatchId": dispatch_id,
+                                "parentAgent": pending.parent_agent,
+                                "parentBlockId": pending.parent_block_id,
+                                "sessionId": pending.session_id,
+                                "newEvents": new_events,
+                                "members": pending.members.iter().map(|(agent_id, events)| {
+                                    json!({ "agentId": agent_id, "events": events })
+                                }).collect::<Vec<_>>(),
+                            }
+                        }
+                    })),
+                };
+                self.event_bus.broadcast_event(&event);
+            }
+
+            for done in &pending.completed {
+                let completed_event = WSEventType {
+                    eventtype: WS_EVENT_RPC.to_string(),
+                    oref: String::new(),
+                    data: Some(json!({
+                        "command": "eventrecv",
+                        "data": {
+                            "event": "subagent:completed",
+                            "data": {
+                                "agentId": done.agent_id,
+                                "parentAgent": pending.parent_agent,
+                                "parentBlockId": pending.parent_block_id,
+                                "totalEvents": done.total_events,
+                                "dispatchId": dispatch_id,
+                            }
+                        }
+                    })),
+                };
+                self.event_bus.broadcast_event(&completed_event);
+                tracing::info!(
+                    agent_id = %done.agent_id,
+                    total_events = done.total_events,
+                    parent_block_id = %pending.parent_block_id,
+                    session_id = %pending.session_id,
+                    dispatch_id = %dispatch_id,
+                    "subagent completed"
+                );
+            }
         }
     }
 

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -244,6 +244,14 @@ struct PendingDispatchActivity {
     spawned: Vec<PendingSpawn>,
     /// Members that finished since the last flush.
     completed: Vec<PendingCompletion>,
+    /// Most recent `AgentDispatch` snapshot since the last flush — coalesces
+    /// `dispatch:updated` the same way (reagent P1 on the coalescing PR: this
+    /// broadcast was still immediate-per-member-file via
+    /// `update_dispatch_membership`/`process_journal_change`, a third event
+    /// type undiminished by the original activity-only coalescing). Only the
+    /// latest snapshot matters — unlike spawned/completed, this is current
+    /// aggregate state, not a per-member event.
+    latest_info: Option<AgentDispatch>,
 }
 
 struct PendingSpawn {
@@ -266,6 +274,7 @@ impl PendingDispatchActivity {
             members: Vec::new(),
             spawned: Vec::new(),
             completed: Vec::new(),
+            latest_info: None,
         }
     }
 }
@@ -1346,6 +1355,10 @@ impl SubagentWatcher {
                     "subagent completed"
                 );
             }
+
+            if let Some(info) = &pending.latest_info {
+                self.broadcast_dispatch_updated(info);
+            }
         }
     }
 
@@ -1389,7 +1402,26 @@ impl SubagentWatcher {
             Self::refresh_dispatch_info(state);
             state.info.clone()
         };
-        self.broadcast_dispatch_updated(&info);
+        self.queue_dispatch_updated(workflow_id, parent_agent, parent_block_id, session_id, info);
+    }
+
+    /// Queue an `AgentDispatch` snapshot for the next coalesced flush instead
+    /// of broadcasting `dispatch:updated` immediately — every caller here is
+    /// a Workflow-kind dispatch (Solo dispatches broadcast directly via
+    /// `broadcast_dispatch_updated`, see `process_jsonl_change`'s solo path).
+    fn queue_dispatch_updated(
+        &self,
+        dispatch_id: &str,
+        parent_agent: &str,
+        parent_block_id: &str,
+        session_id: &str,
+        info: AgentDispatch,
+    ) {
+        let mut pending = self.pending_activity.lock().unwrap();
+        let entry = pending
+            .entry(dispatch_id.to_string())
+            .or_insert_with(|| PendingDispatchActivity::new(parent_agent, parent_block_id, session_id));
+        entry.latest_info = Some(info);
     }
 
     /// Process a changed workflow journal (subagents/workflows/<wf>/journal.jsonl):
@@ -1454,11 +1486,11 @@ impl SubagentWatcher {
             }
             state.info.clone()
         };
-        // Only broadcast when the counters actually moved — an offset-only
+        // Only queue when the counters actually moved — an offset-only
         // advance (non-started/result lines) has no observable effect on
         // AgentDispatch, so a broadcast would just be noise.
         if has_new_records {
-            self.broadcast_dispatch_updated(&info);
+            self.queue_dispatch_updated(&workflow_id, parent_agent, parent_block_id, &session_id, info);
         }
     }
 

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -2742,9 +2742,9 @@ mod tests {
             BACKFILL_MAX_FILES,
             "member files are still capped inside a workflow run"
         );
-        let workflows = watcher.list_workflows();
-        assert_eq!(workflows.len(), 1, "the run's journal must still be processed");
-        assert_eq!(workflows[0].workflow_id, "wf_test-run");
+        let dispatches = watcher.list_dispatches();
+        assert_eq!(dispatches.len(), 1, "the run's journal must still be processed");
+        assert_eq!(dispatches[0].dispatch_id, "wf_test-run");
 
         std::fs::remove_dir_all(&config_dir).ok();
     }

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -192,7 +192,7 @@ pub(crate) async fn generate_pushed_activity_summary(
 /// Ambient-call purpose tag for the on-demand subagent display name (see
 /// `generate_subagent_name`). One-shot per subagent — `generation` is always
 /// the constant `1` since a name, once generated, is cached on
-/// `SubagentInfo.display_name` and never regenerated; there is no "newer
+/// `SubAgent.display_name` and never regenerated; there is no "newer
 /// turn" to supersede an in-flight naming call the way there is for the
 /// per-turn pull RPCs above.
 const AMBIENT_PURPOSE_SUBAGENT_NAME: &str = "subagent_name";

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -48,9 +48,9 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
             let subagents = state.subagent_watcher.list_active();
             WebReturnType::success(serde_json::to_value(&subagents).unwrap_or_default())
         }
-        ("subagent", "ListWorkflows") => {
-            let workflows = state.subagent_watcher.list_workflows();
-            WebReturnType::success(serde_json::to_value(&workflows).unwrap_or_default())
+        ("subagent", "ListDispatches") => {
+            let dispatches = state.subagent_watcher.list_dispatches();
+            WebReturnType::success(serde_json::to_value(&dispatches).unwrap_or_default())
         }
         ("subagent", "GetHistory") => {
             let agent_id: String = match service::get_arg(args, 0) {

--- a/docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md
+++ b/docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md
@@ -277,7 +277,72 @@ pub struct SubAgent {
   the new two-level model too. Flagging rather than deciding since it's a
   product-surface call, not a schema one.
 
-## 7. Migration plan
+## 7. Swarm-pane rendering rule: one row per AgentDispatch, members concatenated
+
+**Confirmed pattern, not just plausible:** a session typically has a handful
+of `AgentDispatch`es (single digits), but a Workflow-kind dispatch can have
+hundreds to low-thousands of members — this session's own crash investigation
+found workflow `wf_ff1c5825-522` with **1,030+ member subagent files** in one
+run (`docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`). Workflow
+patterns are *designed* to fan out this way (loop-until-dry, judge panels,
+multi-modal sweeps) — a single dispatch legitimately produces far more
+members than a human would ever want listed as individual rows.
+
+**Current behavior falls short at this scale.** `WorkflowGroupRow`
+(`frontend/app/view/swarm/swarm-view.tsx:315-354`) already collapses the
+*top-level* row — one row per `workflow_id`, not one per member, matching
+`REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`'s "group, not truncate"
+approach. But its expand state (L345-350) still renders one `<SubagentRow>`
+per member via `<For each={group.subagents}>` — fine at the scale the
+surrounding code comment anchors to (`"observed live: 45"`,
+`swarm-model.ts:66`), but this session's real corpus is ~20x past that:
+expanding a 1,030-member dispatch today would mount 1,030 `SubagentRow`
+components, each with its own state/handlers/detail-expand affordance.
+
+**New rule: a Workflow-kind `AgentDispatch` never renders one row per
+member, at any expand depth.** Expanding it shows a single **concatenated
+activity feed** instead of N nested rows — every member's events merged into
+one chronological, scrollable stream, each entry tagged with which member it
+came from (agent_id/slug/display_name prefix), the same shape as `docker
+compose logs` interleaving multiple services with a per-line service tag, or
+a CI matrix job's combined-log view. No per-member expand/collapse
+affordance, no per-member row mount cost, regardless of whether the dispatch
+has 3 members or 3,000.
+
+- **Solo-kind `AgentDispatch`** (`member_count == 1`) needs no wrapper row at
+  all — render its one member directly, identical to today's un-grouped
+  `SubagentRow`. Not a behavior change from today, just confirmed under the
+  new schema: the "concatenate" rule only has teeth once there's more than
+  one member to concatenate.
+- **`NameGroup`'s role shifts, not disappears.** Today it groups *loose*
+  (non-workflow) subagents sharing a generated `display_name`
+  (`swarm-model.ts:84-119`) — e.g. repeated "review this file" calls across
+  many files. Under the new schema that becomes grouping multiple *separate
+  solo* `AgentDispatch`es sharing a generated name — same real, common
+  pattern, just operating one level up (across dispatches, not across raw
+  members within one dispatch).
+- **Backend event-coalescing follow-on — do this in the same pass, not as a
+  separate later fix.** Today every member, however many, broadcasts its own
+  `subagent:spawned`/`subagent:activity`/`subagent:completed` WS event
+  individually — the exact mechanism behind the 1,030-event-in-10-seconds
+  broadcast storm in the OOM retro. If the product-level view for a large
+  Workflow dispatch is a concatenated feed rather than N individually-
+  tracked rows, there is no remaining product reason to broadcast N granular
+  per-member events for a large dispatch. The backend can batch new events
+  across a dispatch's members into a single throttled `dispatch:activity`
+  broadcast (e.g. coalesced every 250ms–1s while a dispatch has pending
+  events) instead of one WS message per member-event. This shrinks the
+  blast radius of the exact failure mode that caused the crash — not just
+  the render cost — so it belongs in the same implementation pass as the
+  `AgentDispatch` schema itself, not filed as a later follow-up.
+- **Open question added to §9**: is the concatenated feed's ordering a
+  strict chronological interleave across all members, or grouped-by-member-
+  then-chronological-within? And — mirroring PR #2205's `BACKFILL_MAX_FILES`
+  precedent — should the concatenated feed itself be capped/paginated rather
+  than rendering unbounded per-dispatch history inline, given a dispatch can
+  now legitimately have thousands of events behind it?
+
+## 8. Migration plan
 
 No data to migrate (§4) — this is a code-only change, phaseable and each
 phase independently shippable:
@@ -304,7 +369,7 @@ phase independently shippable:
    that citation, or a short lifecycle-reconciliation note should be written
    to actually back it.
 
-## 8. Open questions
+## 9. Open questions
 
 1. **Naming, final call**: primary recommendation (`AgentDispatch` +
    `SubAgent`) vs. the literal ask (`SubAgent` + `SubSubAgent`) vs. another
@@ -324,14 +389,24 @@ phase independently shippable:
    case of a Workflow dispatch with **zero** members yet (just started,
    before its first member file appears) — `Running`, presumably, but worth
    confirming explicitly in the implementation spec.
+4. **Concatenated-feed ordering and cap** (§7): strict chronological
+   interleave across all members, or grouped-by-member-then-chronological-
+   within? And should the feed itself be capped/paginated (mirroring PR
+   #2205's `BACKFILL_MAX_FILES` precedent) rather than rendering unbounded
+   per-dispatch history inline, now that a dispatch can legitimately have
+   thousands of events behind it?
+5. **`dispatch:activity` coalescing window** (§7): 250ms–1s was floated as a
+   plausible throttle range, not measured — needs a real number, likely
+   tuned against how "live" the concatenated feed needs to feel for an
+   actively-running large dispatch versus how much broadcast volume it saves.
 
-## 9. Sources
+## 10. Sources
 
 - `agentmux-srv/src/backend/subagent_watcher.rs` (current types, file-layout
   doc comment, `Abandoned` dangling citation)
 - `agentmux-srv/src/server/service/misc.rs:47-88`, `agentmux-srv/src/server/app_api/session.rs:195-279`
   (RPC surface)
-- `frontend/app/view/swarm/swarm-model.ts`, `frontend/app/view/subagent/subagent-model.ts`
+- `frontend/app/view/swarm/swarm-model.ts`, `frontend/app/view/swarm/swarm-view.tsx:315-354` (current per-member expand rendering), `frontend/app/view/subagent/subagent-model.ts`
 - `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md` (this session — the crash that motivated re-examining this schema)
 - `docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md`, `REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`, `REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md`
 - GitHub Actions docs (Workflow Run → Job → Step): https://runs-on.com/github-actions/jobs-and-steps/

--- a/docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md
+++ b/docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md
@@ -235,6 +235,15 @@ pub struct SubAgent {
     pub event_count: usize,
     pub model: Option<String>,
     pub display_name: Option<String>,
+    /// New (§9.2): the JSONL transcript's own `"parentUuid"` field, parsed
+    /// verbatim. `None` in every real transcript checked so far (228/228) —
+    /// nested subagent spawning is permitted for unrestricted-tool subagent
+    /// types but has never actually been observed on this machine. Captured
+    /// defensively since we already read this line for other fields; if
+    /// ever `Some`, this SubAgent is a grandchild of another SubAgent, not
+    /// a direct member of its nominal `dispatch_id` — the frontend should
+    /// attribute/nest it accordingly rather than showing it as a flat peer.
+    pub spawned_from_agent_id: Option<String>,
 }
 ```
 
@@ -349,8 +358,10 @@ phase independently shippable:
 
 1. **Backend types**: add `AgentDispatch`/`DispatchKind`/`DispatchStatus`;
    rename `SubagentInfo`→`SubAgent`, `workflow_id: Option<String>`→
-   `dispatch_id: String`. `WorkflowInfo`/`WorkflowStatus` are subsumed (every
-   existing `WorkflowInfo` becomes a `DispatchKind::Workflow` `AgentDispatch`).
+   `dispatch_id: String`, add `spawned_from_agent_id: Option<String>` parsed
+   from the transcript's `parentUuid` (§9.2). `WorkflowInfo`/`WorkflowStatus`
+   are subsumed (every existing `WorkflowInfo` becomes a
+   `DispatchKind::Workflow` `AgentDispatch`).
 2. **RPC + WS**: add `ListDispatches`, retire `ListWorkflows`; add
    `dispatch:updated`, retire `workflow:updated`; thread `dispatch_id`
    through the three `subagent:*` event payloads.
@@ -371,19 +382,30 @@ phase independently shippable:
 
 ## 9. Open questions
 
-1. **Naming, final call**: primary recommendation (`AgentDispatch` +
-   `SubAgent`) vs. the literal ask (`SubAgent` + `SubSubAgent`) vs. another
-   container noun from §3's list — this is the one decision this spec can't
-   make unilaterally.
-2. **Depth**: is two levels really the ceiling? Per Claude Code's own file
-   layout (§4) and the Workflow tool's documented constraint ("Nesting is one
-   level only: `workflow()` inside a child throws"), yes today — a Task-tool
-   call made *from inside* a subagent writes into that subagent's own
-   transcript, not a new top-level file `subagent_watcher.rs` would ever see.
-   Worth re-confirming empirically before implementation, but stated here as
-   the working assumption. If this ever changes, §2's "recursive systems
-   reuse one noun + a parent pointer" lesson is the pattern to reach for —
-   not a third stacked prefix.
+1. **Naming, final call: RESOLVED — `AgentDispatch` + `SubAgent`** (§3's
+   primary recommendation). Decided 2026-07-17.
+2. **Depth: RESOLVED — two levels, empirically confirmed, not just assumed.**
+   Structurally, nesting *is* possible: `general-purpose` and `claude`
+   (catch-all) subagent types have unrestricted tool access (`Tools: *`),
+   which includes the Agent tool itself — a subagent of one of those types
+   could call it and spawn a grandchild. `Explore`/`Plan` explicitly exclude
+   the Agent tool, blocking this for those types. The CLI has a field for
+   exactly this case: every subagent transcript's first JSONL line carries
+   `"parentUuid"`, presumably recording which turn's UUID the subagent's
+   conversation forked from. **Checked every real subagent transcript on
+   this machine — 228 files across 8+ distinct project sessions, spanning
+   weeks of actual usage, including sessions that used unrestricted-tool
+   subagent types — `parentUuid` is `null` in every single one.** Nested
+   spawning has never been observed to actually happen here, despite being
+   permitted. Two levels is empirically sufficient today.
+   `subagent_watcher.rs` currently does not parse `parentUuid` at all, so if
+   nesting ever did occur, AgentMux would have no way to notice — a
+   grandchild would land as an unexplained flat sibling file. Since we're
+   already reading this file's first line for other fields, capture
+   `parentUuid` from day one anyway (cheap, defensive) rather than adding it
+   only after the first real occurrence with no historical baseline to
+   validate the two-level assumption against — see §5's `SubAgent.
+   spawned_from_agent_id` field and §8 step 1.
 3. **`DispatchStatus::Abandoned` semantics**: proposed aggregation rule in
    §5 (`Completed` iff all members `Completed`) needs a decision on the edge
    case of a Workflow dispatch with **zero** members yet (just started,

--- a/docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md
+++ b/docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md
@@ -1,0 +1,342 @@
+# SPEC: two-level dispatch/member schema for subagents and workflows
+
+**Date:** 2026-07-17
+**Status:** Proposed — design only, no implementation yet.
+**Ask (verbatim):** "the subagents are actually subsubagents .. We want to keep
+track of the Agent and Workflow tool calls. each should produce one type of
+SubAgent entity, which then has SubSubAgents, unless you can think of a better
+name, research best practices, write spec to file"
+
+---
+
+## 1. Problem
+
+`agentmux-srv/src/backend/subagent_watcher.rs` currently has one member-level
+entity (`SubagentInfo`) and one container-level entity (`WorkflowInfo`) that
+was bolted on after the fact — and the container only exists for Workflow-tool
+runs. A solo Task-tool call (the common case) has **no container record at
+all**: it's just a bare `SubagentInfo` with `workflow_id: None`, floating at
+the top level next to Workflow-tool member agents.
+
+This conflation is visible in three places:
+
+1. **The RPC namespace itself.** `subagent.ListWorkflows`
+   (`agentmux-srv/src/server/service/misc.rs:51-54`) lives under the
+   `"subagent"` RPC namespace as a sibling of `subagent.ListActive` — a
+   workflow *run* is being modeled as a kind of subagent-list query, when
+   conceptually it's the container one level up.
+2. **The frontend had to invent the missing entity itself.**
+   `frontend/app/view/swarm/swarm-model.ts:59-72` defines `WorkflowGroup`, a
+   client-only wrapper, with the comment *"backend has no separate
+   workflow-name concept."* Because this wrapper has no backend-issued stable
+   ID, the frontend then needs `shallowEqualGroup` / `stabilizeGroupIdentity`
+   / `pruneGroupIdentityCache` (`swarm-model.ts:165-218`) purely to keep
+   SolidJS's `<For>` from remounting (and collapsing expand-state on) a
+   *synthesized* group every time a fresh `ListActive()` poll returns a new
+   array. A solo Task-tool dispatch gets none of this — it has no group
+   wrapper, stable or otherwise, because the backend gives it no dispatch-
+   level identity to hang one on.
+3. **The crash this session traced to it.** `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`
+   (this session, same day) root-caused a launcher-killing OOM crash to an
+   unbounded historical replay of *raw JSONL files* on every srv restart —
+   1,030+ replayed files in ~10s. The fix (PR #2205) caps by file count
+   because file count is the only unit the current schema has. A dispatch-
+   level entity would make "replay the N most recent **dispatches**" the
+   natural cap instead — a more meaningful unit than raw file count (one
+   Workflow dispatch can span dozens of files; one solo dispatch is one
+   file). Noted as a follow-up in §7, not required by this spec.
+
+## 2. Research: how other systems name this exact shape
+
+The shape here — one "thing that got kicked off" containing N "things that
+actually ran" — is a solved problem elsewhere. Every mainstream system gives
+the **container its own distinct noun**, not a doubled prefix on the child's
+name:
+
+| System | Container (one per trigger) | Member (one per unit of work) |
+|---|---|---|
+| GitHub Actions | Workflow **Run** | **Job** → **Step** |
+| Apache Airflow | **DAG Run** | **Task Instance** |
+| Temporal | **Workflow Execution** | **Activity Execution** / Child Workflow Execution |
+| Kubernetes | **Job** | **Pod** |
+| OpenTelemetry | Trace | Span (parent/child spans reuse the *same* noun at every depth, distinguished by a parent-pointer, not a prefix) |
+| Google ADK (multi-agent) | root agent | **sub-agent** (reused recursively at every depth — same pattern as OpenTelemetry, not stacked) |
+| Swarm-pattern frameworks | Lead | **Worker** / member |
+
+Two consistent lessons, independent of domain:
+
+1. **When there are exactly two levels, give each its own noun** (Run/Job,
+   DAGRun/TaskInstance, WorkflowExecution/ActivityExecution). Nobody names
+   the member "RunJob" or "DAGRunTaskInstance."
+2. **When a system is recursive** (a sub-agent that can itself have
+   sub-agents, arbitrary depth), the convention flips: reuse the *same* noun
+   at every level and distinguish by a parent pointer, not by stacking
+   prefixes per depth. AgentMux's shape is **not** recursive today — Claude
+   Code's own file layout is exactly two levels deep (see §4) — so lesson 1
+   applies, not lesson 2. If Task-tool calls made *from inside* a Workflow
+   member ever became visible as their own nested dispatch, lesson 2's
+   "same noun, parent pointer" pattern is the one to reach for then, not a
+   third stacked prefix.
+
+**Conclusion: "SubSubAgent" is the one pattern no reference system actually
+uses.** It's a plausible first guess (and the reasoning behind it — "the
+member is a sub-thing of a sub-thing" — is completely correct), but every
+precedent gives the container its own name instead of doubling the child's.
+
+## 3. Recommendation
+
+**Primary recommendation — two entities, two distinct nouns:**
+
+- **`AgentDispatch`** *(new)* — one per Agent-tool (Task tool) call **or**
+  Workflow-tool call from a parent turn. Represents "what got kicked off."
+- **`SubAgent`** *(renamed in place from today's `SubagentInfo`)* — one per
+  actually-spawned Claude Code agent instance. Represents "what ran."
+
+A solo Task-tool call is an `AgentDispatch` with exactly one `SubAgent`. A
+Workflow-tool call is an `AgentDispatch` with however many `SubAgent`s the
+run has spawned so far.
+
+**Why keep "SubAgent" at the member level instead of promoting it to the
+container** (the reverse of the literal ask): the member-level vocabulary is
+already load-bearing across the app — `subagent:spawned`/`subagent:activity`/
+`subagent:completed` WS events, the `subagent_watcher.rs` module name, the
+`subagent.*` RPC namespace, the "Swarm pane," and four existing spec/report
+docs (§4) all mean *member agent* when they say "subagent" today. Keeping
+that meaning and only adding a new container noun is a strict subset of the
+work the literal `SubAgent`→`SubSubAgent` proposal would require (which
+renames *everything* at the member level to free up "SubAgent" for the
+container, then invents the awkward doubled name anyway).
+
+**Alternative — the literal ask, fairly stated:** keep `SubAgent` as the
+container and use `SubSubAgent` for the member. Structurally identical to the
+primary recommendation, so the runtime behavior is the same either way — this
+is purely a naming choice. Cost: every existing "subagent = member" reference
+(WS event names, RPC namespace, module name, 4 doc titles/bodies) means the
+*opposite* thing afterward and needs renaming or an explicit note that the
+term shifted meaning. If there's a strong preference for `SubAgent` to always
+mean "the dispatch," this is the one to pick — call it out and I'll write the
+migration against this shape instead.
+
+Other container-noun candidates considered, if neither of the above lands:
+`AgentCall`, `AgentRun`, `SubAgentGroup`, `SubAgentBatch`, `Dispatch`. Any of
+these slot into the "primary recommendation" shape unchanged — only the noun
+differs.
+
+## 4. Current state (exact citations)
+
+All of the following is **in-memory only** — confirmed no DB schema exists
+for this data (`agentmux-srv/src/backend/storage/migrations.rs:102-117,546,1012-1054`'s
+`db_workflow_definitions`/`db_workflow_runs` are a dead, unrelated legacy
+Drone-DAG feature). Everything here is rebuilt every process start by
+scanning JSONL files on disk. **This means the migration in §6 has no data
+to move — it's a pure code change**, which is unusually cheap for a schema
+redesign.
+
+**File layout** (`subagent_watcher.rs:7-14`, Claude Code's own convention,
+not AgentMux's to change):
+```
+<claude-config>/projects/<ws>/subagents/agent-<id>.jsonl                        — solo dispatch
+<claude-config>/projects/<ws>/subagents/workflows/<run-id>/agent-<id>.jsonl     — workflow member
+<claude-config>/projects/<ws>/subagents/workflows/<run-id>/journal.jsonl        — workflow run journal
+```
+This maps directly onto the two-level model: a bare `agent-*.jsonl` is a
+solo `AgentDispatch` of exactly one `SubAgent`; a `workflows/<run-id>/`
+directory is a Workflow-kind `AgentDispatch` identified by `run-id`,
+containing its member `SubAgent`s.
+
+**Backend types** (`subagent_watcher.rs`):
+- `SubagentInfo` (L39-57): `agent_id, slug, jsonl_path, parent_agent,
+  parent_block_id, session_id, spawned_at, last_event_at, status,
+  event_count, model, workflow_id: Option<String>, display_name`
+- `SubagentStatus` (L64-77): `Active | Completed | Abandoned` — the
+  `Abandoned` variant's doc comment cites
+  `docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`, which
+  **does not exist on disk** (confirmed by search) — a dangling reference
+  worth fixing alongside this redesign.
+- `WorkflowInfo` (L100-113): `workflow_id, parent_agent, parent_block_id,
+  session_id, agents_total, agents_done, status, last_event_at`
+- `WorkflowStatus`: `Running | Completed`
+
+**RPC surface** (`agentmux-srv/src/server/service/misc.rs:47-88`, all under
+the `"subagent"` namespace): `ListActive → Vec<SubagentInfo>`,
+`ListWorkflows → Vec<WorkflowInfo>`, `GetHistory`, `GetInfo`, `GenerateName`
+(`agentmux-srv/src/server/app_api/session.rs:195-279`, keyed on
+`agent_id`/`jsonl_path`/`parent_block_id`).
+
+**WS events** (emitted only from `subagent_watcher.rs`): `subagent:spawned`,
+`subagent:activity`, `subagent:completed`, `workflow:updated`.
+
+**Frontend** — two parallel implementations:
+- Current: `frontend/app/view/swarm/swarm-model.ts` — `ActiveSubagent`,
+  `WorkflowGroup` (client-synthesized, §1), `SwarmChild = ActiveSubagent |
+  WorkflowGroup`, `groupSubagentsByWorkflow` (L96-126), `buildTree()`
+  (L583-618). Identity-preservation hacks at L128-218 (see §1).
+- Legacy: `frontend/app/view/subagent/subagent-model.ts` — separate,
+  simpler types, **not workflow-aware at all** (no `workflow_id`/
+  `display_name`). Still present; §6 asks what to do with it.
+
+**Doc trail** (chronological, all in `docs/specs/`): `swarm-redesign-active-retired-2026-05-03.md`
+→ `SPEC_SWARM_TREE_REDESIGN_2026_06_19.md` → `SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md`
+(states, pre-`WorkflowInfo`: *"No workflow tracking... Workflow tool runs
+exist only as files"* — the doc that led to `WorkflowInfo` being bolted on)
+→ `SPEC_SWARM_LIVE_FEED_UI_2026_07_05.md` → `REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`
+(root cause: state reconstructed from raw filesystem truth with no scoping —
+the same root-cause shape as this session's OOM retro) →
+`REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md` (→ `display_name`/
+`GenerateName`).
+
+## 5. Proposed data model
+
+```rust
+/// One per Agent-tool (Task tool) call or Workflow-tool call — the unit of
+/// dispatch from a parent turn. "What got kicked off," not "what ran": a
+/// Solo dispatch always has exactly one SubAgent; a Workflow dispatch has
+/// however many the run has spawned so far (may still be growing).
+pub struct AgentDispatch {
+    /// Stable identity. Workflow kind: the run-id Claude Code already uses
+    /// for `subagents/workflows/<run-id>/` — stable across srv restarts,
+    /// unlike an agent_id. Solo kind: `format!("solo:{agent_id}")` — a solo
+    /// dispatch is 1:1 with its one member, so no new ID-minting is needed.
+    pub dispatch_id: String,
+    pub kind: DispatchKind,          // Solo | Workflow
+    pub parent_agent: String,
+    pub parent_block_id: String,
+    pub session_id: String,
+    pub spawned_at: u64,
+    pub last_event_at: u64,
+    pub status: DispatchStatus,      // Running | Completed | Abandoned
+    pub member_count: usize,
+    pub members_done: usize,
+}
+
+pub enum DispatchKind { Solo, Workflow }
+
+/// Status aggregation rule: Completed iff every member is Completed;
+/// Abandoned if the dispatch's parent turn ended with any member not
+/// Completed (mirrors SubAgentStatus::Abandoned's existing reconciliation
+/// rule, applied one level up); else Running.
+pub enum DispatchStatus { Running, Completed, Abandoned }
+
+/// One spawned Claude Code agent instance. Unchanged in spirit from today's
+/// SubagentInfo — only workflow_id: Option<String> becomes a mandatory
+/// dispatch_id, present for solo members too (today they have no container
+/// reference at all).
+pub struct SubAgent {
+    pub agent_id: String,
+    pub slug: String,
+    pub jsonl_path: String,
+    pub dispatch_id: String,         // was: workflow_id: Option<String>
+    pub parent_agent: String,
+    pub parent_block_id: String,
+    pub session_id: String,
+    pub spawned_at: u64,
+    pub last_event_at: u64,
+    pub status: SubAgentStatus,      // Active | Completed | Abandoned — unchanged
+    pub event_count: usize,
+    pub model: Option<String>,
+    pub display_name: Option<String>,
+}
+```
+
+**RPC surface** (naming here is a detail, not load-bearing — bikeshed freely):
+- `subagent.ListDispatches → Vec<AgentDispatch>` — replaces
+  `subagent.ListWorkflows`, but now also lists Solo dispatches. This is the
+  RPC that lets the frontend delete `WorkflowGroup`/`groupSubagentsByWorkflow`
+  entirely (§6) — every dispatch, solo or workflow, is now a real
+  backend-issued list item with a stable ID.
+- `subagent.ListActive → Vec<SubAgent>` — renamed from `SubagentInfo`, same
+  shape plus `dispatch_id`.
+- `subagent.GetHistory`, `subagent.GetInfo`, `subagent.GenerateName` —
+  unchanged, still keyed on `agent_id`.
+- Optional: `subagent.GetDispatch(dispatch_id) → AgentDispatch` for a
+  detail-view fetch; not required for an MVP cutover.
+
+**WS events:**
+- `subagent:spawned` / `subagent:activity` / `subagent:completed` — unchanged
+  wire shape, `workflow_id` field replaced by `dispatch_id`.
+- `workflow:updated` → **`dispatch:updated`** — now fires for both kinds, not
+  just Workflow. This is what removes the frontend's need to synthesize a
+  group locally: Solo dispatches get the same "the container changed, here's
+  its stable ID" signal Workflow dispatches already get.
+
+## 6. Frontend implications
+
+- `swarm-model.ts`'s `WorkflowGroup`, `groupSubagentsByWorkflow`,
+  `shallowEqualGroup`/`stabilizeGroupIdentity`/`pruneGroupIdentityCache`
+  (L59-72, 96-126, 165-218) become **deletable**, not just simplified: once
+  `subagent.ListDispatches` returns a real, backend-stable `dispatch_id` for
+  every dispatch (solo included), the exact same reference-preservation
+  technique already used for `ActiveSubagent`
+  (`mergeSubagentsPreservingIdentity`, L128-163) applies uniformly one level
+  up too — no bespoke synthesized-group version needed.
+- `buildTree()` (L583-618) simplifies from "one real level + one synthesized
+  level" to two real levels (`AgentDispatch` → `SubAgent`).
+- `frontend/app/view/subagent/subagent-model.ts` (the older, non-workflow-
+  aware standalone pane) is a decision point this spec surfaces but doesn't
+  resolve: retire it in favor of the Swarm pane exclusively, or bring it onto
+  the new two-level model too. Flagging rather than deciding since it's a
+  product-surface call, not a schema one.
+
+## 7. Migration plan
+
+No data to migrate (§4) — this is a code-only change, phaseable and each
+phase independently shippable:
+
+1. **Backend types**: add `AgentDispatch`/`DispatchKind`/`DispatchStatus`;
+   rename `SubagentInfo`→`SubAgent`, `workflow_id: Option<String>`→
+   `dispatch_id: String`. `WorkflowInfo`/`WorkflowStatus` are subsumed (every
+   existing `WorkflowInfo` becomes a `DispatchKind::Workflow` `AgentDispatch`).
+2. **RPC + WS**: add `ListDispatches`, retire `ListWorkflows`; add
+   `dispatch:updated`, retire `workflow:updated`; thread `dispatch_id`
+   through the three `subagent:*` event payloads.
+3. **Frontend**: point `swarm-model.ts` at `ListDispatches` +
+   `dispatch:updated`; delete the synthesized-group identity code (§6);
+   update `swarm-view.tsx`'s render tree to the two real levels.
+4. **Legacy pane decision** (§6) — separate follow-up, not blocking 1-3.
+5. **Optional follow-up, not required by this spec**: revisit PR #2205's
+   `BACKFILL_MAX_FILES` cap (currently caps raw JSONL file count on cold
+   backfill) to cap by dispatch recency instead, now that `dispatch_id`
+   exists as a natural grouping key — a more meaningful unit than raw file
+   count for the same reason `AgentDispatch` is more meaningful than a flat
+   file list generally.
+6. **Fix the dangling doc reference**: `SubAgentStatus::Abandoned`'s comment
+   cites a spec that doesn't exist (§4) — either this document supersedes
+   that citation, or a short lifecycle-reconciliation note should be written
+   to actually back it.
+
+## 8. Open questions
+
+1. **Naming, final call**: primary recommendation (`AgentDispatch` +
+   `SubAgent`) vs. the literal ask (`SubAgent` + `SubSubAgent`) vs. another
+   container noun from §3's list — this is the one decision this spec can't
+   make unilaterally.
+2. **Depth**: is two levels really the ceiling? Per Claude Code's own file
+   layout (§4) and the Workflow tool's documented constraint ("Nesting is one
+   level only: `workflow()` inside a child throws"), yes today — a Task-tool
+   call made *from inside* a subagent writes into that subagent's own
+   transcript, not a new top-level file `subagent_watcher.rs` would ever see.
+   Worth re-confirming empirically before implementation, but stated here as
+   the working assumption. If this ever changes, §2's "recursive systems
+   reuse one noun + a parent pointer" lesson is the pattern to reach for —
+   not a third stacked prefix.
+3. **`DispatchStatus::Abandoned` semantics**: proposed aggregation rule in
+   §5 (`Completed` iff all members `Completed`) needs a decision on the edge
+   case of a Workflow dispatch with **zero** members yet (just started,
+   before its first member file appears) — `Running`, presumably, but worth
+   confirming explicitly in the implementation spec.
+
+## 9. Sources
+
+- `agentmux-srv/src/backend/subagent_watcher.rs` (current types, file-layout
+  doc comment, `Abandoned` dangling citation)
+- `agentmux-srv/src/server/service/misc.rs:47-88`, `agentmux-srv/src/server/app_api/session.rs:195-279`
+  (RPC surface)
+- `frontend/app/view/swarm/swarm-model.ts`, `frontend/app/view/subagent/subagent-model.ts`
+- `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md` (this session — the crash that motivated re-examining this schema)
+- `docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md`, `REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md`, `REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md`
+- GitHub Actions docs (Workflow Run → Job → Step): https://runs-on.com/github-actions/jobs-and-steps/
+- Apache Airflow docs (DAG Run → Task Instance): https://www.sparkcodehub.com/airflow/task-management/task-instances
+- Temporal docs (Workflow Execution → Activity/Child-Workflow Execution): https://docs.temporal.io/child-workflows
+- OpenTelemetry span parent-child model: https://opentelemetry.io/docs/concepts/signals/traces/
+- Google ADK sub-agent delegation model (recursive, same-noun-per-level): search summary, 2026 multi-agent framework comparisons (dev.to/medium roundups, April 2026)
+- Swarm-pattern Lead/Worker terminology: https://www.ai21.com/glossary/foundational-llm/agent-swarm/, https://docs.agent-swarm.dev/docs

--- a/frontend/app/view/agent/activity/subagent-adapter.test.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.test.ts
@@ -16,7 +16,7 @@ function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id"
         last_event_at: 1000,
         event_count: 0,
         model: null,
-        workflow_id: null,
+        dispatch_id: `solo:${overrides.agent_id}`,
         display_name: null,
         ...overrides,
     };
@@ -68,15 +68,15 @@ describe("subagentActivities", () => {
         expect(subagentActivities([mk({ agent_id: "a1", parent_block_id: "block-2" })], "block-1")).toEqual([]);
     });
 
-    it("collapses subagents sharing a workflow_id into one activity, not one per subagent", () => {
+    it("collapses subagents sharing a dispatch_id into one activity, not one per subagent", () => {
         const all = [
-            mk({ agent_id: "a1", workflow_id: "wf_1", slug: "reviewer", status: "active" }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", slug: "reviewer", status: "completed" }),
-            mk({ agent_id: "a3", workflow_id: "wf_1", slug: "reviewer", status: "completed" }),
+            mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "reviewer", status: "active" }),
+            mk({ agent_id: "a2", dispatch_id: "wf_1", slug: "reviewer", status: "completed" }),
+            mk({ agent_id: "a3", dispatch_id: "wf_1", slug: "reviewer", status: "completed" }),
         ];
         const result = subagentActivities(all, "block-1");
         expect(result).toHaveLength(1);
-        expect(result[0].id).toBe("wf:wf_1");
+        expect(result[0].id).toBe("wf_1");
         expect(result[0].title).toBe("reviewer (3)");
         expect(result[0].status).toBe("running"); // one member still active
         expect(result[0].subagent).toBeUndefined();
@@ -85,18 +85,18 @@ describe("subagentActivities", () => {
 
     it("marks a workflow group done only once every member is terminal", () => {
         const all = [
-            mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed", last_event_at: 100 }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", status: "completed", last_event_at: 200 }),
+            mk({ agent_id: "a1", dispatch_id: "wf_1", status: "completed", last_event_at: 100 }),
+            mk({ agent_id: "a2", dispatch_id: "wf_1", status: "completed", last_event_at: 200 }),
         ];
         const result = subagentActivities(all, "block-1");
         expect(result[0].status).toBe("done");
         expect(result[0].endedAt).toBe(200);
     });
 
-    it("does not group standalone subagents (no workflow_id, no shared display_name)", () => {
+    it("does not group standalone subagents (distinct solo dispatch_ids, no shared display_name)", () => {
         const all = [
-            mk({ agent_id: "a1", workflow_id: null, display_name: null }),
-            mk({ agent_id: "a2", workflow_id: null, display_name: null }),
+            mk({ agent_id: "a1", display_name: null }),
+            mk({ agent_id: "a2", display_name: null }),
         ];
         const result = subagentActivities(all, "block-1");
         expect(result.map((a) => a.id)).toEqual(["a1", "a2"]);

--- a/frontend/app/view/agent/activity/subagent-adapter.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.ts
@@ -7,11 +7,20 @@
  * filtered to one agent pane's own spawns (`parent_block_id`). Phase 2 of the
  * dock — proves the `PinnedActivity` abstraction generalizes beyond shells.
  *
- * Grouping reuses `groupSubagentsByWorkflow` verbatim — the same algorithm
- * the Swarm pane's own tree view uses to collapse a Task/Workflow-tool run's
- * dozens of subagents into one row. Without it, the dock showed one row per
- * `ActiveSubagent` instead of one row per Agent tool call (a single run can
- * spawn dozens at once — observed live: 45).
+ * Groups by `dispatch_id` (collapsing a Workflow dispatch's members into one
+ * row, mirroring the Swarm pane's tree view), then by shared `display_name`
+ * among the solo leftovers — `NameGroup`, reused directly from
+ * swarm-model.ts. Deliberately NOT reusing swarm-model.ts's
+ * `buildDispatchChildren`/`WorkflowDispatch` for the dispatch half: that
+ * type intentionally drops the member list (SPEC_AGENT_DISPATCH_SUBAGENT_
+ * HIERARCHY_2026_07_17 §7 — a Workflow dispatch can have thousands of
+ * members, too many to hold in the Swarm pane's frequently-recomputed tree
+ * atom), but this adapter needs each member's `spawned_at`/`status` to
+ * compute one summary row — and the dock's own scale (pinned activity, not
+ * a full tree) makes holding that list here safe. Without grouping at all,
+ * the dock would show one row per `ActiveSubagent` instead of one row per
+ * Agent-tool-or-Workflow-tool call (a single workflow run can spawn dozens
+ * to hundreds at once).
  *
  * `canStop` is always `false`: no subagent-cancel RPC/UI exists anywhere in
  * the app today (confirmed — `AgentStopCommand` targets a pane's own agent
@@ -24,14 +33,98 @@
 
 import {
     groupCacheKey,
-    groupSubagentsByWorkflow,
     isNameGroup,
-    isWorkflowGroup,
     type ActiveSubagent,
     type NameGroup,
-    type WorkflowGroup,
 } from "../../swarm/swarm-model";
 import type { ActivityStatus, PinnedActivity } from "./types";
+
+/** One dock row summarizing every member of a shared `dispatch_id` — the
+ *  dock-local counterpart of the Swarm pane's `WorkflowDispatch`, but
+ *  carrying the member list (see this file's header comment for why). */
+interface DispatchGroup {
+    kind: "dispatchGroup";
+    dispatchId: string;
+    name: string;
+    subagents: ActiveSubagent[];
+    activeCount: number;
+    totalCount: number;
+    lastEventAt: number;
+}
+
+function isDispatchGroup(x: ActiveSubagent | DispatchGroup | NameGroup): x is DispatchGroup {
+    return "kind" in x && x.kind === "dispatchGroup";
+}
+
+/** Group `subagents` (already filtered to one parent block) by `dispatch_id`
+ *  — 2+ members sharing one id (always a Workflow dispatch; a Solo dispatch
+ *  is 1:1 with its one member by construction) collapse into a
+ *  `DispatchGroup`. Among what's left, 2+ subagents sharing an identical,
+ *  non-empty `display_name` collapse into a `NameGroup`. A single subagent
+ *  stays a loose, ungrouped row. */
+function groupSubagentsForDock(
+    subagents: ActiveSubagent[]
+): (ActiveSubagent | DispatchGroup | NameGroup)[] {
+    const byDispatch = new Map<string, ActiveSubagent[]>();
+    for (const s of subagents) {
+        const members = byDispatch.get(s.dispatch_id) ?? [];
+        members.push(s);
+        byDispatch.set(s.dispatch_id, members);
+    }
+
+    const loose: ActiveSubagent[] = [];
+    const dispatchGroups: DispatchGroup[] = [];
+    for (const [dispatchId, members] of byDispatch) {
+        if (members.length < 2) {
+            loose.push(...members);
+            continue;
+        }
+        const sorted = [...members].sort((a, b) => b.last_event_at - a.last_event_at);
+        const activeCount = sorted.filter((m) => m.status === "active").length;
+        dispatchGroups.push({
+            kind: "dispatchGroup",
+            dispatchId,
+            name: sorted.find((m) => m.slug)?.slug || dispatchId,
+            subagents: sorted,
+            activeCount,
+            totalCount: sorted.length,
+            lastEventAt: sorted[0]?.last_event_at ?? 0,
+        });
+    }
+
+    const stillLoose: ActiveSubagent[] = [];
+    const byName = new Map<string, ActiveSubagent[]>();
+    for (const s of loose) {
+        if (s.display_name) {
+            const members = byName.get(s.display_name) ?? [];
+            members.push(s);
+            byName.set(s.display_name, members);
+        } else {
+            stillLoose.push(s);
+        }
+    }
+    const nameGroups: NameGroup[] = [];
+    for (const [name, members] of byName) {
+        if (members.length < 2) {
+            stillLoose.push(...members);
+            continue;
+        }
+        const sorted = [...members].sort((a, b) => b.last_event_at - a.last_event_at);
+        const activeCount = sorted.filter((m) => m.status === "active").length;
+        nameGroups.push({
+            kind: "nameGroup",
+            name,
+            parentBlockId: sorted[0].parent_block_id,
+            subagents: sorted,
+            activeCount,
+            totalCount: sorted.length,
+            status: activeCount > 0 ? "active" : "retired",
+            lastEventAt: sorted[0]?.last_event_at ?? 0,
+        });
+    }
+
+    return [...stillLoose, ...dispatchGroups, ...nameGroups];
+}
 
 function subagentStatusToActivity(s: ActiveSubagent["status"]): ActivityStatus {
     switch (s) {
@@ -65,17 +158,17 @@ export function subagentToActivity(s: ActiveSubagent): PinnedActivity {
     };
 }
 
-/** A `WorkflowGroup`/`NameGroup` → one dock row summarizing every member,
+/** A `DispatchGroup`/`NameGroup` → one dock row summarizing every member,
  *  instead of one row per subagent. `startedAt` is the earliest member's
  *  spawn (the group's own lifetime, not just its most-recently-active
  *  member's); `endedAt` only lands once every member is terminal, matching
  *  `subagentToActivity`'s own "no member still running" rule. */
-function subagentGroupToActivity(group: WorkflowGroup | NameGroup): PinnedActivity {
+function subagentGroupToActivity(group: DispatchGroup | NameGroup): PinnedActivity {
     const members = group.subagents;
     const anyAbandoned = members.some((m) => m.status === "abandoned");
     const status: ActivityStatus = group.activeCount > 0 ? "running" : anyAbandoned ? "stopped" : "done";
     return {
-        id: groupCacheKey(group),
+        id: isDispatchGroup(group) ? group.dispatchId : groupCacheKey(group),
         kind: "subagent",
         title: `${group.name} (${group.totalCount})`,
         status,
@@ -86,14 +179,13 @@ function subagentGroupToActivity(group: WorkflowGroup | NameGroup): PinnedActivi
     };
 }
 
-/** This pane's own subagents (`parent_block_id === blockId`), grouped the
- *  same way the Swarm pane's tree view groups them — by shared `workflow_id`,
- *  then by shared `display_name` among what's left — and mapped to
- *  activities. One dock row per Agent tool call, not per individual
- *  subagent. */
+/** This pane's own subagents (`parent_block_id === blockId`), grouped by
+ *  shared `dispatch_id` then by shared `display_name` among what's left,
+ *  and mapped to activities. One dock row per Agent-tool-or-Workflow-tool
+ *  call, not per individual subagent. */
 export function subagentActivities(all: ReadonlyArray<ActiveSubagent>, blockId: string): PinnedActivity[] {
     const mine = all.filter((s) => s.parent_block_id === blockId);
-    return groupSubagentsByWorkflow(mine).map((child) =>
-        isWorkflowGroup(child) || isNameGroup(child) ? subagentGroupToActivity(child) : subagentToActivity(child)
+    return groupSubagentsForDock(mine).map((child) =>
+        isDispatchGroup(child) || isNameGroup(child) ? subagentGroupToActivity(child) : subagentToActivity(child)
     );
 }

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -119,6 +119,24 @@ describe("buildDispatchChildren", () => {
         expect(loose).toHaveLength(1);
     });
 
+    it("falls back to a loose row for a workflow-kind subagent whose dispatch is missing from `dispatches` (stale/failed ListDispatches)", () => {
+        // `loadDispatches()` silently swallows RPC errors, so `dispatches`
+        // can lag or miss entries that `subagents` (a separate fetch)
+        // already has. A workflow member with no matching AgentDispatch row
+        // must degrade to a loose row, not vanish from the tree.
+        const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 1 })];
+        const subagents = [
+            mk({ agent_id: "a1", dispatch_id: "wf_1" }),
+            mk({ agent_id: "a2", dispatch_id: "wf_missing" }),
+        ];
+        const result = buildDispatchChildren(dispatches, subagents);
+        const groups = result.filter(isWorkflowDispatch);
+        const loose = result.filter((c) => !isWorkflowDispatch(c));
+        expect(groups).toHaveLength(1);
+        expect(loose).toHaveLength(1);
+        expect(childId(loose[0])).toBe("a2");
+    });
+
     it("passes AgentDispatch.status through directly — running → active, completed → retired", () => {
         const running = buildDispatchChildren(
             [mkDispatch({ dispatch_id: "wf_1", status: "running" })],

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -3,25 +3,26 @@
 
 import { describe, expect, it } from "vitest";
 import {
+    buildDispatchChildren,
     groupCacheKey,
-    groupSubagentsByWorkflow,
     isNameGroup,
-    isWorkflowGroup,
+    isWorkflowDispatch,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     type ActiveSubagent,
+    type AgentDispatch,
     type NameGroup,
     type SwarmChild,
-    type WorkflowGroup,
+    type WorkflowDispatch,
 } from "./swarm-model";
 
 /** Extract a SwarmChild's own identifying id, for assertions that don't care
  *  which of the three variants they got — narrows through all three via
- *  isWorkflowGroup/isNameGroup rather than an unsafe cast. */
+ *  isWorkflowDispatch/isNameGroup rather than an unsafe cast. */
 function childId(c: SwarmChild): string {
-    if (isWorkflowGroup(c)) return c.workflowId;
+    if (isWorkflowDispatch(c)) return c.dispatchId;
     if (isNameGroup(c)) return c.name;
     return c.agent_id;
 }
@@ -37,141 +38,158 @@ function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id"
         last_event_at: 0,
         event_count: 1,
         model: null,
-        workflow_id: null,
+        dispatch_id: `solo:${overrides.agent_id}`,
         display_name: null,
         ...overrides,
     };
 }
 
-describe("groupSubagentsByWorkflow", () => {
-    it("leaves subagents with no workflow_id as loose, unrouped rows", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: null }),
-            mk({ agent_id: "a2", workflow_id: null }),
-        ]);
+function mkDispatch(overrides: Partial<AgentDispatch> & Pick<AgentDispatch, "dispatch_id">): AgentDispatch {
+    return {
+        kind: "workflow",
+        parent_agent: "parent",
+        parent_block_id: "block-1",
+        session_id: "session-1",
+        member_count: 0,
+        members_done: 0,
+        status: "running",
+        last_event_at: 0,
+        ...overrides,
+    };
+}
+
+describe("buildDispatchChildren", () => {
+    it("leaves solo-dispatch subagents (no tracked AgentDispatch) as loose, ungrouped rows", () => {
+        const result = buildDispatchChildren([], [mk({ agent_id: "a1" }), mk({ agent_id: "a2" })]);
         expect(result).toHaveLength(2);
-        expect(result.every((c) => !isWorkflowGroup(c))).toBe(true);
+        expect(result.every((c) => !isWorkflowDispatch(c))).toBe(true);
     });
 
-    it("collapses subagents sharing a workflow_id into one group", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
-            mk({ agent_id: "a3", workflow_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
-        ]);
+    it("renders a Workflow-kind AgentDispatch as one row regardless of member count", () => {
+        const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 3, status: "running" })];
+        const subagents = [
+            mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
+            mk({ agent_id: "a2", dispatch_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
+            mk({ agent_id: "a3", dispatch_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
+        ];
+        const result = buildDispatchChildren(dispatches, subagents);
         expect(result).toHaveLength(1);
         const group = result[0];
-        expect(isWorkflowGroup(group)).toBe(true);
-        if (isWorkflowGroup(group)) {
-            expect(group.totalCount).toBe(3);
+        expect(isWorkflowDispatch(group)).toBe(true);
+        if (isWorkflowDispatch(group)) {
+            expect(group.memberCount).toBe(3);
             expect(group.name).toBe("cheerful-enchanting-sketch");
         }
     });
 
-    it("mixes loose subagents and groups independently, one group per distinct workflow_id", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_1" }),
-            mk({ agent_id: "a2", workflow_id: "wf_1" }),
-            mk({ agent_id: "a3", workflow_id: "wf_2" }),
-            mk({ agent_id: "a4", workflow_id: null }),
-        ]);
-        const groups = result.filter(isWorkflowGroup);
-        const loose = result.filter((c) => !isWorkflowGroup(c));
+    it("never renders one row per member — SPEC §7, even for a dispatch this test can't realistically construct at full scale (1,030+ observed live)", () => {
+        const dispatches = [mkDispatch({ dispatch_id: "wf_big", member_count: 200 })];
+        const subagents = Array.from({ length: 50 }, (_, i) =>
+            mk({ agent_id: `m${i}`, dispatch_id: "wf_big" })
+        );
+        const result = buildDispatchChildren(dispatches, subagents);
+        // One row for the dispatch — the (partial, in this test) member list
+        // never expands into its own rows.
+        expect(result).toHaveLength(1);
+        expect(isWorkflowDispatch(result[0])).toBe(true);
+    });
+
+    it("does not carry a member list on WorkflowDispatch — SPEC §7 (a large dispatch can't hold thousands of members in the tree atom)", () => {
+        const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 2 })];
+        const subagents = [mk({ agent_id: "a1", dispatch_id: "wf_1" }), mk({ agent_id: "a2", dispatch_id: "wf_1" })];
+        const [group] = buildDispatchChildren(dispatches, subagents);
+        expect("subagents" in (group as object)).toBe(false);
+    });
+
+    it("mixes loose subagents and workflow dispatches independently, one row per distinct dispatch", () => {
+        const dispatches = [
+            mkDispatch({ dispatch_id: "wf_1", member_count: 2 }),
+            mkDispatch({ dispatch_id: "wf_2", member_count: 1 }),
+        ];
+        const subagents = [
+            mk({ agent_id: "a1", dispatch_id: "wf_1" }),
+            mk({ agent_id: "a2", dispatch_id: "wf_1" }),
+            mk({ agent_id: "a3", dispatch_id: "wf_2" }),
+            mk({ agent_id: "a4" }), // solo
+        ];
+        const result = buildDispatchChildren(dispatches, subagents);
+        const groups = result.filter(isWorkflowDispatch);
+        const loose = result.filter((c) => !isWorkflowDispatch(c));
         expect(groups).toHaveLength(2);
         expect(loose).toHaveLength(1);
     });
 
-    it("marks a group active if any member is still active", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed" }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", status: "active" }),
-        ]);
-        const group = result[0];
-        if (isWorkflowGroup(group)) {
-            expect(group.status).toBe("active");
-            expect(group.activeCount).toBe(1);
+    it("passes AgentDispatch.status through directly — running → active, completed → retired", () => {
+        const running = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_1", status: "running" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        )[0];
+        const completed = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_2", status: "completed" })],
+            [mk({ agent_id: "a2", dispatch_id: "wf_2" })]
+        )[0];
+        if (isWorkflowDispatch(running) && isWorkflowDispatch(completed)) {
+            expect(running.status).toBe("active");
+            expect(completed.status).toBe("retired");
         } else {
-            throw new Error("expected a workflow group");
+            throw new Error("expected workflow dispatch rows");
         }
     });
 
-    it("marks a group retired only once every member has completed", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed" }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", status: "completed" }),
-        ]);
+    it("derives the dispatch name from the first member with a non-empty slug", () => {
+        const result = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_1" })],
+            [
+                mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "", last_event_at: 200 }),
+                mk({ agent_id: "a2", dispatch_id: "wf_1", slug: "zesty-crafting-kahan", last_event_at: 100 }),
+            ]
+        );
         const group = result[0];
-        if (isWorkflowGroup(group)) {
-            expect(group.status).toBe("retired");
-            expect(group.activeCount).toBe(0);
-        } else {
-            throw new Error("expected a workflow group");
-        }
-    });
-
-    it("treats an abandoned member the same as a completed one for grouping purposes (both terminal)", () => {
-        // SubagentStatus::Abandoned (SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md)
-        // — a subagent whose parent turn ended without a Result line. Like
-        // "completed", it must NOT count toward activeCount and must let the
-        // group retire.
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed" }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", status: "abandoned" }),
-        ]);
-        const group = result[0];
-        if (isWorkflowGroup(group)) {
-            expect(group.status).toBe("retired");
-            expect(group.activeCount).toBe(0);
-            expect(group.totalCount).toBe(2);
-        } else {
-            throw new Error("expected a workflow group");
-        }
-    });
-
-    it("derives the group name from the first member with a non-empty slug", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_1", slug: "", last_event_at: 200 }),
-            mk({ agent_id: "a2", workflow_id: "wf_1", slug: "zesty-crafting-kahan", last_event_at: 100 }),
-        ]);
-        const group = result[0];
-        if (isWorkflowGroup(group)) {
+        if (isWorkflowDispatch(group)) {
             expect(group.name).toBe("zesty-crafting-kahan");
         } else {
-            throw new Error("expected a workflow group");
+            throw new Error("expected a workflow dispatch");
         }
     });
 
-    it("falls back to the workflow id as the name when no member has a slug", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "wf_unnamed", slug: "" }),
-        ]);
+    it("falls back to the dispatch id as the name when no member has a slug (or no members are known yet)", () => {
+        const result = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_unnamed" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_unnamed", slug: "" })]
+        );
         const group = result[0];
-        if (isWorkflowGroup(group)) {
+        if (isWorkflowDispatch(group)) {
             expect(group.name).toBe("wf_unnamed");
         } else {
-            throw new Error("expected a workflow group");
+            throw new Error("expected a workflow dispatch");
         }
     });
 
-    it("sorts loose subagents and groups together by most recent activity", () => {
-        const result = groupSubagentsByWorkflow([
-            mk({ agent_id: "old-loose", workflow_id: null, last_event_at: 100 }),
-            mk({ agent_id: "a1", workflow_id: "wf_1", last_event_at: 500 }),
-            mk({ agent_id: "newest-loose", workflow_id: null, last_event_at: 900 }),
-        ]);
+    it("sorts loose subagents and dispatches together by most recent activity", () => {
+        const result = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_1", last_event_at: 500 })],
+            [
+                mk({ agent_id: "old-loose", last_event_at: 100 }),
+                mk({ agent_id: "a1", dispatch_id: "wf_1", last_event_at: 500 }),
+                mk({ agent_id: "newest-loose", last_event_at: 900 }),
+            ]
+        );
         expect(result).toHaveLength(3);
-        // newest-loose (900) > wf_1 group (500) > old-loose (100)
+        // newest-loose (900) > wf_1 dispatch (500) > old-loose (100)
         expect(childId(result[0])).toBe("newest-loose");
         expect(childId(result[2])).toBe("old-loose");
     });
 
-    describe("name-based grouping of loose subagents (issue: same-name duplicate rows)", () => {
-        it("collapses 2+ loose subagents sharing a display_name into one NameGroup", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: null, display_name: "Code Reviewer" }),
-                mk({ agent_id: "a2", workflow_id: null, display_name: "Code Reviewer" }),
-                mk({ agent_id: "a3", workflow_id: null, display_name: "Code Reviewer" }),
-            ]);
+    describe("name-based grouping of solo dispatches (issue: same-name duplicate rows)", () => {
+        it("collapses 2+ solo dispatches sharing a display_name into one NameGroup", () => {
+            const result = buildDispatchChildren(
+                [],
+                [
+                    mk({ agent_id: "a1", display_name: "Code Reviewer" }),
+                    mk({ agent_id: "a2", display_name: "Code Reviewer" }),
+                    mk({ agent_id: "a3", display_name: "Code Reviewer" }),
+                ]
+            );
             expect(result).toHaveLength(1);
             const group = result[0];
             expect(isNameGroup(group)).toBe(true);
@@ -182,38 +200,42 @@ describe("groupSubagentsByWorkflow", () => {
         });
 
         it("leaves a single subagent with a unique display_name as a loose row (no group chrome for a non-dupe)", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: null, display_name: "Only One" }),
-            ]);
+            const result = buildDispatchChildren([], [mk({ agent_id: "a1", display_name: "Only One" })]);
             expect(result).toHaveLength(1);
             expect(isNameGroup(result[0])).toBe(false);
             expect(childId(result[0])).toBe("a1");
         });
 
         it("leaves subagents with no display_name yet as loose, ungrouped rows even if several exist", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: null, display_name: null }),
-                mk({ agent_id: "a2", workflow_id: null, display_name: null }),
-            ]);
+            const result = buildDispatchChildren(
+                [],
+                [mk({ agent_id: "a1", display_name: null }), mk({ agent_id: "a2", display_name: null })]
+            );
             expect(result).toHaveLength(2);
             expect(result.every((c) => !isNameGroup(c))).toBe(true);
         });
 
-        it("workflow grouping takes priority — same-named subagents in a workflow never form a NameGroup", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: "wf_1", display_name: "Worker" }),
-                mk({ agent_id: "a2", workflow_id: "wf_1", display_name: "Worker" }),
-            ]);
+        it("workflow dispatches take priority — same-named subagents in a workflow never form a NameGroup", () => {
+            const result = buildDispatchChildren(
+                [mkDispatch({ dispatch_id: "wf_1", member_count: 2 })],
+                [
+                    mk({ agent_id: "a1", dispatch_id: "wf_1", display_name: "Worker" }),
+                    mk({ agent_id: "a2", dispatch_id: "wf_1", display_name: "Worker" }),
+                ]
+            );
             expect(result).toHaveLength(1);
-            expect(isWorkflowGroup(result[0])).toBe(true);
+            expect(isWorkflowDispatch(result[0])).toBe(true);
             expect(result.some(isNameGroup)).toBe(false);
         });
 
         it("marks a NameGroup active if any member is still active", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: null, display_name: "N", status: "completed" }),
-                mk({ agent_id: "a2", workflow_id: null, display_name: "N", status: "active" }),
-            ]);
+            const result = buildDispatchChildren(
+                [],
+                [
+                    mk({ agent_id: "a1", display_name: "N", status: "completed" }),
+                    mk({ agent_id: "a2", display_name: "N", status: "active" }),
+                ]
+            );
             const group = result[0];
             if (isNameGroup(group)) {
                 expect(group.status).toBe("active");
@@ -224,10 +246,13 @@ describe("groupSubagentsByWorkflow", () => {
         });
 
         it("marks a NameGroup retired only once every member has completed", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: null, display_name: "N", status: "completed" }),
-                mk({ agent_id: "a2", workflow_id: null, display_name: "N", status: "completed" }),
-            ]);
+            const result = buildDispatchChildren(
+                [],
+                [
+                    mk({ agent_id: "a1", display_name: "N", status: "completed" }),
+                    mk({ agent_id: "a2", display_name: "N", status: "completed" }),
+                ]
+            );
             const group = result[0];
             if (isNameGroup(group)) {
                 expect(group.status).toBe("retired");
@@ -237,10 +262,13 @@ describe("groupSubagentsByWorkflow", () => {
         });
 
         it("treats an abandoned NameGroup member the same as a completed one (both terminal)", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "a1", workflow_id: null, display_name: "N", status: "completed" }),
-                mk({ agent_id: "a2", workflow_id: null, display_name: "N", status: "abandoned" }),
-            ]);
+            const result = buildDispatchChildren(
+                [],
+                [
+                    mk({ agent_id: "a1", display_name: "N", status: "completed" }),
+                    mk({ agent_id: "a2", display_name: "N", status: "abandoned" }),
+                ]
+            );
             const group = result[0];
             if (isNameGroup(group)) {
                 expect(group.status).toBe("retired");
@@ -250,19 +278,22 @@ describe("groupSubagentsByWorkflow", () => {
             }
         });
 
-        it("mixes loose subagents, workflow groups, and name groups together, sorted by recency", () => {
-            const result = groupSubagentsByWorkflow([
-                mk({ agent_id: "solo", workflow_id: null, display_name: "Unique", last_event_at: 50 }),
-                mk({ agent_id: "n1", workflow_id: null, display_name: "Dup", last_event_at: 300 }),
-                mk({ agent_id: "n2", workflow_id: null, display_name: "Dup", last_event_at: 700 }),
-                mk({ agent_id: "w1", workflow_id: "wf_1", last_event_at: 500 }),
-            ]);
+        it("mixes loose subagents, workflow dispatches, and name groups together, sorted by recency", () => {
+            const result = buildDispatchChildren(
+                [mkDispatch({ dispatch_id: "wf_1", last_event_at: 500 })],
+                [
+                    mk({ agent_id: "solo", display_name: "Unique", last_event_at: 50 }),
+                    mk({ agent_id: "n1", display_name: "Dup", last_event_at: 300 }),
+                    mk({ agent_id: "n2", display_name: "Dup", last_event_at: 700 }),
+                    mk({ agent_id: "w1", dispatch_id: "wf_1", last_event_at: 500 }),
+                ]
+            );
             expect(result).toHaveLength(3);
             const nameGroups = result.filter(isNameGroup);
-            const workflowGroups = result.filter(isWorkflowGroup);
+            const workflowDispatches = result.filter(isWorkflowDispatch);
             expect(nameGroups).toHaveLength(1);
-            expect(workflowGroups).toHaveLength(1);
-            // Dup group's lastEventAt (700, from n2) > wf_1 (500) > solo (50)
+            expect(workflowDispatches).toHaveLength(1);
+            // Dup group's lastEventAt (700, from n2) > wf_1 dispatch (500) > solo (50)
             expect(childId(result[0])).toBe("Dup");
             expect(childId(result[2])).toBe("solo");
         });
@@ -308,67 +339,77 @@ describe("mergeSubagentsPreservingIdentity", () => {
 });
 
 describe("stabilizeGroupIdentity", () => {
-    it("reuses the cached WorkflowGroup reference when nothing about the group changed", () => {
-        const cache = new Map<string, WorkflowGroup>();
-        const members = [mk({ agent_id: "a1", workflow_id: "wf_1" })];
-        const first = groupSubagentsByWorkflow(members);
+    it("reuses the cached WorkflowDispatch reference when nothing about the dispatch changed", () => {
+        const cache = new Map<string, WorkflowDispatch>();
+        const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 1 })];
+        const members = [mk({ agent_id: "a1", dispatch_id: "wf_1" })];
+        const first = buildDispatchChildren(dispatches, members);
         const stabilizedFirst = stabilizeGroupIdentity(cache, first);
 
-        // A second, independently-built (but content-identical) group for the
-        // same workflow — mirrors what a fresh groupSubagentsByWorkflow() call
+        // A second, independently-built (but content-identical) row for the
+        // same dispatch — mirrors what a fresh buildDispatchChildren() call
         // produces on an unrelated buildTree() recompute.
-        const second = groupSubagentsByWorkflow(members);
+        const second = buildDispatchChildren(dispatches, members);
         const stabilizedSecond = stabilizeGroupIdentity(cache, second);
 
         expect(stabilizedSecond[0]).toBe(stabilizedFirst[0]);
     });
 
-    it("returns a fresh reference when the group's member set actually changed", () => {
-        const cache = new Map<string, WorkflowGroup>();
-        const first = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1", status: "active" })]);
+    it("returns a fresh reference when the dispatch's own fields actually changed", () => {
+        const cache = new Map<string, WorkflowDispatch>();
+        const first = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_1", member_count: 1, members_done: 0 })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        );
         const stabilizedFirst = stabilizeGroupIdentity(cache, first);
 
-        const second = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1", status: "completed" })]);
+        const second = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_1", member_count: 1, members_done: 1, status: "completed" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        );
         const stabilizedSecond = stabilizeGroupIdentity(cache, second);
 
         expect(stabilizedSecond[0]).not.toBe(stabilizedFirst[0]);
     });
 
     it("passes loose (non-group) subagents through unchanged", () => {
-        const cache = new Map<string, WorkflowGroup>();
-        const loose = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: null })]);
+        const cache = new Map<string, WorkflowDispatch>();
+        const loose = buildDispatchChildren([], [mk({ agent_id: "a1" })]);
         const stabilized = stabilizeGroupIdentity(cache, loose);
         expect(stabilized[0]).toBe(loose[0]);
         expect(cache.size).toBe(0);
     });
 
     it("reuses the cached NameGroup reference when nothing about the group changed", () => {
-        const cache = new Map<string, WorkflowGroup | NameGroup>();
+        const cache = new Map<string, WorkflowDispatch | NameGroup>();
         const members = [
-            mk({ agent_id: "a1", workflow_id: null, display_name: "Dup" }),
-            mk({ agent_id: "a2", workflow_id: null, display_name: "Dup" }),
+            mk({ agent_id: "a1", display_name: "Dup" }),
+            mk({ agent_id: "a2", display_name: "Dup" }),
         ];
-        const first = groupSubagentsByWorkflow(members);
+        const first = buildDispatchChildren([], members);
         const stabilizedFirst = stabilizeGroupIdentity(cache, first);
 
-        const second = groupSubagentsByWorkflow(members);
+        const second = buildDispatchChildren([], members);
         const stabilizedSecond = stabilizeGroupIdentity(cache, second);
 
         expect(stabilizedSecond[0]).toBe(stabilizedFirst[0]);
     });
 
-    it("keeps a WorkflowGroup and a NameGroup with the same raw id/name as distinct cache entries", () => {
+    it("keeps a WorkflowDispatch and a NameGroup with the same raw id/name as distinct cache entries", () => {
         // groupCacheKey namespaces with "wf:"/"name:" precisely so this
         // coincidence can't collide two unrelated groups into one cache slot.
-        const cache = new Map<string, WorkflowGroup | NameGroup>();
-        const wfChildren = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: "shared-id" }),
-            mk({ agent_id: "a2", workflow_id: "shared-id" }),
-        ]);
-        const nameChildren = groupSubagentsByWorkflow([
-            mk({ agent_id: "b1", workflow_id: null, display_name: "shared-id" }),
-            mk({ agent_id: "b2", workflow_id: null, display_name: "shared-id" }),
-        ]);
+        const cache = new Map<string, WorkflowDispatch | NameGroup>();
+        const wfChildren = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "shared-id", member_count: 2 })],
+            [mk({ agent_id: "a1", dispatch_id: "shared-id" }), mk({ agent_id: "a2", dispatch_id: "shared-id" })]
+        );
+        const nameChildren = buildDispatchChildren(
+            [],
+            [
+                mk({ agent_id: "b1", display_name: "shared-id" }),
+                mk({ agent_id: "b2", display_name: "shared-id" }),
+            ]
+        );
         stabilizeGroupIdentity(cache, wfChildren);
         stabilizeGroupIdentity(cache, nameChildren);
         expect(cache.size).toBe(2);
@@ -378,20 +419,26 @@ describe("stabilizeGroupIdentity", () => {
 
     it("keeps same-named NameGroups from two different agent blocks as distinct cache entries (reagent P1 on #2123)", () => {
         // groupIdentityCache/expandedIds are shared across the WHOLE tree
-        // (buildTree() calls groupSubagentsByWorkflow once per block, into
-        // one cache) — a Haiku-generated name like "Code Reviewer" can
-        // plausibly repeat across two unrelated agent panes. Without
-        // parentBlockId in the key, block A's and block B's same-named
-        // groups would stomp each other's identity/expand state.
-        const cache = new Map<string, WorkflowGroup | NameGroup>();
-        const blockAChildren = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", parent_block_id: "block-A", workflow_id: null, display_name: "Code Reviewer" }),
-            mk({ agent_id: "a2", parent_block_id: "block-A", workflow_id: null, display_name: "Code Reviewer" }),
-        ]);
-        const blockBChildren = groupSubagentsByWorkflow([
-            mk({ agent_id: "b1", parent_block_id: "block-B", workflow_id: null, display_name: "Code Reviewer" }),
-            mk({ agent_id: "b2", parent_block_id: "block-B", workflow_id: null, display_name: "Code Reviewer" }),
-        ]);
+        // (buildTree() calls buildDispatchChildren once per block, into one
+        // cache) — a Haiku-generated name like "Code Reviewer" can plausibly
+        // repeat across two unrelated agent panes. Without parentBlockId in
+        // the key, block A's and block B's same-named groups would stomp
+        // each other's identity/expand state.
+        const cache = new Map<string, WorkflowDispatch | NameGroup>();
+        const blockAChildren = buildDispatchChildren(
+            [],
+            [
+                mk({ agent_id: "a1", parent_block_id: "block-A", display_name: "Code Reviewer" }),
+                mk({ agent_id: "a2", parent_block_id: "block-A", display_name: "Code Reviewer" }),
+            ]
+        );
+        const blockBChildren = buildDispatchChildren(
+            [],
+            [
+                mk({ agent_id: "b1", parent_block_id: "block-B", display_name: "Code Reviewer" }),
+                mk({ agent_id: "b2", parent_block_id: "block-B", display_name: "Code Reviewer" }),
+            ]
+        );
         const stabilizedA = stabilizeGroupIdentity(cache, blockAChildren);
         const stabilizedB = stabilizeGroupIdentity(cache, blockBChildren);
         expect(cache.size).toBe(2);
@@ -406,28 +453,37 @@ describe("stabilizeGroupIdentity", () => {
 });
 
 describe("groupCacheKey", () => {
-    it("namespaces a WorkflowGroup key with 'wf:' and a NameGroup key with 'name:<parentBlockId>:'", () => {
-        const [wf] = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_1" })]).filter(isWorkflowGroup);
-        const [ng] = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: null, display_name: "N" }),
-            mk({ agent_id: "a2", workflow_id: null, display_name: "N" }),
-        ]).filter(isNameGroup);
+    it("namespaces a WorkflowDispatch key with 'wf:' and a NameGroup key with 'name:<parentBlockId>:'", () => {
+        const [wf] = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_1" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
+        ).filter(isWorkflowDispatch);
+        const [ng] = buildDispatchChildren(
+            [],
+            [mk({ agent_id: "a1", display_name: "N" }), mk({ agent_id: "a2", display_name: "N" })]
+        ).filter(isNameGroup);
         expect(groupCacheKey(wf)).toBe("wf:wf_1");
         expect(groupCacheKey(ng)).toBe("name:block-1:N");
     });
 });
 
 describe("pruneGroupIdentityCache", () => {
-    it("drops entries for workflows no longer live, keeps the rest", () => {
-        const cache = new Map<string, WorkflowGroup>();
-        const groupA = groupSubagentsByWorkflow([mk({ agent_id: "a1", workflow_id: "wf_a" })]);
-        const groupB = groupSubagentsByWorkflow([mk({ agent_id: "b1", workflow_id: "wf_b" })]);
+    it("drops entries for dispatches no longer live, keeps the rest", () => {
+        const cache = new Map<string, WorkflowDispatch>();
+        const groupA = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_a" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_a" })]
+        );
+        const groupB = buildDispatchChildren(
+            [mkDispatch({ dispatch_id: "wf_b" })],
+            [mk({ agent_id: "b1", dispatch_id: "wf_b" })]
+        );
         stabilizeGroupIdentity(cache, groupA);
         stabilizeGroupIdentity(cache, groupB);
         expect(cache.size).toBe(2);
 
         // Live keys use groupCacheKey's namespaced "wf:<id>" form, not the
-        // raw workflowId.
+        // raw dispatchId.
         pruneGroupIdentityCache(cache, new Set(["wf:wf_a"]));
         expect(cache.size).toBe(1);
         expect(cache.has("wf:wf_a")).toBe(true);
@@ -435,15 +491,15 @@ describe("pruneGroupIdentityCache", () => {
     });
 
     it("drops entries for name groups no longer live, keeps the rest", () => {
-        const cache = new Map<string, WorkflowGroup | NameGroup>();
-        const groupA = groupSubagentsByWorkflow([
-            mk({ agent_id: "a1", workflow_id: null, display_name: "A" }),
-            mk({ agent_id: "a2", workflow_id: null, display_name: "A" }),
-        ]);
-        const groupB = groupSubagentsByWorkflow([
-            mk({ agent_id: "b1", workflow_id: null, display_name: "B" }),
-            mk({ agent_id: "b2", workflow_id: null, display_name: "B" }),
-        ]);
+        const cache = new Map<string, WorkflowDispatch | NameGroup>();
+        const groupA = buildDispatchChildren(
+            [],
+            [mk({ agent_id: "a1", display_name: "A" }), mk({ agent_id: "a2", display_name: "A" })]
+        );
+        const groupB = buildDispatchChildren(
+            [],
+            [mk({ agent_id: "b1", display_name: "B" }), mk({ agent_id: "b2", display_name: "B" })]
+        );
         stabilizeGroupIdentity(cache, groupA);
         stabilizeGroupIdentity(cache, groupB);
         expect(cache.size).toBe(2);

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -197,7 +197,18 @@ export function buildDispatchChildren(
 
     const solo = subagents.filter((s) => s.dispatch_id.startsWith("solo:"));
 
-    const stillLoose: ActiveSubagent[] = [];
+    // Fallback for a failed/lagging `ListDispatches` call: `loadDispatches()`
+    // swallows RPC errors and leaves `dispatchesAtom` stale (see its call
+    // site), so `dispatches` here can lag or miss entries `subagents` (a
+    // separate fetch) already has. Without this, any workflow-kind subagent
+    // whose dispatch has no matching row in `workflowRows` would vanish from
+    // the tree entirely instead of degrading to an individual row.
+    const workflowDispatchIds = new Set(workflowRows.map((w) => w.dispatchId));
+    const orphanedWorkflowMembers = subagents.filter(
+        (s) => !s.dispatch_id.startsWith("solo:") && !workflowDispatchIds.has(s.dispatch_id)
+    );
+
+    const stillLoose: ActiveSubagent[] = [...orphanedWorkflowMembers];
     const byName = new Map<string, ActiveSubagent[]>();
     for (const s of solo) {
         if (s.display_name) {

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -14,19 +14,24 @@ import { createSignal, type Accessor, type Setter } from "solid-js";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
+// SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17: the backend now models
+// two levels — `AgentDispatch` (one per Agent-tool-or-Workflow-tool call)
+// containing N `SubAgent` members. The TS interface here keeps the
+// `ActiveSubagent` name (unlike the Rust `SubagentInfo`→`SubAgent` rename)
+// to limit churn across this file/swarm-view.tsx — it maps 1:1 to the
+// backend's `SubAgent` either way.
 export interface ActiveSubagent {
     agent_id: string;
     slug: string;
     parent_agent: string;
     parent_block_id: string;
     session_id: string;
-    /** `"abandoned"` (SubagentStatus::Abandoned, Rust) — the parent block's
+    /** `"abandoned"` (SubAgentStatus::Abandoned, Rust) — the parent block's
      *  turn ended without a Result line ever appearing for this subagent
      *  (crashed, killed, or interrupted by an app/srv restart). Distinct
      *  from `"completed"`: it didn't finish, it was cut off. Set by the
      *  backend's `reconcile_stale_subagents`, currently only on pane
-     *  reopen/backfill — see
-     *  docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md. */
+     *  reopen/backfill. */
     status: "active" | "completed" | "abandoned";
     /** Unix ms when this subagent was first observed — set once, immutable.
      *  Distinct from `last_event_at`, which advances on every journal read. */
@@ -34,14 +39,34 @@ export interface ActiveSubagent {
     last_event_at: number;
     event_count: number;
     model: string | null;
-    // Already on the wire (SubagentInfo.workflow_id, Rust) — was previously
-    // typed away here. Some("wf_<id>") for a Task/Workflow-tool run that
-    // spawned multiple subagents together; null for a standalone subagent.
-    workflow_id: string | null;
-    // Concise Haiku-generated name (SubagentInfo.display_name, Rust). Null
+    /** Always present now (was `workflow_id: string | null`) — every
+     *  subagent has a real dispatch container. A Workflow-tool member
+     *  carries the run's own id (`"wf_<id>"`); a solo Task-tool call gets a
+     *  synthesized `"solo:<agent_id>"` (Rust's `solo_dispatch_id`). Use
+     *  `dispatch_id.startsWith("solo:")` to tell them apart client-side. */
+    dispatch_id: string;
+    // Concise Haiku-generated name (SubAgent.display_name, Rust). Null
     // until a client expands this subagent's row for the first time — see
     // `subagent.GenerateName` / the `subagent:named` event below.
     display_name: string | null;
+}
+
+/**
+ * Mirrors the backend's `AgentDispatch` (one per Agent-tool-or-Workflow-tool
+ * call). Only Workflow-kind dispatches get their own tree row
+ * (`WorkflowDispatch`, below) — a Solo-kind dispatch's one member renders as
+ * a plain `ActiveSubagent` row directly, no wrapper (SPEC §5/§7).
+ */
+export interface AgentDispatch {
+    dispatch_id: string;
+    kind: "solo" | "workflow";
+    parent_agent: string;
+    parent_block_id: string;
+    session_id: string;
+    member_count: number;
+    members_done: number;
+    status: "running" | "completed";
+    last_event_at: number;
 }
 
 // ── Subagent event log (inline-expand detail) ───────────────────────────
@@ -60,39 +85,41 @@ export type SubagentEventType =
     | { type: "result"; content: string };
 
 /**
- * A group of subagents spawned together by one Task/Workflow-tool run
- * (shared `workflow_id`). Collapsed into one row in the tree instead of one
- * row per member — a single workflow run can spawn dozens of subagents at
- * once (observed live: 45), which read as a "flood" when listed flat. See
- * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md Finding 4.
+ * One row for a Workflow-kind `AgentDispatch` — SPEC §7: never one row per
+ * member, regardless of member count (a single workflow run can spawn
+ * hundreds to low-thousands of members; see
+ * docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md, which found
+ * 1,030+ in one run). Deliberately does NOT carry the member list — a
+ * dispatch this large can't hold its members' event histories in the tree
+ * atom without reintroducing the same unbounded-volume problem this
+ * redesign exists to fix. Expanding this row shows a live concatenated
+ * activity feed instead (`createDispatchDetail`), not nested member rows.
  */
-export interface WorkflowGroup {
-    kind: "workflowGroup";
-    workflowId: string;
-    /** Derived client-side from the first member with a non-empty slug —
-     *  the backend has no separate workflow-name concept (see report). */
+export interface WorkflowDispatch {
+    kind: "workflowDispatch";
+    dispatchId: string;
+    /** Derived client-side from a member's slug (SPEC keeps this — the
+     *  backend still has no separate dispatch-name concept). */
     name: string;
-    subagents: ActiveSubagent[];
-    activeCount: number;
-    totalCount: number;
+    memberCount: number;
+    membersDone: number;
     /** "active" if any member is still active; "retired" once every member
-     *  has completed. */
+     *  has completed. Derived from AgentDispatch.status ("running" |
+     *  "completed") — different vocabulary, same meaning as the rest of
+     *  this file's group rows. */
     status: "active" | "retired";
     lastEventAt: number;
 }
 
 /**
- * A group of LOOSE subagents (no `workflow_id` — not spawned together by one
- * Task/Workflow-tool run) that independently earned the same Haiku-generated
+ * A group of solo-dispatch subagents (no Workflow-tool run — a Solo
+ * `AgentDispatch` each) that independently earned the same Haiku-generated
  * `display_name`. A user repeatedly spawning similar tasks (e.g. "review this
  * file" across many files) legitimately gets the same/near-identical name for
  * each invocation — the naming model doing its job, not a malfunction — but
- * left flat that reads as "dozens of duplicate rows." Workflow grouping takes
- * priority: a subagent already collapsed into a `WorkflowGroup` never also
- * enters this grouping pass, regardless of name. See
- * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md — this extends
- * that report's chosen "group, not truncate" approach to same-name loose
- * subagents, which the original workflow-only grouping didn't cover.
+ * left flat that reads as "dozens of duplicate rows." A subagent belonging to
+ * a Workflow dispatch never enters this grouping pass, regardless of name —
+ * it's already represented by its one `WorkflowDispatch` row.
  */
 export interface NameGroup {
     kind: "nameGroup";
@@ -100,10 +127,10 @@ export interface NameGroup {
      *  a name exists (display_name is null before subagent.GenerateName
      *  resolves), so ungrouped/unnamed subagents never form a NameGroup. */
     name: string;
-    /** Every member's shared parent_block_id — groupSubagentsByWorkflow is
+    /** Every member's shared parent_block_id — buildDispatchChildren is
      *  always called with an already block-filtered subagent list (see
      *  buildTree()), so this is uniform across the group. Required for
-     *  groupCacheKey: unlike WorkflowGroup's backend-unique workflowId, a
+     *  groupCacheKey: unlike WorkflowDispatch's backend-unique dispatchId, a
      *  Haiku-generated display_name can plausibly repeat across two
      *  unrelated agent panes (e.g. "Code Reviewer" in both), and
      *  groupIdentityCache/expandedIds are shared across the WHOLE tree —
@@ -118,10 +145,10 @@ export interface NameGroup {
     lastEventAt: number;
 }
 
-export type SwarmChild = ActiveSubagent | WorkflowGroup | NameGroup;
+export type SwarmChild = ActiveSubagent | WorkflowDispatch | NameGroup;
 
-export function isWorkflowGroup(child: SwarmChild): child is WorkflowGroup {
-    return "kind" in child && child.kind === "workflowGroup";
+export function isWorkflowDispatch(child: SwarmChild): child is WorkflowDispatch {
+    return "kind" in child && child.kind === "workflowDispatch";
 }
 
 export function isNameGroup(child: SwarmChild): child is NameGroup {
@@ -139,46 +166,40 @@ export interface AgentTreeNode {
 }
 
 /**
- * Group `subagents` (already filtered to one parent block) by `workflow_id`,
- * then, for the loose remainder, by shared `display_name`. Subagents sharing
- * a `workflow_id` collapse into a `WorkflowGroup`; among what's left, two or
- * more subagents sharing an identical, non-empty `display_name` collapse
- * into a `NameGroup`. A single subagent with a unique name (or no name yet)
- * stays a loose, ungrouped row — group chrome for something that isn't
- * actually a dupe would be noise of its own. Result is sorted by most recent
+ * Build one block's tree children from its `AgentDispatch`es (already
+ * block-filtered) and raw `SubAgent`s. Every Workflow-kind dispatch becomes
+ * exactly one `WorkflowDispatch` row (SPEC §7 — never one row per member).
+ * Every Solo-kind dispatch's one member renders as a plain `ActiveSubagent`
+ * row, no wrapper (SPEC §5) — among those, two or more sharing an identical,
+ * non-empty `display_name` still collapse into a `NameGroup` (grouping
+ * solo DISPATCHES now, not raw subagents, but every subagent has exactly one
+ * dispatch so the input set is the same). Result is sorted by most recent
  * activity, mixing loose subagents and both group kinds in one recency order.
  */
-export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChild[] {
-    const loose: ActiveSubagent[] = [];
-    const byWorkflow = new Map<string, ActiveSubagent[]>();
-    for (const s of subagents) {
-        if (s.workflow_id) {
-            const members = byWorkflow.get(s.workflow_id) ?? [];
-            members.push(s);
-            byWorkflow.set(s.workflow_id, members);
-        } else {
-            loose.push(s);
-        }
-    }
+export function buildDispatchChildren(
+    dispatches: AgentDispatch[],
+    subagents: ActiveSubagent[]
+): SwarmChild[] {
+    const workflowRows: WorkflowDispatch[] = dispatches
+        .filter((d) => d.kind === "workflow")
+        .map((d) => {
+            const namedMember = subagents.find((s) => s.dispatch_id === d.dispatch_id && s.slug);
+            return {
+                kind: "workflowDispatch" as const,
+                dispatchId: d.dispatch_id,
+                name: namedMember?.slug || d.dispatch_id,
+                memberCount: d.member_count,
+                membersDone: d.members_done,
+                status: d.status === "completed" ? ("retired" as const) : ("active" as const),
+                lastEventAt: d.last_event_at,
+            };
+        });
 
-    const groups: WorkflowGroup[] = [...byWorkflow.entries()].map(([workflowId, members]) => {
-        const sorted = [...members].sort((a, b) => b.last_event_at - a.last_event_at);
-        const activeCount = sorted.filter((m) => m.status === "active").length;
-        return {
-            kind: "workflowGroup" as const,
-            workflowId,
-            name: sorted.find((m) => m.slug)?.slug || workflowId,
-            subagents: sorted,
-            activeCount,
-            totalCount: sorted.length,
-            status: activeCount > 0 ? "active" as const : "retired" as const,
-            lastEventAt: sorted[0]?.last_event_at ?? 0,
-        };
-    });
+    const solo = subagents.filter((s) => s.dispatch_id.startsWith("solo:"));
 
     const stillLoose: ActiveSubagent[] = [];
     const byName = new Map<string, ActiveSubagent[]>();
-    for (const s of loose) {
+    for (const s of solo) {
         if (s.display_name) {
             const members = byName.get(s.display_name) ?? [];
             members.push(s);
@@ -199,20 +220,20 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
         nameGroups.push({
             kind: "nameGroup" as const,
             name,
-            // Uniform across the group — groupSubagentsByWorkflow is always
+            // Uniform across the group — buildDispatchChildren is always
             // called with an already block-filtered list (buildTree()).
             parentBlockId: sorted[0].parent_block_id,
             subagents: sorted,
             activeCount,
             totalCount: sorted.length,
-            status: activeCount > 0 ? "active" as const : "retired" as const,
+            status: activeCount > 0 ? ("active" as const) : ("retired" as const),
             lastEventAt: sorted[0]?.last_event_at ?? 0,
         });
     }
 
     const lastEventOf = (c: SwarmChild): number =>
-        isWorkflowGroup(c) || isNameGroup(c) ? c.lastEventAt : c.last_event_at;
-    return [...stillLoose, ...groups, ...nameGroups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
+        isWorkflowDispatch(c) || isNameGroup(c) ? c.lastEventAt : c.last_event_at;
+    return [...stillLoose, ...workflowRows, ...nameGroups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
 }
 
 /**
@@ -229,7 +250,7 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
  * already established as an expected, non-buggy signature in
  * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md Finding 3
  * ("one shared slug = one legitimate concurrent spawn") and relied on by
- * `groupSubagentsByWorkflow`'s `WorkflowGroup.name` derivation above.
+ * `buildDispatchChildren`'s `WorkflowDispatch.name` derivation above.
  *
  * Falling back to a bare `slug` as a ROW LABEL, though, silently assumed
  * the opposite — that it WAS subagent-unique — so every member of such a
@@ -238,7 +259,7 @@ export function groupSubagentsByWorkflow(subagents: ActiveSubagent[]): SwarmChil
  * distinct `agent_id`s, one shared literal slug, spawned within ~50ms of
  * each other under one parent, rendered as 17 apparently-duplicate rows —
  * not a slug-generation bug or a spawn-dedup bug (all 17 were genuinely
- * separate, correctly-ungrouped subagents; `workflow_id`/`display_name`
+ * separate, correctly-ungrouped subagents; `dispatch_id`/`display_name`
  * grouping never entered the picture since neither had resolved yet).
  * Appending a short, always-unique `agent_id` suffix keeps same-slug
  * siblings visually distinct without claiming a uniqueness `slug` never
@@ -261,7 +282,7 @@ function shallowEqualSubagent(a: ActiveSubagent, b: ActiveSubagent): boolean {
         a.last_event_at === b.last_event_at &&
         a.event_count === b.event_count &&
         a.model === b.model &&
-        a.workflow_id === b.workflow_id &&
+        a.dispatch_id === b.dispatch_id &&
         a.display_name === b.display_name &&
         a.parent_agent === b.parent_agent &&
         a.parent_block_id === b.parent_block_id &&
@@ -291,48 +312,61 @@ export function mergeSubagentsPreservingIdentity(
     });
 }
 
-/** Common fields shared by both group kinds — `shallowEqualGroupContent`
- *  compares only these, so it works for a `WorkflowGroup` or `NameGroup`
- *  pair without needing to know which kind it's looking at. */
-function shallowEqualGroupContent(a: WorkflowGroup | NameGroup, b: WorkflowGroup | NameGroup): boolean {
+/** `shallowEqualGroupContent` — type-aware, since `WorkflowDispatch` no
+ *  longer carries a member list (SPEC §7 — a dispatch can have thousands of
+ *  members, too many to hold in the tree atom) while `NameGroup` still does.
+ *  A kind mismatch is never equal (defensive; `groupCacheKey`'s namespacing
+ *  already prevents the two kinds from ever sharing a cache key). */
+function shallowEqualGroupContent(a: WorkflowDispatch | NameGroup, b: WorkflowDispatch | NameGroup): boolean {
+    if (isWorkflowDispatch(a) !== isWorkflowDispatch(b)) return false;
+    if (isWorkflowDispatch(a) && isWorkflowDispatch(b)) {
+        return (
+            a.dispatchId === b.dispatchId &&
+            a.name === b.name &&
+            a.memberCount === b.memberCount &&
+            a.membersDone === b.membersDone &&
+            a.status === b.status &&
+            a.lastEventAt === b.lastEventAt
+        );
+    }
+    const na = a as NameGroup;
+    const nb = b as NameGroup;
     return (
-        a.name === b.name &&
-        a.activeCount === b.activeCount &&
-        a.totalCount === b.totalCount &&
-        a.status === b.status &&
-        a.lastEventAt === b.lastEventAt &&
-        a.subagents.length === b.subagents.length &&
-        a.subagents.every((m, i) => m === b.subagents[i])
+        na.name === nb.name &&
+        na.activeCount === nb.activeCount &&
+        na.totalCount === nb.totalCount &&
+        na.status === nb.status &&
+        na.lastEventAt === nb.lastEventAt &&
+        na.subagents.length === nb.subagents.length &&
+        na.subagents.every((m, i) => m === nb.subagents[i])
     );
 }
 
-/** Namespaced cache key so a `WorkflowGroup`'s `workflowId` and a
+/** Namespaced cache key so a `WorkflowDispatch`'s `dispatchId` and a
  *  `NameGroup`'s `name` can never collide in the shared identity cache.
- *  `NameGroup` additionally scopes by `parentBlockId`: a `workflowId` is
+ *  `NameGroup` additionally scopes by `parentBlockId`: a `dispatchId` is
  *  backend-unique so a bare name would never collide there, but a
  *  Haiku-generated `display_name` (e.g. "Code Reviewer") can plausibly
  *  repeat across two unrelated agent panes, and `groupIdentityCache`/
  *  `expandedIds` are shared across the WHOLE tree (every block) — without
  *  the block scope, two blocks' same-named groups would stomp each other's
  *  cached identity and expand/collapse state. Reagent P1 on PR #2123. */
-export function groupCacheKey(child: WorkflowGroup | NameGroup): string {
-    return isWorkflowGroup(child)
-        ? `wf:${child.workflowId}`
+export function groupCacheKey(child: WorkflowDispatch | NameGroup): string {
+    return isWorkflowDispatch(child)
+        ? `wf:${child.dispatchId}`
         : `name:${child.parentBlockId}:${child.name}`;
 }
 
 /**
- * Stabilize `WorkflowGroup`/`NameGroup` wrapper identity across `buildTree()`
- * calls, mirroring `mergeSubagentsPreservingIdentity` one level up.
- * `groupSubagentsByWorkflow` is a pure function — it unconditionally builds
- * brand-new group objects per call, even when every member (already
- * reference-stable thanks to `mergeSubagentsPreservingIdentity`) is
- * unchanged. Left alone, that fresh wrapper still remounts `WorkflowGroupRow`/
- * `NameGroupRow` — and everything nested inside an expanded one
- * (`SubagentRow`, `SubagentDetailPane`, `SubagentDetailEvent`) — on every
- * unrelated tree recompute, which for a workflow group (the highest-volume
- * case: a single run can spawn dozens of subagents) defeats the very
- * remount fix `expandedIdsAtom`/`getSubagentDetail` were meant to provide.
+ * Stabilize `WorkflowDispatch`/`NameGroup` wrapper identity across
+ * `buildTree()` calls, mirroring `mergeSubagentsPreservingIdentity` one
+ * level up. `buildDispatchChildren` is a pure function — it unconditionally
+ * builds brand-new group objects per call, even when nothing about a given
+ * group actually changed. Left alone, that fresh wrapper still remounts
+ * `WorkflowDispatchRow`/`NameGroupRow` — and everything nested inside an
+ * expanded one — on every unrelated tree recompute, which for a large
+ * workflow dispatch defeats the very remount fix `expandedIdsAtom`/
+ * `getDispatchDetail` were meant to provide.
  *
  * `cache` is a `Map<groupCacheKey, group>` the caller keeps around (one per
  * `SwarmViewModel`), shared and called once per BLOCK within one
@@ -344,11 +378,11 @@ export function groupCacheKey(child: WorkflowGroup | NameGroup): string {
  * `pruneGroupIdentityCache`.
  */
 export function stabilizeGroupIdentity(
-    cache: Map<string, WorkflowGroup | NameGroup>,
+    cache: Map<string, WorkflowDispatch | NameGroup>,
     children: SwarmChild[]
 ): SwarmChild[] {
     return children.map((child) => {
-        if (!isWorkflowGroup(child) && !isNameGroup(child)) return child;
+        if (!isWorkflowDispatch(child) && !isNameGroup(child)) return child;
         const key = groupCacheKey(child);
         const old = cache.get(key);
         const stable = old && shallowEqualGroupContent(old, child) ? old : child;
@@ -362,7 +396,7 @@ export function stabilizeGroupIdentity(
  *  `stabilizeGroupIdentity`), so it can't grow unbounded across sessions.
  *  `liveGroupKeys` must use the same `wf:<id>` / `name:<name>` namespacing
  *  as `groupCacheKey` — see `SwarmViewModel.buildTree()`. */
-export function pruneGroupIdentityCache(cache: Map<string, WorkflowGroup | NameGroup>, liveGroupKeys: Set<string>): void {
+export function pruneGroupIdentityCache(cache: Map<string, WorkflowDispatch | NameGroup>, liveGroupKeys: Set<string>): void {
     for (const key of [...cache.keys()]) {
         if (!liveGroupKeys.has(key)) cache.delete(key);
     }
@@ -454,6 +488,68 @@ export function createSubagentDetail(subagentId: string): SubagentDetail {
     };
 }
 
+// ── Dispatch concatenated activity feed (SPEC §7) ───────────────────────
+
+export interface DispatchActivityEntry {
+    agentId: string;
+    event: SubagentEvent;
+}
+
+export interface DispatchDetail {
+    entriesAtom: Accessor<DispatchActivityEntry[]>;
+    dispose: () => void;
+}
+
+/** Hard cap on the concatenated feed's retained entries — a Workflow
+ *  dispatch with hundreds of members can generate activity fast enough that
+ *  an unbounded feed would itself become the same unbounded-growth problem
+ *  this redesign exists to avoid. Oldest entries drop first. */
+const MAX_DISPATCH_FEED_ENTRIES = 500;
+
+/**
+ * Expanding a `WorkflowDispatchRow` shows this instead of nested member rows
+ * (SPEC §7): every member's new events, merged into one chronological,
+ * member-tagged stream, fed by the backend's coalesced `dispatch:activity`
+ * broadcast (`subagent_watcher.rs`'s `flush_pending_dispatch_activity`).
+ *
+ * Deliberately LIVE-ONLY — no historical backfill fetch when a dispatch is
+ * expanded. SPEC §9.4 leaves the backfill/pagination question explicitly
+ * open: a large dispatch can have thousands of prior events across hundreds
+ * of members, and eagerly fetching + merging that on every expand would
+ * reintroduce the exact request/render volume problem this redesign exists
+ * to fix. Until that's designed, the feed only shows what happens from the
+ * moment of expand onward.
+ */
+export function createDispatchDetail(dispatchId: string): DispatchDetail {
+    const [entries, setEntries] = createSignal<DispatchActivityEntry[]>([]);
+
+    const unsub = waveEventSubscribe({
+        eventType: "dispatch:activity",
+        handler: (event: WaveEvent) => {
+            const data = event?.data as any;
+            if (data?.dispatchId !== dispatchId) return;
+            const members = (data?.members as { agentId: string; events: SubagentEvent[] }[]) ?? [];
+            const incoming: DispatchActivityEntry[] = members.flatMap((m) =>
+                (m.events ?? []).map((event) => ({ agentId: m.agentId, event }))
+            );
+            if (incoming.length === 0) return;
+            setEntries((prev) => {
+                const merged = [...prev, ...incoming].sort((a, b) => a.event.timestamp - b.event.timestamp);
+                return merged.length > MAX_DISPATCH_FEED_ENTRIES
+                    ? merged.slice(merged.length - MAX_DISPATCH_FEED_ENTRIES)
+                    : merged;
+            });
+        },
+    });
+
+    return {
+        entriesAtom: entries,
+        dispose: () => {
+            unsub?.();
+        },
+    };
+}
+
 // ── Status derivation ────────────────────────────────────────────────────
 
 /**
@@ -498,6 +594,13 @@ export class SwarmViewModel implements ViewModel {
     subagentsAtom: Accessor<ActiveSubagent[]> = this._subagents[0];
     private setSubagents: Setter<ActiveSubagent[]> = this._subagents[1];
 
+    // AgentDispatches (SPEC §5) — one per Agent-tool-or-Workflow-tool call.
+    // Fetched separately from subagentsAtom via subagent.ListDispatches;
+    // buildTree() cross-references the two by dispatch_id/parent_block_id.
+    private _dispatches = createSignal<AgentDispatch[]>([]);
+    dispatchesAtom: Accessor<AgentDispatch[]> = this._dispatches[0];
+    private setDispatches: Setter<AgentDispatch[]> = this._dispatches[1];
+
     // Map of blockId → "running" | "idle" — updated by controllerstatus events
     private _agentStatuses = createSignal<Map<string, "running" | "idle">>(new Map());
     agentStatusesAtom: Accessor<Map<string, "running" | "idle">> = this._agentStatuses[0];
@@ -512,11 +615,11 @@ export class SwarmViewModel implements ViewModel {
     loadingAtom: Accessor<boolean> = this._loading[0];
     private setLoading: Setter<boolean> = this._loading[1];
 
-    // Rows the user has expanded — keyed by workflowId (WorkflowGroupRow) or
-    // agent_id (SubagentRow). Lives here, not as row-local component state:
+    // Rows the user has expanded — keyed by dispatchId (WorkflowDispatchRow)
+    // or agent_id (SubagentRow). Lives here, not as row-local component state:
     // `tree()` recomputes on every trackedBlockIds/subagents/agentStatuses
     // change (agentStatuses updates on every controllerstatus tick — very
-    // frequent during an active turn) and rebuilds fresh WorkflowGroup/
+    // frequent during an active turn) and rebuilds fresh WorkflowDispatch/
     // AgentTreeNode wrapper objects every time regardless of whether that
     // row's own data changed, so `<For>`'s reference-diffing remounts row
     // components far more often than "the user actually changed something."
@@ -545,17 +648,20 @@ export class SwarmViewModel implements ViewModel {
     // row is open during an active turn.
     private detailCache = new Map<string, SubagentDetail>();
 
+    // One DispatchDetail (concatenated activity feed, SPEC §7) per
+    // currently-expanded WorkflowDispatch row — same lazy-create/dispose-on-
+    // collapse rationale as detailCache above.
+    private dispatchDetailCache = new Map<string, DispatchDetail>();
+
     // Persisted across buildTree() calls so stabilizeGroupIdentity can reuse
-    // the same WorkflowGroup/NameGroup wrapper object when a group's own
+    // the same WorkflowDispatch/NameGroup wrapper object when a group's own
     // content is unchanged — without this, expandedIds/detailCache above
     // still don't help a subagent NESTED inside a group, since <For> remounts
-    // the whole WorkflowGroupRow/NameGroupRow subtree (SubagentRow,
-    // SubagentDetailPane, SubagentDetailEvent — including the latter's own
-    // local `expanded` signal for a tool_use/tool_result toggle) whenever the
+    // the whole WorkflowDispatchRow/NameGroupRow subtree whenever the
     // group's own wrapper reference changes, which is every buildTree() call
     // otherwise. Keyed by groupCacheKey's namespaced "wf:<id>" / "name:<name>"
     // strings so the two group kinds' key spaces never collide.
-    private groupIdentityCache = new Map<string, WorkflowGroup | NameGroup>();
+    private groupIdentityCache = new Map<string, WorkflowDispatch | NameGroup>();
 
     private unsubs: (() => void)[] = [];
     // Per-block controllerstatus unsubs — cleaned up when block list refreshes
@@ -588,6 +694,16 @@ export class SwarmViewModel implements ViewModel {
             handler: () => this.scheduleLoadSubagents(),
         });
         if (unsubCompleted) this.unsubs.push(unsubCompleted);
+
+        // dispatch:updated fires for both Solo and Workflow kinds (SPEC §5) —
+        // a member count/status change on either warrants the same reload
+        // used for subagent spawn/completion (they're closely correlated:
+        // a workflow member spawning/completing IS a dispatch update).
+        const unsubDispatchUpdated = waveEventSubscribe({
+            eventType: "dispatch:updated",
+            handler: () => this.scheduleLoadSubagents(),
+        });
+        if (unsubDispatchUpdated) this.unsubs.push(unsubDispatchUpdated);
 
         // Patch display_name in place (not a full loadSubagents() reload) so
         // every client watching this session picks up a generated name —
@@ -644,7 +760,7 @@ export class SwarmViewModel implements ViewModel {
     loadAll = async (): Promise<void> => {
         this.setLoading(true);
         try {
-            await Promise.all([this.loadTrackedBlocks(), this.loadSubagents()]);
+            await Promise.all([this.loadTrackedBlocks(), this.loadSubagents(), this.loadDispatches()]);
         } finally {
             this.setLoading(false);
         }
@@ -671,9 +787,20 @@ export class SwarmViewModel implements ViewModel {
         }
     };
 
-    // Coalesces a burst of subagent:spawned/subagent:completed events (e.g. a
-    // backfill scan on pane reopen) into a single loadSubagents() call fired
-    // after the burst settles, instead of one RPC per event.
+    loadDispatches = async (): Promise<void> => {
+        try {
+            const result = await callBackendService("subagent", "ListDispatches", []);
+            this.setDispatches((result as AgentDispatch[]) ?? []);
+        } catch {
+            // silently ignore
+        }
+    };
+
+    // Coalesces a burst of subagent:spawned/subagent:completed/dispatch:
+    // updated events (e.g. a backfill scan on pane reopen, or a large
+    // workflow dispatch spawning many members at once) into a single
+    // reload fired after the burst settles, instead of one RPC pair per
+    // event.
     scheduleLoadSubagents = (): void => {
         if (this.loadSubagentsDebounceTimer !== undefined) {
             clearTimeout(this.loadSubagentsDebounceTimer);
@@ -681,6 +808,7 @@ export class SwarmViewModel implements ViewModel {
         this.loadSubagentsDebounceTimer = setTimeout(() => {
             this.loadSubagentsDebounceTimer = undefined;
             void this.loadSubagents();
+            void this.loadDispatches();
         }, SwarmViewModel.LOAD_SUBAGENTS_DEBOUNCE_MS);
     };
 
@@ -736,6 +864,27 @@ export class SwarmViewModel implements ViewModel {
         return detail;
     }
 
+    /** WorkflowDispatchRow's toggle — mirrors toggleSubagentExpanded, tearing
+     *  down the cached DispatchDetail (and its dispatch:activity
+     *  subscription) on collapse. */
+    toggleDispatchExpanded(dispatchId: string): void {
+        const wasExpanded = this.isExpanded(dispatchId);
+        this.toggleExpanded(dispatchId);
+        if (wasExpanded) {
+            this.dispatchDetailCache.get(dispatchId)?.dispose();
+            this.dispatchDetailCache.delete(dispatchId);
+        }
+    }
+
+    getDispatchDetail(dispatchId: string): DispatchDetail {
+        let detail = this.dispatchDetailCache.get(dispatchId);
+        if (!detail) {
+            detail = createDispatchDetail(dispatchId);
+            this.dispatchDetailCache.set(dispatchId, detail);
+        }
+        return detail;
+    }
+
     // Subscribe to controllerstatus events for each tracked block and
     // seed the initial status from GetControllerStatus (not assumed "idle").
     // Tears down old per-block subs first so we don't leak on block-list refresh.
@@ -785,6 +934,7 @@ export class SwarmViewModel implements ViewModel {
     buildTree(): AgentTreeNode[] {
         const blockIds = this.trackedBlockIdsAtom();
         const subagents = this.subagentsAtom();
+        const dispatches = this.dispatchesAtom();
         const statuses = this.agentStatusesAtom();
 
         // Include parent block IDs from subagents as fallback for agent panes
@@ -794,7 +944,7 @@ export class SwarmViewModel implements ViewModel {
 
         // Collected from the groups actually produced below, not derived
         // from the raw subagent list — a NameGroup only exists once 2+
-        // subagents share a name (see groupSubagentsByWorkflow), so a
+        // subagents share a name (see buildDispatchChildren), so a
         // subagent-list-level heuristic ("any subagent with this name is
         // live") would wrongly keep singleton entries' keys alive forever.
         // Harmless either way (stabilizeGroupIdentity only ever cache.set()s
@@ -812,9 +962,12 @@ export class SwarmViewModel implements ViewModel {
             const rawCtx = block?.meta?.["term:ctx-tokens"];
             const contextTokens = typeof rawCtx === "number" ? rawCtx : null;
             const agentStatus = statuses.get(blockId) ?? "idle";
-            const rawChildren = groupSubagentsByWorkflow(subagents.filter((s) => s.parent_block_id === blockId));
+            const rawChildren = buildDispatchChildren(
+                dispatches.filter((d) => d.parent_block_id === blockId),
+                subagents.filter((s) => s.parent_block_id === blockId)
+            );
             for (const c of rawChildren) {
-                if (isWorkflowGroup(c) || isNameGroup(c)) liveGroupKeys.add(groupCacheKey(c));
+                if (isWorkflowDispatch(c) || isNameGroup(c)) liveGroupKeys.add(groupCacheKey(c));
             }
             const children = stabilizeGroupIdentity(this.groupIdentityCache, rawChildren);
             return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, subagents: children };
@@ -836,6 +989,8 @@ export class SwarmViewModel implements ViewModel {
         }
         for (const detail of this.detailCache.values()) detail.dispose();
         this.detailCache.clear();
+        for (const detail of this.dispatchDetailCache.values()) detail.dispose();
+        this.dispatchDetailCache.clear();
         this.groupIdentityCache.clear();
     }
 }

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -243,6 +243,42 @@
     }
 }
 
+// ── Dispatch concatenated activity feed (SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17 §7) ──
+// A Workflow-kind dispatch expands into this instead of nested member rows —
+// never one row per member, however many the dispatch has.
+
+.swarm-dispatch-feed {
+    display: flex;
+    flex-direction: column;
+    margin: 0 6px 4px 30px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--panel-bg-color, var(--main-bg-color));
+    max-height: 320px;
+    overflow-y: auto;
+    padding: 2px 8px 4px;
+}
+
+.swarm-dispatch-feed-empty {
+    padding: 8px 0;
+    font-size: 11px;
+    color: var(--secondary-text-color);
+}
+
+.swarm-dispatch-feed-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+}
+
+.swarm-dispatch-feed-tag {
+    flex-shrink: 0;
+    padding-top: 2px;
+    font-size: 10px;
+    font-family: var(--monospace-font, monospace);
+    color: var(--secondary-text-color);
+}
+
 // ── Subagent child row ───────────────────────────────────────────────────
 
 .swarm-subagent-group {

--- a/frontend/app/view/swarm/swarm-view.test.ts
+++ b/frontend/app/view/swarm/swarm-view.test.ts
@@ -16,7 +16,7 @@ function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id"
         last_event_at: 0,
         event_count: 1,
         model: null,
-        workflow_id: null,
+        dispatch_id: `solo:${overrides.agent_id}`,
         display_name: null,
         ...overrides,
     };

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowGroup, NameGroup, SubagentDetail, SubagentEvent } from "./swarm-model";
-import { isWorkflowGroup, isNameGroup, groupCacheKey, subagentDisplayLabel } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowDispatch, NameGroup, SubagentDetail, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
+import { isWorkflowDispatch, isNameGroup, groupCacheKey, subagentDisplayLabel } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -298,8 +298,8 @@ function AgentRow({
             <Show when={!collapsed()}>
                 <div class="swarm-children">
                     <For each={node.subagents}>
-                        {(child) => isWorkflowGroup(child)
-                            ? <WorkflowGroupRow group={child} model={model} parentAgentStatus={node.agentStatus} />
+                        {(child) => isWorkflowDispatch(child)
+                            ? <WorkflowDispatchRow group={child} model={model} />
                             : isNameGroup(child)
                             ? <NameGroupRow group={child} model={model} parentAgentStatus={node.agentStatus} />
                             : <SubagentRow sub={child} model={model} parentAgentStatus={node.agentStatus} />}
@@ -310,47 +310,137 @@ function AgentRow({
     );
 }
 
-// ── Workflow group row (collapsed by default) ───────────────────────────
+// ── Workflow dispatch row (collapsed by default) ────────────────────────
 
-function WorkflowGroupRow({
+/**
+ * One row for a Workflow-kind `AgentDispatch`. SPEC_AGENT_DISPATCH_SUBAGENT_
+ * HIERARCHY_2026_07_17 §7: never one row per member, however many the
+ * dispatch has (this session's own crash retro found one workflow run with
+ * 1,030+ members). Expanding shows a concatenated activity feed
+ * (`DispatchActivityFeed`) instead of nested `SubagentRow`s.
+ */
+function WorkflowDispatchRow({
     group,
     model,
-    parentAgentStatus,
 }: {
-    group: WorkflowGroup;
+    group: WorkflowDispatch;
     model: SwarmViewModel;
-    parentAgentStatus: "running" | "idle";
 }): JSX.Element {
     // Expand state lives on the ViewModel, not a local signal — see
     // SwarmViewModel._expandedIds for why a local signal here silently
     // collapses on unrelated tree refreshes.
-    const expanded = createMemo(() => model.isExpanded(group.workflowId));
+    const expanded = createMemo(() => model.isExpanded(group.dispatchId));
+    const activeCount = createMemo(() => group.memberCount - group.membersDone);
 
     return (
         <div class={`swarm-workflow-group swarm-workflow-group--${group.status}`}>
             <div
                 class="swarm-workflow-header"
-                onClick={() => model.toggleExpanded(group.workflowId)}
+                onClick={() => model.toggleDispatchExpanded(group.dispatchId)}
                 title={group.name}
             >
                 <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-workflow-expand-icon`} />
                 <span class="swarm-workflow-name">{group.name}</span>
                 <span class="swarm-workflow-count">
-                    {group.status === "active" ? `${group.activeCount}/${group.totalCount} active` : `${group.totalCount} retired`}
+                    {group.status === "active"
+                        ? `${activeCount()}/${group.memberCount} active`
+                        : `${group.memberCount} retired`}
                 </span>
                 <span class={`swarm-workflow-status-badge swarm-workflow-status-badge--${group.status}`}>
                     {group.status === "active" ? "Active" : "Retired"}
                 </span>
             </div>
             <Show when={expanded()}>
-                <div class="swarm-workflow-members">
-                    <For each={group.subagents}>
-                        {(sub) => <SubagentRow sub={sub} model={model} parentAgentStatus={parentAgentStatus} />}
-                    </For>
-                </div>
+                <DispatchActivityFeed dispatchId={group.dispatchId} model={model} />
             </Show>
         </div>
     );
+}
+
+/**
+ * Concatenated activity feed for an expanded `WorkflowDispatchRow` (SPEC
+ * §7) — one chronological, member-tagged stream instead of nested member
+ * rows, fed by `createDispatchDetail`'s `dispatch:activity` subscription.
+ * Live-only: nothing to show until new activity arrives after expand (see
+ * that function's doc comment for why there's no historical backfill).
+ */
+function DispatchActivityFeed({ dispatchId, model }: { dispatchId: string; model: SwarmViewModel }): JSX.Element {
+    const detail = model.getDispatchDetail(dispatchId);
+    const entries = detail.entriesAtom;
+    return (
+        <div class="swarm-dispatch-feed">
+            <Show when={entries().length === 0}>
+                <div class="swarm-dispatch-feed-empty">
+                    Waiting for activity — showing new events from now on, not history.
+                </div>
+            </Show>
+            <For each={entries()}>{(entry) => <DispatchActivityFeedEntry entry={entry} />}</For>
+        </div>
+    );
+}
+
+function DispatchActivityFeedEntry({ entry }: { entry: DispatchActivityEntry }): JSX.Element {
+    const et = entry.event.event_type;
+    const [expanded, setExpanded] = createSignal(false);
+    const tag = <span class="swarm-dispatch-feed-tag">{entry.agentId.substring(0, 7)}</span>;
+
+    switch (et.type) {
+        case "text":
+        case "result":
+            return (
+                <div class="swarm-dispatch-feed-entry">
+                    {tag}
+                    <pre class="swarm-subagent-detail-text">{et.content}</pre>
+                </div>
+            );
+        case "tool_use":
+            return (
+                <div class="swarm-dispatch-feed-entry">
+                    {tag}
+                    <div class="swarm-subagent-detail-tool">
+                        <div class="swarm-subagent-detail-tool-header" onClick={() => setExpanded(!expanded())}>
+                            <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-detail-expand-icon`} />
+                            <span class="swarm-subagent-detail-tool-name">{et.name}</span>
+                        </div>
+                        <Show when={expanded()}>
+                            <pre class="swarm-subagent-detail-text">{et.input_summary}</pre>
+                        </Show>
+                    </div>
+                </div>
+            );
+        case "tool_result":
+            return (
+                <div class="swarm-dispatch-feed-entry">
+                    {tag}
+                    <div class="swarm-subagent-detail-tool">
+                        <div
+                            class={`swarm-subagent-detail-tool-header ${et.is_error ? "swarm-subagent-detail-tool-header--error" : ""}`}
+                            onClick={() => setExpanded(!expanded())}
+                        >
+                            <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-detail-expand-icon`} />
+                            <span>{et.is_error ? "Error" : "Result"}</span>
+                        </div>
+                        <Show when={expanded()}>
+                            <pre class={`swarm-subagent-detail-text ${et.is_error ? "swarm-subagent-detail-text--error" : ""}`}>
+                                {et.preview}
+                            </pre>
+                        </Show>
+                    </div>
+                </div>
+            );
+        case "progress":
+            return (
+                <div class="swarm-dispatch-feed-entry">
+                    {tag}
+                    <div class="swarm-subagent-detail-progress">
+                        <i class="fa-solid fa-spinner fa-spin" />
+                        <span>{et.output}</span>
+                    </div>
+                </div>
+            );
+        default:
+            return null;
+    }
 }
 
 // ── Name group row (loose subagents sharing one display_name) ──────────


### PR DESCRIPTION
Implements `docs/specs/SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md` (bundled in this PR — spec commits first, implementation on top).

## Why

Motivated directly by this session's OOM crash investigation (`docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`, PRs #2205/#2206/#2207): a single Workflow-tool run had **1,030+ members** with no first-class backend entity representing "the dispatch as a whole." The frontend had already been forced to synthesize one client-side (`WorkflowGroup`, with its own identity-preservation workarounds — the code's own comment: *"backend has no separate workflow-name concept"*), and the backend broadcast one WS message **per member-event**, which is the literal mechanism behind the 1,030-events-in-10-seconds storm that contributed to the crash.

## What

**New model**: `AgentDispatch` (one per Agent-tool-or-Workflow-tool call) containing N `SubAgent` members. A solo Task call = one Solo dispatch, one member. A Workflow run = one Workflow dispatch, N members. Naming chosen over the literal `SubAgent`→`SubSubAgent` alternative — see spec §2/§3 for the research (GitHub Actions Run→Job→Step, Airflow DAGRun→TaskInstance, Temporal WorkflowExecution→ActivityExecution all give the container its own noun, not a doubled prefix) and the migration-cost tradeoff.

**Backend** (`agentmux-srv/src/backend/subagent_watcher.rs`):
- `SubagentInfo`→`SubAgent`, `workflow_id: Option<String>`→`dispatch_id: String` (solo calls get a synthesized `"solo:<agent_id>"` — every subagent now has a real container). `WorkflowInfo`/`WorkflowStatus` subsumed into `AgentDispatch`/`DispatchKind`/`DispatchStatus`.
- New `SubAgent.spawned_from_agent_id`, parsed from the transcript's own `"parentUuid"` field — checked all 228 real subagent transcripts on this machine, always `null`, but captured defensively (nested spawning is technically permitted for unrestricted-tool subagent types like `general-purpose`).
- `subagent.ListWorkflows`→`ListDispatches` (now lists Solo dispatches too). `workflow:updated`→`dispatch:updated` (fires for both kinds).
- **Coalescing**: a Workflow member's new events buffer instead of broadcasting `subagent:activity` immediately; a background task flushes every 500ms as one `dispatch:activity` broadcast per dispatch with pending activity — this directly shrinks the broadcast-storm blast radius, not just render cost. Solo dispatches (no coalescing benefit) keep immediate broadcasts.

**Frontend** (`frontend/app/view/swarm/`, `frontend/app/view/agent/activity/`):
- `WorkflowGroup`→`WorkflowDispatch`, deliberately **without** a member list (a dispatch can have thousands of members — too many to hold in the frequently-recomputed tree atom). `buildDispatchChildren` replaces `groupSubagentsByWorkflow`.
- **A Workflow-kind dispatch renders as exactly one row, regardless of member count** — expanding it shows a live concatenated activity feed (`DispatchActivityFeed`, chronological, member-tagged) instead of nested per-member rows. Deliberately no historical backfill on expand (spec §9.4, explicit open question).
- `subagent-adapter.ts` (the activity dock) — a **third consumer** of the old grouping logic discovered mid-implementation, not accounted for in the original spec survey. It needs each member's `spawned_at`/status for its summary row, so it keeps its own local grouping (`groupSubagentsForDock`) rather than depending on the now member-list-free `WorkflowDispatch`.

## Verification

- `cargo test -p agentmux-srv`: 1522/1522 (42/42 in `subagent_watcher` — 36 pre-existing + 6 new covering dispatch synthesis, workflow tracking, activity coalescing/flush, `parentUuid` round-trip).
- `tsc --noEmit`: clean.
- Full frontend `vitest run`: **1787/1787** passed (0 failures), including the RPC frontend↔backend contract test — confirms `ListDispatches` is correctly wired on both sides.
- `cargo build -p agentmux-srv` / frontend typecheck: clean, no new warnings.

## Known follow-ups (flagged in spec, not blocking)

- §9.4: concatenated-feed ordering/cap and the `dispatch:activity` coalescing window (500ms picked as a reasonable default, not measured) are explicit open questions.
- The legacy standalone `subagent-model.ts` pane (non-workflow-aware) is a flagged decision point, not touched here.
- `unix.rs` launcher parity and the `BACKFILL_MAX_FILES`→dispatch-recency follow-up from PR #2205 are separate, independent items.

<!-- agentmux:agent_id=agenta-07017 -->