### PR TITLE
feat(lan-discovery): UDP broadcast probe fallback for filtered mDNS

### DIFF
--- a/.changesets/1784573464-feat-lan-discovery-udp-broadcast-probe-fallback-for-filtered-h4w8.md
+++ b/.changesets/1784573464-feat-lan-discovery-udp-broadcast-probe-fallback-for-filtered-h4w8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(lan-discovery): UDP broadcast probe fallback for filtered mDNS

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -13,15 +13,71 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use tokio::net::UdpSocket;
+use tokio::sync::oneshot;
 
 use super::eventbus::{EventBus, WSEventType};
 
 const SERVICE_TYPE: &str = "_agentmux._tcp.local.";
 const LAN_AGENT_CACHE_TTL_SECS: u64 = 60;
 const LAN_PEER_QUERY_TIMEOUT_SECS: u64 = 2;
+
+/// UDP broadcast discovery fallback (Layer 2), for LANs where mDNS multicast
+/// is filtered (common on corporate/guest WiFi). Mobile clients broadcast a
+/// small JSON probe to this port; any listening desktop instance unicasts a
+/// response straight back to the sender's source address.
+///
+/// Port 47891 is picked from the "ephemeral-safe-but-memorable" range: above
+/// both the well-known (0-1023) and IANA-registered (1024-49151) ranges, so
+/// it never collides with a registered service, while still being a fixed,
+/// easy-to-grep value in logs and firewall rules (unlike a random ephemeral
+/// port, which a fixed-port broadcast probe cannot target).
+const UDP_DISCOVERY_PORT: u16 = 47891;
+
+/// Wire-protocol `type` value a probe datagram must carry.
+const UDP_PROBE_TYPE: &str = "agentmux_discover";
+/// Wire-protocol `type` value this responder replies with.
+const UDP_RESPONSE_TYPE: &str = "agentmux_discover_response";
+/// Wire-protocol version. Bump alongside the mobile client if the schema
+/// changes; `is_valid_probe` rejects anything else.
+const UDP_PROTOCOL_VERSION: u64 = 1;
+
+/// Build the JSON response payload for a valid probe. Pure/free function
+/// (no `&self`) so it is trivially testable without spinning up a full
+/// `LanDiscovery` (which owns a real mDNS `ServiceDaemon`). `LanDiscovery`'s
+/// production loop calls this via `build_probe_response`.
+fn probe_response_json(
+    instance_id: &str,
+    hostname: &str,
+    version: &str,
+    port: u16,
+    auth_key: &str,
+) -> serde_json::Value {
+    json!({
+        "type": UDP_RESPONSE_TYPE,
+        "v": UDP_PROTOCOL_VERSION,
+        "instance_id": instance_id,
+        "hostname": hostname,
+        "version": version,
+        "port": port,
+        "auth_key": auth_key,
+    })
+}
+
+/// Validate a received UDP datagram as an in-protocol discovery probe.
+/// Anything that fails to parse as JSON, or does not carry the exact
+/// `type`/`v` fields, is treated as noise (unrelated LAN traffic or a
+/// future/older protocol version) and silently ignored by the caller.
+fn is_valid_probe(bytes: &[u8]) -> bool {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return false;
+    };
+    value.get("type").and_then(|t| t.as_str()) == Some(UDP_PROBE_TYPE)
+        && value.get("v").and_then(|v| v.as_u64()) == Some(UDP_PROTOCOL_VERSION)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LanInstance {
@@ -50,6 +106,15 @@ pub struct LanDiscovery {
     event_bus: Arc<EventBus>,
     service_fullname: String,
     auth_key: String,
+    hostname: String,
+    version: String,
+    port: u16,
+    /// Cancellation half for the UDP responder task spawned in `start()`.
+    /// `None` once `shutdown()` has fired (or if the UDP socket never bound
+    /// — see `spawn_udp_responder`). Guarded by a sync mutex since
+    /// `shutdown()` is `&self` and called from both an explicit live-toggle
+    /// path and `Drop`.
+    udp_cancel: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 /// Normalize an OS hostname into a valid mDNS host name by appending the
@@ -118,12 +183,27 @@ impl LanDiscovery {
             event_bus: event_bus.clone(),
             service_fullname,
             auth_key,
+            hostname,
+            version,
+            port,
+            udp_cancel: Mutex::new(None),
         });
 
         // Spawn event receiver on a blocking thread to avoid starving the tokio runtime
         let disc = discovery.clone();
         tokio::task::spawn_blocking(move || {
             disc.event_loop(browse_receiver);
+        });
+
+        // Spawn the UDP broadcast-probe responder (Layer 2 fallback for
+        // filtered mDNS). `UdpSocket::recv_from` is natively async, so this
+        // uses `tokio::spawn` (not `spawn_blocking`, unlike the mdns-sd event
+        // loop above whose receiver is a sync channel).
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        *discovery.udp_cancel.lock() = Some(cancel_tx);
+        let disc_udp = discovery.clone();
+        tokio::spawn(async move {
+            disc_udp.udp_responder_loop(cancel_rx).await;
         });
 
         tracing::info!(
@@ -133,6 +213,92 @@ impl LanDiscovery {
         );
 
         Ok(discovery)
+    }
+
+    /// Build the JSON response payload for this instance's identity — see
+    /// `probe_response_json` for the pure field-assembly logic shared with
+    /// tests.
+    fn build_probe_response(&self) -> serde_json::Value {
+        probe_response_json(
+            &self.instance_id,
+            &self.hostname,
+            &self.version,
+            self.port,
+            &self.auth_key,
+        )
+    }
+
+    /// UDP broadcast-probe responder loop (Layer 2 discovery fallback).
+    ///
+    /// Binds `0.0.0.0:UDP_DISCOVERY_PORT` and answers valid probes with a
+    /// unicast response back to the sender's `recv_from` source address.
+    /// Deliberately does NOT set `SO_REUSEADDR`: this codebase supports
+    /// running multiple AgentMux instances on one host simultaneously, and
+    /// on Windows `SO_REUSEADDR` lets a second process silently steal a UDP
+    /// port already owned by another — an inappropriate risk for a socket
+    /// that hands out `auth_key`. If the bind fails (most likely because
+    /// another local instance already holds the port), this task logs and
+    /// exits quietly — mDNS discovery (already running via `event_loop`)
+    /// is unaffected, matching the "never fail `start()` over this" contract.
+    ///
+    /// We do not call `set_broadcast(true)`: that flag is only required to
+    /// *send* to a broadcast address, and this socket only receives (probes
+    /// arrive as broadcast/subnet-broadcast datagrams addressed to us, which
+    /// requires no special socket option on the receiving end) and replies
+    /// with a plain unicast send back to the probe's source address.
+    async fn udp_responder_loop(self: Arc<Self>, mut cancel_rx: oneshot::Receiver<()>) {
+        let socket = match UdpSocket::bind(("0.0.0.0", UDP_DISCOVERY_PORT)).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(
+                    port = UDP_DISCOVERY_PORT,
+                    "UDP discovery responder not started (bind failed, likely a second \
+                     local instance already holds this port): {e}"
+                );
+                return;
+            }
+        };
+
+        tracing::debug!(port = UDP_DISCOVERY_PORT, "UDP discovery responder listening");
+
+        let mut buf = [0u8; 1024];
+        loop {
+            tokio::select! {
+                _ = &mut cancel_rx => {
+                    tracing::debug!("UDP discovery responder stopping");
+                    break;
+                }
+                result = socket.recv_from(&mut buf) => {
+                    match result {
+                        Ok((len, src)) => {
+                            // Noise (unrelated LAN UDP traffic, malformed
+                            // packets) is expected on a live network — do
+                            // not log per-packet above debug.
+                            if !is_valid_probe(&buf[..len]) {
+                                continue;
+                            }
+                            tracing::debug!(src = %src, "UDP discovery probe received");
+                            let response = self.build_probe_response();
+                            match serde_json::to_vec(&response) {
+                                Ok(payload) => {
+                                    if let Err(e) = socket.send_to(&payload, src).await {
+                                        tracing::debug!("UDP discovery response send failed: {e}");
+                                    } else {
+                                        tracing::debug!(src = %src, "UDP discovery probe answered");
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::debug!("UDP discovery response serialize failed: {e}");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!("UDP discovery recv_from error: {e}");
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn event_loop(&self, receiver: mdns_sd::Receiver<ServiceEvent>) {
@@ -250,16 +416,28 @@ impl LanDiscovery {
         self.instances.read().len()
     }
 
-    /// Stop the mDNS daemon — synchronously closes the daemon socket
-    /// (UDP:5353), causing the `browse_receiver` to return Err and the
-    /// event-loop thread spawned by `start()` to exit.
+    /// Stop the mDNS daemon and the UDP broadcast-probe responder.
     ///
-    /// Required for live-disable to actually stop discovery: the event-loop
-    /// thread holds its own `Arc<Self>` clone, so simply dropping the
+    /// The mDNS side synchronously closes the daemon socket (UDP:5353),
+    /// causing the `browse_receiver` to return Err and the event-loop thread
+    /// spawned by `start()` to exit. The UDP responder is stopped by firing
+    /// its cancellation channel, which the `tokio::select!` in
+    /// `udp_responder_loop` is racing against `recv_from` — this is what
+    /// makes a live setting toggle actually stop responding to probes, not
+    /// just stop the mDNS advertisement.
+    ///
+    /// Required for live-disable to actually stop discovery: both background
+    /// tasks hold their own `Arc<Self>` clone, so simply dropping the
     /// controller's Arc never reaches refcount zero and `Drop` does not
     /// run. Callers must invoke `shutdown()` before clearing their Arc.
     /// Idempotent — safe to call from both the explicit path and `Drop`.
     pub fn shutdown(&self) {
+        if let Some(tx) = self.udp_cancel.lock().take() {
+            // Ignore send errors: an `Err` here just means the responder
+            // task already exited on its own (e.g. the bind failed), which
+            // is a no-op we're happy with.
+            let _ = tx.send(());
+        }
         if let Err(e) = self.daemon.unregister(&self.service_fullname) {
             // Likely already unregistered; do not warn loudly.
             tracing::debug!("mDNS unregister returned: {e}");
@@ -481,7 +659,12 @@ impl LanDiscoveryController {
 
 #[cfg(test)]
 mod tests {
-    use super::mdns_hostname;
+    use super::{
+        is_valid_probe, mdns_hostname, probe_response_json, UDP_PROBE_TYPE,
+        UDP_PROTOCOL_VERSION, UDP_RESPONSE_TYPE,
+    };
+    use serde_json::json;
+    use tokio::net::UdpSocket;
 
     #[test]
     fn appends_local_dot_to_bare_hostname() {
@@ -510,5 +693,88 @@ mod tests {
         let once = mdns_hostname("claudius");
         let twice = mdns_hostname(&once);
         assert_eq!(twice, once);
+    }
+
+    // -- UDP broadcast-probe wire protocol (Layer 2 discovery fallback) --
+
+    #[test]
+    fn is_valid_probe_accepts_well_formed_probe() {
+        let bytes = serde_json::to_vec(&json!({"type": UDP_PROBE_TYPE, "v": 1})).unwrap();
+        assert!(is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn is_valid_probe_rejects_non_json() {
+        assert!(!is_valid_probe(b"not json at all"));
+    }
+
+    #[test]
+    fn is_valid_probe_rejects_wrong_type() {
+        let bytes = serde_json::to_vec(&json!({"type": "something_else", "v": 1})).unwrap();
+        assert!(!is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn is_valid_probe_rejects_wrong_version() {
+        let bytes = serde_json::to_vec(&json!({"type": UDP_PROBE_TYPE, "v": 2})).unwrap();
+        assert!(!is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn is_valid_probe_rejects_unrelated_json() {
+        // Simulates non-AgentMux JSON noise landing on the port.
+        let bytes = serde_json::to_vec(&json!({"hello": "world"})).unwrap();
+        assert!(!is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn probe_response_json_populates_all_fields() {
+        let response = probe_response_json("inst-1", "myhost", "1.2.3", 9999, "secret-key");
+        assert_eq!(response["type"], UDP_RESPONSE_TYPE);
+        assert_eq!(response["v"], UDP_PROTOCOL_VERSION);
+        assert_eq!(response["instance_id"], "inst-1");
+        assert_eq!(response["hostname"], "myhost");
+        assert_eq!(response["version"], "1.2.3");
+        assert_eq!(response["port"], 9999);
+        assert_eq!(response["auth_key"], "secret-key");
+    }
+
+    /// End-to-end probe/response round trip over real loopback sockets
+    /// (ephemeral ports, NOT the fixed UDP_DISCOVERY_PORT — avoids CI port
+    /// collisions and avoids needing a full `LanDiscovery` + real mDNS
+    /// `ServiceDaemon` just to exercise the wire format). Exercises the same
+    /// `is_valid_probe` / `probe_response_json` functions the production
+    /// `udp_responder_loop` calls.
+    #[tokio::test]
+    async fn udp_probe_round_trip_returns_valid_response() {
+        let responder = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let responder_addr = responder.local_addr().unwrap();
+        let prober = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let probe = json!({"type": UDP_PROBE_TYPE, "v": UDP_PROTOCOL_VERSION});
+        prober
+            .send_to(&serde_json::to_vec(&probe).unwrap(), responder_addr)
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 1024];
+        let (len, src) = responder.recv_from(&mut buf).await.unwrap();
+        assert!(is_valid_probe(&buf[..len]));
+
+        let response = probe_response_json("inst-1", "myhost", "1.2.3", 9999, "secret-key");
+        responder
+            .send_to(&serde_json::to_vec(&response).unwrap(), src)
+            .await
+            .unwrap();
+
+        let (len, _) = prober.recv_from(&mut buf).await.unwrap();
+        let received: serde_json::Value = serde_json::from_slice(&buf[..len]).unwrap();
+        assert_eq!(received["type"], UDP_RESPONSE_TYPE);
+        assert_eq!(received["v"], UDP_PROTOCOL_VERSION);
+        assert_eq!(received["instance_id"], "inst-1");
+        assert_eq!(received["hostname"], "myhost");
+        assert_eq!(received["version"], "1.2.3");
+        assert_eq!(received["port"], 9999);
+        assert_eq!(received["auth_key"], "secret-key");
     }
 }

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -75,8 +75,19 @@ fn is_valid_probe(bytes: &[u8]) -> bool {
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
         return false;
     };
-    value.get("type").and_then(|t| t.as_str()) == Some(UDP_PROBE_TYPE)
-        && value.get("v").and_then(|v| v.as_u64()) == Some(UDP_PROTOCOL_VERSION)
+    value.get("type").and_then(|t| t.as_str()) == Some(UDP_PROBE_TYPE) && is_probe_version_match(&value)
+}
+
+/// Match the probe's `v` field against `UDP_PROTOCOL_VERSION`, accepting
+/// either JSON integer or float encoding. Some JSON serializers (e.g. a
+/// client whose numeric type is inferred as `double`) emit a whole number
+/// like `1` as `1.0`; `Value::as_u64()` alone returns `None` for that
+/// representation, which would silently drop an otherwise-conformant probe.
+fn is_probe_version_match(value: &serde_json::Value) -> bool {
+    let Some(v) = value.get("v") else {
+        return false;
+    };
+    v.as_u64() == Some(UDP_PROTOCOL_VERSION) || v.as_f64() == Some(UDP_PROTOCOL_VERSION as f64)
 }
 
 /// Trust-boundary check for the UDP responder: is `addr` reachable only from
@@ -820,6 +831,20 @@ mod tests {
     #[test]
     fn is_valid_probe_rejects_wrong_version() {
         let bytes = serde_json::to_vec(&json!({"type": UDP_PROBE_TYPE, "v": 2})).unwrap();
+        assert!(!is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn is_valid_probe_accepts_version_encoded_as_float() {
+        // A client whose JSON serializer infers a `double` type for the
+        // version field emits `1.0` rather than `1` — both must validate.
+        let bytes = serde_json::to_vec(&json!({"type": UDP_PROBE_TYPE, "v": 1.0})).unwrap();
+        assert!(is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn is_valid_probe_rejects_version_encoded_as_non_integral_float() {
+        let bytes = serde_json::to_vec(&json!({"type": UDP_PROBE_TYPE, "v": 1.5})).unwrap();
         assert!(!is_valid_probe(&bytes));
     }
 

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -79,6 +79,43 @@ fn is_valid_probe(bytes: &[u8]) -> bool {
         && value.get("v").and_then(|v| v.as_u64()) == Some(UDP_PROTOCOL_VERSION)
 }
 
+/// Trust-boundary check for the UDP responder: is `addr` reachable only from
+/// a private/link-local network, i.e. plausibly on this LAN? Unlike mDNS
+/// (link-local multicast, structurally non-routable off-subnet), this socket
+/// binds `0.0.0.0` and would otherwise answer *any* routable unicast probe
+/// with `auth_key` — an internet-facing disclosure oracle / UDP reflection
+/// vector if the port is ever reachable externally (port forward, hairpin
+/// NAT). Mirrors the private/loopback/link-local classification used for the
+/// opposite purpose (SSRF egress checks) in
+/// `drone/executor/blocks/api.rs::is_reserved_v4`/`is_reserved_v6`, minus the
+/// broadcast/unspecified/multicast cases that don't apply to a source addr.
+fn is_lan_source(addr: &std::net::SocketAddr) -> bool {
+    match addr.ip() {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(v6) => {
+            if v6.is_loopback()
+                // unique-local fc00::/7
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                // link-local fe80::/10
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+            {
+                return true;
+            }
+            // IPv4-mapped/-compatible v6 literals route to the embedded v4
+            // address on most kernels — delegate so a private v4 source
+            // wearing a v6 wrapper isn't misclassified as public.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return v4.is_loopback() || v4.is_private() || v4.is_link_local();
+            }
+            #[allow(deprecated)]
+            if let Some(v4) = v6.to_ipv4() {
+                return v4.is_loopback() || v4.is_private() || v4.is_link_local();
+            }
+            false
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LanInstance {
     pub instance_id: String,
@@ -230,7 +267,8 @@ impl LanDiscovery {
 
     /// UDP broadcast-probe responder loop (Layer 2 discovery fallback).
     ///
-    /// Binds `0.0.0.0:UDP_DISCOVERY_PORT` and answers valid probes with a
+    /// Binds `0.0.0.0:UDP_DISCOVERY_PORT` and answers valid probes from
+    /// private/link-local source addresses (see `is_lan_source`) with a
     /// unicast response back to the sender's `recv_from` source address.
     /// Deliberately does NOT set `SO_REUSEADDR`: this codebase supports
     /// running multiple AgentMux instances on one host simultaneously, and
@@ -277,6 +315,17 @@ impl LanDiscovery {
                             if !is_valid_probe(&buf[..len]) {
                                 continue;
                             }
+                            // Trust boundary: never hand out auth_key to a
+                            // source address outside the private/link-local
+                            // ranges, even if the packet is a well-formed
+                            // probe (see is_lan_source doc comment).
+                            if !is_lan_source(&src) {
+                                tracing::debug!(
+                                    src = %src,
+                                    "UDP discovery probe from non-LAN source, ignoring"
+                                );
+                                continue;
+                            }
                             tracing::debug!(src = %src, "UDP discovery probe received");
                             let response = self.build_probe_response();
                             match serde_json::to_vec(&response) {
@@ -293,7 +342,13 @@ impl LanDiscovery {
                             }
                         }
                         Err(e) => {
+                            // A persistent OS-level error (e.g. Windows
+                            // WSAECONNRESET/10054 from an ICMP
+                            // port-unreachable triggered by our own prior
+                            // send_to) would otherwise spin this loop at
+                            // full CPU with no delay between retries.
                             tracing::debug!("UDP discovery recv_from error: {e}");
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                         }
                     }
                 }
@@ -660,11 +715,59 @@ impl LanDiscoveryController {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_valid_probe, mdns_hostname, probe_response_json, UDP_PROBE_TYPE,
+        is_lan_source, is_valid_probe, mdns_hostname, probe_response_json, UDP_PROBE_TYPE,
         UDP_PROTOCOL_VERSION, UDP_RESPONSE_TYPE,
     };
     use serde_json::json;
+    use std::net::SocketAddr;
     use tokio::net::UdpSocket;
+
+    #[test]
+    fn is_lan_source_accepts_private_v4_ranges() {
+        for addr in [
+            "127.0.0.1:1234",
+            "10.0.0.5:1234",
+            "172.16.4.4:1234",
+            "192.168.1.50:1234",
+            "169.254.1.1:1234", // link-local / APIPA
+        ] {
+            let addr: SocketAddr = addr.parse().unwrap();
+            assert!(is_lan_source(&addr), "{addr} should be treated as LAN");
+        }
+    }
+
+    #[test]
+    fn is_lan_source_rejects_public_v4() {
+        for addr in ["8.8.8.8:1234", "1.1.1.1:1234", "203.0.113.7:1234"] {
+            let addr: SocketAddr = addr.parse().unwrap();
+            assert!(!is_lan_source(&addr), "{addr} should NOT be treated as LAN");
+        }
+    }
+
+    #[test]
+    fn is_lan_source_accepts_v6_loopback_and_local_ranges() {
+        for addr in ["[::1]:1234", "[fe80::1]:1234", "[fc00::1]:1234"] {
+            let addr: SocketAddr = addr.parse().unwrap();
+            assert!(is_lan_source(&addr), "{addr} should be treated as LAN");
+        }
+    }
+
+    #[test]
+    fn is_lan_source_rejects_public_v6() {
+        let addr: SocketAddr = "[2001:4860:4860::8888]:1234".parse().unwrap();
+        assert!(!is_lan_source(&addr));
+    }
+
+    #[test]
+    fn is_lan_source_unwraps_v4_mapped_v6() {
+        // A private v4 address wearing a v6 mapped-address wrapper must
+        // still be classified by its embedded v4 range, not treated as an
+        // opaque public v6 address.
+        let addr: SocketAddr = "[::ffff:10.0.0.5]:1234".parse().unwrap();
+        assert!(is_lan_source(&addr));
+        let addr: SocketAddr = "[::ffff:8.8.8.8]:1234".parse().unwrap();
+        assert!(!is_lan_source(&addr));
+    }
 
     #[test]
     fn appends_local_dot_to_bare_hostname() {

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -856,6 +856,18 @@ mod tests {
     }
 
     #[test]
+    fn is_valid_probe_rejects_missing_version_field() {
+        let bytes = serde_json::to_vec(&json!({"type": UDP_PROBE_TYPE})).unwrap();
+        assert!(!is_valid_probe(&bytes));
+    }
+
+    #[test]
+    fn is_valid_probe_rejects_missing_type_field() {
+        let bytes = serde_json::to_vec(&json!({"v": UDP_PROTOCOL_VERSION})).unwrap();
+        assert!(!is_valid_probe(&bytes));
+    }
+
+    #[test]
     fn probe_response_json_populates_all_fields() {
         let response = probe_response_json("inst-1", "myhost", "1.2.3", 9999, "secret-key");
         assert_eq!(response["type"], UDP_RESPONSE_TYPE);


### PR DESCRIPTION
## Summary

Layer 2 of the LAN-discovery reliability plan: a UDP broadcast probe/responder
fallback for networks where mDNS multicast is filtered (corporate/guest
WiFi). This is the desktop/backend (Rust) half; a Flutter mobile agent is
building the client half against the identical wire protocol in parallel.

Folded into the existing `LanDiscovery` struct (`agentmux-srv/src/backend/lan_discovery.rs`)
rather than a sibling module, since it already owns `instance_id` /
`hostname` / `version` / `port` / `auth_key` and already spawns background
tasks from `start()`.

### Wire protocol (JSON over UDP, fixed port **47891**)

Port 47891 is above both the well-known and IANA-registered ranges — fixed
(so a broadcast probe can target it) and easy to grep in logs/firewall
rules. Documented in a code comment at `UDP_DISCOVERY_PORT`.

Probe (mobile → desktop, broadcast to `255.255.255.255:47891` or subnet
broadcast):
```json
{"type":"agentmux_discover","v":1}
```

Response (desktop → mobile, unicast back to the probe's `recv_from` source
address):
```json
{"type":"agentmux_discover_response","v":1,"instance_id":"...","hostname":"...","version":"...","port":12345,"auth_key":"..."}
```

Malformed/unrelated/wrong-version packets are silently ignored
(`is_valid_probe`) — logged at `tracing::debug!` only, since this port will
see LAN noise and the task explicitly calls for non-chatty logging.

### Gating & shutdown

Gated on the exact same `network_lan_discovery` setting as the mDNS daemon,
including on a **live toggle**, not just at boot. `LanDiscovery::shutdown()`
now also fires a `tokio::sync::oneshot` cancellation channel that the UDP
responder's `tokio::select!` races against `recv_from`, so `apply(false)`
actually stops answering probes — previously `shutdown()` only touched the
mDNS daemon.

### SO_REUSEADDR trade-off

Deliberately **not** set. This codebase explicitly supports running multiple
AgentMux instances on one host simultaneously; on Windows, `SO_REUSEADDR`
lets a second process silently steal a UDP port already owned by another
process — inappropriate for a socket that hands out `auth_key` in its
responses. If the bind to :47891 fails (most likely a second local instance
that also has LAN discovery enabled), the UDP task logs at `debug!` and
exits quietly — `LanDiscovery::start()` still succeeds and mDNS discovery is
unaffected. This mirrors the security posture already documented at
`find_agent()`: the auth_key is broadcast because LAN traffic here is
already a trusted-network assumption, and this doesn't add new exposure.

`set_broadcast(true)` was considered but is not needed: it's only required
to *send* to a broadcast address; this socket only receives probes and
replies via plain unicast.

### Testing

Extracted two small, directly-testable functions used by both the
production loop and the tests: `is_valid_probe(bytes) -> bool` and the free
function `probe_response_json(...) -> serde_json::Value` (wrapped by
`LanDiscovery::build_probe_response(&self)` for the production path). Added
a `#[tokio::test]` round-trip test binding two `UdpSocket`s on
`127.0.0.1:0` (ephemeral, not the fixed port, to avoid CI collisions) plus
unit tests for probe validation edge cases, in the existing
`#[cfg(test)] mod tests` block.

## Verification

- `cargo build -p agentmux-srv` — succeeds, no new warnings from
  `lan_discovery.rs`.
- `cargo test -p agentmux-srv lan_discovery` — 12/12 passed.
- `cargo test -p agentmux-srv` (full suite) — 1558 passed, 0 failed, 4
  ignored (pre-existing, unrelated).

## Test plan

- [x] `cargo build -p agentmux-srv`
- [x] `cargo test -p agentmux-srv lan_discovery` (new tests)
- [x] `cargo test -p agentmux-srv` (full suite, no regressions)

<!-- agentmux:agent_id=agenty -->