### PR TITLE
feat(swarm): show cron jobs as a per-agent row bucket

### DIFF
--- a/.changesets/1784594444-feat-swarm-show-cron-jobs-as-a-per-agent-row-bucket-fs6n.md
+++ b/.changesets/1784594444-feat-swarm-show-cron-jobs-as-a-per-agent-row-bucket-fs6n.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): show cron jobs as a per-agent row bucket

--- a/agentmux-srv/src/backend/cron/mod.rs
+++ b/agentmux-srv/src/backend/cron/mod.rs
@@ -23,6 +23,7 @@ use cron::Schedule;
 
 use crate::backend::storage::store::Store;
 use crate::backend::storage::cron::CronJob;
+use crate::backend::wps::{Broker, WaveEvent, EVENT_CRON_CHANGED};
 
 /// Abort handles for every currently scheduled cron task.
 type HandleMap = Mutex<HashMap<String, tokio::task::AbortHandle>>;
@@ -33,6 +34,7 @@ pub struct CronScheduler {
     http_client: reqwest::Client,
     local_url: String,
     auth_key: String,
+    broker: Arc<Broker>,
 }
 
 impl CronScheduler {
@@ -41,6 +43,7 @@ impl CronScheduler {
         http_client: reqwest::Client,
         local_url: String,
         auth_key: String,
+        broker: Arc<Broker>,
     ) -> Arc<Self> {
         Arc::new(Self {
             handles: Mutex::new(HashMap::new()),
@@ -48,7 +51,18 @@ impl CronScheduler {
             http_client,
             local_url,
             auth_key,
+            broker,
         })
+    }
+
+    fn publish_changed(&self) {
+        self.broker.publish(WaveEvent {
+            event: EVENT_CRON_CHANGED.to_string(),
+            scopes: vec![],
+            sender: String::new(),
+            persist: 0,
+            data: None,
+        });
     }
 
     /// Load all enabled jobs from the DB and schedule them. Call once at startup.
@@ -136,6 +150,7 @@ impl CronScheduler {
                             let _ = store.cron_set_enabled(&job_id, false);
                         }
                         sched.handles.lock().unwrap().remove(&job_id);
+                        sched.publish_changed();
                         break;
                     }
                 }
@@ -157,6 +172,7 @@ impl CronScheduler {
                             let _ = store.cron_set_enabled(&job_id, false);
                         }
                         sched.handles.lock().unwrap().remove(&job_id);
+                        sched.publish_changed();
                         break;
                     }
                 }
@@ -205,6 +221,7 @@ impl CronScheduler {
                 tracing::warn!(id, error = %e, "cron: failed to record fire in DB");
             }
         }
+        self.publish_changed();
     }
 }
 

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -57,6 +57,12 @@ pub const EVENT_SHELL_CHUNK: &str = "shell_chunk";
 /// so the frontend can surface it as a `term:osc_title` tab label.
 /// Payload: `{ "blockId": "...", "activity": "auth refactor" }`.
 pub const EVENT_BLOCK_ACTIVITY: &str = "block:activity";
+/// Fired whenever a cron job is created, fires, is paused/resumed, or
+/// deleted (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 2).
+/// Payload-free, unscoped — the Swarm pane just reloads the full list via
+/// `cron.ListActive` on receipt, the same "any event of this type ⇒ refetch"
+/// pattern `shell_node_create`/`shell_chunk(op:"exit")` already use.
+pub const EVENT_CRON_CHANGED: &str = "cron_changed";
 
 // File operation constants
 #[allow(dead_code)]

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1121,7 +1121,7 @@ async fn main() {
         filestore,
         global_transcript_store,
         event_bus,
-        broker,
+        broker: broker.clone(),
         reactive_handler,
         poller,
         config_watcher,
@@ -1177,6 +1177,7 @@ async fn main() {
             reqwest::Client::new(),
             local_web_url.clone(),
             config.auth_key.clone(),
+            Arc::clone(&broker),
         ),
         editor_file_watcher,
     };

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -324,7 +324,7 @@ mod recent_sessions_tests {
             filestore: filestore.clone(),
             global_transcript_store: None,
             event_bus: event_bus.clone(),
-            broker,
+            broker: broker.clone(),
             reactive_handler,
             poller,
             config_watcher,
@@ -356,6 +356,7 @@ mod recent_sessions_tests {
                 reqwest::Client::new(),
                 String::new(),
                 "test".to_string(),
+                broker,
             ),
             editor_file_watcher: None,
         };
