### PR TITLE
feat(tabs): shrink-to-fit pane tab strip + double-click rename

### DIFF
--- a/.changesets/1784830298-feat-tabs-shrink-to-fit-pane-tab-strip-sizing-double-click-r-q2ac.md
+++ b/.changesets/1784830298-feat-tabs-shrink-to-fit-pane-tab-strip-sizing-double-click-r-q2ac.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(tabs): shrink-to-fit pane tab strip sizing + double-click rename for agent fork and terminal tabs

--- a/agentmux-srv/src/backend/rpc_types/agent.rs
+++ b/agentmux-srv/src/backend/rpc_types/agent.rs
@@ -635,3 +635,11 @@ pub struct CommandForkAgentDefinitionSuggestData {
 pub struct ForkAgentDefinitionSuggestResult {
     pub suggested_label: String,
 }
+
+/// SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §4 — renames
+/// whichever field a fork tab's title actually resolves from.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandRenameAgentDefinitionTitleData {
+    pub id: String,
+    pub title: String,
+}

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -209,6 +209,12 @@ pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
 /// Returns the suggested branch label for a fork without mutating anything.
 /// Called when the user clicks "Open new session" to pre-fill the name input.
 pub const COMMAND_FORK_AGENT_DEFINITION_SUGGEST: &str = "forkagentdefinitionsuggest";
+/// Renames a fork/agent tab's displayed title — SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §4.
+/// Writes `branch_label` when the definition already has one set (a fork),
+/// else `name` (a lineage root) — whichever field `fork-set.ts`'s `titleOf()`
+/// actually displays. Deliberately separate from `updateagent`, which keeps
+/// `branch_label` immutable for every other caller.
+pub const COMMAND_RENAME_AGENT_DEFINITION_TITLE: &str = "renameagentdefinitiontitle";
 
 /// Two-tier picker (Phase 1 — SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md).
 /// Clone a seeded template into a new user-owned agent definition with

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -746,10 +746,19 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// Update an existing agent definition (all fields except id, created_at, is_seeded).
-    /// `parent_id` and `branch_label` are NOT updatable post-insert — they
-    /// describe the agent's provenance; renaming or re-branching is done by
-    /// creating a new fork, not mutating the original.
+    /// Update an existing agent definition (all fields except id, created_at, is_seeded, `parent_id`).
+    /// `parent_id` is NOT updatable post-insert — it describes the agent's
+    /// lineage; re-parenting is done by creating a new fork, not mutating the
+    /// original.
+    ///
+    /// `branch_label` IS written here (unlike `parent_id`) — this storage-
+    /// layer function persists whatever is on `agent`. Immutability for most
+    /// callers is enforced one layer up, at the RPC handler: `updateagent`
+    /// always passes back `old.branch_label.clone()` unchanged, so it's a
+    /// no-op for that caller. `renameagentdefinitiontitle` is the one
+    /// deliberate exception that supplies a real change — see
+    /// `agentmux-srv/src/server/agent_handlers/template.rs` and
+    /// docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §4.
     ///
     /// Self-stamps `updated_at` with the current time and writes it back into
     /// `agent.updated_at`, so the caller's struct (e.g. an RPC response body)
@@ -767,7 +776,7 @@ impl Store {
                  restart_on_crash=?9, idle_timeout_minutes=?10,
                  agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15,
                  container_image=?17, container_volumes=?18, container_name=?19,
-                 use_ambient_login=?20
+                 use_ambient_login=?20, branch_label=?21
                  WHERE id=?16",
                 params![
                     agent.name,
@@ -790,6 +799,7 @@ impl Store {
                     agent.container_volumes,
                     agent.container_name,
                     agent.use_ambient_login,
+                    agent.branch_label,
                 ],
             )?
         };

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -2391,6 +2391,57 @@
         );
     }
 
