### PR TITLE
fix(ci): wire patched CEF into nightly macOS + fix Linux tag resolver

### DIFF
--- a/.github/workflows/ci-nightly-artifacts.yml
+++ b/.github/workflows/ci-nightly-artifacts.yml
@@ -116,6 +116,7 @@ jobs:
       contents: write
     env:
       OUT: ${{ github.workspace }}/artifacts
+      CEF_RUNTIME_DIR_DARWIN: ${{ github.workspace }}/cef-runtime-darwin
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -132,6 +133,40 @@ jobs:
       - run: npm install
       - name: Install go-task
         run: brew install go-task
+      # Patched CEF framework (BeginWindowDrag). Mirrors the Linux block below;
+      # see docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md
+      # Piece 2. Without this, task bundle:darwin falls through to the
+      # cef-dll-sys cargo-cache fallback (stock upstream CEF), which
+      # verify-cef-framework-darwin.sh correctly refuses to package.
+      - name: Resolve patched macOS CEF framework tag
+        id: cef
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+                  --json tagName --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Cache patched macOS CEF framework
+        id: cef-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CEF_RUNTIME_DIR_DARWIN }}
+          key: cef-runtime-darwin-${{ steps.cef.outputs.tag }}
+      - name: Download patched macOS CEF framework
+        if: steps.cef-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
+        run: |
+          mkdir -p /tmp/cef-x "$CEF_RUNTIME_DIR_DARWIN"
+          gh release download "${{ steps.cef.outputs.tag }}" \
+            --repo agentmuxai/cef --pattern "*.tar.gz" --dir /tmp/cef-x --clobber
+          tar -xzf /tmp/cef-x/*.tar.gz -C /tmp/cef-x
+          FW=$(find /tmp/cef-x -name "Chromium Embedded Framework.framework" -maxdepth 3 | head -1)
+          if [ -z "$FW" ]; then echo "ERROR: framework not found in tarball"; exit 1; fi
+          ditto "$FW" "$CEF_RUNTIME_DIR_DARWIN/Chromium Embedded Framework.framework"
+          rm -rf /tmp/cef-x
+      - name: Set AGENTMUX_CEF_RUNTIME_DIR_DARWIN
+        run: echo "AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$CEF_RUNTIME_DIR_DARWIN" >> "$GITHUB_ENV"
       - name: Import Developer ID certificate into temp keychain
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -215,8 +250,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
         run: |
-          TAG=$(gh release list --repo agentmuxai/cef --limit 1 \
-                  --json tagName --jq '.[0].tagName')
+          # agentmuxai/cef holds both platforms' releases interleaved by date —
+          # filter by the Linux prefix so a newer macOS tag can't shadow it
+          # (this bit us: the unfiltered --limit 1 grabbed a macOS tarball with
+          # no libcef.so inside, see docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md).
+          TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
+                  --json tagName --jq '[.[].tagName | select(startswith("cef-linux-x86_64-"))][0]')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Cache patched libcef.so
         id: cef-cache


### PR DESCRIPTION
## Summary
- `ci-nightly-artifacts.yml`'s `macos` job never provisioned the patched CEF framework (missed in `SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md` Piece 2), so it fell through to the unpatched `cef-dll-sys` cargo-cache fallback — `verify-cef-framework-darwin.sh` correctly refused to package it, failing every nightly run since 2026-07-11 (8 days straight).
- `build-macos.yml` and `release.yml` already had this wiring correctly; this brings the nightly workflow's macOS job in line with them (same steps, same env var).
- Also fixes the `linux` job's CEF tag resolver: it used an unfiltered `gh release list --limit 1` which grabbed whichever platform's tag is newest in `agentmuxai/cef` — today it picked up a macOS tarball, then failed with "libcef.so not found in tarball". Filters by the `cef-linux-x86_64-` prefix now, matching `build-linux.yml`'s already-fixed resolver.

## Test plan
- [ ] Nightly artifacts workflow (`workflow_dispatch`) run to confirm macOS job resolves `cef-macos-arm64-148.23.21` and passes the patch-verify gate
- [ ] Same run confirms Linux job resolves a `cef-linux-x86_64-*` tag, not a macOS one
- [ ] Windows job unaffected (untouched by this diff)