### PR TITLE
feat(editor): extract shared PaneTabStrip, add + new-tab button

### DIFF
--- a/.changesets/1784575431-feat-editor-extract-shared-panetabstrip-component-add-new-ta-54he.md
+++ b/.changesets/1784575431-feat-editor-extract-shared-panetabstrip-component-add-new-ta-54he.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(editor): extract shared PaneTabStrip component, add + new-tab button

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -1,0 +1,131 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared tab-strip chrome, promoted from the editor's original
+// .editor-tab-strip/.editor-tab (editor-view.scss) so agent-pane forks and
+// terminal-pane shell tabs can reuse the identical box model, active-state
+// underline, and hover/close behavior instead of each pane type growing
+// its own copy. See PaneTabStrip.tsx and
+// docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1.
+
+.pane-tab-strip {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    height: 28px;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--secondary-bg-color, var(--block-bg-color));
+    overflow-x: hidden;
+}
+
+// Tooltip wrapper (shared Tooltip component) — carries the flex sizing the
+// tab used to own, so wrapping the tab for a hover tooltip doesn't change
+// layout.
+.pane-tab-tip {
+    flex: 1 1 140px;
+    min-width: 80px;
+    max-width: 200px;
+    display: flex;
+    align-items: stretch;
+}
+
+.pane-tab {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 0 var(--space-1) 0 var(--space-2);
+    border-right: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: default;
+    user-select: none;
+    font-size: 11px;
+    overflow: hidden;
+    transition: background 80ms ease, color 80ms ease;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.03);
+        color: var(--main-text-color);
+
+        .pane-tab-close {
+            opacity: 1;
+        }
+    }
+
+    &--active {
+        background: var(--block-bg-color);
+        color: var(--main-text-color);
+        // Subtle bottom-border that visually connects the active tab to the
+        // pane content below (the strip's own border-bottom is hidden under
+        // the active tab via the negative margin trick).
+        box-shadow: inset 0 -2px 0 0 var(--accent-color);
+    }
+
+    // "Attention" tabs (unsaved changes, needs-review, …) always show their
+    // × so the user knows a close may need confirmation.
+    &--attention {
+        .pane-tab-close {
+            opacity: 1;
+        }
+    }
+}
+
+.pane-tab-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.pane-tab-close {
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: inherit;
+    cursor: default;
+    font-size: 14px;
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 80ms ease, background 80ms ease;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.1);
+    }
+}
+
+// The far-right "+" — always the strip's last flex child (rendered after
+// the <For> in PaneTabStrip.tsx), so it stays pinned at the visual end of
+// the row regardless of tab count.
+.pane-tab-strip-add {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    border-left: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: default;
+    font-size: 15px;
+    line-height: 1;
+    transition: background 80ms ease, color 80ms ease;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.06);
+        color: var(--main-text-color);
+    }
+}

