### PR TITLE
fix(term): drop await on init resync to stop N-pane spawn serialization

### DIFF
--- a/.changesets/1784893740-fix-term-drop-await-on-init-resync-to-stop-n-pane-spawn-seri-anu6.md
+++ b/.changesets/1784893740-fix-term-drop-await-on-init-resync-to-stop-n-pane-spawn-seri-anu6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): drop await on init resync to stop N-pane spawn serialization (#121)

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -329,8 +329,12 @@ export class TermWrap {
         // At this point we are fully subscribed and ready to receive data.
         this.customFit();
         this.sendTermSize();
-        await this.resyncController("init");
+        // hasResized must flip before the fire-and-forget resync below: it gates the
+        // TermResyncHandler effect, and the terminal is already sized at this point
+        // (customFit/sendTermSize above), so a reconnect event arriving mid-spawn must
+        // not be dropped. See issue #121.
         this.hasResized = true;
+        void this.resyncController("init"); // fire-and-forget — PTY data subscription is already active
 
         // One re-fit after first paint to catch any remaining layout shift (slow CSS,
         // late style recalculation, font swap that landed after fonts.ready resolved).

--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -97,6 +97,11 @@ export class TermWrap {
     private thawTimeoutId: ReturnType<typeof setTimeout> | null = null;
     private thawRafId: number | null = null;
     private disposed: boolean = false;
+    // Tracks the fire-and-forget resyncController("init") call so the
+    // post-paint rAF re-fit (below) can wait for the controller to actually
+    // exist before sending a corrective resize, instead of racing it — see
+    // the comment at the rAF callback for why.
+    private initResyncPromise: Promise<void> = Promise.resolve();
 
     // ── Phase 1: CONSTRUCT (sync) ──────────────────────────────────────
 
@@ -334,19 +339,28 @@ export class TermWrap {
         // (customFit/sendTermSize above), so a reconnect event arriving mid-spawn must
         // not be dropped. See issue #121.
         this.hasResized = true;
-        void this.resyncController("init"); // fire-and-forget — PTY data subscription is already active
+        // fire-and-forget — PTY data subscription is already active. Kept so the rAF
+        // re-fit below can wait for the controller to exist before resizing it: the
+        // backend drops setblocktermsize entirely (no queue/retry) when the block's
+        // controller hasn't been created yet, and resyncController("init") is what
+        // creates it.
+        this.initResyncPromise = this.resyncController("init");
 
         // One re-fit after first paint to catch any remaining layout shift (slow CSS,
         // late style recalculation, font swap that landed after fonts.ready resolved).
         // If dimensions changed, sendTermSize() issues a SIGWINCH to the PTY so the
         // controller redraws against the correct size before producing meaningful output.
+        // Waits on initResyncPromise first (only when a resize is actually needed —
+        // the common no-change case stays instant): otherwise this can race ahead of
+        // the still-in-flight "init" resync and get silently dropped for having no
+        // controller yet, leaving the PTY at stale geometry until a manual resize.
         requestAnimationFrame(() => {
             if (!this.terminal) return;
             const oldRows = this.terminal.rows;
             const oldCols = this.terminal.cols;
             this.customFit();
             if (oldRows !== this.terminal.rows || oldCols !== this.terminal.cols) {
-                this.sendTermSize();
+                void this.initResyncPromise.then(() => this.sendTermSize());
             }
         });
 


### PR DESCRIPTION
## Summary
Implements Fix A from #121: opening N terminal panes concurrently produced an N×~10ms UI stall because `termwrap.ts::init()` awaited `resyncController("init")` before returning, even though the PTY data subscription is already active by that point (there's no correctness reason to block on it for a new pane). Moves `hasResized = true` ahead of the call (per the issue's own review comment, so a reconnect event arriving mid-spawn during the fire-and-forget window isn't missed by the `TermResyncHandler` gate) and fires `resyncController` without awaiting, matching the codebase's existing `void this.foo()` fire-and-forget convention.

Verified via `git grep` that this was still unapplied (the SolidJS migration mentioned in the issue's comments landed, but this specific line was untouched).

**Scope note:** this is Fix A only. Fix B (wrapping the backend's `spawn_command` fork+exec in `tokio::task::spawn_blocking`) is real, agreed-upon follow-up work, but turned out to touch 3 separate async RPC call sites (`websocket.rs`, `agent_open.rs` ×2) with Send/'static implications across the PTY-spawn hot path — bigger than a same-PR change I wanted to make without dedicated review. Left #121 referenced but not auto-closed by this PR since B is still open; will note in the issue.

Fixes (partially) #121.

## Test plan
- [x] `tsc --noEmit` passes with no new errors
- [ ] Manually verify opening 4+ terminal panes in a burst no longer visibly serializes (dev build)

<!-- agentmux:agent_id=agenta -->