@@ -635,7 +636,7 @@ mod recent_sessions_tests {
             filestore: filestore.clone(),
             global_transcript_store: None,
             event_bus: event_bus.clone(),
-            broker,
+            broker: broker.clone(),
             reactive_handler,
             poller,
             config_watcher,
@@ -667,6 +668,7 @@ mod recent_sessions_tests {
                 reqwest::Client::new(),
                 String::new(),
                 "test".to_string(),
+                broker,
             ),
             editor_file_watcher: None,
         };

--- a/agentmux-srv/src/server/cron.rs
+++ b/agentmux-srv/src/server/cron.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::backend::storage::cron::CronJob;
+use crate::backend::wps::{WaveEvent, EVENT_CRON_CHANGED};
 use super::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -88,6 +89,57 @@ fn next_fire_utc(expression: &str) -> Option<String> {
     Some(next.to_rfc3339())
 }
 
+/// Swarm-pane row shape for one cron job (SPEC_SWARM_LONG_RUNNING_PROCESS_
+/// ROWS_2026_07_20 Phase 2) — `CronJobView` plus the `created_by` agent's
+/// resolved `block_id`, so the frontend can group it under that agent's row
+/// the same way `ShellSummary` does for the Shell bucket.
+#[derive(Debug, Serialize)]
+pub struct CronSummary {
+    pub id: String,
+    pub block_id: String,
+    pub name: String,
+    pub expression: String,
+    pub target: String,
+    pub created_by: String,
+    pub enabled: bool,
+    pub last_fired: Option<i64>,
+    pub fire_count: i64,
+    pub max_fires: Option<i64>,
+    /// ISO-8601 string of the next scheduled fire (UTC), or null if disabled.
+    pub next_fire: Option<String>,
+}
+
+pub(crate) fn to_summary(job: &CronJob, block_id: String) -> CronSummary {
+    let next_fire = if job.enabled {
+        next_fire_utc(&job.expression)
+    } else {
+        None
+    };
+    CronSummary {
+        id: job.id.clone(),
+        block_id,
+        name: job.name.clone(),
+        expression: job.expression.clone(),
+        target: job.target.clone(),
+        created_by: job.created_by.clone(),
+        enabled: job.enabled,
+        last_fired: job.last_fired,
+        fire_count: job.fire_count,
+        max_fires: job.max_fires,
+        next_fire,
+    }
+}
+
+fn publish_cron_changed(state: &AppState) {
+    state.broker.publish(WaveEvent {
+        event: EVENT_CRON_CHANGED.to_string(),
+        scopes: vec![],
+        sender: String::new(),
+        persist: 0,
+        data: None,
+    });
+}
+
 pub(super) async fn handle_cron_create(
     State(state): State<AppState>,
     Json(req): Json<CronCreateRequest>,
@@ -126,6 +178,7 @@ pub(super) async fn handle_cron_create(
 
     // Register the new job with the live scheduler.
     state.cron_scheduler.schedule_job(&job);
+    publish_cron_changed(&state);
 
     (StatusCode::CREATED, Json(json!({"job": to_view(&job)})))
 }
@@ -160,7 +213,10 @@ pub(super) async fn handle_cron_delete(
     state.cron_scheduler.cancel_job(&id);
 
     match store.cron_delete(&id) {
-        Ok(true) => (StatusCode::OK, Json(json!({"ok": true}))),
+        Ok(true) => {
+            publish_cron_changed(&state);
+            (StatusCode::OK, Json(json!({"ok": true})))
+        }
         Ok(false) => (StatusCode::NOT_FOUND, Json(json!({"error": "job not found"}))),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()}))),
     }
@@ -195,6 +251,55 @@ pub(super) async fn handle_cron_patch(
     } else {
         state.cron_scheduler.cancel_job(&id);
     }
