### PR TITLE
chore(ci): de-duplicate CEF-provisioning logic in release.yml

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,6 +32,26 @@ on:
   repository_dispatch:
     types: [build-linux]
     # client_payload: { ref: "vX.Y.Z", release_tag: "vX.Y.Z", cef_runtime_tag: "" }
+  workflow_call:
+    # Lets release.yml invoke this as a reusable workflow instead of inlining
+    # a second copy of the CEF-provisioning steps. `inputs.*` below is
+    # populated from the caller's `with:` block exactly like workflow_dispatch
+    # — the "Resolve inputs" step needs no changes for this path.
+    inputs:
+      ref:
+        description: "agentmux ref to build (tag / branch / SHA)"
+        required: true
+        type: string
+      release-tag:
+        description: "GitHub release tag to upload the AppImage to (blank = skip upload)"
+        required: false
+        type: string
+        default: ""
+      cef-runtime-tag:
+        description: "agentmuxai/cef release tag for patched libcef.so (blank = latest)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write   # needed to upload release assets via GITHUB_TOKEN

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,6 +33,26 @@ on:
   repository_dispatch:
     types: [build-macos]
     # client_payload: { ref: "vX.Y.Z", release_tag: "vX.Y.Z", cef_runtime_tag: "" }
+  workflow_call:
+    # Lets release.yml invoke this as a reusable workflow instead of inlining
+    # a second copy of the CEF-provisioning + signing/notarization steps.
+    # `inputs.*` below is populated from the caller's `with:` block exactly
+    # like workflow_dispatch — the "Resolve inputs" step needs no changes.
+    inputs:
+      ref:
+        description: "agentmux ref to build (tag / branch / SHA)"
+        required: true
+        type: string
+      release-tag:
+        description: "GitHub release tag to upload the DMG to (blank = skip upload)"
+        required: false
+        type: string
+        default: ""
+      cef-runtime-tag:
+        description: "agentmuxai/cef release tag for patched framework (blank = latest macOS)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write   # needed to upload release assets via GITHUB_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,111 +146,24 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # Reuses build-linux.yml's own job instead of inlining a second copy of the
+  # CEF-provisioning steps (previously ~100 lines duplicated verbatim — see
+  # docs/analysis/ANALYSIS_CI_WORKFLOW_CATALOG_2026_07_18.md §2.2). release-tag
+  # is left blank: the release doesn't exist yet at this point in the pipeline
+  # (publish creates it after all three platforms finish) — the reused
+  # workflow's own `actions/upload-artifact` step (name: linux-appimage) is
+  # what `publish` downloads below, exactly as when this was inlined.
   build-linux:
     name: Build — Linux AppImage
     needs: verify