--- a/frontend/app/element/PaneTabStrip.test.tsx
+++ b/frontend/app/element/PaneTabStrip.test.tsx
@@ -1,0 +1,206 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for PaneTabStrip — the shared, pane-type-agnostic tab strip.
+ * Spec: docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PaneTabStrip } from "./PaneTabStrip";
+
+afterEach(() => cleanup());
+
+interface T {
+    id: string;
+    label: string;
+    dirty?: boolean;
+}
+
+const TABS: T[] = [
+    { id: "a", label: "alpha" },
+    { id: "b", label: "beta", dirty: true },
+];
+
+describe("PaneTabStrip", () => {
+    it("renders one tab per item via accessor props", () => {
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+            />
+        ));
+        expect(screen.getByText("alpha")).toBeInTheDocument();
+        expect(screen.getByText("beta")).toBeInTheDocument();
+    });
+
+    it("marks the active tab", () => {
+        const { container } = render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="b"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+            />
+        ));
+        const tabs = container.querySelectorAll(".pane-tab");
+        expect(tabs[0].classList.contains("pane-tab--active")).toBe(false);
+        expect(tabs[1].classList.contains("pane-tab--active")).toBe(true);
+    });
+
+    it("fires onActivate when a non-active tab is clicked, not when the active tab is re-clicked", async () => {
+        const onActivate = vi.fn();
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={onActivate}
+            />
+        ));
+        const user = userEvent.setup();
+        await user.click(screen.getByText("alpha"));
+        expect(onActivate).not.toHaveBeenCalled();
+        await user.click(screen.getByText("beta"));
+        expect(onActivate).toHaveBeenCalledWith("b");
+        expect(onActivate).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires onClose when the close button is clicked, without also activating", async () => {
+        const onActivate = vi.fn();
+        const onClose = vi.fn();
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={onActivate}
+                onClose={onClose}
+            />
+        ));
+        const user = userEvent.setup();
+        await user.click(screen.getAllByRole("button", { name: "Close tab" })[1]);
+        expect(onClose).toHaveBeenCalledWith("b");
+        expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    it("omits the close button entirely when onClose is not provided", () => {
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+            />
+        ));
+        expect(screen.queryByRole("button", { name: "Close tab" })).toBeNull();
+    });
+
+    it("marks attention tabs via getAttention", () => {
+        const { container } = render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                getAttention={(t: T) => !!t.dirty}
+                onActivate={vi.fn()}
+            />
+        ));
+        const tabs = container.querySelectorAll(".pane-tab");
+        expect(tabs[0].classList.contains("pane-tab--attention")).toBe(false);
+        expect(tabs[1].classList.contains("pane-tab--attention")).toBe(true);
+    });
+
+    it("applies extra classes from getTabClass", () => {
+        const { container } = render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                getTabClass={(t: T) => ({ "custom-preview": t.id === "a" })}
+                onActivate={vi.fn()}
+            />
+        ));
+        const tabs = container.querySelectorAll(".pane-tab");
+        expect(tabs[0].classList.contains("custom-preview")).toBe(true);
+        expect(tabs[1].classList.contains("custom-preview")).toBe(false);
+    });
+
+    it("does not render the + button when onAdd is omitted", () => {
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+            />
+        ));
+        expect(screen.queryByRole("button", { name: "New tab" })).toBeNull();
+    });
+
+    it("renders the + button pinned last and fires onAdd", async () => {
+        const onAdd = vi.fn();
+        const { container } = render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+                onAdd={onAdd}
+                addTitle="New shell tab"
+            />
+        ));
+        const addBtn = screen.getByRole("button", { name: "New shell tab" });
+        const strip = container.querySelector(".pane-tab-strip");
+        expect(strip?.lastElementChild).toBe(addBtn);
+        const user = userEvent.setup();
+        await user.click(addBtn);
+        expect(onAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders custom label content from renderLabel instead of the plain label", () => {
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                renderLabel={(t: T) => <span data-testid={`custom-${t.id}`}>{t.label.toUpperCase()}</span>}
+                onActivate={vi.fn()}
+            />
+        ));
+        expect(screen.getByTestId("custom-a")).toHaveTextContent("ALPHA");
+        expect(screen.queryByText("alpha")).toBeNull();
+    });
+
+    it("fires onTabDoubleClick with the tab item", async () => {
+        const onDbl = vi.fn();
+        render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+                onTabDoubleClick={onDbl}
+            />
+        ));
+        const user = userEvent.setup();
+        await user.dblClick(screen.getByText("beta"));
+        expect(onDbl).toHaveBeenCalledWith(TABS[1]);
+    });
+});

--- a/frontend/app/element/PaneTabStrip.tsx
+++ b/frontend/app/element/PaneTabStrip.tsx
@@ -22,7 +22,6 @@
  * Spec: docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1.
  */
 
-import clsx from "clsx";
 import { For, Show, type JSX } from "solid-js";
 import { Tooltip } from "./tooltip";
 import "./PaneTabStrip.scss";

