### PR TITLE
feat(swarm): two-bucket Agent Tool / Workflow row model (Phase B, frontend)

### DIFF
--- a/.changesets/1784491314-feat-swarm-two-bucket-agent-tool-workflow-row-model-with-eag-t5fl.md
+++ b/.changesets/1784491314-feat-swarm-two-bucket-agent-tool-workflow-row-model-with-eag-t5fl.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): two-bucket Agent Tool / Workflow row model with eager dispatch naming (Phase B, frontend)

--- a/frontend/app/view/agent/activity/subagent-adapter.ts
+++ b/frontend/app/view/agent/activity/subagent-adapter.ts
@@ -8,19 +8,26 @@
  * dock — proves the `PinnedActivity` abstraction generalizes beyond shells.
  *
  * Groups by `dispatch_id` (collapsing a Workflow dispatch's members into one
- * row, mirroring the Swarm pane's tree view), then by shared `display_name`
- * among the solo leftovers — `NameGroup`, reused directly from
- * swarm-model.ts. Deliberately NOT reusing swarm-model.ts's
- * `buildDispatchChildren`/`WorkflowDispatch` for the dispatch half: that
- * type intentionally drops the member list (SPEC_AGENT_DISPATCH_SUBAGENT_
- * HIERARCHY_2026_07_17 §7 — a Workflow dispatch can have thousands of
- * members, too many to hold in the Swarm pane's frequently-recomputed tree
- * atom), but this adapter needs each member's `spawned_at`/`status` to
- * compute one summary row — and the dock's own scale (pinned activity, not
- * a full tree) makes holding that list here safe. Without grouping at all,
- * the dock would show one row per `ActiveSubagent` instead of one row per
- * Agent-tool-or-Workflow-tool call (a single workflow run can spawn dozens
- * to hundreds at once).
+ * row, mirroring the Swarm pane's tree view) — 2+ members sharing one id
+ * (always a Workflow dispatch; a Solo dispatch is 1:1 with its one member)
+ * collapse into a `DispatchGroup`. Does NOT additionally group loose solo
+ * subagents by shared `display_name` — the `NameGroup` mechanism this used
+ * to reuse from swarm-model.ts was retired in
+ * SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 (superseded by eager
+ * per-dispatch Haiku naming, which removes the "many rows share one
+ * uninformative name" problem that grouping existed to paper over — see
+ * that spec §2). This dock mirrors the same simplification.
+ *
+ * Deliberately NOT reusing swarm-model.ts's `buildDispatchBuckets`/
+ * `WorkflowDispatch` for the dispatch half: that type intentionally drops
+ * the member list (SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17 §7 — a
+ * Workflow dispatch can have thousands of members, too many to hold in the
+ * Swarm pane's frequently-recomputed tree atom), but this adapter needs
+ * each member's `spawned_at`/`status` to compute one summary row — and the
+ * dock's own scale (pinned activity, not a full tree) makes holding that
+ * list here safe. Without grouping at all, the dock would show one row per
+ * `ActiveSubagent` instead of one row per Agent-tool-or-Workflow-tool call
+ * (a single workflow run can spawn dozens to hundreds at once).
  *
  * `canStop` is always `false`: no subagent-cancel RPC/UI exists anywhere in
  * the app today (confirmed — `AgentStopCommand` targets a pane's own agent
@@ -31,12 +38,7 @@
  * Spec: docs/specs/SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md (§3, §7)
  */
 
-import {
-    groupCacheKey,
-    isNameGroup,
-    type ActiveSubagent,
-    type NameGroup,
-} from "../../swarm/swarm-model";
+import type { ActiveSubagent } from "../../swarm/swarm-model";
 import type { ActivityStatus, PinnedActivity } from "./types";
 
 /** One dock row summarizing every member of a shared `dispatch_id` — the
@@ -52,19 +54,17 @@ interface DispatchGroup {
     lastEventAt: number;
 }
 
-function isDispatchGroup(x: ActiveSubagent | DispatchGroup | NameGroup): x is DispatchGroup {
+function isDispatchGroup(x: ActiveSubagent | DispatchGroup): x is DispatchGroup {
     return "kind" in x && x.kind === "dispatchGroup";
 }
 
 /** Group `subagents` (already filtered to one parent block) by `dispatch_id`
  *  — 2+ members sharing one id (always a Workflow dispatch; a Solo dispatch
  *  is 1:1 with its one member by construction) collapse into a
- *  `DispatchGroup`. Among what's left, 2+ subagents sharing an identical,
- *  non-empty `display_name` collapse into a `NameGroup`. A single subagent
- *  stays a loose, ungrouped row. */
+ *  `DispatchGroup`. A single subagent stays a loose, ungrouped row. */
 function groupSubagentsForDock(
     subagents: ActiveSubagent[]
-): (ActiveSubagent | DispatchGroup | NameGroup)[] {
+): (ActiveSubagent | DispatchGroup)[] {
     const byDispatch = new Map<string, ActiveSubagent[]>();
     for (const s of subagents) {
         const members = byDispatch.get(s.dispatch_id) ?? [];
@@ -92,38 +92,7 @@ function groupSubagentsForDock(
         });
     }
 
-    const stillLoose: ActiveSubagent[] = [];
-    const byName = new Map<string, ActiveSubagent[]>();
-    for (const s of loose) {
-        if (s.display_name) {
-            const members = byName.get(s.display_name) ?? [];
-            members.push(s);
-            byName.set(s.display_name, members);
-        } else {
-            stillLoose.push(s);
-        }
-    }
-    const nameGroups: NameGroup[] = [];
-    for (const [name, members] of byName) {
-        if (members.length < 2) {
-            stillLoose.push(...members);
-            continue;
-        }
-        const sorted = [...members].sort((a, b) => b.last_event_at - a.last_event_at);
-        const activeCount = sorted.filter((m) => m.status === "active").length;
-        nameGroups.push({
-            kind: "nameGroup",
-            name,
-            parentBlockId: sorted[0].parent_block_id,
-            subagents: sorted,
-            activeCount,
-            totalCount: sorted.length,
-            status: activeCount > 0 ? "active" : "retired",
-            lastEventAt: sorted[0]?.last_event_at ?? 0,
-        });
-    }
-
-    return [...stillLoose, ...dispatchGroups, ...nameGroups];
+    return [...loose, ...dispatchGroups];
 }
 
 function subagentStatusToActivity(s: ActiveSubagent["status"]): ActivityStatus {
@@ -158,17 +127,17 @@ export function subagentToActivity(s: ActiveSubagent): PinnedActivity {
     };
 }
 
-/** A `DispatchGroup`/`NameGroup` → one dock row summarizing every member,
- *  instead of one row per subagent. `startedAt` is the earliest member's
- *  spawn (the group's own lifetime, not just its most-recently-active
- *  member's); `endedAt` only lands once every member is terminal, matching
+/** A `DispatchGroup` → one dock row summarizing every member, instead of one
+ *  row per subagent. `startedAt` is the earliest member's spawn (the
+ *  group's own lifetime, not just its most-recently-active member's);
+ *  `endedAt` only lands once every member is terminal, matching
  *  `subagentToActivity`'s own "no member still running" rule. */
-function subagentGroupToActivity(group: DispatchGroup | NameGroup): PinnedActivity {
+function subagentGroupToActivity(group: DispatchGroup): PinnedActivity {
     const members = group.subagents;
     const anyAbandoned = members.some((m) => m.status === "abandoned");
     const status: ActivityStatus = group.activeCount > 0 ? "running" : anyAbandoned ? "stopped" : "done";
     return {
-        id: isDispatchGroup(group) ? group.dispatchId : groupCacheKey(group),
+        id: group.dispatchId,
         kind: "subagent",
         title: `${group.name} (${group.totalCount})`,
         status,
@@ -180,12 +149,11 @@ function subagentGroupToActivity(group: DispatchGroup | NameGroup): PinnedActivi
 }
 
 /** This pane's own subagents (`parent_block_id === blockId`), grouped by
- *  shared `dispatch_id` then by shared `display_name` among what's left,
- *  and mapped to activities. One dock row per Agent-tool-or-Workflow-tool
- *  call, not per individual subagent. */
+ *  shared `dispatch_id` and mapped to activities. One dock row per
+ *  Agent-tool-or-Workflow-tool call, not per individual subagent. */
 export function subagentActivities(all: ReadonlyArray<ActiveSubagent>, blockId: string): PinnedActivity[] {
     const mine = all.filter((s) => s.parent_block_id === blockId);
     return groupSubagentsForDock(mine).map((child) =>
-        isDispatchGroup(child) || isNameGroup(child) ? subagentGroupToActivity(child) : subagentToActivity(child)
+        isDispatchGroup(child) ? subagentGroupToActivity(child) : subagentToActivity(child)
     );
 }

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -25,10 +25,10 @@ import { KIND_SIGIL, type PinnedActivity } from "../activity/types";
 import type { ToolLogChunk } from "../types";
 
 /** One-line text summary per subagent event kind — deliberately simpler than
- *  the Swarm pane's own `SubagentDetailEvent` (no per-event expand/collapse,
- *  no dedicated CSS): the dock reuses the existing shell-log line chrome
- *  (`.agent-tool-log-line`) instead of depending on `swarm-view.scss`, which
- *  only loads once the user has opened a Swarm pane this session. */
+ *  the Swarm pane's own `DispatchActivityFeedEntry` (no per-event expand/
+ *  collapse, no dedicated CSS): the dock reuses the existing shell-log line
+ *  chrome (`.agent-tool-log-line`) instead of depending on `swarm-view.scss`,
+ *  which only loads once the user has opened a Swarm pane this session. */
 function subagentEventLine(e: SubagentEvent): string {
     const t = e.event_type;
     switch (t.type) {
@@ -143,7 +143,7 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
             setDispatchDetail(null);
             return;
         }
-        const detail = createDispatchDetail(sub.dispatch_id);
+        const detail = createDispatchDetail(sub.dispatch_id, sub.agent_id);
         setDispatchDetail(detail);
         onCleanup(() => detail.dispose());
     });

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -15,10 +15,10 @@ import { useTick } from "@/app/hook/useTick";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import {
-    createSubagentDetail,
+    createDispatchDetail,
     subagentDisplayLabel,
     type ActiveSubagent,
-    type SubagentDetail,
+    type DispatchDetail,
     type SubagentEvent,
 } from "../../swarm/swarm-model";
 import { KIND_SIGIL, type PinnedActivity } from "../activity/types";
@@ -136,15 +136,15 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
     // expanded (mirrors SwarmViewModel's own lazy `getSubagentDetail` cache),
     // disposed on collapse/unmount so an idle dock isn't holding N live
     // event subscriptions for subagents nobody is looking at.
-    const [subagentDetail, setSubagentDetail] = createSignal<SubagentDetail | null>(null);
+    const [dispatchDetail, setDispatchDetail] = createSignal<DispatchDetail | null>(null);
     createEffect(() => {
         const sub = props.activity()?.subagent;
         if (!props.expanded() || !sub) {
-            setSubagentDetail(null);
+            setDispatchDetail(null);
             return;
         }
-        const detail = createSubagentDetail(sub.agent_id);
-        setSubagentDetail(detail);
+        const detail = createDispatchDetail(sub.dispatch_id);
+        setDispatchDetail(detail);
         onCleanup(() => detail.dispose());
     });
 
@@ -209,14 +209,11 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
                             class="agent-activity-log agent-tool-overlay-log"
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <Show when={subagentDetail()?.statusAtom() === "loading"}>
-                                <pre class="agent-tool-log-line">Loading…</pre>
-                            </Show>
-                            <Show when={subagentDetail() && subagentDetail()!.eventsAtom().length === 0 && subagentDetail()!.statusAtom() !== "loading"}>
+                            <Show when={dispatchDetail() && dispatchDetail()!.entriesAtom().length === 0}>
                                 <pre class="agent-tool-log-line">No activity yet</pre>
                             </Show>
-                            <For each={subagentDetail()?.eventsAtom() ?? []}>
-                                {(event) => <pre class="agent-tool-log-line">{subagentEventLine(event)}</pre>}
+                            <For each={dispatchDetail()?.entriesAtom() ?? []}>
+                                {(entry) => <pre class="agent-tool-log-line">{subagentEventLine(entry.event)}</pre>}
                             </For>
                         </div>
                     </Show>

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -133,7 +133,7 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
     });
 
     // Expanded subagent transcript — created only while this row is actually
-    // expanded (mirrors SwarmViewModel's own lazy `getSubagentDetail` cache),
+    // expanded (mirrors SwarmViewModel's own lazy `getDispatchDetail` cache),
     // disposed on collapse/unmount so an idle dock isn't holding N live
     // event subscriptions for subagents nobody is looking at.
     const [dispatchDetail, setDispatchDetail] = createSignal<DispatchDetail | null>(null);

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -3,29 +3,16 @@
 
 import { describe, expect, it } from "vitest";
 import {
-    buildDispatchChildren,
+    buildDispatchBuckets,
     groupCacheKey,
-    isNameGroup,
-    isWorkflowDispatch,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     type ActiveSubagent,
     type AgentDispatch,
-    type NameGroup,
-    type SwarmChild,
     type WorkflowDispatch,
 } from "./swarm-model";
-
-/** Extract a SwarmChild's own identifying id, for assertions that don't care
- *  which of the three variants they got — narrows through all three via
- *  isWorkflowDispatch/isNameGroup rather than an unsafe cast. */
-function childId(c: SwarmChild): string {
-    if (isWorkflowDispatch(c)) return c.dispatchId;
-    if (isNameGroup(c)) return c.name;
-    return c.agent_id;
-}
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -54,32 +41,32 @@ function mkDispatch(overrides: Partial<AgentDispatch> & Pick<AgentDispatch, "dis
         members_done: 0,
         status: "running",
         last_event_at: 0,
+        dispatch_name: null,
         ...overrides,
     };
 }
 
