### PR TITLE
fix(cef,srv): cascade-aware browser-pane teardown on tab/workspace delete

### DIFF
--- a/.changesets/1784391769-fix-cef-srv-cascade-aware-browser-pane-teardown-on-tab-works-ap5i.md
+++ b/.changesets/1784391769-fix-cef-srv-cascade-aware-browser-pane-teardown-on-tab-works-ap5i.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef,srv): cascade-aware browser-pane teardown on tab/workspace delete

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -198,6 +198,15 @@ fn pane_close_idempotent_for_missing() {
     let mut state = HostState::default();
     let out = update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "missing".into() });
     assert!(out.events.is_empty()); // idempotent no-op
+    // The load-bearing property for issue #2218 B.4:
+    // BrowserPaneManager::close() (browser_panes.rs) checks exactly this
+    // field to decide whether to do any HWND/UI-thread work at all. B.4
+    // calls close() unconditionally for every block_id cascaded out of a
+    // deleted tab/workspace (most of which are never browser panes), so
+    // this field staying None for an unknown block_id is what makes that
+    // safe — pin it explicitly, not just via the events-are-empty proxy
+    // above.
+    assert!(out.closed_browser_pane_label.is_none());
 }
 
 // ── H.1.d (PR #5) — TryRegisterBrowserPaneLive / EnqueueBrowserPaneClose return-values

--- a/agentmux-cef/src/srv_ipc.rs
+++ b/agentmux-cef/src/srv_ipc.rs
@@ -138,6 +138,17 @@ pub async fn connect_to_srv(
                             _ => &[],
                         };
                         for block_id in cascaded_block_ids {
+                            // Cancel any pending HTTP-auth callback parked for
+                            // this pane BEFORE tearing it down — mirrors the
+                            // established `browser_pane_close` invokeCommand
+                            // path (ipc.rs), which does the same ordering for
+                            // the same reason: without this, a pane torn down
+                            // via this cascade path while an auth prompt is
+                            // pending leaks the CEF AuthCallback for the full
+                            // 5-minute TTL instead of being cancelled
+                            // immediately. No-op (returns 0) for a block_id
+                            // with nothing pending, same as `close()` below.
+                            crate::browser_pane::auth::cancel_for_block(block_id);
                             state_for_reader.browser_panes.close(block_id, &state_for_reader);
                         }
                         crate::srv_event_bridge::dispatch_to_renderers(&state_for_reader, &event);