--- a/frontend/app/element/PaneTabStrip.tsx
+++ b/frontend/app/element/PaneTabStrip.tsx
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PaneTabStrip — the shared, pane-type-agnostic tab strip. Extracted from
+ * the editor's tab strip (`frontend/app/view/editor/editor-tab-strip.tsx`,
+ * `.editor-tab-strip`/`.editor-tab`) so agent-pane forks and terminal-pane
+ * shell tabs can reuse the exact same chrome and interaction model instead
+ * of each pane type growing its own copy.
+ *
+ * Deliberately accessor-based rather than requiring tabs to conform to a
+ * fixed shape (`{id, label, ...}`) — callers pass closures that read
+ * whatever fields their own tab type actually has (e.g. the editor's
+ * `EditorTab.filePath`/`.dirty`/`.displayName`, a future fork entry's
+ * `.title`/`.blockId`). This keeps `props.tabs` as the caller's own array
+ * reference (no per-render remapping into throwaway objects), so Solid's
+ * `<For>` keeps its row-reuse identity optimization intact.
+ *
+ * Presentational only: renders a row of tabs + an optional trailing `+`,
+ * reports intent via callbacks. Owns no tab state.
+ *
+ * Spec: docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1.
+ */
+
+import clsx from "clsx";
+import { For, Show, type JSX } from "solid-js";
+import { Tooltip } from "./tooltip";
+import "./PaneTabStrip.scss";
+
+export interface PaneTabStripProps<T> {
+    tabs: T[];
+    activeId: string | null;
+
+    getId: (tab: T) => string;
+    getLabel: (tab: T) => string;
+    /** Full tooltip text; falls back to the label when omitted. */
+    getTooltip?: (tab: T) => string;
+    /** "Attention" tabs (unsaved changes, needs-review, …) always show
+     *  their close × instead of only on hover. */
+    getAttention?: (tab: T) => boolean;
+    /** Extra classes beyond active/attention (e.g. an editor preview tab's
+     *  italic label, a fork's running/idle status accent). */
+    getTabClass?: (tab: T) => Record<string, boolean>;
+
+    onActivate: (id: string) => void;
+    /** Omit entirely (not just disable) to render tabs with no close ×. */
+    onClose?: (id: string) => void;
+    onTabDoubleClick?: (tab: T) => void;
+    /** Custom label content (e.g. an inline "Save As" path input) instead
+     *  of the plain text label. */
+    renderLabel?: (tab: T) => JSX.Element;
+
+    /** The far-right `+` — omitted entirely when the pane type has no
+     *  "add tab" action. Always pinned last regardless of tab count or
+     *  strip scroll state. */
+    onAdd?: () => void;
+    addTitle?: string;
+}
+
+export function PaneTabStrip<T>(props: PaneTabStripProps<T>): JSX.Element {
+    return (
+        <div
+            class="pane-tab-strip"
+            // Double-click inside the strip should never bubble up and
+            // maximize the pane — matches the icon-toggle pattern from
+            // blockframe.tsx. True for every consumer, not just the editor.
+            onDblClick={(e) => e.stopPropagation()}
+        >
+            <For each={props.tabs}>
+                {(tab) => (
+                    <PaneTabStripItem
+                        tab={tab}
+                        active={props.activeId === props.getId(tab)}
+                        getId={props.getId}
+                        getLabel={props.getLabel}
+                        getTooltip={props.getTooltip}
+                        getAttention={props.getAttention}
+                        getTabClass={props.getTabClass}
+                        onActivate={props.onActivate}
+                        onClose={props.onClose}
+                        onDoubleClick={props.onTabDoubleClick}
+                        renderLabel={props.renderLabel}
+                    />
+                )}
+            </For>
+            <Show when={props.onAdd}>
+                <button
+                    type="button"
+                    class="pane-tab-strip-add"
+                    title={props.addTitle ?? "New tab"}
+                    aria-label={props.addTitle ?? "New tab"}
+                    onClick={() => props.onAdd!()}
+                >
+                    +
+                </button>
+            </Show>
+        </div>
+    );
+}
+
+interface PaneTabStripItemProps<T> {
+    tab: T;
+    active: boolean;
+    getId: (tab: T) => string;
+    getLabel: (tab: T) => string;
+    getTooltip?: (tab: T) => string;
+    getAttention?: (tab: T) => boolean;
+    getTabClass?: (tab: T) => Record<string, boolean>;
+    onActivate: (id: string) => void;
+    onClose?: (id: string) => void;
+    onDoubleClick?: (tab: T) => void;
+    renderLabel?: (tab: T) => JSX.Element;
+}
+
+function PaneTabStripItem<T>(props: PaneTabStripItemProps<T>): JSX.Element {
+    const id = () => props.getId(props.tab);
+    const attention = () => props.getAttention?.(props.tab) ?? false;
+
+    const onMouseDown = (e: MouseEvent) => {
+        // Middle-click → close (matches VS Code / Chrome convention).
+        if (e.button === 1) {
+            e.preventDefault();
+            props.onClose?.(id());
+        }
+    };
+
+    const onClick = (e: MouseEvent) => {
+        // Ignore middle-click here — onMouseDown already handled it.
+        if (e.button !== 0) return;
+        if (!props.active) props.onActivate(id());
+    };
+
+    const onDblClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        props.onDoubleClick?.(props.tab);
+    };
+
+    const onCloseClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        props.onClose?.(id());
+    };
+
+    // Tooltip (Portal-based) rather than native `title` — the strip has
+    // overflow:hidden, which would clip a CSS tooltip, and native `title`
+    // is slow/inconsistent in CEF. The Tooltip's wrapper div carries the
+    // flex sizing (.pane-tab-tip); the tab keeps its own mousedown/click/
+    // dblclick handlers.
+    return (
+        <Tooltip
+            placement="bottom"
+            divClassName="pane-tab-tip"
+            content={props.getTooltip?.(props.tab) ?? props.getLabel(props.tab)}
+        >
+            <div
+                class="pane-tab"
+                classList={{
+                    "pane-tab--active": props.active,
+                    "pane-tab--attention": attention(),
+                    ...(props.getTabClass?.(props.tab) ?? {}),
+                }}
+                onMouseDown={onMouseDown}
+                onClick={onClick}
+                onDblClick={onDblClick}
+            >
+                {props.renderLabel ? (
+                    props.renderLabel(props.tab)
+                ) : (
+                    <span class="pane-tab-label">{props.getLabel(props.tab)}</span>
+                )}
+                <Show when={props.onClose}>
+                    <button
+                        class="pane-tab-close"
+                        onClick={onCloseClick}
+                        title={attention() ? "Close (unsaved changes)" : "Close"}
+                        aria-label="Close tab"
+                    >
+                        {/* Always in the DOM for attention tabs (closing
+                            those may need confirmation); hover-shown
+                            otherwise, purely via CSS opacity. */}
+                        ×
+                    </button>
+                </Show>
+            </div>
+        </Tooltip>
+    );
+}

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -5,9 +5,17 @@
 // Renders above CodeMirror; one tab per open file. Click to activate,
 // × (hover-shown) to close, middle-click to close. No overflow chip yet
 // (tabs compress to min-width when crowded); chip lands in Phase 2.
