### PR TITLE
fix(launcher): macOS splash rows now animate instead of snapping

### DIFF
--- a/.changesets/1784781999-fix-launcher-macos-splash-rows-now-animate-instead-of-snappi-ygwe.md
+++ b/.changesets/1784781999-fix-launcher-macos-splash-rows-now-animate-instead-of-snappi-ygwe.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): macOS splash rows now animate instead of snapping to their final value

--- a/agentmux-launcher/src/splash_mac.rs
+++ b/agentmux-launcher/src/splash_mac.rs
@@ -138,6 +138,15 @@ struct StageRow {
     subs: Vec<SubRow>,
 }
 
+/// Identifies which row a `Begin` event created, so `run_until_dismissed`'s
+/// drain loop can recognize when a matching `End` arrives for a row that was
+/// *itself* created in this same drain pass — see the count-up note there.
+#[derive(PartialEq)]
+enum BeginKey {
+    Stage(&'static str),
+    Sub(&'static str, String),
+}
+
 /// Same state machine as splash.rs's (Windows) `apply_event` /
 /// splash_linux's `StageList::apply` — see the module doc above for why this
 /// isn't shared code yet.
@@ -175,6 +184,65 @@ fn apply_event(stages: &mut Vec<StageRow>, ev: StartupEvent) {
             }
         }
     }
