### PR TITLE
feat(swarm): Retire action to dismiss a terminal-status Swarm pane row

### DIFF
--- a/.changesets/1784530167-feat-swarm-retire-action-to-dismiss-a-terminal-status-swarm--f9vh.md
+++ b/.changesets/1784530167-feat-swarm-retire-action-to-dismiss-a-terminal-status-swarm--f9vh.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): Retire action to dismiss a terminal-status Swarm pane row

--- a/docs/specs/REPORT_SWARM_SUBAGENT_INTERRUPTED_STATUS_2026_07_20.md
+++ b/docs/specs/REPORT_SWARM_SUBAGENT_INTERRUPTED_STATUS_2026_07_20.md
@@ -1,0 +1,135 @@
+# REPORT — why every subagent under a long-running pane shows "Interrupted"
+
+**Date:** 2026-07-20
+**Trigger:** Live observation after landing #2231/#2232/#2233 tonight — opened
+the agent pane "Lzop" (a long-running session with many prior Agent-tool
+calls) in the two-bucket Swarm pane and every single row displayed
+"Interrupted," including ones the user could confirm had actually finished
+their work cleanly. User asked: what are the possible states, do subagents
+ever show as genuinely done, and can a row be manually dismissed once it is.
+
+**Scope:** Diagnosis only — no code changes. Companion implementation plan:
+`SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md`.
+
+---
+
+## 1. The three backend states
+
+`SubAgentStatus` (`agentmux-srv/src/backend/subagent_watcher.rs:100-112`):
+
+| Variant | Set by | When |
+|---|---|---|
+| `Active` | `process_jsonl_change` | Default, the instant a subagent's JSONL file is first observed |
+| `Completed` | `process_jsonl_change` (subagent_watcher.rs:1363-1374) | The last event read for that subagent is a `"type":"result"` line — checked live, on every filesystem-watcher tick and every backfill scan, **no reopen required** |
+| `Abandoned` | `reconcile_stale_subagents` (subagent_watcher.rs:1062-1123) ONLY | The parent block's turn is confirmed not-active (`turn_active: false` via `get_block_controller_status`) and the subagent is still `Active` |
+
+**So yes — subagents do complete, and completion detection itself works
+correctly and live.** A subagent that finishes cleanly gets `Completed` the
+moment its `result` line is read, with no dependency on reopening anything.
+
+## 2. What the UI actually shows
+
+`subagentDisplayStatus` (`frontend/app/view/swarm/swarm-view.tsx:209-215`):
+
+```ts
+export function subagentDisplayStatus(sub: ActiveSubagent, parentAgentStatus: "running" | "idle"): AgentDisplayStatus {
+    if (sub.status === "abandoned") return "interrupted";
+    if (sub.status === "active") {
+        return parentAgentStatus === "idle" ? "interrupted" : "working";
+    }
+    return "idle"; // completed
+}
+```
+
+Three outputs reachable for a subagent row: `"working"`, `"idle"`,
+`"interrupted"`. Critically: **`Completed` always renders `"idle"`,
+unconditionally** — a genuinely-finished subagent can never display
+"Interrupted." The only path to "Interrupted" is a subagent still sitting as
+backend `Active` (`Abandoned` also maps there, but that variant is itself
+only ever produced by the same reconciliation gap described below).
+
+## 3. Root cause: reconciliation only runs at pane reopen
+
+`reconcile_stale_subagents` has exactly **one** production call site —
+`scan_session_subagents` (subagent_watcher.rs:1034), itself called from
+exactly one place: `handle_reactive_register` (`server/reactive.rs:350`),
+the reactive-registration handshake that fires when a pane (re)opens or
+reconnects. **Nothing else calls it** — no timer, no per-turn hook, no
+live trigger of any kind. Confirmed by exhaustive grep of both files.
+
+This means: any subagent whose JSONL never got a `Result` line read while
+its `SubagentWatcher` in-memory record was alive stays `Active` forever,
+until the next time its pane is closed and reopened. On a **long-running
+pane like Lzop's** — open continuously, never reopened — every subagent
+that got orphaned this way (crashed, was actually cut off, or simply hasn't
+had its completion re-checked) sits `Active` in memory indefinitely.
+
+The frontend has a documented client-side backstop for exactly this gap
+(`swarm-view.tsx:196-208`, doc comment cites
+`docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md` Open
+Question 1 by name): whenever `sub.status === "active"` and the *parent*
+agent's own turn is currently idle (`parentAgentStatus === "idle"`), display
+"Interrupted" rather than a misleading "working." This is correct given the
+information available — a subagent literally cannot still be running once
+its parent's turn has ended, since a Task-tool call is synchronous within
+the parent's own turn. But a parent pane spends the **overwhelming majority
+of its lifetime idle-between-turns** (that's the normal, expected steady
+state, not a sign of anything wrong) — so this backstop fires essentially
+every time a user looks at a long-running pane's Swarm rows, for any
+subagent the backend hasn't gotten around to reconciling.
+
+**Net effect on Lzop:** a long-open pane accumulates `Active`-forever
+subagent records (some genuinely abandoned, some possibly still correctly
+`Active` momentarily, some that may have actually completed but whose
+completion detection lagged/missed for some reason not yet isolated), and
+every one of them displays "Interrupted" continuously because Lzop itself
+is idle between turns essentially all the time the user is looking at it.
+
+## 4. This is a previously-identified, explicitly-deferred gap
+
+`docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md` designed
+and shipped most of this system eight days ago — the `Abandoned` variant,
+`reconcile_stale_subagents`, and the frontend backstop described above are
+all exactly what that spec proposed (§6.1-6.3, §6.5). Its **Open Question
+1** explicitly named the tradeoff being hit right now:
+
+> "should `ParentTurnEnded` fire from the exact moment `persistent.rs` flips
+> `turn_active` to false (real-time...), or is it sufficient to only
+> reconcile at `scan_session_subagents` time (reopen/backfill only, simpler,
+> but **leaves a subagent stuck "Active" for the rest of the CURRENT
+> session between the parent turn ending and the next pane reopen**)?
+> Recommend starting with the reopen-time-only version... and evaluating
+> whether the live case is common enough in practice to warrant the
+> real-time wiring as a fast-follow."
+
+The reopen-only version shipped; the real-time fast-follow never did. Lzop
+tonight is the "is the live case common enough in practice" question
+answered empirically: yes — any pane left open across multiple subagent
+spawns without being reopened will show this.
+
+## 5. Retire/dismiss: confirmed net-new gap
+
+Grepped the whole Swarm pane frontend (`swarm-model.ts`, `swarm-view.tsx`)
+for "retire"/"dismiss"/"archive" — the only hits are the *Workflow dispatch
+grouping* label ("Active"/"Retired" chip on a `WorkflowDispatchRow`, driven
+purely by `DispatchStatus`), not a per-row user action. There is no
+mechanism anywhere to manually remove a subagent or dispatch row from the
+Swarm pane view. The prior spec's own Open Question 2 ("is `Abandoned`
+worth a visible status, or should it fall into idle" — SPEC_SUBAGENT_
+LIFECYCLE_RECONCILIATION_2026_07_12.md §9.2) explicitly considered and
+rejected silently hiding it, but never proposed an explicit user-driven
+dismiss action either way. This is a genuinely new ask, not something
+previously scoped and dropped.
+
+## 6. Summary for the implementation plan
+
+Two independent, separable pieces of work close this out — detailed in
+`SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md`:
+
+1. Close Open Question 1 for real: wire `ParentTurnEnded` reconciliation at
+   the exact moment a turn ends (`persistent.rs:921-922`, the
+   `set_active_turn(false)` call site — already identified and cited by
+   name in the 07-12 spec as the future hook point), not just at reopen.
+2. Add an explicit Retire/dismiss action for terminal-status
+   (`Completed`/`Abandoned`) rows — net-new UI surface, no prior design to
+   build on.

