### PR TITLE
fix(auth): single-point login enforcement for oauth providers

### DIFF
--- a/.changesets/1784593520-fix-auth-single-point-login-enforcement-every-oauth-class-ag-zdqv.md
+++ b/.changesets/1784593520-fix-auth-single-point-login-enforcement-every-oauth-class-ag-zdqv.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(auth): single-point login enforcement — every oauth-class agent requires a real bound Armory account

--- a/.changesets/1784697483-fix-auth-runproviderlogin-cancels-abandoned-tier-1-login-chi-l2p1.md
+++ b/.changesets/1784697483-fix-auth-runproviderlogin-cancels-abandoned-tier-1-login-chi-l2p1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): runProviderLogin cancels abandoned tier-1 login child, dedupes tier2/3 account minting; open_login_terminal fixes on macOS/Linux

--- a/.changesets/1784699000-fix-auth-non-claude-oauth-providers-were-permanently-unable--snou.md
+++ b/.changesets/1784699000-fix-auth-non-claude-oauth-providers-were-permanently-unable--snou.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): non-Claude oauth providers were permanently unable to log in via terminal fallback

--- a/.changesets/1784699876-fix-auth-loginviaterminal-consolidated-onto-runproviderlogin-xz28.md
+++ b/.changesets/1784699876-fix-auth-loginviaterminal-consolidated-onto-runproviderlogin-xz28.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): loginViaTerminal consolidated onto runProviderLogin — was a sibling duplicate of the tier-2/3 P0 bug just fixed

--- a/.changesets/1784700385-docs-correct-stale-ambient-creds-claim-in-plan-login-single--aohj.md
+++ b/.changesets/1784700385-docs-correct-stale-ambient-creds-claim-in-plan-login-single--aohj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: correct stale ambient-creds claim in PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION — was reverted, doc never updated

--- a/.changesets/1784701316-fix-auth-retry-login-reported-failure-right-after-a-successf-nt9c.md
+++ b/.changesets/1784701316-fix-auth-retry-login-reported-failure-right-after-a-successf-nt9c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): Retry Login reported failure right after a successful login, and orphaned an account on every retry

--- a/.changesets/1784702100-fix-auth-retry-account-persist-once-after-a-successful-seed--9ryt.md
+++ b/.changesets/1784702100-fix-auth-retry-account-persist-once-after-a-successful-seed--9ryt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): retry account persist once after a successful seed instead of confusingly falling through to a terminal prompt

--- a/.changesets/1784703054-fix-agent-remove-the-dead-use-global-cli-login-toggle-the-sp-ktbn.md
+++ b/.changesets/1784703054-fix-agent-remove-the-dead-use-global-cli-login-toggle-the-sp-ktbn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): remove the dead 'Use global CLI login' toggle — the spawn gate stopped honoring it, but the UI kept promising it works

--- a/.changesets/1784703969-fix-auth-tier-1-login-success-never-bound-an-account-for-any-2fqb.md
+++ b/.changesets/1784703969-fix-auth-tier-1-login-success-never-bound-an-account-for-any-2fqb.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(auth): tier-1 login success never bound an account for any oauth-class provider whose CLI actually prints a URL

--- a/.changesets/1784705476-fix-auth-address-reagent-p1-review-on-2260-relogin-and-login-feqk.md
+++ b/.changesets/1784705476-fix-auth-address-reagent-p1-review-on-2260-relogin-and-login-feqk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): address reagent P1 review on #2260 — relogin() and /login left tier-1 'opened' logins unpersisted

--- a/.changesets/1784707413-fix-auth-sweep-orphaned-account-dirs-from-abandoned-failed-l-3zkw.md
+++ b/.changesets/1784707413-fix-auth-sweep-orphaned-account-dirs-from-abandoned-failed-l-3zkw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): sweep orphaned account dirs from abandoned/failed logins

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1346,19 +1346,43 @@ pub fn open_login_terminal(args: &serde_json::Value) -> Result<serde_json::Value
         // `open -a Terminal` can't carry env vars or a shell command directly,
         // so write a disposable script and open Terminal.app on that instead.
         // The script self-deletes on exit so repeated logins don't litter tmp.
+        //
+        // reagent P1 on #2255: the old name (`agentmux-login-{pid}.command`,
+        // just the host process's own PID) is CONSTANT for the process's
+        // whole lifetime — a second login attempt (a different agent, or a
+        // retry) before the first script finishes executing overwrote the
+        // same path, so a running/about-to-run shell could execute mixed or
+        // wrong content, or the self-delete (`rm -f -- "$0"`) could remove
+        // the file out from under a concurrent attempt. A UUID per call
+        // makes every attempt's script path unique regardless of timing.
         let script_path = std::env::temp_dir().join(format!(
-            "agentmux-login-{}.command",
-            std::process::id()
+            "agentmux-login-{}-{}.command",
+            std::process::id(),
+            uuid::Uuid::new_v4(),
         ));
         let mut script = String::from("#!/bin/sh\n");
         for (k, v) in &auth_env {
             script.push_str(&format!("export {}={}\n", k, shell_quote(v)));
         }
         script.push_str(&format!("{}\nrm -f -- \"$0\"\n", cmd_str));
-        std::fs::write(&script_path, script)
+        // reagent P1 on #2260 (surfaced via this file's inclusion in that
+        // PR's diff, but the code — and the fix — belong here): the old
+        // `fs::write` then `set_permissions(0o700)` sequence left a TOCTOU
+        // window where the pid-named script, containing exported auth_env
+        // values, was briefly world-readable in the shared temp dir under a
+        // default umask. Setting the mode AT CREATION via OpenOptions closes
+        // that window — the file never exists with broader permissions.
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o700)
+            .open(&script_path)
+            .map_err(|e| format!("open_login_terminal: failed to create launch script: {e}"))?;
+        file.write_all(script.as_bytes())
             .map_err(|e| format!("open_login_terminal: failed to write launch script: {e}"))?;
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700));
+        drop(file);
         std::process::Command::new("open")
             .args(["-a", "Terminal", script_path.to_string_lossy().as_ref()])
             .spawn()
@@ -1371,7 +1395,24 @@ pub fn open_login_terminal(args: &serde_json::Value) -> Result<serde_json::Value
         // in order and use whichever spawns successfully. `-e` runs the
         // command and the shell stays open after exit so any CLI error is
         // visible instead of the window vanishing immediately.
-        let sh_cmd = format!("{}; echo; echo '[login finished — press Enter to close]'; read _", cmd_str);
+        //
+        // reagent P2 on #2255: single-instance terminal emulators like
+        // gnome-terminal proxy the "open a window" request to an
+        // already-running server process via D-Bus — the freshly spawned
+        // client process just sends that message and exits, so `.envs()`
+        // on THIS Command never reaches the shell the server process
+        // actually runs. Embed the env vars as `export` lines in the shell
+        // command text itself instead (same approach the macOS branch
+        // already uses) — that text is what actually gets relayed to the
+        // server-owned shell, regardless of which process env it came from.
+        let mut export_prelude = String::new();
+        for (k, v) in &auth_env {
+            export_prelude.push_str(&format!("export {}='{}'; ", k, v.replace('\'', "'\\''")));
+        }
+        let sh_cmd = format!(
+            "{}{}; echo; echo '[login finished — press Enter to close]'; read _",
+            export_prelude, cmd_str,
+        );
         let candidates: [(&str, &[&str]); 4] = [
             ("x-terminal-emulator", &["-e", "sh", "-c"]),
             ("gnome-terminal", &["--", "sh", "-c"]),
@@ -1381,6 +1422,10 @@ pub fn open_login_terminal(args: &serde_json::Value) -> Result<serde_json::Value
         let mut spawned = false;
         for (bin, prefix_args) in candidates {
             let mut command = std::process::Command::new(bin);
+            // Still set .envs() too — harmless for emulators that DON'T
+            // proxy via a persistent server (xterm, konsole typically
+            // fork a fresh process per invocation and would inherit it),
+            // and costs nothing for the ones that ignore it.
             command.args(prefix_args).arg(&sh_cmd).envs(&auth_env);
             if command.spawn().is_ok() {
                 spawned = true;

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1271,6 +1271,13 @@ pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, Stri
     Ok(serde_json::Value::Null)
 }
 
+/// Single-quote a value for embedding in the POSIX launch script
+/// `open_login_terminal` writes on macOS.
+#[cfg(target_os = "macos")]
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 /// Spawn the CLI login command in a NEW visible console window so the OS can
 /// open a browser (the piped/PTY paths used by `run_cli_login` are headless
 /// and block the browser from launching — confirmed for Claude v2.1.x).
@@ -1334,11 +1341,58 @@ pub fn open_login_terminal(args: &serde_json::Value) -> Result<serde_json::Value
             .map_err(|e| format!("open_login_terminal: spawn failed: {e}"))?;
     }
 
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
     {
-        // macOS / Linux: xterm / open -a Terminal. Tracked follow-up.
-        let _ = (cmd_str, auth_env);
-        return Err("open_login_terminal: not yet implemented on this platform".to_string());
+        // `open -a Terminal` can't carry env vars or a shell command directly,
+        // so write a disposable script and open Terminal.app on that instead.
+        // The script self-deletes on exit so repeated logins don't litter tmp.
+        let script_path = std::env::temp_dir().join(format!(
+            "agentmux-login-{}.command",
+            std::process::id()
+        ));
+        let mut script = String::from("#!/bin/sh\n");
+        for (k, v) in &auth_env {
+            script.push_str(&format!("export {}={}\n", k, shell_quote(v)));
+        }
+        script.push_str(&format!("{}\nrm -f -- \"$0\"\n", cmd_str));
+        std::fs::write(&script_path, script)
+            .map_err(|e| format!("open_login_terminal: failed to write launch script: {e}"))?;
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700));
+        std::process::Command::new("open")
+            .args(["-a", "Terminal", script_path.to_string_lossy().as_ref()])
+            .spawn()
+            .map_err(|e| format!("open_login_terminal: spawn failed: {e}"))?;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // No single terminal emulator is guaranteed present; try common ones
+        // in order and use whichever spawns successfully. `-e` runs the
+        // command and the shell stays open after exit so any CLI error is
+        // visible instead of the window vanishing immediately.
+        let sh_cmd = format!("{}; echo; echo '[login finished — press Enter to close]'; read _", cmd_str);
+        let candidates: [(&str, &[&str]); 4] = [
+            ("x-terminal-emulator", &["-e", "sh", "-c"]),
+            ("gnome-terminal", &["--", "sh", "-c"]),
+            ("konsole", &["-e", "sh", "-c"]),
+            ("xterm", &["-e", "sh", "-c"]),
+        ];
+        let mut spawned = false;
+        for (bin, prefix_args) in candidates {
+            let mut command = std::process::Command::new(bin);
+            command.args(prefix_args).arg(&sh_cmd).envs(&auth_env);
+            if command.spawn().is_ok() {
+                spawned = true;
+                break;
+            }
+        }
+        if !spawned {
+            return Err(
+                "open_login_terminal: no terminal emulator found (tried x-terminal-emulator, gnome-terminal, konsole, xterm)"
+                    .to_string(),
+            );
+        }
     }
 
     Ok(serde_json::json!({ "opened": true }))

--- a/agentmux-srv/src/identity/cleanup.rs
+++ b/agentmux-srv/src/identity/cleanup.rs
@@ -30,8 +30,9 @@
 //! it needs per-provider subprocess plumbing this module doesn't have.
 
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
-use crate::backend::storage::store::{IdentityAccount, SecretRef};
+use crate::backend::storage::store::{IdentityAccount, SecretRef, Store};
 
 /// What `cleanup_account_secrets` did, for callers/tests to assert on.
 /// Logging already happened inside the function.
@@ -178,6 +179,106 @@ fn cleanup_oauth_dir(
             SecretCleanup::OAuthDirFailed { dir: dir.to_path_buf(), error: e.to_string() }
         }
     }
+}
+
+/// Canonicalizes both `dir` and `root`, then removes `dir`'s tree only if
+/// it resolves strictly inside `root` (never the root itself) — the same
+/// escape guard `cleanup_oauth_dir` uses for a single account's credential
+/// dir, generalized for `sweep_orphaned_account_dirs` below, which removes
+/// a whole per-account dir rather than one provider's subdir within it.
+fn remove_tree_if_contained(dir: &Path, root: &Path) -> Result<(), String> {
+    let canon_root =
+        std::fs::canonicalize(root).map_err(|e| format!("root not canonicalizable: {e}"))?;
+    let canon_dir =
+        std::fs::canonicalize(dir).map_err(|e| format!("dir not canonicalizable: {e}"))?;
+    if canon_dir == canon_root || !canon_dir.starts_with(&canon_root) {
+        return Err(format!(
+            "{} is not strictly inside {}",
+            canon_dir.display(),
+            canon_root.display()
+        ));
+    }
+    std::fs::remove_dir_all(&canon_dir).map_err(|e| e.to_string())
+}
+
+/// Sweep `identities_root`'s direct children for orphaned per-account
+/// dirs: `compute_and_ensure_account_dir` mints a fresh `<account_id>/`
+/// dir and writes real credential files into it BEFORE the login that
+/// dir belongs to ever completes, so no `IdentityAccount` row exists yet
+/// to reference it. A login that's abandoned, times out, or crashes the
+/// app mid-flow leaves that directory behind forever — reagent's finding
+/// on #2260: "abandoned/failed attempts leave orphaned directories with
+/// no cleanup path."
+///
+/// Called opportunistically from `compute_and_ensure_account_dir` right
+/// before every FRESH mint (never on a reconnect — reusing an existing
+/// account's dir needs no sweep). Age-gated via `min_age_secs` so a
+/// login that's still genuinely in progress — which legitimately has no
+/// DB row yet either — is never swept out from under it; callers should
+/// pick a margin comfortably above every frontend poll timeout (5
+/// minutes as of this writing) to leave room for a slow user plus retry.
+///
+/// Best-effort and silent-safe: `identity_get` failures or an unreadable
+/// root skip that candidate (or the whole sweep) rather than risk
+/// deleting a real, in-use account's dir on a false read. Returns the
+/// dirs actually removed, mainly for tests to assert on.
+pub fn sweep_orphaned_account_dirs(
+    store: &Store,
+    identities_root: &Path,
+    min_age_secs: u64,
+) -> Vec<PathBuf> {
+    let mut removed = Vec::new();
+    let entries = match std::fs::read_dir(identities_root) {
+        Ok(e) => e,
+        Err(_) => return removed, // root doesn't exist yet — nothing to sweep
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(account_id) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        match store.identity_get(account_id) {
+            // A real, persisted account — never touch it.
+            Ok(Some(_)) => continue,
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    account_id,
+                    error = %e,
+                    "identity.sweep: identity_get failed — skipping candidate rather than risk a false orphan"
+                );
+                continue;
+            }
+        }
+        let age_secs = match entry.metadata().and_then(|m| m.modified()) {
+            Ok(mtime) => SystemTime::now()
+                .duration_since(mtime)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            Err(_) => continue, // can't determine age — skip, don't guess
+        };
+        if age_secs < min_age_secs {
+            continue; // could still be a login in progress
+        }
+        match remove_tree_if_contained(&path, identities_root) {
+            Ok(()) => {
+                tracing::info!(
+                    account_id,
+                    dir = %path.display(),
+                    age_secs,
+                    "identity.sweep: orphaned account dir removed (no matching account row, past age threshold)"
+                );
+                removed.push(path);
+            }
+            Err(e) => {
+                tracing::debug!(account_id, dir = %path.display(), error = %e, "identity.sweep: candidate not removed");
+            }
+        }
+    }
+    removed
 }
 
 #[cfg(test)]
@@ -342,5 +443,90 @@ mod tests {
             "got {out:?}"
         );
         assert!(canary.exists(), "keychain cleanup must not touch the filesystem");
