### PR TITLE
fix(tabs): hide single tab pill until a 2nd tab exists, transparent strip bg

### DIFF
--- a/.changesets/1784870112-fix-tabs-hide-the-single-tab-pill-until-a-2nd-tab-exists-tra-t4p4.md
+++ b/.changesets/1784870112-fix-tabs-hide-the-single-tab-pill-until-a-2nd-tab-exists-tra-t4p4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): hide the single tab pill until a 2nd tab exists, transparent strip background

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -29,7 +29,12 @@
     align-items: stretch;
     height: 28px;
     border-bottom: 1px solid var(--border-color);
-    background: var(--secondary-bg-color, var(--block-bg-color));
+    // No fill on the container itself — only .pane-tab (active/hover) and
+    // .pane-tab-strip-add (hover) paint a background. Any stray width the
+    // container ends up with beyond its actual tabs/+ (rounding, a flex
+    // edge case in a given renderer) reads as transparent instead of a
+    // stray colored block.
+    background: transparent;
     overflow-x: hidden;
 }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -200,6 +200,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // unopenable fork simply isn't offered as a tab at all, rather than
     // being offered and then silently doing nothing.
     const switchableForks = createMemo(() => forks().filter((f) => f.isActive || !!f.blockId));
+    // Only render tab pills once there's something to switch BETWEEN — a
+    // lone conversation shows just the "+" (no pill for itself). The
+    // moment a 2nd fork exists, both (including the first) appear as tabs.
+    const visibleForkTabs = createMemo(() => (switchableForks().length > 1 ? switchableForks() : []));
     // Activating a fork tab has two cases, both "switch," neither "create":
     // (1) the fork's block already lives in THIS pane's own block-stack
     //     (only possible once Phase 4 ships pushBlockOntoStack) — swap the
@@ -1253,16 +1257,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
             {/* Fork tab strip — top region, above everything else, matching
                 the editor's own tab-strip placement and every general
-                tabbed-UI convention. Phase 4 note: unlike Phase 3's
-                read-only bar (which hid itself entirely with only one
-                conversation, since there was nothing to switch to), the
-                strip is now always shown once an agent is running — the
-                "+" is exactly how you'd get to a second conversation, so
-                hiding the whole strip until a second one already exists
-                would make that action undiscoverable. See
-                SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.3. */}
+                tabbed-UI convention. The "+" always renders once an agent
+                is running — that's how you'd get to a second conversation —
+                but the tab pill itself stays hidden until there's something
+                to switch BETWEEN — a lone conversation shows only the "+";
+                the moment a fork exists, both appear.
+                SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md. */}
             <PaneTabStrip
-                tabs={switchableForks()}
+                tabs={visibleForkTabs()}
                 activeId={agentId}
                 getId={(f) => f.definitionId}
                 getLabel={(f) => f.title}

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -122,6 +122,10 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             return { blockId: id, label: overrides[id] ?? persistedTitle ?? `Terminal ${i + 1}` };
         });
     });
+    // Only render tab pills once there's something to switch BETWEEN — a
+    // lone terminal shows just the "+" (no pill for itself). The moment a
+    // 2nd tab exists, both (including the first) appear as tabs.
+    const visibleTermTabs = createMemo(() => (termTabs().length > 1 ? termTabs() : []));
     const activeBlockId = createMemo(() => {
         layoutModel.localTreeStateAtom();
         return layoutModel.getNodeByBlockId(blockId)?.data?.activeBlockId ?? blockId;
@@ -512,14 +516,14 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             style={{ position: "relative" }}
         >
             {/* Tab strip — top region, above everything else, matching the
-                editor's and agent pane's own tab-strip placement. Always
-                shown once >0 tabs exist (i.e. always, since the active tab
-                is always one) — the "+" is exactly how you'd get a second
-                tab, so hiding the whole strip until a second one already
-                exists would make that action undiscoverable (same
-                reasoning as the agent-pane fork strip, Phase 4). */}
+                editor's and agent pane's own tab-strip placement. The "+"
+                always renders (that's how you'd get a second tab), but the
+                tab pill itself stays hidden until there's something to
+                switch BETWEEN — a lone terminal shows only the "+"; the
+                moment a 2nd tab exists, both appear.
+                SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md. */}
             <PaneTabStrip
-                tabs={termTabs()}
+                tabs={visibleTermTabs()}
                 activeId={activeBlockId()}
                 getId={(t) => t.blockId}
                 getLabel={(t) => t.label}


### PR DESCRIPTION
## Summary
Live-QA follow-up on PR #2282. Two visual issues reported while running the change:
- A lone conversation/terminal still showed its own tab pill next to the `+`. Now the tab list passed to `PaneTabStrip` is empty until there's a 2nd tab to switch between — only `+` renders for a single tab; the first tab appears alongside it the moment a 2nd one opens.
- `.pane-tab-strip`'s own background fill painted a colored block over any stray container width beyond the actual tabs/`+`. Removed it — only `.pane-tab` (active/hover) and `.pane-tab-strip-add` (hover) paint a background now, so empty area reads as transparent.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run app/element app/view/agent app/view/term` — 63 files / 761 tests pass.
- [ ] Manual: confirm a single agent/terminal pane shows only `+`, and opening a 2nd tab reveals both.

<!-- agentmux:agent_id=agent3 -->