+}
+
+/// Applies one tick's worth of already-fetched events to `stages`. Returns
+/// `true` if anything changed. Pulled out of `run_until_dismissed` as a pure
+/// function (taking a plain `Vec<StartupEvent>` instead of draining
+/// `self.startup_rx` directly) so the deferral logic is unit-testable
+/// without a live splash window.
+///
+/// A row is created `done: None` on Begin and only shows a live "running"
+/// time once a render happens before its End is applied (`flatten_rows`). If
+/// a step finishes fast enough that both its Begin and End are already
+/// queued by the time a tick drains, they'd otherwise be applied back-to-back
+/// in this same pass — the row is created already-done and no "running"
+/// frame is ever painted, so it just snaps to its final value instead of
+/// visibly counting up (docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md
+/// §2). Fix: apply anything deferred from the *previous* tick first
+/// (guaranteeing its row spent at least one tick — and one render, since
+/// `run_until_dismissed` always redraws while `ready_at.is_none()` — in the
+/// "running" state), then apply this tick's fresh events, holding back any
+/// End whose matching Begin was *also* seen in this same batch rather than
+/// applying it immediately.
+fn apply_tick(
+    stages: &mut Vec<StageRow>,
+    deferred: &mut Vec<StartupEvent>,
+    fresh: Vec<StartupEvent>,
+) -> bool {
+    let mut changed = false;
+    for ev in deferred.drain(..) {
+        apply_event(stages, ev);
+        changed = true;
+    }
+    let mut began_this_tick: Vec<BeginKey> = Vec::new();
+    for ev in fresh {
+        let defer = match &ev {
+            StartupEvent::StageEnd { stage, .. } => {
+                began_this_tick.contains(&BeginKey::Stage(stage))
+            }
+            StartupEvent::SubEnd { stage, id, .. } => {
+                began_this_tick.contains(&BeginKey::Sub(stage, id.clone()))
+            }
+            _ => false,
+        };
+        if defer {
+            deferred.push(ev);
+            continue;
+        }
+        match &ev {
+            StartupEvent::StageBegin { stage, .. } => {
+                began_this_tick.push(BeginKey::Stage(stage));
+            }
+            StartupEvent::SubBegin { stage, id, .. } => {
+                began_this_tick.push(BeginKey::Sub(stage, id.clone()));
+            }
+            _ => {}
+        }
+        apply_event(stages, ev);
+        changed = true;
+    }
+    changed
 }
 
 fn trunc(s: &str, max: usize) -> String {
@@ -689,6 +757,10 @@ impl Splash {
         let mut hold_duration = Duration::ZERO;
         let mut total_ms: u64 = 0;
         let mut stages: Vec<StageRow> = Vec::new();
+        // Events held back from a tick where their matching Begin *also*
+        // landed, applied at the start of the next tick instead — see the
+        // count-up note in the drain loop below.
+        let mut deferred: Vec<StartupEvent> = Vec::new();
 
         loop {
             // NSApp event pump (not bare CFRunLoop) so a reopen Apple Event that
@@ -697,12 +769,14 @@ impl Splash {
                 pump_app_events(0.016);
             }
 
-            // Drain pending startup events (non-blocking) into the stage list.
-            let mut changed = false;
+            // Drain pending startup events (non-blocking) into the stage
+            // list. See `apply_tick`'s doc comment for why this isn't a
+            // plain "apply everything as it arrives" drain.
+            let mut fresh = Vec::new();
             while let Ok(ev) = self.startup_rx.try_recv() {
-                apply_event(&mut stages, ev);
-                changed = true;
+                fresh.push(ev);
             }
+            let mut changed = apply_tick(&mut stages, &mut deferred, fresh);
 
             let t = start.elapsed().as_secs_f64();
 
@@ -1201,5 +1275,140 @@ mod tests {
         assert_eq!(rows.len(), MAX_STAGE_ROWS);
         assert!(other_row_text(&rows).is_none());
         assert!(total_row_text(&rows).is_some());
+    }
+
+    fn stage_row<'a>(stages: &'a [StageRow], stage: &str) -> &'a StageRow {
+        stages.iter().find(|s| s.stage == stage).unwrap()
+    }
+
+    #[test]
+    fn a_same_tick_begin_and_end_pair_is_deferred_not_snapped_done() {
+        // The count-up bug: if a step's Begin and End are both already
+        // queued by the time a tick drains, applying both immediately would
+        // create the row already-done — no "running" frame ever painted.
+        let mut stages = Vec::new();
+        let mut deferred = Vec::new();
+        let fresh = vec![
+            StartupEvent::StageBegin { stage: "prep", label: "Prep" },
+            StartupEvent::StageEnd {
+                stage: "prep",
+                duration_ms: 5,
+                status: StartupStatus::Ok,
+                detail: None,
+            },
+        ];
+        let changed = apply_tick(&mut stages, &mut deferred, fresh);
+        assert!(changed);
+        // Begin applied, End held back — row exists but is still "running".
+        assert_eq!(stages.len(), 1);
+        assert!(stage_row(&stages, "prep").done.is_none());
+        assert_eq!(deferred.len(), 1);
+    }
+
+    #[test]
+    fn the_deferred_end_applies_on_the_next_tick() {
+        let mut stages = Vec::new();
+        let mut deferred = Vec::new();
+        apply_tick(
+            &mut stages,
+            &mut deferred,
+            vec![
+                StartupEvent::StageBegin { stage: "prep", label: "Prep" },
+                StartupEvent::StageEnd {
+                    stage: "prep",
+                    duration_ms: 5,
+                    status: StartupStatus::Ok,
+                    detail: None,
+                },
+            ],
+        );
+        // Next tick: nothing fresh, just the deferred End flushing in.
+        let changed = apply_tick(&mut stages, &mut deferred, Vec::new());
+        assert!(changed);
+        assert!(deferred.is_empty());
+        assert_eq!(stage_row(&stages, "prep").done.as_ref().unwrap().0, 5);
+    }
+
+    #[test]
+    fn a_begin_and_end_landing_in_different_ticks_is_never_deferred() {
+        // The common/expected case (step genuinely takes longer than one
+        // tick) must not be held back an *extra* tick on top of that.
+        let mut stages = Vec::new();
+        let mut deferred = Vec::new();
+        apply_tick(
+            &mut stages,
+            &mut deferred,
+            vec![StartupEvent::StageBegin { stage: "host", label: "Host" }],
+        );
+        assert!(deferred.is_empty());
+        assert!(stage_row(&stages, "host").done.is_none());
+
+        let changed = apply_tick(
+            &mut stages,
+            &mut deferred,
+            vec![StartupEvent::StageEnd {
+                stage: "host",
+                duration_ms: 40,
+                status: StartupStatus::Ok,
+                detail: None,
+            }],
+        );
+        assert!(changed);
+        assert!(deferred.is_empty());
+        assert_eq!(stage_row(&stages, "host").done.as_ref().unwrap().0, 40);
+    }
+
+    #[test]
+    fn a_same_tick_sub_begin_and_end_pair_is_deferred_too() {
+        let mut stages = vec![running_stage("migrations", "Migrations")];
+        let mut deferred = Vec::new();
+        let fresh = vec![
+            StartupEvent::SubBegin {
+                stage: "migrations",
+                id: "001".into(),
+                label: "001_init".into(),
+            },
+            StartupEvent::SubEnd {
+                stage: "migrations",
+                id: "001".into(),
+                duration_ms: 3,
+                status: StartupStatus::Ok,
+                detail: None,
+            },
+        ];
+        apply_tick(&mut stages, &mut deferred, fresh);
+        let sub = &stage_row(&stages, "migrations").subs[0];
+        assert!(sub.done.is_none());
+        assert_eq!(deferred.len(), 1);
+    }
+
+    #[test]
+    fn unrelated_deferred_and_fresh_events_do_not_interfere() {
+        // A deferred End from a previous tick and a brand-new, unrelated
+        // same-tick Begin+End pair in this tick must each be judged on their
+        // own — the deferred flush must not seed `began_this_tick`.
+        let mut stages = Vec::new();
+        let mut deferred = vec![StartupEvent::StageEnd {
+            stage: "prep",
+            duration_ms: 5,
+            status: StartupStatus::Ok,
+            detail: None,
+        }];
+        stages.push(running_stage("prep", "Prep"));
+        let fresh = vec![
+            StartupEvent::StageBegin { stage: "migrations", label: "Migrations" },
+            StartupEvent::StageEnd {
+                stage: "migrations",
+                duration_ms: 2,
+                status: StartupStatus::Ok,
+                detail: None,
+            },
+        ];
+        apply_tick(&mut stages, &mut deferred, fresh);
+        // "prep"'s deferred End flushed in this tick.
+        assert_eq!(stage_row(&stages, "prep").done.as_ref().unwrap().0, 5);
+        // "migrations" is new-and-fast this tick — its own End is deferred.
+        assert!(stage_row(&stages, "migrations").done.is_none());
+        assert_eq!(deferred.len(), 1);
     }
 }

