### PR TITLE
fix(identity): gemini/copilot now get real OAuth isolation-dir + spawn-gate treatment

### DIFF
--- a/.changesets/1784696421-fix-identity-gemini-copilot-now-get-real-oauth-isolation-dir-2gnx.md
+++ b/.changesets/1784696421-fix-identity-gemini-copilot-now-get-real-oauth-isolation-dir-2gnx.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(identity): gemini/copilot now get real OAuth isolation-dir + spawn-gate treatment, closing a frontend/backend drift gap

--- a/.changesets/1784704633-docs-identity-fix-stale-claude-codex-openclaw-comment-in-per-atv1.md
+++ b/.changesets/1784704633-docs-identity-fix-stale-claude-codex-openclaw-comment-in-per-atv1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(identity): fix stale claude/codex/openclaw comment in per-account isolation-dir gate

--- a/.changesets/1784706352-docs-identity-fix-4th-stale-claude-codex-openclaw-comment-in-8wcg.md
+++ b/.changesets/1784706352-docs-identity-fix-4th-stale-claude-codex-openclaw-comment-in-8wcg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(identity): fix 4th stale claude/codex/openclaw comment in resolver test

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -334,9 +334,21 @@ pub fn provider_class(provider: &str) -> Option<ProviderClass> {
         // source of truth per CLI for which env var redirects its
         // config / auth directory. The match arm enumerates which
         // providers we currently treat as OAuth-class for identity
-        // bundles (claude / codex / openclaw — per spec §4.3); the
-        // env-var string is read from the registry, not duplicated.
-        "claude" | "codex" | "openclaw" => {
+        // bundles. Originally just claude / codex / openclaw (spec
+        // §4.3) — gemini and copilot were added later
+        // (REPORT_AUTH_ARCHITECTURE_STATE_AND_RETHINK_2026_07_21.md
+        // §2.5 / §6, Phase C) to close a drift gap: the frontend's
+        // `ProviderDefinition` table already marked both
+        // `authType: "oauth"`, but this match arm (the actual gate
+        // for the spawn-time enforcement AND the per-account
+        // isolation-dir minting in identity_handlers.rs, both of
+        // which key off this single function) hadn't caught up —
+        // meaning neither actually applied to them despite the UI
+        // already presenting them as oauth-class. See
+        // `oauth_class_matches_frontend_authtype_oauth_set` below,
+        // which pins this set staying in sync with the frontend going
+        // forward so this doesn't silently drift again.
+        "claude" | "codex" | "openclaw" | "gemini" | "copilot" => {
             crate::backend::providers::get_provider(provider).map(|cfg| {
                 ProviderClass::OAuth {
                     config_dir_env_var: cfg.auth_config_dir_env_var,
@@ -1027,12 +1039,11 @@ mod tests {
 
     #[test]
     fn provider_class_oauth_providers() {
-        // Spec §4.3 — the three known oauth providers must classify
-        // as OAuth with the SAME config-dir env vars the CLI provider
-        // registry defines (single source of truth). Pinning the
-        // expected strings here catches drift in either direction —
-        // if the registry changes a value, this test fails and the
-        // change becomes deliberate.
+        // The known oauth providers must classify as OAuth with the SAME
+        // config-dir env vars the CLI provider registry defines (single
+        // source of truth). Pinning the expected strings here catches drift
+        // in either direction — if the registry changes a value, this test
+        // fails and the change becomes deliberate.
         assert_eq!(
             provider_class("claude"),
             Some(ProviderClass::OAuth { config_dir_env_var: "CLAUDE_CONFIG_DIR" }),
@@ -1045,6 +1056,44 @@ mod tests {
             provider_class("openclaw"),
             Some(ProviderClass::OAuth { config_dir_env_var: "OPENCLAW_HOME" }),
         );
+        assert_eq!(
+            provider_class("gemini"),
+            Some(ProviderClass::OAuth { config_dir_env_var: "GEMINI_CLI_HOME" }),
+        );
+        assert_eq!(
+            provider_class("copilot"),
+            Some(ProviderClass::OAuth { config_dir_env_var: "COPILOT_HOME" }),
+        );
+    }
+
+    #[test]
+    fn oauth_class_matches_frontend_authtype_oauth_set() {
+        // REPORT_AUTH_ARCHITECTURE_STATE_AND_RETHINK_2026_07_21.md §2.5
+        // found gemini/copilot marked `authType: "oauth"` in the frontend's
+        // `ProviderDefinition` table (frontend/app/view/agent/providers/
+        // index.ts) while this function — the actual gate for both the
+        // spawn-time enforcement AND the per-account isolation-dir minting
+        // — hadn't caught up, so neither mechanism applied to them despite
+        // the UI already presenting them as oauth-class. This pins the two
+        // sets staying equal going forward. There's no automated cross-
+        // language check available, so this list is a manually-maintained
+        // mirror of the frontend table — if you add a new `authType:
+        // "oauth"` provider there, update FRONTEND_OAUTH_TYPED here too, in
+        // the SAME change, not as a follow-up.
+        const FRONTEND_OAUTH_TYPED: &[&str] = &["claude", "codex", "gemini", "openclaw", "copilot"];
+        const ALL_KNOWN_PROVIDERS: &[&str] = &[
+            "claude", "codex", "muxcode", "gemini", "qwen", "openclaw", "kimi", "copilot", "pi",
+        ];
+        for p in ALL_KNOWN_PROVIDERS {
+            let is_oauth_class = matches!(provider_class(p), Some(ProviderClass::OAuth { .. }));
+            let is_frontend_oauth_typed = FRONTEND_OAUTH_TYPED.contains(p);
+            assert_eq!(
+                is_oauth_class, is_frontend_oauth_typed,
+                "provider '{p}': backend OAuth-class ({is_oauth_class}) must match \
+                 frontend authType:\"oauth\" ({is_frontend_oauth_typed}) — see this \
+                 test's doc comment",
+            );
+        }
     }
 
     #[cfg(debug_assertions)]

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -1521,10 +1521,13 @@ mod tests {
             slug: String::new(),
             name: "T".to_string(),
             icon: "✦".to_string(),
-            // Not oauth-class (§4.3) — the layer-3 gate only applies to
-            // claude/codex/openclaw definitions, so a non-oauth def here
-            // keeps this test focused on the api-key round trip below
-            // without a claude account fixture it doesn't otherwise need.
+            // Not oauth-class — the layer-3 gate only applies to providers
+            // `provider_class` classifies as OAuth-class (claude / codex /
+            // openclaw / gemini / copilot as of
+            // REPORT_AUTH_ARCHITECTURE_STATE_AND_RETHINK_2026_07_21.md
+            // §2.5/§6), so a non-oauth def here keeps this test focused on
+            // the api-key round trip below without a claude account fixture
+            // it doesn't otherwise need.
             provider: "kimi".to_string(),
             description: String::new(),
             working_directory: String::new(),

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -1025,7 +1025,9 @@ fn spawn_auth_cli_pty(
 ///   - `into_bundle_id` is `Some` and non-empty AND
 ///   - the provider is registered in the CLI provider registry AND
 ///   - the provider declares an `auth_config_dir_env_var` (oauth-class
-///     providers — claude / codex / openclaw — per spec §4.3) AND
+///     providers per `identity::resolver::provider_class` — claude / codex /
+///     openclaw / gemini / copilot as of
+///     REPORT_AUTH_ARCHITECTURE_STATE_AND_RETHINK_2026_07_21.md §2.5/§6) AND
 ///   - `DataPaths::from_env()` resolves AND
 ///   - `create_dir_all` succeeds.
 ///
@@ -1048,8 +1050,10 @@ fn compute_and_ensure_bundle_dir(
     // Gate on provider_class so api-key-class providers (which have a
     // registry entry with a non-empty `auth_config_dir_env_var` —
     // e.g. kimi's `KIMI_SHARE_DIR`) never go through the per-bundle
-    // OAuth-dir path. Only claude / codex / openclaw — the spec §4.3
-    // oauth-class providers — get the per-bundle override.
+    // OAuth-dir path. Only providers `provider_class` classifies as
+    // OAuth-class (claude / codex / openclaw / gemini / copilot) get the
+    // per-bundle override — see that function's own doc comment for the
+    // current, authoritative set.
     match crate::identity::resolver::provider_class(provider_id) {
         Some(crate::identity::resolver::ProviderClass::OAuth { .. }) => {}
         _ => return None,
@@ -1158,8 +1162,11 @@ fn compute_and_ensure_account_dir(
         existing_account_id.to_string()
     };
 
-    // Same provider_class gate as the bundle path — only oauth-class
-    // providers (claude/codex/openclaw) get a per-account isolation dir.
+    // Same provider_class gate as the bundle path — only providers
+    // `provider_class` classifies as OAuth-class (claude / codex /
+    // openclaw / gemini / copilot as of
+    // REPORT_AUTH_ARCHITECTURE_STATE_AND_RETHINK_2026_07_21.md §2.5/§6)
+    // get a per-account isolation dir.
     match crate::identity::resolver::provider_class(provider_id) {
         Some(crate::identity::resolver::ProviderClass::OAuth { .. }) => {}
         _ => return (account_id, None),


### PR DESCRIPTION
## Summary

Phase C of the auth-architecture rethink (partial — see scope note below).
**Stacked on #2260 (Phase A)** — this PR's base branch includes Phase A's broker
module since gemini/copilot classifying as OAuth means they'd otherwise flow
through the same account-dir minting path Phase A touched; the diff here shows
only this PR's own changes.

`resolver::provider_class` is the single source of truth both the layer-3 spawn
gate **and** `identity_handlers.rs`'s per-account isolation-dir minting key off
(confirmed by reading both call sites directly, not assuming). It only classified
`claude`/`codex`/`openclaw` as OAuth-class, while the frontend's `ProviderDefinition`
table already marks `gemini` and `copilot` as `authType: "oauth"` too — so neither
mechanism actually applied to them despite the UI already presenting them as
oauth-class accounts. This was flagged in the auth-architecture report as unexamined
drift, not a deliberate choice.

- Extended `provider_class`'s match arm to include `gemini`/`copilot`.
- Added `oauth_class_matches_frontend_authtype_oauth_set`, a regression test pinning
  the backend OAuth-class set equal to the frontend's `authType: "oauth"` set going
  forward. No automated cross-language check exists in this codebase, so it's a
  manually-mirrored list — the test's doc comment tells future changes to update both
  together in the same change, not as a follow-up.
- Extended the existing `provider_class_oauth_providers` test with the two new
  providers' expected config-dir env vars (`GEMINI_CLI_HOME`, `COPILOT_HOME` —
  verified against `backend/providers.rs` directly).

## Scope note — one item from the plan dropped, with reasoning

The plan's other Phase C item was routing the OAuth expiry probe
(`inject_identity_env_with_broker`'s `probe_oauth_status` call) through the Phase A
broker. On closer look at the actual code, this doesn't apply yet: CLI-provider
credentials have **no active AgentMux-side refresh mechanism** today (unlike MuxBus,
which calls `pkce::refresh_token` itself) — the provider CLI manages its own token
refresh internally, and AgentMux only ever reads its token file read-only. Routing
that existing read-only probe through the broker without a real `refresh` behavior
behind it would be a hollow indirection — register a closure that does nothing but
re-run the same probe — not an actual improvement, and the broker's `HashMap` would
need per-account entry lifecycle handling that Phase A didn't design for. Revisiting
this makes more sense once there's a real CLI-provider refresh mechanism to broker
(plausibly alongside a future device-flow shim), not before.

## Test plan

- [x] `cargo test -p agentmux-srv identity::resolver::` — 29 passed, including the
      new regression test.
- [x] `cargo test -p agentmux-srv` (full suite) — 1587 passed, 0 failed, 4 ignored
      (pre-existing, unrelated).
- [ ] Manual: connect a `gemini` account via the New Agent modal and confirm it gets a
      real isolated account dir the same way `claude` does — not performed this
      session (would benefit from Phase B being available in the same build first,
      since that's what makes the New Agent modal's Connect flow work reliably for
      TTY-requiring providers; gemini itself doesn't require TTY, so this is
      lower-risk, but still worth a live check before merge).

Follow-up to #2260 (Phase A, base of this PR) — part of the same auth-architecture
rethink as #2262 (Phase B).

<!-- agentmux:agent_id=agenta -->