### PR TITLE
fix(agent): only refresh Haiku ghost-text summaries on genuine turn completion

### DIFF
--- a/.changesets/1784573047-fix-agent-only-refresh-haiku-ghost-text-summaries-on-genuine-7wh6.md
+++ b/.changesets/1784573047-fix-agent-only-refresh-haiku-ghost-text-summaries-on-genuine-7wh6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): only refresh Haiku ghost-text summaries on genuine turn completion

--- a/docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md
+++ b/docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md
@@ -1,0 +1,61 @@
+# Report: Haiku ambient-summary ghost text populates outside genuine turn completion
+
+**Date:** 2026-07-20
+**Author:** AgentX
+**Type:** Investigation report + fix, shipped in the same PR.
+**Purpose:** The agent pane header's Haiku-generated "ghost text" mini-summary (`term:ambient_summary`) is supposed to populate once per completed agent turn. In practice it populates "at all sorts of times." This report traces the exact over-trigger paths and fixes them by switching the trigger from the frontend's own `TurnPhase.kind === "Done"` to the backend-authoritative `turn_active` edge.
+
+---
+
+## 1. What's supposed to happen (and mostly does, at the UI layer)
+
+`frontend/app/store/activitySummary.ts:19-25` (`readActivitySummary`) resolves `term:ambient_summary` (Haiku-derived) over `term:osc_title` (free, CLI-emitted, no LLM call) for both the agent pane header (`agent-model.ts:108-125`, `viewText()`) and the Swarm tree row (`swarm-model.ts:1012`). Nothing wrong with the read/render side — the bug is entirely in when a fresh value gets written.
+
+A sibling feature, the composer's "predicted next message" ghost text (`term:next_prompt_suggestion`, read in `AgentFooter.tsx`), shares the identical trigger architecture and had the identical bug — both are fixed together here.
+
+## 2. Root cause: `TurnPhase.kind === "Done"` is not 1:1 with "the agent finished responding"
+
+`useAgentActivitySummary.ts` and `useNextPromptSuggestion.ts` both fired their Haiku RPC on any `TurnPhase.kind === "Done"` transition, `createEffect(on(turnPhase, ...))`. `Done` fires on five distinct paths, only one of which is a genuine turn completion:
+
+1. **The dominant cause — a premature per-round `session_end`.** `frontend/app/view/agent/providers/claude-translator.ts:224-233`: *"a non-partial assistant message with no tool_use blocks is always the final text response of a turn. Emit session_end so TurnPhase transitions to Done → idle."* This heuristic assumes the CLI process never exits between turns, so it treats every interim text-only assistant message (which can legitimately precede more tool calls in the same turn) as if it were the real end. `frontend/app/store/agent-pane-state/reducer.ts:213-221` documents the exact failure mode this causes: *"session_end fires after every model API round, so Done.completed can mean 'first round of a multi-round tool-continuation finished'"* — and compensates by re-promoting `Done.completed → Streaming` on the next output flush (`reducer.ts:246`). **Verified directly:** the `TurnEnd` reducer arm (`reducer.ts:537-541`) sets `outcome: "completed"` for this premature case exactly the same as a real completion — there is no way to distinguish a premature per-round `Done` from a genuine one by reading `phase.outcome` alone. A naive fix that only gated on `outcome === "completed"` would not have closed this path.
+2. `InterruptTimeoutElapsed → Done.interrupted` (`reducer.ts:752-782`) — a bounded 5s force-transition when a user-requested stop's ack never arrives.
+3. `SubmitTimeoutElapsed → Done.errored` (`reducer.ts:784-819`) — a bounded 30s force-transition when the backend never acks a send.
+4. `FailureObserved → Done.errored` (`reducer.ts:923-950`) — any classified backend failure (rate limit, etc.) force-ends a working turn.
+5. The genuine path: real `session_end` from the CLI's actual turn-boundary event (`useAgentStream.ts:463-467`, `TurnEnd` dispatched from the real event at `useAgentStream.ts:850-854`).
+
+Codex and Gemini's translators (`codex-translator.ts:47-67`, `gemini-translator.ts:39-57`) don't have path 1's problem — they only emit `session_end` on the provider's real turn-boundary event. **Claude Code, the default and most common provider, is the one with the per-round misfire**, making it the dominant real-world contributor to "populates at all sorts of times."
+
+## 3. Why not fix the premature `session_end` synthesis directly?
+
+Considered and rejected. `claude-translator.ts`'s premature-`Done` behavior is load-bearing elsewhere — `reducer.ts:198-253`'s `StreamFlushObserved` handler explicitly special-cases `Done.completed` (re-promoting it to `Streaming` on the next flush) specifically *because* this premature transition is expected and relied upon to clear the "Working…" indicator between tool-call rounds. Changing the synthesis itself risks a much wider blast radius across the whole turn-lifecycle state machine for a fix that only needs to change when two ambient-summary hooks fire. Fixing the *consumers* instead (§4) is strictly narrower and lower-risk.
+
+## 4. The fix: trigger off the backend-authoritative `turn_active` edge instead
+
+The backend already has, and already surfaces to the frontend, a signal that genuinely is 1:1 with turn completion: `BlockControllerRuntimeStatus.turn_active` (`agentmux-srv/src/backend/blockcontroller/mod.rs`), flipped `false` by the health monitor **only** on the CLI's real `"result"` line (`agentmux-srv/src/backend/blockcontroller/persistent.rs:918-923`) — not per tool-call round — and re-armed per turn by `send_message`'s `mark_turn_active_returning_was_active()` (`persistent.rs:356-359`). This is already streamed live to the frontend via the `controllerstatus` WPS event and already consumed by `useControllerStatusEvents.ts`'s `onTurnActive` callback, which `agent-view.tsx` already used to dispatch `ReconcileTurnActive` (added for a different bug — stuck `Streaming`/`Idle` phases, `docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md`) but never consulted for the ambient-summary trigger.
+
+**Change:**
+- `useControllerStatusEvents.ts` gains a new pure, exported, unit-tested function `didTurnJustEnd(prev: boolean | undefined, next: boolean): boolean` — true exactly on a `true → false` edge; `undefined → false` (a pane opened onto an already-idle agent) is explicitly NOT a turn-end, since there's nothing new to summarize.
+- `agent-view.tsx` adds a `turnJustEndedAtom` signal (`createSignal<number>(0)`) and a `reconcileTurnActive(active)` helper that both the mount-time one-shot (`onControllerStatus`) and every live `controllerstatus` event (`useControllerStatusEvents`'s `onTurnActive`) now route through — replacing their previous direct `dispatchPaneIfRegistered({type: "ReconcileTurnActive", ...})` calls with a single shared helper that also bumps `turnJustEndedAtom` on `didTurnJustEnd`.
+- `useAgentActivitySummary.ts` / `useNextPromptSuggestion.ts` each split their single `createEffect(on(turnPhase, ...))` into two: one unchanged (still watches `turnPhase` for `Submitting`, to bump the local `activeTurnId` staleness guard and, for the suggestion hook, clear the stale suggestion — guard 1 in that hook's own doc comment), and a new one, `createEffect(on(turnJustEndedAtom, ..., { defer: true }))`, which fires the Haiku RPC. `defer: true` skips the effect's initial run at mount (the atom starts at 0).
+
+This closes all five over-trigger paths in §2 at once: none of the frontend's synthetic/forced `Done` transitions (premature per-round, both bounded timeouts, `FailureObserved`) correspond to a real backend `turn_active` flip, so none of them bump `turnJustEndedAtom`. Only a genuine CLI `"result"` line does.
+
+## 5. Explicitly out of scope: the unconsumed 20s pushed-summary sweep
+
+`agentmux-srv/src/backend/reactive/activity_watcher.rs::run_agent_summary_loop` runs a flat 20-second timer, independent of turn state entirely — its only gating is `shellprocstatus == STATUS_RUNNING` (true for a persistent-mode process's entire life, not just mid-turn) and whether the block's output changed since the last summary (lines 99-119). It calls the same Haiku primitive via `generate_pushed_activity_summary` and publishes a `WaveEvent{event: "agent:summary", ...}` (`activity_watcher.rs:155-166`) — **verified directly: it does not write `term:ambient_summary` itself**, only publishes that event.
+
+**Verified directly: this event has zero frontend consumers.** `swarm-model.ts` (the documented intended consumer per `docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md` §4) derives its activity-summary field purely by re-reading `term:ambient_summary`/`term:osc_title` off the reactive block-meta atom, with no `agent:summary` WPS subscription anywhere in the frontend tree. So today this sweep is not the cause of the reported symptom — it's a separate, currently-inert cost leak: a real Haiku CLI subprocess spawned every 20 seconds for every running agent, for a UI signal nothing reads. `SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md`'s own "Open questions" §1 already flagged the flat-timer design as unresolved (*"Haiku push cadence 20s ok? … Alternative: only on turn-phase transitions"*). Left untouched here — deliberately scoped out, not missed. Re-wiring it to fire on `turn_active` edges (mirroring §4) or removing it outright is a real, separate follow-up someone should pick up; flagging it here so it isn't lost.
+
+## 6. Test coverage
+
+`useControllerStatusEvents.test.ts` gained 6 new cases for `didTurnJustEnd` covering every transition (`true→false`, `false→true`, `true→true`, `false→false`, and both `undefined→*` first-reading cases). Full frontend suite (851 tests, 59 files) passes with no regressions.
+
+## 7. References
+
+- Internal: `frontend/app/view/agent/hooks/useAgentActivitySummary.ts`, `frontend/app/view/agent/hooks/useNextPromptSuggestion.ts`, `frontend/app/view/agent/hooks/useControllerStatusEvents.ts`, `frontend/app/view/agent/agent-view.tsx`, `frontend/app/store/agent-pane-state/reducer.ts:198-253,497-560,752-950`, `frontend/app/view/agent/providers/claude-translator.ts:201-235`, `agentmux-srv/src/backend/blockcontroller/persistent.rs:356-359,918-923`, `agentmux-srv/src/backend/reactive/activity_watcher.rs`, `agentmux-srv/src/server/app_api/session.rs`.
+- `docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md` — the gateway this feature is routed through; §0 already named "calls firing too often" as a pre-existing symptom, but its own fix (single-flight + generation fencing) addressed concurrency/staleness, not over-triggering from spurious `Done` transitions — §6 "Open questions" explicitly flagged a debounce/rate-limit primitive as designed but never implemented.
+- `docs/specs/SPEC_SWARM_LIVE_FEED_BINDINGS_2026_07_05.md` §4, "Open questions" §1 — the spec that shipped the 20s pushed sweep, with its own author flagging the flat-timer-vs-turn-phase-transition question as unresolved (§5 above).
+- `docs/specs/SPEC_AMBIENT_SUMMARY_SANITIZATION_AND_TERSENESS_2026_07_08.md` §2.3 — explicitly scoped out changing "when these calls fire," confirming the over-trigger problem was known and deliberately left for a later fix (this one).
+- `docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md` — Finding 1 produced the `ReconcileTurnActive`/`turn_active` machinery this fix reuses; Finding 3 produced the `MAX_CONCURRENT_PULL_CALLS` semaphore (a related but separate concurrency fix, already shipped).
+- `docs/retro/retro-haiku-activity-pane-header-2026-06-24.md` — an earlier, unrelated bug in this same feature (summary never fired at all, reading an empty WPS ring buffer instead of the FileStore) — already fixed; confirms this feature has a history of trigger-plumbing issues, of which this is the second.
+- `docs/retro/retro-agent2-stuck-queued-message-2026-07-16.md` — origin of the live `useControllerStatusEvents`/`onTurnActive` wiring this fix builds on.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -44,7 +44,7 @@ import { useAgentKeyboard } from "./hooks/useAgentKeyboard";
 import { useProcessCount } from "./hooks/useProcessCount";
 import { usePtyWidth, computeTermSizeFromEl } from "./hooks/usePtyWidth";
 import { useSubagentEvents } from "./hooks/useSubagentEvents";
-import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
+import { useControllerStatusEvents, didTurnJustEnd } from "./hooks/useControllerStatusEvents";
 import { useBlockActivity } from "./hooks/useBlockActivity";
 import { useAgentActivitySummary } from "./hooks/useAgentActivitySummary";
 import { useNextPromptSuggestion } from "./hooks/useNextPromptSuggestion";
@@ -441,6 +441,28 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // before onMount fires). Also consumed by dropAttach + usePtyWidth below.
     let rootRef: HTMLDivElement | undefined;
 
+    // Bumped exactly once per genuine, backend-confirmed turn completion —
+    // the `turn_active: true -> false` edge, fed by both the mount-time
+    // one-shot reconcile and every live controllerstatus event below. This
+    // is the trigger useAgentActivitySummary/useNextPromptSuggestion use
+    // instead of TurnPhase.kind === "Done" (which over-triggers — see
+    // docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md).
+    // `wasTurnActive` is plain (non-reactive) — it only exists to detect the
+    // edge, not to be read anywhere.
+    let wasTurnActive: boolean | undefined;
+    const [turnJustEndedAtom, setTurnJustEndedAtom] = createSignal(0);
+    function reconcileTurnActive(active: boolean): void {
+        dispatchPaneIfRegistered(
+            model.blockId,
+            { type: "ReconcileTurnActive", at: Date.now(), active },
+            "system",
+        );
+        if (didTurnJustEnd(wasTurnActive, active)) {
+            setTurnJustEndedAtom((n) => n + 1);
+        }
+        wasTurnActive = active;
+    }
+
     const status = useAgentControllerStatus({
         blockId: model.blockId,
         provider,
@@ -471,11 +493,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // this can resolve before registerPane() has run for a pane still
         // mid-mount.
         onControllerStatus: (rts) => {
-            dispatchPaneIfRegistered(
-                model.blockId,
-                { type: "ReconcileTurnActive", at: Date.now(), active: !!rts.turn_active },
-                "system",
-            );
+            reconcileTurnActive(!!rts.turn_active);
         },
     });
 
@@ -499,11 +517,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         blockId: model.blockId,
         log,
         onTurnActive: (active) => {
-            dispatchPaneIfRegistered(
-                model.blockId,
-                { type: "ReconcileTurnActive", at: Date.now(), active },
-                "system",
-            );
+            reconcileTurnActive(active);
             // A real controllerstatus event for this pane is independent
             // proof the CLI is alive and running turns — clear any stale
             // "Retry Login" / auth notice left over from the mount-time
@@ -522,13 +536,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     useBlockActivity({ blockId: model.blockId });
 
     // Haiku-powered live mini-summary: generates a fresh phrase in
-    // term:ambient_summary on every completed agent turn, preferred over
+    // term:ambient_summary on every genuine, backend-confirmed turn
+    // completion (turnJustEndedAtom, declared above — NOT TurnPhase.Done,
+    // which over-triggers, see that atom's doc comment), preferred over
     // the OSC title above when both are present. Routed through the
     // backend's Ambient Model Call gateway — see
     // docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md.
     useAgentActivitySummary({
         blockId: model.blockId,
         turnPhase: agentAtoms().turnPhaseAtom[0],
+        turnJustEndedAtom,
         getRootWidth: () => rootRef?.offsetWidth,
     });
 
@@ -540,6 +557,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     useNextPromptSuggestion({
         blockId: model.blockId,
         turnPhase: agentAtoms().turnPhaseAtom[0],
+        turnJustEndedAtom,
         isComposerEmpty: () => composerIsEmptyFn?.() ?? true,
     });
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -442,21 +442,43 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     let rootRef: HTMLDivElement | undefined;
 
     // Bumped exactly once per genuine, backend-confirmed turn completion —
-    // the `turn_active: true -> false` edge, fed by both the mount-time
-    // one-shot reconcile and every live controllerstatus event below. This
-    // is the trigger useAgentActivitySummary/useNextPromptSuggestion use
-    // instead of TurnPhase.kind === "Done" (which over-triggers — see
+    // the `turn_active: true -> false` edge, fed ONLY by live controllerstatus
+    // events (see trackTurnJustEnded below, and NOT reconcileTurnActive — the
+    // mount-time one-shot deliberately does not participate; reagent P1 on
+    // PR #2241). This is the trigger useAgentActivitySummary/
+    // useNextPromptSuggestion use instead of TurnPhase.kind === "Done" (which
+    // over-triggers — see
     // docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md).
     // `wasTurnActive` is plain (non-reactive) — it only exists to detect the
     // edge, not to be read anywhere.
     let wasTurnActive: boolean | undefined;
     const [turnJustEndedAtom, setTurnJustEndedAtom] = createSignal(0);
+
+    // Dispatches ReconcileTurnActive to the pane reducer so TurnPhase follows
+    // the backend's live turn state — used by BOTH the mount-time one-shot
+    // (useAgentControllerStatus's Phase 3 GetControllerStatus) and every live
+    // controllerstatus event. Does NOT touch turnJustEndedAtom — see
+    // trackTurnJustEnded for why that's kept separate.
     function reconcileTurnActive(active: boolean): void {
         dispatchPaneIfRegistered(
             model.blockId,
             { type: "ReconcileTurnActive", at: Date.now(), active },
             "system",
         );
+    }
+
+    // Feeds the turnJustEndedAtom edge-detector. Deliberately called ONLY
+    // from the live useControllerStatusEvents subscription (up from onMount,
+    // always current), never from the mount-time GetControllerStatus
+    // one-shot. That one-shot can resolve up to ~300s late — after Phase 1/2's
+    // auth wait — by which point the live subscription may have already
+    // tracked a real turn starting AND ending. Letting the stale snapshot
+    // also drive wasTurnActive could clobber the correct live-tracked state
+    // back to a value that no longer reflects reality, making the next live
+    // event compute a spurious edge and re-fire the Haiku RPC for a turn that
+    // isn't actually ending — reintroducing the over-trigger bug this fix
+    // closes (reagent P1 on PR #2241).
+    function trackTurnJustEnded(active: boolean): void {
         if (didTurnJustEnd(wasTurnActive, active)) {
             setTurnJustEndedAtom((n) => n + 1);
         }
@@ -518,6 +540,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         log,
         onTurnActive: (active) => {
             reconcileTurnActive(active);
+            trackTurnJustEnded(active);
             // A real controllerstatus event for this pane is independent
             // proof the CLI is alive and running turns — clear any stale
             // "Retry Login" / auth notice left over from the mount-time

--- a/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
+++ b/frontend/app/view/agent/hooks/useAgentActivitySummary.ts
@@ -4,12 +4,20 @@
 /**
  * useAgentActivitySummary — drives the live mini-summary in the agent pane header.
  *
- * On every completed agent turn, sends recent session output to
- * claude-haiku-4-5-20251001 and asks for a short phrase (~word_target words)
- * describing what was just done. The result is written to the
- * `term:ambient_summary` block meta key, which agent-model.ts and
- * swarm-model.ts read (preferring it over the free `term:osc_title` signal —
- * see docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §3.4).
+ * Fires exactly once per genuine, backend-confirmed turn completion — see
+ * `turnJustEndedAtom` below, NOT on `TurnPhase.kind === "Done"` (a previous
+ * version triggered off that; `Done` also fires on several non-terminal
+ * transitions — a premature per-round `session_end` the Claude Code
+ * translator synthesizes between tool-call rounds, and the bounded-timeout
+ * force-transitions for a stop/submit that never got acked — none of which
+ * mean the agent actually finished responding. See
+ * docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md for the full
+ * diagnosis). Sends recent session output to claude-haiku-4-5-20251001 and
+ * asks for a short phrase (~word_target words) describing what was just
+ * done. The result is written to the `term:ambient_summary` block meta key,
+ * which agent-model.ts and swarm-model.ts read (preferring it over the free
+ * `term:osc_title` signal — see
+ * docs/specs/SPEC_AMBIENT_MODEL_CALLS_FRAMEWORK_2026_07_03.md §3.4).
  *
  * Word target is derived from pane width so narrow panes get ~5 words and wide
  * panes can accommodate up to 12.
@@ -47,11 +55,21 @@ import type { TurnPhase } from "@/app/store/agent-pane-state/types";
 export interface UseAgentActivitySummaryOptions {
     blockId: string;
     turnPhase: Accessor<TurnPhase>;
+    /**
+     * Bumped exactly once per genuine, backend-confirmed turn completion —
+     * the `turn_active: true -> false` edge derived from the live
+     * `controllerstatus` event (see agent-view.tsx's `reconcileTurnActive`),
+     * which the backend only flips on the CLI's own real "result" line
+     * (`agentmux-srv/src/backend/blockcontroller/persistent.rs`), not per
+     * tool-call round. This is the trigger — see the module doc comment for
+     * why `TurnPhase.kind === "Done"` isn't used instead.
+     */
+    turnJustEndedAtom: Accessor<number>;
     getRootWidth: () => number | undefined;
 }
 
 export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): void {
-    const { blockId, turnPhase, getRootWidth } = opts;
+    const { blockId, turnPhase, turnJustEndedAtom, getRootWidth } = opts;
 
     // Monotonically increasing turn ID, scoped to this mount. Bumped on every
     // Submitting transition and re-checked locally when the response lands
@@ -61,34 +79,35 @@ export function useAgentActivitySummary(opts: UseAgentActivitySummaryOptions): v
     createEffect(on(turnPhase, (phase) => {
         if (phase.kind === "Submitting") {
             activeTurnId++;
-            return;
-        }
-
-        if (phase.kind === "Done") {
-            const myTurnId = activeTurnId;
-            const rootWidth = getRootWidth() ?? 400;
-            const textWidth = Math.max(0, rootWidth - 280);
-            const wordTarget = Math.max(5, Math.min(12, Math.floor(textWidth / 48)));
-
-            RpcApi.AgentActivitySummaryCommand(
-                TabRpcClient,
-                { block_id: blockId, word_target: wordTarget, generation: Date.now() },
-                { timeout: 20_000 },
-            ).then((result) => {
-                if (activeTurnId !== myTurnId) return; // superseded by a newer turn
-                if (result.tokens) {
-                    recordTurn("ambient:activity_summary", result.tokens);
-                }
-                if (result.summary) {
-                    fireAndForget(() =>
-                        ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
-                            "term:ambient_summary": result.summary,
-                        } as any)
-                    );
-                }
-            }).catch(() => {
-                // Silently ignore — the header just stays blank.
-            });
         }
     }));
+
+    // `defer: true` — skip the run at mount (turnJustEndedAtom starts at 0;
+    // a freshly-opened pane onto an already-idle agent must not fire).
+    createEffect(on(turnJustEndedAtom, () => {
+        const myTurnId = activeTurnId;
+        const rootWidth = getRootWidth() ?? 400;
+        const textWidth = Math.max(0, rootWidth - 280);
+        const wordTarget = Math.max(5, Math.min(12, Math.floor(textWidth / 48)));
+
+        RpcApi.AgentActivitySummaryCommand(
+            TabRpcClient,
+            { block_id: blockId, word_target: wordTarget, generation: Date.now() },
+            { timeout: 20_000 },
+        ).then((result) => {
+            if (activeTurnId !== myTurnId) return; // superseded by a newer turn
+            if (result.tokens) {
+                recordTurn("ambient:activity_summary", result.tokens);
+            }
+            if (result.summary) {
+                fireAndForget(() =>
+                    ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
+                        "term:ambient_summary": result.summary,
+                    } as any)
+                );
+            }
+        }).catch(() => {
+            // Silently ignore — the header just stays blank.
+        });
+    }, { defer: true }));
 }

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.test.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { deriveTurnActive } from "./useControllerStatusEvents";
+import { deriveTurnActive, didTurnJustEnd } from "./useControllerStatusEvents";
 
 // Guards the exact wire contract that a P0 review caught: BlockControllerRuntime
 // Status.is_agent_pane and .turn_active are both serialized
