### PR TITLE
chore: release v0.54.2

### DIFF
--- a/.changesets/1784562834-feat-scripts-resolve-per-agent-github-pat-via-gh-agent-sh-in-t69k.md
+++ b/.changesets/1784562834-feat-scripts-resolve-per-agent-github-pat-via-gh-agent-sh-in-t69k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(scripts): resolve per-agent GitHub PAT via gh-agent.sh instead of shared gh session

--- a/.changesets/1784571888-docs-add-armory-architecture-reference-doc-fix-stale-identit-qhja.md
+++ b/.changesets/1784571888-docs-add-armory-architecture-reference-doc-fix-stale-identit-qhja.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: add Armory architecture reference doc, fix stale Identities tab note

--- a/.changesets/1784572059-fix-agent-session-context-assigned-accounts-reads-db-agent-i-6qgg.md
+++ b/.changesets/1784572059-fix-agent-session-context-assigned-accounts-reads-db-agent-i-6qgg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): Session Context assigned-accounts reads db_agent_identity_links, not the stale AgentDefinition.accounts blob

--- a/.changesets/1784572507-feat-agent-word-wrapped-command-tooltip-on-tool-call-hover-g7w4.md
+++ b/.changesets/1784572507-feat-agent-word-wrapped-command-tooltip-on-tool-call-hover-g7w4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): word-wrapped command tooltip on tool-call hover

--- a/.changesets/1784572698-docs-correct-memory-id-consumption-claim-and-identityaccount-wmm8.md
+++ b/.changesets/1784572698-docs-correct-memory-id-consumption-claim-and-identityaccount-wmm8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: correct memory_id consumption claim and IdentityAccount field list in Armory architecture doc

--- a/.changesets/1784573047-fix-agent-only-refresh-haiku-ghost-text-summaries-on-genuine-7wh6.md
+++ b/.changesets/1784573047-fix-agent-only-refresh-haiku-ghost-text-summaries-on-genuine-7wh6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): only refresh Haiku ghost-text summaries on genuine turn completion

--- a/.changesets/1784573075-fix-swarm-separate-row-collapse-toggle-from-focus-default-co-k3xj.md
+++ b/.changesets/1784573075-fix-swarm-separate-row-collapse-toggle-from-focus-default-co-k3xj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): separate row collapse-toggle from focus, default collapsed

--- a/.changesets/1784573850-feat-lan-show-qr-code-for-mobile-pairing-when-lan-discovery--b4aa.md
+++ b/.changesets/1784573850-feat-lan-show-qr-code-for-mobile-pairing-when-lan-discovery--b4aa.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(lan): show QR code for mobile pairing when LAN discovery is enabled

--- a/.changesets/1784574706-feat-launcher-macos-splash-add-an-other-row-closing-the-tota-1my2.md
+++ b/.changesets/1784574706-feat-launcher-macos-splash-add-an-other-row-closing-the-tota-1my2.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(launcher): macOS splash — add an "other" row closing the total-vs-items gap

--- a/.changesets/1784575431-feat-editor-extract-shared-panetabstrip-component-add-new-ta-54he.md
+++ b/.changesets/1784575431-feat-editor-extract-shared-panetabstrip-component-add-new-ta-54he.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(editor): extract shared PaneTabStrip component, add + new-tab button

--- a/.changesets/1784577196-feat-swarm-show-active-background-shells-as-a-per-agent-row--nbfl.md
+++ b/.changesets/1784577196-feat-swarm-show-active-background-shells-as-a-per-agent-row--nbfl.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): show active background shells as a per-agent row bucket

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.1"
+version = "0.54.2"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.54.2 — 2026-07-20
+
+- feat(scripts): resolve per-agent GitHub PAT via gh-agent.sh instead of shared gh session
+- docs: add Armory architecture reference doc, fix stale Identities tab note
+- fix(agent): Session Context assigned-accounts reads db_agent_identity_links, not the stale AgentDefinition.accounts blob
+- feat(agent): word-wrapped command tooltip on tool-call hover
+- docs: correct memory_id consumption claim and IdentityAccount field list in Armory architecture doc
+- fix(agent): only refresh Haiku ghost-text summaries on genuine turn completion
+- fix(swarm): separate row collapse-toggle from focus, default collapsed
+- feat(lan): show QR code for mobile pairing when LAN discovery is enabled
+- feat(launcher): macOS splash — add an "other" row closing the total-vs-items gap
+- feat(editor): extract shared PaneTabStrip component, add + new-tab button
+- feat(swarm): show active background shells as a per-agent row bucket
+
+
 ## 0.54.1 — 2026-07-20
 
 - fix(agent): Login Again always forces fresh OAuth, opens the system browser (which already has the user's session) instead of an in-app pane

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR — consumes all 11 pending changesets, forced to a **patch** bump (`--as patch`) overriding the computed `minor` (several `feat:`-tagged changesets are queued; shipping them under a patch version per explicit instruction).

**0.54.1 → 0.54.2**

Changes shipping in this release:
- feat(scripts): resolve per-agent GitHub PAT via gh-agent.sh instead of shared gh session
- docs: add Armory architecture reference doc, fix stale Identities tab note
- fix(agent): Session Context assigned-accounts reads db_agent_identity_links, not the stale AgentDefinition.accounts blob
- feat(agent): word-wrapped command tooltip on tool-call hover
- docs: correct memory_id consumption claim and IdentityAccount field list in Armory architecture doc
- fix(agent): only refresh Haiku ghost-text summaries on genuine turn completion
- fix(swarm): separate row collapse-toggle from focus, default collapsed
- feat(lan): show QR code for mobile pairing when LAN discovery is enabled
- feat(launcher): macOS splash — add an "other" row closing the total-vs-items gap
- feat(editor): extract shared PaneTabStrip component, add + new-tab button
- feat(swarm): show active background shells as a per-agent row bucket

Version-consistency invariant verified — all 5 locations agree at `0.54.2`: `VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock` (workspace members), `package-lock.json`.

## Test plan

- [x] `scripts/release.sh --as patch` completed cleanly, printed "all 5 version locations agree at 0.54.2"
- [x] Manually re-verified all 5 locations directly (`package.json`, `Cargo.toml`, `package-lock.json`, `Cargo.lock`)
- [ ] CI

<!-- agentmux:agent_id=agentx -->