### PR TITLE
refactor(broker): reducer-based state machine for credential refresh coordination

### DIFF
--- a/.changesets/1784761584-refactor-broker-reducer-based-state-machine-for-credential-r-rp7z.md
+++ b/.changesets/1784761584-refactor-broker-reducer-based-state-machine-for-credential-r-rp7z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(broker): reducer-based state machine for credential refresh coordination

--- a/agentmux-srv/src/broker/mod.rs
+++ b/agentmux-srv/src/broker/mod.rs
@@ -19,8 +19,10 @@
 //! (Phase C+), not touched here.
 
 pub mod scheduler;
+pub mod state;
 
 pub use scheduler::RefreshScheduler;
+pub use state::{CredentialState, RefreshErrorKind};
 
 use std::sync::{Arc, OnceLock};
 

--- a/agentmux-srv/src/broker/scheduler.rs
+++ b/agentmux-srv/src/broker/scheduler.rs
@@ -140,6 +140,19 @@ impl RefreshScheduler {
     pub async fn ensure_fresh(&self, credential_id: &str) -> Result<(), String> {
         let id = credential_id.to_string();
         loop {
+            // Create the Notified future *before* dispatching CheckRequested
+            // (and thus before releasing the states lock that gates whether
+            // we're about to become the AlreadyInFlight waiter). Tokio
+            // guarantees a Notified future observes any notify_waiters()
+            // issued after it is created, even before its first poll — so
+            // creating it here closes the lost-wakeup window where the
+            // in-flight refresh finishes and calls wake() between our
+            // CheckRequested dispatch and a `.notified()` call made only
+            // after we see AlreadyInFlight (reagent P1 on #2275: notify_
+            // waiters() retains no permit for a waiter not yet registered).
+            let notify = self.notifier_for(&id);
+            let notified = notify.notified();
+
             let events = {
                 let mut states = self.states.lock().unwrap();
                 state::update(&mut states, Command::CheckRequested { id: id.clone() })
@@ -149,7 +162,7 @@ impl RefreshScheduler {
                     return Err(format!("no credential registered as '{id}'"));
                 }
                 [Event::AlreadyInFlight { .. }] => {
-                    self.notifier_for(&id).notified().await;
+                    notified.await;
                     continue;
                 }
                 [Event::RunFreshnessCheck { .. }] => {

--- a/agentmux-srv/src/broker/scheduler.rs
+++ b/agentmux-srv/src/broker/scheduler.rs
@@ -17,11 +17,17 @@
 //!    production issues from exactly this failure mode (concurrent CLI
 //!    sessions racing to refresh a shared credentials file with no lock).
 //!    `ensure_fresh` collapses concurrent callers for the same id onto one
-//!    in-flight refresh via a per-id async mutex with a double-checked
-//!    freshness read after acquiring it.
+//!    in-flight refresh.
 //! 2. **Reactive-only refresh.** `run_sweep_loop` proactively walks every
 //!    registered credential on a timer instead of only refreshing when
 //!    something happens to ask for one.
+//!
+//! Coordination state (fresh / refreshing / failed / needs-reauth) is owned
+//! by the pure reducer in `super::state` — this module is a thin async
+//! orchestrator: dispatch a command, execute whatever the returned events
+//! say to do (call `is_fresh()`/`refresh()`), dispatch the result back in.
+//! Same split as every other reducer in this codebase (e.g. `agentmux-cef`'s
+//! host reducer emitting `HostEvent::Effect` for `AppState` to execute).
 //!
 //! Preserve-on-failure (never overwrite a valid stored credential with a
 //! failed/partial refresh result) is NOT enforced here — it's the
@@ -31,21 +37,30 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, Notify};
+
+use super::state::{self, Command, CredentialState, Event, RefreshErrorKind};
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-struct Entry {
+struct RegisteredClosures {
     is_fresh: Box<dyn Fn() -> BoxFuture<'static, bool> + Send + Sync>,
-    refresh: Box<dyn Fn() -> BoxFuture<'static, Result<(), String>> + Send + Sync>,
-    lock: Arc<AsyncMutex<()>>,
+    refresh: Box<dyn Fn() -> BoxFuture<'static, Result<(), RefreshErrorKind>> + Send + Sync>,
 }
 
 pub struct RefreshScheduler {
-    entries: AsyncMutex<HashMap<String, Arc<Entry>>>,
+    closures: AsyncMutex<HashMap<String, Arc<RegisteredClosures>>>,
+    // Reducer-owned coordination state. std::sync::Mutex, not AsyncMutex —
+    // the reducer never awaits, every hold is sub-millisecond, matching the
+    // discipline every other reducer in this codebase follows.
+    states: Mutex<HashMap<String, CredentialState>>,
+    // Per-id wake signal for concurrent `ensure_fresh` callers waiting on an
+    // in-flight check/refresh (the reducer decides single-flight; this just
+    // wakes waiters once that decision resolves).
+    notifiers: Mutex<HashMap<String, Arc<Notify>>>,
 }
 
 impl Default for RefreshScheduler {
@@ -56,78 +71,216 @@ impl Default for RefreshScheduler {
 
 impl RefreshScheduler {
     pub fn new() -> Self {
-        Self { entries: AsyncMutex::new(HashMap::new()) }
+        Self {
+            closures: AsyncMutex::new(HashMap::new()),
+            states: Mutex::new(HashMap::new()),
+            notifiers: Mutex::new(HashMap::new()),
+        }
     }
 
     /// Register (or replace) a credential for proactive management.
-    /// `is_fresh` must be side-effect-free (called under the per-id lock on
-    /// every `ensure_fresh`/sweep tick) — async so a caller whose freshness
-    /// check needs a blocking read (e.g. an OS keychain call, which can hang
-    /// on a slow/unresponsive Secret Service D-Bus daemon on headless Linux)
-    /// can route it through `tokio::task::spawn_blocking` instead of
-    /// stalling the tokio worker thread this scheduler's own async tasks
-    /// run on (reagent P1 on #2260). `refresh` performs the actual refresh
-    /// and is responsible for persisting the result itself (and for NOT
-    /// persisting anything on failure).
+    /// `is_fresh` must be side-effect-free (may be called on every
+    /// `ensure_fresh`/sweep tick) — async so a caller whose freshness check
+    /// needs a blocking read (e.g. an OS keychain call, which can hang on a
+    /// slow/unresponsive Secret Service D-Bus daemon on headless Linux) can
+    /// route it through `tokio::task::spawn_blocking` instead of stalling
+    /// the tokio worker thread this scheduler's own async tasks run on
+    /// (reagent P1 on #2260). `refresh` performs the actual refresh and is
+    /// responsible for persisting the result itself (and for NOT persisting
+    /// anything on failure) — and for classifying a failure as
+    /// `RefreshErrorKind::Transient` (worth retrying) vs
+    /// `::PermanentAuthFailure` (the credential itself is rejected; only a
+    /// fresh login can fix it — see that type's own doc comment).
     pub async fn register(
         &self,
         credential_id: impl Into<String>,
         is_fresh: impl Fn() -> BoxFuture<'static, bool> + Send + Sync + 'static,
-        refresh: impl Fn() -> BoxFuture<'static, Result<(), String>> + Send + Sync + 'static,
+        refresh: impl Fn() -> BoxFuture<'static, Result<(), RefreshErrorKind>> + Send + Sync + 'static,
     ) {
-        let mut entries = self.entries.lock().await;
-        entries.insert(
-            credential_id.into(),
-            Arc::new(Entry {
-                is_fresh: Box::new(is_fresh),
-                refresh: Box::new(refresh),
-                lock: Arc::new(AsyncMutex::new(())),
-            }),
-        );
+        let id: String = credential_id.into();
+        {
+            let mut closures = self.closures.lock().await;
+            closures.insert(
+                id.clone(),
+                Arc::new(RegisteredClosures {
+                    is_fresh: Box::new(is_fresh),
+                    refresh: Box::new(refresh),
+                }),
+            );
+        }
+        {
+            let mut states = self.states.lock().unwrap();
+            state::update(&mut states, Command::Register { id: id.clone() });
+        }
+        self.notifiers
+            .lock()
+            .unwrap()
+            .entry(id)
+            .or_insert_with(|| Arc::new(Notify::new()));
     }
 
     pub async fn unregister(&self, credential_id: &str) {
-        self.entries.lock().await.remove(credential_id);
+        self.closures.lock().await.remove(credential_id);
+        let mut states = self.states.lock().unwrap();
+        state::update(&mut states, Command::Unregister { id: credential_id.to_string() });
+    }
+
+    /// The credential's current coordination state, if registered —
+    /// diagnostics/future-UI hook (e.g. surfacing `NeedsReauth` distinctly
+    /// from a routine in-progress refresh). Not used by `ensure_fresh`
+    /// itself, which always dispatches through the reducer regardless.
+    pub fn state(&self, credential_id: &str) -> Option<CredentialState> {
+        self.states.lock().unwrap().get(credential_id).cloned()
     }
 
     /// Ensure `credential_id` is fresh, single-flight-guarded. If another
     /// caller is already mid-refresh for this id, this waits for that
-    /// refresh's lock to release, then re-checks freshness rather than
-    /// starting a second refresh. Returns `Err` if the id was never
-    /// registered.
+    /// attempt to finish, then re-checks freshness rather than starting a
+    /// second refresh. Returns `Err` if the id was never registered.
     pub async fn ensure_fresh(&self, credential_id: &str) -> Result<(), String> {
-        let entry = {
-            let entries = self.entries.lock().await;
-            entries
-                .get(credential_id)
-                .cloned()
-                .ok_or_else(|| format!("no credential registered as '{credential_id}'"))?
-        };
-        let _guard = entry.lock.lock().await;
-        // Double-checked: another caller may have refreshed this credential
-        // while we were waiting for the lock above.
-        if (entry.is_fresh)().await {
-            return Ok(());
+        let id = credential_id.to_string();
+        loop {
+            let events = {
+                let mut states = self.states.lock().unwrap();
+                state::update(&mut states, Command::CheckRequested { id: id.clone() })
+            };
+            match events.as_slice() {
+                [Event::Unregistered { .. }] => {
+                    return Err(format!("no credential registered as '{id}'"));
+                }
+                [Event::AlreadyInFlight { .. }] => {
+                    self.notifier_for(&id).notified().await;
+                    continue;
+                }
+                [Event::RunFreshnessCheck { .. }] => {
+                    let Some(closures) = self.closures.lock().await.get(&id).cloned() else {
+                        // Unregistered concurrently between the dispatch
+                        // above and this lookup.
+                        return Err(format!("no credential registered as '{id}'"));
+                    };
+                    let is_fresh = (closures.is_fresh)().await;
+                    let events = {
+                        let mut states = self.states.lock().unwrap();
+                        state::update(&mut states, Command::FreshnessChecked { id: id.clone(), is_fresh })
+                    };
+                    self.trace(&events);
+                    if is_fresh {
+                        self.wake(&id);
+                        return Ok(());
+                    }
+                    debug_assert!(matches!(events.as_slice(), [Event::RunRefresh { .. }]));
+                    let result = (closures.refresh)().await;
+                    let (msg, cmd) = match result {
+                        Ok(()) => (None, Command::RefreshSucceeded { id: id.clone() }),
+                        Err(error) => {
+                            let msg = match &error {
+                                RefreshErrorKind::Transient(m) | RefreshErrorKind::PermanentAuthFailure(m) => {
+                                    m.clone()
+                                }
+                            };
+                            (Some(msg), Command::RefreshFailed { id: id.clone(), error })
+                        }
+                    };
+                    let events = {
+                        let mut states = self.states.lock().unwrap();
+                        state::update(&mut states, cmd)
+                    };
+                    self.trace(&events);
+                    self.wake(&id);
+                    return match msg {
+                        None => Ok(()),
+                        Some(m) => Err(m),
+                    };
+                }
+                other => unreachable!("unexpected reducer events for CheckRequested: {other:?}"),
+            }
         }
-        (entry.refresh)().await
     }
 
     /// Background sweep — checks every registered credential every
-    /// `interval` and proactively refreshes anything stale. Spawn once via
-    /// `tokio::spawn`; runs until the process exits.
+    /// `interval` and proactively refreshes anything stale. Skips entries
+    /// currently `NeedsReauth`: retrying a credential already known to
+    /// require a fresh human login is pointless and just hammers the
+    /// backing server; `ensure_fresh` called on-demand still re-checks
+    /// those (see `state`'s own doc comment). Spawn once via `tokio::spawn`;
+    /// runs until the process exits.
     pub async fn run_sweep_loop(self: Arc<Self>, interval: Duration) {
         let mut tick = tokio::time::interval(interval);
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             tick.tick().await;
             let ids: Vec<String> = {
-                let entries = self.entries.lock().await;
-                entries.keys().cloned().collect()
+                let closures = self.closures.lock().await;
+                closures.keys().cloned().collect()
             };
             for id in ids {
+                let needs_reauth = matches!(
+                    self.states.lock().unwrap().get(&id),
+                    Some(CredentialState::NeedsReauth { .. })
+                );
+                if needs_reauth {
+                    continue;
+                }
                 if let Err(e) = self.ensure_fresh(&id).await {
                     tracing::warn!(credential_id = %id, error = %e, "broker: proactive refresh failed");
                 }
+            }
+        }
+    }
+
+    fn notifier_for(&self, id: &str) -> Arc<Notify> {
+        self.notifiers
+            .lock()
+            .unwrap()
+            .entry(id.to_string())
+            .or_insert_with(|| Arc::new(Notify::new()))
+            .clone()
+    }
+
+    fn wake(&self, id: &str) {
+        if let Some(n) = self.notifiers.lock().unwrap().get(id) {
+            n.notify_waiters();
+        }
+    }
+
+    /// Map diagnostics-only reducer events to `tracing` — `auth.broker.*`
+    /// message prefixes land in `muxlog auth`'s existing filter regex
+    /// (`\bauth\.\w+|...`) with zero changes needed there. Control-flow
+    /// events (`RunFreshnessCheck`/`RunRefresh`/`AlreadyInFlight`/
+    /// `Unregistered`) are acted on directly by callers and not
+    /// double-logged here — every `ensure_fresh` call would otherwise emit
+    /// noise even when nothing changed.
+    fn trace(&self, events: &[Event]) {
+        for event in events {
+            match event {
+                Event::BecameFresh { id } => {
+                    tracing::info!(target: "identity", credential_id = %id, "auth.broker.fresh: credential is fresh");
+                }
+                Event::BecameFailed {
+                    id,
+                    consecutive_failures,
+                    error,
+                } => {
+                    tracing::warn!(
+                        target: "identity",
+                        credential_id = %id,
+                        consecutive_failures,
+                        error = %error,
+                        "auth.broker.failed: refresh attempt failed, will retry"
+                    );
+                }
+                Event::BecameNeedsReauth { id, reason } => {
+                    tracing::warn!(
+                        target: "identity",
+                        credential_id = %id,
+                        reason = %reason,
+                        "auth.broker.needs_reauth: credential needs a fresh login, no longer auto-retrying"
+                    );
+                }
+                Event::RunFreshnessCheck { .. }
+                | Event::RunRefresh { .. }
+                | Event::AlreadyInFlight { .. }
+                | Event::Unregistered { .. } => {}
             }
         }
     }
@@ -185,6 +338,7 @@ mod tests {
             1,
             "10 concurrent callers for the same credential must collapse onto exactly one refresh"
         );
+        assert_eq!(scheduler.state("test:cred"), Some(CredentialState::Fresh));
     }
 
     #[tokio::test]
@@ -218,7 +372,13 @@ mod tests {
             .register(
                 "test:cred",
                 || Box::pin(async { false }), // never becomes fresh in this test — refresh always fails
-                || Box::pin(async { Err("simulated refresh failure".to_string()) }),
+                || {
+                    Box::pin(async {
+                        Err(RefreshErrorKind::Transient(
+                            "simulated refresh failure".to_string(),
+                        ))
+                    })
+                },
             )
             .await;
 
@@ -228,6 +388,10 @@ mod tests {
         // failed attempt as having succeeded).
         let result2 = scheduler.ensure_fresh("test:cred").await;
         assert!(result2.is_err());
+        assert!(matches!(
+            scheduler.state("test:cred"),
+            Some(CredentialState::Failed { consecutive_failures: 2, .. })
+        ));
     }
 
     #[tokio::test]
@@ -235,5 +399,100 @@ mod tests {
         let scheduler = RefreshScheduler::new();
         let result = scheduler.ensure_fresh("nope").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn permanent_auth_failure_stops_the_sweep_loop_retrying_but_ensure_fresh_still_rechecks() {
+        let scheduler = Arc::new(RefreshScheduler::new());
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let calls = refresh_calls.clone();
+        scheduler
+            .register(
+                "test:cred",
+                || Box::pin(async { false }),
+                move || {
+                    let calls = calls.clone();
+                    Box::pin(async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Err(RefreshErrorKind::PermanentAuthFailure("invalid_grant".into()))
+                    })
+                },
+            )
+            .await;
+
+        assert!(scheduler.ensure_fresh("test:cred").await.is_err());
+        assert!(matches!(
+            scheduler.state("test:cred"),
+            Some(CredentialState::NeedsReauth { .. })
+        ));
+
+        // An on-demand ensure_fresh call still re-attempts (a human may
+        // have logged in again out-of-band) — this is call #2.
+        assert!(scheduler.ensure_fresh("test:cred").await.is_err());
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn re_registering_a_credential_mid_refresh_does_not_orphan_a_waiting_second_caller() {
+        // Pre-refactor latent race: register() on an already-registered id
+        // replaced the Entry (including its per-id lock), so a SECOND
+        // caller already blocked waiting on the OLD entry's lock waited
+        // forever — the replacement entry's lock was a different object
+        // nothing would ever signal for that waiter. Here, single-flight is
+        // reducer-state-driven and waiting goes through a per-id Notify
+        // that `register()` never replaces (only ensures exists), so a
+        // second caller that observed AlreadyInFlight is woken regardless
+        // of a concurrent re-register.
+        let scheduler = Arc::new(RefreshScheduler::new());
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_wait = gate.clone();
+        scheduler
+            .register(
+                "test:cred",
+                || Box::pin(async { false }),
+                move || {
+                    let gate_wait = gate_wait.clone();
+                    Box::pin(async move {
+                        gate_wait.notified().await;
+                        Ok(())
+                    })
+                },
+            )
+            .await;
+
+        let s1 = scheduler.clone();
+        let first = tokio::spawn(async move { s1.ensure_fresh("test:cred").await });
+        // Give the first call time to reach the gated refresh closure and
+        // land the credential in `Refreshing`.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            scheduler.state("test:cred"),
+            Some(CredentialState::Refreshing { prior_failures: 0 })
+        );
+
+        // A second caller now dispatches while still Refreshing — gets
+        // AlreadyInFlight and waits on the id's Notify.
+        let s2 = scheduler.clone();
+        let second = tokio::spawn(async move { s2.ensure_fresh("test:cred").await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!second.is_finished(), "second caller must be waiting, not returned yet");
+
+        // Re-register while BOTH the first call is gated inside `refresh`
+        // AND the second call is waiting on AlreadyInFlight.
+        scheduler
+            .register("test:cred", || Box::pin(async { true }), || Box::pin(async { Ok(()) }))
+            .await;
+
+        gate.notify_waiters();
+        let first_result = tokio::time::timeout(Duration::from_secs(2), first)
+            .await
+            .expect("first caller must not hang after a concurrent re-register")
+            .unwrap();
+        assert!(first_result.is_ok());
+        let second_result = tokio::time::timeout(Duration::from_secs(2), second)
+            .await
+            .expect("second (waiting) caller must not be orphaned by a concurrent re-register")
+            .unwrap();
+        assert!(second_result.is_ok());
     }
 }

--- a/agentmux-srv/src/broker/scheduler.rs
+++ b/agentmux-srv/src/broker/scheduler.rs
@@ -51,12 +51,22 @@ struct RegisteredClosures {
     refresh: Box<dyn Fn() -> BoxFuture<'static, Result<(), RefreshErrorKind>> + Send + Sync>,
 }
 
+// Bundled behind ONE mutex (not two) so a `states`/`generations` pair is
+// always read and written atomically — the reducer needs both together to
+// tell a stale, superseded-registration completion apart from a current one
+// (see `state::Event::RunFreshnessCheck`'s doc comment).
+#[derive(Default)]
+struct ReducerTables {
+    states: HashMap<String, CredentialState>,
+    generations: HashMap<String, u64>,
+}
+
 pub struct RefreshScheduler {
     closures: AsyncMutex<HashMap<String, Arc<RegisteredClosures>>>,
     // Reducer-owned coordination state. std::sync::Mutex, not AsyncMutex —
     // the reducer never awaits, every hold is sub-millisecond, matching the
     // discipline every other reducer in this codebase follows.
-    states: Mutex<HashMap<String, CredentialState>>,
+    tables: Mutex<ReducerTables>,
     // Per-id wake signal for concurrent `ensure_fresh` callers waiting on an
     // in-flight check/refresh (the reducer decides single-flight; this just
     // wakes waiters once that decision resolves).
@@ -73,7 +83,7 @@ impl RefreshScheduler {
     pub fn new() -> Self {
         Self {
             closures: AsyncMutex::new(HashMap::new()),
-            states: Mutex::new(HashMap::new()),
+            tables: Mutex::new(ReducerTables::default()),
             notifiers: Mutex::new(HashMap::new()),
         }
     }
@@ -109,8 +119,9 @@ impl RefreshScheduler {
             );
         }
         {
-            let mut states = self.states.lock().unwrap();
-            state::update(&mut states, Command::Register { id: id.clone() });
+            let mut tables = self.tables.lock().unwrap();
+            let ReducerTables { states, generations } = &mut *tables;
+            state::update(states, generations, Command::Register { id: id.clone() });
         }
         self.notifiers
             .lock()
@@ -122,8 +133,13 @@ impl RefreshScheduler {
     pub async fn unregister(&self, credential_id: &str) {
         self.closures.lock().await.remove(credential_id);
         let events = {
-            let mut states = self.states.lock().unwrap();
-            state::update(&mut states, Command::Unregister { id: credential_id.to_string() })
+            let mut tables = self.tables.lock().unwrap();
+            let ReducerTables { states, generations } = &mut *tables;
+            state::update(
+                states,
+                generations,
+                Command::Unregister { id: credential_id.to_string() },
+            )
         };
         self.trace(&events);
         // A caller elsewhere may be parked on notified().await after seeing
@@ -137,7 +153,7 @@ impl RefreshScheduler {
     /// from a routine in-progress refresh). Not used by `ensure_fresh`
     /// itself, which always dispatches through the reducer regardless.
     pub fn state(&self, credential_id: &str) -> Option<CredentialState> {
-        self.states.lock().unwrap().get(credential_id).cloned()
+        self.tables.lock().unwrap().states.get(credential_id).cloned()
     }
 
     /// Ensure `credential_id` is fresh, single-flight-guarded. If another
@@ -161,8 +177,9 @@ impl RefreshScheduler {
             let notified = notify.notified();
 
             let events = {
-                let mut states = self.states.lock().unwrap();
-                state::update(&mut states, Command::CheckRequested { id: id.clone() })
+                let mut tables = self.tables.lock().unwrap();
+                let ReducerTables { states, generations } = &mut *tables;
+                state::update(states, generations, Command::CheckRequested { id: id.clone() })
             };
             match events.as_slice() {
                 [Event::Unregistered { .. }] => {
@@ -172,7 +189,8 @@ impl RefreshScheduler {
                     notified.await;
                     continue;
                 }
-                [Event::RunFreshnessCheck { .. }] => {
+                [Event::RunFreshnessCheck { generation, .. }] => {
+                    let generation = *generation;
                     let Some(closures) = self.closures.lock().await.get(&id).cloned() else {
                         // Unregistered concurrently between the dispatch
                         // above and this lookup. Wake any other caller
@@ -185,30 +203,45 @@ impl RefreshScheduler {
                     };
                     let is_fresh = (closures.is_fresh)().await;
                     let events = {
-                        let mut states = self.states.lock().unwrap();
-                        state::update(&mut states, Command::FreshnessChecked { id: id.clone(), is_fresh })
+                        let mut tables = self.tables.lock().unwrap();
+                        let ReducerTables { states, generations } = &mut *tables;
+                        state::update(
+                            states,
+                            generations,
+                            Command::FreshnessChecked { id: id.clone(), is_fresh, generation },
+                        )
                     };
                     self.trace(&events);
                     if is_fresh {
                         self.wake(&id);
                         return Ok(());
                     }
-                    debug_assert!(matches!(events.as_slice(), [Event::RunRefresh { .. }]));
+                    // events is normally [RunRefresh{..}], but can be empty
+                    // if this completion lost a race with a concurrent
+                    // register()/unregister() — the reducer discards a
+                    // stale-epoch result rather than let it clobber newer
+                    // state (see state::Event::RunFreshnessCheck's doc
+                    // comment). Either way THIS caller still proceeds with
+                    // its own refresh using its own already-captured
+                    // closures; its return value reflects what it actually
+                    // observed regardless of whether the broker's shared
+                    // state accepted the transition.
                     let result = (closures.refresh)().await;
                     let (msg, cmd) = match result {
-                        Ok(()) => (None, Command::RefreshSucceeded { id: id.clone() }),
+                        Ok(()) => (None, Command::RefreshSucceeded { id: id.clone(), generation }),
                         Err(error) => {
                             let msg = match &error {
                                 RefreshErrorKind::Transient(m) | RefreshErrorKind::PermanentAuthFailure(m) => {
                                     m.clone()
                                 }
                             };
-                            (Some(msg), Command::RefreshFailed { id: id.clone(), error })
+                            (Some(msg), Command::RefreshFailed { id: id.clone(), error, generation })
                         }
                     };
                     let events = {
-                        let mut states = self.states.lock().unwrap();
-                        state::update(&mut states, cmd)
+                        let mut tables = self.tables.lock().unwrap();
+                        let ReducerTables { states, generations } = &mut *tables;
+                        state::update(states, generations, cmd)
                     };
                     self.trace(&events);
                     self.wake(&id);
@@ -240,7 +273,7 @@ impl RefreshScheduler {
             };
             for id in ids {
                 let needs_reauth = matches!(
-                    self.states.lock().unwrap().get(&id),
+                    self.tables.lock().unwrap().states.get(&id),
                     Some(CredentialState::NeedsReauth { .. })
                 );
                 if needs_reauth {

--- a/agentmux-srv/src/broker/scheduler.rs
+++ b/agentmux-srv/src/broker/scheduler.rs
@@ -51,14 +51,15 @@ struct RegisteredClosures {
     refresh: Box<dyn Fn() -> BoxFuture<'static, Result<(), RefreshErrorKind>> + Send + Sync>,
 }
 
-// Bundled behind ONE mutex (not two) so a `states`/`generations` pair is
-// always read and written atomically — the reducer needs both together to
-// tell a stale, superseded-registration completion apart from a current one
-// (see `state::Event::RunFreshnessCheck`'s doc comment).
+// Bundled behind ONE mutex (not three) so `states`/`generations`/
+// `next_generation` are always read and written atomically — the reducer
+// needs all three together to tell a stale, superseded-registration
+// completion apart from a current one (see `state::update`'s doc comment).
 #[derive(Default)]
 struct ReducerTables {
     states: HashMap<String, CredentialState>,
     generations: HashMap<String, u64>,
+    next_generation: u64,
 }
 
 pub struct RefreshScheduler {
@@ -120,8 +121,8 @@ impl RefreshScheduler {
         }
         {
             let mut tables = self.tables.lock().unwrap();
-            let ReducerTables { states, generations } = &mut *tables;
-            state::update(states, generations, Command::Register { id: id.clone() });
+            let ReducerTables { states, generations, next_generation } = &mut *tables;
+            state::update(states, generations, next_generation, Command::Register { id: id.clone() });
         }
         self.notifiers
             .lock()
@@ -134,10 +135,11 @@ impl RefreshScheduler {
         self.closures.lock().await.remove(credential_id);
         let events = {
             let mut tables = self.tables.lock().unwrap();
-            let ReducerTables { states, generations } = &mut *tables;
+            let ReducerTables { states, generations, next_generation } = &mut *tables;
             state::update(
                 states,
                 generations,
+                next_generation,
                 Command::Unregister { id: credential_id.to_string() },
             )
         };
@@ -178,8 +180,8 @@ impl RefreshScheduler {
 
             let events = {
                 let mut tables = self.tables.lock().unwrap();
-                let ReducerTables { states, generations } = &mut *tables;
-                state::update(states, generations, Command::CheckRequested { id: id.clone() })
+                let ReducerTables { states, generations, next_generation } = &mut *tables;
+                state::update(states, generations, next_generation, Command::CheckRequested { id: id.clone() })
             };
             match events.as_slice() {
                 [Event::Unregistered { .. }] => {
@@ -204,10 +206,11 @@ impl RefreshScheduler {
                     let is_fresh = (closures.is_fresh)().await;
                     let events = {
                         let mut tables = self.tables.lock().unwrap();
-                        let ReducerTables { states, generations } = &mut *tables;
+                        let ReducerTables { states, generations, next_generation } = &mut *tables;
                         state::update(
                             states,
                             generations,
+                            next_generation,
                             Command::FreshnessChecked { id: id.clone(), is_fresh, generation },
                         )
                     };
@@ -240,8 +243,8 @@ impl RefreshScheduler {
                     };
                     let events = {
                         let mut tables = self.tables.lock().unwrap();
-                        let ReducerTables { states, generations } = &mut *tables;
-                        state::update(states, generations, cmd)
+                        let ReducerTables { states, generations, next_generation } = &mut *tables;
+                        state::update(states, generations, next_generation, cmd)
                     };
                     self.trace(&events);
                     self.wake(&id);

--- a/agentmux-srv/src/broker/scheduler.rs
+++ b/agentmux-srv/src/broker/scheduler.rs
@@ -121,8 +121,15 @@ impl RefreshScheduler {
 
     pub async fn unregister(&self, credential_id: &str) {
         self.closures.lock().await.remove(credential_id);
-        let mut states = self.states.lock().unwrap();
-        state::update(&mut states, Command::Unregister { id: credential_id.to_string() });
+        let events = {
+            let mut states = self.states.lock().unwrap();
+            state::update(&mut states, Command::Unregister { id: credential_id.to_string() })
+        };
+        self.trace(&events);
+        // A caller elsewhere may be parked on notified().await after seeing
+        // AlreadyInFlight for this id; nothing else will ever wake it once
+        // the entry is gone (reagent re-review on #2275).
+        self.wake(credential_id);
     }
 
     /// The credential's current coordination state, if registered —
@@ -168,7 +175,12 @@ impl RefreshScheduler {
                 [Event::RunFreshnessCheck { .. }] => {
                     let Some(closures) = self.closures.lock().await.get(&id).cloned() else {
                         // Unregistered concurrently between the dispatch
-                        // above and this lookup.
+                        // above and this lookup. Wake any other caller
+                        // parked on AlreadyInFlight for this id — this path
+                        // owns the only Refreshing state that existed for
+                        // it, so nothing else will ever notify them
+                        // (reagent re-review on #2275).
+                        self.wake(&id);
                         return Err(format!("no credential registered as '{id}'"));
                     };
                     let is_fresh = (closures.is_fresh)().await;
@@ -507,5 +519,61 @@ mod tests {
             .expect("second (waiting) caller must not be orphaned by a concurrent re-register")
             .unwrap();
         assert!(second_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn unregistering_a_credential_mid_refresh_wakes_a_waiting_second_caller() {
+        // reagent re-review on #2275: unregister() dispatched
+        // Command::Unregister without ever calling wake(), so a second
+        // caller already parked on AlreadyInFlight's notified().await for
+        // this id would hang forever once the entry was gone — nothing else
+        // was ever going to notify it.
+        let scheduler = Arc::new(RefreshScheduler::new());
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_wait = gate.clone();
+        scheduler
+            .register(
+                "test:cred",
+                || Box::pin(async { false }),
+                move || {
+                    let gate_wait = gate_wait.clone();
+                    Box::pin(async move {
+                        gate_wait.notified().await;
+                        Ok(())
+                    })
+                },
+            )
+            .await;
+
+        let s1 = scheduler.clone();
+        let first = tokio::spawn(async move { s1.ensure_fresh("test:cred").await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            scheduler.state("test:cred"),
+            Some(CredentialState::Refreshing { prior_failures: 0 })
+        );
+
+        let s2 = scheduler.clone();
+        let second = tokio::spawn(async move { s2.ensure_fresh("test:cred").await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!second.is_finished(), "second caller must be waiting, not returned yet");
+
+        // Unregister while BOTH the first call is gated inside `refresh` AND
+        // the second call is waiting on AlreadyInFlight.
+        scheduler.unregister("test:cred").await;
+
+        let second_result = tokio::time::timeout(Duration::from_secs(2), second)
+            .await
+            .expect("second (waiting) caller must not hang after a concurrent unregister")
+            .unwrap();
+        assert!(
+            second_result.is_err(),
+            "credential is gone — the woken caller should see it as unregistered"
+        );
+
+        // Release the gate so the orphaned first call's own refresh
+        // resolves and its spawned task doesn't leak past the test.
+        gate.notify_waiters();
+        let _ = tokio::time::timeout(Duration::from_secs(2), first).await;
     }
 }

--- a/agentmux-srv/src/broker/state.rs
+++ b/agentmux-srv/src/broker/state.rs
@@ -86,17 +86,39 @@ pub enum Command {
     /// is fresh.
     CheckRequested { id: String },
     /// The orchestrator ran `is_fresh()` and is reporting the result.
-    FreshnessChecked { id: String, is_fresh: bool },
-    RefreshSucceeded { id: String },
-    RefreshFailed { id: String, error: RefreshErrorKind },
+    /// `generation` is the value from the `RunFreshnessCheck` event that
+    /// triggered this call — see `Event::RunFreshnessCheck`'s doc comment.
+    FreshnessChecked {
+        id: String,
+        is_fresh: bool,
+        generation: u64,
+    },
+    /// `generation` carried forward from the `RunRefresh` event that
+    /// triggered this call.
+    RefreshSucceeded { id: String, generation: u64 },
+    RefreshFailed {
+        id: String,
+        error: RefreshErrorKind,
+        generation: u64,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
     /// Orchestrator should call the registered `is_fresh()` closure now.
-    RunFreshnessCheck { id: String },
+    /// `generation` is this id's registration epoch at dispatch time — the
+    /// orchestrator must echo it back unchanged in the resulting
+    /// `Command::FreshnessChecked` (and, if a refresh follows, in
+    /// `RefreshSucceeded`/`RefreshFailed` too). This lets the reducer detect
+    /// a stale completion: if `register()` replaces this id's closures
+    /// (bumping its generation) while `is_fresh()`/`refresh()` is still
+    /// awaiting, the eventual result would otherwise silently clobber the
+    /// freshly re-registered credential's state with a verdict about
+    /// closures that no longer apply (reagent re-review on #2275).
+    RunFreshnessCheck { id: String, generation: u64 },
     /// Orchestrator should call the registered `refresh()` closure now.
-    RunRefresh { id: String },
+    /// `generation` carries the same epoch forward from `RunFreshnessCheck`.
+    RunRefresh { id: String, generation: u64 },
     /// Another caller is already checking/refreshing this id — the
     /// orchestrator should wait on the id's `Notify` and re-dispatch
     /// `CheckRequested` once woken.
@@ -120,9 +142,16 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
-/// `states` is the orchestrator's whole coordination table — one reducer
+/// `states` is the orchestrator's whole coordination table; `generations`
+/// tracks each id's registration epoch (bumped on every `Register`) so a
+/// completion from a superseded registration can be told apart from a
+/// current one — see `Event::RunFreshnessCheck`'s doc comment. One reducer
 /// call per dispatched command, sub-millisecond, never awaits.
-pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Vec<Event> {
+pub fn update(
+    states: &mut HashMap<String, CredentialState>,
+    generations: &mut HashMap<String, u64>,
+    cmd: Command,
+) -> Vec<Event> {
     match cmd {
         Command::Register { id } => {
             // Replacing an already-registered id is safe here specifically
@@ -130,11 +159,15 @@ pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Ve
             // not by an external lock a caller could be left blocked on
             // (the pre-refactor design's latent race). A caller currently
             // waiting via AlreadyInFlight re-dispatches CheckRequested once
-            // woken and just sees the fresh entry's is_fresh() result.
+            // woken and just sees the fresh entry's is_fresh() result. The
+            // generation bump is what lets a stale in-flight completion from
+            // the OLD registration be told apart from this new one.
+            *generations.entry(id.clone()).or_insert(0) += 1;
             states.insert(id, CredentialState::Fresh);
             Vec::new()
         }
         Command::Unregister { id } => {
+            generations.remove(&id);
             states.remove(&id);
             vec![Event::Unregistered { id }]
         }
@@ -156,16 +189,21 @@ pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Ve
                     CredentialState::Refreshing { .. } => unreachable!("matched above"),
                 };
                 states.insert(id.clone(), CredentialState::Refreshing { prior_failures });
-                vec![Event::RunFreshnessCheck { id }]
+                let generation = *generations.get(&id).unwrap_or(&0);
+                vec![Event::RunFreshnessCheck { id, generation }]
             }
         },
-        Command::FreshnessChecked { id, is_fresh } => {
-            if !states.contains_key(&id) {
-                // Unregistered while this in-flight check's is_fresh() was
-                // still awaiting — don't resurrect a phantom entry for a
-                // credential nothing still owns; the sweep loop only walks
-                // registered closures, so a resurrected entry would leak
-                // forever (reagent re-review on #2275).
+        Command::FreshnessChecked {
+            id,
+            is_fresh,
+            generation,
+        } => {
+            if generations.get(&id).copied() != Some(generation) {
+                // Stale completion: id was unregistered (generation gone)
+                // or re-registered (generation bumped) while is_fresh() was
+                // still awaiting. Either way this result is about closures
+                // that no longer apply — discard it rather than clobber the
+                // current epoch's state (reagent re-review on #2275).
                 return Vec::new();
             }
             if is_fresh {
@@ -178,20 +216,24 @@ pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Ve
                 }
             } else {
                 // Stays Refreshing — orchestrator now runs the actual refresh.
-                vec![Event::RunRefresh { id }]
+                vec![Event::RunRefresh { id, generation }]
             }
         }
-        Command::RefreshSucceeded { id } => {
-            if !states.contains_key(&id) {
-                // Same phantom-entry hazard as FreshnessChecked above.
+        Command::RefreshSucceeded { id, generation } => {
+            if generations.get(&id).copied() != Some(generation) {
+                // Same stale-epoch hazard as FreshnessChecked above.
                 return Vec::new();
             }
             states.insert(id.clone(), CredentialState::Fresh);
             vec![Event::BecameFresh { id }]
         }
-        Command::RefreshFailed { id, error } => {
-            if !states.contains_key(&id) {
-                // Same phantom-entry hazard as FreshnessChecked above.
+        Command::RefreshFailed {
+            id,
+            error,
+            generation,
+        } => {
+            if generations.get(&id).copied() != Some(generation) {
+                // Same stale-epoch hazard as FreshnessChecked above.
                 return Vec::new();
             }
             let reason = error.message().to_string();
@@ -232,10 +274,38 @@ pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Ve
 mod tests {
     use super::*;
 
-    fn registered() -> HashMap<String, CredentialState> {
-        let mut m = HashMap::new();
-        update(&mut m, Command::Register { id: "cred".into() });
-        m
+    /// Bundles `states` + `generations` so tests can dispatch commands
+    /// without threading two maps through every call site by hand.
+    struct Harness {
+        states: HashMap<String, CredentialState>,
+        generations: HashMap<String, u64>,
+    }
+
+    impl Harness {
+        fn dispatch(&mut self, cmd: Command) -> Vec<Event> {
+            update(&mut self.states, &mut self.generations, cmd)
+        }
+
+        fn get(&self, id: &str) -> Option<&CredentialState> {
+            self.states.get(id)
+        }
+
+        fn contains_key(&self, id: &str) -> bool {
+            self.states.contains_key(id)
+        }
+
+        fn generation_of(&self, id: &str) -> u64 {
+            *self.generations.get(id).expect("id should be registered")
+        }
+    }
+
+    fn registered() -> Harness {
+        let mut h = Harness {
+            states: HashMap::new(),
+            generations: HashMap::new(),
+        };
+        h.dispatch(Command::Register { id: "cred".into() });
+        h
     }
 
     #[test]
@@ -247,8 +317,15 @@ mod tests {
     #[test]
     fn check_on_fresh_transitions_to_refreshing_and_requests_a_check() {
         let mut m = registered();
-        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
-        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+        let gen = m.generation_of("cred");
+        let events = m.dispatch(Command::CheckRequested { id: "cred".into() });
+        assert_eq!(
+            events,
+            vec![Event::RunFreshnessCheck {
+                id: "cred".into(),
+                generation: gen
+            }]
+        );
         assert_eq!(
             m.get("cred"),
             Some(&CredentialState::Refreshing { prior_failures: 0 })
@@ -258,8 +335,8 @@ mod tests {
     #[test]
     fn a_second_check_while_refreshing_gets_already_in_flight_not_a_second_run() {
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::CheckRequested { id: "cred".into() });
         assert_eq!(events, vec![Event::AlreadyInFlight { id: "cred".into() }]);
         // Still just one credential, still Refreshing — the second dispatch
         // did not disturb the in-flight state.
@@ -272,14 +349,13 @@ mod tests {
     #[test]
     fn freshness_checked_true_returns_to_fresh_and_reports_became_fresh() {
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(
-            &mut m,
-            Command::FreshnessChecked {
-                id: "cred".into(),
-                is_fresh: true,
-            },
-        );
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::FreshnessChecked {
+            id: "cred".into(),
+            is_fresh: true,
+            generation: gen,
+        });
         assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
         assert_eq!(events, vec![Event::BecameFresh { id: "cred".into() }]);
     }
@@ -287,15 +363,20 @@ mod tests {
     #[test]
     fn freshness_checked_false_requests_a_refresh_and_stays_refreshing() {
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(
-            &mut m,
-            Command::FreshnessChecked {
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::FreshnessChecked {
+            id: "cred".into(),
+            is_fresh: false,
+            generation: gen,
+        });
+        assert_eq!(
+            events,
+            vec![Event::RunRefresh {
                 id: "cred".into(),
-                is_fresh: false,
-            },
+                generation: gen
+            }]
         );
-        assert_eq!(events, vec![Event::RunRefresh { id: "cred".into() }]);
         assert_eq!(
             m.get("cred"),
             Some(&CredentialState::Refreshing { prior_failures: 0 })
@@ -305,16 +386,18 @@ mod tests {
     #[test]
     fn refresh_succeeded_returns_to_fresh_and_resets_any_failure_count() {
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        update(
-            &mut m,
-            Command::RefreshFailed {
-                id: "cred".into(),
-                error: RefreshErrorKind::Transient("boom".into()),
-            },
-        );
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(&mut m, Command::RefreshSucceeded { id: "cred".into() });
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::Transient("boom".into()),
+            generation: gen,
+        });
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::RefreshSucceeded {
+            id: "cred".into(),
+            generation: gen,
+        });
         assert_eq!(events, vec![Event::BecameFresh { id: "cred".into() }]);
         assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
     }
@@ -322,14 +405,13 @@ mod tests {
     #[test]
     fn refresh_failed_transient_moves_to_failed_with_count_one() {
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(
-            &mut m,
-            Command::RefreshFailed {
-                id: "cred".into(),
-                error: RefreshErrorKind::Transient("network blip".into()),
-            },
-        );
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::Transient("network blip".into()),
+            generation: gen,
+        });
         assert_eq!(
             events,
             vec![Event::BecameFailed {
@@ -352,30 +434,34 @@ mod tests {
         // Port of the pre-refactor scheduler test — a second check after a
         // failure must retry (not treat the failed attempt as success).
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        update(
-            &mut m,
-            Command::RefreshFailed {
-                id: "cred".into(),
-                error: RefreshErrorKind::Transient("nope".into()),
-            },
-        );
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::Transient("nope".into()),
+            generation: gen,
+        });
         assert!(!matches!(m.get("cred"), Some(CredentialState::Fresh)));
-        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
-        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+        let events = m.dispatch(Command::CheckRequested { id: "cred".into() });
+        assert_eq!(
+            events,
+            vec![Event::RunFreshnessCheck {
+                id: "cred".into(),
+                generation: gen
+            }]
+        );
     }
 
     #[test]
     fn permanent_auth_failure_skips_straight_to_needs_reauth_on_the_first_failure() {
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(
-            &mut m,
-            Command::RefreshFailed {
-                id: "cred".into(),
-                error: RefreshErrorKind::PermanentAuthFailure("invalid_grant".into()),
-            },
-        );
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::PermanentAuthFailure("invalid_grant".into()),
+            generation: gen,
+        });
         assert!(matches!(
             events.as_slice(),
             [Event::BecameNeedsReauth { .. }]
@@ -389,28 +475,25 @@ mod tests {
     #[test]
     fn five_consecutive_transient_failures_escalate_to_needs_reauth() {
         let mut m = registered();
+        let gen = m.generation_of("cred");
         for i in 1..=(NEEDS_REAUTH_THRESHOLD - 1) {
-            update(&mut m, Command::CheckRequested { id: "cred".into() });
-            let events = update(
-                &mut m,
-                Command::RefreshFailed {
-                    id: "cred".into(),
-                    error: RefreshErrorKind::Transient(format!("attempt {i}")),
-                },
-            );
+            m.dispatch(Command::CheckRequested { id: "cred".into() });
+            let events = m.dispatch(Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::Transient(format!("attempt {i}")),
+                generation: gen,
+            });
             assert!(
                 matches!(events.as_slice(), [Event::BecameFailed { .. }]),
                 "attempt {i} should still be a transient Failed, not NeedsReauth yet"
             );
         }
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        let events = update(
-            &mut m,
-            Command::RefreshFailed {
-                id: "cred".into(),
-                error: RefreshErrorKind::Transient("final straw".into()),
-            },
-        );
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        let events = m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::Transient("final straw".into()),
+            generation: gen,
+        });
         assert!(matches!(
             events.as_slice(),
             [Event::BecameNeedsReauth { .. }]
@@ -427,30 +510,38 @@ mod tests {
         // since the credential was marked NeedsReauth — on-demand checks
         // (unlike the sweep loop) must not just give up permanently.
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
-        update(
-            &mut m,
-            Command::RefreshFailed {
+        let gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+        m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::PermanentAuthFailure("dead".into()),
+            generation: gen,
+        });
+        let events = m.dispatch(Command::CheckRequested { id: "cred".into() });
+        assert_eq!(
+            events,
+            vec![Event::RunFreshnessCheck {
                 id: "cred".into(),
-                error: RefreshErrorKind::PermanentAuthFailure("dead".into()),
-            },
+                generation: gen
+            }]
         );
-        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
-        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
     }
 
     #[test]
     fn check_requested_on_an_unregistered_id_reports_unregistered() {
-        let mut m: HashMap<String, CredentialState> = HashMap::new();
-        let events = update(&mut m, Command::CheckRequested { id: "nope".into() });
+        let mut m = Harness {
+            states: HashMap::new(),
+            generations: HashMap::new(),
+        };
+        let events = m.dispatch(Command::CheckRequested { id: "nope".into() });
         assert_eq!(events, vec![Event::Unregistered { id: "nope".into() }]);
     }
 
     #[test]
     fn unregister_then_check_reports_unregistered() {
         let mut m = registered();
-        update(&mut m, Command::Unregister { id: "cred".into() });
-        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        m.dispatch(Command::Unregister { id: "cred".into() });
+        let events = m.dispatch(Command::CheckRequested { id: "cred".into() });
         assert_eq!(events, vec![Event::Unregistered { id: "cred".into() }]);
     }
 
@@ -463,15 +554,22 @@ mod tests {
         // cleanly to Fresh, and the next CheckRequested from any caller
         // (old or new) just sees that fresh state.
         let mut m = registered();
-        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
         assert_eq!(
             m.get("cred"),
             Some(&CredentialState::Refreshing { prior_failures: 0 })
         );
-        update(&mut m, Command::Register { id: "cred".into() });
+        m.dispatch(Command::Register { id: "cred".into() });
         assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
-        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
-        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+        let new_gen = m.generation_of("cred");
+        let events = m.dispatch(Command::CheckRequested { id: "cred".into() });
+        assert_eq!(
+            events,
+            vec![Event::RunFreshnessCheck {
+                id: "cred".into(),
+                generation: new_gen
+            }]
+        );
     }
 
     #[test]
@@ -481,32 +579,82 @@ mod tests {
         // for an id nothing owns anymore — the sweep loop only walks
         // registered closures, so a resurrected entry would leak forever
         // and scheduler.state(id) would misreport it as still registered.
-        for stale_completion in [
+        fn mid_check_then_unregistered() -> (Harness, u64) {
+            let mut m = registered();
+            let gen = m.generation_of("cred");
+            m.dispatch(Command::CheckRequested { id: "cred".into() });
+            m.dispatch(Command::Unregister { id: "cred".into() });
+            assert!(!m.contains_key("cred"));
+            (m, gen)
+        }
+
+        // A fresh registration's generation is always 1 (Register starts
+        // the counter at 0 and increments once) — hardcoded below just to
+        // build the Command literals; the real value is still read back via
+        // mid_check_then_unregistered()'s own gen for the actual dispatch.
+        let stale_completions = [
             Command::FreshnessChecked {
                 id: "cred".into(),
                 is_fresh: true,
+                generation: 1,
             },
             Command::FreshnessChecked {
                 id: "cred".into(),
                 is_fresh: false,
+                generation: 1,
             },
-            Command::RefreshSucceeded { id: "cred".into() },
+            Command::RefreshSucceeded {
+                id: "cred".into(),
+                generation: 1,
+            },
             Command::RefreshFailed {
                 id: "cred".into(),
                 error: RefreshErrorKind::Transient("late".into()),
+                generation: 1,
             },
-        ] {
-            let mut m = registered();
-            update(&mut m, Command::CheckRequested { id: "cred".into() });
-            update(&mut m, Command::Unregister { id: "cred".into() });
-            assert!(!m.contains_key("cred"));
-
-            let events = update(&mut m, stale_completion);
+        ];
+        for stale_completion in stale_completions {
+            let (mut m, gen) = mid_check_then_unregistered();
+            assert_eq!(gen, 1, "sanity: a fresh registration's generation is 1");
+            let events = m.dispatch(stale_completion);
             assert_eq!(events, Vec::new());
             assert!(
                 !m.contains_key("cred"),
                 "a stale completion must not resurrect the entry"
             );
         }
+    }
+
+    #[test]
+    fn a_stale_completion_after_re_register_does_not_clobber_the_new_epoch() {
+        // reagent re-review on #2275: if register() is called again for an
+        // id while an OLD in-flight check/refresh for that same id is still
+        // awaiting, the stale completion (belonging to the pre-registration
+        // closures) must not overwrite the freshly re-registered
+        // credential's Fresh state — it belongs to a superseded epoch and
+        // has nothing meaningful to say about the current one.
+        let mut m = registered();
+        let old_gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+
+        // Re-register while the "old" check/refresh is still in flight —
+        // bumps the generation and resets to Fresh.
+        m.dispatch(Command::Register { id: "cred".into() });
+        assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
+        let new_gen = m.generation_of("cred");
+        assert_ne!(old_gen, new_gen);
+
+        // The old attempt's belated failure must not land.
+        let events = m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::PermanentAuthFailure("stale invalid_grant".into()),
+            generation: old_gen,
+        });
+        assert_eq!(events, Vec::new());
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Fresh),
+            "a stale completion from a superseded registration must not mask the new one"
+        );
     }
 }

--- a/agentmux-srv/src/broker/state.rs
+++ b/agentmux-srv/src/broker/state.rs
@@ -160,6 +160,14 @@ pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Ve
             }
         },
         Command::FreshnessChecked { id, is_fresh } => {
+            if !states.contains_key(&id) {
+                // Unregistered while this in-flight check's is_fresh() was
+                // still awaiting — don't resurrect a phantom entry for a
+                // credential nothing still owns; the sweep loop only walks
+                // registered closures, so a resurrected entry would leak
+                // forever (reagent re-review on #2275).
+                return Vec::new();
+            }
             if is_fresh {
                 let became_fresh = !matches!(states.get(&id), Some(CredentialState::Fresh));
                 states.insert(id.clone(), CredentialState::Fresh);
@@ -174,10 +182,18 @@ pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Ve
             }
         }
         Command::RefreshSucceeded { id } => {
+            if !states.contains_key(&id) {
+                // Same phantom-entry hazard as FreshnessChecked above.
+                return Vec::new();
+            }
             states.insert(id.clone(), CredentialState::Fresh);
             vec![Event::BecameFresh { id }]
         }
         Command::RefreshFailed { id, error } => {
+            if !states.contains_key(&id) {
+                // Same phantom-entry hazard as FreshnessChecked above.
+                return Vec::new();
+            }
             let reason = error.message().to_string();
             let permanent = matches!(error, RefreshErrorKind::PermanentAuthFailure(_));
             let prior_failures = match states.get(&id) {
@@ -456,5 +472,41 @@ mod tests {
         assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
         let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
         assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+    }
+
+    #[test]
+    fn a_stale_completion_after_unregister_does_not_resurrect_a_phantom_entry() {
+        // reagent re-review on #2275: an in-flight check/refresh that loses
+        // a race with a concurrent unregister() must not reinsert an entry
+        // for an id nothing owns anymore — the sweep loop only walks
+        // registered closures, so a resurrected entry would leak forever
+        // and scheduler.state(id) would misreport it as still registered.
+        for stale_completion in [
+            Command::FreshnessChecked {
+                id: "cred".into(),
+                is_fresh: true,
+            },
+            Command::FreshnessChecked {
+                id: "cred".into(),
+                is_fresh: false,
+            },
+            Command::RefreshSucceeded { id: "cred".into() },
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::Transient("late".into()),
+            },
+        ] {
+            let mut m = registered();
+            update(&mut m, Command::CheckRequested { id: "cred".into() });
+            update(&mut m, Command::Unregister { id: "cred".into() });
+            assert!(!m.contains_key("cred"));
+
+            let events = update(&mut m, stale_completion);
+            assert_eq!(events, Vec::new());
+            assert!(
+                !m.contains_key("cred"),
+                "a stale completion must not resurrect the entry"
+            );
+        }
     }
 }

--- a/agentmux-srv/src/broker/state.rs
+++ b/agentmux-srv/src/broker/state.rs
@@ -143,13 +143,21 @@ fn now_unix() -> u64 {
 }
 
 /// `states` is the orchestrator's whole coordination table; `generations`
-/// tracks each id's registration epoch (bumped on every `Register`) so a
-/// completion from a superseded registration can be told apart from a
-/// current one — see `Event::RunFreshnessCheck`'s doc comment. One reducer
+/// tracks each id's CURRENT registration epoch so a completion from a
+/// superseded registration can be told apart from a current one (see
+/// `Event::RunFreshnessCheck`'s doc comment); `next_generation` is a single
+/// counter shared across ALL ids, strictly increasing, never reused —
+/// deliberately NOT a per-id counter restarted at 0 on each `Register`,
+/// because an unregister-then-re-register sequence would then hand the new
+/// registration the SAME generation number the old one had, and a stale
+/// completion from the old registration (still in flight when the
+/// unregister/re-register raced in) would wrongly pass the staleness check
+/// instead of being discarded (reagent re-review on #2275). One reducer
 /// call per dispatched command, sub-millisecond, never awaits.
 pub fn update(
     states: &mut HashMap<String, CredentialState>,
     generations: &mut HashMap<String, u64>,
+    next_generation: &mut u64,
     cmd: Command,
 ) -> Vec<Event> {
     match cmd {
@@ -159,14 +167,18 @@ pub fn update(
             // not by an external lock a caller could be left blocked on
             // (the pre-refactor design's latent race). A caller currently
             // waiting via AlreadyInFlight re-dispatches CheckRequested once
-            // woken and just sees the fresh entry's is_fresh() result. The
-            // generation bump is what lets a stale in-flight completion from
-            // the OLD registration be told apart from this new one.
-            *generations.entry(id.clone()).or_insert(0) += 1;
+            // woken and just sees the fresh entry's is_fresh() result.
+            let generation = *next_generation;
+            *next_generation += 1;
+            generations.insert(id.clone(), generation);
             states.insert(id, CredentialState::Fresh);
             Vec::new()
         }
         Command::Unregister { id } => {
+            // Removing the entry here is just memory hygiene, not a
+            // correctness requirement — next_generation never reuses a
+            // number, so a future re-registration can't collide with a
+            // stale completion's captured generation either way.
             generations.remove(&id);
             states.remove(&id);
             vec![Event::Unregistered { id }]
@@ -274,16 +286,24 @@ pub fn update(
 mod tests {
     use super::*;
 
-    /// Bundles `states` + `generations` so tests can dispatch commands
-    /// without threading two maps through every call site by hand.
+    /// Bundles `states` + `generations` + `next_generation` so tests can
+    /// dispatch commands without threading three pieces of state through
+    /// every call site by hand.
+    #[derive(Default)]
     struct Harness {
         states: HashMap<String, CredentialState>,
         generations: HashMap<String, u64>,
+        next_generation: u64,
     }
 
     impl Harness {
         fn dispatch(&mut self, cmd: Command) -> Vec<Event> {
-            update(&mut self.states, &mut self.generations, cmd)
+            update(
+                &mut self.states,
+                &mut self.generations,
+                &mut self.next_generation,
+                cmd,
+            )
         }
 
         fn get(&self, id: &str) -> Option<&CredentialState> {
@@ -300,10 +320,7 @@ mod tests {
     }
 
     fn registered() -> Harness {
-        let mut h = Harness {
-            states: HashMap::new(),
-            generations: HashMap::new(),
-        };
+        let mut h = Harness::default();
         h.dispatch(Command::Register { id: "cred".into() });
         h
     }
@@ -529,10 +546,7 @@ mod tests {
 
     #[test]
     fn check_requested_on_an_unregistered_id_reports_unregistered() {
-        let mut m = Harness {
-            states: HashMap::new(),
-            generations: HashMap::new(),
-        };
+        let mut m = Harness::default();
         let events = m.dispatch(Command::CheckRequested { id: "nope".into() });
         assert_eq!(events, vec![Event::Unregistered { id: "nope".into() }]);
     }
@@ -588,35 +602,30 @@ mod tests {
             (m, gen)
         }
 
-        // A fresh registration's generation is always 1 (Register starts
-        // the counter at 0 and increments once) — hardcoded below just to
-        // build the Command literals; the real value is still read back via
-        // mid_check_then_unregistered()'s own gen for the actual dispatch.
-        let stale_completions = [
-            Command::FreshnessChecked {
+        let stale_completion_builders: [fn(u64) -> Command; 4] = [
+            |gen| Command::FreshnessChecked {
                 id: "cred".into(),
                 is_fresh: true,
-                generation: 1,
+                generation: gen,
             },
-            Command::FreshnessChecked {
+            |gen| Command::FreshnessChecked {
                 id: "cred".into(),
                 is_fresh: false,
-                generation: 1,
+                generation: gen,
             },
-            Command::RefreshSucceeded {
+            |gen| Command::RefreshSucceeded {
                 id: "cred".into(),
-                generation: 1,
+                generation: gen,
             },
-            Command::RefreshFailed {
+            |gen| Command::RefreshFailed {
                 id: "cred".into(),
                 error: RefreshErrorKind::Transient("late".into()),
-                generation: 1,
+                generation: gen,
             },
         ];
-        for stale_completion in stale_completions {
+        for build_stale_completion in stale_completion_builders {
             let (mut m, gen) = mid_check_then_unregistered();
-            assert_eq!(gen, 1, "sanity: a fresh registration's generation is 1");
-            let events = m.dispatch(stale_completion);
+            let events = m.dispatch(build_stale_completion(gen));
             assert_eq!(events, Vec::new());
             assert!(
                 !m.contains_key("cred"),
@@ -655,6 +664,42 @@ mod tests {
             m.get("cred"),
             Some(&CredentialState::Fresh),
             "a stale completion from a superseded registration must not mask the new one"
+        );
+    }
+
+    #[test]
+    fn a_stale_completion_survives_an_unregister_then_re_register_of_the_same_id() {
+        // reagent re-review on #2275, second round: a PER-ID counter that
+        // restarts at 0 on each Register would hand an unregister-then-
+        // re-register sequence the SAME generation number the original
+        // registration had, so a stale completion from before the
+        // unregister would wrongly pass the staleness check after the
+        // re-register instead of being discarded. next_generation is a
+        // single counter shared across every id specifically so this can't
+        // happen — assert the two registrations never collide even across
+        // an intervening unregister.
+        let mut m = registered();
+        let old_gen = m.generation_of("cred");
+        m.dispatch(Command::CheckRequested { id: "cred".into() });
+
+        m.dispatch(Command::Unregister { id: "cred".into() });
+        m.dispatch(Command::Register { id: "cred".into() });
+        let new_gen = m.generation_of("cred");
+        assert_ne!(
+            old_gen, new_gen,
+            "unregister-then-register must never reissue a prior generation number"
+        );
+
+        let events = m.dispatch(Command::RefreshFailed {
+            id: "cred".into(),
+            error: RefreshErrorKind::PermanentAuthFailure("stale invalid_grant".into()),
+            generation: old_gen,
+        });
+        assert_eq!(events, Vec::new());
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Fresh),
+            "a stale completion from before the unregister must not mask the re-registered credential"
         );
     }
 }

--- a/agentmux-srv/src/broker/state.rs
+++ b/agentmux-srv/src/broker/state.rs
@@ -1,0 +1,460 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure reducer for the Credential Broker's per-credential coordination
+//! state — fresh / refreshing / failed / needs-reauth. Same shape as every
+//! other reducer in this codebase (`agentmux-launcher/src/reducer/`,
+//! `agentmux-srv/src/reducer.rs`, `agentmux-cef/src/reducer/mod.rs`):
+//! `update(&mut State, Command) -> Vec<Event>`, no I/O, no async,
+//! sub-millisecond lock hold when called from `scheduler.rs`'s orchestrator.
+//!
+//! Internal-only, like the CEF host reducer — this never crosses IPC, so it
+//! does not reuse `agentmux_common::ipc::{Command, Event}` (the
+//! srv<->launcher<->host wire protocol); it defines its own local types.
+//!
+//! This module never holds a credential's actual secret/value — only enough
+//! coordination state to decide WHEN `scheduler.rs`'s caller-supplied
+//! `is_fresh`/`refresh` closures should run, and to make that decision
+//! observable. Events are mapped 1:1 to `auth.broker.*`-prefixed `tracing`
+//! calls by the orchestrator — that prefix lands in `muxlog auth`'s existing
+//! filter regex (`\bauth\.\w+|...`) with zero changes needed there.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// After this many consecutive TRANSIENT refresh failures, a credential is
+/// considered permanently broken rather than retried forever — the sweep
+/// loop stops hammering a dead refresh_token on every tick. `ensure_fresh`
+/// (on-demand, e.g. right before a reconnect attempt) still re-checks
+/// freshness even from `NeedsReauth`: if an external login has since
+/// succeeded, `is_fresh()` will report true and state naturally moves back
+/// to `Fresh`. No explicit "clear" API needed.
+pub const NEEDS_REAUTH_THRESHOLD: u32 = 5;
+
+/// Coordination state for one registered credential.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CredentialState {
+    /// Registered; last check (if any) said fresh, or never checked yet.
+    Fresh,
+    /// A freshness check or refresh attempt is currently in flight — this
+    /// IS the single-flight guard: a second `CheckRequested` while already
+    /// `Refreshing` gets `Event::AlreadyInFlight`, never a second
+    /// `RunFreshnessCheck`/`RunRefresh`. Carries forward the failure count
+    /// from whatever `Failed` state (if any) preceded this attempt — the
+    /// only place that count lives, since transitioning through
+    /// `Refreshing` would otherwise lose it before `RefreshFailed` can read
+    /// it back out to increment.
+    Refreshing { prior_failures: u32 },
+    /// Last refresh attempt failed with a transient error (network, parse,
+    /// etc.) — will be retried on the next `ensure_fresh`/sweep tick.
+    Failed {
+        consecutive_failures: u32,
+        last_error: String,
+    },
+    /// Either `consecutive_failures` crossed `NEEDS_REAUTH_THRESHOLD`, or a
+    /// refresh closure explicitly reported
+    /// `RefreshErrorKind::PermanentAuthFailure` (no need to accumulate
+    /// failures for an error already known permanent). Retrying
+    /// automatically is pointless; a human needs to log in again.
+    NeedsReauth { since_unix: u64, reason: String },
+}
+
+/// What a registered refresh closure's failure means for scheduling.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RefreshErrorKind {
+    /// Network blip, parse failure, transient server error — worth retrying.
+    Transient(String),
+    /// The credential itself is rejected (e.g. an OAuth server's
+    /// `invalid_grant` for a revoked/expired refresh_token) — retrying with
+    /// the SAME credential will never succeed; only a fresh login fixes it.
+    PermanentAuthFailure(String),
+}
+
+impl RefreshErrorKind {
+    fn message(&self) -> &str {
+        match self {
+            RefreshErrorKind::Transient(m) | RefreshErrorKind::PermanentAuthFailure(m) => m,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Command {
+    Register { id: String },
+    Unregister { id: String },
+    /// `ensure_fresh` or a sweep tick wants to know/ensure this credential
+    /// is fresh.
+    CheckRequested { id: String },
+    /// The orchestrator ran `is_fresh()` and is reporting the result.
+    FreshnessChecked { id: String, is_fresh: bool },
+    RefreshSucceeded { id: String },
+    RefreshFailed { id: String, error: RefreshErrorKind },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    /// Orchestrator should call the registered `is_fresh()` closure now.
+    RunFreshnessCheck { id: String },
+    /// Orchestrator should call the registered `refresh()` closure now.
+    RunRefresh { id: String },
+    /// Another caller is already checking/refreshing this id — the
+    /// orchestrator should wait on the id's `Notify` and re-dispatch
+    /// `CheckRequested` once woken.
+    AlreadyInFlight { id: String },
+    /// `id` was never registered (or was just unregistered).
+    Unregistered { id: String },
+    /// Diagnostics-only — mapped 1:1 to `tracing` by the orchestrator.
+    BecameFresh { id: String },
+    BecameFailed {
+        id: String,
+        consecutive_failures: u32,
+        error: String,
+    },
+    BecameNeedsReauth { id: String, reason: String },
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// `states` is the orchestrator's whole coordination table — one reducer
+/// call per dispatched command, sub-millisecond, never awaits.
+pub fn update(states: &mut HashMap<String, CredentialState>, cmd: Command) -> Vec<Event> {
+    match cmd {
+        Command::Register { id } => {
+            // Replacing an already-registered id is safe here specifically
+            // because single-flight is guarded by THIS reducer's own state,
+            // not by an external lock a caller could be left blocked on
+            // (the pre-refactor design's latent race). A caller currently
+            // waiting via AlreadyInFlight re-dispatches CheckRequested once
+            // woken and just sees the fresh entry's is_fresh() result.
+            states.insert(id, CredentialState::Fresh);
+            Vec::new()
+        }
+        Command::Unregister { id } => {
+            states.remove(&id);
+            vec![Event::Unregistered { id }]
+        }
+        Command::CheckRequested { id } => match states.get(&id) {
+            None => vec![Event::Unregistered { id }],
+            Some(CredentialState::Refreshing { .. }) => vec![Event::AlreadyInFlight { id }],
+            Some(state) => {
+                // Carry the failure count forward through the Refreshing
+                // transition — it's the only place it lives, so overwriting
+                // it with a bare Refreshing here would otherwise strand
+                // RefreshFailed with no way to read the prior count back
+                // out and every failure would reset to 1.
+                let prior_failures = match state {
+                    CredentialState::Failed {
+                        consecutive_failures,
+                        ..
+                    } => *consecutive_failures,
+                    CredentialState::Fresh | CredentialState::NeedsReauth { .. } => 0,
+                    CredentialState::Refreshing { .. } => unreachable!("matched above"),
+                };
+                states.insert(id.clone(), CredentialState::Refreshing { prior_failures });
+                vec![Event::RunFreshnessCheck { id }]
+            }
+        },
+        Command::FreshnessChecked { id, is_fresh } => {
+            if is_fresh {
+                let became_fresh = !matches!(states.get(&id), Some(CredentialState::Fresh));
+                states.insert(id.clone(), CredentialState::Fresh);
+                if became_fresh {
+                    vec![Event::BecameFresh { id }]
+                } else {
+                    Vec::new()
+                }
+            } else {
+                // Stays Refreshing — orchestrator now runs the actual refresh.
+                vec![Event::RunRefresh { id }]
+            }
+        }
+        Command::RefreshSucceeded { id } => {
+            states.insert(id.clone(), CredentialState::Fresh);
+            vec![Event::BecameFresh { id }]
+        }
+        Command::RefreshFailed { id, error } => {
+            let reason = error.message().to_string();
+            let permanent = matches!(error, RefreshErrorKind::PermanentAuthFailure(_));
+            let prior_failures = match states.get(&id) {
+                Some(CredentialState::Refreshing { prior_failures }) => *prior_failures,
+                _ => 0,
+            };
+            let consecutive_failures = prior_failures + 1;
+            if permanent || consecutive_failures >= NEEDS_REAUTH_THRESHOLD {
+                states.insert(
+                    id.clone(),
+                    CredentialState::NeedsReauth {
+                        since_unix: now_unix(),
+                        reason: reason.clone(),
+                    },
+                );
+                vec![Event::BecameNeedsReauth { id, reason }]
+            } else {
+                states.insert(
+                    id.clone(),
+                    CredentialState::Failed {
+                        consecutive_failures,
+                        last_error: reason.clone(),
+                    },
+                );
+                vec![Event::BecameFailed {
+                    id,
+                    consecutive_failures,
+                    error: reason,
+                }]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registered() -> HashMap<String, CredentialState> {
+        let mut m = HashMap::new();
+        update(&mut m, Command::Register { id: "cred".into() });
+        m
+    }
+
+    #[test]
+    fn register_starts_fresh() {
+        let m = registered();
+        assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
+    }
+
+    #[test]
+    fn check_on_fresh_transitions_to_refreshing_and_requests_a_check() {
+        let mut m = registered();
+        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Refreshing { prior_failures: 0 })
+        );
+    }
+
+    #[test]
+    fn a_second_check_while_refreshing_gets_already_in_flight_not_a_second_run() {
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(events, vec![Event::AlreadyInFlight { id: "cred".into() }]);
+        // Still just one credential, still Refreshing — the second dispatch
+        // did not disturb the in-flight state.
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Refreshing { prior_failures: 0 })
+        );
+    }
+
+    #[test]
+    fn freshness_checked_true_returns_to_fresh_and_reports_became_fresh() {
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(
+            &mut m,
+            Command::FreshnessChecked {
+                id: "cred".into(),
+                is_fresh: true,
+            },
+        );
+        assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
+        assert_eq!(events, vec![Event::BecameFresh { id: "cred".into() }]);
+    }
+
+    #[test]
+    fn freshness_checked_false_requests_a_refresh_and_stays_refreshing() {
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(
+            &mut m,
+            Command::FreshnessChecked {
+                id: "cred".into(),
+                is_fresh: false,
+            },
+        );
+        assert_eq!(events, vec![Event::RunRefresh { id: "cred".into() }]);
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Refreshing { prior_failures: 0 })
+        );
+    }
+
+    #[test]
+    fn refresh_succeeded_returns_to_fresh_and_resets_any_failure_count() {
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        update(
+            &mut m,
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::Transient("boom".into()),
+            },
+        );
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(&mut m, Command::RefreshSucceeded { id: "cred".into() });
+        assert_eq!(events, vec![Event::BecameFresh { id: "cred".into() }]);
+        assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
+    }
+
+    #[test]
+    fn refresh_failed_transient_moves_to_failed_with_count_one() {
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(
+            &mut m,
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::Transient("network blip".into()),
+            },
+        );
+        assert_eq!(
+            events,
+            vec![Event::BecameFailed {
+                id: "cred".into(),
+                consecutive_failures: 1,
+                error: "network blip".into(),
+            }]
+        );
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Failed {
+                consecutive_failures: 1,
+                last_error: "network blip".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_failed_refresh_does_not_mark_the_credential_fresh() {
+        // Port of the pre-refactor scheduler test — a second check after a
+        // failure must retry (not treat the failed attempt as success).
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        update(
+            &mut m,
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::Transient("nope".into()),
+            },
+        );
+        assert!(!matches!(m.get("cred"), Some(CredentialState::Fresh)));
+        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+    }
+
+    #[test]
+    fn permanent_auth_failure_skips_straight_to_needs_reauth_on_the_first_failure() {
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(
+            &mut m,
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::PermanentAuthFailure("invalid_grant".into()),
+            },
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [Event::BecameNeedsReauth { .. }]
+        ));
+        assert!(matches!(
+            m.get("cred"),
+            Some(CredentialState::NeedsReauth { .. })
+        ));
+    }
+
+    #[test]
+    fn five_consecutive_transient_failures_escalate_to_needs_reauth() {
+        let mut m = registered();
+        for i in 1..=(NEEDS_REAUTH_THRESHOLD - 1) {
+            update(&mut m, Command::CheckRequested { id: "cred".into() });
+            let events = update(
+                &mut m,
+                Command::RefreshFailed {
+                    id: "cred".into(),
+                    error: RefreshErrorKind::Transient(format!("attempt {i}")),
+                },
+            );
+            assert!(
+                matches!(events.as_slice(), [Event::BecameFailed { .. }]),
+                "attempt {i} should still be a transient Failed, not NeedsReauth yet"
+            );
+        }
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        let events = update(
+            &mut m,
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::Transient("final straw".into()),
+            },
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [Event::BecameNeedsReauth { .. }]
+        ));
+        assert!(matches!(
+            m.get("cred"),
+            Some(CredentialState::NeedsReauth { .. })
+        ));
+    }
+
+    #[test]
+    fn check_requested_on_needs_reauth_still_runs_a_fresh_check_on_demand() {
+        // A human may have logged in again out-of-band (e.g. muxbus.login)
+        // since the credential was marked NeedsReauth — on-demand checks
+        // (unlike the sweep loop) must not just give up permanently.
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        update(
+            &mut m,
+            Command::RefreshFailed {
+                id: "cred".into(),
+                error: RefreshErrorKind::PermanentAuthFailure("dead".into()),
+            },
+        );
+        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+    }
+
+    #[test]
+    fn check_requested_on_an_unregistered_id_reports_unregistered() {
+        let mut m: HashMap<String, CredentialState> = HashMap::new();
+        let events = update(&mut m, Command::CheckRequested { id: "nope".into() });
+        assert_eq!(events, vec![Event::Unregistered { id: "nope".into() }]);
+    }
+
+    #[test]
+    fn unregister_then_check_reports_unregistered() {
+        let mut m = registered();
+        update(&mut m, Command::Unregister { id: "cred".into() });
+        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(events, vec![Event::Unregistered { id: "cred".into() }]);
+    }
+
+    #[test]
+    fn re_registering_an_id_that_is_mid_refresh_does_not_leave_anything_orphaned() {
+        // The pre-refactor design's latent race: register() on an
+        // already-registered id replaced the Entry (including its lock), so
+        // a caller already blocked on the OLD entry's lock waited forever.
+        // Here there's no separate lock to orphan — Register always resets
+        // cleanly to Fresh, and the next CheckRequested from any caller
+        // (old or new) just sees that fresh state.
+        let mut m = registered();
+        update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(
+            m.get("cred"),
+            Some(&CredentialState::Refreshing { prior_failures: 0 })
+        );
+        update(&mut m, Command::Register { id: "cred".into() });
+        assert_eq!(m.get("cred"), Some(&CredentialState::Fresh));
+        let events = update(&mut m, Command::CheckRequested { id: "cred".into() });
+        assert_eq!(events, vec![Event::RunFreshnessCheck { id: "cred".into() }]);
+    }
+}

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -34,6 +34,7 @@ use tokio_tungstenite::{connect_async_tls_with_config, tungstenite::Message};
 use crate::backend::reactive::handler::get_global_handler;
 use crate::backend::reactive::types::InjectionRequest;
 use crate::backend::storage::store::Store;
+use crate::broker::RefreshErrorKind;
 
 // Dedicated custom domain on the API Gateway WebSocket API (apigatewayv2
 // DomainName + ApiMapping), not a path under muxbus.agentmux.ai's CloudFront
@@ -237,23 +238,36 @@ async fn run_loop(
                         let load_store = wstore.clone();
                         let current = tokio::task::spawn_blocking(move || load_store.muxbus_load())
                             .await
-                            .map_err(|e| format!("muxbus_load task: {e}"))?
-                            .map_err(|e| e.to_string())?
-                            .ok_or_else(|| "no muxbus credentials stored".to_string())?;
+                            .map_err(|e| RefreshErrorKind::Transient(format!("muxbus_load task: {e}")))?
+                            .map_err(|e| RefreshErrorKind::Transient(e.to_string()))?
+                            // Nothing stored at all — not a transient storage
+                            // blip, there's genuinely no credential to refresh;
+                            // only a fresh login produces one.
+                            .ok_or_else(|| {
+                                RefreshErrorKind::PermanentAuthFailure(
+                                    "no muxbus credentials stored".to_string(),
+                                )
+                            })?;
                         if current.refresh_token.is_empty() {
-                            return Err("no refresh_token stored".to_string());
+                            // Same reasoning: no refresh_token will ever
+                            // appear on its own — only re-login fixes it.
+                            return Err(RefreshErrorKind::PermanentAuthFailure(
+                                "no refresh_token stored".to_string(),
+                            ));
                         }
                         // Preserve-on-failure: `refresh_token` returning Err
                         // here means `muxbus_save` is simply never called —
                         // the last-known-good credential in the store is
                         // left untouched rather than overwritten with a
                         // failed/partial result.
-                        let refreshed = crate::muxbus::pkce::refresh_token(&current, &http).await?;
+                        let refreshed = crate::muxbus::pkce::refresh_token(&current, &http)
+                            .await
+                            .map_err(classify_refresh_token_error)?;
                         let save_store = wstore.clone();
                         tokio::task::spawn_blocking(move || save_store.muxbus_save(&refreshed))
                             .await
-                            .map_err(|e| format!("muxbus_save task: {e}"))?
-                            .map_err(|e| e.to_string())
+                            .map_err(|e| RefreshErrorKind::Transient(format!("muxbus_save task: {e}")))?
+                            .map_err(|e| RefreshErrorKind::Transient(e.to_string()))
                     })
                 },
             )
@@ -755,10 +769,73 @@ async fn load_valid_token(
     }
 }
 
+/// Classify a `pkce::refresh_token` failure for the broker's
+/// `RefreshErrorKind` — `NoRefreshToken`/`Rejected` in the 4xx range mean
+/// the credential itself is the problem (only a fresh `muxbus.login` fixes
+/// it); everything else (network blips, 5xx, response parse failures) is
+/// worth retrying on the next sweep tick.
+fn classify_refresh_token_error(e: crate::muxbus::pkce::RefreshTokenError) -> RefreshErrorKind {
+    use crate::muxbus::pkce::RefreshTokenError;
+    match &e {
+        RefreshTokenError::NoRefreshToken => RefreshErrorKind::PermanentAuthFailure(e.to_string()),
+        RefreshTokenError::Rejected { status, .. } if (400..500).contains(status) => {
+            RefreshErrorKind::PermanentAuthFailure(e.to_string())
+        }
+        RefreshTokenError::Rejected { .. }
+        | RefreshTokenError::Network(_)
+        | RefreshTokenError::ParseFailed(_) => RefreshErrorKind::Transient(e.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::classify_refresh_token_error;
+    use crate::broker::RefreshErrorKind;
+    use crate::muxbus::pkce::RefreshTokenError;
     use tokio_tungstenite::tungstenite::client::IntoClientRequest;
     use tokio_tungstenite::tungstenite::ClientRequestBuilder;
+
+    #[test]
+    fn no_refresh_token_is_permanent() {
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::NoRefreshToken),
+            RefreshErrorKind::PermanentAuthFailure(_)
+        ));
+    }
+
+    #[test]
+    fn a_4xx_rejection_is_permanent() {
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::Rejected {
+                status: 400,
+                body: "invalid_grant".into(),
+            }),
+            RefreshErrorKind::PermanentAuthFailure(_)
+        ));
+    }
+
+    #[test]
+    fn a_5xx_rejection_is_transient() {
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::Rejected {
+                status: 503,
+                body: "unavailable".into(),
+            }),
+            RefreshErrorKind::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn network_and_parse_errors_are_transient() {
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::Network("timeout".into())),
+            RefreshErrorKind::Transient(_)
+        ));
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::ParseFailed("bad json".into())),
+            RefreshErrorKind::Transient(_)
+        ));
+    }
 
     /// Regression for issue #2091: every connection attempt failed the
     /// WebSocket handshake with "Missing, duplicated or incorrect header

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -772,13 +772,18 @@ async fn load_valid_token(
 /// Classify a `pkce::refresh_token` failure for the broker's
 /// `RefreshErrorKind` — `NoRefreshToken`/`Rejected` in the 4xx range mean
 /// the credential itself is the problem (only a fresh `muxbus.login` fixes
-/// it); everything else (network blips, 5xx, response parse failures) is
-/// worth retrying on the next sweep tick.
+/// it) *except* 408/429, which mean the request itself was throttled or
+/// timed out, not that the refresh_token was rejected — treating those as
+/// permanent would strand the credential in `NeedsReauth` past a temporary
+/// rate limit (reagent P2 on #2275). Everything else (network blips, 5xx,
+/// response parse failures) is worth retrying on the next sweep tick.
 fn classify_refresh_token_error(e: crate::muxbus::pkce::RefreshTokenError) -> RefreshErrorKind {
     use crate::muxbus::pkce::RefreshTokenError;
     match &e {
         RefreshTokenError::NoRefreshToken => RefreshErrorKind::PermanentAuthFailure(e.to_string()),
-        RefreshTokenError::Rejected { status, .. } if (400..500).contains(status) => {
+        RefreshTokenError::Rejected { status, .. }
+            if (400..500).contains(status) && !matches!(status, 408 | 429) =>
+        {
             RefreshErrorKind::PermanentAuthFailure(e.to_string())
         }
         RefreshTokenError::Rejected { .. }
@@ -820,6 +825,27 @@ mod tests {
             classify_refresh_token_error(RefreshTokenError::Rejected {
                 status: 503,
                 body: "unavailable".into(),
+            }),
+            RefreshErrorKind::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn rate_limit_and_timeout_rejections_are_transient_not_permanent() {
+        // A 429/408 means the request was throttled/timed out, not that the
+        // refresh_token itself was rejected — must not strand the
+        // credential in NeedsReauth past a temporary rate limit.
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::Rejected {
+                status: 429,
+                body: "rate limited".into(),
+            }),
+            RefreshErrorKind::Transient(_)
+        ));
+        assert!(matches!(
+            classify_refresh_token_error(RefreshTokenError::Rejected {
+                status: 408,
+                body: "request timeout".into(),
             }),
             RefreshErrorKind::Transient(_)
         ));

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -230,12 +230,40 @@ pub async fn run_pkce_login(
     })
 }
 
+/// Typed so callers (the credential broker's registered `refresh` closure)
+/// can distinguish "worth retrying" from "this refresh_token is dead, only
+/// a fresh login fixes it" without string-sniffing an error message.
+/// `Rejected` specifically means the token endpoint responded but rejected
+/// the request (Cognito's `invalid_grant`-class 4xx for a revoked/expired
+/// refresh_token) — the credential itself is the problem. `Network`/
+/// `ParseFailed` mean the ATTEMPT failed, not the credential.
+#[derive(Debug)]
+pub enum RefreshTokenError {
+    NoRefreshToken,
+    Network(String),
+    Rejected { status: u16, body: String },
+    ParseFailed(String),
+}
+
+impl std::fmt::Display for RefreshTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RefreshTokenError::NoRefreshToken => write!(f, "no refresh token stored"),
+            RefreshTokenError::Network(e) => write!(f, "refresh request failed: {e}"),
+            RefreshTokenError::Rejected { status, body } => {
+                write!(f, "token refresh failed ({status}): {body}")
+            }
+            RefreshTokenError::ParseFailed(e) => write!(f, "refresh response parse failed: {e}"),
+        }
+    }
+}
+
 pub async fn refresh_token(
     creds: &MuxBusCredentials,
     http_client: &reqwest::Client,
-) -> Result<MuxBusCredentials, String> {
+) -> Result<MuxBusCredentials, RefreshTokenError> {
     if creds.refresh_token.is_empty() {
-        return Err("no refresh token stored".to_string());
+        return Err(RefreshTokenError::NoRefreshToken);
     }
     let token_url = format!("{}/oauth2/token", creds.cognito_domain);
     let params = [
@@ -248,15 +276,16 @@ pub async fn refresh_token(
         .form(&params)
         .send()
         .await
-        .map_err(|e| format!("refresh request failed: {e}"))?;
+        .map_err(|e| RefreshTokenError::Network(e.to_string()))?;
     if !resp.status().is_success() {
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("token refresh failed: {body}"));
+        return Err(RefreshTokenError::Rejected { status, body });
     }
     let json: serde_json::Value = resp
         .json()
         .await
-        .map_err(|e| format!("refresh response parse failed: {e}"))?;
+        .map_err(|e| RefreshTokenError::ParseFailed(e.to_string()))?;
 
     let access_token = json["access_token"].as_str().unwrap_or("").to_string();
     let expires_in = json["expires_in"].as_i64().unwrap_or(3600);


### PR DESCRIPTION
## Summary

Refactors the Credential Broker (`agentmux-srv/src/broker/`, shipped as PR #2260) from implicit state (a bare `is_fresh()` boolean + an unqueryable per-credential `AsyncMutex<()>`) to an explicit reducer-based state machine, matching AgentMux's existing 4-tier reducer convention (`agentmux-launcher/src/reducer/`, `agentmux-srv/src/reducer.rs`, `agentmux-cef/src/reducer/mod.rs`, and the frontend reducer spec).

- **New:** `agentmux-srv/src/broker/state.rs` — pure `update(&mut HashMap<String, CredentialState>, Command) -> Vec<Event>` reducer. No I/O, no async, sub-millisecond, easily unit-testable in isolation.
- **`CredentialState`:** `Fresh` / `Refreshing { prior_failures }` / `Failed { consecutive_failures, last_error }` / `NeedsReauth { since_unix, reason }`. Escalates to `NeedsReauth` after 5 consecutive transient failures, or immediately on a classified-permanent error — closing a real gap where the old scheduler retried a dead refresh_token forever with no distinct "give up, a human needs to log in again" state.
- **`agentmux-srv/src/broker/scheduler.rs`** rewritten as a thin async orchestrator: dispatches commands to the reducer, executes whatever effects the returned events call for (`is_fresh()`/`refresh()`), dispatches the result back in, wakes waiters via a per-id `Notify`. Public API (`register`/`unregister`/`ensure_fresh`/`run_sweep_loop`) unchanged — no caller changes needed beyond the error-type update below.
- **`agentmux-srv/src/muxbus/pkce.rs`:** `refresh_token` now returns a typed `RefreshTokenError` (`NoRefreshToken` / `Network` / `Rejected{status,body}` / `ParseFailed`) instead of a bare `String`, so callers can classify failures instead of string-sniffing.
- **`agentmux-srv/src/muxbus/cloud_subscriber.rs`:** classifies `RefreshTokenError` into the broker's `RefreshErrorKind` (4xx rejection or no-refresh-token → `PermanentAuthFailure`; everything else → `Transient`).
- Every transition logs under `auth.broker.*`, which lands directly in `muxlog auth`'s existing filter regex with zero changes needed there — this was a real diagnostic gap surfaced while debugging the login-terminal stdin bug (#2272) this session.

## Test plan

- [x] `cargo test -p agentmux-srv broker::` — 20/20 passing (reducer + orchestrator, including a register-while-refreshing race test the old design had no coverage for)
- [x] `cargo test -p agentmux-srv cloud_subscriber::` — new `classify_refresh_token_error` unit tests (permanent vs. transient classification)
- [x] `cargo test -p agentmux-srv` (full workspace) — 1620/1620 passing, 0 regressions
- [ ] Manual: force a MuxBus refresh failure and confirm `muxlog auth` shows `Failed` accumulating and `NeedsReauth` once escalated, and that the sweep loop stops retrying at that point

<!-- agentmux:agent_id=agenta -->