@@ -37,5 +37,37 @@ describe("deriveTurnActive (controllerstatus wire-shape guard)", () => {
         expect(deriveTurnActive(undefined)).toBe(null);
         expect(deriveTurnActive(null)).toBe(null);
         expect(deriveTurnActive("nope")).toBe(null);
+    });
+});
+
+// Guards the trigger for the Haiku ambient-summary/next-prompt-suggestion
+// hooks (docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md) — must
+// fire on a genuine busy→idle edge only, never on other transitions or on a
+// pane's first-ever turn_active reading.
+describe("didTurnJustEnd (ambient-summary trigger edge)", () => {
+    it("true -> false is a genuine turn-end", () => {
+        expect(didTurnJustEnd(true, false)).toBe(true);
+    });
+
+    it("false -> true (turn starting) is not a turn-end", () => {
+        expect(didTurnJustEnd(false, true)).toBe(false);
+    });
+
+    it("true -> true (still busy, e.g. a mid-turn tool-call round) is not a turn-end", () => {
+        expect(didTurnJustEnd(true, true)).toBe(false);
+    });
+
+    it("false -> false (still idle) is not a turn-end", () => {
+        expect(didTurnJustEnd(false, false)).toBe(false);
+    });
+
+    it("undefined -> false (first reading ever, pane opened onto an already-idle agent) is NOT a turn-end", () => {
+        // No prior "busy" was ever observed this mount, so there's nothing
+        // new to summarize — must not fire on every pane open/tab switch.
+        expect(didTurnJustEnd(undefined, false)).toBe(false);
+    });
+
+    it("undefined -> true (first reading ever, agent already mid-turn) is not a turn-end", () => {
+        expect(didTurnJustEnd(undefined, true)).toBe(false);
     });
 });

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
@@ -36,6 +36,26 @@ export function deriveTurnActive(data: unknown): boolean | null {
     return d.turn_active === true;
 }
 
