### PR TITLE
chore: release v0.54.3

### DIFF
--- a/.changesets/1784573464-feat-lan-discovery-udp-broadcast-probe-fallback-for-filtered-h4w8.md
+++ b/.changesets/1784573464-feat-lan-discovery-udp-broadcast-probe-fallback-for-filtered-h4w8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(lan-discovery): UDP broadcast probe fallback for filtered mDNS

--- a/.changesets/1784582590-feat-layout-block-stack-mechanism-for-in-pane-tabs-phase-2-xnty.md
+++ b/.changesets/1784582590-feat-layout-block-stack-mechanism-for-in-pane-tabs-phase-2-xnty.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(layout): block-stack mechanism for in-pane tabs (Phase 2)

--- a/.changesets/1784584750-feat-agent-fork-tab-strip-read-only-switch-between-related-f-xyju.md
+++ b/.changesets/1784584750-feat-agent-fork-tab-strip-read-only-switch-between-related-f-xyju.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): fork tab strip -- read-only switch between related forks (Phase 3)

--- a/.changesets/1784593520-fix-auth-single-point-login-enforcement-every-oauth-class-ag-zdqv.md
+++ b/.changesets/1784593520-fix-auth-single-point-login-enforcement-every-oauth-class-ag-zdqv.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(auth): single-point login enforcement — every oauth-class agent requires a real bound Armory account

--- a/.changesets/1784593529-feat-armory-ctrl-wheel-zoom-reusing-the-per-block-term-zoom--dg05.md
+++ b/.changesets/1784593529-feat-armory-ctrl-wheel-zoom-reusing-the-per-block-term-zoom--dg05.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): Ctrl+Wheel zoom, reusing the per-block term:zoom pipeline

--- a/.changesets/1784593648-feat-agent-select-an-armory-bundle-as-an-agent-s-startup-ins-elvo.md
+++ b/.changesets/1784593648-feat-agent-select-an-armory-bundle-as-an-agent-s-startup-ins-elvo.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): select an Armory Bundle as an agent's Startup Instructions

--- a/.changesets/1784593673-feat-agent-open-armory-icon-in-the-pane-header-header-now-na-khou.md
+++ b/.changesets/1784593673-feat-agent-open-armory-icon-in-the-pane-header-header-now-na-khou.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): vault icon on the Agent-setup button, responsive tabs in the per-agent armory modal

--- a/.changesets/1784593925-feat-agent-fork-creation-action-on-the-fork-tab-strip-phase--jv4l.md
+++ b/.changesets/1784593925-feat-agent-fork-creation-action-on-the-fork-tab-strip-phase--jv4l.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): fork creation action -- + on the fork tab strip (Phase 4)

--- a/.changesets/1784594444-feat-swarm-show-cron-jobs-as-a-per-agent-row-bucket-fs6n.md
+++ b/.changesets/1784594444-feat-swarm-show-cron-jobs-as-a-per-agent-row-bucket-fs6n.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): show cron jobs as a per-agent row bucket

--- a/.changesets/1784644126-fix-agents-stop-dropping-working-directory-in-agent-consolid-eaza.md
+++ b/.changesets/1784644126-fix-agents-stop-dropping-working-directory-in-agent-consolid-eaza.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agents): stop dropping working_directory in agent consolidation migration and surface Claude API errors/tool-results correctly in the translator

--- a/.changesets/1784644352-fix-agent-config-expand-agent-slug-working-dir-template-vars-edmh.md
+++ b/.changesets/1784644352-fix-agent-config-expand-agent-slug-working-dir-template-vars-edmh.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-config): expand AGENT_SLUG/WORKING_DIR template vars, delete dead build_config_files_with_bus

--- a/.changesets/1784644448-fix-clipboard-route-editor-toolchain-panes-through-the-cef-s-04z3.md
+++ b/.changesets/1784644448-fix-clipboard-route-editor-toolchain-panes-through-the-cef-s-04z3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(clipboard): route Editor/Toolchain panes through the CEF-safe clipboard wrapper

