### PR TITLE
fix(agent): auto-clear error activity-dock rows after 15s, add landing/departure flash

### DIFF
--- a/.changesets/1784922128-fix-agent-auto-clear-error-activity-dock-rows-after-15s-add--odmy.md
+++ b/.changesets/1784922128-fix-agent-auto-clear-error-activity-dock-rows-after-15s-add--odmy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): auto-clear error activity-dock rows after 15s, add landing/departure flash

--- a/docs/retro/retro-activity-dock-error-retention-2026-07-24.md
+++ b/docs/retro/retro-activity-dock-error-retention-2026-07-24.md
@@ -1,0 +1,102 @@
+# Retro — ActivityDock error rows persisted forever ("racking up above the composer")
+
+**Date:** 2026-07-24
+**Trigger:** User report, live: "i see the docks racking up above the model
+selector bar." Reported mid-session, after a stretch of background-shell-heavy
+work (several `mcp__agentmux__Shell` invocations that failed) in this same
+agent pane.
+**Audience:** anyone touching `ActivityDock.tsx`, `ActivityRow.tsx`, or
+`activity/types.ts`, and anyone about to hand-roll a "flash to draw attention"
+animation instead of checking for an existing one first.
+
+---
+
+## 1. What was wrong
+
+`ActivityDock` (spec: `SPEC_LONG_RUNNING_SHELL_PINNED_DOCK_2026_06_15.md`) pins
+one row per long-running shell/subagent above the composer. Its D4 retention
+policy (`activity/types.ts`'s `RETENTION_MS`) auto-clears terminal rows after a
+short window — **except `error`, which was `Infinity`**, i.e. "persists until
+the user manually dismisses it," by original design ("error → until
+acknowledged," per the code comment).
+
+In practice, a session that spawns several background shells that fail (this
+one: two failed `task dev` attempts via the MCP Shell tool, exit codes 201 and
+127; a diagnostic check, exit 1) accumulates one permanent row per failure,
+each requiring a manual click on its own × dismiss button. Over a long agent
+session doing real debugging work — which fails plenty, by nature — this reads
+as an ever-growing, cluttered strip crowding the space right above the
+composer, not a helpful error log.
+
+## 2. The fix
+
+- **`RETENTION_MS.error`: `Infinity` → `15_000`** (`activity/types.ts`). Long
+  enough to actually read the error (well above `done`'s 8s / `stopped`'s 3s),
+  short enough that a bad debugging session doesn't leave a permanent wall of
+  dead rows. The manual × dismiss button still exists for clearing one early.
+- **A landing/departure flash**, so a row's appearance and (now genuinely
+  imminent) disappearance are both conspicuous rather than a silent DOM
+  mutation the user might miss:
+  - On mount (`ActivityRow.tsx`): a local `entering` signal, true for
+    `EXIT_FLASH_MS` (400ms) after `onMount`.
+  - Just before removal: `ActivityDock`'s `visible` memo now keeps a row
+    mounted for `RETENTION_MS[status] + EXIT_FLASH_MS` instead of exactly
+    `RETENTION_MS[status]`, and exposes an `isLeaving(id)` helper that's true
+    only during that extra grace window. `hasExpiring`'s precise-retimer
+    effect was extended the same way so it still fires exactly when needed.
+  - Both apply the **same** animation: `tab-bounce` (`tabbar.scss`), the
+    spring-bounce already used for a tab landing after a drag/drop. Reused
+    directly by name (SCSS `@use`/component-colocated imports don't scope
+    `@keyframes` — it's a plain CSS-level name, visible from any stylesheet in
+    the bundle) rather than duplicating the keyframe, per the user's explicit
+    ask to reuse "the same flash as the tab landing in the chrome."
+
+Net effect: an error row now flashes in, sits for 15s (dismissible early), then
+flashes out on its own. No more permanent accumulation.
+
+## 3. A pattern worth abstracting — scoped, not built, this pass
+
+The user asked to look into whether the flash-on-mount/flash-before-removal
+pattern should become a standard, reusable primitive, separately from this
+fix. Worth doing — the codebase already has **at least four independent,
+structurally near-identical** "flash to draw attention" implementations, none
+aware of the others:
+
+| Where | Keyframe | Trigger mechanism | Duration |
+|---|---|---|---|
+| `tabbar.scss` | `tab-bounce` | signal (`bouncingTabId`) + `setTimeout` clear | 300-400ms |
+| `block.scss` (terminal activity) | `term-activity-flash` | conditional class, `--flash` modifier | 500ms |
+| `swarm-view.scss` | `swarm-activity-flash` | conditional class, `--flash` modifier | 500ms |
+| `_search.scss` (match nav) | `search-match-flash` | plain CSS, fires on selector match | 250ms |
+| `_shell-node.scss` (this fix) | reuses `tab-bounce` | local `entering` signal / parent-supplied `leaving()` | 300ms |
+
+Each reinvents: a keyframe, a class-toggle trigger (either an imperative
+signal + timeout, or a CSS-only conditional class), and its own duration/easing
+choice — with no shared vocabulary for "this UI element just appeared/is about
+to matter/is about to disappear, draw the eye."
+
+**Recommendation for a follow-up (not done here):** a single `useFlash()`
+hook or `<Flash>` wrapper in a shared location (candidate:
+`frontend/app/hook/` alongside `useTick`) that takes a duration and an
+`active: () => boolean` accessor, applies a standard flash class, and lets
+call sites pick from a small set of pre-defined visual treatments (bounce,
+color-pulse, invert-strobe) rather than each hand-rolling a keyframe. Should
+absorb `tab-bounce` and this fix's usage first (both are the same visual,
+literally), then evaluate whether `term-activity-flash`/`swarm-activity-flash`
+(same color/opacity shape as each other already) and `search-match-flash` are
+close enough to consolidate too, or different enough (different semantic
+purpose: landing vs. draw-attention vs. match-nav) to stay separate by design.
+Also worth checking the already-WCAG-2.3.1-hardened `tab-drop-invert-strobe`
+(400ms steps(1,end) 2, capped at 2.5Hz per PR #2105's review finding) — any
+generalized primitive needs to inherit that flash-rate ceiling by default, not
+let a new call site accidentally reintroduce a seizure-risk flash rate.
+
+## 4. What this retro is explicitly not
+
+Not a claim that `done`'s 8s / `stopped`'s 3s retention windows are also
+wrong — only `error`'s `Infinity` was the reported problem. Not a claim the
+generalized flash primitive is trivial — the table above undersells the real
+work (auditing every existing call site's actual visual intent before
+consolidating, and getting the reduced-motion/seizure-safety behavior right
+for all of them at once) — it's scoped as a separate follow-up specifically
+because it's real design work, not a quick refactor to bundle into this fix.

--- a/frontend/app/view/agent/activity/types.ts
+++ b/frontend/app/view/agent/activity/types.ts
@@ -57,10 +57,20 @@ export const KIND_SIGIL: Record<ActivityKind, string> = {
 };
 
 /** Milliseconds a terminal row lingers in the dock before auto-dismiss (D4).
- *  `error` is Infinity — it persists until the user acknowledges it. */
+ *  `error` used to be Infinity (persist until the user manually dismissed it)
+ *  — in practice this let failed background shells rack up in the dock
+ *  indefinitely across a long session. 15s gives the user time to actually
+ *  read the error (well above `done`/`stopped`) while still self-clearing. */
 export const RETENTION_MS: Record<ActivityStatus, number> = {
     running: Infinity,
     done: 8_000,
     stopped: 3_000,
-    error: Infinity,
+    error: 15_000,
 };
+
+/** Duration of the landing/departure flash (ActivityRow) — matches the tab
+ *  landing bounce's own clear-timeout (tab-reorder.ts / tab-tearoff-events.ts)
+ *  so a row visually reads the same way a dropped tab does. The dock's own
+ *  visibility window is extended by this much past RETENTION_MS so the exit
+ *  flash has time to actually play before the row leaves the DOM. */
+export const EXIT_FLASH_MS = 400;

--- a/frontend/app/view/agent/components/ActivityDock.tsx
+++ b/frontend/app/view/agent/components/ActivityDock.tsx
@@ -27,7 +27,7 @@ import { ActivityRow } from "./ActivityRow";
 import { shellActivities } from "../activity/shell-adapter";
 import { subagentActivities } from "../activity/subagent-adapter";
 import { allSubagentsAtom } from "../activity/subagent-source";
-import { RETENTION_MS, type ActivityKind, type ActivityStatus, type PinnedActivity } from "../activity/types";
+import { EXIT_FLASH_MS, RETENTION_MS, type ActivityKind, type ActivityStatus, type PinnedActivity } from "../activity/types";
 import type { SignalPair } from "../state";
 import type { DocumentNode } from "../types";
 
@@ -91,7 +91,9 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
         let maxExpiry = 0;
         for (const a of activities) {
             if (a.status !== "running" && RETENTION_MS[a.status] !== Infinity && a.endedAt != null) {
-                maxExpiry = Math.max(maxExpiry, a.endedAt + RETENTION_MS[a.status]);
+                // + EXIT_FLASH_MS: the row stays in `visible` a bit past its nominal
+                // retention so the departure flash (below) has time to play.
+                maxExpiry = Math.max(maxExpiry, a.endedAt + RETENTION_MS[a.status] + EXIT_FLASH_MS);
             }
         }
         const remaining = maxExpiry - Date.now();
@@ -104,7 +106,8 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
         onCleanup(() => clearTimeout(timer));
     });
 