+    publish_cron_changed(&state);
 
     (StatusCode::OK, Json(json!({"ok": true, "enabled": enabled})))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_job(enabled: bool, max_fires: Option<i64>, fire_count: i64) -> CronJob {
+        CronJob {
+            id: "job-1".to_string(),
+            name: "nightly build".to_string(),
+            expression: "0 9 * * *".to_string(),
+            prompt: "run the build".to_string(),
+            target: "target-agent".to_string(),
+            created_by: "creator-agent".to_string(),
+            enabled,
+            last_fired: Some(1_700_000_000),
+            fire_count,
+            max_fires,
+            created_at: 1_699_000_000,
+        }
+    }
+
+    #[test]
+    fn to_summary_carries_the_resolved_block_id() {
+        let job = mk_job(true, None, 3);
+        let summary = to_summary(&job, "block-42".to_string());
+        assert_eq!(summary.id, "job-1");
+        assert_eq!(summary.block_id, "block-42");
+        assert_eq!(summary.created_by, "creator-agent");
+        assert_eq!(summary.fire_count, 3);
+        assert_eq!(summary.max_fires, None);
+    }
+
+    #[test]
+    fn to_summary_omits_next_fire_when_disabled() {
+        let job = mk_job(false, Some(5), 5);
+        let summary = to_summary(&job, "block-1".to_string());
+        assert!(!summary.enabled);
+        assert_eq!(summary.next_fire, None);
+    }
+
+    #[test]
+    fn to_summary_computes_next_fire_when_enabled() {
+        let job = mk_job(true, None, 0);
+        let summary = to_summary(&job, "block-1".to_string());
+        assert!(summary.enabled);
+        assert!(summary.next_fire.is_some());
+    }
 }

--- a/agentmux-srv/src/server/service/misc.rs
+++ b/agentmux-srv/src/server/service/misc.rs
@@ -50,6 +50,30 @@ pub(super) async fn handle_misc_service(state: &AppState, call: &WebCallType) ->
             WebReturnType::success(serde_json::to_value(&shells).unwrap_or_default())
         }
 
