### PR TITLE
fix(launcher): teardown backstop — SIGTERM srv before SIGKILL so agent shells get cleaned up

### DIFF
--- a/.changesets/1784344845-fix-launcher-teardown-backstop-sigterm-srv-before-sigkill-so-5fyn.md
+++ b/.changesets/1784344845-fix-launcher-teardown-backstop-sigterm-srv-before-sigkill-so-5fyn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): teardown backstop — SIGTERM srv before SIGKILL so agent shells get cleaned up

--- a/agentmux-launcher/src/host_spawn.rs
+++ b/agentmux-launcher/src/host_spawn.rs
@@ -206,6 +206,52 @@ pub(crate) fn terminate_child_gracefully(child: &tokio::process::Child) {
     }
 }
 
+/// Send `signal` to an entire process group in one shot (negated pid — see
+/// the two public wrappers below for why this targets a whole group, not
+/// just one process). Shared by both so the return-value handling — a
+/// silently-ignored failure would otherwise let a genuinely-failed kill
+/// (anything but the expected "already empty" ESRCH) read as a successful
+/// teardown — lives in exactly one place. Logs on any failure OTHER than
+/// ESRCH (the routine no-op case: the group was already empty, e.g. a prior
+/// SIGTERM's own graceful shutdown already reaped it).
+#[cfg(not(target_os = "windows"))]
+fn kill_process_group(child: &tokio::process::Child, signal: libc::c_int, signal_name: &str) {
+    let Some(pid) = child.id() else { return };
+    // SAFETY: kill(2) with a process-scoped pid + a constant signal — no
+    // memory is touched. A stale pid just returns ESRCH (ignored below).
+    let rc = unsafe { libc::kill(-(pid as libc::pid_t), signal) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ESRCH) {
+            crate::logging::log(&format!(
+                "WARN: kill(-{}, {}) failed: {}",
+                pid, signal_name, err
+            ));
+        }
+    }
+}
+
+/// SIGTERM an entire process group — gives a process that installs a signal
+/// handler (srv does: SIGINT/SIGTERM → `shell_sessions.stop_all()`,
+/// `agentmux-srv/src/main.rs`) a chance to run its own graceful shutdown
+/// before the harder `kill_process_group_forcefully` follows. Matters
+/// specifically for srv: its tracked agent shells (`shell_node.rs`) are each
+/// spawned into THEIR OWN process group (`.process_group(0)`, same mechanism
+/// this backstop itself uses, applied for a different scoping purpose), so
+/// they are NOT members of srv's own group and a bare group-SIGKILL of srv
+/// would orphan them. `stop_all()` reaches them anyway — `kill_tree()`
+/// signals each tracked shell BY ITS OWN pid/pgid directly
+/// (`kill(-shell_pgid, SIGTERM)` then `SIGKILL`), independent of ambient
+/// process-group membership. host is not presumed capable of a meaningful
+/// graceful response here (the whole premise of a teardown-backstop
+/// scenario is that its UI thread is wedged) but SIGTERM-ing it too is
+/// harmless — a wedged process with no custom SIGTERM handler just
+/// terminates on it the same as SIGKILL would.
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn kill_process_group_gracefully(child: &tokio::process::Child) {
+    kill_process_group(child, libc::SIGTERM, "SIGTERM");
+}
+
 /// SIGKILL an entire process group in one shot — the unix analogue of
 /// Windows' `TerminateJobObject`. `child` must have been spawned with
 /// `.process_group(0)` (both `spawn_host_unix` and `srv_spawner::spawn_srv`
