### PR TITLE
fix(swarm): group solo dispatches by slug when display_name isn't resolved yet

### DIFF
--- a/.changesets/1784431564-fix-swarm-group-solo-dispatches-by-slug-when-display-name-un-iccs.md
+++ b/.changesets/1784431564-fix-swarm-group-solo-dispatches-by-slug-when-display-name-un-iccs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): group solo dispatches by slug when display_name unresolved

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -224,13 +224,56 @@ describe("buildDispatchChildren", () => {
             expect(childId(result[0])).toBe("a1");
         });
 
-        it("leaves subagents with no display_name yet as loose, ungrouped rows even if several exist", () => {
+        it("leaves subagents with no display_name AND no slug as loose, ungrouped rows even if several exist", () => {
             const result = buildDispatchChildren(
                 [],
                 [mk({ agent_id: "a1", display_name: null }), mk({ agent_id: "a2", display_name: null })]
             );
             expect(result).toHaveLength(2);
             expect(result.every((c) => !isNameGroup(c))).toBe(true);
+        });
+
+        it("collapses 2+ solo dispatches sharing only a slug (no display_name resolved yet) into one NameGroup", () => {
+            // The common case: Claude Code stamps one slug per CLI session on
+            // every subagent it spawns (not per-subagent), and display_name
+            // only resolves once a client manually expands a row — so most
+            // solo dispatches are seen here with display_name: null and an
+            // identical slug. Without the slug fallback, a session with many
+            // solo Task-tool calls renders one row per call at the top level,
+            // which is the "dozens of copies of the same slug" regression.
+            const result = buildDispatchChildren(
+                [],
+                [
+                    mk({ agent_id: "a1", display_name: null, slug: "quizzical-tumbling-valiant" }),
+                    mk({ agent_id: "a2", display_name: null, slug: "quizzical-tumbling-valiant" }),
+                    mk({ agent_id: "a3", display_name: null, slug: "quizzical-tumbling-valiant" }),
+                ]
+            );
+            expect(result).toHaveLength(1);
+            const group = result[0];
+            expect(isNameGroup(group)).toBe(true);
+            if (isNameGroup(group)) {
+                expect(group.name).toBe("quizzical-tumbling-valiant");
+                expect(group.totalCount).toBe(3);
+            }
+        });
+
+        it("prefers display_name over slug as the grouping key — a named member does not join its same-slug siblings' slug-keyed group", () => {
+            const result = buildDispatchChildren(
+                [],
+                [
+                    mk({ agent_id: "a1", display_name: null, slug: "shared-slug" }),
+                    mk({ agent_id: "a2", display_name: null, slug: "shared-slug" }),
+                    mk({ agent_id: "a3", display_name: "Named Differently", slug: "shared-slug" }),
+                ]
+            );
+            const groups = result.filter(isNameGroup);
+            // a1/a2 collapse under the shared slug; a3 (resolved display_name)
+            // is its own loose row since nothing else shares "Named Differently".
+            expect(groups).toHaveLength(1);
+            expect(groups[0].name).toBe("shared-slug");
+            expect(groups[0].totalCount).toBe(2);
+            expect(result.some((c) => !isNameGroup(c) && !isWorkflowDispatch(c) && c.agent_id === "a3")).toBe(true);
         });
 
         it("workflow dispatches take priority — same-named subagents in a workflow never form a NameGroup", () => {

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -113,19 +113,23 @@ export interface WorkflowDispatch {
 
 /**
  * A group of solo-dispatch subagents (no Workflow-tool run — a Solo
- * `AgentDispatch` each) that independently earned the same Haiku-generated
- * `display_name`. A user repeatedly spawning similar tasks (e.g. "review this
- * file" across many files) legitimately gets the same/near-identical name for
- * each invocation — the naming model doing its job, not a malfunction — but
- * left flat that reads as "dozens of duplicate rows." A subagent belonging to
- * a Workflow dispatch never enters this grouping pass, regardless of name —
- * it's already represented by its one `WorkflowDispatch` row.
+ * `AgentDispatch` each) that share one grouping key: `display_name` once a
+ * client has resolved it (Haiku-generated, on-demand), or `slug` before that —
+ * see `groupKeyFor` below. A user repeatedly spawning similar tasks (e.g.
+ * "review this file" across many files) legitimately gets the same/
+ * near-identical name for each invocation — the naming model doing its job,
+ * not a malfunction — but left flat that reads as "dozens of duplicate rows."
+ * A subagent belonging to a Workflow dispatch never enters this grouping
+ * pass, regardless of name — it's already represented by its one
+ * `WorkflowDispatch` row.
  */
 export interface NameGroup {
     kind: "nameGroup";
-    /** The shared display_name — always non-empty; grouping only fires once
-     *  a name exists (display_name is null before subagent.GenerateName
-     *  resolves), so ungrouped/unnamed subagents never form a NameGroup. */
+    /** The shared grouping key (`display_name` if resolved, else `slug`) —
+     *  always non-empty; see `groupKeyFor`. A member that later gets its own
+     *  `display_name` resolved (via `subagent.GenerateName`) migrates out of
+     *  a slug-keyed group into a display_name-keyed one on the next
+     *  `buildDispatchChildren()` pass — no explicit "ungroup" step needed. */
     name: string;
     /** Every member's shared parent_block_id — buildDispatchChildren is
      *  always called with an already block-filtered subagent list (see
@@ -166,13 +170,30 @@ export interface AgentTreeNode {
 }
 
 /**
+ * A solo dispatch's grouping key: its resolved `display_name` if a client
+ * has already expanded it once (Haiku-generated via `subagent.GenerateName`),
+ * else its `slug`. Falling back to `slug` here — instead of leaving
+ * not-yet-named subagents ungrouped — matters because `slug` is itself
+ * usually shared across an entire CLI session/batch (see
+ * `subagentDisplayLabel`'s doc comment below), so a session that has spawned
+ * many solo Task-tool calls and never had any of them individually expanded
+ * would otherwise render every single one as its own top-level row — the
+ * exact "one line per Agent Tool call/workflow" goal (SPEC §5/§7) violated
+ * by omission, not by a grouping bug. Empty string is treated as "no key"
+ * (both fields can legitimately be empty before either resolves).
+ */
+function groupKeyFor(s: ActiveSubagent): string {
+    return s.display_name || s.slug;
+}
+
+/**
  * Build one block's tree children from its `AgentDispatch`es (already
  * block-filtered) and raw `SubAgent`s. Every Workflow-kind dispatch becomes
  * exactly one `WorkflowDispatch` row (SPEC §7 — never one row per member).
  * Every Solo-kind dispatch's one member renders as a plain `ActiveSubagent`
- * row, no wrapper (SPEC §5) — among those, two or more sharing an identical,
- * non-empty `display_name` still collapse into a `NameGroup` (grouping
- * solo DISPATCHES now, not raw subagents, but every subagent has exactly one
+ * row, no wrapper (SPEC §5) — among those, two or more sharing a
+ * `groupKeyFor` value still collapse into a `NameGroup` (grouping solo
+ * DISPATCHES now, not raw subagents, but every subagent has exactly one
  * dispatch so the input set is the same). Result is sorted by most recent
  * activity, mixing loose subagents and both group kinds in one recency order.
  */
@@ -211,10 +232,11 @@ export function buildDispatchChildren(
     const stillLoose: ActiveSubagent[] = [...orphanedWorkflowMembers];
     const byName = new Map<string, ActiveSubagent[]>();
     for (const s of solo) {
-        if (s.display_name) {
-            const members = byName.get(s.display_name) ?? [];
+        const key = groupKeyFor(s);
+        if (key) {
+            const members = byName.get(key) ?? [];
             members.push(s);
-            byName.set(s.display_name, members);
+            byName.set(key, members);
         } else {
             stillLoose.push(s);
         }


### PR DESCRIPTION
## Summary

Root-caused a live UX report: under AgentA's swarm pane, dozens of rows all showed the identical name "quizzical-tumbling-valiant."

Traced to raw JSONL transcripts: Claude Code stamps one `slug` per CLI **session**, not per subagent — every subagent spawned within one session inherits the same literal slug (confirmed against 5 distinct historical subagent transcripts in this session, all carrying `"slug": "quizzical-tumbling-valiant"`). This is expected/documented CLI behavior, not a bug in this repo.

`buildDispatchChildren` (swarm-model.ts) already collapses solo dispatches sharing a **`display_name`** into one `NameGroup` row (task #44) — but `display_name` only resolves lazily, via `subagent.GenerateName`, when a client manually expands a row. Until then, every never-expanded solo dispatch renders as its own top-level row, all showing the same slug text. The SPEC §5/§7 "one row per AgentDispatch" grouping is structurally correct underneath (confirmed via srv logs: ~50 genuinely distinct historical dispatches, correctly tracked by separate `dispatch_id`s) — the only actual defect is the *default label* making them look like duplicates.

## Change

Widen `NameGroup`'s grouping key from `display_name` alone to `display_name ?? slug` (`groupKeyFor`). A member that later gets its own `display_name` resolved migrates out of the slug-keyed group automatically on the next `buildDispatchChildren()` pass — no explicit "ungroup" step needed.

Frontend-only change; no backend/RPC/wire changes.

## Test plan

- [x] `npx vitest run frontend/app/view/swarm/swarm-model.test.ts` — 37/37 passing, including 3 new tests: slug-only grouping, display_name-takes-priority-over-slug, and the pre-existing "no key at all" no-op case
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [ ] Manual: reload the swarm pane in a session with several un-expanded solo dispatches sharing a slug; confirm they collapse into one `NameGroup` row instead of N loose rows

<!-- agentmux:agent_id=agenta -->