### PR TITLE
feat(agent): select an Armory Bundle as an agent's Startup Instructions

### DIFF
--- a/.changesets/1784593648-feat-agent-select-an-armory-bundle-as-an-agent-s-startup-ins-elvo.md
+++ b/.changesets/1784593648-feat-agent-select-an-armory-bundle-as-an-agent-s-startup-ins-elvo.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): select an Armory Bundle as an agent's Startup Instructions

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -840,14 +840,33 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             if (!agent) return;
 
             // Gather inputs in parallel where possible
-            const [startupContentResult, version, identityLinks] = await Promise.all([
+            const [startupContentResult, startupBundleIdResult, version, identityLinks] = await Promise.all([
                 RpcApi.GetAgentContentCommand(TabRpcClient, {
                     agent_id: agentId,
                     content_type: "startup",
                 }).catch(() => null),
+                RpcApi.GetAgentContentCommand(TabRpcClient, {
+                    agent_id: agentId,
+                    content_type: "startup_bundle_id",
+                }).catch(() => null),
                 Promise.resolve(getApi().getAboutModalDetails().version),
                 RpcApi.ListAgentIdentitiesCommand(TabRpcClient, { agent_id: agentId }).catch(() => []),
             ]);
+
+            // If this agent has a Bundle selected as its startup source
+            // (AgentStartupModal, Armory → Bundles content), its
+            // `instructions` take precedence over the legacy freeform
+            // "startup" blob — which has no live authoring UI anywhere, see
+            // docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md §5. Falls back to
+            // the freeform blob when no bundle is selected (or it no longer
+            // resolves, e.g. deleted), preserving any seed-manifest content.
+            const startupBundleId = startupBundleIdResult?.content?.trim() || null;
+            const startupBundle = startupBundleId
+                ? await RpcApi.GetMemoryCommand(TabRpcClient, { id: startupBundleId }).catch(() => null)
+                : null;
+            const startupContent = startupBundle?.instructions?.trim()
+                ? startupBundle.instructions
+                : (startupContentResult?.content ?? null);
 
             // Resolve assigned accounts from the same db_agent_identity_links
             // rows spawn-time credential resolution and the agent pane's own
@@ -867,7 +886,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 version,
                 accounts,
                 peerAgents: agentDefinitions(),
-                startupContent: startupContentResult?.content ?? null,
+                startupContent,
             });
 
             if (payload) {

--- a/frontend/app/view/agent/components/AgentSetupModal.tsx
+++ b/frontend/app/view/agent/components/AgentSetupModal.tsx
@@ -10,10 +10,12 @@
  *   - Memory      — the native-memory browser (AgentNativeMemoryModal).
  *   - MCP Servers — the standalone MCP Server primitive (AgentMcpModal).
  *   - Skills      — the standalone Skill primitive (AgentSkillsModal).
+ *   - Startup     — select an existing Bundle as Session Context's
+ *                   "Startup Instructions" (AgentStartupModal).
  *
  * The tab list is a data array so future primitives slot in trivially.
- * Briefs · Bundle are not wired here — Briefs has no backend primitive at
- * all yet (tracked separately); Bundle already has its own Armory tab.
+ * Briefs is not wired here — it has no backend primitive at all yet
+ * (tracked separately).
  *
  * Spec: SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md §3.2b +
  *       docs/specs/archive/EXPLAINER_COMPOSABLE_MODEL_AND_AGENT_PANE_2026_07_02.md §4.
@@ -24,9 +26,10 @@ import { AgentIdentityModalPanel } from "./AgentIdentityModal";
 import { AgentMcpModal } from "./AgentMcpModal";
 import { AgentNativeMemoryModal } from "./AgentNativeMemoryModal";
 import { AgentSkillsModal } from "./AgentSkillsModal";
+import { AgentStartupModal } from "./AgentStartupModal";
 import "./AgentSetupModal.scss";
 
-type SetupTabId = "accounts" | "memory" | "mcp" | "skills";
+type SetupTabId = "accounts" | "memory" | "mcp" | "skills" | "startup";
 
 interface AgentSetupModalProps {
     /** Agent definition for the Accounts tab. Null for quick-launch panes
@@ -46,13 +49,14 @@ interface SetupTabDef {
 }
 
 export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
-    // Data-driven tab list — Briefs · Bundle slot in here later (Briefs has
-    // no backend primitive yet; Bundle has its own Armory tab already).
+    // Data-driven tab list — Briefs slots in here later (no backend
+    // primitive yet).
     const tabs: SetupTabDef[] = [
         { id: "accounts", label: "Accounts" },
         { id: "memory", label: "Memories" },
         { id: "mcp", label: "MCP Servers" },
         { id: "skills", label: "Skills" },
+        { id: "startup", label: "Startup" },
     ];
 
     const [activeTab, setActiveTab] = createSignal<SetupTabId>(props.initialTab ?? "accounts");
@@ -113,7 +117,11 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
                     <AgentSkillsModal agentId={props.agentId} />
                 </Show>
 
-                {/* Future primitives: Briefs · Bundle */}
+                <Show when={activeTab() === "startup"}>
+                    <AgentStartupModal agentId={props.agentId} />
+                </Show>
+
+                {/* Future primitives: Briefs */}
             </div>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentStartupModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentStartupModal.test.tsx
@@ -1,0 +1,130 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for AgentStartupModal — the "Startup" tab that lets an agent select
+ * an existing Bundle as its Session Context "Startup Instructions" source.
+ * See docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md §5.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const listMemories = vi.fn();
+const getAgentContent = vi.fn();
+const setAgentContent = vi.fn();
+const openOrFocusPaneByView = vi.fn();
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ListMemoriesCommand: (...args: unknown[]) => listMemories(...args),
+        GetAgentContentCommand: (...args: unknown[]) => getAgentContent(...args),
+        SetAgentContentCommand: (...args: unknown[]) => setAgentContent(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/global", () => ({
+    openOrFocusPaneByView: (...args: unknown[]) => openOrFocusPaneByView(...args),
+}));
+
+import { AgentStartupModal } from "./AgentStartupModal";
+
+function mkBundle(overrides: Partial<Memory>): Memory {
+    return {
+        id: "bundle-1",
+        name: "Code Reviewer",
+        is_blank: false,
+        is_global: false,
+        instructions: "Review the diff for bugs.",
+        ...overrides,
+    } as Memory;
+}
+
+describe("AgentStartupModal", () => {
+    beforeEach(() => {
+        listMemories.mockReset();
+        getAgentContent.mockReset();
+        setAgentContent.mockReset();
+        openOrFocusPaneByView.mockReset();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it("lists non-blank bundles and pre-selects the agent's current startup bundle", async () => {
+        listMemories.mockResolvedValue([
+            mkBundle({ id: "blank", name: "Vanilla CLI", is_blank: true }),
+            mkBundle({ id: "bundle-1", name: "Code Reviewer" }),
+            mkBundle({ id: "bundle-2", name: "Release Notes Writer" }),
+        ]);
+        getAgentContent.mockResolvedValue({ content: "bundle-2" });
+
+        render(() => <AgentStartupModal agentId="agent-1" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("combobox")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("Code Reviewer")).toBeInTheDocument();
+        expect(screen.getByText("Release Notes Writer")).toBeInTheDocument();
+        expect(screen.queryByText("Vanilla CLI")).not.toBeInTheDocument(); // blank singleton filtered out
+
+        const select = screen.getByRole("combobox") as HTMLSelectElement;
+        expect(select.value).toBe("bundle-2");
+    });
+
+    it("saves immediately when a bundle is selected", async () => {
+        listMemories.mockResolvedValue([mkBundle({ id: "bundle-1", name: "Code Reviewer" })]);
+        getAgentContent.mockResolvedValue(null);
+        setAgentContent.mockResolvedValue({});
+
+        render(() => <AgentStartupModal agentId="agent-1" />);
+
+        const select = await screen.findByRole("combobox");
+        fireEvent.change(select, { target: { value: "bundle-1" } });
+
+        await waitFor(() => {
+            expect(setAgentContent).toHaveBeenCalledWith(
+                {},
+                { agent_id: "agent-1", content_type: "startup_bundle_id", content: "bundle-1" },
+            );
+        });
+    });
+
+    it("shows the Armory edit note only once a bundle is selected", async () => {
+        listMemories.mockResolvedValue([mkBundle({ id: "bundle-1", name: "Code Reviewer" })]);
+        getAgentContent.mockResolvedValue(null);
+
+        render(() => <AgentStartupModal agentId="agent-1" />);
+        await screen.findByRole("combobox");
+        expect(screen.queryByText(/Armory → Bundles/)).not.toBeInTheDocument();
+
+        setAgentContent.mockResolvedValue({});
+        const select = screen.getByRole("combobox");
+        fireEvent.change(select, { target: { value: "bundle-1" } });
+
+        await waitFor(() => {
+            expect(screen.getByText(/Armory → Bundles/)).toBeInTheDocument();
+        });
+    });
+
+    it("clearing the selection back to None saves an empty content_type value", async () => {
+        listMemories.mockResolvedValue([mkBundle({ id: "bundle-1", name: "Code Reviewer" })]);
+        getAgentContent.mockResolvedValue({ content: "bundle-1" });
+        setAgentContent.mockResolvedValue({});
+
+        render(() => <AgentStartupModal agentId="agent-1" />);
+        const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
+        expect(select.value).toBe("bundle-1");
+
+        fireEvent.change(select, { target: { value: "" } });
+
+        await waitFor(() => {
+            expect(setAgentContent).toHaveBeenCalledWith(
+                {},
+                { agent_id: "agent-1", content_type: "startup_bundle_id", content: "" },
+            );
+        });
+    });
+});

--- a/frontend/app/view/agent/components/AgentStartupModal.tsx
+++ b/frontend/app/view/agent/components/AgentStartupModal.tsx
@@ -1,0 +1,119 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentStartupModal — the "Startup" tab body inside AgentSetupModal.
+ *
+ * Lets an agent select an existing Armory Bundle to serve as its Session
+ * Context "Startup Instructions" (see buildStartupPayload.ts). This is a
+ * single-selection field, not a CRUD primitive like AgentMcpModal/
+ * AgentSkillsModal — no draft/edit state, no model class, just a select
+ * that saves immediately on change (same convention as
+ * AgentIdentityModal.tsx's ambient-login toggle).
+ *
+ * The selection itself is stored under a new db_agent_content content_type
+ * ("startup_bundle_id") rather than a new AgentDefinition column, reusing
+ * the existing getagentcontent/setagentcontent RPCs end-to-end — see
+ * docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md §5 for why (adding a real
+ * schema column would require touching three separate AgentDefinition
+ * storage mirrors).
+ */
+
+import { createResource, createSignal, For, Show, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { openOrFocusPaneByView } from "@/app/store/global";
+import "./AgentPrimitiveModal.scss";
+
+const STARTUP_BUNDLE_CONTENT_TYPE = "startup_bundle_id";
+
+interface AgentStartupModalProps {
+    agentId: string;
+}
+
+export const AgentStartupModal = (props: AgentStartupModalProps): JSX.Element => {
+    const [bundles] = createResource(() => RpcApi.ListMemoriesCommand(TabRpcClient, {}));
+    const [selectedId, setSelectedId] = createSignal<string | null>(null);
+    const [loaded, setLoaded] = createSignal(false);
+    const [saving, setSaving] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    void RpcApi.GetAgentContentCommand(TabRpcClient, {
+        agent_id: props.agentId,
+        content_type: STARTUP_BUNDLE_CONTENT_TYPE,
+    })
+        .then((c) => setSelectedId(c?.content?.trim() || null))
+        .catch(() => setSelectedId(null))
+        .finally(() => setLoaded(true));
+
+    // Non-blank bundles only — "blank" is the vanilla-CLI sentinel with no
+    // instructions worth surfacing here (same filter convention used by the
+    // launch modal's own bundle picker).
+    const selectable = () => (bundles() ?? []).filter((m) => !m.is_blank);
+    const selectedBundle = () => selectable().find((m) => m.id === selectedId());
+
+    const handleChange = async (id: string): Promise<void> => {
+        setError(null);
+        setSaving(true);
+        try {
+            await RpcApi.SetAgentContentCommand(TabRpcClient, {
+                agent_id: props.agentId,
+                content_type: STARTUP_BUNDLE_CONTENT_TYPE,
+                content: id,
+            });
+            setSelectedId(id || null);
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div class="agent-primitive-modal-detail">
+            <div class="agent-primitive-modal-readonly">
+                <span class="agent-primitive-modal-field-label">Startup instructions</span>
+                <p class="agent-primitive-modal-global-note">
+                    Select an existing Bundle to use as this agent's Session Context
+                    "Startup Instructions" — the message it receives at the start of
+                    every new session, in addition to its identity and assigned
+                    accounts.
+                </p>
+                <Show when={error()}>
+                    <div class="agent-primitive-modal-error">{error()}</div>
+                </Show>
+                <div class="agent-primitive-modal-bind-row">
+                    <select
+                        class="agent-primitive-modal-input"
+                        disabled={!loaded() || saving()}
+                        value={selectedId() ?? ""}
+                        onChange={(e) => void handleChange(e.currentTarget.value)}
+                    >
+                        <option value="">None</option>
+                        <For each={selectable()}>
+                            {(bundle) => <option value={bundle.id}>{bundle.name}</option>}
+                        </For>
+                    </select>
+                </div>
+                <Show when={selectedBundle()}>
+                    {(bundle) => (
+                        <p class="agent-primitive-modal-global-note">
+                            Edited from{" "}
+                            <button
+                                type="button"
+                                class="agent-primitive-modal-link-btn"
+                                onClick={() => void openOrFocusPaneByView("armory")}
+                            >
+                                Armory → Bundles
+                            </button>
+                            . Changing "{bundle().name}" there updates every agent using
+                            it, including this one.
+                        </p>
+                    )}
+                </Show>
+            </div>
+        </div>
+    );
+};
+
+AgentStartupModal.displayName = "AgentStartupModal";


### PR DESCRIPTION
## Summary
- Session Context's "Custom Startup Instructions" section previously sourced from `content_type: "startup"` — a freeform `db_agent_content` blob with **no live authoring UI anywhere** (`docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md` §5).
- Adds a **"Startup" tab** to `AgentSetupModal` (`AgentStartupModal.tsx`) where an agent selects one existing Armory Bundle to serve as that source instead — a single-selection field (not a CRUD primitive, not a ref-table like Skills/MCP use, since an agent only ever needs one startup-instructions source).
- **Implementation note worth flagging for review:** the selection is stored under a *new `content_type` key* (`"startup_bundle_id"`) in the same `db_agent_content` table, via the same `getagentcontent`/`setagentcontent` RPCs already wired end-to-end — **not** a new `AgentDefinition` schema column. Research during planning found that adding a real column would require touching three separate storage mirrors (`db_agent_definitions`, the dual-written `db_agents` consolidated table, and the cross-channel JSON registry) plus ~15-20 struct-literal call sites across the Rust backend, for what's conceptually "store one string per agent." This alternative achieves the identical design/UX with **zero backend changes**.
- `agent-view.tsx`'s `onReadyFn` now fetches the selected bundle (if any) and uses its `instructions` as `startupContent`, falling back to the legacy freeform blob when no bundle is selected — preserves any seed-manifest content, zero regression for agents that don't use this feature. `buildStartupPayload.ts` itself is unchanged; precedence is resolved entirely by the caller.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] New `AgentStartupModal.test.tsx` (4 tests: list + pre-select, immediate save on change, Armory-edit note only when selected, clearing back to None) — all passing
- [x] `npx vitest run frontend/app/view/agent` — 674/674 passing, zero regressions
- [ ] Manual: `task dev`, agent setup modal → Startup tab, select a bundle, start a new session, confirm Session Context shows the bundle's instructions (with `{{AGENT}}`-style template expansion still applying)

<!-- agentmux:agent_id=agent2 -->