### PR TITLE
fix(agent): Agent setup's Accounts tab wrote to a column nothing reads

### DIFF
--- a/.changesets/1784846138-fix-agent-accounts-tab-in-agent-setup-wrote-to-a-dead-column-qwyy.md
+++ b/.changesets/1784846138-fix-agent-accounts-tab-in-agent-setup-wrote-to-a-dead-column-qwyy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): Accounts tab in Agent setup wrote to a dead column

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -284,11 +284,9 @@ export function renderRequest(
                 label: requestLabel(req),
                 panel: (
                     <AgentSetupModal
-                        agent={req.agent}
                         agentId={req.agentId}
                         agentName={req.agentName}
                         workingDirectory={req.workingDirectory}
-                        blockId={req.blockId}
                         initialTab={req.initialTab}
                         onClose={api.close}
                     />

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -303,17 +303,12 @@ export interface AgentMemoryRequest {
  */
 export interface AgentSetupRequest {
     kind: "agent-setup";
-    /** Agent definition to show/edit accounts for (Accounts tab). May be
-     *  null for quick-launch panes with no loadable definition — the
-     *  Accounts tab renders its own empty state in that case. */
-    agent: AgentDefinition | null;
-    /** Provider/definition id — used by the Memory tab. */
+    /** Provider/definition id — used by the Accounts tab (read-only linked-
+     *  accounts view, keyed on agentId alone) and the Memory tab. */
     agentId: string;
     agentName: string;
     /** Agent's working directory — used to compute the memory folder path. */
     workingDirectory: string;
-    /** Block id of the pane — used to construct the IdentityViewModel. */
-    blockId: string;
     /** Which tab to open on. Defaults to "accounts". */
     initialTab?: "accounts" | "memory";
 }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -336,14 +336,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             const agent = currentAgent() ?? null;
             modalLayer.open({
                 kind: "agent-setup",
-                agent,
                 agentId,
                 agentName: agentName(),
                 workingDirectory,
-                blockId: model.blockId,
                 // No loadable definition (quick-launch pane) → default to
-                // the Memory tab, which needs no AgentDefinition; the
-                // Accounts tab still renders its own empty state.
+                // the Memory tab; the Accounts tab works from agentId alone
+                // but the Memory tab is the more useful default for a pane
+                // with no saved definition yet.
                 initialTab: agent ? "accounts" : "memory",
             });
         };

--- a/frontend/app/view/agent/components/AgentSetupModal.scss
+++ b/frontend/app/view/agent/components/AgentSetupModal.scss
@@ -128,9 +128,8 @@
     // Neutralize the embedded panels' standalone-modal sizing so each tab fills
     // the shared panel area at one consistent size — no horizontal overflow past
     // the 780px frame, and no height jump when switching tabs (the Memory panel
-    // otherwise forces its own 780×520; the Accounts body is auto-height).
-    .agent-memory-modal,
-    .agent-identity-modal-body {
+    // otherwise forces its own 780×520).
+    .agent-memory-modal {
         width: 100%;
         height: 100%;
         max-width: none;
@@ -138,11 +137,4 @@
         min-width: 0;
         box-sizing: border-box;
     }
-}
-
-.agent-setup-modal-empty {
-    padding: var(--space-6) var(--space-5);
-    font-size: var(--text-sm);
-    color: var(--secondary-text-color);
-    line-height: 1.5;
 }

--- a/frontend/app/view/agent/components/AgentSetupModal.tsx
+++ b/frontend/app/view/agent/components/AgentSetupModal.tsx
@@ -6,7 +6,10 @@
  * opened by the single "Agent setup" (vault) icon in the agent pane
  * header. Consolidates the former two icons (identity + native memory)
  * into one modal with tabs:
- *   - Accounts    — the former Identity panel (AgentIdentityModalPanel).
+ *   - Accounts    — read-only linked-accounts view (AgentIdentityLinksPanel).
+ *                   New bindings are created from the agent-launch flow;
+ *                   see that component's own doc comment for why this tab
+ *                   is not a create/edit surface.
  *   - Memory      — the native-memory browser (AgentNativeMemoryModal).
  *   - MCP Servers — the standalone MCP Server primitive (AgentMcpModal).
  *   - Skills      — the standalone Skill primitive (AgentSkillsModal).
@@ -22,7 +25,7 @@
  */
 
 import { createSignal, For, Show, type JSX } from "solid-js";
-import { AgentIdentityModalPanel } from "./AgentIdentityModal";
+import { AgentIdentityLinksPanel } from "@/app/view/identity/agent-identity-links-panel";
 import { AgentMcpModal } from "./AgentMcpModal";
 import { AgentNativeMemoryModal } from "./AgentNativeMemoryModal";
 import { AgentSkillsModal } from "./AgentSkillsModal";
@@ -32,13 +35,9 @@ import "./AgentSetupModal.scss";
 type SetupTabId = "accounts" | "memory" | "mcp" | "skills" | "startup";
 
 interface AgentSetupModalProps {
-    /** Agent definition for the Accounts tab. Null for quick-launch panes
-     *  with no loadable definition — the Accounts tab shows an empty state. */
-    agent: AgentDefinition | null;
     agentId: string;
     agentName: string;
     workingDirectory: string;
-    blockId: string;
     initialTab?: SetupTabId;
     onClose: () => void;
 }
@@ -93,23 +92,7 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
 
             <div class="agent-setup-modal-panel">
                 <Show when={activeTab() === "accounts"}>
-                    <Show
-                        when={props.agent}
-                        fallback={
-                            <div class="agent-setup-modal-empty">
-                                Account assignment is unavailable for this pane — it isn't
-                                backed by a saved agent definition.
-                            </div>
-                        }
-                    >
-                        {(agent) => (
-                            <AgentIdentityModalPanel
-                                agent={agent()}
-                                blockId={props.blockId}
-                                onClose={props.onClose}
-                            />
-                        )}
-                    </Show>
+                    <AgentIdentityLinksPanel agentId={props.agentId} />
                 </Show>
 
                 <Show when={activeTab() === "memory"}>


### PR DESCRIPTION
## Summary
Found during the Armory architecture review (docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md, #2284, §2.2). `AgentSetupModal`'s "Accounts" tab looked like fully functional per-agent credential-assignment UI, but wrote to `AgentDefinition.accounts` -- a legacy JSON blob column that the spawn-time credential resolver (`identity/resolver.rs::resolve_bindings_for_instance`) never reads. It reads only `db_agent_identity_links`, written exclusively by the agent-launch flow. So a user picking "assign this account to this agent" in that modal saw it save successfully, with zero effect on what credentials the agent actually launches with.

**Fix:** replaced the write-path modal with `AgentIdentityLinksPanel` -- the existing, already-tested, read-only view built against the table the resolver actually reads (it already backs the agent pane's own Identity tab). It only needs `agentId`, so as a bonus it now also works for quick-launch panes that previously hit an "unavailable" fallback. Removed the `agent`/`blockId` plumbing that only existed to support the removed write path (`AgentSetupRequest`, `modal-dispatch.tsx`, `agent-view.tsx`'s `modalLayer.open` call), and the CSS rule that only ever styled the removed component.

`AgentIdentityModalPanel`/`AgentIdentityPanel.tsx` are left in place -- they were already unreachable dead code before this change (the standalone `"agent-identity"` modal-layer kind they back has no live caller anywhere, before or after this PR) -- not touched here to keep this fix scoped to the actual bug.

## Test plan
- [x] `npx tsc --noEmit` -- clean
- [x] `npx vitest run` across `frontend/app/view/agent` + `frontend/app/element` -- 738/739 passing (1 unrelated pre-existing flaky timeout in `tool-renderers/registry.test.ts`, confirmed passing standalone in 1.8s)
- [x] `frontend/app/view/identity/agent-identity-links-panel.test.tsx` already covers the reused component's per-agentId scoping behavior
- [x] Verified no other caller of the removed `agent`/`blockId` fields on `AgentSetupRequest`

<!-- agentmux:agent_id=agent2 -->