--- a/agentmux-launcher/src/supervisor/unix.rs
+++ b/agentmux-launcher/src/supervisor/unix.rs
@@ -78,13 +78,31 @@ pub(crate) async fn run_unix(
     launcher_exe_dir: &std::path::Path,
     real_exe: &std::path::Path,
     args: &[String],
-    // Linux: pre-created sink whose rx was handed to the splash thread.
-    // macOS / other Unix: None; a fresh sink (rx dropped) is created below.
+    // macOS/Linux: pre-created sink whose rx was already handed to the
+    // splash thread in main() (both platforms paint the splash before
+    // calling into here). Other Unix / splash disabled: None; a fresh sink
+    // (rx dropped) is created below.
     startup_sink_opt: Option<startup_events::StartupEventSink>,
 ) {
     use tokio::signal::unix::{signal, SignalKind};
 
     let version = env!("CARGO_PKG_VERSION");
+
+    // Startup telemetry bus, resolved up front (rather than after the
+    // pre-supervisor work below, where it used to live) so that work itself
+    // can be wrapped in a "prep" stage — previously invisible in the splash
+    // panel on every platform (confirmed via grep: only "migrations"/
+    // "backend"/"host" were ever reported; the selftest fixture's "prep"/
+    // "Launcher setup" fixture data implied this stage already existed for
+    // real, but it never did). See
+    // docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md item 4.
+    let startup_sink = startup_sink_opt.unwrap_or_else(|| {
+        let (s, rx) = startup_events::StartupEventSink::new();
+        drop(rx);
+        s
+    });
+    startup_sink.stage_begin("prep", "Launcher setup");
+    let prep_t = std::time::Instant::now();
 
     // 1. Resolve + create data dirs (same authority as run_windows: srv +
     //    host receive these via env so they can't drift).
@@ -235,16 +253,16 @@ pub(crate) async fn run_unix(
         }
     }
 
-    // Startup telemetry bus.
-    // Linux: sink was created in main() before the splash thread launched;
-    // its rx is already being drained by the splash — reuse it so stage
-    // events flow live. macOS/other: create a fresh sink and drop rx
-    // (macOS splash doesn't yet consume typed events).
-    let startup_sink = startup_sink_opt.unwrap_or_else(|| {
-        let (s, rx) = startup_events::StartupEventSink::new();
-        drop(rx);
-        s
-    });
+    // "prep" ends here — everything above (paths, IPC socket, single-instance
+    // handshake, other-instances check, event log, saga registry legacy
+    // cleanup) is done. What follows (saga coordinator + IPC server setup,
+    // srv spawn) has its own stages/overlap already.
+    startup_sink.stage_end(
+        "prep",
+        prep_t.elapsed().as_millis() as u64,
+        startup_events::StartupStatus::Ok,
+        None,
+    );
 
     // Saga coordinator-setup/IPC-server-startup run concurrently with the
     // srv boot below (tokio::join!) instead of sequentially before it.

