### PR TITLE
fix(identity): restore resolve_provider_alias, broken by #2267's dead-code sweep

### DIFF
--- a/.changesets/1784743591-fix-identity-restore-resolve-provider-alias-deleted-by-2267--fo6w.md
+++ b/.changesets/1784743591-fix-identity-restore-resolve-provider-alias-deleted-by-2267--fo6w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): restore resolve_provider_alias deleted by #2267's dead-code sweep

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -419,6 +419,21 @@ static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(||
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
+/// Resolve a provider alias to its canonical ID.
+///
+/// Returns `id` unchanged if it is not a known alias.
+pub fn resolve_provider_alias(id: &str) -> &'static str {
+    ALIASES.get(id).copied().unwrap_or_else(|| {
+        // If the id itself is a canonical key return the interned key, otherwise
+        // return a best-effort static ref. The caller should treat the return
+        // value as a lookup key only.
+        REGISTRY
+            .get_key_value(id)
+            .map(|(k, _)| *k)
+            .unwrap_or("") // unknown — get_provider will return None
+    })
+}
+
 /// Look up a provider by canonical ID or alias.
 ///
 /// Returns `None` when the ID (and any resolved alias) does not match a known


### PR DESCRIPTION
## Summary
`main` is currently broken for `cargo check --workspace --tests` (confirmed via CI on an unrelated PR — both `windows-latest` and `ubuntu-latest` fail with `error[E0425]: cannot find function resolve_provider_alias`).

Root cause: #2267 ("delete confirmed-dead Rust + frontend code") deleted `resolve_provider_alias` from `backend/providers.rs`, believing it had zero callers per its audit re-verification pass. But #2263 (merged immediately before it) had just added a real caller in `identity/resolver.rs:324`'s `provider_class()` — a P1 fix ensuring `provider_class` and `get_provider` can't disagree on an alias ID. The "zero-caller" re-check missed this call site.

Fix: restored the function verbatim from #2267's own diff. Nothing else changed — the same commit's unrelated deletion of `resolver.rs`'s genuinely-unused `oauth_status::UNKNOWN` const is correct and left alone.

## Test plan
- [x] `cargo check -p agentmux-srv --tests` — now succeeds (was failing before this fix, reproduced locally).
- [x] `cargo test -p agentmux-srv --bin agentmux-srv identity::resolver` — 30 passed, 0 failed, including `provider_class_resolves_aliases_to_the_same_result_as_canonical`.

## Priority
This blocks CI for every open PR in the repo, not just this fix. Requesting a fast merge.

<!-- agentmux:agent_id=agent2 -->