### PR TITLE
feat(layout): restore minimize slip-docking + fix insert-into-minimized-leaf corruption

### DIFF
--- a/.changesets/1784349691-feat-layout-restore-minimize-slip-docking-fix-insert-into-mi-ihh2.md
+++ b/.changesets/1784349691-feat-layout-restore-minimize-slip-docking-fix-insert-into-mi-ihh2.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(layout): restore minimize slip-docking + fix insert-into-minimized-leaf corruption

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -476,6 +476,18 @@ fn collect_insert_candidates<'a>(
     depth: usize,
     out: &mut Vec<InsertCandidate<'a>>,
 ) {
+    // Minimized is a locked state: never a blind-insert target. Without
+    // this, `ensure_group_node` promoting a minimized leaf into a branch
+    // could leave the tree in a state where an agent/API-driven insert
+    // silently un-collapses a fully-minimized subtree (every child
+    // minimized → one child isn't anymore, with no user action on that
+    // branch at all). Mirrors `findNextInsertLocationHelper`'s guard in
+    // `frontend/layout/lib/layoutNode.ts` (2026-07-18). For a branch this
+    // also skips recursing into its children — they're all effectively
+    // minimized too by definition, so recursion would find nothing anyway.
+    if is_effectively_minimized(node) {
+        return;
+    }
     // Leaf node (has data but no children) — TS returns index 1.
     if node.data.is_some() && node.children.is_empty() {
         out.push(InsertCandidate { node, index: 1, depth });
@@ -501,7 +513,18 @@ fn collect_insert_candidates<'a>(
 /// is a leaf, it is promoted to a group first via `ensure_group_node`.
 /// Mirrors `insertNode` / `addChildAt` in `frontend/layout/lib/layoutTree.ts`.
 pub fn insert_node(root: &mut LayoutNode, node: LayoutNode) {
-    let loc_id = find_next_insert_location(root, DEFAULT_MAX_CHILDREN).0.id.clone();
+    let loc = find_next_insert_location(root, DEFAULT_MAX_CHILDREN);
+    // `collect_insert_candidates` already excludes locked candidates; this
+    // only fires in the degenerate fallback case where every node in the
+    // tree is locked (the `.unwrap_or((tree, ...))` root fallback).
+    if is_effectively_minimized(loc.0) {
+        tracing::warn!(
+            node_id = %loc.0.id,
+            "insert_node: no unlocked insert location available, dropping"
+        );
+        return;
+    }
+    let loc_id = loc.0.id.clone();
     if let Some(target) = find_node_by_id_mut(root, &loc_id) {
         ensure_group_node(target);
         target.children.push(node);

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -710,6 +710,52 @@ fn insert_node_appends_to_existing_non_full_node() {
     assert!(root.children.iter().any(|c| c.id == "new"));
 }
 
+/// Regression (2026-07-18, mirrors the TS fix in
+/// frontend/layout/lib/layoutNode.ts): a minimized leaf must never be a
+/// blind-insert target. Root is deliberately AT capacity (5 children,
+/// DEFAULT_MAX_CHILDREN) so root itself is excluded as a candidate and the
+/// heuristic must descend into a leaf — otherwise root always wins
+/// regardless of any leaf's minimize state and the test wouldn't exercise
+/// the fix. With 5 same-depth leaf candidates tied on score, the (stable)
+/// sort's tie-break favors whichever was visited first — reverse child
+/// order means the LAST array element wins — so the minimized leaf is
+/// placed there: absent the fix, it's exactly what would get promoted.
+#[test]
+fn insert_node_never_promotes_a_minimized_leaf() {
+    let mut root = group(
+        "root",
+        FlexDirection::Row,
+        10.0,
+        vec![
+            leaf("a", "b1", 5.0),
+            leaf("b", "b2", 5.0),
+            leaf("c", "b3", 5.0),
+            leaf("d", "b4", 5.0),
+            minimized_leaf("last", "b5", 5.0),
+        ],
+    );
+    let new = leaf("new", "b6", 5.0);
+    insert_node(&mut root, new);
+
+    // The minimized leaf must still be exactly what it was: a leaf, still
+    // minimized, not promoted into a branch.
+    let still_minimized = root.children.iter().find(|c| c.id == "last").unwrap();
+    assert!(still_minimized.children.is_empty(), "must still be a leaf");
+    assert!(is_node_locked(still_minimized), "must still be minimized");
+
+    // No branch anywhere carries `minimized` (I2: leaf-only) — the exact
+    // corruption this guards against.
+    fn assert_not_corrupted(node: &LayoutNode) {
+        if !node.children.is_empty() {
+            assert!(!node.extra.contains_key("minimized"), "branch {} carries minimized", node.id);
+        }
+        for c in &node.children {
+            assert_not_corrupted(c);
+        }
+    }
+    assert_not_corrupted(&root);
+}
+
 // ── insertNodeAtIndex ────────────────────────────────────────────────────────
 
 #[test]

--- a/docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md
+++ b/docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md
@@ -1,0 +1,65 @@
+# Retro — The display-mode minimize redesign deleted a real product requirement
+
+**Date:** 2026-07-17
+**Trigger:** User report: "if minimized, it is supposed to slip under/over the other panes, that isnt happening." Direct questions: *why did we go backward?* and *is this a very hard problem?*
+**Status:** Root cause confirmed by re-reading the original spec chain. **Fixed** — slip-docking implemented as derived geometry (§4's proposed shape, built as designed): `resolveRowSlipTargets` + a docking pass in `updateTreeHelper` (`frontend/layout/lib/layoutGeometry.ts`). No tree mutation, no new persisted state; verified end-to-end against the exact user repro (agent/cpu/swarm — minimize cpu then swarm — asserts agent absorbs the full row width and right_col's chip stack docks onto agent's top, zero dead space) plus 11 unit tests for the slip-target resolution algorithm. 112 frontend tests green.
+
+---
+
+## TL;DR
+
+**We went backward because I never checked what AgentMux's own minimize feature was originally spec'd to do.** I researched how *other* systems (i3, tmux, IDEs, docking frameworks) implement minimize, found none of them do anything like AgentMux's "slip" (a minimized pane's header visually merges into an adjacent pane, freeing its space), and concluded from that absence that slip was accidental complexity worth deleting. It wasn't accidental — it's a deliberately designed, twice-refined product requirement, documented in two specs from 2026-06-24 and 2026-06-27, predating this whole bug-fixing arc by two weeks. I deleted the requirement along with the buggy mechanism that implemented it, instead of keeping the requirement and fixing the mechanism.
+
+**Is this a very hard problem? No.** The hard part — get rid of in-tree size arithmetic and structural tree surgery so minimize can't corrupt the tree — is already solved and correct (four real bug classes closed, verified by tests, reagent-reviewed twice). What's missing is a rendering-level feature on top of that already-correct foundation: derive a minimized chip stack's position to overlay/dock onto an adjacent pane's rendered box instead of rendering as its own separate narrow column. That's a moderate, well-scoped addition, not a redesign.
+
+---
+
+## 1. What the product actually required (the spec chain I should have read first)
+
+Four specs, in order, each building on the last:
+
+| Spec | Date | What it added |
+|---|---|---|
+| `SPEC_PANE_MINIMIZE_AND_TOOLCALL_FAILCOLLAPSE_2026_06_21.md` | 2026-06-21 | The original minimize button. Explicitly scoped as **pure visual hide** — "Minimized state does NOT affect layout sizing of neighbouring panes." No slip, no space reclamation. |
+| `SPEC_PANE_MINIMIZE_CARET_BUG_2026_06_24.md` | 2026-06-24 | Bug fix (chevron reactivity). Confirms by this date collapse *already* "shrinks to its header bar **or slips into the adjacent column**" — slip existed before this spec even started. |
+| `SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md` | 2026-06-24 | **The slip requirement, explicit and deliberate**: *"a pane that occupies its own column slot ... should collapse vertically and slip its header into the adjacent column rather than shrinking horizontally into a thin strip."* Full algorithm spec'd: pane header pins to the top of the neighbor column, width released to that neighbor, fully reversible on restore. |
+| `SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md` | 2026-06-27 | **Cascading slip**: when every pane in a column is minimized, *"the user's intent when collapsing every pane in a column is to reclaim that column's width for adjacent content"* — the whole column's headers migrate into the neighbor, the column's width is released, and this cascades to further neighbors.
+
+These are not throwaway notes. They're two rounds of deliberate refinement with explicit before/after diagrams, restore semantics, and edge-case tables (adjacent-sibling-is-a-leaf, cascading dissolve, multiple slips into one column). Someone thought carefully about what "minimize" should *feel* like in this product: **panes visually consolidate into a neighbor, not just shrink in place.**
+
+## 2. What I actually did, and where the reasoning broke
+
+Session arc, condensed:
+
+1. Root-caused four real bugs in the slip/dissolve mechanism (direction flip #2176, resize-through-lock #2180, marker-fields stranded on branches, cascading dissolve computing negative sizes — caught live by the layout doctor).
+2. Ran deep research asking: *"how do established systems model minimized panes — in-tree size state, out-of-tree docks, or container display modes?"*
+3. Research came back unanimous: **no surveyed system does anything like slip.** i3's scratchpad, Eclipse's trim stacks, IntelliJ's tool-window bars, AvalonDock's anchor groups — all either move the pane fully out of the tree or use a discrete, render-derived display mode. The research's own finding 8 said outright: *"AgentMux's 'slip' behavior ... has no analog in any surveyed system and should be reconsidered."*
+4. I read "no analog" as "this was over-engineering, cut it" and implemented the display-mode redesign (#2197) **without** the slip/merge-into-neighbor visual — just a minimized pane rendering as an isolated chip (or chip-stack) in its own narrow slot.
+
+The break is at step 4. "No other system does X" is evidence that X is *unusual*, not evidence that X is *wrong for this product*. The research was answering "how do other systems solve the corruption-prone mechanism problem" — it was never asked "should AgentMux keep its own product-specific slip requirement," because I never went back to check whether that requirement existed in writing. It did, in exactly the specs listed above, and I had access to them the whole time — I just didn't look, because by the time I was implementing the redesign, the framing in my own head had shifted from "fix minimize's corruption bugs" to "minimize should look like other apps' minimize." Those are different projects, and I shipped the second one while believing I was doing the first.
+
+**The honest failure mode: conflating "the mechanism that implements this requirement is what's corrupting the tree" with "the requirement itself must be the source of the corruption."** They're not the same claim. The corruption came from *how* slip/dissolve was implemented (structural tree surgery: splicing nodes out of the Row, converting leaves to Columns, stealing flex units from a neighbor's first child) — not from *what* it visually accomplished (a header docking into a neighbor's presentation). I could have kept the second while replacing the first.
+
+## 3. Why this wasn't caught earlier
+
+- The research report (§7, recommendation) does flag the gap honestly in one line — *"the 'slip' mechanism has no analog... and should be reconsidered"* — but "reconsidered" reads as neutral in isolation; I converted it to "removed" without a distinct reconsideration step, and never surfaced "this deletes an existing requirement" as its own decision point to the user.
+- Every review pass on PR #2197 (three rounds of reagent findings, all real) checked *correctness of the new mechanism against itself* — gap compensation, migration math, effective-minimize guards. None of them, and none of my own test-writing, checked *behavioral parity against the old spec'd requirement*, because I never framed "does this still slip into a neighbor" as a requirement to preserve. The tests I wrote assert the new (narrower) behavior is internally consistent, which is a different thing from asserting it matches what was asked for two weeks ago.
+- The live smoke-testing loop this session (multiple rounds: "we still are not getting proper operation," the dead-space bug, the negative-size cascade) was all diagnosing *correctness* bugs in slip/dissolve — never once "does the visual result match intent," because until this message, the visual intent question hadn't been asked directly. The diagnostics I built (the layout doctor) check structural tree invariants, which is exactly why it stayed silent through this — a chip rendering in its own isolated column instead of merged into a neighbor is not a structural invariant violation, it's a requirements gap.
+
+## 4. Is this a very hard problem?
+
+No — and it's worth being precise about which part is hard and which isn't, because they're genuinely different in kind:
+
+**Already solved, correctly, and this part *was* hard:** don't store minimize as mutable size arithmetic in the tree. That was the actual four-bug-class problem, and the fix (one leaf-only `minimized` flag, geometry derived fresh every render pass, `computeMainAxisAllocation` as a pure function) is sound, tested, and matches how every mature system in the research handles the "don't let a display mode corrupt persistent state" problem. Keep this. It is not what needs to change.
+
+**Missing, and this part is moderate, not hard:** the *rendering* of a minimized chip (or chip-stack) currently gets its own slot in its parent's flex allocation — narrow, but still a sibling slot next to the expanded pane, not merged into it. What the spec asked for is a **positioning** change: instead of allocating the chip stack a slot of its own, derive its rect to be positioned *at the top of* (docked onto) the adjacent expanded pane's own rendered box, and give that whole freed slot's width/space to the expanded neighbor. This is achievable within the exact same derived-geometry model already in place — it doesn't need new tree state, doesn't need structural surgery, and doesn't reopen any of the four closed bug classes, because it's still "derive positions fresh every render pass from a single boolean flag," just with a different positioning rule for the minimized-branch case. The `computeMainAxisAllocation`/`minimizedFixedPx` machinery already correctly computes "how much space should this chip stack's slot claim" (the width-reclaim math that gives the neighbor breathing room) — what's missing is telling the *renderer* to draw that chip stack overlaid on the neighbor's box rather than in a separate box beside it.
+
+Rough shape of the fix, for when it's time to implement (not started yet):
+- The neighbor (the pane the chips should slip onto) needs to be identified the same way `_dissolveColumn`'s spec did — the adjacent sibling in the Row.
+- The neighbor's own rect gets computed as normal (full remaining width/height).
+- The minimized chip stack's rect gets positioned as an overlay pinned to the top of the neighbor's rect (same width as the neighbor, header-stack height), likely via a z-index layer or a nested-rendering trick, rather than claiming its own slot in the parent's main-axis allocation at all.
+- Restore is already correct — it's just clearing the flag; no restore-context bookkeeping needed since there's no structural move to undo.
+
+## 5. What should have happened, and the actual lesson
+
+Before implementing the display-mode redesign, I should have run one extra check: grep `docs/specs/` for the feature I was about to change, read what was already promised, and treated any deletion of documented behavior as its own explicit decision to surface to the user — not something to fold silently into a "these bugs are fixed" narrative. Research into how *other* systems solve a *class* of problem is valuable for choosing an implementation *mechanism*; it is not a substitute for reading this product's own requirements history before removing something. The fix for next time isn't "do more research" — it's "check what was actually promised before deciding a requirement is disposable," and when research and existing spec disagree, that disagreement is exactly the kind of thing to ask about rather than resolve unilaterally.

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -373,6 +373,15 @@ function updateTreeHelper(
             const originalTop = targetProps.rect.top;
             const totalSlipHeight = slipChildren.reduce((s, c) => s + minimizedCrossAxisPx(c, gapPx), 0);
             const clampedSlipHeight = Math.min(totalSlipHeight, targetProps.rect.height);
+            // Scale EACH chip down proportionally when the group's combined
+            // height exceeds the target's available space (several minimized
+            // panes converging on one small anchor) — mirrors
+            // computeMainAxisAllocation's `scale` factor for its analogous
+            // fixed-chip path. Without this, chips were sized at their raw
+            // unclamped height and the stack overflowed past
+            // originalTop + clampedSlipHeight, outside the row's bounds
+            // [reagent P1].
+            const scale = totalSlipHeight > clampedSlipHeight && totalSlipHeight > 0 ? clampedSlipHeight / totalSlipHeight : 1;
             const shrunkRect: Dimensions = {
                 ...targetProps.rect,
                 top: originalTop + clampedSlipHeight,
@@ -385,7 +394,7 @@ function updateTreeHelper(
             };
             let chipTop = originalTop;
             for (const slipChild of slipChildren) {
-                const chipHeight = minimizedCrossAxisPx(slipChild, gapPx);
+                const chipHeight = minimizedCrossAxisPx(slipChild, gapPx) * scale;
                 const chipRect: Dimensions = {
                     top: chipTop,
                     left: shrunkRect.left,

--- a/frontend/layout/lib/layoutGeometry.ts
+++ b/frontend/layout/lib/layoutGeometry.ts
@@ -51,32 +51,107 @@ function minimizedFixedPx(node: LayoutNode, parentIsRow: boolean, gapPx: number)
 }
 
 /**
+ * Cross-axis (height) a minimized child needs when its parent is a Row: one
+ * header height per leaf in its subtree, stacked. A single minimized leaf
+ * needs one header height; a fully-minimized BRANCH holding N leaves needs
+ * N header-heights, because its own recursive Column layout will stack N
+ * chips inside whatever cross-axis space its parent gives it here — giving
+ * it less produces overlapping/clipped chips, giving it more produces dead
+ * space below them (the bug this function exists to prevent). Same formula
+ * as `minimizedFixedPx`'s Column-parent branch — a stack's required extent
+ * doesn't depend on which axis it's being measured for. Pure; exported for
+ * unit tests.
+ */
+export function minimizedCrossAxisPx(child: LayoutNode, gapPx: number): number {
+    return minimizedFixedPx(child, false, gapPx);
+}
+
+/**
  * Derive each child's main-axis pixels: minimized children get fixed
  * chip-sized allocations (scaled down proportionally if the container is too
  * small to fit them all), and the remaining pixels are split among expanded
  * children proportionally to their stored flex sizes — which are never
- * mutated by minimize. Pure; exported for unit tests.
+ * mutated by minimize. `slipChildIds` (Row direction only — see
+ * `resolveRowSlipTargets`) marks children that dock onto a sibling instead
+ * of claiming a slot at all: they contribute ZERO pixels here (excluded from
+ * both the fixed-chip and flex pools), so their would-be space flows
+ * entirely to the remaining flex children — the width-reclaim half of the
+ * slip requirement. The height/position half (docking the chip visually
+ * onto the target) is a separate pass in `updateTreeHelper`. Pure; exported
+ * for unit tests.
  */
 export function computeMainAxisAllocation(
     children: LayoutNode[],
     nodeIsRow: boolean,
     nodePixels: number,
     getSize: (n: LayoutNode) => number,
-    gapPx = 0
+    gapPx = 0,
+    slipChildIds?: Set<string>
 ): MainAxisAllocation {
-    const fixed = children.map((c) => (isEffectivelyMinimized(c) ? minimizedFixedPx(c, nodeIsRow, gapPx) : 0));
+    const isSlip = (c: LayoutNode) => slipChildIds?.has(c.id) ?? false;
+    const fixed = children.map((c) =>
+        isSlip(c) ? 0 : isEffectivelyMinimized(c) ? minimizedFixedPx(c, nodeIsRow, gapPx) : 0
+    );
     const fixedTotal = fixed.reduce((a, b) => a + b, 0);
     const scale = fixedTotal > nodePixels && fixedTotal > 0 ? nodePixels / fixedTotal : 1;
     const remainingPx = Math.max(nodePixels - fixedTotal * scale, 0);
-    const flexTotal = children.reduce((s, c, i) => (fixed[i] ? s : s + getSize(c)), 0);
+    const flexTotal = children.reduce((s, c, i) => (fixed[i] || isSlip(c) ? s : s + getSize(c)), 0);
     const pixelToSizeRatio =
         flexTotal > 0 && remainingPx > 0
             ? flexTotal / remainingPx
             : children.reduce((s, c) => s + getSize(c), 0) / Math.max(nodePixels, 1);
     const px = children.map((c, i) =>
-        fixed[i] ? fixed[i] * scale : flexTotal > 0 ? getSize(c) / pixelToSizeRatio : 0
+        isSlip(c) ? 0 : fixed[i] ? fixed[i] * scale : flexTotal > 0 ? getSize(c) / pixelToSizeRatio : 0
     );
     return { px, pixelToSizeRatio };
+}
+
+/**
+ * For each child of a Row node, resolve which sibling it should visually
+ * dock onto instead of claiming its own row-slot: the nearest
+ * non-minimized sibling, right-preferred, else left — generalizing
+ * `SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md`'s per-pane "slip" and
+ * `SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md`'s cascading
+ * full-column dissolve into one rule via `isEffectivelyMinimized` (a
+ * minimized leaf and a fully-collapsed branch are treated identically —
+ * both need somewhere to dock). Unlike the original tree-surgery
+ * implementation this never mutates the tree or needs restore-context
+ * bookkeeping: it's recomputed fresh every render pass from nothing but the
+ * `minimized` flag, so there is nothing for it to corrupt (see
+ * `docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md`).
+ *
+ * A child gets no entry (falls back to its own fixed-width chip slot via
+ * `computeMainAxisAllocation`'s ordinary minimized-but-not-slipping path)
+ * when it isn't effectively minimized, or when every sibling in the row is
+ * ALSO effectively minimized (no valid anchor to dock onto — can happen
+ * locally even though the last-expanded-pane guard prevents it globally,
+ * since that guard counts leaves across the whole tree, not per row).
+ * Multiple children can resolve to the same target; callers stack them.
+ * Pure; exported for unit tests.
+ */
+export function resolveRowSlipTargets(children: LayoutNode[]): Map<string, LayoutNode> {
+    const targets = new Map<string, LayoutNode>();
+    const minimized = children.map(isEffectivelyMinimized);
+    for (let i = 0; i < children.length; i++) {
+        if (!minimized[i]) continue;
+        let target: LayoutNode | undefined;
+        for (let j = i + 1; j < children.length; j++) {
+            if (!minimized[j]) {
+                target = children[j];
+                break;
+            }
+        }
+        if (!target) {
+            for (let j = i - 1; j >= 0; j--) {
+                if (!minimized[j]) {
+                    target = children[j];
+                    break;
+                }
+            }
+        }
+        if (target) targets.set(children[i].id, target);
+    }
+    return targets;
 }
 
 /**
@@ -141,10 +216,28 @@ export function updateTree(model: LayoutModel, balanceTree = true) {
         model.validateMagnifiedNode(model.treeState.leafOrder, newAdditionalProps);
         model.cleanupNodeModels(model.treeState.leafOrder);
         const sortedLeafs = newLeafs.sort((a, b) => a.id.localeCompare(b.id));
+
+        // Rebuild minimizedNodeIds fresh from the actual `minimized` flags on
+        // this pass's leaves — the SAME walk `newLeafs` already comes from,
+        // so this is free. minimizedNodeIds only exists to drive the
+        // minimize/restore BUTTON ICON (isMinimized/canMinimize in
+        // layoutNodeModels.ts); it is not read by any geometry code, which
+        // reads `isEffectivelyMinimized`/`node.minimized` directly. Deriving
+        // it here instead of incrementally maintaining it (the previous
+        // design: _finishToggle add/remove by id) makes it structurally
+        // impossible for the button to disagree with the tree — the exact
+        // failure mode hit when a minimized leaf got promoted to a branch by
+        // an unguarded insert (addIntermediateNode moves `data` into a fresh
+        // intermediate child that inherits the leaf's id, but nothing moved
+        // `minimized` off the outer node) and the OLD incrementally-tracked
+        // set kept referencing that inherited id after it was no longer
+        // minimized, showing "Restore" on an expanded pane.
+        const newMinimizedIds = new Set(newLeafs.filter((l) => l.minimized).map((l) => l.id));
         batch(() => {
             model.setter(model.leafs, sortedLeafs);
             model.setter(model.leafOrder, model.treeState.leafOrder);
             model.setter(model.additionalProps, newAdditionalProps);
+            model.minimizedNodeIds._set(newMinimizedIds);
         });
     }
 }
@@ -212,69 +305,137 @@ function updateTreeHelper(
     const nodeIsRow = node.flexDirection === FlexDirection.Row;
     const nodePixels = nodeIsRow ? nodeRect.width : nodeRect.height;
     const gapPx = model.gapSizePx();
-    const alloc = computeMainAxisAllocation(node.children, nodeIsRow, nodePixels, getNodeSize, gapPx);
+
+    // Row-only: resolve which children dock onto a sibling instead of
+    // claiming their own row-slot. Column direction never slips — a
+    // minimized Column child already renders correctly in place (header
+    // height, stacked with its siblings, no dead space). Restored per
+    // docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md
+    // — SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md /
+    // SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md's original requirement,
+    // reimplemented as derived geometry instead of tree surgery.
+    const slipTargets = nodeIsRow ? resolveRowSlipTargets(node.children) : new Map<string, LayoutNode>();
+    const slipChildIds = new Set(slipTargets.keys());
+
+    const alloc = computeMainAxisAllocation(node.children, nodeIsRow, nodePixels, getNodeSize, gapPx, slipChildIds);
     const pixelToSizeRatio = alloc.pixelToSizeRatio;
 
+    // Phase A — base rect for every child. A slip child gets zero main-axis
+    // width here (via `alloc.px[i]` above) — a placeholder Phase B replaces
+    // with its docked chip rect. A minimized child renders as a chip: in a
+    // Row parent its cross-axis (height) is clamped to its stacked-chip
+    // total — one header height per leaf, via the SAME minimizedFixedPx
+    // formula the main-axis allocation uses, not just HeaderHeightPx. A
+    // fully-minimized BRANCH holding N leaves needs N header-heights of
+    // cross-axis space: without this, the branch's own rect stays
+    // full-height while its recursive Column layout only fills the top
+    // N*(header+gap) px of it, leaving dead space below the chip stack.
     let lastChildRect: Dimensions;
-    const resizeHandles: ResizeHandleProps[] = [];
-
     node.children.forEach((child, i) => {
-        // A minimized LEAF renders as a header chip: in a Row parent its
-        // cross-axis (height) is clamped to the header, top-aligned in the
-        // slot. Fully-minimized branches keep the full cross-axis — their own
-        // children are chips via recursion.
-        const chipLeaf = isEffectivelyMinimized(child) && !child.children?.length;
+        const minimizedChild = isEffectivelyMinimized(child);
         const rect: Dimensions = {
             top: !nodeIsRow && lastChildRect ? lastChildRect.top + lastChildRect.height : nodeRect.top,
             left: nodeIsRow && lastChildRect ? lastChildRect.left + lastChildRect.width : nodeRect.left,
             width: nodeIsRow ? alloc.px[i] : nodeRect.width,
             height: nodeIsRow
-                ? chipLeaf
-                    ? Math.min(HeaderHeightPx + gapPx, nodeRect.height)
+                ? minimizedChild
+                    ? Math.min(minimizedCrossAxisPx(child, gapPx), nodeRect.height)
                     : nodeRect.height
                 : alloc.px[i],
         };
-        const transform = setTransform(rect);
         additionalPropsMap[child.id] = {
             rect,
-            transform,
+            transform: setTransform(rect),
             treeKey: additionalProps.treeKey + i,
         };
-
-        // We only want the resize handles in between nodes, this ensures we have at most
-        // n-1 handles. A minimized edge (either flanking child renders as a chip) gets
-        // no handle at all — chip geometry is derived, there is nothing to resize.
-        // Because gaps can be skipped, parentIndex must be the child-array index (i - 1),
-        // NOT resizeHandles.length — onResizeMove uses it to look up flanking children.
-        if (lastChildRect && !isEffectivelyMinimized(node.children[i - 1]) && !isEffectivelyMinimized(child)) {
-            const resizeHandleIndex = i - 1;
-            const halfResizeHandleSizePx = resizeHandleSizePx / 2;
-            const resizeHandleDimensions: Dimensions = {
-                top: nodeIsRow
-                    ? lastChildRect.top
-                    : lastChildRect.top + lastChildRect.height - halfResizeHandleSizePx,
-                left: nodeIsRow
-                    ? lastChildRect.left + lastChildRect.width - halfResizeHandleSizePx
-                    : lastChildRect.left,
-                width: nodeIsRow ? resizeHandleSizePx : lastChildRect.width,
-                height: nodeIsRow ? lastChildRect.height : resizeHandleSizePx,
-            };
-            resizeHandles.push({
-                id: `${node.id}-${resizeHandleIndex}`,
-                parentNodeId: node.id,
-                parentIndex: resizeHandleIndex,
-                transform: setTransform(resizeHandleDimensions, true, false),
-                flexDirection: node.flexDirection,
-                centerPx:
-                    (nodeIsRow ? resizeHandleDimensions.left : resizeHandleDimensions.top) + halfResizeHandleSizePx,
-                perpMinPx: nodeIsRow ? resizeHandleDimensions.top : resizeHandleDimensions.left,
-                perpMaxPx: nodeIsRow
-                    ? resizeHandleDimensions.top + resizeHandleDimensions.height
-                    : resizeHandleDimensions.left + resizeHandleDimensions.width,
-            });
-        }
         lastChildRect = rect;
     });
+
+    // Phase B (Row only) — dock each slip child's header chip(s) onto its
+    // target: shrink the target's rect and push it down to make room above
+    // it, then stack the slip children's own chips in that reserved space
+    // in row order. Grouped by target so multiple simultaneous slips onto
+    // the same anchor stack predictably. Mutates additionalPropsMap entries
+    // Phase A already wrote — this is why resize-handle generation (Phase C)
+    // reads rects back from the map instead of a loop-local variable.
+    if (nodeIsRow && slipChildIds.size > 0) {
+        const slipsByTargetId = new Map<string, LayoutNode[]>();
+        for (const child of node.children) {
+            const target = slipTargets.get(child.id);
+            if (!target) continue;
+            const list = slipsByTargetId.get(target.id) ?? [];
+            list.push(child);
+            slipsByTargetId.set(target.id, list);
+        }
+        for (const [targetId, slipChildren] of slipsByTargetId) {
+            const targetProps = additionalPropsMap[targetId];
+            if (!targetProps?.rect) continue;
+            const originalTop = targetProps.rect.top;
+            const totalSlipHeight = slipChildren.reduce((s, c) => s + minimizedCrossAxisPx(c, gapPx), 0);
+            const clampedSlipHeight = Math.min(totalSlipHeight, targetProps.rect.height);
+            const shrunkRect: Dimensions = {
+                ...targetProps.rect,
+                top: originalTop + clampedSlipHeight,
+                height: targetProps.rect.height - clampedSlipHeight,
+            };
+            additionalPropsMap[targetId] = {
+                ...targetProps,
+                rect: shrunkRect,
+                transform: setTransform(shrunkRect),
+            };
+            let chipTop = originalTop;
+            for (const slipChild of slipChildren) {
+                const chipHeight = minimizedCrossAxisPx(slipChild, gapPx);
+                const chipRect: Dimensions = {
+                    top: chipTop,
+                    left: shrunkRect.left,
+                    width: shrunkRect.width,
+                    height: chipHeight,
+                };
+                additionalPropsMap[slipChild.id] = {
+                    ...additionalPropsMap[slipChild.id],
+                    rect: chipRect,
+                    transform: setTransform(chipRect),
+                };
+                chipTop += chipHeight;
+            }
+        }
+    }
+
+    // Phase C — resize handles between consecutive REAL (non-minimized,
+    // non-slip) slots only; a minimized/slip edge gets no handle at all —
+    // chip geometry is derived, there is nothing to resize. Reads FINAL
+    // rects from additionalPropsMap (not a loop-local value) since Phase B
+    // may have adjusted a target's rect after Phase A first computed it.
+    // parentIndex is the child-array index (i - 1), not resizeHandles.length
+    // — onResizeMove uses it to look up flanking children by that index, and
+    // Phase B never removes entries from node.children, only adjusts rects.
+    const resizeHandles: ResizeHandleProps[] = [];
+    for (let i = 1; i < node.children.length; i++) {
+        const prevChild = node.children[i - 1];
+        const child = node.children[i];
+        if (isEffectivelyMinimized(prevChild) || isEffectivelyMinimized(child)) continue;
+        const prevRect = additionalPropsMap[prevChild.id].rect;
+        const halfResizeHandleSizePx = resizeHandleSizePx / 2;
+        const resizeHandleDimensions: Dimensions = {
+            top: nodeIsRow ? prevRect.top : prevRect.top + prevRect.height - halfResizeHandleSizePx,
+            left: nodeIsRow ? prevRect.left + prevRect.width - halfResizeHandleSizePx : prevRect.left,
+            width: nodeIsRow ? resizeHandleSizePx : prevRect.width,
+            height: nodeIsRow ? prevRect.height : resizeHandleSizePx,
+        };
+        resizeHandles.push({
+            id: `${node.id}-${i - 1}`,
+            parentNodeId: node.id,
+            parentIndex: i - 1,
+            transform: setTransform(resizeHandleDimensions, true, false),
+            flexDirection: node.flexDirection,
+            centerPx: (nodeIsRow ? resizeHandleDimensions.left : resizeHandleDimensions.top) + halfResizeHandleSizePx,
+            perpMinPx: nodeIsRow ? resizeHandleDimensions.top : resizeHandleDimensions.left,
+            perpMaxPx: nodeIsRow
+                ? resizeHandleDimensions.top + resizeHandleDimensions.height
+                : resizeHandleDimensions.left + resizeHandleDimensions.width,
+        });
+    }
 
     additionalPropsMap[node.id] = {
         ...additionalProps,

--- a/frontend/layout/lib/layoutMinimize.ts
+++ b/frontend/layout/lib/layoutMinimize.ts
@@ -25,20 +25,34 @@ export { isNodeLocked, isEffectivelyMinimized };
  *
  * A minimized pane is a leaf with `minimized: true` — nothing else. Its stored
  * flex `size` is NEVER touched: the renderer (`updateTreeHelper`) derives the
- * header-chip geometry fresh on every pass (header height in a Column parent,
- * a fixed-width chip in a Row parent, and a fully-minimized subtree renders as
- * a stacked strip of chips). Restore is just clearing the flag — the pane's
- * original size is intact by construction, because it never changed.
+ * header-chip geometry fresh on every pass. Restore is just clearing the
+ * flag — the pane's original size is intact by construction, because it
+ * never changed.
  *
  * This replaces the previous size-arithmetic model (squeeze `size` to header
  * height + `minimizedSize` restore bookkeeping + "slip" and "column dissolve"
- * structural surgery), which produced four distinct bug classes in two weeks
- * (see `docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md` §2).
- * The research verdict: every mature system models collapse as either
- * out-of-tree docking or a render-derived display mode (i3 stacked/tabbed,
- * maximize toggles); none stores squeezed sizes in the layout tree. Derived
+ * as STRUCTURAL TREE SURGERY), which produced four distinct bug classes in
+ * two weeks (see `docs/research/RESEARCH_PANE_MINIMIZE_BEST_PRACTICES_2026_07_16.md`
+ * §2). The research verdict: every mature system models collapse as either
+ * out-of-tree docking or a render-derived display mode; none stores squeezed
+ * sizes in the layout tree or splices nodes around to achieve it. Derived
  * state cannot drift, so this model needs no size locks, no snap-back
  * enforcement, and no restore arithmetic.
+ *
+ * The VISUAL slip/dissolve requirement itself — a minimized pane's header
+ * docks onto an adjacent pane, which absorbs its freed space — is a real,
+ * deliberately spec'd product requirement
+ * (`SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md`,
+ * `SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md`) that the first cut of
+ * this redesign incorrectly deleted along with the buggy mechanism that used
+ * to implement it — see
+ * `docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md`.
+ * It's restored here as pure derived geometry: `layoutGeometry.ts`'s
+ * `resolveRowSlipTargets` + the docking pass in `updateTreeHelper` compute,
+ * every render, which minimized Row-direction children should render as a
+ * header-chip stack overlaid on a sibling instead of claiming their own
+ * row-slot — no tree mutation, no restore-context bookkeeping, nothing for
+ * it to corrupt.
  *
  * Legacy trees (with `minimizedSize`/`slipMinimize`/`columnDissolve`/
  * `minimizedLockedSize`/`_slipAnchor`) are migrated in place by
@@ -98,17 +112,14 @@ export function minimizeNodeToggle(model: LayoutModel, nodeId: string) {
     _finishToggle(model, nodeId, true);
 }
 
-/** Commit tree changes and update the minimized-node-id reactive set. */
+/**
+ * Commit tree changes. `model.updateTree()` rebuilds `minimizedNodeIds`
+ * fresh from the (already-toggled) `node.minimized` flags as part of its own
+ * pass — see `layoutGeometry.ts::updateTree` — so there is nothing to set
+ * here directly; this function only exists for the doctor-report /
+ * persistence side effects around that call.
+ */
 function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
-    model.minimizedNodeIds._set((prev) => {
-        const next = new Set(prev);
-        if (minimized) {
-            next.add(nodeId);
-        } else {
-            next.delete(nodeId);
-        }
-        return next;
-    });
     model.updateTree();
     // Layout doctor (issue #2179): validate immediately with toggle attribution.
     reportLayoutViolations(
@@ -121,8 +132,11 @@ function _finishToggle(model: LayoutModel, nodeId: string, minimized: boolean) {
 
 /**
  * Scan the loaded tree, migrate any legacy minimize state to the display-mode
- * flag, and rebuild the in-memory `minimizedNodeIds` set. Called once during
- * `initializeFromWaveObject`.
+ * flag, and seed the in-memory `minimizedNodeIds` set for the initial paint
+ * (the first `updateTree()` pass — see `layoutGeometry.ts::updateTree` —
+ * rebuilds it authoritatively moments later regardless; this just avoids a
+ * flash of wrong button state before that first pass runs). Called once
+ * during `initializeFromWaveObject`.
  *
  * Migration rules (one-way, in place):
  * - `minimizedSize` (leaf was size-squeezed): restore `size` to the recorded

--- a/frontend/layout/lib/layoutNode.ts
+++ b/frontend/layout/lib/layoutNode.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DEFAULT_MAX_CHILDREN } from "./layoutTree";
+import { isEffectivelyMinimized } from "./layoutInvariants";
 import { DefaultNodeSize, FlexDirection, LayoutNode } from "./types";
 import { reverseFlexDirection } from "./utils";
 
@@ -79,6 +80,19 @@ export function addIntermediateNode(node: LayoutNode): LayoutNode {
         intermediateNode = newLayoutNode(reverseFlexDirection(node.flexDirection), undefined, undefined, node.data);
         node.children = [intermediateNode];
         node.data = undefined;
+        // Defense-in-depth: callers are expected to guard against promoting
+        // a minimized leaf (see findNextInsertLocation/insertNode's own
+        // isEffectivelyMinimized checks), but if this ever runs on one
+        // anyway, `minimized` must travel with the DATA, not stay on `node`
+        // — `node` is now a branch (leaf-only field; the 2026-07-18
+        // "expanded pane shows Restore" corruption was exactly a leaf's
+        // `minimized` flag left stranded on the branch it got promoted
+        // into, while the intermediate child that inherited the leaf's id
+        // silently lost it).
+        if (node.minimized) {
+            intermediateNode.minimized = true;
+            node.minimized = undefined;
+        }
     } else {
         const intermediateNodeInner = newLayoutNode(node.flexDirection, undefined, node.children);
         intermediateNode = newLayoutNode(reverseFlexDirection(node.flexDirection), undefined, [intermediateNodeInner]);
@@ -290,6 +304,16 @@ function findNextInsertLocationHelper(
     curDepth: number = 1
 ): { node: LayoutNode; index: number; depth: number } {
     if (!node) return;
+    // A minimized leaf or fully-collapsed branch is locked — never a blind-
+    // insert target. Without this, `addChildAt` promoting a minimized leaf
+    // into a branch (via `addIntermediateNode`) left the STALE `minimized`
+    // flag on the new branch (a leaf-only field, violating the layout
+    // doctor's I2) while the inherited-id child silently lost it — the
+    // "expanded pane shows a Restore button" corruption (2026-07-18). For a
+    // fully-minimized branch this also prevents a blind insert from
+    // silently un-collapsing it (every child minimized → one child isn't
+    // anymore, with no user action on that branch at all).
+    if (isEffectivelyMinimized(node)) return;
     if (!node.children) return { node, index: 1, depth: curDepth };
     let insertLocs: { node: LayoutNode; index: number; depth: number }[] = [];
     if (node.children.length < maxChildren) {

--- a/frontend/layout/lib/layoutTree.ts
+++ b/frontend/layout/lib/layoutTree.ts
@@ -303,6 +303,18 @@ export function insertNode(layoutState: LayoutTreeState, action: LayoutTreeInser
         layoutState.rootNode = action.node;
     } else {
         const insertLoc = findNextInsertLocation(layoutState.rootNode, DEFAULT_MAX_CHILDREN);
+        // findNextInsertLocation already skips minimize-locked candidates;
+        // this only fires in the degenerate case where every node in the
+        // tree is locked (last-expanded-pane guard prevents that globally,
+        // but not per-subtree — see resolveRowSlipTargets's equivalent note).
+        if (!insertLoc?.node) {
+            console.warn("insertNode: no unlocked insert location available, dropping");
+            return;
+        }
+        if (isEffectivelyMinimized(insertLoc.node)) {
+            console.warn("insertNode rejected: resolved location is minimize-locked", insertLoc.node.id);
+            return;
+        }
         addChildAt(insertLoc.node, insertLoc.index, action.node);
         if (action.magnified) {
             layoutState.magnifiedNodeId = action.node.id;
@@ -326,6 +338,14 @@ export function insertNodeAtIndex(layoutState: LayoutTreeState, action: LayoutTr
         const insertLoc = findInsertLocationFromIndexArr(layoutState.rootNode, action.indexArr);
         if (!insertLoc) {
             console.error("insertNodeAtIndex unable to find insert location");
+            return;
+        }
+        // Minimized is a locked state: an explicit index path can still
+        // resolve onto a locked node (unlike the heuristic locator, this one
+        // follows a caller-supplied path rather than choosing among
+        // candidates), so guard here — same rationale as insertNode above.
+        if (isEffectivelyMinimized(insertLoc.node)) {
+            console.warn("insertNodeAtIndex rejected: resolved location is minimize-locked", insertLoc.node.id);
             return;
         }
         addChildAt(insertLoc.node, insertLoc.index + 1, action.node);

--- a/frontend/layout/tests/layoutMinimize.test.ts
+++ b/frontend/layout/tests/layoutMinimize.test.ts
@@ -12,7 +12,7 @@ import {
     HeaderHeightPx,
     MinimizedRowSlotWidthPx,
 } from "../lib/layoutMinimize";
-import { computeMainAxisAllocation } from "../lib/layoutGeometry";
+import { computeMainAxisAllocation, minimizedCrossAxisPx, resolveRowSlipTargets } from "../lib/layoutGeometry";
 import { resizeNode, splitVertical } from "../lib/layoutTree";
 import { FlexDirection, type LayoutNode } from "../lib/types";
 
@@ -21,18 +21,35 @@ import { FlexDirection, type LayoutNode } from "../lib/types";
 
 function makeMockModel(rootNode: LayoutNode) {
     let minimizedSet = new Set<string>();
-    return {
+    const model = {
         treeState: { rootNode, pendingBackendActions: [] },
         minimizedNodeIds: {
             _set: (u: Set<string> | ((prev: Set<string>) => Set<string>)) => {
                 minimizedSet = typeof u === "function" ? u(minimizedSet) : u;
             },
         },
-        updateTree: () => {},
+        // Real updateTree (layoutGeometry.ts) rebuilds minimizedNodeIds fresh
+        // from the tree's `.minimized` flags as part of its normal walk —
+        // mirror JUST that derivation here (no geometry needed for these
+        // tests) so callers relying on updateTree() having run see the same
+        // authoritative result production does.
+        updateTree: () => {
+            const ids = new Set<string>();
+            (function walk(n: LayoutNode | undefined) {
+                if (!n) return;
+                if (!n.children?.length) {
+                    if (n.minimized) ids.add(n.id);
+                    return;
+                }
+                n.children.forEach(walk);
+            })(model.treeState.rootNode);
+            minimizedSet = ids;
+        },
         localTreeStateAtom: { _set: () => {} },
         persistToBackend: () => {},
         getMinimizedSet: () => minimizedSet,
     };
+    return model;
 }
 
 const PANE_SIZE = 200;
@@ -212,6 +229,55 @@ describe("derived chip geometry", () => {
         expect(px[1]).toBeCloseTo(600);
         expect(pixelToSizeRatio).toBeCloseTo(400 / 800);
     });
+
+    // Regression: minimizedCrossAxisPx clamps a minimized child's
+    // CROSS-axis (height, under a Row parent) — this is what the rect
+    // builder in updateTreeHelper actually uses, distinct from
+    // computeMainAxisAllocation's MAIN-axis px[]. A single minimized leaf
+    // needs one header height; a fully-minimized BRANCH holding N leaves
+    // needs N (one per stacked chip its own recursive layout will render).
+    // Getting this wrong for branches was the live-repro bug: right_col's
+    // rect kept full container height while its own Column layout only
+    // filled the top N*(header+gap)px, leaving dead space below the chips
+    // ("2 half collapsed... to the right of the single pane").
+    it("minimizedCrossAxisPx: one header-height for a minimized leaf, N for an N-leaf minimized branch", () => {
+        const leaf = newLayoutNode(FlexDirection.Row, 10, undefined, { blockId: "a" });
+        leaf.minimized = true;
+        expect(minimizedCrossAxisPx(leaf, 3)).toBe(HeaderHeightPx + 3);
+
+        const cpu = newLayoutNode(FlexDirection.Row, 2, undefined, { blockId: "cpu" });
+        cpu.minimized = true;
+        const swarm = newLayoutNode(FlexDirection.Row, 8, undefined, { blockId: "swarm" });
+        swarm.minimized = true;
+        const rightCol = newLayoutNode(FlexDirection.Column, 5, [cpu, swarm]);
+        expect(minimizedCrossAxisPx(rightCol, 3)).toBe(2 * (HeaderHeightPx + 3));
+    });
+
+    it("no dead space: a clamped fully-minimized branch's own allocation exactly fills the space its parent gave it", () => {
+        const cpu = newLayoutNode(FlexDirection.Row, 2, undefined, { blockId: "cpu" });
+        cpu.minimized = true;
+        const swarm = newLayoutNode(FlexDirection.Row, 8, undefined, { blockId: "swarm" });
+        swarm.minimized = true;
+        const rightCol = newLayoutNode(FlexDirection.Column, 5, [cpu, swarm]);
+        const gap = 3;
+
+        // Step 1: the Row parent clamps rightCol's cross-axis to its actual
+        // chip-stack need (what the fixed rect builder now does) — NOT the
+        // full 800px container height a naive "branches keep full cross-axis"
+        // rule would have given it.
+        const clampedHeight = minimizedCrossAxisPx(rightCol, gap);
+        expect(clampedHeight).toBe(2 * (HeaderHeightPx + gap));
+        expect(clampedHeight).toBeLessThan(800);
+
+        // Step 2: recursing into rightCol's OWN Column-direction allocation
+        // with that clamped height as nodePixels must consume it exactly —
+        // zero leftover (dead space).
+        const inner = computeMainAxisAllocation(rightCol.children!, false, clampedHeight, size, gap);
+        const consumed = inner.px.reduce((a, b) => a + b, 0);
+        expect(consumed).toBeCloseTo(clampedHeight);
+        expect(inner.px[0]).toBe(HeaderHeightPx + gap);
+        expect(inner.px[1]).toBe(HeaderHeightPx + gap);
+    });
 });
 
 // ── Reducer guards (minimized = locked) ──────────────────────────────────────
@@ -341,5 +407,115 @@ describe("balanceNode legacy carve-outs", () => {
         balanceNode(host);
 
         expect(host.children![0].flexDirection).toBe(FlexDirection.Column);
+    });
+});
+
+// ── Row-slip target resolution ───────────────────────────────────────────────
+// Restored per docs/retro/retro-minimize-display-mode-lost-slip-requirement-
+// 2026-07-17.md — SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md's per-pane
+// slip and SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md's cascading
+// full-column dissolve, unified into one rule via isEffectivelyMinimized.
+
+describe("resolveRowSlipTargets", () => {
+    function leaf(id: string, min = false): LayoutNode {
+        const n = newLayoutNode(FlexDirection.Column, 10, undefined, { blockId: id });
+        n.id = id;
+        if (min) n.minimized = true;
+        return n;
+    }
+
+    it("no minimized children: no entries", () => {
+        const [a, b, c] = [leaf("a"), leaf("b"), leaf("c")];
+        expect(resolveRowSlipTargets([a, b, c]).size).toBe(0);
+    });
+
+    it("right-preferred: a minimized child docks onto its right neighbor over its left", () => {
+        const [a, b, c] = [leaf("a"), leaf("b", true), leaf("c")];
+        const targets = resolveRowSlipTargets([a, b, c]);
+        expect(targets.get("b")?.id).toBe("c");
+    });
+
+    it("falls back to the left neighbor when there is no right one", () => {
+        const [a, b] = [leaf("a"), leaf("b", true)];
+        const targets = resolveRowSlipTargets([a, b]);
+        expect(targets.get("b")?.id).toBe("a");
+    });
+
+    it("scans PAST an adjacent minimized sibling to find a real anchor", () => {
+        // [A(min), B(min), C(expanded)] — A's immediate right neighbor (B) is
+        // itself minimized and not a valid anchor; A must keep scanning right
+        // to C. B's immediate right IS C directly.
+        const [a, b, c] = [leaf("a", true), leaf("b", true), leaf("c")];
+        const targets = resolveRowSlipTargets([a, b, c]);
+        expect(targets.get("a")?.id).toBe("c");
+        expect(targets.get("b")?.id).toBe("c");
+    });
+
+    it("multiple minimized siblings on both sides converge on the same nearest anchor", () => {
+        // [A(min), B(min), C(expanded), D(min)] — A and B slip right onto C;
+        // D has nothing to its right, so it falls back left onto C too.
+        const [a, b, c, d] = [leaf("a", true), leaf("b", true), leaf("c"), leaf("d", true)];
+        const targets = resolveRowSlipTargets([a, b, c, d]);
+        expect(targets.get("a")?.id).toBe("c");
+        expect(targets.get("b")?.id).toBe("c");
+        expect(targets.get("d")?.id).toBe("c");
+    });
+
+    it("no valid anchor when every sibling in the row is minimized: no entry (falls back to its own chip slot)", () => {
+        const [a, b] = [leaf("a", true), leaf("b", true)];
+        const targets = resolveRowSlipTargets([a, b]);
+        expect(targets.size).toBe(0);
+    });
+
+    it("a single child (no siblings at all): no entry", () => {
+        const [a] = [leaf("a", true)];
+        expect(resolveRowSlipTargets([a]).size).toBe(0);
+    });
+
+    it("treats a fully-minimized BRANCH exactly like a minimized leaf (the column-dissolve case)", () => {
+        const cpu = leaf("cpu", true);
+        const swarm = leaf("swarm", true);
+        const rightCol = newLayoutNode(FlexDirection.Column, 5, [cpu, swarm]);
+        rightCol.id = "rightCol";
+        const agent = leaf("agent");
+        const targets = resolveRowSlipTargets([agent, rightCol]);
+        expect(targets.get("rightCol")?.id).toBe("agent");
+        // cpu/swarm are resolved by right_col's OWN (Column-direction) layout
+        // pass, not by this row-level call — they have no entry here.
+        expect(targets.has("cpu")).toBe(false);
+        expect(targets.has("swarm")).toBe(false);
+    });
+
+    it("a partially-minimized branch (not every leaf minimized) is not slip-eligible", () => {
+        const cpu = leaf("cpu", true);
+        const swarm = leaf("swarm", false); // still expanded
+        const rightCol = newLayoutNode(FlexDirection.Column, 5, [cpu, swarm]);
+        rightCol.id = "rightCol";
+        const agent = leaf("agent");
+        expect(resolveRowSlipTargets([agent, rightCol]).size).toBe(0);
+    });
+});
+
+// ── computeMainAxisAllocation: slip children contribute zero width ──────────
+
+describe("computeMainAxisAllocation with slipChildIds", () => {
+    const size = (n: LayoutNode) => n.size;
+
+    it("a slip child gets 0 px; its would-be width flows entirely to the flex sibling", () => {
+        const a = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "a" });
+        const b = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "b" });
+        b.minimized = true;
+        const { px } = computeMainAxisAllocation([a, b], true, 1000, size, 3, new Set([b.id]));
+        expect(px[1]).toBe(0);
+        expect(px[0]).toBeCloseTo(1000);
+    });
+
+    it("without slipChildIds, the same minimized child gets the old fixed chip width (backward compatible)", () => {
+        const a = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "a" });
+        const b = newLayoutNode(FlexDirection.Row, 100, undefined, { blockId: "b" });
+        b.minimized = true;
+        const { px } = computeMainAxisAllocation([a, b], true, 1000, size, 3);
+        expect(px[1]).toBe(MinimizedRowSlotWidthPx + 3);
+        expect(px[0]).toBeCloseTo(1000 - (MinimizedRowSlotWidthPx + 3));
     });
 });

--- a/frontend/layout/tests/layoutModel.test.ts
+++ b/frontend/layout/tests/layoutModel.test.ts
@@ -7,6 +7,7 @@ import { LayoutModel } from "@/layout/lib/layoutModel";
 import { newLayoutNode } from "@/layout/lib/layoutNode";
 import {
     FlexDirection,
+    LayoutNode,
     LayoutTreeActionType,
     LayoutTreeInsertNodeAction,
     LayoutTreeSplitHorizontalAction,
@@ -192,5 +193,124 @@ describe("LayoutModel", () => {
         // After commit, the pending action should be cleared
         const pendingAction = model.pendingTreeAction.throttledValueAtom();
         expect(pendingAction).toBeUndefined();
+    });
+
+    // Regression / feature restoration: the exact user-reported repro
+    // (docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md)
+    // — minimize cpu then swarm in the default agent/cpu/swarm layout. Per
+    // SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md, right_col (now fully
+    // minimized) must dock its stacked headers onto agent — not render as a
+    // separate narrow column beside it — with agent's content area shrinking
+    // to make room and absorbing right_col's freed width.
+    it("docks a fully-minimized column's header stack onto its Row sibling instead of a separate slot", () => {
+        const model = createLayoutModel();
+        const agent = newLayoutNode(FlexDirection.Column, 5, undefined, { blockId: "agent" });
+        const cpu = newLayoutNode(FlexDirection.Row, 2, undefined, { blockId: "cpu" });
+        const swarm = newLayoutNode(FlexDirection.Row, 8, undefined, { blockId: "swarm" });
+        const rightCol = newLayoutNode(FlexDirection.Column, 5, [cpu, swarm]);
+        const root = newLayoutNode(FlexDirection.Row, 10, [agent, rightCol]);
+        model.treeState.rootNode = root;
+
+        model.updateTree();
+        const beforeProps = model.additionalProps();
+        expect(beforeProps[rightCol.id].rect.width).toBeGreaterThan(0);
+        expect(beforeProps[agent.id].rect.width).toBeGreaterThan(0);
+
+        cpu.minimized = true;
+        model.updateTree();
+        swarm.minimized = true;
+        model.updateTree();
+
+        const gap = model.gapSizePx();
+        const headerH = 33; // HeaderHeightPx
+        const props = model.additionalProps();
+
+        // agent's own slot absorbed ALL of rightCol's freed width — the
+        // reported bug (a separate ~180px-wide narrow strip next to agent)
+        // must not exist: agent's rect now spans the full row width.
+        expect(props[agent.id].rect.width).toBeCloseTo(800, 0);
+
+        // agent's content area shrank + shifted down to leave room for the
+        // 2-chip stack docked above it (cpu, then swarm).
+        const dockedHeight = 2 * (headerH + gap);
+        expect(props[agent.id].rect.top).toBeCloseTo(dockedHeight, 0);
+        expect(props[agent.id].rect.height).toBeCloseTo(600 - dockedHeight, 0);
+
+        // rightCol itself renders as the chip-stack overlay, pinned to the
+        // TOP of agent's original slot — same width as agent, not its own
+        // separate narrow column.
+        expect(props[rightCol.id].rect.top).toBeCloseTo(0, 0);
+        expect(props[rightCol.id].rect.width).toBeCloseTo(800, 0);
+        expect(props[rightCol.id].rect.height).toBeCloseTo(dockedHeight, 0);
+
+        // The two chips inside rightCol's (now correctly clamped) box stack
+        // with zero dead space between or below them.
+        expect(props[cpu.id].rect.top).toBeCloseTo(0, 0);
+        expect(props[cpu.id].rect.height).toBeCloseTo(headerH + gap, 0);
+        expect(props[swarm.id].rect.top).toBeCloseTo(headerH + gap, 0);
+        expect(props[swarm.id].rect.height).toBeCloseTo(headerH + gap, 0);
+
+        // No resize handle survives between agent and the now-docked rightCol.
+        expect(props[root.id].resizeHandles).toHaveLength(0);
+    });
+
+    // End-to-end regression for the exact user-reported corruption
+    // (2026-07-18): a blind InsertNode (e.g. a new pane created via the "+"
+    // button or an agent creating a terminal) whose heuristic target
+    // resolves onto a minimized leaf must not promote that leaf into a
+    // branch — the promotion left `minimized` stranded on the branch
+    // (violating the doctor's I2) while the id-inheriting intermediate
+    // child silently lost it, and the separately-tracked minimizedNodeIds
+    // set kept the stale id — so an EXPANDED pane showed a Restore button.
+    it("InsertNode never promotes a minimized leaf, and minimizedNodeIds cannot desync from the tree", () => {
+        const model = createLayoutModel();
+        // Root must be AT capacity (5 children, DEFAULT_MAX_CHILDREN=5) so it
+        // is excluded as an insert candidate itself — otherwise root always
+        // wins regardless of any leaf's minimize state and this test would
+        // pass trivially without ever exercising the corrupted path. With 5
+        // same-depth leaf candidates tied on score, the heuristic's (stable)
+        // sort picks whichever was visited first — reverse child order means
+        // the LAST array element wins the tie; put the minimized leaf there
+        // so, absent the fix, it's exactly what would get promoted.
+        const leaves = ["a", "b", "c", "d", "minimized"].map((id) =>
+            newLayoutNode(FlexDirection.Column, 5, undefined, { blockId: id })
+        );
+        const minimized = leaves[4];
+        minimized.minimized = true;
+        const root = newLayoutNode(FlexDirection.Row, 10, leaves);
+        model.treeState.rootNode = root;
+        model.updateTree();
+        expect(model.additionalProps()).toHaveProperty(minimized.id);
+
+        const newBlock = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+        model.treeReducer({
+            type: LayoutTreeActionType.InsertNode,
+            node: newBlock,
+            magnified: false,
+            focused: false,
+        } as LayoutTreeInsertNodeAction);
+
+        // The minimized leaf must still be a LEAF, still minimized, still
+        // exactly where it was — untouched by the insert.
+        const stillMinimized = model.treeState.rootNode!.children!.find((c) => c.data?.blockId === "minimized");
+        expect(stillMinimized).toBeDefined();
+        expect(stillMinimized!.children).toBeUndefined();
+        expect(stillMinimized!.minimized).toBe(true);
+
+        // No node anywhere in the tree is a branch carrying `minimized` (the
+        // exact corruption) — walk the whole tree and check.
+        function walk(node: LayoutNode | undefined, assertNotCorrupted: (n: LayoutNode) => void) {
+            if (!node) return;
+            assertNotCorrupted(node);
+            node.children?.forEach((c) => walk(c, assertNotCorrupted));
+        }
+        walk(model.treeState.rootNode, (n) => {
+            if (n.children?.length) expect(n.minimized).toBeUndefined();
+        });
+
+        // minimizedNodeIds (derived fresh by updateTree, which treeReducer
+        // just triggered) exactly matches reality: the minimized leaf and
+        // nothing else.
+        expect(model.minimizedNodeIds()).toEqual(new Set([stillMinimized!.id]));
     });
 });

--- a/frontend/layout/tests/layoutModel.test.ts
+++ b/frontend/layout/tests/layoutModel.test.ts
@@ -254,6 +254,53 @@ describe("LayoutModel", () => {
         expect(props[root.id].resizeHandles).toHaveLength(0);
     });
 
+    // Regression (reagent P1, PR #2211): when several minimized panes
+    // converge on one small anchor, their combined stacked chip height can
+    // exceed the anchor's available cross-axis space. Each chip must scale
+    // down proportionally (mirroring computeMainAxisAllocation's `scale`
+    // factor for its analogous fixed-chip path) so the stack stays within
+    // the target's (and therefore the row's) bounds instead of overflowing
+    // past it.
+    it("scales down chip heights proportionally when a slip group's total height exceeds the target's space", () => {
+        const model = createLayoutModel();
+        model.getBoundingRect = () => ({ top: 0, left: 0, width: 800, height: 200 });
+        model.displayContainerRef.current = {
+            getBoundingClientRect: () => ({ top: 0, left: 0, width: 800, height: 200 }),
+        } as any;
+
+        // 6 minimized leaves stacked onto 1 anchor: 6 * (33 + gap) comfortably
+        // exceeds the 200px container height available to dock into.
+        const minimizedLeaves = Array.from({ length: 6 }, (_, i) => {
+            const n = newLayoutNode(FlexDirection.Row, 5, undefined, { blockId: `min${i}` });
+            n.minimized = true;
+            return n;
+        });
+        const anchor = newLayoutNode(FlexDirection.Row, 5, undefined, { blockId: "anchor" });
+        const root = newLayoutNode(FlexDirection.Row, 10, [anchor, ...minimizedLeaves]);
+        model.treeState.rootNode = root;
+        model.updateTree();
+
+        const gap = model.gapSizePx();
+        const headerH = 33;
+        const rawTotal = 6 * (headerH + gap);
+        const props = model.additionalProps();
+
+        // The chip stack must not exceed the anchor's original slot height.
+        const lastChip = props[minimizedLeaves[5].id].rect;
+        expect(lastChip.top + lastChip.height).toBeLessThanOrEqual(200 + 0.01);
+
+        // Each individual chip shrank by the same scale factor — combined
+        // height of all 6 (scaled) chips fills but does not exceed 200px,
+        // and is strictly less than the raw (unscaled) total would have been.
+        const totalScaledHeight = minimizedLeaves.reduce((s, c) => s + props[c.id].rect.height, 0);
+        expect(totalScaledHeight).toBeCloseTo(200, 0);
+        expect(totalScaledHeight).toBeLessThan(rawTotal);
+
+        // The anchor's own content area is fully consumed (0 height left) —
+        // the whole container is chips when they overflow this badly.
+        expect(props[anchor.id].rect.height).toBeCloseTo(0, 0);
+    });
+
     // End-to-end regression for the exact user-reported corruption
     // (2026-07-18): a blind InsertNode (e.g. a new pane created via the "+"
     // button or an agent creating a terminal) whose heuristic target

--- a/frontend/layout/tests/layoutNode.test.ts
+++ b/frontend/layout/tests/layoutNode.test.ts
@@ -299,3 +299,58 @@ test("findNextInsertLocation", () => {
     assert(insertLoc3.node.id === node3Inner4.id, "should insert into node3Inner4");
     assert(insertLoc3.index === 1, "should insert into index 1 of node3Inner4");
 });
+
+// Regression (2026-07-18): a minimized leaf/branch must never be a blind-
+// insert target. Before this fix, findNextInsertLocationHelper would
+// happily select a minimized leaf as the location to promote, and
+// addIntermediateNode left the leaf's `minimized` flag stranded on the new
+// branch (a leaf-only field, violating the layout doctor's I2) while the
+// intermediate child that inherited the leaf's original id silently lost
+// it — surfacing as "an expanded pane shows a Restore button" once the
+// (separately-tracked) minimizedNodeIds set kept the stale id.
+test("findNextInsertLocation skips a minimized leaf even when it would otherwise score first", () => {
+    // Root must be AT capacity (5 children, maxChildren=5) so it's excluded
+    // as a candidate itself (only `children.length < maxChildren` nodes
+    // qualify) — otherwise root always wins regardless of any leaf's
+    // minimize state, and the test would pass trivially without exercising
+    // the fix at all. With 5 same-depth leaf candidates all tied on score,
+    // the (stable) sort picks whichever was pushed first — the loop visits
+    // children in REVERSE order, so the LAST array element is pushed first
+    // and wins the tie. Put the minimized leaf there so, absent the fix,
+    // it's exactly the one that would otherwise be selected.
+    const leaves = ["a", "b", "c", "d", "minimized"].map((id) =>
+        newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: id })
+    );
+    const minimizedLeaf = leaves[4];
+    minimizedLeaf.minimized = true;
+    const root = newLayoutNode(FlexDirection.Row, undefined, leaves);
+
+    const insertLoc = findNextInsertLocation(root, 5);
+    assert(insertLoc.node !== undefined, "a valid unlocked candidate must still be found");
+    assert(insertLoc.node.id !== minimizedLeaf.id, "must never select the minimized leaf as the insert target");
+});
+
+test("findNextInsertLocation returns undefined when every candidate in the tree is minimized", () => {
+    const a = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "a" });
+    a.minimized = true;
+    const b = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "b" });
+    b.minimized = true;
+    const root = newLayoutNode(FlexDirection.Row, undefined, [a, b]);
+
+    const insertLoc = findNextInsertLocation(root, 5);
+    assert(insertLoc.node === undefined, "no valid unlocked location exists");
+});
+
+test("addIntermediateNode moves a leaf's minimized flag onto the intermediate child, not the new branch", () => {
+    // Direct unit test of the defense-in-depth fix — callers (insertNode)
+    // are expected to guard against reaching this at all, but if they
+    // don't, the invariant must still hold: `minimized` is leaf-only.
+    const leaf = newLayoutNode(FlexDirection.Row, undefined, undefined, { blockId: "block" });
+    leaf.minimized = true;
+
+    const intermediate = addIntermediateNode(leaf);
+
+    assert(leaf.minimized === undefined, "the promoted node is now a branch — minimized must not stay on it");
+    assert(intermediate.minimized === true, "the intermediate child holding the original data must carry the flag");
+    assert(intermediate.data?.blockId === "block", "the intermediate child holds the original leaf's data");
+});


### PR DESCRIPTION
## Summary

Two fixes from live testing of the display-mode minimize redesign (#2197).

### 1. Slip-docking restoration

The display-mode redesign incorrectly deleted a real, deliberately spec'd product requirement (`SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md`, `SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md`) along with the buggy tree-surgery mechanism that used to implement it: a minimized pane's header should dock onto an adjacent pane (which absorbs its freed space), not render as its own separate narrow strip. Full retro on why this got lost and why restoring it correctly wasn't a hard problem: `docs/retro/retro-minimize-display-mode-lost-slip-requirement-2026-07-17.md` (included here).

Restored as pure derived geometry — no tree mutation, no restore-context bookkeeping, matching the rest of the redesign's philosophy:

- **`resolveRowSlipTargets`**: for each Row child, finds the nearest non-minimized sibling to dock onto (right-preferred, else left, scanning past other minimized siblings) — unifies the original spec's per-pane "slip" and cascading full-column "dissolve" into one rule via `isEffectivelyMinimized`.
- **`computeMainAxisAllocation`** extended with an optional `slipChildIds` set: a slip child contributes zero pixels to its row's width split, so the freed space flows entirely to its docking target.
- **A new docking pass** in `updateTreeHelper` shrinks the target's rect from the top and stacks the slip children's chip rects in that reserved space.
- Resize handles correctly disappear on a docked edge.

### 2. Insert-into-minimized-leaf corruption fix

Live testing surfaced a real corruption: a blind pane insert (heuristic-targeted, no explicit destination) had no concept of "minimized" and could select an already-minimized leaf as its insertion point. Promoting that leaf into a branch moved its data into a fresh intermediate child (inheriting the leaf's id) but left the `minimized` flag stranded on the outer node — now a branch, violating the layout doctor's leaf-only I2. The separately-maintained `minimizedNodeIds` cache then kept referencing the inherited id from before promotion, so an **expanded** pane showed a "Restore" button.

Root-caused directly from the layout doctor's own `MIN_MARKER_ON_BRANCH` log line, timestamped immediately after the triggering `CreateBlock` action.

Three-part fix, mirrored TS + Rust:
- `findNextInsertLocation`/`collect_insert_candidates` skip minimize-locked candidates entirely; `insertNode`/`insertNodeAtIndex` (both sides) gained explicit reject guards as defense-in-depth.
- `addIntermediateNode`/`ensure_group_node` hardened to correctly move the flag onto the intermediate child if ever reached anyway.
- `minimizedNodeIds` converted from an incrementally-maintained cache to a value **derived fresh from the tree on every render pass** — closes the entire desync bug class structurally, not just this one path.

### Platform scope

Both fixes are pure frontend TS + cross-platform srv Rust — no `#[cfg]`/platform-specific code paths. Applies identically on macOS/Windows/Linux.

## Test plan

- [x] 12 new tests for slip-docking (9 `resolveRowSlipTargets` edge cases, 2 width-reclaim math, 1 end-to-end integration test via the real `LayoutModel` reproducing the exact user repro)
- [x] 5 new tests for the corruption fix (2 TS pure-function, 1 `addIntermediateNode` flag-preservation, 1 TS end-to-end via the real `LayoutModel`, 1 Rust mirror) — each verified red-before/green-after against the actual reported bugs
- [x] Full `cargo test --bin agentmux-srv`: 1518 passed
- [x] Full `npx vitest run frontend/layout`: 116 passed