+/**
+ * True exactly when a turn genuinely just ended: the last-known state was
+ * confirmed `true` (busy) and this event reports `false` (idle). `prev` is
+ * `undefined` before any turn_active-bearing event has ever been seen for
+ * this pane's current mount — a fresh pane opened onto an already-idle agent
+ * reports `false` with `prev === undefined`, which must NOT count as a
+ * just-ended turn (there's nothing new to summarize).
+ *
+ * This is the trigger for `useAgentActivitySummary`/`useNextPromptSuggestion`
+ * (their `turnJustEndedAtom`, see agent-view.tsx's `reconcileTurnActive`) —
+ * deliberately independent of the frontend's own `TurnPhase.kind === "Done"`,
+ * which fires on several non-terminal transitions (a premature per-round
+ * `session_end`, bounded-timeout force-transitions) that don't correspond to
+ * a real backend turn_active flip. See
+ * docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md.
+ */
+export function didTurnJustEnd(prev: boolean | undefined, next: boolean): boolean {
+    return prev === true && next === false;
+}
+
 export interface UseControllerStatusEventsOptions {
     blockId: string;
     log: LogFn;

--- a/frontend/app/view/agent/hooks/useNextPromptSuggestion.ts
+++ b/frontend/app/view/agent/hooks/useNextPromptSuggestion.ts
@@ -13,12 +13,16 @@
  * second Ambient Model Call gateway purpose. See
  * docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md.
  *
- * On every completed agent turn, sends recent session output to
- * claude-haiku-4-5-20251001 and asks for a short, natural next user message.
- * The result is written to `term:next_prompt_suggestion` block meta, which
- * the composer reads as ghost text (dimmed, shown only while the input is
- * empty; Tab accepts it into the real input; any other keystroke dismisses
- * it — see AgentFooter.tsx).
+ * Fires exactly once per genuine, backend-confirmed turn completion — see
+ * `turnJustEndedAtom` below, NOT on `TurnPhase.kind === "Done"` (mirrors
+ * useAgentActivitySummary.ts's identical fix — see that module's doc
+ * comment and docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md
+ * for the full diagnosis of why `Done` over-triggers). Sends recent session
+ * output to claude-haiku-4-5-20251001 and asks for a short, natural next
+ * user message. The result is written to `term:next_prompt_suggestion`
+ * block meta, which the composer reads as ghost text (dimmed, shown only
+ * while the input is empty; Tab accepts it into the real input; any other
+ * keystroke dismisses it — see AgentFooter.tsx).
  *
  * Unlike the read-only activity summary (which persists across turns), a
  * stale suggestion here is a correctness bug, not a cosmetic one — it can
@@ -59,6 +63,9 @@ import type { TurnPhase } from "@/app/store/agent-pane-state/types";
 export interface UseNextPromptSuggestionOptions {
     blockId: string;
     turnPhase: Accessor<TurnPhase>;
+    /** See useAgentActivitySummary.ts's identically-named option for what
+     *  this is and why it replaces a `TurnPhase.kind === "Done"` trigger. */
+    turnJustEndedAtom: Accessor<number>;
     /** Checked at write time — see the module doc comment, guard 3. */
     isComposerEmpty: () => boolean;
 }
@@ -72,7 +79,7 @@ function clearSuggestion(blockId: string): void {
 }
 
 export function useNextPromptSuggestion(opts: UseNextPromptSuggestionOptions): void {
-    const { blockId, turnPhase, isComposerEmpty } = opts;
+    const { blockId, turnPhase, turnJustEndedAtom, isComposerEmpty } = opts;
 
     // Scoped to this mount — see useAgentActivitySummary.ts's doc comment for
     // why the wire `generation` is Date.now() instead of this counter.
@@ -82,31 +89,32 @@ export function useNextPromptSuggestion(opts: UseNextPromptSuggestionOptions): v
         if (phase.kind === "Submitting") {
             activeTurnId++;
             clearSuggestion(blockId); // guard 1 — see module doc comment
-            return;
-        }
-
-        if (phase.kind === "Done") {
-            const myTurnId = activeTurnId;
-
-            RpcApi.NextPromptSuggestionCommand(
-                TabRpcClient,
-                { block_id: blockId, generation: Date.now() },
-                { timeout: 20_000 },
-            ).then((result) => {
-                if (activeTurnId !== myTurnId) return; // superseded by a newer turn
-                if (result.tokens) {
-                    recordTurn("ambient:next_prompt_suggestion", result.tokens);
-                }
-                if (result.suggestion && isComposerEmpty()) {
-                    fireAndForget(() =>
-                        ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
-                            "term:next_prompt_suggestion": result.suggestion,
-                        } as any)
-                    );
-                }
-            }).catch(() => {
-                // Silently ignore — no ghost text shows.
-            });
         }
     }));
