### PR TITLE
docs: fix stale Presets/Settings/WebView2/log-path docs (ARCH-011, ARCH-012)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -32,7 +32,7 @@ These instructions cover setting up dependencies and building AgentMux from sour
    - Download: https://visualstudio.microsoft.com/visual-cpp-build-tools/
    - Install: "Desktop development with C++"
 
-3. **WebView2** is pre-installed on Windows 10/11. If missing, it will auto-install on first launch.
+3. No WebView2 install is needed — AgentMux embeds Chromium via CEF and bundles its own runtime.
 
 #### macOS
 
@@ -124,8 +124,9 @@ task dev
 
 Features:
 - Frontend hot reload (Solid Refresh via Vite)
-- Auto-rebuild on Rust changes
 - DevTools available (Ctrl+Shift+I)
+
+Rust changes are **not** auto-rebuilt — run `task build:backend` (or `task build:host`) and restart `task dev`, see below.
 
 **Important:** Always use `task dev` for development.
 
@@ -153,14 +154,14 @@ This rebuilds:
 Create a local portable build (Windows):
 
 ```bash
-task package             # branch-scoped data dir (session persists across rebuilds)
-task package -- --fresh  # throwaway data dir for a clean-slate test
-task package -- ~/Desktop/staging   # alternate output dir
+task package                         # portable build, per-build data dir
+task package -- --fresh              # no-op — every build is already isolated (kept for muscle memory)
+task package -- ~/Desktop/staging    # alternate output dir
 ```
 
 Output: `~/Desktop/agentmux-<version>+g<sha>[.dirty].<stamp>-x64-portable/` and `.zip`
 
-`task package` is for **local** builds. It does **not** bump the version and does **not** touch git — the artifact carries an ephemeral build *label* (the part after `+` is semver build metadata, ignored for precedence), not a new release version. Every build gets a unique stamped folder (so a running instance never locks the next build) and a per-branch data dir keyed on the `local-<branch>` channel (so agents/panes/auth survive an iterate-rebuild loop). `--fresh` suffixes the channel with the build stamp for a one-off clean dir. The committed version moves only through `task release` (changesets, below). Full rationale: [docs/specs/SPEC_LOCAL_BUILD_VERSIONING_2026_05_28.md](./docs/specs/SPEC_LOCAL_BUILD_VERSIONING_2026_05_28.md).
+`task package` is for **local** builds. It does **not** bump the version and does **not** touch git — the artifact carries an ephemeral build *label* (the part after `+` is semver build metadata, ignored for precedence), not a new release version. Every build bakes a unique per-build channel (`local-<branch>-<hash>-<build-id>`), so each build is its own AgentMux instance with its own data dir and cef-cache — a running instance never blocks the next build, and two builds never collide on disk. Agents and auth are global and carry over across builds; only pane layout and memories start fresh per build. `--fresh` is redundant given per-build isolation and is a no-op. The committed version moves only through `task release` (changesets, below). Full rationale: [docs/specs/SPEC_LOCAL_BUILD_VERSIONING_2026_05_28.md](./docs/specs/SPEC_LOCAL_BUILD_VERSIONING_2026_05_28.md) and [docs/specs/SPEC_MULTI_INSTANCE_ISOLATION_HARDENING_2026_06_03.md](./docs/specs/SPEC_MULTI_INSTANCE_ISOLATION_HARDENING_2026_06_03.md).
 
 ---
 
@@ -280,19 +281,17 @@ Logs appear in the Console tab.
 
 ### Backend Logs
 
-Rust backend logs (agentmux-srv):
-- **Development:** `~/.agentmux-dev/agentmux.log`
-- **Production:** `~/.agentmux/agentmux.log`
-
-View logs in real-time:
+Use the `muxlog` helper (shipped in every AgentMux terminal) — it discovers and
+renders NDJSON logs across every running instance (shared dir, each `task dev`
+branch under `~/.agentmux/dev/<branch>/`, and per-build channels), defaulting
+to the most-recently-active one:
 
 ```bash
-# Development
-tail -f ~/.agentmux-dev/agentmux.log
-
-# Production
-tail -f ~/.agentmux/agentmux.log
+muxlog srv          # tail the active sidecar (agentmux-srv) log, follow
+muxlog ls            # list every instance's logs first if several are running
 ```
+
+Full reference: [docs/MUXLOG.md](docs/MUXLOG.md).
 
 ### Host Logs
 
@@ -398,7 +397,7 @@ git push origin main --tags
 ### Windows
 
 - Uses **NSIS** for installers
