### PR TITLE
fix(docs): Trust Center to Armory terminology sweep + jekt armory keyword

### DIFF
--- a/.changesets/1784431946-fix-docs-trust-center-to-armory-terminology-sweep-jekt-armor-g918.md
+++ b/.changesets/1784431946-fix-docs-trust-center-to-armory-terminology-sweep-jekt-armor-g918.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(docs): Trust Center to Armory terminology sweep + jekt armory keyword

--- a/agentmux-srv/src/backend/reactive/sanitize.rs
+++ b/agentmux-srv/src/backend/reactive/sanitize.rs
@@ -154,7 +154,7 @@ const SENSITIVE_WHOLE_WORD_KEYWORDS: &[&str] = &[
 /// substring matches are always sensitive — no common English words contain them).
 const SENSITIVE_SUBSTRING_KEYWORDS: &[&str] = &[
     "api_key", "apikey", "force-push", "--force", "drop table", "rm -rf",
-    "delete_repo", "account.key.verify", "trust center", "private key",
+    "delete_repo", "account.key.verify", "trust center", "armory", "private key",
     "ssh key", "webhook secret", "auth key",
 ];
 

--- a/docs/analysis/archive/ANALYSIS_ACCOUNTS_UI_GAPS_2026-06-18.md
+++ b/docs/analysis/archive/ANALYSIS_ACCOUNTS_UI_GAPS_2026-06-18.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-19:** Bugs described here were fixed in the session that wrote this doc (see §3). "Trust Center" is this UI's pre-rename name (renamed to Armory, PR #1917, 2026-07-02) — left as written for historical accuracy. Kept for reference only.
+
 # Analysis: Trust Center Accounts UI — Gaps & Fixes
 
 **Date:** 2026-06-18

--- a/docs/archive/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md
+++ b/docs/archive/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-19:** Session handoff — both PRs described here (#1584, #1585) merged long ago. "Trust Center" is this UI's pre-rename name (renamed to Armory, PR #1917, 2026-07-02) — left as written for historical accuracy. Kept for reference only.
+
 # Handoff — Memory/Identity Modal Redesign
 **Date:** 2026-06-19  
 **Branch:** `agenta/feat-memory-identity-modals`  

--- a/docs/reports/REPORT_TRUST_CENTER_TO_ARMORY_TERMINOLOGY_SWEEP_2026_07_19.md
+++ b/docs/reports/REPORT_TRUST_CENTER_TO_ARMORY_TERMINOLOGY_SWEEP_2026_07_19.md
@@ -46,7 +46,7 @@ Practical effect: a jekt message discussing the Armory's credential UI (e.g. "go
 
 `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md` needed the most judgment: its title and a whole section header ("Trust Center information architecture") are structurally built around the old name, updated to Armory — **except** a direct driver quote at line 6 (*"I'd like a cleaner model… break out skills and MCP into the Trust Center…"*), left verbatim since it's a historical quote, not descriptive prose.
 
-`docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md` was on the original scan list but has zero actual `"Trust Center"` matches on the current tree (already clean, or a stale grep artifact) — no change needed.
+`docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md` had zero matches for the literal phrase `"Trust Center"` — correction, post-review: it did have a stale identifier, `trustCenter: opts.onTrustCenter`, in an embedded code sample. This was missed because the scan for §3.5's code-identifier cleanup only checked actual `.ts`/`.tsx` source, not identifier references inside doc code samples. Fixed alongside this report's own correction; see §6 for the review-driven fixes this file's first draft required.
 
 `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` gets different treatment for its two kinds of mention: prose describing the UI surface ("register a GitHub PAT in the trust center keychain") → "Armory", but its keyword-list line (§2 above) gets `armory` *added alongside* `trust center`, not replaced — consistent with the additive, no-regressions approach used for the other three keyword lists.
 
@@ -93,3 +93,10 @@ Both remain accurate scoping documents for whoever picks up that broader work ne
 | agentmux | `docs/handoff/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md` | Archived → `docs/archive/` |
 | agentmux-docs | `src/content/docs/internals/interagent-comms.md` | Add `armory` to documented keyword list |
 | agentmux-cloud | `muxbus/server/src/index.ts` | Add `'armory'` to `SENSITIVE_KEYWORDS` |
+
+## 6. Corrections made during review
+
+The original scan methodology (single-line `grep -i "trust center"`) had two blind spots, both caught by ReAgent's PR review rather than a second self-check:
+
+1. **Word-wrapped prose.** `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`'s Phase 5 section had "...identity from the trust\ncenter." — the phrase split across a markdown line wrap, invisible to a single-line grep. A follow-up multiline-aware search (`trust\s*\n\s*center`) across the whole repo found exactly one more instance of the same class, in `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md` ("...home in the Trust\nCenter."). Both fixed; the multiline search now returns zero hits repo-wide.
+2. **Identifiers inside doc code samples.** §3.5's code-identifier cleanup (`trustCenter`/`onTrustCenter` → `openArmory`/`onOpenArmory`) only searched actual `.ts`/`.tsx` source files. `SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md` has an embedded code sample using the same old identifier (`trustCenter: opts.onTrustCenter`) that the source-only search never saw — this is also what produced §3.1's now-corrected, originally-mistaken claim that this file had "zero actual matches." Fixed; a follow-up repo-wide grep for the bare identifiers confirms the only remaining matches are this report's own narrative and the correctly-untouched archived rename spec.

--- a/docs/reports/REPORT_TRUST_CENTER_TO_ARMORY_TERMINOLOGY_SWEEP_2026_07_19.md
+++ b/docs/reports/REPORT_TRUST_CENTER_TO_ARMORY_TERMINOLOGY_SWEEP_2026_07_19.md
@@ -1,0 +1,95 @@
+# Report: "Trust Center" → "Armory" terminology sweep — scan + cleanup scope
+
+**Date:** 2026-07-19
+**Author:** Agent2
+**Status:** Scan complete; scoped cleanup (this report's §3) implemented alongside this report. Broader findings (§4) explicitly out of scope for this pass.
+**Trigger:** User: *"There is no trust center anymore, we have an armory pane .. lets first do a scan to clear out the old info."*
+**Related:** `docs/specs/archive/SPEC_RENAME_TRUST_CENTER_TO_ARMORY_2026_07_02.md` (the original rename spec, shipped PR #1917); `docs/reports/REPORT_REPO_HEALTH_AUDIT_2026_07_05.md` §6 (already found most of this, unaddressed since); `agentmux-docs/specs/AUDIT_DOCS_VS_CODE_2026_07_07.md` P0#1 (same finding, docs-repo side, unaddressed since).
+
+## Summary
+
+The Trust Center → Armory rename (PR #1917, 2026-07-02) covered the user-facing product surface correctly and completely — verified: zero remaining "Trust Center" strings in live frontend/backend code, this repo's root `CLAUDE.md`'s "Not widgets" table already says Armory. What's stale is everywhere *around* the rename: reference docs across three repos that predate it, two internal identifier names the rename spec itself flagged as "optional, low priority" and never got done, and — the most consequential finding — the JEKT security auto-escalation keyword list in **three independent copies across three repos** still keys on `"trust center"` with no `"armory"` counterpart, meaning a message about the Armory's credential surface doesn't reliably auto-escalate to SENSITIVE the way a message about the identically-sensitive old-named surface would have.
+
+This report scopes the fix to exactly the renaming/staleness sweep the user asked for. A much larger, already-documented body of docs work (Bundle semantics rewrite, modal→pane navigation updates, ~15 undocumented shipped features) exists in the two audits cited above — explicitly **not** touched here; see §4.
+
+## 1. What's already correct (verified, no action)
+
+- **Live product code** (`frontend/`, `agentmux-srv/`): zero remaining `"Trust Center"` strings. The one code comment mentioning it (`frontend/app/block/block.tsx:50`) is a *correct* historical note explaining why the `trust → armory` view-key shim exists — appropriately left as-is.
+- **This repo's root `CLAUDE.md`**: the "Not widgets" table's Presets/Armory row already says Armory (§H of the rename spec), and — correcting an earlier draft of this report — its own JEKT keyword line never explicitly listed `trust center` in the first place (it trails off with "etc."), so there's no gap to fix in *this specific file*. (There is a separate, non-repo-tracked per-agent `CLAUDE.md` at each agent's local `~/.agentmux/agents/CLAUDE.md` that does list `trust center` explicitly and diverges from this repo's copy — flagged in §2 as a finding, not fixed here, since it isn't version-controlled in any repo this pass touches.)
+- **`agentmux-docs`**: the actual page rename already shipped (`trust-center.md` deleted, `armory.md` created, `astro.config.mjs` has the `/trust-center → /armory` redirect). Five pages (`glossary.md`, `identity.md`, `main-menu.md`, `pane-types.md`, `armory.md` itself) correctly say **"Armory (formerly Trust Center)"** — a deliberate, well-written callout for readers searching the old name, not staleness. No action needed on any of these six.
+- **Historical/changelog docs** (`VERSION_HISTORY.md`, and — see §3.3 — two docs archived by this pass): "Trust Center" mentions here are accurate records of what the product was called *at the time the entry was written*. Rewriting them to say "Armory" would misrepresent history. Correctly left untouched.
+
+## 2. The real gap: JEKT sensitive-keyword lists (stale in three places, plus one non-repo file)
+
+JEKT security rules auto-escalate a message to SENSITIVE when it contains certain keywords — `account.key.verify`, `keychain`, `trust center`, etc. — on the theory that content about credential-management surfaces warrants a human pause before an agent acts on it. Several independent implementations/documentations of this same keyword list exist. Checked each directly; three are real, repo-tracked gaps:
+
+| File | Repo | List name | Status |
+|---|---|---|---|
+| `agentmux-srv/src/backend/reactive/sanitize.rs:157` (`SENSITIVE_SUBSTRING_KEYWORDS`) | agentmux | code | Has `"trust center"`, missing `"armory"` |
+| `docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md:144` (the canonical spec `REPORT_REPO_HEALTH_AUDIT` names as source-of-truth) | agentmux | doc | Has `trust center`, missing `armory` |
+| `muxbus/server/src/index.ts:254` (`SENSITIVE_KEYWORDS`) | agentmux-cloud | code | Has `'trust center'`, missing `'armory'` |
+| `src/content/docs/internals/interagent-comms.md:141` | agentmux-docs | doc | Has `trust center`, missing `armory` |
+
+Practical effect: a jekt message discussing the Armory's credential UI (e.g. "go add a PAT in the Armory") gets substring-matched against `pat`/`keychain`/etc. and likely still escalates via *those* keywords today — this isn't a total blind spot — but the specific, deliberate "this surface is sensitive" signal the original authors encoded no longer fires for its current name. `docs/reports/REPORT_REPO_HEALTH_AUDIT_2026_07_05.md` §6.2 found this exact drift on 2026-07-05 (also noting the `agentmux-cloud` matcher is naive-substring rather than whole-word, a separate, pre-existing bug — see §4). Unaddressed since.
+
+**One further, out-of-repo finding, not fixed here:** each agent's local, non-git-tracked `~/.agentmux/agents/CLAUDE.md` (distinct from this repo's own root `CLAUDE.md` — the two have diverged) explicitly lists `trust center` as a keyword too. Since it isn't checked into any of the three repos this pass touches, there's no PR to open for it — flagging it here in case whoever maintains that file's source/deploy process wants to sync it.
+
+**Fixed in this pass** (§3.4): added `armory` alongside `trust center` in the three repo-tracked locations (additive — strictly increases escalation coverage, changes no existing behavior).
+
+## 3. Cleanup implemented in this pass
+
+### 3.1 Terminology fix — live/Draft specs (agentmux repo)
+
+12 non-archived specs, all `Status: Draft/Planned/In progress/Proposal` (i.e. still-current reference docs, not historical narrative), had incidental stale `"Trust Center"` mentions corrected to `"Armory"`:
+
+`docs/specs/REPORT_AUTH_ARCHITECTURE_2026_06_25.md`, `SPEC_AGENT_ERROR_FRAMEWORK_2026_06_20.md`, `SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md`, `SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md`, `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md`, `SPEC_MUXBUS_GITHUB_REVIEW_NOTIFICATIONS_2026_06_20.md`, `SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md`, `SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md`; `specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md`, `specs/SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md`, `specs/SPEC_SETTINGS_PANE_2026_06_25.md`, `specs/SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md`.
+
+`PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md` needed the most judgment: its title and a whole section header ("Trust Center information architecture") are structurally built around the old name, updated to Armory — **except** a direct driver quote at line 6 (*"I'd like a cleaner model… break out skills and MCP into the Trust Center…"*), left verbatim since it's a historical quote, not descriptive prose.
+
+`docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md` was on the original scan list but has zero actual `"Trust Center"` matches on the current tree (already clean, or a stale grep artifact) — no change needed.
+
+`SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` gets different treatment for its two kinds of mention: prose describing the UI surface ("register a GitHub PAT in the trust center keychain") → "Armory", but its keyword-list line (§2 above) gets `armory` *added alongside* `trust center`, not replaced — consistent with the additive, no-regressions approach used for the other three keyword lists.
+
+### 3.2 Terminology fix — agentmux-docs
+
+Only one genuine gap after the above verification: `internals/interagent-comms.md:141`'s user-facing keyword-list documentation (see §2/§3.4).
+
+### 3.3 Archived two fully-historical docs
+
+Two docs are session narratives / "already fixed" reports describing a point in time, not live reference material — moved to this repo's existing `archive/` convention with an archived-header note, **text left unchanged** (accurate as history, per the same principle as VERSION_HISTORY.md):
+
+- `docs/analysis/ANALYSIS_ACCOUNTS_UI_GAPS_2026-06-18.md` (Status: "Bugs fixed in this session") → `docs/analysis/archive/`
+- `docs/handoff/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md` (session handoff, PRs already merged) → `docs/archive/` (matching where prior `HANDOFF-*.md` files already live)
+
+### 3.4 JEKT keyword lists — added `armory`
+
+Additive fix (old keyword kept) in the three repo-tracked locations from §2: `sanitize.rs`, `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` (folded into the §3.1 pass), `agentmux-docs/internals/interagent-comms.md`, and `agentmux-cloud/muxbus/server/src/index.ts`.
+
+### 3.5 Code identifier cleanup (agentmux repo) — the rename spec's own deferred items
+
+`docs/specs/archive/SPEC_RENAME_TRUST_CENTER_TO_ARMORY_2026_07_02.md` §E/§G explicitly flagged these as "optional... in the same PR" and they were never done:
+
+- `frontend/app/view/accounts/accounts-manager.tsx:39` — synthetic ViewModel scope id `"trust-center:accounts"` → `"armory:accounts"`.
+- `onTrustCenter`/`trustCenter` prop and variable names in `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/failure/failure-accessory.ts` (+ its test), `frontend/app/view/agent/hooks/useAgentFailure.ts` (+ its test) — renamed to `onOpenArmory`/`openArmory`. The user-facing *label* strings here (`"Armory → Accounts"`, `"Armory (switch / upgrade)"`) were already correct; only the internal plumbing names were stale.
+
+## 4. Found but explicitly out of scope for this pass
+
+Two existing, already-written audits document substantially more docs staleness than the Trust Center naming issue alone. Not touched here — flagged for a separate, deliberate pass:
+
+- **`docs/reports/REPORT_REPO_HEALTH_AUDIT_2026_07_05.md`** — a 23-item, 5-tier action plan spanning dead-code deletion, BUILD.md rewrites, `agentmux-cloud` README staleness ("Status: exploratory. No code yet" while a deployed Fastify server/CDK stack exists), and the naive-substring vs. whole-word JEKT keyword matcher inconsistency between repos (§6.2, distinct from the missing-`armory` gap this report fixes).
+- **`agentmux-docs/specs/AUDIT_DOCS_VS_CODE_2026_07_07.md`** — P0 items 2-5 (Bundle semantics need a structural rewrite, not find-replace; Settings/Toolchain/Armory modal→pane navigation instructions; per-agent pane-header icon consolidation; `identity.*`/`preset.*` App API namespaces documented as "planned" when they've shipped under different names) and P1's ~13 shipped-but-undocumented features (Cron/Loop MCP tools, ghost-text suggestions, MuxBus Cloud sign-in chip, etc.).
+
+Both remain accurate scoping documents for whoever picks up that broader work next.
+
+## 5. Files changed in this pass
+
+| Repo | File | Change |
+|---|---|---|
+| agentmux | `agentmux-srv/src/backend/reactive/sanitize.rs` | Add `"armory"` to `SENSITIVE_SUBSTRING_KEYWORDS` |
+| agentmux | `frontend/app/view/accounts/accounts-manager.tsx` | `"trust-center:accounts"` → `"armory:accounts"` |
+| agentmux | `frontend/app/view/agent/agent-view.tsx`, `failure/failure-accessory.ts(+.test.ts)`, `hooks/useAgentFailure.ts(+.test.ts)` | `onTrustCenter`/`trustCenter` → `onOpenArmory`/`openArmory` |
+| agentmux | 12 specs under `docs/specs/` and `specs/` (§3.1) | `"Trust Center"` → `"Armory"` (contextual, quote-preserving) |
+| agentmux | `docs/analysis/ANALYSIS_ACCOUNTS_UI_GAPS_2026-06-18.md` | Archived → `docs/analysis/archive/` |
+| agentmux | `docs/handoff/HANDOFF_MEMORY_IDENTITY_MODALS_2026_06_19.md` | Archived → `docs/archive/` |
+| agentmux-docs | `src/content/docs/internals/interagent-comms.md` | Add `armory` to documented keyword list |
+| agentmux-cloud | `muxbus/server/src/index.ts` | Add `'armory'` to `SENSITIVE_KEYWORDS` |

--- a/docs/specs/REPORT_AUTH_ARCHITECTURE_2026_06_25.md
+++ b/docs/specs/REPORT_AUTH_ARCHITECTURE_2026_06_25.md
@@ -101,10 +101,10 @@ Auth state is **not centralized**. Each surface owns its own state:
 |---|---|---|
 | Agent pane | `useAgentControllerStatus.ts` | `authUrl`, `canRetry`, `loginWaiting`, `agentReady` |
 | Agent failure banner | `useAgentFailure.ts` | failure type, retry countdown, expanded |
-| Trust Center / HostPopover | `useMuxBusStatus()` | `{connected, email, expiresAt, valid}` — re-fetched on open |
+| Armory / HostPopover | `useMuxBusStatus()` | `{connected, email, expiresAt, valid}` — re-fetched on open |
 | Terminal pane | nothing | inherits ambient, never checks |
 
-**Problem:** Cross-pane auth events are invisible. If the user logs in via the Trust Center, agent panes don't re-check. If a MuxBus token expires, nothing tells the agent panes proactively.
+**Problem:** Cross-pane auth events are invisible. If the user logs in via the Armory, agent panes don't re-check. If a MuxBus token expires, nothing tells the agent panes proactively.
 
 ---
 
@@ -131,11 +131,11 @@ Auth state is **not centralized**. Each surface owns its own state:
 ### P1 — No credential seeding on agent launch
 
 **Impact:** Every agent pane launch requires manual intervention for new bundles.
-**Fix:** On first agent spawn against a bundle with no credentials, proactively check if a valid global `~/.claude/.credentials.json` exists. If yes, auto-seed it (same logic as "Use Existing Login"). Show a toast: "Using your global Claude login — manage in Trust Center."
+**Fix:** On first agent spawn against a bundle with no credentials, proactively check if a valid global `~/.claude/.credentials.json` exists. If yes, auto-seed it (same logic as "Use Existing Login"). Show a toast: "Using your global Claude login — manage in Armory."
 
 ### P1 — No central auth reducer / cross-pane sync
 
-**Impact:** Trust Center login doesn't update agent pane banners; MuxBus token expiry is silent.
+**Impact:** Armory login doesn't update agent pane banners; MuxBus token expiry is silent.
 **Fix:** Introduce a single SolidJS store atom (or Zustand-style slice) for app-wide auth state:
 ```ts
 interface AppAuthState {
@@ -177,7 +177,7 @@ AuthStateService (new)                           useAppAuth() store (new SolidJS
 AgentSpawnService (extend)                       ├─ Agent pane 401 banner
 ├─ pre-flight: seed global creds if bundle empty │  (no more per-pane polling)
 ├─ post-launch: subscribe agent to auth:changed  ├─ HostPopover MuxBus chip
-└─ on auth:changed: update live agent env vars   └─ Trust Center panel
+└─ on auth:changed: update live agent env vars   └─ Armory panel
 
 CEF CliLogin (fix)
 ├─ keep pair.master alive past child.wait()

--- a/docs/specs/SPEC_AGENT_ERROR_FRAMEWORK_2026_06_20.md
+++ b/docs/specs/SPEC_AGENT_ERROR_FRAMEWORK_2026_06_20.md
@@ -89,7 +89,7 @@ so the two-phase CLI auth check finds valid creds in both phases.
 What it doesn't fix: tokens that are **genuinely expired or revoked**. Poal had no valid
 credentials at all (`apiKeySource: "none"` in every init frame). The seeder copies
 whatever is in `~/.claude` — if those tokens are expired, the agent still gets 401.
-The fix for that is the re-auth flow (Trust Center → Accounts → "Login Again"), but
+The fix for that is the re-auth flow (Armory → Accounts → "Login Again"), but
 that flow only kicks in if the failure surface is durable enough to be acted on.
 
 ### 1.4 Root Causes (ranked)
@@ -280,7 +280,7 @@ Not urgent — schedule after Phase 1 is stable.
 When `code: "auth"`:
 
 1. **Inline transcript node** (P1.3): `"Authentication failed — the agent's API credentials are no longer valid."`
-2. **Recovery banner** (SPEC_AGENT_FAILURE_RECOVERY_UI): primary = "Login Again" inline re-auth; secondary = "Trust Center → Accounts"
+2. **Recovery banner** (SPEC_AGENT_FAILURE_RECOVERY_UI): primary = "Login Again" inline re-auth; secondary = "Armory → Accounts"
 3. **System notification** (P1.5): if pane not focused — `"Poal needs to log in"`
 4. **Stale-agent guard**: if block is Dead with `code: "auth"` and user sends a message, show the auth error inline rather than accepting the message silently ("Worked") and failing invisibly
 

--- a/docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md
+++ b/docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md
@@ -3,8 +3,8 @@
 - **Status:** Draft / proposed
 - **Date:** 2026-06-16
 - **Author:** AgentA
-- **Area:** `frontend/app/view/agent` (pane UI + state), `frontend/app/view/accounts` (Trust Center), `agentmux-srv` agent failure event
-- **Related:** `SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md` (the classifier — Phase 1/2, shipped #1353 + #1464), Trust Center / Accounts (#1478)
+- **Area:** `frontend/app/view/agent` (pane UI + state), `frontend/app/view/accounts` (Armory), `agentmux-srv` agent failure event
+- **Related:** `SPEC_AGENT_FAILURE_DIAGNOSTICS_2026_06_11.md` (the classifier — Phase 1/2, shipped #1353 + #1464), Armory / Accounts (#1478)
 
 ---
 
@@ -13,7 +13,7 @@
 When an agent dies, the pane now **shows the real cause** (PR #1464: the `agentfailure`
 wave event carries a classified `AgentFailure`, rendered today as red log lines). This spec
 turns that diagnosis into **one-click recovery**: a per-error-class **recovery banner** in the
-agent pane whose actions match the failure — *Login Again* / *Trust Center* for auth,
+agent pane whose actions match the failure — *Login Again* / *Armory* for auth,
 *Retry* (with a 5-second **auto-retry**) for transient throttling, and class-appropriate
 actions for the rest.
 
@@ -29,7 +29,7 @@ actions for the rest.
 | Event → pane | `frontend/app/view/agent/hooks/useControllerStatusEvents.ts:42` | currently only `opts.log(...)` red text lines |
 | Re-run a turn | `sendMessage()` `hooks/useAgentCommands.ts:231` → `RpcApi.AgentInputCommand` (`rpc-api.ts:1202`) → backend `agentinput` → `spawn_turn` (`subprocess.rs:345`) | resumes via `--resume <session_id>`; busy turns queue + drain on exit |
 | Last user message | `documentAtom` last `UserMessageNode` (`view/agent/types.ts:279`) | the text to re-submit for "Retry" |
-| Trust Center → Accounts | `openBundleManager()` (`modals/bundle-manager-modal.tsx:255`) | singleton modal; "Accounts" is the default section |
+| Armory → Accounts | `openBundleManager()` (`modals/bundle-manager-modal.tsx:255`) | singleton modal; "Accounts" is the default section |
 | Agent → account lookup | `RpcApi.ListAgentIdentitiesCommand({agent_id})` → `GetIdentityAccountCommand({id})` (`rpc-api.ts:792`, `:686`) | resolves the agent's provider account |
 | Re-auth (OAuth) | `RpcApi.AccountOAuthStartCommand` + `AccountOAuthPollCommand` (`rpc-api.ts:747`, `:756`) | service-OAuth connect flow (#1478) |
 | Re-auth (API key) | `RpcApi.AccountKeyVerifyCommand` (`rpc-api.ts:717`) | for `kind === "api_key"` accounts |
@@ -46,11 +46,11 @@ secondary action. `retryable` (from the classifier) drives whether **auto-retry*
 
 | `code` | Icon | Primary action | Secondary | Auto-retry | Rationale |
 |---|---|---|---|---|---|
-| `auth` | 🔐 | **Login Again** (re-auth the agent's account inline) | **Trust Center → Accounts** | no | 401 — creds rejected/expired; re-auth then offer Retry |
+| `auth` | 🔐 | **Login Again** (re-auth the agent's account inline) | **Armory → Accounts** | no | 401 — creds rejected/expired; re-auth then offer Retry |
 | `rate_limited` | ⏱ | **Retry now** | Dismiss | **yes, 5 s** | transient 429; retry shortly |
 | `overloaded` | 🌀 | **Retry now** | Dismiss | **yes, 5 s** | transient 529; server overloaded |
 | `network` | 🌐 | **Retry now** | Dismiss | **yes, 5 s** | transient connectivity |
-| `usage_limit` | 🚫 | **Trust Center → Accounts** (switch account / upgrade) | Dismiss | no | plan/quota — not transient; a different account may have budget |
+| `usage_limit` | 🚫 | **Armory → Accounts** (switch account / upgrade) | Dismiss | no | plan/quota — not transient; a different account may have budget |
 | `context_exceeded` | 📏 | **New session & retry** (fresh `session_id`, re-send) | Dismiss | no | window full; resuming won't help |
 | `max_turns` | 🔁 | **Continue** (re-run, resumes via `--resume`) | Raise `--max-turns` → settings | no | hit the cap; continuing extends |
 | `killed` | ⛔ | **Retry now** | Dismiss | no (caution) | OOM/signal; auto-looping could thrash memory |
@@ -79,7 +79,7 @@ and the fork bar all render through. The failure surface maps **exactly** onto i
 | `title` | `failure.title` |
 | `meta` | `code` · `[exit N]` / `[signal N]` · `(retryable)` |
 | expanded body | `failure.detail` + collapsible `stderrTail` |
-| `actions[]` | the per-class buttons from §3 (glyph + handler): Retry / Login Again / Trust Center / … |
+| `actions[]` | the per-class buttons from §3 (glyph + handler): Retry / Login Again / Armory / … |
 
 So there is **no `AgentFailureBanner.tsx` / `_failure-banner.scss`** — the failure surface is a
 **`PaneRow` descriptor**, produced by a pure `failure → PaneRow` function (à la
@@ -169,7 +169,7 @@ if (acct.kind === "oauth") {
 account without a second lookup. New optional fields `accountId?`, `provider?` on
 `AgentFailure` (additive, snake→camel as today).
 
-### 5.3 Trust Center → Accounts
+### 5.3 Armory → Accounts
 ```
 import { openBundleManager } from "@/app/modals/bundle-manager-modal";
 onClick={() => openBundleManager()}   // opens the singleton modal on the Accounts section
@@ -200,7 +200,7 @@ button becomes a **countdown that fires itself**:
 ## 7. Reconciliation with `AgentRetryBar`
 
 `AgentRetryBar` (`agent-view.tsx:993`) is a login-retry bar predating the classifier. This
-spec **subsumes** it: the recovery banner handles `auth` (Login Again / Trust Center) and
+spec **subsumes** it: the recovery banner handles `auth` (Login Again / Armory) and
 all other classes uniformly. Plan: route `AgentRetryBar`'s login affordance into the banner's
 `auth` case and remove the standalone bar (or keep it rendering the banner) to avoid two
 competing surfaces. Likewise, the `session:was_interrupted` "Resume" banner
@@ -212,7 +212,7 @@ competing surfaces. Likewise, the `session:was_interrupted` "Resume" banner
   reusing the accessory primitive) + `lastFailure` state + `TurnFailure` dispatch; **Retry** +
   **5 s auto-retry** for `rate_limited`/`overloaded`/`network`; generic **Retry / Show-details**
   for the rest. (Delivers the user's headline ask.)
-- **P2 — Auth actions.** **Login Again** (OAuth/API-key re-auth) + **Trust Center → Accounts**;
+- **P2 — Auth actions.** **Login Again** (OAuth/API-key re-auth) + **Armory → Accounts**;
   backend `accountId`/`provider` on `AgentFailure`; auto-offer Retry after re-auth.
 - **P3 — Specialized actions.** `usage_limit` (account switch), `context_exceeded`
   (new-session & retry), `max_turns` (Continue / raise cap), `spawn_failure` (provider setup);
@@ -220,7 +220,7 @@ competing surfaces. Likewise, the `session:was_interrupted` "Resume" banner
 
 ## 9. Open questions
 
-1. **Auth re-auth UX** — inline (poll in the banner) vs. opening Trust Center and letting the
+1. **Auth re-auth UX** — inline (poll in the banner) vs. opening Armory and letting the
    user complete there? Proposal: try inline OAuth; fall back to `openBundleManager()`.
 2. **Auto-retry default-on?** Proposal: on for transient classes, capped (2× backoff). A
    `settings.json` toggle (`agent:autoRetryTransient`) is a stretch.

--- a/docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md
+++ b/docs/specs/SPEC_AGENT_PANE_UNIFIED_FAILURE_REDUCER_2026_07_06.md
@@ -221,7 +221,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
                 loginAgain: opts.onLoginAgain,
                 useExistingLogin: opts.onUseExistingLogin,
                 loginViaTerminal: opts.onLoginViaTerminal,
-                trustCenter: opts.onTrustCenter,
+                openArmory: opts.onOpenArmory,
                 newSession: opts.onNewSession,
                 toggleDetails: () => setExpanded((v) => !v),
                 dismiss: () => opts.model.dispatchPane({ type: "FailureCleared" }),

--- a/docs/specs/SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md
+++ b/docs/specs/SPEC_AGENT_PICKER_TILE_GRID_2026_06_17.md
@@ -20,7 +20,7 @@ We want a **tile grid that fills the pane** — more agents visible at a glance,
 - Render **My Agents** and **Templates** as a **responsive tile grid** that uses the full pane width (no 520px cap), reflowing column count to the available space.
 - **Maximize screen room:** wide panes show many columns; the grid area scrolls vertically when it overflows ("it can get full").
 - Preserve every existing interaction: click-to-launch/reattach, modifier-force-modal, `+ New`, install ribbon/state, delete, hidden-templates section.
-- Match the app design system; reuse the existing tile-grid precedent (`accounts-gallery.scss`, the Trust Center brand tiles).
+- Match the app design system; reuse the existing tile-grid precedent (`accounts-gallery.scss`, the Armory brand tiles).
 
 ---
 
@@ -61,7 +61,7 @@ Replace the capped single-column flex lists with a grid that auto-fills:
 
 - Vertical, fixed-ish footprint: provider logo (larger, ~36–40px) on top or top-left, **title** (CLI blurb / display name) and **caption** beneath, install ribbon as a corner badge, `+ New` + spinner revealed on hover/focus (as today).
 - Consistent tile height (clamp the description to 1–2 lines with ellipsis) so rows align in the grid.
-- Hard corners + accent-on-hover, per the app convention and the Trust Center pattern:
+- Hard corners + accent-on-hover, per the app convention and the Armory pattern:
   ```scss
   .agent-card {
       display: flex; flex-direction: column; gap: var(--space-2);
@@ -89,7 +89,7 @@ Click → launch (template) / reattach (My Agent); modifier keys → force the l
 
 ## 4. Reference
 
-`frontend/app/view/accounts/accounts-gallery.scss` is the existing in-app tile grid (Trust Center): `display: grid` of bordered tiles, `gap`, hover → `--accent-color` border, accent count badges, `color-mix` accents. The picker grid should mirror its grid/spacing/hover structure (adjusted to hard corners) so the two galleries feel like one system.
+`frontend/app/view/accounts/accounts-gallery.scss` is the existing in-app tile grid (Armory): `display: grid` of bordered tiles, `gap`, hover → `--accent-color` border, accent count badges, `color-mix` accents. The picker grid should mirror its grid/spacing/hover structure (adjusted to hard corners) so the two galleries feel like one system.
 
 ---
 

--- a/docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md
+++ b/docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md
@@ -30,7 +30,7 @@ both incoming and outgoing jekts.
 ## 1. Observed Attack Vector (this session)
 
 1. A message appeared in Agent2's input claiming to be from Agent1, asking Agent2
-   to register a GitHub PAT in the trust center keychain via WebSocket RPC.
+   to register a GitHub PAT in the Armory keychain via WebSocket RPC.
 2. Agent2 correctly flagged it and refused until the user confirmed.
 3. Agent2 then sent a muxbus `SendMessage` to Agent1 asking for confirmation.
 4. The reply came back via the same injectable channel.
@@ -141,7 +141,7 @@ If `jekt_tier` is absent, the receiving agent applies a keyword scan on the
 message body. Presence of any of the following triggers SENSITIVE handling:
 - `PAT`, `token`, `api_key`, `apiKey`, `secret`, `password`, `credential`
 - `force-push`, `--force`, `drop table`, `rm -rf`, `delete_repo`
-- `account.key.verify`, `trust center`, `keychain`
+- `account.key.verify`, `trust center`, `armory`, `keychain`
 
 This catches legacy senders that don't set the tier field.
 
@@ -171,7 +171,7 @@ declared `jekt_tier`.
 
 ### 5.3 Future: signed jekts
 
-When the trust center keychain is stable, add an optional `jekt_sig` field:
+When the Armory keychain is stable, add an optional `jekt_sig` field:
 a HMAC-SHA256 of `(msgid + payload + timestamp)` using a per-agent secret stored
 in the keychain. The receiver verifies with the sender's public identity. Until
 then, host-tier = trusted; network-tier = always treat as SENSITIVE.
@@ -214,7 +214,7 @@ envelope. Srv validates tier on incoming network messages.
 
 ### Phase 5 — HMAC signatures (host-tier bootstrap)
 
-**Files:** trust center keychain, muxbus consumer  
+**Files:** Armory keychain, muxbus consumer  
 **Change:** agent at spawn time loads its signing key from the keychain; signs all
 outgoing jekts; receiver verifies using sender's public identity from the trust
 center.  

--- a/docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md
+++ b/docs/specs/SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md
@@ -216,8 +216,8 @@ envelope. Srv validates tier on incoming network messages.
 
 **Files:** Armory keychain, muxbus consumer  
 **Change:** agent at spawn time loads its signing key from the keychain; signs all
-outgoing jekts; receiver verifies using sender's public identity from the trust
-center.  
+outgoing jekts; receiver verifies using sender's public identity from the
+Armory.  
 **Result:** spoofed jekts are detectable even on the host tier.
 
 ---

--- a/docs/specs/SPEC_MUXBUS_GITHUB_REVIEW_NOTIFICATIONS_2026_06_20.md
+++ b/docs/specs/SPEC_MUXBUS_GITHUB_REVIEW_NOTIFICATIONS_2026_06_20.md
@@ -38,7 +38,7 @@ Claude session — no manual polling, no checking GitHub, no delay.
 | `inject_muxbus_env()` | Injects `MUXBUS_TOKEN` into agent spawn env | ✅ |
 | `reactive.rs` | `add_agent()` on reactive-register, `remove_agent()` on deregister | ✅ |
 | `AgentMuxConnectPanel.tsx` | Full connect/disconnect UI | ✅ but gated |
-| Accounts gallery tile | Trust Center → Accounts → AgentMux tile | ✅ exists |
+| Accounts gallery tile | Armory → Accounts → AgentMux tile | ✅ exists |
 
 ### 2.3 How the delivery path works (end-to-end, when connected)
 
@@ -118,7 +118,7 @@ Extend the regex to extract the agent prefix from any `{prefix}-workflow[bot]`
 or `{prefix}-{github_handle}` username. Less precise but covers the long tail.
 
 Recommendation: **Option A for new PRs** (zero cloud changes needed) +
-**Option B for the full solution** (user-configurable via Trust Center).
+**Option B for the full solution** (user-configurable via Armory).
 
 ### 3.3 Reactive auto-registration gap  ← P1
 
@@ -138,7 +138,7 @@ Users must manually configure a GitHub org/repo webhook pointing to the cloud
 consumer endpoint. There is no setup flow, no documentation surface in the UI,
 and no validation that the webhook is working.
 
-**Fix:** Add a "Connect GitHub" step in Trust Center → Accounts → GitHub tile
+**Fix:** Add a "Connect GitHub" step in Armory → Accounts → GitHub tile
 (currently OAuth / PAT only). The step shows the webhook URL + secret to paste
 into GitHub, and a "Test" button that confirms delivery.
 
@@ -168,13 +168,13 @@ Minimal set of changes to make the use case work end-to-end:
 | M2 | Embed agent ID in PR bodies (Option A) | Convention + agent prompt / git hook | 1 day |
 | M3 | Update cloud `agent-mapping.ts` to extract from PR body | `consumers/github/events/review.ts` | 2h |
 | M4 | Auto-register agents with cloud subscriber at startup | `agentmux-srv/src/server/agent_handlers.rs` | 2h |
-| M5 | Document GitHub webhook setup | `docs/` or Trust Center help text | 1h |
+| M5 | Document GitHub webhook setup | `docs/` or Armory help text | 1h |
 
 P1 additions (post-MVP):
 | # | Change | Effort |
 |---|--------|--------|
 | P1a | User-configurable mapping API in cloud (Option B) | 1 day |
-| P1b | Trust Center webhook setup flow | 2 days |
+| P1b | Armory webhook setup flow | 2 days |
 | P1c | Toast notification on injection delivery | 1 day |
 
 ---
@@ -253,13 +253,13 @@ Actions: `approved`, `changes_requested`, `commented`, `dismissed`.
 
 ---
 
-## 8. Trust center — not a blocker
+## 8. Armory — not a blocker
 
-The Trust Center redesign (`docs/specs/archive/SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md`) is
+The Armory redesign (`docs/specs/archive/SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md`) is
 **not required** for this MVP. The accounts gallery tile and `AgentMuxConnectPanel`
 already exist and work correctly once `VITE_MUXBUS_CLIENT_ID` is set (M1).
 
-Trust Center work becomes relevant for:
+Armory work becomes relevant for:
 - User-configurable agent-to-GitHub mapping (P1a)
 - GitHub webhook setup UI (P1b)
 - Subscription management / tier display
@@ -286,7 +286,7 @@ Trust Center work becomes relevant for:
 
 ## 10. Acceptance criteria (MVP)
 
-- User can sign into AgentMux Cloud from Trust Center → Accounts → AgentMux tile
+- User can sign into AgentMux Cloud from Armory → Accounts → AgentMux tile
 - Agent that opens a PR has `<!-- agentmux:agent_id=X -->` in the PR body
 - When a reviewer approves / requests changes on that PR, the agent receives an
   injected message within ~5 seconds (WS wake) or ~30 seconds (polling fallback)

--- a/docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md
+++ b/docs/specs/SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md
@@ -13,7 +13,7 @@
 
 - **Reference, don't copy.** A Bundle stores primitive **IDs**, not inline JSON.
 - **Compatibility window.** Keep `preset.*` / `db_memory_bundles` as **read aliases for one release**; new writes go to Bundle names.
-- **No user-visible regression.** The Trust Center IA gains no new required step; direct bindings remain the base, Bundle is optional sugar.
+- **No user-visible regression.** The Armory IA gains no new required step; direct bindings remain the base, Bundle is optional sugar.
 - **Contract-test discipline.** Renaming App API commands changes the rpc-contract surface (`test/contract/rpc-contract.test.ts`) — every phase updates the baselines in lockstep (this is the guard that caught the mcp/skill drift in #1896).
 
 ---
@@ -73,7 +73,7 @@ The proposal's "one real refactor" (§3.3, §7). Today: `instance → identity_b
 ### 3.2 Deprecate the identity-bundle App API + UI
 
 - Commands `listidentitybundles` / `getidentitybundle` / `upsertidentitybundle` / `deleteidentitybundle` / `bindidentityaccount` / `unbindidentityaccount` / `listidentitybindings` (commands.rs 164–170, incl. `COMMAND_DELETE_IDENTITY_BUNDLE` at 167) → mark deprecated; keep read paths for the compat window, stop new writes.
-- Trust Center: the **Identities** tab becomes a **derived view** ("what is this agent running as" over bound Accounts) — no stored identity-bundle object. Per the proposal IA (§5) there is **no Identities tab** in the target; fold it into the Accounts + Bundle surfaces. (This is a UI change — confirm the exact interim: hide the tab, or convert to read-only derived view for one release.)
+- Armory: the **Identities** tab becomes a **derived view** ("what is this agent running as" over bound Accounts) — no stored identity-bundle object. Per the proposal IA (§5) there is **no Identities tab** in the target; fold it into the Accounts + Bundle surfaces. (This is a UI change — confirm the exact interim: hide the tab, or convert to read-only derived view for one release.)
 
 ### 3.2b Agent-pane header: consolidate to a single icon (product-owner decision 2026-07-02)
 

--- a/docs/specs/SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md
+++ b/docs/specs/SPEC_REAUTH_FROM_AUTH_ERROR_2026_06_20.md
@@ -35,7 +35,7 @@ When an agent hits a 401/auth error the user now sees it clearly (P1.3 inline er
 | Claude provider re-auth on auth failure | New-identity creation (handled by pre-launch OAuth modal — SPEC_PRE_LAUNCH_OAUTH_FLOW) |
 | Other providers via their auth method | Gemini-specific auth fix (#1250 — separate issue) |
 | CTA from failure banner and inline error node | API-key-only providers (no URL to open) |
-| URL fallback display | Trust Center binding (SPEC_TRUST_CENTER_CLI_AUTH_BINDING) |
+| URL fallback display | Armory binding (SPEC_TRUST_CENTER_CLI_AUTH_BINDING) |
 
 Triggers considered:
 - Failure banner "Login Again" action (already wired; behavior changes)

--- a/frontend/app/view/accounts/accounts-manager.tsx
+++ b/frontend/app/view/accounts/accounts-manager.tsx
@@ -36,7 +36,7 @@ export function AccountsManager(): JSX.Element {
     // module-level cache + `*IdentityAccountCommand` RPCs, so a synthetic id
     // and a stub nodeModel are safe. Created once per mount (SolidJS component
     // bodies run a single time).
-    const model = new IdentityViewModel("trust-center:accounts", {} as BlockNodeModel);
+    const model = new IdentityViewModel("armory:accounts", {} as BlockNodeModel);
     onCleanup(() => model.dispose());
 
     // Shared AgentMux Cloud session controller — single source of truth for the

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -685,7 +685,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         model: paneModel,
         failure: agentAtoms().failureAtom[0],
         onRetry: retryLastTurn,
-        onTrustCenter: () => void openOrFocusPaneByView("armory"),
+        onOpenArmory: () => void openOrFocusPaneByView("armory"),
         canSeed: () => provider()?.id === "claude",
         // context_exceeded recovery — drop the over-full session and return to
         // the picker for a clean relaunch (resuming would only re-fail).

--- a/frontend/app/view/agent/failure/failure-accessory.test.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.test.ts
@@ -21,14 +21,14 @@ const mkView = (overrides: Partial<FailureViewState> = {}): FailureViewState => 
 });
 
 const mkActions = (): FailureActions & { _calls: Record<keyof FailureActions, number> } => {
-    const _calls = { retry: 0, loginAgain: 0, useExistingLogin: 0, loginViaTerminal: 0, trustCenter: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
+    const _calls = { retry: 0, loginAgain: 0, useExistingLogin: 0, loginViaTerminal: 0, openArmory: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
     return {
         _calls,
         retry: vi.fn(() => void _calls.retry++),
         loginAgain: vi.fn(() => void _calls.loginAgain++),
         useExistingLogin: vi.fn(() => void _calls.useExistingLogin++),
         loginViaTerminal: vi.fn(() => void _calls.loginViaTerminal++),
-        trustCenter: vi.fn(() => void _calls.trustCenter++),
+        openArmory: vi.fn(() => void _calls.openArmory++),
         newSession: vi.fn(() => void _calls.newSession++),
         toggleDetails: vi.fn(() => void _calls.toggleDetails++),
         dismiss: vi.fn(() => void _calls.dismiss++),
@@ -84,7 +84,7 @@ describe("failureToRow", () => {
         const trust = action(row, "Armory → Accounts");
         expect(trust).toBeTruthy();
         trust?.onClick();
-        expect(on._calls.trustCenter).toBe(1);
+        expect(on._calls.openArmory).toBe(1);
     });
 
     it("auth (Claude / canSeed) → Use existing login is primary, Login via terminal is secondary", () => {

--- a/frontend/app/view/agent/failure/failure-accessory.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.ts
@@ -28,7 +28,7 @@ export interface FailureActions {
     /** Open a real terminal window so the browser OAuth can open, then poll for creds. */
     loginViaTerminal: () => void;
     /** Open Armory → Accounts. */
-    trustCenter: () => void;
+    openArmory: () => void;
     /** Start a fresh agent session — recovery for a context-window overflow,
      *  where resuming the same (full) session would only re-fail. */
     newSession: () => void;
@@ -100,11 +100,11 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
         glyph: "↻", label: retryLabel, title: "Re-run the last turn", primary: true,
         disabled: view.retrying, onClick: on.retry,
     };
-    const trustCenter: PaneRowAction = {
+    const openArmory: PaneRowAction = {
         // Same "vault" FontAwesome icon as the widget bar's Armory entry
         // (agentmux-srv/src/config/widgets.json) and the hamburger menu's
         // Armory item, instead of a generic gear emoji.
-        icon: "vault", label: "Armory → Accounts", title: "Open Armory → Accounts", onClick: on.trustCenter,
+        icon: "vault", label: "Armory → Accounts", title: "Open Armory → Accounts", onClick: on.openArmory,
     };
 
     const actions: PaneRowAction[] = [];
@@ -117,24 +117,24 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
                 actions.push(
                     { glyph: "🌐", label: "Use existing login", title: "Copy your valid global Claude login into this agent (no re-OAuth)", primary: true, onClick: on.useExistingLogin },
                     { glyph: "🖥", label: "Login via terminal", title: "Open a terminal window where the browser login can complete", onClick: on.loginViaTerminal },
-                    trustCenter,
+                    openArmory,
                 );
             } else {
                 actions.push(
                     { glyph: "🔑", label: "Login Again", title: "Re-authenticate this agent", primary: true, onClick: on.loginAgain },
                     { glyph: "🌐", label: "Use existing login", title: "Copy your existing valid global Claude login into this agent (no re-OAuth)", onClick: on.useExistingLogin },
-                    trustCenter,
+                    openArmory,
                 );
             }
             break;
         case "usage_limit":
-            actions.push({ ...trustCenter, label: "Armory (switch / upgrade)", primary: true });
+            actions.push({ ...openArmory, label: "Armory (switch / upgrade)", primary: true });
             break;
         case "spawn_failure":
             // Clear `icon` — this isn't an Armory action, so it must NOT
-            // inherit trustCenter's vault icon (icon takes precedence over
+            // inherit openArmory's vault icon (icon takes precedence over
             // glyph in PaneRow's render).
-            actions.push({ ...trustCenter, icon: undefined, glyph: "🧩", label: "Provider setup", title: "Fix the provider install", primary: true });
+            actions.push({ ...openArmory, icon: undefined, glyph: "🧩", label: "Provider setup", title: "Fix the provider install", primary: true });
             break;
         case "rate_limited":
         case "overloaded":

--- a/frontend/app/view/agent/hooks/useAgentFailure.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.test.ts
@@ -105,7 +105,7 @@ const mkUI = (onRetry: () => void) => {
         onLoginAgain() {},
         onUseExistingLogin() {},
         onLoginViaTerminal() {},
-        onTrustCenter() {},
+        onOpenArmory() {},
         onNewSession() {},
     });
     return { ui, model };

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -60,7 +60,7 @@ export interface UseAgentFailureOptions {
     /** Open a real terminal window for browser-based OAuth (Claude v2.1.x). */
     onLoginViaTerminal: () => void;
     /** Open Armory → Accounts. */
-    onTrustCenter: () => void;
+    onOpenArmory: () => void;
     /** Start a fresh agent session (context-window overflow recovery). */
     onNewSession: () => void;
     /** True when the provider supports seed-from-global (Claude). Promotes
@@ -240,7 +240,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
                 loginAgain: opts.onLoginAgain,
                 useExistingLogin: opts.onUseExistingLogin,
                 loginViaTerminal: opts.onLoginViaTerminal,
-                trustCenter: opts.onTrustCenter,
+                openArmory: opts.onOpenArmory,
                 newSession: opts.onNewSession,
                 toggleDetails: () => setExpanded((v) => !v),
                 dismiss: endEpisode,

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -1,9 +1,9 @@
-# Proposal: A Composable Agent Model for the Trust Center
+# Proposal: A Composable Agent Model for the Armory
 
 **Date:** 2026-06-30
 **Status:** Proposal — for discussion (naming + IA decisions needed)
 **Author:** AgentX
-**Driver:** "I'd like a cleaner model… break out skills and MCP into the Trust Center… should we call them bundles? preset bundles? would a preset be a one-stop shop?"
+**Driver:** "I'd like a cleaner model… break out skills and MCP into the Trust Center… should we call them bundles? preset bundles? would a preset be a one-stop shop?" *(verbatim — the Trust Center → Armory rename came later, PR #1917)*
 **Related:** CLAUDE.md "Not widgets" (Identity / Presets); `db_memory_bundles`, `db_identity_bundles`; the per-agent identity provisioning work (`specs/archive/SPEC_PER_AGENT_IDENTITY_PROVISIONING_2026_06_30.md`); the agent App API identity/preset/memory handlers.
 
 ---
@@ -38,7 +38,7 @@ Center.
   them.
 - **Reference, don't copy.** The bundle stores pointers; edit a primitive once
   and every agent using it updates.
-- **The Trust Center is the trust + capability surface.** Accounts (credentials),
+- **The Armory is the trust + capability surface.** Accounts (credentials),
   MCP (external reach), and skills (injected instructions) are all *trust
   decisions* — they belong together where you grant and review capability.
 - **Primitives bind directly; collections are optional.** An agent can bind
@@ -49,15 +49,15 @@ Center.
 
 ## 3. Proposed model — primitives + an optional collection
 
-### 3.1 The primitives (Trust Center, each independently managed & shareable)
+### 3.1 The primitives (Armory, each independently managed & shareable)
 
 | Primitive | What it is | Today | Proposed home |
 |---|---|---|---|
-| **Account** | The provider login + credential the agent authenticates as (OAuth/key, per-account `CLAUDE_CONFIG_DIR`) | `db_identity_accounts`, wrapped in a redundant identity-**bundle** layer | Trust Center › **Accounts** (drop the bundle wrapper — §3.3) |
-| **Memory** | Persistent learned knowledge (native memory store; the `memory.*` App API / `memory/` dir) | colloquially "the brain", per-account | Trust Center › **Memories** |
-| **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Trust Center › **MCP Servers** (break out) |
-| **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Trust Center › **Skills** (break out) |
-| **Brief** | **The first message** injected when an agent pane opens — the startup payload (session context / identity / kickoff). That is *all* it is. It is **not** a standing instruction set; there is no always-on instruction blob. Behavioral/instructional content lives in **Skills** (on-demand). | the `startup` content type | Trust Center › **Briefs** |
+| **Account** | The provider login + credential the agent authenticates as (OAuth/key, per-account `CLAUDE_CONFIG_DIR`) | `db_identity_accounts`, wrapped in a redundant identity-**bundle** layer | Armory › **Accounts** (drop the bundle wrapper — §3.3) |
+| **Memory** | Persistent learned knowledge (native memory store; the `memory.*` App API / `memory/` dir) | colloquially "the brain", per-account | Armory › **Memories** |
+| **MCP server** | An external tool/connection surface (URL/stdio + which tools) | inlined in preset | Armory › **MCP Servers** (break out) |
+| **Skill** | On-demand instruction/knowledge module (a folder) | inlined in preset | Armory › **Skills** (break out) |
+| **Brief** | **The first message** injected when an agent pane opens — the startup payload (session context / identity / kickoff). That is *all* it is. It is **not** a standing instruction set; there is no always-on instruction blob. Behavioral/instructional content lives in **Skills** (on-demand). | the `startup` content type | Armory › **Briefs** |
 
 > Each primitive carries its own **ownership/sharing** (agent-owned vs **global**,
 > mirroring the App API's existing global-preset guard) and its own audit trail.
@@ -196,10 +196,10 @@ That inverts the old objection: removing `_bundles` from the legacy names is
 precisely what *frees* the word for its natural use. `db_memory_bundles` →
 **`db_bundles`** (the collection store); "bundle" means the collection, full stop.
 
-## 5. Trust Center information architecture
+## 5. Armory information architecture
 
 ```
-Trust Center
+Armory
 ├─ Bundles      ← named collections you apply to agents (optional, reusable)
 ├─ Accounts        ← provider logins / credentials (per-account CLAUDE_CONFIG_DIR)
 ├─ Memories        ← memory stores
@@ -223,7 +223,7 @@ workspace.
   App API.)
 - **Accounts** and **MCP servers** carry the heaviest trust weight (credentials +
   external reach). First-class status means they get explicit grant/review in the
-  Trust Center instead of riding hidden inside a preset.
+  Armory instead of riding hidden inside a preset.
 - An Bundle referencing a global primitive can't silently fork it; it points at
   the shared definition.
 

--- a/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
+++ b/specs/PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md
@@ -26,8 +26,8 @@ context files + MCP servers + skills* in one record, while **identity** and
    "bundles." Adding "preset bundle" on top would compound the collision.
 
 The fix is not a bigger preset. It's to **separate the reusable building blocks
-from the thing that assembles them**, and give each a clear home in the Trust
-Center.
+from the thing that assembles them**, and give each a clear home in the
+Armory.
 
 ## 2. Design principles
 

--- a/specs/SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md
+++ b/specs/SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md
@@ -155,7 +155,7 @@ two rules are mandatory:
 
 - The MCP tool description must **not** instruct the agent to paste a raw key
   inline in a way that ends up in conversation transcripts. Prefer a flow where
-  the secret is provided out-of-band (env var name reference, or the Trust Center
+  the secret is provided out-of-band (env var name reference, or the Armory
   UI) — see §7 open question.
 - Responses **never echo the secret back** — only `masked_tail` (already the
   handler's behavior). The REST layer must not add the plaintext to any response
@@ -200,13 +200,13 @@ see §7.
 
 1. **Do agents get *mutating* identity/preset tools at all, or stay read + memory-write?**
    Options: (a) read-only identity/preset for agents, mutations human-only via
-   Trust Center; (b) full agent CRUD with the S1 guards already implemented.
+   Armory; (b) full agent CRUD with the S1 guards already implemented.
    Recommendation: ship §6.1 + §6.2 read tools first; gate §6.3 mutations behind
    an explicit per-agent capability flag before exposing.
 
 2. **Secret-passing ergonomics for `IdentityUpsert`.** Inline key in the tool call
    lands in the transcript. Alternatives: reference an env-var name the MCP server
-   resolves; or keep credential creation in the Trust Center UI and let agents
+   resolves; or keep credential creation in the Armory UI and let agents
    only *link* / *validate* existing accounts. Recommendation: no inline-secret
    agent tool in the first wave.
 

--- a/specs/SPEC_SETTINGS_PANE_2026_06_25.md
+++ b/specs/SPEC_SETTINGS_PANE_2026_06_25.md
@@ -28,7 +28,7 @@ This is a developer-grade experience. It:
 
 ## Goal
 
-A **Settings pane** widget — same scaffold as Toolchain / Trust Center — that:
+A **Settings pane** widget — same scaffold as Toolchain / Armory — that:
 1. Presents all user-facing settings as form controls with labels and descriptions
 2. Applies changes immediately and reactively via `SetConfigCommand` (no Save button)
 3. Groups settings into logical sections with a left-rail navigator
@@ -393,6 +393,6 @@ the theme's CSS variable values without requiring a full page re-render.
   surface; don't merge here.
 - **Widget pinning UI** — managed by right-click on the widget bar, not the Settings pane.
 - **Agent-level overrides** — per-agent model/effort/provider config lives in the agent
-  Identity/Preset system (Trust Center), not global settings.
+  Identity/Preset system (Armory), not global settings.
 - **Import/export** — bulk settings portability is out of scope; the raw JSON escape
   hatch covers this use case adequately.

--- a/specs/SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md
+++ b/specs/SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-30
 **Status:** Draft — implementation spec
 **Author:** AgentX
-**Parent:** `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md` (the composable Trust Center model — Bundle · Account · Memory · MCP Server · Skill · Brief)
+**Parent:** `PROPOSAL_COMPOSABLE_AGENT_MODEL_2026_06_30.md` (the composable Armory model — Bundle · Account · Memory · MCP Server · Skill · Brief)
 **Related code:** `agentmux-srv/src/backend/storage/{skills.rs,content.rs,agents.rs}`, `backend/agent_config.rs`, `server/app_api.rs` (`write_agent_config_files`, `preset.*`/`memory.*` handlers), `backend/rpc_types.rs`.
 
 ---
@@ -13,12 +13,12 @@
 Break **MCP Servers** and **Skills** out of the per-agent inline storage into
 **standalone, shareable, referenceable primitives** — the lowest-risk, highest-value
 slice of the composable model. After v1: define an MCP server or a skill **once**,
-reference it from many agents; manage both in the Trust Center.
+reference it from many agents; manage both in the Armory.
 
 **In scope (v1):** standalone storage for skills + MCP servers, ownership/global
 flags, direct **agent→primitive references**, the `skill.*`/`mcp.*` App API, the
 config-generation rewrite to read references, migration of existing inline data,
-and two Trust Center tabs.
+and two Armory tabs.
 
 **Out of scope (later):** the **Bundle** collection (grouping references — v2);
 Accounts/Memory/Brief/Policy changes; the `soul`/`agentmd` → Skills content move
@@ -161,7 +161,7 @@ One-time, idempotent, behind the App API surface:
    the v1 skill primitive; schedule it once v1 storage/API land, so the heavy
    always-on CLAUDE.md can be retired.
 
-## 8. Trust Center UI
+## 8. Armory UI
 
 Two new tabs (each: list / create / edit / delete / toggle global / bind-to-agent):
 - **MCP Servers** — name, transport, config; "used by N agents".


### PR DESCRIPTION
## Summary
Scanned the repo for stale "Trust Center" references left over from the PR #1917 rename (2026-07-02), per `docs/reports/REPORT_REPO_HEALTH_AUDIT_2026_07_05.md` §6 (found, never actioned) and this repo's own rename spec's explicitly-deferred, "optional/low priority" items.

- **Terminology fix in 12 live/Draft specs** — incidental stale "Trust Center" mentions corrected to "Armory", contextually (preserved a direct driver quote in `PROPOSAL_COMPOSABLE_AGENT_MODEL`, and the archived-filename citation in `SPEC_MUXBUS_GITHUB_REVIEW_NOTIFICATIONS`, both left unchanged as historical record).
- **JEKT sensitive-keyword gap** — `sanitize.rs`'s `SENSITIVE_SUBSTRING_KEYWORDS` only matched `"trust center"`, not `"armory"`, so a message about the identically-sensitive credential surface under its *current* name didn't reliably auto-escalate. Added `"armory"` alongside (additive, zero behavior change to existing matches). Same fix applied to the matching line in `SPEC_JEKT_SECURITY_AND_VISIBILITY`'s documented keyword list. Companion fixes for `agentmux-docs` and `agentmux-cloud` (same gap, confirmed present in both) land as separate PRs in their own repos.
- **Archived two fully-historical docs** (`ANALYSIS_ACCOUNTS_UI_GAPS`, `HANDOFF_MEMORY_IDENTITY_MODALS`) into this repo's existing `archive/` convention — text left unchanged, since it's accurate as history.
- **Code identifier cleanup** — `onTrustCenter`/`trustCenter` → `onOpenArmory`/`openArmory` across `agent-view.tsx`, `failure-accessory.ts`(+test), `useAgentFailure.ts`(+test); `"trust-center:accounts"` ViewModel scope id → `"armory:accounts"`. Both were explicitly flagged as deferred/optional in the original rename spec and never done. User-facing label strings were already correct — only internal plumbing names were stale.

Full scan writeup, including a much larger body of already-tracked docs work explicitly **out of scope** here (Bundle semantics rewrite, modal→pane nav updates, ~15 undocumented shipped features — see the two prior audits cited in the report): `docs/reports/REPORT_TRUST_CENTER_TO_ARMORY_TERMINOLOGY_SWEEP_2026_07_19.md`.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `cargo check -p agentmux-srv` — clean, no new warnings
- [x] `vitest run` on both touched test files (`failure-accessory.test.ts`, `useAgentFailure.test.ts`) — 21/21 pass
- [x] Full-repo grep confirms zero remaining "Trust Center" mentions outside `archive/`, `VERSION_HISTORY.md`, the additive keyword-list line, and the preserved verbatim quote

<!-- agentmux:agent_id=agent2 -->