### PR TITLE
fix(swarm): separate row collapse-toggle from focus, default collapsed

### DIFF
--- a/.changesets/1784573075-fix-swarm-separate-row-collapse-toggle-from-focus-default-co-k3xj.md
+++ b/.changesets/1784573075-fix-swarm-separate-row-collapse-toggle-from-focus-default-co-k3xj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): separate row collapse-toggle from focus, default collapsed

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -603,16 +603,19 @@ export class SwarmViewModel implements ViewModel {
     expandedIdsAtom: Accessor<Set<string>> = this._expandedIds[0];
     private setExpandedIds: Setter<Set<string>> = this._expandedIds[1];
 
-    // Top-level agent rows collapse with the OPPOSITE default from the group/
-    // subagent rows above: agents default EXPANDED, so this tracks the
-    // exception set (collapsed blockIds) rather than reusing expandedIds
-    // (whose absent-means-collapsed semantics would flip every agent shut on
-    // mount). Same ViewModel-residency rationale as _expandedIds: tree()
-    // rebuilds wrapper objects on every status tick, so row-local state would
+    // Top-level agent rows now share the SAME default (collapsed) and
+    // polarity (absent-means-collapsed) as the group/subagent _expandedIds
+    // set above — this tracks which agent blockIds have been explicitly
+    // expanded, so the empty default set means every agent starts
+    // collapsed. Kept as its own signal rather than folded into
+    // _expandedIds since agent blockIds and subagent/workflow row keys are
+    // different id spaces that could theoretically collide. Same
+    // ViewModel-residency rationale as _expandedIds: tree() rebuilds
+    // wrapper objects on every status tick, so row-local state would
     // silently reset on unrelated refreshes.
-    private _collapsedAgentIds = createSignal<Set<string>>(new Set());
-    collapsedAgentIdsAtom: Accessor<Set<string>> = this._collapsedAgentIds[0];
-    private setCollapsedAgentIds: Setter<Set<string>> = this._collapsedAgentIds[1];
+    private _expandedAgentIds = createSignal<Set<string>>(new Set());
+    expandedAgentIdsAtom: Accessor<Set<string>> = this._expandedAgentIds[0];
+    private setExpandedAgentIds: Setter<Set<string>> = this._expandedAgentIds[1];
 
     // Rows the user has retired (dismissed) — client-local, ephemeral (no
     // backend write, resets on reload/restart, same as memory-pressure-
@@ -854,14 +857,15 @@ export class SwarmViewModel implements ViewModel {
         });
     }
 
