### PR TITLE
fix(agent): Login Again always forces fresh OAuth, opens system browser first

### DIFF
--- a/.changesets/1784376845-fix-agent-login-again-always-forces-fresh-oauth-opens-the-sy-i99i.md
+++ b/.changesets/1784376845-fix-agent-login-again-always-forces-fresh-oauth-opens-the-sy-i99i.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): Login Again always forces fresh OAuth, opens the system browser (which already has the user's session) instead of an in-app pane

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -947,13 +947,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 authProviderId={provider()?.id ?? providerKey()}
                 onSubagentClick={handleSubagentClick}
                 onAgentErrorLogin={() => {
-                    if (provider()?.id === "claude") {
-                        log("auth", "Use existing login (inline error node) — seeding from global Claude login");
-                        void status.useGlobalLogin();
-                    } else {
-                        log("auth", "Login Again (inline error node) — forcing a fresh provider login");
-                        void status.relogin();
-                    }
+                    // Must match onLoginAgain above: the button is labeled "Login
+                    // Again", so it has to force a fresh OAuth regardless of
+                    // provider. A prior version special-cased Claude into
+                    // useGlobalLogin() instead — silently reusing the (possibly
+                    // equally-stale) global credential under a "Login Again"
+                    // label, which is exactly the kind of no-op this button
+                    // exists to avoid (retro-agent-auth-relogin-noop-2026-07-01).
+                    log("auth", "Login Again (inline error node) — forcing a fresh provider login");
+                    void status.relogin();
                 }}
                 onLoadOlder={history.loadOlder}
                 loadingOlder={history.loadingOlder}

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -261,13 +261,13 @@ function AuthUrlBox(props: AuthUrlBoxProps): JSX.Element {
 
             <div class="agent-auth-url-label">1 · Authorize in your browser</div>
             <div class="agent-auth-hint">
-                A browser pane should have opened. If it didn't, open this link:
+                Your browser should have opened. If it didn't, open this link:
             </div>
             <div class="agent-auth-url-row">
                 <span class="agent-auth-url-text">{props.url}</span>
                 <button
                     class="agent-auth-url-copy"
-                    title="Open this URL in an in-app browser pane"
+                    title="Open this URL in your browser"
                     onClick={() => {
                         void import("../flows/open-oauth-pane").then(m => m.openOAuthBrowserPane(props.url));
                     }}

--- a/frontend/app/view/agent/flows/force-login.ts
+++ b/frontend/app/view/agent/flows/force-login.ts
@@ -14,7 +14,7 @@
  * or the `/login` command) we KNOW the token is bad, so we must force a fresh
  * OAuth instead of trusting the check.
  *
- * Opens the OAuth in an in-app browser pane (with the system browser as a
+ * Opens the OAuth in the system browser (with an in-app browser pane as a
  * fallback) and surfaces the URL via `setAuthUrl` so the auth box appears above
  * the composer with the URL + paste-the-code input. The running persistent
  * agent re-reads its credential per request, so it picks up the fresh token on

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -217,10 +217,11 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             if (loginUrl) {
                 setAuthUrl(loginUrl);
                 log("auth", "opening browser...");
-                // Open the OAuth URL in an in-app browser pane (the "browser
-                // window" half of SPEC_REAUTH_FROM_AUTH_ERROR); falls back to the
-                // system browser if the pane can't be created. The auth-url box
-                // above the composer is the URL backup either way.
+                // Open the OAuth URL in the system browser — it already has the
+                // user's session/cookies, so login there is more likely to
+                // auto-complete; falls back to an in-app browser pane if the
+                // system browser can't be opened. The auth-url box above the
+                // composer is the URL backup either way.
                 const opened = await openOAuthBrowserPane(loginUrl);
                 if (opened === "pane") {
                     log("auth", "opened login in an in-app browser pane — complete login there");

--- a/frontend/app/view/agent/flows/open-oauth-pane.test.ts
+++ b/frontend/app/view/agent/flows/open-oauth-pane.test.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Tests for openOAuthBrowserPane (P2.1 of SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20).
+ * Tests for openOAuthBrowserPane (P2.1 of SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20,
+ * flipped to system-browser-first — retro-agent-login-browser-2026-07-18).
  *
- * Pane-first, system-browser fallback, never-throws contract:
- *   - success → createBlock with a browser BlockDef, returns "pane"
- *   - createBlock throws → openExternal fires, returns "external"
+ * System-browser-first, in-app-pane fallback, never-throws contract:
+ *   - success → open_external fires, returns "external"
+ *   - open_external throws → createBlock with a browser BlockDef, returns "pane"
  *   - both fail → returns "failed" (no throw)
  */
 
@@ -14,12 +15,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hub = vi.hoisted(() => ({
     createBlock: vi.fn(),
-    openExternal: vi.fn(),
+    invokeCommand: vi.fn(),
 }));
 
 vi.mock("@/app/store/global", () => ({
     createBlock: hub.createBlock,
-    getApi: () => ({ openExternal: hub.openExternal }),
+}));
+
+vi.mock("@/app/platform/ipc", () => ({
+    invokeCommand: hub.invokeCommand,
 }));
 
 import { openOAuthBrowserPane } from "./open-oauth-pane";
@@ -28,32 +32,32 @@ const URL = "https://claude.ai/oauth/authorize?client_id=abc";
 
 beforeEach(() => {
     hub.createBlock.mockReset();
-    hub.openExternal.mockReset();
+    hub.invokeCommand.mockReset();
 });
 afterEach(() => vi.clearAllMocks());
 
 describe("openOAuthBrowserPane", () => {
-    it("opens an in-app browser pane and returns 'pane' on success", async () => {
+    it("opens the system browser and returns 'external' on success", async () => {
+        hub.invokeCommand.mockResolvedValue(undefined);
+        const result = await openOAuthBrowserPane(URL);
+
+        expect(result).toBe("external");
+        expect(hub.invokeCommand).toHaveBeenCalledExactlyOnceWith("open_external", { url: URL });
+        expect(hub.createBlock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to an in-app browser pane and returns 'pane' when the system browser fails", async () => {
+        hub.invokeCommand.mockRejectedValue(new Error("no shell"));
         hub.createBlock.mockResolvedValue("block-1");
         const result = await openOAuthBrowserPane(URL);
 
         expect(result).toBe("pane");
-        expect(hub.createBlock).toHaveBeenCalledTimes(1);
-        expect(hub.createBlock).toHaveBeenCalledWith({ meta: { view: "browser", url: URL } });
-        expect(hub.openExternal).not.toHaveBeenCalled();
+        expect(hub.createBlock).toHaveBeenCalledExactlyOnceWith({ meta: { view: "browser", url: URL } });
     });
 
-    it("falls back to the system browser and returns 'external' when the pane fails", async () => {
+    it("returns 'failed' (no throw) when both the system browser and pane fail", async () => {
+        hub.invokeCommand.mockRejectedValue(new Error("no shell"));
         hub.createBlock.mockRejectedValue(new Error("no layout model"));
-        const result = await openOAuthBrowserPane(URL);
-
-        expect(result).toBe("external");
-        expect(hub.openExternal).toHaveBeenCalledExactlyOnceWith(URL);
-    });
-
-    it("returns 'failed' (no throw) when both pane and system browser fail", async () => {
-        hub.createBlock.mockRejectedValue(new Error("no layout model"));
-        hub.openExternal.mockImplementation(() => { throw new Error("no shell"); });
 
         await expect(openOAuthBrowserPane(URL)).resolves.toBe("failed");
     });

--- a/frontend/app/view/agent/flows/open-oauth-pane.ts
+++ b/frontend/app/view/agent/flows/open-oauth-pane.ts
@@ -4,38 +4,36 @@
 /**
  * Open a provider login / OAuth URL for an agent re-auth.
  *
- * SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20: the user asked for "a browser window
- * + url as backup". The idiomatic, in-app "browser window" in AgentMux is a
- * **browser pane** (`createBlock({ meta: { view: "browser", url } })`), which
- * splits the current tab and renders a real CEF browser. A modal-embedded CEF
- * browser is architecturally impossible (the pane needs a native HWND child
- * window that can't be CSS-positioned inside a modal overlay).
- *
- * We split (not magnify) so the agent pane's AuthUrlBox — the URL text + the
- * paste-the-code input — stays visible beside the browser. If the in-app pane
- * can't be created (no layout model, RPC failure) we fall back to the system
- * browser via `openExternal`. The AuthUrlBox is the URL backup in either case.
+ * The system's default browser is the primary target: it already carries the
+ * user's existing session/cookies for most providers, so OAuth there is far
+ * more likely to auto-complete than in a fresh, cookie-less in-app pane
+ * (retro-agent-login-browser-2026-07-18 — the in-app pane was also fighting a
+ * separate rendering issue, but reusing the logged-in system browser is the
+ * better outcome either way). If the system browser can't be opened, we fall
+ * back to an in-app **browser pane** (`createBlock({ meta: { view: "browser",
+ * url } })`), which splits the current tab and renders a real CEF browser. The
+ * AuthUrlBox above the composer stays visible as a URL backup in both cases.
  *
  * Never throws: login UX must degrade gracefully, never crash the launch flow.
  */
 
-import { createBlock, getApi } from "@/app/store/global";
+import { createBlock } from "@/app/store/global";
+import { invokeCommand } from "@/app/platform/ipc";
 
 export type OAuthOpenResult = "pane" | "external" | "failed";
 
 export async function openOAuthBrowserPane(url: string): Promise<OAuthOpenResult> {
     try {
-        // In-app browser pane — the primary "browser window". Split beside the
-        // agent pane (magnified=false) so the AuthUrlBox paste-code input stays
-        // reachable for providers that hand back a code instead of redirecting.
-        await createBlock({ meta: { view: "browser", url } });
-        return "pane";
+        // Awaited (unlike getApi().openExternal's fire-and-forget form) so a
+        // real failure — no default browser handler, disallowed scheme, spawn
+        // error — falls through to the in-app pane instead of silently
+        // reporting "external" with nothing having opened.
+        await invokeCommand("open_external", { url });
+        return "external";
     } catch {
-        // Pane creation failed — fall back to the system browser. openExternal
-        // is fire-and-forget and swallows its own errors, so this won't throw.
         try {
-            getApi().openExternal(url);
-            return "external";
+            await createBlock({ meta: { view: "browser", url } });
+            return "pane";
         } catch {
             return "failed";
         }


### PR DESCRIPTION
## Summary
- The inline "Login Again" button in the transcript error node silently routed Claude users to `useGlobalLogin()` (reuse existing global credential) instead of `relogin()` (fresh OAuth) — mislabeled, and a genuine no-op when the global credential doesn't fix the underlying 401. It now always forces a fresh login, matching the failure banner's already-correct button.
- `openOAuthBrowserPane` now tries the system browser first (`open_external`, awaited so a real failure correctly falls through) instead of an in-app browser pane. The system browser already carries the user's session/cookies for most providers, so login is far more likely to auto-complete than in a fresh, cookie-less in-app pane — and it sidesteps a separate in-app browser-pane rendering issue currently under investigation. The in-app pane remains a fallback if the system browser can't be opened.

Both changes verified live via CDP against a running dev instance: clicking "Login Again" now correctly spawns `run_cli_login` and opens a real system Chrome window (confirmed via process list) instead of silently reusing a stale credential or creating an in-app pane.

## Test plan
- [x] Live-verified: clicking the inline "Login Again →" button now triggers `run_cli_login` (not `seed_provider_auth_from_global`)
- [x] Live-verified: the captured OAuth URL opens via `open_external` (system browser), no `object.CreateBlock` call
- [x] `npx tsc --noEmit` clean on touched files
- [ ] Manual: complete a real Claude re-login end-to-end in the system browser and confirm the agent's 401 clears

<!-- agentmux:agent_id=claude -->