+    // Reagent P0 on PR #2282: `agent_def_update`'s legacy `db_agent_definitions`
+    // UPDATE never touches `branch_label` — but the dual-write upsert into
+    // `db_agents` (the table `agent_def_list` actually reads) does, via its
+    // `branch_label = excluded.branch_label` ON CONFLICT clause. Verifies the
+    // end-to-end round-trip `renameagentdefinitiontitle` depends on: a
+    // `branch_label` change made through `agent_def_update` is both persisted
+    // in `db_agents` and visible through `agent_def_list`.
+    #[test]
+    fn dual_write_agent_def_update_persists_branch_label_change() {
+        let store = make_store();
+        let mut def = AgentDefinition {
+            id: "fork-rename-test".to_string(),
+            slug: String::new(),
+            name: "Fork Name".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: "bash".to_string(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1000,
+            agent_type: "standalone".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: "some-parent".to_string(),
+            branch_label: "Old Branch".to_string(),
+            updated_at: 1000,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        };
+        store.agent_def_insert(&mut def).unwrap();
+        def.branch_label = "New Branch".to_string();
+        assert!(store.agent_def_update(&mut def).unwrap());
+        assert_eq!(
+            read_agent_field(&store, "fork-rename-test", "branch_label"),
+            Some("New Branch".to_string()),
+            "branch_label should persist into db_agents after agent_def_update"
+        );
+        let listed = store.agent_def_list().unwrap();
+        let row = listed.iter().find(|a| a.id == "fork-rename-test").unwrap();
+        assert_eq!(row.branch_label, "New Branch", "agent_def_list should reflect the new branch_label");
+    }
+
     #[test]
     fn dual_write_agent_def_delete_removes_db_agents_row() {
         let store = make_store();

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -19,6 +19,8 @@ use crate::backend::rpc_types::{
     COMMAND_FORK_AGENT_DEFINITION_SUGGEST,
     CommandForkAgentDefinitionSuggestData, ForkAgentDefinitionSuggestResult,
     CommandForkAgentDefinitionData,
+    COMMAND_RENAME_AGENT_DEFINITION_TITLE,
+    CommandRenameAgentDefinitionTitleData,
 };
 use crate::backend::storage::{AgentDefinition, AgentContent, AgentSkill};
 
@@ -431,6 +433,66 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 let result = ForkAgentDefinitionSuggestResult { suggested_label };
                 Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // ---- Rename a fork/agent tab's displayed title ----
+    //
+    // Deliberately separate from `updateagent`, which preserves
+    // `branch_label` unconditionally (core.rs: "parent_id + branch_label
+    // describe provenance and are immutable post-insert"). That contract
+    // stays true for every OTHER caller of `updateagent` — this handler is
+    // the one narrow, explicit path that's allowed to change it, and only
+    // the field `fork-set.ts`'s `titleOf()` actually displays: `branch_label`
+    // when the row already has one (a fork), else `name` (a lineage root).
+    // See SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §4.
+    let wstore_rn = state.wstore.clone();
+    let broker_rn = state.broker.clone();
+    engine.register_handler(
+        COMMAND_RENAME_AGENT_DEFINITION_TITLE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_rn.clone();
+            let broker = broker_rn.clone();
+            Box::pin(async move {
+                let cmd: CommandRenameAgentDefinitionTitleData = serde_json::from_value(data)
+                    .map_err(|e| format!("renameagentdefinitiontitle: {e}"))?;
+                let title = cmd.title.trim();
+                if title.is_empty() {
+                    return Err("renameagentdefinitiontitle: title must not be empty".to_string());
+                }
+
+                let all = wstore
+                    .agent_def_list()
+                    .map_err(|e| format!("renameagentdefinitiontitle: {e}"))?;
+                let old = all
+                    .iter()
+                    .find(|a| a.id == cmd.id)
+                    .ok_or_else(|| format!("renameagentdefinitiontitle: agent {} not found", cmd.id))?;
+
+                let mut updated = old.clone();
+                if !updated.branch_label.is_empty() {
+                    updated.branch_label = title.to_string();
+                } else {
+                    updated.name = title.to_string();
+                }
+
+                let found = wstore
+                    .agent_def_update(&mut updated)
+                    .map_err(|e| format!("renameagentdefinitiontitle: {e}"))?;
+                if !found {
+                    return Err(format!("renameagentdefinitiontitle: agent {} not found", cmd.id));
+                }
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "agents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+
+                Ok(Some(serde_json::to_value(&updated).unwrap_or_default()))
             })
         }),
     );

