### PR TITLE
fix(changeset): correct armory zoom changeset type to minor

### DIFF
--- a/.changesets/1784593529-feat-armory-ctrl-wheel-zoom-reusing-the-per-block-term-zoom--dg05.md
+++ b/.changesets/1784593529-feat-armory-ctrl-wheel-zoom-reusing-the-per-block-term-zoom--dg05.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(armory): Ctrl+Wheel zoom, reusing the per-block term:zoom pipeline


### PR DESCRIPTION
## Summary
- The Armory Ctrl+Wheel zoom changeset (`.changesets/1784593529-...md`, from already-merged PR #2251) was typed `patch` for a `feat(...)` commit.
- Repo convention (enforced by reagent) is `feat` -> `minor`. This corrects the type so the next release picks up the right bump.

## Test plan
- N/A — single-line frontmatter fix in an unconsumed changeset file, no code change.

<!-- agentmux:agent_id=agent1 -->