### PR TITLE
fix(agent): Session Context assigned-accounts reads db_agent_identity_links

### DIFF
--- a/.changesets/1784572059-fix-agent-session-context-assigned-accounts-reads-db-agent-i-6qgg.md
+++ b/.changesets/1784572059-fix-agent-session-context-assigned-accounts-reads-db-agent-i-6qgg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): Session Context assigned-accounts reads db_agent_identity_links, not the stale AgentDefinition.accounts blob

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -84,7 +84,7 @@ import { ConfirmModal } from "@/element/modal";
 import { ModalLayer } from "@/element/ModalLayer";
 import { useModalLayer } from "@/element/modal-layer";
 import { ContextMenuModel } from "@/app/store/contextmenu";
-import { parseAgentAccounts, loadAccounts } from "@/app/view/identity/identity-model";
+import { loadAccounts, type AgentAccounts } from "@/app/view/identity/identity-model";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
 import "./agent-view.scss";
 
@@ -754,16 +754,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             if (!agent) return;
 
             // Gather inputs in parallel where possible
-            const [startupContentResult, version] = await Promise.all([
+            const [startupContentResult, version, identityLinks] = await Promise.all([
                 RpcApi.GetAgentContentCommand(TabRpcClient, {
                     agent_id: agentId,
                     content_type: "startup",
                 }).catch(() => null),
                 Promise.resolve(getApi().getAboutModalDetails().version),
+                RpcApi.ListAgentIdentitiesCommand(TabRpcClient, { agent_id: agentId }).catch(() => []),
             ]);
 
-            // Resolve assigned accounts from Identity localStorage
-            const agentAccounts = parseAgentAccounts(agent);
+            // Resolve assigned accounts from the same db_agent_identity_links
+            // rows spawn-time credential resolution and the agent pane's own
+            // Identity tab already use — NOT the legacy AgentDefinition.accounts
+            // JSON blob, which can silently diverge from what the agent
+            // actually launches with (see docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md §1).
+            const agentAccounts: AgentAccounts = {};
+            for (const link of identityLinks) {
+                agentAccounts[link.provider as keyof AgentAccounts] = link.account_id;
+            }
             const accounts = resolveAccounts(agentAccounts, loadAccounts());
 
             const payload = buildStartupPayload({


### PR DESCRIPTION
## Summary
- `buildStartupPayload.ts`'s "Assigned Accounts" section (the first-turn Session Context message) was fed by `parseAgentAccounts(agent)`, which parses `AgentDefinition.accounts` — a legacy JSON blob column whose own doc comment (`agents.rs:56-62`) admits the intended migration to `db_agent_identity_links` "never completed."
- Actual spawn-time credential resolution (`identity/resolver.rs`'s `resolve_bindings_for_instance`) and Armory's own Accounts/Identity displays already read `db_agent_identity_links` exclusively — so Session Context could show accounts that don't match what the agent actually launched with.
- Fetches via the same `ListAgentIdentitiesCommand` RPC the agent pane's own read-only Identity tab already uses, instead of the stale blob. Standalone fix — no migration, the legacy blob and its writer (`AgentIdentityPanel.tsx`) are untouched, this only changes what Session Context *reads*.
- Surfaced during research for `docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md` (#2238).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent/startup/buildStartupPayload.test.ts frontend/app/view/identity` — 32/32 passing, no regressions
- [ ] Manual: `task dev`, launch an agent with a linked GitHub identity, confirm the new session's "Assigned Accounts" section matches the agent pane's own Identity tab

<!-- agentmux:agent_id=agent2 -->