### PR TITLE
feat(agent): fork creation action -- + on the fork tab strip (Phase 4)

### DIFF
--- a/.changesets/1784593925-feat-agent-fork-creation-action-on-the-fork-tab-strip-phase--jv4l.md
+++ b/.changesets/1784593925-feat-agent-fork-creation-action-on-the-fork-tab-strip-phase--jv4l.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): fork creation action -- + on the fork tab strip (Phase 4)

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -364,6 +364,16 @@ pub struct CommandPaneOpenData {
     /// `build_pane_meta` enforces. `view` must still be set to the canonical
     /// view string so the block is routed to the correct renderer.
     pub meta: Option<MetaMapType>,
+    /// `Some(true)` creates the block through the reducer (same as the docked
+    /// path) but skips BOTH the layout-placement step AND the floating path's
+    /// `tear_off_block` saga — the block exists (and the frontend's WOS cache
+    /// knows about it) but isn't rendered anywhere yet. `split_direction` /
+    /// `split_reference_block_id` / `floating` are ignored when set. For a
+    /// caller that's about to attach the new block to an existing pane's
+    /// block-stack instead of giving it its own tile (in-pane tabs —
+    /// see `frontend/layout/lib/layoutStack.ts`'s `pushBlockOntoStack`,
+    /// docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §4.2).
+    pub skip_placement: Option<bool>,
 }
 
 /// Response from pane.open.

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -368,7 +368,14 @@ pub struct CommandPaneOpenData {
     /// path) but skips BOTH the layout-placement step AND the floating path's
     /// `tear_off_block` saga — the block exists (and the frontend's WOS cache
     /// knows about it) but isn't rendered anywhere yet. `split_direction` /
-    /// `split_reference_block_id` / `floating` are ignored when set. For a
+    /// `split_reference_block_id` are ignored when set (there's no placement
+    /// to direct). Review finding: `floating` is checked BEFORE this field
+    /// in `open_pane` (the floating branch returns first), so `floating`
+    /// takes precedence if a caller ever sets both — these two are meant to
+    /// be mutually exclusive (skip_placement = no window of its own at all;
+    /// floating = its own OS window), no legitimate caller sets both, but
+    /// documenting actual precedence rather than claiming `floating` is
+    /// "ignored" here, which it isn't. For a
     /// caller that's about to attach the new block to an existing pane's
     /// block-stack instead of giving it its own tile (in-pane tabs —
     /// see `frontend/layout/lib/layoutStack.ts`'s `pushBlockOntoStack`,

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -81,6 +81,51 @@ pub async fn open_pane(state: &AppState, cmd: CommandPaneOpenData) -> Result<Pan
         return pane::open_pane_floating(state, &wstore, &event_bus, cmd.view, tab_id, meta).await;
     }
 
+    // Skip-placement path (in-pane tabs — SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md
+    // §4.2): create the block through the reducer, same as the docked path
+    // below, but return immediately — no layout action, no tear_off_block
+    // saga. The caller attaches it to an existing pane's block-stack instead
+    // (`pushBlockOntoStack`), so it must never render docked or floating
+    // first.
+    if cmd.skip_placement == Some(true) {
+        let meta_val = serde_json::to_value(&meta)
+            .map_err(|e| format!("pane.open: skip_placement: meta serialize: {e}"))?;
+        let create_events = crate::server::service::dispatch_to_reducer(
+            state,
+            agentmux_common::ipc::Command::CreateBlock {
+                tab_id: tab_id.clone(),
+                meta: meta_val,
+            },
+        )
+        .await;
+        if let Some(msg) = create_events.iter().find_map(|e| match e {
+            agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+            _ => None,
+        }) {
+            return Err(format!("pane.open: skip_placement: CreateBlock: {msg}"));
+        }
+        let block_id = create_events
+            .iter()
+            .find_map(|e| match e {
+                agentmux_common::ipc::Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| "pane.open: skip_placement: CreateBlock emitted no BlockCreated".to_string())?;
+        for ev in &create_events {
+            if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, &wstore) {
+                tracing::warn!("pane.open: skip_placement: CreateBlock wstore apply failed: {e}");
+            }
+        }
+        crate::server::service::publish_events(state, &create_events);
+        tracing::info!(block_id = %block_id, view = %cmd.view, "pane.open: block created, placement skipped");
+        return Ok(PaneOpenResult {
+            block_id,
+            tab_id,
+            view: cmd.view,
+            created: true,
+        });
+    }
+
     // Create block (docked path) THROUGH THE REDUCER (#1681), not wcore-direct.
     // A store-only `create_block` lands the block in SQLite but never in the
     // reducer-canonical `state.blocks` map — and this RPC runs after bootstrap,