+//
+// Chrome/behavior (click/middle-click/hover-close/tooltip/active-underline)
+// is the shared <PaneTabStrip> (frontend/app/element/PaneTabStrip.tsx),
+// promoted out of this file so agent-pane forks and terminal-pane shell
+// tabs can reuse the identical strip instead of each pane type growing its
+// own copy. Only the editor-specific bits (preview italics, pin-on-
+// double-click, the inline Save-As path input, the "+" → new scratch
+// buffer) stay local. See docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md.
 
-import { createSignal, For, onMount, Show, type JSX } from "solid-js";
-import { Tooltip } from "@/app/element/tooltip";
+import { createSignal, onMount, type JSX } from "solid-js";
+import { PaneTabStrip } from "@/app/element/PaneTabStrip";
 import type { EditorViewModel } from "./editor-model";
 import type { EditorTab } from "@/app/store/editor-pane-state-store";
 
@@ -19,127 +27,56 @@ interface Props {
     onSaveAsCancel?: () => void;
 }
 
+function basenameOf(tab: EditorTab): string {
+    if (tab.displayName) return tab.displayName;
+    const fp = tab.filePath;
+    const i = Math.max(fp.lastIndexOf("/"), fp.lastIndexOf("\\"));
+    return i >= 0 ? fp.slice(i + 1) : fp;
+}
+
 export function EditorTabStrip(props: Props): JSX.Element {
     const tabs = props.model.tabsAtom;
     const activeId = props.model.activeIdAtom;
 
+    const isSaveAsMode = (tab: EditorTab) =>
+        props.saveAsTabId != null && props.saveAsTabId === tab.id;
+
     return (
-        <div
-            class="editor-tab-strip"
-            // Double-click inside the strip should not maximize the pane —
-            // matches the icon-toggle pattern from blockframe.tsx.
-            onDblClick={(e) => e.stopPropagation()}
-        >
-            <For each={tabs()}>
-                {(tab) => (
-                    <Tab
-                        tab={tab}
-                        active={activeId() === tab.id}
-                        model={props.model}
-                        saveAsTabId={props.saveAsTabId}
-                        onSaveAsConfirm={props.onSaveAsConfirm}
-                        onSaveAsCancel={props.onSaveAsCancel}
-                    />
-                )}
-            </For>
-        </div>
-    );
-}
-
-interface TabProps {
-    tab: EditorTab;
-    active: boolean;
-    model: EditorViewModel;
-    saveAsTabId?: string | null;
-    onSaveAsConfirm?: (path: string) => void;
-    onSaveAsCancel?: () => void;
-}
-
-function Tab(props: TabProps): JSX.Element {
-    const basename = () => {
-        if (props.tab.displayName) return props.tab.displayName;
-        const fp = props.tab.filePath;
-        const i = Math.max(fp.lastIndexOf("/"), fp.lastIndexOf("\\"));
-        return i >= 0 ? fp.slice(i + 1) : fp;
-    };
-
-    const isSaveAsMode = () => props.saveAsTabId != null && props.saveAsTabId === props.tab.id;
-
-    const onMouseDown = (e: MouseEvent) => {
-        // Middle-click → close (matches VS Code / Chrome convention).
-        if (e.button === 1) {
-            e.preventDefault();
-            props.model.closeTab(props.tab.id);
-        }
-    };
-
-    const onClick = (e: MouseEvent) => {
-        // Ignore middle-click here — onMouseDown already handled it.
-        if (e.button !== 0) return;
-        if (!props.active) props.model.switchTab(props.tab.id);
-    };
-
-    const onDblClick = (e: MouseEvent) => {
-        e.stopPropagation();
-        // Double-clicking a preview tab pins it (matches VS Code). For an
-        // already-pinned tab, dblclick is a no-op at the strip layer
-        // (.editor-tab-strip already stops the dblclick from reaching the
-        // pane header, so the pane won't maximize either).
-        if (props.tab.isPreview) {
-            props.model.pinActiveTab();
-        }
-    };
-
-    const onCloseClick = (e: MouseEvent) => {
-        e.stopPropagation();
-        props.model.closeTab(props.tab.id);
-    };
-
-    // Full path on hover. Uses the shared Tooltip (Portal-based) rather than a
-    // native `title` — the strip + tab both have `overflow:hidden`, which would
-    // clip a CSS tooltip, and native `title` is slow/inconsistent in CEF. The
-    // Tooltip's wrapper div carries the flex sizing (.editor-tab-tip); the tab
-    // keeps its own mousedown/click/dblclick handlers.
-    return (
-        <Tooltip
-            placement="bottom"
-            divClassName="editor-tab-tip"
-            content={
-                props.tab.isPreview
-                    ? `${props.tab.filePath} (preview — double-click to pin)`
-                    : props.tab.filePath
+        <PaneTabStrip<EditorTab>
+            tabs={tabs()}
+            activeId={activeId()}
+            getId={(tab) => tab.id}
+            getLabel={basenameOf}
+            getTooltip={(tab) =>
+                tab.isPreview
+                    ? `${tab.filePath} (preview — double-click to pin)`
+                    : tab.filePath
             }
-        >
-            <div
-                class="editor-tab"
-                classList={{
-                    "editor-tab--active": props.active,
-                    "editor-tab--dirty": props.tab.dirty,
-                    "editor-tab--preview": props.tab.isPreview,
-                    "editor-tab--saveas": isSaveAsMode(),
-                }}
-                onMouseDown={onMouseDown}
-                onClick={onClick}
-                onDblClick={onDblClick}
-            >
-                <Show when={isSaveAsMode()} fallback={<span class="editor-tab-label">{basename()}</span>}>
+            getAttention={(tab) => tab.dirty}
+            getTabClass={(tab) => ({
+                "editor-tab--preview": tab.isPreview,
+                "editor-tab--saveas": isSaveAsMode(tab),
+            })}
+            onActivate={(id) => props.model.switchTab(id)}
+            onClose={(id) => props.model.closeTab(id)}
+            onTabDoubleClick={(tab) => {
+                // Double-clicking a preview tab pins it (matches VS Code).
+                // No-op for an already-pinned tab.
+                if (tab.isPreview) props.model.pinActiveTab();
+            }}
+            renderLabel={(tab) =>
+                isSaveAsMode(tab) ? (
                     <SaveAsInput
                         onConfirm={props.onSaveAsConfirm ?? (() => undefined)}
                         onCancel={props.onSaveAsCancel ?? (() => undefined)}
                     />
-                </Show>
-                <button
-                    class="editor-tab-close"
-                    onClick={onCloseClick}
-                    title={props.tab.dirty ? "Close (unsaved changes)" : "Close"}
-                    aria-label="Close tab"
-                >
-                    {/* The × always renders for dirty tabs (since closing prompts
-                        the user in a follow-up commit); hover-shown otherwise. */}
-                    ×
-                </button>
-            </div>
-        </Tooltip>
+                ) : (
+                    <span class="editor-tab-label">{basenameOf(tab)}</span>
+                )
+            }
+            onAdd={() => void props.model.openScratch()}
+            addTitle="New scratch buffer"
+        />
     );
 }
 

--- a/frontend/app/view/editor/editor-tab-strip.tsx
+++ b/frontend/app/view/editor/editor-tab-strip.tsx
@@ -71,7 +71,7 @@ export function EditorTabStrip(props: Props): JSX.Element {
                         onCancel={props.onSaveAsCancel ?? (() => undefined)}
                     />
                 ) : (
-                    <span class="editor-tab-label">{basenameOf(tab)}</span>
+                    <span class="pane-tab-label">{basenameOf(tab)}</span>
                 )
             }
             onAdd={() => void props.model.openScratch()}

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -242,110 +242,21 @@
 
 // ── Tab strip (Phase 1B of SPEC_EDITOR_TABS_2026-05-26.md) ─────────────────
 // Tabs flex 80–140px; overflow chip lands in Phase 2.