--- a/.changesets/1784644695-fix-identity-remove-non-functional-assigned-agents-field-fro-yc6e.md
+++ b/.changesets/1784644695-fix-identity-remove-non-functional-assigned-agents-field-fro-yc6e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): remove non-functional Assigned agents field from AccountForm

--- a/.changesets/1784678493-feat-browser-pane-individual-ctrl-wheel-zoom-per-pane-via-cs-st0q.md
+++ b/.changesets/1784678493-feat-browser-pane-individual-ctrl-wheel-zoom-per-pane-via-cs-st0q.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser-pane): individual Ctrl+Wheel zoom per pane via CSS injection

--- a/.changesets/1784695288-feat-auth-credential-broker-skeleton-single-flight-guarded-p-98v3.md
+++ b/.changesets/1784695288-feat-auth-credential-broker-skeleton-single-flight-guarded-p-98v3.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(auth): credential broker skeleton — single-flight-guarded proactive refresh, MuxBus tokens moved to OS keychain

--- a/.changesets/1784695324-feat-term-in-pane-tabs-for-terminal-panes-phase-5-mbb5.md
+++ b/.changesets/1784695324-feat-term-in-pane-tabs-for-terminal-panes-phase-5-mbb5.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(term): in-pane tabs for terminal panes (Phase 5)

--- a/.changesets/1784696096-fix-auth-new-agent-modal-connect-button-real-terminal-fallba-b3g8.md
+++ b/.changesets/1784696096-fix-auth-new-agent-modal-connect-button-real-terminal-fallba-b3g8.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(auth): New Agent modal Connect button — real terminal fallback for requiresLoginTty providers

--- a/.changesets/1784696421-fix-identity-gemini-copilot-now-get-real-oauth-isolation-dir-2gnx.md
+++ b/.changesets/1784696421-fix-identity-gemini-copilot-now-get-real-oauth-isolation-dir-2gnx.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(identity): gemini/copilot now get real OAuth isolation-dir + spawn-gate treatment, closing a frontend/backend drift gap

--- a/.changesets/1784696741-docs-auth-phase-d-device-flow-shim-spike-not-viable-for-clau-8c5n.md
+++ b/.changesets/1784696741-docs-auth-phase-d-device-flow-shim-spike-not-viable-for-clau-8c5n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(auth): Phase D device-flow shim spike — not viable for Claude or Codex, decision recorded

--- a/.changesets/1784697483-fix-auth-runproviderlogin-cancels-abandoned-tier-1-login-chi-l2p1.md
+++ b/.changesets/1784697483-fix-auth-runproviderlogin-cancels-abandoned-tier-1-login-chi-l2p1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): runProviderLogin cancels abandoned tier-1 login child, dedupes tier2/3 account minting; open_login_terminal fixes on macOS/Linux

--- a/.changesets/1784697772-fix-auth-muxbus-load-no-longer-collapses-a-real-keychain-fai-424e.md
+++ b/.changesets/1784697772-fix-auth-muxbus-load-no-longer-collapses-a-real-keychain-fai-424e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): muxbus_load no longer collapses a real keychain failure into 'no credentials'

--- a/.changesets/1784699000-fix-auth-non-claude-oauth-providers-were-permanently-unable--snou.md
+++ b/.changesets/1784699000-fix-auth-non-claude-oauth-providers-were-permanently-unable--snou.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): non-Claude oauth providers were permanently unable to log in via terminal fallback

--- a/.changesets/1784699876-fix-auth-loginviaterminal-consolidated-onto-runproviderlogin-xz28.md
+++ b/.changesets/1784699876-fix-auth-loginviaterminal-consolidated-onto-runproviderlogin-xz28.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): loginViaTerminal consolidated onto runProviderLogin — was a sibling duplicate of the tier-2/3 P0 bug just fixed

