### PR TITLE
fix(agent): vault icon on Agent-setup + eliminate horizontal scroll in the agent armory

### DIFF
--- a/.changesets/1784593673-feat-agent-open-armory-icon-in-the-pane-header-header-now-na-khou.md
+++ b/.changesets/1784593673-feat-agent-open-armory-icon-in-the-pane-header-header-now-na-khou.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): vault icon on the Agent-setup button, responsive tabs in the per-agent armory modal

--- a/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
@@ -268,8 +268,73 @@ it at `100% - 48px` of a real ancestor, but a max is not a definite height).
 Per CSS, a percentage height with no definite containing-block height
 resolves to `auto`; mixing that into `min(560px, 100%)` is undefined/
 inconsistent across engines in practice, and in this codebase's actual CEF
-renderer it broke. Width doesn't have this problem — percentage-width
-resolution against a shrink-to-fit ancestor is well-defined and works.
+renderer it broke.
+
+**Third correction — width had the same collapse bug, just not caught until
+live DOM inspection.** After the height revert shipped, Asaf reported the
+modal *still* stuck on a blurred backdrop, unrecoverable, even after a full
+process restart (ruling out stale HMR). The claim above — "percentage-width
+resolution against a shrink-to-fit ancestor is well-defined and works" — was
+wrong. Verified live via Chrome DevTools Protocol against the running CEF
+renderer (`--remote-debugging-port`, `Runtime.evaluate` reading
+`getComputedStyle()`/`getBoundingClientRect()` on the actual stuck modal):
+the full DOM tree rendered correctly (tabs, Accounts panel, provider rows,
+all present in `outerHTML`) but `.agent-setup-modal` computed to `width:
+0px` and `.modal-panel` to `width: 2px` (just its border) — invisible, not
+broken. Root cause: `min(780px, 100%)` on `.agent-setup-modal` is a
+percentage on a *child* of `.modal-panel[data-size="fit"]`
+(`width: auto; max-width: 100%` — shrink-to-fit, sized *by* its content).
+The parent's width depends on the child's preferred size; the child's `%`
+depends on the (not-yet-resolved) parent's size — a circular dependency
+that Chromium resolves by treating the percentage as ~0, collapsing both
+boxes.
+
+A first attempt at fixing this swapped `100%` for `100cqw` (a CSS
+container-query length unit, resolving against the nearest
+`container-type` ancestor — `.modal-layer-mount`, `container-name:
+modal-mount`, `ModalLayer.tsx:104-107` — instead of the immediate parent).
+That did stop the collapse (confirmed live: non-zero width), but introduced
+a *different* live-confirmed bug: `modal-mount` tracks the full pane, which
+is wider than `.modal-panel`'s own shrink-wrapped, backdrop-clamped box, so
+the child (595px) ended up wider than its actual parent (547px) —
+re-overflowing past `.modal-panel`'s edge from the other direction.
+
+**Final fix:** stop trying to size `.agent-setup-modal` (the child)
+independently at all. Instead put the `min(780px, 100%)` sizing on
+`.modal-panel` itself, scoped with a `:has()` selector to only apply when
+it's hosting this modal (`:has()` is already precedented in this codebase —
+`_document.scss:107-120` — and supported by the pinned CEF version, Chromium
+105+):
+
+```scss
+.modal-panel:has(.agent-setup-modal) {
+    width: min(780px, 100%);
+    height: 560px;
+    max-height: 85vh;
+}
+
+.agent-setup-modal {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    container-type: inline-size;
+    container-name: agent-setup;
+}
+```
+
+This is the exact same technique `modal.scss`'s own `[data-size="sm"|"md"|
+"lg"|"xl"]` rules already use — the percentage lives on `.modal-panel`,
+resolving against *its* parent `.modal-root` (`position: fixed|absolute;
+inset: 0` — genuinely definite, unlike `.modal-panel` itself). The child
+then just fills whatever `.modal-panel` resolves to; no circular dependency,
+no independent sizing that can disagree with the parent. Re-verified live
+via the same CDP DOM-inspection technique across all 5 tabs at the pane's
+actual (narrow) width: `.modal-panel` / `.agent-setup-modal` both resolve to
+547px / 545px (2px border), `scrollWidth === clientWidth` on every tab
+(no horizontal scroll), and the icon-only tab-label breakpoint fires
+correctly at that width.
 
 For the `min-width: 0` rescue, rather than adopting the `modal-panel-body`
 class (which also carries generic padding/font-size from `modal.scss:217-221`

--- a/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
@@ -1,0 +1,197 @@
+# SPEC: Vault Icon on the Agent-Setup Button + Responsive Tabs in the Per-Agent "Armory"
+
+**Date:** 2026-07-20 (corrected 2026-07-21)
+**Status:** Implemented
+**Scope:** `frontend/app/view/agent/agent-model.ts`,
+`frontend/app/view/agent/components/AgentSetupModal.tsx` / `.scss`
+
+---
+
+## 0. Correction note
+
+The first version of this spec (and its initial implementation) misread the
+ask as "add a **new** header icon that opens the **global** Armory pane, and
+make the pane **header** itself narrow-width responsive." That was wrong on
+both counts:
+
+- There is no new icon and no new "open the global Armory" action. The
+  existing "Agent setup" (`id-card`) icon **gets restyled to the vault icon**
+  — same button, same click handler, icon only.
+- "The armory" in the original ask refers to **`AgentSetupModal`** — the
+  tabbed Accounts/Memories/MCP Servers/Skills modal that icon already opens,
+  informally called "the agent armory" (a per-agent-scoped analogue of the
+  global Armory pane) — not the global Armory pane itself. All the
+  thinner-panes discussion was about making *that modal* degrade the way the
+  global Armory pane does, not about the pane header.
+
+The pane-header changes from the first pass (a second `endIconButtons` entry,
+a `block.scss` container-query + hide-priority system) have been reverted in
+full. Nothing in `blockframe.tsx`/`block.scss` is touched by this spec anymore
+— see §5 for confirmation of that reduced blast radius.
+
+---
+
+## 1. Ask (corrected)
+
+The existing "Agent setup" icon (top-right of an agent pane, opens
+`AgentSetupModal`) should simply **use the vault icon** instead of `id-card` —
+same icon Armory uses elsewhere, since this modal is effectively a per-agent
+Armory. Separately, `AgentSetupModal` itself should support thinner widths the
+way the global Armory pane does (it can genuinely get narrow, since it caps at
+`92vw` of the app window, not a fixed size).
+
+---
+
+## 2. Current state (investigated)
+
+### 2.1 The existing button — `agent-model.ts:141-152`
+
+```ts
+this.endIconButtons = () => {
+    const agentId = this.blockAtom()?.meta?.["agentId"];
+    if (!agentId) return [];
+    return [
+        { elemtype: "iconbutton", icon: "id-card", title: "Agent setup",
+          click: () => { this._openAgentSetupModal?.(); } },
+    ];
+};
+```
+
+Hidden until an agent is loaded (empty array on the picker screen). Icons are
+rendered through the shared `IconButton` component
+(`frontend/app/element/iconbutton.tsx:12`) via the declarative `IconButtonDecl`
+type — `icon: "vault"` resolves to `fa fa-solid fa-vault fa-fw` via
+`makeIconClass`. Changing the icon is a one-line edit; the click handler,
+gating, and everything else about the button stays exactly as-is.
+
+### 2.2 What it opens — `AgentSetupModal.tsx`, "the agent armory"
+
+```
+frontend/app/view/agent/components/AgentSetupModal.tsx
+```
+
+A modal (opened via the global `useModalLayer()`, not confined to the
+originating pane's DOM bounds — `agent-view.tsx:194-218`) with a horizontal
+top tab bar and four tabs, each delegating to an existing standalone panel:
+
+| Tab id | Label | Delegates to |
+|---|---|---|
+| `accounts` | Accounts | `AgentIdentityModalPanel` |
+| `memory` | Memories | `AgentNativeMemoryModal` |
+| `mcp` | MCP Servers | `AgentMcpModal` |
+| `skills` | Skills | `AgentSkillsModal` |
+
+Before this change, the tab bar was **text-only** (`{tab.label}`, no icons at
+all), and the modal (`.agent-setup-modal`, `AgentSetupModal.scss:9-20`) had a
+fixed `width: 780px; max-width: 92vw;` with **no responsive/container-query
+handling whatsoever** — the tab bar just sat there at whatever width the
+92vw cap left it, with no adaptation.
+
+### 2.3 The reference pattern — the global Armory pane's rail
+
+`frontend/app/view/armory/armory-view.tsx` / `.scss` — same four concepts
+(plus a fifth, Bundles, which has no per-agent equivalent) as a vertical rail
+with icon + label:
+
+```ts
+const RAIL: { id: ArmorySection; label: string; icon: string }[] = [
+    { id: "accounts", label: "Accounts",    icon: "key" },
+    { id: "brain",    label: "Memories",    icon: "brain" },
+    { id: "skills",   label: "Skills",      icon: "wand-magic-sparkles" },
+    { id: "mcp",      label: "MCP Servers", icon: "plug" },
+    { id: "memories", label: "Bundles",     icon: "layer-group" },
+];
+```
+
+Markup per item: `<i class="fa-sharp fa-solid fa-{icon}" aria-hidden="true"
+/><span>{label}</span>` — the label lives in its own `<span>` specifically so
+CSS can hide just the text and keep the icon.
+
+Responsiveness is pure CSS `@container`, no JS/`ResizeObserver`:
+- `.armory-container` (a wrapper `armory-view.tsx:30-31` needs, since a
+  container can't query its own width) carries
+  `container-type: inline-size; container-name: armory;`
+  (`armory-view.scss:9-14`).
+- `@container armory (max-width: 767px)` — compress the rail from `168px` to
+  `48px`, hide `span` labels, icon-only.
+- `@container armory (max-width: 479px)` — swap layouts entirely: hide the
+  rail, show a bottom tab bar instead (always in the DOM, toggled by
+  `display`).
+
+`AgentSetupModal`'s tab bar is **already** a horizontal row (Armory's *narrow*
+fallback shape), so only the label-hiding half of Armory's pattern applies —
+there's no rail-to-swap transition needed since it never had a rail to begin
+with.
+
+---
+
+## 3. Implementation (done)
+
+### 3.1 Icon swap — `agent-model.ts`
+
+`icon: "id-card"` → `icon: "vault"`. No other change to that button.
+
+### 3.2 Icons + responsive tabs — `AgentSetupModal.tsx` / `.scss`
+
+- `SetupTabDef` gained an `icon: string` field; each tab now carries the same
+  icon as its matching Armory-rail concept (`key` / `brain` / `plug` /
+  `wand-magic-sparkles`) — visual parity with the pane this modal is the
+  per-agent analogue of.
+- Tab button markup now matches Armory's exactly: `<i class="fa-sharp
+  fa-solid fa-{icon}" aria-hidden="true" /><span>{label}</span>`, plus a
+  native `title={label}` on the button (Armory uses a `<Tooltip>` wrapper for
+  this; a native `title` attribute was used here instead to avoid pulling in
+  that component for one tab bar — same information, simpler dependency
+  footprint).
+- `.agent-setup-modal` gained
+  `container-type: inline-size; container-name: agent-setup;` — it's already
+  the right ancestor for `.agent-setup-modal-tab` (a descendant), so unlike
+  Armory this needed no extra wrapper `<div>`.
+- One breakpoint, `@container agent-setup (max-width: 560px) { .agent-setup-modal-tab
+  span { display: none; } }` — hides tab labels, keeps icons, once the modal
+  gets narrow (a real scenario given the `92vw` cap on a small window).
+  560px, not Armory's 767px: this bar only ever holds 4 short-ish labels
+  (vs. Armory's rail holding 5, some longer — "MCP Servers"), and the
+  available width per tab in a horizontal bar differs from a vertical rail's
+  per-item width, so reusing Armory's number wasn't meaningful here either —
+  picked to leave comfortable room for 4 icon-only tabs well before the tab
+  bar would visibly wrap or truncate.
+
+---
+
+## 4. Verified
+
+- `npx tsc --noEmit` — clean.
+- `npm run lint:scss` — no new errors.
+- `npx vitest run frontend/app/view/agent` — 669/670 passing (1 pre-existing,
+  unrelated timeout flake under full-suite machine load — confirmed passing
+  in isolation). No dedicated test file exists for `AgentSetupModal`.
+- Not done: live interactive click-through of the narrow-width collapse.
+  `task dev` was launched separately for manual testing rather than scripted
+  automation, since no project skill/driver exists for interactively driving
+  this native macOS CEF app (not Electron, no existing Playwright-style
+  harness), and a competing dev instance risked interfering with the live
+  production session this conversation itself runs inside of.
+
+---
+
+## 5. Blast radius (now much smaller than the first pass)
+
+Three files: `agent-model.ts` (one-line icon change), `AgentSetupModal.tsx`
+(tab icons + markup), `AgentSetupModal.scss` (container query + icon
+styling). `blockframe.tsx` and `block.scss` — shared by every pane view type
+— are **untouched**, unlike the reverted first attempt. Nothing outside the
+agent-setup surface is affected.
+
+---
+
+## 6. Non-goals
+
+- Not touching the global Armory pane's own code
+  (`armory-view.tsx`/`.scss`) — reference pattern only.
+- Not touching the existing failure-state "Open Armory" banner
+  (`failure-accessory.ts`), which does open the *global* Armory pane — that's
+  a genuinely different, unrelated affordance and was never in scope.
+- Not adding a rail-to-bottom-bar layout swap to `AgentSetupModal` — its tab
+  bar is already the shape Armory swaps *to* at narrow widths, so there's no
+  second layout to transition into.

--- a/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
@@ -254,12 +254,38 @@ this one outer shell.
   (`modal.tsx:626-628`) applies. `AgentSetupModal`'s root div never carries
   this class, so this rescue doesn't reach it either.
 
-**Fix:** change `.agent-setup-modal` to `width: min(780px, 100%); height:
-min(560px, 100%);` (dropping `max-width`/`max-height`'s vw/vh values
-entirely — `min()` subsumes them), and add `modal-panel-body` to its class
-list so Layer C's existing `min-width: 0` rescue applies to its direct
-children (`.agent-setup-modal-tabs`, `.agent-setup-modal-panel`) below 400px.
-Same underlying bug independently affects the still-live standalone
+**Fix, as actually implemented (revised once — see the live-bug note
+below):** change `.agent-setup-modal`'s `width` to `min(780px, 100%)`,
+dropping the `max-width: 92vw` — `min()` subsumes it. **Height stays a plain
+`height: 560px; max-height: 85vh;`, unchanged from before.** The first
+attempt applied the same `min(560px, 100%)` treatment to height, symmetric
+with width — this was untested scope creep (the reported bug was
+horizontal-only) and broke the modal outright in live testing: stuck on a
+blurred backdrop with unrenderable/unreachable content, no way to dismiss
+it. Root cause: unlike width, `.modal-panel` never gets an *explicit*
+height — only `max-height` (`modal.scss:151-154`'s pane-scoped override caps
+it at `100% - 48px` of a real ancestor, but a max is not a definite height).
+Per CSS, a percentage height with no definite containing-block height
+resolves to `auto`; mixing that into `min(560px, 100%)` is undefined/
+inconsistent across engines in practice, and in this codebase's actual CEF
+renderer it broke. Width doesn't have this problem — percentage-width
+resolution against a shrink-to-fit ancestor is well-defined and works.
+
+For the `min-width: 0` rescue, rather than adopting the `modal-panel-body`
+class (which also carries generic padding/font-size from `modal.scss:217-221`
+that don't belong on this component), the same rule was written scoped to
+`AgentSetupModal`'s own classes directly, targeting the same `modal-mount`
+container `ModalLayer.tsx`'s mount node already establishes:
+```scss
+@container modal-mount (max-width: 400px) {
+    .agent-setup-modal-tabs,
+    .agent-setup-modal-panel {
+        min-width: 0;
+    }
+}
+```
+
+Same underlying width bug independently affects the still-live standalone
 `agent-identity`/`agent-memory` modal-dispatch paths
 (`AgentIdentityModal.scss:12-13`, `AgentNativeMemoryModal.scss:13-14`) — out
 of scope here (they're superseded by the tabbed modal per

--- a/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
+++ b/docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
@@ -1,9 +1,15 @@
 # SPEC: Vault Icon on the Agent-Setup Button + Responsive Tabs in the Per-Agent "Armory"
 
-**Date:** 2026-07-20 (corrected 2026-07-21)
-**Status:** Implemented
+**Date:** 2026-07-20 (corrected 2026-07-21, extended 2026-07-21 §7)
+**Status:** §1-6 implemented and merged (PR #2253). §7 (eliminating horizontal
+scroll) is a live follow-up — live-tested by Asaf via `task dev`, found real
+horizontal scrolling on every tab, planned in §7, not yet implemented.
 **Scope:** `frontend/app/view/agent/agent-model.ts`,
-`frontend/app/view/agent/components/AgentSetupModal.tsx` / `.scss`
+`frontend/app/view/agent/components/AgentSetupModal.tsx` / `.scss`,
+`frontend/app/view/agent/components/AgentNativeMemoryModal.tsx` / `.scss`,
+`frontend/app/view/agent/agent-native-memory-model.ts`,
+`frontend/app/view/agent/components/AgentIdentityModal.tsx` /
+`_identity-panel.scss`
 
 ---
 
@@ -195,3 +201,166 @@ agent-setup surface is affected.
 - Not adding a rail-to-bottom-bar layout swap to `AgentSetupModal` — its tab
   bar is already the shape Armory swaps *to* at narrow widths, so there's no
   second layout to transition into.
+
+---
+
+## 7. Follow-up: eliminating horizontal scroll (live-tested 2026-07-21)
+
+Asaf tested §1-6 in a real `task dev` session and found horizontal scrolling
+on the modal — not isolated to one tab. Direct quote: *"horizontal scrolling
+should not appear on any tabs. the whole design needs to be rethought."*
+Investigated fully before touching more code, since this task had already
+been misread twice.
+
+### 7.1 Root cause — one bug, hits every tab identically
+
+`AgentSetupModal.scss`:
+
+```scss
+.agent-setup-modal {
+    width: 780px;
+    max-width: 92vw;
+    height: 560px;
+    max-height: 85vh;
+    ...
+}
+```
+
+This modal opens **pane-scoped** (`useModalLayer()` inside a per-agent-pane
+component, `agent-view.tsx:194-218`) — its root sits inside the originating
+pane's own mount node (`frontend/app/element/ModalLayer.tsx:104-107`,
+`.modal-layer-mount`), not the whole browser window. `92vw`/`85vh` are
+computed against the **viewport**, not that mount node — so on a narrow pane
+inside a wide window, `92vw` evaluates to something far larger than the
+pane's real width and constrains nothing. The modal renders at its literal
+`780px`/`560px`. `.modal-panel` (`modal.scss:87-97`) correctly clamps itself
+to `max-width: 100%` of its real ancestor and has `overflow: auto` — so the
+780px child overflows it, and `.modal-panel`'s own scrollbar is exactly the
+"horizontal scrolling" reported, present on every tab because they all share
+this one outer shell.
+
+**The fix already exists in this codebase, just isn't applied here.**
+`modal.scss` documents two layers (comments at lines 106-146, tagged
+"MODAL_COMPACT_VARIANT_ARCHITECTURE_2026_05_26"):
+- **Layer B** — fluid sizing via `width: min(<target>px, 100%)` instead of a
+  raw px/vw combo (already used by `.modal-panel[data-size="sm"|"md"|"lg"|"xl"]`,
+  `modal.scss:112-115`). `ModalLayer.tsx:114` hardcodes `size="fit"` for every
+  `modalLayer.open()` call, so `.modal-panel` itself is `width: auto; max-width:
+  100%` — sizing is the *content's* job for a "fit" modal, and
+  `AgentSetupModal.scss` never applied Layer B's technique to itself.
+- **Layer C** — a `min-width: 0` cascade for modal body content, gated by
+  `@container modal-mount (max-width: 400px)`, but scoped to
+  `.modal-panel-body[class]` (`modal.scss:141-146`) — a class `ModalBody`
+  (`modal.tsx:626-628`) applies. `AgentSetupModal`'s root div never carries
+  this class, so this rescue doesn't reach it either.
+
+**Fix:** change `.agent-setup-modal` to `width: min(780px, 100%); height:
+min(560px, 100%);` (dropping `max-width`/`max-height`'s vw/vh values
+entirely — `min()` subsumes them), and add `modal-panel-body` to its class
+list so Layer C's existing `min-width: 0` rescue applies to its direct
+children (`.agent-setup-modal-tabs`, `.agent-setup-modal-panel`) below 400px.
+Same underlying bug independently affects the still-live standalone
+`agent-identity`/`agent-memory` modal-dispatch paths
+(`AgentIdentityModal.scss:12-13`, `AgentNativeMemoryModal.scss:13-14`) — out
+of scope here (they're superseded by the tabbed modal per
+`AgentSetupModal.tsx`'s own doc comment) but flagged for awareness.
+
+### 7.2 Memories tab — fixed 220px list column, zero fallback
+
+`AgentNativeMemoryModal.scss:74-75`: `.agent-memory-modal-list { flex-shrink:
+0; width: 220px; }` inside a two-column flex row
+(`.agent-memory-modal-body`). Unlike Accounts (§7.3), there's no responsive
+fallback at all here — the column is simply pinned, and independently forces
+overflow once the modal is much narrower than ~350-400px, even after §7.1's
+fix.
+
+MCP Servers and Skills tabs already solved this exact "list + detail, must
+work at any width" shape properly, via a shared, already-adopted component:
+`PrimitiveListDetail` (`frontend/app/element/primitive-list-detail.tsx`,
+from `SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md`) — shows
+**exactly one** of {list, detail} at a time, no side-by-side split, no fixed
+widths anywhere. Memories never adopted it (predates it, or was just missed).
+
+**Fix: migrate Memories to `PrimitiveListDetail`**, matching
+`AgentMcpModal.tsx`'s existing wiring pattern (`showDetail`, `backLabel`,
+`onBack`, `list`, `detail` props):
+- `showDetail = () => model.selectedFilenameAtom() != null`.
+- `list` = the existing file-list + new-file-input + "+ New file" button
+  (today's `.agent-memory-modal-list` content), **with the current
+  `EmptyState`'s "no files yet" call-to-action (heading + description + "+
+  Create MEMORY.md" button) moved into the list's empty branch**, replacing
+  the current bare "No files" text — that CTA needs to live somewhere
+  reachable now that there's no separate detail pane to show it in.
+- `detail` = the existing view/edit content (today's `.agent-memory-modal-detail`
+  content), with its `Show ... fallback={<EmptyState .../>}` **removed** —
+  under `PrimitiveListDetail`, detail only ever renders when a file *is*
+  selected, so the "nothing selected" fallback can't occur there anymore.
+- `onBack` clears the selection — needs a new `clearSelection()` method on
+  `AgentNativeMemoryModel` (currently only `selectFile(filename: string)`
+  exists, no way to set it back to `null`).
+- **Behavior change, called out explicitly:** `loadFiles()`
+  (`agent-native-memory-model.ts:112-125`) currently auto-selects the first
+  file whenever none is selected and files exist, specifically so — per its
+  own comment — "the modal never opens to an empty right pane." Under
+  single-pane, that rationale no longer applies (there is no separate right
+  pane to be empty), and keeping the auto-select would make Memories
+  inconsistent with its sibling tabs — MCP Servers/Skills/Startup all open to
+  their list, never jump straight into an item's detail. **Removing the
+  auto-select** so Memories opens to its list too, matching the other tabs,
+  is the more consistent choice — flagged here since it's a real, deliberate
+  behavior change, not an incidental side effect of the refactor.
+
+### 7.3 Accounts tab — provider-row grid has a non-shrinking floor
+
+`_identity-panel.scss:38-40`: `.agent-identity-provider-row { display: grid;
+grid-template-columns: 16px 72px 1fr auto; }`. The `auto` track holds a
+`<select>` (`max-width: 140px`, no min-width) plus a "+ New" button
+(`white-space: nowrap`, no ellipsis) plus, when assigned, an unassign "×"
+button. Grid `auto` tracks size to their content's min-content and do not
+shrink below it regardless of ancestor `min-width: 0` (that fixes flex items;
+it doesn't touch a grid track's own intrinsic sizing) — rough floor ≈
+370-420px for one row, before the panel's own padding.
+
+**Fix: reflow to two rows per provider below a breakpoint**, rather than
+trying to force the actions cell to compress (a `<select>` and two buttons
+don't have meaningful room left to give). Add a container-query breakpoint
+(reusing `.agent-setup-modal`'s own `agent-setup` container context from §1,
+since `AgentIdentityModalPanel` renders as a descendant of it when embedded)
+that switches `.agent-identity-provider-row` from
+`grid-template-columns: 16px 72px 1fr auto` to `grid-template-columns: 16px
+1fr; grid-template-rows: auto auto;`, with the actions cell
+(`.agent-identity-provider-assignment` or a wrapping element) spanning the
+second row's full width — giving the select + buttons the whole row's width
+to work with instead of a squeezed single column. Exact breakpoint: pick
+empirically against the ~370-420px floor above (a value comfortably above it,
+so the reflow triggers before content actually clips) — recommend starting
+around 440-460px and adjusting after a live check, same approach as §3.2's
+560px pick.
+
+Also worth a one-line fix regardless of the breakpoint:
+`.agent-identity-provider-label` (line 57-60) has `white-space: nowrap`
+with no `overflow: hidden; text-overflow: ellipsis` pair — harmless today
+(short labels, fixed 72px column) but a latent "forces wider, doesn't
+truncate" bug if a longer provider label is ever added.
+
+### 7.4 MCP Servers, Skills, Startup — no changes needed
+
+Already fully fluid: `PrimitiveListDetail` + `primitive-list-detail.scss`
+use `width: 100%` throughout, no fixed px widths at any level; their
+`<pre>` detail fields use `white-space: pre-wrap; overflow-wrap: break-word;`
+correctly. Startup has no fixed-width content at all. Confirmed via full
+read of all three tabs' `.tsx`/`.scss` — nothing to change.
+
+### 7.5 Priority / sequencing
+
+1. §7.1 (root cause) first — fixes the reported symptom on every tab at
+   once, and is a small, mechanical, low-risk change (two CSS lines + one
+   class attribute).
+2. §7.2 (Memories) — the bigger piece; real component restructuring plus one
+   small, deliberate behavior change (drop auto-select). Worth landing
+   separately from §7.1 for a cleaner diff/review, but both are needed for
+   the "no scrolling on any tab" bar to actually hold.
+3. §7.3 (Accounts) — the row-reflow breakpoint value is a judgment call
+   (§ itself proposes ~440-460px as a starting point); smallest blast radius
+   of the three, touches only `_identity-panel.scss` + one new container
+   query.

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -130,7 +130,7 @@ export class AgentViewModel implements ViewModel {
             await RpcApi.SetMetaCommand(TabRpcClient, { oref, meta: { agentName: name.trim() } });
         };
 
-        // Pane-frame header button: a single "Agent setup" (id-card) icon
+        // Pane-frame header button: a single "Agent setup" (vault) icon
         // when an agent is loaded — opens the unified tabbed modal
         // (Accounts + Memory). Hidden when no agent is loaded (picker
         // screen). Always shown when agentId exists: quick-launch panes

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -144,7 +144,13 @@ export class AgentViewModel implements ViewModel {
             return [
                 {
                     elemtype: "iconbutton",
-                    icon: "id-card",
+                    // Same "vault" FontAwesome icon as the global Armory pane
+                    // (hamburger menu, failure-accessory banner) — visual
+                    // parity, since this opens the per-agent analogue of it
+                    // (AgentSetupModal: Accounts/Memories/MCP Servers/Skills
+                    // scoped to this one agent). Was "id-card"; same click
+                    // handler, icon only.
+                    icon: "vault",
                     title: "Agent setup",
                     click: () => { this._openAgentSetupModal?.(); },
                 },

--- a/frontend/app/view/agent/agent-native-memory-model.ts
+++ b/frontend/app/view/agent/agent-native-memory-model.ts
@@ -132,8 +132,17 @@ export class AgentNativeMemoryModel {
         }
     }
 
-    /** Clear the current selection — returns to the list view. */
+    /** Clear the current selection — returns to the list view. Refuses
+     *  while an edit is in flight, mirroring `selectFile`'s guard below, so
+     *  the always-visible Back button can't silently discard an unsaved
+     *  draft (and can't leave `editingAtom` stuck true with `selected`
+     *  cleared, which would permanently fail every future `selectFile`
+     *  guard check until the modal is closed and reopened). */
     clearSelection(): void {
+        if (this.editingAtom()) {
+            this.setError("Finish editing (Save or Cancel) before going back.");
+            return;
+        }
         this.setSelected(null);
         this.setContent(null);
     }

--- a/frontend/app/view/agent/agent-native-memory-model.ts
+++ b/frontend/app/view/agent/agent-native-memory-model.ts
@@ -109,9 +109,14 @@ export class AgentNativeMemoryModel {
         void this.loadFiles();
     }
 
-    /** Re-fetch the file list. Auto-selects MEMORY.md (or the first file)
-     *  if nothing is selected yet, so the modal never opens to an empty
-     *  right pane when files exist. */
+    /** Re-fetch the file list. No longer auto-selects a file on load (see
+     *  SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.2) — the modal
+     *  moved to a single-pane list/detail layout (PrimitiveListDetail),
+     *  where opening straight to the list is the norm for every sibling
+     *  tab (MCP Servers, Skills, Startup); the old auto-select existed only
+     *  to avoid an empty right pane in the previous two-column layout, and
+     *  keeping it would make this tab the one inconsistent case that jumps
+     *  straight into an item's detail. */
     async loadFiles(): Promise<void> {
         this.setLoading(true);
         try {
@@ -120,14 +125,17 @@ export class AgentNativeMemoryModel {
             });
             this.setFiles(res.files);
             this.setError(null);
-            if (this.selectedFilenameAtom() === null && res.files.length > 0) {
-                void this.selectFile(res.files[0].filename);
-            }
         } catch (e) {
             this.setError(`Failed to list memory files: ${(e as Error).message ?? e}`);
         } finally {
             this.setLoading(false);
         }
+    }
+
+    /** Clear the current selection — returns to the list view. */
+    clearSelection(): void {
+        this.setSelected(null);
+        this.setContent(null);
     }
 
     /** Select a file and fetch its content. Cancels any in-flight edit so

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -295,7 +295,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     };
 
     // Wire the pane-scoped modal callback into the model so the single
-    // title-bar "Agent setup" (id-card) icon can open the unified tabbed
+    // title-bar "Agent setup" (vault) icon can open the unified tabbed
     // modal (Accounts + Memory) without holding a SolidJS context in the
     // model. Mirrors the former _setOverlayTab pattern; supersedes the
     // separate _openIdentityModal / _openMemoryModal callbacks.

--- a/frontend/app/view/agent/components/AgentNativeMemoryModal.scss
+++ b/frontend/app/view/agent/components/AgentNativeMemoryModal.scss
@@ -5,7 +5,17 @@
 // Canonical modal chrome (backdrop, panel, ESC) lives in
 // frontend/app/element/modal.scss; this file styles the body only.
 // The hosting <Modal> is size="fit", so the root sets explicit
-// dimensions to give the two-column browser a bounded box.
+// dimensions to give the single-pane browser a bounded box (when used via
+// the standalone agent-memory dispatch; neutralized to 100%/100% when
+// embedded in AgentSetupModal — see that file's override).
+//
+// Single-pane list/detail via PrimitiveListDetail (element/primitive-list-
+// detail.scss) — was a fixed two-column split with a non-shrinking 220px
+// list rail; migrated per SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md
+// §7.2 to eliminate horizontal scroll on narrow panes. .agent-memory-modal-list
+// and .agent-memory-modal-detail below are now full-width/full-height
+// content for PrimitiveListDetail's own .primitive-list-detail-list /
+// .primitive-list-detail-detail-body wrappers, not a fixed sidebar.
 
 .agent-memory-modal {
     display: flex;
@@ -60,22 +70,19 @@
     font-size: var(--text-sm);
 }
 
-// ── Body: two columns ──────────────────────────────────────────────────────
-
-.agent-memory-modal-body {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    margin-top: var(--space-2);
-    border: 1px solid var(--border-color);
-}
+// ── Body: single-pane list/detail (PrimitiveListDetail) ────────────────────
+// PrimitiveListDetail (the component wrapping these) provides its own
+// full-height flex-column container + scroll handling — see
+// primitive-list-detail.scss. This file only needs to style the content.
 
 .agent-memory-modal-list {
-    flex-shrink: 0;
-    width: 220px;
+    flex: 1;
+    min-height: 0;
+    width: 100%;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--border-color);
+    margin-top: var(--space-2);
+    border: 1px solid var(--border-color);
     overflow-y: auto;
 }
 
@@ -205,8 +212,13 @@
 .agent-memory-modal-detail {
     flex: 1;
     min-width: 0;
+    min-height: 0;
     display: flex;
     flex-direction: column;
+    // Matches .agent-memory-modal-list's margin/border so the frame looks
+    // consistent whichever of the two PrimitiveListDetail shows.
+    margin-top: var(--space-2);
+    border: 1px solid var(--border-color);
 }
 
 .agent-memory-modal-view,

--- a/frontend/app/view/agent/components/AgentNativeMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNativeMemoryModal.tsx
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentNativeMemoryModal — the agent pane's brain modal. A two-column
+ * AgentNativeMemoryModal — the agent pane's brain modal. Single-pane
  * browser/editor over the agent's native memory folder
- * (`~/.claude/projects/<sanitized>/memory/`): file list on the left,
- * read/edit view on the right.
+ * (`~/.claude/projects/<sanitized>/memory/`) — list, or one file's
+ * read/edit view, never both at once (PrimitiveListDetail; matches the MCP
+ * Servers / Skills tabs' convention). Was a fixed two-column split with a
+ * 220px list rail; migrated to eliminate horizontal scroll on narrow panes
+ * — see SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.2.
  *
  * Replaces the Phase 1 placeholder (AgentMemoryModalPanel). Backend RPCs
  * live in native_memory_handlers.rs.
@@ -14,6 +17,7 @@
  */
 
 import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { AgentNativeMemoryModel, normalizeMemoryFilename, validateMemoryFilename } from "../agent-native-memory-model";
 import "./AgentNativeMemoryModal.scss";
 
@@ -82,6 +86,157 @@ export const AgentNativeMemoryModal = (props: AgentNativeMemoryModalProps): JSX.
         if (e.key === "Escape") { e.preventDefault(); cancelNewInput(); }
     };
 
+    // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md,
+    // adopted here per SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.2.
+    const inDetail = () => model.selectedFilenameAtom() !== null;
+    const [creatingIndex, setCreatingIndex] = createSignal(false);
+
+    const listView = (
+        <div class="agent-memory-modal-list">
+            <Show
+                when={model.filesAtom().length > 0}
+                fallback={
+                    <Show
+                        when={!model.loadingAtom()}
+                        fallback={<div class="agent-memory-modal-list-empty">Loading…</div>}
+                    >
+                        <div class="agent-memory-modal-empty">
+                            <p class="agent-memory-modal-empty-heading">No memory files yet.</p>
+                            <p class="agent-memory-modal-empty-desc">
+                                Claude Code creates this folder when it first saves a memory for
+                                this agent. You can also create files manually — they'll be
+                                available at the next session start.
+                            </p>
+                            <button
+                                class="agent-memory-modal-btn agent-memory-modal-btn-primary"
+                                disabled={creatingIndex()}
+                                onClick={() => {
+                                    setCreatingIndex(true);
+                                    void model.createMemoryIndex().finally(() => setCreatingIndex(false));
+                                }}
+                            >
+                                + Create MEMORY.md
+                            </button>
+                        </div>
+                    </Show>
+                }
+            >
+                <For each={model.filesAtom()}>
+                    {(file) => (
+                        <button
+                            class="agent-memory-modal-list-item"
+                            classList={{
+                                "is-selected": model.selectedFilenameAtom() === file.filename,
+                                "is-index": file.is_index,
+                            }}
+                            onClick={() => void model.selectFile(file.filename)}
+                            title={fileRoleLabel(file)}
+                        >
+                            <span class="agent-memory-modal-list-item-name">
+                                {file.filename}
+                            </span>
+                            <Show when={file.is_index}>
+                                <span
+                                    class="agent-memory-modal-list-item-badge"
+                                    title="Loaded into every new Claude session for this agent. Edits take effect on the next session start."
+                                >
+                                    index
+                                </span>
+                            </Show>
+                            <Show when={!file.is_index && file.metadata_type}>
+                                <span class="agent-memory-modal-list-item-type">
+                                    {file.metadata_type}
+                                </span>
+                            </Show>
+                        </button>
+                    )}
+                </For>
+            </Show>
+
+            <Show when={showNewInput()}>
+                <div class="agent-memory-modal-new-input-row">
+                    <input
+                        class="agent-memory-modal-new-input"
+                        classList={{ "is-error": newFileError() !== null }}
+                        type="text"
+                        placeholder="filename.md"
+                        value={newFileName()}
+                        autofocus
+                        onInput={(e) => { setNewFileName(e.currentTarget.value); setNewFileError(null); }}
+                        onKeyDown={onNewFileKeyDown}
+                    />
+                    <Show when={newFileError()}>
+                        <div class="agent-memory-modal-new-input-error">{newFileError()}</div>
+                    </Show>
+                    <div class="agent-memory-modal-new-input-actions">
+                        <button class="agent-memory-modal-btn" onClick={cancelNewInput}>Cancel</button>
+                        <button class="agent-memory-modal-btn agent-memory-modal-btn-primary" onClick={commitNewFile}>Create</button>
+                    </div>
+                </div>
+            </Show>
+
+            <button
+                class="agent-memory-modal-new-btn"
+                classList={{ "is-hidden": showNewInput() }}
+                onClick={openNewInput}
+            >
+                + New file
+            </button>
+        </div>
+    );
+
+    // Only rendered when inDetail() is true (a file is selected) —
+    // PrimitiveListDetail never shows list and detail at once, so there's
+    // no "nothing selected" case to handle here anymore.
+    const detailView = (
+        <div class="agent-memory-modal-detail">
+            <Show
+                when={model.editingAtom()}
+                fallback={
+                    <div class="agent-memory-modal-view">
+                        <pre class="agent-memory-modal-content">
+                            {model.contentAtom() ?? "Loading…"}
+                        </pre>
+                        <div class="agent-memory-modal-detail-actions">
+                            <button
+                                class="agent-memory-modal-btn"
+                                disabled={model.contentAtom() === null}
+                                onClick={() => model.startEdit()}
+                            >
+                                Edit
+                            </button>
+                        </div>
+                    </div>
+                }
+            >
+                <div class="agent-memory-modal-edit">
+                    <textarea
+                        class="agent-memory-modal-textarea"
+                        value={model.draftContentAtom()}
+                        onInput={(e) => model.setDraftContent(e.currentTarget.value)}
+                        spellcheck={false}
+                    />
+                    <div class="agent-memory-modal-detail-actions">
+                        <button
+                            class="agent-memory-modal-btn"
+                            disabled={model.savingAtom()}
+                            onClick={() => model.cancelEdit()}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            class="agent-memory-modal-btn agent-memory-modal-btn-primary"
+                            disabled={model.savingAtom()}
+                            onClick={() => void model.saveEdit()}
+                        >
+                            {model.savingAtom() ? "Saving…" : "Save"}
+                        </button>
+                    </div>
+                </div>
+            </Show>
+        </div>
+    );
+
     return (
         <div class="agent-memory-modal">
             <div class="agent-memory-modal-header">
@@ -98,134 +253,13 @@ export const AgentNativeMemoryModal = (props: AgentNativeMemoryModalProps): JSX.
                 <div class="agent-memory-modal-error">{model.errorAtom()}</div>
             </Show>
 
-            <div class="agent-memory-modal-body">
-                <div class="agent-memory-modal-list">
-                    <Show
-                        when={model.filesAtom().length > 0}
-                        fallback={
-                            <Show
-                                when={!model.loadingAtom()}
-                                fallback={<div class="agent-memory-modal-list-empty">Loading…</div>}
-                            >
-                                <div class="agent-memory-modal-list-empty">No files</div>
-                            </Show>
-                        }
-                    >
-                        <For each={model.filesAtom()}>
-                            {(file) => (
-                                <button
-                                    class="agent-memory-modal-list-item"
-                                    classList={{
-                                        "is-selected": model.selectedFilenameAtom() === file.filename,
-                                        "is-index": file.is_index,
-                                    }}
-                                    onClick={() => void model.selectFile(file.filename)}
-                                    title={fileRoleLabel(file)}
-                                >
-                                    <span class="agent-memory-modal-list-item-name">
-                                        {file.filename}
-                                    </span>
-                                    <Show when={file.is_index}>
-                                        <span
-                                            class="agent-memory-modal-list-item-badge"
-                                            title="Loaded into every new Claude session for this agent. Edits take effect on the next session start."
-                                        >
-                                            index
-                                        </span>
-                                    </Show>
-                                    <Show when={!file.is_index && file.metadata_type}>
-                                        <span class="agent-memory-modal-list-item-type">
-                                            {file.metadata_type}
-                                        </span>
-                                    </Show>
-                                </button>
-                            )}
-                        </For>
-                    </Show>
-
-                    <Show when={showNewInput()}>
-                        <div class="agent-memory-modal-new-input-row">
-                            <input
-                                class="agent-memory-modal-new-input"
-                                classList={{ "is-error": newFileError() !== null }}
-                                type="text"
-                                placeholder="filename.md"
-                                value={newFileName()}
-                                autofocus
-                                onInput={(e) => { setNewFileName(e.currentTarget.value); setNewFileError(null); }}
-                                onKeyDown={onNewFileKeyDown}
-                            />
-                            <Show when={newFileError()}>
-                                <div class="agent-memory-modal-new-input-error">{newFileError()}</div>
-                            </Show>
-                            <div class="agent-memory-modal-new-input-actions">
-                                <button class="agent-memory-modal-btn" onClick={cancelNewInput}>Cancel</button>
-                                <button class="agent-memory-modal-btn agent-memory-modal-btn-primary" onClick={commitNewFile}>Create</button>
-                            </div>
-                        </div>
-                    </Show>
-
-                    <button
-                        class="agent-memory-modal-new-btn"
-                        classList={{ "is-hidden": showNewInput() }}
-                        onClick={openNewInput}
-                    >
-                        + New file
-                    </button>
-                </div>
-
-                <div class="agent-memory-modal-detail">
-                    <Show
-                        when={model.selectedFilenameAtom()}
-                        fallback={<EmptyState model={model} hasFiles={model.filesAtom().length > 0} />}
-                    >
-                        <Show
-                            when={model.editingAtom()}
-                            fallback={
-                                <div class="agent-memory-modal-view">
-                                    <pre class="agent-memory-modal-content">
-                                        {model.contentAtom() ?? "Loading…"}
-                                    </pre>
-                                    <div class="agent-memory-modal-detail-actions">
-                                        <button
-                                            class="agent-memory-modal-btn"
-                                            disabled={model.contentAtom() === null}
-                                            onClick={() => model.startEdit()}
-                                        >
-                                            Edit
-                                        </button>
-                                    </div>
-                                </div>
-                            }
-                        >
-                            <div class="agent-memory-modal-edit">
-                                <textarea
-                                    class="agent-memory-modal-textarea"
-                                    value={model.draftContentAtom()}
-                                    onInput={(e) => model.setDraftContent(e.currentTarget.value)}
-                                    spellcheck={false}
-                                />
-                                <div class="agent-memory-modal-detail-actions">
-                                    <button
-                                        class="agent-memory-modal-btn"
-                                        disabled={model.savingAtom()}
-                                        onClick={() => model.cancelEdit()}
-                                    >
-                                        Cancel
-                                    </button>
-                                    <button
-                                        class="agent-memory-modal-btn agent-memory-modal-btn-primary"
-                                        disabled={model.savingAtom()}
-                                        onClick={() => void model.saveEdit()}
-                                    >
-                                        {model.savingAtom() ? "Saving…" : "Save"}
-                                    </button>
-                                </div>
-                            </div>
-                        </Show>
-                    </Show>
-                </div>
-            </div>
+            <PrimitiveListDetail
+                showDetail={inDetail()}
+                backLabel="Memories"
+                onBack={() => model.clearSelection()}
+                list={listView}
+                detail={detailView}
+            />
 
             <div class="agent-memory-modal-footer">
                 <button class="agent-memory-modal-btn" data-modal-dismiss onClick={props.onClose}>
@@ -237,38 +271,3 @@ export const AgentNativeMemoryModal = (props: AgentNativeMemoryModalProps): JSX.
 };
 
 AgentNativeMemoryModal.displayName = "AgentNativeMemoryModal";
-
-/** Right-pane empty state: differs depending on whether the folder has any
- *  files at all. */
-function EmptyState(props: { model: AgentNativeMemoryModel; hasFiles: boolean }): JSX.Element {
-    const [creating, setCreating] = createSignal(false);
-    return (
-        <Show
-            when={!props.hasFiles}
-            fallback={
-                <div class="agent-memory-modal-empty">
-                    Select a file from the list to view it.
-                </div>
-            }
-        >
-            <div class="agent-memory-modal-empty">
-                <p class="agent-memory-modal-empty-heading">No memory files yet.</p>
-                <p class="agent-memory-modal-empty-desc">
-                    Claude Code creates this folder when it first saves a memory for this
-                    agent. You can also create files manually — they'll be available at the
-                    next session start.
-                </p>
-                <button
-                    class="agent-memory-modal-btn agent-memory-modal-btn-primary"
-                    disabled={creating()}
-                    onClick={() => {
-                        setCreating(true);
-                        void props.model.createMemoryIndex().finally(() => setCreating(false));
-                    }}
-                >
-                    + Create MEMORY.md
-                </button>
-            </div>
-        </Show>
-    );
-}

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -9,18 +9,25 @@
 .agent-setup-modal {
     display: flex;
     flex-direction: column;
-    // One fixed size for the whole modal so the frame doesn't resize between
-    // tabs. Sized to fit the widest/tallest embedded panel (the Memory panel,
-    // which is 780×520 in its standalone form) plus the tab bar.
-    width: 780px;
-    max-width: 92vw;
-    height: 560px;
-    max-height: 85vh;
+    // Target size for the widest/tallest embedded panel (the Memory panel,
+    // 780×520 in its standalone form) plus the tab bar — but fluid via
+    // min(), not a raw px + vw/vh combo. This modal opens pane-scoped
+    // (ModalLayer's mount node sits inside the originating agent pane, not
+    // the browser window), so a vw/vh cap resolves against the wrong
+    // ancestor and doesn't actually constrain anything on a narrow pane in
+    // a wide window — the modal then renders at its literal 780×560 and
+    // .modal-panel's own overflow:auto produces exactly the horizontal
+    // scrollbar this fix addresses. min(target, 100%) is the same
+    // fluid-width technique modal.scss's own .modal-panel[data-size] rules
+    // already use (Layer B, MODAL_COMPACT_VARIANT_ARCHITECTURE_2026_05_26 §7)
+    // — 100% here resolves against .modal-panel, which correctly clamps to
+    // the pane's real width via its own max-width: 100%.
+    // See docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.1.
+    width: min(780px, 100%);
+    height: min(560px, 100%);
     min-width: 0;
     // Container-query context for .agent-setup-modal-tab below (a
-    // descendant) — same technique as armory-view.scss's .armory-container,
-    // needed here on the modal itself since max-width: 92vw means this can
-    // genuinely get narrow on a small window.
+    // descendant) — same technique as armory-view.scss's .armory-container.
     container-type: inline-size;
     container-name: agent-setup;
 }
@@ -68,12 +75,27 @@
     }
 }
 
-// Narrow modal (a real possibility since the modal caps at 92vw of the app
-// window, not a fixed pane) — icon-only tabs, same "hide the label, keep the
-// icon" compression armory-view.scss's rail does at its 767px breakpoint.
+// Narrow modal — icon-only tabs, same "hide the label, keep the icon"
+// compression armory-view.scss's rail does at its 767px breakpoint.
 @container agent-setup (max-width: 560px) {
     .agent-setup-modal-tab span {
         display: none;
+    }
+}
+
+// Same min-width:0 rescue modal.scss's Layer C already provides for
+// .modal-panel-body descendants (@container modal-mount, modal.scss:141-146)
+// — scoped to our own classes instead of adopting that shared class, which
+// also carries generic .modal-panel-body padding/font-size we don't want
+// here. .modal-layer-mount (ModalLayer.tsx) is the ancestor that establishes
+// the `modal-mount` container, so this fires correctly regardless of the
+// `agent-setup` container above (flex children default to min-width:auto,
+// which this overrides once the real mount node — the pane, ultimately —
+// is this narrow).
+@container modal-mount (max-width: 400px) {
+    .agent-setup-modal-tabs,
+    .agent-setup-modal-panel {
+        min-width: 0;
     }
 }
 

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -9,22 +9,35 @@
 .agent-setup-modal {
     display: flex;
     flex-direction: column;
-    // Target size for the widest/tallest embedded panel (the Memory panel,
-    // 780×520 in its standalone form) plus the tab bar — but fluid via
-    // min(), not a raw px + vw/vh combo. This modal opens pane-scoped
-    // (ModalLayer's mount node sits inside the originating agent pane, not
-    // the browser window), so a vw/vh cap resolves against the wrong
-    // ancestor and doesn't actually constrain anything on a narrow pane in
-    // a wide window — the modal then renders at its literal 780×560 and
-    // .modal-panel's own overflow:auto produces exactly the horizontal
-    // scrollbar this fix addresses. min(target, 100%) is the same
-    // fluid-width technique modal.scss's own .modal-panel[data-size] rules
-    // already use (Layer B, MODAL_COMPACT_VARIANT_ARCHITECTURE_2026_05_26 §7)
-    // — 100% here resolves against .modal-panel, which correctly clamps to
-    // the pane's real width via its own max-width: 100%.
+    // Target size for the widest embedded panel (the Memory panel, 780px
+    // wide in its standalone form) plus the tab bar — but fluid via min(),
+    // not a raw px + vw combo. This modal opens pane-scoped (ModalLayer's
+    // mount node sits inside the originating agent pane, not the browser
+    // window), so a vw cap resolves against the wrong ancestor and doesn't
+    // actually constrain anything on a narrow pane in a wide window — the
+    // modal then renders at its literal 780px wide and .modal-panel's own
+    // overflow:auto produces exactly the horizontal scrollbar this fix
+    // addresses. min(target, 100%) is the same fluid-width technique
+    // modal.scss's own .modal-panel[data-size] rules already use (Layer B,
+    // MODAL_COMPACT_VARIANT_ARCHITECTURE_2026_05_26 §7) — 100% here resolves
+    // against .modal-panel, which correctly clamps to the pane's real width
+    // via its own max-width: 100%.
     // See docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.1.
     width: min(780px, 100%);
-    height: min(560px, 100%);
+    // Height deliberately stays a plain px + vh cap, NOT the same min()
+    // treatment as width above. .modal-panel never gets an explicit height
+    // (only max-height — modal.scss:151-154's pane-scoped override caps it
+    // at 100% of a real ancestor, but that's still a *max*, not a definite
+    // height), so a percentage height here has no definite containing-block
+    // height to resolve against and computes to `auto` per spec — mixing
+    // that into min(560px, 100%) produced a genuinely broken, stuck-blurry,
+    // unrenderable modal in live testing (reagent-caught-in-practice, not
+    // hypothetical). The original bug report was horizontal scrolling only;
+    // height was never reported broken, so this reverts to the simple,
+    // known-working px+vh form rather than fixing something that wasn't
+    // asked for and didn't need it.
+    height: 560px;
+    max-height: 85vh;
     min-width: 0;
     // Container-query context for .agent-setup-modal-tab below (a
     // descendant) — same technique as armory-view.scss's .armory-container.

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -17,6 +17,12 @@
     height: 560px;
     max-height: 85vh;
     min-width: 0;
+    // Container-query context for .agent-setup-modal-tab below (a
+    // descendant) — same technique as armory-view.scss's .armory-container,
+    // needed here on the modal itself since max-width: 92vw means this can
+    // genuinely get narrow on a small window.
+    container-type: inline-size;
+    container-name: agent-setup;
 }
 
 .agent-setup-modal-tabs {
@@ -27,6 +33,9 @@
 }
 
 .agent-setup-modal-tab {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
     font-size: var(--text-sm);
     font-weight: var(--font-weight-medium);
@@ -35,6 +44,14 @@
     border: none;
     border-bottom: 2px solid transparent;
     cursor: default;
+
+    // Same icon treatment as the global Armory rail (bundle-manager-rail-item
+    // in armory-view.scss) — width-pinned, slightly dimmed.
+    i {
+        width: 16px;
+        text-align: center;
+        opacity: 0.8;
+    }
 
     &:hover:not(.is-active) {
         color: var(--main-text-color);
@@ -48,6 +65,15 @@
     &:focus-visible {
         outline: none;
         box-shadow: var(--shadow-focus-ring);
+    }
+}
+
+// Narrow modal (a real possibility since the modal caps at 92vw of the app
+// window, not a fixed pane) — icon-only tabs, same "hide the label, keep the
+// icon" compression armory-view.scss's rail does at its 767px breakpoint.
+@container agent-setup (max-width: 560px) {
+    .agent-setup-modal-tab span {
+        display: none;
     }
 }
 

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -6,38 +6,44 @@
 // (_identity-panel.scss / AgentNativeMemoryModal.scss); this file only styles
 // the top tab bar + panel wrapper.
 
+// This modal opens through the shared ModalLayer with `size="fit"` (the
+// same host every other modal kind uses), so `.modal-panel` is deliberately
+// `width: auto; max-width: 100%` (modal.scss:116) — shrink-to-fit, sized BY
+// its content, not a definite box. Two earlier attempts tried to size
+// *this* element (a CHILD of that shrink-to-fit panel) directly:
+//   - `min(780px, 100%)` — the % has no definite containing block to
+//     resolve against (the parent's own width depends on OUR width — a
+//     circular dependency), so Chromium collapsed both this element and
+//     .modal-panel to ~0. Confirmed live via CDP DOM inspection: modal
+//     fully rendered (all tabs/content present) but computed width: 0px —
+//     invisible, not broken.
+//   - `min(780px, 100cqw)` — container query units resolve against the
+//     nearest `container-type` ancestor (.modal-layer-mount, "modal-mount"
+//     — modal.scss:30-38) instead of the immediate parent, which fixed the
+//     collapse-to-zero — but that mount tracks the full pane, which is
+//     WIDER than .modal-panel's own shrink-wrapped, backdrop-clamped box.
+//     Result: this element asserted a width bigger than its actual parent,
+//     re-overflowing past .modal-panel's edge (confirmed via CDP: child
+//     595px inside a 547px parent).
+//
+// The fix instead sizes `.modal-panel` itself, via `:has()` scoped to when
+// it's hosting us — exactly the pattern modal.scss's own `[data-size]`
+// rules already use (min(Npx, 100%), resolving against `.modal-panel`'s
+// own parent `.modal-root`, which is `position: fixed|absolute; inset: 0`
+// — genuinely definite, unlike `.modal-panel` itself). This element then
+// just fills whatever `.modal-panel` resolves to.
+// See docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.1.
+.modal-panel:has(.agent-setup-modal) {
+    width: min(780px, 100%);
+    height: 560px;
+    max-height: 85vh;
+}
+
 .agent-setup-modal {
     display: flex;
     flex-direction: column;
-    // Target size for the widest embedded panel (the Memory panel, 780px
-    // wide in its standalone form) plus the tab bar — but fluid via min(),
-    // not a raw px + vw combo. This modal opens pane-scoped (ModalLayer's
-    // mount node sits inside the originating agent pane, not the browser
-    // window), so a vw cap resolves against the wrong ancestor and doesn't
-    // actually constrain anything on a narrow pane in a wide window — the
-    // modal then renders at its literal 780px wide and .modal-panel's own
-    // overflow:auto produces exactly the horizontal scrollbar this fix
-    // addresses. min(target, 100%) is the same fluid-width technique
-    // modal.scss's own .modal-panel[data-size] rules already use (Layer B,
-    // MODAL_COMPACT_VARIANT_ARCHITECTURE_2026_05_26 §7) — 100% here resolves
-    // against .modal-panel, which correctly clamps to the pane's real width
-    // via its own max-width: 100%.
-    // See docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.1.
-    width: min(780px, 100%);
-    // Height deliberately stays a plain px + vh cap, NOT the same min()
-    // treatment as width above. .modal-panel never gets an explicit height
-    // (only max-height — modal.scss:151-154's pane-scoped override caps it
-    // at 100% of a real ancestor, but that's still a *max*, not a definite
-    // height), so a percentage height here has no definite containing-block
-    // height to resolve against and computes to `auto` per spec — mixing
-    // that into min(560px, 100%) produced a genuinely broken, stuck-blurry,
-    // unrenderable modal in live testing (reagent-caught-in-practice, not
-    // hypothetical). The original bug report was horizontal scrolling only;
-    // height was never reported broken, so this reverts to the simple,
-    // known-working px+vh form rather than fixing something that wasn't
-    // asked for and didn't need it.
-    height: 560px;
-    max-height: 85vh;
+    width: 100%;
+    height: 100%;
     min-width: 0;
     // Container-query context for .agent-setup-modal-tab below (a
     // descendant) — same technique as armory-view.scss's .armory-container.

--- a/frontend/app/view/agent/components/AgentSetupModal.tsx
+++ b/frontend/app/view/agent/components/AgentSetupModal.tsx
@@ -46,22 +46,32 @@ interface AgentSetupModalProps {
 interface SetupTabDef {
     id: SetupTabId;
     label: string;
+    /** FontAwesome icon name — same choice as the matching section in the
+     *  global Armory pane (armory-view.tsx's RAIL), for visual parity since
+     *  this modal is the per-agent-scoped analogue of it. */
+    icon: string;
 }
 
 export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
     // Data-driven tab list — Briefs slots in here later (no backend
     // primitive yet).
     const tabs: SetupTabDef[] = [
-        { id: "accounts", label: "Accounts" },
-        { id: "memory", label: "Memories" },
-        { id: "mcp", label: "MCP Servers" },
-        { id: "skills", label: "Skills" },
-        { id: "startup", label: "Startup" },
+        { id: "accounts", label: "Accounts", icon: "key" },
+        { id: "memory", label: "Memories", icon: "brain" },
+        { id: "mcp", label: "MCP Servers", icon: "plug" },
+        { id: "skills", label: "Skills", icon: "wand-magic-sparkles" },
+        // layer-group: same icon armory-view.tsx's RAIL uses for "Bundles" —
+        // this tab picks a Bundle as startup instructions, so it's the same
+        // concept scoped to one agent.
+        { id: "startup", label: "Startup", icon: "layer-group" },
     ];
 
     const [activeTab, setActiveTab] = createSignal<SetupTabId>(props.initialTab ?? "accounts");
 
     return (
+        // agent-setup-modal carries container-type so the tabs below (a
+        // descendant) can be targeted by @container agent-setup queries —
+        // same technique as armory-view.tsx's .armory-container wrapper.
         <div class="agent-setup-modal">
             <div class="agent-setup-modal-tabs" role="tablist">
                 <For each={tabs}>
@@ -71,9 +81,11 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
                             classList={{ "is-active": activeTab() === tab.id }}
                             role="tab"
                             aria-selected={activeTab() === tab.id}
+                            title={tab.label}
                             onClick={() => setActiveTab(tab.id)}
                         >
-                            {tab.label}
+                            <i class={`fa-sharp fa-solid fa-${tab.icon}`} aria-hidden="true" />
+                            <span>{tab.label}</span>
                         </button>
                     )}
                 </For>

--- a/frontend/app/view/agent/components/AgentSetupModal.tsx
+++ b/frontend/app/view/agent/components/AgentSetupModal.tsx
@@ -3,7 +3,7 @@
 
 /**
  * AgentSetupModal — unified tabbed container for per-agent setup surfaces,
- * opened by the single "Agent setup" (id-card) icon in the agent pane
+ * opened by the single "Agent setup" (vault) icon in the agent pane
  * header. Consolidates the former two icons (identity + native memory)
  * into one modal with tabs:
  *   - Accounts    — the former Identity panel (AgentIdentityModalPanel).

--- a/frontend/app/view/agent/styles/_identity-panel.scss
+++ b/frontend/app/view/agent/styles/_identity-panel.scss
@@ -38,6 +38,7 @@
 .agent-identity-provider-row {
     display: grid;
     grid-template-columns: 16px 72px 1fr auto;
+    grid-template-areas: "icon label assign actions";
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-1) var(--space-1-5);
@@ -48,19 +49,53 @@
     }
 }
 
+// Narrow modal — the actions cell (a <select> + up to two buttons) has an
+// irreducible min-content width (~370-420px for the whole row) that no
+// ancestor min-width:0 can rescue, since it's a *grid* track's own sizing,
+// not a flex item's. Reflow to a 2-row stack instead of trying to compress
+// content that has no room left to give — the assignment info and the
+// actions cell each get a full-width row of their own.
+// See SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.3.
+@container agent-setup (max-width: 460px) {
+    .agent-identity-provider-row {
+        grid-template-columns: 16px 1fr;
+        grid-template-areas:
+            "icon label"
+            "assign assign"
+            "actions actions";
+        row-gap: var(--space-1);
+    }
+
+    .agent-identity-provider-assignment {
+        justify-content: flex-start;
+    }
+
+    .agent-identity-provider-actions {
+        justify-content: flex-start;
+    }
+}
+
 .agent-identity-provider-icon {
+    grid-area: icon;
     font-size: 13px;
     text-align: center;
     opacity: 0.6;
 }
 
 .agent-identity-provider-label {
+    grid-area: label;
     font-size: 11px;
     color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
+    // nowrap is safe today (short labels, fixed 72px column at the wide
+    // breakpoint) but doesn't truncate — pair with ellipsis so a future
+    // longer label degrades instead of forcing the row wider.
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .agent-identity-provider-assignment {
+    grid-area: assign;
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -89,6 +124,7 @@
 }
 
 .agent-identity-provider-actions {
+    grid-area: actions;
     display: flex;
     align-items: center;
     gap: var(--space-1);


### PR DESCRIPTION
## Summary
Two rounds so far:

1. **Vault icon** — the existing "Agent setup" icon changes from `id-card` to `vault`, plus icons + a container-query breakpoint on the modal's tab bar (matching the global Armory pane's icon choices and responsive technique). See §1-6 of the spec.

2. **Eliminate horizontal scroll** — live-tested by Asaf via `task dev`: scrolling appeared on every tab, not just the ones in round 1's review. Root cause + fix in full: `docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md` §7.
   - **Root cause (every tab):** the modal's own sizing used a raw `width: 780px; max-width: 92vw`. Since it opens pane-scoped, `92vw` resolves against the browser window, not the pane — on a narrow pane in a wide window it constrained nothing, so the modal always rendered at 780px and overflowed. Switched to `width: min(780px, 100%)` (the same fluid-width technique `modal.scss`'s own `data-size` modals already use) + a scoped `min-width: 0` rescue.
   - **Memories tab:** migrated off a fixed 220px list column onto `PrimitiveListDetail` — the same single-pane list/detail component MCP Servers and Skills already use. Also dropped the old auto-select-first-file behavior (existed only to avoid an empty second column that no longer exists; keeping it would make this the one tab that doesn't open to its list like its siblings).
   - **Accounts tab:** the provider-row grid had a non-shrinking `auto` actions column with a ~370-420px floor. Added a breakpoint that reflows to a 2-row stack instead of trying to compress content with nowhere left to go.
   - MCP Servers, Skills, Startup — no changes needed, already fully fluid.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:scss` — no new errors
- [x] `npx vitest run frontend/app/view/agent` — 673/674 passing (1 pre-existing unrelated timeout flake, confirmed passing in isolation)
- [ ] Live check — `task dev` is up (labeled "agentx: agent-armory no-scroll fix"); please confirm no horizontal scroll appears on any tab at narrow pane widths, and that Memories' list/detail toggle + Accounts' row-reflow both look right