### PR TITLE
fix(subagent-watcher): scope live fs events to the owning block and tear down watchers on block delete

### DIFF
--- a/.changesets/1784846624-fix-subagent-watcher-scope-live-fs-events-to-the-owning-bloc-p215.md
+++ b/.changesets/1784846624-fix-subagent-watcher-scope-live-fs-events-to-the-owning-bloc-p215.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(subagent-watcher): scope live fs events to the owning block and tear down watchers on block delete

--- a/agentmux-srv/src/backend/subagent_watcher/mod.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/mod.rs
@@ -37,7 +37,13 @@
 //!     `Event::BlockDeleted`/`TabDeleted`/`WorkspaceDeleted`). Without this,
 //!     `ListActive`/`ListDispatches` kept returning a closed block's
 //!     subagents forever, so the Swarm pane kept rendering a ghost row for
-//!     it until the whole app/srv restarted.
+//!     it until the whole app/srv restarted. `prune_block` also tears down
+//!     the block's own filesystem watcher (`unwatch_block`) — without that,
+//!     a closed block's watcher leaked indefinitely and kept re-creating
+//!     fresh (mis-)attributions the next time another agent sharing its
+//!     watched directory wrote to its own subagent transcript; see
+//!     `session_belongs_to_block` and
+//!     docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md.
 //!
 //! Split into submodules (pure relocation, no behavior change): `types` (the
 //! state/event types), `query` (the read/naming API), `scan` (session/dir
@@ -78,7 +84,7 @@ use serde_json::json;
 use tokio::sync::mpsc;
 
 use super::eventbus::{EventBus, WSEventType, WS_EVENT_RPC};
-use parse::nearest_existing_ancestor;
+use parse::{derive_session_id, nearest_existing_ancestor};
 use types::{DispatchState, PendingDispatchActivity, SessionWatch, WatchedAgent};
 
 /// Flush cadence for buffered dispatch activity (SPEC §9.5 — 250ms-1s was
@@ -315,6 +321,7 @@ impl SubagentWatcher {
             let mut watched = self.watched_agents.lock().unwrap();
             watched.push(WatchedAgent {
                 agent_id: agent_id.to_string(),
+                parent_block_id: parent_block_id.to_string(),
                 config_dir: config_dir.clone(),
                 _watcher: watcher,
             });
@@ -364,6 +371,28 @@ impl SubagentWatcher {
                 }
 
                 for changed_path in paths {
+                    // Agents without a per-identity bundle override all
+                    // resolve to the same shared default Claude config dir
+                    // (see resolve_claude_config_dir's doc comment), so this
+                    // watcher's notify subscription can legitimately be on a
+                    // directory tree several OTHER agents' watchers are also
+                    // subscribed to. Without this check, one agent's real
+                    // subagent write fans out to every other agent sharing
+                    // that path, each misattributing it to their own
+                    // parent_block_id. See
+                    // docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md.
+                    let session_id = derive_session_id(&changed_path);
+                    if !self_clone.session_belongs_to_block(&parent_block_id, &session_id) {
+                        tracing::debug!(
+                            agent = %parent_agent,
+                            parent_block_id = %parent_block_id,
+                            session_id = %session_id,
+                            path = %changed_path.display(),
+                            "dropping subagent fs event: session does not belong to this block"
+                        );
+                        continue;
+                    }
+
                     let is_journal = changed_path.file_name().and_then(|n| n.to_str())
                         == Some("journal.jsonl");
                     if is_journal {
@@ -386,6 +415,29 @@ impl SubagentWatcher {
                 }
             }
         });
+    }
+
+    /// True if `session_id` is the session currently persisted on
+    /// `block_id`'s own `agent:sessionid` meta. Used by the live
+    /// filesystem-watch dispatch loop (`watch_agent`) to reject an event for
+    /// a session this block doesn't actually own before it can be
+    /// misattributed — necessary because agents without a per-identity
+    /// bundle override all share one `notify` subscription on the same
+    /// default Claude config dir (see `resolve_claude_config_dir`), so any
+    /// one of their watchers can receive any other's raw file-change events.
+    /// `false` for a block that no longer exists (closed pane) or has since
+    /// moved to a different session — both cases mean this event isn't this
+    /// block's to process. See
+    /// docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md.
+    fn session_belongs_to_block(&self, block_id: &str, session_id: &str) -> bool {
+        let Ok(Some(block)) = self.wstore.get::<crate::backend::obj::Block>(block_id) else {
+            return false;
+        };
+        crate::backend::obj::meta_get_string(
+            &block.meta,
+            crate::backend::blockcontroller::core::META_SESSION_ID,
+            "",
+        ) == session_id
     }
 
     /// Stop watching an agent: drop its filesystem watcher, which closes the