@@ -213,20 +259,15 @@ pub(crate) fn terminate_child_gracefully(child: &tokio::process::Child) {
 /// whole group instead of just the one process, reaping any descendants
 /// (e.g. CEF's forked renderer/GPU subprocesses) the launcher never tracks
 /// individually. Used by the teardown backstop
-/// (SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11) — a deliberately harsher
-/// exit than `terminate_child_gracefully`'s SIGTERM, reserved for the case
-/// where the host's UI thread is provably wedged and there is no graceful
-/// shutdown to wait for. No-op if the child has already exited (its pid may
-/// have been reaped; a stale pid's negated kill returns ESRCH, ignored).
+/// (SPEC_LAUNCHER_TEARDOWN_BACKSTOP_2026_07_11) as the hard backstop after
+/// `kill_process_group_gracefully`'s brief grace window — reserved for
+/// whatever a graceful SIGTERM didn't reap (a wedged-or-dead srv, or shells
+/// its own `stop_all()` couldn't finish in time). No-op if the child has
+/// already exited (its pid may have been reaped; a stale pid's negated kill
+/// returns ESRCH, ignored).
 #[cfg(not(target_os = "windows"))]
 pub(crate) fn kill_process_group_forcefully(child: &tokio::process::Child) {
-    if let Some(pid) = child.id() {
-        // SAFETY: kill(2) with a process-scoped pid + a constant signal —
-        // no memory is touched. A stale pid just returns ESRCH (ignored).
-        unsafe {
-            libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-        }
-    }
+    kill_process_group(child, libc::SIGKILL, "SIGKILL");
 }
 
 #[cfg(all(test, not(target_os = "windows")))]
@@ -242,7 +283,7 @@ mod tests {
     //! `.process_group(pid)` instead of `.process_group(0)`) would compile
     //! fine and silently fail to create a new group.
 
-    use super::kill_process_group_forcefully;
+    use super::{kill_process_group_forcefully, kill_process_group_gracefully};
 
     /// `.process_group(0)` makes the spawned child its own group leader —
     /// pgid must equal its own pid, not the test process's pgid.
@@ -303,6 +344,38 @@ mod tests {
         let _ = child.wait().await; // let it exit and get reaped
 
         kill_process_group_forcefully(&child); // must not panic
+    }
+
+    /// `kill_process_group_gracefully` sends SIGTERM, not SIGKILL — the
+    /// half of the two-phase teardown a process WITH a signal handler (srv)
+    /// gets a real chance to act on.
+    #[tokio::test]
+    async fn kill_process_group_gracefully_sends_sigterm_not_sigkill() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut cmd = tokio::process::Command::new("sleep");
+        cmd.arg("5").kill_on_drop(false).process_group(0);
+        let mut child = cmd.spawn().expect("spawn sleep");
+
+        kill_process_group_gracefully(&child);
+
+        let status = tokio::time::timeout(std::time::Duration::from_secs(2), child.wait())
+            .await
+            .expect("child did not exit after graceful group kill")
+            .expect("wait succeeded");
+        assert_eq!(status.signal(), Some(libc::SIGTERM));
+    }
+
+    /// Same no-op-on-already-exited guarantee as the forceful variant — the
+    /// teardown arm calls both unconditionally.
+    #[tokio::test]
+    async fn kill_process_group_gracefully_is_a_noop_on_an_already_exited_child() {
+        let mut cmd = tokio::process::Command::new("true");
+        cmd.kill_on_drop(false).process_group(0);
+        let mut child = cmd.spawn().expect("spawn true");
+        let _ = child.wait().await; // let it exit and get reaped
+
+        kill_process_group_gracefully(&child); // must not panic
     }
 }
 