--- a/.changesets/1784700385-docs-correct-stale-ambient-creds-claim-in-plan-login-single--aohj.md
+++ b/.changesets/1784700385-docs-correct-stale-ambient-creds-claim-in-plan-login-single--aohj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: correct stale ambient-creds claim in PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION — was reverted, doc never updated

--- a/.changesets/1784701316-fix-auth-retry-login-reported-failure-right-after-a-successf-nt9c.md
+++ b/.changesets/1784701316-fix-auth-retry-login-reported-failure-right-after-a-successf-nt9c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): Retry Login reported failure right after a successful login, and orphaned an account on every retry

--- a/.changesets/1784702100-fix-auth-retry-account-persist-once-after-a-successful-seed--9ryt.md
+++ b/.changesets/1784702100-fix-auth-retry-account-persist-once-after-a-successful-seed--9ryt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): retry account persist once after a successful seed instead of confusingly falling through to a terminal prompt

--- a/.changesets/1784702701-fix-auth-muxbus-login-no-longer-reports-success-on-a-keychai-xio4.md
+++ b/.changesets/1784702701-fix-auth-muxbus-login-no-longer-reports-success-on-a-keychai-xio4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): muxbus.login no longer reports success on a keychain save failure; corrupted token blob surfaces as an error, not a logout

--- a/.changesets/1784703054-fix-agent-remove-the-dead-use-global-cli-login-toggle-the-sp-ktbn.md
+++ b/.changesets/1784703054-fix-agent-remove-the-dead-use-global-cli-login-toggle-the-sp-ktbn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove the dead 'Use global CLI login' toggle — the spawn gate stopped honoring it, but the UI kept promising it works

--- a/.changesets/1784703901-fix-agent-fork-tab-strip-no-longer-leaks-unrelated-agents-cl-6d1v.md
+++ b/.changesets/1784703901-fix-agent-fork-tab-strip-no-longer-leaks-unrelated-agents-cl-6d1v.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): fork tab strip no longer leaks unrelated agents cloned from the same template

--- a/.changesets/1784703969-fix-auth-tier-1-login-success-never-bound-an-account-for-any-2fqb.md
+++ b/.changesets/1784703969-fix-auth-tier-1-login-success-never-bound-an-account-for-any-2fqb.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(auth): tier-1 login success never bound an account for any oauth-class provider whose CLI actually prints a URL

--- a/.changesets/1784704444-chore-cleanup-delete-20-confirmed-dead-rust-items-zero-calle-9pbm.md
+++ b/.changesets/1784704444-chore-cleanup-delete-20-confirmed-dead-rust-items-zero-calle-9pbm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(cleanup): delete ~20 confirmed-dead Rust items (zero-caller functions, vestigial fields, superseded helpers)

--- a/.changesets/1784704474-chore-cleanup-delete-dead-agent-def-directory-filtercontrols-xnbv.md
+++ b/.changesets/1784704474-chore-cleanup-delete-dead-agent-def-directory-filtercontrols-xnbv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(cleanup): delete dead agent-def directory, FilterControls/NewAgentCard, dead IdentityView export, legacy scss/icon field/detectAgentFromPath

--- a/.changesets/1784704633-docs-identity-fix-stale-claude-codex-openclaw-comment-in-per-atv1.md
+++ b/.changesets/1784704633-docs-identity-fix-stale-claude-codex-openclaw-comment-in-per-atv1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(identity): fix stale claude/codex/openclaw comment in per-account isolation-dir gate

--- a/.changesets/1784704886-docs-auth-fix-phase-d-report-section-numbering-gap-and-uneva-3qtb.md
+++ b/.changesets/1784704886-docs-auth-fix-phase-d-report-section-numbering-gap-and-uneva-3qtb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(auth): fix Phase D report — section numbering gap and unevaluated Gemini device-flow scope