--- a/docs/specs/SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md
+++ b/docs/specs/SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md
@@ -1,0 +1,291 @@
+# SPEC — live subagent reconciliation + Retire action (best-practices plan)
+
+**Date:** 2026-07-20
+**Status:** Phase A shipped (#2234, merged). Phase B (#2235, this PR) implements
+the rest of this doc.
+**Builds on:** `docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`
+(closes its Open Question 1; makes a fresh product decision on Open
+Question 2). Diagnosis: `docs/specs/REPORT_SWARM_SUBAGENT_INTERRUPTED_STATUS_2026_07_20.md`.
+**Scope:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`,
+`agentmux-srv/src/backend/subagent_watcher.rs` (backend); `frontend/app/view/swarm/swarm-model.ts`,
+`swarm-view.tsx` (frontend).
+
+---
+
+## 1. Context
+
+A long-running agent pane accumulates subagent records that never get
+reconciled to a terminal status, because `reconcile_stale_subagents` only
+runs when its pane is closed and reopened — never live, never on a timer.
+The frontend's client-side "Interrupted" backstop (a deliberate,
+already-shipped guard — not a bug in itself) then fires for every such
+stuck-`Active` row every time the parent pane is idle between turns, which
+is most of the time. On a pane like "Lzop" — open continuously, spawning
+many subagents, never reopened — this reads as "everything is always
+Interrupted," even for subagents that may have genuinely finished. See the
+companion report for full root-cause detail and citations.
+
+This is exactly the tradeoff the 07-12 spec's Open Question 1 named and
+deliberately deferred ("recommend starting with the reopen-time-only
+version... and evaluating whether the live case is common enough in
+practice to warrant the real-time wiring as a fast-follow"). Tonight's
+observation answers that question: yes, it's common enough — any
+long-lived pane hits it, not an edge case.
+
+## 2. Goals
+
+1. Reconcile a subagent's status the moment its parent's turn actually
+   ends, not just at the next pane reopen — closing Open Question 1.
+2. Give the user an explicit way to remove a terminal-status
+   (`Completed`/`Abandoned`) row from the Swarm pane view — a Retire
+   action, addressing the user's direct request tonight and Open Question
+   2 (never resolved either way in the 07-12 spec).
+
+## 3. Non-goals
+
+- Persisting subagent status across `agentmux-srv` restarts — out of
+  scope, same as the 07-12 spec's own non-goals.
+- Changing Workflow-level dispatch status/aggregation
+  (`DispatchStatus`/`refresh_dispatch_status`) — unaffected by either
+  change here.
+- A bulk "retire all" action — start with per-row, revisit if the manual
+  cost proves real in practice (see §7 open questions).
+- Persisting *retired* state across `agentmux-srv` restarts or across
+  devices — see §6's design rationale for why this should start
+  client-local/ephemeral, matching the existing
+  `memory-pressure-banner.tsx` dismiss precedent (`dismissedAt` is a plain
+  `createSignal`, resets on reload, no backend write).
+
+## 4. Phase A — real-time reconciliation on turn-end
+
+**The hook point already exists and is already commented for this exact
+purpose.** `agentmux-srv/src/backend/blockcontroller/persistent.rs:917-922`,
+the one place `turn_active` flips back to `false` for a persistent
+(never-exits-between-turns) agent process:
+
+```rust
+// Claude's turn-ending marker. Persistent mode never exits
+// between turns, so this is the only place `turn_active`
+// can go back to false without waiting for process exit —
+// see `send_message`'s matching `set_active_turn(true)`.
+if parsed.get("type").and_then(|v| v.as_str()) == Some("result") {
+    health_read.set_active_turn(false);
+    // Publish the flip so the Swarm view's live
+    // ControllerStatus subscription reflects "turn
+    // ended" immediately ...
+    if let Some(ref broker) = broker_read {
+        let status = { /* ... */ };
+        super::publish_controller_status(broker, &status);
+    }
+```
+
+Add one call here: `subagent_watcher.reconcile_stale_subagents(&block_id, &session_id)`
+(the method already exists, `subagent_watcher.rs:1062`, `fn` not `pub fn` —
+needs `pub(crate)` or `pub` to be callable from `blockcontroller`, a
+one-line visibility change). This block already needs a
+`session_id` in scope for the call — confirm it's available at this call
+site (likely via the same `inner_read` lock already taken for the status
+snapshot) or thread it in from wherever `persistent.rs` already tracks the
+current session id per block.
+
+This closes the exact gap: a subagent stuck `Active` now gets resolved to
+`Completed` (if it has a `Result` line — it may have raced the turn-end
+event, worth double-checking ordering) or honest `Abandoned` within the
+same tick the parent's turn ends, not at the next reopen. No new state,
+enum, or wire format — purely calling an existing function from a new,
+better-timed call site.
+
+**Broadcast note:** `reconcile_stale_subagents` doesn't currently broadcast
+anything on its own (confirmed — it mutates `SubAgentStatus` in place with
+no WS emission). At reopen time this doesn't matter (the reopening pane's
+own `loadSubagents()` picks up the corrected status on its next fetch
+anyway). Live, it does matter — a connected Swarm pane watching this block
+needs a push, not just a corrected value sitting server-side until some
+unrelated event triggers a reload. Add a broadcast (reuse the
+`subagent:completed`/`dispatch:updated` pattern the frontend already
+listens to and reloads on) for any subagent this pass actually downgrades.
+
+## 5. Reopen-time edge cases — audited
+
+Phase A adds a *second* reconciliation trigger (live, turn-end) alongside
+the existing one (`scan_session_subagents` → `reconcile_stale_subagents`,
+fired from `handle_reactive_register`, `server/reactive.rs:350`, on pane
+(re)open). Before adding a second call site, the existing reopen path was
+audited end to end for correctness, since Phase A's live trigger inherits
+the same `reconcile_stale_subagents` logic and any bug there would now
+fire twice as often. Each case below is marked **Confirmed correct**
+(verified in code, often already covered by an existing test),
+**Confirmed correct, but out of scope** (a real gap, deliberately not
+fixed here), or **Needs verification** (plausible, not yet confirmed —
+flagged for the implementing PR, not resolved by this doc).
+
+1. **Backfill-before-reconcile ordering** — does a subagent that actually
+   finished (has a `Result` line already on disk) risk being reconciled to
+   `Abandoned` before its own completion gets parsed? **Confirmed
+   correct.** `scan_session_subagents` (subagent_watcher.rs:1000-1038)
+   calls `scan_subagents_dir` (which reads every file, including any
+   `Result` line, setting `Completed`) at line 1033, THEN
+   `reconcile_stale_subagents` at line 1034 — the ordering is right, no
+   race. `reconcile_stale_subagents` only ever touches subagents still
+   `Active` after that pass (subagent_watcher.rs:1097), so an
+   already-just-`Completed` one is untouched.
+
+2. **No controller registered at reconcile time.** `reconcile_stale_subagents`
+   reads `get_block_controller_status(parent_block_id).map(|s| s.turn_active).unwrap_or(true)`
+   (subagent_watcher.rs:1063-1066) — `None` (no controller in
+   `CONTROLLER_REGISTRY` for this block yet, `blockcontroller/mod.rs:218-224`)
+   is treated as "assume active, don't touch," a deliberately conservative
+   default (never guess a false demotion). **Needs verification:** does
+   `handle_reactive_register` (which triggers the backfill+reconcile pass)
+   ever run before this block's controller has registered itself in
+   `CONTROLLER_REGISTRY`? If so, that reconcile pass silently no-ops, and
+   the stale subagents wait for either a live Phase A trigger (which also
+   needs a registered, *running* controller to fire from at all) or the
+   *next* reopen. Add a trace/test for this exact ordering before
+   shipping Phase A — if the race is real, the fix is likely "run the
+   backfill+reconcile pass after controller registration is guaranteed,"
+   not a change to `reconcile_stale_subagents` itself.
+
+3. **Workflow dispatch aggregates don't reflect member-level reconciliation.**
+   `refresh_dispatch_status` (subagent_watcher.rs:1829-1838) computes a
+   Workflow dispatch's own `status`/`members_done` from journal counters
+   (`journal_started`/`journal_results`) and a 60s-quiet heuristic on
+   `last_event_at` — entirely independent of individual `SubAgent.status`.
+   Reconciling one member to `Abandoned` (live or at reopen) does **not**
+   update the dispatch's own aggregate "N/M active" count. **Confirmed
+   correct, but out of scope** — this is the exact boundary
+   `SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md`'s own Non-goals
+   drew ("Redesigning workflow-level status... already has its own
+   (heuristic but functioning) staleness handling"). Not fixed here;
+   flagging so it isn't mistaken for something Phase A was supposed to
+   also close.
+
+4. **Idempotency of repeated reopens.** Rapid close/reopen cycles, or a
+   reopen immediately followed by a live Phase A trigger for the same
+   subagent — does re-reconciling cause any flapping? **Confirmed
+   correct.** `reconcile_stale_subagents` only demotes subagents currently
+   `Active` (subagent_watcher.rs:1097); already-`Abandoned` or
+   `Completed` entries are untouched on a repeat pass — covered by the
+   existing `reconcile_stale_subagents_never_downgrades_an_already_completed_subagent`
+   test. No new test needed, but worth re-running that suite once Phase A
+   adds the second call site to confirm it still holds when reconciliation
+   can now fire from two places instead of one.
+
+5. **Pane merely switching tabs vs. actually closing.** `TermWrap.dispose()`
+   (`termwrap.ts:414-433`) fires `unregisterAgent()` → backend
+   `unwatch_agent()`, which doesn't just reconcile — it fully **removes**
+   every subagent/dispatch/pending-activity record for that agent identity
+   (subagent_watcher.rs:604-630, extended in #2233 to also prune
+   `dispatches`/`pending_activity`, not just `sessions`). **Needs
+   verification:** does switching between tabs in the same workspace
+   actually unmount the previous tab's pane component (triggering
+   `dispose()`), or does AgentMux keep inactive tabs mounted-but-hidden
+   (the more likely design, given xterm.js/PTY reconnection cost)? If tab
+   switches genuinely dispose+reregister every time, that's not a
+   *correctness* bug (backfill reconstructs the same state fresh from the
+   JSONL files on disk — the source of truth isn't touched), but it would
+   mean every tab switch pays a full unwatch+rewatch+backfill cost. Worth
+   a quick trace before/independent of this spec's two phases — it's a
+   possible performance finding, not a blocker for either phase.
+
+6. **Interaction with #2233's block-delete pruning.** A block that's
+   actually *deleted* (not just closed) now gets its subagent state
+   removed entirely via `SubagentWatcher::prune_block`
+   (`#2233`, subagent_watcher.rs) rather than reconciled — the row
+   disappears outright instead of showing `Abandoned`. **Confirmed
+   correct** — this is the right outcome (nothing to reconcile toward if
+   the block no longer exists) and doesn't interact badly with either
+   Phase A or Phase B: a deleted block's rows are gone before Retire would
+   ever apply to them, and Phase A's live reconciliation only fires for
+   blocks whose controller is still registered, which a deleted block's
+   isn't.
+
+## 6. Phase B — Retire action
+
+**Design: client-local, ephemeral, per-row dismiss set — not a backend
+concept.** Precedent: `frontend/app/notification/memory-pressure-banner.tsx`'s
+`dismissedAt` — a plain `createSignal`, no backend write, resets on
+reload/restart. Retiring a row is "I've seen this, stop showing it to me
+right now," not a durable data mutation; the underlying `SubAgent`/
+`AgentDispatch` record is untouched server-side (still available via
+`GetHistory` if ever needed, still counted correctly for any future
+"how many subagents has this session run" reporting).
+
+- `SwarmViewModel` gains `retiredRowKeys: Set<string>` (same `rowKey`
+  concept introduced in #2232's `getDispatchDetail`/
+  `toggleDispatchExpanded` refactor — `agent:${agent_id}` for a
+  single-subagent row, `dispatchId` for a `WorkflowDispatchRow`) and a
+  `retireRow(rowKey: string)` method that adds to the set and triggers a
+  tree recompute (same `buildTree()`-invalidation path an expand/collapse
+  toggle already uses).
+- `buildDispatchBuckets()` (or its caller, `buildTree()`) filters out any
+  row whose key is in `retiredRowKeys` before returning `agentToolRows`/
+  `workflowRows` — same shape as the existing `parentIds` fallback
+  filtering, just subtractive instead of additive.
+- **Gate Retire to terminal status only** — a row still genuinely
+  `"working"` has no Retire action available (nothing to dismiss; it's
+  legitimately in progress). Available for `"idle"` (Completed) and
+  `"interrupted"` (Abandoned, or the stuck-Active backstop case Phase A
+  mostly eliminates but doesn't guarantee zero of).
+- UI: a small "×" or "Retire" affordance on the row, symmetrical with the
+  existing per-row expand chevron — mirrors `AgentToolRow`/
+  `WorkflowDispatchRow`'s existing hover-affordance conventions in
+  `swarm-view.scss`.
+- **Un-retiring:** none needed for v1 — a retired row reappears
+  automatically the moment the underlying subagent/dispatch produces new
+  activity (spawns again isn't possible for the same `agent_id`, but a
+  dispatch could in principle; simplest correct behavior is: retiring
+  is keyed to the CURRENT state snapshot, and any subsequent
+  `subagent:spawned`/`dispatch:updated` event for that same key implicitly
+  un-retires it by virtue of `scheduleLoadSubagents()` producing a fresh
+  object — the filter only suppresses what's already known-dismissed, it
+  doesn't block new information from that same key). If this proves
+  surprising in practice, revisit with an explicit "un-retire" affordance.
+
+## 7. Open questions
+
+1. **Does Phase A's new call site race the `Result`-line processing?**
+   `set_active_turn(false)` fires from the stdout-reader loop the instant
+   a `"type":"result"` line is seen on the *parent's own* stream — but a
+   subagent's own completion is detected separately, reading the
+   *subagent's* JSONL file via the filesystem watcher
+   (`process_jsonl_change`). If the subagent's own `Result` line hasn't
+   been read yet by the time the parent's turn-end fires (plausible if the
+   fs-watcher's 200ms debounce hasn't ticked), `reconcile_stale_subagents`
+   would (correctly, per its own logic) mark it `Abandoned` even though a
+   `Completed` line arrives moments later — but `reconcile_stale_subagents`
+   only touches subagents still `Active`, and once `Abandoned` is set, does
+   anything downgrade it back to `Completed` if the `Result` line shows up
+   right after? Confirmed no — `process_jsonl_change`'s completion check
+   (`subagent_watcher.rs:1363-1374`) sets `Completed` unconditionally on
+   seeing `Result`, regardless of current status, so this self-corrects if
+   the late line does eventually get read. Worth an explicit test:
+   reconcile-then-late-result-arrives ends at `Completed`, not stuck
+   `Abandoned`.
+2. **Retire scope** — per-row only, or does retiring a `WorkflowDispatchRow`
+   also implicitly retire... nothing, since dispatch rows don't expose
+   member rows anymore (SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19).
+   No cascading concern — flagging only to confirm during implementation.
+3. **Should Retire persist across app restart?** Recommended no for v1
+   (§6's rationale) — but if user feedback says otherwise once this ships,
+   the natural persistence layer would be `AGENTMUX_DEV`-style local
+   settings, not a backend/wire concept, since retiring is a purely
+   client-side display preference.
+4. **§5.2's controller-registration race** and **§5.5's tab-switch-vs-close
+   question** — both need a direct trace/test before Phase A ships, not
+   just this doc's reasoning. Neither blocks Phase B.
+
+## 8. Rollout
+
+Two independent PRs, either order:
+
+1. Phase A (backend): visibility change + one new call site + one new
+   broadcast. Small, testable in isolation (extend the existing
+   `reconcile_stale_subagents_*` test suite in `subagent_watcher.rs` with
+   a "called from the turn-end hook, not just reopen" case).
+2. Phase B (frontend): `retiredRowKeys` set + filter + UI affordance. No
+   backend dependency — can ship before or after Phase A, though Phase A
+   landing first means fewer rows need retiring in the first place (they
+   self-correct to `Completed`/honest `Abandoned` live instead of
+   requiring the user to manually dismiss stuck-`Active` "Interrupted"
+   noise).

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -4,12 +4,14 @@
 import { describe, expect, it } from "vitest";
 import {
     buildDispatchBuckets,
+    filterRetired,
     groupCacheKey,
     mergeDispatchActivityEntries,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
     stabilizeGroupIdentity,
     subagentDisplayLabel,
+    subagentRowKey,
     type ActiveSubagent,
     type AgentDispatch,
     type DispatchActivityEntry,
@@ -351,6 +353,43 @@ describe("groupCacheKey", () => {
             [mk({ agent_id: "a1", dispatch_id: "wf_1" })]
         ).workflowRows;
         expect(groupCacheKey(wf)).toBe("wf:wf_1");
+    });
+});
+
+describe("subagentRowKey", () => {
+    it("prefixes with 'agent:'", () => {
+        expect(subagentRowKey("abc123")).toBe("agent:abc123");
+    });
+});
+
+describe("filterRetired", () => {
+    const keyFn = (n: number) => `row-${n}`;
+
+    it("keeps a row whose key is not in the retired map", () => {
+        const retired = new Map<string, number>();
+        const rows = filterRetired([1, 2], retired, keyFn, () => 100);
+        expect(rows).toEqual([1, 2]);
+    });
+
+    it("drops a row whose key is retired and lastEventAt still matches the retired snapshot", () => {
+        const retired = new Map<string, number>([["row-1", 100]]);
+        const rows = filterRetired([1, 2], retired, keyFn, () => 100);
+        expect(rows).toEqual([2]);
+    });
+
+    it("un-retires automatically once the row's own lastEventAt moves past the retired snapshot", () => {
+        // Same key as a retired row, but new activity has since advanced
+        // lastEventAt past what was snapshotted at retire time — SPEC_
+        // SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6: no
+        // separate un-retire action needed, the row just reappears.
+        const retired = new Map<string, number>([["row-1", 100]]);
+        const rows = filterRetired([1], retired, keyFn, () => 200);
+        expect(rows).toEqual([1]);
+    });
+
+    it("is a no-op (identity semantics aside) when nothing is retired", () => {
+        const rows = filterRetired([1, 2, 3], new Map(), keyFn, () => 0);
+        expect(rows).toEqual([1, 2, 3]);
     });
 });
 

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -9,6 +9,7 @@ import {
     mergeDispatchActivityEntries,
     mergeSubagentsPreservingIdentity,
     pruneGroupIdentityCache,
+    pruneRetiredEntries,
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     subagentRowKey,
@@ -390,6 +391,40 @@ describe("filterRetired", () => {
     it("is a no-op (identity semantics aside) when nothing is retired", () => {
         const rows = filterRetired([1, 2, 3], new Map(), keyFn, () => 0);
         expect(rows).toEqual([1, 2, 3]);
+    });
+});
+
+describe("pruneRetiredEntries", () => {
+    it("drops entries whose key is no longer in liveKeys", () => {
+        const retired = new Map<string, number>([
+            ["agent:a1", 100],
+            ["agent:a2", 200],
+        ]);
+        const pruned = pruneRetiredEntries(retired, new Set(["agent:a1"]));
+        expect(pruned.has("agent:a1")).toBe(true);
+        expect(pruned.has("agent:a2")).toBe(false);
+    });
+
+    it("keeps every entry whose key is still live, even if not un-retired yet", () => {
+        // Still-live rows keep their retired entry regardless of this pass —
+        // only pruneRetiredEntries' own liveness check matters here, not
+        // filterRetired's separate lastEventAt comparison.
+        const retired = new Map<string, number>([["agent:a1", 100]]);
+        const pruned = pruneRetiredEntries(retired, new Set(["agent:a1"]));
+        expect(pruned.get("agent:a1")).toBe(100);
+    });
+
+    it("returns the same Map reference when nothing was dropped", () => {
+        const retired = new Map<string, number>([["agent:a1", 100]]);
+        const pruned = pruneRetiredEntries(retired, new Set(["agent:a1"]));
+        expect(pruned).toBe(retired);
+    });
+
+    it("returns a new Map when something was dropped", () => {
+        const retired = new Map<string, number>([["agent:gone", 100]]);
+        const pruned = pruneRetiredEntries(retired, new Set());
+        expect(pruned).not.toBe(retired);
+        expect(pruned.size).toBe(0);
     });
 });
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -325,6 +325,30 @@ export function filterRetired<T>(
 }
 
 /**
+ * Drop `retired` entries whose key is no longer in `liveKeys` at all — a row
+ * gone from live state entirely (block closed, dispatch pruned — #2233) can
+ * never un-retire itself (`filterRetired`'s lastEventAt-snapshot comparison
+ * has nothing left to compare against), so keeping its retired entry around
+ * is pure unbounded growth for the life of the session (reagent P2 on
+ * #2235). A row still genuinely live keeps its entry regardless of this
+ * pass — only entries for keys absent from `liveKeys` are dropped. Returns
+ * `retired` unchanged (same reference) if nothing was actually dropped, so
+ * callers using this in a signal setter don't trigger a no-op update.
+ */
+export function pruneRetiredEntries(retired: Map<string, number>, liveKeys: Set<string>): Map<string, number> {
+    let changed = false;
+    const next = new Map<string, number>();
+    for (const [key, lastEventAt] of retired) {
+        if (liveKeys.has(key)) {
+            next.set(key, lastEventAt);
+        } else {
+            changed = true;
+        }
+    }
+    return changed ? next : retired;
+}
+
+/**
  * Stabilize `WorkflowDispatch` wrapper identity across `buildTree()` calls,
  * mirroring `mergeSubagentsPreservingIdentity` one level up.
  * `buildDispatchBuckets` is a pure function — it unconditionally builds
@@ -746,6 +770,7 @@ export class SwarmViewModel implements ViewModel {
         this.setLoading(true);
         try {
             await Promise.all([this.loadTrackedBlocks(), this.loadSubagents(), this.loadDispatches()]);
+            this.pruneRetiredRowKeys();
         } finally {
             this.setLoading(false);
         }
@@ -792,10 +817,26 @@ export class SwarmViewModel implements ViewModel {
         }
         this.loadSubagentsDebounceTimer = setTimeout(() => {
             this.loadSubagentsDebounceTimer = undefined;
-            void this.loadSubagents();
-            void this.loadDispatches();
+            void Promise.all([this.loadSubagents(), this.loadDispatches()]).then(() => this.pruneRetiredRowKeys());
         }, SwarmViewModel.LOAD_SUBAGENTS_DEBOUNCE_MS);
     };
+
+    /** Drop `_retiredRowKeys` entries for rows no longer present in live
+     *  state at all (block closed, dispatch pruned — #2233) — those can
+     *  never un-retire themselves (`filterRetired`'s lastEventAt-snapshot
+     *  comparison has nothing left to compare against), so keeping them
+     *  around is pure unbounded growth for the life of the session (reagent
+     *  P2 on #2235). Called after `loadSubagents`/`loadDispatches` settle
+     *  (a plain state update, not from inside `buildTree()`'s own read of
+     *  `retiredRowKeysAtom`, which would be a reactive write-during-read). */
+    private pruneRetiredRowKeys(): void {
+        const liveKeys = new Set<string>();
+        for (const s of this.subagentsAtom()) liveKeys.add(subagentRowKey(s.agent_id));
+        for (const d of this.dispatchesAtom()) {
+            if (d.kind === "workflow") liveKeys.add(d.dispatch_id);
+        }
+        this.setRetiredRowKeys((prev) => pruneRetiredEntries(prev, liveKeys));
+    }
 
     // ── Row expand/collapse (workflow groups + subagent detail) ──────────
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -656,9 +656,14 @@ export class SwarmViewModel implements ViewModel {
 
         // One or more subagents just reconciled active -> abandoned, either
         // live (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20
-        // Phase A — the instant their parent's turn ends) or at reopen —
-        // reload so the row's display status (subagentDisplayStatus)
-        // updates without waiting for an unrelated event.
+        // Phase A, #2234 — the instant their parent's turn ends) or at
+        // reopen — reload so the row's display status
+        // (subagentDisplayStatus) updates without waiting for an unrelated
+        // event. The backend broadcast for this event lives in #2234, a
+        // separate PR from this one (Phase B) — if this merges first, the
+        // listener is simply inert until #2234 lands (subagent:abandoned
+        // is never emitted yet), not broken; #2234's own PR description
+        // covers the same sequencing from the backend side.
         const unsubAbandoned = waveEventSubscribe({
             eventType: "subagent:abandoned",
             handler: () => this.scheduleLoadSubagents(),

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -294,6 +294,36 @@ export function groupCacheKey(child: WorkflowDispatch): string {
     return `wf:${child.dispatchId}`;
 }
 
+/** Row identity for an Agent Tool row — the same `agent:${agent_id}` key
+ *  `swarm-view.tsx`'s `SubagentRow` already computes locally for expand-
+ *  state/`DispatchActivityFeed` identity (SPEC_SWARM_DISPATCH_NAMING_AND_
+ *  ROW_MODEL_2026_07_19 §4, decoupled from `dispatch_id` in the reagent
+ *  P1 fix on #2232 — see `getDispatchDetail`'s doc comment). Exported so
+ *  `SwarmViewModel`'s retire filter (§ below) and the row's own Retire
+ *  button compute the identical key rather than two independently-written
+ *  string templates drifting apart. */
+export function subagentRowKey(agentId: string): string {
+    return `agent:${agentId}`;
+}
+
+/**
+ * Drop any row whose key is in `retired` AND whose own `lastEventAt` still
+ * matches the snapshot taken at retire time — genuinely new activity for
+ * that same key (a later `lastEventAt`) makes the row visible again
+ * automatically, without a separate un-retire action
+ * (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6). Shared by
+ * both `AgentTreeNode` buckets in `buildTree()` — parameterized over `T`
+ * rather than duplicated per row type.
+ */
+export function filterRetired<T>(
+    rows: T[],
+    retired: Map<string, number>,
+    rowKey: (row: T) => string,
+    lastEventAt: (row: T) => number
+): T[] {
+    return rows.filter((row) => retired.get(rowKey(row)) !== lastEventAt(row));
+}
+
 /**
  * Stabilize `WorkflowDispatch` wrapper identity across `buildTree()` calls,
  * mirroring `mergeSubagentsPreservingIdentity` one level up.
@@ -560,6 +590,19 @@ export class SwarmViewModel implements ViewModel {
     collapsedAgentIdsAtom: Accessor<Set<string>> = this._collapsedAgentIds[0];
     private setCollapsedAgentIds: Setter<Set<string>> = this._collapsedAgentIds[1];
 
+    // Rows the user has retired (dismissed) — client-local, ephemeral (no
+    // backend write, resets on reload/restart, same as memory-pressure-
+    // banner.tsx's dismissedAt). Maps rowKey -> the row's own lastEventAt
+    // AT THE MOMENT it was retired, not just a bare membership set: this is
+    // what lets a row un-retire itself automatically the moment genuinely
+    // new activity arrives for that same key (buildTree()'s filter only
+    // suppresses a row whose CURRENT lastEventAt still matches the
+    // snapshot) instead of requiring an explicit un-retire action — see
+    // SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6.
+    private _retiredRowKeys = createSignal<Map<string, number>>(new Map());
+    retiredRowKeysAtom: Accessor<Map<string, number>> = this._retiredRowKeys[0];
+    private setRetiredRowKeys: Setter<Map<string, number>> = this._retiredRowKeys[1];
+
     // One DispatchDetail (concatenated activity feed) per currently-expanded
     // row — Agent Tool (solo) rows and Workflow rows alike, unified in
     // SPEC_SWARM_DISPATCH_NAMING_AND_ROW_MODEL_2026_07_19 §4 (retired the
@@ -610,6 +653,17 @@ export class SwarmViewModel implements ViewModel {
             handler: () => this.scheduleLoadSubagents(),
         });
         if (unsubCompleted) this.unsubs.push(unsubCompleted);
+
+        // One or more subagents just reconciled active -> abandoned, either
+        // live (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20
+        // Phase A — the instant their parent's turn ends) or at reopen —
+        // reload so the row's display status (subagentDisplayStatus)
+        // updates without waiting for an unrelated event.
+        const unsubAbandoned = waveEventSubscribe({
+            eventType: "subagent:abandoned",
+            handler: () => this.scheduleLoadSubagents(),
+        });
+        if (unsubAbandoned) this.unsubs.push(unsubAbandoned);
 
         // dispatch:updated fires for both Solo and Workflow kinds (SPEC §5) —
         // a member count/status change on either warrants the same reload
@@ -769,6 +823,22 @@ export class SwarmViewModel implements ViewModel {
         });
     }
 
+    /** Retire (dismiss) a row — `rowKey` is `subagentRowKey(agent_id)` for
+     *  an Agent Tool row or the raw `dispatchId` for a `WorkflowDispatchRow`
+     *  (same keys `buildTree()`'s filter checks against). `lastEventAt` is
+     *  the row's own value at the moment of retiring — see `_retiredRowKeys`
+     *  for why this snapshot, not a bare membership set, is what makes a
+     *  row un-retire itself automatically on new activity. Callers should
+     *  only expose this for a terminal-status row (`"idle"`/`"interrupted"`)
+     *  — nothing to dismiss on a row still genuinely `"working"`. */
+    retireRow(rowKey: string, lastEventAt: number): void {
+        this.setRetiredRowKeys((prev) => {
+            const next = new Map(prev);
+            next.set(rowKey, lastEventAt);
+            return next;
+        });
+    }
+
     /** Every row's toggle. `rowKey` must be a per-ROW-unique identity, NOT
      *  necessarily the row's `dispatch_id` — a `WorkflowDispatchRow`'s own
      *  `dispatch_id` is always 1:1 with its row, but an Agent Tool row's
@@ -884,6 +954,7 @@ export class SwarmViewModel implements ViewModel {
         // pass — same "harmless either way, but this is the precise set"
         // rationale the pre-two-bucket design used for NameGroup keys.
         const liveGroupKeys = new Set<string>();
+        const retired = this.retiredRowKeysAtom();
         const nodes = allBlockIds.map((blockId) => {
             const blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
             const block = blockAtom();
@@ -896,13 +967,19 @@ export class SwarmViewModel implements ViewModel {
             const rawCtx = block?.meta?.["term:ctx-tokens"];
             const contextTokens = typeof rawCtx === "number" ? rawCtx : null;
             const agentStatus = statuses.get(blockId) ?? "idle";
-            const { agentToolRows, workflowRows: rawWorkflowRows } = buildDispatchBuckets(
+            const { agentToolRows: rawAgentToolRows, workflowRows: rawWorkflowRows } = buildDispatchBuckets(
                 dispatches.filter((d) => d.parent_block_id === blockId),
                 subagents.filter((s) => s.parent_block_id === blockId)
             );
             for (const w of rawWorkflowRows) liveGroupKeys.add(groupCacheKey(w));
             const workflowRows = stabilizeGroupIdentity(this.groupIdentityCache, rawWorkflowRows);
-            return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, agentToolRows, workflowRows };
+            // Retired rows are filtered here, not inside buildDispatchBuckets
+            // (kept a pure, ViewModel-independent function) — see
+            // filterRetired's doc comment for the un-retire-on-new-activity
+            // mechanism (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6).
+            const agentToolRows = filterRetired(rawAgentToolRows, retired, (s) => subagentRowKey(s.agent_id), (s) => s.last_event_at);
+            const visibleWorkflowRows = filterRetired(workflowRows, retired, (w) => w.dispatchId, (w) => w.lastEventAt);
+            return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, agentToolRows, workflowRows: visibleWorkflowRows };
         });
 
         // Prune once per full pass (not per-block — see stabilizeGroupIdentity).

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -369,6 +369,41 @@
     flex-shrink: 0;
 }
 
+// Retire/dismiss (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20
+// §6) — offered only on a terminal-status row (SubagentRow gates this via
+// `canRetire`; WorkflowDispatchRow via `group.status === "retired"`).
+// Dim by default, full opacity + error tint on hover — same interaction
+// shape as the pinned-activity dock's `.agent-activity-dismiss`
+// (`_shell-node.scss`), scaled down for this row's compact 30px height.
+.swarm-subagent-retire {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 11px;
+    border-radius: 4px;
+    cursor: default;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.swarm-subagent-row:hover .swarm-subagent-retire,
+.swarm-workflow-header:hover .swarm-subagent-retire {
+    opacity: 0.75;
+}
+
+.swarm-subagent-retire:hover {
+    opacity: 1;
+    color: var(--error-color, #ff6b6b);
+    background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
+}
+
 // ── Subagent detail event rendering (shared by the concatenated dispatch
 // feed above — DispatchActivityFeedEntry, swarm-view.tsx) ────────────────
 

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -3,7 +3,7 @@
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
 import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
-import { subagentDisplayLabel } from "./swarm-model";
+import { subagentDisplayLabel, subagentRowKey } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -371,6 +371,17 @@ function WorkflowDispatchRow({
     const expanded = createMemo(() => model.isExpanded(group.dispatchId));
     const activeCount = createMemo(() => group.memberCount - group.membersDone);
 
+    // `group.status === "retired"` here is the pre-existing "every member
+    // done" label (SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17) — NOT
+    // the same concept as the user-driven Retire action below (SPEC_
+    // SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6), just a
+    // same-word coincidence. Retire is only offered once a dispatch is
+    // ALREADY (label-)retired — nothing to dismiss on one still running.
+    const handleRetire = (e: MouseEvent) => {
+        e.stopPropagation();
+        model.retireRow(group.dispatchId, group.lastEventAt);
+    };
+
     return (
         <div class={`swarm-workflow-group swarm-workflow-group--${group.status}`}>
             <div
@@ -388,6 +399,11 @@ function WorkflowDispatchRow({
                 <span class={`swarm-workflow-status-badge swarm-workflow-status-badge--${group.status}`}>
                     {group.status === "active" ? "Active" : "Retired"}
                 </span>
+                <Show when={group.status === "retired"}>
+                    <button class="swarm-subagent-retire" title="Dismiss" onClick={handleRetire}>
+                        <i class="fa-solid fa-xmark" />
+                    </button>
+                </Show>
             </div>
             <Show when={expanded()}>
                 <DispatchActivityFeed rowKey={group.dispatchId} dispatchId={group.dispatchId} model={model} />
@@ -529,7 +545,7 @@ function SubagentRow({
     // `ListDispatches` shares it) — keying expand-state/cache off it would
     // collide every sibling row's expand toggle and cached feed onto the
     // first one (reagent P1 on #2232). `agent_id` is always unique per row.
-    const rowKey = createMemo(() => `agent:${sub.agent_id}`);
+    const rowKey = createMemo(() => subagentRowKey(sub.agent_id));
     const expanded = createMemo(() => model.isExpanded(rowKey()));
     // See subagentDisplayLabel's doc comment (swarm-model.ts) — as of Phase A
     // this resolves eagerly at dispatch time for the common case; the
@@ -553,16 +569,27 @@ function SubagentRow({
         }
     };
 
+    const displayStatus = createMemo(() => subagentDisplayStatus(sub, parentAgentStatus));
+
     // Row/group dimming must track the same effective status as the chip
     // (reagent P2 on #2134) — otherwise a client-side "interrupted" backstop
     // shows the new chip/dot but the row stays full-opacity, since only a
     // backend-confirmed sub.status === "abandoned" would dim it directly.
     const dimVariant = createMemo(() => {
-        const displayStatus = subagentDisplayStatus(sub, parentAgentStatus);
-        if (displayStatus === "interrupted") return "abandoned";
-        if (displayStatus === "idle") return "completed";
+        const status = displayStatus();
+        if (status === "interrupted") return "abandoned";
+        if (status === "idle") return "completed";
         return "active";
     });
+
+    // Retire (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6):
+    // only a terminal-status row has anything to dismiss — a still-"working"
+    // row is legitimately in progress, nothing to retire yet.
+    const canRetire = createMemo(() => displayStatus() === "idle" || displayStatus() === "interrupted");
+    const handleRetire = (e: MouseEvent) => {
+        e.stopPropagation();
+        model.retireRow(rowKey(), sub.last_event_at);
+    };
 
     return (
         <div class={`swarm-subagent-group swarm-subagent-group--${dimVariant()}`}>
@@ -573,7 +600,12 @@ function SubagentRow({
             >
                 <i class={`fa-solid fa-${expanded() ? "chevron-down" : "chevron-right"} swarm-subagent-expand-icon`} />
                 <span class="swarm-subagent-slug">{displayLabel()}</span>
-                <AgentStatusChip status={subagentDisplayStatus(sub, parentAgentStatus)} />
+                <AgentStatusChip status={displayStatus()} />
+                <Show when={canRetire()}>
+                    <button class="swarm-subagent-retire" title="Retire" onClick={handleRetire}>
+                        <i class="fa-solid fa-xmark" />
+                    </button>
+                </Show>
             </div>
             <Show when={expanded()}>
                 <DispatchActivityFeed

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -400,7 +400,7 @@ function WorkflowDispatchRow({
                     {group.status === "active" ? "Active" : "Retired"}
                 </span>
                 <Show when={group.status === "retired"}>
-                    <button class="swarm-subagent-retire" title="Dismiss" onClick={handleRetire}>
+                    <button class="swarm-subagent-retire" title="Retire" onClick={handleRetire}>
                         <i class="fa-solid fa-xmark" />
                     </button>
                 </Show>


### PR DESCRIPTION
## Summary

Phase B of docs/specs/SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20.md — follow-up to #2234 (Phase A, backend live reconciliation), answers docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md's Open Question 2 (never resolved either way): give the user an explicit way to dismiss a `Completed`/`Interrupted` Swarm pane row.

**The `subagent:abandoned` WS event this PR subscribes to is broadcast by #2234**, a separate PR. If this merges first, the listener is simply inert until #2234 lands (the event is never emitted yet), not broken — everything else in this PR (the Retire action itself, `filterRetired`, the UI affordance) works standalone regardless of merge order.

- Client-local and ephemeral — no backend write, resets on reload/restart, same pattern as `memory-pressure-banner.tsx`'s `dismissedAt`. Nothing durable to design around.
- Gated to terminal-status rows only (`"idle"`/`"interrupted"`) — a still-`"working"` row has nothing to dismiss.
- `retireRow()` snapshots the row's own `lastEventAt` at retire time rather than a bare membership set — a row automatically un-retires itself the moment genuinely new activity moves `lastEventAt` past that snapshot, so no separate un-retire action is needed (SPEC §6).
- `filterRetired()` is a small, shared, unit-tested pure function both `AgentTreeNode` buckets (Agent Tool rows and Workflow rows) run through in `buildTree()`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` (swarm suite) — 41/41 passed (9 new: `subagentRowKey`, `filterRetired`)
- [ ] Live `task dev` verification: retire a Completed/Interrupted row, confirm it disappears; confirm a still-working row has no Retire affordance; confirm a retired row reappears if genuinely new activity arrives for the same key

<!-- agentmux:agent_id=AGENTA-07017 -->