--- a/docs/retro/retro-splash-screen-rows-dont-count-up-2026-07-22.md
+++ b/docs/retro/retro-splash-screen-rows-dont-count-up-2026-07-22.md
@@ -1,0 +1,98 @@
+# Retro: macOS splash screen rows still don't "count up"
+
+**Date:** 2026-07-22
+**Severity:** Low (cosmetic — no functional impact on startup)
+**Area:** `agentmux-launcher` macOS native splash (`splash_mac.rs`)
+**Related PR:** #2244 (`feat(launcher): macOS splash — add an "other" row closing the total-vs-items gap`, merged 2026-07-20, commit `27d45f5d`)
+**Status:** Root-caused (again) — not fixed. This retro exists because the earlier investigation's conclusion ("deferred") wasn't visible enough for Asaf to know the count-up bug was never in scope for #2244.
+
+---
+
+## 1. What the user saw
+
+> "i just loaded it, and I notice the splash screen still has parts that dont count up .. what happened to that work?"
+
+The expectation, reasonable from the outside: PR #2244 touched the splash screen's row rendering, so it should have fixed the rows that don't animate. It didn't — because it was never meant to. It fixed a *different*, narrower complaint.
+
+---
+
+## 2. What #2244 actually shipped
+
+The ask behind #2244 was that the splash's "total" row and the sum of the individual stage/sub rows didn't add up — there was unaccounted time with no row explaining where it went. The fix, in `flatten_rows()` (`splash_mac.rs`, current lines ~284–309):
+
+```rust
+let accounted_ms: u64 = stages
+    .iter()
+    .filter_map(|s| s.done.as_ref().map(|(dur, _, _)| *dur))
+    .sum();
+let other_ms = ms.saturating_sub(accounted_ms);
+if out.len() + 2 <= MAX_STAGE_ROWS {
+    out.push(FlatRow {
+        indented: false,
+        label: String::new(),
+        time_text: format!("other: {}", format_ms(other_ms)),
+        label_color: (SUB_R, SUB_G, SUB_B),
+        time_color: (SUB_R, SUB_G, SUB_B),
+        ..
+    });
+}
+```
+
+This whole block runs only inside `if let Some(ms) = total_ms { ... }` — and `total_ms` is only `Some` once `ready_at` is set, i.e. once the host has already signaled first paint and startup is effectively over. So the "other" row is computed **once**, from already-final numbers (`total_ms - accounted_ms`), and appended already at its final value. It was never designed to animate — it has no `started_at`, no "running" state, nothing to count from. Same pattern the pre-existing "total" row already used.
+
+The same PR added `docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md`, which investigated the *count-up* behavior as background research while diagnosing the total-vs-items gap — but the doc is explicit that this was investigation only:
+
+> "Not implemented here — investigation only, per the ask."
+
+In other words: the count-up problem was found, written up, and consciously left out of #2244's scope on the same day it was documented. That framing didn't carry forward into how the PR was described/merged, so it read from the outside as "the splash counting work," when it was really "the splash total-accounting work."
+
+---
+
+## 3. Why rows don't count up — the actual mechanism
+
+None of this is new to this retro; it's a restatement of `ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md` §2, reverified against current `main` (`c8f141e5`, v0.54.3) — nothing has touched `splash_mac.rs` since #2244.
+
+Each row's live time comes from `StageRow`/`SubRow` (lines ~126–133): a `started_at: Instant`, and `done: Option<(u64, StartupStatus, Option<String>)>` that's only set once the matching `StageEnd`/`SubEnd` event arrives. `flatten_rows()` recomputes every row on every tick: while `done` is `None` it renders live elapsed time (`format_running(started_at)`, blue); once `done` it freezes on the final duration (green).
+
+The render loop (`run_until_dismissed()`, ~line 685) only *ticks* — drains the event channel and redraws — on a fixed ~8–24ms cadence, and only before `ready_at` fires. So "counting up" is not sourced from a real progress stream with item counts; it's a side effect of how many ticks land between a step's Begin and End events:
+
+- If a step's real work finishes fast enough that its `StageBegin` and `StageEnd` land in the channel before the splash's next drain, they're processed back-to-back in one tick — the row is created **already done**. No "running" frame is ever painted, so it just snaps to its final value.
+- If the Begin→End gap spans more than roughly one tick, at least one intermediate `format_running` frame gets drawn — that's the visible count-up.
+
+There is no minimum-duration threshold anywhere in the crate forcing a step to show at least one running frame. It's a pure emergent effect of tick cadence vs. how fast each startup step happens to run — not a deliberate on/off per row. That's consistent with what "parts that don't count up" looks like from the outside: fast steps (and the two structurally-static rows, "total" and "other") don't animate; slower steps do.
+
+A second, related defect from the same analysis: a row whose `End` event never arrives before `ready_at` fires gets frozen forever at whatever the one forced final-refresh produced — stuck in the "in progress" (blue) color, never turns green, never updates again.
+
+---
+
+## 4. Root cause, one line
+
+**The count-up bug and the total-vs-items-gap bug are two independent defects that happen to live in the same function (`flatten_rows`) and the same PR's diagnosis pass. #2244 fixed the gap; the count-up race (tick cadence vs. event-arrival timing in `run_until_dismissed`) was identified, documented, and explicitly deferred the same day — and nothing since has picked it back up.**
+
+---
+
+## 5. Why this wasn't caught sooner
+
+- The deferral was recorded in an analysis doc (`docs/analysis/...`), not in a follow-up task, issue, or a "known limitation" note in the PR description itself — so there was no forcing function to come back to it.
+- The PR title/description read as "splash screen work" broadly, which made "did that fix the counting?" a reasonable but wrong inference from the outside.
+- No `docs/retro/` entry existed for the splash counters before now — this is the first.
+
+---
+
+## 6. If we want to actually fix it (not implemented here)
+
+Per `ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md` §7, two concrete options, neither implemented:
+
+1. **Insert a minimum artificial delay** before processing a same-tick Begin+End pair, so every row gets at least one "running" paint frame regardless of how fast the real work was. Simple, but adds latency to an already latency-sensitive startup path — needs a small enough constant (~1 tick) to stay invisible.
+2. **Decouple rendering from the drain loop** — redraw on a fixed timer independent of `try_recv`, so a fast item's single tick-worth of "running" state still gets painted before the End event is processed. More correct, more invasive (event draining and repaint currently share one loop).
+
+Either fix should also close the "row frozen forever if End never arrives before `ready_at`" edge case, since both are symptoms of the same drain-loop-vs-wall-clock coupling.
+
+**Recommendation:** treat this as a real (if low-severity) follow-up ticket, not just an analysis doc — that's the gap that let it silently ride along on #2244 without becoming a decision anyone signed off on.
+
+---
+
+## 7. Timeline
+
+- **2026-07-20** — #2244 opened/merged (commit `27d45f5d`): adds the static "other" row, closing the total-vs-sum-of-items gap. Same PR adds `ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md`, which investigates and documents the separate count-up race but explicitly defers a fix.
+- **2026-07-22** — Asaf loads a fresh build, notices rows still don't count up, asks what happened to "that work." This retro written to make the scope split (gap-fix vs. count-up) and the deferred status explicit and discoverable.