--- a/.changesets/1784705476-fix-auth-address-reagent-p1-review-on-2260-relogin-and-login-feqk.md
+++ b/.changesets/1784705476-fix-auth-address-reagent-p1-review-on-2260-relogin-and-login-feqk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): address reagent P1 review on #2260 — relogin() and /login left tier-1 'opened' logins unpersisted

--- a/.changesets/1784706352-docs-identity-fix-4th-stale-claude-codex-openclaw-comment-in-8wcg.md
+++ b/.changesets/1784706352-docs-identity-fix-4th-stale-claude-codex-openclaw-comment-in-8wcg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(identity): fix 4th stale claude/codex/openclaw comment in resolver test

--- a/.changesets/1784707413-fix-auth-sweep-orphaned-account-dirs-from-abandoned-failed-l-3zkw.md
+++ b/.changesets/1784707413-fix-auth-sweep-orphaned-account-dirs-from-abandoned-failed-l-3zkw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): sweep orphaned account dirs from abandoned/failed logins

--- a/.changesets/1784707973-docs-auth-fix-stale-10-cross-reference-and-provider-count-in-zp9n.md
+++ b/.changesets/1784707973-docs-auth-fix-stale-10-cross-reference-and-provider-count-in-zp9n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(auth): fix stale §10 cross-reference and provider count in Phase D report intro

--- a/.changesets/1784711759-fix-agent-distinguish-user-cancel-from-any-other-exit-from-w-af7s.md
+++ b/.changesets/1784711759-fix-agent-distinguish-user-cancel-from-any-other-exit-from-w-af7s.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): distinguish user Cancel from any other exit from waiting in PreLaunchAuthPanel's tier-3 poll

--- a/.changesets/1784712128-fix-auth-muxbus-save-rolls-back-the-keychain-write-if-the-pa-wls3.md
+++ b/.changesets/1784712128-fix-auth-muxbus-save-rolls-back-the-keychain-write-if-the-pa-wls3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): muxbus_save rolls back the keychain write if the paired SQL write fails

--- a/.changesets/1784712648-fix-auth-muxbus-save-rollback-no-longer-deletes-a-real-crede-gx4l.md
+++ b/.changesets/1784712648-fix-auth-muxbus-save-rollback-no-longer-deletes-a-real-crede-gx4l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): muxbus_save rollback no longer deletes a real credential it just couldn't read

--- a/.changesets/1784728962-fix-auth-serialize-muxbus-save-against-concurrent-callers-ma-xo8f.md
+++ b/.changesets/1784728962-fix-auth-serialize-muxbus-save-against-concurrent-callers-ma-xo8f.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): serialize muxbus_save against concurrent callers, make is_fresh side-effect-free

--- a/.changesets/1784729634-fix-agent-guard-prelaunchauthpanel-s-requireslogintty-reconn-rtrl.md
+++ b/.changesets/1784729634-fix-agent-guard-prelaunchauthpanel-s-requireslogintty-reconn-rtrl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): guard PreLaunchAuthPanel's requiresLoginTty Reconnect against double-click and misleading timeout-after-cancel

--- a/.changesets/1784730216-fix-agent-connectclicked-now-honored-from-ready-fixes-the-re-hd9e.md
+++ b/.changesets/1784730216-fix-agent-connectclicked-now-honored-from-ready-fixes-the-re-hd9e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): ConnectClicked now honored from ready — fixes the Reconnect flow never showing success or failure

--- a/.changesets/1784730915-fix-auth-route-every-blocking-muxbus-keychain-call-through-s-5ejp.md
+++ b/.changesets/1784730915-fix-auth-route-every-blocking-muxbus-keychain-call-through-s-5ejp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): route every blocking muxbus keychain call through spawn_blocking

--- a/.changesets/1784732029-fix-auth-muxbus-load-s-lazy-migration-write-is-now-covered-b-u2du.md
+++ b/.changesets/1784732029-fix-auth-muxbus-load-s-lazy-migration-write-is-now-covered-b-u2du.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): muxbus_load's lazy-migration write is now covered by muxbus_save_lock too

