### PR TITLE
Fix stale Claude Code version doc and exe-return-codes.md

### DIFF
--- a/docker/Dockerfile.agent-agentmux
+++ b/docker/Dockerfile.agent-agentmux
@@ -33,7 +33,7 @@ RUN usermod -l agent -d /home/agent -m node \
 
 # Claude Code — version pinned at build time for reproducible images.
 # Managed by rebuilding with a new CLAUDE_VERSION arg, not npm update.
-ARG CLAUDE_VERSION=2.1.197
+ARG CLAUDE_VERSION=2.1.198
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 
 # Prevent in-container auto-updates — version is managed at the image level.

--- a/docs/exe-return-codes.md
+++ b/docs/exe-return-codes.md
@@ -23,4 +23,4 @@ The Windows installer moved from NSIS to **Inno Setup** (`packaging/windows/agen
 
 - On Windows, `agentmux-launcher` auto-spawns `agentmux-srv` as a sidecar process (owning its lifecycle directly, rather than `agentmux-cef` spawning it) and also spawns `agentmux-cef` itself. If the backend exits with code 1, the application will not function correctly.
 - Child processes running inside terminal panes (shells, commands) have their own exit codes which are tracked internally but do not affect the application's exit code.
-- `wsh` (the old shell-integration binary) has been retired — see `specs/SPEC_RETIRE_WSH_2026_04_12.md`. There is no binary to deploy or document return codes for anymore.
+- `wsh` (the old shell-integration binary) has been retired — see `specs/archive/SPEC_RETIRE_WSH_2026_04_12.md`. There is no binary to deploy or document return codes for anymore.

--- a/docs/exe-return-codes.md
+++ b/docs/exe-return-codes.md
@@ -1,12 +1,22 @@
 # AgentMux Executable Return Codes
 
+## agentmux.exe / agentmux-launcher (Windows entry point)
+
+On Windows, the executable users actually launch is `agentmux.exe` — `scripts/package-portable.sh` builds it by copying `agentmux-launcher.exe`, and `packaging/windows/agentmux.iss` installs it under that name. The launcher owns `agentmux-srv`'s lifecycle directly and spawns `agentmux-cef` itself (see the Architecture section of `CLAUDE.md`).
+
+| Exit Code | Description |
+|-----------|-------------|
+| **0** | Clean exit — the launcher supervisor finished normally (host exited, or a `--diag` subcommand succeeded) |
+| **1** | Fatal startup/supervision error — causes include: the supervisor thread panicking, the runtime being misconfigured (host binary resolves to the launcher itself), the CEF host binary not found in `runtime/`, or a `--diag sagas` failure |
+| **2** | `--diag` CLI usage error (missing or unknown topic; known topics: `wrr`, `srv`, `sagas`) |
+
 ## agentmux-cef (Desktop Host)
 
 | Exit Code | Description |
 |-----------|-------------|
 | **0** | Clean exit — application closed normally (e.g., user quit via tray icon or window close) |
 
-On Windows, `agentmux-launcher` is what actually launches `agentmux-cef` (and, in turn, owns `agentmux-srv`'s lifecycle) — see the Architecture section of `CLAUDE.md`. `agentmux-cef` is not spawned directly by the user on that platform.
+`agentmux-cef` is not spawned directly by the user on Windows — `agentmux-launcher` launches it, per the table above. On macOS/Linux, `agentmux-cef` is invoked via the launcher too (see `CLAUDE.md`'s Architecture section) rather than run standalone.
 
 ## agentmux-srv (Backend Server)
 

--- a/docs/exe-return-codes.md
+++ b/docs/exe-return-codes.md
@@ -4,11 +4,15 @@
 
 On Windows, the executable users actually launch is `agentmux.exe` — `scripts/package-portable.sh` builds it by copying `agentmux-launcher.exe`, and `packaging/windows/agentmux.iss` installs it under that name. The launcher owns `agentmux-srv`'s lifecycle directly and spawns `agentmux-cef` itself (see the Architecture section of `CLAUDE.md`).
 
+This table is not a small fixed enum — on Windows, `supervisor/windows.rs` can also **pass through the CEF host's or `agentmux-srv`'s own raw OS exit code** once a restart/recovery budget is exhausted (`break code`, e.g. after repeated abnormal host exits or repeated system-OOM restarts) or a relaunch attempt itself fails to spawn. Codes below are the launcher's own, not inherited ones.
+
 | Exit Code | Description |
 |-----------|-------------|
 | **0** | Clean exit — the launcher supervisor finished normally (host exited, a `--diag` subcommand succeeded, or on macOS/Linux, `second_instance.rs` detected a running peer and exited cleanly as the second instance) |
 | **1** | Fatal startup/supervision error — causes include: the supervisor thread panicking, the runtime being misconfigured (host binary resolves to the launcher itself), the CEF host binary not found in `runtime/`, or a `--diag sagas` failure |
-| **2** | Fatal setup error unrelated to `--diag`: on Windows, a `--diag` CLI usage error (missing or unknown topic; known topics: `wrr`, `srv`, `sagas`); on macOS/Linux, `second_instance.rs::bind_socket_with_recovery` failing to bind/recover the IPC socket (initial bind failure, lockfile open failure, `flock` failure, post-lock or post-recovery rebind failure) |
+| **2** | Fatal IPC setup failure unrelated to `--diag`: on Windows, `supervisor/windows.rs` failing to bind/forward the named pipe (also used for the `--diag` CLI usage-error case: missing or unknown topic, known topics `wrr`/`srv`/`sagas`); on macOS/Linux, `second_instance.rs::bind_socket_with_recovery` failing to bind/recover the IPC Unix socket (initial bind failure, lockfile open failure, `flock` failure, post-lock or post-recovery rebind failure) |
+| **86** | Windows-only: `TEARDOWN_BACKSTOP_EXIT_CODE` (`supervisor/windows.rs`) — the CEF host wedged with zero user windows open and stopped responding to UI-thread liveness probes past the grace period; the launcher force-terminates the job and exits with this distinct code so the failure is unambiguous in log/exit-code triage |
+| *(other)* | Windows-only: the host's or `agentmux-srv`'s own raw exit code, passed through after `supervisor/windows.rs` gives up retrying that failure class (host/srv restart budget exhausted, OOM-recovery budget exhausted, or a relaunch attempt itself failed to spawn) |
 
 ## agentmux-cef (Desktop Host)
 

--- a/docs/exe-return-codes.md
+++ b/docs/exe-return-codes.md
@@ -1,42 +1,26 @@
 # AgentMux Executable Return Codes
 
-## agentmux.exe (Desktop Application)
+## agentmux-cef (Desktop Host)
 
 | Exit Code | Description |
 |-----------|-------------|
 | **0** | Clean exit — application closed normally (e.g., user quit via tray icon or window close) |
 
-## agentmuxsrv-rs.exe (Backend Server)
+On Windows, `agentmux-launcher` is what actually launches `agentmux-cef` (and, in turn, owns `agentmux-srv`'s lifecycle) — see the Architecture section of `CLAUDE.md`. `agentmux-cef` is not spawned directly by the user on that platform.
+
+## agentmux-srv (Backend Server)
 
 | Exit Code | Description |
 |-----------|-------------|
 | **0** | Clean shutdown — server exited normally. This includes: version/help flag requested, signal-based shutdown (SIGTERM/SIGINT), lock file indicates another instance is running, or graceful stop via internal command |
 | **1** | Fatal startup error — server failed to start. Causes include: lock file creation failure, database migration failure, HTTP/WebSocket server bind failure, or other unrecoverable initialization error |
 
-## wsh.exe (Shell Integration)
+## Windows Installer (Inno Setup)
 
-| Exit Code | Description |
-|-----------|-------------|
-| **0** | Command completed successfully |
-| **1** | Command failed or invalid arguments |
-
-## NSIS Installer (AgentMux_*_x64-setup.exe)
-
-| Exit Code | Description |
-|-----------|-------------|
-| **0** | Installation completed successfully |
-| **1** | Installation cancelled by user (clicked Cancel or closed installer) |
-| **2** | Application already exists on the device (silent/passive mode only) |
-| **3** | Another installation is already in progress |
-| **4** | Insufficient disk space to complete installation |
-| **5** | A restart is required to complete the install |
-| **6** | Network failure (e.g., WebView2 download failed) |
-| **7** | Package rejected during installation (binary missing after extraction) |
-
-These codes are required for Microsoft Store compliance. The standard NSIS `/S` (silent) and `/P` (passive) flags are supported.
+The Windows installer moved from NSIS to **Inno Setup** (`packaging/windows/agentmux.iss`, driven by `scripts/package-installer.ps1`). It uses Inno Setup's own standard `Setup.exe` exit codes (not the NSIS table this doc previously listed) — see the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes) for the authoritative list, since no custom exit-code handling is defined in `agentmux.iss`. Standard silent-install flags apply: `/SILENT`, `/VERYSILENT`.
 
 ## Notes
 
-- The desktop application (`agentmux.exe`) auto-spawns `agentmuxsrv-rs.exe` as a sidecar process. If the backend exits with code 1, the application will not function correctly.
+- On Windows, `agentmux-launcher` auto-spawns `agentmux-srv` as a sidecar process (owning its lifecycle directly, rather than `agentmux-cef` spawning it) and also spawns `agentmux-cef` itself. If the backend exits with code 1, the application will not function correctly.
 - Child processes running inside terminal panes (shells, commands) have their own exit codes which are tracked internally but do not affect the application's exit code.
-- On Windows, the NSIS installer (`AgentMux_*_x64-setup.exe`) supports the `/S` flag for silent installation.
+- `wsh` (the old shell-integration binary) has been retired — see `specs/SPEC_RETIRE_WSH_2026_04_12.md`. There is no binary to deploy or document return codes for anymore.

--- a/docs/exe-return-codes.md
+++ b/docs/exe-return-codes.md
@@ -6,9 +6,9 @@ On Windows, the executable users actually launch is `agentmux.exe` — `scripts/
 
 | Exit Code | Description |
 |-----------|-------------|
-| **0** | Clean exit — the launcher supervisor finished normally (host exited, or a `--diag` subcommand succeeded) |
+| **0** | Clean exit — the launcher supervisor finished normally (host exited, a `--diag` subcommand succeeded, or on macOS/Linux, `second_instance.rs` detected a running peer and exited cleanly as the second instance) |
 | **1** | Fatal startup/supervision error — causes include: the supervisor thread panicking, the runtime being misconfigured (host binary resolves to the launcher itself), the CEF host binary not found in `runtime/`, or a `--diag sagas` failure |
-| **2** | `--diag` CLI usage error (missing or unknown topic; known topics: `wrr`, `srv`, `sagas`) |
+| **2** | Fatal setup error unrelated to `--diag`: on Windows, a `--diag` CLI usage error (missing or unknown topic; known topics: `wrr`, `srv`, `sagas`); on macOS/Linux, `second_instance.rs::bind_socket_with_recovery` failing to bind/recover the IPC socket (initial bind failure, lockfile open failure, `flock` failure, post-lock or post-recovery rebind failure) |
 
 ## agentmux-cef (Desktop Host)
 

--- a/docs/spec-claude-code-versioning.md
+++ b/docs/spec-claude-code-versioning.md
@@ -1,7 +1,7 @@
 # Spec: Claude Code Version Management
 
 **Status:** Active  
-**Current pinned version:** `2.1.197`  
+**Current pinned version:** `2.1.198`  
 **Previous default:** `latest` (floating)
 
 ## Problem
@@ -11,26 +11,36 @@ installing whatever `@anthropic-ai/claude-code@latest` resolved to at image buil
 time. This meant two builds triggered minutes apart could embed different Claude Code
 versions, breaking reproducibility and making regressions harder to bisect.
 
-## Version pins (two locations)
+## Version pins (five locations)
 
 | File | Location | Purpose |
 |------|----------|---------|
-| `docker/Dockerfile.agent-agentmux` line 36 | `ARG CLAUDE_VERSION=2.1.197` | Fallback for local `docker build` without passing the arg |
-| `.github/workflows/container-image.yml` line 12 | `default: '2.1.197'` | Default used when CI is triggered via `workflow_dispatch` without an explicit version input |
+| `docker/Dockerfile.agent-agentmux` line 36 | `ARG CLAUDE_VERSION=2.1.198` | Fallback for local `docker build` without passing the arg |
+| `.github/workflows/container-image.yml` line 16 | `default: '2.1.198'` | Default used when CI is triggered via `workflow_dispatch` without an explicit version input |
+| `agentmux-srv/src/backend/providers.rs` | `pinned_version: "2.1.198"` (CLAUDE static) | Version the backend sidecar installs |
+| `agentmux-cef/src/commands/providers.rs` | `const CLAUDE_VERSION: &str = "2.1.198"` | Version the host installer installs |
+| `frontend/app/view/agent/providers/index.ts` | `pinnedVersion: "2.1.198"` (PROVIDERS.claude) | Version surfaced in the UI |
 
 The CI workflow's "Resolve Claude Code version" step (`id: claude_ver`) has a special case:
 - Input non-empty and not `"latest"` → use the input value verbatim (shell injection safe via `env:`)
 - Input empty or `"latest"` → resolve via `npm view @anthropic-ai/claude-code version` at build time
 
-Both pins must be updated together when bumping.
+`frontend/app/view/agent/providers/pin-consistency.test.ts` enforces agreement across
+the last three (frontend, srv, cef) plus the workflow default — it does **not**
+cover the Dockerfile `ARG`, so that one location can still drift silently; double
+check it by hand when bumping. All five must be updated together.
 
 ## How to bump
 
 1. Check the latest release: `npm view @anthropic-ai/claude-code version`
 2. In `docker/Dockerfile.agent-agentmux`: update `ARG CLAUDE_VERSION=<new>`
 3. In `.github/workflows/container-image.yml`: update `default: '<new>'`
-4. Open a PR and merge it.
-5. To publish the image, either:
+4. In `agentmux-srv/src/backend/providers.rs`: update the CLAUDE static's `pinned_version`
+5. In `agentmux-cef/src/commands/providers.rs`: update `CLAUDE_VERSION`
+6. In `frontend/app/view/agent/providers/index.ts`: update `PROVIDERS.claude.pinnedVersion`
+7. Run `pin-consistency.test.ts` to confirm 2-6 agree (it won't catch the Dockerfile).
+8. Open a PR and merge it.
+9. To publish the image, either:
    - **Push a `v*` git tag** (e.g. `git tag v0.50.0 && git push origin v0.50.0`) — this triggers the workflow automatically and publishes both the semver tag and `:latest`.
    - **Manually dispatch** the `Container Agent Image` workflow — this builds and pushes a `dispatch-<sha>` tag only; `:latest` is *not* updated by a manual dispatch.
 
@@ -39,6 +49,7 @@ Both pins must be updated together when bumping.
 | Version | Date | Notes |
 |---------|------|-------|
 | `2.1.197` | 2026-06-30 | First explicit pin; replaced floating `latest` default |
+| `2.1.198` | 2026-07-02 | Bump; initially missed the cef host installer and workflow default (see `pin-consistency.test.ts` history note) |
 
 ## Escape hatch
 


### PR DESCRIPTION
## Summary
- Doc-analyst findings DOC-003, DOC-007 from the Weekly Documentation Analyst's first report.
- `spec-claude-code-versioning.md` said current pin was 2.1.197 across "two locations"; actual current pin is 2.1.198 across five locations, and the Dockerfile ARG (not covered by `pin-consistency.test.ts`) had silently drifted behind the rest. Bumped it to match and documented all five pin sites.
- `exe-return-codes.md` referenced renamed/retired binaries (`agentmuxsrv-rs.exe` -> `agentmux-srv`, `wsh.exe` retired) and an NSIS installer table; Windows packaging moved to Inno Setup (`packaging/windows/agentmux.iss`). Updated names and pointed at Inno Setup's own exit-code reference instead of fabricating a replacement table.

## Test plan
- [x] Verified pin values via `pin-consistency.test.ts`, `providers.rs` (srv + cef), `frontend/.../index.ts`, and `container-image.yml`
- [x] Verified binary names via `agentmux-cef/src/sidecar.rs`
- [x] Verified installer via `packaging/windows/agentmux.iss` / `scripts/package-installer.ps1` and repo-wide grep for NSIS vs. Inno Setup references
- [ ] No app code paths changed besides a Docker build-arg default; no build/test run needed beyond the above

<!-- agentmux:agent_id=agent2 -->