### PR TITLE
feat(srv): eager per-dispatch Haiku naming (Phase A, backend)

### DIFF
--- a/.changesets/1784489350-feat-srv-eager-per-dispatch-haiku-naming-for-agent-tool-work-icni.md
+++ b/.changesets/1784489350-feat-srv-eager-per-dispatch-haiku-naming-for-agent-tool-work-icni.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(srv): eager per-dispatch Haiku naming for Agent-tool/Workflow-tool calls

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -15,14 +15,22 @@
 //!
 //! This module watches those directories and emits:
 //!   - `subagent:spawned`   — new subagent JSONL file detected
-//!   - `subagent:activity`  — new events for a Solo dispatch's one member
-//!     (Workflow-dispatch member activity is coalesced into
-//!     `dispatch:activity` instead — see `PendingDispatchActivity`)
+//!   - `subagent:activity`  — new events for a Solo dispatch's one member,
+//!     broadcast immediately (existing per-member consumers, e.g. the
+//!     agent-pane activity dock, still rely on this)
 //!   - `subagent:completed` — subagent finished (result event seen)
-//!   - `dispatch:updated`   — an `AgentDispatch`'s member count or status
-//!     changed (both Solo and Workflow kinds; see `AgentDispatch`)
-//!   - `dispatch:activity`  — coalesced new events across a Workflow
-//!     dispatch's members, flushed every `DISPATCH_ACTIVITY_FLUSH_INTERVAL`
+//!   - `subagent:named`     — a `SubAgent.display_name` resolved (on-demand
+//!     click-triggered, or eager at dispatch time — see `trigger_eager_naming`)
+//!   - `dispatch:updated`   — an `AgentDispatch`'s member count, status, or
+//!     `dispatch_name` changed (both Solo and Workflow kinds)
+//!   - `dispatch:activity`  — coalesced new events across a dispatch's
+//!     members, flushed every `DISPATCH_ACTIVITY_FLUSH_INTERVAL`. Workflow
+//!     dispatches are ONLY ever represented here (no per-member broadcast).
+//!     Solo dispatches are ALSO queued here in addition to the immediate
+//!     `subagent:activity` above (dual emission, not a replacement) — see
+//!     docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md
+//!     Phase A, added so a solo dispatch's row can use the same
+//!     concatenated-feed expand mechanism a Workflow row already had.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
@@ -142,6 +150,14 @@ pub struct AgentDispatch {
     pub members_done: usize,
     pub status: DispatchStatus,
     pub last_event_at: u64,
+    /// Concise Haiku-generated name, resolved eagerly the first time this
+    /// dispatch's first member is observed live (never during cold-backfill
+    /// replay — see `process_jsonl_change`'s `live` gate). One call per
+    /// dispatch, not per member — mirrors `SubAgent.display_name` one level
+    /// up. `None` until resolved; callers fall back to a member's `slug`/the
+    /// raw `dispatch_id` themselves (unchanged from before this field
+    /// existed). See docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md.
+    pub dispatch_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -286,20 +302,46 @@ const DISPATCH_ACTIVITY_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
 
 pub struct SubagentWatcher {
     event_bus: Arc<EventBus>,
+    wstore: Arc<crate::backend::storage::store::Store>,
     sessions: Mutex<HashMap<String, SessionWatch>>,
     watched_agents: Mutex<Vec<WatchedAgent>>,
     dispatches: Mutex<HashMap<String, DispatchState>>,
     pending_activity: Mutex<HashMap<String, PendingDispatchActivity>>,
+    /// Dispatch IDs that have already had their one eager Haiku-naming call
+    /// triggered (issue: SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19)
+    /// — checked-and-inserted atomically at the same point `is_new` is
+    /// computed in `process_jsonl_change`, so a Workflow dispatch (whose
+    /// `dispatch_id` is shared by every member) only ever triggers once,
+    /// on its first-observed-live member, not once per member. Never
+    /// cleared — naming is "at most once ever per dispatch," not a
+    /// retryable in-flight guard (unlike `activity_watcher.rs`'s
+    /// `in_flight` set, which this deliberately does NOT mirror: there's no
+    /// "try again later" concept for a dispatch's name).
+    naming_triggered: Mutex<std::collections::HashSet<String>>,
+    /// Weak self-reference, populated once by `spawn()` right after the
+    /// `Arc::new` that wraps this watcher — lets any `&self` method upgrade
+    /// to `Arc<Self>` to move into a `tokio::spawn`ed background task (the
+    /// eager-naming trigger) without threading `Arc<Self>` through every
+    /// caller of `process_jsonl_change` (`scan_subagents_dir`/
+    /// `scan_session_subagents`, both `&self` today). `None` for a
+    /// `SubagentWatcher` built via bare `new()` (as most tests do, to skip
+    /// the background flush loop) — eager naming silently no-ops in that
+    /// case rather than panicking, matching this module's existing
+    /// "unknown/untracked -> safe no-op" convention (see `set_display_name`).
+    self_ref: Mutex<Option<std::sync::Weak<SubagentWatcher>>>,
 }
 
 impl SubagentWatcher {
-    pub fn new(event_bus: Arc<EventBus>) -> Self {
+    pub fn new(event_bus: Arc<EventBus>, wstore: Arc<crate::backend::storage::store::Store>) -> Self {
         Self {
             event_bus,
+            wstore,
             sessions: Mutex::new(HashMap::new()),
             watched_agents: Mutex::new(Vec::new()),
             dispatches: Mutex::new(HashMap::new()),
             pending_activity: Mutex::new(HashMap::new()),
+            naming_triggered: Mutex::new(std::collections::HashSet::new()),
+            self_ref: Mutex::new(None),
         }
     }
 
@@ -307,8 +349,9 @@ impl SubagentWatcher {
     /// starts the background flush loop for coalesced dispatch activity
     /// (SPEC §7) — runs for the lifetime of the process, mirroring
     /// `watch_agent`'s existing `tokio::spawn` pattern.
-    pub fn spawn(event_bus: Arc<EventBus>) -> Arc<Self> {
-        let watcher = Arc::new(Self::new(event_bus));
+    pub fn spawn(event_bus: Arc<EventBus>, wstore: Arc<crate::backend::storage::store::Store>) -> Arc<Self> {
+        let watcher = Arc::new(Self::new(event_bus, wstore));
+        *watcher.self_ref.lock().unwrap() = Some(Arc::downgrade(&watcher));
         tracing::info!("subagent watcher initialized");
         let flusher = Arc::clone(&watcher);
         tokio::spawn(async move {
@@ -524,10 +567,14 @@ impl SubagentWatcher {
                             &changed_path,
                         );
                     } else {
+                        // live=true: this came from the filesystem watcher
+                        // observing a real, in-the-moment change — eligible
+                        // to trigger eager Haiku naming.
                         self_clone.process_jsonl_change(
                             &parent_agent,
                             &parent_block_id,
                             &changed_path,
+                            true,
                         );
                     }
                 }
@@ -638,6 +685,10 @@ impl SubagentWatcher {
             members_done: done as usize,
             status: if done { DispatchStatus::Completed } else { DispatchStatus::Running },
             last_event_at: sub.last_event_at,
+            // A solo dispatch's name IS its one member's display_name — no
+            // separate dispatch_name storage needed for the Solo kind (only
+            // Workflow-kind DispatchState carries its own dispatch_name).
+            dispatch_name: sub.display_name.clone(),
         })
     }
 
@@ -730,6 +781,77 @@ impl SubagentWatcher {
             self.event_bus.broadcast_event(&named_event);
         }
         found
+    }
+
+    /// Set a Workflow-kind dispatch's Haiku-generated name and broadcast
+    /// `dispatch:updated` so every client watching this session picks up the
+    /// result. Mirrors `set_display_name` one level up — see that method's
+    /// doc comment for the "found=false is a safe no-op" convention. Only
+    /// Workflow-kind dispatches store a `dispatch_name` here; a Solo
+    /// dispatch's name IS its one member's `display_name` (`solo_dispatch`
+    /// reads it straight through), so `set_display_name` already covers the
+    /// Solo case — this method is never called for a `solo:` dispatch_id.
+    pub fn set_dispatch_name(&self, dispatch_id: &str, name: &str) -> bool {
+        let info = {
+            let mut dispatches = self.dispatches.lock().unwrap();
+            match dispatches.get_mut(dispatch_id) {
+                Some(state) => {
+                    state.info.dispatch_name = Some(name.to_string());
+                    Some(state.info.clone())
+                }
+                None => None,
+            }
+        };
+        // Mutex released here — broadcast outside the lock
+
+        let Some(info) = info else { return false };
+        tracing::info!(
+            dispatch_id = %dispatch_id,
+            dispatch_name = %name,
+            parent_block_id = %info.parent_block_id,
+            session_id = %info.session_id,
+            "dispatch display_name resolved"
+        );
+        self.broadcast_dispatch_updated(&info);
+        true
+    }
+
+    /// Fire the one eager Haiku-naming call for a dispatch's first-observed
+    /// live spawn (issue: SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19).
+    /// Caller (`process_jsonl_change`) has already atomically claimed
+    /// `dispatch_id` in `naming_triggered` before calling this — this method
+    /// itself does no further dedup.
+    ///
+    /// Upgrades `self_ref` to a real `Arc<Self>` to move into the spawned
+    /// task; silently no-ops if this watcher was built via bare `new()`
+    /// (most unit tests) rather than `spawn()` — there is no Arc to upgrade
+    /// to in that case, matching this module's "untracked -> safe no-op"
+    /// convention rather than panicking.
+    #[cfg(test)]
+    pub(crate) fn naming_triggered_contains(&self, dispatch_id: &str) -> bool {
+        self.naming_triggered.lock().unwrap().contains(dispatch_id)
+    }
+
+    fn trigger_eager_naming(&self, dispatch_id: String, first_member_agent_id: String, is_workflow: bool) {
+        let Some(watcher) = self.self_ref.lock().unwrap().as_ref().and_then(|w| w.upgrade()) else {
+            return;
+        };
+        tokio::spawn(async move {
+            if is_workflow {
+                crate::server::app_api::session::generate_dispatch_name(
+                    &watcher.wstore,
+                    &watcher,
+                    &dispatch_id,
+                    &first_member_agent_id,
+                ).await;
+            } else {
+                crate::server::app_api::session::generate_subagent_name(
+                    &watcher.wstore,
+                    &watcher,
+                    &first_member_agent_id,
+                ).await;
+            }
+        });
     }
 
     // ── Internal methods ──────────────────────────────────────────────────
@@ -954,7 +1076,10 @@ impl SubagentWatcher {
             );
         }
         for (_, path) in candidates.into_iter().take(BACKFILL_MAX_FILES) {
-            self.process_jsonl_change(parent_agent, parent_block_id, &path);
+            // live=false: this is a cold-backfill replay (pane reopen / srv
+            // restart), not a genuinely-live spawn — must never trigger eager
+            // Haiku naming (see process_jsonl_change's `live` param doc).
+            self.process_jsonl_change(parent_agent, parent_block_id, &path, false);
         }
         for path in journals {
             self.process_journal_change(parent_agent, parent_block_id, &path);
@@ -963,7 +1088,18 @@ impl SubagentWatcher {
 
     /// Process a changed/new JSONL subagent file. Reads new lines, updates state,
     /// and broadcasts events via EventBus.
-    fn process_jsonl_change(&self, parent_agent: &str, parent_block_id: &str, jsonl_path: &Path) {
+    ///
+    /// `live`: `true` only when this call originates from the filesystem
+    /// watcher observing a real, in-the-moment change; `false` for a
+    /// cold-backfill replay (`scan_subagents_dir`, capped at
+    /// `BACKFILL_MAX_FILES`, run on pane reopen / srv restart). Eager
+    /// Haiku-naming (see the `is_new` handling below) is gated on `live` —
+    /// without this, every restart of a long-lived session would re-fire a
+    /// naming call for every dispatch replayed from history, repeating the
+    /// broadcast-storm incident class in
+    /// docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md, just for
+    /// Haiku spend instead of WS events.
+    fn process_jsonl_change(&self, parent_agent: &str, parent_block_id: &str, jsonl_path: &Path, live: bool) {
         // Extract agent ID from filename: agent-<id>.jsonl
         let agent_id = match jsonl_path
             .file_stem()
@@ -1118,6 +1254,17 @@ impl SubagentWatcher {
         // Mutex released here — broadcast outside the lock
 
         if is_new {
+            // Eager per-dispatch Haiku naming (issue:
+            // SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19). Gated on
+            // `live` (never during backfill replay) and on `naming_triggered`
+            // atomically claiming this dispatch_id — for a Workflow dispatch,
+            // every member's is_new fires with the SAME dispatch_id, so only
+            // the first member to reach this point wins the claim; a Solo
+            // dispatch's dispatch_id is unique to its one member, so it
+            // always wins its own claim exactly once.
+            if live && self.naming_triggered.lock().unwrap().insert(dispatch_id.clone()) {
+                self.trigger_eager_naming(dispatch_id.clone(), agent_id.clone(), workflow_id.is_some());
+            }
             if workflow_id.is_some() {
                 let mut pending = self.pending_activity.lock().unwrap();
                 let entry = pending
@@ -1174,8 +1321,24 @@ impl SubagentWatcher {
                     .or_insert_with(|| PendingDispatchActivity::new(parent_agent, parent_block_id, &session_id));
                 entry.members.push((agent_id.clone(), new_events.clone()));
             } else {
-                // Solo dispatch: exactly one member, no coalescing benefit —
-                // broadcast immediately, same as before the redesign.
+                // Solo dispatch: exactly one member, no coalescing benefit for
+                // this event itself — broadcast subagent:activity immediately,
+                // same as before the redesign (existing consumers, e.g. the
+                // agent-pane activity dock, still rely on this per-member
+                // stream). ADDITIONALLY queue into pending_activity so
+                // dispatch:activity also flows for solo dispatch_ids — Phase B
+                // of SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19's
+                // unified concatenated feed needs this for solo rows, which
+                // dispatch:activity never covered before. Deliberate dual
+                // emission, not a replacement — see that spec's Phase A notes
+                // for why the existing subagent:activity stream is kept as-is.
+                {
+                    let mut pending = self.pending_activity.lock().unwrap();
+                    let entry = pending
+                        .entry(dispatch_id.clone())
+                        .or_insert_with(|| PendingDispatchActivity::new(parent_agent, parent_block_id, &session_id));
+                    entry.members.push((agent_id.clone(), new_events.clone()));
+                }
                 let activity_event = WSEventType {
                     eventtype: WS_EVENT_RPC.to_string(),
                     oref: String::new(),
@@ -1514,6 +1677,7 @@ impl SubagentWatcher {
                     members_done: 0,
                     status: DispatchStatus::Running,
                     last_event_at: now_millis(),
+                    dispatch_name: None,
                 },
                 journal_offset: 0,
                 journal_started: 0,
@@ -1565,6 +1729,7 @@ impl SubagentWatcher {
                         "memberCount": info.member_count,
                         "membersDone": info.members_done,
                         "status": info.status,
+                        "dispatchName": info.dispatch_name,
                     }
                 }
             })),
@@ -2015,7 +2180,8 @@ mod tests {
     use super::*;
 
     fn fixture_watcher() -> SubagentWatcher {
-        SubagentWatcher::new(Arc::new(EventBus::new()))
+        let wstore = Arc::new(crate::backend::storage::store::Store::open_in_memory().unwrap());
+        SubagentWatcher::new(Arc::new(EventBus::new()), wstore)
     }
 
     /// Write a minimal terminated subagent JSONL file with an explicit mtime
@@ -2261,7 +2427,7 @@ mod tests {
         .unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         {
             let sessions = watcher.sessions.lock().unwrap();
@@ -2289,7 +2455,7 @@ mod tests {
         .unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         {
             let sessions = watcher.sessions.lock().unwrap();
@@ -2318,7 +2484,7 @@ mod tests {
         .unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         let sessions = watcher.sessions.lock().unwrap();
         let session = sessions.values().next().expect("session recorded");
@@ -2343,7 +2509,7 @@ mod tests {
         .unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         let sessions = watcher.sessions.lock().unwrap();
         let session = sessions.values().next().expect("session recorded");
@@ -2365,7 +2531,7 @@ mod tests {
         .unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         let dispatches = watcher.list_dispatches();
         assert_eq!(dispatches.len(), 1, "one solo dispatch, synthesized on demand");
@@ -2392,7 +2558,7 @@ mod tests {
         std::fs::write(&jsonl_path, "{\"type\":\"result\",\"result\":\"done\"}\n").unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         let dispatches = watcher.list_dispatches();
         assert_eq!(dispatches.len(), 1);
@@ -2449,7 +2615,7 @@ mod tests {
         .unwrap();
 
         let watcher = fixture_watcher();
-        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path);
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
 
         {
             let pending = watcher.pending_activity.lock().unwrap();
@@ -2464,6 +2630,73 @@ mod tests {
             let pending = watcher.pending_activity.lock().unwrap();
             assert!(pending.is_empty(), "flush must drain every dispatch's buffer");
         }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Issue: SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A —
+    /// a Workflow dispatch's `dispatch_id` is shared by every member, so
+    /// `naming_triggered` must claim it exactly once, on the first member's
+    /// live `is_new`, not once per member. `fixture_watcher()` has no
+    /// `self_ref` (built via bare `new()`), so `trigger_eager_naming` itself
+    /// no-ops after the gate — this test only exercises the synchronous
+    /// gating logic in `process_jsonl_change`, not the async Haiku call.
+    #[test]
+    fn process_jsonl_change_claims_naming_triggered_once_per_workflow_not_once_per_member() {
+        let dir = std::env::temp_dir().join(format!("amx-naming-wf-{}", now_millis()));
+        let run_dir = dir.join("subagents").join("workflows").join("wf_naming1");
+        std::fs::create_dir_all(&run_dir).unwrap();
+
+        let watcher = fixture_watcher();
+        assert!(!watcher.naming_triggered_contains("wf_naming1"));
+
+        for member in ["member-a", "member-b"] {
+            let jsonl_path = run_dir.join(format!("agent-{member}.jsonl"));
+            std::fs::write(
+                &jsonl_path,
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+            )
+            .unwrap();
+            watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, true);
+        }
+
+        // Claimed after the FIRST member's live is_new — this is the
+        // dedup key that keeps the eventual Haiku call to exactly one per
+        // dispatch regardless of member count.
+        assert!(watcher.naming_triggered_contains("wf_naming1"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Issue: SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A —
+    /// the non-negotiable backfill guard: `live=false` (the exact value
+    /// `scan_subagents_dir`'s cold-backfill replay passes) must never claim
+    /// `naming_triggered`, even though `is_new` is still true for a file the
+    /// in-memory `sessions` map has never seen before (which is the whole
+    /// backfill mechanism). Without this, every srv restart / pane reopen
+    /// against a long-lived session would re-fire a Haiku call for every
+    /// dispatch replayed from history — the exact incident class in
+    /// docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md, just for
+    /// Haiku spend instead of WS broadcast volume.
+    #[test]
+    fn process_jsonl_change_never_claims_naming_triggered_during_backfill_replay() {
+        let dir = std::env::temp_dir().join(format!("amx-naming-backfill-{}", now_millis()));
+        let subagents_dir = dir.join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+        let jsonl_path = subagents_dir.join("agent-replayed.jsonl");
+        std::fs::write(
+            &jsonl_path,
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n",
+        )
+        .unwrap();
+
+        let watcher = fixture_watcher();
+        watcher.process_jsonl_change("parent-1", "block-1", &jsonl_path, false);
+
+        assert!(
+            !watcher.naming_triggered_contains("solo:replayed"),
+            "backfill replay (live=false) must never claim naming_triggered"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/agentmux-srv/src/backend/subagent_watcher.rs
+++ b/agentmux-srv/src/backend/subagent_watcher.rs
@@ -816,6 +816,16 @@ impl SubagentWatcher {
         true
     }
 
+    /// Test-only accessor for `naming_triggered` — lets tests assert the
+    /// dedup gate claimed (or didn't claim) a given dispatch_id without
+    /// needing a real `Arc<Self>`/spawned task (see `trigger_eager_naming`'s
+    /// doc comment below for why `naming_triggered_contains` alone, not the
+    /// full eager-naming flow, is what unit tests can exercise).
+    #[cfg(test)]
+    pub(crate) fn naming_triggered_contains(&self, dispatch_id: &str) -> bool {
+        self.naming_triggered.lock().unwrap().contains(dispatch_id)
+    }
+
     /// Fire the one eager Haiku-naming call for a dispatch's first-observed
     /// live spawn (issue: SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19).
     /// Caller (`process_jsonl_change`) has already atomically claimed
@@ -827,11 +837,6 @@ impl SubagentWatcher {
     /// (most unit tests) rather than `spawn()` — there is no Arc to upgrade
     /// to in that case, matching this module's "untracked -> safe no-op"
     /// convention rather than panicking.
-    #[cfg(test)]
-    pub(crate) fn naming_triggered_contains(&self, dispatch_id: &str) -> bool {
-        self.naming_triggered.lock().unwrap().contains(dispatch_id)
-    }
-
     fn trigger_eager_naming(&self, dispatch_id: String, first_member_agent_id: String, is_workflow: bool) {
         let Some(watcher) = self.self_ref.lock().unwrap().as_ref().and_then(|w| w.upgrade()) else {
             return;

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -920,7 +920,7 @@ async fn main() {
     let messagebus = Arc::new(backend::messagebus::MessageBus::new());
 
     // Subagent watcher — monitors Claude Code session dirs for spawned subagents
-    let subagent_watcher = backend::subagent_watcher::SubagentWatcher::spawn(event_bus.clone());
+    let subagent_watcher = backend::subagent_watcher::SubagentWatcher::spawn(event_bus.clone(), wstore.clone());
 
     // History service — discovers and indexes past CLI agent conversations
     let history_service = Arc::new(backend::history::HistoryService::new());

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -331,7 +331,7 @@ mod recent_sessions_tests {
             messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
             http_client: reqwest::Client::new(),
             local_web_url: String::new(),
-            subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone())),
+            subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone(), wstore.clone())),
             history_service: Arc::new(crate::backend::history::HistoryService::new()),
             lan_discovery: Arc::new(crate::backend::lan_discovery::LanDiscoveryController::new(
                 "test-instance".to_string(),
@@ -642,7 +642,7 @@ mod recent_sessions_tests {
             messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
             http_client: reqwest::Client::new(),
             local_web_url: String::new(),
-            subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone())),
+            subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone(), wstore.clone())),
             history_service: Arc::new(crate::backend::history::HistoryService::new()),
             lan_discovery: Arc::new(crate::backend::lan_discovery::LanDiscoveryController::new(
                 "test-instance".to_string(),

--- a/agentmux-srv/src/server/app_api/session.rs
+++ b/agentmux-srv/src/server/app_api/session.rs
@@ -280,6 +280,97 @@ pub(crate) async fn generate_subagent_name(
     Some((name, tokens))
 }
 
+/// Ambient-call purpose tag for eager Workflow-dispatch naming — distinct
+/// from `AMBIENT_PURPOSE_SUBAGENT_NAME` so cost-dashboard tagging can tell
+/// the two apart even though they share the same gateway/semaphore. See
+/// docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md.
+const AMBIENT_PURPOSE_DISPATCH_NAME: &str = "dispatch_name";
+
+/// Generate the one Haiku display name for a Workflow-kind dispatch,
+/// eagerly, the first time its first member is observed live (never called
+/// for a Solo dispatch — a Solo dispatch's name IS its one member's
+/// `display_name`, already covered by `generate_subagent_name`; never called
+/// during cold-backfill replay — see `subagent_watcher.rs`'s
+/// `trigger_eager_naming`/`process_jsonl_change`'s `live` gate).
+///
+/// A workflow has no single task prompt the way a solo call does (members
+/// can have different prompts) — this reads `first_member_agent_id`'s own
+/// task prompt via the same `read_task_prompt()` `generate_subagent_name`
+/// uses, on the resolved design basis that the first member's prompt is a
+/// reasonable stand-in for the whole batch (SPEC §3 — not a perfect
+/// representation of every member's task, an accepted v1 trade-off).
+///
+/// Otherwise mirrors `generate_subagent_name`'s admission/semaphore/prompt/
+/// block-resolve/haiku-call shape exactly — no cache-hit short-circuit here
+/// (unlike that function): this is only ever called once per dispatch,
+/// already guarded by `naming_triggered` at the call site, so a cache check
+/// would be dead code, not a real fast path.
+pub(crate) async fn generate_dispatch_name(
+    wstore: &Store,
+    subagent_watcher: &Arc<crate::backend::subagent_watcher::SubagentWatcher>,
+    dispatch_id: &str,
+    first_member_agent_id: &str,
+) -> Option<(String, Option<crate::agents::TokenCounts>)> {
+    let info = subagent_watcher.get_info(first_member_agent_id)?;
+
+    let key = crate::ambient::AmbientCallKey::new(dispatch_id.to_string(), AMBIENT_PURPOSE_DISPATCH_NAME);
+    let guard = match crate::ambient::gateway().admit(key, 1) {
+        crate::ambient::Admission::Proceed(guard) => guard,
+        crate::ambient::Admission::StaleOnArrival => return None,
+    };
+    let cancel = guard.cancellation();
+
+    // Same cross-block concurrency cap as every other ambient caller — see
+    // AMBIENT_PURPOSE_SUBAGENT_NAME's comment above.
+    let permit = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        permit = pull_call_semaphore().acquire() => permit.ok(),
+    };
+    let Some(_permit) = permit else {
+        drop(guard);
+        return None;
+    };
+
+    let Some(task_prompt) = crate::backend::subagent_watcher::read_task_prompt(&info.jsonl_path) else {
+        drop(guard);
+        return None;
+    };
+
+    let block: Block = match wstore.get(&info.parent_block_id) {
+        Ok(Some(b)) => b,
+        _ => {
+            drop(guard);
+            return None;
+        }
+    };
+    let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
+    if cli_path.is_empty() {
+        drop(guard);
+        return None;
+    }
+
+    let prompt = format!(
+        "Give a concise ~5-word name for this workflow batch, based on its \
+         first task. Plain text only — no markdown, no code fences, no \
+         backticks, no punctuation, no quotes, no preamble. Respond with \
+         just the name.\n\n\
+         Task:\n\n{task_prompt}"
+    );
+
+    let result = invoke_ambient_haiku_call(&cli_path, &prompt, &block.meta, cancel).await.ok();
+    drop(guard);
+
+    let (name, tokens) = result?;
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+
+    subagent_watcher.set_dispatch_name(dispatch_id, &name);
+    Some((name, tokens))
+}
+
 fn register_session_activity_summary(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let filestore = state.filestore.clone();

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -40,7 +40,7 @@ pub(crate) fn test_state() -> AppState {
         app_path: String::new(),
         wstore: wstore.clone(),
         shared_store: None,
-        id_store: wstore,
+        id_store: wstore.clone(),
         filestore,
         global_transcript_store: None,
         event_bus: event_bus.clone(),
@@ -51,7 +51,7 @@ pub(crate) fn test_state() -> AppState {
         messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
         http_client: reqwest::Client::new(),
         local_web_url: String::new(),
-        subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone())),
+        subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus.clone(), wstore.clone())),
         history_service: Arc::new(crate::backend::history::HistoryService::new()),
         lan_discovery: Arc::new(crate::backend::lan_discovery::LanDiscoveryController::new(
             "test-instance".to_string(),

--- a/docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md
+++ b/docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md
@@ -1,0 +1,307 @@
+# SPEC: eager per-dispatch naming + two-bucket swarm row model
+
+**Date:** 2026-07-19
+**Status:** Proposed — design only, no implementation yet.
+**Ask (verbatim):** "we want 1 haiku call be agent tool call, and 1 per
+workflow tool call, which should be 54 .. actually, lets split Agents and
+Workflows, they should be top-level ... AgentA -> Agent Tool -> All
+subagents concatenated by time and AgentA -> Workflow -> All subagents
+concatenated ... also the Agent Tool/Workflow slug gets a haiku name at the
+beginning" — refined down to: at this point we only want a spec written to
+file, no implementation.
+
+---
+
+## 1. Problem
+
+Live investigation this session (see the two reports below) found that the
+Swarm pane's row labels come from Claude Code's per-**session** `slug`, not a
+per-subagent identifier — every subagent spawned within one CLI session
+inherits the identical literal slug. A long session with many Agent-tool and
+Workflow-tool calls therefore renders as a wall of visually-duplicate rows,
+even though the backend correctly tracks each dispatch as a distinct entity
+(`dispatch_id`).
+
+Two prior docs (this session, kept local/uncommitted) capture the
+investigation and the real numbers behind this spec:
+
+- `docs/specs/REPORT_SWARM_PANE_ROW_MODEL_2026_07_18.md` — the row-kind model
+  as of PR #2208 (one row per `AgentDispatch`, Workflow membership always
+  wins, `NameGroup` collapses same-slug/same-name solo dispatches).
+- `docs/specs/REPORT_SWARM_SUBAGENT_INVENTORY_2026_07_19.md` — ground-truth
+  counts for this session's own history: **52 Agent-tool calls, 2
+  Workflow-tool calls, 265 subagents total** (213 of them workflow members),
+  spanning 14 days, all but one sharing the slug
+  `quizzical-tumbling-valiant`.
+
+PR #2226 (merged earlier this session) patched the visible symptom by
+widening `NameGroup`'s grouping key to fall back to `slug` when a subagent's
+Haiku-generated `display_name` hasn't resolved yet — naming today is lazy,
+resolved on-demand only when a client expands a row
+(`subagent.GenerateName`, `agentmux-srv/src/server/app_api/session.rs:215-281`).
+That fix is sound as far as it goes, but it's a patch on a lazy-naming model.
+
+## 2. What's actually wanted (superseding #2226's approach)
+
+Instead of collapsing same-slug rows into a data-driven `NameGroup`, give
+every dispatch its own real, distinct name **eagerly, at dispatch-detection
+time** — one Haiku call per Agent-tool call, one per Workflow-tool call (54
+for this session, not 265 — never one call per workflow *member*). Organize
+the tree into two **fixed** top-level buckets per agent block:
+
+```
+▾ 🤖 AgentA
+  ▾ Agent Tool (52)
+      ├─ ▸ "Verify per-turn overhead doc claims"                  07-04  ○
+      ├─ ▸ "Audit swarm dedup regression"                          07-07  ○
+      ├─ ...49 more, each its own Haiku title, own row...
+      └─ ▸ "Armory consolidation identities and reorder"           07-18  ○
+  ▾ Workflow (2)
+      ├─ ▸ "Pool-eviction under memory pressure" — 107/107 done    07-13  ✓
+      └─ ▸ "Consolidate open issues"              — 106/106 done   07-14  ✓
+```
+
+`Agent Tool` and `Workflow` are always exactly these two headers, not
+data-driven groups — they don't appear/disappear based on shared names, and
+nothing collapses multiple dispatches into one row anymore. Every leaf,
+solo or workflow, expands to **one concatenated chronological text feed**
+(reusing/generalizing the mechanism `WorkflowDispatchRow` already has today)
+instead of the structured per-event tool_use/tool_result tree solo rows
+currently show.
+
+This directly **removes `NameGroup`** (`swarm-model.ts:124-146`,
+`groupKeyFor`, and the two slug-fallback tests added minutes earlier in PR
+#2226) — call this out plainly as a superseding design decision, not an
+oversight. With every dispatch eagerly and individually named, and no more
+"collapse same-name things into one row" concept, `NameGroup` has no reason
+to exist. `frontend/app/view/agent/activity/subagent-adapter.ts` directly
+imports `NameGroup`/`isNameGroup`/`groupCacheKey` today for its own
+independent activity-dock grouping (`groupSubagentsForDock()`) — needs a
+compatibility pass when those types disappear, scope to be confirmed at
+implementation time.
+
+## 3. Backend: eager naming infrastructure
+
+Traced against `agentmux-srv/src/backend/subagent_watcher.rs` and
+`agentmux-srv/src/server/app_api/session.rs`:
+
+- **The existing naming call** (`generate_subagent_name`, `session.rs:215-281`)
+  already does the right thing per-subagent: checks the `SubagentWatcher`
+  cache first (no re-spend), admits through the Ambient Model Call gateway
+  (`crate::ambient::gateway()`, purpose `AMBIENT_PURPOSE_SUBAGENT_NAME`),
+  acquires `pull_call_semaphore()` (`session.rs:110-125`, cap 2 concurrent —
+  shared across every ambient caller in the backend), reads the subagent's
+  own first JSONL line via `read_task_prompt()`
+  (`subagent_watcher.rs:1695-1728`), and calls
+  `invoke_ambient_haiku_call` (`session.rs:526-625`, hardcoded
+  `--model claude-haiku-4-5-20251001`, the only model this whole ambient-call
+  subsystem ever uses). This machinery is reused as-is — the change is
+  *when* it fires, not *how* it works.
+- **The hook point**: `process_jsonl_change`'s `is_new` computation
+  (`subagent_watcher.rs:1018`) is where a subagent's first appearance is
+  detected today, immediately followed by the existing solo/workflow branch
+  (`workflow_id.is_some()`, lines 1121/1131) that already decides between
+  buffering into `pending_activity` vs. broadcasting `subagent:spawned`
+  directly. This is the natural place to trigger eager naming too.
+- **New tracking needed**: a `naming_triggered: Mutex<HashSet<String>>` keyed
+  by `dispatch_id`, checked-and-inserted atomically at that same point,
+  *before* spawning any background task — this is what caps naming to
+  exactly once per dispatch (the one member for a solo call; the first of N
+  for a workflow). No existing state fits this role: `dispatches: Mutex<HashMap<...>>`
+  (`subagent_watcher.rs:291`) is populated from both the live debounce loop
+  AND `process_journal_change` (workflow `journal.jsonl` processing,
+  `subagent_watcher.rs:1429-1495`), which can land in the same debounce batch
+  in either order — reusing "does `dispatches` already have this key" as an
+  "already named" proxy is racy and would silently skip naming a workflow
+  whose journal event happened to process first.
+- **Naming source for a workflow**: no single task prompt exists for a whole
+  workflow (members can have different prompts) — per the resolved design
+  decision, base the one workflow-level Haiku call on the **first member's**
+  task prompt, reusing `read_task_prompt()` unchanged. Simple, no new
+  prompt-sourcing logic; the name may not perfectly represent every member's
+  task, accepted as a reasonable v1 trade-off.
+- **New surface area for workflow naming**: `AgentDispatch`
+  (`subagent_watcher.rs:125-145`) has no name field at all today — only
+  `SubAgent.display_name` exists (`subagent_watcher.rs:70-73`, written by
+  `set_display_name`, `subagent_watcher.rs:678-733`). Add
+  `AgentDispatch.dispatch_name: Option<String>`, a
+  `set_dispatch_display_name`-equivalent, and a `dispatch:named`-equivalent
+  broadcast (mirroring `subagent:named`'s shape), wired into
+  `broadcast_dispatch_updated` (`subagent_watcher.rs:1551-1573`) and the
+  coalesced flush's `latest_info` (`subagent_watcher.rs:1359-1361`) so every
+  client watching the session picks up the resolved workflow name, not just
+  whichever one triggered it — this is genuinely new backend surface, not a
+  relocation of the existing per-member RPC (today's `WorkflowDispatchRow`
+  derives its label purely client-side from a member's `slug`,
+  `swarm-model.ts:207-211`, and never calls `GenerateName` for a workflow at
+  all).
+- **Non-negotiable guard — never during backfill.** `scan_subagents_dir`
+  (`subagent_watcher.rs:903-962`, capped at `BACKFILL_MAX_FILES=200`) replays
+  historical `agent-*.jsonl` files as `is_new` on every srv restart / pane
+  reopen — this session alone would trigger ~54 unwanted Haiku calls on every
+  restart if eager naming isn't explicitly scoped to genuinely-live,
+  filesystem-watched spawns only. `process_jsonl_change` has no
+  caller-context signal today distinguishing a backfill replay from the live
+  debounce loop (`subagent_watcher.rs:492-535`) — one needs to be added
+  (e.g. a `live: bool` parameter threaded from each call site). This directly
+  guards against repeating the incident class documented in
+  `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`.
+- **Async pattern to follow**: `agentmux-srv/src/backend/reactive/activity_watcher.rs:99-141`
+  is the closest existing precedent for "background/non-request-driven
+  ambient call, capped and de-duplicated" — an `in_flight: Arc<Mutex<HashSet<String>>>`
+  guard, its own `Semaphore`, `tokio::spawn`, cleanup on every exit path.
+  Mirror this shape for the eager-naming task rather than inventing a new
+  pattern.
+- **`SubagentWatcher` currently has no `Store` handle.** `generate_subagent_name`
+  needs `wstore: &Store` to resolve the parent Block's `cmd`/`cmd:env` (a
+  subagent borrows its parent's CLI path + auth env — it has no Block of its
+  own). Plumbing `wstore: Arc<Store>` into `SubagentWatcher::new`/`spawn`
+  touches 3 construction call sites: `agentmux-srv/src/main.rs:923`,
+  `agentmux-srv/src/server/agent_handlers/mod.rs:334` and `:645`,
+  `agentmux-srv/src/server/tests.rs:54`. Mechanical, not architecturally
+  hard — `wstore` is already constructed earlier in `main.rs`, right before
+  `subagent_watcher` (line 923).
+- **Groundwork this also requires for the frontend's unified feed (§4):**
+  solo-dispatch activity/spawn/completion currently bypass
+  `pending_activity` entirely via three `else` branches gated on
+  `workflow_id.is_some()` (`subagent_watcher.rs:~1131-1161` spawn,
+  `~1176-1199` activity, `~1212-1239` completion) — confirmed live,
+  `dispatch:activity` is never broadcast for a `solo:<agent_id>` dispatch_id
+  today (only the old `subagent:activity` event fires). Route solo dispatches
+  through the same `pending_activity`/`flush_pending_dispatch_activity`
+  machinery (`subagent_watcher.rs:1267-1329`) instead, so
+  `createDispatchDetail("solo:<agent_id>")` actually receives events.
+
+## 4. Frontend: two-bucket tree + unified expand
+
+Traced against `frontend/app/view/swarm/swarm-model.ts` and `swarm-view.tsx`:
+
+- **`buildDispatchChildren()`/`AgentTreeNode.subagents`**
+  (`swarm-model.ts:162-270`) today produces one flat, recency-sorted
+  `SwarmChild[]` mixing three row kinds. Replace with two fixed arrays
+  (`agentToolRows: ActiveSubagent[]`, `workflowRows: WorkflowDispatch[]`),
+  dropping `NameGroup`/`groupKeyFor` entirely. Keep `WorkflowDispatch`'s half
+  of `stabilizeGroupIdentity`/`groupCacheKey`/`pruneGroupIdentityCache` — the
+  object-identity-stabilization problem those solve (SolidJS `<For>`
+  remounting wrapper objects on every unrelated tree recompute,
+  `swarm-model.ts:371-414`) doesn't go away just because `NameGroup` does.
+- **`AgentRow`'s single flat `<For>`** (`swarm-view.tsx:300-307`) becomes two
+  new bucket-header components (`AgentToolBucket`, `WorkflowBucket`), each
+  with its own live count and its own color. No existing "kind"-based (as
+  opposed to status-based) color axis exists anywhere in
+  `swarm-view.scss` today — the only current color differentiation is
+  active/retired/completed/abandoned status (e.g. the status-badge pattern
+  at `swarm-view.scss:218-235`, `color-mix(in srgb, var(--warning-color, ...) 15%, transparent)`).
+  Follow that same CSS-custom-property + `color-mix()` convention for the two
+  new bucket colors rather than hardcoding hex values — this is a new
+  precedent, not a reuse of an existing one. Buckets hide when empty,
+  matching the existing `hasChildren`-gated collapse-chevron precedent
+  (`swarm-view.tsx:236,268-279`) — no "always visible even when empty"
+  behavior; there's no analog for that anywhere in this codebase and no
+  stated reason to invent one.
+- **Unified concatenated-feed expand.** Generalize
+  `DispatchActivityFeed`/`createDispatchDetail`
+  (`swarm-view.tsx:322-444`, `swarm-model.ts:534-562`) — today wired only for
+  Workflow-kind dispatches — to cover solo rows too (depends on §3's backend
+  routing fix). Two gaps to close while doing this:
+  1. `createDispatchDetail` is explicitly **live-only**, no historical
+     backfill on expand (`swarm-model.ts:526-533` doc comment: "a large
+     dispatch can have thousands of prior events... eagerly fetching +
+     merging on every expand would reintroduce the exact volume problem this
+     redesign exists to fix"). The mechanism it replaces for solo rows,
+     `createSubagentDetail` (`swarm-model.ts:459-522`), DOES backfill via
+     `subagent.GetHistory`/`subagent.GetInfo`. Don't regress that — add
+     backfill to the generalized feed (bounded, matching the existing
+     `MAX_DISPATCH_FEED_ENTRIES = 500` cap, `swarm-model.ts:540`).
+  2. Once the unified feed covers both cases, retire
+     `SubagentDetailPane`/`SubagentDetailEvent`/`createSubagentDetail`
+     (`swarm-view.tsx:553-642`, `swarm-model.ts:459-522`) — dead code after
+     the migration.
+- **Naming display**: every row (solo and workflow) shows its
+  eagerly-resolved title immediately — no more `handleToggle`-triggered
+  `GenerateName` call on first expand (`swarm-view.tsx:509-519`), since
+  naming already happened at dispatch time per §3. `subagentDisplayLabel`'s
+  `slug`-fallback logic (`swarm-model.ts:281-287`, added for #2226) becomes
+  a true last-resort fallback only (e.g. a dispatch whose naming call is
+  still in flight or failed), not the common case it is today.
+- **`subagent-adapter.ts` compatibility**: it imports
+  `NameGroup`/`isNameGroup`/`groupCacheKey` directly
+  (`frontend/app/view/agent/activity/subagent-adapter.ts:34-39`) for its own
+  independent `groupSubagentsForDock()` — confirm at implementation time
+  whether it needs updating or is already self-contained enough not to.
+- **Test rewrite**: `swarm-model.test.ts`'s `buildDispatchChildren` describe
+  block (`swarm-model.test.ts:61-362`) needs rewriting against the two-bucket
+  shape, including dropping the `NameGroup` describe block
+  (`swarm-model.test.ts:201-320`ish) — which includes the two slug-fallback
+  tests (`collapses 2+ solo dispatches sharing only a slug...`,
+  `prefers display_name over slug as the grouping key...`) added minutes
+  earlier in PR #2226. Their removal is an expected, direct consequence of
+  §2, not a regression.
+
+## 5. Phasing
+
+Implement as two phases, each verified live in the already-running `task dev`
+instance (`dev:main`, `~/.agentmux/dev/main/`) before the next starts:
+
+**Phase A (backend)** — §3 in full: `wstore` plumbing, `naming_triggered`
+set, the backfill-vs-live guard, the eager-naming background task, workflow
+`dispatch_name` + broadcast, solo activity routed through
+`pending_activity`. Verify: dispatch a real solo call and a real workflow
+batch from a live agent pane, confirm via `muxlog srv grep` exactly one
+naming-resolved log line fires per dispatch immediately (not on click),
+confirm **zero** naming calls fire on an srv restart against this session's
+existing 265-subagent backfill (the critical regression to rule out), confirm
+`dispatch:activity` now flows for solo dispatch_ids too.
+
+**Phase B (frontend)** — §4 in full: two-bucket tree, bucket-header
+components + colors, generalized concatenated feed with backfill,
+`NameGroup` removal, `subagent-adapter.ts` compatibility pass, test rewrite.
+Verify: in `task dev`, confirm two colored buckets under AgentA showing
+live counts (52/2-style for a session like this one), each leaf showing its
+eagerly-resolved title with no click needed, expand showing the concatenated
+feed with historical entries present (not just live-from-expand-onward).
+
+## 6. Explicitly deferred / open questions
+
+- **No global ambient-call budget/rate-limit exists in the codebase today.**
+  `docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md:339-342`
+  already flags this as an unimplemented gap for the whole ambient-call
+  framework, not something specific to this feature. Eager firing turns a
+  click-paced trigger into a filesystem-event-paced one, which makes the gap
+  more relevant than it was for the lazy design — a session that spawns many
+  dispatches now pays for every single one unconditionally, throttled only
+  to 2 concurrent Haiku calls via the existing `pull_call_semaphore`, with no
+  cap on total spend. **This question was explicitly left open by the user
+  rather than resolved** — Phase A ships reusing only the existing semaphore,
+  no new per-session/global budget. Revisit if real-world cost from eager
+  firing turns out to be a problem.
+- **Always-visible-even-empty buckets** — not building this; buckets hide
+  when empty per §4, no existing precedent for the alternative.
+
+## 7. Files (representative, not exhaustive)
+
+**Backend:**
+- `agentmux-srv/src/backend/subagent_watcher.rs`
+- `agentmux-srv/src/server/app_api/session.rs`
+- `agentmux-srv/src/main.rs`
+- `agentmux-srv/src/server/agent_handlers/mod.rs`
+- `agentmux-srv/src/server/tests.rs`
+
+**Frontend:**
+- `frontend/app/view/swarm/swarm-model.ts`
+- `frontend/app/view/swarm/swarm-view.tsx`
+- `frontend/app/view/swarm/swarm-view.scss`
+- `frontend/app/view/swarm/swarm-model.test.ts`
+- `frontend/app/view/agent/activity/subagent-adapter.ts` (compatibility check)
+
+## 8. Verification (for the eventual implementation, not this spec pass)
+
+Backend: `cargo check -p agentmux-srv`, `cargo test -p agentmux-srv` for the
+touched modules, then the live Phase A steps in §5 (Rust changes need
+`task build:backend` + restart — `task dev`'s frontend hot-reload doesn't
+cover this). Frontend: `npx vitest run frontend/app/view/swarm/`,
+`npx tsc --noEmit -p tsconfig.json`, then the live Phase B steps in §5
+(hot-reloads directly in the running `task dev` window). No CI coverage
+exists for the live dispatch/naming behavior itself (WS events, Haiku call
+timing) — manual verification via `muxlog srv` is the only signal for
+whether eager naming and the two-bucket tree actually work end-to-end.


### PR DESCRIPTION
## Summary

Phase A of `docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md` — implementing the design from a live conversation about the Swarm pane's row model. Gives every Agent-tool/Workflow-tool dispatch its own Haiku-generated name **eagerly, at dispatch-detection time**, instead of lazily on first row-expand click. This is backend-only; Phase B (frontend two-bucket tree + unified expand) is a separate follow-up PR, per the spec's phasing.

## Key pieces

- `SubagentWatcher` gains a `wstore` handle, a `naming_triggered` dedup set (`dispatch_id` → "already fired"), and a weak self-reference (populated by `spawn()`, not bare `new()`) to upgrade to `Arc<Self>` for the naming background task.
- `process_jsonl_change` gains a `live: bool` param — **eager naming never fires during cold-backfill replay** (pane reopen / srv restart), only for genuinely-live filesystem-watched spawns. Without this, every restart of a long session would re-fire a naming call per historical dispatch — same incident class as `docs/retro/retro-subagent-backfill-storm-oom-2026-07-17.md`, just for Haiku spend instead of broadcast volume.
- The `naming_triggered` claim happens at the same `is_new` check that already splits solo vs. workflow — so a Workflow dispatch (shared `dispatch_id` across members) fires exactly once, on its first member, not once per member.
- New `AgentDispatch.dispatch_name` + `generate_dispatch_name` (session.rs) + `set_dispatch_name`, for Workflow-kind dispatches (based on the first member's task prompt — no single prompt exists for a whole batch). A Solo dispatch's name is just its one member's `display_name` — no new storage needed there, reuses `generate_subagent_name` unchanged.
- Solo-dispatch activity now also queues into `pending_activity` (dual emission alongside the existing immediate `subagent:activity`) — groundwork Phase B needs (`dispatch:activity` didn't fire for solo dispatch_ids before this).

Reuses the existing `pull_call_semaphore` (cap 2 concurrent) — no new global ambient-call budget this pass, per the spec's explicitly-deferred open question.

## Test plan

- [x] `cargo check -p agentmux-srv` clean
- [x] `cargo test -p agentmux-srv` — 1538/1539 pass (1 pre-existing flaky temp-dir race in an unrelated `read_task_prompt` test, confirmed passes in isolation, not touched by this diff)
- [x] 2 new targeted tests: naming claimed once per workflow (not per member), never claimed during backfill replay
- [x] `task dev` boots cleanly with the new backend, no runtime errors over several minutes of heartbeat
- [ ] Live end-to-end (dispatch a real Task-tool call, watch `muxlog srv` for the naming-resolved log line) — **not possible in this environment**, no way to drive the native CEF window's UI here. Flagging honestly rather than claiming coverage I don't have.

<!-- agentmux:agent_id=agenta -->