-    /** Top-level AgentRow collapse — see _collapsedAgentIds for the
-     *  inverted (default-expanded) semantics vs isExpanded/toggleExpanded. */
+    /** Top-level AgentRow collapse — same default-collapsed,
+     *  absent-means-collapsed semantics as isExpanded/toggleExpanded above,
+     *  backed by its own _expandedAgentIds set (see there for why). */
     isAgentCollapsed(blockId: string): boolean {
-        return this.collapsedAgentIdsAtom().has(blockId);
+        return !this.expandedAgentIdsAtom().has(blockId);
     }
 
     toggleAgentCollapsed(blockId: string): void {
-        this.setCollapsedAgentIds((prev) => {
+        this.setExpandedAgentIds((prev) => {
             const next = new Set(prev);
             if (next.has(blockId)) next.delete(blockId);
             else next.add(blockId);

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -76,7 +76,7 @@
 // ── Agent card (name row + activity summary, enclosed together) ──────────
 
 .swarm-agent-card {
-    cursor: default;
+    cursor: pointer;
     border-radius: 4px;
     user-select: none;
 
@@ -155,6 +155,37 @@
         opacity: 0.6;
         white-space: nowrap;
     }
+}
+
+// Focus button — same hover-reveal shape as .swarm-subagent-retire, but the
+// hover-trigger ancestor is .swarm-agent-card (this row's click target),
+// not .swarm-agent-row, since that's what the click-to-toggle now lives on.
+.swarm-agent-focus {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 11px;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.swarm-agent-card:hover .swarm-agent-focus {
+    opacity: 0.75;
+}
+
+.swarm-agent-focus:hover {
+    opacity: 1;
+    color: var(--accent-color);
+    background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
 }
 
 // ── Children area ────────────────────────────────────────────────────────

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -258,25 +258,19 @@ function AgentRow({
                     [`swarm-agent-card--${node.agentStatus}`]: true,
                     "swarm-agent-card--active": focusedBlockId() === node.blockId,
                 }}
-                onClick={() => node.blockId && void focusBlock(node.blockId)}
+                onClick={() => node.blockId && model.toggleAgentCollapsed(node.blockId)}
                 title={node.agentName}
             >
                 <div class="swarm-agent-row">
                     {/* Chevron only when there's a subtree to collapse; a
                         fixed-width spacer otherwise so labels stay aligned
-                        across rows with and without children. stopPropagation:
-                        the enclosing card's click focuses the block. */}
+                        across rows with and without children. No own click
+                        handler — the enclosing card's click already toggles. */}
                     <Show
                         when={hasChildren()}
                         fallback={<span class="swarm-agent-expand-spacer" />}
                     >
-                        <i
-                            class={`fa-solid fa-${collapsed() ? "chevron-right" : "chevron-down"} swarm-agent-expand-icon`}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                model.toggleAgentCollapsed(node.blockId);
-                            }}
-                        />
+                        <i class={`fa-solid fa-${collapsed() ? "chevron-right" : "chevron-down"} swarm-agent-expand-icon`} />
                     </Show>
                     <span class="swarm-agent-icon">
                         <ProviderLogo provider={node.agentProvider ?? "agentmux"} size={16} />
@@ -289,6 +283,16 @@ function AgentRow({
                         <span class="swarm-ctx-size">{fmtCtx(node.contextTokens!)}</span>
                     </Show>
                     <AgentStatusChip status={displayStatus()} />
+                    <button
+                        class="swarm-agent-focus"
+                        title="Focus"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            if (node.blockId) void focusBlock(node.blockId);
+                        }}
+                    >
+                        <i class="fa-solid fa-arrow-up-right-from-square" />
+                    </button>
                 </div>
                 <Show when={node.activitySummary}>
                     <div classList={{ "swarm-activity-summary": true, "swarm-activity-summary--flash": summaryFlash() }}>


### PR DESCRIPTION
## Summary

Three changes to the Swarm pane's top-level agent rows:

- Rows now load **fully collapsed** (previously expanded by default).
- Clicking a row's name/card now **toggles expand/collapse** instead of focusing the agent's pane elsewhere in the UI.
- Focus moves to a new, dedicated **Focus button** at the right of the row (hover-revealed, mirrors the existing Retire button's shape on `SubagentRow`/`WorkflowDispatchRow`) — calls the same `focusBlock()` unchanged.

Minimal-diff on the model side: `_collapsedAgentIds` (absent = expanded) renamed to `_expandedAgentIds` (absent = collapsed), matching the sibling `_expandedIds` set's polarity already used by `SubagentRow`/`WorkflowDispatchRow`. Public API (`isAgentCollapsed`/`toggleAgentCollapsed`) unchanged — only the internal signal's semantics flip, so the empty default set now correctly means every agent starts collapsed.

The chevron's own click handler (redundant now that the whole card toggles) is removed; `.swarm-agent-card`'s cursor fixed from `default` to `pointer` since the click purpose is now explicit.

Spec: `docs/specs/SPEC_SWARM_ROW_COLLAPSE_VS_FOCUS_SPLIT_2026_07_20.md` (kept local, not included in this PR).

## Test plan
- [x] `npm run build` — clean, no TS errors
- [x] `npx vitest run` — 120 test files / 1816 tests passing, no regressions
- [x] `npx stylelint` on the touched file — the 12 flagged violations are all pre-existing debt outside my diff (confirmed via `git diff -U0`)
- [ ] Manual: open the Swarm pane fresh, confirm agent rows load collapsed; click a name, confirm it toggles without changing focus; click the new Focus button, confirm it jumps to/highlights the agent's pane without toggling the row

No new unit tests: the sibling `isExpanded`/`toggleExpanded` method (same class, same pattern) already has zero direct coverage today — `SwarmViewModel`'s constructor has real RPC/event-subscription side effects that make isolated instantiation impractical without a larger mocking effort, so this follows existing precedent rather than force one.

<!-- agentmux:agent_id=camper -->