-    // D4 — running always; terminal within its retention window; never dismissed.
+    // D4 — running always; terminal within its retention window (+ a grace
+    // period so the departure flash below can play) — never dismissed.
     const visible = createMemo(() => {
         const dm = dismissed();
         const t = hasExpiring() ? (tick(), Date.now()) : Date.now();
@@ -112,10 +115,21 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
             if (dm.has(a.id)) return false;
             if (a.status === "running") return true;
             const ret = RETENTION_MS[a.status];
-            if (ret === Infinity) return true; // error → until acknowledged
-            return a.endedAt != null && t - a.endedAt < ret;
+            if (ret === Infinity) return true;
+            return a.endedAt != null && t - a.endedAt < ret + EXIT_FLASH_MS;
         });
     });
+
+    // True once a row has passed its nominal retention window and is only
+    // still mounted for the departure flash — ActivityRow uses this to play
+    // the flash and stays out of the way of D4's actual removal logic above.
+    const isLeaving = (id: string): boolean => {
+        const a = activityById().get(id);
+        if (!a || a.status === "running" || a.endedAt == null) return false;
+        const ret = RETENTION_MS[a.status];
+        if (ret === Infinity) return false;
+        return (hasExpiring() ? (tick(), Date.now()) : Date.now()) - a.endedAt >= ret;
+    };
 
     // D3 — running-first, expanded-first, newest-first.
     const ordered = createMemo(() => {
@@ -211,6 +225,7 @@ export const ActivityDock = (props: ActivityDockProps): JSX.Element => {
                         <ActivityRow
                             activity={() => activityById().get(id)}
                             expanded={() => expandedIds().has(id)}
+                            leaving={() => isLeaving(id)}
                             onToggle={() => togglePin(id)}
                             onStop={() => stop(id)}
                             onDismiss={() => dismiss(id)}

--- a/frontend/app/view/agent/components/ActivityRow.tsx
+++ b/frontend/app/view/agent/components/ActivityRow.tsx
@@ -10,7 +10,7 @@
  */
 
 import clsx from "clsx";
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import { useTick } from "@/app/hook/useTick";
 import { capChars, createChunkCapper, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
@@ -21,7 +21,7 @@ import {
     type DispatchDetail,
     type SubagentEvent,
 } from "../../swarm/swarm-model";
-import { KIND_SIGIL, type PinnedActivity } from "../activity/types";
+import { EXIT_FLASH_MS, KIND_SIGIL, type PinnedActivity } from "../activity/types";
 import type { ToolLogChunk } from "../types";
 
 /** One-line text summary per subagent event kind — deliberately simpler than
@@ -68,6 +68,9 @@ interface ActivityRowProps {
     /** Reactive accessor — returns undefined if the activity just left. */
     activity: () => PinnedActivity | undefined;
     expanded: () => boolean;
+    /** True once this row is past its retention window and only still
+     *  mounted for the departure flash — see ActivityDock's `isLeaving`. */
+    leaving: () => boolean;
     onToggle: () => void;
     onStop: () => void;
     onDismiss: () => void;
@@ -75,6 +78,16 @@ interface ActivityRowProps {
 
 export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
     const tick = useTick(1000);
+
+    // Landing flash on first mount — same visual as a tab landing after a
+    // drag/drop (tab-bounce, tabbar.scss), reused here rather than a new
+    // bespoke animation. Cleared after EXIT_FLASH_MS so it plays once, not
+    // on every re-render.
+    const [entering, setEntering] = createSignal(true);
+    onMount(() => {
+        const timer = setTimeout(() => setEntering(false), EXIT_FLASH_MS);
+        onCleanup(() => clearTimeout(timer));
+    });
 
     const elapsed = createMemo(() => {
         const a = props.activity();
@@ -154,6 +167,8 @@ export const ActivityRow = (props: ActivityRowProps): JSX.Element => {
                 <div
                     class={clsx("agent-activity-row", a().kind, a().status, {
                         expanded: props.expanded(),
+                        "activity-flash-in": entering(),
+                        "activity-flash-out": !entering() && props.leaving(),
                     })}
                 >
                     <div class="agent-activity-summary" onClick={props.onToggle}>

--- a/frontend/app/view/agent/styles/_shell-node.scss
+++ b/frontend/app/view/agent/styles/_shell-node.scss
@@ -213,6 +213,17 @@
     &.stopped  { border-left-color: var(--secondary-text-color); opacity: 0.6; }
 
     & + & { border-top: 1px solid var(--border-color); }
+
+    // Landing/departure flash — reuses `tab-bounce` (tabbar.scss), the same
+    // spring-bounce played when a dragged tab lands, so a dock row appearing
+    // or about to disappear reads the same way a tab drop does elsewhere in
+    // the app. Both are transform-only (no layout shift) so they're safe to
+    // fire on a row that's about to be removed from the list.
+    &.activity-flash-in,
+    &.activity-flash-out {
+        transform-origin: center bottom;
+        animation: tab-bounce 300ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    }
 }
 
 .agent-activity-summary {


### PR DESCRIPTION
## Summary
- `ActivityDock` (the strip of pinned shell/subagent rows above the composer) gave `error`-status rows `Infinity` retention -- "persist until manually dismissed." Reported live: a session with several failed background shells accumulated permanent rows above the composer with no self-clearing ("docks racking up above the model selector bar").
- `RETENTION_MS.error`: `Infinity` -> `15_000` (15s) -- still well above `done`'s 8s / `stopped`'s 3s, long enough to actually read the error. The manual × dismiss button still works for clearing one early.
- Added a landing/departure flash so a row's appearance and (now genuinely imminent) disappearance are both conspicuous: reuses `tab-bounce` (`tabbar.scss`) -- the same spring-bounce already played when a dragged tab lands -- rather than a new bespoke animation. `ActivityDock`'s visibility window is extended by `EXIT_FLASH_MS` (400ms) past nominal retention so the exit flash has time to play before the row actually leaves the DOM.
- Retro: `docs/retro/retro-activity-dock-error-retention-2026-07-24.md` -- also documents 4 other independent ad-hoc "flash" implementations already in the codebase as a scoping note for a possible follow-up reusable primitive (not built in this PR, deliberately out of scope).

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manually verify: spawn a background shell that fails, confirm the row flashes in, sits ~15s, flashes out and clears without manual dismissal

<!-- agentmux:agent_id=agenta -->