+
+    // `defer: true` — skip the run at mount, same reasoning as
+    // useAgentActivitySummary.ts.
+    createEffect(on(turnJustEndedAtom, () => {
+        const myTurnId = activeTurnId;
+
+        RpcApi.NextPromptSuggestionCommand(
+            TabRpcClient,
+            { block_id: blockId, generation: Date.now() },
+            { timeout: 20_000 },
+        ).then((result) => {
+            if (activeTurnId !== myTurnId) return; // superseded by a newer turn
+            if (result.tokens) {
+                recordTurn("ambient:next_prompt_suggestion", result.tokens);
+            }
+            if (result.suggestion && isComposerEmpty()) {
+                fireAndForget(() =>
+                    ObjectService.UpdateObjectMeta(makeORef("block", blockId), {
+                        "term:next_prompt_suggestion": result.suggestion,
+                    } as any)
+                );
+            }
+        }).catch(() => {
+            // Silently ignore — no ghost text shows.
+        });
+    }, { defer: true }));
 }


### PR DESCRIPTION
## Summary

The agent pane header's Haiku-generated activity-summary ghost text (and the composer's next-prompt-suggestion ghost text, same architecture) fired on any `TurnPhase.kind === "Done"`, which is not 1:1 with "the agent finished responding to the user":

