### PR TITLE
fix(auth): open_login_terminal no longer nulls stdin on Windows

### DIFF
--- a/.changesets/1784760432-fix-auth-open-login-terminal-no-longer-nulls-stdin-on-window-yjrg.md
+++ b/.changesets/1784760432-fix-auth-open-login-terminal-no-longer-nulls-stdin-on-window-yjrg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): open_login_terminal no longer nulls stdin on Windows, restoring browser-open

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -1331,11 +1331,26 @@ pub fn open_login_terminal(args: &serde_json::Value) -> Result<serde_json::Value
         // CREATE_NEW_CONSOLE (0x10): the child gets its own visible console
         // window, separate from the host's hidden console. This is what allows
         // the Claude CLI to open the OS default browser for OAuth.
+        //
+        // Deliberately NOT setting .stdin()/.stdout()/.stderr() here (was
+        // .stdin(Stdio::null()) — confirmed live, root-caused this session:
+        // the CLI opened a real browser and completed OAuth correctly when
+        // run manually with normal stdio, but silently failed to open a
+        // browser under this exact spawn once stdin was forced to NUL).
+        // Rust only sets STARTF_USESTDHANDLES (which overrides whatever
+        // handles CREATE_NEW_CONSOLE would otherwise wire up for the new
+        // console) when a stdio method is explicitly called; leaving all
+        // three untouched lets CreateProcess give the child fresh handles
+        // tied to its own new console, exactly like a normal interactively-
+        // launched console app gets. That's required for two things: the
+        // CLI's own TTY detection (gates whether it attempts the browser-
+        // open call at all) AND the "Paste code here if prompted >" manual
+        // fallback this same command prints — impossible to use with a
+        // NUL'd stdin regardless of the browser-open outcome.
         const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
         std::process::Command::new("cmd.exe")
             .args(["/k", &cmd_str])
             .envs(&auth_env)
-            .stdin(std::process::Stdio::null())
             .creation_flags(CREATE_NEW_CONSOLE)
             .spawn()
             .map_err(|e| format!("open_login_terminal: spawn failed: {e}"))?;


### PR DESCRIPTION
## Summary

`open_login_terminal`'s Windows path (`CREATE_NEW_CONSOLE` + `cmd.exe /k`) explicitly set `.stdin(Stdio::null())`. Live-tested this session: the exact same `claude.cmd auth login` command, with the same isolated `CLAUDE_CONFIG_DIR` AgentMux sets, opened a real browser and completed OAuth correctly when run interactively (PowerShell) — but produced no browser at all when spawned via AgentMux's actual terminal-fallback path, whose only difference was the NUL'd stdin.

Rust's `Command` only sets `STARTF_USESTDHANDLES` (overriding whatever handles `CREATE_NEW_CONSOLE` would otherwise wire up for the new console) when a stdio method is explicitly called. Removing the explicit `.stdin()` call lets `CreateProcess` give the child fresh handles tied to its own new console — required both for the CLI's own TTY detection (gates whether it even attempts the browser-open call) and for the "Paste code here if prompted >" manual fallback the same command prints, which a NUL'd stdin made impossible to use regardless.

macOS/Linux are unaffected — neither path touches stdio explicitly; both already spawn via a real terminal app/emulator.

## Test plan

- [x] Live-tested: ran the exact command manually via PowerShell with the same isolated `CLAUDE_CONFIG_DIR` — browser opened, OAuth completed successfully (confirmed by the user completing login twice during diagnosis).
- [x] `cargo check -p agentmux-cef` clean.
- [x] Built a fresh portable with the fix; awaiting live in-app confirmation.

<!-- agentmux:agent_id=agenta -->