-    runs-on: ubuntu-22.04
-    env:
-      OUT: ${{ github.workspace }}/artifacts
-      CEF_RUNTIME_DIR: ${{ github.workspace }}/cef-runtime
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1-ubuntu22-release"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Auth npm for @a5af GitHub Packages
-        run: |
-          {
-            echo "@a5af:registry=https://npm.pkg.github.com"
-            echo "//npm.pkg.github.com/:_authToken=${{ secrets.A5AF_PACKAGES_TOKEN }}"
-          } >> .npmrc
-
-      - run: npm install
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build \
-            libwayland-dev libxkbcommon-dev libgtk-3-dev \
-            libglib2.0-dev libpango1.0-dev libcairo2-dev \
-            libgdk-pixbuf2.0-dev libatk1.0-dev
-
-      - name: Install go-task
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-
-      - name: Resolve patched libcef.so tag
-        id: cef
-        env:
-          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
-        run: |
-          # agentmuxai/cef holds BOTH platforms' releases — filter to the Linux
-          # x86_64 prefix (a bare --limit 1 would grab whichever platform released
-          # most recently, e.g. a macOS framework, and break the libcef.so lookup).
-          TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                  --json tagName \
-                  --jq '[.[].tagName | select(startswith("cef-linux-x86_64-"))][0]')
-          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
-            echo "❌ no cef-linux-x86_64-* release found in agentmuxai/cef" >&2
-            exit 1
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Cache patched libcef.so
-        id: cef-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CEF_RUNTIME_DIR }}
-          key: cef-runtime-${{ steps.cef.outputs.tag }}
-
-      - name: Download patched libcef.so
-        if: steps.cef-cache.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
-        run: |
-          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR"
-          gh release download "${{ steps.cef.outputs.tag }}" \
-            --repo agentmuxai/cef --pattern "*.tar.gz" \
-            --dir /tmp/cef-extract --clobber
-          tar -xzf /tmp/cef-extract/*.tar.gz -C /tmp/cef-extract
-          LIBCEF=$(find /tmp/cef-extract -name "libcef.so" | head -1)
-          if [ -z "$LIBCEF" ]; then echo "ERROR: libcef.so not found in tarball"; exit 1; fi
-          cp -r "$(dirname "$LIBCEF")/." "$CEF_RUNTIME_DIR/"
-          rm -rf /tmp/cef-extract
-
-      - name: Set AGENTMUX_CEF_RUNTIME_DIR
-        run: echo "AGENTMUX_CEF_RUNTIME_DIR=$CEF_RUNTIME_DIR" >> "$GITHUB_ENV"
-
-      - name: Install appimagetool
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -fsSL -o "$HOME/.local/bin/appimagetool" \
-            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
-          chmod +x "$HOME/.local/bin/appimagetool"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          echo "APPIMAGE_EXTRACT_AND_RUN=1" >> "$GITHUB_ENV"
-
-      - name: Build AppImage
-        run: |
-          mkdir -p "$OUT"
-          RELEASE_CHANNEL=stable bash scripts/package-linux.sh "$OUT"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: linux-appimage
-          path: ${{ env.OUT }}/AgentMux_*_amd64.AppImage
-          if-no-files-found: error
-          retention-days: 7
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      ref: ${{ github.event.inputs.tag || github.ref }}
+      release-tag: ""
+      cef-runtime-tag: ""
+    secrets: inherit
 
   # check-macos probes the APPLE_CEF_AVAILABLE secret and exposes it as a job
   # output, because the `secrets` context is not available in job-level `if`
@@ -271,140 +184,25 @@ jobs:
             echo "available=false" >> $GITHUB_OUTPUT
           fi
 
+  # Reuses build-macos.yml's own job instead of inlining a second copy of the
+  # CEF-provisioning + signing/notarization steps (previously ~135 lines
+  # duplicated verbatim — see docs/analysis/ANALYSIS_CI_WORKFLOW_CATALOG_2026_07_18.md
+  # §2.2). release-tag is left blank: the release doesn't exist yet at this
+  # point (publish creates it after all three platforms finish) — the reused
+  # workflow's own `actions/upload-artifact` step (name: macos-dmg) is what
+  # `publish` downloads below, exactly as when this was inlined.
   build-macos:
     name: Build — macOS arm64 DMG
     needs: [verify, check-macos]
     if: needs.check-macos.outputs.available == 'true'
-    runs-on: macos-latest
     permissions:
       contents: write
-    env:
-      OUT: ${{ github.workspace }}/artifacts
-      CEF_RUNTIME_DIR_DARWIN: ${{ github.workspace }}/cef-runtime-darwin
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
-
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Auth npm for @a5af GitHub Packages
-        run: |
-          {
-            echo "@a5af:registry=https://npm.pkg.github.com"
-            echo "//npm.pkg.github.com/:_authToken=${{ secrets.A5AF_PACKAGES_TOKEN }}"
-          } >> .npmrc
-
-      - run: npm install
-
-      - name: Install go-task
-        run: brew install go-task
-
-      # ── Patched CEF framework ─────────────────────────────────────────────
-      # The upstream cef-dll-sys framework lacks CefWindow::BeginWindowDrag, so
-      # native window drag / floating-pane resize silently no-ops on macOS. Download
-      # the pre-built PATCHED framework (agentmuxai/cef release) and point
-      # AGENTMUX_CEF_RUNTIME_DIR_DARWIN at it — the macOS analogue of build-linux's
-      # patched-libcef.so download. package-macos.sh's patch gate then verifies the
-      # framework carries BeginWindowDrag before signing.
-      # See docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md.
-      - name: Resolve patched CEF framework tag
-        id: cef
-        env:
-          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
-        run: |
-          # agentmuxai/cef holds BOTH platforms' releases — filter to macOS arm64
-          # (a bare --limit 1 would grab whichever platform released most recently).
-          TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                  --json tagName \
-                  --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
-          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
-            echo "❌ no cef-macos-arm64-* release found in agentmuxai/cef" >&2
-            exit 1
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved patched CEF framework tag: $TAG"
-
-      - name: Cache patched CEF framework
-        id: cef-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CEF_RUNTIME_DIR_DARWIN }}
-          key: cef-runtime-darwin-${{ steps.cef.outputs.tag }}
-
-      - name: Download patched CEF framework
-        if: steps.cef-cache.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
-        run: |
-          mkdir -p /tmp/cef-extract "$CEF_RUNTIME_DIR_DARWIN"
-          gh release download "${{ steps.cef.outputs.tag }}" \
-            --repo agentmuxai/cef \
-            --pattern "*.tar.gz" \
-            --dir /tmp/cef-extract \
-            --clobber
-          tar -xzf /tmp/cef-extract/*.tar.gz -C /tmp/cef-extract
-          # Find the .framework regardless of whether the tarball has a top-level dir
-          FW=$(find /tmp/cef-extract -maxdepth 3 -name "Chromium Embedded Framework.framework" -type d | head -1)
-          if [ -z "$FW" ]; then echo "❌ framework not found in tarball"; exit 1; fi
-          # ditto preserves the Versions/Current symlink chain the CEF loader follows.
-          ditto "$FW" "$CEF_RUNTIME_DIR_DARWIN/Chromium Embedded Framework.framework"
-          rm -rf /tmp/cef-extract
-
-      - name: Set AGENTMUX_CEF_RUNTIME_DIR_DARWIN
-        run: echo "AGENTMUX_CEF_RUNTIME_DIR_DARWIN=$CEF_RUNTIME_DIR_DARWIN" >> "$GITHUB_ENV"
-
-      - name: Import Developer ID certificate
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH="$RUNNER_TEMP/build-${{ github.run_id }}.keychain"
-          KEYCHAIN_PASS="$(uuidgen)"
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PASS=$KEYCHAIN_PASS" >> "$GITHUB_ENV"
-          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
-          security default-keychain -s "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
-          security set-keychain-settings -t 3600 -u "$KEYCHAIN_PATH"
-          echo "$APPLE_CERTIFICATE" | base64 --decode > /tmp/cert.p12
-          security import /tmp/cert.p12 \
-            -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign -T /usr/bin/security
-          rm -f /tmp/cert.p12
-          security set-key-partition-list \
-            -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
-
-      - name: Store notarytool credentials
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          xcrun notarytool store-credentials "notarytool" \
-            --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" --keychain "$KEYCHAIN_PATH" --no-validate
-
-      - name: Build, sign, and notarize DMG
-        run: |
-          mkdir -p "$OUT"
-          task package:macos -- "$OUT"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: macos-dmg
-          path: ${{ env.OUT }}/AgentMux_*_arm64.dmg
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Delete temp keychain
-        if: always()
-        run: security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      ref: ${{ github.event.inputs.tag || github.ref }}
+      release-tag: ""
+      cef-runtime-tag: ""
+    secrets: inherit
 
   # ── Phase 3: Publish GitHub Release ───────────────────────────────────────
   # GitHub Releases is the single source of truth for distribution. The landing

--- a/docs/analysis/ANALYSIS_CI_WORKFLOW_CATALOG_2026_07_18.md
+++ b/docs/analysis/ANALYSIS_CI_WORKFLOW_CATALOG_2026_07_18.md
@@ -1,0 +1,251 @@
+# CI Workflow Catalog — What We Have, What's Redundant, What to Cut
+
+**Date:** 2026-07-18
+**Primary scope:** `agentmuxai/agentmux` `.github/workflows/` (12 registered workflows)
+**Also checked:** `agentmuxai/agentmux-builder`, `agentmuxai/agentmux-landing`,
+`agentmuxai/cef`, `a5af/shared-infrastructure` — cross-repo context needed to
+answer this doc's own open questions (see §5). Could not locate `a5af/dev-tools`
+or `agentmuxai/dev-tools` under any spelling — flagged in §5.4.
+**Trigger:** investigating the nightly-macOS CEF gate failure (PR #2223) surfaced
+that the repo has two similarly-named "nightly" build workflows and a monitoring
+system (`a5af/shared-infrastructure`'s `gh-reporter`) that only watches one of
+them. That prompted a full inventory.
+
+---
+
+## 1. The catalog
+
+| # | Workflow (name) | File | Trigger | Purpose | Last activity | Status |
+|---|---|---|---|---|---|---|
+| 1 | CI (PR) — compile tests + run | `ci-pr.yml` | every PR + push to `main` | `cargo check --workspace --tests` + `cargo test` (Windows required, Ubuntu non-blocking) + `vitest`. The merge-time gate. | Runs constantly, all green | **Essential** |
+| 2 | CI — nightly cross-platform build + test | `ci-nightly-build.yml` | schedule 07:00 UTC + manual | `cargo build --release --workspace` + `cargo test` + `vitest`, matrix over Windows/Ubuntu/macOS (Windows required, others non-blocking). | Daily, all green | **Mostly redundant — see §2.1** |
+| 3 | CI — nightly artifacts (all platforms) | `ci-nightly-artifacts.yml` | schedule 06:00 UTC + manual | Full packaging health-check: builds + signs + notarizes a real DMG/AppImage/portable-ZIP+installer+MSIX for all 3 platforms, uploads as workflow artifacts (not a GitHub release). | Daily; **macOS leg failing 19 days straight** (fix in #2223) | **Essential — was silently broken** |
+| 4 | build-linux | `build-linux.yml` | manual / `repository_dispatch` | On-demand: build **one** platform's AppImage from an arbitrary ref, optionally upload to an existing GitHub release. | **Last run 2026-06-25** (23 days ago), several releases since | **Idle but intentional break-glass tool — see §2.2, §5.1** |
+| 5 | build-macos | `build-macos.yml` | manual / `repository_dispatch` | Same as #4 but for the signed+notarized macOS DMG. | **Last run 2026-06-25** (23 days ago) | **Idle but intentional break-glass tool — see §2.2, §5.1** |
+| 6 | Release | `release.yml` | push tag `vX.Y.Z` + manual | The actual release pipeline: verify version consistency → build Windows/Linux/macOS → publish GitHub Release → WinGet + MS Store submission → trigger landing-page deploy. | Fires on every release (07-03, 07-04, 07-07, 07-11, 07-15), all green | **Essential** |
+| 7 | Release consistency check | `release-consistency.yml` | PR/push touching `VERSION_HISTORY.md` | Deterministic CI gate for the 5-location version-agreement invariant (post-mortem: `retro-release-version-desync-2026-05-22.md`). Fast, no build. | Fires only on release PRs, all green | **Essential, well-scoped** |
+| 8 | Container Agent Image | `container-image.yml` | push tag `v*` + manual | Builds + pushes the `agentmuxai/agent-claude` Docker image (amd64+arm64) to GHCR. | Fires alongside every release tag | **Essential, distinct purpose** |
+| 9 | Input-handler layout-read guardrail | `input-handler-layout-reads.yml` | schedule 10:00 UTC + manual | Grep gate: no `scrollHeight`/`getBoundingClientRect`/etc. on the keystroke path (regression class: 22ms/keystroke reflow, `agent-typing-lag-trace-2026-04-12.md`). | Daily, all green, sub-minute job | **Keep — near-duplicate shape of #10, could merge files** |
+| 10 | Input-handler sync-IPC guardrail | `input-handler-sync-ipc.yml` | schedule 10:00 UTC + manual | Grep gate: no blocking IPC on the keystroke path before paint. | Daily, all green, sub-minute job | **Keep — near-duplicate shape of #9, could merge files** |
+| 11 | Input-latency bench (report) | `input-bench-report.yml` | manual only | Keystroke/echo latency benchmark vs. committed baseline. **Requires a self-hosted runner labeled `input-bench` that does not exist** — the job queues forever. | **Zero runs, ever** | **Dead — see §2.3** |
+| 12 | Kimi Code Review | `kimi-review.yml` | (registered, not on `main`) | Community PR auto-reviewer (Kimi model). File only exists on the unmerged, abandoned branch `agenty/kimi-community-reviewer` (last commit 2026-05-05). GitHub still lists it "active" because it ran twice there. | 2 runs total, both on 2026-05-06, **both failed**, on its own branch | **Ghost — see §2.4** |
+
+---
+
+## 2. Findings
+
+### 2.1 Two "nightly" workflows, only one of which is watched
+
+`ci-nightly-build.yml` ("build + test") and `ci-nightly-artifacts.yml`
+("artifacts") sound like variants of the same thing and are easy to conflate —
+which is exactly what happened: `gh-reporter` (the nightly health-report Lambda
+in `a5af/shared-infrastructure`) hardcodes `NIGHTLY_BUILD_WORKFLOW =
+"ci-nightly-build.yml"` and has never watched the artifacts workflow. Result:
+the artifacts pipeline's macOS leg was broken for 19 consecutive days while the
+nightly email reported all-green, because the thing it checked (does the code
+compile and pass tests) was genuinely fine the whole time.
+
+Now that `ci-pr.yml` runs `cargo check --tests` + `cargo test` on **every PR**
+for Windows (required) and Ubuntu (non-blocking) — added 2026-06-23 specifically
+because manual-only release workflows and diff-only review were letting broken
+test builds merge unnoticed (issues #1823, #1876) — `ci-nightly-build.yml`'s
+Windows and Ubuntu legs are now redundant with a much tighter, per-PR gate.
+**Its only remaining unique value is the macOS compile leg**, which nothing else
+covers (no PR-time macOS compile check exists).
+
+### 2.2 `build-linux.yml` / `build-macos.yml` — real tooling, just idle for 23 days
+
+**Update after checking `agentmuxai/agentmux-builder` (§5.1): this is not
+dead code.** Its README explicitly documents these two workflows, living in
+the public `agentmux` repo on purpose, as the break-glass path — "rebuild one
+platform's artifact against an *existing* release, without re-running the whole
+pipeline" — with worked `gh workflow run` examples. The 23-day idle period isn't
+neglect, it's the expected shape of a rarely-needed tool: every release since
+2026-06-25 went through `release.yml` cleanly enough that nobody needed a
+single-platform patch. That's a *good* sign, not evidence of cruft.
+
+The real issue is still duplication, not disuse: their packaging logic is
+**fully copy-pasted, not called** — `release.yml`'s own `build-linux`/`build-macos`
+jobs inline the identical CEF-resolve/cache/download steps rather than
+dispatching to these workflows. That's three independent copies of the same
+~40-line CEF-provisioning block across `build-linux.yml`, `build-macos.yml`, and
+`release.yml` (plus a fourth, until today's fix, in `ci-nightly-artifacts.yml`
+— exactly how the Linux resolver bug and the missing macOS wiring both
+happened: a fix landed in one copy and silently didn't propagate to the
+others). Keep the capability, collapse the copies.
+
+### 2.3 `input-bench-report.yml` — dead on arrival
+
+Zero runs, ever. It requires a self-hosted runner labeled `input-bench` that,
+per the workflow's own comment, "does not exist" — every dispatch just queues
+forever with nothing to pick it up. This was correctly scoped as
+`workflow_dispatch`-only and clearly labeled as blocked on infra that was never
+provisioned; it's not broken, it's just not live.
+
+### 2.4 `kimi-review.yml` — a ghost workflow
+
+Registered as "active" in the Actions tab, but the file doesn't exist on `main`
+— it only exists on `agenty/kimi-community-reviewer`, a branch that was never
+merged and hasn't been touched since 2026-05-05. Its only two runs (2026-05-06)
+both failed. GitHub keeps workflows that ran at least once listed as "active"
+even after the source branch goes stale, which is why it still shows up
+alongside the 11 real ones.
+
+### 2.5 Minor: the two input-handler guardrails are near-identical shape
+
+`input-handler-layout-reads.yml` and `input-handler-sync-ipc.yml` are
+byte-for-byte the same trigger, same runner, same single-step structure —
+differing only in which lint script they invoke. Not a correctness issue, just
+file sprawl; trivial to fold into one workflow with two jobs (or a matrix) if
+reducing the *count* of workflow files is a goal, at no loss of function.
+
+---
+
+## 3. Proposed distillation — status
+
+Ordered by confidence. All decided/executed 2026-07-18 except one deliberately
+deferred item — see §6 for the actual PRs.
+
+1. ✅ **Done.** Fixed the monitoring gap: `a5af/shared-infrastructure` PR #382
+   adds an independently-watched `ci-nightly-artifacts.yml` section to
+   `gh-reporter` rather than swapping which workflow it watches (swapping just
+   relocates the blind spot — the two workflows fail independently).
+
+2. ✅ **Done.** Deleted `input-bench-report.yml` — `agentmuxai/agentmux` PR #2225.
+
+3. ✅ **Done.** Deleted the abandoned `agenty/kimi-community-reviewer` branch —
+   confirmed with Asaf, no plans to revive it. Removes the ghost workflow entry.
+
+4. ✅ **Done, revised scope.** `build-linux.yml`/`build-macos.yml` kept (confirmed
+   intentional). De-duplicated the CEF-provisioning logic — `release.yml`'s
+   `build-linux`/`build-macos` jobs now call the two standalone workflows as
+   *reusable workflows* (`workflow_call`, not `repository_dispatch` — that
+   trigger can't block on / consume outputs from the dispatched run, so it
+   wasn't actually usable for this) instead of inlining a third copy of the
+   same ~40-line block. `agentmuxai/agentmux` PR (pending open, see §6).
+   (`agentmux-builder`'s `build-windows.yml` — the Windows sibling — is moot;
+   the repo it lived in was deleted 2026-07-18, see §5.1.)
+
+5. ⏸ **Deferred — Asaf's call.** Asked directly: keep all three platforms in
+   `ci-nightly-build.yml`'s nightly matrix, intentionally, as an independent
+   signal from `ci-pr.yml` rather than pure overlap. No change made.
+
+6. ✅ **Done.** Merged `input-handler-layout-reads.yml` +
+   `input-handler-sync-ipc.yml` into one `input-handler-guardrails.yml` with two
+   jobs — `agentmuxai/agentmux` PR #2225 (same PR as item 2).
+
+**Not touched:** `ci-pr.yml`, `ci-nightly-artifacts.yml`, `release.yml`,
+`release-consistency.yml`, `container-image.yml` — each covers a distinct,
+currently-exercised need with no overlap.
+
+---
+
+## 4. Open questions — resolved
+
+- ~~Is `kimi-review.yml` intended to come back?~~ Resolved: no, deleted the
+  branch (§3.3).
+- ~~Is the Windows/Ubuntu leg of `ci-nightly-build.yml` deliberately
+  redundant with `ci-pr.yml`?~~ Resolved: yes, intentional — keeping as-is
+  (§3.5).
+- ~~`build-windows.yml` in `agentmux-builder`~~ — resolved: repo deleted
+  2026-07-18 (§5.1), question moot.
+
+---
+
+## 5. Cross-repo context
+
+You asked whether I'd checked `agentmux-landing`, the rest of
+`a5af/shared-infrastructure`, `a5af/dev-tools`, and `agentmuxai/cef` — I hadn't,
+beyond the one `gh-reporter` file from the earlier monitoring-gap thread. Here's
+what each actually contains, and what it resolves.
+
+### 5.1 `agentmuxai/agentmux-builder` — deleted 2026-07-18, was reference-only
+
+**Update:** this repo has since been deleted. Per Asaf: it was deprecated —
+AgentMux is open source and doesn't need a separate private repo to manage
+signing secrets, so `agentmux-builder` was being kept around purely for
+reference, and its stale docs (§4.2's outdated example commands, the
+never-validated `build-windows.yml`) were actively causing confusion rather
+than adding value. All signing secrets live directly in the public
+`agentmux` repo. The analysis below is preserved as a record of what it
+contained and why it doesn't change any conclusion in this report — the repo
+itself is gone.
+
+Its own README stated the architecture explicitly:
+
+> **Status (2026-06): native-CEF CI across all three platforms.**
+> - `build-windows.yml` (here) — builds the portable + Inno Setup installer...
+>   **Needs runner validation.**
+> - `build-macos.yml` + `build-linux.yml` — live in `agentmuxai/agentmux`
+>   (public repo, unlimited free CI minutes)...
+
+So `build-linux.yml`/`build-macos.yml` living in the public `agentmux` repo,
+separate from `agentmux-builder`, is the *documented, intended* split — not
+architectural drift. `agentmux-builder` exists specifically to keep Apple/
+signing secrets out of the public repo's Action logs while still using free CI
+minutes for the platforms that don't need those secrets managed there. I also
+grepped `github-router/lambda/router.py` and did an org-wide code search in
+`a5af/shared-infrastructure` for `build-linux`/`build-macos`/
+`repository_dispatch` — zero hits, confirming nothing external triggers them
+either. Combined: real, deliberately-placed, rarely-needed break-glass tooling.
+Recommendation in §3.4 updated accordingly (keep, de-duplicate).
+
+`agentmux-builder` hosted exactly one workflow, `build-windows.yml` — the
+Windows sibling of the same family. Unlike its macOS/Linux counterparts, it had
+**zero runs, ever**, and carried its own status banner: "⚠️ initial scaffold —
+VALIDATE ON A RUNNER before relying on it." It was also missing its signing
+secrets (`SIGNPATH_*` "not set; deferred"), so even a first run would have
+produced an unsigned installer. That workflow, and the org's only Windows
+single-platform-rebuild path, no longer exists anywhere — it's gone with the
+repo, not migrated. If a Windows equivalent to `build-linux.yml`/`build-macos.yml`
+is ever wanted, it'd need to be rebuilt from scratch (or from git history —
+`agentmuxai/agentmux-builder` isn't recoverable, but nothing in it was unique;
+Windows packaging logic already exists in `release.yml` and
+`ci-nightly-artifacts.yml` in the public repo).
+
+### 5.2 `agentmuxai/agentmux-landing` (private)
+
+One workflow: `landing-deploy.yml`, triggered by `repository_dispatch`. Its run
+timestamps (07-15, 07-11, 07-07) line up exactly with `release.yml`'s tag-push
+runs in the main repo — confirming `release.yml`'s documented "trigger the
+landing page deploy" step is working as designed. No overlap, no redundancy,
+nothing to distill.
+
+### 5.3 `agentmuxai/cef` (public)
+
+No CI workflows at all — checked both the Actions API and the `.github/`
+directory contents directly. This is the source tree holding the
+`BeginWindowDrag`/transparency patches; the patched-framework release assets
+(`cef-macos-arm64-*`, `cef-linux-x86_64-*`) referenced throughout §2.1/§2.2 are
+cut **manually**, by running the build + `gh release create` commands locally
+per `docs/cef-build/build-patched-framework-macos.md` — not by any automated
+pipeline. Nothing to catalog or distill here; flagging only because it was
+explicitly in scope for this pass.
+
+### 5.4 `a5af/dev-tools` — not found
+
+Tried `a5af/dev-tools`, `a5af/devtools`, `a5af/dev_tools`, and
+`agentmuxai/dev-tools` directly via the API, plus `gh search repos` scoped to
+both owners — no match. Full `gh repo list` for both `a5af` and `agentmuxai`
+doesn't show anything by that name either. Either it's under a different
+owner/org I don't have visibility into, it's private and hasn't been shared
+with me the way `shared-infrastructure` was, or the name's slightly different
+from what I'm guessing. If it's relevant here, the exact owner/repo would help.
+
+---
+
+## 6. Execution log
+
+What actually shipped from this catalog, 2026-07-18:
+
+| Item | PR | Status |
+|---|---|---|
+| Nightly macOS CEF wiring fix (the bug that started this whole investigation) | `agentmuxai/agentmux#2223` | Open, checks clean, awaiting merge approval |
+| Delete `input-bench-report.yml` + merge input-handler guardrails | `agentmuxai/agentmux#2225` | Open |
+| De-duplicate CEF-provisioning logic (`build-linux.yml`/`build-macos.yml` as reusable workflows called from `release.yml`) | `agentmuxai/agentmux` (branch `chore/dedupe-cef-provisioning`) | Open — smoke-tested `build-linux.yml`'s own `workflow_dispatch` path standalone before opening; the new `workflow_call` path from `release.yml` itself is **not** end-to-end validated (would require a real `release.yml` run, which touches production signing credentials and an existing release's assets — deferred to Asaf's judgment on when/how to validate before it's relied on for a real release) |
+| `gh-reporter` monitoring fix (watch both nightly workflows independently) | `a5af/shared-infrastructure#382` | Open, tests pass (76/76), `tsc` compiles clean |
+| Delete abandoned `agenty/kimi-community-reviewer` branch | — | Done directly (branch deleted) |
+| Delete `agentmuxai/agentmux-builder` | — | Done by Asaf directly on GitHub (my token lacked the `delete_repo` scope) |
+
+No merges happened without explicit approval — all four PRs above are open,
+pending review/merge decisions.


### PR DESCRIPTION
## Summary
`release.yml`'s `build-linux`/`build-macos` jobs inlined a full copy of the CEF-resolve/cache/download steps rather than dispatching to `build-linux.yml`/`build-macos.yml` — three independent copies of the same ~40-line block across those two standalone workflows and `release.yml` (a fourth existed in `ci-nightly-artifacts.yml` until #2223). That's exactly how the Linux resolver bug and the missing macOS wiring both happened: a fix landed in one copy and didn't propagate to the others.

- Added a `workflow_call` trigger to `build-linux.yml`/`build-macos.yml` — their `inputs.*` context works identically to `workflow_dispatch`, no other changes needed to either file.
- `release.yml`'s `build-linux`/`build-macos` jobs now invoke those two as reusable workflows (`uses: ./.github/workflows/...`, `secrets: inherit`) instead of inlining a second/third copy. `release-tag` is left blank on the call since the release doesn't exist yet at that point in the pipeline — `publish` still downloads the reused workflows' own `actions/upload-artifact` output exactly as before.
- Net: `release.yml` drops from ~590 lines to 359.

See `docs/analysis/ANALYSIS_CI_WORKFLOW_CATALOG_2026_07_18.md` §2.2.

## ⚠️ Not yet end-to-end validated
I smoke-tested `build-linux.yml`'s own `workflow_dispatch` path standalone (unaffected functionally, confirms the file itself still works — [run](https://github.com/agentmuxai/agentmux/actions/runs/29671442682), succeeded) and validated the YAML/logic carefully by hand. But the actual **new** code path — `release.yml` calling `build-linux.yml`/`build-macos.yml` via `workflow_call` — has not been exercised by a real run. Doing so requires an actual `release.yml` invocation, which touches production Apple signing/notarization credentials and (via `workflow_dispatch` against an existing tag) would re-upload real release assets. I deliberately did not do that without sign-off. Recommend validating via a `workflow_dispatch` dry run against the current release tag before this lands, or accepting it validates itself on the next real release with a documented revert-to-inline fallback if `workflow_call` behaves unexpectedly.

## Test plan
- [x] YAML parses clean on all three files
- [x] `build-linux.yml` standalone `workflow_dispatch` smoke test passes
- [ ] `release.yml`'s new `workflow_call` path validated via a real or dry-run release invocation