--- a/agentmux-launcher/src/supervisor/unix.rs
+++ b/agentmux-launcher/src/supervisor/unix.rs
@@ -445,6 +445,29 @@ pub(crate) async fn run_unix(
                     // exception to "never kill what a saga can reconcile" —
                     // zero user windows remain and the UI thread is provably
                     // dead, so there is nothing to reconcile.
+                    //
+                    // SIGTERM first, brief grace, then the hard SIGKILL
+                    // backstop — not a straight SIGKILL. Host is presumed
+                    // wedged by this whole scenario (its UI thread didn't
+                    // answer probes), but srv is NOT — nothing here indicates
+                    // srv itself is unresponsive, only that the host lost
+                    // track of its windows. A bare group-SIGKILL of srv would
+                    // orphan its tracked agent shells: each is spawned into
+                    // ITS OWN process group (`shell_node.rs`'s own
+                    // `.process_group(0)`, same mechanism, different scoping
+                    // purpose), so they are NOT members of srv's group and a
+                    // signal to srv's group alone never reaches them. Giving
+                    // srv a moment to catch SIGTERM lets its own handler
+                    // (`agentmux-srv/src/main.rs` → `shell_sessions.stop_all()`)
+                    // run first — `stop_all()` reaches every tracked shell by
+                    // its own pid/pgid directly (`shell_node.rs::kill_tree`),
+                    // independent of ambient process-group membership, so it
+                    // closes exactly the gap a launcher-level group-kill
+                    // can't. Same 1500ms grace `terminate_child_gracefully`
+                    // uses elsewhere in this file, for consistency.
+                    crate::host_spawn::kill_process_group_gracefully(&host_child);
+                    crate::host_spawn::kill_process_group_gracefully(&srv_child);
+                    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
                     crate::host_spawn::kill_process_group_forcefully(&host_child);
                     crate::host_spawn::kill_process_group_forcefully(&srv_child);
                     break TEARDOWN_BACKSTOP_EXIT_CODE;


### PR DESCRIPTION
Follow-up to #2200 (issue #2188), which shipped the unix teardown backstop's core mechanism while a Linux-specific parallel implementation (#2204, issue #2189) was independently in flight. #2204 is closed in favor of this — porting its one substantive improvement onto #2200's already-merged design instead of forcing a conflicting rebase of a duplicate mechanism.

## The gap

Reagent flagged this on #2204, and it applies equally to #2200's now-merged code: agent-spawned PTY shells (`agentmux-srv/src/backend/shell_node.rs`'s own `.process_group(0)` — the same mechanism this backstop uses, applied for a different scoping purpose) deliberately escape into **their own** process groups. A bare `kill_process_group_forcefully(srv)` never reaches them — they were never members of srv's group — so a wedged-host teardown with active agent panes open orphans those shells.

(Investigated whether this was a Linux-specific gap Windows didn't have: it isn't. srv's per-agent `JobObjectTracker` on Windows creates a brand-new, **unnested** Job Object per agent block — `TerminateJobObject(J0)` doesn't reach those either. Pre-existing, cross-platform limit on what "teardown backstop" was ever scoped to guarantee, not a regression either PR introduced.)

## Fix

`kill_process_group_gracefully` (new, SIGTERM) on both host and srv first, same 1500ms grace `terminate_child_gracefully` already uses elsewhere in this file, **then** the existing `kill_process_group_forcefully` (SIGKILL) as the hard backstop.

srv — unlike host — isn't presumed wedged by this scenario (only the host's UI thread failed to answer probes), so its own signal handler (`agentmux-srv/src/main.rs`, SIGINT/SIGTERM → `shell_sessions.stop_all()`) gets a real chance to run first. Traced `stop_all()` → `shell_node.rs::kill_tree()`: it signals every tracked shell **by its own pid/pgid directly** (`kill(-pgid, SIGTERM)` then `SIGKILL`), independent of ambient process-group membership — so it reaches exactly the escaped subgroups a launcher-level group-kill can't.

Also: both kill functions now share one helper that checks `kill(2)`'s return value and logs on any failure other than `ESRCH` (the routine "already empty" case) — the previous code silently treated any outcome as a successful teardown.

## Test plan

- `cargo test -p agentmux-launcher`: 211 passed, including 2 new tests for the graceful variant (mirroring #2200's existing real-process pattern: `getpgid`/actual-signal-delivery checks, not just asserting on the builder call).
- `cargo check --workspace`: clean.
- **Live end-to-end**, re-run against the actual merged two-group design (not just ported and assumed to work): `task dev` + `AGENTMUX_DEBUG_HANG=1` + `debug:hang_ui` + last-window close via raw HTTP IPC (not CDP — a parked UI thread can't answer a CDP round-trip; `window.api` calls actually ride a plain Bearer-token HTTP server the host runs, not DevTools Protocol). Confirmed: ARMED instantly, 2 consecutive unanswered UI-liveness probes, teardown fired at 146s (within the spec's ~150s worst-case envelope), **zero surviving processes in either process group** (host's own and srv's own, checked independently), launcher exited cleanly with code 86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)