--- a/docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md
+++ b/docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md
@@ -1,0 +1,285 @@
+# SPEC: Pane tab strip — compact (shrink-to-fit) sizing + double-click rename
+
+**Date:** 2026-07-22
+**Status:** Implemented — §4 resolved via option 2 (dedicated `renameagentdefinitiontitle` RPC)
+**Scope:** `frontend/app/element/PaneTabStrip.tsx` / `.scss` (shared strip), agent-pane fork
+tabs (`frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/fork/**`), terminal-pane
+tabs (`frontend/app/view/term/term.tsx`)
+**Author:** Agent3
+**Related:**
+`docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md` (introduced the shared
+`PaneTabStrip` component and both consumers this spec refines — Phases 1–5, all merged),
+`frontend/app/tab/tab-measure.ts` (the window-tab-bar's existing content-width-measurement
+precedent, reused conceptually below),
+`frontend/app/block/titlebar.tsx` (the existing per-block click-to-rename precedent, reused
+conceptually below)
+
+---
+
+## 1. Intent
+
+Three follow-up polish items on the tab strip shipped by
+`SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md`, stated by the user directly:
+
+1. **Shrink-to-fit strip.** When an agent or terminal pane has only one tab open, the strip
+   should show just that tab (or, per the user's literal wording, just the `+`) hugging the
+   left edge — not a full-pane-width bar with dead, blank space trailing after the `+`. "The
+   bar grows as it is used, not a whole bar of blank."
+2. **Content-sized tabs.** When `+` is clicked and a new tab opens, that tab's width should be
+   exactly the width of its label (plus padding) — not a fixed/flex-stretched width unrelated
+   to the text it holds.
+3. **Double-click to rename.** A tab should be renamable by double-clicking it.
+
+## 2. Current state (verified against `main` @ `6ab7e60cc`)
+
+### 2.1 Why the strip shows dead space today
+
+`frontend/app/element/PaneTabStrip.scss`:
+
+```scss
+.pane-tab-strip {
+    display: flex;
+    flex-direction: row;
+    // no explicit width — a block-level flex container defaults to 100% of
+    // its parent, i.e. the full pane width.
+}
+
+.pane-tab-tip {           // the Tooltip wrapper that carries the tab's flex sizing
+    flex: 1 1 140px;
+    min-width: 80px;
+    max-width: 200px;
+}
+
+.pane-tab-strip-add {     // the trailing "+"
+    flex: 0 0 auto;
+    width: 28px;
+}
+```
+
+With one tab open, the tab's `flex: 1 1 140px` grows to fill available space, capped at
+`max-width: 200px`. The `+` (`flex: 0 0 auto`, 28px) sits immediately after it. Neither item can
+absorb the pane's remaining width past that point, so the flex container — which *is* full pane
+width — ends with unclaimed, unstyled background trailing the `+` out to the pane's right edge.
+That trailing area is the reported "dead space."
+
+### 2.2 Why tabs don't size to their label today
+
+Same block: `flex: 1 1 140px; min-width: 80px; max-width: 200px` on `.pane-tab-tip`, plus
+`.pane-tab { flex: 1 1 auto; width: 100%; }` on the tab itself. Every tab's width is a function
+of *available flex space distributed across siblings*, clamped to an 80–200px band — never a
+function of the label's actual rendered width. A tab named "x" and a tab named "Claude Code
+Review Session #4" get the same width today (both hit the 80–200px band based on sibling count,
+not content).
+
+### 2.3 Existing precedent for content-sized tabs: `frontend/app/tab/tab-measure.ts`
+
+The *window*-level tab bar (`frontend/app/tab/tab.tsx`, a different, older tab strip — the
+outer app's workspace switcher, not `PaneTabStrip`) already solves "tab width = label width" via
+`measureTabWidth(label)`: a singleton `<canvas>` 2D context measures the label's rendered text
+width (no DOM reflow), adds a fixed non-text padding budget (52px — left/right pad + gap +
+close-button + slack), and clamps the result to `[TAB_STANDARD_WIDTH=232, TAB_MAX_WIDTH=260]`,
+with a floor at `TAB_STANDARD_WIDTH` so short labels don't shrink below a normal-looking tab.
+The result is written to a `--tab-natural-width` CSS custom property consumed by drag-reorder
+layout math.
+
+That canvas-measurement machinery exists there specifically because that tab bar supports
+drag-to-reorder, which needs a precise numeric width up front for transform math. `PaneTabStrip`
+has no drag-reorder. **Recommendation: don't port the canvas-measurement approach — use plain
+CSS shrink-to-fit instead** (§3.2), which is simpler and gets the same visual result without a
+JS measurement pass on every rename/relabel.
+
+### 2.4 Existing precedent for double-click rename
+
+Two real, shipped patterns to choose between:
+
+- **Inline `<input>` swap** (`frontend/app/view/editor/editor-tab-strip.tsx`'s Save-As flow):
+  `PaneTabStrip`'s existing `renderLabel?: (tab: T) => JSX.Element` prop lets a caller swap the
+  plain `<span class="pane-tab-label">` for a custom element. The editor uses this today (for
+  Save-As, not rename) with a local `SaveAsInput` component: autofocuses on mount, tracks value
+  via a signal, commits on Enter, cancels on Escape, commits-as-cancel on blur, with a
+  `committed` flag guarding double-fire between blur and Enter.
+- **`contentEditable` toggle** (`frontend/app/tab/tab.tsx`'s window-tab rename): a
+  `contentEditable={isEditable()}` div toggled on `onDblClick`, auto-selected on entry, commits
+  via `ObjectService.UpdateTabName` on blur, Enter confirms + blurs, Escape reverts text + blurs.
+
+`PaneTabStrip` already exposes `onTabDoubleClick?: (tab: T) => void` (used today by the editor to
+pin a preview tab) and `renderLabel` (used today for Save-As). **No changes to the shared
+component are needed** — rename is entirely a per-consumer concern, following the editor's
+`renderLabel`-swap pattern (§2.4's first bullet), since it composes more simply with
+`getTooltip`/`getTabClass` than a raw `contentEditable` node would.
+
+### 2.5 Persistence: where would a renamed label actually get saved?
+
+**Agent fork tabs** — `ForkSetEntry.title` (`frontend/app/view/agent/fork/fork-set.ts`,
+`titleOf()`) resolves to `branch_label` when set, else `AgentDefinition.name`. The only mutation
+RPC is `updateagent` (`agentmux-srv/src/server/agent_handlers/core.rs`,
+`RpcApi.UpdateAgentDefinitionCommand`), which can change `name` — but **`branch_label` is
+explicitly immutable post-insert**:
+
+```rust
+// parent_id + branch_label describe provenance and
+// are immutable post-insert (forks are separate rows,
+// not in-place edits).
+parent_id: old.parent_id.clone(),
+branch_label: old.branch_label.clone(),
+```
+
+This is a real conflict with the rename feature: **for any tab whose `branch_label` is set (every
+fork except a lineage root), renaming via `name` would have zero visible effect**, because
+`titleOf()` prefers `branch_label` over `name` unconditionally. §4 calls this out as an open
+question — it needs a product decision, not a workaround.
+
+**Terminal tabs** — `frontend/app/view/term/term.tsx`'s `termTabs` memo synthesizes
+`Terminal ${i+1}` unconditionally today; there is no persisted label at all. The code already
+anticipates this as a follow-up:
+
+```ts
+// Position-based labels ("Terminal 1", "Terminal 2", …) — matches
+// common terminal-app convention for an unnamed session. ... a
+// cwd-derived or user-renamable label is a follow-up, not something
+// cheaply available here yet.
+```
+
+A real persistence mechanism already exists and fits without inventing anything new: per-block
+`meta["pane-title"]`, set via `RpcApi.SetMetaCommand(client, { oref: WOS.makeORef("block", id),
+meta: {"pane-title": title} })` — this is exactly what `frontend/app/block/titlebar.tsx`'s
+existing click-to-edit pane title already does. Block meta is readable independent of whether a
+block's view is mounted (`WOS.getObjectValue(oref)`), which matters here: a dormant (non-active)
+terminal tab's block has no live `TermViewModel` to read a title from (per `termTabs`'s own
+comment), but its meta is always fetchable directly from the WOS object cache regardless of
+mount state.
+
+## 3. Proposed design
+
+### 3.1 Shrink-to-fit strip
+
+`.pane-tab-strip` stops being an implicit full-width block-level flex container and becomes
+shrink-to-fit:
+
+```scss
+.pane-tab-strip {
+    display: inline-flex;   // was: flex — shrinks to content width instead of filling the pane
+    max-width: 100%;        // still can't overflow the pane; falls back to internal scroll/ellipsis
+    flex-direction: row;
+    align-items: stretch;
+    height: 28px;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--secondary-bg-color, var(--block-bg-color));
+}
+```
+
+One tab today would render as: `[tab sized to its label] [+ 28px]`, full stop — no trailing
+background. As more tabs open, the strip naturally grows tab-by-tab; it only reaches full pane
+width once enough tabs are open to fill it, and only then does horizontal overflow/scroll
+behavior (already `overflow-x: hidden` today — worth revisiting to a scroll-on-overflow pattern
+in a later pass, out of scope here) kick in.
+
+Callers that render the strip inside a parent using `justify-content` or that assumed a
+full-width strip (none currently do — both `agent-view.tsx` and `term.tsx` just insert
+`<PaneTabStrip>` as a flex child of a column layout) are unaffected; `inline-flex` still
+participates in the parent's block/flex flow normally, it just no longer *claims* full width for
+itself.
+
+### 3.2 Content-sized tabs
+
+Replace the flex-grow/clamp band with shrink-to-fit + a reasonable upper bound, so a single very
+long label can't push a tab arbitrarily wide:
+
+```scss
+.pane-tab-tip {
+    flex: 0 0 auto;         // was: flex: 1 1 140px
+    max-width: 240px;       // was: 200px cap; kept as a ceiling, no floor
+    display: flex;
+    align-items: stretch;
+}
+
+.pane-tab {
+    flex: 0 0 auto;         // was: flex: 1 1 auto
+    width: auto;            // was: width: 100%
+    min-width: 0;
+    // ... padding/gap/etc. unchanged — these already determine the tab's
+    // "natural" width once flex-grow is no longer forcing it wider.
+}
+```
+
+`.pane-tab-label`'s existing `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;`
+still applies once a label would exceed the 240px ceiling, so pathological names degrade the same
+way they do today (truncated + full text in the hover tooltip) rather than blowing out the strip.
+
+No JS measurement pass needed (§2.3) — the browser's own intrinsic/shrink-to-fit flex sizing
+does this for free once `flex: 1 1 …` stops forcing growth.
+
+**Interaction with §3.1:** with both changes, a lone tab renders at its natural (short) width,
+immediately followed by `+`, immediately followed by nothing — matching the user's stated
+target exactly ("only show the + at the left ... no dead space").
+
+### 3.3 Double-click to rename
+
+No changes to `PaneTabStrip.tsx` itself. Per consumer:
+
+**Terminal tabs** (`term.tsx`):
+- `termTabs` memo gains a per-stack-member label read: for each `id` in `stack`, read
+  `WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta?.["pane-title"]`, falling back to
+  today's `Terminal ${i + 1}` when unset. This makes the memo depend on block meta as well as
+  layout state — needs a reactive read (the existing `wos.ts` object-value accessors are already
+  Solid-signal-backed for the currently-open blocks, matching the pattern `blockData()` already
+  uses for the pane's own block).
+- New local `renamingBlockId` signal (mirrors editor's `saveAsTabId`), set via
+  `onTabDoubleClick={(tab) => setRenamingBlockId(tab.blockId)}`.
+- `renderLabel` swaps in an inline `<input>` (same commit/cancel/blur contract as the editor's
+  `SaveAsInput`) when `tab.blockId === renamingBlockId()`; on confirm, calls
+  `RpcApi.SetMetaCommand(TabRpcClient, { oref: WOS.makeORef("block", tab.blockId), meta: {
+  "pane-title": trimmedValue } })`.
+
+**Agent fork tabs** (`agent-view.tsx`) — blocked on the §4 decision below. Once resolved, the
+wiring is the same shape: a `renamingDefinitionId` signal, `onTabDoubleClick`, a `renderLabel`
+swap, and a commit handler that calls `RpcApi.UpdateAgentDefinitionCommand` with whichever field
+the §4 decision lands on.
+
+## 4. Open question — how does renaming a *fork* tab actually persist?
+
+`branch_label` is immutable by explicit prior design decision (§2.5), and it's also the field
+`titleOf()` prefers whenever it's set — which is every fork tab except a lineage root. Renaming
+a fork tab therefore cannot be implemented by calling today's `updateagent` RPC alone; it would
+silently no-op for exactly the tabs users are most likely to want to rename (the forks, not the
+original). Three ways to resolve this, for the user to pick before agent-tab rename is
+implemented:
+
+1. **Make `branch_label` mutable via `updateagent`.** Reverses the earlier "immutable
+   provenance" decision. Simplest change, but that decision may have been made for a reason not
+   visible from the code alone (e.g. some other part of the system keying off `branch_label` as
+   a stable identifier) — worth confirming it's safe before reversing.
+2. **Add a dedicated `renameagentfork` RPC** that updates only `branch_label`, leaving
+   `updateagent`'s immutability contract untouched for every other caller. More backend surface,
+   but the immutability guarantee stays intact for non-rename callers.
+3. **Restrict double-click-rename to the root tab only** (the one with no `branch_label`, where
+   renaming `name` already changes the visible title today with zero backend changes). Fork tabs
+   would not be renamable via this feature. Ships fastest; likely reads as an inconsistent
+   limitation to users ("why can I rename this tab but not that one").
+
+**Recommendation: option 2.** It's a small, additive RPC, doesn't require re-litigating the
+provenance-immutability decision, and gives every tab (root or fork) the same renamable
+behavior the user asked for.
+
+## 5. Suggested phasing
+
+1. **Phase A — sizing only** (§3.1 + §3.2): pure CSS, no backend, no open questions, affects
+   editor/agent/terminal strips identically since they share `PaneTabStrip.scss`. Lowest risk,
+   ships immediately.
+2. **Phase B — terminal tab rename** (§3.3, terminal half): no open questions, reuses existing
+   `pane-title` meta + `SetMetaCommand` plumbing verified in §2.5.
+3. **Phase C — agent fork tab rename** (§3.3, agent half): blocked on §4's decision.
+
+## 6. Verification plan
+
+- Manual, in `task dev`: open a single agent pane → confirm the fork strip is exactly
+  `[agent name tab][+]` wide with no trailing space. Fork it (or open a second terminal tab) →
+  confirm the strip grows by exactly the new tab's natural width. Open a tab with a long name →
+  confirm it truncates at the 240px ceiling with a working hover tooltip showing the full text.
+- Double-click a terminal tab → confirm the input appears, Enter commits and the label persists
+  across a pane close/reopen (meta survives), Escape reverts, blur commits (matching the
+  Save-As/`titlebar.tsx` convention already used elsewhere).
+- `npx vitest run app/view/agent app/view/term app/element` + `npx tsc --noEmit` — no regressions
+  in the existing `PaneTabStrip.test.tsx` (11 tests) or the editor tab strip's own tests, which
+  exercise the sizing CSS indirectly via class assertions, not layout math, so should be
+  unaffected by the SCSS-only sizing change.

--- a/frontend/app/element/PaneTabRenameInput.test.tsx
+++ b/frontend/app/element/PaneTabRenameInput.test.tsx
@@ -1,0 +1,113 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for PaneTabRenameInput — the inline rename input shared by the
+ * agent-fork and terminal tab strips (double-click-to-rename).
+ * Spec: docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PaneTabRenameInput } from "./PaneTabRenameInput";
+
+afterEach(() => cleanup());
+
+describe("PaneTabRenameInput", () => {
+    it("autofocuses and selects all text on mount", () => {
+        render(() => (
+            <PaneTabRenameInput initialValue="Terminal 1" onConfirm={vi.fn()} onCancel={vi.fn()} />
+        ));
+        const input = screen.getByDisplayValue("Terminal 1") as HTMLInputElement;
+        expect(document.activeElement).toBe(input);
+        expect(input.selectionStart).toBe(0);
+        expect(input.selectionEnd).toBe("Terminal 1".length);
+    });
+
+    it("confirms the trimmed value on Enter", async () => {
+        const onConfirm = vi.fn();
+        const onCancel = vi.fn();
+        render(() => (
+            <PaneTabRenameInput initialValue="old" onConfirm={onConfirm} onCancel={onCancel} />
+        ));
+        const user = userEvent.setup();
+        const input = screen.getByDisplayValue("old");
+        await user.clear(input);
+        await user.type(input, "  new name  {Enter}");
+        expect(onConfirm).toHaveBeenCalledWith("new name");
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it("confirms on blur (unlike Save-As, which cancels on blur)", async () => {
+        const onConfirm = vi.fn();
+        render(() => (
+            <>
+                <PaneTabRenameInput initialValue="old" onConfirm={onConfirm} onCancel={vi.fn()} />
+                <button>elsewhere</button>
+            </>
+        ));
+        const user = userEvent.setup();
+        const input = screen.getByDisplayValue("old");
+        await user.clear(input);
+        await user.type(input, "new name");
+        await user.click(screen.getByText("elsewhere"));
+        expect(onConfirm).toHaveBeenCalledWith("new name");
+    });
+
+    it("cancels on Escape without confirming, reverting nothing further", async () => {
+        const onConfirm = vi.fn();
+        const onCancel = vi.fn();
+        render(() => (
+            <PaneTabRenameInput initialValue="old" onConfirm={onConfirm} onCancel={onCancel} />
+        ));
+        const user = userEvent.setup();
+        const input = screen.getByDisplayValue("old");
+        await user.type(input, " more{Escape}");
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("cancels instead of confirming when the value is unchanged", async () => {
+        const onConfirm = vi.fn();
+        const onCancel = vi.fn();
+        render(() => (
+            <PaneTabRenameInput initialValue="same" onConfirm={onConfirm} onCancel={onCancel} />
+        ));
+        const user = userEvent.setup();
+        await user.type(screen.getByDisplayValue("same"), "{Enter}");
+        expect(onConfirm).not.toHaveBeenCalled();
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels instead of confirming when the trimmed value is empty", async () => {
+        const onConfirm = vi.fn();
+        const onCancel = vi.fn();
+        render(() => (
+            <PaneTabRenameInput initialValue="old" onConfirm={onConfirm} onCancel={onCancel} />
+        ));
+        const user = userEvent.setup();
+        const input = screen.getByDisplayValue("old");
+        await user.clear(input);
+        await user.type(input, "   {Enter}");
+        expect(onConfirm).not.toHaveBeenCalled();
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not double-fire between Enter and the subsequent blur", async () => {
+        const onConfirm = vi.fn();
+        render(() => (
+            <>
+                <PaneTabRenameInput initialValue="old" onConfirm={onConfirm} onCancel={vi.fn()} />
+                <button>elsewhere</button>
+            </>
+        ));
+        const user = userEvent.setup();
+        const input = screen.getByDisplayValue("old");
+        await user.clear(input);
+        await user.type(input, "new{Enter}");
+        await user.click(screen.getByText("elsewhere"));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/app/element/PaneTabRenameInput.tsx
+++ b/frontend/app/element/PaneTabRenameInput.tsx
@@ -1,0 +1,73 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PaneTabRenameInput — the inline "rename this tab" text input, shared by
+ * every `PaneTabStrip` consumer that wires double-click-to-rename (agent
+ * fork tabs, terminal tabs). Swapped in via `PaneTabStrip`'s existing
+ * `renderLabel` prop, same mechanism the editor's Save-As path input
+ * already uses (`frontend/app/view/editor/editor-tab-strip.tsx`).
+ *
+ * Commit-on-blur (unlike Save-As's cancel-on-blur — Save-As is "type a new
+ * path," rename is "edit existing text," so blur here matches the
+ * click-away-commits convention of `frontend/app/block/titlebar.tsx`'s pane
+ * title editor). Auto-selects all text on mount so typing immediately
+ * replaces it, matching `frontend/app/tab/tab.tsx`'s window-tab rename.
+ *
+ * Spec: docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
+ */
+
+import { createSignal, onMount, type JSX } from "solid-js";
+
+export interface PaneTabRenameInputProps {
+    initialValue: string;
+    /** Called on Enter or blur, only when the trimmed value is non-empty and differs from initialValue. */
+    onConfirm: (value: string) => void;
+    /** Called on Escape, or on blur/Enter when the value is empty/unchanged. */
+    onCancel: () => void;
+}
+
+export function PaneTabRenameInput(props: PaneTabRenameInputProps): JSX.Element {
+    let inputRef: HTMLInputElement | undefined;
+    const [value, setValue] = createSignal(props.initialValue);
+    let committed = false;
+
+    onMount(() => {
+        inputRef?.focus();
+        inputRef?.select();
+    });
+
+    const confirm = () => {
+        if (committed) return;
+        committed = true;
+        const trimmed = value().trim();
+        if (trimmed && trimmed !== props.initialValue) {
+            props.onConfirm(trimmed);
+        } else {
+            props.onCancel();
+        }
+    };
+    const cancel = () => {
+        if (committed) return;
+        committed = true;
+        props.onCancel();
+    };
+
+    return (
+        <input
+            ref={inputRef}
+            class="pane-tab-label pane-tab-rename-input"
+            type="text"
+            value={value()}
+            onInput={(e) => setValue(e.currentTarget.value)}
+            onKeyDown={(e) => {
+                if (e.key === "Enter") { e.preventDefault(); confirm(); }
+                if (e.key === "Escape") { e.preventDefault(); cancel(); }
+                e.stopPropagation();
+            }}
+            onClick={(e) => e.stopPropagation()}
+            onDblClick={(e) => e.stopPropagation()}
+            onBlur={confirm}
+        />
+    );
+}

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -9,8 +9,12 @@
 // docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1.
 
 .pane-tab-strip {
-    flex: 0 0 auto;
-    display: flex;
+    // Shrink-to-fit (not full pane width) — with one tab open, the strip is
+    // exactly [tab][+] wide, no trailing dead space. Grows tab-by-tab as
+    // more open; only reaches full pane width once enough tabs fill it.
+    // See docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.1.
+    display: inline-flex;
+    max-width: 100%;
     flex-direction: row;
     align-items: stretch;
     height: 28px;
@@ -21,19 +25,28 @@
 
 // Tooltip wrapper (shared Tooltip component) — carries the flex sizing the
 // tab used to own, so wrapping the tab for a hover tooltip doesn't change
-// layout.
+// layout. `flex: 0 0 auto` — no grow (doesn't stretch into free strip
+// space), hypothetical size follows content (the tab's label + padding),
+// hard-clamped at max-width regardless of shrink factor. `min-width: 0` lets
+// that clamp actually squeeze the box below its content's natural width
+// instead of overflowing it — required for the tab's ellipsis (below) to
+// ever engage.
 .pane-tab-tip {
-    flex: 1 1 140px;
-    min-width: 80px;
-    max-width: 200px;
+    flex: 0 0 auto;
+    min-width: 0;
+    max-width: 240px;
     display: flex;
     align-items: stretch;
 }
 
 .pane-tab {
+    // Fills (and, when the wrapper above is clamped by its max-width,
+    // shrinks within) its Tooltip wrapper — NOT the strip. min-width: 0
+    // overrides the flex default (min-width: auto = content's intrinsic
+    // width), which would otherwise block shrinking below the label's full
+    // unclamped width.
     flex: 1 1 auto;
     min-width: 0;
-    width: 100%;
     display: flex;
     align-items: center;
     gap: var(--space-1);
@@ -76,9 +89,26 @@
 
 .pane-tab-label {
     flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+// The inline rename input swapped in via renderLabel (PaneTabRenameInput) —
+// same box as the plain label it replaces, styled to look native to the tab
+// rather than like a distinct form control.
+.pane-tab-rename-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: text;
 }
 
 .pane-tab-close {

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -13,7 +13,17 @@
     // exactly [tab][+] wide, no trailing dead space. Grows tab-by-tab as
     // more open; only reaches full pane width once enough tabs fill it.
     // See docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.1.
+    //
+    // Codex review on PR #2282: `display: inline-flex` alone only governs
+    // how THIS element lays out its own children — it does nothing to
+    // prevent the element ITSELF from being stretched by a parent flex
+    // container. Both real consumers (`.view-term`, `.agent-view`) are
+    // column flex containers with the default `align-items: stretch`,
+    // which was blowing the strip back out to full pane width regardless
+    // of inline-flex. `align-self: flex-start` opts this item out of that
+    // stretch so its own (now content-driven) width is what's rendered.
     display: inline-flex;
+    align-self: flex-start;
     max-width: 100%;
     flex-direction: row;
     align-items: stretch;

--- a/frontend/app/store/rpc-api/agent.ts
+++ b/frontend/app/store/rpc-api/agent.ts
@@ -332,6 +332,17 @@ export const AgentApi = {
         return client.rpcCall("forkagentdefinitionsuggest", data, opts);
     },
 
+    // Renames a fork tab's displayed title — writes branch_label when the
+    // definition already has one (a fork), else name (a lineage root). See
+    // SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §4.
+    RenameAgentDefinitionTitleCommand(
+        client: RpcClient,
+        data: { id: string; title: string },
+        opts?: RpcOpts,
+    ): Promise<AgentDefinition> {
+        return client.rpcCall("renameagentdefinitiontitle", data, opts);
+    },
+
     SubprocessSpawnCommand(client: RpcClient, data: CommandSubprocessSpawnData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("subprocessspawn", data, opts);
     },

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -52,6 +52,7 @@ import { useAgentCommands } from "./hooks/useAgentCommands";
 import { useAgentFailure } from "./hooks/useAgentFailure";
 import { PaneRow } from "./components/PaneRow";
 import { PaneTabStrip } from "@/app/element/PaneTabStrip";
+import { PaneTabRenameInput } from "@/app/element/PaneTabRenameInput";
 import { useForkSet } from "./fork/useForkSet";
 import { getLayoutModelForStaticTab, pushBlockOntoStack, setActiveBlockInStack } from "@/layout/index";
 import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
@@ -185,6 +186,28 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             setActiveBlockInStack(layoutModel, myNode.id, entry.blockId);
         } else {
             refocusNode(entry.blockId);
+        }
+    };
+    // Double-click a fork tab to rename it —
+    // SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3/§4.
+    // No local override needed (unlike the terminal tab strip): the RPC
+    // broadcasts `agents:changed`, which `useAgentDefinitions()` already
+    // subscribes to, so `forks()`/`switchableForks()` pick up the new title
+    // through the normal reactive chain once the round-trip completes.
+    const [renamingForkId, setRenamingForkId] = createSignal<string | null>(null);
+    const handleForkRenameConfirm = async (definitionId: string, title: string): Promise<void> => {
+        setRenamingForkId(null);
+        try {
+            await RpcApi.RenameAgentDefinitionTitleCommand(TabRpcClient, { id: definitionId, title });
+        } catch (e: unknown) {
+            pushNotification({
+                icon: "fa-triangle-exclamation",
+                title: "Rename failed",
+                message: e instanceof Error ? e.message : String(e),
+                timestamp: new Date().toISOString(),
+                type: "error",
+                expiration: Date.now() + 8000,
+            });
         }
     };
     // "+" on the fork tab strip — Phase 4. Reuses the existing launch
@@ -1164,6 +1187,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 getId={(f) => f.definitionId}
                 getLabel={(f) => f.title}
                 onActivate={handleForkSwitch}
+                onTabDoubleClick={(f) => setRenamingForkId(f.definitionId)}
+                renderLabel={(f) =>
+                    renamingForkId() === f.definitionId ? (
+                        <PaneTabRenameInput
+                            initialValue={f.title}
+                            onConfirm={(title) => void handleForkRenameConfirm(f.definitionId, title)}
+                            onCancel={() => setRenamingForkId(null)}
+                        />
+                    ) : (
+                        <span class="pane-tab-label">{f.title}</span>
+                    )
+                }
                 onAdd={() => void handleForkCreate()}
                 addTitle="Fork this conversation"
             />

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -19,6 +19,7 @@ import { TermWrap } from "./termwrap";
 import "./xterm.css";
 import { DragOverlay } from "@/app/element/dragoverlay";
 import { PaneTabStrip } from "@/app/element/PaneTabStrip";
+import { PaneTabRenameInput } from "@/app/element/PaneTabRenameInput";
 import { detectHost, invokeCommand } from "@/app/platform/ipc";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -85,11 +86,18 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
     // cross-pane derivation needed.
     const layoutModel = getLayoutModelForStaticTab();
     interface TermTab { blockId: string; label: string }
+    // Rename overrides, keyed by blockId — set synchronously by
+    // handleTermTabRename below so a just-renamed tab (including a dormant,
+    // non-active one whose block meta isn't reactively tracked here) reflects
+    // its new label immediately, without waiting on a cross-pane event.
+    // SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
+    const [titleOverrides, setTitleOverrides] = createSignal<Record<string, string>>({});
     const termTabs = createMemo<TermTab[]>(() => {
         // Reactive dependency: re-derive whenever ANY layout mutation
         // happens (matches the pattern getNodeModel's own isFocused/
         // isMagnified memos already use in layoutNodeModels.ts).
         layoutModel.localTreeStateAtom();
+        const overrides = titleOverrides();
         const node = layoutModel.getNodeByBlockId(blockId);
         // No stack yet (the common default case — a single, never-forked
         // terminal) → synthesize this pane's own one-tab list rather than
@@ -98,14 +106,21 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
         // confusing; every other pane type's strip always shows at least
         // its own active entry (see agent-view.tsx's switchableForks).
         const stack = node?.data?.blockStack?.length ? node.data.blockStack : [blockId];
-        // Position-based labels ("Terminal 1", "Terminal 2", …) — matches
-        // common terminal-app convention for an unnamed session. A dormant
-        // (non-active) tab's own block isn't mounted (no live TermViewModel
-        // to read a richer title from — see layoutStack.ts's header comment
-        // on why switching is a remount, not a reactive update), so a
-        // cwd-derived or user-renamable label is a follow-up, not something
-        // cheaply available here yet.
-        return stack.map((id, i) => ({ blockId: id, label: `Terminal ${i + 1}` }));
+        // Position-based labels ("Terminal 1", "Terminal 2", …) as the
+        // fallback for an unnamed session — matches common terminal-app
+        // convention. A user-set title (double-click to rename, persisted on
+        // the tab's own block as meta["pane-title"] — the same field
+        // titlebar.tsx's pane title editor uses) wins when present, read via
+        // a non-reactive lookup since a dormant tab's block isn't mounted
+        // (no live TermViewModel — see layoutStack.ts's header comment on
+        // why switching is a remount, not a reactive update); `overrides`
+        // above is what makes a just-performed rename show up immediately.
+        return stack.map((id, i) => {
+            const persistedTitle = WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta?.["pane-title"] as
+                | string
+                | undefined;
+            return { blockId: id, label: overrides[id] ?? persistedTitle ?? `Terminal ${i + 1}` };
+        });
     });
     const activeBlockId = createMemo(() => {
         layoutModel.localTreeStateAtom();
@@ -156,6 +171,19 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                 expiration: Date.now() + 8000,
             });
         }
+    };
+
+    // Double-click-to-rename — SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
+    const [renamingBlockId, setRenamingBlockId] = createSignal<string | null>(null);
+    const handleTermTabRenameConfirm = (targetBlockId: string, title: string) => {
+        setRenamingBlockId(null);
+        setTitleOverrides((prev) => ({ ...prev, [targetBlockId]: title }));
+        fireAndForget(() =>
+            RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", targetBlockId),
+                meta: { "pane-title": title } as any,
+            }),
+        );
     };
 
     const termSettingsAtom = getSettingsPrefixAtom("term");
@@ -497,6 +525,18 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                 getLabel={(t) => t.label}
                 onActivate={handleTermTabSwitch}
                 onClose={handleTermTabClose}
+                onTabDoubleClick={(t) => setRenamingBlockId(t.blockId)}
+                renderLabel={(t) =>
+                    renamingBlockId() === t.blockId ? (
+                        <PaneTabRenameInput
+                            initialValue={t.label}
+                            onConfirm={(title) => handleTermTabRenameConfirm(t.blockId, title)}
+                            onCancel={() => setRenamingBlockId(null)}
+                        />
+                    ) : (
+                        <span class="pane-tab-label">{t.label}</span>
+                    )
+                }
                 onAdd={() => void handleTermTabAdd()}
                 addTitle="New terminal tab"
             />


### PR DESCRIPTION
## Summary
- **Shrink-to-fit strip**: with one tab open, the strip is exactly `[tab][+]` wide instead of stretching to full pane width with dead trailing space (`display: inline-flex` + dropping the tabs' flex-grow).
- **Content-sized tabs**: tabs size to their label + padding instead of an 80–200px flex-grow band, capped at 240px with existing ellipsis truncation for long names.
- **Double-click to rename**: both agent fork tabs and terminal tabs. No changes needed to the shared `PaneTabStrip` component — reuses its existing `onTabDoubleClick`/`renderLabel` hooks via a new shared `PaneTabRenameInput`.
  - Terminal tabs persist via the existing `pane-title` block-meta mechanism (same one the block title bar already uses).
  - Agent fork tabs persist via a new dedicated `renameagentdefinitiontitle` RPC that writes `branch_label` when the definition already has one (a fork) else `name` (a lineage root) — whichever field `titleOf()` actually displays. Kept deliberately separate from `updateagent`, which stays immutable on `branch_label` for every other caller.

Full design/rationale: `docs/specs/SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md`.

## Test plan
- [x] New tests: `PaneTabRenameInput.test.tsx` (7 tests — autofocus/select, Enter/blur/Escape commit-cancel semantics, empty/unchanged no-op, no double-fire).
- [x] `PaneTabStrip.test.tsx` (11 tests, unchanged) still pass — sizing change is SCSS-only.
- [x] `npx vitest run` (frontend) — 1868/1869 pass (1 pre-existing, unrelated flaky timing test, confirmed passes in isolation).
- [x] `cargo test -p agentmux-srv` — 1589 + 4 + 7 pass, including `dual_write_agent_def_update_refreshes_name_in_db_agents` and the full `agent_handlers`/template suite.
- [x] `npx tsc --noEmit` / `cargo check` / `cargo build` — clean (one pre-existing unrelated `qrcode` module error).
- [ ] Manual: open a single agent/terminal pane, confirm no trailing dead space; add a second tab, confirm width matches its label; double-click a tab, confirm rename persists across pane close/reopen.

<!-- agentmux:agent_id=agent3 -->