@@ -480,8 +532,19 @@ impl SubagentWatcher {
     /// blocks over time — pruning by `parent_block_id` can never touch a
     /// different, still-live block that happens to share an agent name.
     ///
-    /// Returns whether anything was actually pruned, so the caller only
-    /// broadcasts a refresh when there's something for clients to refresh.
+    /// Also tears down this block's own filesystem watcher (`unwatch_block`,
+    /// below) — without this, `prune_block` only cleared the DERIVED
+    /// subagent/dispatch state at the moment it ran, while the underlying
+    /// `notify` watcher (and its dedicated tokio task, keyed by
+    /// `parent_block_id`) kept running indefinitely, silently re-creating
+    /// fresh entries for this closed block the next time any OTHER agent
+    /// sharing its watched directory wrote to its own subagent transcript
+    /// — see `session_belongs_to_block`'s doc comment and
+    /// docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md.
+    ///
+    /// Returns whether any DERIVED state was actually pruned, so the caller
+    /// only broadcasts a refresh when there's something for clients to
+    /// refresh — independent of whether a watcher also got torn down.
     pub fn prune_block(&self, block_id: &str) -> bool {
         let mut pruned = false;
 
@@ -514,10 +577,30 @@ impl SubagentWatcher {
         }
         drop(pending);
 
+        self.unwatch_block(block_id);
+
         if pruned {
             tracing::debug!(block_id = %block_id, "pruned subagent/dispatch state for deleted block");
         }
         pruned
+    }
+
+    /// Stop watching a block's filesystem watcher (drop its `notify`
+    /// subscription, closing the debounce channel so the associated
+    /// processing task self-terminates on its next `rx.recv()`). Block-
+    /// scoped, not agent-name-scoped — mirrors `unwatch_agent`'s teardown
+    /// mechanism, keyed by `parent_block_id` instead of `agent_id` so an
+    /// agent identity reused across multiple blocks over time only loses
+    /// the ONE watcher tied to the block that actually closed, never a
+    /// different still-open block sharing its name. Idempotent — a no-op if
+    /// no watcher is registered for this block.
+    fn unwatch_block(&self, block_id: &str) {
+        let mut watched = self.watched_agents.lock().unwrap();
+        let before = watched.len();
+        watched.retain(|w| w.parent_block_id != block_id);
+        if watched.len() != before {
+            tracing::info!(block_id = %block_id, "stopped watching subagent dir for deleted block");
+        }
     }
 
     fn broadcast_block_pruned(&self, block_id: &str) {

--- a/agentmux-srv/src/backend/subagent_watcher/mod.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/mod.rs
@@ -455,10 +455,29 @@ impl SubagentWatcher {
         ) == session_id
     }
 
-    /// Stop watching an agent: drop its filesystem watcher, which closes the
-    /// debounce channel — so the processing task self-terminates on the next
-    /// `rx.recv()` returning `None`. Idempotent: a no-op if the agent isn't
-    /// currently watched.
+    /// Stop watching an agent from the graceful `/agentmux/reactive/unregister`
+    /// path: remove `block_id` as a dependent of its watcher (same
+    /// mechanism as `unwatch_block`, keyed by `agent_id` first since that's
+    /// what the caller has), tearing down the underlying filesystem watcher
+    /// — which closes the debounce channel, so the processing task
+    /// self-terminates on its next `rx.recv()` returning `None` — only once
+    /// no block depends on it anymore. Idempotent: a no-op if the agent
+    /// isn't currently watched.
+    ///
+    /// `block_id` is `None` when the reactive registry has no record of
+    /// this agent_id (already unregistered, or never registered) — nothing
+    /// to disassociate in that case, so the watcher-teardown step is
+    /// skipped entirely rather than guessing.
+    ///
+    /// `watch_agent` dedupes by `agent_id`: two blocks registering the same
+    /// agent_id share one `WatchedAgent` entry. Removing that whole entry
+    /// unconditionally here (as this method used to) killed the shared
+    /// watcher — and with it, live tracking — for every OTHER still-open
+    /// block sharing that agent identity the moment any ONE of them
+    /// gracefully closed, since this is the primary, far-more-common
+    /// teardown path (`unwatch_block` only covers the crash/API-delete
+    /// backstop). See `WatchedAgent::parent_block_ids`'s doc comment and
+    /// docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md.
     ///
     /// Without this, `watched_agents` was push-only: every distinct agent that
     /// ever ran leaked one OS watch handle + channel + idle task for the rest of
@@ -474,14 +493,20 @@ impl SubagentWatcher {
     /// pruning added alongside `prune_block`'s block-scoped equivalent,
     /// below — this method previously only pruned `sessions`, silently
     /// leaking a Workflow-kind `DispatchState` for the agent's lifetime.)
-    pub fn unwatch_agent(&self, agent_id: &str) {
-        let mut watched = self.watched_agents.lock().unwrap();
-        let before = watched.len();
-        watched.retain(|w| w.agent_id != agent_id);
-        if watched.len() != before {
-            tracing::info!(agent = %agent_id, "stopped watching subagent dir");
+    pub fn unwatch_agent(&self, agent_id: &str, block_id: Option<&str>) {
+        if let Some(block_id) = block_id {
+            let mut watched = self.watched_agents.lock().unwrap();
+            for w in watched.iter_mut() {
+                if w.agent_id == agent_id {
+                    w.parent_block_ids.remove(block_id);
+                }
+            }
+            let before = watched.len();
+            watched.retain(|w| !(w.agent_id == agent_id && w.parent_block_ids.is_empty()));
+            if watched.len() != before {
+                tracing::info!(agent = %agent_id, block_id = %block_id, "stopped watching subagent dir");
+            }
         }
-        drop(watched);
 
         let mut sessions = self.sessions.lock().unwrap();
         let mut pruned_subagents = 0usize;

--- a/agentmux-srv/src/backend/subagent_watcher/mod.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/mod.rs
@@ -200,11 +200,17 @@ impl SubagentWatcher {
             );
         }
 
-        // Check if already watching this agent
+        // Check if already watching this agent. A second block registering
+        // the same agent_id adds itself as a dependent of the existing
+        // shared watcher (see WatchedAgent::parent_block_ids) instead of
+        // being silently dropped — otherwise `unwatch_block` (below) had no
+        // way to tell that a still-open second block also depended on this
+        // watcher when the first one closed.
         {
-            let watched = self.watched_agents.lock().unwrap();
-            if watched.iter().any(|w| w.agent_id == agent_id) {
-                tracing::debug!(agent = %agent_id, "already watching this agent");
+            let mut watched = self.watched_agents.lock().unwrap();
+            if let Some(existing) = watched.iter_mut().find(|w| w.agent_id == agent_id) {
+                existing.parent_block_ids.insert(parent_block_id.to_string());
+                tracing::debug!(agent = %agent_id, parent_block_id = %parent_block_id, "already watching this agent");
                 return;
             }
         }
@@ -321,7 +327,7 @@ impl SubagentWatcher {
             let mut watched = self.watched_agents.lock().unwrap();
             watched.push(WatchedAgent {
                 agent_id: agent_id.to_string(),
-                parent_block_id: parent_block_id.to_string(),
+                parent_block_ids: std::iter::once(parent_block_id.to_string()).collect(),
                 config_dir: config_dir.clone(),
                 _watcher: watcher,
             });
@@ -381,8 +387,17 @@ impl SubagentWatcher {
                     // that path, each misattributing it to their own
                     // parent_block_id. See
                     // docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md.
+                    //
+                    // Skipped entirely when parent_block_id is empty — the
+                    // legacy/manual `subagent.WatchAgent` RPC entry point
+                    // (server/service/misc.rs) deliberately passes "" for
+                    // callers with no pane to scope to; there's no block to
+                    // own the session against, so the check would otherwise
+                    // reject every event from that path unconditionally.
                     let session_id = derive_session_id(&changed_path);
-                    if !self_clone.session_belongs_to_block(&parent_block_id, &session_id) {
+                    if !parent_block_id.is_empty()
+                        && !self_clone.session_belongs_to_block(&parent_block_id, &session_id)
+                    {
                         tracing::debug!(
                             agent = %parent_agent,
                             parent_block_id = %parent_block_id,
@@ -585,21 +600,31 @@ impl SubagentWatcher {
         pruned
     }
 
-    /// Stop watching a block's filesystem watcher (drop its `notify`
-    /// subscription, closing the debounce channel so the associated
-    /// processing task self-terminates on its next `rx.recv()`). Block-
-    /// scoped, not agent-name-scoped — mirrors `unwatch_agent`'s teardown
-    /// mechanism, keyed by `parent_block_id` instead of `agent_id` so an
-    /// agent identity reused across multiple blocks over time only loses
-    /// the ONE watcher tied to the block that actually closed, never a
-    /// different still-open block sharing its name. Idempotent — a no-op if
-    /// no watcher is registered for this block.
+    /// Remove `block_id` as a dependent of its watcher, tearing down the
+    /// underlying `notify` subscription (closing the debounce channel so the
+    /// associated processing task self-terminates on its next `rx.recv()`)
+    /// only once NO block depends on it anymore. Block-scoped, not
+    /// agent-name-scoped — mirrors `unwatch_agent`'s teardown mechanism, but
+    /// keyed by `parent_block_id`.
+    ///
+    /// `watch_agent` dedupes by `agent_id`: a second block registering an
+    /// already-watched agent_id adds itself to that entry's
+    /// `parent_block_ids` instead of getting its own watcher. Tearing down
+    /// the whole entry the moment ANY one dependent block closes would kill
+    /// live tracking for every other still-open block sharing that agent
+    /// identity — removing just this block_id from the set (and only
+    /// dropping the entry once the set is empty) keeps the watcher alive for
+    /// as long as any block still needs it. Idempotent — a no-op if
+    /// `block_id` isn't a dependent of any watcher.
     fn unwatch_block(&self, block_id: &str) {
         let mut watched = self.watched_agents.lock().unwrap();
+        for w in watched.iter_mut() {
+            w.parent_block_ids.remove(block_id);
+        }
         let before = watched.len();
-        watched.retain(|w| w.parent_block_id != block_id);
+        watched.retain(|w| !w.parent_block_ids.is_empty());
         if watched.len() != before {
-            tracing::info!(block_id = %block_id, "stopped watching subagent dir for deleted block");
+            tracing::info!(block_id = %block_id, "stopped watching subagent dir: last dependent block closed");
         }
     }
 

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -874,8 +874,48 @@ async fn prune_block_also_tears_down_that_blocks_filesystem_watcher() {
 
     let watched = watcher.watched_agents.lock().unwrap();
     assert_eq!(watched.len(), 1, "prune_block must tear down the closed block's own watcher");
-    assert_eq!(watched[0].parent_block_id, "block-2", "a different, still-open block's watcher must be untouched");
+    assert!(
+        watched[0].parent_block_ids.contains("block-2"),
+        "a different, still-open block's watcher must be untouched"
+    );
     drop(watched);
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn prune_block_does_not_kill_a_watcher_still_depended_on_by_another_block() {
+    // Regression test for reagent's P1 on the first version of this fix:
+    // watch_agent dedupes by agent_id, so two blocks registering the SAME
+    // agent_id share one WatchedAgent entry. Pruning the first-registered
+    // block must not silently kill live tracking for the second, still-open
+    // block sharing that agent identity — only pruning BOTH should tear
+    // down the underlying watcher.
+    let home = dirs::home_dir().expect("test requires a resolvable home dir");
+    let root = home.join(format!("amx-prune-shared-agent-test-{}", now_millis()));
+    std::fs::create_dir_all(&root).unwrap();
+    let config_dir = root.join("claude-shared-agent");
+
+    let watcher = Arc::new(fixture_watcher());
+    watcher.watch_agent("shared-agent", "block-1", config_dir.clone());
+    watcher.watch_agent("shared-agent", "block-2", config_dir.clone());
+    // Same agent_id dedupes to one entry, now depended on by both blocks.
+    assert_eq!(watcher.watched_agents.lock().unwrap().len(), 1);
+
+    watcher.prune_block("block-1");
+    {
+        let watched = watcher.watched_agents.lock().unwrap();
+        assert_eq!(watched.len(), 1, "watcher must survive: block-2 still depends on it");
+        assert!(!watched[0].parent_block_ids.contains("block-1"));
+        assert!(watched[0].parent_block_ids.contains("block-2"));
+    }
+
+    watcher.prune_block("block-2");
+    assert_eq!(
+        watcher.watched_agents.lock().unwrap().len(),
+        0,
+        "once the last dependent block is pruned, the watcher must be torn down"
+    );
 
     std::fs::remove_dir_all(&root).ok();
 }
@@ -947,6 +987,37 @@ async fn live_fs_event_is_not_misattributed_to_a_block_that_does_not_own_the_ses
         active[0].parent_block_id, "block-owner",
         "must be attributed to the block that actually owns the session, never the other block sharing its watched directory"
     );
+
+    std::fs::remove_dir_all(&config_dir).ok();
+}
+
+#[tokio::test]
+async fn live_fs_event_with_empty_block_id_bypasses_the_ownership_check() {
+    // Regression test for reagent's P1 on the first version of this fix:
+    // the legacy/manual `subagent.WatchAgent` RPC entry point
+    // (server/service/misc.rs) deliberately passes block_id="" for callers
+    // with no pane to scope events to. No block has oid "", so the new
+    // session-ownership gate must not apply to it — otherwise every live
+    // event from that path is silently dropped.
+    let home = dirs::home_dir().expect("test requires a resolvable home dir");
+    let config_dir = home.join(format!("amx-empty-block-id-test-{}", now_millis()));
+    let subagents_dir = config_dir.join("projects").join("ws-enc").join("some-session").join("subagents");
+    std::fs::create_dir_all(&subagents_dir).unwrap();
+
+    let watcher = Arc::new(fixture_watcher());
+    watcher.watch_agent("manual-agent", "", config_dir.clone());
+
+    std::fs::write(
+        subagents_dir.join("agent-x.jsonl"),
+        "{\"type\":\"result\",\"result\":\"done\"}\n",
+    )
+    .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let active = watcher.list_active();
+    assert_eq!(active.len(), 1, "an empty block_id must not cause every live event to be dropped");
+    assert_eq!(active[0].parent_block_id, "");
 
     std::fs::remove_dir_all(&config_dir).ok();
 }

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -74,7 +74,7 @@ fn unwatch_agent_prunes_only_matching_parent_subagents() {
         sessions.insert("s2".to_string(), s2);
     }
 
-    watcher.unwatch_agent("parent-1");
+    watcher.unwatch_agent("parent-1", None);
 
     let sessions = watcher.sessions.lock().unwrap();
     // s1: parent-1's subagent gone, parent-2's remains.
@@ -194,7 +194,7 @@ fn unwatch_agent_on_unknown_agent_is_noop() {
         sessions.insert("s1".to_string(), s1);
     }
 
-    watcher.unwatch_agent("never-watched");
+    watcher.unwatch_agent("never-watched", None);
 
     let sessions = watcher.sessions.lock().unwrap();
     assert!(sessions.get("s1").unwrap().subagents.contains_key("sub-a"));
@@ -322,7 +322,7 @@ fn unwatch_agent_also_prunes_matching_dispatches_and_pending_activity() {
         pending.insert("wf_2".to_string(), PendingDispatchActivity::new("parent-2", "block-2", "s1"));
     }
 
-    watcher.unwatch_agent("parent-1");
+    watcher.unwatch_agent("parent-1", None);
 
     let dispatches = watcher.dispatches.lock().unwrap();
     assert!(!dispatches.contains_key("wf_1"));
@@ -915,6 +915,45 @@ async fn prune_block_does_not_kill_a_watcher_still_depended_on_by_another_block(
         watcher.watched_agents.lock().unwrap().len(),
         0,
         "once the last dependent block is pruned, the watcher must be torn down"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn unwatch_agent_does_not_kill_a_watcher_still_depended_on_by_another_block() {
+    // Regression test for reagent's P1 on the second version of this fix:
+    // unwatch_agent is the PRIMARY teardown path (called on every graceful
+    // pane close via /agentmux/reactive/unregister — far more common than
+    // prune_block's crash/API-delete backstop). It must respect the same
+    // parent_block_ids dependency set prune_block/unwatch_block do, or two
+    // blocks sharing one agent_id still kill each other's live tracking the
+    // moment either one gracefully closes.
+    let home = dirs::home_dir().expect("test requires a resolvable home dir");
+    let root = home.join(format!("amx-unwatch-agent-shared-test-{}", now_millis()));
+    std::fs::create_dir_all(&root).unwrap();
+    let config_dir = root.join("claude-shared-agent");
+
+    let watcher = Arc::new(fixture_watcher());
+    watcher.watch_agent("shared-agent", "block-1", config_dir.clone());
+    watcher.watch_agent("shared-agent", "block-2", config_dir.clone());
+    assert_eq!(watcher.watched_agents.lock().unwrap().len(), 1);
+
+    // block-1's process disconnects gracefully.
+    watcher.unwatch_agent("shared-agent", Some("block-1"));
+    {
+        let watched = watcher.watched_agents.lock().unwrap();
+        assert_eq!(watched.len(), 1, "watcher must survive: block-2 still depends on it");
+        assert!(!watched[0].parent_block_ids.contains("block-1"));
+        assert!(watched[0].parent_block_ids.contains("block-2"));
+    }
+
+    // block-2's process disconnects too — now the watcher must go.
+    watcher.unwatch_agent("shared-agent", Some("block-2"));
+    assert_eq!(
+        watcher.watched_agents.lock().unwrap().len(),
+        0,
+        "once the last dependent block is unwatched, the watcher must be torn down"
     );
 
     std::fs::remove_dir_all(&root).ok();

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -333,6 +333,39 @@ fn unwatch_agent_also_prunes_matching_dispatches_and_pending_activity() {
     assert!(pending.contains_key("wf_2"));
 }
 
+// ── session_belongs_to_block (docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md) ──
+
+#[test]
+fn session_belongs_to_block_matches_only_the_blocks_own_persisted_session() {
+    let watcher = fixture_watcher();
+    let mut meta = crate::backend::obj::MetaMapType::new();
+    meta.insert(
+        crate::backend::blockcontroller::core::META_SESSION_ID.to_string(),
+        serde_json::Value::String("s1".to_string()),
+    );
+    let mut block = crate::backend::obj::Block {
+        oid: "block-1".to_string(),
+        meta,
+        ..Default::default()
+    };
+    watcher.wstore.insert(&mut block).unwrap();
+
+    assert!(watcher.session_belongs_to_block("block-1", "s1"));
+    assert!(
+        !watcher.session_belongs_to_block("block-1", "s2"),
+        "a different session id must not match, even for a real block"
+    );
+}
+
+#[test]
+fn session_belongs_to_block_is_false_for_a_block_that_no_longer_exists() {
+    let watcher = fixture_watcher();
+    assert!(
+        !watcher.session_belongs_to_block("closed-block", "s1"),
+        "a closed/deleted block owns nothing — must reject, not fall through"
+    );
+}
+
 #[test]
 fn subagent_events_are_capped_at_max() {
     let mut state = fixture_state("parent-1", "sub-a", "s1");
@@ -817,6 +850,105 @@ async fn watch_agent_falls_back_to_nearest_existing_ancestor_when_config_dir_is_
     assert_eq!(watcher.watched_agents.lock().unwrap().len(), 1);
 
     std::fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn prune_block_also_tears_down_that_blocks_filesystem_watcher() {
+    // Regression test for docs/retro/retro-subagent-watcher-shared-dir-
+    // fanout-and-leak-2026-07-23.md Bug B: prune_block used to only clear
+    // derived session/dispatch/pending-activity state, leaving the
+    // underlying notify watcher (and its dedicated tokio task) running
+    // forever for a closed block — which kept re-creating fresh
+    // (mis-)attributed entries the next time another agent sharing its
+    // watched directory wrote to its own subagent transcript.
+    let home = dirs::home_dir().expect("test requires a resolvable home dir");
+    let root = home.join(format!("amx-prune-watch-test-{}", now_millis()));
+    std::fs::create_dir_all(&root).unwrap();
+
+    let watcher = Arc::new(fixture_watcher());
+    watcher.watch_agent("agent-1", "block-1", root.join("claude-agent-1"));
+    watcher.watch_agent("agent-2", "block-2", root.join("claude-agent-2"));
+    assert_eq!(watcher.watched_agents.lock().unwrap().len(), 2);
+
+    watcher.prune_block("block-1");
+
+    let watched = watcher.watched_agents.lock().unwrap();
+    assert_eq!(watched.len(), 1, "prune_block must tear down the closed block's own watcher");
+    assert_eq!(watched[0].parent_block_id, "block-2", "a different, still-open block's watcher must be untouched");
+    drop(watched);
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn live_fs_event_is_not_misattributed_to_a_block_that_does_not_own_the_session() {
+    // End-to-end regression test for docs/retro/retro-subagent-watcher-
+    // shared-dir-fanout-and-leak-2026-07-23.md Bug A: two blocks share
+    // one config_dir (the common case — every agent without a per-
+    // identity bundle override resolves to the same default provider
+    // path), so both watchers see the same raw filesystem event. Only
+    // the block that actually owns the session (via its own persisted
+    // agent:sessionid meta) may record the subagent; the other must
+    // drop the event, not misattribute it to itself.
+    let home = dirs::home_dir().expect("test requires a resolvable home dir");
+    let config_dir = home.join(format!("amx-shared-dir-fanout-test-{}", now_millis()));
+    let session_id = "owned-session";
+    let subagents_dir = config_dir.join("projects").join("ws-enc").join(session_id).join("subagents");
+    std::fs::create_dir_all(&subagents_dir).unwrap();
+
+    let watcher = Arc::new(fixture_watcher());
+
+    let mut owner_block = crate::backend::obj::Block {
+        oid: "block-owner".to_string(),
+        meta: {
+            let mut m = crate::backend::obj::MetaMapType::new();
+            m.insert(
+                crate::backend::blockcontroller::core::META_SESSION_ID.to_string(),
+                serde_json::Value::String(session_id.to_string()),
+            );
+            m
+        },
+        ..Default::default()
+    };
+    watcher.wstore.insert(&mut owner_block).unwrap();
+
+    let mut other_block = crate::backend::obj::Block {
+        oid: "block-other".to_string(),
+        meta: {
+            let mut m = crate::backend::obj::MetaMapType::new();
+            m.insert(
+                crate::backend::blockcontroller::core::META_SESSION_ID.to_string(),
+                serde_json::Value::String("some-other-session".to_string()),
+            );
+            m
+        },
+        ..Default::default()
+    };
+    watcher.wstore.insert(&mut other_block).unwrap();
+
+    // Both watch the SAME shared config_dir — simulating two agents
+    // without a per-identity bundle override.
+    watcher.watch_agent("agent-owner", "block-owner", config_dir.clone());
+    watcher.watch_agent("agent-other", "block-other", config_dir.clone());
+
+    std::fs::write(
+        subagents_dir.join("agent-x.jsonl"),
+        "{\"type\":\"result\",\"result\":\"done\"}\n",
+    )
+    .unwrap();
+
+    // Debounce is 200ms; give the watcher's async task ample margin to
+    // observe the write and process it.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let active = watcher.list_active();
+    assert_eq!(active.len(), 1, "the subagent must be recorded exactly once");
+    assert_eq!(
+        active[0].parent_block_id, "block-owner",
+        "must be attributed to the block that actually owns the session, never the other block sharing its watched directory"
+    );
+
+    std::fs::remove_dir_all(&config_dir).ok();
 }
 
 /// Regression test for the observed flood: reopening a pane for an

--- a/agentmux-srv/src/backend/subagent_watcher/types.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/types.rs
@@ -200,6 +200,7 @@ pub(super) struct DispatchState {
 #[allow(dead_code)]
 pub(super) struct WatchedAgent {
     pub(super) agent_id: String,
+    pub(super) parent_block_id: String,
     pub(super) config_dir: PathBuf,
     pub(super) _watcher: RecommendedWatcher,
 }

--- a/agentmux-srv/src/backend/subagent_watcher/types.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/types.rs
@@ -7,7 +7,7 @@
 //! tracking counterparts, and the `PendingDispatchActivity` coalescing
 //! buffer filled and flushed by `subagent_watcher::jsonl`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use notify::RecommendedWatcher;
@@ -200,7 +200,13 @@ pub(super) struct DispatchState {
 #[allow(dead_code)]
 pub(super) struct WatchedAgent {
     pub(super) agent_id: String,
-    pub(super) parent_block_id: String,
+    /// Every block currently depending on this shared watcher. `watch_agent`
+    /// dedupes by `agent_id` — a second block registering the same agent_id
+    /// gets no watcher of its own, it just adds itself here. `unwatch_block`
+    /// only tears down the underlying `notify` watcher once this set is
+    /// empty, so closing one of several blocks sharing an agent identity
+    /// never kills live tracking for the others still depending on it.
+    pub(super) parent_block_ids: HashSet<String>,
     pub(super) config_dir: PathBuf,
     pub(super) _watcher: RecommendedWatcher,
 }

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -403,7 +403,9 @@ pub(super) async fn handle_reactive_unregister(
     agent_registry::remove(&data_dir, &req.agent_id);
     // Drop the subagent filesystem watcher (handle + channel + task) — the
     // symmetric teardown for the watch_agent() call in the register handler.
-    state.subagent_watcher.unwatch_agent(&req.agent_id);
+    // Passes block_id (captured above) so a shared-agent-id watcher with
+    // another still-open dependent block survives this one's teardown.
+    state.subagent_watcher.unwatch_agent(&req.agent_id, block_id.as_deref());
     // Notify cloud subscriber so it stops subscribing for this agent
     if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
         sub.remove_agent(&req.agent_id);

--- a/docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md
+++ b/docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md
@@ -1,0 +1,101 @@
+# Retro: subagent watcher misattributes one agent's subagents to unrelated, closed panes
+
+**Date:** 2026-07-23
+**Severity:** Medium (data-quality/resource leak — no crash, but corrupts the Swarm data model and leaks OS watch handles + tokio tasks indefinitely)
+**Area:** `agentmux-srv/src/backend/subagent_watcher.rs` (since split into `subagent_watcher/` submodules by #2283, landed after this investigation but before this fix — the fix below targets the new module layout)
+**Status:** Root-caused and fixed. See the companion PR for the code change.
+
+---
+
+## 1. What the user saw
+
+> "why do I see 'nobile-percolating-ritchie ab9384' in the conversation pane? it appears to be an agent from somewhere else...pull in latest from github, figure out whats causing that"
+
+The concern was reasonable: an unfamiliar-looking agent name appearing unprompted looks like it could be a cross-tenant/security leak (this repo has a documented, real gap along those lines — see `docs/specs/SPEC_MUXBUS_MULTI_TENANT_SECURITY_2026_07_06.md`). It is not that. The actual name (log-verified, not "nobile") is `noble-percolating-ritchie` — a real subagent slug, misattributed to five unrelated, already-closed local agent panes.
+
+---
+
+## 2. Ground truth, with evidence
+
+### 2.1 One real subagent, six attributed owners
+
+Every occurrence of the slug across `~/.agentmux/logs/agentmuxsrv-v0.54.0.log.2026-07-23` carries the identical `session_id`:
+
+```
+d019e2e4-7223-4eeb-a2a6-b16b688b9893
+```
+
+logged under six different `parent`/`parent_block_id` pairs — `Agent1`, `Agent2`, `Agent3`, `AgentX`, `AgentY`, `Camper`:
+
+```
+{"message":"subagent spawned","agent_id":"ad0b1f3b89525bbcf","slug":"noble-percolating-ritchie","parent":"Agent2","parent_block_id":"930f221a-9302-4578-9346-5cc311aef8ff","session_id":"d019e2e4-7223-4eeb-a2a6-b16b688b9893", ...}
+{"message":"subagent spawned","agent_id":"a82039d9d4ebab07e","slug":"noble-percolating-ritchie","parent":"AgentY","parent_block_id":"864330fd-339e-4991-9034-ab6da1dc026b","session_id":"d019e2e4-7223-4eeb-a2a6-b16b688b9893", ...}
+{"message":"subagent spawned","agent_id":"ae39a5c4a7c274a05","slug":"noble-percolating-ritchie","parent":"Camper","parent_block_id":"fbf55f24-8d30-4c8b-ba8e-7718288ea84d","session_id":"d019e2e4-7223-4eeb-a2a6-b16b688b9893", ...}
+```
+
+`find ~/.agentmux -type d -name d019e2e4-7223-4eeb-a2a6-b16b688b9893` returns exactly **one** match:
+
+```
+/c/Users/asafe/.agentmux/shared/providers/claude/projects/C--Users-asafe--agentmux-agents-agentx-0623n/d019e2e4-7223-4eeb-a2a6-b16b688b9893
+```
+
+— i.e. this is genuinely `AgentX`'s own, real, single session. There is no UUID collision and no duplicate session file. The other five names are misattributions of AgentX's activity to themselves, not five agents that coincidentally share a session.
+
+### 2.2 The five other block_ids no longer exist
+
+Brute-forced every `objects.db` under `~/.agentmux` (93 files, all channels/dev branches/versions) for the six `parent_block_id`s seen in the logs. **Zero matches anywhere** — including in the `stable` channel's own `db_block` table, which is where a currently-open pane's block record would live. These five panes are closed and gone; only `AgentX`'s session is still live and actually producing subagent activity.
+
+### 2.3 The events are not coming from pane-(re)open backfill
+
+The only production caller of `SubagentWatcher::scan_session_subagents` (the backfill path, which logs `"reactive register request"` right before it can run) is `handle_reactive_register` in `agentmux-srv/src/server/reactive.rs:301-357` — confirmed identical in both current `main` and the exact `v0.54.0` release commit (`3d1eb999`) the running binary was built from.
+
+`grep -c -i "register" agentmuxsrv-v0.54.0.log.2026-07-23` → **0**. No register requests happened today. Yet 21 fresh `"subagent spawned"` events (plus continuous `"re-observed under a different parent_block_id"` churn) fired today alone. So these are not backfill-on-reopen events — they are coming from somewhere else entirely.
+
+### 2.4 The timing signature: one fs event, six near-simultaneous attributions
+
+Isolating one burst (`18:04:57.634` → `18:05:01.523`), a *single* underlying change is processed once per synthetic id, and for each one, `"re-observed under a different parent_block_id"` cycles through the exact same six `parent_block_id`s, sub-millisecond apart, in a stable order (`dec53dd5`→`c7f6f560`→`fbf55f24`→`930f221a`→`df70402b`→`864330fd`). That is the signature of **one real filesystem event being delivered to six independent, already-registered watchers**, each of which processes it under its own identity — not six agents independently calling the same backfill function with (coincidentally) the same argument.
+
+---
+
+## 3. Root cause — two independent bugs
+
+### Bug A — `watch_agent()`'s filesystem watch isn't scoped to the calling agent's own files
+
+`agentmux-srv/src/backend/subagent_watcher.rs`, `watch_agent()` (~line 407 onward) sets up a `notify` watcher, recursively, on the agent's resolved Claude `config_dir`. Per `docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md` Finding 3, any agent **without an explicit per-identity bundle override** resolves to the single shared default path: `~/.agentmux/shared/providers/claude/`. `Agent1`, `Agent2`, `Agent3`, `AgentX`, `AgentY`, and `Camper` all use the default provider auth, so all six independently registered a recursive watch on the *same physical directory tree*.
+
+The live-watch dispatch loop (lines ~565-609) captures `parent_agent`/`parent_block_id` once per `watch_agent()` call and, for every path the shared `notify` watcher reports changed — with no check that the changed file actually belongs to a subagent spawned within *that* watcher's own agent/session — calls:
+
+```rust
+self_clone.process_jsonl_change(&parent_agent, &parent_block_id, &changed_path, true);
+```
+
+So one real write to `AgentX`'s subagent transcript fans out to every other agent's watcher on the same shared directory, and each stamps the discovery with its own (wrong) identity. This is the direct cause of the misattribution.
+
+### Bug B — the fs watcher is never torn down when a pane closes ungracefully
+
+The *only* code that removes a `watched_agents` entry (and thereby stops its `notify` watcher + associated tokio task) is `unwatch_agent()` (line 631), called from exactly one place: `handle_reactive_unregister` in `reactive.rs:406`, itself only reached via the frontend's graceful `/agentmux/reactive/unregister` round trip.
+
+The code's own doc comment on `prune_block()` (line ~686) already acknowledges this is unreliable:
+
+> "independent of whether the frontend's normal `/agentmux/reactive/unregister` teardown path (which drives `unwatch_agent`) actually fires for this close — that path depends on a live renderer's `TermWrap.dispose()` completing an async fetch, which an API-driven delete, a tab/workspace cascade delete, or a crash can all skip."
+
+`prune_block()` was built as the "robust backstop" for exactly that gap — triggered off `Event::BlockDeleted`/`TabDeleted`/`WorkspaceDeleted` — but reading its actual body (lines 706-742), it only prunes the **derived** state: `sessions`, `dispatches`, `pending_activity`, all keyed by `block_id`. It never touches `watched_agents` and never calls `unwatch_agent`. So even when the backstop correctly notices a block was deleted and prunes its existing subagent rows, the underlying filesystem watcher for that agent keeps running — and per Bug A, keeps re-creating fresh, wrongly-attributed rows the next time *any* other shared-path agent (here, the still-live `AgentX`) writes to its own subagent transcript.
+
+### Combined effect
+
+`Agent1`, `Agent2`, `Agent3`, `AgentY`, and `Camper` closed at some point before today (ungracefully enough that `unwatch_agent` never ran for them), leaking five filesystem watchers on the shared Claude config path. `AgentX` is still actively running and spawning subagents. Every write to AgentX's own subagent transcript is broadcast (via the shared-directory `notify` watch) to all six leaked-or-live watchers, each of which relabels it under its own long-dead identity — which is what surfaced in the Swarm/conversation UI as an agent that "appears to be from somewhere else." It has been happening continuously since at least 2026-07-20 (first "backfilling" log line found) and was still firing at the time of writing (2026-07-23T18:35).
+
+---
+
+## 4. Why this isn't the muxbus/cross-tenant issue it initially resembled
+
+Ruled out early and worth stating plainly: every `parent` name involved (`Agent1`, `Agent2`, `Agent3`, `AgentX`, `AgentY`, `Camper`) is a local agent identity on this same machine, in this same srv process's own `db_block`/log history — not an external account, not a WAN/muxbus-delivered identity. `SPEC_MUXBUS_MULTI_TENANT_SECURITY_2026_07_06.md`'s documented `agent_id` authorization gap is real but unrelated to this symptom.
+
+---
+
+## 5. Fix
+
+- **Bug A:** a new `session_belongs_to_block(block_id, session_id)` check — compares the changed file's derived session id against the block's own currently-persisted `agent:sessionid` meta (read live from `wstore`) — gates every live filesystem event in the watch dispatch loop before it's processed.
+- **Bug B:** added `parent_block_id` to `WatchedAgent`, plus a new block-scoped `unwatch_block`, called from `prune_block`. Block-scoped (not agent-name-scoped, unlike `unwatch_agent`) so an agent identity reused across multiple blocks over time only loses the watcher tied to the block that actually closed.
+
+Landed alongside `agentmux-srv/src/backend/subagent_watcher/`'s Tier 2 modularization split (#2283) — the fix targets the new `mod.rs`/`types.rs`/`tests.rs` layout rather than the old monolithic file.


### PR DESCRIPTION
## Summary

Fixes the root cause behind a user report of an unfamiliar agent slug appearing in the Swarm/conversation UI ("nobile-percolating-ritchie ab9384" — log-verified actual spelling: `noble-percolating-ritchie`). Full investigation with evidence: `docs/retro/retro-subagent-watcher-shared-dir-fanout-and-leak-2026-07-23.md`.

Two independent bugs in `agentmux-srv/src/backend/subagent_watcher.rs`, both real and both required to fully close the symptom:

**Bug A — unscoped shared-directory fan-out.** Agents without a per-identity bundle override all resolve to the same default Claude config dir (`resolve_claude_config_dir`), so their `notify` filesystem watches observe the *same* directory tree. The live-watch dispatch loop attributed any changed file to its own `parent_agent`/`parent_block_id` with no check that the file's session actually belongs to it — one agent's real subagent write fanned out to every other watcher sharing that path, each misattributing it to itself.

Fix: a new `session_belongs_to_block(block_id, session_id)` check — compares the changed file's derived session id against the block's own currently-persisted `agent:sessionid` meta (read live from `wstore`) — gates every live fs event before it's processed.

**Bug B — leaked watchers on ungraceful pane close.** The only teardown for a block's filesystem watcher (`unwatch_agent`) runs through the frontend's graceful `/agentmux/reactive/unregister` round trip — something a crash, API-driven delete, or cascade delete can all skip (already documented in the existing `prune_block` doc comment). The "robust backstop" built for exactly that gap (`prune_block`, driven by `BlockDeleted`/`TabDeleted`/`WorkspaceDeleted`) only pruned derived session/dispatch/pending-activity state — it never tore down the underlying watcher. So a closed block's watcher leaked indefinitely, continuing to receive shared-directory events and (per Bug A) re-creating fresh misattributions for days after the pane was gone — confirmed live: five closed panes' block_ids no longer exist in any `objects.db` on the machine, yet their misattributions were still firing today.

Fix: added `parent_block_id` to `WatchedAgent`, a new block-scoped `unwatch_block` (mirrors `unwatch_agent`'s teardown mechanism, keyed by block instead of agent name so an agent identity reused across blocks over time isn't affected), called from `prune_block`.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv subagent_watcher::` — 56/56 passing, including 4 new tests:
  - `session_belongs_to_block_matches_only_the_blocks_own_persisted_session`
  - `session_belongs_to_block_is_false_for_a_block_that_no_longer_exists`
  - `prune_block_also_tears_down_that_blocks_filesystem_watcher`
  - `live_fs_event_is_not_misattributed_to_a_block_that_does_not_own_the_session` — end-to-end: two blocks share one `config_dir` (the real-world scenario), a file is written to a session owned by only one of them, and only that block records the subagent.
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` (full suite) — 1643/1643 passing, 0 failed, 4 ignored (pre-existing).
- [x] `cargo check -p agentmux-srv` — clean.

<!-- agentmux:agent_id=agent1 -->
