### PR TITLE
fix(deps): raise ws/vite/vitest version floors to patched minimums

### DIFF
--- a/.changesets/1784742719-fix-deps-raise-ws-vite-vitest-version-floors-to-patched-mini-0z2j.md
+++ b/.changesets/1784742719-fix-deps-raise-ws-vite-vitest-version-floors-to-patched-mini-0z2j.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(deps): raise ws/vite/vitest version floors to patched minimums

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.2",
         "vite-plugin-solid": "^2.11.10",
-        "ws": "^8.19.0"
+        "ws": "^8.21.1"
       },
       "devDependencies": {
         "@eslint/js": "^8.57.0",
@@ -85,7 +85,7 @@
         "@types/sprintf-js": "^1",
         "@types/throttle-debounce": "^5",
         "@types/ws": "^8",
-        "@vitest/coverage-istanbul": "^3.0.9",
+        "@vitest/coverage-istanbul": "^3.2.7",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^10.1.8",
         "jsdom": "^29.1.1",
@@ -106,10 +106,10 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.52.0",
-        "vite": "^6.3.6",
+        "vite": "^6.4.3",
         "vite-plugin-svgr": "^4.5.0",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.9"
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/sprintf-js": "^1",
     "@types/throttle-debounce": "^5",
     "@types/ws": "^8",
-    "@vitest/coverage-istanbul": "^3.0.9",
+    "@vitest/coverage-istanbul": "^3.2.7",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^10.1.8",
     "jsdom": "^29.1.1",
@@ -65,10 +65,10 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.52.0",
-    "vite": "^6.3.6",
+    "vite": "^6.4.3",
     "vite-plugin-svgr": "^4.5.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.9"
+    "vitest": "^3.2.7"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
@@ -126,7 +126,7 @@
     "unist-util-visit": "^5.0.0",
     "unist-util-visit-parents": "^6.0.2",
     "vite-plugin-solid": "^2.11.10",
-    "ws": "^8.19.0"
+    "ws": "^8.21.1"
   },
   "packageManager": "npm@11.6.2",
   "engines": {


### PR DESCRIPTION
## Summary
`package.json` declared `ws@^8.19.0`, `vitest@^3.0.9`, `vite@^6.3.6`, and `@vitest/coverage-istanbul@^3.0.9` — all below the versions that patch known CVEs flagged in the 2026-06-22 security-researcher report:
- `ws 8.0.0-8.20.1`: memory exhaustion via tiny fragments + uninitialized memory disclosure (CVSS 7.5) — fixed `>=8.21.0`
- `vitest <3.2.6`: arbitrary file read/exec when the UI server is listening (CVSS 9.8, GHSA-5xrq-8626-4rwp) — fixed `>=3.2.6`
- `vite <=6.4.2`: dev-server arbitrary file read (GHSA-p9ff-h696-f583) and `server.fs.deny` bypass on Windows (GHSA-fx2h-pf6j-xcff) — fixed `>6.4.2`

`npm audit` currently reports 0 vulnerabilities because the committed lockfile already resolved to safe versions (`ws 8.21.1`, `vitest`/`@vitest/coverage-istanbul` `3.2.7`, `vite 6.4.3`) via transitive resolution — but the `package.json` floors themselves still permit a vulnerable resolution on a clean `npm install` without that lockfile (e.g. after deleting `package-lock.json`, or any lockfile regeneration that doesn't land on the same versions). Raised the floors to match what's already locked, closing that gap.

## Test plan
- [x] `npx tsc --noEmit` — one pre-existing error in `swarm-model.test.ts` (`ActiveCron.next_fire` optionality), confirmed present on unmodified `main` via `git stash` before/after comparison — unrelated to this change.
- [x] `npx vitest run` — 1891 passed, 3 skipped, 0 failed.
- [x] `npm audit` — 0 vulnerabilities, before and after.

<!-- agentmux:agent_id=agent2 -->