### PR TITLE
feat(launcher): macOS splash — add an "other" row closing the total-vs-items gap

### DIFF
--- a/.changesets/1784574706-feat-launcher-macos-splash-add-an-other-row-closing-the-tota-1my2.md
+++ b/.changesets/1784574706-feat-launcher-macos-splash-add-an-other-row-closing-the-tota-1my2.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(launcher): macOS splash — add an "other" row closing the total-vs-items gap

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -267,6 +267,35 @@ fn flatten_rows(stages: &[StageRow], total_ms: Option<u64>) -> Vec<FlatRow> {
         }
     }
     if let Some(ms) = total_ms {
+        // "other" — the gap between `total` (a wall-clock stopwatch running
+        // from splash-window creation to first-paint-detected) and the sum
+        // of top-level stage durations. Only completed (`done`) stages are
+        // summed: they're already exclusive of each other (a stage's own
+        // duration already covers whatever its subs took), and an
+        // undone stage would inflate the sum with an ever-changing partial
+        // count. Any residual is genuinely uncovered by any instrumented
+        // stage — e.g. cef_init-end -> first-paint, or process-spawn
+        // scheduling gaps between stages — not a double-count or a bug; see
+        // docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md §5.
+        // saturating_sub guards the (should-be-impossible, but not worth a
+        // panic over) case where accounted time exceeds total_ms.
+        let accounted_ms: u64 = stages
+            .iter()
+            .filter_map(|s| s.done.as_ref().map(|(dur, _, _)| *dur))
+            .sum();
+        let other_ms = ms.saturating_sub(accounted_ms);
+        // "total" is the existing, higher-priority row: only add "other"
+        // when there's room for both, so a nearly-full panel still shows the
+        // total rather than silently dropping it for the new row.
+        if out.len() + 2 <= MAX_STAGE_ROWS {
+            out.push(FlatRow {
+                indented: false,
+                label: String::new(),
+                time_text: format!("other: {}", format_ms(other_ms)),
+                label_color: (SUB_R, SUB_G, SUB_B),
+                time_color: (SUB_R, SUB_G, SUB_B),
+            });
+        }
         if out.len() < MAX_STAGE_ROWS {
             out.push(FlatRow {
                 indented: false,
@@ -1054,4 +1083,123 @@ unsafe fn build_window() -> (id, id, Vec<(id, id)>) {
     send_void_bool(app, sel(b"activateIgnoringOtherApps:\0"), 1);
     send_void(window, sel(b"orderFrontRegardless\0"));
     (window, image_view, stage_fields)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn done_stage(stage: &'static str, label: &'static str, ms: u64) -> StageRow {
+        StageRow {
+            stage,
+            label,
+            started_at: Instant::now(),
+            done: Some((ms, StartupStatus::Ok, None)),
+            subs: Vec::new(),
+        }
+    }
+
+    fn running_stage(stage: &'static str, label: &'static str) -> StageRow {
+        StageRow {
+            stage,
+            label,
+            started_at: Instant::now(),
+            done: None,
+            subs: Vec::new(),
+        }
+    }
+
+    /// Pulls the "other: ..." row's time_text out of a flatten_rows() result,
+    /// if present.
+    fn other_row_text(rows: &[FlatRow]) -> Option<&str> {
+        rows.iter()
+            .find(|r| r.time_text.starts_with("other: "))
+            .map(|r| r.time_text.as_str())
+    }
+
+    fn total_row_text(rows: &[FlatRow]) -> Option<&str> {
+        rows.iter()
+            .find(|r| r.time_text.starts_with("total: "))
+            .map(|r| r.time_text.as_str())
+    }
+
+    #[test]
+    fn no_other_or_total_row_while_total_ms_is_none() {
+        let stages = vec![done_stage("prep", "Prep", 100)];
+        let rows = flatten_rows(&stages, None);
+        assert!(other_row_text(&rows).is_none());
+        assert!(total_row_text(&rows).is_none());
+    }
+
+    #[test]
+    fn other_row_is_the_gap_between_total_and_summed_stages() {
+        let stages = vec![
+            done_stage("prep", "Prep", 100),
+            done_stage("migrations", "Migrations", 250),
+        ];
+        // 100 + 250 = 350 accounted; total is 500 -> 150ms unaccounted.
+        let rows = flatten_rows(&stages, Some(500));
+        assert_eq!(other_row_text(&rows), Some("other: 150ms"));
+        assert_eq!(total_row_text(&rows), Some("total: 500ms"));
+    }
+
+    #[test]
+    fn other_row_excludes_a_still_running_stage_from_the_sum() {
+        // A stage with no StageEnd yet must not be counted as 0 duration
+        // *or* as its still-changing partial elapsed time — it's simply
+        // excluded from `accounted_ms`, same treatment either way here
+        // since we only ever fold `done` stages.
+        let stages = vec![done_stage("prep", "Prep", 100), running_stage("host", "Host")];
+        let rows = flatten_rows(&stages, Some(300));
+        assert_eq!(other_row_text(&rows), Some("other: 200ms"));
+    }
+
+    #[test]
+    fn other_row_saturates_at_zero_rather_than_underflowing() {
+        // Pathological: reported stage durations sum to more than the
+        // wall-clock total (e.g. a race at the ready-detection instant).
+        // Must not panic or wrap around via unsigned subtraction.
+        let stages = vec![done_stage("prep", "Prep", 900)];
+        let rows = flatten_rows(&stages, Some(500));
+        assert_eq!(other_row_text(&rows), Some("other: 0ms"));
+    }
+
+    #[test]
+    fn sub_row_durations_are_not_double_counted_into_other() {
+        // A sub's time is already inside its parent stage's own reported
+        // duration_ms (the stage spans stage-begin to stage-end, which
+        // wraps its subs) — summing subs separately would double-count and
+        // shrink "other" incorrectly. accounted_ms must come from top-level
+        // stages only.
+        let mut migrations = done_stage("migrations", "Migrations", 250);
+        migrations.subs.push(SubRow {
+            id: "001".into(),
+            label: "001_init".into(),
+            started_at: Instant::now(),
+            done: Some((90, StartupStatus::Ok, None)),
+        });
+        let stages = vec![done_stage("prep", "Prep", 100), migrations];
+        let rows = flatten_rows(&stages, Some(500));
+        // If subs were double-counted this would be 500 - (100+250+90) = 60,
+        // not 150.
+        assert_eq!(other_row_text(&rows), Some("other: 150ms"));
+    }
+
+    #[test]
+    fn total_row_still_shown_when_panel_is_nearly_full() {
+        // MAX_STAGE_ROWS(12) - 1 stage rows leaves exactly one slot: "total"
+        // must win that slot over "other" per the priority documented at
+        // the call site.
+        let stages: Vec<StageRow> = (0..MAX_STAGE_ROWS - 1)
+            .map(|i| {
+                let label: &'static str = Box::leak(format!("s{i}").into_boxed_str());
+                let stage: &'static str = label;
+                done_stage(stage, label, 10)
+            })
+            .collect();
+        let rows = flatten_rows(&stages, Some(1000));
+        assert_eq!(rows.len(), MAX_STAGE_ROWS);
+        assert!(other_row_text(&rows).is_none());
+        assert!(total_row_text(&rows).is_some());
+    }
 }

--- a/docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md
+++ b/docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md
@@ -1,0 +1,218 @@
+# macOS Splash Screen — Countup Timing & the Total-vs-Items Gap
+
+**Date:** 2026-07-20
+**Scope:** `agentmux-launcher/src/splash_mac.rs` (macOS-native splash renderer) +
+`agentmux-launcher/src/startup_events.rs` (event model) + emitters in
+`agentmux-launcher/src/srv_spawner.rs`, `agentmux-launcher/src/supervisor/unix.rs`,
+`agentmux-cef/src/lib.rs`.
+
+**Two questions asked:** (1) why do some splash lines show a live countup while
+others just snap to their final value, and (2) why is there a visible gap
+between the sum of the per-item numbers and the "total" row at the bottom.
+
+Note on scope: `splash.rs` at the repo root of `agentmux-launcher/src/` is the
+**Windows** splash (`#![cfg(target_os = "windows")]`) — a structurally similar
+but entirely separate, non-shared implementation from `splash_mac.rs` (the
+duplication is called out as a known follow-up in `splash_mac.rs:79-84`).
+`splash_text.rs` is also Windows-only — macOS renders every line via retained
+`NSTextField`s instead (`splash_mac.rs:1034-1045`). Everything below is macOS
+(`splash_mac.rs`) specifically.
+
+---
+
+## 1. What drives a redraw
+
+`Splash::run_until_dismissed` (`splash_mac.rs:656-754`) runs a loop with two
+distinct phases:
+
+- **Before the host signals first paint** (`ready_at` is still `None`): the
+  loop runs unconditionally on a fixed cadence — `pump_app_events(0.016)`
+  (16ms AppKit event wait, line 668) followed by
+  `std::thread::sleep(Duration::from_millis(8))` (line 740) — roughly an
+  8–24ms tick. `update_stage_fields(...)` is called **every tick**, whether or
+  not a new event arrived: `if changed || ready_at.is_none() { ... }`
+  (lines 713-718). So pre-ready, this is genuinely timer-driven.
+- **After ready** (host signaled, or the 10s `DISMISS_TIMEOUT` fired): the
+  condition collapses to event-driven only — the display only updates again
+  when a new `StartupEvent` shows up (`changed`). One forced final refresh
+  fires exactly at the ready transition (line 707, `changed = true; // force
+  one final refresh showing the "total:" row`) to freeze the display with the
+  total visible.
+
+Events are drained non-blocking every tick:
+`while let Ok(ev) = self.startup_rx.try_recv() { apply_event(...); changed = true; }`
+(lines 672-676).
+
+---
+
+## 2. Why some lines countup live and others just flash to a final value
+
+**It is not "only the currently-active row animates."** `flatten_rows`
+(`splash_mac.rs:218-281`) recomputes *every* row with `done == None` on every
+single tick, all at once — there's no concept of a single "active" item.
+
+The actual mechanism:
+- `apply_event` pushes a new row on `StageBegin`/`SubBegin`
+  (`done: None`, `started_at: Instant::now()`) and only flips `done` when the
+  matching `StageEnd`/`SubEnd` arrives (lines 144-178).
+- Both Begin and End travel over the same unbounded `mpsc` channel
+  (`startup_events.rs:56-65`) and get drained together in one `try_recv` loop
+  per tick.
+- **If a step's real work finishes fast enough that both its Begin and End
+  land in the channel before the splash's next drain, `apply_event` processes
+  them back-to-back within one tick** — the row is created *already done*.
+  No "running" frame is ever rendered for it, so it just appears with its
+  final value.
+- If the Begin→End gap is longer than roughly one tick (~8–24ms), at least
+  one intermediate `format_running(started_at)` frame gets drawn before the
+  End arrives — that's the live countup.
+
+**There is no minimum-duration threshold constant anywhere in the crate for
+this.** It's a pure emergent effect of tick cadence vs. item speed, not a
+deliberate design choice. The `--splash-selftest` fixture (`main.rs:218-245`)
+demonstrates exactly this — it inserts real `std::thread::sleep`s (80ms, 40ms,
+1500ms, etc.) between paired begin/end calls specifically so the countup is
+visible in the demo; without an artificial delay, fast steps just wouldn't
+show one.
+
+**Related edge case:** a row whose End event never arrives before `ready_at`
+fires gets frozen forever at whatever value the one forced final refresh
+produced — stuck in the "in progress" color, never turns green, never updates
+again (post-ready refreshes only happen on `changed`, and nothing will mark it
+done after that point).
+
+---
+
+## 3. How each per-item duration is computed
+
+Two independent numbers exist per row, and the splash only ever shows one:
+
+- **Splash-local `started_at: Instant`** (lines 129, 136) — stamped when the
+  splash thread *processes* the Begin event (i.e. at whatever tick actually
+  drains it), used only to drive the live counter while `done` is `None`.
+- **Reported `duration_ms: u64`** — carried as data inside the `StageEnd`/
+  `SubEnd` event itself (`startup_events.rs:30-35, 43-50`), computed
+  independently by whatever code emits it, not by the splash:
+  - "migrations" stage: `srv_spawner.rs:105` (`Instant::now()`) through
+    `srv_spawner.rs:187` (`t.elapsed()`).
+  - "host" stage: `supervisor/unix.rs:363, 368`.
+  - Individual sub-migrations: self-reported in each migration binary's own
+    stdout JSON, parsed at `srv_spawner.rs:155-163, 220, 234`.
+  - CEF-side stages (`dlopen`, `cef_init`): computed by the host process and
+    forwarded cross-process over IPC
+    (`agentmux-cef/src/lib.rs:577-578, 883-958` →
+    `Command::ReportStartupStageBegin/End` →
+    `agentmux-launcher/src/ipc/server.rs:527-555`).
+
+Once `apply_event` stores the reported value in `done`, `format_ms(ms)`
+renders it verbatim forever — the splash never recomputes or reconciles it
+against its own clock.
+
+---
+
+## 4. How the "total" is computed
+
+A **separate wall-clock stopwatch**, unrelated to any item's duration:
+
+```rust
+let start = Instant::now();               // splash_mac.rs:657, at run_until_dismissed entry
+...
+if ready_at.is_none() && (self.ready_file.exists() || start.elapsed() > DISMISS_TIMEOUT) {
+    ...
+    total_ms = start.elapsed().as_millis() as u64;   // splash_mac.rs:695-700
+}
+```
+
+`start` begins right after the splash window is built (`Splash::show`, called
+from `main.rs:131`) — i.e. before the "prep" stage even begins. It stops the
+instant the host's ready-file appears (first paint detected) or the 10s
+timeout fires. This `total_ms` is threaded into
+`flatten_rows(stages, total_ms)` and rendered as the `"total: {}"` row
+(lines 269-278). **It has zero arithmetic relationship to any stage/sub
+`duration_ms` value** — it's purely `Instant::now() - start` at the moment
+readiness is detected.
+
+---
+
+## 5. Why the gap exists, concretely
+
+The splash **never sums the item durations itself** — `flatten_rows` /
+`draw_stages` don't compute a "sum of items" anywhere. That comparison only
+exists if someone manually adds up the displayed per-row numbers and compares
+against the separately-displayed total. Once you do that, the gap comes from
+several genuinely additive sources:
+
+1. **Real elapsed time that no stage/sub covers at all.** The "host" stage is
+   explicitly scoped to process-spawn latency only, not full first paint — the
+   code says so directly:
+   > `supervisor/unix.rs:352-361`: "'host' stage currently covers process-spawn
+   > latency only (begin → spawn_host_unix returning a live Child), not full
+   > first-paint... Extending this stage to span to first-paint is a
+   > follow-up."
+
+   Even after `cef_init` ends (`agentmux-cef/src/lib.rs:953-958`, right after
+   `cef::initialize()` returns), there's still browser-window creation,
+   frontend navigation, and full page load before `on_load_end` writes the
+   ready-file that stops `total_ms`
+   (`agentmux-cef/src/client/navigation.rs:293-315`). None of
+   dlopen-end→cef_init-begin or cef_init-end→on_load_end is wrapped in any
+   stage/sub event — invisible to "sum of items," fully counted in "total."
+
+2. **Idle time between stages isn't attributed to anything.** `total_ms` runs
+   continuously from before "prep" starts; any gap between one stage's End and
+   the next stage's Begin (process-spawn latency, IPC round-trips, scheduler
+   delay) accrues to the wall-clock total but to no row. The self-test fixture
+   makes this explicit with genuine sleeps *between* items (e.g. a 100ms gap
+   between `stage_end("prep",...)` and `stage_begin("migrations",...)`,
+   `main.rs:227-238`) — dead time with no owning row, by construction.
+
+3. **A stage's own reported duration already exceeds the sum of its own
+   subs**, for legitimate reasons — the same pattern repeats one level down.
+   In `run_migrate` (`srv_spawner.rs:99-213`), the "migrations" stage's
+   `duration_ms` (line 187) spans process spawn through process wait,
+   including subprocess spawn overhead and stdout-parsing latency between
+   sub-migrations — none of which is attributed to any individual
+   sub-migration's own self-reported duration.
+
+4. **Unsynchronized clock sources.** The splash's own `Instant`s (`started_at`,
+   the total's `start`) and each emitter's own timers are independent
+   monotonic clocks running in different threads/processes. Nothing
+   reconciles them against each other; they're just displayed side by side.
+
+No double-counting or overlap is happening — the "gap" is real elapsed time
+that's genuinely uncovered by any instrumented stage, not an arithmetic bug.
+
+---
+
+## 6. Related constants
+
+| Constant | Value | Location | Effect |
+|---|---|---|---|
+| `DISMISS_TIMEOUT` | 10s | `splash_mac.rs:72` | Safety cap forcing `ready_at`/`total_ms` even if the host never signals readiness |
+| Tick cadence | ~8–24ms (16ms event wait + 8ms sleep, both literals, no named constant) | `splash_mac.rs:668, 740` | The de facto "poll interval" — determines whether a fast item's Begin/End land in the same drain batch (→ no countup) or different ones (→ countup) |
+| `AGENTMUX_SPLASH_HOLD_MS` | env, default 2000ms | `splash_mac.rs:701-704` | Post-ready hold before fade-out; capped to `min(1000)` if `total_ms < 500` (line 705) |
+| `FADE_OUT` | 0.16s | `splash_mac.rs:73` | Fade-out duration after the hold |
+
+**No minimum-duration-to-animate threshold exists anywhere in the crate** —
+confirmed by grep. The animate/no-animate split is a pure side effect of tick
+cadence vs. item speed, not a deliberate design decision.
+
+---
+
+## 7. If we want to change the behavior
+
+Not implemented here — investigation only, per the ask. But worth noting for
+a follow-up:
+
+- **To make every item show at least one countup frame:** insert a minimum
+  artificial delay before processing an End event whose paired Begin landed in
+  the same tick (cheap, but adds latency to fast steps purely for cosmetics),
+  or decouple rendering from the drain loop — poll/redraw on a fixed timer
+  independent of `try_recv`, so a fast item's "running" state gets at least
+  one paint even if its End is already queued behind it in the channel.
+- **To close the total-vs-items gap** (if the goal is for them to visibly
+  reconcile, not just to explain it): would need genuinely new instrumentation
+  — e.g. a stage spanning cef_init-end → on_load_end (extending the "host"
+  stage's documented scope per the `supervisor/unix.rs:352-361` comment), and
+  an explicit "idle"/"other" row that gets whatever `total_ms` minus sum-of-
+  stages leaves over, rather than leaving that time unlabeled.


### PR DESCRIPTION
## Summary
Follow-up to the investigation in `docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md`: the splash's "total" row is an independent wall-clock stopwatch, unrelated to the sum of the individual stage/sub durations shown above it, so the gap between them was previously unexplained on screen.

`flatten_rows` now sums only completed top-level stage durations (summing subs too would double-count — a stage's own reported duration already spans its subs) and renders `total_ms - accounted_ms` (saturating, never negative) as a new `other: Xms` row directly above `total`. Same priority handling as the existing total row: if the panel is nearly full, `total` wins the last slot over `other` rather than silently displacing it.

macOS only (`splash_mac.rs`) — Windows (`splash.rs`) and Linux (`splash_linux/`) are deliberately separate, non-shared implementations per the existing module doc, same policy this file's original PR followed.

## Test plan
- [x] 6 new unit tests on `flatten_rows()`: gap computation, still-running-stage exclusion, sub-duration non-double-counting, saturating-sub underflow guard, row-budget priority
- [x] `cargo test -p agentmux-launcher splash_mac` — all pass
- [x] Visual check via `--splash-selftest` + `AGENTMUX_SPLASH_DUMP_PNG` (temporary, reverted-before-commit tweak to the dev-only `dump_png` helper to capture the frozen "total" state): with the fixture's 120+220+1500+90=1930ms accounted, rendered `other: 720ms` / `total: 2.6s` — 1930 + 720 = 2650, matches exactly