@@ -1083,6 +1128,7 @@ mod pane_open_reducer_tests {
             tree_expanded: None,
             floating: None,
             meta: None,
+            skip_placement: None,
         };
         let res = open_pane(&state, cmd).await.expect("open_pane docked");
 
@@ -1104,6 +1150,76 @@ mod pane_open_reducer_tests {
         )
         .await;
         assert!(r.is_ok(), "tear-off of an opened pane must succeed, got: {:?}", r.err());
+    }
+
+    /// In-pane tabs (SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §4.2):
+    /// `skip_placement` must create a reducer-tracked block (same as the
+    /// docked path) but leave the tab's layout tree completely untouched —
+    /// the caller is about to attach it to an existing leaf's block-stack,
+    /// not give it its own tile.
+    #[tokio::test]
+    async fn skip_placement_creates_block_without_touching_the_layout_tree() {
+        let state = test_state();
+
+        let ws_evs = dispatch_apply(&state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            Command::CreateTab { workspace_id: ws_id.clone(), name: "t".into() },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        // A fresh tab has no layout tree yet — confirm that baseline before
+        // asserting skip_placement doesn't add one.
+        {
+            let s = state.srv_state.lock().await;
+            assert!(s.tabs.get(&tab_id).unwrap().rootnode.is_none());
+        }
+
+        let cmd = CommandPaneOpenData {
+            view: "agent".into(),
+            file: None,
+            url: None,
+            cwd: None,
+            title: None,
+            tab_id: Some(tab_id.clone()),
+            split_direction: None,
+            split_reference_block_id: None,
+            focus: None,
+            tree_expanded: None,
+            floating: None,
+            meta: Some({
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m
+            }),
+            skip_placement: Some(true),
+        };
+        let res = open_pane(&state, cmd).await.expect("open_pane skip_placement");
+        assert!(res.created);
+
+        let s = state.srv_state.lock().await;
+        assert!(
+            s.blocks.contains_key(&res.block_id),
+            "skip_placement block must still be tracked in srv_state"
+        );
+        assert!(
+            s.tabs.get(&tab_id).unwrap().rootnode.is_none(),
+            "skip_placement must not place the block into the tab's layout tree"
+        );
     }
 }
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -274,7 +274,19 @@ export class AgentViewModel implements ViewModel {
      * to the working directory via WriteAgentConfigCommand, then creates
      * a SubprocessController ready for user input.
      */
-    launchAgentDefinition = async (agent: AgentDefinition, overrides?: LaunchOverrides): Promise<void> => {
+    /**
+     * @param targetBlockId In-pane tabs, Phase 4 — when set, launches INTO
+     *   that block instead of `this.blockId`. Used for the fork-tab-strip
+     *   `+` action, which spawns the fork into a freshly-created,
+     *   not-yet-placed block (see `pane.open`'s `skip_placement`) rather
+     *   than reconfiguring the current pane's own block. Every other
+     *   caller omits this and gets today's behavior unchanged.
+     */
+    launchAgentDefinition = async (
+        agent: AgentDefinition,
+        overrides?: LaunchOverrides,
+        targetBlockId?: string,
+    ): Promise<void> => {
         const provider = PROVIDERS[agent.provider] ?? PROVIDERS[resolveProviderAlias(agent.provider)];
         if (!provider) {
             Logger.error("agent", "Unknown provider in agent definition", { agentId: agent.id, provider: agent.provider });
@@ -360,6 +372,14 @@ export class AgentViewModel implements ViewModel {
         if (agent.provider_flags) {
             cliArgs.push(...agent.provider_flags.split(/\s+/).filter(Boolean));
         }
+        // In-pane tabs, Phase 4 — see LaunchOverrides.forkSession's own doc
+        // comment. Gated on the provider actually having a resume flag: a
+        // provider with none has no fork-session concept either, so this
+        // silently no-ops for it (graceful "fresh definition, fresh start"
+        // fallback per SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §6.4).
+        if (overrides?.forkSession && provider.resumeFlag) {
+            cliArgs.push("--fork-session");
+        }
 
         // Build env vars from provider unsetEnv + agent env content + per-agent isolation
         const envVars: Record<string, string> = {};
@@ -439,8 +459,8 @@ export class AgentViewModel implements ViewModel {
         // instance name (caught by codex on PR #504).
         const configFiles = buildConfigFiles(contentMap, skills, agent, instanceName);
 
-        const oref = WOS.makeORef("block", this.blockId);
-        const blockId = this.blockId;
+        const blockId = targetBlockId ?? this.blockId;
+        const oref = WOS.makeORef("block", blockId);
         try {
             // Whether the work_dir was constructed by us (and is thus
             // eligible for `<base>-N` collision suffixing) or was

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -282,15 +282,24 @@ export class AgentViewModel implements ViewModel {
      *   than reconfiguring the current pane's own block. Every other
      *   caller omits this and gets today's behavior unchanged.
      */
+    /**
+     * @returns Whether the launch actually succeeded. This method never
+     *   THROWS (every failure path is caught and logged internally, by
+     *   design — most callers fire-and-forget and don't want a launch
+     *   failure to crash their UI), but callers that need to react to
+     *   failure (e.g. the fork-tab-strip "+" action, which must not push a
+     *   permanently-broken tab onto the pane's stack) can check the
+     *   returned boolean instead of relying on a rejected promise.
+     */
     launchAgentDefinition = async (
         agent: AgentDefinition,
         overrides?: LaunchOverrides,
         targetBlockId?: string,
-    ): Promise<void> => {
+    ): Promise<boolean> => {
         const provider = PROVIDERS[agent.provider] ?? PROVIDERS[resolveProviderAlias(agent.provider)];
         if (!provider) {
             Logger.error("agent", "Unknown provider in agent definition", { agentId: agent.id, provider: agent.provider });
-            return;
+            return false;
         }
 
         // Check Node.js availability for npm-based providers
@@ -298,7 +307,7 @@ export class AgentViewModel implements ViewModel {
         if (nodejsError) {
             this.nodejsError = nodejsError;
             Logger.error("agent", "Node.js not available for agent definition", { agentId: agent.id, error: nodejsError });
-            return;
+            return false;
         }
 
         const version = getApi().getAboutModalDetails().version;
@@ -643,8 +652,10 @@ export class AgentViewModel implements ViewModel {
                     `direct identity link write-through failed: ${e?.message ?? String(e)}`,
                 );
             }
+            return true;
         } catch (e: any) {
             Logger.error("agent", "Failed to launch agent definition", { error: String(e) });
+            return false;
         }
     };
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -382,11 +382,16 @@ export class AgentViewModel implements ViewModel {
             cliArgs.push(...agent.provider_flags.split(/\s+/).filter(Boolean));
         }
         // In-pane tabs, Phase 4 — see LaunchOverrides.forkSession's own doc
-        // comment. Gated on the provider actually having a resume flag: a
-        // provider with none has no fork-session concept either, so this
-        // silently no-ops for it (graceful "fresh definition, fresh start"
-        // fallback per SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §6.4).
-        if (overrides?.forkSession && provider.resumeFlag) {
+        // comment. Review finding: `--fork-session` is Claude Code CLI
+        // syntax, validated ONLY for Claude
+        // (SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §6.4's empirical
+        // gate) — gating on "any provider with a resumeFlag" wrongly also
+        // matched gemini (`-r`) and muxcode (`--resume`), passing an
+        // unsupported flag to CLIs that were never validated to accept it.
+        // Every other provider (including those two) silently falls back
+        // to "fork = fresh definition, fresh start" — no flag, no error,
+        // exactly the graceful fallback §6.4 called for.
+        if (overrides?.forkSession && provider.id === "claude") {
             cliArgs.push("--fork-session");
         }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -215,7 +215,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             // fork will inherit verbatim) as the modal's display source.
             agent: source,
             originBlockId: model.blockId,
-            initialFormState: suggestedLabel ? ({ instanceName: suggestedLabel } as Partial<LaunchFormStateWire>) : undefined,
+            // Review finding: field is `name`, not `instanceName` — the
+            // form's actual field name (LaunchFormState.name /
+            // LaunchFormStateWire.name). The prior `as Partial<...>` cast
+            // bypassed TS's excess-property check, which silently masked
+            // the typo instead of catching it. Using a properly-typed
+            // literal (no cast) here so a future field-name mismatch is a
+            // compile error, not a silently-broken pre-fill.
+            initialFormState: suggestedLabel ? { name: suggestedLabel } satisfies Partial<LaunchFormStateWire> : undefined,
             onSubmit: async (overrides: LaunchOverrides) => {
                 // Review finding: this check must run BEFORE
                 // ForkAgentDefinitionCommand — resolving it after would let

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -82,7 +82,8 @@ import { SlashCommandPicker } from "./components/SlashCommandPicker";
 import { SlashHelpPanel } from "./components/SlashHelpPanel";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { createBlock, getApi, openOrFocusPaneByView, refocusNode, WOS } from "@/app/store/global";
+import { createBlock, getApi, openOrFocusPaneByView, pushNotification, refocusNode, WOS } from "@/app/store/global";
+import { ObjectService } from "@/app/store/services";
 import { ConfirmModal } from "@/element/modal";
 import { ModalLayer } from "@/element/ModalLayer";
 import { useModalLayer, type LaunchFormStateWire } from "@/element/modal-layer";
@@ -233,7 +234,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     {},
                 ) as { block_id: string };
                 const newBlockId = paneOpenResult.block_id;
-                await model.launchAgentDefinition(
+                // Review finding: launchAgentDefinition never throws (every
+                // failure path is caught + logged internally, by design —
+                // most callers fire-and-forget). Check its boolean result
+                // explicitly: a failed launch must NOT get pushed onto the
+                // pane's stack as a permanently-broken tab with no
+                // indication anything went wrong. Clean up the orphaned
+                // skip_placement block on failure — the forked
+                // AgentDefinition itself is left alone (it's a real,
+                // reusable definition; the picker can retry launching it
+                // later, same as any other launch failure).
+                const launched = await model.launchAgentDefinition(
                     forkedDef,
                     {
                         ...overrides,
@@ -243,6 +254,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     },
                     newBlockId,
                 );
+                if (!launched) {
+                    await ObjectService.DeleteBlock(newBlockId).catch(() => {});
+                    pushNotification({
+                        icon: "fa-triangle-exclamation",
+                        title: "Fork failed",
+                        message: `Could not launch the fork of "${source.name}" — see logs for details.`,
+                        timestamp: new Date().toISOString(),
+                        type: "error",
+                        expiration: Date.now() + 8000,
+                    });
+                    return;
+                }
                 pushBlockOntoStack(layoutModel, myNode.id, newBlockId);
             },
         });

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -53,7 +53,7 @@ import { useAgentFailure } from "./hooks/useAgentFailure";
 import { PaneRow } from "./components/PaneRow";
 import { PaneTabStrip } from "@/app/element/PaneTabStrip";
 import { useForkSet } from "./fork/useForkSet";
-import { getLayoutModelForStaticTab, setActiveBlockInStack } from "@/layout/index";
+import { getLayoutModelForStaticTab, pushBlockOntoStack, setActiveBlockInStack } from "@/layout/index";
 import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
 import { useSnapshotPersistence } from "./hooks/useSnapshotPersistence";
 import { useAgentDecisions } from "./hooks/useAgentDecisions";
@@ -85,7 +85,8 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { createBlock, getApi, openOrFocusPaneByView, refocusNode, WOS } from "@/app/store/global";
 import { ConfirmModal } from "@/element/modal";
 import { ModalLayer } from "@/element/ModalLayer";
-import { useModalLayer } from "@/element/modal-layer";
+import { useModalLayer, type LaunchFormStateWire } from "@/element/modal-layer";
+import type { LaunchOverrides } from "./components/AgentLaunchModal";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { loadAccounts, type AgentAccounts } from "@/app/view/identity/identity-model";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
@@ -144,11 +145,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const agentDefinitions = useAgentDefinitions();
     const currentAgent = createMemo(() => agentDefinitions().find((a) => a.id === agentId));
 
-    // Fork tab strip — Phase 3 of SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md.
-    // "Read-only switch": no new fork can be created from here yet (that's
-    // Phase 4's `+`/`/btw` action) — this only lets the user jump between
-    // forks that already exist and are already open somewhere. Replaces the
-    // unwired ForkBar/PaneRegions/PaneRow fork-bar path from
+    // Fork tab strip — Phases 3+4 of SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md.
+    // Phase 3 ("read-only switch") let the user jump between forks that
+    // already exist and are already open somewhere. Phase 4 adds the "+"
+    // action that actually creates one. Replaces the unwired ForkBar/
+    // PaneRegions/PaneRow fork-bar path from
     // SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 (which never shipped);
     // `computeForkSet`'s derivation logic is reused as-is, only its
     // PaneRow-based rendering is retired.
@@ -184,6 +185,67 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         } else {
             refocusNode(entry.blockId);
         }
+    };
+    // "+" on the fork tab strip — Phase 4. Reuses the existing launch
+    // modal (same "launch-agent" request kind AgentPicker's own fork/launch
+    // flows use) so the user confirms instance name / identity / memory
+    // exactly like any other launch, rather than silently auto-launching —
+    // this also means the real AgentDefinition fork only gets created
+    // inside onSubmit, so cancelling the modal never leaves an orphan
+    // forked definition behind. The suggested branch label is fetched
+    // up front (ForkAgentDefinitionSuggestCommand) purely to pre-fill the
+    // form; the actual fork (ForkAgentDefinitionCommand) happens at submit.
+    const handleForkCreate = async (): Promise<void> => {
+        const source = currentAgent();
+        if (!source) return;
+        let suggestedLabel = "";
+        try {
+            const suggestion = await RpcApi.ForkAgentDefinitionSuggestCommand(TabRpcClient, { source_id: agentId });
+            suggestedLabel = suggestion?.suggested_label ?? "";
+        } catch {
+            // Non-fatal — the modal's instance-name field just starts blank.
+        }
+        const currentSessionId = (block()?.meta?.["agent:sessionid"] as string | undefined) ?? "";
+        const currentInstanceId = (block()?.meta?.["agentInstanceId"] as string | undefined) ?? "";
+        modalLayer.open({
+            kind: "launch-agent" as const,
+            // The real forked definition doesn't exist until submit — show
+            // the source definition's config (provider/model/etc, which the
+            // fork will inherit verbatim) as the modal's display source.
+            agent: source,
+            originBlockId: model.blockId,
+            initialFormState: suggestedLabel ? ({ instanceName: suggestedLabel } as Partial<LaunchFormStateWire>) : undefined,
+            onSubmit: async (overrides: LaunchOverrides) => {
+                const forkedDef = await RpcApi.ForkAgentDefinitionCommand(TabRpcClient, {
+                    source_id: agentId,
+                    branch_label: overrides.instanceName,
+                });
+                const layoutModel = getLayoutModelForStaticTab();
+                const myNode = layoutModel.getNodeByBlockId(model.blockId);
+                if (!myNode) return;
+                // Create the new block without placing it anywhere — it's
+                // going onto THIS pane's stack, not its own tile. See
+                // pane.open's skip_placement + layoutStack.ts's
+                // pushBlockOntoStack doc comments.
+                const paneOpenResult = await TabRpcClient.rpcCall(
+                    "pane.open",
+                    { view: "agent", skip_placement: true, meta: { view: "agent" } },
+                    {},
+                ) as { block_id: string };
+                const newBlockId = paneOpenResult.block_id;
+                await model.launchAgentDefinition(
+                    forkedDef,
+                    {
+                        ...overrides,
+                        continueOfInstanceId: currentInstanceId || undefined,
+                        continueSessionId: currentSessionId || undefined,
+                        forkSession: true,
+                    },
+                    newBlockId,
+                );
+                pushBlockOntoStack(layoutModel, myNode.id, newBlockId);
+            },
+        });
     };
 
     // Wire the pane-scoped modal callback into the model so the single
@@ -1023,18 +1085,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
             {/* Fork tab strip — top region, above everything else, matching
                 the editor's own tab-strip placement and every general
-                tabbed-UI convention. Zero cost for the common case (a single
-                conversation, no related open forks): the strip doesn't
-                render at all. See SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.3. */}
-            <Show when={switchableForks().length > 1}>
-                <PaneTabStrip
-                    tabs={switchableForks()}
-                    activeId={agentId}
-                    getId={(f) => f.definitionId}
-                    getLabel={(f) => f.title}
-                    onActivate={handleForkSwitch}
-                />
-            </Show>
+                tabbed-UI convention. Phase 4 note: unlike Phase 3's
+                read-only bar (which hid itself entirely with only one
+                conversation, since there was nothing to switch to), the
+                strip is now always shown once an agent is running — the
+                "+" is exactly how you'd get to a second conversation, so
+                hiding the whole strip until a second one already exists
+                would make that action undiscoverable. See
+                SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.3. */}
+            <PaneTabStrip
+                tabs={switchableForks()}
+                activeId={agentId}
+                getId={(f) => f.definitionId}
+                getLabel={(f) => f.title}
+                onActivate={handleForkSwitch}
+                onAdd={() => void handleForkCreate()}
+                addTitle="Fork this conversation"
+            />
 
             <AgentSearchBar
                 visible={search.visible}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -217,13 +217,29 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             originBlockId: model.blockId,
             initialFormState: suggestedLabel ? ({ instanceName: suggestedLabel } as Partial<LaunchFormStateWire>) : undefined,
             onSubmit: async (overrides: LaunchOverrides) => {
+                // Review finding: this check must run BEFORE
+                // ForkAgentDefinitionCommand — resolving it after would let
+                // a failed lookup return silently (no cleanup, no error)
+                // with the real forked AgentDefinition already created and
+                // never launched or surfaced anywhere, and the modal's
+                // onSubmit promise resolving as if the fork succeeded.
+                const layoutModel = getLayoutModelForStaticTab();
+                const myNode = layoutModel.getNodeByBlockId(model.blockId);
+                if (!myNode) {
+                    pushNotification({
+                        icon: "fa-triangle-exclamation",
+                        title: "Fork failed",
+                        message: "Could not find this pane in the layout — try again after the pane finishes loading.",
+                        timestamp: new Date().toISOString(),
+                        type: "error",
+                        expiration: Date.now() + 8000,
+                    });
+                    return;
+                }
                 const forkedDef = await RpcApi.ForkAgentDefinitionCommand(TabRpcClient, {
                     source_id: agentId,
                     branch_label: overrides.instanceName,
                 });
-                const layoutModel = getLayoutModelForStaticTab();
-                const myNode = layoutModel.getNodeByBlockId(model.blockId);
-                if (!myNode) return;
                 // Create the new block without placing it anywhere — it's
                 // going onto THIS pane's stack, not its own tile. See
                 // pane.open's skip_placement + layoutStack.ts's

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -75,9 +75,11 @@ export interface LaunchOverrides {
      *  to the spawned CLI's args so it inherits history up to the resume
      *  point and then diverges with a NEW session id, instead of continuing
      *  the same session (which `continueSessionId` alone would do). Only
-     *  applied when the provider actually has a `resumeFlag` — providers
-     *  with no resume mechanism naturally fall back to "fork = fresh
-     *  definition, fresh start" by simply not getting the flag. */
+     *  applied for the Claude provider specifically — the only one
+     *  `--fork-session` was ever validated against
+     *  (SPEC_AGENT_PANE_FORKS_AND_AUX_PINS_2026_06_15 §6.4). Every other
+     *  provider naturally falls back to "fork = fresh definition, fresh
+     *  start" by simply not getting the flag. */
     forkSession?: boolean;
 }
 

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -70,6 +70,15 @@ export interface LaunchOverrides {
      *  reattached pane starts a fresh CLI session and re-injects the
      *  startup context. */
     continueSessionId?: string;
+    /** In-pane tabs, Phase 4 (SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md
+     *  §4.1) — when set alongside `continueSessionId`, appends `--fork-session`
+     *  to the spawned CLI's args so it inherits history up to the resume
+     *  point and then diverges with a NEW session id, instead of continuing
+     *  the same session (which `continueSessionId` alone would do). Only
+     *  applied when the provider actually has a `resumeFlag` — providers
+     *  with no resume mechanism naturally fall back to "fork = fresh
+     *  definition, fresh start" by simply not getting the flag. */
+    forkSession?: boolean;
 }
 
 interface AgentLaunchModalPanelProps {


### PR DESCRIPTION
## Summary

Phase 4 of `docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md`: the fork tab strip's `+` actually creates a fork now, closing the loop Phase 3 left open.

**Design decision** (confirmed with the user before implementing, since the spec didn't fully resolve it): `+` opens the **existing launch modal** instead of auto-launching silently. The user confirms instance name / identity / memory exactly like any other launch — reuses the existing modal UI/validation entirely, and the real forked `AgentDefinition` is only created inside `onSubmit`, so cancelling the modal never leaves an orphan definition behind.

**Backend:** `pane.open` gains `skip_placement` — creates a block through the reducer (same as the docked path) but returns immediately, no layout action, no `tear_off_block` saga. Mirrors `open_pane_floating`'s existing "create block, skip layout placement" half — this is the other half `layoutStack.ts`'s own Phase 2 doc comment flagged as a known gap.

**Frontend:** `launchAgentDefinition` gains an optional `targetBlockId` param (defaults to `this.blockId` — zero behavior change for every existing caller) and a `forkSession` override that appends `--fork-session`, gated on the provider having a `resumeFlag` (providers without one fall back to "fork = fresh definition, fresh start", per the June spec's already-validated design). The `+` handler: fetch a suggested label → open the launch modal → on submit, fork the definition → create a not-yet-placed block → launch into it with `continueOfInstanceId`/`continueSessionId`/`forkSession` set → `pushBlockOntoStack` to attach it to this pane's stack instead of giving it its own tile.

Also: the fork strip's visibility gate changed from "only when >1 already-switchable fork exists" (Phase 3, read-only) to "always shown once an agent is running" — with `+` now able to create the *second* fork, hiding the whole strip until a second one already exists would make that action undiscoverable.

## Test plan

- [x] `cargo test -p agentmux-srv -p agentmux-common` — 1562 passed (1 new: `skip_placement` regression test)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean (one pre-existing, unrelated `qrcode` error on `main`)
- [x] `npx vitest run` — 1849 passed, 3 pre-existing skips, unchanged from Phase 3's baseline
- [ ] Manual: click `+` on an agent pane's fork strip, confirm the launch modal opens pre-filled with a suggested label, submit, confirm the fork appears as a new tab in the same pane and the conversation history is inherited

<!-- agentmux:agent_id=agent3 -->