+        // ---- CronService (Swarm-pane Cron bucket, Phase 2 of the same
+        // spec) — unfiltered like `shell.ListActive`/`subagent.ListActive`
+        // above: every job whose `created_by` resolves to a live agent
+        // block, frontend groups by block_id in buildTree(). A job whose
+        // creator has no live registration (agent pane closed, or created
+        // via a raw HTTP call with no matching reactive registration) is
+        // silently omitted — nothing to attach it to in a per-agent tree. ----
+        ("cron", "ListActive") => {
+            let jobs = match &state.shared_store {
+                Some(s) => s.cron_list().unwrap_or_default(),
+                None => Vec::new(),
+            };
+            let summaries: Vec<_> = jobs
+                .iter()
+                .filter_map(|job| {
+                    state
+                        .reactive_handler
+                        .get_agent(&job.created_by)
+                        .map(|agent| super::super::cron::to_summary(job, agent.block_id))
+                })
+                .collect();
+            WebReturnType::success(serde_json::to_value(&summaries).unwrap_or_default())
+        }
+
         // ---- SubagentService ----
         ("subagent", "ListActive") => {
             let subagents = state.subagent_watcher.list_active();

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -44,7 +44,7 @@ pub(crate) fn test_state() -> AppState {
         filestore,
         global_transcript_store: None,
         event_bus: event_bus.clone(),
-        broker,
+        broker: broker.clone(),
         reactive_handler,
         poller,
         config_watcher,
@@ -80,6 +80,7 @@ pub(crate) fn test_state() -> AppState {
             reqwest::Client::new(),
             String::new(),
             "test-secret-key".to_string(),
+            broker,
         ),
         editor_file_watcher: None,
     }

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -89,6 +89,11 @@
     --error-color: rgb(229, 77, 46);
     --warning-color: rgb(224, 185, 86);
     --success-color: rgb(78, 154, 6);
+    // Fourth semantic tone — used by the Swarm pane's Cron bucket
+    // (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 2) to stay
+    // visually distinct from Agent Tool (accent/blue), Workflow (warning/
+    // yellow), and Shell (success/green).
+    --info-color: rgb(155, 108, 224);
     --hover-bg-color: rgba(255, 255, 255, 0.1);
     --block-bg-color: rgba(0, 0, 0, 0.5);
     --block-bg-solid-color: rgb(0, 0, 0);

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+    buildCronRows,
     buildDispatchBuckets,
     buildShellRows,
     filterRetired,
@@ -14,6 +15,7 @@ import {
     stabilizeGroupIdentity,
     subagentDisplayLabel,
     subagentRowKey,
+    type ActiveCron,
     type ActiveShell,
     type ActiveSubagent,
     type AgentDispatch,
@@ -27,6 +29,20 @@ function mkShell(overrides: Partial<ActiveShell> & Pick<ActiveShell, "shell_id" 
         title: "npm run dev",
         started_at: 0,
         line_count: 0,
+        ...overrides,
+    };
+}
+
+function mkCron(overrides: Partial<ActiveCron> & Pick<ActiveCron, "id" | "block_id">): ActiveCron {
+    return {
+        name: "nightly build",
+        expression: "0 9 * * *",
+        target: "target-agent",
+        created_by: "creator-agent",
+        enabled: true,
+        last_fired: null,
+        fire_count: 0,
+        max_fires: null,
         ...overrides,
     };
 }
@@ -545,5 +561,47 @@ describe("buildShellRows", () => {
     it("returns an empty array for a null blockId", () => {
         const shells = [mkShell({ shell_id: "s1", block_id: "block-a" })];
         expect(buildShellRows(shells, null)).toEqual([]);
+    });
+});
+
+describe("buildCronRows", () => {
+    it("keeps only cron jobs matching the given block_id", () => {
+        const crons = [
+            mkCron({ id: "c1", block_id: "block-a" }),
+            mkCron({ id: "c2", block_id: "block-b" }),
+            mkCron({ id: "c3", block_id: "block-a" }),
+        ];
+        const rows = buildCronRows(crons, "block-a");
+        expect(new Set(rows.map((r) => r.id))).toEqual(new Set(["c1", "c3"]));
+        expect(rows.every((r) => r.block_id === "block-a")).toBe(true);
+    });
+
+    it("sorts newest-last_fired-first", () => {
+        const crons = [
+            mkCron({ id: "old", block_id: "block-a", last_fired: 100 }),
+            mkCron({ id: "new", block_id: "block-a", last_fired: 300 }),
+            mkCron({ id: "mid", block_id: "block-a", last_fired: 200 }),
+        ];
+        const rows = buildCronRows(crons, "block-a");
+        expect(rows.map((r) => r.id)).toEqual(["new", "mid", "old"]);
+    });
+
+    it("sorts a never-fired (null last_fired) job last", () => {
+        const crons = [
+            mkCron({ id: "never", block_id: "block-a", last_fired: null }),
+            mkCron({ id: "fired", block_id: "block-a", last_fired: 100 }),
+        ];
+        const rows = buildCronRows(crons, "block-a");
+        expect(rows.map((r) => r.id)).toEqual(["fired", "never"]);
+    });
+
+    it("returns an empty array when no cron jobs match", () => {
+        const crons = [mkCron({ id: "c1", block_id: "block-a" })];
+        expect(buildCronRows(crons, "block-z")).toEqual([]);
+    });
+
+    it("returns an empty array for a null blockId", () => {
+        const crons = [mkCron({ id: "c1", block_id: "block-a" })];
+        expect(buildCronRows(crons, null)).toEqual([]);
     });
 });

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -70,6 +70,29 @@ export interface ActiveShell {
 }
 
 /**
+ * Mirrors the backend's `CronSummary` (`server/cron.rs`) — one persistent
+ * cron job whose `created_by` agent currently resolves to a live block.
+ * Fetched via `cron.ListActive` (unfiltered, like `ActiveShell` above);
+ * `buildTree()` groups by `block_id` client-side. Unlike Shell, a job stays
+ * visible whether `enabled` or paused — Phase 2's scope is "does this agent
+ * have a recurring job", not just "is it firing right now". See
+ * SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 2.
+ */
+export interface ActiveCron {
+    id: string;
+    block_id: string;
+    name: string;
+    expression: string;
+    target: string;
+    created_by: string;
+    enabled: boolean;
+    last_fired: number | null;
+    fire_count: number;
+    max_fires: number | null;
+    next_fire: string | null;
+}
+
+/**
  * Mirrors the backend's `AgentDispatch` (one per Agent-tool-or-Workflow-tool
  * call). Only Workflow-kind dispatches get their own tree row
  * (`WorkflowDispatch`, below) — a Solo-kind dispatch's one member renders as
@@ -165,6 +188,10 @@ export interface AgentTreeNode {
      *  (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 1). Sorted
      *  newest-first, same convention as the other two buckets. */
     shellRows: ActiveShell[];
+    /** One row per cron job this agent created (SPEC_SWARM_LONG_RUNNING_
+     *  PROCESS_ROWS_2026_07_20 Phase 2), enabled or paused. Sorted
+     *  newest-first by `last_fired` (nulls — never fired — last). */
+    cronRows: ActiveCron[];
 }
 
 /**
@@ -225,6 +252,19 @@ export function buildShellRows(shells: ActiveShell[], blockId: string | null): A
     return shells
         .filter((s) => s.block_id === blockId)
         .sort((a, b) => b.started_at - a.started_at);
+}
+
+/**
+ * Build one block's Cron bucket rows (SPEC_SWARM_LONG_RUNNING_PROCESS_
+ * ROWS_2026_07_20 Phase 2) — every cron job whose `block_id` matches,
+ * newest-last-fired-first; a job that has never fired sorts last (nulls
+ * carry no recency signal). Extracted as a pure function for the same
+ * reason as `buildShellRows` — directly unit-testable, no ViewModel needed.
+ */
+export function buildCronRows(crons: ActiveCron[], blockId: string | null): ActiveCron[] {
+    return crons
+        .filter((c) => c.block_id === blockId)
+        .sort((a, b) => (b.last_fired ?? -1) - (a.last_fired ?? -1));
 }
 
 /**
@@ -608,6 +648,13 @@ export class SwarmViewModel implements ViewModel {
     shellsAtom: Accessor<ActiveShell[]> = this._shells[0];
     private setShells: Setter<ActiveShell[]> = this._shells[1];
 
+    // Cron jobs (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 2) —
+    // fetched separately via cron.ListActive; buildTree() groups by
+    // block_id the same way it does for shells above.
+    private _crons = createSignal<ActiveCron[]>([]);
+    cronsAtom: Accessor<ActiveCron[]> = this._crons[0];
+    private setCrons: Setter<ActiveCron[]> = this._crons[1];
+
     // AgentDispatches (SPEC §5) — one per Agent-tool-or-Workflow-tool call.
     // Fetched separately from subagentsAtom via subagent.ListDispatches;
     // buildTree() cross-references the two by dispatch_id/parent_block_id.
@@ -711,6 +758,11 @@ export class SwarmViewModel implements ViewModel {
     private loadShellsDebounceTimer: ReturnType<typeof setTimeout> | undefined;
     private static readonly LOAD_SHELLS_DEBOUNCE_MS = 150;
 
+    // Same debounce shape as loadShellsDebounceTimer above, for cron_changed
+    // bursts (e.g. several jobs firing close together).
+    private loadCronsDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+    private static readonly LOAD_CRONS_DEBOUNCE_MS = 150;
+
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
@@ -785,6 +837,15 @@ export class SwarmViewModel implements ViewModel {
         });
         if (unsubShellChunk) this.unsubs.push(unsubShellChunk);
 
+        // Cron bucket (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 2).
+        // Payload-free — any create/fire/pause/resume/delete just triggers a
+        // full reload of the (already-cheap, unfiltered) active list.
+        const unsubCronChanged = waveEventSubscribe({
+            eventType: "cron_changed",
+            handler: () => this.scheduleLoadCrons(),
+        });
+        if (unsubCronChanged) this.unsubs.push(unsubCronChanged);
+
         // Patch display_name in place (not a full loadSubagents() reload) so
         // every client watching this session picks up a generated name —
         // not just the one whose expand click triggered subagent.GenerateName.
@@ -845,6 +906,7 @@ export class SwarmViewModel implements ViewModel {
                 this.loadSubagents(),
                 this.loadDispatches(),
                 this.loadShells(),
+                this.loadCrons(),
             ]);
             this.pruneRetiredRowKeys();
         } finally {
@@ -891,6 +953,15 @@ export class SwarmViewModel implements ViewModel {
         }
     };
 
+    loadCrons = async (): Promise<void> => {
+        try {
+            const result = await callBackendService("cron", "ListActive", []);
+            this.setCrons((result as ActiveCron[]) ?? []);
+        } catch {
+            // silently ignore
+        }
+    };
+
     // Coalesces a burst of subagent:spawned/subagent:completed/dispatch:
     // updated events (e.g. a backfill scan on pane reopen, or a large
     // workflow dispatch spawning many members at once) into a single
@@ -916,6 +987,17 @@ export class SwarmViewModel implements ViewModel {
             this.loadShellsDebounceTimer = undefined;
             void this.loadShells();
         }, SwarmViewModel.LOAD_SHELLS_DEBOUNCE_MS);
+    };
+
+    // Coalesces a burst of cron_changed events into a single reload.
+    scheduleLoadCrons = (): void => {
+        if (this.loadCronsDebounceTimer !== undefined) {
+            clearTimeout(this.loadCronsDebounceTimer);
+        }
+        this.loadCronsDebounceTimer = setTimeout(() => {
+            this.loadCronsDebounceTimer = undefined;
+            void this.loadCrons();
+        }, SwarmViewModel.LOAD_CRONS_DEBOUNCE_MS);
     };
 
     /** Drop `_retiredRowKeys` entries for rows no longer present in live
@@ -1086,6 +1168,7 @@ export class SwarmViewModel implements ViewModel {
         const subagents = this.subagentsAtom();
         const dispatches = this.dispatchesAtom();
         const shells = this.shellsAtom();
+        const crons = this.cronsAtom();
         const statuses = this.agentStatusesAtom();
 
         // Include parent block IDs from subagents as fallback for agent panes
@@ -1125,6 +1208,7 @@ export class SwarmViewModel implements ViewModel {
             const agentToolRows = filterRetired(rawAgentToolRows, retired, (s) => subagentRowKey(s.agent_id), (s) => s.last_event_at);
             const visibleWorkflowRows = filterRetired(workflowRows, retired, (w) => w.dispatchId, (w) => w.lastEventAt);
             const shellRows = buildShellRows(shells, blockId);
+            const cronRows = buildCronRows(crons, blockId);
             return {
                 blockId,
                 agentName,
@@ -1135,6 +1219,7 @@ export class SwarmViewModel implements ViewModel {
                 agentToolRows,
                 workflowRows: visibleWorkflowRows,
                 shellRows,
+                cronRows,
             };
         });
 
@@ -1155,6 +1240,10 @@ export class SwarmViewModel implements ViewModel {
         if (this.loadShellsDebounceTimer !== undefined) {
             clearTimeout(this.loadShellsDebounceTimer);
             this.loadShellsDebounceTimer = undefined;
+        }
+        if (this.loadCronsDebounceTimer !== undefined) {
+            clearTimeout(this.loadCronsDebounceTimer);
+            this.loadCronsDebounceTimer = undefined;
         }
         for (const detail of this.dispatchDetailCache.values()) detail.dispose();
         this.dispatchDetailCache.clear();

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -221,6 +221,13 @@
     &--shell .swarm-bucket-label {
         color: var(--success-color);
     }
+    // Cron (Phase 2 of the same spec) — a fourth, distinct hue; --info-color
+    // was added to theme.scss specifically for this (no existing semantic
+    // var was free to reuse without misleading connotations — see that
+    // var's own doc comment).
+    &--cron .swarm-bucket-label {
+        color: var(--info-color);
+    }
 }
 
 .swarm-bucket-header {
@@ -507,6 +514,66 @@
     // actually applies).
     color: var(--error-color);
     background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
+}
+
+// ── Cron row (SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20 Phase 2) —
+// same flat 30px-row shape as .swarm-shell-row, but no hover-reveal action
+// (Phase 2 is read-only — see CronBucket's doc comment in swarm-view.tsx).
+
+.swarm-cron-row {
+    display: flex;
+    align-items: center;
+    height: 30px;
+    padding: 0 6px 0 30px;
+    gap: 8px;
+    user-select: none;
+}
+
+.swarm-cron-name {
+    flex: 1;
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--main-text-color);
+}
+
+.swarm-cron-expression {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-family: var(--monospace-font, monospace);
+    color: var(--secondary-text-color);
+    opacity: 0.8;
+    white-space: nowrap;
+}
+
+.swarm-cron-last-fired,
+.swarm-cron-fire-count {
+    flex-shrink: 0;
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    opacity: 0.6;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.swarm-cron-status-badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    padding: 1px 6px;
+    border-radius: 3px;
+
+    &--active {
+        color: var(--info-color);
+        background: color-mix(in srgb, var(--info-color) 15%, transparent);
+    }
+    &--paused {
+        color: var(--secondary-text-color);
+        background: var(--highlight-bg-color);
+    }
 }
 
 // ── Subagent detail event rendering (shared by the concatenated dispatch

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
 import { subagentDisplayLabel, subagentRowKey } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import { callBackendService } from "@/store/wos";
@@ -235,7 +235,7 @@ function AgentRow({
     );
     const collapsed = createMemo(() => model.isAgentCollapsed(node.blockId));
     const totalRows = createMemo(
-        () => node.agentToolRows.length + node.workflowRows.length + node.shellRows.length
+        () => node.agentToolRows.length + node.workflowRows.length + node.shellRows.length + node.cronRows.length
     );
     const hasChildren = createMemo(() => totalRows() > 0);
 
@@ -308,6 +308,7 @@ function AgentRow({
                     <AgentToolBucket rows={node.agentToolRows} model={model} parentAgentStatus={node.agentStatus} />
                     <WorkflowBucket rows={node.workflowRows} model={model} />
                     <ShellBucket rows={node.shellRows} />
+                    <CronBucket rows={node.cronRows} />
                 </div>
             </Show>
         </div>
@@ -407,6 +408,62 @@ function ShellRow({ shell }: { shell: ActiveShell }): JSX.Element {
             <button class="swarm-shell-stop" title="Stop" onClick={handleStop}>
                 <i class="fa-solid fa-stop" />
             </button>
+        </div>
+    );
+}
+
+// Cron bucket — Phase 2 of SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20.
+// Appended last (after Shell) — the spec's resolved ordering question is
+// most-abstract-first; a recurring scheduled job sits at the same
+// "mechanical" tier as a shell, so it's grouped alongside rather than
+// interleaved with Agent Tool/Workflow. Flat rows, same shape as
+// ShellBucket — no pause/resume/delete action here; Phase 2 is read-only
+// visibility, matching the spec's stated row content (no action button).
+function CronBucket({ rows }: { rows: ActiveCron[] }): JSX.Element {
+    return (
+        <Show when={rows.length > 0}>
+            <div class="swarm-bucket swarm-bucket--cron">
+                <div class="swarm-bucket-header">
+                    <span class="swarm-bucket-label">Cron</span>
+                    <span class="swarm-bucket-count">{rows.length}</span>
+                </div>
+                <For each={rows}>{(cron) => <CronRow cron={cron} />}</For>
+            </div>
+        </Show>
+    );
+}
+
+function formatLastFired(unixSec: number | null): string {
+    if (unixSec == null) return "never fired";
+    const deltaMin = Math.floor((Date.now() - unixSec * 1000) / 60_000);
+    if (deltaMin < 1) return "just now";
+    if (deltaMin < 60) return `${deltaMin}m ago`;
+    const deltaHr = Math.floor(deltaMin / 60);
+    if (deltaHr < 24) return `${deltaHr}h ago`;
+    return `${Math.floor(deltaHr / 24)}d ago`;
+}
+
+function CronRow({ cron }: { cron: ActiveCron }): JSX.Element {
+    // 60s tick — "last fired" doesn't need per-second granularity like a
+    // shell's live elapsed counter.
+    const tick = useTick(60_000);
+    const lastFired = createMemo(() => {
+        tick();
+        return formatLastFired(cron.last_fired);
+    });
+    const fireCountLabel = createMemo(() =>
+        cron.max_fires != null ? `${cron.fire_count}/${cron.max_fires}` : `${cron.fire_count}`
+    );
+
+    return (
+        <div class="swarm-cron-row" title={`${cron.expression} → ${cron.target}`}>
+            <span class="swarm-cron-name">{cron.name}</span>
+            <span class="swarm-cron-expression">{cron.expression}</span>
+            <span class="swarm-cron-last-fired">{lastFired()}</span>
+            <span class="swarm-cron-fire-count">{fireCountLabel()}</span>
+            <span class={`swarm-cron-status-badge swarm-cron-status-badge--${cron.enabled ? "active" : "paused"}`}>
+                {cron.enabled ? "Active" : "Paused"}
+            </span>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Phase 2 of `docs/specs/SPEC_SWARM_LONG_RUNNING_PROCESS_ROWS_2026_07_20.md` (kept local) — the Swarm pane now shows every persistent cron job an agent created as a fourth bucket, alongside the existing Agent Tool / Workflow / Shell (#2247). This closes out the spec's phased plan — Loop and ScheduleWakeup are explicitly deferred there as separate architecture-change follow-ups, not part of this spec.

Unlike Shell, a cron row stays visible whether `enabled` or paused — the point of this bucket is "does this agent have a recurring job and what's its state," not just "is it firing right now."

**Backend**
- `CronScheduler` now carries an `Arc<Broker>` and publishes a payload-free `cron_changed` event on fire, pause/resume/delete, and `max_fires` auto-disable — same "any event of this type ⇒ reload" contract the Shell bucket already established (`shell_node_create`/`shell_chunk(op:"exit")`), not a scoped/replayed event.
- New `cron.ListActive` RPC: every job whose `created_by` agent resolves to a live block via the existing `ReactiveHandler::get_agent` lookup (the same agent-id→block-id resolution the reactive/inject subsystem already uses) — unfiltered, like `shell.ListActive`; frontend groups by `block_id` client-side. A job whose creator has no live registration is silently omitted, same as an exited shell.
- `CronSummary` mirrors the existing `CronJobView` HTTP DTO plus the resolved `block_id`.
- 3 new backend unit tests.

**Frontend**
- `ActiveCron` type + `cronsAtom`/`loadCrons`/`scheduleLoadCrons` on `SwarmViewModel`, mirroring the Shell bucket's load+debounce pattern exactly.
- `buildCronRows()` pure function (mirrors `buildShellRows`) + `AgentTreeNode.cronRows`.
- `CronBucket`/`CronRow` components, appended after Shell (spec's resolved ordering question — most-abstract-first). Flat, read-only rows (name, expression, last-fired, fire count vs max_fires, active/paused badge) — no pause/resume/delete action, matching the spec's stated row content, which doesn't call for one.
- New `--info-color` theme token (violet) so the fourth bucket reads apart from Agent Tool (blue), Workflow (yellow), and Shell (green) — no existing semantic var was free to reuse without a misleading connotation.
- 5 new frontend unit tests, including the never-fired-sorts-last edge case.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1555/1555 passing (3 new)
- [x] `npm run build` — clean, no TS errors
- [x] `npx vitest run` — 120/121 files, 1846/1850 tests passing; the one failure (`tool-renderers/registry.test.ts`, a timeout) is unrelated and passes in isolation — confirmed pre-existing flakiness, not caused by this change
- [x] `npx stylelint` on the touched scss — 0 new violations (confirmed via `git diff`; same 12 pre-existing violations as before)
- [ ] Manual: create a cron job from an agent, confirm it appears in the Swarm pane's Cron bucket; pause/resume/let it fire, confirm the row updates live

<!-- agentmux:agent_id=camper -->