### PR TITLE
chore: release v0.54.4

### DIFF
--- a/.changesets/1784704684-fix-batch-of-small-triaged-issue-fixes-1397-780-859-2155-4vum.md
+++ b/.changesets/1784704684-fix-batch-of-small-triaged-issue-fixes-1397-780-859-2155-4vum.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix: batch of small triaged issue fixes (#1397, #780, #859, #2155)

--- a/.changesets/1784760432-fix-auth-open-login-terminal-no-longer-nulls-stdin-on-window-yjrg.md
+++ b/.changesets/1784760432-fix-auth-open-login-terminal-no-longer-nulls-stdin-on-window-yjrg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): open_login_terminal no longer nulls stdin on Windows, restoring browser-open

--- a/.changesets/1784760543-feat-process-broker-unify-agent-process-status-tracking-behi-a33g.md
+++ b/.changesets/1784760543-feat-process-broker-unify-agent-process-status-tracking-behi-a33g.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(process-broker): unify agent process/status tracking behind one broker (Phase A)

--- a/.changesets/1784760768-docs-reports-large-file-modularization-scan-across-rust-back-kfai.md
+++ b/.changesets/1784760768-docs-reports-large-file-modularization-scan-across-rust-back-kfai.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(reports): large-file modularization scan across Rust backend, CEF/launcher host, and frontend

--- a/.changesets/1784761584-refactor-broker-reducer-based-state-machine-for-credential-r-rp7z.md
+++ b/.changesets/1784761584-refactor-broker-reducer-based-state-machine-for-credential-r-rp7z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(broker): reducer-based state machine for credential refresh coordination

--- a/.changesets/1784781999-fix-launcher-macos-splash-rows-now-animate-instead-of-snappi-ygwe.md
+++ b/.changesets/1784781999-fix-launcher-macos-splash-rows-now-animate-instead-of-snappi-ygwe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher): macOS splash rows now animate instead of snapping to their final value

--- a/.changesets/1784787715-feat-agent-drop-the-shell-s-activity-log-panel-write-output--lb9i.md
+++ b/.changesets/1784787715-feat-agent-drop-the-shell-s-activity-log-panel-write-output--lb9i.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): drop the shell's activity-log panel, write output into the terminal instead

--- a/.changesets/1784822275-fix-term-terminal-scrollback-now-survives-reconnect-all-view-d1q7.md
+++ b/.changesets/1784822275-fix-term-terminal-scrollback-now-survives-reconnect-all-view-d1q7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): terminal scrollback now survives reconnect (all view:term panes)

--- a/.changesets/1784822887-refactor-implement-tier-1-modularization-items-state-rs-serv-g54u.md
+++ b/.changesets/1784822887-refactor-implement-tier-1-modularization-items-state-rs-serv-g54u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor: implement Tier 1 modularization items (state.rs, service handlers, reducer tests, TileLayout dedup, global.ts, providers, modal.tsx)

--- a/.changesets/1784830298-feat-tabs-shrink-to-fit-pane-tab-strip-sizing-double-click-r-q2ac.md
+++ b/.changesets/1784830298-feat-tabs-shrink-to-fit-pane-tab-strip-sizing-double-click-r-q2ac.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tabs): shrink-to-fit pane tab strip sizing + double-click rename for agent fork and terminal tabs

--- a/.changesets/1784831535-refactor-implement-tier-2-modularization-items-12-large-file-6vbm.md
+++ b/.changesets/1784831535-refactor-implement-tier-2-modularization-items-12-large-file-6vbm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor: implement Tier 2 modularization items (12 large files across Rust backend, CEF/launcher host, and frontend)

--- a/.changesets/1784846138-fix-agent-accounts-tab-in-agent-setup-wrote-to-a-dead-column-qwyy.md
+++ b/.changesets/1784846138-fix-agent-accounts-tab-in-agent-setup-wrote-to-a-dead-column-qwyy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): Accounts tab in Agent setup wrote to a dead column

--- a/.changesets/1784846624-fix-subagent-watcher-scope-live-fs-events-to-the-owning-bloc-p215.md
+++ b/.changesets/1784846624-fix-subagent-watcher-scope-live-fs-events-to-the-owning-bloc-p215.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(subagent-watcher): scope live fs events to the owning block and tear down watchers on block delete

