### PR TITLE
fix(agent): clear stale "Retry Login" bar once the controller proves itself healthy

### DIFF
--- a/.changesets/1784348819-fix-agent-clear-stale-retry-login-bar-once-the-controller-pr-w5pv.md
+++ b/.changesets/1784348819-fix-agent-clear-stale-retry-login-bar-once-the-controller-pr-w5pv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): clear stale 'Retry Login' bar once the controller proves itself healthy

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -504,6 +504,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 { type: "ReconcileTurnActive", at: Date.now(), active },
                 "system",
             );
+            // A real controllerstatus event for this pane is independent
+            // proof the CLI is alive and running turns — clear any stale
+            // "Retry Login" / auth notice left over from the mount-time
+            // gated launch flow's auth_failed classification. Otherwise
+            // the button can outlive the failure it was reporting: an
+            // agent recovers and starts answering messages through this
+            // same event stream, but nothing ever told useAgentControllerStatus
+            // its earlier canRetry=true was stale. Reported live 2026-07-18.
+            status.notifyControllerHealthy();
         },
     });
 

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -115,6 +115,22 @@ export interface UseAgentControllerStatus {
      */
     loginViaTerminal: () => Promise<void>;
     cancelLogin: () => void;
+    /**
+     * Clear stale auth-recovery UI (the "Retry Login" bar / any lingering
+     * `authNotice`) once we have independent proof the controller is
+     * healthy. `canRetry`/`authNotice` are set once, from the mount-time
+     * gated launch flow or an explicit recovery attempt, and nothing
+     * previously reset them if the agent later became healthy through a
+     * DIFFERENT path — e.g. a `controllerstatus` event proving the CLI is
+     * alive and running turns, which is exactly what
+     * `useControllerStatusEvents`'s continuous `onTurnActive` already
+     * tracks for `TurnPhase` reconciliation (Agent1/Agent2 stuck-"Working"
+     * incidents). Call this from that same signal so "Retry Login" can't
+     * outlive the failure it was reporting — a leak reported live: an
+     * agent recovered and was answering messages, but the initial
+     * auth_failed launch had left the button stuck showing.
+     */
+    notifyControllerHealthy: () => void;
 }
 
 /**
@@ -423,6 +439,11 @@ export function useAgentControllerStatus(
         opts.log("auth", "login cancelled", "warn");
     };
 
+    const notifyControllerHealthy = () => {
+        setCanRetry(false);
+        setAuthNotice(null);
+    };
+
     // If the pane is closed while login is in progress, cancel and kill
     // the host CLI process. This onCleanup is registered against the
     // SolidJS owner context that called useAgentControllerStatus — the
@@ -451,6 +472,7 @@ export function useAgentControllerStatus(
         relogin,
         useGlobalLogin,
         loginViaTerminal,
+        notifyControllerHealthy,
         cancelLogin,
     };
 }


### PR DESCRIPTION
Reported live: agent "Nark" got stuck showing "Working…", then self-resolved into a state where it was responding to messages normally — but a **"Retry Login" bar stayed stuck showing**, even though the agent was clearly authenticated and functional (it was actively answering messages). This is distinct from the "Login Again" / "Use existing login" / "Login via terminal" failure-row buttons already covered by prior auth-recovery work (#2192) — it's a separate, older bar gated by `useAgentControllerStatus`'s own `canRetry` signal.

## Root cause

`canRetry` is set `true` **exactly once** — when the mount-time *gated* launch flow's one-shot auth check classifies the result as `auth_failed` (`agent-view.tsx`'s `onMount` calls `startLaunchFlow()` once). Nothing ever reset it back to `false` except the user clicking the button and re-running that same flow — **not** when the agent became healthy through any other path.

Meanwhile `useControllerStatusEvents`'s continuous `onTurnActive` subscription already exists specifically to catch this *class* of bug for `TurnPhase` — a `controllerstatus` event proving the backend is alive reconciles the phase even when the frontend missed the terminal signal (the Agent1/Agent2 stuck-"Working"/"Queued" incidents, `docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md`). But that reconciliation only ever touched `TurnPhase` — a completely disconnected piece of state from `useAgentControllerStatus`'s local `canRetry`/`authNotice` signals. Two correct-in-isolation mechanisms that were never wired together.

## Fix

New `notifyControllerHealthy()` clears both `canRetry` and `authNotice` (same category of stale auth-recovery leak, same shape as the existing "clear `authNotice` on a fresh launch attempt" logic from #2192). Called from `useControllerStatusEvents`'s `onTurnActive` callback in `agent-view.tsx` — receiving **any** real `controllerstatus` event for this pane is independent proof the CLI is alive and running turns, exactly the same signal already trusted for the `TurnPhase` reconciliation right next to it.

## Test plan

- `tsc --noEmit`: clean.
- `useControllerStatusEvents.test.ts` + `force-login.test.ts`: 10 passed, no regressions.
- No dedicated unit test added — `useAgentControllerStatus` has no existing test harness (tightly coupled to the ~1000-line `agent-view.tsx`), and this is a small, low-risk addition (two `setX` calls on an already-tested event callback, no new IPC/process logic). Live-reproducing the original bug requires the mount-time gated flow to hit `auth_failed` specifically, which needs a purpose-built broken-auth-at-launch scenario; happy to build one on a separate dev instance if useful before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)