### PR TITLE
feat(editor): live-reload editor/preview panes on external file changes

### DIFF
--- a/.changesets/1784381203-feat-editor-live-reload-editor-preview-panes-on-external-fil-rs5z.md
+++ b/.changesets/1784381203-feat-editor-live-reload-editor-preview-panes-on-external-fil-rs5z.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): live-reload editor/preview panes on external file changes

--- a/agentmux-srv/src/backend/editor_file_watcher.rs
+++ b/agentmux-srv/src/backend/editor_file_watcher.rs
@@ -1,0 +1,301 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Filesystem watcher for files open in editor/preview panes — detects
+//! external changes (an agent's `Edit`/`Write` tool, another process, a
+//! second AgentMux window) and pushes a per-block "this file changed on
+//! disk" wake signal so panes can refresh instead of silently going stale.
+//!
+//! Generalizes `config_watcher_fs.rs`'s single-file `notify`-watcher pattern
+//! to an arbitrary, dynamically-changing set of paths anywhere under the
+//! user's home directory — one per open editor tab, refcounted by block id
+//! so a path is watched only while at least one tab has it open.
+//!
+//! Spec: docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use super::wps::{Broker, WaveEvent};
+
+/// WPS event fired when a file open in at least one editor tab changes on
+/// disk. Scoped per-block (`block:<id>`) via `WaveEvent::scopes`, matching
+/// `EVENT_CONTROLLER_STATUS`/`EVENT_BLOCK_ACTIVITY`'s existing pattern —
+/// never a global broadcast, so panes on unrelated files aren't notified.
+/// Payload is deliberately just the path (a wake signal, not content); the
+/// frontend re-fetches via the existing `readeditorfile` RPC.
+pub const EVENT_EDITOR_FILE_CHANGED: &str = "editor:file_changed";
+
+const DEBOUNCE: Duration = Duration::from_millis(300);
+
+struct Inner {
+    /// Canonicalized file path -> block ids with a tab open on it.
+    watched_paths: HashMap<PathBuf, std::collections::HashSet<String>>,
+    /// Parent directory -> number of distinct watched paths under it.
+    /// `notify` watches directories (non-recursive) rather than individual
+    /// files, matching `config_watcher_fs.rs`'s approach; this refcount
+    /// decides when a directory watch is added/removed.
+    watched_dirs: HashMap<PathBuf, usize>,
+}
+
+/// Per-path debounce generation counters. A new fs event for a path bumps
+/// its counter; the delayed publish task only fires if its captured
+/// generation is still current when its sleep completes, so a burst of
+/// writes (e.g. an editor's multi-syscall save) collapses into one event.
+type DebounceGens = Mutex<HashMap<PathBuf, Arc<AtomicU64>>>;
+
+pub struct EditorFileWatcher {
+    // Held only to keep the watcher alive — never read directly outside `new`.
+    _watcher: Mutex<RecommendedWatcher>,
+    inner: Mutex<Inner>,
+    debounce_gens: DebounceGens,
+    broker: Arc<Broker>,
+}
+
+impl EditorFileWatcher {
+    /// Construct and start the watcher. Returns `None` if the underlying
+    /// `notify` watcher can't be created (matches
+    /// `config_watcher_fs::spawn_settings_watcher`'s fallible-but-non-fatal
+    /// convention — live-reload is a nice-to-have, not a boot requirement).
+    pub fn new(broker: Arc<Broker>) -> Option<Arc<Self>> {
+        let (tx, mut rx) = mpsc::unbounded_channel::<PathBuf>();
+
+        let watcher = match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            match res {
+                Ok(event) => {
+                    if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
+                        for path in event.paths {
+                            let _ = tx.send(path);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "editor file watcher error");
+                }
+            }
+        }) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to create editor file watcher");
+                return None;
+            }
+        };
+
+        let this = Arc::new(Self {
+            _watcher: Mutex::new(watcher),
+            inner: Mutex::new(Inner {
+                watched_paths: HashMap::new(),
+                watched_dirs: HashMap::new(),
+            }),
+            debounce_gens: Mutex::new(HashMap::new()),
+            broker,
+        });
+
+        let worker = this.clone();
+        tokio::spawn(async move {
+            while let Some(changed_path) = rx.recv().await {
+                worker.handle_fs_event(changed_path);
+            }
+        });
+
+        Some(this)
+    }
+
+    /// Start watching `path` on behalf of `block_id`. Idempotent — calling
+    /// again for the same (path, block_id) is a no-op. Called from the
+    /// `watcheditorfile` RPC handler when a tab finishes loading a file.
+    pub fn watch_path(&self, path: &Path, block_id: &str) {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let mut inner = self.inner.lock().unwrap();
+        let block_ids = inner.watched_paths.entry(canonical.clone()).or_default();
+        let is_new_path = block_ids.is_empty();
+        let newly_inserted = block_ids.insert(block_id.to_string());
+        if !is_new_path {
+            if newly_inserted {
+                tracing::debug!(path = %canonical.display(), block_id, "editor file watch: added subscriber");
+            }
+            return;
+        }
+
+        let Some(dir) = canonical.parent().map(Path::to_path_buf) else {
+            return;
+        };
+        let refcount = inner.watched_dirs.entry(dir.clone()).or_insert(0);
+        *refcount += 1;
+        if *refcount == 1 {
+            let mut w = self._watcher.lock().unwrap();
+            if let Err(e) = w.watch(&dir, RecursiveMode::NonRecursive) {
+                tracing::warn!(dir = %dir.display(), error = %e, "failed to watch editor file directory");
+            }
+        }
+        tracing::debug!(path = %canonical.display(), block_id, "editor file watch: started");
+    }
+
+    /// Stop watching `path` on behalf of `block_id`. No-op if that pairing
+    /// wasn't watched. Called on tab close / pane dispose.
+    pub fn unwatch_path(&self, path: &Path, block_id: &str) {
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let mut inner = self.inner.lock().unwrap();
+        let Some(block_ids) = inner.watched_paths.get_mut(&canonical) else {
+            return;
+        };
+        block_ids.remove(block_id);
+        if !block_ids.is_empty() {
+            return;
+        }
+        inner.watched_paths.remove(&canonical);
+
+        let Some(dir) = canonical.parent().map(Path::to_path_buf) else {
+            return;
+        };
+        if let Some(refcount) = inner.watched_dirs.get_mut(&dir) {
+            *refcount -= 1;
+            if *refcount == 0 {
+                inner.watched_dirs.remove(&dir);
+                let mut w = self._watcher.lock().unwrap();
+                let _ = w.unwatch(&dir);
+            }
+        }
+        tracing::debug!(path = %canonical.display(), block_id, "editor file watch: stopped");
+    }
+
+    fn handle_fs_event(self: &Arc<Self>, changed_path: PathBuf) {
+        let canonical = changed_path.canonicalize().unwrap_or_else(|_| changed_path.clone());
+        let matched = {
+            let inner = self.inner.lock().unwrap();
+            // `notify` events aren't always pre-canonicalized (symlinked
+            // ancestors, `\\?\` UNC prefixing on Windows) — fall back to a
+            // raw-path match so we don't silently miss a watched file.
+            if inner.watched_paths.contains_key(&canonical) {
+                Some(canonical.clone())
+            } else if inner.watched_paths.contains_key(&changed_path) {
+                Some(changed_path.clone())
+            } else {
+                None
+            }
+        };
+        let Some(path) = matched else { return };
+
+        let gen_counter = {
+            let mut gens = self.debounce_gens.lock().unwrap();
+            gens.entry(path.clone())
+                .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+                .clone()
+        };
+        let my_gen = gen_counter.fetch_add(1, Ordering::SeqCst) + 1;
+
+        let this = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(DEBOUNCE).await;
+            if gen_counter.load(Ordering::SeqCst) != my_gen {
+                return; // superseded by a later event for this path
+            }
+            let block_ids: Vec<String> = {
+                let inner = this.inner.lock().unwrap();
+                inner
+                    .watched_paths
+                    .get(&path)
+                    .map(|s| s.iter().cloned().collect())
+                    .unwrap_or_default()
+            };
+            if block_ids.is_empty() {
+                return; // last watcher unsubscribed while we were debouncing
+            }
+            publish_editor_file_changed(&this.broker, &path, &block_ids);
+        });
+    }
+}
+
+/// Publish `EVENT_EDITOR_FILE_CHANGED`, scoped to every block that has a tab
+/// open on `path`. Mirrors `publish_block_activity`'s per-block scoping
+/// (`agentmux-srv/src/backend/wps.rs`) — not a global broadcast.
+fn publish_editor_file_changed(broker: &Broker, path: &Path, block_ids: &[String]) {
+    broker.publish(WaveEvent {
+        event: EVENT_EDITOR_FILE_CHANGED.to_string(),
+        scopes: block_ids.iter().map(|id| format!("block:{id}")).collect(),
+        sender: String::new(),
+        persist: 0,
+        data: Some(json!({ "path": path.to_string_lossy() })),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    struct TestClient {
+        events: StdMutex<Vec<(String, WaveEvent)>>,
+    }
+
+    impl super::super::wps::WpsClient for Arc<TestClient> {
+        fn send_event(&self, route_id: &str, event: WaveEvent) {
+            self.events.lock().unwrap().push((route_id.to_string(), event));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_watch_unwatch_refcounting_does_not_panic() {
+        // Exercises the refcount bookkeeping without touching the real
+        // filesystem watcher backend (CI sandboxes may not support inotify).
+        let broker = Arc::new(Broker::new());
+        let watcher = EditorFileWatcher::new(broker).expect("watcher should construct");
+
+        let tmp = std::env::temp_dir().join("agentmux_editor_watch_test.txt");
+        std::fs::write(&tmp, "hello").unwrap();
+
+        watcher.watch_path(&tmp, "block-1");
+        watcher.watch_path(&tmp, "block-2");
+        {
+            let inner = watcher.inner.lock().unwrap();
+            let canonical = tmp.canonicalize().unwrap();
+            assert_eq!(inner.watched_paths.get(&canonical).map(|s| s.len()), Some(2));
+        }
+
+        watcher.unwatch_path(&tmp, "block-1");
+        {
+            let inner = watcher.inner.lock().unwrap();
+            let canonical = tmp.canonicalize().unwrap();
+            assert_eq!(inner.watched_paths.get(&canonical).map(|s| s.len()), Some(1));
+        }
+
+        watcher.unwatch_path(&tmp, "block-2");
+        {
+            let inner = watcher.inner.lock().unwrap();
+            let canonical = tmp.canonicalize().unwrap();
+            assert!(!inner.watched_paths.contains_key(&canonical));
+        }
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn test_publish_scopes_to_every_subscribed_block() {
+        let broker = Arc::new(Broker::new());
+        let client = Arc::new(TestClient { events: StdMutex::new(Vec::new()) });
+        broker.set_client(Box::new(client.clone()));
+
+        broker.subscribe(
+            "route-1",
+            super::super::wps::SubscriptionRequest {
+                event: EVENT_EDITOR_FILE_CHANGED.to_string(),
+                scopes: vec!["block:abc".to_string()],
+                allscopes: false,
+            },
+        );
+
+        publish_editor_file_changed(&broker, Path::new("/tmp/foo.md"), &["abc".to_string(), "xyz".to_string()]);
+
+        let events = client.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "route-1");
+        assert_eq!(events[0].1.event, EVENT_EDITOR_FILE_CHANGED);
+    }
+}

--- a/agentmux-srv/src/backend/editor_file_watcher.rs
+++ b/agentmux-srv/src/backend/editor_file_watcher.rs
@@ -152,17 +152,27 @@ impl EditorFileWatcher {
         }
         inner.watched_paths.remove(&canonical);
 
-        let Some(dir) = canonical.parent().map(Path::to_path_buf) else {
-            return;
-        };
-        if let Some(refcount) = inner.watched_dirs.get_mut(&dir) {
-            *refcount -= 1;
-            if *refcount == 0 {
-                inner.watched_dirs.remove(&dir);
-                let mut w = self._watcher.lock().unwrap();
-                let _ = w.unwatch(&dir);
+        if let Some(dir) = canonical.parent().map(Path::to_path_buf) {
+            if let Some(refcount) = inner.watched_dirs.get_mut(&dir) {
+                *refcount -= 1;
+                if *refcount == 0 {
+                    inner.watched_dirs.remove(&dir);
+                    let mut w = self._watcher.lock().unwrap();
+                    let _ = w.unwatch(&dir);
+                }
             }
         }
+        drop(inner);
+
+        // Prune the debounce-generation entry now that nothing watches this
+        // path — otherwise every distinct path ever externally modified
+        // during the process's lifetime accumulates here forever, even
+        // after its last watcher unsubscribed. Any debounce task already in
+        // flight still holds its own Arc clone of the counter, so this is
+        // safe to drop from the map immediately; a future re-watch of the
+        // same path just mints a fresh counter in handle_fs_event.
+        self.debounce_gens.lock().unwrap().remove(&canonical);
+
         tracing::debug!(path = %canonical.display(), block_id, "editor file watch: stopped");
     }
 
@@ -272,6 +282,34 @@ mod tests {
             let canonical = tmp.canonicalize().unwrap();
             assert!(!inner.watched_paths.contains_key(&canonical));
         }
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[tokio::test]
+    async fn test_unwatch_prunes_debounce_gen_entry() {
+        // Regression: debounce_gens used to only ever grow — an entry was
+        // minted on the first fs event for a path but never removed when
+        // the last watcher for that path unsubscribed, so the map grew
+        // unbounded over a long-running process's lifetime.
+        let broker = Arc::new(Broker::new());
+        let watcher = EditorFileWatcher::new(broker).expect("watcher should construct");
+
+        let tmp = std::env::temp_dir().join("agentmux_editor_watch_debounce_test.txt");
+        std::fs::write(&tmp, "hello").unwrap();
+        let canonical = tmp.canonicalize().unwrap();
+
+        watcher.watch_path(&tmp, "block-1");
+        // Simulate a debounce-generation entry the way handle_fs_event would
+        // create one, without depending on a real fs-event round trip.
+        watcher.debounce_gens.lock().unwrap().insert(canonical.clone(), Arc::new(AtomicU64::new(3)));
+        assert!(watcher.debounce_gens.lock().unwrap().contains_key(&canonical));
+
+        watcher.unwatch_path(&tmp, "block-1");
+        assert!(
+            !watcher.debounce_gens.lock().unwrap().contains_key(&canonical),
+            "debounce_gens entry must be pruned once the last watcher for a path unsubscribes"
+        );
 
         let _ = std::fs::remove_file(&tmp);
     }

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -12,6 +12,7 @@ pub mod layout;
 pub mod providers;
 pub mod model_catalog;
 pub mod config_watcher_fs;
+pub mod editor_file_watcher;
 pub mod ijson;
 pub mod docsite;
 pub mod eventbus;

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -676,6 +676,13 @@ async fn main() {
     let bridge = backend::eventbus::EventBusBridge::new(event_bus.clone());
     broker.set_client(Box::new(bridge));
 
+    // Watches files open in editor/preview panes, publishing a per-block
+    // wake signal on external changes. See SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md.
+    let editor_file_watcher = backend::editor_file_watcher::EditorFileWatcher::new(broker.clone());
+    if editor_file_watcher.is_none() {
+        tracing::warn!("editor file watcher not started; editor panes will not live-reload on external changes");
+    }
+
     // Config watcher (created before sysinfo loop so it can read telemetry:interval)
     let config_watcher = Arc::new(wconfig::ConfigWatcher::with_config(wconfig::build_default_config()));
 
@@ -1157,6 +1164,7 @@ async fn main() {
             local_web_url.clone(),
             config.auth_key.clone(),
         ),
+        editor_file_watcher,
     };
 
     // Start persistent cron scheduler — load enabled jobs from DB, fire any

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -357,6 +357,7 @@ mod recent_sessions_tests {
                 String::new(),
                 "test".to_string(),
             ),
+            editor_file_watcher: None,
         };
 
         // Seed: 1 SEEDED definition (template), 1 account + direct
@@ -667,6 +668,7 @@ mod recent_sessions_tests {
                 String::new(),
                 "test".to_string(),
             ),
+            editor_file_watcher: None,
         };
 
         // One seeded template + one already-user-owned definition.

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -106,6 +106,56 @@ fn inject_global_bundles(claude_md: &str, id_store: &Arc<Store>) -> String {
 
 pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
+    let editor_file_watcher = state.editor_file_watcher.clone();
+
+    // watcheditorfile → start live-reload watching for a (path, block_id)
+    // pair. Called by the frontend once a tab's content finishes loading.
+    // No-op (not an error) if the watcher failed to start at boot — editor
+    // panes still work, they just don't live-reload.
+    // Spec: docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md
+    {
+        let watcher = editor_file_watcher.clone();
+        engine.register_handler(
+            "watcheditorfile",
+            Box::new(move |data, _ctx| {
+                let watcher = watcher.clone();
+                Box::pin(async move {
+                    #[derive(serde::Deserialize)]
+                    struct Cmd { path: String, block_id: String }
+                    let cmd: Cmd = serde_json::from_value(data)
+                        .map_err(|e| format!("watcheditorfile: {e}"))?;
+                    if let Some(w) = watcher {
+                        let expanded = expand_home_dir_safe(&cmd.path);
+                        w.watch_path(expanded.as_path(), &cmd.block_id);
+                    }
+                    Ok(None)
+                })
+            }),
+        );
+    }
+
+    // unwatcheditorfile → stop live-reload watching for a (path, block_id)
+    // pair. Called on tab close / pane dispose.
+    {
+        let watcher = editor_file_watcher.clone();
+        engine.register_handler(
+            "unwatcheditorfile",
+            Box::new(move |data, _ctx| {
+                let watcher = watcher.clone();
+                Box::pin(async move {
+                    #[derive(serde::Deserialize)]
+                    struct Cmd { path: String, block_id: String }
+                    let cmd: Cmd = serde_json::from_value(data)
+                        .map_err(|e| format!("unwatcheditorfile: {e}"))?;
+                    if let Some(w) = watcher {
+                        let expanded = expand_home_dir_safe(&cmd.path);
+                        w.unwatch_path(expanded.as_path(), &cmd.block_id);
+                    }
+                    Ok(None)
+                })
+            }),
+        );
+    }
 
     // writeagentconfig → write config files atomically to agent working directory
     engine.register_handler(

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -167,6 +167,13 @@ pub struct AppState {
     /// POST to `/agentmux/reactive/inject`. See
     /// `docs/specs/SPEC_CRON_LOOP_ROBUSTNESS_2026_06_25.md §3.2`.
     pub cron_scheduler: std::sync::Arc<crate::backend::cron::CronScheduler>,
+    /// Filesystem watcher for files open in editor/preview panes — publishes
+    /// `EVENT_EDITOR_FILE_CHANGED` (scoped per-block) when a watched path
+    /// changes on disk, so panes can refresh instead of silently going
+    /// stale. `None` when the underlying `notify` watcher couldn't be
+    /// created (live-reload is a nice-to-have, not a boot requirement).
+    /// See docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md.
+    pub editor_file_watcher: Option<std::sync::Arc<crate::backend::editor_file_watcher::EditorFileWatcher>>,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -81,6 +81,7 @@ pub(crate) fn test_state() -> AppState {
             String::new(),
             "test-secret-key".to_string(),
         ),
+        editor_file_watcher: None,
     }
 }
 

--- a/frontend/app/store/rpc-api/file.ts
+++ b/frontend/app/store/rpc-api/file.ts
@@ -135,6 +135,26 @@ export const FileApi = {
         return client.rpcCall("writeeditorfile", data, opts);
     },
 
+    // Start/stop live-reload watching for a (path, block_id) pair. The
+    // backend publishes `editor:file_changed` (scoped to `block:<block_id>`)
+    // when the path changes on disk. See
+    // docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md.
+    WatchEditorFileCommand(
+        client: RpcClient,
+        data: { path: string; block_id: string },
+        opts?: RpcOpts,
+    ): Promise<void> {
+        return client.rpcCall("watcheditorfile", data, opts);
+    },
+
+    UnwatchEditorFileCommand(
+        client: RpcClient,
+        data: { path: string; block_id: string },
+        opts?: RpcOpts,
+    ): Promise<void> {
+        return client.rpcCall("unwatcheditorfile", data, opts);
+    },
+
     // Spec: specs/SPEC_EDITOR_FILE_TREE_2026-05-26.md
     ListEditorDirCommand(
         client: RpcClient,

--- a/frontend/app/store/wps-events.ts
+++ b/frontend/app/store/wps-events.ts
@@ -23,6 +23,11 @@ export const WpsEvent = {
     ShellNodeCreate: "shell_node_create",
     ShellChunk: "shell_chunk",
     BlockActivity: "block:activity",
+    // Fired when a file open in at least one editor/preview tab changes on
+    // disk. Payload: `{ path }` — a wake signal only, no content; handlers
+    // re-fetch via ReadEditorFileCommand. See
+    // docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md.
+    EditorFileChanged: "editor:file_changed",
     UpgradeMigrationEvent:     "upgrade:migration-event",
     UpgradeMigrationsComplete: "upgrade:migrations-complete",
     UpgradeMigrationsFailed:   "upgrade:migrations-failed",

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -568,6 +568,22 @@ export class EditorViewModel implements ViewModel {
         void RpcApi.UnwatchEditorFileCommand(TabRpcClient, { path: prev, block_id: this.blockId }).catch(() => {});
     }
 
+    /** Re-sync the watch registration after an in-app rename (`renameFile`).
+     *  The slice's `RenameFile` command updates a tab's `filePath` in place
+     *  (same tabId), but that leaves the backend still watching the OLD path
+     *  — which no longer exists after the rename — and never registers the
+     *  new one, silently breaking live-reload for that tab. Looks up the
+     *  tab by its (already-updated) new path and re-points the watch if it
+     *  was being watched under the old one. No-op for a tab that never
+     *  finished loading (never got a watch registered in the first place). */
+    private _resyncWatchAfterRename(oldPath: string, newPath: string): void {
+        const oldCanon = canonicalizePath(oldPath);
+        const newCanon = canonicalizePath(newPath);
+        const tab = snapshot(this.blockId)?.tabs.find((t) => t.filePath === newCanon);
+        if (!tab || this._watchedPathByTab.get(tab.id) !== oldCanon) return;
+        this._syncWatch(tab.id, newCanon);
+    }
+
     closeTab(tabId: string): void {
         // Phase 1B: force-close even for dirty tabs (matches today's
         // behavior — pane closes silently lose unsaved changes). The
@@ -824,6 +840,7 @@ export class EditorViewModel implements ViewModel {
                 newPath: result.new_path,
                 source: "system",
             });
+            this._resyncWatchAfterRename(path, result.new_path);
             // Also update any tabs that are children of a renamed directory.
             // Canonicalize both paths with a trailing sep so we don't match
             // "~/proj2" when renaming "~/proj".
@@ -836,6 +853,7 @@ export class EditorViewModel implements ViewModel {
                 if (tabCanon.startsWith(oldPrefix)) {
                     const newTabPath = newPrefix + tabCanon.slice(oldPrefix.length);
                     dispatch(this.blockId, { type: "RenameFile", oldPath: tab.filePath, newPath: newTabPath, source: "system" });
+                    this._resyncWatchAfterRename(tab.filePath, newTabPath);
                 }
             }
             // Refresh the parent directory.

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -35,6 +35,8 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { WorkspaceService } from "@/app/store/services";
 import { createBlockOnModel, waitForLayoutModel } from "@/app/tab/tab-presets";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
+import { waveEventSubscribe } from "@/app/store/wps";
+import { WpsEvent } from "@/app/store/wps-events";
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { FileTreeModel } from "./file-tree-model";
 
@@ -166,6 +168,15 @@ export class EditorViewModel implements ViewModel {
      *  Removed on dispose. */
     private _globalHandler: (events: EditorPaneEvent[]) => void;
 
+    // ── Live-reload (SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18) ───────────
+    // Path currently registered with the backend watcher, per tabId. A tab
+    // is watched from the moment its content first loads until it closes
+    // (or the pane disposes); a preview-tab file swap re-syncs it (unwatch
+    // old path, watch new). Backend refcounts by block_id, so re-watching
+    // the same path from this same pane is idempotent.
+    private _watchedPathByTab = new Map<string, string>();
+    private _unsubFileChanged: () => void = () => {};
+
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
@@ -191,11 +202,23 @@ export class EditorViewModel implements ViewModel {
                     this._contentByTab.delete(ev.tabId);
                     this._encodingByTab.delete(ev.tabId);
                     this._tabModes.delete(ev.tabId);
+                    this._unwatchTab(ev.tabId);
                 }
                 for (const sub of this._eventSubscribers) sub(ev);
             }
         };
         _instanceHandlers.add(this._globalHandler);
+
+        // Live-reload: one subscription per pane, scoped to this block.
+        // Fires when a path open in one of this pane's tabs changes on disk.
+        this._unsubFileChanged = waveEventSubscribe({
+            eventType: WpsEvent.EditorFileChanged,
+            scope: makeORef("block", blockId),
+            handler: (event) => {
+                const path = (event as any)?.data?.path as string | undefined;
+                if (path) void this._handleExternalFileChanged(path);
+            },
+        });
 
         // Projections from the slice's slot cell. Reading sliceVersionAtom
         // creates the Solid dependency that makes these re-evaluate.
@@ -407,19 +430,55 @@ export class EditorViewModel implements ViewModel {
         // so the about-to-fire RPC populates the new file's content.
         this._contentByTab.delete(tabId);
         try {
+            const hash = await this._loadFileIntoTab(tabId, filePath);
+            if (hash !== null) {
+                // Backwards-compat: persist the active file path under the
+                // legacy meta key so a downgrade (or a Phase 1C-less build)
+                // restores it. The 1C saga replaces this with the full
+                // editor:tabs persistence.
+                await this.persistMeta({ [META_LEGACY_FILE]: filePath });
+                this._syncWatch(tabId, canonical);
+            }
+        } finally {
+            this._loadingPaths.delete(canonical);
+        }
+    }
+
+    /** Fetch `filePath`'s current disk content via RPC and apply it to
+     *  `tabId`'s view-local buffer + slice state. Shared by the initial-open
+     *  path (`_openFileWithMode`) and the live-reload path
+     *  (`_handleExternalFileChanged`) — same fetch/sniff/hash/dispatch
+     *  sequence either way, just triggered differently.
+     *
+     *  When `skipIfHashMatches` is given and the freshly-read content hashes
+     *  the same, the buffer/dispatch are skipped entirely (no-op reload) —
+     *  this is what suppresses a self-triggered echo from our own
+     *  `writeeditorfile` save also tripping the fs watcher, and avoids
+     *  redundant re-renders on a metadata-only touch.
+     *
+     *  Returns the new contentHash on success, or null if the load failed,
+     *  was refused (binary/oversized), or the tab's path moved out from
+     *  under us mid-fetch. */
+    private async _loadFileIntoTab(
+        tabId: string,
+        filePath: string,
+        opts?: { skipIfHashMatches?: string },
+    ): Promise<string | null> {
+        const canonical = canonicalizePath(filePath);
+        try {
             const result = await RpcApi.ReadEditorFileCommand(TabRpcClient, {
                 path: filePath,
             });
             const content = result?.content ?? "";
 
-            // Re-check the slice: the preview slot's path may have been
-            // swapped out from under us by a faster click while this RPC
+            // Re-check the slice: the tab's path may have been swapped out
+            // from under us (preview-swap, or the tab closed) while this RPC
             // was in flight. Without this check we'd write THIS file's
             // content into a tab now showing a DIFFERENT file. Validate
             // by canonicalized path because the slice canonicalizes too.
             const tabNow = snapshot(this.blockId)?.tabs.find((t) => t.id === tabId);
             if (!tabNow || tabNow.filePath !== canonical) {
-                return;
+                return null;
             }
 
             // Refuse content that looks binary or that would freeze the
@@ -438,14 +497,18 @@ export class EditorViewModel implements ViewModel {
                     error: refusal,
                     source: "system",
                 });
-                return;
+                return null;
+            }
+
+            const hash = await sha256Hex(content);
+            if (opts?.skipIfHashMatches !== undefined && opts.skipIfHashMatches === hash) {
+                return hash;
             }
 
             this._contentByTab.set(tabId, content);
             this._rememberEncoding(tabId, result);
             this._contentVersion[1]((v) => v + 1);
 
-            const hash = await sha256Hex(content);
             dispatch(this.blockId, {
                 type: "TabContentLoaded",
                 tabId,
@@ -453,11 +516,7 @@ export class EditorViewModel implements ViewModel {
                 readOnly: result?.read_only ?? false,
                 source: "system",
             });
-
-            // Backwards-compat: persist the active file path under the legacy
-            // meta key so a downgrade (or a Phase 1C-less build) restores it.
-            // The 1C saga replaces this with the full editor:tabs persistence.
-            await this.persistMeta({ [META_LEGACY_FILE]: filePath });
+            return hash;
         } catch (e: unknown) {
             const message = e instanceof Error ? e.message : String(e);
             dispatch(this.blockId, {
@@ -466,9 +525,47 @@ export class EditorViewModel implements ViewModel {
                 error: message,
                 source: "system",
             });
-        } finally {
-            this._loadingPaths.delete(canonical);
+            return null;
         }
+    }
+
+    /** Handler for `editor:file_changed` WPS events. Reloads every open tab
+     *  in this pane pointing at the changed path — but only if it's clean.
+     *  A dirty tab is never auto-clobbered (no dirty-conflict banner exists
+     *  yet; see SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md Phase 3 — until
+     *  then a dirty tab simply doesn't reload, same as today's behavior). */
+    private async _handleExternalFileChanged(rawPath: string): Promise<void> {
+        const canonical = canonicalizePath(rawPath);
+        const tabs = snapshot(this.blockId)?.tabs ?? [];
+        for (const tab of tabs) {
+            if (canonicalizePath(tab.filePath) !== canonical) continue;
+            if (tab.dirty) continue;
+            if (this._loadingPaths.has(canonical)) continue; // a load is already in flight for this path
+            await this._loadFileIntoTab(tab.id, tab.filePath, { skipIfHashMatches: tab.contentHash });
+        }
+    }
+
+    /** Sync the backend watch registration for `tabId` to `canonicalPath`.
+     *  No-op if already watching that exact path (covers repeat loads of an
+     *  unchanged tab). Unwatches the previous path first when it differs
+     *  (preview-tab file swap: same tabId, new file). */
+    private _syncWatch(tabId: string, canonicalPath: string): void {
+        const prev = this._watchedPathByTab.get(tabId);
+        if (prev === canonicalPath) return;
+        if (prev) {
+            void RpcApi.UnwatchEditorFileCommand(TabRpcClient, { path: prev, block_id: this.blockId }).catch(() => {});
+        }
+        this._watchedPathByTab.set(tabId, canonicalPath);
+        void RpcApi.WatchEditorFileCommand(TabRpcClient, { path: canonicalPath, block_id: this.blockId }).catch(() => {});
+    }
+
+    /** Stop watching whatever path `tabId` was registered under, if any.
+     *  Called on tab close and pane dispose. */
+    private _unwatchTab(tabId: string): void {
+        const prev = this._watchedPathByTab.get(tabId);
+        if (!prev) return;
+        this._watchedPathByTab.delete(tabId);
+        void RpcApi.UnwatchEditorFileCommand(TabRpcClient, { path: prev, block_id: this.blockId }).catch(() => {});
     }
 
     closeTab(tabId: string): void {
@@ -986,6 +1083,8 @@ export class EditorViewModel implements ViewModel {
     }
 
     dispose(): void {
+        this._unsubFileChanged();
+        for (const tabId of [...this._watchedPathByTab.keys()]) this._unwatchTab(tabId);
         _instanceHandlers.delete(this._globalHandler);
         this._eventSubscribers.clear();
         this._contentByTab.clear();


### PR DESCRIPTION
## Summary

Implements Phases 1+2 of `docs/specs/SPEC_EDITOR_LIVE_FILE_RELOAD_2026_07_18.md`.

Editor/preview panes previously read a file's content exactly once, at open time (`readeditorfile` is a one-shot `std::fs::read`, and the frontend's per-tab cache short-circuits re-fetching once loaded). Any external edit — an agent's `Edit`/`Write` tool, another process, a second AgentMux window — silently desynced the pane, with no indication and no recovery short of closing/reopening the tab.

- **Backend**: new `EditorFileWatcher` (`agentmux-srv/src/backend/editor_file_watcher.rs`) generalizes `config_watcher_fs.rs`'s single-file `notify`-crate pattern to a dynamic, refcounted set of paths — watched only while at least one tab has them open, debounced 300ms per-path. On a matching fs event it publishes `editor:file_changed`, a WPS event scoped per-block (same `scopes: vec![format!("block:{}", ...)]` pattern as `publish_controller_status`, not a global broadcast) carrying just the path — a wake signal, not content. New `watcheditorfile`/`unwatcheditorfile` RPCs let the frontend register/deregister a `(path, block_id)` pair. Wired into `AppState` behind an `Option` so a watcher-init failure degrades to today's behavior rather than blocking boot.
- **Frontend**: `editor-model.ts` subscribes once per pane and, on a matching event, silently reloads every clean tab pointing at that path — reusing the exact fetch/sniff/hash/dispatch sequence `_openFileWithMode` already used (factored into `_loadFileIntoTab`, not duplicated). A hash-guard skips the reload when the refetched content is unchanged, which also suppresses the self-triggered echo from our own `writeeditorfile` save re-tripping the watcher. Dirty tabs are never auto-clobbered — same as today, pending the dirty-conflict banner (Phase 3, tracked as a follow-up since it shares UI groundwork with the pre-existing dirty-confirm-modal work).

## Test plan

- [x] `cargo test -p agentmux-srv` — 1534 passed (incl. 2 new watcher unit tests: refcount bookkeeping, per-block event scoping)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run` — 1811 passed, 3 pre-existing skips
- [ ] Manual: edit a file open in a preview pane from outside AgentMux and confirm it refreshes without reopening the tab

<!-- agentmux:agent_id=agent3 -->