-- WebView2 runtime required (auto-installs if missing)
+- CEF bundles its own Chromium runtime — no WebView2 required
 - No CGO / no Zig required (pure Rust)
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF ho
 - **Interagent comms** — `SendMessage` routes one agent's output into another agent's input, so you can build hand-offs and reactive pipelines.
 - **Swarm** — A live two-level agent/subagent tree. Watch delegation chains and every subagent's activity in one view.
 - **Identity bundles** — Named credential sets (GitHub PAT, AWS profile, Anthropic key, etc.), keychain-backed, assigned per agent at launch. Survive renames; swappable without restart.
-- **Reusable presets** — Capture an agent's provider, model, instructions, MCP servers, skills, and environment once and relaunch it as that agent. (Backend: `db_bundles`; surfaced as Presets in the UI.)
+- **Bundles** — Capture an agent's instructions and context files once and reuse them across agents (renamed from "presets"). Backend: `db_bundles`; managed from the Armory tab (hamburger → Armory → Bundles).
 - **Native memory** — Agents read and write their own memory files (`agent:memory:*`). Deeper cross-session memory is actively in development.
 - **One-shot CLIs, AgentMux owns state** — Most provider CLIs are invoked per turn (Subprocess/ACP controllers); Claude Code runs as a persistent stream. Either way AgentMux holds the durable session state, so a 150–350MB Rust core stays flat over long sessions (no GC pauses, no heap growth).
 - **Reducer stack** — A multi-layer reducer architecture (launcher / host / sidecar / frontend) with structured event logs, so "what mutated this state?" has one place to look.
@@ -136,9 +136,8 @@ Every widget is pinned by default — the widget bar shows the full set directly
 
 | Surface | How to reach it |
 |---|---|
-| **Identity** | Tab inside an Agent pane (cog → settings → Identity). Manage the credential bundle assigned to this instance. |
-| **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle (provider, model, instructions, MCP, skills). Replaces the old Forge concept. |
-| **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in your default editor. |
+| **Agent setup** | Vault icon in an Agent pane's header → Accounts / Memories / MCP Servers / Skills / Startup tabs. Accounts assigns the credential bundle for this instance; Memories browses native memory; MCP Servers and Skills bind agent-private or global entries; Startup selects an Armory Bundle as Session Context's startup instructions. Replaces the old Forge concept. |
+| **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens the Settings pane (Appearance, Window & Panes, Terminal, Sounds, Network, Advanced); a footer button opens the raw `settings.json` in your default editor as an escape hatch. |
 | **DevTools** | Hamburger menu (≡) in the top tab bar → DevTools. Toggles Chromium DevTools (no longer a widget). |
 
 ## Agents


### PR DESCRIPTION
## Summary
- ARCH-011: `README.md` still described the Bundle feature (renamed from "preset" in PR #1918) as "Reusable presets... surfaced as Presets in the UI", and described Settings as opening `settings.json` directly — stale since the Settings pane shipped (Appearance/Window & Panes/Terminal/Sounds/Network/Advanced, with `settings.json` now just a footer escape hatch). Also updated the README's "Identity"/"Memory" per-agent-pane rows, which described two separate `cog → settings → *` tabs that have since been consolidated into one "Agent setup" (vault icon) modal with Accounts/Memories/MCP Servers/Skills/Startup tabs.
- ARCH-012: `BUILD.md` contradicted `CLAUDE.md` in three places:
  - Claimed a WebView2 dependency (auto-installs on Windows) — stale from before the CEF migration; AgentMux bundles its own Chromium via CEF and needs no WebView2 on any platform.
  - Described `--fresh` as producing "a throwaway data dir" distinct from a persistent "branch-scoped" default — the actual model (per `CLAUDE.md`) is that every `task package` build already gets its own isolated per-build channel/data dir, making `--fresh` a no-op.
  - Pointed at flat `~/.agentmux-dev/agentmux.log` / `~/.agentmux/agentmux.log` paths for backend logs — logging has since moved to NDJSON logs across three root trees, discovered via the `muxlog` helper.
  - Also fixed a self-contradiction where the Development section claimed "Auto-rebuild on Rust changes" directly above a "Backend Rebuild" section explaining you must run `task build:backend` manually.

Docs-only change; no changeset needed per `.changesets/README.md`.

## Test plan
- [x] Grep-swept `README.md`/`BUILD.md`/`CLAUDE.md` for remaining stale `preset`/`webview2`/`agentmux.log` references — none found.
- [x] Manually diffed against current `CLAUDE.md` (source of truth for Bundles, Settings, per-build isolation, and `muxlog`) to confirm accuracy.

<!-- agentmux:agent_id=agent2 -->