--- a/.changesets/1784847016-refactor-implement-tier-3-modularization-items-main-rs-boots-hda7.md
+++ b/.changesets/1784847016-refactor-implement-tier-3-modularization-items-main-rs-boots-hda7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor: implement Tier 3 modularization items (main.rs bootstrap, lib.rs macOS compat, identity/resolver.rs, useAgentStream.ts)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.3"
+version = "0.54.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.3"
+version = "0.54.4"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.3"
+version = "0.54.4"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.3"
+version = "0.54.4"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.3"
+version = "0.54.4"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.3"
+version = "0.54.4"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.3"
+version = "0.54.4"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,23 @@
 # AgentMux Version History
 
+## 0.54.4 — 2026-07-23
+
+- fix: batch of small triaged issue fixes (#1397, #780, #859, #2155)
+- fix(auth): open_login_terminal no longer nulls stdin on Windows, restoring browser-open
+- feat(process-broker): unify agent process/status tracking behind one broker (Phase A)
+- docs(reports): large-file modularization scan across Rust backend, CEF/launcher host, and frontend
+- refactor(broker): reducer-based state machine for credential refresh coordination
+- fix(launcher): macOS splash rows now animate instead of snapping to their final value
+- feat(agent): drop the shell's activity-log panel, write output into the terminal instead
+- fix(term): terminal scrollback now survives reconnect (all view:term panes)
+- refactor: implement Tier 1 modularization items (state.rs, service handlers, reducer tests, TileLayout dedup, global.ts, providers, modal.tsx)
+- feat(tabs): shrink-to-fit pane tab strip sizing + double-click rename for agent fork and terminal tabs
+- refactor: implement Tier 2 modularization items (12 large files across Rust backend, CEF/launcher host, and frontend)
+- fix(agent): Accounts tab in Agent setup wrote to a dead column
+- fix(subagent-watcher): scope live fs events to the owning block and tear down watchers on block delete
+- refactor: implement Tier 3 modularization items (main.rs bootstrap, lib.rs macOS compat, identity/resolver.rs, useAgentStream.ts)
+
+
 ## 0.54.3 — 2026-07-22
 
 - fix(identity): restore resolve_provider_alias deleted by #2267's dead-code sweep

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.3",
+      "version": "0.54.4",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Patch release, forced (`task release -- --as patch`) despite the pending changesets computing to a `minor` bump — 14 changesets consumed, one (`feat(process-broker)`) is genuinely a `minor`-level change shipping under this patch version per the forced override.

Version: 0.54.3 → 0.54.4, all five locations verified in agreement (`VERSION_HISTORY.md`, `package.json`, `Cargo.toml`, `Cargo.lock`, `package-lock.json`).

## Changes in this release
- fix: batch of small triaged issue fixes (#1397, #780, #859, #2155)
- fix(auth): open_login_terminal no longer nulls stdin on Windows, restoring browser-open
- feat(process-broker): unify agent process/status tracking behind one broker (Phase A)
- docs(reports): large-file modularization scan across Rust backend, CEF/launcher host, and frontend
- refactor(broker): reducer-based state machine for credential refresh coordination
- fix(launcher): macOS splash rows now animate instead of snapping to their final value
- feat(agent): drop the shell's activity-log panel, write output into the terminal instead
- fix(term): terminal scrollback now survives reconnect (all view:term panes)
- refactor: implement Tier 1 modularization items (state.rs, service handlers, reducer tests, TileLayout dedup, global.ts, providers, modal.tsx)
- feat(tabs): shrink-to-fit pane tab strip sizing + double-click rename for agent fork and terminal tabs
- refactor: implement Tier 2 modularization items (12 large files across Rust backend, CEF/launcher host, and frontend)
- fix(agent): Accounts tab in Agent setup wrote to a dead column
- fix(subagent-watcher): scope live fs events to the owning block and tear down watchers on block delete
- refactor: implement Tier 3 modularization items (main.rs bootstrap, lib.rs macOS compat, identity/resolver.rs, useAgentStream.ts)

## Test plan
- [x] `task release -- --as patch` — all five version locations agree at 0.54.4
- [x] Release-consistency invariant self-checked by `scripts/release.sh`

<!-- agentmux:agent_id=camper -->