+//
+// The strip chrome itself (.pane-tab-strip/.pane-tab/.pane-tab-label/
+// .pane-tab-close/.pane-tab-tip) was promoted to the shared
+// frontend/app/element/PaneTabStrip.scss so agent-pane forks and
+// terminal-pane shell tabs can reuse it — see
+// docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1. Only
+// the editor-specific modifiers (applied via getTabClass in
+// editor-tab-strip.tsx) stay here.
 
-.editor-tab-strip {
-    flex: 0 0 auto;
-    display: flex;
-    flex-direction: row;
-    align-items: stretch;
-    height: 28px;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--secondary-bg-color, var(--block-bg-color));
-    overflow-x: hidden;
-}
-
-// Tooltip wrapper (shared Tooltip component) — carries the flex sizing the tab
-// used to own, so wrapping the tab for a hover tooltip doesn't change layout.
-.editor-tab-tip {
-    flex: 1 1 140px;
-    min-width: 80px;
-    max-width: 200px;
-    display: flex;
-    align-items: stretch;
-}
-
-.editor-tab {
-    flex: 1 1 auto;
-    min-width: 0;
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: 0 var(--space-1) 0 var(--space-2);
-    border-right: 1px solid var(--border-color);
-    background: transparent;
-    color: var(--secondary-text-color);
-    cursor: default;
-    user-select: none;
-    font-size: 11px;
-    overflow: hidden;
-    transition: background 80ms ease, color 80ms ease;
-
-    &:hover {
-        background: rgba(255, 255, 255, 0.03);
-        color: var(--main-text-color);
-
-        .editor-tab-close {
-            opacity: 1;
-        }
-    }
-
-    &--active {
-        background: var(--block-bg-color);
-        color: var(--main-text-color);
-        // Subtle bottom-border that visually connects the active tab to the
-        // editor area below (the strip's own border-bottom is hidden under
-        // the active tab via the negative margin trick).
-        box-shadow: inset 0 -2px 0 0 var(--accent-color);
-    }
-
-    &--dirty {
-        // Dirty tabs always show their × so the user knows close requires
-        // confirmation (modal lands in a follow-up commit).
-        .editor-tab-close {
-            opacity: 1;
-        }
-    }
-
-    // Preview tab — italic title (matches VS Code). At most one preview
-    // tab per pane; tree single-click replaces its file in place, tree
-    // double-click (or editing) pins it. Visual cue tells the user this
-    // tab is "transient".
-    &--preview {
-        .editor-tab-label {
-            font-style: italic;
-        }
-    }
-}
-
-.editor-tab-label {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.editor-tab-close {
-    flex: 0 0 16px;
-    width: 16px;
-    height: 16px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    border: none;
-    border-radius: 3px;
-    background: transparent;
-    color: inherit;
-    cursor: default;
-    font-size: 14px;
-    line-height: 1;
-    opacity: 0;
-    transition: opacity 80ms ease, background 80ms ease;
-
-    &:hover {
-        background: rgba(255, 255, 255, 0.1);
-    }
+// Preview tab — italic title (matches VS Code). At most one preview tab
+// per pane; tree single-click replaces its file in place, tree
+// double-click (or editing) pins it. Visual cue tells the user this tab
+// is "transient".
+.pane-tab.editor-tab--preview .pane-tab-label {
+    font-style: italic;
 }
 
 // Inline save-as path input — replaces the tab label when Ctrl+S / Ctrl+Shift+S
@@ -368,7 +279,7 @@
     }
 }
 