--- a/docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md
+++ b/docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md
@@ -22,7 +22,7 @@ a full read of its own body names 7).
 | 1 | **Count-up race** — rows whose Begin+End land in the same tick snap instead of animating | **High** | Low | ✅ **Fixed this pass** |
 | 2 | **B.7-1** — verify whether `cef`/`frontend`/channel-pruner stage events were ever wired | High (cheap) | ~0 | ✅ **Verified this pass — not wired** |
 | 3 | **B.7-2** — verify Linux's shipped `SUMMARY_HOLD_MS`/hold-equivalent value | High (cheap) | ~0 | ✅ **Verified this pass — see finding** |
-| 4 | Pre-supervisor stage instrumentation (macOS/Windows) | Medium | Low | Open |
+| 4 | Pre-supervisor stage instrumentation (macOS+Linux via `unix.rs`) | Medium | Low | ✅ **Done this pass** (Windows still open — see below) |
 | 5 | §B.4.3 — consolidate `StageRow`/`apply_event` across Windows/Linux/macOS into one shared module | Medium (maintainability) | Medium | Open |
 | 6 | A.4.4 — IPC-signal-based splash dismiss instead of file-existence poll | Low | Medium | Open (deferred by design) |
 | 7 | Extend the `"host"` stage to cover full spawn→first-paint (currently spawn-latency only) | Medium | Medium-High | Open (blocked on #6's signal work) |
@@ -65,9 +65,13 @@ More importantly, this also confirms a **semantic mismatch** the spec didn't fla
 
 ---
 
-## 4. Pre-supervisor stage instrumentation (macOS/Windows) — open
+## 4. Pre-supervisor stage instrumentation — ✅ done for macOS+Linux, still open for Windows
 
-Only Linux currently creates its `StartupEventSink` early enough in `main()` to capture a pre-supervisor (binary-path resolution etc.) stage. macOS and Windows create it later, so that window of startup work is invisible in both splashes' telemetry panels. Mechanical, low-risk, mirrors an already-working pattern — good next pickup. Not attempted this pass; deferred to keep this pass scoped to the two verified-cheap items + the one real bug fix.
+**Correction to the original spec's framing:** its claim was "only Linux creates its `StartupEventSink` early enough in `main()`." Re-verified against current code and that's stale — macOS has created its sink in `main()` at the same point as Linux (before the splash exists) since the original macOS splash consumer landed (#1933). The **actual** gap, confirmed by grep across every real (non-selftest) call site of `stage_begin`/`stage_end`/`sub_begin`/`sub_end`, was different: only three stages were ever reported anywhere — `"migrations"`, `"backend"` (both `srv_spawner.rs`), and `"host"` (`unix.rs`/`windows.rs`). The pre-supervisor work in `run_unix` — path resolution, IPC socket setup, the single-instance handshake, the older-running-instances check, event-log/saga-registry setup — was never wrapped in any stage at all, on any platform. (The selftest fixture's synthetic `"prep"`/`"Launcher setup"` row in `main.rs` implied this stage already existed for real; it never did.)
+
+**Fixed this pass, macOS+Linux (`agentmux-launcher/src/supervisor/unix.rs`):** moved the `startup_sink` resolution to the top of `run_unix` and wrapped everything from function entry through the single-instance handshake / event-log / saga-registry setup in a new `"prep"` stage, ending right before the `tokio::join!` that overlaps saga-coordinator setup with srv spawn. `cargo check`/`cargo test -p agentmux-launcher` both clean (222/222 passing) — purely additive, same `stage_begin`/`stage_end` idiom already used by the `"host"` stage, no control-flow changes.
+
+**Windows still genuinely open, for a different and larger reason than "sink timing":** `run_windows` creates its *own* `startup_sink`/spawns its *own* splash internally (`supervisor/windows.rs:259,274`), well after its own pre-supervisor work (path resolution, Job Object creation) already ran — unlike macOS/Linux, Windows' splash doesn't exist yet at that point, so there's no live splash to report a "prep" stage to at all. Closing this gap needs restructuring `main.rs`'s Windows branch to create the splash earlier (mirroring the macOS/Linux pattern), which is a real, Windows-specific behavior change I can't build or verify from this (macOS) environment — correctly left open rather than attempted blind.
 
 ## 5. §B.4.3 — StageRow/apply_event consolidation — open
 
@@ -87,6 +91,6 @@ Blocked by a real dependency: the host's env vars (`ws_endpoint`, etc.) are pars
 
 ---
 
-## Why items 4-8 weren't attempted this pass
+## Why items 5-8 (and Windows' half of item 4) weren't attempted this pass
 
-This pass intentionally stopped after the highest-ROI items (#1-3): #1 is the actual user-facing bug that prompted this consolidation, and #2-3 were free (pure verification, no code risk). Items 4-8 are each real, but every one of them either (a) needs cross-platform verification this single-platform (macOS) environment can't provide safely, or (b) was already deliberately deferred with sound reasoning that still holds. Picking one of them up should be a separate, individually-scoped pass — not bundled reactively into this one, per the same discipline the original spec called for and which this consolidation exists to make easier to follow going forward.
+This pass worked through the highest-ROI items in order: #1 is the actual user-facing bug that prompted this consolidation; #2-3 were free (pure verification, no code risk); #4's macOS+Linux half was low-effort and used an already-proven idiom, so it got picked up too once the real gap was understood precisely. Items 5-8, and Windows' half of #4, are each real, but every one of them either (a) needs Windows-specific verification this single-platform (macOS) environment can't provide safely, or (b) was already deliberately deferred with sound reasoning that still holds. Picking one of them up should be a separate, individually-scoped pass — not bundled reactively into this one, per the same discipline the original spec called for and which this consolidation exists to make easier to follow going forward.

--- a/docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md
+++ b/docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md
@@ -1,0 +1,92 @@
+# PLAN: Splash telemetry — consolidated open-items tracker
+
+**Date:** 2026-07-22
+**Purpose:** Single place to track every still-open item across the splash-telemetry
+work, replacing the scattered state where open items lived in three different
+documents with no shared tally. Supersedes the "Stack status" section of
+`SPEC_MACOS_LAUNCH_SPEED_AND_SPLASH_TELEMETRY_2026_07_02.md` (§ below) as the
+source of truth for what's left — that section undercounted (named 3 open items;
+a full read of its own body names 7).
+
+**Sources consolidated:**
+1. `docs/specs/SPEC_MACOS_LAUNCH_SPEED_AND_SPLASH_TELEMETRY_2026_07_02.md` — original design spec, 7 open items buried across §A.4/§B.4/§B.7.
+2. `docs/analysis/ANALYSIS_SPLASH_SCREEN_TIMING_2026_07_20.md` — the count-up race, found and deferred the same day as PR #2244.
+3. `docs/retro/retro-splash-screen-rows-dont-count-up-2026-07-22.md` — retro explaining why #2244 didn't fix the count-up bug.
+
+---
+
+## Status at a glance
+
+| # | Item | ROI | Effort | Status |
+|---|---|---|---|---|
+| 1 | **Count-up race** — rows whose Begin+End land in the same tick snap instead of animating | **High** | Low | ✅ **Fixed this pass** |
+| 2 | **B.7-1** — verify whether `cef`/`frontend`/channel-pruner stage events were ever wired | High (cheap) | ~0 | ✅ **Verified this pass — not wired** |
+| 3 | **B.7-2** — verify Linux's shipped `SUMMARY_HOLD_MS`/hold-equivalent value | High (cheap) | ~0 | ✅ **Verified this pass — see finding** |
+| 4 | Pre-supervisor stage instrumentation (macOS/Windows) | Medium | Low | Open |
+| 5 | §B.4.3 — consolidate `StageRow`/`apply_event` across Windows/Linux/macOS into one shared module | Medium (maintainability) | Medium | Open |
+| 6 | A.4.4 — IPC-signal-based splash dismiss instead of file-existence poll | Low | Medium | Open (deferred by design) |
+| 7 | Extend the `"host"` stage to cover full spawn→first-paint (currently spawn-latency only) | Medium | Medium-High | Open (blocked on #6's signal work) |
+| 8 | A.4.1 — full srv/host spawn parallelization | Low (right now) | High | Open (deferred by design — real architectural dependency) |
+
+Row-frozen-forever edge case (a row whose End never arrives before `ready_at` stays stuck in the "running" color forever) is a **related but distinct** defect from #1 — not fixed this pass, tracked separately below.
+
+---
+
+## 1. Count-up race — ✅ fixed this pass
+
+**Root cause** (confirmed via code read + the 2026-07-20 analysis): `splash_mac.rs`'s render loop drained *all* pending `StartupEvent`s from the channel before redrawing. If a step's `Begin` and `End` were both already queued by the time a tick drained (i.e. the real work finished in well under one ~8–24ms tick), they were applied back-to-back in the same pass — the row was created already-`done`, so no "running" frame was ever painted. Visually: fast steps snap straight to their final value; only steps slower than one tick visibly count up.
+
+**Fix:** `agentmux-launcher/src/splash_mac.rs` — extracted the per-tick event-application logic into a pure `apply_tick()` function. It now holds back (defers to the next tick) any `End` whose matching `Begin` was *also* seen in the same drain batch, guaranteeing every row spends at least one tick — and one render — in the "running" state before flipping to done. Deferred events from the previous tick are flushed first, before draining anything fresh, so genuinely slow steps (Begin and End in different ticks, the common case) are never held back an extra tick on top of their real duration.
+
+Covered by 5 new unit tests (`splash_mac::tests::*`) exercising: same-tick Begin+End deferral (stage and sub-item), the deferred End applying cleanly next tick, the common different-tick case never being deferred, and a deferred-plus-fresh-same-tick-pair combination not cross-contaminating each other's state. `cargo test -p agentmux-launcher splash_mac`: 11/11 passing (6 pre-existing + 5 new). `cargo check`/`cargo clippy` clean on the touched code.
+
+**Not fixed by this change** (separate defect, same root area): a row whose `End` genuinely never arrives before `ready_at` fires still freezes forever in the "running" (blue) color — that's a missing-event problem, not a same-tick-ordering problem, and needs its own fix (e.g. a fallback that marks any still-`None` row "unknown" once the hold starts, rather than leaving it visually implying it's still in flight). Tracked here as a follow-up, not scoped into this pass.
+
+---
+
+## 2. B.7-1 — cef/frontend/channel-pruner stage wiring — ✅ verified, not wired
+
+Exhaustive grep across `agentmux-cef/src/**`, `agentmux-launcher/src/ipc/**`, and `frontend/**` for `report_startup_stage_*`/`ReportStartupStage*`/`channel.pruner`/`ChannelPruner`:
+
+- The only two stages ever reported over this IPC path are **`"dlopen"`** and **`"cef_init"`** (`agentmux-cef/src/lib.rs:577-578, 884, 953`) — both CEF sub-stages of what the spec calls the `"host"` stage.
+- **No** distinct top-level `"cef"` or `"frontend"` stage exists.
+- **No** channel-pruner stage exists anywhere in the current tree — `SPEC_LOCAL_CHANNEL_PRUNER_2026_06_25.md`'s concept, if implemented at all, was never wired into splash telemetry.
+- `frontend/` has zero references to startup-stage reporting of any kind.
+
+**Conclusion:** confirmed a real, still-open gap (item #7/"host" stage below), not a documentation error — anyone building on top of "the splash shows frontend-load timing" would be wrong to assume that.
+
+---
+
+## 3. B.7-2 — Linux's shipped hold-duration value — ✅ verified
+
+`agentmux-launcher/src/splash_linux/mod.rs:224-229` (`min_hold()`): default is **450ms**, overridable via `AGENTMUX_SPLASH_HOLD_MS` — not the spec's cited "design intent" of 1500ms.
+
+More importantly, this also confirms a **semantic mismatch** the spec didn't flag: Linux's `min_hold()` is a *minimum total on-screen time* (so a sub-perceptible flash doesn't happen on a very fast cold start) — it can overlap with real loading time. macOS's `hold_duration` (`splash_mac.rs`, default 2000ms) is a *pause added after* `ready_at`, specifically so the user can read the finished stage timeline before it fades. These are two different mechanisms answering two different questions, both currently reusing the same env var name (`AGENTMUX_SPLASH_HOLD_MS`) with different defaults and different effective behavior. Not fixed here — flagged as a real (if minor) design inconsistency worth a decision (either genuinely unify the semantics, or rename one to stop implying they're the same knob).
+
+---
+
+## 4. Pre-supervisor stage instrumentation (macOS/Windows) — open
+
+Only Linux currently creates its `StartupEventSink` early enough in `main()` to capture a pre-supervisor (binary-path resolution etc.) stage. macOS and Windows create it later, so that window of startup work is invisible in both splashes' telemetry panels. Mechanical, low-risk, mirrors an already-working pattern — good next pickup. Not attempted this pass; deferred to keep this pass scoped to the two verified-cheap items + the one real bug fix.
+
+## 5. §B.4.3 — StageRow/apply_event consolidation — open
+
+Windows (`splash.rs`), Linux (`splash_linux/mod.rs`), and macOS (`splash_mac.rs`, this file) each independently reimplement the same `StageRow`/`apply_event`/formatting state machine. Real cleanup opportunity, explicitly deferred when macOS's version was first added (2026-07-03) specifically because doing the extraction then would have meant editing two already-working splashes with no way to build/verify Windows from this (macOS) environment. Same constraint still applies today — still correctly deferred, not attempted this pass.
+
+## 6. A.4.4 — IPC-signal-based dismiss instead of file-poll — open, deferred by design
+
+`splash_mac.rs` polls `std::fs::metadata` every ~8ms for up to `DISMISS_TIMEOUT` (10s) waiting for the ready-file. Real, but minor CPU/wake overhead — not a latency win. Fixing it means replacing a dismiss protocol shared across all three platform backends and `agentmux-cef`'s `on_load_end` with an IPC-socket signal — real cross-crate risk for low payoff. Correctly still deferred.
+
+## 7. Extend `"host"` stage to full spawn→first-paint — open, blocked on #6
+
+Currently only spawn *latency* is instrumented (`agentmux-launcher/src/supervisor/{unix,windows}.rs`), not the full spawn-to-first-paint window. Needs the same race-safe first-paint signal work as item #6 — bundling them is the efficient path if #6 is ever picked up, since implementing one without the other leaves half the protocol change undone.
+
+## 8. A.4.1 — full srv/host spawn parallelization — open, deferred by design
+
+Blocked by a real dependency: the host's env vars (`ws_endpoint`, etc.) are parsed out of srv's self-reported `AGENTMUXSRV-ESTART` line, since srv self-binds a dynamic port. Two viable fixes exist (launcher pre-allocates the port, or host bootstraps via IPC-push instead of env vars) but both are materially bigger changes needing their own design spec and a full GUI-driven multi-instance test pass to verify safely. Correctly still deferred — highest raw upside of anything on this list, but not attempted here given the verification requirement this environment can't satisfy end-to-end.
+
+---
+
+## Why items 4-8 weren't attempted this pass
+
+This pass intentionally stopped after the highest-ROI items (#1-3): #1 is the actual user-facing bug that prompted this consolidation, and #2-3 were free (pure verification, no code risk). Items 4-8 are each real, but every one of them either (a) needs cross-platform verification this single-platform (macOS) environment can't provide safely, or (b) was already deliberately deferred with sound reasoning that still holds. Picking one of them up should be a separate, individually-scoped pass — not bundled reactively into this one, per the same discipline the original spec called for and which this consolidation exists to make easier to follow going forward.


### PR DESCRIPTION
## Summary
- Fixes the reported "splash rows don't count up" bug: rows whose Begin+End both land in the same ~8-24ms render tick were applied back-to-back and created already-done, so no "running" frame ever painted — fast steps just snapped to their final value.
- Fix defers an End to the next tick whenever its matching Begin was also seen in the same drain pass, guaranteeing every row spends at least one tick visibly "running" before flipping done.
- Adds `docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md`, consolidating the splash-telemetry spec's scattered open items (7 found vs. the spec's own tally of 3) into one tracker, and resolves two of them for free via verification (no code risk): confirmed `cef`/`frontend` stage events were never wired end-to-end, and confirmed Linux's actual shipped hold-duration default is 450ms (not the 1500ms the original spec assumed) — and that it's a semantically different knob (min on-screen time vs. macOS's post-ready hold) despite sharing an env var name.
- Adds `docs/retro/retro-splash-screen-rows-dont-count-up-2026-07-22.md` explaining why PR #2244 never fixed this (it closed a different, unrelated complaint about the "total" row not matching the sum of item rows).

## Test plan
- [x] `cargo test -p agentmux-launcher splash_mac` — 11/11 passing (6 pre-existing + 5 new covering the deferral logic)
- [x] `cargo test -p agentmux-launcher` (full crate) — 222/222 passing
- [x] `cargo check` / `cargo clippy` clean on touched code
- [ ] Live visual verification on a real macOS launch (can't screen-record/verify AppKit rendering from this environment — Asaf to confirm rows visibly count up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)