--- a/agentmux-cef/src/srv_ipc.rs
+++ b/agentmux-cef/src/srv_ipc.rs
@@ -119,6 +119,27 @@ pub async fn connect_to_srv(
                 Ok(Some(line)) if line.trim().is_empty() => continue,
                 Ok(Some(line)) => match serde_json::from_str::<Event>(&line) {
                     Ok(event) => {
+                        // B.4 (issue #2218): tear down any browser-pane
+                        // renderer implicated by this delete, independent of
+                        // whether a live renderer has that tab loaded to
+                        // notice via the normal BrowserView-unmount ->
+                        // invokeCommand("browser_pane_close") path. close()
+                        // is a guaranteed no-op for a block_id with no
+                        // browser_panes entry (browser_panes.rs), so calling
+                        // it unconditionally for every cascaded block_id —
+                        // including a large tab/workspace delete where only
+                        // one block happens to be a browser pane — is safe.
+                        let cascaded_block_ids: &[String] = match &event {
+                            Event::BlockDeleted { block_id, .. } => {
+                                std::slice::from_ref(block_id)
+                            }
+                            Event::TabDeleted { block_ids, .. } => block_ids.as_slice(),
+                            Event::WorkspaceDeleted { block_ids, .. } => block_ids.as_slice(),
+                            _ => &[],
+                        };
+                        for block_id in cascaded_block_ids {
+                            state_for_reader.browser_panes.close(block_id, &state_for_reader);
+                        }
                         crate::srv_event_bridge::dispatch_to_renderers(&state_for_reader, &event);
                     }
                     Err(e) => {

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -1290,6 +1290,15 @@ pub enum Event {
     /// Phase E.2 — workspace was deleted.
     WorkspaceDeleted {
         workspace_id: String,
+        /// Every block_id cascaded out with this workspace (every block in
+        /// every tab it contained) — `TabDeleted`/`WorkspaceDeleted` never
+        /// emitted per-block events (see `reducer/tab.rs::handle_delete_tab`),
+        /// so this is the host's only signal to tear down a browser-pane
+        /// renderer whose tab/workspace was deleted while unloaded/inactive
+        /// (issue #2218, B.4). `#[serde(default)]` so replaying an old
+        /// saga-log entry (predating this field) still deserializes.
+        #[serde(default)]
+        block_ids: Vec<String>,
         version: u64,
     },
     /// Phase E.2b — tab was created inside a workspace. Carries the
@@ -1305,6 +1314,10 @@ pub enum Event {
     TabDeleted {
         workspace_id: String,
         tab_id: String,
+        /// Every block_id cascaded out with this tab. See `WorkspaceDeleted`'s
+        /// `block_ids` doc — same rationale (issue #2218, B.4).
+        #[serde(default)]
+        block_ids: Vec<String>,
         version: u64,
     },
     /// Phase E.2b — a workspace's active tab changed. `tab_id: None`

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -489,7 +489,7 @@ fn format_srv_event(e: &Event) -> String {
         Event::WorkspaceCreated { workspace_id, name, version } => {
             format!("v={:>3} WorkspaceCreated   id={} name={}", version, workspace_id, name)
         }
-        Event::WorkspaceDeleted { workspace_id, version } => {
+        Event::WorkspaceDeleted { workspace_id, version, .. } => {
             format!("v={:>3} WorkspaceDeleted   id={}", version, workspace_id)
         }
         Event::TabCreated { workspace_id, tab_id, name, version } => {

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -1298,6 +1298,7 @@ mod tests {
         apply_event_to_wstore(
             &Event::WorkspaceDeleted {
                 workspace_id: "ghost".into(),
+                block_ids: Vec::new(),
                 version: 1,
             },
             &s,
@@ -1991,6 +1992,7 @@ mod tests {
         apply_event_to_wstore(
             &Event::WorkspaceDeleted {
                 workspace_id: ws.oid.clone(),
+                block_ids: Vec::new(),
                 version: 1,
             },
             &s,

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -1192,6 +1192,121 @@ mod tests {
         assert!(!state.workspaces.contains_key(&ws_id));
     }
 
+    /// issue #2218 (B.4): TabDeleted/WorkspaceDeleted never emitted a
+    /// per-block BlockDeleted, so the host had no signal to tear down a
+    /// browser-pane renderer whose tab/workspace was deleted while it was
+    /// never live/loaded in a window. `block_ids` on these events is that
+    /// signal — this test locks the cascade actually carries them.
+    #[test]
+    fn delete_tab_emits_cascaded_block_ids() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "t1".into() },
+            &ctx(1),
+        );
+        let tab1_id = state.workspaces[&ws_id].tab_ids[0].clone();
+        // A second tab so the delete isn't a last-tab delete (needs force).
+        let _ = update(
+            &mut state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "t2".into() },
+            &ctx(2),
+        );
+        let block1 = match &update(
+            &mut state,
+            Command::CreateBlock { tab_id: tab1_id.clone(), meta: serde_json::Value::Null },
+            &ctx(3),
+        )[0] {
+            Event::BlockCreated { block_id, .. } => block_id.clone(),
+            other => panic!("expected BlockCreated, got {:?}", other),
+        };
+        let block2 = match &update(
+            &mut state,
+            Command::CreateBlock { tab_id: tab1_id.clone(), meta: serde_json::Value::Null },
+            &ctx(4),
+        )[0] {
+            Event::BlockCreated { block_id, .. } => block_id.clone(),
+            other => panic!("expected BlockCreated, got {:?}", other),
+        };
+        let events = update(
+            &mut state,
+            Command::DeleteTab { workspace_id: ws_id, tab_id: tab1_id, force: false },
+            &ctx(5),
+        );
+        match &events[0] {
+            Event::TabDeleted { block_ids, .. } => {
+                assert_eq!(block_ids.len(), 2);
+                assert!(block_ids.contains(&block1));
+                assert!(block_ids.contains(&block2));
+            }
+            other => panic!("expected TabDeleted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn delete_tab_with_zero_blocks_emits_empty_block_ids() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "t1".into() },
+            &ctx(1),
+        );
+        let tab1_id = state.workspaces[&ws_id].tab_ids[0].clone();
+        let _ = update(
+            &mut state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "t2".into() },
+            &ctx(2),
+        );
+        let events = update(
+            &mut state,
+            Command::DeleteTab { workspace_id: ws_id, tab_id: tab1_id, force: false },
+            &ctx(3),
+        );
+        match &events[0] {
+            Event::TabDeleted { block_ids, .. } => assert!(block_ids.is_empty()),
+            other => panic!("expected TabDeleted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn delete_workspace_emits_cascaded_block_ids_across_all_tabs() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab1_id = create_tab(&mut state, &ws_id, "t1");
+        let tab2_id = create_tab(&mut state, &ws_id, "t2");
+        let mut expected = Vec::new();
+        for (i, tab_id) in [&tab1_id, &tab2_id].into_iter().enumerate() {
+            for j in 0..2 {
+                let block_id = match &update(
+                    &mut state,
+                    Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
+                    &ctx(10 + (i * 2 + j) as u64),
+                )[0] {
+                    Event::BlockCreated { block_id, .. } => block_id.clone(),
+                    other => panic!("expected BlockCreated, got {:?}", other),
+                };
+                expected.push(block_id);
+            }
+        }
+        assert_eq!(expected.len(), 4);
+        let events = update(
+            &mut state,
+            Command::DeleteWorkspace { workspace_id: ws_id.clone(), force: false },
+            &ctx(20),
+        );
+        match &events[0] {
+            Event::WorkspaceDeleted { block_ids, .. } => {
+                assert_eq!(block_ids.len(), 4);
+                for b in &expected {
+                    assert!(block_ids.contains(b));
+                }
+            }
+            other => panic!("expected WorkspaceDeleted, got {:?}", other),
+        }
+    }
+
     fn create_tab(state: &mut State, workspace_id: &str, name: &str) -> String {
         let events = update(
             state,

--- a/agentmux-srv/src/reducer/tab.rs
+++ b/agentmux-srv/src/reducer/tab.rs
@@ -139,7 +139,14 @@ pub(super) fn handle_delete_tab(
     // Phase E.3 — cascade to blocks. Subscribers observing TabDeleted
     // are expected to drop dependent block state (no per-block
     // BlockDeleted events emitted; mirrors workspace→tabs cascade
-    // semantics).
+    // semantics). `block_ids` on the event below carries the cascaded ids
+    // anyway (issue #2218, B.4) — the host uses it to tear down any
+    // browser-pane renderer that was never live/loaded in a window and so
+    // never got a chance to reach the renderer-mediated close path.
+    let cascaded_block_ids: Vec<String> = removed_tab
+        .as_ref()
+        .map(|t| t.block_ids.clone())
+        .unwrap_or_default();
     if let Some(tab) = &removed_tab {
         for block_id in &tab.block_ids {
             state.blocks.remove(block_id);
@@ -150,6 +157,7 @@ pub(super) fn handle_delete_tab(
     events.push(Event::TabDeleted {
         workspace_id: workspace_id.clone(),
         tab_id,
+        block_ids: cascaded_block_ids,
         version: v,
     });
     if let Some(new_active) = active_changed {

--- a/agentmux-srv/src/reducer/workspace.rs
+++ b/agentmux-srv/src/reducer/workspace.rs
@@ -58,8 +58,14 @@ pub(super) fn handle_delete_workspace(
     let Some(removed) = state.workspaces.remove(&workspace_id) else {
         return Vec::new();
     };
+    // `cascaded_block_ids` rides the WorkspaceDeleted event below so the
+    // host can tear down any browser-pane renderer whose block was never
+    // live/loaded in a window (issue #2218, B.4) — same rationale as
+    // TabDeleted's `block_ids` (reducer/tab.rs::handle_delete_tab).
+    let mut cascaded_block_ids: Vec<String> = Vec::new();
     for tab_id in &removed.tab_ids {
         if let Some(tab) = state.tabs.remove(tab_id) {
+            cascaded_block_ids.extend(tab.block_ids.iter().cloned());
             for block_id in &tab.block_ids {
                 state.blocks.remove(block_id);
             }
@@ -83,6 +89,7 @@ pub(super) fn handle_delete_workspace(
     let v = state.bump_version();
     events.push(Event::WorkspaceDeleted {
         workspace_id,
+        block_ids: cascaded_block_ids,
         version: v,
     });
     for window_id in dropped_window_ids {


### PR DESCRIPTION
## Summary
Item 2 of the B.4/B.5 commit-charge-growth plan (issue #2218). Base branch note: this stacks conceptually on #2220 (item 1, threshold fix) but has no file overlap — mergeable independently.

A browser-pane block's renderer only reliably tears down today via a *renderer-mediated* path: a live window has that tab loaded, its React `BrowserView` unmounts, and that fires `invokeCommand("browser_pane_close")` → `BrowserPaneManager::close()`. If no open window has that tab loaded (inactive tab, no window open, API-driven delete), the host never hears about it and the renderer leaks for the life of the process.

Deeper than the direct-delete case: closing a *tab* or deleting a *workspace* containing a browser pane never gave the host any signal at all — `handle_delete_tab`/`handle_delete_workspace` cascade blocks out of srv's own state but only emitted `TabDeleted`/`WorkspaceDeleted` (no per-block event), by explicit design ("mirrors workspace→tabs cascade semantics"). Almost certainly more common in practice than deleting a single block via the API.

Both events now carry the cascaded `block_ids` (`#[serde(default)]`, backward-compatible with replayed saga-log JSON). The host's `srv_ipc.rs` read loop calls `BrowserPaneManager::close()` for every block_id implicated by whichever event just arrived, unconditionally — `close()` is already a guaranteed no-op for a block_id with no `browser_panes` entry, so this is safe even for a 50-block tab close where only one block happens to be a browser pane.

## Test plan
- [x] `agentmux-srv` reducer: `delete_tab_emits_cascaded_block_ids`, `delete_tab_with_zero_blocks_emits_empty_block_ids`, `delete_workspace_emits_cascaded_block_ids_across_all_tabs` — 120/120 reducer tests pass
- [x] `agentmux-srv` persist_subscriber: 33/33 pass (2 test-construction sites updated for the new `Event` field)
- [x] `agentmux-cef` reducer: strengthened `pane_close_idempotent_for_missing` to explicitly assert `closed_browser_pane_label.is_none()` — the exact safety property this PR's unconditional-close-call design leans on
- [x] `cargo check --workspace --tests` — clean
- [ ] Manual: open a browser pane in a tab, close the *tab* (not the block), confirm via `muxlog host grep "browser pane closed"` that the renderer tears down despite no direct `browser_pane_close` IPC ever firing — this is the actual regression target and needs a live build to verify

<!-- agentmux:agent_id=agenta -->