-.editor-tab--saveas {
+.pane-tab.editor-tab--saveas {
     // Expand slightly to accommodate the path input without the close button
     // being too cramped.
     min-width: 180px;


### PR DESCRIPTION
## Summary

Phase 1 of `docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md` — the DRY groundwork the rest of that spec (agent-pane forks, terminal-pane shell tabs) builds on.

- Extracts the editor's tab-strip chrome and interaction model (click-to-activate, middle-click-close, hover-reveal ×, `Tooltip` on hover, active-state accent underline) out of `editor-tab-strip.tsx` into a new generic, pane-type-agnostic `frontend/app/element/PaneTabStrip.tsx`, so agent-pane forks and terminal-pane shell tabs (later phases) can reuse the identical strip instead of each pane type growing its own copy.
- Deliberately accessor-based (`getId`/`getLabel`/`getTooltip`/`getAttention`/`getTabClass` closures) rather than requiring tabs to conform to a fixed shape — callers pass closures reading whatever fields their own tab type actually has. Lets the editor pass its `EditorTab[]` array straight through with no per-render remapping into throwaway objects, keeping Solid's `<For>` row-reuse identity intact.
- The editor's own strip now consumes the shared component; all editor-specific behavior (preview-tab italics, pin-on-double-click, the inline Save-As path input) is preserved via `renderLabel`/`getTabClass`/`onTabDoubleClick` escape hatches — pixel-identical behavior for existing tabs.
- New: a persistent `+` pinned to the strip's far right, wired to the editor's existing `openScratch()` — the editor gains the explicit "add tab" affordance it lacked, as a side effect of the shared component gaining one (needed for the agent/terminal phases, where `+` is the *primary* way to add a tab).

This PR only touches the editor pane — no other consumer exists yet (that's the next phases).

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run` — 1827 passed, 3 pre-existing skips (11 new `PaneTabStrip` tests)
- [x] `npx stylelint frontend/app/element/PaneTabStrip.scss frontend/app/view/editor/editor-view.scss` — clean on touched lines (pre-existing hex-color/`!important`/z-index lint debt elsewhere in `editor-view.scss`, unrelated to this change)
- [ ] Manual: open the editor pane with a file, confirm tabs look/behave identically to before, click the new `+` and confirm it opens a scratch buffer

<!-- agentmux:agent_id=agent3 -->