--- a/.changesets/1784732405-fix-auth-muxbus-clear-now-serializes-against-muxbus-save-too-2nej.md
+++ b/.changesets/1784732405-fix-auth-muxbus-clear-now-serializes-against-muxbus-save-too-2nej.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): muxbus_clear now serializes against muxbus_save too

--- a/.changesets/1784732943-fix-agent-requireslogintty-login-outcome-is-now-discarded-if-7zmg.md
+++ b/.changesets/1784732943-fix-agent-requireslogintty-login-outcome-is-now-discarded-if-7zmg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): requiresLoginTty login outcome is now discarded if the user moved on before it resolved

--- a/.changesets/1784742719-fix-deps-raise-ws-vite-vitest-version-floors-to-patched-mini-0z2j.md
+++ b/.changesets/1784742719-fix-deps-raise-ws-vite-vitest-version-floors-to-patched-mini-0z2j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(deps): raise ws/vite/vitest version floors to patched minimums

--- a/.changesets/1784743591-fix-identity-restore-resolve-provider-alias-deleted-by-2267--fo6w.md
+++ b/.changesets/1784743591-fix-identity-restore-resolve-provider-alias-deleted-by-2267--fo6w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): restore resolve_provider_alias deleted by #2267's dead-code sweep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.2"
+version = "0.54.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.2"
+version = "0.54.3"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.2"
+version = "0.54.3"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.2"
+version = "0.54.3"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.2"
+version = "0.54.3"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.2"
+version = "0.54.3"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.2"
+version = "0.54.3"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,57 @@
 # AgentMux Version History
 
