### PR TITLE
fix(term): give .view-term an opaque background to mask the block frame's translucent tint

### DIFF
--- a/.changesets/1784889011-fix-term-give-view-term-an-opaque-background-so-the-tab-stri-82rn.md
+++ b/.changesets/1784889011-fix-term-give-view-term-an-opaque-background-so-the-tab-stri-82rn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): give .view-term an opaque background so the tab-strip row doesn't show the block frame's translucent tint

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -12,6 +12,14 @@
 }
 
 .view-term {
+    // .view-term itself never painted a background — xterm's own canvas
+    // (starting only where .term-connectelem sits, below the tab strip)
+    // was the only opaque content in the pane. Nothing covered the tab
+    // strip's reserved row once its own background went transparent
+    // (compact-sizing work), so the ancestor block frame's translucent
+    // fill (.block-frame-default-inner, rgba(..., 0.5)) showed through
+    // there — same convention .agent-view already uses.
+    background: var(--main-bg-color);
     display: flex;
     flex-direction: column;
     width: 100%;


### PR DESCRIPTION
## Summary
Live-QA follow-up on PR #2289. The user kept seeing a non-transparent area to the right of the tab strip's `+` even after a fresh rebuild — ruling out stale HMR.

Root-caused via Chrome DevTools Protocol against the actual running dev build (CDP is exposed on `localhost:9223` in dev builds — used `Runtime.evaluate`/`elementFromPoint`/`Page.captureScreenshot` to inspect real computed styles and screenshot the live window, rather than guessing from source alone):

- `.pane-tab-strip` itself was already correctly narrow (34px) and fully transparent (`rgba(0,0,0,0)`) — that part of PR #2289's fix was working as intended.
- The empty area beyond it showed `.block-frame-default-inner`'s own background: `rgba(39, 40, 34, 0.5)` — a **translucent** fill on an ancestor wrapper used by every pane type, unrelated to the tab-strip code.
- `.view-term` never set its own background (confirmed via computed styles: `rgba(0,0,0,0)`). Previously the OLD tab strip's own opaque, full-width background happened to mask this translucent ancestor fill across that entire row. Once the strip shrank to content-width (PR #2282/#2289), that masking went away for the area beyond the strip's own box — the tab-strip's *row* isn't part of the strip *element*, so no amount of change to `.pane-tab-strip`'s own CSS could fix it.
- `.agent-view` already sets `background: var(--main-bg-color)` for presumably this exact reason. `.view-term` just never got the same treatment.

Fix: add `background: var(--main-bg-color)` to `.view-term`, matching `.agent-view`'s existing convention. Verified live via CDP: `.view-term`'s computed background is now `rgba(39, 40, 34, 0.95)` (opaque), and a zoomed screenshot of the running window confirms the row is now visually uniform with no seam.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run app/view/term` — 22/22 pass (no dedicated CSS coverage exists for this, consistent with the rest of the pane-chrome styling).
- [x] Manual, live: verified via CDP screenshot against the running dev build — confirmed both before (visible seam) and after (uniform, blended) states.

<!-- agentmux:agent_id=agent3 -->