+    }
+
+    fn make_store() -> Store {
+        Store::open_in_memory().unwrap()
+    }
+
+    /// An orphaned dir (no matching `IdentityAccount` row) past the age
+    /// threshold is removed and reported.
+    #[test]
+    fn sweep_removes_orphaned_dir_past_age_threshold() {
+        let store = make_store();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        let orphan = root.join("orphan-uuid").join("claude");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join(".credentials.json"), "{}").unwrap();
+
+        let removed = sweep_orphaned_account_dirs(&store, &root, 0);
+
+        assert_eq!(removed, vec![root.join("orphan-uuid")]);
+        assert!(!root.join("orphan-uuid").exists(), "orphaned dir must be gone");
+    }
+
+    /// A dir with a real, persisted `IdentityAccount` row is never swept,
+    /// no matter the age threshold — this is the guard that keeps an
+    /// in-use account's credentials safe.
+    #[test]
+    fn sweep_never_removes_a_dir_with_a_real_account_row() {
+        let store = make_store();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        let real = root.join("real-account-id").join("claude");
+        std::fs::create_dir_all(&real).unwrap();
+
+        store
+            .identity_upsert(&IdentityAccount {
+                id: "real-account-id".to_string(),
+                name: "asaf-claude".to_string(),
+                provider: "claude".to_string(),
+                kind: "oauth".to_string(),
+                display_name: String::new(),
+                secret_ref: SecretRef::OAuthConfigDir {
+                    dir: real.to_string_lossy().to_string(),
+                },
+                context: serde_json::json!({}),
+                status: "valid".to_string(),
+                created_at: 0,
+                updated_at: 0,
+            })
+            .unwrap();
+
+        let removed = sweep_orphaned_account_dirs(&store, &root, 0);
+
+        assert!(removed.is_empty());
+        assert!(real.exists(), "a real account's dir must survive the sweep");
+    }
+
+    /// An orphaned dir younger than `min_age_secs` is left alone — it
+    /// could be a login that's still genuinely in progress.
+    #[test]
+    fn sweep_never_removes_a_dir_younger_than_the_age_threshold() {
+        let store = make_store();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities");
+        let fresh = root.join("fresh-uuid").join("claude");
+        std::fs::create_dir_all(&fresh).unwrap();
+
+        // Effectively "just created" vs. an implausibly high age floor.
+        let removed = sweep_orphaned_account_dirs(&store, &root, 999_999);
+
+        assert!(removed.is_empty());
+        assert!(root.join("fresh-uuid").exists(), "a fresh in-progress dir must survive");
+    }
+
+    /// The identities root not existing yet (fresh install, nothing ever
+    /// minted) is a normal state, not an error — empty result, no panic.
+    #[test]
+    fn sweep_on_missing_root_returns_empty_without_panicking() {
+        let store = make_store();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("identities-never-created");
+
+        let removed = sweep_orphaned_account_dirs(&store, &root, 0);
+
+        assert!(removed.is_empty());
     }
 }

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -306,7 +306,25 @@ pub enum ProviderClass {
 
 /// Classify a provider id. `None` for unknown providers — the
 /// resolver logs and skips them.
+///
+/// reagent P1 on #2263: this used to match only canonical IDs directly, but
+/// `backend/providers.rs` registers aliases (`gemini-cli`→`gemini`,
+/// `copilot-cli`/`github-copilot`→`copilot`, `claude-code`→`claude`, etc.)
+/// that `get_provider` already resolves — meaning `provider_class` and
+/// `get_provider` could disagree on a definition/link still using an alias
+/// ID, silently skipping both the spawn gate and config-dir injection for
+/// it. Resolve to the canonical ID first so the two can never drift.
+///
+/// `resolve_provider_alias` only knows the CLI-tool registry (claude/codex/
+/// gemini/etc.) — it returns `""` as a sentinel for anything outside that
+/// registry, which includes the api-key-class service identifiers below
+/// ("github"/"anthropic"/"openai"/"kimi"/"aws" — a completely different
+/// namespace, not CLI tools). Only substitute the resolved value when it's
+/// non-empty; otherwise keep matching on the original id so that namespace
+/// is untouched.
 pub fn provider_class(provider: &str) -> Option<ProviderClass> {
+    let resolved = crate::backend::providers::resolve_provider_alias(provider);
+    let provider = if resolved.is_empty() { provider } else { resolved };
     match provider {
         // ── API-key class ─────────────────────────────────────────
         // ApiKey.env_vars values match the legacy provider_env_vars
@@ -1045,6 +1063,24 @@ mod tests {
             provider_class("openclaw"),
             Some(ProviderClass::OAuth { config_dir_env_var: "OPENCLAW_HOME" }),
         );
+    }
+
+    #[test]
+    fn provider_class_resolves_aliases_to_the_same_result_as_canonical() {
+        // reagent P1 on #2263: provider_class used to match only canonical
+        // IDs, silently disagreeing with get_provider (which already
+        // resolves aliases) for any definition/link still using one.
+        assert_eq!(provider_class("claude-code"), provider_class("claude"));
+        assert_eq!(provider_class("claude_code"), provider_class("claude"));
+        assert_eq!(provider_class("codex-cli"), provider_class("codex"));
+        assert_eq!(provider_class("openclaw-cli"), provider_class("openclaw"));
+        assert_eq!(provider_class("open-claw"), provider_class("openclaw"));
+        // Api-key-class aliases must resolve identically too — this isn't
+        // gated on oauth-class providers specifically.
+        assert_eq!(provider_class("kimi-cli"), provider_class("kimi"));
+        // A truly unknown id must still classify as None, not panic or
+        // silently match something via an empty-string fallback.
+        assert_eq!(provider_class("totally-unknown-provider-xyz"), None);
     }
 
     #[cfg(debug_assertions)]

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -225,15 +225,16 @@ pub enum SpawnGateError {
 impl std::fmt::Display for SpawnGateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            // The quoted toggle name must match AgentIdentityModal.tsx's
-            // label VERBATIM so users can find it (reagent P2, PR #2164
-            // round 2).
+            // "Bind an account in the Armory" is now the ONLY path — the
+            // ambient/"use global CLI login" opt-in this used to also
+            // suggest was retired (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_
+            // 2026_07_20.md §7): it let a credential the app couldn't
+            // attribute to any account run indefinitely, invisible to
+            // Armory. Don't point users at a toggle that no longer works.
             SpawnGateError::MissingCredentials { provider } => write!(
                 f,
                 "no credentials for {}: the bound account was deleted or is \
-                 unresolvable. Bind an account in the Armory, or enable \
-                 \"Use global CLI login when no account is bound\" in this \
-                 agent's settings.",
+                 unresolvable. Bind an account for this provider in the Armory.",
                 provider,
             ),
             SpawnGateError::InjectionUnavailable { detail } => write!(
@@ -682,35 +683,36 @@ pub fn inject_identity_env_with_broker(
     let mut injected_oauth: std::collections::HashSet<String> =
         std::collections::HashSet::new();
 
-    // Gate helper for an unresolvable oauth-class binding/provider.
-    // Returns Ok(()) when the agent opted into ambient (caller skips the
-    // binding), Err(SpawnGateError) otherwise (caller aborts the spawn).
+    // Gate helper for an unresolvable oauth-class binding/provider. Always
+    // blocks the spawn — an oauth-class provider must resolve to a real
+    // bound IdentityAccount, full stop.
+    //
+    // `use_ambient_login` used to let this fall through to the user's
+    // global/ambient CLI login instead of blocking. That escape hatch is
+    // retired (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7,
+    // "single point, not global"): a credential the app can't attribute to
+    // a specific Armory account is exactly the state that left Marks
+    // silently working with an untracked, unrefreshed shared-dir credential
+    // and no visible account anywhere in Armory. `use_ambient` is kept as a
+    // parameter (read below only for the log line) rather than deleted
+    // outright, so the still-live `use_ambient_login` DB column and its
+    // callers don't need a synchronized migration to compile — it no longer
+    // has any effect on the outcome.
     let gate_oauth_failure = |provider: &str, detail: &str| -> Result<(), SpawnGateError> {
-        if use_ambient {
-            tracing::info!(
-                target: "identity",
-                "identity.spawn.ambient: using global CLI login (per-agent opt-in) — \
-                 provider {}, definition {} ({})",
-                provider,
-                instance.definition_id,
-                detail,
-            );
-            Ok(())
-        } else {
-            tracing::warn!(
-                target: "identity",
-                "identity.spawn.blocked: no credentials for provider {} \
-                 (definition {}, identity {}) — {}; spawn refused \
-                 (use_ambient_login=false)",
-                provider,
-                instance.definition_id,
-                instance.identity_id,
-                detail,
-            );
-            Err(SpawnGateError::MissingCredentials {
-                provider: provider.to_string(),
-            })
-        }
+        tracing::warn!(
+            target: "identity",
+            "identity.spawn.blocked: no credentials for provider {} \
+             (definition {}, identity {}) — {}; spawn refused \
+             (single-point enforcement — use_ambient_login={}, ignored)",
+            provider,
+            instance.definition_id,
+            instance.identity_id,
+            detail,
+            use_ambient,
+        );
+        Err(SpawnGateError::MissingCredentials {
+            provider: provider.to_string(),
+        })
     };
 
     for binding in &bindings {
@@ -1273,16 +1275,17 @@ mod tests {
         // wording) — pin the load-bearing pieces.
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("no credentials for claude"), "got: {msg}");
-        assert!(msg.contains("Armory"), "got: {msg}");
-        assert!(msg.contains("Use global CLI login when no account is bound"), "got: {msg}");
+        assert!(msg.contains("Bind an account for this provider in the Armory"), "got: {msg}");
     }
 
     #[test]
-    fn spawn_proceeds_ambient_when_bound_oauth_account_missing_and_flag_true() {
-        // Spec §2.5 test 2: binding → missing account → flag true → no
-        // injection + spawn proceeds (the sanctioned ambient path; the
-        // `identity.spawn.ambient:` info line is asserted-by-return-value
-        // here since this codebase has no tracing capture).
+    fn spawn_still_blocked_when_bound_oauth_account_missing_and_flag_true() {
+        // Was spawn_proceeds_ambient_when_bound_oauth_account_missing_and_flag_true
+        // — the ambient opt-in it exercised is retired
+        // (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7). A missing
+        // account now blocks the spawn unconditionally; `use_ambient_login`
+        // no longer changes the outcome. This test pins that the flag is
+        // truly inert, not just untested.
         let store = make_store();
         let mut def = gate_def(1);
         store.agent_def_insert(&mut def).unwrap();
@@ -1305,11 +1308,12 @@ mod tests {
         store.instance_create(&inst).unwrap();
 
         let mut env: HashMap<String, String> = HashMap::new();
-        inject_identity_env(store.clone(), store, "block-gate-2", &mut env).unwrap();
+        let res = inject_identity_env(store.clone(), store, "block-gate-2", &mut env);
 
-        // No config dir injected — the CLI uses its global login, by
-        // explicit opt-in, never silently.
-        assert!(env.get("CLAUDE_CONFIG_DIR").is_none());
+        assert_eq!(
+            res,
+            Err(SpawnGateError::MissingCredentials { provider: "claude".to_string() }),
+        );
         assert!(env.is_empty());
     }
 
@@ -1432,7 +1436,11 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            // Not oauth-class (§4.3) — the layer-3 gate only applies to
+            // claude/codex/openclaw definitions, so a non-oauth def here
+            // keeps this test focused on the api-key round trip below
+            // without a claude account fixture it doesn't otherwise need.
+            provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1453,11 +1461,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
-            // Ambient opt-in: this test exercises api-key / zero-link behavior,
-            // not the layer-3 oauth gate. The def provider (claude) has no
-            // oauth binding here, so without the opt-in the gate would
-            // block the spawn (covered by the spawn_blocked_* tests).
-            use_ambient_login: 1,
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1517,7 +1521,9 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            // Not oauth-class (§4.3) — see the identical note in
+            // inject_full_round_trip_plaintext_dev above.
+            provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1538,11 +1544,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
-            // Ambient opt-in: this test exercises api-key / zero-link behavior,
-            // not the layer-3 oauth gate. The def provider (claude) has no
-            // oauth binding here, so without the opt-in the gate would
-            // block the spawn (covered by the spawn_blocked_* tests).
-            use_ambient_login: 1,
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1582,7 +1584,11 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            // Not oauth-class (§4.3) — this test targets the zero-direct-
+            // links path itself, which is a distinct concern from the
+            // layer-3 oauth gate (covered separately by the spawn_blocked_*
+            // tests below).
+            provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1603,11 +1609,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
-            // Ambient opt-in: this test exercises api-key / zero-link behavior,
-            // not the layer-3 oauth gate. The def provider (claude) has no
-            // oauth binding here, so without the opt-in the gate would
-            // block the spawn (covered by the spawn_blocked_* tests).
-            use_ambient_login: 1,
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1647,7 +1649,9 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            // Not oauth-class (§4.3) — same rationale as
+            // inject_no_direct_links_injects_nothing above.
+            provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1668,11 +1672,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
-            // Ambient opt-in: this test exercises api-key / zero-link behavior,
-            // not the layer-3 oauth gate. The def provider (claude) has no
-            // oauth binding here, so without the opt-in the gate would
-            // block the spawn (covered by the spawn_blocked_* tests).
-            use_ambient_login: 1,
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1721,7 +1721,10 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            // Not oauth-class (§4.3) — this test targets partial-success
+            // skip behavior across api-key bindings, unrelated to the
+            // layer-3 oauth gate.
+            provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1742,11 +1745,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
-            // Ambient opt-in: this test exercises api-key / zero-link behavior,
-            // not the layer-3 oauth gate. The def provider (claude) has no
-            // oauth binding here, so without the opt-in the gate would
-            // block the spawn (covered by the spawn_blocked_* tests).
-            use_ambient_login: 1,
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -1800,7 +1799,9 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            provider: "claude".to_string(),
+            // Not oauth-class (§4.3) — this test targets the unknown-
+            // provider skip path, unrelated to the layer-3 oauth gate.
+            provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),
             shell: String::new(),
@@ -1821,11 +1822,7 @@ mod tests {
             container_image: String::new(),
             container_volumes: "[]".to_string(),
             container_name: String::new(),
-            // Ambient opt-in: this test exercises api-key / zero-link behavior,
-            // not the layer-3 oauth gate. The def provider (claude) has no
-            // oauth binding here, so without the opt-in the gate would
-            // block the spawn (covered by the spawn_blocked_* tests).
-            use_ambient_login: 1,
+            use_ambient_login: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -286,7 +286,7 @@ async fn connect_and_run(
     token: &str,
     agents: Arc<Mutex<HashSet<String>>>,
     ctrl_rx: &mut mpsc::UnboundedReceiver<CtrlMsg>,
-    _wstore: &Arc<Store>,
+    wstore: &Arc<Store>,
     http: &reqwest::Client,
 ) -> Result<(), String> {
     use tokio_tungstenite::tungstenite::ClientRequestBuilder;
@@ -337,8 +337,37 @@ async fn connect_and_run(
 
     loop {
         tokio::select! {
-            // Keepalive — see CLIENT_PING_INTERVAL_SECS.
+            // Keepalive — see CLIENT_PING_INTERVAL_SECS. Also the only
+            // standing check on the stored credential's freshness: a
+            // healthy WS session never otherwise revisits `db_muxbus_credentials`
+            // (the crate's own reconnect-triggered `load_valid_token` is the
+            // sole other caller of the refresh path). Without this, a
+            // long-lived session leaves the STORED token to expire in place —
+            // still fine for this connection (it doesn't re-present the
+            // token after handshake), but every OTHER consumer reading the
+            // same row (e.g. `inject_muxbus_env` at agent spawn) sees a
+            // correctly-but-avoidably expired credential and skips
+            // injection, even though a valid refresh_token has been sitting
+            // right there the whole time. Piggybacking the check on the
+            // existing ping tick (240s) against a 300s "nearly expired"
+            // window leaves a full cycle of margin to complete the refresh
+            // before the stored token actually lapses.
             _ = ping_interval.tick() => {
+                if let Ok(Some(creds)) = wstore.muxbus_load() {
+                    if creds.nearly_expired() {
+                        tracing::info!("cloud_subscriber: stored token nearing expiry, proactively refreshing");
+                        match crate::muxbus::pkce::refresh_token(&creds, http).await {
+                            Ok(refreshed) => {
+                                if let Err(e) = wstore.muxbus_save(&refreshed) {
+                                    tracing::warn!(error = %e, "cloud_subscriber: failed to save proactively refreshed credentials");
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "cloud_subscriber: proactive mid-session refresh failed — will retry next tick");
+                            }
+                        }
+                    }
+                }
                 let ping_msg = serde_json::to_string(&ClientMsg::Ping)
                     .map_err(|e| format!("serialize ping: {e}"))?;
                 if let Err(e) = write.send(Message::Text(ping_msg.into())).await {

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -37,6 +37,15 @@ pub const COMMAND_AUTH_POLL: &str = "auth.poll";
 pub const COMMAND_AUTH_SUBMIT_CALLBACK: &str = "auth.submitcallback";
 pub const COMMAND_AUTH_CANCEL: &str = "auth.cancel";
 pub const COMMAND_AUTH_SUBMIT_API_KEY: &str = "auth.submitapikey";
+/// Mints (or reuses) a per-account isolated config dir without spawning any
+/// CLI — a standalone entry point onto `compute_and_ensure_account_dir` for
+/// callers that seed a credential file directly (`seed_provider_auth_from_global`)
+/// instead of driving a fresh OAuth handshake through `auth.start`. See
+/// `docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md` §7 —
+/// "single point, not global": every credential-bearing dir a running agent
+/// reads from must belong to a real `IdentityAccount` row, never the shared
+/// default dir.
+pub const COMMAND_ENSURE_ACCOUNT_DIR: &str = "identity.ensureaccountdir";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -129,6 +138,27 @@ struct AckResp {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EnsureAccountDirReq {
+    provider_id: String,
+    /// Non-empty to resolve an already-minted account's own dir
+    /// (reconnect-in-place); empty mints a fresh account id.
+    #[serde(default)]
+    existing_account_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EnsureAccountDirResp {
+    account_id: String,
+    /// `None` when the provider isn't oauth-class or the dir couldn't be
+    /// resolved/created — same soft-failure contract as `auth.start`'s
+    /// internal use of `compute_and_ensure_account_dir`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dir: Option<String>,
 }
 
 pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -293,6 +323,24 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
                     "auth.submitapikey: bundle persistence lands in PR C"
                         .to_string(),
                 )
+            })
+        }),
+    );
+
+    engine.register_handler(
+        COMMAND_ENSURE_ACCOUNT_DIR,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let req: EnsureAccountDirReq = serde_json::from_value(data)
+                    .map_err(|e| format!("identity.ensureaccountdir: {e}"))?;
+                let mut auth_env = std::collections::HashMap::new();
+                let (account_id, dir) = compute_and_ensure_account_dir(
+                    &req.existing_account_id,
+                    &req.provider_id,
+                    &mut auth_env,
+                );
+                let resp = EnsureAccountDirResp { account_id, dir };
+                Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
             })
         }),
     );

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -165,6 +165,7 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
     let mgr = state.auth_session_manager.clone();
     let wstore = state.id_store.clone();
     let broker = state.broker.clone();
+    let wstore_for_ensure_dir = wstore.clone();
     engine.register_handler(
         COMMAND_AUTH_START,
         Box::new(move |data, _ctx| {
@@ -201,6 +202,7 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
                 let mut auth_env = req.auth_env;
                 let (account_id, bundle_dir) = if req.direct_account {
                     let (account_id, dir) = compute_and_ensure_account_dir(
+                        &wstore,
                         &req.existing_account_id,
                         &req.provider_id,
                         &mut auth_env,
@@ -330,11 +332,13 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
     engine.register_handler(
         COMMAND_ENSURE_ACCOUNT_DIR,
         Box::new(move |data, _ctx| {
+            let wstore = wstore_for_ensure_dir.clone();
             Box::pin(async move {
                 let req: EnsureAccountDirReq = serde_json::from_value(data)
                     .map_err(|e| format!("identity.ensureaccountdir: {e}"))?;
                 let mut auth_env = std::collections::HashMap::new();
                 let (account_id, dir) = compute_and_ensure_account_dir(
+                    &wstore,
                     &req.existing_account_id,
                     &req.provider_id,
                     &mut auth_env,
@@ -1142,12 +1146,22 @@ fn compute_and_ensure_bundle_dir(
 /// (Reconnect — refresh tokens in place, same isolation dir, same
 /// account row updated in place).
 ///
+/// Every fresh mint (`existing_account_id` empty) is swept for BEFORE it,
+/// giving prior abandoned/failed attempts a chance to be cleaned up
+/// (reagent finding on #2260 — see `sweep_orphaned_account_dirs`'s own
+/// doc comment). 30 minutes comfortably clears every frontend poll
+/// timeout in this flow (5 minutes, as of this writing) plus room for a
+/// slow user plus one retry, so an in-progress login's dir is never
+/// swept out from under it.
+const ORPHAN_SWEEP_MIN_AGE_SECS: u64 = 30 * 60;
+
 /// Returns `(account_id, dir)` — `account_id` is always populated (even
 /// on a dir-resolution failure, so the caller can still log/track it);
 /// `dir` is `None` on the same gate/registry/fs failures
 /// `compute_and_ensure_bundle_dir` treats as soft failures — never
 /// abort `auth.start` over a config-dir issue.
 fn compute_and_ensure_account_dir(
+    store: &Store,
     existing_account_id: &str,
     provider_id: &str,
     auth_env: &mut std::collections::HashMap<String, String>,
@@ -1191,6 +1205,22 @@ fn compute_and_ensure_account_dir(
             return (account_id, None);
         }
     };
+    if existing_account_id.is_empty() {
+        let removed = crate::identity::cleanup::sweep_orphaned_account_dirs(
+            store,
+            &paths.identities_dir(),
+            ORPHAN_SWEEP_MIN_AGE_SECS,
+        );
+        if !removed.is_empty() {
+            tracing::info!(
+                target: "identity",
+                provider_id,
+                account_id,
+                swept = removed.len(),
+                "auth.start (direct-account): swept orphaned account dirs before minting a fresh one"
+            );
+        }
+    }
     // identity_dir is already generic (not bundle-specific) — same
     // unsafe-path-segment rejection applies to account_id here.
     let account_root = match paths.identity_dir(&account_id) {
@@ -1531,8 +1561,9 @@ mod tests {
             std::env::set_var(k, v);
         }
 
+        let wstore = Store::open_in_memory().unwrap();
         let mut env = std::collections::HashMap::new();
-        let (account_id, dir) = compute_and_ensure_account_dir("", "claude", &mut env);
+        let (account_id, dir) = compute_and_ensure_account_dir(&wstore, "", "claude", &mut env);
         assert!(!account_id.is_empty(), "must mint a fresh id when none supplied");
         let dir = dir.expect("oauth-class provider must yield a dir");
         let expected = paths.identity_dir(&account_id).unwrap().join("claude");
@@ -1561,8 +1592,9 @@ mod tests {
             std::env::set_var(k, v);
         }
 
+        let wstore = Store::open_in_memory().unwrap();
         let mut env = std::collections::HashMap::new();
-        let (account_id, _) = compute_and_ensure_account_dir("acc-reconnect", "claude", &mut env);
+        let (account_id, _) = compute_and_ensure_account_dir(&wstore, "acc-reconnect", "claude", &mut env);
         assert_eq!(account_id, "acc-reconnect", "reconnect must reuse the supplied id, not mint a new one");
 
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
@@ -1577,8 +1609,9 @@ mod tests {
         // but the account id is still returned (unlike bundle mode,
         // there's no "skip entirely" case here — the account always
         // gets minted/reused, only the isolation dir is conditional).
+        let wstore = Store::open_in_memory().unwrap();
         let mut env = std::collections::HashMap::new();
-        let (account_id, dir) = compute_and_ensure_account_dir("", "kimi", &mut env);
+        let (account_id, dir) = compute_and_ensure_account_dir(&wstore, "", "kimi", &mut env);
         assert!(!account_id.is_empty());
         assert!(dir.is_none(), "api-key provider class must skip the OAuth dir path");
         assert!(env.get("KIMI_SHARE_DIR").is_none());

--- a/docs/retro/retro-headless-login-browser-open-2026-07-20.md
+++ b/docs/retro/retro-headless-login-browser-open-2026-07-20.md
@@ -1,0 +1,226 @@
+# Retro — `/login` has a working browser-opener sitting unused right next to it
+
+**Date:** 2026-07-20
+**Trigger:** Live repro — AgentA's pane hit Claude Code CLI's "Not logged in.
+Please run `/login`." banner. Running `/login` visibly did nothing: no
+browser opened, no URL appeared, no state changed. Separately, the shared
+provider auth dir (`~/.agentmux/shared/providers/claude/`) turned out to
+have been silently logged out (empty tokens) 47 minutes earlier, with zero
+`muxlog auth` evidence of what caused it — see §4.
+**Audience:** anyone touching `run_cli_login`/`run_cli_login_pty`,
+`open_login_terminal`, `frontend/app/view/agent/commands/global/login.ts`,
+or `force-login.ts`. Read this before changing how a login attempt picks
+its spawn strategy.
+**Follow-up:** the fix below (§5) initially covered `/login` and "Login
+Again" only. Live verification found a THIRD, independent implementation
+of the same "spawn login, wait for URL" pattern in the gated launch flow —
+the one the "Retry Login" button actually triggers — that bypassed both
+the fix and the diagnosis here. See
+`docs/retro/retro-login-three-code-paths-2026-07-20.md` for that gap and
+its fix; read both before touching login flows.
+
+---
+
+## 1. The question this retro answers
+
+**"Why does AgentMux have such a hard time opening the browser to log in?"**
+
+It doesn't, actually — the OS-level opener works fine and is exercised
+constantly for ordinary links (`open_url_in_default_browser`,
+`agentmux-cef/src/commands/platform.rs:1518-1560`: `rundll32.exe
+url.dll,FileProtocolHandler` on Windows, `open` on macOS, `xdg-open` on
+Linux — chosen specifically to avoid `explorer.exe`/`cmd /C start`
+injection and file-manager-window bugs, per the comment at `:1531-1538`).
+
+The actual problem is one step upstream: **AgentMux never gets a URL to
+hand that opener.** `/login` and "Login Again" both call
+`forceProviderLogin` → the CEF `run_cli_login`/`run_cli_login_pty` IPC path
+(`ipc.rs:399`, `platform.rs:417-640` / `880-1131`), which spawns the Claude
+CLI **headless** — piped stdio (`Stdio::piped()`, `platform.rs:504-514`) or
+a PTY with no attached visible console — and then scans its output for an
+`https://` URL (`extract_url`, `platform.rs:1164-1242`).
+
+For Claude Code v2.1.x, that scan finds nothing, ever, in any headless
+context. Per the prior investigation this retro builds on
+(`docs/retro/retro-claude-v2-1-auth-spawn-2026-06-23.md`,
+`docs/specs/SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md:56-67`): the CLI's
+OAuth flow opens the browser **itself**, directly, via its own OS calls —
+it does not print a URL for a wrapper process to scrape. In a piped/PTY/
+detached spawn there is no attached console for the CLI's own browser-open
+call to succeed from, so the flow just hangs or silently no-ops. `/login`
+"doing nothing" is that CLI-internal browser-open call failing silently,
+not a missing feature in AgentMux's opener.
+
+**The fix already exists in this codebase and is not used by default.**
+`open_login_terminal` (`platform.rs:1274-1345`) spawns the exact same login
+command with `CREATE_NEW_CONSOLE` — a real, visible console window — whose
+own doc comment states the diagnosis outright:
+
+> "Spawn the CLI login command in a NEW visible console window so the OS
+> can open a browser (the piped/PTY paths used by `run_cli_login` are
+> headless and block the browser from launching — confirmed for Claude
+> v2.1.x)."
+
+This path works. It is wired to a separate **"Login via terminal"** button
+(`useAgentControllerStatus.ts:367-434`, `cef-api.ts:687-688`) that most
+users never discover, and it is **Windows-only** —
+`platform.rs:1337-1342` returns `Err("open_login_terminal: not yet
+implemented on this platform")` on macOS/Linux.
+
+`/login`'s own handler (`frontend/app/view/agent/commands/global/login.ts:44-59`)
+already knows this — when `forceProviderLogin` returns `"no-url"`, the error
+message it shows is literally:
+
+> "/login: the CLI didn't produce a login URL, so no browser was opened.
+> Use the "Login via terminal" or "Use existing login" actions instead."
+
+So the code contains its own correct answer and still doesn't act on it. A
+human has to read the error, know which of two other buttons to click, and
+retry manually. That hand-off — not the browser-opening mechanism itself —
+is "why AgentMux has such a hard time."
+
+## 2. Two more contributing gaps, same shape
+
+- **AgentMux's own default pane spawn is unconditionally headless**, for a
+  reason that has nothing to do with auth: `CREATE_NO_WINDOW` + fully piped
+  stdio on the "persistent" controller (`agentmux-srv/src/backend/blockcontroller/persistent.rs:674-690`)
+  and the subprocess controller (`.../subprocess.rs:393-404`) exists to fix
+  a **Windows Terminal window leak**
+  (`docs/retro/retro-windows-terminal-window-leak-2026-06-21.md`). That fix
+  is correct for its own problem — but its side effect is that every normal
+  agent pane's long-running Claude process is permanently in exactly the
+  spawn shape (§1) that defeats interactive OAuth. There's no cross-link
+  between that retro and this login-capture problem anywhere in the repo;
+  each was fixed in isolation.
+- **`/login`'s no-url failure used to be silent**, not just unhelpful — the
+  explicit error message quoted above (`login.ts:51-59`) and the equivalent
+  branch in `useAgentControllerStatus.ts:299-306` were both added by
+  `docs/retro/retro-agent-auth-relogin-noop-2026-07-01.md` specifically to
+  stop the *"no error, no browser, nothing happens"* failure mode from
+  looking like success. That retro's fix made the dead end **visible**. It
+  did not make the dead end **navigable** — the user still has to
+  self-serve the correct button.
+
+Three retros (`2026-06-23`, `2026-07-01`, this one) have now separately
+diagnosed pieces of the same underlying gap: *the piped/headless path is
+structurally incapable of completing Claude v2.1.x's login, and the working
+alternative is not the default.* Each fix narrowed the symptom without
+closing the gap.
+
+## 3. Why this specific incident additionally involved a fully dead credential file
+
+Independent of §1–2, the *reason* AgentA's pane was logged out at all: the
+shared, account-wide `~/.agentmux/shared/providers/claude/.credentials.json`
+had `accessToken:""`/`refreshToken:""`/`expiresAt:0` (confirmed on disk,
+mtime 07:43 today), while the `.agentmux-cred-seeded` sentinel
+(`cli_handlers.rs:313`, created 2026-06-23) was already present. Per the
+comment at `cli_handlers.rs:305-310`, that sentinel exists specifically "so
+a later `claude auth logout` in this provider space sticks" — i.e.
+AgentMux will not silently re-import a fresh global `~/.claude` login once
+this shared dir has been explicitly logged out, by design, to avoid
+clobbering an intentional sign-out.
+
+The self-heal path that *can* recover a stale-but-present token
+(`refresh_claude_dir_from_global_if_stale`, `cli_handlers.rs:770-807`, "the
+Pozl 401" — a named recurring repro in the comments, not documented
+elsewhere in the repo under that name) is only reached when a token exists
+and fails validation. It is never reached when the token is empty, so an
+empty-token shared dir is a dead end that **only** an actual completed
+login (§1/§2's gap) or a manual file operation can clear — which is exactly
+why a working `/login` matters here: absent the sentinel/self-heal gap
+being separately revisited, `/login` succeeding is the only supported way
+out of this state.
+
+No scheduled process, cron job, or cleanup task in this repository writes
+to this dir (checked: `agentmux-srv/src/backend/cron/*`,
+`agentmux-srv/src/identity/cleanup.rs` — the latter is delete-triggered,
+not scheduled, and is containment-guarded to
+`~/.agentmux/shared/identities/`, which structurally excludes
+`~/.agentmux/shared/providers/claude/`; see `cleanup.rs:140-146` and its
+test `oauth_dir_outside_data_root_is_skipped`). The zeroing is consistent
+with an explicit `claude auth logout` (or CLI-internal token-expiry
+self-clear) having run against this dir at 07:43 — not with any AgentMux
+background process. This is included for completeness; it is not this
+retro's main finding and is not re-litigated further here.
+
+## 4. Reinforcement — how this closes for good instead of narrowing again
+
+1. **Make `/login` and "Login Again" try the visible-console path
+   automatically on `no-url`, instead of erroring and pointing at a
+   different button.** `forceProviderLogin` already knows the outcome was
+   `"no-url"` (`login.ts:51`); on that outcome it should invoke
+   `open_login_terminal` itself (fire-and-forget, exactly as the "Login via
+   terminal" button already does) rather than surface an error asking a
+   human to do it. Keep the piped attempt first — it's cheap, and if a
+   future CLI version does print a scrapeable URL, the fast path still
+   wins — but no-url should fall through automatically, not dead-end.
+2. **Port `open_login_terminal` to macOS/Linux.** Today it's `Err("not yet
+   implemented")` outside Windows (`platform.rs:1337-1342`), which means
+   the *only* working escape hatch for this entire failure class doesn't
+   exist on two of three platforms. `xterm -e`/`open -a Terminal.app` per
+   the existing `// Tracked follow-up` comment.
+3. **Cross-link the two retros that created this gap** — add a pointer from
+   `retro-windows-terminal-window-leak-2026-06-21.md` to this doc (and vice
+   versa) so a future change to pane-spawn stdio handling surfaces the auth
+   consequence, and the reverse: a future auth-capture change checks
+   whether the window-leak fix still applies.
+4. **A standing test, not another spec note** — per the lesson already
+   written twice in `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`
+   and `docs/retro/retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md`
+   ("a written invariant is worthless if nothing re-checks it when the
+   ground moves"): add a test asserting that for any provider whose login
+   flow is known not to produce a scrapeable URL in a headless spawn (a
+   flag/allowlist, keyed off the same signal `open_login_terminal`'s doc
+   comment already encodes for Claude v2.1.x), the `no-url` outcome results
+   in an automatic terminal-fallback attempt, not a terminal error state.
+   This should fail loudly if a future refactor of `login.ts`/`force-login.ts`
+   reintroduces the dead-end branch as the last step.
+5. **Resolve the "Pozl 401" name.** It's cited twice in
+   `cli_handlers.rs` (`:426`, `:776`) as a specific, apparently
+   well-understood repro, but is undocumented anywhere else in the repo. If
+   it refers to the "Poal"/"Nark" divergence case in
+   `docs/reports/REPORT_AGENT_AUTH_DIVERGENCE_2026_06_20.md`, rename the
+   comment to cite that doc directly; if it's a distinct case, write it up
+   so the next person reading `cli_handlers.rs` doesn't have to guess.
+
+## 5. Implemented same-day
+
+Items 1, 2, and 4 of §4 shipped immediately after this retro was written,
+without waiting for a second manual-recovery incident to justify them:
+
+- **`runProviderLogin`** (`frontend/app/view/agent/flows/run-provider-login.ts`,
+  new) — the shared three-tier orchestrator: `forceProviderLogin` (URL
+  capture) → `seedGlobalLogin` (Claude-only, copy a valid global login) →
+  `openLoginTerminal` + poll (real terminal, up to 5 min). `/login`
+  (`commands/global/login.ts`) and "Login Again" (`useAgentControllerStatus.ts`'s
+  `relogin`) both call it now instead of dead-ending on `forceProviderLogin`'s
+  bare `"no-url"`. The manual "Login via terminal" button's own poll loop was
+  deduped against the same helper (`pollForGlobalLoginSeed`,
+  `flows/seed-global-login.ts`) rather than left duplicated.
+- **`open_login_terminal` ported to macOS/Linux** (`agentmux-cef/src/commands/platform.rs`) —
+  macOS writes a disposable `.command` script (env vars can't be passed to
+  `open -a Terminal` directly) and opens it in Terminal.app; Linux tries
+  `x-terminal-emulator` → `gnome-terminal` → `konsole` → `xterm` in order.
+  Previously `Err("not yet implemented")` on both.
+- **A standing test**, not just this doc: `run-provider-login.test.ts` pins
+  the tier order, the Claude-only gating of tier 2, the config-dir-env
+  stripping before tier 3, and that a cancelled/failed tier 3 doesn't hang
+  the caller.
+
+Item 3 (cross-linking the window-leak retro) is done inline above. Item 5
+(the "Pozl 401" naming) is intentionally left open — resolving it needs
+someone who was actually present for that repro to confirm the name, not a
+guess dressed up as a citation.
+
+## 6. What this retro is explicitly not
+
+Not a claim that the piped/PTY capture path (`run_cli_login`/
+`run_cli_login_pty`) is badly built — its URL-scraping, ANSI/OSC-8
+handling, and pipe-draining fix (`platform.rs:532-539`, avoiding an earlier
+EPIPE hang) are solid engineering for the CLIs where it works. Not a claim
+that `CREATE_NO_WINDOW` piped spawning for agent panes was the wrong call —
+it correctly fixed a real window-leak bug and should stay. The claim is
+narrower: AgentMux already built the correct fallback for the one CLI where
+the primary path is known to structurally fail, and then didn't call it
+automatically from the two places (`/login`, "Login Again") a stuck user
+actually reaches for.

--- a/docs/retro/retro-login-three-code-paths-2026-07-20.md
+++ b/docs/retro/retro-login-three-code-paths-2026-07-20.md
@@ -1,0 +1,140 @@
+# Retro — fixing "no login URL" in two named call sites left a third, unnamed one broken
+
+**Date:** 2026-07-20
+**Trigger:** Live verification of `retro-headless-login-browser-open-2026-07-20`'s
+fix. A fresh portable build (0.54.1, containing that fix) was launched
+specifically to confirm `/login`/"Login Again" no longer dead-end. Instead of
+testing those two, the tester clicked the pane's own **"Retry Login"** button
+— the one that actually appears when an agent pane fails to authenticate —
+and hit the exact same "stuck on Working…" symptom the fix was supposed to
+have eliminated.
+**Audience:** anyone touching agent-pane login/auth flows. Read this
+alongside `retro-headless-login-browser-open-2026-07-20` — that retro fixed
+the *mechanism*; this one is about why fixing it in two places wasn't fixing
+it everywhere.
+
+---
+
+## 1. What actually happened, with evidence
+
+The "Retry Login" button in `agent-view.tsx`:
+
+```tsx
+<button class="agent-retry-btn" onClick={status.startLaunchFlow}>
+    Retry Login
+</button>
+```
+
+(`frontend/app/view/agent/agent-view.tsx:1002-1007`) calls `startLaunchFlow`
+— the **gated launch flow** (`runLaunchFlow`,
+`frontend/app/view/agent/flows/launch-flow.ts`) — not `relogin`. This is a
+third, independent implementation of "log the provider in," and it was never
+touched by the previous retro's fix.
+
+The fresh 0.54.1 build's own host log
+(`~/.agentmux/channels/local-agenta-release-v0.54.1-*/versions/0.54.1/logs/agentmux-host-v0.54.1.log`)
+shows exactly what it did instead:
+
+```
+18:20:17.475  run_cli_login: spawned (PTY), waiting for OAuth URL
+18:20:32.481  WARN  run_cli_login_pty: no auth URL captured within 15s
+18:20:32.484  WARN  [fe] [perf] ipc run_cli_login 15012.1ms
+                                  ← the IPC call itself DID return promptly.
+                                    Nothing failed here.
+   ...(nothing for the next ~5 minutes — no seed_provider_auth_from_global,
+       no open_login_terminal, no further auth activity of any kind)...
+18:25:33.011  cancel_cli_login: PTY child killed
+18:25:33.242  run_cli_login_pty: child exited, exit_code=1
+```
+
+Five minutes and one second — `launch-flow.ts`'s own hardcoded
+`deadline = Date.now() + 5 * 60 * 1000` — between the 15-second URL-scrape
+timeout and the eventual `cancelCliLogin()`. The gap is
+`launch-flow.ts`'s Phase 2 (pre-fix, `:198-300`): when `runCliLogin` returned
+no URL, it logged two lines (*"attempting to open browser for login..."*,
+*"if no browser opened, run the login command manually"*) and fell straight
+into an **unconditional 5-minute `CheckCliAuth` poll loop** — waiting for a
+credential that nothing was ever going to produce, because nothing else was
+attempted. This is the identical "no-url → dead end" bug the previous retro
+diagnosed and fixed — just in a call site that fix never reached.
+
+## 2. Why the first fix missed this
+
+`retro-headless-login-browser-open-2026-07-20`'s fix worked by finding every
+caller of the shared `forceProviderLogin` helper
+(`frontend/app/view/agent/flows/force-login.ts`) and inserting the new
+`runProviderLogin` orchestrator in front of it. That covered `/login`
+(`commands/global/login.ts`) and "Login Again"
+(`useAgentControllerStatus.ts`'s `relogin`) — both of which called
+`forceProviderLogin`.
+
+`launch-flow.ts` never called `forceProviderLogin`. It called the
+lower-level primitive underneath it — `getApi().runCliLogin(...)` — directly,
+with its own hand-rolled URL-open logic and its own hand-rolled poll loop,
+predating (or written in parallel with) `force-login.ts`'s extraction. Two
+call sites that both wrap the same primitive, maintained independently, is
+exactly the shape that lets a fix land in one and not the other — and
+because `launch-flow.ts` is what actually runs on **every agent pane launch
+while unauthenticated**, not just on an explicit `/login` or a failure-banner
+click, it's the highest-traffic of the three, not an edge case.
+
+This is the same class of failure this repo has now named three times on
+three different invariants: `retro-provider-auth-isolation-regression-2026-06-05.md`
+and `retro-auth-isolation-invariant-silently-orphaned-2026-07-14.md` both
+end with a version of "a written fix / invariant is worthless if nothing
+re-checks it when the ground moves." Here the "ground" was simply: how many
+places in the codebase independently know how to spawn a provider login.
+Nobody had counted.
+
+## 3. The fix — one code path, not two-of-three
+
+`launch-flow.ts`'s Phase 2 now calls `runProviderLogin` (the same
+orchestrator `/login` and "Login Again" use) instead of `getApi().runCliLogin`
+directly, keeping its own poll-after-`"opened"` loop (launch flow explicitly
+needs to know the login *completed*, not just that a browser opened, before
+declaring `"success"`) but deleting the duplicated URL-open/browser-pane
+logic that `forceProviderLogin` already does internally.
+
+After this change, `getApi().runCliLogin` has exactly one caller left in the
+entire frontend: `force-login.ts` itself. Every UI surface that can trigger a
+provider login — `/login`, the failure-banner "Login Again", and the gated
+launch flow (which backs both automatic pane-open login **and** the "Retry
+Login" button) — now goes through the same three-tier `runProviderLogin`
+(`flows/run-provider-login.ts`): capture a URL, else (Claude) copy a valid
+global login, else open a real terminal and poll for the result.
+
+## 4. Reinforcement — making "one code path" durable, not just true today
+
+Writing "there's one path now" in this file doesn't stop a fourth call site
+from appearing the same way the third one already existed silently for
+months. Per the same lesson the two invariant retros above already drew:
+
+1. **A grep-shaped test, not a sentence.** Add a test (or a lint rule) that
+   fails if `getApi().runCliLogin` / `.runCliLogin(` has more than one match
+   in `frontend/`. It should stay pinned to `force-login.ts`. This is
+   deliberately narrower than testing behavior — it's testing *topology*,
+   which is exactly what silently drifted here.
+2. **Module-doc the constraint at the source**, not just in this retro:
+   `run-provider-login.ts`'s doc comment should say outright that it is the
+   only sanctioned entry point for triggering a provider login, so the next
+   person adding a login-triggering surface finds the rule before they need
+   a retro to find it for them.
+3. **When auditing "who calls X," grep for X itself, not for the last
+   refactor's name for X.** The previous retro's audit found every caller of
+   `forceProviderLogin` — a helper that already had a good name and a test
+   file, so it was easy to find. The bug survived in exactly the place that
+   *didn't* use the helper. The lesson generalizes: an audit anchored on a
+   convenient abstraction will miss whatever never adopted that abstraction.
+
+## 5. What this retro is explicitly not
+
+Not a claim that the three-tier fallback logic itself (URL capture → global
+seed → terminal fallback) was wrong — it worked correctly the moment it was
+actually invoked, which is exactly what today's live test on the "Marks"
+agent went on to confirm once `launch-flow.ts` was fixed. Not a claim the
+original retro should have caught this the first time by being more
+careful — grepping for a well-named helper's callers is a normal, correct
+audit strategy; it just isn't sufficient when a second, independent
+implementation of the same behavior exists under a different name. The fix
+here is structural (delete the second implementation), not just "look
+harder."

--- a/docs/retro/retro-windows-terminal-window-leak-2026-06-21.md
+++ b/docs/retro/retro-windows-terminal-window-leak-2026-06-21.md
@@ -176,3 +176,10 @@ Windows Terminal window. ConPTY terminal panes are unaffected (already headless)
 - **2026-06-21** — diagnosis: inventory → EnumWindows → spawn audit; killed instances
   + WindowsTerminal (54→1 windows); root-caused to missing `CREATE_NO_WINDOW` in
   `persistent.rs`/`runner.rs`/`supervisor.rs`; fix applied + verified; PR opened.
+
+**Side effect flagged later:** the `CREATE_NO_WINDOW` fix here makes every agent
+pane's CLI spawn permanently headless — which is also exactly the spawn shape
+that silently defeats Claude Code v2.1.x's browser-based OAuth login. See
+`docs/retro/retro-headless-login-browser-open-2026-07-20.md` §2 — that retro's
+fix (auto-fallback to a real visible terminal window when a login needs one)
+is the reconciliation; this fix itself was correct and should not be reverted.

--- a/docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+++ b/docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
@@ -240,7 +240,25 @@ same files, or ship standalone.
   fallback fix as a follow-up once spike item 2 (state-machine needs) is
   answered, not bundled into phases 1/2.
 
-### Resolved — implemented same-day, ahead of the phase 3 merge design
+### Superseded same-day — the "ambient creds" relaxation below was reverted
+
+**Correction (2026-07-22, reagent P2 on #2255):** the section below describes
+a same-day fix that was real and did ship — briefly. Later the same session,
+the policy changed: "the claude agent should not work if there is no armory
+account for claude... same for all providers... close it everywhere, now."
+`identity/resolver.rs`'s layer-3 spawn gate's `use_ambient_login` escape
+hatch was removed entirely (unconditional block on a missing bound account,
+no per-agent opt-out), and `AgentLaunchModal.tsx`'s `authBlocksLaunch()`/
+`canSubmit()` were reverted back to requiring `accountId() !== ""` for every
+oauth-class provider — see the `2026-07-20: reverted...` comment directly
+above `authBlocksLaunch()` in that file for the actual, current reasoning.
+**The "leaving Identity blank is now fully supported" claim below is
+therefore false as of the code actually shipped in commit 721f9c5 (the same
+commit this plan doc itself landed in) — reagent caught the doc and the code
+contradicting each other in the same commit.** Left the original text
+below, struck through in spirit if not in markdown, as a record of what was
+tried and why it didn't stick — not as current guidance. Do not implement
+against this section; read the code's own comment instead.
 
 The user clarified: they want the New Agent create screen to stay simple —
 create the session and let it authenticate with vanilla/ambient settings,
@@ -259,19 +277,13 @@ already renders `"(ambient creds)"` for exactly this state
 recognized state elsewhere in the same file — just not honored at the
 launch gate.
 
-**Fix shipped:** `authBlocksLaunch()` now only blocks when an account was
-*explicitly selected* but doesn't supply the provider — not merely because
-none was picked. `canSubmit()` dropped its `accountId() !== ""`
-requirement. Net effect: leaving the "Identity" field blank at agent
-creation is now a fully supported path — `PreLaunchAuthPanel` (the OAuth
-Connect/"Use existing login" sub-flow) doesn't even mount, and the newly
-created pane authenticates the same way an existing pane does, through the
-already-fixed `runLaunchFlow` Phase 2 → `runProviderLogin`. This is also a
-"single path" win in its own right: it makes the New Agent modal's default
-flow reuse the SAME already-working mechanism instead of needing phase 3's
-merge to be functional for the common case. The account `<select>`/"+ Add
-account" UI (`:749-767`) stays visible and optional for users who do want
-to bind a specific account now — not removed, just no longer required.
+**Fix shipped, then reverted:** `authBlocksLaunch()` briefly only blocked
+when an account was *explicitly selected* but doesn't supply the provider —
+not merely because none was picked, and `canSubmit()` briefly dropped its
+`accountId() !== ""` requirement. **This was reverted later the same
+session** once the policy shifted to unconditional enforcement (see the
+correction note above) — both functions require a bound account again,
+for every oauth-class provider, no exception.
 
 Phase 3 (merging `PreLaunchAuthPanel`'s OAuth-Connect path itself, for
 users who explicitly want a dedicated bound account) is unaffected by this

--- a/docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+++ b/docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
@@ -1,0 +1,278 @@
+# Plan — collapse every provider-login code path onto one
+
+**Date:** 2026-07-20
+**Status:** proposed, not started. §7's open questions are now answered —
+see the update at the bottom of §5 phase 3 and the new §7 for what changed.
+**Context:** `docs/retro/retro-headless-login-browser-open-2026-07-20.md` and
+`docs/retro/retro-login-three-code-paths-2026-07-20.md`. Those two retros
+fixed three call sites (`/login`, "Login Again", the gated launch flow behind
+"Retry Login") by routing them through a new orchestrator,
+`runProviderLogin` (`frontend/app/view/agent/flows/run-provider-login.ts`).
+A full audit today found that orchestrator is not actually the only login
+implementation in the app — it's the third. This plan proposes closing the
+rest.
+
+---
+
+## 1. Current state (as of this audit — see inventory for full citations)
+
+Four independent implementations of "spawn a provider CLI, get it
+authenticated" exist today:
+
+| # | Implementation | Where | Reaches `runProviderLogin`? |
+|---|---|---|---|
+| A | `runProviderLogin` (3-tier: URL-capture → global-seed → terminal+poll) | `flows/run-provider-login.ts` | — (this is the shared core) |
+| B | `useGlobalLogin()` — "Use existing login" button | `hooks/useAgentControllerStatus.ts:355-395` | **No** — calls `seedGlobalLogin` directly, reimplementing tier 2 |
+| C | `loginViaTerminal()` — "Login via terminal" button | `hooks/useAgentControllerStatus.ts:399-456` | **No** — calls `openLoginTerminal` + `pollForGlobalLoginSeed` directly, reimplementing tier 3 |
+| D | `PreLaunchAuthPanel` / `AuthFlowController` — "Connect"/"Reconnect" in the New Agent launch modal | `components/PreLaunchAuthPanel.tsx`, `auth/auth-flow-controller.ts` | **No** — an entirely separate implementation, backed by different RPCs (`auth.start`/`auth.poll`/`auth.cancel`/`auth.submitcallback` in `agentmux-srv`, not the CEF host's `run_cli_login`). Its own "Use my existing login" button (`:177-202`) also calls `seedGlobalLogin` directly — a third direct caller of that function. |
+
+Plus two smaller, structurally distinct pieces that aren't duplicates but
+are part of the same surface area:
+
+- **`AuthUrlBox`'s paste-code submit** (`components/AgentDocumentView.tsx:237-256`)
+  calls `getApi().setProviderAuth(...)` directly — delivers a manually
+  pasted code to tier 1's in-flight CLI stdin, or writes to
+  `provider_config.json` as a fallback. Not a duplicate of any tier; a
+  complement to tier 1 specifically.
+- **Three CEF host IPC commands with zero current frontend callers**:
+  `clear_provider_auth`, `get_provider_auth_status`, `check_cli_auth_status`
+  (all in `agentmux-cef/src/commands/providers.rs`). Dead-code candidates,
+  not duplicates.
+
+## 2. A correctness bug found while auditing, not just a duplication
+
+`runProviderLogin` (tier 1 → tier 2 → tier 3) never cancels tier 1's PTY
+child before starting tier 2 or 3. Confirmed from the live "Marks" repro's
+host log during today's testing: `run_cli_login_pty` spawned at `T`,
+timed out at `T+15s` (the IPC call correctly resolved `null` at that point),
+but the **child process itself kept running** — `cancel_cli_login: PTY
+child killed` / `child exited` didn't appear until a caller explicitly
+called `cancelCliLogin()` much later. In the current code, that call only
+happens *after* `runProviderLogin` fully returns (in `relogin()` and
+`launch-flow.ts`, post-outcome) — meaning tiers 2 and 3 now run for up to
+several more minutes with tier 1's abandoned child still alive in the
+background. Best case this is a wasted process; worst case a lingering
+`claude auth login` process interferes with tier 3 spawning a *second*
+concurrent login attempt for the same CLI (untested, but plausible — same
+CLI, same config dir, two live login sessions). This should be fixed
+regardless of how much of the rest of this plan ships.
+
+## 3. Goals
+
+1. **One function that knows how to log a provider in.** Every UI action
+   that starts a login — of any kind, from any screen — calls
+   `runProviderLogin` (or a thin, explicit variant of it), never a raw tier
+   directly.
+2. **Explicit tier selection, not reimplementation.** "Use existing login"
+   and "Login via terminal" are legitimate *user intents* ("skip straight to
+   X") — the fix is to make `runProviderLogin` accept a starting tier, not
+   to force every button through the full 1→2→3 chain or to keep three
+   independently-maintained copies of the underlying logic.
+3. **Fix the tier-1-child-leak bug (§2) as part of the consolidation**, not
+   as an afterthought — it's naturally fixed once there's one orchestrator
+   responsible for the whole lifecycle.
+4. **Decide, explicitly, what to do about the pre-launch flow (D)** — this
+   is the biggest single duplication (a whole parallel backend
+   implementation) and the riskiest to touch. This plan scopes it as a
+   separate phase with its own go/no-go, not something to merge blind.
+
+## 4. Non-goals
+
+- Not merging the five CEF host IPC *mechanisms* (`run_cli_login`,
+  `open_login_terminal`, `seed_provider_auth_from_global`, `set_provider_auth`,
+  `cancel_cli_login`) into fewer host commands. They do structurally
+  different things (pipe/PTY-scrape vs. new-console-spawn vs. file-copy vs.
+  stdin-delivery). The duplication worth removing is in the *frontend
+  orchestration* above them, not the primitives themselves.
+- Not redesigning the account/identity data model (`compute_and_ensure_account_dir`,
+  per-account isolated dirs) — out of scope here; flagged only where it
+  affects whether phase 3 (below) is safe to attempt.
+- ~~Not deciding the UX question of *which buttons the failure banner
+  shows*~~ **Decided 2026-07-20 (see §7): one button.** The failure banner
+  collapses to a single login action; "Use existing login" and "Login via
+  terminal" as separate user-facing buttons go away once phase 2 ships.
+
+## 5. Phased plan
+
+### Phase 1 — fix the tier-1 leak (§2), independent of everything else
+
+Add an explicit `getApi().cancelCliLogin()` call inside `runProviderLogin`
+right after tier 1 resolves with `"no-url"`, before tier 2 starts. Low risk,
+no behavior change to any caller's outcome contract, closes a real resource
+leak. Ship this alone first — it doesn't depend on any other phase.
+
+**Files:** `flows/run-provider-login.ts`.
+**Tests:** extend `run-provider-login.test.ts` to assert `cancelCliLogin` is
+called between tier 1 failing and tier 2 starting.
+
+### Phase 2 — fold B and C into A
+
+Give `runProviderLogin` an optional `startAtTier?: 1 | 2 | 3` param
+(default `1`). "Use existing login" calls it with `startAtTier: 2`; "Login
+via terminal" calls it with `startAtTier: 3`. Delete `useGlobalLogin()` and
+`loginViaTerminal()`'s independent bodies in `useAgentControllerStatus.ts`,
+replacing them with thin wrappers that call `runProviderLogin` with the
+right `startAtTier` and map the outcome to the existing `authNotice`/
+`onRecovered` behavior — i.e. keep the two buttons and their current labels
+and behavior from the user's perspective; change only what's underneath
+them. `seedGlobalLogin`/`pollForGlobalLoginSeed` stay as exported building
+blocks (`runProviderLogin` still calls them) but stop being called directly
+from `useAgentControllerStatus.ts`.
+
+**Files:** `flows/run-provider-login.ts` (add `startAtTier`),
+`hooks/useAgentControllerStatus.ts` (`useGlobalLogin`, `loginViaTerminal`).
+**Tests:** update/extend `run-provider-login.test.ts` for `startAtTier`;
+existing `useAgentControllerStatus` behavior should be covered by whatever
+already exercises `useGlobalLogin`/`loginViaTerminal` today (check current
+coverage before deleting the bodies — if none exists, add it here, don't
+delete blind).
+**Follow-on — decided 2026-07-20, do this as part of phase 2, not a later
+step:** collapse the failure banner to a single login button. Once B and C
+are thin wrappers around `runProviderLogin`, there's no remaining reason for
+"Login Again" / "Use existing login" / "Login via terminal" to be three
+separate user choices — the single button calls `runProviderLogin` with the
+default `startAtTier: 1` and the existing automatic 1→2→3 fallback handles
+what the three buttons used to require the user to pick manually. Delete the
+two extra buttons from `failure-accessory.ts`'s `"auth"` case (`:118-125`)
+and the per-message inline banner (`DocumentRow.tsx`) stays as-is (it
+already only has one "Login Again →" action). `useGlobalLogin`/
+`loginViaTerminal` as *functions* may still be worth keeping internally
+(e.g. if phase 3 or a future advanced/debug affordance wants
+`startAtTier` control) but should have no directly-wired UI button once this
+ships.
+
+### Phase 3 — the pre-launch flow (D): investigate before merging
+
+`PreLaunchAuthPanel`/`AuthFlowController` is architecturally separate for a
+possibly-legitimate reason: it runs *before* an agent exists, so it needs
+`compute_and_ensure_account_dir` to mint a brand-new per-account identity
+dir — `runProviderLogin` today always operates on an *already-resolved*
+`authEnv` for an *already-existing* agent/pane. Merging them isn't a
+find-and-replace; it's a design decision about whether account-dir minting
+belongs inside `runProviderLogin` (parameterized) or should stay a distinct
+pre-step that hands `runProviderLogin` a resolved `authEnv` afterward — the
+latter seems more promising and lower-risk (minting stays where it is;
+`PreLaunchAuthPanel`'s Connect/Reconnect/"Use existing login" buttons call
+`runProviderLogin` with the freshly-minted `authEnv` instead of driving
+`AuthFlowController`'s own backend RPCs).
+
+**Spike item 1 is now CONFIRMED, not speculative** — the user independently
+reproduced "the login browser doesn't appear to work when creating a new
+agent either" (2026-07-20), and the code backs it up:
+`agentmux-srv/src/server/identity_handlers.rs:405-409` sets
+`CREATE_NO_WINDOW` on `auth.spawn`'s pipe-path child, exactly the pattern
+`retro-headless-login-browser-open-2026-07-20` diagnosed on the CEF host
+side (`agentmux-cef`'s `run_cli_login`). The PTY branch (`requires_tty`,
+`:354-373`, delegating to `spawn_auth_cli_pty`) is the same headless shape.
+**There is no equivalent to `open_login_terminal` anywhere in
+`identity_handlers.rs`** — grepped for `CREATE_NEW_CONSOLE`/
+`open_login_terminal`, zero hits. So the New Agent modal's "Connect" button
+has no working fallback at all today, not even the manual "Login via
+terminal"-equivalent escape hatch the pane-level flow has — it's strictly
+worse off than "Retry Login" was before this morning's fix.
+
+This elevates phase 3 from "investigate, maybe later" to "there is a live,
+confirmed, currently-unfixed bug here" — but the FIX is still gated on the
+same architectural question as before (does account-dir minting move inside
+`runProviderLogin`, or does `PreLaunchAuthPanel` mint first and then hand
+off to it?), which spike item 2 below still needs answering before writing
+code. **Interim stopgap, decided 2026-07-20 (see §7): rather than block the
+New Agent flow on the full merge, do NOT try to show/resolve identity info
+at agent-creation time beyond what already works — leave the
+not-yet-resolved parts of the launch modal's identity display blank rather
+than showing something. Ship the real fix (routing `PreLaunchAuthPanel`
+through the same terminal-fallback capability `runProviderLogin` already
+has) as its own follow-up once spike item 2 is answered — don't fold it
+into phases 1/2's rollout.**
+
+Spike item 2, still open:
+**What does `auth.poll`/the `AuthFlowController` state machine actually
+need from the login process that `runProviderLogin`'s simpler
+opened/seeded/terminal-success/terminal-timeout/terminal-unavailable
+outcome enum doesn't provide?** (e.g. intermediate "waiting"/"exchanging
+code" states the panel renders.) If the state needs are materially
+richer, `runProviderLogin`'s outcome type may need to grow, not just be
+reused as-is.
+
+**Do not schedule full-merge implementation for this phase until spike item
+2 is done** — but the minimal terminal-fallback fix (giving `auth.spawn` an
+`open_login_terminal`-equivalent, independent of whether it ever shares code
+with `runProviderLogin`) is small enough to ship on its own once someone
+picks it up, without waiting on the merge design.
+
+### Phase 4 — cleanup
+
+- Delete `clear_provider_auth`, `get_provider_auth_status`,
+  `check_cli_auth_status` (CEF host commands) if the phase-1/2/3 work
+  confirms they're still unused — re-grep at that point, don't rely on
+  today's snapshot.
+- Wire an actual Cancel button into the pane-level failure banner —
+  `cancelLogin()` exists (`useAgentControllerStatus.ts:458-462`) and is
+  fully implemented but has no UI caller today. A pending login (especially
+  tier 3's up-to-5-minute wait) with no visible way to cancel from the pane
+  is a real gap independent of everything else in this plan.
+- Once phase 2 ships, add a repo-topology test in the spirit of
+  `run-cli-login-single-caller.test.ts` for `seedGlobalLogin` /
+  `getApi().openLoginTerminal` — assert they're each called from exactly one
+  place (`run-provider-login.ts`), the same enforcement pattern that caught
+  nothing catching B/C's duplication until this audit.
+
+## 6. Sequencing recommendation
+
+Ship phase 1 immediately (small, self-contained, fixes a real bug). Ship
+phase 2 next (moderate size, no product-visible behavior change, directly
+answers "single path" for every pane-level surface). Treat phase 3 as its
+own follow-up spec after the research spike — don't bundle it with 1/2.
+Phase 4's cleanup items can ride along with whichever of 1-3 touches the
+same files, or ship standalone.
+
+## 7. Decisions (2026-07-20)
+
+- **Failure banner → one button.** Resolves the former open question: the
+  three-button banner ("Login Again" / "Use existing login" / "Login via
+  terminal") collapses to a single action as part of phase 2. See the
+  updated phase 2 "Follow-on" above.
+- **Phase 3's risk is confirmed, not hypothetical.** The user independently
+  hit the New Agent modal's login not working, matching spike item 1's
+  prediction exactly. Interim stopgap decided: don't try to resolve/display
+  identity info at agent-creation time beyond what already works — leave it
+  blank rather than show something wrong — and ship the real terminal-
+  fallback fix as a follow-up once spike item 2 (state-machine needs) is
+  answered, not bundled into phases 1/2.
+
+### Resolved — implemented same-day, ahead of the phase 3 merge design
+
+The user clarified: they want the New Agent create screen to stay simple —
+create the session and let it authenticate with vanilla/ambient settings,
+consistent with how every other pane already works, and defer the richer
+per-account "Connect" UX to a later Armory-integrated redesign.
+
+This turned out to be directly achievable without waiting on phase 3's
+merge design, because the code already half-intended it and just didn't
+follow through: `AgentLaunchModal.tsx`'s `authBlocksLaunch()` comment
+literally said *"No account selected — ambient creds, OAuth flow runs
+once"* — but the code treated `accountId() === ""` as a **blocking**
+condition anyway, and `canSubmit()` independently hard-required a non-empty
+`accountId()`. The "Continue an existing agent" dropdown a few lines away
+already renders `"(ambient creds)"` for exactly this state
+(`:623`), confirming "no account = ambient" was already a first-class,
+recognized state elsewhere in the same file — just not honored at the
+launch gate.
+
+**Fix shipped:** `authBlocksLaunch()` now only blocks when an account was
+*explicitly selected* but doesn't supply the provider — not merely because
+none was picked. `canSubmit()` dropped its `accountId() !== ""`
+requirement. Net effect: leaving the "Identity" field blank at agent
+creation is now a fully supported path — `PreLaunchAuthPanel` (the OAuth
+Connect/"Use existing login" sub-flow) doesn't even mount, and the newly
+created pane authenticates the same way an existing pane does, through the
+already-fixed `runLaunchFlow` Phase 2 → `runProviderLogin`. This is also a
+"single path" win in its own right: it makes the New Agent modal's default
+flow reuse the SAME already-working mechanism instead of needing phase 3's
+merge to be functional for the common case. The account `<select>`/"+ Add
+account" UI (`:749-767`) stays visible and optional for users who do want
+to bind a specific account now — not removed, just no longer required.
+
+Phase 3 (merging `PreLaunchAuthPanel`'s OAuth-Connect path itself, for
+users who explicitly want a dedicated bound account) is unaffected by this
+and still gated on its own spike item 2.

--- a/frontend/app/store/rpc-api/identity.ts
+++ b/frontend/app/store/rpc-api/identity.ts
@@ -253,6 +253,20 @@ export const IdentityApi = {
         return client.rpcCall("resolve.prereqs", data, opts);
     },
 
+    // command "identity.ensureaccountdir" — mints (or resolves, when
+    // existingAccountId is set) a per-account isolated config dir without
+    // spawning a CLI or an OAuth handshake. Used by the seed-from-global
+    // recovery path so a seeded credential lands under a real account's own
+    // dir instead of the shared/global one — "single point, not global",
+    // PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7.
+    EnsureAccountDirCommand(
+        client: RpcClient,
+        data: { providerId: string; existingAccountId?: string },
+        opts?: RpcOpts,
+    ): Promise<{ accountId: string; dir?: string }> {
+        return client.rpcCall("identity.ensureaccountdir", data, opts);
+    },
+
     AuthSubmitApiKeyCommand(
         client: RpcClient,
         data: {

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -18,7 +18,9 @@
  * is the exception. See spec §4.4 dispatcher note.
  */
 
-import { runProviderLogin } from "../../flows/run-provider-login";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { persistAndLinkAccount, runProviderLogin } from "../../flows/run-provider-login";
 import type { SlashCommand, SlashResult } from "../types";
 
 export const loginCommand: SlashCommand = {
@@ -49,20 +51,71 @@ export const loginCommand: SlashCommand = {
             // linkTarget lets a tier-2/3 success register a real Armory account
             // bound to this agent (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7).
             const agentDefinitionId = ctx.block()?.meta?.["agentId"] as string | undefined;
+            const linkTarget = agentDefinitionId
+                ? { blockId: ctx.blockId, agentDefinitionId }
+                : undefined;
+            // Tier 1 mints the account dir but does NOT persist/link it (it
+            // returns "opened" before confirming completion) — captured here
+            // so the poll below can call persistAndLinkAccount once IT
+            // confirms the login actually finished. reagent P1: without
+            // this, a tier-1 login that succeeds for any provider whose CLI
+            // actually prints a URL (not requiresLoginTty, e.g. codex) via
+            // /login left the minted account unpersisted/unlinked — the
+            // resolver's spawn gate then blocks the agent on its very next
+            // spawn even though this handler just reported "run /cost to
+            // verify" as if the login were already usable.
+            let openedAccountId: string | undefined;
+            let openedAccountDir: string | undefined;
+            let recheckAuthEnv = authEnv;
             const outcome = await runProviderLogin({
                 provider: prov,
                 cliPath,
                 authEnv,
                 setAuthUrl: ctx.setAuthUrl,
                 log: ctx.log,
-                linkTarget: agentDefinitionId
-                    ? { blockId: ctx.blockId, agentDefinitionId }
-                    : undefined,
+                linkTarget,
+                onAccountRegistered: (accountId, dir) => {
+                    openedAccountId = accountId;
+                    openedAccountDir = dir;
+                    if (prov.authConfigDirEnvVar) {
+                        recheckAuthEnv = { ...authEnv, [prov.authConfigDirEnvVar]: dir };
+                    }
+                },
             });
             switch (outcome) {
-                case "opened":
-                    ctx.log("auth", "run /cost to verify authentication once logged in");
-                    return { kind: "ok" };
+                case "opened": {
+                    ctx.log("auth", "waiting for login to complete...");
+                    let authenticated = false;
+                    const deadline = Date.now() + 5 * 60 * 1000;
+                    while (Date.now() < deadline && !authenticated) {
+                        await new Promise<void>((r) => setTimeout(r, 2000));
+                        try {
+                            const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+                                cli_path: cliPath,
+                                auth_check_args: prov.authCheckCommand,
+                                auth_env: recheckAuthEnv,
+                            }, { timeout: 10000 });
+                            if (recheck.authenticated) authenticated = true;
+                        } catch {
+                            // keep polling on transient RPC errors
+                        }
+                    }
+                    if (authenticated && openedAccountId && openedAccountDir) {
+                        await persistAndLinkAccount(
+                            { provider: prov, cliPath, authEnv, setAuthUrl: ctx.setAuthUrl, log: ctx.log, linkTarget },
+                            openedAccountId,
+                            openedAccountDir,
+                        );
+                        ctx.log("auth", "login complete — run /cost to verify");
+                        return { kind: "ok" };
+                    }
+                    return {
+                        kind: "error",
+                        message:
+                            "/login: opened a login page, but no login was detected within 5 minutes. " +
+                            "Complete the login there, then run /login again.",
+                    };
+                }
                 case "seeded":
                     return { kind: "ok" };
                 case "terminal-success":

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -4,7 +4,11 @@
 /**
  * /login — run a GUI OAuth flow via the host API, capture the returned
  * URL, and push it into ctx.setAuthUrl so the auth box appears above
- * the composer.
+ * the composer. Falls all the way through `runProviderLogin`'s three
+ * recovery tiers (retro-headless-login-browser-open-2026-07-20) instead of
+ * dead-ending the moment the CLI produces no scrapeable URL — Claude Code
+ * v2.1.x never does, in any headless spawn, so that used to mean "does
+ * nothing" for the single most common provider.
  *
  * Migrated from useAgentCommands.runLoginCommand (PR #378 era). Unlike
  * pure commands, /login logs progress directly via ctx.log because the
@@ -14,7 +18,7 @@
  * is the exception. See spec §4.4 dispatcher note.
  */
 
-import { forceProviderLogin } from "../../flows/force-login";
+import { runProviderLogin } from "../../flows/run-provider-login";
 import type { SlashCommand, SlashResult } from "../types";
 
 export const loginCommand: SlashCommand = {
@@ -40,26 +44,45 @@ export const loginCommand: SlashCommand = {
             }
             // Shared with the failure-banner / inline-error "Login Again" action
             // (useAgentControllerStatus.relogin) — opens the OAuth in an in-app
-            // browser pane and surfaces the URL box. See force-login.ts.
-            const outcome = await forceProviderLogin({
+            // browser pane, or falls through to the global-login copy / real-terminal
+            // tiers when the CLI produces no scrapeable URL. See run-provider-login.ts.
+            // linkTarget lets a tier-2/3 success register a real Armory account
+            // bound to this agent (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7).
+            const agentDefinitionId = ctx.block()?.meta?.["agentId"] as string | undefined;
+            const outcome = await runProviderLogin({
                 provider: prov,
                 cliPath,
                 authEnv,
                 setAuthUrl: ctx.setAuthUrl,
                 log: ctx.log,
+                linkTarget: agentDefinitionId
+                    ? { blockId: ctx.blockId, agentDefinitionId }
+                    : undefined,
             });
-            if (outcome === "no-url") {
-                // Never report success for a login that opened nothing
-                // (retro-agent-auth-relogin-noop-2026-07-01 §5.1).
-                return {
-                    kind: "error",
-                    message:
-                        "/login: the CLI didn't produce a login URL, so no browser was opened. " +
-                        "Use the “Login via terminal” or “Use existing login” actions instead.",
-                };
+            switch (outcome) {
+                case "opened":
+                    ctx.log("auth", "run /cost to verify authentication once logged in");
+                    return { kind: "ok" };
+                case "seeded":
+                    return { kind: "ok" };
+                case "terminal-success":
+                    ctx.log("auth", "login complete — run /cost to verify");
+                    return { kind: "ok" };
+                case "terminal-timeout":
+                    // Never report success for a login that didn't complete
+                    // (retro-agent-auth-relogin-noop-2026-07-01 §5.1).
+                    return {
+                        kind: "error",
+                        message:
+                            "/login: opened a terminal window, but no login was detected within 5 minutes. " +
+                            "Complete the login there, then run /login again.",
+                    };
+                case "terminal-unavailable":
+                    return {
+                        kind: "error",
+                        message: "/login: the CLI produced no login URL, and a terminal window couldn't be opened on this platform.",
+                    };
             }
-            ctx.log("auth", "run /cost to verify authentication once logged in");
-            return { kind: "ok" };
         } catch (err: any) {
             return { kind: "error", message: `/login failed: ${err?.message ?? String(err)}` };
         }

--- a/frontend/app/view/agent/components/AgentIdentityModal.scss
+++ b/frontend/app/view/agent/components/AgentIdentityModal.scss
@@ -13,90 +13,10 @@
     max-width: 560px;
 }
 
-// Layer-3 ambient-login opt-in row (spec §2.3 —
-// SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md). Local switch
-// styling mirrors the settings pane's .setting-toggle (that stylesheet
-// isn't loaded in the agent-pane modal context).
-.agent-ambient-login-section {
-    padding: var(--space-3) var(--space-5);
-    border-top: 1px solid var(--border-color);
-}
-
-.agent-ambient-login-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-}
-
-.agent-ambient-login-text {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-    flex: 1;
-    min-width: 0;
-}
-
-.agent-ambient-login-label {
-    font-size: var(--text-sm);
-    font-weight: var(--font-weight-medium);
-    color: var(--main-text-color);
-}
-
-.agent-ambient-login-help {
-    font-size: var(--text-xs);
-    color: var(--secondary-text-color);
-    line-height: 1.4;
-}
-
-.agent-ambient-login-toggle {
-    flex: none;
-    position: relative;
-    width: 34px;
-    height: 18px;
-    padding: 0;
-    border: 1px solid var(--border-color);
-    border-radius: 9px;
-    background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
-    cursor: default;
-
-    &:disabled {
-        opacity: 0.6;
-    }
-
-    &:focus-visible {
-        outline: none;
-        box-shadow: var(--shadow-focus-ring);
-    }
-
-    .agent-ambient-login-toggle-thumb {
-        position: absolute;
-        top: 1px;
-        left: 1px;
-        width: 14px;
-        height: 14px;
-        border-radius: 50%;
-        background: var(--main-text-color);
-        opacity: 0.7;
-        transition: transform 120ms ease;
-    }
-
-    &--on {
-        background: var(--accent-color);
-        border-color: var(--accent-color);
-
-        .agent-ambient-login-toggle-thumb {
-            transform: translateX(16px);
-            background: var(--button-text-color);
-            opacity: 1;
-        }
-    }
-}
-
-.agent-ambient-login-error {
-    margin-top: var(--space-2);
-    font-size: var(--text-xs);
-    color: var(--error-color);
-}
+// The ambient-login opt-in row that used to live here was removed (reagent
+// P1 on #2262 — see AgentIdentityModal.tsx's doc comment): the layer-3
+// spawn gate no longer honors use_ambient_login at all, so the toggle was
+// dead UI promising a fallback that no longer existed.
 
 .agent-modal-footer {
     display: flex;

--- a/frontend/app/view/agent/components/AgentIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityModal.tsx
@@ -15,16 +15,23 @@
  * the snapshot so the next assignment builds on the latest state rather
  * than the snapshot from when the modal opened (Codex P2 on PR #1587).
  *
- * Also hosts the per-agent "Use global CLI login" toggle
- * (`use_ambient_login`) — the explicit opt-in that lets a spawn proceed
- * on the CLI's global login when no oauth-class account resolves.
- * Without it, such spawns fail with a visible error (layer-3 spawn
- * gating, SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.2-§2.3).
+ * The per-agent "Use global CLI login" toggle (`use_ambient_login`) that
+ * used to live here has been removed (reagent P1 on #2262): the layer-3
+ * spawn gate (`identity/resolver.rs`'s `gate_oauth_failure`) was changed to
+ * unconditionally refuse an oauth-class spawn with no bound account — every
+ * provider, no per-agent opt-out — per the explicit "single point, not
+ * global... close it everywhere, now" policy
+ * (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7). The toggle kept
+ * rendering as fully interactive with help text promising a working
+ * fallback that the backend had already stopped honoring, misleading users
+ * into believing they'd configured something that did nothing. The
+ * `use_ambient_login` DB column/field itself is untouched (still read and
+ * logged, just never gates) — only this now-dead UI is removed.
  *
  * Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md §4.
  */
 
-import { createSignal, onCleanup, Show, type JSX } from "solid-js";
+import { createSignal, onCleanup, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import {
@@ -50,11 +57,9 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
     // memo keeps reading the original snapshot and the second assignment
     // overwrites the first.
     const [liveAgent, setLiveAgent] = createSignal<AgentDefinition>(props.agent);
-    const [ambientSaving, setAmbientSaving] = createSignal(false);
-    const [ambientError, setAmbientError] = createSignal<string | null>(null);
 
     /** Common UpdateAgentDefinitionCommand payload from the live snapshot.
-     *  `accounts` / `use_ambient_login` are layered on by the callers. */
+     *  `accounts` is layered on by the caller. */
     const basePayload = (a: AgentDefinition): CommandUpdateAgentDefinitionData => ({
         id: a.id,
         name: a.name,
@@ -82,26 +87,6 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
         setLiveAgent({ ...a, accounts: serialized });
     };
 
-    const ambientOn = () => (liveAgent().use_ambient_login ?? 0) !== 0;
-
-    const handleAmbientToggle = async (): Promise<void> => {
-        const a = liveAgent();
-        const next = ambientOn() ? 0 : 1;
-        setAmbientError(null);
-        setAmbientSaving(true);
-        try {
-            await RpcApi.UpdateAgentDefinitionCommand(TabRpcClient, {
-                ...basePayload(a),
-                use_ambient_login: next,
-            });
-            setLiveAgent({ ...a, use_ambient_login: next });
-        } catch (e) {
-            setAmbientError(String(e));
-        } finally {
-            setAmbientSaving(false);
-        }
-    };
-
     return (
         <div class="agent-identity-modal-body">
             <AgentIdentityPanel
@@ -109,38 +94,6 @@ export const AgentIdentityModalPanel = (props: AgentIdentityModalPanelProps): JS
                 model={model}
                 onUpdate={handleUpdate}
             />
-            {/* Layer-3 ambient-login opt-in (spec §2.3). Immediate RPC on
-                change — same convention as the account dropdowns above. */}
-            <div class="agent-ambient-login-section">
-                <div class="agent-ambient-login-row">
-                    <div class="agent-ambient-login-text">
-                        <span class="agent-ambient-login-label">
-                            Use global CLI login when no account is bound
-                        </span>
-                        <span class="agent-ambient-login-help">
-                            When on, this agent may launch with your machine-wide CLI
-                            login (e.g. ~/.claude) if no managed account resolves.
-                            When off, launching fails instead — deleting an account in
-                            the Armory reliably deauthenticates this agent's next start.
-                        </span>
-                    </div>
-                    <button
-                        type="button"
-                        role="switch"
-                        aria-checked={ambientOn()}
-                        aria-label="Use global CLI login when no account is bound"
-                        class="agent-ambient-login-toggle"
-                        classList={{ "agent-ambient-login-toggle--on": ambientOn() }}
-                        disabled={ambientSaving()}
-                        onClick={() => void handleAmbientToggle()}
-                    >
-                        <span class="agent-ambient-login-toggle-thumb" />
-                    </button>
-                </div>
-                <Show when={ambientError()}>
-                    <div class="agent-ambient-login-error">{ambientError()}</div>
-                </Show>
-            </div>
             <div class="agent-modal-footer">
                 <button
                     class="agent-modal-done-btn"

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -483,7 +483,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // selected account can't supply credentials for the agent's
     // provider. That's true when:
     //
-    // - No account selected — ambient creds, OAuth flow runs once.
+    // - No account selected at all.
     // - A selected account for a different provider.
     //
     // Bypasses:
@@ -494,13 +494,21 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // Hard auth-blockers: launch CANNOT proceed without the user
     // completing OAuth. Drives both the panel mount AND the launch
     // gate.
+    //
+    // 2026-07-20: reverted a same-day "no account = ambient creds is fine"
+    // relaxation. `identity/resolver.rs`'s layer-3 spawn gate was ALREADY
+    // hard-blocking an oauth-class agent with no bound account by default
+    // (`use_ambient_login=0`) — that relaxation let Launch enable and then
+    // had the agent fail its first real turn with a raw backend error,
+    // which is worse than being blocked up front with a clear reason. The
+    // gate's ambient escape hatch is now removed entirely (single point,
+    // not global — PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7),
+    // so "no account selected" must block here again, for every provider,
+    // with no exception.
     const authBlocksLaunch = () =>
         !isContinue()
         && provider()?.authType === "oauth"
-        && (
-            accountId() === ""
-            || !accountSupplies()
-        );
+        && (accountId() === "" || !accountSupplies());
     // Soft nudges: show the Connect CTA (with status-aware wording)
     // when the account is selected but its status is `needs_reauth` /
     // `expired`. Per spec §4.4 this is a "wording-only nudge" — does

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -43,7 +43,7 @@ import {
     type SelectionOutcome,
 } from "../auth";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
-import { seedGlobalLogin } from "../flows/seed-global-login";
+import { registerSeededAccount } from "../flows/register-seeded-account";
 import type { ProviderDefinition } from "../providers";
 import type { LogFn } from "../types";
 import "./PreLaunchAuthPanel.scss";
@@ -170,28 +170,25 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
 
     // "Use my existing login" — the PRIMARY path for Claude v2.1.x, whose
     // in-app OAuth can't open a browser when WE spawn it (a dead end —
-    // SPEC_HOST_CLI_LOGIN_CAPTURE §0). Copies the user's valid GLOBAL login
-    // into the agent's isolated dir, then marks the controller `ready` so
-    // Launch enables — no in-app browser, no OAuth.
+    // SPEC_HOST_CLI_LOGIN_CAPTURE §0). Mints a real per-account isolated dir,
+    // copies the user's valid GLOBAL login into it, and persists a real
+    // IdentityAccount row (not just a file in the shared dir — this used to
+    // call `seedGlobalLogin` directly against `ensureAuthDir`'s SHARED
+    // default dir and only fake local "ready" state via `markSeeded`,
+    // leaving Armory with no record the account ever existed. See
+    // PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7 — the resolver's
+    // spawn gate now requires a real bound account, so a fake-ready panel
+    // would have let Launch enable and then had the agent immediately fail
+    // its first turn). No in-app browser, no OAuth. `props.accountId()` is
+    // passed through as `existingAccountId` so a Reconnect (not a fresh
+    // Connect) refreshes the SAME account's dir in place.
     const seedLog: LogFn = (_cat, msg) => console.log(`[auth-diag] seed: ${msg}`);
     const handleUseExistingLogin = async (): Promise<void> => {
         const prov = props.provider;
         if (!prov) return;
-        // Resolve the agent's isolated auth dir so the seed lands where the
-        // agent reads it (host falls back to the shared dir if absent/invalid).
-        let configDir: string | undefined;
-        if (prov.authConfigDirEnvVar) {
-            try {
-                configDir = await getApi().ensureAuthDir(prov.id);
-            } catch (e) {
-                console.warn(
-                    `[auth-diag] seed ensureAuthDir failed: ${(e as Error)?.message ?? String(e)}`,
-                );
-            }
-        }
-        const ok = await seedGlobalLogin(prov.id, seedLog, configDir);
-        if (ok) {
-            controller.markSeeded(props.accountId());
+        const reg = await registerSeededAccount(prov.id, seedLog, props.accountId() || undefined);
+        if (reg.ok && reg.accountId) {
+            controller.markSeeded(reg.accountId);
         } else {
             controller.failConnect(
                 new Error(

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -39,7 +39,7 @@ import { WpsEvent } from "@/app/store/wps-events";
 import * as WOS from "@/app/store/wos";
 import { BlockService } from "@/app/store/services";
 import { getApi, staticTabId } from "@/app/store/global";
-import { runProviderLogin } from "./run-provider-login";
+import { persistAndLinkAccount, runProviderLogin } from "./run-provider-login";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -240,6 +240,19 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             // authenticated: false even though the login just succeeded,
             // defeating the entire "Retry Login" flow this file exists for.
             let recheckAuthEnv = authEnv ?? {};
+            // Captured for the "opened" case specifically — tier 1 mints
+            // and reports the account but does NOT persist/link it (it
+            // returns before confirming completion); once THIS function's
+            // own poll below confirms authenticated: true, it must call
+            // persistAndLinkAccount itself using these. reagent P0 on
+            // #2263: without this, a tier-1 login that succeeds for any
+            // provider whose CLI actually prints a URL (not
+            // requiresLoginTty — e.g. gemini/copilot) never gets a real
+            // IdentityAccount, and the resolver's spawn gate blocks the
+            // agent on its very next spawn regardless of what this poll
+            // reports now.
+            let openedAccountId: string | undefined;
+            let openedAccountDir: string | undefined;
             const outcome = await runProviderLogin({
                 provider,
                 cliPath: cliResult.cli_path,
@@ -249,7 +262,9 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 isCancelled,
                 linkTarget: agentDefinitionId ? { blockId, agentDefinitionId } : undefined,
                 existingAccountId,
-                onAccountRegistered: (_accountId, dir) => {
+                onAccountRegistered: (accountId, dir) => {
+                    openedAccountId = accountId;
+                    openedAccountDir = dir;
                     if (provider.authConfigDirEnvVar) {
                         recheckAuthEnv = { ...(authEnv ?? {}), [provider.authConfigDirEnvVar]: dir };
                     }
@@ -280,6 +295,24 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                     } catch {
                         // keep polling on transient RPC errors
                     }
+                }
+                // Tier 1 minted the account but deliberately didn't persist
+                // it (see run-provider-login.ts's persistAndLinkAccount doc
+                // comment) — now that THIS poll has confirmed the login
+                // actually completed, persist and link it for real.
+                if (authenticated && openedAccountId && openedAccountDir) {
+                    await persistAndLinkAccount(
+                        {
+                            provider,
+                            cliPath: cliResult.cli_path,
+                            authEnv: authEnv ?? {},
+                            setAuthUrl,
+                            log,
+                            linkTarget: agentDefinitionId ? { blockId, agentDefinitionId } : undefined,
+                        },
+                        openedAccountId,
+                        openedAccountDir,
+                    );
                 }
             } else if (outcome === "seeded" || outcome === "terminal-success") {
                 // A credential already landed on disk (copied from a valid

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -39,7 +39,7 @@ import { WpsEvent } from "@/app/store/wps-events";
 import * as WOS from "@/app/store/wos";
 import { BlockService } from "@/app/store/services";
 import { getApi, staticTabId } from "@/app/store/global";
-import { openOAuthBrowserPane } from "./open-oauth-pane";
+import { runProviderLogin } from "./run-provider-login";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -197,85 +197,96 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
 
     if (needsLogin) {
         log("auth", "not authenticated — starting login flow...");
+        setLoginWaiting(true);
         try {
-            // Run from the CEF host (GUI process) so the browser opens correctly on Windows.
-            // Returns immediately after spawning — browser opens, frontend polls for completion.
-            //
-            // The host API may return an OAuth URL string captured from the
-            // CLI's stdout (Claude Code does this reliably; other providers
-            // may not). When available, push it into setAuthUrl so the
-            // auth-url box renders above the composer with a Copy button —
-            // the user can paste the URL into their browser manually if the
-            // auto-open didn't fire or got blocked. See
-            // SPEC_AGENT_PANE_FOLLOWUPS item #3.
-            const loginUrl = await getApi().runCliLogin(
-                cliResult.cli_path,
-                provider.authLoginCommand,
-                authEnv ?? {},
-                provider.requiresLoginTty ?? false,
-            );
-            if (loginUrl) {
-                setAuthUrl(loginUrl);
-                log("auth", "opening browser...");
-                // Open the OAuth URL in the system browser — it already has the
-                // user's session/cookies, so login there is more likely to
-                // auto-complete; falls back to an in-app browser pane if the
-                // system browser can't be opened. The auth-url box above the
-                // composer is the URL backup either way.
-                const opened = await openOAuthBrowserPane(loginUrl);
-                if (opened === "pane") {
-                    log("auth", "opened login in an in-app browser pane — complete login there");
-                } else if (opened === "external") {
-                    log("auth", "opened login in your system browser — complete login there");
-                } else {
-                    log("auth", "could not open a browser; copy the URL from the box above and open it manually", "warn");
-                }
-            } else {
-                log("auth", "attempting to open browser for login...");
-                log("auth", "if no browser opened, run the login command manually", "warn");
-            }
+            // Shared with `/login` and the "Login Again" failure-banner action
+            // (retro-headless-login-browser-open-2026-07-20 / retro-login-
+            // three-code-paths-2026-07-20) — this used to be a hand-rolled
+            // `runCliLogin` call with no fallback when the CLI produced no
+            // scrapeable URL, which is every time for Claude Code v2.1.x. That
+            // left this specific call site — the one "Retry Login" actually
+            // triggers — stuck polling CheckCliAuth against a dir nothing was
+            // writing to, for the full 5-minute deadline, every single click.
+            // linkTarget lets a tier-2/3 success register a real Armory
+            // account bound to THIS agent instead of just seeding a file
+            // nothing tracks (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+            // §7 — required now that the resolver's spawn gate has no
+            // ambient exception).
+            const agentDefinitionId = blockData?.meta?.agentId as string | undefined;
+            const outcome = await runProviderLogin({
+                provider,
+                cliPath: cliResult.cli_path,
+                authEnv: authEnv ?? {},
+                setAuthUrl,
+                log,
+                isCancelled,
+                linkTarget: agentDefinitionId ? { blockId, agentDefinitionId } : undefined,
+            });
 
-            // Poll until authenticated, cancelled, or timed out (5 minutes)
-            log("auth", "waiting for login to complete...");
-            setLoginWaiting(true);
-            const deadline = Date.now() + 5 * 60 * 1000;
             let authenticated = false;
-            while (!isCancelled() && Date.now() < deadline) {
-                await new Promise<void>((r) => setTimeout(r, 2000));
-                if (isCancelled()) break;
+            let authedEmail: string | null = null;
+
+            if (outcome === "opened") {
+                // A real OAuth URL was captured and opened — poll until the
+                // user finishes there, cancels, or 5 minutes elapse.
+                log("auth", "waiting for login to complete...");
+                const deadline = Date.now() + 5 * 60 * 1000;
+                while (!isCancelled() && Date.now() < deadline && !authenticated) {
+                    await new Promise<void>((r) => setTimeout(r, 2000));
+                    if (isCancelled()) break;
+                    try {
+                        const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+                            cli_path: cliResult.cli_path,
+                            auth_check_args: provider.authCheckCommand,
+                            auth_env: authEnv,
+                        }, { timeout: 10000 });
+                        if (recheck.authenticated) {
+                            authenticated = true;
+                            authedEmail = recheck.email ?? null;
+                        }
+                    } catch {
+                        // keep polling on transient RPC errors
+                    }
+                }
+            } else if (outcome === "seeded" || outcome === "terminal-success") {
+                // A credential already landed on disk (copied from a valid
+                // global login, or completed in the terminal-fallback tier,
+                // which already polled internally) — one-shot confirm instead
+                // of polling again.
                 try {
-                    const recheckResult = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+                    const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
                         cli_path: cliResult.cli_path,
                         auth_check_args: provider.authCheckCommand,
                         auth_env: authEnv,
                     }, { timeout: 10000 });
-                    if (recheckResult.authenticated) {
-                        const emailPart = recheckResult.email ? ` as ${recheckResult.email}` : "";
-                        log("auth", `authenticated${emailPart}`);
-                        opts.onLoginSuccess?.(recheckResult.email ?? null);
-                        authenticated = true;
-                        break;
-                    }
+                    authenticated = recheck.authenticated;
+                    authedEmail = recheck.email ?? null;
                 } catch {
-                    // keep polling on transient RPC errors
+                    // The credential is on disk even if this recheck RPC
+                    // itself failed transiently — don't block success on it.
+                    authenticated = true;
                 }
             }
-            setLoginWaiting(false);
+            // "terminal-timeout" / "terminal-unavailable" leave authenticated
+            // false and fall through to the AMX-AUTH-002 error below.
 
+            setLoginWaiting(false);
             // Reap the login CLI now the attempt has concluded (success,
             // timeout, or cancel). On manual-paste success the child self-exits;
             // if creds appeared without a paste it would otherwise linger at the
             // prompt. cancelCliLogin is idempotent and host-side.
             getApi().cancelCliLogin().catch(() => {});
-
-            // Always clear auth URL after the login attempt
             setAuthUrl(null);
 
             if (isCancelled()) {
                 return "auth_failed";
             }
 
-            if (!authenticated) {
+            if (authenticated) {
+                const emailPart = authedEmail ? ` as ${authedEmail}` : "";
+                log("auth", `authenticated${emailPart}`);
+                opts.onLoginSuccess?.(authedEmail);
+            } else {
                 // Synthesize an AMX-AUTH-002 wire payload so the log
                 // entry renders with the catalog's friendly title +
                 // retry hint, matching the typed-error pattern used

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -213,6 +213,33 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             // §7 — required now that the resolver's spawn gate has no
             // ambient exception).
             const agentDefinitionId = blockData?.meta?.agentId as string | undefined;
+
+            // Reuse the account already bound to this agent for this
+            // provider, if any — reagent P1: without this, every retry
+            // through this flow minted a brand-new account+dir instead of
+            // refreshing the one already in use, orphaning an unlinked
+            // IdentityAccount row/dir on every failed "Retry Login" click.
+            let existingAccountId: string | undefined;
+            if (agentDefinitionId) {
+                try {
+                    const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, {
+                        agent_id: agentDefinitionId,
+                    });
+                    existingAccountId = links.find((l) => l.provider === provider.id)?.account_id;
+                } catch {
+                    // Best-effort — a fresh account still gets minted below if this lookup fails.
+                }
+            }
+
+            // Tier 2/3 mint (or reuse) an isolated account dir that's
+            // DIFFERENT from the pre-login `authEnv` closure above — this
+            // local copy is what the post-login recheck below actually
+            // queries, so it must be refreshed. reagent P0: without this,
+            // the "seeded"/"terminal-success" recheck queried the OLD
+            // directory (nothing had ever been written there) and reported
+            // authenticated: false even though the login just succeeded,
+            // defeating the entire "Retry Login" flow this file exists for.
+            let recheckAuthEnv = authEnv ?? {};
             const outcome = await runProviderLogin({
                 provider,
                 cliPath: cliResult.cli_path,
@@ -221,6 +248,12 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 log,
                 isCancelled,
                 linkTarget: agentDefinitionId ? { blockId, agentDefinitionId } : undefined,
+                existingAccountId,
+                onAccountRegistered: (_accountId, dir) => {
+                    if (provider.authConfigDirEnvVar) {
+                        recheckAuthEnv = { ...(authEnv ?? {}), [provider.authConfigDirEnvVar]: dir };
+                    }
+                },
             });
 
             let authenticated = false;
@@ -238,7 +271,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                         const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
                             cli_path: cliResult.cli_path,
                             auth_check_args: provider.authCheckCommand,
-                            auth_env: authEnv,
+                            auth_env: recheckAuthEnv,
                         }, { timeout: 10000 });
                         if (recheck.authenticated) {
                             authenticated = true;
@@ -257,7 +290,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                     const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
                         cli_path: cliResult.cli_path,
                         auth_check_args: provider.authCheckCommand,
-                        auth_env: authEnv,
+                        auth_env: recheckAuthEnv,
                     }, { timeout: 10000 });
                     authenticated = recheck.authenticated;
                     authedEmail = recheck.email ?? null;

--- a/frontend/app/view/agent/flows/register-seeded-account.ts
+++ b/frontend/app/view/agent/flows/register-seeded-account.ts
@@ -1,0 +1,130 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * registerSeededAccount — the single, sanctioned way to turn "copy my
+ * existing global login" into a real, Armory-visible IdentityAccount,
+ * instead of just a credential file sitting in the shared default dir.
+ *
+ * PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7 ("single point, not
+ * global"): `identity/resolver.rs`'s layer-3 spawn gate now unconditionally
+ * requires a real bound account for any oauth-class provider — the
+ * `use_ambient_login` escape hatch that used to let a shared-dir credential
+ * work invisibly (no Armory row, no expiry tracking, no way to tell it
+ * apart from a genuinely unconfigured agent) is retired. So "seed from
+ * global" has to do three things now, not one:
+ *
+ *   1. Mint a per-account isolated dir (`ensureAccountDir` — a thin wrapper
+ *      around the `identity.ensureaccountdir` RPC, itself the same
+ *      `compute_and_ensure_account_dir` `auth.start` already uses for a
+ *      real OAuth handshake).
+ *   2. Seed a valid credential into THAT dir (`seedGlobalLogin`, unchanged —
+ *      it already accepts an arbitrary target dir under `~/.agentmux`), or
+ *      — for the terminal-fallback tier — let the user complete a fresh
+ *      OAuth login that lands there.
+ *   3. Persist the account row (`persistSeededAccount`) so Armory can see
+ *      it, the expiry probe can track it, and the resolver's gate can find
+ *      it.
+ *
+ * Exported as separate steps (not just the composed `registerSeededAccount`)
+ * because the terminal-fallback tier needs the dir minted BEFORE it opens a
+ * terminal (to know where to point the login), but can only persist AFTER
+ * the user finishes and a poll detects the credential.
+ *
+ * Linking the new account to a specific agent is deliberately NOT this
+ * module's job — callers differ on when that's possible. A pane-level
+ * recovery (an agent that already exists) should call
+ * `LinkAgentIdentityCommand` right after persisting. A New Agent modal flow
+ * has no agent yet — its own launch-time reconcile links it once one is
+ * created.
+ */
+
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { seedGlobalLogin } from "./seed-global-login";
+import type { LogFn } from "../types";
+
+export interface MintedAccountDir {
+    accountId: string;
+    dir: string;
+}
+
+/** Step 1: mint (or resolve, when `existingAccountId` is set) a per-account
+ *  isolated dir. Returns `null` if the provider isn't oauth-class or the
+ *  dir couldn't be created. */
+export async function ensureAccountDir(
+    providerId: string,
+    log: LogFn,
+    existingAccountId?: string,
+): Promise<MintedAccountDir | null> {
+    try {
+        const mint = await RpcApi.EnsureAccountDirCommand(TabRpcClient, {
+            providerId,
+            existingAccountId,
+        });
+        if (!mint.dir) {
+            log("auth", `${providerId} has no isolated config dir to seed into`, "error");
+            return null;
+        }
+        return { accountId: mint.accountId, dir: mint.dir };
+    } catch (e: any) {
+        log("auth", `couldn't allocate an account directory: ${e?.message ?? String(e)}`, "error");
+        return null;
+    }
+}
+
+/** Step 3: persist the IdentityAccount row once a valid credential is
+ *  confirmed sitting in `dir`. */
+export async function persistSeededAccount(
+    providerId: string,
+    accountId: string,
+    dir: string,
+    log: LogFn,
+): Promise<boolean> {
+    try {
+        await RpcApi.UpsertIdentityAccountCommand(TabRpcClient, {
+            id: accountId,
+            name: `${providerId}-oauth`,
+            provider: providerId,
+            kind: "oauth",
+            secret_ref: { backend: "oauth_config_dir", dir },
+            status: "valid",
+        });
+        log("auth", "registered a real Armory account from your existing login");
+        return true;
+    } catch (e: any) {
+        log(
+            "auth",
+            `credential seeded but the Armory account couldn't be registered: ${e?.message ?? String(e)}`,
+            "error",
+        );
+        return false;
+    }
+}
+
+export interface RegisterSeededAccountResult {
+    ok: boolean;
+    accountId?: string;
+    dir?: string;
+}
+
+/** Steps 1+2+3 composed — the common case (tier 2: seed from an
+ *  already-valid global login, synchronous, no user action needed). */
+export async function registerSeededAccount(
+    providerId: string,
+    log: LogFn,
+    existingAccountId?: string,
+): Promise<RegisterSeededAccountResult> {
+    const minted = await ensureAccountDir(providerId, log, existingAccountId);
+    if (!minted) return { ok: false };
+
+    if (!(await seedGlobalLogin(providerId, log, minted.dir))) {
+        return { ok: false };
+    }
+
+    if (!(await persistSeededAccount(providerId, minted.accountId, minted.dir, log))) {
+        return { ok: false };
+    }
+
+    return { ok: true, accountId: minted.accountId, dir: minted.dir };
+}

--- a/frontend/app/view/agent/flows/run-cli-login-single-caller.test.ts
+++ b/frontend/app/view/agent/flows/run-cli-login-single-caller.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins the topology fix from retro-login-three-code-paths-2026-07-20: the
+ * raw host primitive `getApi().runCliLogin` must have exactly one caller in
+ * the whole frontend — `force-login.ts`, which `runProviderLogin` wraps.
+ *
+ * The previous incident wasn't a logic bug in the fallback tiers; it was a
+ * SECOND, independent call site (`launch-flow.ts`) that spawned the login
+ * CLI directly and never got the "no URL captured" fallback a sibling call
+ * site already had. Grepping for callers of a well-named helper
+ * (`forceProviderLogin`) missed it precisely because it didn't use that
+ * helper. This test grep-shapes the invariant itself — "only force-login.ts
+ * may call the raw primitive" — so a future direct call regresses a test,
+ * not just a user's "Retry Login" click.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const APP_ROOT = join(__dirname, "..", "..", "..");
+const SANCTIONED_CALLER = join(__dirname, "force-login.ts");
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const stat = statSync(full);
+        if (stat.isDirectory()) {
+            collectSourceFiles(full, out);
+        } else if (/\.(ts|tsx)$/.test(entry) && !entry.endsWith(".test.ts") && !entry.endsWith(".test.tsx")) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+describe("getApi().runCliLogin call-site topology", () => {
+    it("is called from exactly one file: force-login.ts", () => {
+        const callers: string[] = [];
+        for (const file of collectSourceFiles(APP_ROOT)) {
+            const text = readFileSync(file, "utf8");
+            if (text.includes(".runCliLogin(")) {
+                callers.push(relative(APP_ROOT, file));
+            }
+        }
+
+        expect(callers).toEqual([relative(APP_ROOT, SANCTIONED_CALLER)]);
+    });
+});

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -135,6 +135,50 @@ describe("runProviderLogin", () => {
         expect(hub.cancelCliLogin).toHaveBeenCalledTimes(1);
     });
 
+    it("retries persistSeededAccount once on a transient failure after a successful seed, instead of silently falling through to tier 3 for a login that already succeeded (reagent P2)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+        hub.upsertIdentityAccount
+            .mockRejectedValueOnce(new Error("transient RPC error"))
+            .mockResolvedValueOnce({});
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+
+        expect(outcome).toBe("seeded");
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledTimes(2);
+        expect(hub.openLoginTerminal).not.toHaveBeenCalled();
+    });
+
+    it("falls through to terminal (with a clear error logged) if persistSeededAccount fails on both attempts", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+        hub.upsertIdentityAccount.mockRejectedValue(new Error("persistent RPC error"));
+        const log = vi.fn();
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log,
+            isCancelled: () => true,
+        });
+
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledTimes(2);
+        expect(outcome).toBe("terminal-timeout");
+        expect(log).toHaveBeenCalledWith(
+            "auth",
+            expect.stringMatching(/login succeeded, but AgentMux couldn't save the account record/i),
+            "error",
+        );
+    });
+
     it("tier 2 mints the account dir exactly once (ensureAccountDir called once, not once per tier)", async () => {
         hub.runCliLogin.mockResolvedValue(null);
         hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const hub = vi.hoisted(() => ({
     runCliLogin: vi.fn(),
     checkCliAuth: vi.fn(),
+    cancelCliLogin: vi.fn(),
     openPane: vi.fn(),
     seedProviderAuthFromGlobal: vi.fn(),
     openLoginTerminal: vi.fn(),
@@ -32,6 +33,7 @@ vi.mock("@/app/store/global", () => ({
     getApi: () => ({
         runCliLogin: hub.runCliLogin,
         checkCliAuth: hub.checkCliAuth,
+        cancelCliLogin: hub.cancelCliLogin,
         seedProviderAuthFromGlobal: hub.seedProviderAuthFromGlobal,
         openLoginTerminal: hub.openLoginTerminal,
     }),
@@ -68,6 +70,7 @@ const MINTED = { accountId: "acct-new", dir: "C:/agentmux/identities/acct-new/cl
 beforeEach(() => {
     hub.runCliLogin.mockReset();
     hub.checkCliAuth.mockReset();
+    hub.cancelCliLogin.mockReset().mockResolvedValue(undefined);
     hub.openPane.mockReset().mockResolvedValue("pane");
     hub.seedProviderAuthFromGlobal.mockReset();
     hub.openLoginTerminal.mockReset().mockResolvedValue({ opened: true });
@@ -97,6 +100,9 @@ describe("runProviderLogin", () => {
         expect(hub.ensureAccountDir).not.toHaveBeenCalled();
         expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
         expect(hub.openLoginTerminal).not.toHaveBeenCalled();
+        // Tier 1 succeeded — nothing to cancel, and no fallback tier ran
+        // that could race against a still-live tier-1 child.
+        expect(hub.cancelCliLogin).not.toHaveBeenCalled();
     });
 
     it("falls through to tier 2 — mints a real account dir, seeds it, and registers the account — when tier 1 captures no URL, for claude", async () => {
@@ -119,6 +125,53 @@ describe("runProviderLogin", () => {
             expect.objectContaining({ id: MINTED.accountId, provider: "claude", kind: "oauth" }),
         );
         expect(hub.openLoginTerminal).not.toHaveBeenCalled();
+        // Tier 1 timed out with no URL — its abandoned CLI child must be
+        // cancelled before tier 2 mints/seeds an account.
+        expect(hub.cancelCliLogin).toHaveBeenCalledTimes(1);
+    });
+
+    it("tier 2 mints the account dir exactly once (ensureAccountDir called once, not once per tier)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+
+        await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+
+        expect(hub.ensureAccountDir).toHaveBeenCalledTimes(1);
+    });
+
+    it("when tier 2's seed fails partway (dir minted but not seeded), tier 3 reuses the SAME minted account instead of minting a second one", async () => {
+        vi.useFakeTimers();
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal
+            .mockResolvedValueOnce({ seeded: false, status: "missing" }) // tier 2: no global login to copy
+            .mockResolvedValueOnce({ seeded: true }); // tier 3's first poll: user finished the browser login
+
+        const promise = runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+        const outcome = await promise;
+
+        expect(outcome).toBe("terminal-success");
+        // Exactly one mint for the whole call, not one per tier — the same
+        // MINTED.accountId/dir is what both tier 2's seed attempt and tier
+        // 3's terminal poll operate against.
+        expect(hub.ensureAccountDir).toHaveBeenCalledTimes(1);
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledTimes(1);
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledWith(
+            {},
+            expect.objectContaining({ id: MINTED.accountId }),
+        );
     });
 
     it("links the new account and updates block meta when a linkTarget is given", async () => {

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for runProviderLogin (retro-headless-login-browser-open-2026-07-20,
+ * PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7).
+ *
+ * Pins the three-tier fallback that replaced the old "no URL captured ->
+ * dead end, go click a different button" behavior of /login and
+ * "Login Again": URL-capture, then (Claude only) mint-a-real-account +
+ * copy-from-global-login, then a real terminal window polled for the
+ * resulting credential — with the same real-account registration on
+ * success. "Single point, not global": a seeded credential must land in a
+ * real IdentityAccount's own dir, not the shared default one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    runCliLogin: vi.fn(),
+    checkCliAuth: vi.fn(),
+    openPane: vi.fn(),
+    seedProviderAuthFromGlobal: vi.fn(),
+    openLoginTerminal: vi.fn(),
+    ensureAccountDir: vi.fn(),
+    upsertIdentityAccount: vi.fn(),
+    linkAgentIdentity: vi.fn(),
+    setMeta: vi.fn(),
+}));
+
+vi.mock("@/app/store/global", () => ({
+    getApi: () => ({
+        runCliLogin: hub.runCliLogin,
+        checkCliAuth: hub.checkCliAuth,
+        seedProviderAuthFromGlobal: hub.seedProviderAuthFromGlobal,
+        openLoginTerminal: hub.openLoginTerminal,
+    }),
+}));
+vi.mock("./open-oauth-pane", () => ({ openOAuthBrowserPane: hub.openPane }));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        EnsureAccountDirCommand: (...args: unknown[]) => hub.ensureAccountDir(...args),
+        UpsertIdentityAccountCommand: (...args: unknown[]) => hub.upsertIdentityAccount(...args),
+        LinkAgentIdentityCommand: (...args: unknown[]) => hub.linkAgentIdentity(...args),
+        SetMetaCommand: (...args: unknown[]) => hub.setMeta(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/wos", () => ({ makeORef: (kind: string, id: string) => `${kind}:${id}` }));
+
+import { runProviderLogin } from "./run-provider-login";
+
+const claude = {
+    id: "claude",
+    authLoginCommand: ["auth", "login"],
+    authConfigDirEnvVar: "CLAUDE_CONFIG_DIR",
+    requiresLoginTty: true,
+} as any;
+
+const codex = {
+    id: "codex",
+    authLoginCommand: ["login"],
+    authConfigDirEnvVar: "CODEX_HOME",
+} as any;
+
+const MINTED = { accountId: "acct-new", dir: "C:/agentmux/identities/acct-new/claude" };
+
+beforeEach(() => {
+    hub.runCliLogin.mockReset();
+    hub.checkCliAuth.mockReset();
+    hub.openPane.mockReset().mockResolvedValue("pane");
+    hub.seedProviderAuthFromGlobal.mockReset();
+    hub.openLoginTerminal.mockReset().mockResolvedValue({ opened: true });
+    hub.ensureAccountDir.mockReset().mockResolvedValue(MINTED);
+    hub.upsertIdentityAccount.mockReset().mockResolvedValue({});
+    hub.linkAgentIdentity.mockReset().mockResolvedValue(undefined);
+    hub.setMeta.mockReset().mockResolvedValue(undefined);
+});
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+});
+
+describe("runProviderLogin", () => {
+    it("returns 'opened' when tier 1 captures a URL — no fallback tier runs", async () => {
+        hub.runCliLogin.mockResolvedValue("https://claude.ai/oauth/authorize");
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+
+        expect(outcome).toBe("opened");
+        expect(hub.ensureAccountDir).not.toHaveBeenCalled();
+        expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
+        expect(hub.openLoginTerminal).not.toHaveBeenCalled();
+    });
+
+    it("falls through to tier 2 — mints a real account dir, seeds it, and registers the account — when tier 1 captures no URL, for claude", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+
+        expect(outcome).toBe("seeded");
+        expect(hub.ensureAccountDir).toHaveBeenCalledWith({}, { providerId: "claude", existingAccountId: undefined });
+        expect(hub.seedProviderAuthFromGlobal).toHaveBeenCalledWith("claude", MINTED.dir);
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledWith(
+            {},
+            expect.objectContaining({ id: MINTED.accountId, provider: "claude", kind: "oauth" }),
+        );
+        expect(hub.openLoginTerminal).not.toHaveBeenCalled();
+    });
+
+    it("links the new account and updates block meta when a linkTarget is given", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            linkTarget: { blockId: "block-1", agentDefinitionId: "def-1" },
+        });
+
+        expect(outcome).toBe("seeded");
+        expect(hub.linkAgentIdentity).toHaveBeenCalledWith({}, {
+            agent_id: "def-1",
+            account_id: MINTED.accountId,
+            provider: "claude",
+        });
+        expect(hub.setMeta).toHaveBeenCalledWith({}, {
+            oref: "block:block-1",
+            meta: { "cmd:env": { CLAUDE_CONFIG_DIR: MINTED.dir } },
+        });
+    });
+
+    it("skips tier 2 for non-claude providers (host rejects seed-from-global for them) and opens a terminal with the config-dir env stripped", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+
+        const outcome = await runProviderLogin({
+            provider: codex,
+            cliPath: "x",
+            authEnv: { CODEX_HOME: "C:/auth", OTHER: "keep" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            isCancelled: () => true, // abort tier 3's poll immediately, we only care it was opened
+        });
+
+        expect(hub.ensureAccountDir).not.toHaveBeenCalled(); // non-claude tier 3 doesn't mint either
+        expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
+        expect(hub.openLoginTerminal).toHaveBeenCalledWith("x", ["login"], { OTHER: "keep" });
+        expect(outcome).toBe("terminal-timeout");
+    });
+
+    it("falls through to tier 3 (real terminal), mints an account dir up front, and registers it once the login lands on disk", async () => {
+        vi.useFakeTimers();
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal
+            .mockResolvedValueOnce({ seeded: false, status: "missing" }) // tier 2: no global login yet
+            .mockResolvedValueOnce({ seeded: true }); // first tier-3 poll: user finished the browser login
+
+        const promise = runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+        const outcome = await promise;
+
+        expect(outcome).toBe("terminal-success");
+        // Tier 3's terminal env is stripped of the config-dir var so the
+        // fresh login lands in the user's global dir, not the minted one.
+        expect(hub.openLoginTerminal).toHaveBeenCalledWith("x", ["auth", "login"], {});
+        expect(hub.seedProviderAuthFromGlobal).toHaveBeenLastCalledWith("claude", MINTED.dir);
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledWith(
+            {},
+            expect.objectContaining({ id: MINTED.accountId, provider: "claude" }),
+        );
+    });
+
+    it("returns 'terminal-timeout' without a full 5-minute wait when cancelled", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: false, status: "missing" });
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            isCancelled: () => true,
+        });
+
+        expect(outcome).toBe("terminal-timeout");
+        expect(hub.upsertIdentityAccount).not.toHaveBeenCalled();
+    });
+
+    it("returns 'terminal-unavailable' when the terminal itself can't be opened (e.g. unsupported platform)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: false, status: "missing" });
+        hub.openLoginTerminal.mockRejectedValue(new Error("open_login_terminal: not yet implemented on this platform"));
+
+        const log = vi.fn();
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log,
+        });
+
+        expect(outcome).toBe("terminal-unavailable");
+        expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/couldn't open a terminal/i), "error");
+    });
+});

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -90,8 +90,9 @@ afterEach(() => {
 });
 
 describe("runProviderLogin", () => {
-    it("returns 'opened' when tier 1 captures a URL — no fallback tier runs", async () => {
+    it("returns 'opened' when tier 1 captures a URL — no fallback tier runs, but the account dir is STILL minted up front and reported via onAccountRegistered (reagent P0 on #2263: a provider whose tier 1 succeeds, e.g. gemini/copilot, must still land in an isolated dir with a real account behind it)", async () => {
         hub.runCliLogin.mockResolvedValue("https://claude.ai/oauth/authorize");
+        const onAccountRegistered = vi.fn();
 
         const outcome = await runProviderLogin({
             provider: claude,
@@ -99,15 +100,40 @@ describe("runProviderLogin", () => {
             authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
             setAuthUrl: vi.fn(),
             log: vi.fn(),
+            onAccountRegistered,
         });
 
         expect(outcome).toBe("opened");
-        expect(hub.ensureAccountDir).not.toHaveBeenCalled();
+        expect(hub.ensureAccountDir).toHaveBeenCalledTimes(1);
+        // Tier 1 doesn't confirm completion — so it must NOT persist/link
+        // the account itself (nothing has actually logged in yet); it only
+        // reports the minted (not-yet-persisted) account to the caller.
+        expect(hub.upsertIdentityAccount).not.toHaveBeenCalled();
+        expect(onAccountRegistered).toHaveBeenCalledWith(MINTED.accountId, MINTED.dir);
         expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
         expect(hub.openLoginTerminal).not.toHaveBeenCalled();
         // Tier 1 succeeded — nothing to cancel, and no fallback tier ran
         // that could race against a still-live tier-1 child.
         expect(hub.cancelCliLogin).not.toHaveBeenCalled();
+    });
+
+    it("tier 1 points the login at the minted isolated dir, not whatever authEnv the caller originally passed", async () => {
+        hub.runCliLogin.mockResolvedValue("https://claude.ai/oauth/authorize");
+
+        await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/some-other-dir" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+
+        expect(hub.runCliLogin).toHaveBeenCalledWith(
+            "x",
+            ["auth", "login"],
+            { CLAUDE_CONFIG_DIR: MINTED.dir },
+            true,
+        );
     });
 
     it("falls through to tier 2 — mints a real account dir, seeds it, and registers the account — when tier 1 captures no URL, for claude", async () => {

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -336,4 +336,63 @@ describe("runProviderLogin", () => {
         expect(outcome).toBe("terminal-unavailable");
         expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/couldn't open a terminal/i), "error");
     });
+
+    it("existingAccountId is threaded through to account minting — reconnects the SAME account instead of minting a new one (reagent P1: retries were orphaning a new account every time)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+
+        await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            existingAccountId: "acct-existing",
+        });
+
+        expect(hub.ensureAccountDir).toHaveBeenCalledWith(
+            {},
+            { providerId: "claude", existingAccountId: "acct-existing" },
+        );
+    });
+
+    it("onAccountRegistered fires with the account id + dir on tier 2 success — before finalizeAccount, so a caller can rebuild its own authEnv to recheck the NEW dir (reagent P0: a caller's stale authEnv otherwise reports authenticated:false right after a successful login)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+        const onAccountRegistered = vi.fn();
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            onAccountRegistered,
+        });
+
+        expect(outcome).toBe("seeded");
+        expect(onAccountRegistered).toHaveBeenCalledWith(MINTED.accountId, MINTED.dir);
+    });
+
+    it("onAccountRegistered fires on non-claude tier 3 success too", async () => {
+        vi.useFakeTimers();
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.checkCliAuthCommand
+            .mockResolvedValueOnce({ authenticated: false })
+            .mockResolvedValueOnce({ authenticated: true });
+        const onAccountRegistered = vi.fn();
+
+        const promise = runProviderLogin({
+            provider: codex,
+            cliPath: "x",
+            authEnv: { CODEX_HOME: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            onAccountRegistered,
+        });
+        await vi.advanceTimersByTimeAsync(10_000);
+        await promise;
+
+        expect(onAccountRegistered).toHaveBeenCalledWith(MINTED.accountId, MINTED.dir);
+    });
 });

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -27,6 +27,7 @@ const hub = vi.hoisted(() => ({
     upsertIdentityAccount: vi.fn(),
     linkAgentIdentity: vi.fn(),
     setMeta: vi.fn(),
+    checkCliAuthCommand: vi.fn(),
 }));
 
 vi.mock("@/app/store/global", () => ({
@@ -45,6 +46,7 @@ vi.mock("@/app/store/rpc-api", () => ({
         UpsertIdentityAccountCommand: (...args: unknown[]) => hub.upsertIdentityAccount(...args),
         LinkAgentIdentityCommand: (...args: unknown[]) => hub.linkAgentIdentity(...args),
         SetMetaCommand: (...args: unknown[]) => hub.setMeta(...args),
+        CheckCliAuthCommand: (...args: unknown[]) => hub.checkCliAuthCommand(...args),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -56,6 +58,7 @@ const claude = {
     id: "claude",
     authLoginCommand: ["auth", "login"],
     authConfigDirEnvVar: "CLAUDE_CONFIG_DIR",
+    authCheckCommand: ["auth", "status"],
     requiresLoginTty: true,
 } as any;
 
@@ -63,6 +66,7 @@ const codex = {
     id: "codex",
     authLoginCommand: ["login"],
     authConfigDirEnvVar: "CODEX_HOME",
+    authCheckCommand: ["auth", "status"],
 } as any;
 
 const MINTED = { accountId: "acct-new", dir: "C:/agentmux/identities/acct-new/claude" };
@@ -78,6 +82,7 @@ beforeEach(() => {
     hub.upsertIdentityAccount.mockReset().mockResolvedValue({});
     hub.linkAgentIdentity.mockReset().mockResolvedValue(undefined);
     hub.setMeta.mockReset().mockResolvedValue(undefined);
+    hub.checkCliAuthCommand.mockReset();
 });
 afterEach(() => {
     vi.clearAllMocks();
@@ -199,8 +204,9 @@ describe("runProviderLogin", () => {
         });
     });
 
-    it("skips tier 2 for non-claude providers (host rejects seed-from-global for them) and opens a terminal with the config-dir env stripped", async () => {
+    it("skips tier 2 for non-claude providers (host rejects seed-from-global for them) but STILL mints an account dir and points the terminal at it directly (not stripped — codex has no seed-from-global to copy back from)", async () => {
         hub.runCliLogin.mockResolvedValue(null);
+        hub.checkCliAuthCommand.mockResolvedValue({ authenticated: false });
 
         const outcome = await runProviderLogin({
             provider: codex,
@@ -211,10 +217,61 @@ describe("runProviderLogin", () => {
             isCancelled: () => true, // abort tier 3's poll immediately, we only care it was opened
         });
 
-        expect(hub.ensureAccountDir).not.toHaveBeenCalled(); // non-claude tier 3 doesn't mint either
+        expect(hub.ensureAccountDir).toHaveBeenCalledTimes(1); // reagent P0: used to skip minting for non-claude entirely
         expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
-        expect(hub.openLoginTerminal).toHaveBeenCalledWith("x", ["login"], { OTHER: "keep" });
+        // The env var is KEPT and points at the minted isolated dir — not
+        // stripped the way Claude's tier 3 strips it (codex has no global
+        // login to copy back from, so the login must land directly here).
+        expect(hub.openLoginTerminal).toHaveBeenCalledWith("x", ["login"], { OTHER: "keep", CODEX_HOME: MINTED.dir });
         expect(outcome).toBe("terminal-timeout");
+    });
+
+    it("non-claude tier 3 success: polls CheckCliAuthCommand against the isolated dir (not seedGlobalLogin) and persists the account once authenticated", async () => {
+        vi.useFakeTimers();
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.checkCliAuthCommand
+            .mockResolvedValueOnce({ authenticated: false }) // first poll: not yet
+            .mockResolvedValueOnce({ authenticated: true }); // second poll: user finished in the terminal
+
+        const promise = runProviderLogin({
+            provider: codex,
+            cliPath: "x",
+            authEnv: { CODEX_HOME: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+        });
+        await vi.advanceTimersByTimeAsync(10_000);
+        const outcome = await promise;
+
+        expect(outcome).toBe("terminal-success");
+        expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
+        expect(hub.checkCliAuthCommand).toHaveBeenCalledWith(
+            {},
+            { cli_path: "x", auth_check_args: ["auth", "status"], auth_env: { CODEX_HOME: MINTED.dir } },
+            { timeout: 10000 },
+        );
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledWith(
+            {},
+            expect.objectContaining({ id: MINTED.accountId, provider: "codex" }),
+        );
+    });
+
+    it("a non-claude tier-3 login that never authenticates times out cleanly instead of crashing (reagent P0: seedGlobalLogin used to be called unconditionally and threw for non-claude providers)", async () => {
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.checkCliAuthCommand.mockResolvedValue({ authenticated: false });
+
+        const outcome = await runProviderLogin({
+            provider: codex,
+            cliPath: "x",
+            authEnv: { CODEX_HOME: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            isCancelled: () => true,
+        });
+
+        expect(outcome).toBe("terminal-timeout");
+        expect(hub.seedProviderAuthFromGlobal).not.toHaveBeenCalled();
+        expect(hub.upsertIdentityAccount).not.toHaveBeenCalled();
     });
 
     it("falls through to tier 3 (real terminal), mints an account dir up front, and registers it once the login lands on disk", async () => {

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -231,11 +231,28 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     if (minted && p.provider.id === "claude") {
         p.log("auth", "no login URL captured — checking for an existing global Claude login…");
         if (await seedGlobalLogin(p.provider.id, p.log, minted.dir)) {
-            if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {
+            // The credential is now valid and sitting in minted.dir — a
+            // persist failure here is a bookkeeping problem, not an auth
+            // one, and is usually transient (a momentary RPC hiccup). One
+            // retry (reagent P2) avoids silently falling through to
+            // "opening a terminal window for a fresh login…" for a login
+            // that already succeeded, which just confuses the user into
+            // thinking they still need to do something.
+            let persisted = await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log);
+            if (!persisted) {
+                p.log("auth", "account registration failed — retrying once…", "warn");
+                persisted = await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log);
+            }
+            if (persisted) {
                 p.onAccountRegistered?.(minted.accountId, minted.dir);
                 await finalizeAccount(p, minted.accountId, minted.dir);
                 return "seeded";
             }
+            p.log(
+                "auth",
+                "your login succeeded, but AgentMux couldn't save the account record — try again in a moment",
+                "error",
+            );
         }
     }
 

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -1,0 +1,161 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * runProviderLogin — the SOLE entry point for triggering a provider login
+ * anywhere in the app: `/login`, the "Login Again" failure-banner action,
+ * and the gated launch flow's auto-login-on-open (which also backs the
+ * "Retry Login" button).
+ *
+ * `getApi().runCliLogin` — the raw host primitive this wraps — must NOT be
+ * called directly from anywhere else. It was, once: `launch-flow.ts` had its
+ * own independent call + hand-rolled "no URL captured" handling that
+ * silently diverged from this file's, and kept a stuck-forever "Working…"
+ * spinner alive for the single most common way a user hits this (opening
+ * any pane while unauthenticated) even after `/login` and "Login Again"
+ * were fixed. See retro-login-three-code-paths-2026-07-20. A test
+ * (`run-cli-login-single-caller.test.ts`) pins that raw primitive to exactly
+ * one call site — this file's `forceProviderLogin` import — so a new direct
+ * caller fails a test instead of silently reintroducing that gap. If you're
+ * adding a new UI surface that can trigger a login, call `runProviderLogin`,
+ * not `forceProviderLogin` and not `getApi().runCliLogin`.
+ *
+ * Three tiers, each tried only if the previous one couldn't complete:
+ *
+ *   1. `forceProviderLogin` — spawn the CLI headless/piped and scrape a
+ *      login URL from its output. Fast, and still the right answer for any
+ *      provider whose CLI prints one. Claude Code v2.1.x never does: its
+ *      OAuth flow opens the browser itself from inside the CLI process, and
+ *      a piped/PTY spawn has no attached console for that call to succeed
+ *      from — see retro-headless-login-browser-open-2026-07-20 §1.
+ *   2. `registerSeededAccount` — if no URL was captured, check whether the
+ *      user already has a VALID login in their global `~/.claude` (common:
+ *      the CLI installed outside AgentMux, or a prior AgentMux session). If
+ *      so, mint a real per-account isolated dir, copy the credential into
+ *      it, and persist an IdentityAccount row — not just a file in the
+ *      shared default dir (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+ *      §7, "single point, not global": `identity/resolver.rs`'s spawn gate
+ *      now requires a real bound account, no ambient exception). No
+ *      browser, no user action, completes in well under a second.
+ *      Claude-only (the host command rejects other providers —
+ *      `providers.rs`'s `seed_provider_auth_from_global`), so this tier is
+ *      skipped for everything else.
+ *   3. `openLoginTerminal` — last resort: mint the same kind of per-account
+ *      dir, spawn the login command in a REAL visible console window (which
+ *      gives the CLI's own browser-open call something to attach to) with
+ *      that dir's env var stripped so the login lands in the user's GLOBAL
+ *      `~/.claude`, then poll for it to land — same "single point" account
+ *      persisted on success. Needs the user to actually finish the OAuth
+ *      flow in their browser, so this tier polls for up to 5 minutes
+ *      instead of returning immediately.
+ *
+ * Before this existed, tier 1 failing meant `/login` and "Login Again" both
+ * dead-ended on an error message telling the user to go click a *different*
+ * button ("Login via terminal") themselves. Tiers 2 and 3 are exactly what
+ * that other button already did — this just tries it automatically instead
+ * of requiring the user to know which button fixes a URL-less CLI.
+ */
+
+import { getApi } from "@/app/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import * as WOS from "@/app/store/wos";
+import { forceProviderLogin, type ForceLoginParams } from "./force-login";
+import { pollForGlobalLoginSeed } from "./seed-global-login";
+import { ensureAccountDir, persistSeededAccount, registerSeededAccount } from "./register-seeded-account";
+
+export interface RunProviderLoginParams extends ForceLoginParams {
+    provider: ForceLoginParams["provider"] & { id: string; authConfigDirEnvVar: string };
+    /** Polled during the tier-3 wait; return true to abort early (e.g. the user hit Cancel). */
+    isCancelled?: () => boolean;
+    /** When set, a newly-registered account (tier 2 or 3) is linked to this
+     *  agent definition and the block's `cmd:env` is updated to point at
+     *  its isolated dir — the pane-level recovery case (an already-running
+     *  agent). Omit for a pre-launch flow with no agent yet; that flow's own
+     *  launch-time reconcile links the account once one is created. */
+    linkTarget?: { blockId: string; agentDefinitionId: string };
+}
+
+export type ProviderLoginOutcome =
+    | "opened" // tier 1: browser/pane opened with a captured URL
+    | "seeded" // tier 2: valid global login copied into a real account, automatically
+    | "terminal-success" // tier 3: terminal login completed and was detected
+    | "terminal-timeout" // tier 3: terminal opened, but no login within 5 min (or cancelled)
+    | "terminal-unavailable"; // tier 3 itself couldn't open (e.g. unsupported platform)
+
+async function finalizeAccount(
+    p: RunProviderLoginParams,
+    accountId: string,
+    dir: string,
+): Promise<void> {
+    if (!p.linkTarget) return;
+    try {
+        await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
+            agent_id: p.linkTarget.agentDefinitionId,
+            account_id: accountId,
+            provider: p.provider.id,
+        });
+    } catch (e: any) {
+        p.log(
+            "auth",
+            `account created but couldn't be linked to this agent: ${e?.message ?? String(e)}`,
+            "warn",
+        );
+        return;
+    }
+    try {
+        const oref = WOS.makeORef("block", p.linkTarget.blockId);
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref,
+            meta: { "cmd:env": { ...p.authEnv, [p.provider.authConfigDirEnvVar]: dir } },
+        });
+    } catch {
+        // Best-effort — the account is linked either way; the next full
+        // resolve (relaunch, or the resolver's own per-turn injection) will
+        // still find it even if this specific pane's cached env is stale.
+    }
+}
+
+export async function runProviderLogin(p: RunProviderLoginParams): Promise<ProviderLoginOutcome> {
+    const tier1 = await forceProviderLogin(p);
+    if (tier1 === "opened") return "opened";
+
+    if (p.provider.id === "claude") {
+        p.log("auth", "no login URL captured — checking for an existing global Claude login…");
+        const reg = await registerSeededAccount(p.provider.id, p.log);
+        if (reg.ok && reg.accountId && reg.dir) {
+            await finalizeAccount(p, reg.accountId, reg.dir);
+            return "seeded";
+        }
+    }
+
+    p.log("auth", "opening a terminal window for a fresh login…");
+
+    // Tier 3 needs a real, persistable account dir too — mint it up front
+    // (Claude only; other providers have no seed-from-global detection path
+    // at all, so they fall back to whatever dir was already resolved, same
+    // as before this account-registration change).
+    const minted = p.provider.id === "claude" ? await ensureAccountDir(p.provider.id, p.log) : null;
+    const configDir = minted?.dir ?? p.authEnv[p.provider.authConfigDirEnvVar];
+
+    const terminalEnv: Record<string, string> = { ...p.authEnv };
+    delete terminalEnv[p.provider.authConfigDirEnvVar];
+    try {
+        await getApi().openLoginTerminal(p.cliPath, p.provider.authLoginCommand, terminalEnv);
+    } catch (err: any) {
+        p.log("auth", `couldn't open a terminal for login: ${err?.message ?? String(err)}`, "error");
+        return "terminal-unavailable";
+    }
+    p.log("auth", "a terminal window opened — complete the login there");
+
+    const isCancelled = p.isCancelled ?? (() => false);
+    const seeded = await pollForGlobalLoginSeed(p.provider.id, configDir, isCancelled);
+    if (!seeded) return "terminal-timeout";
+
+    if (minted) {
+        if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {
+            await finalizeAccount(p, minted.accountId, minted.dir);
+        }
+    }
+    return "terminal-success";
+}

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -87,6 +87,25 @@ export interface RunProviderLoginParams extends ForceLoginParams {
      *  agent). Omit for a pre-launch flow with no agent yet; that flow's own
      *  launch-time reconcile links the account once one is created. */
     linkTarget?: { blockId: string; agentDefinitionId: string };
+    /** Reconnect (not fresh-connect) into this account id, if set — threaded
+     *  through to tier 2/3's account-dir minting so the SAME account's
+     *  isolated dir is reused/refreshed instead of a new one being minted.
+     *  Omit for a genuinely fresh connect. Callers that already know this
+     *  agent has a bound account for this provider (e.g. a retry after a
+     *  failed login) should always pass it — otherwise every retry mints
+     *  and orphans a brand-new account instead of refreshing the one
+     *  already in use. */
+    existingAccountId?: string;
+    /** Fired as soon as tier 2 or 3 registers a real IdentityAccount row —
+     *  before `linkTarget`'s own linking (if any). Callers that need to know
+     *  the resulting account id/dir for their own purposes (e.g. rebuilding
+     *  a local `authEnv` copy to recheck auth status against the NEW
+     *  isolated dir, since `finalizeAccount` only updates the persisted
+     *  block meta — a caller's own in-memory `authEnv` variable is never
+     *  refreshed by this function) should use this instead of threading a
+     *  new return shape through `runProviderLogin` — `linkTarget`-driven
+     *  pane callers that don't need the value don't have to care it exists. */
+    onAccountRegistered?: (accountId: string, dir: string) => void;
     /** Skip tier 1 (headless URL-capture) entirely and go straight to tier 2.
      *  For providers where tier 1 is a documented, unconditional dead end —
      *  e.g. `requiresLoginTty` providers, whose CLI opens its own browser
@@ -203,7 +222,7 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     // real IdentityAccount at all, so the agent reported "Login successful"
     // but stayed permanently blocked by the resolver's unconditional
     // oauth-class spawn gate on its very next spawn.
-    const minted = await ensureAccountDir(p.provider.id, p.log);
+    const minted = await ensureAccountDir(p.provider.id, p.log, p.existingAccountId);
 
     // Claude-only: seed-from-global. seed_provider_auth_from_global
     // hard-rejects every other provider server-side, so this tier is
@@ -213,6 +232,7 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
         p.log("auth", "no login URL captured — checking for an existing global Claude login…");
         if (await seedGlobalLogin(p.provider.id, p.log, minted.dir)) {
             if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {
+                p.onAccountRegistered?.(minted.accountId, minted.dir);
                 await finalizeAccount(p, minted.accountId, minted.dir);
                 return "seeded";
             }
@@ -262,6 +282,7 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
 
     if (minted) {
         if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {
+            p.onAccountRegistered?.(minted.accountId, minted.dir);
             await finalizeAccount(p, minted.accountId, minted.dir);
         }
     }

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -28,26 +28,35 @@
  *      OAuth flow opens the browser itself from inside the CLI process, and
  *      a piped/PTY spawn has no attached console for that call to succeed
  *      from — see retro-headless-login-browser-open-2026-07-20 §1.
- *   2. `registerSeededAccount` — if no URL was captured, check whether the
- *      user already has a VALID login in their global `~/.claude` (common:
- *      the CLI installed outside AgentMux, or a prior AgentMux session). If
- *      so, mint a real per-account isolated dir, copy the credential into
- *      it, and persist an IdentityAccount row — not just a file in the
- *      shared default dir (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
- *      §7, "single point, not global": `identity/resolver.rs`'s spawn gate
- *      now requires a real bound account, no ambient exception). No
- *      browser, no user action, completes in well under a second.
- *      Claude-only (the host command rejects other providers —
- *      `providers.rs`'s `seed_provider_auth_from_global`), so this tier is
- *      skipped for everything else.
- *   3. `openLoginTerminal` — last resort: mint the same kind of per-account
- *      dir, spawn the login command in a REAL visible console window (which
- *      gives the CLI's own browser-open call something to attach to) with
- *      that dir's env var stripped so the login lands in the user's GLOBAL
- *      `~/.claude`, then poll for it to land — same "single point" account
- *      persisted on success. Needs the user to actually finish the OAuth
- *      flow in their browser, so this tier polls for up to 5 minutes
- *      instead of returning immediately.
+ *   2. `seedGlobalLogin` + `persistSeededAccount` — Claude only: check
+ *      whether the user already has a VALID login in their global
+ *      `~/.claude` (common: the CLI installed outside AgentMux, or a prior
+ *      AgentMux session). If so, mint a real per-account isolated dir, copy
+ *      the credential into it, and persist an IdentityAccount row — not
+ *      just a file in the shared default dir
+ *      (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7, "single
+ *      point, not global": `identity/resolver.rs`'s spawn gate now requires
+ *      a real bound account, no ambient exception). No browser, no user
+ *      action, completes in well under a second. Skipped for every other
+ *      provider — the host command rejects them (`providers.rs`'s
+ *      `seed_provider_auth_from_global`), and unlike tier 3 there's no
+ *      substitute strategy for tier 2 specifically; they just fall through.
+ *   3. `openLoginTerminal` — last resort, same real per-account dir minted
+ *      up front for EVERY oauth-class provider (not just Claude). Two
+ *      different completion strategies depending on the provider, since
+ *      only Claude has a seed-from-global capability to fall back on:
+ *        - **Claude**: the dir's env var is stripped so the login lands in
+ *          the user's GLOBAL `~/.claude` instead, then polled via
+ *          `pollForGlobalLoginSeed` until it copies into the isolated dir.
+ *        - **Every other oauth-class provider** (codex, openclaw, gemini,
+ *          copilot): the env var is left pointed AT the isolated dir, so
+ *          the login writes there directly, then polled via
+ *          `pollForCliAuthReady` (asks the CLI's own auth-check command
+ *          whether it's authenticated in that dir) since there's no
+ *          global-login file to watch for. Persisted on success either way
+ *          — same "single point" account. Needs the user to actually
+ *          finish the OAuth flow in their browser, so this tier polls for
+ *          up to 5 minutes instead of returning immediately.
  *
  * Before this existed, tier 1 failing meant `/login` and "Login Again" both
  * dead-ended on an error message telling the user to go click a *different*
@@ -65,7 +74,11 @@ import { pollForGlobalLoginSeed, seedGlobalLogin } from "./seed-global-login";
 import { ensureAccountDir, persistSeededAccount } from "./register-seeded-account";
 
 export interface RunProviderLoginParams extends ForceLoginParams {
-    provider: ForceLoginParams["provider"] & { id: string; authConfigDirEnvVar: string };
+    provider: ForceLoginParams["provider"] & {
+        id: string;
+        authConfigDirEnvVar: string;
+        authCheckCommand: string[];
+    };
     /** Polled during the tier-3 wait; return true to abort early (e.g. the user hit Cancel). */
     isCancelled?: () => boolean;
     /** When set, a newly-registered account (tier 2 or 3) is linked to this
@@ -116,6 +129,43 @@ async function finalizeAccount(
     }
 }
 
+/** Poll `CheckCliAuthCommand` against a login that was told to write
+ *  DIRECTLY into `authEnv`'s isolated dir, until it reports authenticated,
+ *  the deadline passes, or `isCancelled` reports true. The provider-agnostic
+ *  sibling of `pollForGlobalLoginSeed` (seed-global-login.ts) — used for
+ *  every oauth-class provider OTHER than Claude, which has no seed-from-
+ *  global capability at all (`seed_provider_auth_from_global` hard-rejects
+ *  every provider but claude — providers.rs) and so must detect completion
+ *  by asking the CLI itself whether it's authenticated in the dir the login
+ *  was pointed at directly, rather than by watching a global dir get copied. */
+async function pollForCliAuthReady(
+    cliPath: string,
+    authCheckArgs: string[],
+    authEnv: Record<string, string>,
+    isCancelled: () => boolean,
+    opts: { pollMs?: number; timeoutMs?: number } = {},
+): Promise<boolean> {
+    const pollMs = opts.pollMs ?? 5_000;
+    const timeoutMs = opts.timeoutMs ?? 5 * 60 * 1_000;
+    const deadline = performance.now() + timeoutMs;
+    while (performance.now() < deadline) {
+        if (isCancelled()) return false;
+        await new Promise<void>((r) => setTimeout(r, pollMs));
+        if (isCancelled()) return false;
+        try {
+            const result = await RpcApi.CheckCliAuthCommand(
+                TabRpcClient,
+                { cli_path: cliPath, auth_check_args: authCheckArgs, auth_env: authEnv },
+                { timeout: 10000 },
+            );
+            if (result.authenticated) return true;
+        } catch {
+            // keep polling on transient RPC errors
+        }
+    }
+    return false;
+}
+
 export async function runProviderLogin(p: RunProviderLoginParams): Promise<ProviderLoginOutcome> {
     const tier1 = await forceProviderLogin(p);
     if (tier1 === "opened") return "opened";
@@ -129,14 +179,24 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     // and launch-flow.ts's existing best-effort uses of the same call).
     await getApi().cancelCliLogin().catch(() => {});
 
-    // Mint the account dir ONCE, up front (Claude only; other providers
-    // have no seed-from-global detection path at all) so tier 2 and tier 3
-    // share the SAME account instead of each minting its own — minting
-    // twice left an orphaned, unpersisted account dir behind on disk
-    // whenever tier 2's seed step failed partway through (ensureAccountDir
-    // succeeded, seedGlobalLogin didn't).
-    const minted = p.provider.id === "claude" ? await ensureAccountDir(p.provider.id, p.log) : null;
+    // Mint the account dir ONCE, up front, for EVERY oauth-class provider —
+    // not just Claude. Account minting itself (ensureAccountDir /
+    // persistSeededAccount) has always been provider-agnostic; the backend
+    // RPC it calls (identity.ensureaccountdir) already gates on the real
+    // oauth-class check (resolver::provider_class), so a non-oauth-class id
+    // reaching this function just gets `null` back here, same as before.
+    // A prior version of this code additionally gated the CALL on
+    // `provider.id === "claude"` — reagent P0: that meant a successful
+    // tier-3 terminal login for codex/openclaw never minted or persisted a
+    // real IdentityAccount at all, so the agent reported "Login successful"
+    // but stayed permanently blocked by the resolver's unconditional
+    // oauth-class spawn gate on its very next spawn.
+    const minted = await ensureAccountDir(p.provider.id, p.log);
 
+    // Claude-only: seed-from-global. seed_provider_auth_from_global
+    // hard-rejects every other provider server-side, so this tier is
+    // structurally Claude-specific — not a coverage gap for the others,
+    // just a different tier-3 completion strategy for them, below.
     if (minted && p.provider.id === "claude") {
         p.log("auth", "no login URL captured — checking for an existing global Claude login…");
         if (await seedGlobalLogin(p.provider.id, p.log, minted.dir)) {
@@ -148,10 +208,23 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     }
 
     p.log("auth", "opening a terminal window for a fresh login…");
-    const configDir = minted?.dir ?? p.authEnv[p.provider.authConfigDirEnvVar];
 
     const terminalEnv: Record<string, string> = { ...p.authEnv };
-    delete terminalEnv[p.provider.authConfigDirEnvVar];
+    const isClaude = p.provider.id === "claude";
+    if (isClaude) {
+        // Claude: strip the isolated dir's env var so the login lands in
+        // the user's GLOBAL ~/.claude instead — seed_provider_auth_from_
+        // global then copies it into the isolated dir once it lands there
+        // (poll below). This is the ONLY provider with that copy-back path.
+        delete terminalEnv[p.provider.authConfigDirEnvVar];
+    } else if (minted) {
+        // Every other oauth-class provider has no seed-from-global
+        // capability to fall back on — instead, let the login write
+        // DIRECTLY into the isolated dir by keeping the env var pointed at
+        // it, and detect completion by asking the CLI itself (below).
+        terminalEnv[p.provider.authConfigDirEnvVar] = minted.dir;
+    }
+
     try {
         await getApi().openLoginTerminal(p.cliPath, p.provider.authLoginCommand, terminalEnv);
     } catch (err: any) {
@@ -161,8 +234,19 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     p.log("auth", "a terminal window opened — complete the login there");
 
     const isCancelled = p.isCancelled ?? (() => false);
-    const seeded = await pollForGlobalLoginSeed(p.provider.id, configDir, isCancelled);
-    if (!seeded) return "terminal-timeout";
+    if (isClaude) {
+        const configDir = minted?.dir ?? p.authEnv[p.provider.authConfigDirEnvVar];
+        const seeded = await pollForGlobalLoginSeed(p.provider.id, configDir, isCancelled);
+        if (!seeded) return "terminal-timeout";
+    } else if (minted) {
+        const ready = await pollForCliAuthReady(p.cliPath, p.provider.authCheckCommand, terminalEnv, isCancelled);
+        if (!ready) return "terminal-timeout";
+    } else {
+        // Not oauth-class (or the dir mint itself failed) — nothing to poll
+        // for and nothing to persist; the terminal opened, but there's no
+        // way to detect or register a completed login for this call.
+        return "terminal-timeout";
+    }
 
     if (minted) {
         if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -27,7 +27,17 @@
  *      provider whose CLI prints one. Claude Code v2.1.x never does: its
  *      OAuth flow opens the browser itself from inside the CLI process, and
  *      a piped/PTY spawn has no attached console for that call to succeed
- *      from — see retro-headless-login-browser-open-2026-07-20 §1.
+ *      from — see retro-headless-login-browser-open-2026-07-20 §1. The
+ *      account dir is minted (see below) and pointed at BEFORE this tier
+ *      runs, for every oauth-class provider, so a provider whose tier 1
+ *      DOES succeed (not `requiresLoginTty` — e.g. gemini/copilot) lands
+ *      the credential in an isolated dir too, not an untracked shared one.
+ *      Tier 1 doesn't confirm completion itself — it returns "opened"
+ *      immediately so its caller can show the auth-url box and poll at its
+ *      own pace — so the caller MUST call the exported
+ *      `persistAndLinkAccount` once its own poll confirms success, or the
+ *      minted account never actually gets persisted/linked (reagent P0 on
+ *      #2263 — see that function's doc comment).
  *   2. `seedGlobalLogin` + `persistSeededAccount` — Claude only: check
  *      whether the user already has a VALID login in their global
  *      `~/.claude` (common: the CLI installed outside AgentMux, or a prior
@@ -158,6 +168,32 @@ async function finalizeAccount(
     }
 }
 
+/** For the tier-1 ("opened") outcome specifically: `runProviderLogin` mints
+ *  the account dir and fires `onAccountRegistered` with it up front, but
+ *  does NOT persist or link it — tier 1 doesn't confirm completion itself
+ *  (it returns immediately so the caller can show the auth-url box), and
+ *  persisting an account row before anything has actually logged in would
+ *  be premature. A caller that does its own completion polling for the
+ *  "opened" case (launch-flow.ts's Phase 2, useAgentControllerStatus.ts's
+ *  relogin()) must call this once ITS OWN poll confirms `authenticated:
+ *  true` — using the `accountId`/`dir` it captured from
+ *  `onAccountRegistered` — to actually persist and link the account.
+ *  Without this call, a tier-1 login that appears to succeed still leaves
+ *  no real IdentityAccount behind, and the resolver's spawn gate blocks
+ *  the agent on its very next spawn regardless of how the CLI's own
+ *  check reports it now (reagent P0 on #2263). */
+export async function persistAndLinkAccount(
+    p: RunProviderLoginParams,
+    accountId: string,
+    dir: string,
+): Promise<boolean> {
+    if (await persistSeededAccount(p.provider.id, accountId, dir, p.log)) {
+        await finalizeAccount(p, accountId, dir);
+        return true;
+    }
+    return false;
+}
+
 /** Poll `CheckCliAuthCommand` against a login that was told to write
  *  DIRECTLY into `authEnv`'s isolated dir, until it reports authenticated,
  *  the deadline passes, or `isCancelled` reports true. The provider-agnostic
@@ -196,9 +232,48 @@ async function pollForCliAuthReady(
 }
 
 export async function runProviderLogin(p: RunProviderLoginParams): Promise<ProviderLoginOutcome> {
+    // Mint the account dir ONCE, up front — before ANY tier runs — for
+    // EVERY oauth-class provider, not just Claude. Account minting itself
+    // (ensureAccountDir / persistSeededAccount) has always been
+    // provider-agnostic; the backend RPC it calls (identity.ensureaccountdir)
+    // already gates on the real oauth-class check (resolver::provider_class),
+    // so a non-oauth-class id reaching this function just gets `null` back
+    // here. existingAccountId threads through so a Reconnect (not a fresh
+    // Connect) refreshes the SAME account's dir.
+    //
+    // reagent P0 (#2260, then #2263 for gemini/copilot specifically): a
+    // prior version only minted for tiers 2/3, gated on
+    // `provider.id === "claude"`. That meant ANY provider whose tier 1
+    // (headless URL-capture) actually succeeds — not `requiresLoginTty`,
+    // so not claude/openclaw, but plausibly gemini/copilot — returned
+    // "opened" without ever minting an account or pointing the login at an
+    // isolated dir. Once gemini/copilot became oauth-class (#2263), a
+    // successful tier-1 login for them landed in a NON-isolated dir with no
+    // IdentityAccount behind it, and the resolver's unconditional spawn
+    // gate then permanently blocked the agent on its next spawn — "Login
+    // successful" for a login that could never actually be used again.
+    //
+    // Minting now happens before tier 1, and every tier's authEnv is
+    // pointed at the SAME isolated dir. Tier 1 doesn't confirm completion
+    // itself (unlike tiers 2/3) — it returns "opened" immediately by
+    // design, so its caller can show the auth-url box and poll at its own
+    // pace. Persisting the account row before that confirmation would be
+    // premature (nothing has actually logged in yet), so tier 1 only fires
+    // `onAccountRegistered` with the minted (not-yet-persisted) account —
+    // a caller that does its own completion polling for the "opened" case
+    // (launch-flow.ts, relogin()) is responsible for calling the exported
+    // `persistAndLinkAccount` once ITS OWN poll confirms success.
+    const minted = await ensureAccountDir(p.provider.id, p.log, p.existingAccountId);
+    const authEnvForTiers = minted
+        ? { ...p.authEnv, [p.provider.authConfigDirEnvVar]: minted.dir }
+        : p.authEnv;
+
     if (!p.skipTier1) {
-        const tier1 = await forceProviderLogin(p);
-        if (tier1 === "opened") return "opened";
+        const tier1 = await forceProviderLogin({ ...p, authEnv: authEnvForTiers });
+        if (tier1 === "opened") {
+            if (minted) p.onAccountRegistered?.(minted.accountId, minted.dir);
+            return "opened";
+        }
     }
 
     // Tier 1's login CLI child (piped/PTY, spawned by forceProviderLogin's
@@ -209,20 +284,6 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     // call even if nothing is running — see useAgentControllerStatus.ts's
     // and launch-flow.ts's existing best-effort uses of the same call).
     await getApi().cancelCliLogin().catch(() => {});
-
-    // Mint the account dir ONCE, up front, for EVERY oauth-class provider —
-    // not just Claude. Account minting itself (ensureAccountDir /
-    // persistSeededAccount) has always been provider-agnostic; the backend
-    // RPC it calls (identity.ensureaccountdir) already gates on the real
-    // oauth-class check (resolver::provider_class), so a non-oauth-class id
-    // reaching this function just gets `null` back here, same as before.
-    // A prior version of this code additionally gated the CALL on
-    // `provider.id === "claude"` — reagent P0: that meant a successful
-    // tier-3 terminal login for codex/openclaw never minted or persisted a
-    // real IdentityAccount at all, so the agent reported "Login successful"
-    // but stayed permanently blocked by the resolver's unconditional
-    // oauth-class spawn gate on its very next spawn.
-    const minted = await ensureAccountDir(p.provider.id, p.log, p.existingAccountId);
 
     // Claude-only: seed-from-global. seed_provider_auth_from_global
     // hard-rejects every other provider server-side, so this tier is

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -87,6 +87,16 @@ export interface RunProviderLoginParams extends ForceLoginParams {
      *  agent). Omit for a pre-launch flow with no agent yet; that flow's own
      *  launch-time reconcile links the account once one is created. */
     linkTarget?: { blockId: string; agentDefinitionId: string };
+    /** Skip tier 1 (headless URL-capture) entirely and go straight to tier 2.
+     *  For providers where tier 1 is a documented, unconditional dead end —
+     *  e.g. `requiresLoginTty` providers, whose CLI opens its own browser
+     *  in-process and needs a real console no piped/PTY spawn has — skipping
+     *  avoids a pointless ~15s wait for an attempt that cannot succeed.
+     *  Also the right default for a caller whose UI already explicitly says
+     *  "login via terminal" (the user has already opted into a real console,
+     *  no point trying headless first). Default false — existing callers
+     *  are unaffected. */
+    skipTier1?: boolean;
 }
 
 export type ProviderLoginOutcome =
@@ -167,8 +177,10 @@ async function pollForCliAuthReady(
 }
 
 export async function runProviderLogin(p: RunProviderLoginParams): Promise<ProviderLoginOutcome> {
-    const tier1 = await forceProviderLogin(p);
-    if (tier1 === "opened") return "opened";
+    if (!p.skipTier1) {
+        const tier1 = await forceProviderLogin(p);
+        if (tier1 === "opened") return "opened";
+    }
 
     // Tier 1's login CLI child (piped/PTY, spawned by forceProviderLogin's
     // getApi().runCliLogin) is left running/abandoned when it doesn't

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -61,8 +61,8 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
 import { forceProviderLogin, type ForceLoginParams } from "./force-login";
-import { pollForGlobalLoginSeed } from "./seed-global-login";
-import { ensureAccountDir, persistSeededAccount, registerSeededAccount } from "./register-seeded-account";
+import { pollForGlobalLoginSeed, seedGlobalLogin } from "./seed-global-login";
+import { ensureAccountDir, persistSeededAccount } from "./register-seeded-account";
 
 export interface RunProviderLoginParams extends ForceLoginParams {
     provider: ForceLoginParams["provider"] & { id: string; authConfigDirEnvVar: string };
@@ -120,22 +120,34 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     const tier1 = await forceProviderLogin(p);
     if (tier1 === "opened") return "opened";
 
-    if (p.provider.id === "claude") {
+    // Tier 1's login CLI child (piped/PTY, spawned by forceProviderLogin's
+    // getApi().runCliLogin) is left running/abandoned when it doesn't
+    // produce a URL within its own timeout — cancel it before tier 2/3
+    // potentially spawn a second, concurrent login CLI process against the
+    // same config dir. cancelCliLogin is idempotent and host-side (safe to
+    // call even if nothing is running — see useAgentControllerStatus.ts's
+    // and launch-flow.ts's existing best-effort uses of the same call).
+    await getApi().cancelCliLogin().catch(() => {});
+
+    // Mint the account dir ONCE, up front (Claude only; other providers
+    // have no seed-from-global detection path at all) so tier 2 and tier 3
+    // share the SAME account instead of each minting its own — minting
+    // twice left an orphaned, unpersisted account dir behind on disk
+    // whenever tier 2's seed step failed partway through (ensureAccountDir
+    // succeeded, seedGlobalLogin didn't).
+    const minted = p.provider.id === "claude" ? await ensureAccountDir(p.provider.id, p.log) : null;
+
+    if (minted && p.provider.id === "claude") {
         p.log("auth", "no login URL captured — checking for an existing global Claude login…");
-        const reg = await registerSeededAccount(p.provider.id, p.log);
-        if (reg.ok && reg.accountId && reg.dir) {
-            await finalizeAccount(p, reg.accountId, reg.dir);
-            return "seeded";
+        if (await seedGlobalLogin(p.provider.id, p.log, minted.dir)) {
+            if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {
+                await finalizeAccount(p, minted.accountId, minted.dir);
+                return "seeded";
+            }
         }
     }
 
     p.log("auth", "opening a terminal window for a fresh login…");
-
-    // Tier 3 needs a real, persistable account dir too — mint it up front
-    // (Claude only; other providers have no seed-from-global detection path
-    // at all, so they fall back to whatever dir was already resolved, same
-    // as before this account-registration change).
-    const minted = p.provider.id === "claude" ? await ensureAccountDir(p.provider.id, p.log) : null;
     const configDir = minted?.dir ?? p.authEnv[p.provider.authConfigDirEnvVar];
 
     const terminalEnv: Record<string, string> = { ...p.authEnv };

--- a/frontend/app/view/agent/flows/seed-global-login.test.ts
+++ b/frontend/app/view/agent/flows/seed-global-login.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for seedGlobalLogin's defensive error handling (reagent P0 on
+ * #2255): `seed_provider_auth_from_global` hard-rejects (throws) for every
+ * provider except claude — this function must never let that throw
+ * propagate as an unhandled rejection, since it's a shared utility called
+ * by more than one caller.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    seedProviderAuthFromGlobal: vi.fn(),
+}));
+
+vi.mock("@/app/store/global", () => ({
+    getApi: () => ({ seedProviderAuthFromGlobal: hub.seedProviderAuthFromGlobal }),
+}));
+
+import { seedGlobalLogin } from "./seed-global-login";
+
+beforeEach(() => {
+    hub.seedProviderAuthFromGlobal.mockReset();
+});
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("seedGlobalLogin", () => {
+    it("returns true on a successful seed", async () => {
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });
+        const result = await seedGlobalLogin("claude", vi.fn(), "/some/dir");
+        expect(result).toBe(true);
+    });
+
+    it("returns false (not throw) when the host reports no valid global login", async () => {
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: false, status: "missing" });
+        const result = await seedGlobalLogin("claude", vi.fn(), "/some/dir");
+        expect(result).toBe(false);
+    });
+
+    it("returns false (not throw) when the host command rejects — e.g. a non-claude provider, which seed_provider_auth_from_global hard-rejects server-side", async () => {
+        hub.seedProviderAuthFromGlobal.mockRejectedValue(
+            new Error("seed_provider_auth_from_global: only supported for claude"),
+        );
+        const log = vi.fn();
+        await expect(seedGlobalLogin("codex", log, "/some/dir")).resolves.toBe(false);
+        expect(log).toHaveBeenCalledWith("auth", expect.stringMatching(/seed-from-global failed/i), "warn");
+    });
+});

--- a/frontend/app/view/agent/flows/seed-global-login.ts
+++ b/frontend/app/view/agent/flows/seed-global-login.ts
@@ -34,17 +34,35 @@ export async function seedGlobalLogin(
     // seeds into it only if it's under ~/.agentmux; a stale ~/.claude is
     // rejected there and falls back to the shared dir — the seed never writes
     // the user's own login (SPEC_PROVIDER_ISOLATION §4.5 / INV-R).
-    const res = await getApi().seedProviderAuthFromGlobal(providerId, configDir);
-    if (res?.seeded) {
-        log("auth", "copied your existing login — just send your message again");
-        return true;
+    //
+    // reagent P0: seed_provider_auth_from_global (providers.rs) hard-rejects
+    // (throws) for every provider except claude — this function is
+    // documented as Claude-specific in its own name, but nothing previously
+    // stopped a caller from invoking it for another provider, and when that
+    // happened the throw propagated as an unhandled rejection through every
+    // caller (pollForGlobalLoginSeed's loop below included), instead of the
+    // graceful "not seeded" this function's own return-false convention
+    // implies. Callers should route non-claude providers elsewhere entirely
+    // (see run-provider-login.ts's per-provider tier-3 strategy), but this
+    // function must never throw regardless — it's a shared utility, and a
+    // host command rejecting an entire class of input is a landmine for any
+    // future caller, not just the ones already found.
+    try {
+        const res = await getApi().seedProviderAuthFromGlobal(providerId, configDir);
+        if (res?.seeded) {
+            log("auth", "copied your existing login — just send your message again");
+            return true;
+        }
+        if (res?.status === "expired") {
+            log("auth", "your global Claude login is also expired — use “Login Again” to re-authenticate", "warn");
+        } else {
+            log("auth", "no valid global Claude login found — use “Login Again” to authenticate", "warn");
+        }
+        return false;
+    } catch (e: any) {
+        log("auth", `seed-from-global failed: ${e?.message ?? String(e)}`, "warn");
+        return false;
     }
-    if (res?.status === "expired") {
-        log("auth", "your global Claude login is also expired — use “Login Again” to re-authenticate", "warn");
-    } else {
-        log("auth", "no valid global Claude login found — use “Login Again” to authenticate", "warn");
-    }
-    return false;
 }
 
 /**

--- a/frontend/app/view/agent/flows/seed-global-login.ts
+++ b/frontend/app/view/agent/flows/seed-global-login.ts
@@ -46,3 +46,31 @@ export async function seedGlobalLogin(
     }
     return false;
 }
+
+/**
+ * Poll `seedGlobalLogin` on an interval until it succeeds, the deadline
+ * passes, or `isCancelled` reports true. Shared by "Login via terminal"
+ * (useAgentControllerStatus) and the terminal-fallback tier of
+ * `runProviderLogin` (retro-headless-login-browser-open-2026-07-20) — both
+ * open a real terminal window for the user to complete an OAuth flow in,
+ * then need to notice the credential landing on disk without the user
+ * having to click anything else.
+ */
+export async function pollForGlobalLoginSeed(
+    providerId: string,
+    configDir: string | undefined,
+    isCancelled: () => boolean,
+    opts: { pollMs?: number; timeoutMs?: number } = {},
+): Promise<boolean> {
+    const pollMs = opts.pollMs ?? 5_000;
+    const timeoutMs = opts.timeoutMs ?? 5 * 60 * 1_000;
+    const deadline = performance.now() + timeoutMs;
+    const silentLog: LogFn = () => {};
+    while (performance.now() < deadline) {
+        if (isCancelled()) return false;
+        await new Promise<void>((r) => setTimeout(r, pollMs));
+        if (isCancelled()) return false;
+        if (await seedGlobalLogin(providerId, silentLog, configDir)) return true;
+    }
+    return false;
+}

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -40,8 +40,7 @@ import * as WOS from "@/app/store/wos";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
 import { runProviderLogin } from "../flows/run-provider-login";
-import { pollForGlobalLoginSeed } from "../flows/seed-global-login";
-import { ensureAccountDir, persistSeededAccount, registerSeededAccount } from "../flows/register-seeded-account";
+import { registerSeededAccount } from "../flows/register-seeded-account";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -433,7 +432,17 @@ export function useAgentControllerStatus(
     };
 
     // Open a real visible terminal window so the browser OAuth flow works,
-    // then poll for credentials seeding into the isolated dir.
+    // then poll for credentials landing (or for the CLI itself to report
+    // authenticated, for non-Claude providers). Shares runProviderLogin's
+    // tier 2/3 logic (skipTier1 — the user explicitly asked for a terminal
+    // login, no point trying headless first) instead of reimplementing it.
+    // This used to be a separate, hand-rolled copy of the same logic —
+    // reagent caught it reproducing a bug (codex/openclaw could never
+    // actually complete a login here: minting was claude-only and the poll
+    // called a host command that hard-rejects every other provider) already
+    // fixed once in runProviderLogin itself. A second hand-rolled copy would
+    // only let that exact class of bug reappear the next time one of the two
+    // was fixed and the other wasn't.
     const loginViaTerminal = async () => {
         if (reloginInFlight) return;
         loginCancelled = false;
@@ -460,62 +469,38 @@ export function useAgentControllerStatus(
                 if (!cliPath) return;
             }
             const authEnv = await recoveryAuthEnv(prov);
-
-            // Mint a real per-account isolated dir to seed into — not the
-            // agent's already-resolved dir, which (for an unlinked/ambient
-            // agent) is the shared default dir the resolver's spawn gate no
-            // longer honors (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
-            // §7). Falls back to the resolved dir only if minting fails, so
-            // this button still does SOMETHING rather than hard-erroring.
-            const minted = prov.id === "claude" ? await ensureAccountDir(prov.id, opts.log) : null;
-            const configDir = minted?.dir
-                ?? (prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined);
-
-            // Strip CLAUDE_CONFIG_DIR (and equivalents) from the terminal env so the
-            // login writes to the user's global ~/.claude instead of the isolated dir.
-            // The poll below watches the global dir and copies on success — if we kept
-            // the isolated dir key the poll would look in global but the creds would
-            // land in isolated, and a terminal-fresh login would never be detected.
-            const terminalEnv: Record<string, string> = { ...authEnv };
-            if (prov.authConfigDirEnvVar) delete terminalEnv[prov.authConfigDirEnvVar];
-
-            await getApi().openLoginTerminal(cliPath, prov.authLoginCommand, terminalEnv);
-            opts.log("auth", "A terminal window opened — complete the login there, then come back.");
-
-            const seeded = await pollForGlobalLoginSeed(prov.id, configDir, () => loginCancelled);
-            if (seeded) {
-                if (minted && (await persistSeededAccount(prov.id, minted.accountId, minted.dir, opts.log))) {
-                    const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
-                    if (agentDefinitionId) {
-                        try {
-                            await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
-                                agent_id: agentDefinitionId,
-                                account_id: minted.accountId,
-                                provider: prov.id,
-                            });
-                            if (prov.authConfigDirEnvVar) {
-                                const oref = WOS.makeORef("block", opts.blockId);
-                                await RpcApi.SetMetaCommand(TabRpcClient, {
-                                    oref,
-                                    meta: { "cmd:env": { ...authEnv, [prov.authConfigDirEnvVar]: minted.dir } },
-                                });
-                            }
-                        } catch (e: any) {
-                            opts.log(
-                                "auth",
-                                `account created but couldn't be linked to this agent: ${e?.message ?? String(e)}`,
-                                "warn",
-                            );
-                        }
+            const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+            const outcome = await runProviderLogin({
+                provider: prov,
+                cliPath,
+                authEnv,
+                setAuthUrl,
+                log: opts.log,
+                isCancelled: () => loginCancelled,
+                skipTier1: true,
+                linkTarget: agentDefinitionId
+                    ? { blockId: opts.blockId, agentDefinitionId }
+                    : undefined,
+            });
+            switch (outcome) {
+                case "opened":
+                    break;
+                case "seeded":
+                case "terminal-success":
+                    opts.log("auth", "Login successful — retrying…");
+                    setAuthNotice(null);
+                    opts.onRecovered?.();
+                    break;
+                case "terminal-timeout":
+                    if (!loginCancelled) {
+                        const msg = "No login detected after 5 minutes. Complete the login in the terminal, then click “Use existing login”.";
+                        opts.log("auth", msg, "warn");
+                        setAuthNotice(msg);
                     }
-                }
-                opts.log("auth", "Login successful — retrying…");
-                setAuthNotice(null);
-                opts.onRecovered?.();
-            } else if (!loginCancelled) {
-                const msg = "No login detected after 5 minutes. Complete the login in the terminal, then click “Use existing login”.";
-                opts.log("auth", msg, "warn");
-                setAuthNotice(msg);
+                    break;
+                case "terminal-unavailable":
+                    setAuthNotice("Couldn't open a terminal window for login on this platform.");
+                    break;
             }
         } catch (err: any) {
             const msg = `Terminal login failed: ${err?.message ?? String(err)}`;

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -39,8 +39,9 @@ import { RpcApi } from "@/app/store/rpc-api";
 import * as WOS from "@/app/store/wos";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
-import { forceProviderLogin } from "../flows/force-login";
-import { seedGlobalLogin } from "../flows/seed-global-login";
+import { runProviderLogin } from "../flows/run-provider-login";
+import { pollForGlobalLoginSeed } from "../flows/seed-global-login";
+import { ensureAccountDir, persistSeededAccount, registerSeededAccount } from "../flows/register-seeded-account";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -110,8 +111,9 @@ export interface UseAgentControllerStatus {
      * Open a real terminal window (CREATE_NEW_CONSOLE on Windows) running the
      * provider's login command so the OS can open the browser — the piped/PTY
      * paths that `runCliLogin` uses are headless and block the browser. After
-     * spawning, polls `seedGlobalLogin` every 5s for up to 5 minutes; seeds
-     * the isolated dir as soon as credentials appear.
+     * spawning, polls every 5s for up to 5 minutes; once credentials appear,
+     * seeds a real per-account isolated dir and registers/links the account
+     * (not just a file — PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md §7).
      */
     loginViaTerminal: () => Promise<void>;
     cancelLogin: () => void;
@@ -278,9 +280,10 @@ export function useAgentControllerStatus(
         }
         setAuthNotice(null);
         // Clear any OAuth URL box left by a PRIOR attempt before starting a
-        // fresh one — otherwise a subsequent "no-url" outcome would stack the
-        // error notice below a stale, contradictory URL box (reagent P2).
+        // fresh one — otherwise a subsequent no-progress outcome would stack
+        // the error notice below a stale, contradictory URL box (reagent P2).
         setAuthUrl(null);
+        loginCancelled = false;
         // The CLI path + auth env are written to block meta at launch; reuse
         // them instead of re-resolving (the agent is already running, so the
         // CLI is installed). If `cmd` is missing, resolve it directly — see
@@ -295,15 +298,53 @@ export function useAgentControllerStatus(
                 if (!cliPath) return;
             }
             const authEnv = await recoveryAuthEnv(prov);
-            const outcome = await forceProviderLogin({ provider: prov, cliPath, authEnv, setAuthUrl, log: opts.log });
-            if (outcome === "no-url") {
-                // Never fail silently (retro §5.1): tell the user nothing
-                // opened and point at the recovery paths that do work.
-                setAuthNotice(
-                    "Couldn't start a browser login — the CLI didn't produce a login URL, so nothing was opened. " +
-                    "Use “Login via terminal” to complete the login in a real terminal window" +
-                    (prov.id === "claude" ? ", or “Use existing login” to copy your global Claude login into this agent." : "."),
-                );
+            // runProviderLogin falls through URL-capture -> global-login-copy ->
+            // real-terminal-with-poll before giving up (retro-headless-login-
+            // browser-open-2026-07-20) — "Login Again" used to dead-end the
+            // instant the CLI produced no URL, which is every time for Claude
+            // Code v2.1.x. linkTarget lets a tier-2/3 success register a real
+            // Armory account and bind it to THIS agent (single-point
+            // enforcement, PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+            // §7) instead of just seeding a file nothing tracks.
+            const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+            const outcome = await runProviderLogin({
+                provider: prov,
+                cliPath,
+                authEnv,
+                setAuthUrl,
+                log: opts.log,
+                isCancelled: () => loginCancelled,
+                linkTarget: agentDefinitionId
+                    ? { blockId: opts.blockId, agentDefinitionId }
+                    : undefined,
+            });
+            switch (outcome) {
+                case "opened":
+                    break;
+                case "seeded":
+                    opts.log("auth", "Signed in from your global login — retrying…");
+                    setAuthNotice(null);
+                    opts.onRecovered?.();
+                    break;
+                case "terminal-success":
+                    opts.log("auth", "Login successful — retrying…");
+                    setAuthNotice(null);
+                    opts.onRecovered?.();
+                    break;
+                case "terminal-timeout":
+                    // Never fail silently (retro §5.1): tell the user nothing
+                    // completed and point at the recovery path that's left.
+                    setAuthNotice(
+                        "Opened a terminal window for login, but no login was detected within 5 minutes. " +
+                        "Complete the login there, then click “Use existing login”.",
+                    );
+                    break;
+                case "terminal-unavailable":
+                    setAuthNotice(
+                        "Couldn't start a browser login or open a terminal window on this platform." +
+                        (prov.id === "claude" ? " Try “Use existing login” if you're already signed in elsewhere." : ""),
+                    );
+                    break;
             }
         } catch (err: any) {
             const msg = `Re-login failed: ${err?.message ?? String(err)}`;
@@ -330,17 +371,46 @@ export function useAgentControllerStatus(
         setAuthNotice(null);
         seedInFlight = true;
         try {
-            // Seed into the agent's RESOLVED auth dir (from cmd:env), not a
-            // guessed one; the host guards it to ~/.agentmux so the seed never
-            // writes the user's ~/.claude (SPEC_PROVIDER_ISOLATION §4.5).
-            const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
-            let configDir: string | undefined;
-            if (prov.authConfigDirEnvVar && envMeta && typeof envMeta === "object") {
-                const v = (envMeta as Record<string, unknown>)[prov.authConfigDirEnvVar];
-                if (typeof v === "string") configDir = v;
-            }
-            const seeded = await seedGlobalLogin(prov.id, opts.log, configDir);
-            if (seeded) {
+            // Mint a REAL per-account isolated dir and persist an
+            // IdentityAccount row — not just a seed into whatever dir was
+            // already resolved. The resolver's spawn gate now requires a
+            // real bound account for oauth-class providers, no ambient
+            // exception (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+            // §7), so a bare file-copy into the old shared/resolved dir
+            // would leave this agent blocked on its next turn regardless of
+            // how valid the credential file itself is.
+            const reg = await registerSeededAccount(prov.id, opts.log);
+            if (reg.ok && reg.accountId && reg.dir) {
+                const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+                if (agentDefinitionId) {
+                    try {
+                        await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
+                            agent_id: agentDefinitionId,
+                            account_id: reg.accountId,
+                            provider: prov.id,
+                        });
+                        if (prov.authConfigDirEnvVar) {
+                            const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
+                            const prevEnv: Record<string, string> = {};
+                            if (envMeta && typeof envMeta === "object") {
+                                for (const [k, v] of Object.entries(envMeta as Record<string, unknown>)) {
+                                    if (typeof v === "string") prevEnv[k] = v;
+                                }
+                            }
+                            const oref = WOS.makeORef("block", opts.blockId);
+                            await RpcApi.SetMetaCommand(TabRpcClient, {
+                                oref,
+                                meta: { "cmd:env": { ...prevEnv, [prov.authConfigDirEnvVar]: reg.dir } },
+                            });
+                        }
+                    } catch (e: any) {
+                        opts.log(
+                            "auth",
+                            `account created but couldn't be linked to this agent: ${e?.message ?? String(e)}`,
+                            "warn",
+                        );
+                    }
+                }
                 // Credential is now valid on disk — but the agent spawns fresh
                 // per turn and the failure row only clears on the next turn, so
                 // a successful seed looks like it "did nothing". Drive the
@@ -390,11 +460,20 @@ export function useAgentControllerStatus(
                 if (!cliPath) return;
             }
             const authEnv = await recoveryAuthEnv(prov);
-            const configDir = prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined;
+
+            // Mint a real per-account isolated dir to seed into — not the
+            // agent's already-resolved dir, which (for an unlinked/ambient
+            // agent) is the shared default dir the resolver's spawn gate no
+            // longer honors (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
+            // §7). Falls back to the resolved dir only if minting fails, so
+            // this button still does SOMETHING rather than hard-erroring.
+            const minted = prov.id === "claude" ? await ensureAccountDir(prov.id, opts.log) : null;
+            const configDir = minted?.dir
+                ?? (prov.authConfigDirEnvVar ? authEnv[prov.authConfigDirEnvVar] : undefined);
 
             // Strip CLAUDE_CONFIG_DIR (and equivalents) from the terminal env so the
             // login writes to the user's global ~/.claude instead of the isolated dir.
-            // seedGlobalLogin polls the global dir and copies on success — if we kept
+            // The poll below watches the global dir and copies on success — if we kept
             // the isolated dir key the poll would look in global but the creds would
             // land in isolated, and a terminal-fresh login would never be detected.
             const terminalEnv: Record<string, string> = { ...authEnv };
@@ -403,18 +482,33 @@ export function useAgentControllerStatus(
             await getApi().openLoginTerminal(cliPath, prov.authLoginCommand, terminalEnv);
             opts.log("auth", "A terminal window opened — complete the login there, then come back.");
 
-            // Poll silently every 5s for up to 5 minutes; seed on first hit.
-            const POLL_MS = 5_000;
-            const TIMEOUT_MS = 5 * 60 * 1_000;
-            const deadline = performance.now() + TIMEOUT_MS;
-            const silentLog: typeof opts.log = () => {};
-            let seeded = false;
-            while (!seeded && performance.now() < deadline && !loginCancelled) {
-                await new Promise<void>((r) => setTimeout(r, POLL_MS));
-                if (loginCancelled) break;
-                seeded = await seedGlobalLogin(prov.id, silentLog, configDir);
-            }
+            const seeded = await pollForGlobalLoginSeed(prov.id, configDir, () => loginCancelled);
             if (seeded) {
+                if (minted && (await persistSeededAccount(prov.id, minted.accountId, minted.dir, opts.log))) {
+                    const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+                    if (agentDefinitionId) {
+                        try {
+                            await RpcApi.LinkAgentIdentityCommand(TabRpcClient, {
+                                agent_id: agentDefinitionId,
+                                account_id: minted.accountId,
+                                provider: prov.id,
+                            });
+                            if (prov.authConfigDirEnvVar) {
+                                const oref = WOS.makeORef("block", opts.blockId);
+                                await RpcApi.SetMetaCommand(TabRpcClient, {
+                                    oref,
+                                    meta: { "cmd:env": { ...authEnv, [prov.authConfigDirEnvVar]: minted.dir } },
+                                });
+                            }
+                        } catch (e: any) {
+                            opts.log(
+                                "auth",
+                                `account created but couldn't be linked to this agent: ${e?.message ?? String(e)}`,
+                                "warn",
+                            );
+                        }
+                    }
+                }
                 opts.log("auth", "Login successful — retrying…");
                 setAuthNotice(null);
                 opts.onRecovered?.();

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -39,7 +39,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import * as WOS from "@/app/store/wos";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
-import { runProviderLogin } from "../flows/run-provider-login";
+import { persistAndLinkAccount, runProviderLogin } from "../flows/run-provider-login";
 import { registerSeededAccount } from "../flows/register-seeded-account";
 import type { ProviderDefinition } from "../providers";
 
@@ -324,6 +324,19 @@ export function useAgentControllerStatus(
             // enforcement, PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
             // §7) instead of just seeding a file nothing tracks.
             const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+            // Tier 1 mints the account dir but does NOT persist/link it (it
+            // returns "opened" before confirming completion) — captured here
+            // so a poll below can call persistAndLinkAccount once IT confirms
+            // the login actually finished. reagent P1: without this, a tier-1
+            // login that succeeds for any provider whose CLI actually prints
+            // a URL (not requiresLoginTty, e.g. codex) via "Login Again" left
+            // the minted account unpersisted/unlinked — the resolver's spawn
+            // gate then blocks the agent on its very next spawn with no error
+            // ever surfaced, since relogin's own "opened" case used to just
+            // `break` and report nothing.
+            let openedAccountId: string | undefined;
+            let openedAccountDir: string | undefined;
+            let recheckAuthEnv = authEnv;
             const outcome = await runProviderLogin({
                 provider: prov,
                 cliPath,
@@ -335,10 +348,62 @@ export function useAgentControllerStatus(
                     ? { blockId: opts.blockId, agentDefinitionId }
                     : undefined,
                 existingAccountId: await existingAccountIdFor(prov.id),
+                onAccountRegistered: (accountId, dir) => {
+                    openedAccountId = accountId;
+                    openedAccountDir = dir;
+                    if (prov.authConfigDirEnvVar) {
+                        recheckAuthEnv = { ...authEnv, [prov.authConfigDirEnvVar]: dir };
+                    }
+                },
             });
             switch (outcome) {
-                case "opened":
+                case "opened": {
+                    // A real OAuth URL was captured and opened — poll until
+                    // the user finishes there, cancels, or 5 minutes elapse
+                    // (same pattern as launch-flow.ts's own "opened" case).
+                    opts.log("auth", "waiting for login to complete...");
+                    let authenticated = false;
+                    const deadline = Date.now() + 5 * 60 * 1000;
+                    while (!loginCancelled && Date.now() < deadline && !authenticated) {
+                        await new Promise<void>((r) => setTimeout(r, 2000));
+                        if (loginCancelled) break;
+                        try {
+                            const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+                                cli_path: cliPath,
+                                auth_check_args: prov.authCheckCommand,
+                                auth_env: recheckAuthEnv,
+                            }, { timeout: 10000 });
+                            if (recheck.authenticated) authenticated = true;
+                        } catch {
+                            // keep polling on transient RPC errors
+                        }
+                    }
+                    if (authenticated && openedAccountId && openedAccountDir) {
+                        await persistAndLinkAccount(
+                            {
+                                provider: prov,
+                                cliPath,
+                                authEnv,
+                                setAuthUrl,
+                                log: opts.log,
+                                linkTarget: agentDefinitionId
+                                    ? { blockId: opts.blockId, agentDefinitionId }
+                                    : undefined,
+                            },
+                            openedAccountId,
+                            openedAccountDir,
+                        );
+                        opts.log("auth", "Login successful — retrying…");
+                        setAuthNotice(null);
+                        opts.onRecovered?.();
+                    } else if (!loginCancelled) {
+                        setAuthNotice(
+                            "Opened a login page, but no login was detected within 5 minutes. " +
+                            "Complete the login there, then click “Login Again”.",
+                        );
+                    }
                     break;
+                }
                 case "seeded":
                     opts.log("auth", "Signed in from your global login — retrying…");
                     setAuthNotice(null);

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -254,6 +254,24 @@ export function useAgentControllerStatus(
         }
     };
 
+    /** Look up the account already bound to THIS agent for `providerId`, if
+     *  any — pass as `runProviderLogin`'s `existingAccountId` so a recovery
+     *  action reuses/refreshes the same account instead of minting and
+     *  orphaning a new one on every retry (the same class of gap reagent
+     *  caught in launch-flow.ts's Phase 2 — this hook's `relogin`/
+     *  `loginViaTerminal` had it too, just never flagged directly since
+     *  neither reported "auth_failed" the same visible way Phase 2 did). */
+    const existingAccountIdFor = async (providerId: string): Promise<string | undefined> => {
+        const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+        if (!agentDefinitionId) return undefined;
+        try {
+            const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, { agent_id: agentDefinitionId });
+            return links.find((l) => l.provider === providerId)?.account_id;
+        } catch {
+            return undefined;
+        }
+    };
+
     /** Auth env for recovery actions: block meta `cmd:env` when present, else rebuilt. */
     const recoveryAuthEnv = async (prov: ProviderDefinition): Promise<Record<string, string>> => {
         const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
@@ -316,6 +334,7 @@ export function useAgentControllerStatus(
                 linkTarget: agentDefinitionId
                     ? { blockId: opts.blockId, agentDefinitionId }
                     : undefined,
+                existingAccountId: await existingAccountIdFor(prov.id),
             });
             switch (outcome) {
                 case "opened":
@@ -378,7 +397,7 @@ export function useAgentControllerStatus(
             // §7), so a bare file-copy into the old shared/resolved dir
             // would leave this agent blocked on its next turn regardless of
             // how valid the credential file itself is.
-            const reg = await registerSeededAccount(prov.id, opts.log);
+            const reg = await registerSeededAccount(prov.id, opts.log, await existingAccountIdFor(prov.id));
             if (reg.ok && reg.accountId && reg.dir) {
                 const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
                 if (agentDefinitionId) {
@@ -481,6 +500,7 @@ export function useAgentControllerStatus(
                 linkTarget: agentDefinitionId
                     ? { blockId: opts.blockId, agentDefinitionId }
                     : undefined,
+                existingAccountId: await existingAccountIdFor(prov.id),
             });
             switch (outcome) {
                 case "opened":


### PR DESCRIPTION
## Summary

Claude Code v2.1.x's OAuth flow can't open a browser from AgentMux's headless
CLI spawn. Before this PR, `/login`, the "Login Again" failure-banner action,
and the gated launch flow (behind "Retry Login") each dead-ended on this
independently — three separate, drifted implementations of "spawn login CLI,
wait for a URL." Live testing on a real stuck agent (repro details in the
first retro below) surfaced a second, deeper problem: the recovery path that
did work (copying a valid global `~/.claude` login) wrote into the shared
default credential directory instead of a real, Armory-tracked account — so
a fully working agent could exist with no visible account anywhere in
Armory, no expiry tracking, and (via the `use_ambient_login` escape hatch) no
enforcement that a real account ever existed.

- Consolidates `/login`, "Login Again", and the launch flow's auto-login onto
  one orchestrator (`runProviderLogin`) with a three-tier fallback:
  URL-capture → copy-from-a-valid-global-login → real terminal window,
  polled for the result.
- Ports `open_login_terminal` (the real-console fallback) to macOS/Linux —
  previously Windows-only, so it was the *only* working escape hatch and
  didn't exist on 2 of 3 platforms.
- Retires the `use_ambient_login` bypass in `identity/resolver.rs`'s spawn
  gate — an oauth-class provider now unconditionally requires a real bound
  `IdentityAccount`. No silent fallback to an untracked credential, for any
  provider.
- Reworks the seed-from-global recovery path to mint a real per-account
  isolated dir (`identity.ensureaccountdir`, wrapping the same
  `compute_and_ensure_account_dir` a real OAuth handshake already uses),
  seed it, and persist + link the account — instead of writing into the
  shared dir and faking "connected" UI state locally.
- Adds a proactive token refresh to the MuxBus cloud subscriber (found via
  the same investigation — a long-lived connection never re-checked its
  stored credential's expiry, so it could sit expired while still working).

**Behavior change reviewers should know about:** any agent currently relying
on `use_ambient_login=true` (pre-existing agents grandfathered by an earlier
migration) will fail its next turn until a real account is bound via "Use
existing login" — which now actually creates one instead of just seeding a
file.

Full investigation and design notes:
- `docs/retro/retro-headless-login-browser-open-2026-07-20.md`
- `docs/retro/retro-login-three-code-paths-2026-07-20.md`
- `docs/specs/PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md`

## Test plan

- [x] `cargo check --workspace` — clean, no errors
- [x] `cargo test -p agentmux-srv identity::resolver` — 28/28 pass (2 rewritten to pin the new invariant)
- [x] `cargo test -p agentmux-srv identity_handlers` — 16/16 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent frontend/app/store/launch-flow-state` — 733/733 pass
- [x] Live-verified end-to-end on a real stuck agent (empty shared-dir credential, valid global login): tier-1 timeout → tier-2 auto-recovery → real credential confirmed on disk, all via `muxlog` trace, before the account-registration work landed
- [ ] Live-verify the account-registration + enforcement changes together (rebuild + restart pending)

<!-- agentmux:agent_id=agenta -->