### PR TITLE
feat(swarm): show active background shells as a per-agent row bucket

### DIFF
--- a/.changesets/1784577196-feat-swarm-show-active-background-shells-as-a-per-agent-row--nbfl.md
+++ b/.changesets/1784577196-feat-swarm-show-active-background-shells-as-a-per-agent-row--nbfl.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): show active background shells as a per-agent row bucket

--- a/agentmux-srv/src/backend/shell_node.rs
+++ b/agentmux-srv/src/backend/shell_node.rs
@@ -16,6 +16,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use parking_lot::Mutex;
+use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::{mpsc, oneshot};
 
@@ -31,10 +32,37 @@ fn now_ms() -> u64 {
 
 /// Live status of a running (or recently exited) shell. Updated by
 /// `ShellNodeRunner` as output arrives and on exit.
+///
+/// `block_id`/`cmd`/`title`/`started_at` are populated once at spawn (see
+/// `ShellNodeRunner::run`) and never change — kept here (rather than a
+/// separate lookup) so `list_active` (SPEC_SWARM_LONG_RUNNING_PROCESS_
+/// ROWS_2026_07_20) can answer "which shells belong to block X" from the
+/// same map `get_status`/`ShellStatus` already query, with no new registry
+/// or second source of truth.
 #[derive(Clone, Default)]
 pub struct ShellStatusInfo {
     pub running: bool,
     pub exit_code: Option<i32>,
+    pub line_count: u64,
+    pub block_id: String,
+    pub cmd: String,
+    pub title: String,
+    pub started_at: u64,
+}
+
+/// Snapshot of one currently-running shell for the Swarm pane's per-agent
+/// long-running-process rows. See `ShellSessionRegistry::list_active`.
+/// Carries `block_id` (unfiltered list — same shape as `subagent.ListActive`/
+/// `ActiveSubagent.parent_block_id`) so the Swarm pane's `buildTree()` groups
+/// by block client-side in one pass, instead of one RPC call per tracked
+/// agent block.
+#[derive(Clone, Serialize)]
+pub struct ShellSummary {
+    pub shell_id: String,
+    pub block_id: String,
+    pub cmd: String,
+    pub title: String,
+    pub started_at: u64,
     pub line_count: u64,
 }
 
@@ -204,6 +232,36 @@ impl ShellSessionRegistry {
             .map(|arc| arc.lock().clone())
             .unwrap_or_default()
     }
+
+    /// List every currently-RUNNING shell across all blocks — the Swarm
+    /// pane's data source for its per-agent long-running-process rows
+    /// (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20). Unfiltered, like
+    /// `subagent.ListActive`/`ListDispatches` — the Swarm pane fetches once
+    /// and groups by `block_id` client-side in `buildTree()`, rather than
+    /// one RPC per tracked agent block. Exited shells are intentionally
+    /// excluded: Phase 1's scope is "what's happening now," not a shell
+    /// history view.
+    pub fn list_active(&self) -> Vec<ShellSummary> {
+        self.status_map
+            .lock()
+            .iter()
+            .filter_map(|(shell_id, arc)| {
+                let s = arc.lock();
+                if s.running {
+                    Some(ShellSummary {
+                        shell_id: shell_id.clone(),
+                        block_id: s.block_id.clone(),
+                        cmd: s.cmd.clone(),
+                        title: s.title.clone(),
+                        started_at: s.started_at,
+                        line_count: s.line_count,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 /// Kill the entire process tree rooted at `pid`. `Child::kill` / `kill_on_drop`
@@ -236,6 +294,10 @@ pub struct ShellNodeRunner {
     pub shell_id: String,
     pub block_id: String,
     pub cmd: String,
+    /// Caller-supplied display title, defaulting to `cmd` — mirrors
+    /// `handle_shell_create`'s own `title` local, threaded through so
+    /// `ShellStatusInfo`/`list_active` can show it without a second lookup.
+    pub title: String,
     pub cwd: Option<String>,
     pub extra_env: HashMap<String, String>,
     pub broker: Arc<Broker>,
@@ -347,7 +409,15 @@ impl ShellNodeRunner {
             None
         };
 
-        let status_arc = Arc::new(Mutex::new(ShellStatusInfo { running: true, exit_code: None, line_count: 0 }));
+        let status_arc = Arc::new(Mutex::new(ShellStatusInfo {
+            running: true,
+            exit_code: None,
+            line_count: 0,
+            block_id: block_id.clone(),
+            cmd: self.cmd.clone(),
+            title: self.title.clone(),
+            started_at: now_ms(),
+        }));
         let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
         let evicted = self.registry.register_full(
             shell_id.clone(),
@@ -519,6 +589,7 @@ mod tests {
             running,
             exit_code: if running { None } else { Some(0) },
             line_count: 1,
+            ..Default::default()
         }));
         // _rx is intentionally dropped; we only exercise the status-map cap.
         reg.register_full(id.to_string(), tx, None, status);
@@ -550,6 +621,37 @@ mod tests {
         // Running shells exceed the exited cap but none are evicted.
         assert_eq!(reg.status_map.lock().len(), total);
         assert!(reg.get_status("r0").running);
+    }
+
+    fn register_running_for_block(reg: &ShellSessionRegistry, id: &str, block_id: &str, cmd: &str) {
+        let (tx, _rx) = oneshot::channel::<()>();
+        let status = Arc::new(Mutex::new(ShellStatusInfo {
+            running: true,
+            block_id: block_id.to_string(),
+            cmd: cmd.to_string(),
+            title: cmd.to_string(),
+            started_at: 1_000,
+            ..Default::default()
+        }));
+        reg.register_full(id.to_string(), tx, None, status);
+    }
+
+    #[tokio::test]
+    async fn list_active_returns_only_running_shells_across_all_blocks() {
+        let reg = ShellSessionRegistry::new();
+        register_running_for_block(&reg, "s1", "block-a", "npm run dev");
+        register_running_for_block(&reg, "s2", "block-b", "task dev");
+        register_exited(&reg, "s3", false); // exited — must not appear
+
+        let mut active = reg.list_active();
+        active.sort_by(|a, b| a.shell_id.cmp(&b.shell_id));
+
+        assert_eq!(active.len(), 2);
+        assert_eq!(active[0].shell_id, "s1");
+        assert_eq!(active[0].block_id, "block-a");
+        assert_eq!(active[0].cmd, "npm run dev");
+        assert_eq!(active[1].shell_id, "s2");
+        assert_eq!(active[1].block_id, "block-b");
     }
 }
 

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -645,6 +645,7 @@ async fn handle_shell_create(
         shell_id: shell_id.clone(),
         block_id: req.agent_block_id,
         cmd: req.cmd,
+        title,
         cwd: effective_cwd,
         extra_env: effective_env,
         broker: Arc::clone(&state.broker),

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -43,6 +43,13 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
             WebReturnType::success_empty()
         }
 
+        // ---- ShellService (Swarm-pane long-running-process rows,
+        // SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20) ----
+        ("shell", "ListActive") => {
+            let shells = state.shell_sessions.list_active();
+            WebReturnType::success(serde_json::to_value(&shells).unwrap_or_default())
+        }
+
         // ---- SubagentService ----
         ("subagent", "ListActive") => {
             let subagents = state.subagent_watcher.list_active();

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import {
     buildDispatchBuckets,
+    buildShellRows,
     filterRetired,
     groupCacheKey,
     mergeDispatchActivityEntries,
@@ -13,11 +14,22 @@ import {
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     subagentRowKey,
+    type ActiveShell,
     type ActiveSubagent,
     type AgentDispatch,
     type DispatchActivityEntry,
     type WorkflowDispatch,
 } from "./swarm-model";
+
+function mkShell(overrides: Partial<ActiveShell> & Pick<ActiveShell, "shell_id" | "block_id">): ActiveShell {
+    return {
+        cmd: "npm run dev",
+        title: "npm run dev",
+        started_at: 0,
+        line_count: 0,
+        ...overrides,
+    };
+}
 
 function mkEntry(opts: { agentId?: string; timestamp: number; content?: string }): DispatchActivityEntry {
     const agentId = opts.agentId ?? "a1";
@@ -500,5 +512,38 @@ describe("subagentDisplayLabel", () => {
         expect(subagentDisplayLabel({ display_name: null, slug: "solo-run", agent_id: "zzzz999yyyy" })).toBe(
             "solo-run · zzzz999"
         );
+    });
+});
+
+describe("buildShellRows", () => {
+    it("keeps only shells matching the given block_id", () => {
+        const shells = [
+            mkShell({ shell_id: "s1", block_id: "block-a" }),
+            mkShell({ shell_id: "s2", block_id: "block-b" }),
+            mkShell({ shell_id: "s3", block_id: "block-a" }),
+        ];
+        const rows = buildShellRows(shells, "block-a");
+        expect(new Set(rows.map((r) => r.shell_id))).toEqual(new Set(["s1", "s3"]));
+        expect(rows.every((r) => r.block_id === "block-a")).toBe(true);
+    });
+
+    it("sorts newest-first by started_at", () => {
+        const shells = [
+            mkShell({ shell_id: "old", block_id: "block-a", started_at: 100 }),
+            mkShell({ shell_id: "new", block_id: "block-a", started_at: 300 }),
+            mkShell({ shell_id: "mid", block_id: "block-a", started_at: 200 }),
+        ];
+        const rows = buildShellRows(shells, "block-a");
+        expect(rows.map((r) => r.shell_id)).toEqual(["new", "mid", "old"]);
+    });
+
+    it("returns an empty array when no shells match", () => {
+        const shells = [mkShell({ shell_id: "s1", block_id: "block-a" })];
+        expect(buildShellRows(shells, "block-z")).toEqual([]);
+    });
+
+    it("returns an empty array for a null blockId", () => {
+        const shells = [mkShell({ shell_id: "s1", block_id: "block-a" })];
+        expect(buildShellRows(shells, null)).toEqual([]);
     });
 });

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -52,6 +52,24 @@ export interface ActiveSubagent {
 }
 
 /**
+ * Mirrors the backend's `ShellSummary` (`shell_node.rs`) — one currently-
+ * RUNNING background shell the agent kicked off via the Shell MCP tool.
+ * Fetched via `shell.ListActive` (unfiltered, like `ActiveSubagent` above);
+ * `buildTree()` groups by `block_id` client-side. Exited shells never
+ * appear here — Phase 1's scope is "what's happening now," not history.
+ * See SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20.
+ */
+export interface ActiveShell {
+    shell_id: string;
+    block_id: string;
+    cmd: string;
+    /** Caller-supplied display title, defaulting to `cmd` server-side. */
+    title: string;
+    started_at: number;
+    line_count: number;
+}
+
+/**
  * Mirrors the backend's `AgentDispatch` (one per Agent-tool-or-Workflow-tool
  * call). Only Workflow-kind dispatches get their own tree row
  * (`WorkflowDispatch`, below) — a Solo-kind dispatch's one member renders as
@@ -143,6 +161,10 @@ export interface AgentTreeNode {
      *  member count (SPEC §7, unchanged from the pre-existing design).
      *  Sorted by most recent activity. */
     workflowRows: WorkflowDispatch[];
+    /** One row per currently-RUNNING background shell this agent started
+     *  (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 1). Sorted
+     *  newest-first, same convention as the other two buckets. */
+    shellRows: ActiveShell[];
 }
 
 /**
@@ -190,6 +212,19 @@ export function buildDispatchBuckets(
     );
 
     return { agentToolRows, workflowRows };
+}
+
+/**
+ * Build one block's Shell bucket rows (SPEC_SWARM_LONG_RUNNING_PROCESS_
+ * ROWS_2026_07_20 Phase 1) — every currently-running shell whose
+ * `block_id` matches, newest-first. Extracted as a pure function (matching
+ * `buildDispatchBuckets` above) purely so it's directly unit-testable
+ * without instantiating `SwarmViewModel`.
+ */
+export function buildShellRows(shells: ActiveShell[], blockId: string | null): ActiveShell[] {
+    return shells
+        .filter((s) => s.block_id === blockId)
+        .sort((a, b) => b.started_at - a.started_at);
 }
 
 /**
@@ -566,6 +601,13 @@ export class SwarmViewModel implements ViewModel {
     subagentsAtom: Accessor<ActiveSubagent[]> = this._subagents[0];
     private setSubagents: Setter<ActiveSubagent[]> = this._subagents[1];
 
+    // Active background shells (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20
+    // Phase 1) — fetched separately via shell.ListActive; buildTree() groups
+    // by block_id the same way it does for subagents/dispatches above.
+    private _shells = createSignal<ActiveShell[]>([]);
+    shellsAtom: Accessor<ActiveShell[]> = this._shells[0];
+    private setShells: Setter<ActiveShell[]> = this._shells[1];
+
     // AgentDispatches (SPEC §5) — one per Agent-tool-or-Workflow-tool call.
     // Fetched separately from subagentsAtom via subagent.ListDispatches;
     // buildTree() cross-references the two by dispatch_id/parent_block_id.
@@ -663,6 +705,12 @@ export class SwarmViewModel implements ViewModel {
     private loadSubagentsDebounceTimer: ReturnType<typeof setTimeout> | undefined;
     private static readonly LOAD_SUBAGENTS_DEBOUNCE_MS = 150;
 
+    // Same debounce shape as loadSubagentsDebounceTimer above, kept separate
+    // since shell_node_create/shell_chunk bursts are unrelated to subagent/
+    // dispatch events — no reason to couple their reload timing.
+    private loadShellsDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+    private static readonly LOAD_SHELLS_DEBOUNCE_MS = 150;
+
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
@@ -716,6 +764,26 @@ export class SwarmViewModel implements ViewModel {
             handler: () => this.scheduleLoadSubagents(),
         });
         if (unsubBlockPruned) this.unsubs.push(unsubBlockPruned);
+
+        // Shell bucket (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 1).
+        // shell_node_create — a new shell appeared, reload the active list.
+        const unsubShellCreate = waveEventSubscribe({
+            eventType: "shell_node_create",
+            handler: () => this.scheduleLoadShells(),
+        });
+        if (unsubShellCreate) this.unsubs.push(unsubShellCreate);
+
+        // shell_chunk fires per output line too — only reload on the
+        // terminal "exit" op, not every line of stdout/stderr (that would
+        // re-fetch the whole active-shells list on every chunk).
+        const unsubShellChunk = waveEventSubscribe({
+            eventType: "shell_chunk",
+            handler: (event: WaveEvent) => {
+                const data = event?.data as any;
+                if (data?.op === "exit") this.scheduleLoadShells();
+            },
+        });
+        if (unsubShellChunk) this.unsubs.push(unsubShellChunk);
 
         // Patch display_name in place (not a full loadSubagents() reload) so
         // every client watching this session picks up a generated name —
@@ -772,7 +840,12 @@ export class SwarmViewModel implements ViewModel {
     loadAll = async (): Promise<void> => {
         this.setLoading(true);
         try {
-            await Promise.all([this.loadTrackedBlocks(), this.loadSubagents(), this.loadDispatches()]);
+            await Promise.all([
+                this.loadTrackedBlocks(),
+                this.loadSubagents(),
+                this.loadDispatches(),
+                this.loadShells(),
+            ]);
             this.pruneRetiredRowKeys();
         } finally {
             this.setLoading(false);
@@ -809,6 +882,15 @@ export class SwarmViewModel implements ViewModel {
         }
     };
 
+    loadShells = async (): Promise<void> => {
+        try {
+            const result = await callBackendService("shell", "ListActive", []);
+            this.setShells((result as ActiveShell[]) ?? []);
+        } catch {
+            // silently ignore
+        }
+    };
+
     // Coalesces a burst of subagent:spawned/subagent:completed/dispatch:
     // updated events (e.g. a backfill scan on pane reopen, or a large
     // workflow dispatch spawning many members at once) into a single
@@ -822,6 +904,18 @@ export class SwarmViewModel implements ViewModel {
             this.loadSubagentsDebounceTimer = undefined;
             void Promise.all([this.loadSubagents(), this.loadDispatches()]).then(() => this.pruneRetiredRowKeys());
         }, SwarmViewModel.LOAD_SUBAGENTS_DEBOUNCE_MS);
+    };
+
+    // Coalesces a burst of shell_node_create/shell_chunk(exit) events (e.g.
+    // several shells starting/exiting close together) into a single reload.
+    scheduleLoadShells = (): void => {
+        if (this.loadShellsDebounceTimer !== undefined) {
+            clearTimeout(this.loadShellsDebounceTimer);
+        }
+        this.loadShellsDebounceTimer = setTimeout(() => {
+            this.loadShellsDebounceTimer = undefined;
+            void this.loadShells();
+        }, SwarmViewModel.LOAD_SHELLS_DEBOUNCE_MS);
     };
 
     /** Drop `_retiredRowKeys` entries for rows no longer present in live
@@ -991,6 +1085,7 @@ export class SwarmViewModel implements ViewModel {
         const blockIds = this.trackedBlockIdsAtom();
         const subagents = this.subagentsAtom();
         const dispatches = this.dispatchesAtom();
+        const shells = this.shellsAtom();
         const statuses = this.agentStatusesAtom();
 
         // Include parent block IDs from subagents as fallback for agent panes
@@ -1029,7 +1124,18 @@ export class SwarmViewModel implements ViewModel {
             // mechanism (SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_RETIRE_2026_07_20 §6).
             const agentToolRows = filterRetired(rawAgentToolRows, retired, (s) => subagentRowKey(s.agent_id), (s) => s.last_event_at);
             const visibleWorkflowRows = filterRetired(workflowRows, retired, (w) => w.dispatchId, (w) => w.lastEventAt);
-            return { blockId, agentName, agentProvider, activitySummary, contextTokens, agentStatus, agentToolRows, workflowRows: visibleWorkflowRows };
+            const shellRows = buildShellRows(shells, blockId);
+            return {
+                blockId,
+                agentName,
+                agentProvider,
+                activitySummary,
+                contextTokens,
+                agentStatus,
+                agentToolRows,
+                workflowRows: visibleWorkflowRows,
+                shellRows,
+            };
         });
 
         // Prune once per full pass (not per-block — see stabilizeGroupIdentity).
@@ -1045,6 +1151,10 @@ export class SwarmViewModel implements ViewModel {
         if (this.loadSubagentsDebounceTimer !== undefined) {
             clearTimeout(this.loadSubagentsDebounceTimer);
             this.loadSubagentsDebounceTimer = undefined;
+        }
+        if (this.loadShellsDebounceTimer !== undefined) {
+            clearTimeout(this.loadShellsDebounceTimer);
+            this.loadShellsDebounceTimer = undefined;
         }
         for (const detail of this.dispatchDetailCache.values()) detail.dispose();
         this.dispatchDetailCache.clear();

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -215,6 +215,12 @@
     &--workflow .swarm-bucket-label {
         color: var(--warning-color, #f5a623);
     }
+    // Shell (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 1) — a
+    // third, distinct hue from the two above so all three read apart at a
+    // glance; --success-color is otherwise unused elsewhere in this file.
+    &--shell .swarm-bucket-label {
+        color: var(--success-color);
+    }
 }
 
 .swarm-bucket-header {
@@ -432,6 +438,74 @@
 .swarm-subagent-retire:hover {
     opacity: 1;
     color: var(--error-color, #ff6b6b);
+    background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
+}
+
+// ── Shell row (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 1) —
+// flat, no expand (Phase 1 doesn't surface live shell output here). Same
+// 30px-row / hover-reveal-stop shape as .swarm-subagent-row/-retire above,
+// deliberately not click-to-expand — the whole row has no toggle target,
+// so cursor stays default and there's no :hover background wash to imply
+// one exists. ────────────────────────────────────────────────────────────
+
+.swarm-shell-row {
+    display: flex;
+    align-items: center;
+    height: 30px;
+    padding: 0 6px 0 30px;
+    gap: 8px;
+    user-select: none;
+}
+
+.swarm-shell-title {
+    flex: 1;
+    font-size: 12px;
+    font-family: var(--monospace-font, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--main-text-color);
+}
+
+.swarm-shell-elapsed {
+    flex-shrink: 0;
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    opacity: 0.6;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.swarm-shell-stop {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.swarm-shell-row:hover .swarm-shell-stop {
+    opacity: 0.75;
+}
+
+.swarm-shell-stop:hover {
+    opacity: 1;
+    // --error-color is unconditionally defined in theme.scss — no hex
+    // fallback needed (unlike the pre-existing .swarm-subagent-retire:hover
+    // this was modeled on, which carries one; not copied here to avoid
+    // adding a new color-no-hex lint violation for a fallback that never
+    // actually applies).
+    color: var(--error-color);
     background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
 }
 

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
 import { subagentDisplayLabel, subagentRowKey } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
@@ -13,6 +13,7 @@ import { getLayoutModelForTabById } from "@/layout/lib/layoutModelHooks";
 import { getBlockTurnPhase } from "@/app/store/agentActivity";
 import { WorkspaceService } from "@/app/store/services";
 import { recordTurn } from "@/app/store/token-usage";
+import { useTick } from "@/app/hook/useTick";
 import "./swarm-view.scss";
 
 // Navigate to the pane for a given block ID, switching tabs and windows as needed.
@@ -233,7 +234,9 @@ function AgentRow({
         phaseToDisplayStatus(node.blockId, node.agentStatus)
     );
     const collapsed = createMemo(() => model.isAgentCollapsed(node.blockId));
-    const totalRows = createMemo(() => node.agentToolRows.length + node.workflowRows.length);
+    const totalRows = createMemo(
+        () => node.agentToolRows.length + node.workflowRows.length + node.shellRows.length
+    );
     const hasChildren = createMemo(() => totalRows() > 0);
 
     const [summaryFlash, setSummaryFlash] = createSignal(false);
@@ -304,6 +307,7 @@ function AgentRow({
                 <div class="swarm-children">
                     <AgentToolBucket rows={node.agentToolRows} model={model} parentAgentStatus={node.agentStatus} />
                     <WorkflowBucket rows={node.workflowRows} model={model} />
+                    <ShellBucket rows={node.shellRows} />
                 </div>
             </Show>
         </div>
@@ -350,6 +354,60 @@ function WorkflowBucket({ rows, model }: { rows: WorkflowDispatch[]; model: Swar
                 <For each={rows}>{(group) => <WorkflowDispatchRow group={group} model={model} />}</For>
             </div>
         </Show>
+    );
+}
+
+// Shell bucket — Phase 1 of SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20.
+// Appended after Agent Tool/Workflow (spec's resolved open question 1):
+// those two are semantically-named, agent-level units of work; shells are
+// lower-level/mechanical (raw commands), so most-abstract-first reads best.
+// No expand-to-feed like the other two buckets — Phase 1 is deliberately
+// flat (title + elapsed + stop), matching the "good starting point" scope;
+// showing live shell output here is a larger follow-up, not attempted now.
+function ShellBucket({ rows }: { rows: ActiveShell[] }): JSX.Element {
+    return (
+        <Show when={rows.length > 0}>
+            <div class="swarm-bucket swarm-bucket--shell">
+                <div class="swarm-bucket-header">
+                    <span class="swarm-bucket-label">Shell</span>
+                    <span class="swarm-bucket-count">{rows.length}</span>
+                </div>
+                <For each={rows}>{(shell) => <ShellRow shell={shell} />}</For>
+            </div>
+        </Show>
+    );
+}
+
+function formatElapsed(ms: number): string {
+    const totalSec = Math.max(0, Math.floor(ms / 1000));
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function ShellRow({ shell }: { shell: ActiveShell }): JSX.Element {
+    const tick = useTick(1000);
+    const elapsed = createMemo(() => {
+        tick();
+        return formatElapsed(Date.now() - shell.started_at);
+    });
+
+    const handleStop = (e: MouseEvent) => {
+        e.stopPropagation();
+        RpcApi.ShellStopCommand(TabRpcClient, { shell_id: shell.shell_id }).catch(() => {
+            // best-effort — the exit event (shell_chunk op:"exit") reconciles
+            // the active list via scheduleLoadShells either way
+        });
+    };
+
+    return (
+        <div class="swarm-shell-row" title={shell.cmd}>
+            <span class="swarm-shell-title">{shell.title}</span>
+            <span class="swarm-shell-elapsed">{elapsed()}</span>
+            <button class="swarm-shell-stop" title="Stop" onClick={handleStop}>
+                <i class="fa-solid fa-stop" />
+            </button>
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of `docs/specs/SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20.md` (kept local) — the Swarm pane now shows every currently-running background shell an agent kicked off (via the Shell MCP tool) as a third bucket alongside the existing Agent Tool and Workflow buckets. Flat rows (title + elapsed + stop button), hover-revealed stop mirroring the existing Retire button's shape/position.

**Backend**
- `ShellStatusInfo` (`shell_node.rs`) gains `block_id`/`cmd`/`title`/`started_at`, populated once at spawn — no new registry or second source of truth, reuses the same `status_map` `ShellStatus`/`get_status` already queries.
- `ShellSessionRegistry::list_active()` — every running shell across all blocks, unfiltered (matches `subagent.ListActive`/`ListDispatches`'s shape); the Swarm pane groups by `block_id` client-side in one pass rather than one RPC per tracked agent.
- New `shell.ListActive` RPC.
- 2 new backend unit tests.

**Frontend**
- `ActiveShell` type + `shellsAtom`/`loadShells`/`scheduleLoadShells` on `SwarmViewModel`, wired into `loadAll()` and `shell_node_create`/`shell_chunk(op:"exit")` events — mirrors the existing subagent/dispatch load+debounce pattern exactly. Per-line data chunks are filtered out (only the terminal exit op triggers a reload) to avoid re-fetching on every line of shell output.
- `buildShellRows()` pure function (mirrors `buildDispatchBuckets`) + `AgentTreeNode.shellRows`, wired into `buildTree()`.
- `ShellBucket`/`ShellRow` components, appended after the two existing buckets (spec's resolved ordering question: most-abstract-first). Stop button calls the existing `RpcApi.ShellStopCommand` — no new backend endpoint needed for that.
- 4 new frontend unit tests.

**Scope note:** exited shells are intentionally excluded — Phase 1 is "what's happening now," not a history view. Cron, ScheduleWakeup, and Loop are explicitly out of scope for this PR per the spec's phased plan (Cron needs its own backend work; ScheduleWakeup doesn't exist yet; Loop's state lives in a different process entirely and needs an architecture change).

## Test plan
- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1552/1552 passing (including 2 new)
- [x] `npm run build` — clean, no TS errors
- [x] `npx vitest run` — 120 test files / 1831 tests passing (including 4 new)
- [x] `npx stylelint` on the touched scss — 0 new violations (confirmed via `git diff -U0`; the file's pre-existing debt is unchanged)
- [ ] Manual: kick off a background shell from an agent, confirm it appears in the Swarm pane's Shell bucket with a live elapsed timer; click Stop, confirm it disappears from the bucket

<!-- agentmux:agent_id=camper -->