- **Dominant cause:** Claude Code's translator synthesizes a premature `session_end` after every model API round (`claude-translator.ts:224-233`) — any non-partial, no-tool-use assistant message, even when more tool calls follow in the same turn. `reducer.ts` already documents this exact failure mode and partially compensates for it elsewhere (re-promoting `Done.completed → Streaming` on the next flush), but by then the ambient-summary hooks had already fired. Verified directly that this premature `Done` carries `outcome: "completed"` — identical to a real completion — so a naive "gate on `outcome === "completed"`" fix would not have closed this path.
- Bounded timeout force-transitions (`InterruptTimeoutElapsed`, `SubmitTimeoutElapsed`) and `FailureObserved` also land in `Done` without the agent having genuinely finished.

**Fix:** switched the trigger to the backend-authoritative `turn_active` edge instead of the frontend's own `TurnPhase`. The health monitor only flips `turn_active` false on the CLI's real `"result"` line (`persistent.rs:918-923`), never per tool-call round, and this is already streamed live via the `controllerstatus` event that `useControllerStatusEvents` already consumes for an unrelated bug (stuck `Streaming`/`Idle` reconciliation) — just never wired to this trigger before.

- New pure, unit-tested `didTurnJustEnd(prev, next)` in `useControllerStatusEvents.ts`.
- New `turnJustEndedAtom` signal + shared `reconcileTurnActive()` helper in `agent-view.tsx`, fed by both the mount-time reconcile and every live `controllerstatus` event.
- `useAgentActivitySummary.ts` / `useNextPromptSuggestion.ts` now fire their Haiku RPC off `turnJustEndedAtom` (deferred, so no fire-on-mount) instead of `TurnPhase.kind === "Done"`. `Submitting`-driven bookkeeping (staleness guard, clearing the stale suggestion) is unchanged.

Also documented, but deliberately left untouched: `activity_watcher.rs`'s 20s pushed-summary sweep is untethered to turn state by design and — verified directly — has zero frontend consumers today, so it's not the cause of this bug. It's a real, separate cost leak (spawns a Haiku subprocess every 20s per running agent for a UI signal nothing reads); flagged in the report as a follow-up rather than silently left lost.

Full investigation + design rationale: `docs/specs/REPORT_AMBIENT_SUMMARY_OVERTRIGGER_2026_07_20.md`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run app/view/agent/hooks/useControllerStatusEvents.test.ts` — 12/12 passing (6 new `didTurnJustEnd` cases covering every transition + both first-reading cases)
- [x] `npx vitest run app/store/agent-pane-state app/view/agent` (full suite) — 851/851 passing, 0 failed, no regressions

<!-- agentmux:agent_id=agentx -->