+## 0.54.3 — 2026-07-22
+
+- feat(lan-discovery): UDP broadcast probe fallback for filtered mDNS
+- feat(layout): block-stack mechanism for in-pane tabs (Phase 2)
+- feat(agent): fork tab strip -- read-only switch between related forks (Phase 3)
+- fix(auth): single-point login enforcement — every oauth-class agent requires a real bound Armory account
+- feat(armory): Ctrl+Wheel zoom, reusing the per-block term:zoom pipeline
+- feat(agent): select an Armory Bundle as an agent's Startup Instructions
+- feat(agent): vault icon on the Agent-setup button, responsive tabs in the per-agent armory modal
+- feat(agent): fork creation action -- + on the fork tab strip (Phase 4)
+- feat(swarm): show cron jobs as a per-agent row bucket
+- fix(agents): stop dropping working_directory in agent consolidation migration and surface Claude API errors/tool-results correctly in the translator
+- fix(agent-config): expand AGENT_SLUG/WORKING_DIR template vars, delete dead build_config_files_with_bus
+- fix(clipboard): route Editor/Toolchain panes through the CEF-safe clipboard wrapper
+- fix(identity): remove non-functional Assigned agents field from AccountForm
+- feat(browser-pane): individual Ctrl+Wheel zoom per pane via CSS injection
+- feat(auth): credential broker skeleton — single-flight-guarded proactive refresh, MuxBus tokens moved to OS keychain
+- feat(term): in-pane tabs for terminal panes (Phase 5)
+- fix(auth): New Agent modal Connect button — real terminal fallback for requiresLoginTty providers
+- fix(identity): gemini/copilot now get real OAuth isolation-dir + spawn-gate treatment, closing a frontend/backend drift gap
+- docs(auth): Phase D device-flow shim spike — not viable for Claude or Codex, decision recorded
+- fix(auth): runProviderLogin cancels abandoned tier-1 login child, dedupes tier2/3 account minting; open_login_terminal fixes on macOS/Linux
+- fix(auth): muxbus_load no longer collapses a real keychain failure into 'no credentials'
+- fix(auth): non-Claude oauth providers were permanently unable to log in via terminal fallback
+- fix(auth): loginViaTerminal consolidated onto runProviderLogin — was a sibling duplicate of the tier-2/3 P0 bug just fixed
+- docs: correct stale ambient-creds claim in PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION — was reverted, doc never updated
+- fix(auth): Retry Login reported failure right after a successful login, and orphaned an account on every retry
+- fix(auth): retry account persist once after a successful seed instead of confusingly falling through to a terminal prompt
+- fix(auth): muxbus.login no longer reports success on a keychain save failure; corrupted token blob surfaces as an error, not a logout
+- fix(agent): remove the dead 'Use global CLI login' toggle — the spawn gate stopped honoring it, but the UI kept promising it works
+- fix(agent): fork tab strip no longer leaks unrelated agents cloned from the same template
+- fix(auth): tier-1 login success never bound an account for any oauth-class provider whose CLI actually prints a URL
+- chore(cleanup): delete ~20 confirmed-dead Rust items (zero-caller functions, vestigial fields, superseded helpers)
+- chore(cleanup): delete dead agent-def directory, FilterControls/NewAgentCard, dead IdentityView export, legacy scss/icon field/detectAgentFromPath
+- docs(identity): fix stale claude/codex/openclaw comment in per-account isolation-dir gate
+- docs(auth): fix Phase D report — section numbering gap and unevaluated Gemini device-flow scope
+- fix(auth): address reagent P1 review on #2260 — relogin() and /login left tier-1 'opened' logins unpersisted
+- docs(identity): fix 4th stale claude/codex/openclaw comment in resolver test
+- fix(auth): sweep orphaned account dirs from abandoned/failed logins
+- docs(auth): fix stale §10 cross-reference and provider count in Phase D report intro
+- fix(agent): distinguish user Cancel from any other exit from waiting in PreLaunchAuthPanel's tier-3 poll
+- fix(auth): muxbus_save rolls back the keychain write if the paired SQL write fails
+- fix(auth): muxbus_save rollback no longer deletes a real credential it just couldn't read
+- fix(auth): serialize muxbus_save against concurrent callers, make is_fresh side-effect-free
+- fix(agent): guard PreLaunchAuthPanel's requiresLoginTty Reconnect against double-click and misleading timeout-after-cancel
+- fix(agent): ConnectClicked now honored from ready — fixes the Reconnect flow never showing success or failure
+- fix(auth): route every blocking muxbus keychain call through spawn_blocking
+- fix(auth): muxbus_load's lazy-migration write is now covered by muxbus_save_lock too
+- fix(auth): muxbus_clear now serializes against muxbus_save too
+- fix(agent): requiresLoginTty login outcome is now discarded if the user moved on before it resolved
+
+
 ## 0.54.2 — 2026-07-20
 
 - feat(scripts): resolve per-agent GitHub PAT via gh-agent.sh instead of shared gh session

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,6 +2,8 @@
 
 ## 0.54.3 — 2026-07-22
 
+- fix(identity): restore resolve_provider_alias deleted by #2267's dead-code sweep
+- fix(deps): raise ws/vite/vitest version floors to patched minimums
 - feat(lan-discovery): UDP broadcast probe fallback for filtered mDNS
 - feat(layout): block-stack mechanism for in-pane tabs (Phase 2)
 - feat(agent): fork tab strip -- read-only switch between related forks (Phase 3)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.2",
+      "version": "0.54.3",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Forced patch release (`task release -- --as patch`) consuming all 48 pending changesets. Several are `feat`-level (would normally force a minor bump) — overridden to patch per explicit direction; every changeset is still consumed and changelogged under 0.54.3.

Bulk of the content is the auth-architecture rethink work (PRs #2255, #2260, #2262, #2263, #2264) plus a couple of earlier feature/fix batches and a dead-code cleanup pass that landed on main just before this release was cut.

All 5 version locations agree at 0.54.3 (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`).

## Test plan

- [x] `scripts/release.sh` regenerated lockfiles and confirmed all 5 version locations agree
- [x] No source changes — version bump + changelog only

<!-- agentmux:agent_id=agenta -->