-describe("buildDispatchChildren", () => {
-    it("leaves solo-dispatch subagents (no tracked AgentDispatch) as loose, ungrouped rows", () => {
-        const result = buildDispatchChildren([], [mk({ agent_id: "a1" }), mk({ agent_id: "a2" })]);
-        expect(result).toHaveLength(2);
-        expect(result.every((c) => !isWorkflowDispatch(c))).toBe(true);
+describe("buildDispatchBuckets", () => {
+    it("puts every solo dispatch in agentToolRows, never grouped", () => {
+        const { agentToolRows, workflowRows } = buildDispatchBuckets(
+            [],
+            [mk({ agent_id: "a1" }), mk({ agent_id: "a2" }), mk({ agent_id: "a3" })]
+        );
+        expect(agentToolRows).toHaveLength(3);
+        expect(workflowRows).toHaveLength(0);
     });
 
-    it("renders a Workflow-kind AgentDispatch as one row regardless of member count", () => {
+    it("renders a Workflow-kind AgentDispatch as one row in workflowRows, regardless of member count", () => {
         const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 3, status: "running" })];
         const subagents = [
             mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
             mk({ agent_id: "a2", dispatch_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
             mk({ agent_id: "a3", dispatch_id: "wf_1", slug: "cheerful-enchanting-sketch" }),
         ];
-        const result = buildDispatchChildren(dispatches, subagents);
-        expect(result).toHaveLength(1);
-        const group = result[0];
-        expect(isWorkflowDispatch(group)).toBe(true);
-        if (isWorkflowDispatch(group)) {
-            expect(group.memberCount).toBe(3);
-            expect(group.name).toBe("cheerful-enchanting-sketch");
-        }
+        const { agentToolRows, workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect(agentToolRows).toHaveLength(0);
+        expect(workflowRows).toHaveLength(1);
+        expect(workflowRows[0].memberCount).toBe(3);
     });
 
     it("never renders one row per member — SPEC §7, even for a dispatch this test can't realistically construct at full scale (1,030+ observed live)", () => {
@@ -87,21 +74,20 @@ describe("buildDispatchChildren", () => {
         const subagents = Array.from({ length: 50 }, (_, i) =>
             mk({ agent_id: `m${i}`, dispatch_id: "wf_big" })
         );
-        const result = buildDispatchChildren(dispatches, subagents);
-        // One row for the dispatch — the (partial, in this test) member list
-        // never expands into its own rows.
-        expect(result).toHaveLength(1);
-        expect(isWorkflowDispatch(result[0])).toBe(true);
+        const { workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect(workflowRows).toHaveLength(1);
+        expect(workflowRows[0].memberCount).toBe(200);
     });
 
     it("does not carry a member list on WorkflowDispatch — SPEC §7 (a large dispatch can't hold thousands of members in the tree atom)", () => {
         const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 2 })];
         const subagents = [mk({ agent_id: "a1", dispatch_id: "wf_1" }), mk({ agent_id: "a2", dispatch_id: "wf_1" })];
-        const [group] = buildDispatchChildren(dispatches, subagents);
-        expect("subagents" in (group as object)).toBe(false);
+        const { workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect("subagents" in (workflowRows[0] as object)).toBe(false);
+        expect("members" in (workflowRows[0] as object)).toBe(false);
     });
 
-    it("mixes loose subagents and workflow dispatches independently, one row per distinct dispatch", () => {
+    it("mixes agentToolRows and workflowRows independently, one row per distinct dispatch", () => {
         const dispatches = [
             mkDispatch({ dispatch_id: "wf_1", member_count: 2 }),
             mkDispatch({ dispatch_id: "wf_2", member_count: 1 }),
@@ -111,253 +97,105 @@ describe("buildDispatchChildren", () => {
             mk({ agent_id: "a2", dispatch_id: "wf_1" }),
             mk({ agent_id: "a3", dispatch_id: "wf_2" }),
             mk({ agent_id: "a4" }), // solo
+            mk({ agent_id: "a5" }), // solo
         ];
-        const result = buildDispatchChildren(dispatches, subagents);
-        const groups = result.filter(isWorkflowDispatch);
-        const loose = result.filter((c) => !isWorkflowDispatch(c));
-        expect(groups).toHaveLength(2);
-        expect(loose).toHaveLength(1);
+        const { agentToolRows, workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect(workflowRows).toHaveLength(2);
+        expect(agentToolRows).toHaveLength(2);
     });
 
-    it("falls back to a loose row for a workflow-kind subagent whose dispatch is missing from `dispatches` (stale/failed ListDispatches)", () => {
+    it("falls back to agentToolRows for a workflow-kind subagent whose dispatch is missing from `dispatches` (stale/failed ListDispatches)", () => {
         // `loadDispatches()` silently swallows RPC errors, so `dispatches`
         // can lag or miss entries that `subagents` (a separate fetch)
         // already has. A workflow member with no matching AgentDispatch row
-        // must degrade to a loose row, not vanish from the tree.
+        // must degrade to an Agent Tool row, not vanish from the tree.
         const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 1 })];
         const subagents = [
             mk({ agent_id: "a1", dispatch_id: "wf_1" }),
             mk({ agent_id: "a2", dispatch_id: "wf_missing" }),
         ];
-        const result = buildDispatchChildren(dispatches, subagents);
-        const groups = result.filter(isWorkflowDispatch);
-        const loose = result.filter((c) => !isWorkflowDispatch(c));
-        expect(groups).toHaveLength(1);
-        expect(loose).toHaveLength(1);
-        expect(childId(loose[0])).toBe("a2");
+        const { agentToolRows, workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect(workflowRows).toHaveLength(1);
+        expect(agentToolRows).toHaveLength(1);
+        expect(agentToolRows[0].agent_id).toBe("a2");
     });
 
     it("passes AgentDispatch.status through directly — running → active, completed → retired", () => {
-        const running = buildDispatchChildren(
-            [mkDispatch({ dispatch_id: "wf_1", status: "running" })],
-            [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
-        )[0];
-        const completed = buildDispatchChildren(
-            [mkDispatch({ dispatch_id: "wf_2", status: "completed" })],
-            [mk({ agent_id: "a2", dispatch_id: "wf_2" })]
-        )[0];
-        if (isWorkflowDispatch(running) && isWorkflowDispatch(completed)) {
-            expect(running.status).toBe("active");
-            expect(completed.status).toBe("retired");
-        } else {
-            throw new Error("expected workflow dispatch rows");
-        }
+        const { workflowRows } = buildDispatchBuckets(
+            [
+                mkDispatch({ dispatch_id: "wf_1", status: "running" }),
+                mkDispatch({ dispatch_id: "wf_2", status: "completed" }),
+            ],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1" }), mk({ agent_id: "a2", dispatch_id: "wf_2" })]
+        );
+        const running = workflowRows.find((w) => w.dispatchId === "wf_1");
+        const completed = workflowRows.find((w) => w.dispatchId === "wf_2");
+        expect(running?.status).toBe("active");
+        expect(completed?.status).toBe("retired");
     });
 
-    it("derives the dispatch name from the first member with a non-empty slug", () => {
-        const result = buildDispatchChildren(
-            [mkDispatch({ dispatch_id: "wf_1" })],
+    it("prefers the backend's eager dispatch_name over a member's slug", () => {
+        const { workflowRows } = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_1", dispatch_name: "Refactor auth module" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "zesty-crafting-kahan" })]
+        );
+        expect(workflowRows[0].name).toBe("Refactor auth module");
+    });
+
+    it("falls back to a member's slug when dispatch_name hasn't resolved yet", () => {
+        const { workflowRows } = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_1", dispatch_name: null })],
             [
                 mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "", last_event_at: 200 }),
                 mk({ agent_id: "a2", dispatch_id: "wf_1", slug: "zesty-crafting-kahan", last_event_at: 100 }),
             ]
         );
-        const group = result[0];
-        if (isWorkflowDispatch(group)) {
-            expect(group.name).toBe("zesty-crafting-kahan");
-        } else {
-            throw new Error("expected a workflow dispatch");
-        }
+        expect(workflowRows[0].name).toBe("zesty-crafting-kahan");
     });
 
-    it("falls back to the dispatch id as the name when no member has a slug (or no members are known yet)", () => {
-        const result = buildDispatchChildren(
-            [mkDispatch({ dispatch_id: "wf_unnamed" })],
+    it("falls back to the raw dispatch id when neither dispatch_name nor any member slug is available", () => {
+        const { workflowRows } = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_unnamed", dispatch_name: null })],
             [mk({ agent_id: "a1", dispatch_id: "wf_unnamed", slug: "" })]
         );
-        const group = result[0];
-        if (isWorkflowDispatch(group)) {
-            expect(group.name).toBe("wf_unnamed");
-        } else {
-            throw new Error("expected a workflow dispatch");
-        }
+        expect(workflowRows[0].name).toBe("wf_unnamed");
     });
 
-    it("sorts loose subagents and dispatches together by most recent activity", () => {
-        const result = buildDispatchChildren(
-            [mkDispatch({ dispatch_id: "wf_1", last_event_at: 500 })],
+    it("sorts agentToolRows by most recent activity", () => {
+        const { agentToolRows } = buildDispatchBuckets(
+            [],
             [
-                mk({ agent_id: "old-loose", last_event_at: 100 }),
-                mk({ agent_id: "a1", dispatch_id: "wf_1", last_event_at: 500 }),
-                mk({ agent_id: "newest-loose", last_event_at: 900 }),
+                mk({ agent_id: "old", last_event_at: 100 }),
+                mk({ agent_id: "newest", last_event_at: 900 }),
+                mk({ agent_id: "mid", last_event_at: 500 }),
             ]
         );
-        expect(result).toHaveLength(3);
-        // newest-loose (900) > wf_1 dispatch (500) > old-loose (100)
-        expect(childId(result[0])).toBe("newest-loose");
-        expect(childId(result[2])).toBe("old-loose");
+        expect(agentToolRows.map((r) => r.agent_id)).toEqual(["newest", "mid", "old"]);
     });
 
-    describe("name-based grouping of solo dispatches (issue: same-name duplicate rows)", () => {
-        it("collapses 2+ solo dispatches sharing a display_name into one NameGroup", () => {
-            const result = buildDispatchChildren(
-                [],
-                [
-                    mk({ agent_id: "a1", display_name: "Code Reviewer" }),
-                    mk({ agent_id: "a2", display_name: "Code Reviewer" }),
-                    mk({ agent_id: "a3", display_name: "Code Reviewer" }),
-                ]
-            );
-            expect(result).toHaveLength(1);
-            const group = result[0];
-            expect(isNameGroup(group)).toBe(true);
-            if (isNameGroup(group)) {
-                expect(group.name).toBe("Code Reviewer");
-                expect(group.totalCount).toBe(3);
-            }
-        });
+    it("sorts workflowRows by most recent activity", () => {
+        const { workflowRows } = buildDispatchBuckets(
+            [
+                mkDispatch({ dispatch_id: "wf_old", last_event_at: 100 }),
+                mkDispatch({ dispatch_id: "wf_newest", last_event_at: 900 }),
+                mkDispatch({ dispatch_id: "wf_mid", last_event_at: 500 }),
+            ],
+            []
+        );
+        expect(workflowRows.map((r) => r.dispatchId)).toEqual(["wf_newest", "wf_mid", "wf_old"]);
+    });
 
-        it("leaves a single subagent with a unique display_name as a loose row (no group chrome for a non-dupe)", () => {
-            const result = buildDispatchChildren([], [mk({ agent_id: "a1", display_name: "Only One" })]);
-            expect(result).toHaveLength(1);
-            expect(isNameGroup(result[0])).toBe(false);
-            expect(childId(result[0])).toBe("a1");
-        });
-
-        it("leaves subagents with no display_name AND no slug as loose, ungrouped rows even if several exist", () => {
-            const result = buildDispatchChildren(
-                [],
-                [mk({ agent_id: "a1", display_name: null }), mk({ agent_id: "a2", display_name: null })]
-            );
-            expect(result).toHaveLength(2);
-            expect(result.every((c) => !isNameGroup(c))).toBe(true);
-        });
-
-        it("collapses 2+ solo dispatches sharing only a slug (no display_name resolved yet) into one NameGroup", () => {
-            // The common case: Claude Code stamps one slug per CLI session on
-            // every subagent it spawns (not per-subagent), and display_name
-            // only resolves once a client manually expands a row — so most
-            // solo dispatches are seen here with display_name: null and an
-            // identical slug. Without the slug fallback, a session with many
-            // solo Task-tool calls renders one row per call at the top level,
-            // which is the "dozens of copies of the same slug" regression.
-            const result = buildDispatchChildren(
-                [],
-                [
-                    mk({ agent_id: "a1", display_name: null, slug: "quizzical-tumbling-valiant" }),
-                    mk({ agent_id: "a2", display_name: null, slug: "quizzical-tumbling-valiant" }),
-                    mk({ agent_id: "a3", display_name: null, slug: "quizzical-tumbling-valiant" }),
-                ]
-            );
-            expect(result).toHaveLength(1);
-            const group = result[0];
-            expect(isNameGroup(group)).toBe(true);
-            if (isNameGroup(group)) {
-                expect(group.name).toBe("quizzical-tumbling-valiant");
-                expect(group.totalCount).toBe(3);
-            }
-        });
-
-        it("prefers display_name over slug as the grouping key — a named member does not join its same-slug siblings' slug-keyed group", () => {
-            const result = buildDispatchChildren(
-                [],
-                [
-                    mk({ agent_id: "a1", display_name: null, slug: "shared-slug" }),
-                    mk({ agent_id: "a2", display_name: null, slug: "shared-slug" }),
-                    mk({ agent_id: "a3", display_name: "Named Differently", slug: "shared-slug" }),
-                ]
-            );
-            const groups = result.filter(isNameGroup);
-            // a1/a2 collapse under the shared slug; a3 (resolved display_name)
-            // is its own loose row since nothing else shares "Named Differently".
-            expect(groups).toHaveLength(1);
-            expect(groups[0].name).toBe("shared-slug");
-            expect(groups[0].totalCount).toBe(2);
-            expect(result.some((c) => !isNameGroup(c) && !isWorkflowDispatch(c) && c.agent_id === "a3")).toBe(true);
-        });
-
-        it("workflow dispatches take priority — same-named subagents in a workflow never form a NameGroup", () => {
-            const result = buildDispatchChildren(
-                [mkDispatch({ dispatch_id: "wf_1", member_count: 2 })],
-                [
-                    mk({ agent_id: "a1", dispatch_id: "wf_1", display_name: "Worker" }),
-                    mk({ agent_id: "a2", dispatch_id: "wf_1", display_name: "Worker" }),
-                ]
-            );
-            expect(result).toHaveLength(1);
-            expect(isWorkflowDispatch(result[0])).toBe(true);
-            expect(result.some(isNameGroup)).toBe(false);
-        });
-
-        it("marks a NameGroup active if any member is still active", () => {
-            const result = buildDispatchChildren(
-                [],
-                [
-                    mk({ agent_id: "a1", display_name: "N", status: "completed" }),
-                    mk({ agent_id: "a2", display_name: "N", status: "active" }),
-                ]
-            );
-            const group = result[0];
-            if (isNameGroup(group)) {
-                expect(group.status).toBe("active");
-                expect(group.activeCount).toBe(1);
-            } else {
-                throw new Error("expected a name group");
-            }
-        });
-
-        it("marks a NameGroup retired only once every member has completed", () => {
-            const result = buildDispatchChildren(
-                [],
-                [
-                    mk({ agent_id: "a1", display_name: "N", status: "completed" }),
-                    mk({ agent_id: "a2", display_name: "N", status: "completed" }),
-                ]
-            );
-            const group = result[0];
-            if (isNameGroup(group)) {
-                expect(group.status).toBe("retired");
-            } else {
-                throw new Error("expected a name group");
-            }
-        });
-
-        it("treats an abandoned NameGroup member the same as a completed one (both terminal)", () => {
-            const result = buildDispatchChildren(
-                [],
-                [
-                    mk({ agent_id: "a1", display_name: "N", status: "completed" }),
-                    mk({ agent_id: "a2", display_name: "N", status: "abandoned" }),
-                ]
-            );
-            const group = result[0];
-            if (isNameGroup(group)) {
-                expect(group.status).toBe("retired");
-                expect(group.activeCount).toBe(0);
-            } else {
-                throw new Error("expected a name group");
-            }
-        });
-
-        it("mixes loose subagents, workflow dispatches, and name groups together, sorted by recency", () => {
-            const result = buildDispatchChildren(
-                [mkDispatch({ dispatch_id: "wf_1", last_event_at: 500 })],
-                [
-                    mk({ agent_id: "solo", display_name: "Unique", last_event_at: 50 }),
-                    mk({ agent_id: "n1", display_name: "Dup", last_event_at: 300 }),
-                    mk({ agent_id: "n2", display_name: "Dup", last_event_at: 700 }),
-                    mk({ agent_id: "w1", dispatch_id: "wf_1", last_event_at: 500 }),
-                ]
-            );
-            expect(result).toHaveLength(3);
-            const nameGroups = result.filter(isNameGroup);
-            const workflowDispatches = result.filter(isWorkflowDispatch);
-            expect(nameGroups).toHaveLength(1);
-            expect(workflowDispatches).toHaveLength(1);
-            // Dup group's lastEventAt (700, from n2) > wf_1 dispatch (500) > solo (50)
-            expect(childId(result[0])).toBe("Dup");
-            expect(childId(result[2])).toBe("solo");
-        });
+    it("workflow membership always wins over same-slug agentToolRows leakage — a tracked workflow member never also appears in agentToolRows", () => {
+        const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 2 })];
+        const subagents = [
+            mk({ agent_id: "a1", dispatch_id: "wf_1", slug: "shared-slug" }),
+            mk({ agent_id: "a2", dispatch_id: "wf_1", slug: "shared-slug" }),
+            mk({ agent_id: "a3", slug: "shared-slug" }), // genuinely solo, same slug
+        ];
+        const { agentToolRows, workflowRows } = buildDispatchBuckets(dispatches, subagents);
+        expect(workflowRows).toHaveLength(1);
+        expect(agentToolRows).toHaveLength(1);
+        expect(agentToolRows[0].agent_id).toBe("a3");
     });
 });
 
@@ -404,13 +242,13 @@ describe("stabilizeGroupIdentity", () => {
         const cache = new Map<string, WorkflowDispatch>();
         const dispatches = [mkDispatch({ dispatch_id: "wf_1", member_count: 1 })];
         const members = [mk({ agent_id: "a1", dispatch_id: "wf_1" })];
-        const first = buildDispatchChildren(dispatches, members);
+        const first = buildDispatchBuckets(dispatches, members).workflowRows;
         const stabilizedFirst = stabilizeGroupIdentity(cache, first);
 
         // A second, independently-built (but content-identical) row for the
-        // same dispatch — mirrors what a fresh buildDispatchChildren() call
+        // same dispatch — mirrors what a fresh buildDispatchBuckets() call
         // produces on an unrelated buildTree() recompute.
-        const second = buildDispatchChildren(dispatches, members);
+        const second = buildDispatchBuckets(dispatches, members).workflowRows;
         const stabilizedSecond = stabilizeGroupIdentity(cache, second);
 
         expect(stabilizedSecond[0]).toBe(stabilizedFirst[0]);
@@ -418,127 +256,60 @@ describe("stabilizeGroupIdentity", () => {
 
     it("returns a fresh reference when the dispatch's own fields actually changed", () => {
         const cache = new Map<string, WorkflowDispatch>();
-        const first = buildDispatchChildren(
+        const first = buildDispatchBuckets(
             [mkDispatch({ dispatch_id: "wf_1", member_count: 1, members_done: 0 })],
             [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
-        );
+        ).workflowRows;
         const stabilizedFirst = stabilizeGroupIdentity(cache, first);
 
-        const second = buildDispatchChildren(
+        const second = buildDispatchBuckets(
             [mkDispatch({ dispatch_id: "wf_1", member_count: 1, members_done: 1, status: "completed" })],
             [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
-        );
+        ).workflowRows;
         const stabilizedSecond = stabilizeGroupIdentity(cache, second);
 
         expect(stabilizedSecond[0]).not.toBe(stabilizedFirst[0]);
     });
 
-    it("passes loose (non-group) subagents through unchanged", () => {
+    it("keeps two distinct dispatches as independent cache entries", () => {
         const cache = new Map<string, WorkflowDispatch>();
-        const loose = buildDispatchChildren([], [mk({ agent_id: "a1" })]);
-        const stabilized = stabilizeGroupIdentity(cache, loose);
-        expect(stabilized[0]).toBe(loose[0]);
-        expect(cache.size).toBe(0);
-    });
-
-    it("reuses the cached NameGroup reference when nothing about the group changed", () => {
-        const cache = new Map<string, WorkflowDispatch | NameGroup>();
-        const members = [
-            mk({ agent_id: "a1", display_name: "Dup" }),
-            mk({ agent_id: "a2", display_name: "Dup" }),
-        ];
-        const first = buildDispatchChildren([], members);
-        const stabilizedFirst = stabilizeGroupIdentity(cache, first);
-
-        const second = buildDispatchChildren([], members);
-        const stabilizedSecond = stabilizeGroupIdentity(cache, second);
-
-        expect(stabilizedSecond[0]).toBe(stabilizedFirst[0]);
-    });
-
-    it("keeps a WorkflowDispatch and a NameGroup with the same raw id/name as distinct cache entries", () => {
-        // groupCacheKey namespaces with "wf:"/"name:" precisely so this
-        // coincidence can't collide two unrelated groups into one cache slot.
-        const cache = new Map<string, WorkflowDispatch | NameGroup>();
-        const wfChildren = buildDispatchChildren(
-            [mkDispatch({ dispatch_id: "shared-id", member_count: 2 })],
-            [mk({ agent_id: "a1", dispatch_id: "shared-id" }), mk({ agent_id: "a2", dispatch_id: "shared-id" })]
-        );
-        const nameChildren = buildDispatchChildren(
-            [],
-            [
-                mk({ agent_id: "b1", display_name: "shared-id" }),
-                mk({ agent_id: "b2", display_name: "shared-id" }),
-            ]
-        );
-        stabilizeGroupIdentity(cache, wfChildren);
-        stabilizeGroupIdentity(cache, nameChildren);
+        const rowsA = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_a" })],
+            [mk({ agent_id: "a1", dispatch_id: "wf_a" })]
+        ).workflowRows;
+        const rowsB = buildDispatchBuckets(
+            [mkDispatch({ dispatch_id: "wf_b" })],
+            [mk({ agent_id: "b1", dispatch_id: "wf_b" })]
+        ).workflowRows;
+        stabilizeGroupIdentity(cache, rowsA);
+        stabilizeGroupIdentity(cache, rowsB);
         expect(cache.size).toBe(2);
-        expect(cache.has("wf:shared-id")).toBe(true);
-        expect(cache.has("name:block-1:shared-id")).toBe(true);
-    });
-
-    it("keeps same-named NameGroups from two different agent blocks as distinct cache entries (reagent P1 on #2123)", () => {
-        // groupIdentityCache/expandedIds are shared across the WHOLE tree
-        // (buildTree() calls buildDispatchChildren once per block, into one
-        // cache) — a Haiku-generated name like "Code Reviewer" can plausibly
-        // repeat across two unrelated agent panes. Without parentBlockId in
-        // the key, block A's and block B's same-named groups would stomp
-        // each other's identity/expand state.
-        const cache = new Map<string, WorkflowDispatch | NameGroup>();
-        const blockAChildren = buildDispatchChildren(
-            [],
-            [
-                mk({ agent_id: "a1", parent_block_id: "block-A", display_name: "Code Reviewer" }),
-                mk({ agent_id: "a2", parent_block_id: "block-A", display_name: "Code Reviewer" }),
-            ]
-        );
-        const blockBChildren = buildDispatchChildren(
-            [],
-            [
-                mk({ agent_id: "b1", parent_block_id: "block-B", display_name: "Code Reviewer" }),
-                mk({ agent_id: "b2", parent_block_id: "block-B", display_name: "Code Reviewer" }),
-            ]
-        );
-        const stabilizedA = stabilizeGroupIdentity(cache, blockAChildren);
-        const stabilizedB = stabilizeGroupIdentity(cache, blockBChildren);
-        expect(cache.size).toBe(2);
-        expect(stabilizedA[0]).not.toBe(stabilizedB[0]);
-        if (isNameGroup(stabilizedA[0]) && isNameGroup(stabilizedB[0])) {
-            expect(stabilizedA[0].subagents.map((s) => s.agent_id)).toEqual(["a1", "a2"]);
-            expect(stabilizedB[0].subagents.map((s) => s.agent_id)).toEqual(["b1", "b2"]);
-        } else {
-            throw new Error("expected two name groups");
-        }
+        expect(cache.has("wf:wf_a")).toBe(true);
+        expect(cache.has("wf:wf_b")).toBe(true);
     });
 });
 
 describe("groupCacheKey", () => {
-    it("namespaces a WorkflowDispatch key with 'wf:' and a NameGroup key with 'name:<parentBlockId>:'", () => {
-        const [wf] = buildDispatchChildren(
+    it("namespaces every key with 'wf:'", () => {
+        const [wf] = buildDispatchBuckets(
             [mkDispatch({ dispatch_id: "wf_1" })],
             [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
-        ).filter(isWorkflowDispatch);
-        const [ng] = buildDispatchChildren(
-            [],
-            [mk({ agent_id: "a1", display_name: "N" }), mk({ agent_id: "a2", display_name: "N" })]
-        ).filter(isNameGroup);
+        ).workflowRows;
         expect(groupCacheKey(wf)).toBe("wf:wf_1");
-        expect(groupCacheKey(ng)).toBe("name:block-1:N");
     });
 });
 
 describe("pruneGroupIdentityCache", () => {
     it("drops entries for dispatches no longer live, keeps the rest", () => {
         const cache = new Map<string, WorkflowDispatch>();
-        const groupA = buildDispatchChildren(
+        const groupA = buildDispatchBuckets(
             [mkDispatch({ dispatch_id: "wf_a" })],
             [mk({ agent_id: "a1", dispatch_id: "wf_a" })]
-        );
-        const groupB = buildDispatchChildren(
+        ).workflowRows;
+        const groupB = buildDispatchBuckets(
             [mkDispatch({ dispatch_id: "wf_b" })],
             [mk({ agent_id: "b1", dispatch_id: "wf_b" })]
-        );
+        ).workflowRows;
         stabilizeGroupIdentity(cache, groupA);
         stabilizeGroupIdentity(cache, groupB);
         expect(cache.size).toBe(2);
@@ -549,26 +320,6 @@ describe("pruneGroupIdentityCache", () => {
         expect(cache.size).toBe(1);
         expect(cache.has("wf:wf_a")).toBe(true);
         expect(cache.has("wf:wf_b")).toBe(false);
-    });
-
-    it("drops entries for name groups no longer live, keeps the rest", () => {
-        const cache = new Map<string, WorkflowDispatch | NameGroup>();
-        const groupA = buildDispatchChildren(
-            [],
-            [mk({ agent_id: "a1", display_name: "A" }), mk({ agent_id: "a2", display_name: "A" })]
-        );
-        const groupB = buildDispatchChildren(
-            [],
-            [mk({ agent_id: "b1", display_name: "B" }), mk({ agent_id: "b2", display_name: "B" })]
-        );
-        stabilizeGroupIdentity(cache, groupA);
-        stabilizeGroupIdentity(cache, groupB);
-        expect(cache.size).toBe(2);
-
-        pruneGroupIdentityCache(cache, new Set(["name:block-1:A"]));
-        expect(cache.size).toBe(1);
-        expect(cache.has("name:block-1:A")).toBe(true);
-        expect(cache.has("name:block-1:B")).toBe(false);
     });
 });
 

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -5,14 +5,28 @@ import { describe, expect, it } from "vitest";
 import {
     buildDispatchBuckets,
     groupCacheKey,
+    mergeDispatchActivityEntries,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     type ActiveSubagent,
     type AgentDispatch,
+    type DispatchActivityEntry,
     type WorkflowDispatch,
 } from "./swarm-model";
+
+function mkEntry(opts: { agentId?: string; timestamp: number; content?: string }): DispatchActivityEntry {
+    const agentId = opts.agentId ?? "a1";
+    return {
+        agentId,
+        event: {
+            agent_id: agentId,
+            timestamp: opts.timestamp,
+            event_type: { type: "text", content: opts.content ?? "hi" },
+        },
+    };
+}
 
 function mk(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -286,6 +300,47 @@ describe("stabilizeGroupIdentity", () => {
         expect(cache.size).toBe(2);
         expect(cache.has("wf:wf_a")).toBe(true);
         expect(cache.has("wf:wf_b")).toBe(true);
+    });
+});
+
+describe("mergeDispatchActivityEntries", () => {
+    it("appends genuinely new entries and re-sorts by timestamp", () => {
+        const prev = [mkEntry({ timestamp: 100 })];
+        const merged = mergeDispatchActivityEntries(prev, [mkEntry({ timestamp: 50 }), mkEntry({ timestamp: 200 })]);
+        expect(merged.map((e) => e.event.timestamp)).toEqual([50, 100, 200]);
+    });
+
+    it("drops an incoming entry that duplicates one already present — the live/backfill race (reagent P1 on #2232)", () => {
+        // A solo dispatch's `GetHistory` backfill and the live
+        // `dispatch:activity` broadcast can both deliver the same
+        // (agentId, timestamp, event) triple if the backend already
+        // flushed it before GetHistory resolved.
+        const prev = [mkEntry({ timestamp: 100, content: "same" })];
+        const merged = mergeDispatchActivityEntries(prev, [mkEntry({ timestamp: 100, content: "same" })]);
+        expect(merged).toHaveLength(1);
+        expect(merged).toBe(prev); // no-op merge returns the same reference
+    });
+
+    it("does not drop two entries that merely share a timestamp but differ in content or agent", () => {
+        const prev = [mkEntry({ timestamp: 100, content: "first" })];
+        const merged = mergeDispatchActivityEntries(prev, [
+            mkEntry({ timestamp: 100, content: "second" }),
+            mkEntry({ timestamp: 100, agentId: "a2", content: "first" }),
+        ]);
+        expect(merged).toHaveLength(3);
+    });
+
+    it("caps the merged feed at MAX_DISPATCH_FEED_ENTRIES (500), dropping the oldest first", () => {
+        const prev = Array.from({ length: 500 }, (_, i) => mkEntry({ timestamp: i }));
+        const merged = mergeDispatchActivityEntries(prev, [mkEntry({ timestamp: 1000 })]);
+        expect(merged).toHaveLength(500);
+        expect(merged[0].event.timestamp).toBe(1);
+        expect(merged[merged.length - 1].event.timestamp).toBe(1000);
+    });
+
+    it("returns the input `prev` array unchanged (by reference) when incoming is empty", () => {
+        const prev = [mkEntry({ timestamp: 100 })];
+        expect(mergeDispatchActivityEntries(prev, [])).toBe(prev);
     });
 });
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -67,6 +67,13 @@ export interface AgentDispatch {
     members_done: number;
     status: "running" | "completed";
     last_event_at: number;
+    /** Concise Haiku-generated name for a Workflow-kind dispatch, resolved
+     *  EAGERLY (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A)
+     *  the first time its first member is observed live — not on-click like
+     *  `ActiveSubagent.display_name`. `null` until resolved (or always
+     *  `null` for a Solo-kind dispatch — a solo dispatch's name IS its one
+     *  member's `display_name`, this field is Workflow-only backend-side). */
+    dispatch_name: string | null;
 }
 
 // ── Subagent event log (inline-expand detail) ───────────────────────────
@@ -98,8 +105,11 @@ export type SubagentEventType =
 export interface WorkflowDispatch {
     kind: "workflowDispatch";
     dispatchId: string;
-    /** Derived client-side from a member's slug (SPEC keeps this — the
-     *  backend still has no separate dispatch-name concept). */
+    /** Prefers the backend's eagerly-resolved `AgentDispatch.dispatch_name`
+     *  (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A) —
+     *  falls back to a member's `slug`, then the raw `dispatchId`, only for
+     *  the brief window before the eager Haiku call resolves (or if it
+     *  never does — see that spec's naming-failure fallback notes). */
     name: string;
     memberCount: number;
     membersDone: number;
@@ -111,52 +121,8 @@ export interface WorkflowDispatch {
     lastEventAt: number;
 }
 
-/**
- * A group of solo-dispatch subagents (no Workflow-tool run — a Solo
- * `AgentDispatch` each) that share one grouping key: `display_name` once a
- * client has resolved it (Haiku-generated, on-demand), or `slug` before that —
- * see `groupKeyFor` below. A user repeatedly spawning similar tasks (e.g.
- * "review this file" across many files) legitimately gets the same/
- * near-identical name for each invocation — the naming model doing its job,
- * not a malfunction — but left flat that reads as "dozens of duplicate rows."
- * A subagent belonging to a Workflow dispatch never enters this grouping
- * pass, regardless of name — it's already represented by its one
- * `WorkflowDispatch` row.
- */
-export interface NameGroup {
-    kind: "nameGroup";
-    /** The shared grouping key (`display_name` if resolved, else `slug`) —
-     *  always non-empty; see `groupKeyFor`. A member that later gets its own
-     *  `display_name` resolved (via `subagent.GenerateName`) migrates out of
-     *  a slug-keyed group into a display_name-keyed one on the next
-     *  `buildDispatchChildren()` pass — no explicit "ungroup" step needed. */
-    name: string;
-    /** Every member's shared parent_block_id — buildDispatchChildren is
-     *  always called with an already block-filtered subagent list (see
-     *  buildTree()), so this is uniform across the group. Required for
-     *  groupCacheKey: unlike WorkflowDispatch's backend-unique dispatchId, a
-     *  Haiku-generated display_name can plausibly repeat across two
-     *  unrelated agent panes (e.g. "Code Reviewer" in both), and
-     *  groupIdentityCache/expandedIds are shared across the WHOLE tree —
-     *  without this, two different blocks' same-named groups would stomp
-     *  each other's cached identity and expand/collapse state. Reagent P1
-     *  on PR #2123. */
-    parentBlockId: string;
-    subagents: ActiveSubagent[];
-    activeCount: number;
-    totalCount: number;
-    status: "active" | "retired";
-    lastEventAt: number;
-}
-
-export type SwarmChild = ActiveSubagent | WorkflowDispatch | NameGroup;
-
-export function isWorkflowDispatch(child: SwarmChild): child is WorkflowDispatch {
-    return "kind" in child && child.kind === "workflowDispatch";
-}
-
-export function isNameGroup(child: SwarmChild): child is NameGroup {
-    return "kind" in child && child.kind === "nameGroup";
+export function isWorkflowDispatch(child: unknown): child is WorkflowDispatch {
+    return !!child && typeof child === "object" && "kind" in child && (child as WorkflowDispatch).kind === "workflowDispatch";
 }
 
 export interface AgentTreeNode {
@@ -166,41 +132,30 @@ export interface AgentTreeNode {
     activitySummary: string | null;
     contextTokens: number | null;
     agentStatus: "running" | "idle";
-    subagents: SwarmChild[];
+    /** One row per Agent-tool (solo) dispatch — always a flat list, never
+     *  grouped/collapsed by shared name (SPEC_SWARM_DISPATCH_NAMING_AND_
+     *  ROW_MODEL_2026_07_19 §2, superseding the `NameGroup` slug-fallback
+     *  approach from PR #2226: eager per-dispatch naming means there's no
+     *  more "many rows share one uninformative label" problem to collapse
+     *  away). Sorted by most recent activity. */
+    agentToolRows: ActiveSubagent[];
+    /** One row per Workflow-tool dispatch, always its own row regardless of
+     *  member count (SPEC §7, unchanged from the pre-existing design).
+     *  Sorted by most recent activity. */
+    workflowRows: WorkflowDispatch[];
 }
 
 /**
- * A solo dispatch's grouping key: its resolved `display_name` if a client
- * has already expanded it once (Haiku-generated via `subagent.GenerateName`),
- * else its `slug`. Falling back to `slug` here — instead of leaving
- * not-yet-named subagents ungrouped — matters because `slug` is itself
- * usually shared across an entire CLI session/batch (see
- * `subagentDisplayLabel`'s doc comment below), so a session that has spawned
- * many solo Task-tool calls and never had any of them individually expanded
- * would otherwise render every single one as its own top-level row — the
- * exact "one line per Agent Tool call/workflow" goal (SPEC §5/§7) violated
- * by omission, not by a grouping bug. Empty string is treated as "no key"
- * (both fields can legitimately be empty before either resolves).
+ * Build one block's two fixed row buckets from its `AgentDispatch`es
+ * (already block-filtered) and raw `SubAgent`s — always exactly these two
+ * groupings, never data-driven collapsing by shared name (see
+ * `AgentTreeNode.agentToolRows`'s doc comment for why that approach was
+ * retired). Each bucket is independently sorted by recency.
  */
-function groupKeyFor(s: ActiveSubagent): string {
-    return s.display_name || s.slug;
-}
-
-/**
- * Build one block's tree children from its `AgentDispatch`es (already
- * block-filtered) and raw `SubAgent`s. Every Workflow-kind dispatch becomes
- * exactly one `WorkflowDispatch` row (SPEC §7 — never one row per member).
- * Every Solo-kind dispatch's one member renders as a plain `ActiveSubagent`
- * row, no wrapper (SPEC §5) — among those, two or more sharing a
- * `groupKeyFor` value still collapse into a `NameGroup` (grouping solo
- * DISPATCHES now, not raw subagents, but every subagent has exactly one
- * dispatch so the input set is the same). Result is sorted by most recent
- * activity, mixing loose subagents and both group kinds in one recency order.
- */
-export function buildDispatchChildren(
+export function buildDispatchBuckets(
     dispatches: AgentDispatch[],
     subagents: ActiveSubagent[]
-): SwarmChild[] {
+): { agentToolRows: ActiveSubagent[]; workflowRows: WorkflowDispatch[] } {
     const workflowRows: WorkflowDispatch[] = dispatches
         .filter((d) => d.kind === "workflow")
         .map((d) => {
@@ -208,13 +163,14 @@ export function buildDispatchChildren(
             return {
                 kind: "workflowDispatch" as const,
                 dispatchId: d.dispatch_id,
-                name: namedMember?.slug || d.dispatch_id,
+                name: d.dispatch_name || namedMember?.slug || d.dispatch_id,
                 memberCount: d.member_count,
                 membersDone: d.members_done,
                 status: d.status === "completed" ? ("retired" as const) : ("active" as const),
                 lastEventAt: d.last_event_at,
             };
-        });
+        })
+        .sort((a, b) => b.lastEventAt - a.lastEventAt);
 
     const solo = subagents.filter((s) => s.dispatch_id.startsWith("solo:"));
 
@@ -223,56 +179,25 @@ export function buildDispatchChildren(
     // site), so `dispatches` here can lag or miss entries `subagents` (a
     // separate fetch) already has. Without this, any workflow-kind subagent
     // whose dispatch has no matching row in `workflowRows` would vanish from
-    // the tree entirely instead of degrading to an individual row.
+    // the tree entirely instead of degrading to an Agent Tool row.
     const workflowDispatchIds = new Set(workflowRows.map((w) => w.dispatchId));
     const orphanedWorkflowMembers = subagents.filter(
         (s) => !s.dispatch_id.startsWith("solo:") && !workflowDispatchIds.has(s.dispatch_id)
     );
 
-    const stillLoose: ActiveSubagent[] = [...orphanedWorkflowMembers];
-    const byName = new Map<string, ActiveSubagent[]>();
-    for (const s of solo) {
-        const key = groupKeyFor(s);
-        if (key) {
-            const members = byName.get(key) ?? [];
-            members.push(s);
-            byName.set(key, members);
-        } else {
-            stillLoose.push(s);
-        }
-    }
+    const agentToolRows = [...solo, ...orphanedWorkflowMembers].sort(
+        (a, b) => b.last_event_at - a.last_event_at
+    );
 
-    const nameGroups: NameGroup[] = [];
-    for (const [name, members] of byName) {
-        if (members.length < 2) {
-            stillLoose.push(...members);
-            continue;
-        }
-        const sorted = [...members].sort((a, b) => b.last_event_at - a.last_event_at);
-        const activeCount = sorted.filter((m) => m.status === "active").length;
-        nameGroups.push({
-            kind: "nameGroup" as const,
-            name,
-            // Uniform across the group — buildDispatchChildren is always
-            // called with an already block-filtered list (buildTree()).
-            parentBlockId: sorted[0].parent_block_id,
-            subagents: sorted,
-            activeCount,
-            totalCount: sorted.length,
-            status: activeCount > 0 ? ("active" as const) : ("retired" as const),
-            lastEventAt: sorted[0]?.last_event_at ?? 0,
-        });
-    }
-
-    const lastEventOf = (c: SwarmChild): number =>
-        isWorkflowDispatch(c) || isNameGroup(c) ? c.lastEventAt : c.last_event_at;
-    return [...stillLoose, ...workflowRows, ...nameGroups].sort((a, b) => lastEventOf(b) - lastEventOf(a));
+    return { agentToolRows, workflowRows };
 }
 
 /**
- * Compute the label `SubagentRow`/`SubagentDetailPane` show for a subagent,
- * in the same priority order both call sites use: `display_name` (once
- * Haiku resolves it) > `slug` > a short prefix of `agent_id`.
+ * Compute the label `SubagentRow` shows for a subagent, in priority order:
+ * `display_name` (Haiku-resolved — as of
+ * SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A, resolved
+ * EAGERLY at dispatch time for the common case, not just on-click) > `slug`
+ * > a short prefix of `agent_id`.
  *
  * `slug` is NOT a per-subagent-unique identifier — it's read straight
  * through from whatever the Claude Code CLI happened to write into the
@@ -283,7 +208,8 @@ export function buildDispatchChildren(
  * already established as an expected, non-buggy signature in
  * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md Finding 3
  * ("one shared slug = one legitimate concurrent spawn") and relied on by
- * `buildDispatchChildren`'s `WorkflowDispatch.name` derivation above.
+ * `buildDispatchBuckets`'s `WorkflowDispatch.name` derivation above as a
+ * fallback for the brief window before eager naming resolves.
  *
  * Falling back to a bare `slug` as a ROW LABEL, though, silently assumed
  * the opposite — that it WAS subagent-unique — so every member of such a
@@ -345,183 +271,73 @@ export function mergeSubagentsPreservingIdentity(
     });
 }
 
-/** `shallowEqualGroupContent` — type-aware, since `WorkflowDispatch` no
- *  longer carries a member list (SPEC §7 — a dispatch can have thousands of
- *  members, too many to hold in the tree atom) while `NameGroup` still does.
- *  A kind mismatch is never equal (defensive; `groupCacheKey`'s namespacing
- *  already prevents the two kinds from ever sharing a cache key). */
-function shallowEqualGroupContent(a: WorkflowDispatch | NameGroup, b: WorkflowDispatch | NameGroup): boolean {
-    if (isWorkflowDispatch(a) !== isWorkflowDispatch(b)) return false;
-    if (isWorkflowDispatch(a) && isWorkflowDispatch(b)) {
-        return (
-            a.dispatchId === b.dispatchId &&
-            a.name === b.name &&
-            a.memberCount === b.memberCount &&
-            a.membersDone === b.membersDone &&
-            a.status === b.status &&
-            a.lastEventAt === b.lastEventAt
-        );
-    }
-    const na = a as NameGroup;
-    const nb = b as NameGroup;
+/** Content-equality check for a `WorkflowDispatch` wrapper — used by
+ *  `stabilizeGroupIdentity` to decide whether to reuse the old object
+ *  reference or accept the freshly-built one. */
+function shallowEqualWorkflowDispatch(a: WorkflowDispatch, b: WorkflowDispatch): boolean {
     return (
-        na.name === nb.name &&
-        na.activeCount === nb.activeCount &&
-        na.totalCount === nb.totalCount &&
-        na.status === nb.status &&
-        na.lastEventAt === nb.lastEventAt &&
-        na.subagents.length === nb.subagents.length &&
-        na.subagents.every((m, i) => m === nb.subagents[i])
+        a.dispatchId === b.dispatchId &&
+        a.name === b.name &&
+        a.memberCount === b.memberCount &&
+        a.membersDone === b.membersDone &&
+        a.status === b.status &&
+        a.lastEventAt === b.lastEventAt
     );
 }
 
-/** Namespaced cache key so a `WorkflowDispatch`'s `dispatchId` and a
- *  `NameGroup`'s `name` can never collide in the shared identity cache.
- *  `NameGroup` additionally scopes by `parentBlockId`: a `dispatchId` is
- *  backend-unique so a bare name would never collide there, but a
- *  Haiku-generated `display_name` (e.g. "Code Reviewer") can plausibly
- *  repeat across two unrelated agent panes, and `groupIdentityCache`/
- *  `expandedIds` are shared across the WHOLE tree (every block) — without
- *  the block scope, two blocks' same-named groups would stomp each other's
- *  cached identity and expand/collapse state. Reagent P1 on PR #2123. */
-export function groupCacheKey(child: WorkflowDispatch | NameGroup): string {
-    return isWorkflowDispatch(child)
-        ? `wf:${child.dispatchId}`
-        : `name:${child.parentBlockId}:${child.name}`;
+/** Cache key for a `WorkflowDispatch` — namespaced (`wf:`) even though only
+ *  one kind uses this cache now, kept from the pre-two-bucket design so
+ *  `expandedIdsAtom`'s ids stay stable across the change (a `NameGroup`'s
+ *  `name:`-namespaced keys no longer exist — see the two-bucket redesign,
+ *  SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19). */
+export function groupCacheKey(child: WorkflowDispatch): string {
+    return `wf:${child.dispatchId}`;
 }
 
 /**
- * Stabilize `WorkflowDispatch`/`NameGroup` wrapper identity across
- * `buildTree()` calls, mirroring `mergeSubagentsPreservingIdentity` one
- * level up. `buildDispatchChildren` is a pure function — it unconditionally
- * builds brand-new group objects per call, even when nothing about a given
- * group actually changed. Left alone, that fresh wrapper still remounts
- * `WorkflowDispatchRow`/`NameGroupRow` — and everything nested inside an
- * expanded one — on every unrelated tree recompute, which for a large
- * workflow dispatch defeats the very remount fix `expandedIdsAtom`/
- * `getDispatchDetail` were meant to provide.
+ * Stabilize `WorkflowDispatch` wrapper identity across `buildTree()` calls,
+ * mirroring `mergeSubagentsPreservingIdentity` one level up.
+ * `buildDispatchBuckets` is a pure function — it unconditionally builds
+ * brand-new wrapper objects per call, even when nothing about a given
+ * dispatch actually changed. Left alone, that fresh wrapper still remounts
+ * `WorkflowDispatchRow` — and everything nested inside an expanded one — on
+ * every unrelated tree recompute, which for a large workflow dispatch
+ * defeats the very remount fix `expandedIdsAtom`/`getDispatchDetail` were
+ * meant to provide.
  *
- * `cache` is a `Map<groupCacheKey, group>` the caller keeps around (one per
- * `SwarmViewModel`), shared and called once per BLOCK within one
+ * `cache` is a `Map<groupCacheKey, dispatch>` the caller keeps around (one
+ * per `SwarmViewModel`), shared and called once per BLOCK within one
  * `buildTree()` pass — this function only reuses-or-replaces into `cache`,
- * it never prunes it (pruning here, scoped to one block's children, would
- * evict entries a DIFFERENT block's call just wrote). Callers doing a full
+ * it never prunes it (pruning here, scoped to one block's rows, would evict
+ * entries a DIFFERENT block's call just wrote). Callers doing a full
  * multi-block tree rebuild should prune the cache once afterward against
- * every group key actually produced across the whole tree — see
+ * every key actually produced across the whole tree — see
  * `pruneGroupIdentityCache`.
  */
 export function stabilizeGroupIdentity(
-    cache: Map<string, WorkflowDispatch | NameGroup>,
-    children: SwarmChild[]
-): SwarmChild[] {
-    return children.map((child) => {
-        if (!isWorkflowDispatch(child) && !isNameGroup(child)) return child;
-        const key = groupCacheKey(child);
+    cache: Map<string, WorkflowDispatch>,
+    rows: WorkflowDispatch[]
+): WorkflowDispatch[] {
+    return rows.map((row) => {
+        const key = groupCacheKey(row);
         const old = cache.get(key);
-        const stable = old && shallowEqualGroupContent(old, child) ? old : child;
+        const stable = old && shallowEqualWorkflowDispatch(old, row) ? old : row;
         cache.set(key, stable);
         return stable;
     });
 }
 
-/** Drop cache entries for groups no longer present anywhere in the tree —
- *  call once after a full `buildTree()` pass, not per-block (see
- *  `stabilizeGroupIdentity`), so it can't grow unbounded across sessions.
- *  `liveGroupKeys` must use the same `wf:<id>` / `name:<name>` namespacing
- *  as `groupCacheKey` — see `SwarmViewModel.buildTree()`. */
-export function pruneGroupIdentityCache(cache: Map<string, WorkflowDispatch | NameGroup>, liveGroupKeys: Set<string>): void {
+/** Drop cache entries for dispatches no longer present anywhere in the tree
+ *  — call once after a full `buildTree()` pass, not per-block (see
+ *  `stabilizeGroupIdentity`), so it can't grow unbounded across sessions. */
+export function pruneGroupIdentityCache(cache: Map<string, WorkflowDispatch>, liveGroupKeys: Set<string>): void {
     for (const key of [...cache.keys()]) {
         if (!liveGroupKeys.has(key)) cache.delete(key);
     }
 }
 
-// ── Subagent detail (inline-expand event log) ───────────────────────────
-
-export interface SubagentDetail {
-    eventsAtom: Accessor<SubagentEvent[]>;
-    infoAtom: Accessor<ActiveSubagent | null>;
-    statusAtom: Accessor<"active" | "completed" | "abandoned" | "loading">;
-    dispose: () => void;
-}
-
-/**
- * Plain-function counterpart of the retired SubagentViewModel — fetches one
- * subagent's event history + info once and keeps them live via
- * subagent:activity/subagent:completed. Deliberately NOT tied to a
- * component's render lifecycle (no `onCleanup`): `SwarmViewModel` caches
- * one of these per expanded subagent (`getSubagentDetail`) so it survives
- * `<For>` remounts `tree()` can still cause for unrelated reasons, instead
- * of refetching/resubscribing on every incidental re-render while a row is
- * open. See `mergeSubagentsPreservingIdentity` and `stabilizeGroupIdentity`
- * above for how row/wrapper object identity itself is kept stable in the
- * first place.
- */
-export function createSubagentDetail(subagentId: string): SubagentDetail {
-    const [events, setEvents] = createSignal<SubagentEvent[]>([]);
-    const [info, setInfo] = createSignal<ActiveSubagent | null>(null);
-    const [status, setStatus] = createSignal<"active" | "completed" | "abandoned" | "loading">("loading");
-
-    const unsubs: (() => void)[] = [];
-
-    const unsubActivity = waveEventSubscribe({
-        eventType: "subagent:activity",
-        handler: (event: WaveEvent) => {
-            const data = event?.data as any;
-            if (data?.agentId !== subagentId) return;
-            const newEvents = (data?.events as SubagentEvent[]) ?? [];
-            if (newEvents.length > 0) setEvents((prev) => [...prev, ...newEvents]);
-            if (data?.totalEvents != null) {
-                setInfo((prev) => (prev ? { ...prev, event_count: data.totalEvents } : prev));
-            }
-        },
-    });
-    if (unsubActivity) unsubs.push(unsubActivity);
-
-    const unsubCompleted = waveEventSubscribe({
-        eventType: "subagent:completed",
-        handler: (event: WaveEvent) => {
-            const data = event?.data as any;
-            if (data?.agentId !== subagentId) return;
-            setStatus("completed");
-            setInfo((prev) => (prev ? { ...prev, status: "completed" } : prev));
-        },
-    });
-    if (unsubCompleted) unsubs.push(unsubCompleted);
-
-    void (async () => {
-        try {
-            const result = await callBackendService("subagent", "GetHistory", [subagentId, 500]);
-            setEvents((result as SubagentEvent[]) ?? []);
-            setStatus("active");
-        } catch {
-            setStatus("active");
-        }
-        // Targeted single-agent lookup (not ListActive's full scan) — this
-        // subagent may have spawned before this pane opened, so its
-        // subagent:spawned event already fired and won't refire.
-        try {
-            const result = await callBackendService("subagent", "GetInfo", [subagentId]);
-            if (result) {
-                const match = result as ActiveSubagent;
-                setInfo(match);
-                setStatus(match.status);
-            }
-        } catch {
-            // ignore
-        }
-    })();
-
-    return {
-        eventsAtom: events,
-        infoAtom: info,
-        statusAtom: status,
-        dispose: () => {
-            for (const unsub of unsubs) unsub();
-        },
-    };
-}
-
-// ── Dispatch concatenated activity feed (SPEC §7) ───────────────────────
+// ── Dispatch concatenated activity feed (SPEC §7, generalized to solo
+//    dispatches in SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4) ──
 
 export interface DispatchActivityEntry {
     agentId: string;
@@ -540,21 +356,37 @@ export interface DispatchDetail {
 const MAX_DISPATCH_FEED_ENTRIES = 500;
 
 /**
- * Expanding a `WorkflowDispatchRow` shows this instead of nested member rows
- * (SPEC §7): every member's new events, merged into one chronological,
- * member-tagged stream, fed by the backend's coalesced `dispatch:activity`
- * broadcast (`subagent_watcher.rs`'s `flush_pending_dispatch_activity`).
+ * Expanding a row (`WorkflowDispatchRow`, or an Agent Tool row —
+ * SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4) shows this: every
+ * member's new events, merged into one chronological, member-tagged stream,
+ * fed by the backend's coalesced `dispatch:activity` broadcast
+ * (`subagent_watcher.rs`'s `flush_pending_dispatch_activity` — as of Phase A
+ * this fires for solo `dispatch_id`s too, dual-emitted alongside the
+ * existing immediate `subagent:activity`).
  *
- * Deliberately LIVE-ONLY — no historical backfill fetch when a dispatch is
- * expanded. SPEC §9.4 leaves the backfill/pagination question explicitly
- * open: a large dispatch can have thousands of prior events across hundreds
- * of members, and eagerly fetching + merging that on every expand would
- * reintroduce the exact request/render volume problem this redesign exists
- * to fix. Until that's designed, the feed only shows what happens from the
- * moment of expand onward.
+ * Live activity is LIVE-ONLY for a Workflow dispatch — SPEC §9.4 leaves the
+ * backfill/pagination question for a large multi-hundred-member workflow
+ * explicitly open (eagerly fetching + merging thousands of prior events on
+ * every expand would reintroduce the exact request/render volume problem
+ * this redesign exists to fix), and there is no bulk-backfill RPC for a
+ * whole workflow's history today. A SOLO dispatch's history, though, is
+ * bounded (one member) and an RPC for it already exists — `subagent.
+ * GetHistory` — so backfilling it here closes the one real regression this
+ * unification would otherwise introduce (the retired `SubagentDetailPane`/
+ * `createSubagentDetail` DID backfill via that same RPC).
  */
 export function createDispatchDetail(dispatchId: string): DispatchDetail {
     const [entries, setEntries] = createSignal<DispatchActivityEntry[]>([]);
+
+    const mergeIncoming = (incoming: DispatchActivityEntry[]): void => {
+        if (incoming.length === 0) return;
+        setEntries((prev) => {
+            const merged = [...prev, ...incoming].sort((a, b) => a.event.timestamp - b.event.timestamp);
+            return merged.length > MAX_DISPATCH_FEED_ENTRIES
+                ? merged.slice(merged.length - MAX_DISPATCH_FEED_ENTRIES)
+                : merged;
+        });
+    };
 
     const unsub = waveEventSubscribe({
         eventType: "dispatch:activity",
@@ -562,18 +394,22 @@ export function createDispatchDetail(dispatchId: string): DispatchDetail {
             const data = event?.data as any;
             if (data?.dispatchId !== dispatchId) return;
             const members = (data?.members as { agentId: string; events: SubagentEvent[] }[]) ?? [];
-            const incoming: DispatchActivityEntry[] = members.flatMap((m) =>
-                (m.events ?? []).map((event) => ({ agentId: m.agentId, event }))
-            );
-            if (incoming.length === 0) return;
-            setEntries((prev) => {
-                const merged = [...prev, ...incoming].sort((a, b) => a.event.timestamp - b.event.timestamp);
-                return merged.length > MAX_DISPATCH_FEED_ENTRIES
-                    ? merged.slice(merged.length - MAX_DISPATCH_FEED_ENTRIES)
-                    : merged;
-            });
+            mergeIncoming(members.flatMap((m) => (m.events ?? []).map((evt) => ({ agentId: m.agentId, event: evt }))));
         },
     });
+
+    if (dispatchId.startsWith("solo:")) {
+        const agentId = dispatchId.slice("solo:".length);
+        void (async () => {
+            try {
+                const result = await callBackendService("subagent", "GetHistory", [agentId, MAX_DISPATCH_FEED_ENTRIES]);
+                const events = (result as SubagentEvent[]) ?? [];
+                mergeIncoming(events.map((event) => ({ agentId, event })));
+            } catch {
+                // ignore — feed still works live-only
+            }
+        })();
+    }
 
     return {
         entriesAtom: entries,
@@ -648,16 +484,18 @@ export class SwarmViewModel implements ViewModel {
     loadingAtom: Accessor<boolean> = this._loading[0];
     private setLoading: Setter<boolean> = this._loading[1];
 
-    // Rows the user has expanded — keyed by dispatchId (WorkflowDispatchRow)
-    // or agent_id (SubagentRow). Lives here, not as row-local component state:
-    // `tree()` recomputes on every trackedBlockIds/subagents/agentStatuses
-    // change (agentStatuses updates on every controllerstatus tick — very
-    // frequent during an active turn) and rebuilds fresh WorkflowDispatch/
-    // AgentTreeNode wrapper objects every time regardless of whether that
-    // row's own data changed, so `<For>`'s reference-diffing remounts row
-    // components far more often than "the user actually changed something."
-    // Local expand state would silently collapse on the very next unrelated
-    // status tick; keying by a stable string id here survives that churn.
+    // Rows the user has expanded — keyed by dispatchId (WorkflowDispatchRow
+    // and, since the two-bucket redesign, SubagentRow too — both use
+    // toggleDispatchExpanded now). Lives here, not as row-local component
+    // state: `tree()` recomputes on every trackedBlockIds/subagents/
+    // agentStatuses change (agentStatuses updates on every controllerstatus
+    // tick — very frequent during an active turn) and rebuilds fresh
+    // WorkflowDispatch/AgentTreeNode wrapper objects every time regardless
+    // of whether that row's own data changed, so `<For>`'s reference-diffing
+    // remounts row components far more often than "the user actually
+    // changed something." Local expand state would silently collapse on the
+    // very next unrelated status tick; keying by a stable string id here
+    // survives that churn.
     private _expandedIds = createSignal<Set<string>>(new Set());
     expandedIdsAtom: Accessor<Set<string>> = this._expandedIds[0];
     private setExpandedIds: Setter<Set<string>> = this._expandedIds[1];
@@ -673,28 +511,24 @@ export class SwarmViewModel implements ViewModel {
     collapsedAgentIdsAtom: Accessor<Set<string>> = this._collapsedAgentIds[0];
     private setCollapsedAgentIds: Setter<Set<string>> = this._collapsedAgentIds[1];
 
-    // One SubagentDetail per currently-expanded subagent, created lazily on
-    // first expand. Same rationale as expandedIds above: if this fetch+
-    // subscribe lifecycle lived inside the row component instead, every
-    // incidental remount (see above) would refetch GetHistory/GetInfo and
-    // resubscribe from scratch — potentially several times a second while a
-    // row is open during an active turn.
-    private detailCache = new Map<string, SubagentDetail>();
-
-    // One DispatchDetail (concatenated activity feed, SPEC §7) per
-    // currently-expanded WorkflowDispatch row — same lazy-create/dispose-on-
-    // collapse rationale as detailCache above.
+    // One DispatchDetail (concatenated activity feed) per currently-expanded
+    // row — Agent Tool (solo) rows and Workflow rows alike, unified in
+    // SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4 (retired the
+    // separate per-subagent SubagentDetail/detailCache this used to be split
+    // from). Created lazily on first expand: if this fetch+subscribe
+    // lifecycle lived inside the row component instead, every incidental
+    // remount (see expandedIds above) would refetch/resubscribe from
+    // scratch — potentially several times a second while a row is open
+    // during an active turn.
     private dispatchDetailCache = new Map<string, DispatchDetail>();
 
     // Persisted across buildTree() calls so stabilizeGroupIdentity can reuse
-    // the same WorkflowDispatch/NameGroup wrapper object when a group's own
-    // content is unchanged — without this, expandedIds/detailCache above
-    // still don't help a subagent NESTED inside a group, since <For> remounts
-    // the whole WorkflowDispatchRow/NameGroupRow subtree whenever the
-    // group's own wrapper reference changes, which is every buildTree() call
-    // otherwise. Keyed by groupCacheKey's namespaced "wf:<id>" / "name:<name>"
-    // strings so the two group kinds' key spaces never collide.
-    private groupIdentityCache = new Map<string, WorkflowDispatch | NameGroup>();
+    // the same WorkflowDispatch wrapper object when a dispatch's own content
+    // is unchanged — without this, expandedIds/dispatchDetailCache above
+    // still don't help a row NESTED inside an expanded one, since <For>
+    // remounts the whole WorkflowDispatchRow subtree whenever the wrapper's
+    // own reference changes, which is every buildTree() call otherwise.
+    private groupIdentityCache = new Map<string, WorkflowDispatch>();
 
     private unsubs: (() => void)[] = [];
     // Per-block controllerstatus unsubs — cleaned up when block list refreshes
@@ -876,30 +710,12 @@ export class SwarmViewModel implements ViewModel {
         });
     }
 
-    /** SubagentRow's toggle — also tears down the cached SubagentDetail
-     *  (and its WS subscriptions) on collapse, so a subagent a user opened
-     *  once and moved on from doesn't keep a live subscription forever. */
-    toggleSubagentExpanded(agentId: string): void {
-        const wasExpanded = this.isExpanded(agentId);
-        this.toggleExpanded(agentId);
-        if (wasExpanded) {
-            this.detailCache.get(agentId)?.dispose();
-            this.detailCache.delete(agentId);
-        }
-    }
-
-    getSubagentDetail(agentId: string): SubagentDetail {
-        let detail = this.detailCache.get(agentId);
-        if (!detail) {
-            detail = createSubagentDetail(agentId);
-            this.detailCache.set(agentId, detail);
-        }
-        return detail;
-    }
-
-    /** WorkflowDispatchRow's toggle — mirrors toggleSubagentExpanded, tearing
-     *  down the cached DispatchDetail (and its dispatch:activity
-     *  subscription) on collapse. */
+    /** Every row's toggle (Agent Tool rows keyed by `solo:<agent_id>`,
+     *  Workflow rows by their own `dispatch_id`) — tears down the cached
+     *  DispatchDetail (and its WS subscriptions) on collapse, so a row a
+     *  user opened once and moved on from doesn't keep a live subscription
+     *  forever. Unified in SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19
+     *  §4 (was split into toggleSubagentExpanded/toggleDispatchExpanded). */
     toggleDispatchExpanded(dispatchId: string): void {
         const wasExpanded = this.isExpanded(dispatchId);
         this.toggleExpanded(dispatchId);
@@ -975,13 +791,11 @@ export class SwarmViewModel implements ViewModel {
         const parentIds = subagents.map((s) => s.parent_block_id).filter(Boolean);
         const allBlockIds = [...new Set([...blockIds, ...parentIds])];
 
-        // Collected from the groups actually produced below, not derived
-        // from the raw subagent list — a NameGroup only exists once 2+
-        // subagents share a name (see buildDispatchChildren), so a
-        // subagent-list-level heuristic ("any subagent with this name is
-        // live") would wrongly keep singleton entries' keys alive forever.
-        // Harmless either way (stabilizeGroupIdentity only ever cache.set()s
-        // keys for groups that actually formed), but this is the precise set.
+        // Collected from the WorkflowDispatch rows actually produced below,
+        // not derived from the raw dispatch list, so stabilizeGroupIdentity's
+        // cache only ever retains keys for dispatches actually present this
+        // pass — same "harmless either way, but this is the precise set"
+        // rationale the pre-two-bucket design used for NameGroup keys.
         const liveGroupKeys = new Set<string>();
         const nodes = allBlockIds.map((blockId) => {
             const blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
@@ -995,15 +809,13 @@ export class SwarmViewModel implements ViewModel {
             const rawCtx = block?.meta?.["term:ctx-tokens"];
             const contextTokens = typeof rawCtx === "number" ? rawCtx : null;
             const agentStatus = statuses.get(blockId) ?? "idle";
-            const rawChildren = buildDispatchChildren(
+            const { agentToolRows, workflowRows: rawWorkflowRows } = buildDispatchBuckets(
                 dispatches.filter((d) => d.parent_block_id === blockId),
                 subagents.filter((s) => s.parent_block_id === blockId)
             );
-            for (const c of rawChildren) {
-                if (isWorkflowDispatch(c) || isNameGroup(c)) liveGroupKeys.add(groupCacheKey(c));
-            }
-            const children = stabilizeGroupIdentity(this.groupIdentityCache, rawChildren);
-            return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, subagents: children };
+            for (const w of rawWorkflowRows) liveGroupKeys.add(groupCacheKey(w));
+            const workflowRows = stabilizeGroupIdentity(this.groupIdentityCache, rawWorkflowRows);
+            return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, agentToolRows, workflowRows };
         });
 
         // Prune once per full pass (not per-block — see stabilizeGroupIdentity).
@@ -1020,8 +832,6 @@ export class SwarmViewModel implements ViewModel {
             clearTimeout(this.loadSubagentsDebounceTimer);
             this.loadSubagentsDebounceTimer = undefined;
         }
-        for (const detail of this.detailCache.values()) detail.dispose();
-        this.detailCache.clear();
         for (const detail of this.dispatchDetailCache.values()) detail.dispose();
         this.dispatchDetailCache.clear();
         this.groupIdentityCache.clear();

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -67,12 +67,16 @@ export interface AgentDispatch {
     members_done: number;
     status: "running" | "completed";
     last_event_at: number;
-    /** Concise Haiku-generated name for a Workflow-kind dispatch, resolved
+    /** For a Workflow-kind dispatch: a concise Haiku-generated name, resolved
      *  EAGERLY (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 Phase A)
      *  the first time its first member is observed live — not on-click like
-     *  `ActiveSubagent.display_name`. `null` until resolved (or always
-     *  `null` for a Solo-kind dispatch — a solo dispatch's name IS its one
-     *  member's `display_name`, this field is Workflow-only backend-side). */
+     *  `ActiveSubagent.display_name`. `null` until resolved.
+     *
+     *  For a Solo-kind dispatch: mirrors that one member's own
+     *  `display_name` directly (`subagent_watcher.rs`'s `solo_dispatch()`) —
+     *  there's no separate dispatch-level naming call for Solo, so this is
+     *  `null` until that member's `display_name` itself resolves, same
+     *  timing as `ActiveSubagent.display_name`, not always `null`. */
     dispatch_name: string | null;
 }
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -121,10 +121,6 @@ export interface WorkflowDispatch {
     lastEventAt: number;
 }
 
-export function isWorkflowDispatch(child: unknown): child is WorkflowDispatch {
-    return !!child && typeof child === "object" && "kind" in child && (child as WorkflowDispatch).kind === "workflowDispatch";
-}
-
 export interface AgentTreeNode {
     blockId: string | null;
     agentName: string;

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -218,9 +218,9 @@ export function buildDispatchBuckets(
  * grouping never entered the picture since neither had resolved yet).
  * Appending a short, always-unique `agent_id` suffix keeps same-slug
  * siblings visually distinct without claiming a uniqueness `slug` never
- * had — mirrors the existing pattern in `SubagentDetailPane`, which
- * already shows `agent_id.substring(0, 7)` as a separate meta chip next to
- * the name for exactly this reason.
+ * had — the same `agent_id.substring(0, 7)` disambiguator the now-retired
+ * `SubagentDetailPane` used to show as a separate meta chip, for the same
+ * reason.
  */
 export function subagentDisplayLabel(
     sub: Pick<ActiveSubagent, "display_name" | "slug" | "agent_id">
@@ -404,13 +404,22 @@ export function mergeDispatchActivityEntries(
  * explicitly open (eagerly fetching + merging thousands of prior events on
  * every expand would reintroduce the exact request/render volume problem
  * this redesign exists to fix), and there is no bulk-backfill RPC for a
- * whole workflow's history today. A SOLO dispatch's history, though, is
+ * whole workflow's history today. A single subagent's history, though, is
  * bounded (one member) and an RPC for it already exists — `subagent.
  * GetHistory` — so backfilling it here closes the one real regression this
  * unification would otherwise introduce (the retired `SubagentDetailPane`/
  * `createSubagentDetail` DID backfill via that same RPC).
+ *
+ * `backfillAgentId` (optional): the agent to backfill via `GetHistory`.
+ * Callers rendering a single-subagent row (any Agent Tool row, including an
+ * orphaned workflow member — see `getDispatchDetail`'s doc comment) should
+ * pass the subagent's own `agent_id` explicitly rather than relying on
+ * `dispatchId` happening to start with `"solo:"` — that prefix alone
+ * doesn't cover the orphaned-member case. Falls back to parsing the
+ * `"solo:"` prefix when omitted, for callers with no `ActiveSubagent` in
+ * scope. Omitted entirely for a genuine multi-member `WorkflowDispatchRow`.
  */
-export function createDispatchDetail(dispatchId: string): DispatchDetail {
+export function createDispatchDetail(dispatchId: string, backfillAgentId?: string): DispatchDetail {
     const [entries, setEntries] = createSignal<DispatchActivityEntry[]>([]);
 
     const mergeIncoming = (incoming: DispatchActivityEntry[]): void => {
@@ -428,8 +437,9 @@ export function createDispatchDetail(dispatchId: string): DispatchDetail {
         },
     });
 
-    if (dispatchId.startsWith("solo:")) {
-        const agentId = dispatchId.slice("solo:".length);
+    const soloAgentId = backfillAgentId ?? (dispatchId.startsWith("solo:") ? dispatchId.slice("solo:".length) : undefined);
+    if (soloAgentId) {
+        const agentId = soloAgentId;
         void (async () => {
             try {
                 const result = await callBackendService("subagent", "GetHistory", [agentId, MAX_DISPATCH_FEED_ENTRIES]);
@@ -755,10 +765,20 @@ export class SwarmViewModel implements ViewModel {
         }
     }
 
-    getDispatchDetail(dispatchId: string): DispatchDetail {
+    /** `backfillAgentId`: pass the row's own single `ActiveSubagent.agent_id`
+     *  whenever the caller is rendering exactly one subagent's row (an Agent
+     *  Tool row, including an orphaned workflow member falling back into
+     *  that bucket — see `buildDispatchBuckets`'s doc comment) — NOT just
+     *  when `dispatchId` happens to start with `"solo:"`. An orphaned
+     *  workflow member's `dispatch_id` is a real `"wf_..."` id even though
+     *  it renders as a single-subagent row, so gating backfill on the
+     *  `"solo:"` prefix alone silently dropped its `GetHistory` backfill
+     *  (reagent P1 on #2232). Omit it for a genuine `WorkflowDispatchRow`,
+     *  which represents many members and has no one agent to backfill. */
+    getDispatchDetail(dispatchId: string, backfillAgentId?: string): DispatchDetail {
         let detail = this.dispatchDetailCache.get(dispatchId);
         if (!detail) {
-            detail = createDispatchDetail(dispatchId);
+            detail = createDispatchDetail(dispatchId, backfillAgentId);
             this.dispatchDetailCache.set(dispatchId, detail);
         }
         return detail;

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -410,14 +410,18 @@ export function mergeDispatchActivityEntries(
  * unification would otherwise introduce (the retired `SubagentDetailPane`/
  * `createSubagentDetail` DID backfill via that same RPC).
  *
- * `backfillAgentId` (optional): the agent to backfill via `GetHistory`.
- * Callers rendering a single-subagent row (any Agent Tool row, including an
- * orphaned workflow member — see `getDispatchDetail`'s doc comment) should
- * pass the subagent's own `agent_id` explicitly rather than relying on
- * `dispatchId` happening to start with `"solo:"` — that prefix alone
- * doesn't cover the orphaned-member case. Falls back to parsing the
- * `"solo:"` prefix when omitted, for callers with no `ActiveSubagent` in
- * scope. Omitted entirely for a genuine multi-member `WorkflowDispatchRow`.
+ * `backfillAgentId` (optional): scopes BOTH the `GetHistory` backfill AND
+ * the live `dispatch:activity` subscription down to this one agent's own
+ * events. Callers rendering a single-subagent row (any Agent Tool row,
+ * including an orphaned workflow member — see `getDispatchDetail`'s doc
+ * comment) should pass the subagent's own `agent_id` explicitly rather than
+ * relying on `dispatchId` happening to start with `"solo:"` — that prefix
+ * alone doesn't cover the orphaned-member case, AND an orphaned member's
+ * `dispatchId` can be shared with sibling rows, so without this filter a
+ * single-subagent row would render every sibling's live events too. Falls
+ * back to parsing the `"solo:"` prefix when omitted, for callers with no
+ * `ActiveSubagent` in scope. Omitted entirely for a genuine multi-member
+ * `WorkflowDispatchRow`, which legitimately wants every member's events.
  */
 export function createDispatchDetail(dispatchId: string, backfillAgentId?: string): DispatchDetail {
     const [entries, setEntries] = createSignal<DispatchActivityEntry[]>([]);
@@ -433,7 +437,8 @@ export function createDispatchDetail(dispatchId: string, backfillAgentId?: strin
             const data = event?.data as any;
             if (data?.dispatchId !== dispatchId) return;
             const members = (data?.members as { agentId: string; events: SubagentEvent[] }[]) ?? [];
-            mergeIncoming(members.flatMap((m) => (m.events ?? []).map((evt) => ({ agentId: m.agentId, event: evt }))));
+            const relevant = backfillAgentId ? members.filter((m) => m.agentId === backfillAgentId) : members;
+            mergeIncoming(relevant.flatMap((m) => (m.events ?? []).map((evt) => ({ agentId: m.agentId, event: evt }))));
         },
     });
 
@@ -750,36 +755,54 @@ export class SwarmViewModel implements ViewModel {
         });
     }
 
-    /** Every row's toggle (Agent Tool rows keyed by `solo:<agent_id>`,
-     *  Workflow rows by their own `dispatch_id`) — tears down the cached
-     *  DispatchDetail (and its WS subscriptions) on collapse, so a row a
-     *  user opened once and moved on from doesn't keep a live subscription
-     *  forever. Unified in SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19
-     *  §4 (was split into toggleSubagentExpanded/toggleDispatchExpanded). */
-    toggleDispatchExpanded(dispatchId: string): void {
-        const wasExpanded = this.isExpanded(dispatchId);
-        this.toggleExpanded(dispatchId);
+    /** Every row's toggle. `rowKey` must be a per-ROW-unique identity, NOT
+     *  necessarily the row's `dispatch_id` — a `WorkflowDispatchRow`'s own
+     *  `dispatch_id` is always 1:1 with its row, but an Agent Tool row's
+     *  `dispatch_id` is NOT: an orphaned workflow member (falling back into
+     *  the Agent Tool bucket while `ListDispatches` is stale/lagging) shares
+     *  its real `dispatch_id` with every sibling member still waiting on
+     *  the same lag. Callers rendering a single-subagent row must pass a
+     *  key derived from something per-row-unique instead (e.g.
+     *  `agent:${sub.agent_id}`) — see `getDispatchDetail`'s doc comment.
+     *  Tears down the cached DispatchDetail (and its WS subscriptions) on
+     *  collapse, so a row a user opened once and moved on from doesn't keep
+     *  a live subscription forever. Unified in
+     *  SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4 (was split
+     *  into toggleSubagentExpanded/toggleDispatchExpanded). */
+    toggleDispatchExpanded(rowKey: string): void {
+        const wasExpanded = this.isExpanded(rowKey);
+        this.toggleExpanded(rowKey);
         if (wasExpanded) {
-            this.dispatchDetailCache.get(dispatchId)?.dispose();
-            this.dispatchDetailCache.delete(dispatchId);
+            this.dispatchDetailCache.get(rowKey)?.dispose();
+            this.dispatchDetailCache.delete(rowKey);
         }
     }
 
-    /** `backfillAgentId`: pass the row's own single `ActiveSubagent.agent_id`
-     *  whenever the caller is rendering exactly one subagent's row (an Agent
-     *  Tool row, including an orphaned workflow member falling back into
-     *  that bucket — see `buildDispatchBuckets`'s doc comment) — NOT just
-     *  when `dispatchId` happens to start with `"solo:"`. An orphaned
-     *  workflow member's `dispatch_id` is a real `"wf_..."` id even though
-     *  it renders as a single-subagent row, so gating backfill on the
-     *  `"solo:"` prefix alone silently dropped its `GetHistory` backfill
-     *  (reagent P1 on #2232). Omit it for a genuine `WorkflowDispatchRow`,
-     *  which represents many members and has no one agent to backfill. */
-    getDispatchDetail(dispatchId: string, backfillAgentId?: string): DispatchDetail {
-        let detail = this.dispatchDetailCache.get(dispatchId);
+    /**
+     * `rowKey`: cache identity for THIS row — must be unique per row (see
+     * `toggleDispatchExpanded`'s doc comment for why this can't just be
+     * `dispatchId` for an Agent Tool row). Two sibling rows sharing one
+     * `dispatchId` but caching under distinct `rowKey`s previously each
+     * subscribed to the SAME live `dispatch:activity` broadcast unfiltered,
+     * so each would render every OTHER sibling's events too — fixed by
+     * `dispatchId`: the real dispatch_id to subscribe to for live
+     * `dispatch:activity` events (may legitimately be shared across sibling
+     * rows — `createDispatchDetail` itself filters live events down to
+     * `backfillAgentId` when one is given, so this is safe even then).
+     *
+     * `backfillAgentId`: pass the row's own single `ActiveSubagent.agent_id`
+     * whenever the caller is rendering exactly one subagent's row (an Agent
+     * Tool row, including an orphaned workflow member) — NOT just when
+     * `dispatchId` happens to start with `"solo:"`, which silently dropped
+     * an orphaned member's `GetHistory` backfill (reagent P1 on #2232).
+     * Omit it for a genuine `WorkflowDispatchRow`, which represents many
+     * members and has no one agent to backfill or filter to.
+     */
+    getDispatchDetail(rowKey: string, dispatchId: string, backfillAgentId?: string): DispatchDetail {
+        let detail = this.dispatchDetailCache.get(rowKey);
         if (!detail) {
             detail = createDispatchDetail(dispatchId, backfillAgentId);
-            this.dispatchDetailCache.set(dispatchId, detail);
+            this.dispatchDetailCache.set(rowKey, detail);
         }
         return detail;
     }

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -355,6 +355,45 @@ export interface DispatchDetail {
  *  this redesign exists to avoid. Oldest entries drop first. */
 const MAX_DISPATCH_FEED_ENTRIES = 500;
 
+/** Identifies one `DispatchActivityEntry` for de-dup purposes — an
+ *  (agentId, timestamp, event payload) triple is stable across both the
+ *  live `dispatch:activity` broadcast and a `GetHistory` backfill, since
+ *  both ultimately read the same underlying event, not a re-generated one. */
+function dispatchActivityEntryKey(e: DispatchActivityEntry): string {
+    return `${e.agentId}:${e.event.timestamp}:${JSON.stringify(e.event.event_type)}`;
+}
+
+/**
+ * Merge freshly-arrived entries into `prev`, de-duplicating by
+ * `dispatchActivityEntryKey`, re-sorting by timestamp, and capping to
+ * `MAX_DISPATCH_FEED_ENTRIES`. Exported (pure, no signal access) so the
+ * de-dup behavior itself is unit-testable — see swarm-model.test.ts.
+ *
+ * De-dup matters because a solo dispatch's `GetHistory` backfill and the
+ * live `dispatch:activity` broadcast race independently: an event the
+ * backend already flushed into `pending_activity` before `GetHistory`
+ * resolves is present in both, so blindly concatenating double-counts it
+ * (reagent P1 on #2232).
+ */
+export function mergeDispatchActivityEntries(
+    prev: DispatchActivityEntry[],
+    incoming: DispatchActivityEntry[]
+): DispatchActivityEntry[] {
+    if (incoming.length === 0) return prev;
+    const seen = new Set(prev.map(dispatchActivityEntryKey));
+    const fresh = incoming.filter((e) => {
+        const key = dispatchActivityEntryKey(e);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+    if (fresh.length === 0) return prev;
+    const merged = [...prev, ...fresh].sort((a, b) => a.event.timestamp - b.event.timestamp);
+    return merged.length > MAX_DISPATCH_FEED_ENTRIES
+        ? merged.slice(merged.length - MAX_DISPATCH_FEED_ENTRIES)
+        : merged;
+}
+
 /**
  * Expanding a row (`WorkflowDispatchRow`, or an Agent Tool row —
  * SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4) shows this: every
@@ -380,12 +419,7 @@ export function createDispatchDetail(dispatchId: string): DispatchDetail {
 
     const mergeIncoming = (incoming: DispatchActivityEntry[]): void => {
         if (incoming.length === 0) return;
-        setEntries((prev) => {
-            const merged = [...prev, ...incoming].sort((a, b) => a.event.timestamp - b.event.timestamp);
-            return merged.length > MAX_DISPATCH_FEED_ENTRIES
-                ? merged.slice(merged.length - MAX_DISPATCH_FEED_ENTRIES)
-                : merged;
-        });
+        setEntries((prev) => mergeDispatchActivityEntries(prev, incoming));
     };
 
     const unsub = waveEventSubscribe({

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -164,6 +164,49 @@
     flex-direction: column;
 }
 
+// ── Dispatch-kind buckets (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19
+// §4) — two fixed sections per agent, "Agent Tool" and "Workflow", each its
+// own color so the two kinds read apart at a glance even before their
+// (eagerly-resolved) names are legible. Hidden entirely when empty — see
+// AgentToolBucket/WorkflowBucket in swarm-view.tsx. Colors reuse existing
+// theme vars only (--accent-color, --warning-color — the latter already
+// tied to "workflow active" status elsewhere in this file, so reusing it
+// for the Workflow bucket label keeps one coherent color association
+// instead of introducing an unrelated third meaning for the same hue). ────
+
+.swarm-bucket {
+    display: flex;
+    flex-direction: column;
+
+    &--agent-tool .swarm-bucket-label {
+        color: var(--accent-color);
+    }
+    &--workflow .swarm-bucket-label {
+        color: var(--warning-color, #f5a623);
+    }
+}
+
+.swarm-bucket-header {
+    display: flex;
+    align-items: center;
+    height: 22px;
+    padding: 0 6px 0 22px;
+    gap: 6px;
+    user-select: none;
+}
+
+.swarm-bucket-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.swarm-bucket-count {
+    font-size: 10px;
+    color: var(--secondary-text-color);
+}
+
 // ── Workflow group (subagents spawned together by one Task/Workflow-tool
 // run, collapsed into one row instead of one row per member) ─────────────
 
@@ -231,15 +274,6 @@
     &--retired {
         color: var(--secondary-text-color);
         background: var(--highlight-bg);
-    }
-}
-
-.swarm-workflow-members {
-    display: flex;
-    flex-direction: column;
-
-    .swarm-subagent-row {
-        padding-left: 48px; // one indent level deeper than a loose subagent row
     }
 }
 
@@ -335,55 +369,8 @@
     flex-shrink: 0;
 }
 
-// ── Subagent inline detail (expanded event log) ──────────────────────────
-
-.swarm-subagent-detail {
-    display: flex;
-    flex-direction: column;
-    margin: 0 6px 4px 30px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--panel-bg-color, var(--main-bg-color));
-    max-height: 320px;
-    overflow: hidden;
-}
-
-.swarm-subagent-detail-header {
-    display: flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: 8px;
-    padding: 6px 8px;
-    border-bottom: 1px solid var(--border-color);
-    flex-shrink: 0;
-}
-
-.swarm-subagent-detail-name {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--main-text-color);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.swarm-subagent-detail-meta {
-    font-size: 10px;
-    color: var(--secondary-text-color);
-    white-space: nowrap;
-}
-
-.swarm-subagent-detail-log {
-    overflow-y: auto;
-    padding: 2px 8px 4px;
-}
-
-.swarm-subagent-detail-loading,
-.swarm-subagent-detail-empty {
-    padding: 8px 0;
-    font-size: 11px;
-    color: var(--secondary-text-color);
-}
+// ── Subagent detail event rendering (shared by the concatenated dispatch
+// feed above — DispatchActivityFeedEntry, swarm-view.tsx) ────────────────
 
 .swarm-subagent-detail-text {
     margin: 2px 0;

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -390,7 +390,7 @@ function WorkflowDispatchRow({
                 </span>
             </div>
             <Show when={expanded()}>
-                <DispatchActivityFeed dispatchId={group.dispatchId} model={model} />
+                <DispatchActivityFeed rowKey={group.dispatchId} dispatchId={group.dispatchId} model={model} />
             </Show>
         </div>
     );
@@ -406,10 +406,26 @@ function WorkflowDispatchRow({
  * and doesn't necessarily mean "no history", hence the kind-neutral copy.
  */
 function DispatchActivityFeed({
+    rowKey,
     dispatchId,
     model,
     backfillAgentId,
 }: {
+    /** Cache/expand-state identity for THIS row — must be unique per row.
+     *  For a `WorkflowDispatchRow` this is the same as `dispatchId` (a
+     *  workflow's own dispatch_id is always 1:1 with its row). For an Agent
+     *  Tool row it must NOT be `dispatchId`: an orphaned workflow member (a
+     *  real "wf_..." dispatch_id shared by every sibling member still
+     *  waiting on a stale/lagging `ListDispatches`) would otherwise collide
+     *  every sibling row onto the same cached `DispatchDetail` and the same
+     *  expand-state entry (reagent P1 on #2232) — pass a per-agent key like
+     *  `agent:${sub.agent_id}` instead, which is always unique. */
+    rowKey: string;
+    /** The dispatch_id to subscribe to for live `dispatch:activity` events —
+     *  the REAL dispatch_id, which may legitimately be shared with sibling
+     *  rows (the orphaned-member case above); `backfillAgentId` (below)
+     *  scopes both the live feed and the backfill down to one agent when
+     *  that's the case. */
     dispatchId: string;
     model: SwarmViewModel;
     /** Pass the row's own single subagent's `agent_id` for an Agent Tool row
@@ -418,7 +434,7 @@ function DispatchActivityFeed({
      *  `WorkflowDispatchRow`. */
     backfillAgentId?: string;
 }): JSX.Element {
-    const detail = model.getDispatchDetail(dispatchId, backfillAgentId);
+    const detail = model.getDispatchDetail(rowKey, dispatchId, backfillAgentId);
     const entries = detail.entriesAtom;
     return (
         <div class="swarm-dispatch-feed">
@@ -505,10 +521,16 @@ function SubagentRow({
     model: SwarmViewModel;
     parentAgentStatus: "running" | "idle";
 }): JSX.Element {
-    // Keyed by dispatch_id ("solo:<agent_id>"), not agent_id — unified with
-    // WorkflowDispatchRow onto the same expandedIds/dispatchDetailCache
-    // mechanism (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4).
-    const expanded = createMemo(() => model.isExpanded(sub.dispatch_id));
+    // Unified with WorkflowDispatchRow onto the same expandedIds/
+    // dispatchDetailCache mechanism (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_
+    // MODEL_2026_07_19 §4), but keyed by `agent_id`, NOT `dispatch_id`: an
+    // orphaned workflow member's `dispatch_id` is a real, possibly-shared
+    // "wf_..." id (every sibling still waiting on a stale/lagging
+    // `ListDispatches` shares it) — keying expand-state/cache off it would
+    // collide every sibling row's expand toggle and cached feed onto the
+    // first one (reagent P1 on #2232). `agent_id` is always unique per row.
+    const rowKey = createMemo(() => `agent:${sub.agent_id}`);
+    const expanded = createMemo(() => model.isExpanded(rowKey()));
     // See subagentDisplayLabel's doc comment (swarm-model.ts) — as of Phase A
     // this resolves eagerly at dispatch time for the common case; the
     // slug/agent_id fallback chain only matters for the brief window before
@@ -517,7 +539,7 @@ function SubagentRow({
 
     const handleToggle = () => {
         const wasExpanded = expanded();
-        model.toggleDispatchExpanded(sub.dispatch_id);
+        model.toggleDispatchExpanded(rowKey());
         if (!wasExpanded && !sub.display_name) {
             // Fallback safety net — eager naming (Phase A) should already
             // have resolved this by the time a user gets here, but fire the
@@ -554,7 +576,12 @@ function SubagentRow({
                 <AgentStatusChip status={subagentDisplayStatus(sub, parentAgentStatus)} />
             </div>
             <Show when={expanded()}>
-                <DispatchActivityFeed dispatchId={sub.dispatch_id} model={model} backfillAgentId={sub.agent_id} />
+                <DispatchActivityFeed
+                    rowKey={rowKey()}
+                    dispatchId={sub.dispatch_id}
+                    model={model}
+                    backfillAgentId={sub.agent_id}
+                />
             </Show>
         </div>
     );

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -405,8 +405,20 @@ function WorkflowDispatchRow({
  * why) — so an empty feed right after expand is expected for a Workflow row
  * and doesn't necessarily mean "no history", hence the kind-neutral copy.
  */
-function DispatchActivityFeed({ dispatchId, model }: { dispatchId: string; model: SwarmViewModel }): JSX.Element {
-    const detail = model.getDispatchDetail(dispatchId);
+function DispatchActivityFeed({
+    dispatchId,
+    model,
+    backfillAgentId,
+}: {
+    dispatchId: string;
+    model: SwarmViewModel;
+    /** Pass the row's own single subagent's `agent_id` for an Agent Tool row
+     *  (including an orphaned workflow member — see `getDispatchDetail`'s
+     *  doc comment in swarm-model.ts); omit for a genuine multi-member
+     *  `WorkflowDispatchRow`. */
+    backfillAgentId?: string;
+}): JSX.Element {
+    const detail = model.getDispatchDetail(dispatchId, backfillAgentId);
     const entries = detail.entriesAtom;
     return (
         <div class="swarm-dispatch-feed">
@@ -542,7 +554,7 @@ function SubagentRow({
                 <AgentStatusChip status={subagentDisplayStatus(sub, parentAgentStatus)} />
             </div>
             <Show when={expanded()}>
-                <DispatchActivityFeed dispatchId={sub.dispatch_id} model={model} />
+                <DispatchActivityFeed dispatchId={sub.dispatch_id} model={model} backfillAgentId={sub.agent_id} />
             </Show>
         </div>
     );

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowDispatch, NameGroup, SubagentDetail, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
-import { isWorkflowDispatch, isNameGroup, groupCacheKey, subagentDisplayLabel } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
+import { subagentDisplayLabel } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -233,7 +233,8 @@ function AgentRow({
         phaseToDisplayStatus(node.blockId, node.agentStatus)
     );
     const collapsed = createMemo(() => model.isAgentCollapsed(node.blockId));
-    const hasChildren = createMemo(() => node.subagents.length > 0);
+    const totalRows = createMemo(() => node.agentToolRows.length + node.workflowRows.length);
+    const hasChildren = createMemo(() => totalRows() > 0);
 
     const [summaryFlash, setSummaryFlash] = createSignal(false);
     let flashTimer: ReturnType<typeof setTimeout> | undefined;
@@ -282,7 +283,7 @@ function AgentRow({
                     </span>
                     <span class="swarm-agent-label">{node.agentName}</span>
                     <Show when={collapsed() && hasChildren()}>
-                        <span class="swarm-agent-collapsed-count">{node.subagents.length}</span>
+                        <span class="swarm-agent-collapsed-count">{totalRows()}</span>
                     </Show>
                     <Show when={node.contextTokens != null}>
                         <span class="swarm-ctx-size">{fmtCtx(node.contextTokens!)}</span>
@@ -297,16 +298,54 @@ function AgentRow({
             </div>
             <Show when={!collapsed()}>
                 <div class="swarm-children">
-                    <For each={node.subagents}>
-                        {(child) => isWorkflowDispatch(child)
-                            ? <WorkflowDispatchRow group={child} model={model} />
-                            : isNameGroup(child)
-                            ? <NameGroupRow group={child} model={model} parentAgentStatus={node.agentStatus} />
-                            : <SubagentRow sub={child} model={model} parentAgentStatus={node.agentStatus} />}
-                    </For>
+                    <AgentToolBucket rows={node.agentToolRows} model={model} parentAgentStatus={node.agentStatus} />
+                    <WorkflowBucket rows={node.workflowRows} model={model} />
                 </div>
             </Show>
         </div>
+    );
+}
+
+// ── Two fixed dispatch-kind buckets (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_
+//    MODEL_2026_07_19 §4) — always exactly these two, never data-driven
+//    groups; each hides entirely when empty (no "always visible" precedent
+//    exists anywhere else in this codebase, see that spec's §6). ─────────
+
+function AgentToolBucket({
+    rows,
+    model,
+    parentAgentStatus,
+}: {
+    rows: ActiveSubagent[];
+    model: SwarmViewModel;
+    parentAgentStatus: "running" | "idle";
+}): JSX.Element {
+    return (
+        <Show when={rows.length > 0}>
+            <div class="swarm-bucket swarm-bucket--agent-tool">
+                <div class="swarm-bucket-header">
+                    <span class="swarm-bucket-label">Agent Tool</span>
+                    <span class="swarm-bucket-count">{rows.length}</span>
+                </div>
+                <For each={rows}>
+                    {(sub) => <SubagentRow sub={sub} model={model} parentAgentStatus={parentAgentStatus} />}
+                </For>
+            </div>
+        </Show>
+    );
+}
+
+function WorkflowBucket({ rows, model }: { rows: WorkflowDispatch[]; model: SwarmViewModel }): JSX.Element {
+    return (
+        <Show when={rows.length > 0}>
+            <div class="swarm-bucket swarm-bucket--workflow">
+                <div class="swarm-bucket-header">
+                    <span class="swarm-bucket-label">Workflow</span>
+                    <span class="swarm-bucket-count">{rows.length}</span>
+                </div>
+                <For each={rows}>{(group) => <WorkflowDispatchRow group={group} model={model} />}</For>
+            </div>
+        </Show>
     );
 }
 
@@ -443,52 +482,7 @@ function DispatchActivityFeedEntry({ entry }: { entry: DispatchActivityEntry }):
     }
 }
 
-// ── Name group row (loose subagents sharing one display_name) ──────────
-
-function NameGroupRow({
-    group,
-    model,
-    parentAgentStatus,
-}: {
-    group: NameGroup;
-    model: SwarmViewModel;
-    parentAgentStatus: "running" | "idle";
-}): JSX.Element {
-    // Same expand-state-on-the-ViewModel rationale as WorkflowGroupRow —
-    // reuses groupCacheKey's "name:<name>" namespacing so this can never
-    // collide with a WorkflowGroupRow's workflowId or a SubagentRow's
-    // agent_id in the shared expandedIds set.
-    const key = groupCacheKey(group);
-    const expanded = createMemo(() => model.isExpanded(key));
-
-    return (
-        <div class={`swarm-workflow-group swarm-workflow-group--${group.status}`}>
-            <div
-                class="swarm-workflow-header"
-                onClick={() => model.toggleExpanded(key)}
-                title={group.name}
-            >
-                <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-workflow-expand-icon`} />
-                <span class="swarm-workflow-name">{group.name}</span>
-                <span class="swarm-workflow-count">
-                    {group.status === "active" ? `${group.activeCount}/${group.totalCount} active` : `${group.totalCount} retired`}
-                </span>
-                <span class={`swarm-workflow-status-badge swarm-workflow-status-badge--${group.status}`}>
-                    {group.status === "active" ? "Active" : "Retired"}
-                </span>
-            </div>
-            <Show when={expanded()}>
-                <div class="swarm-workflow-members">
-                    <For each={group.subagents}>
-                        {(sub) => <SubagentRow sub={sub} model={model} parentAgentStatus={parentAgentStatus} />}
-                    </For>
-                </div>
-            </Show>
-        </div>
-    );
-}
-
-// ── Subagent child row ───────────────────────────────────────────────────
+// ── Agent Tool (solo dispatch) row ──────────────────────────────────────
 
 function SubagentRow({
     sub,
@@ -499,20 +493,26 @@ function SubagentRow({
     model: SwarmViewModel;
     parentAgentStatus: "running" | "idle";
 }): JSX.Element {
-    const expanded = createMemo(() => model.isExpanded(sub.agent_id));
-    // See subagentDisplayLabel's doc comment (swarm-model.ts) — slug is a
-    // shared per-batch codename, not a per-subagent identifier, so this
-    // disambiguates same-slug siblings with a short agent_id suffix instead
-    // of assuming slug alone is unique (task #44).
+    // Keyed by dispatch_id ("solo:<agent_id>"), not agent_id — unified with
+    // WorkflowDispatchRow onto the same expandedIds/dispatchDetailCache
+    // mechanism (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4).
+    const expanded = createMemo(() => model.isExpanded(sub.dispatch_id));
+    // See subagentDisplayLabel's doc comment (swarm-model.ts) — as of Phase A
+    // this resolves eagerly at dispatch time for the common case; the
+    // slug/agent_id fallback chain only matters for the brief window before
+    // that resolves (or if it never does).
     const displayLabel = createMemo(() => subagentDisplayLabel(sub));
 
     const handleToggle = () => {
         const wasExpanded = expanded();
-        model.toggleSubagentExpanded(sub.agent_id);
+        model.toggleDispatchExpanded(sub.dispatch_id);
         if (!wasExpanded && !sub.display_name) {
-            // Fire-and-forget — the row's label/detail header picks up the
-            // name via the subagent:named event (swarm-model.ts), not this
-            // call's return; we only need the return here for cost accounting.
+            // Fallback safety net — eager naming (Phase A) should already
+            // have resolved this by the time a user gets here, but fire the
+            // on-demand call too in case it hasn't (still in flight, or
+            // failed). Fire-and-forget — the row's label picks up the name
+            // via the subagent:named event (swarm-model.ts), not this call's
+            // return; we only need the return here for cost accounting.
             void callBackendService("subagent", "GenerateName", [sub.agent_id]).then((result: any) => {
                 if (result?.tokens) recordTurn("ambient:subagent_name", result.tokens);
             });
@@ -542,104 +542,13 @@ function SubagentRow({
                 <AgentStatusChip status={subagentDisplayStatus(sub, parentAgentStatus)} />
             </div>
             <Show when={expanded()}>
-                <SubagentDetailPane sub={sub} detail={model.getSubagentDetail(sub.agent_id)} />
+                <DispatchActivityFeed dispatchId={sub.dispatch_id} model={model} />
             </Show>
         </div>
     );
 }
 
-// ── Subagent inline detail (expanded event log) ──────────────────────────
-
-function SubagentDetailPane({ sub, detail }: { sub: ActiveSubagent; detail: SubagentDetail }): JSX.Element {
-    const info = detail.infoAtom;
-    const events = detail.eventsAtom;
-    const status = detail.statusAtom;
-
-    // Same slug-is-not-unique reasoning as SubagentRow's displayLabel (see
-    // subagentDisplayLabel's doc comment in swarm-model.ts) — prefer the
-    // freshest info() read, falling back to the row's own `sub` fields.
-    const name = createMemo(() =>
-        subagentDisplayLabel({
-            display_name: info()?.display_name ?? sub.display_name,
-            slug: info()?.slug ?? sub.slug,
-            agent_id: sub.agent_id,
-        })
-    );
-    const modelName = createMemo(() => info()?.model ?? sub.model);
-    const eventCount = createMemo(() => info()?.event_count ?? sub.event_count);
-
-    return (
-        <div class="swarm-subagent-detail">
-            <div class="swarm-subagent-detail-header">
-                <span class="swarm-subagent-detail-name">{name()}</span>
-                <span class="swarm-subagent-detail-meta">{sub.agent_id.substring(0, 7)}</span>
-                <span class="swarm-subagent-detail-meta">{eventCount()} events</span>
-                <Show when={modelName()}>
-                    <span class="swarm-subagent-detail-meta">{modelName()}</span>
-                </Show>
-                <span class="swarm-subagent-detail-meta">{sub.parent_agent}</span>
-            </div>
-            <div class="swarm-subagent-detail-log">
-                <Show when={status() === "loading"}>
-                    <div class="swarm-subagent-detail-loading">Loading…</div>
-                </Show>
-                <Show when={events().length === 0 && status() !== "loading"}>
-                    <div class="swarm-subagent-detail-empty">No activity yet</div>
-                </Show>
-                <For each={events()}>{(event) => <SubagentDetailEvent event={event} />}</For>
-            </div>
-        </div>
-    );
-}
-
-function SubagentDetailEvent({ event }: { event: SubagentEvent }): JSX.Element {
-    const et = event.event_type;
-    const [expanded, setExpanded] = createSignal(false);
-
-    switch (et.type) {
-        case "text":
-        case "result":
-            return <pre class="swarm-subagent-detail-text">{et.content}</pre>;
-        case "tool_use":
-            return (
-                <div class="swarm-subagent-detail-tool">
-                    <div class="swarm-subagent-detail-tool-header" onClick={() => setExpanded(!expanded())}>
-                        <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-detail-expand-icon`} />
-                        <span class="swarm-subagent-detail-tool-name">{et.name}</span>
-                    </div>
-                    <Show when={expanded()}>
-                        <pre class="swarm-subagent-detail-text">{et.input_summary}</pre>
-                    </Show>
-                </div>
-            );
-        case "tool_result":
-            return (
-                <div class="swarm-subagent-detail-tool">
-                    <div
-                        class={`swarm-subagent-detail-tool-header ${et.is_error ? "swarm-subagent-detail-tool-header--error" : ""}`}
-                        onClick={() => setExpanded(!expanded())}
-                    >
-                        <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-detail-expand-icon`} />
-                        <span>{et.is_error ? "Error" : "Result"}</span>
-                    </div>
-                    <Show when={expanded()}>
-                        <pre class={`swarm-subagent-detail-text ${et.is_error ? "swarm-subagent-detail-text--error" : ""}`}>
-                            {et.preview}
-                        </pre>
-                    </Show>
-                </div>
-            );
-        case "progress":
-            return (
-                <div class="swarm-subagent-detail-progress">
-                    <i class="fa-solid fa-spinner fa-spin" />
-                    <span>{et.output}</span>
-                </div>
-            );
-        default:
-            return null;
-    }
-}
+// ── Status chip ──────────────────────────────────────────────────────────
 
 // ── Status chip ──────────────────────────────────────────────────────────
 

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -397,11 +397,13 @@ function WorkflowDispatchRow({
 }
 
 /**
- * Concatenated activity feed for an expanded `WorkflowDispatchRow` (SPEC
- * §7) — one chronological, member-tagged stream instead of nested member
- * rows, fed by `createDispatchDetail`'s `dispatch:activity` subscription.
- * Live-only: nothing to show until new activity arrives after expand (see
- * that function's doc comment for why there's no historical backfill).
+ * Concatenated activity feed for an expanded Agent Tool or Workflow row —
+ * one chronological, member-tagged stream instead of nested member rows,
+ * fed by `createDispatchDetail`'s `dispatch:activity` subscription. A solo
+ * (Agent Tool) dispatch also backfills history via `GetHistory`; a Workflow
+ * dispatch stays live-only (see `createDispatchDetail`'s doc comment for
+ * why) — so an empty feed right after expand is expected for a Workflow row
+ * and doesn't necessarily mean "no history", hence the kind-neutral copy.
  */
 function DispatchActivityFeed({ dispatchId, model }: { dispatchId: string; model: SwarmViewModel }): JSX.Element {
     const detail = model.getDispatchDetail(dispatchId);
@@ -409,9 +411,7 @@ function DispatchActivityFeed({ dispatchId, model }: { dispatchId: string; model
     return (
         <div class="swarm-dispatch-feed">
             <Show when={entries().length === 0}>
-                <div class="swarm-dispatch-feed-empty">
-                    Waiting for activity — showing new events from now on, not history.
-                </div>
+                <div class="swarm-dispatch-feed-empty">No activity yet.</div>
             </Show>
             <For each={entries()}>{(entry) => <DispatchActivityFeedEntry entry={entry} />}</For>
         </div>
@@ -547,8 +547,6 @@ function SubagentRow({
         </div>
     );
 }
-
-// ── Status chip ──────────────────────────────────────────────────────────
 
 // ── Status chip ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Phase B (frontend) of the Swarm pane redesign — follow-up to #2231 (Phase A, backend eager naming), completing docs/specs/SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19.md.

- Reorganizes each agent block's Swarm pane rows into two fixed, differently-colored top-level buckets — **Agent Tool** (one row per solo dispatch) and **Workflow** (one row per workflow dispatch) — via new `buildDispatchBuckets()` in `swarm-model.ts`, replacing `buildDispatchChildren()`/`NameGroup`/`groupKeyFor` (the slug-fallback grouping from #2226, now superseded since every dispatch gets a real distinct name eagerly at dispatch time instead of lazily on click).
- `AgentTreeNode` now exposes `agentToolRows`/`workflowRows` instead of one mixed `subagents: SwarmChild[]`; each bucket hides when empty (mirrors the existing chevron-gating precedent) and gets its own accent color in `swarm-view.scss`.
- Generalizes `DispatchActivityFeed`/`createDispatchDetail` to cover solo Agent-tool rows too, not just Workflow rows — backfills via the existing `subagent.GetHistory` RPC so this doesn't regress the retired `SubagentDetailPane`/`createSubagentDetail`'s backfill behavior (relies on Phase A's backend change that now dual-emits `dispatch:activity` for solo `dispatch_id`s too).
- Retires `SubagentDetailPane`/`SubagentDetailEvent`/`createSubagentDetail`, and updates `ActivityRow.tsx` (pinned activity dock) and `subagent-adapter.ts` to match (drops the "group loose subagents by shared display_name" pass, since eager naming removes the problem it existed to paper over).
- Rewrites `swarm-model.test.ts`'s test suite for the new `buildDispatchBuckets` shape.

Note: live GUI verification in `task dev` wasn't possible in this environment — verified via `tsc --noEmit` (clean) and the full `vitest` suite (1802 passed, 3 skipped — 2 known e2e no-build-dir skips, 1 pre-existing unrelated flaky test not observed failing this run).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run` — 1802/1805 passing (3 skipped, none newly failing)
- [ ] Live `task dev` verification: two colored buckets under an agent block, eagerly-resolved titles with no click needed, expand shows concatenated feed with backfill

<!-- agentmux:agent_id=agenta -->