### PR TITLE
feat(cef): add dev-only GPU memory trace commands for #2218 diagnostics

### DIFF
--- a/.changesets/1784926378-feat-cef-add-dev-only-gpu-memory-trace-commands-for-2218-dia-w3mj.md
+++ b/.changesets/1784926378-feat-cef-add-dev-only-gpu-memory-trace-commands-for-2218-dia-w3mj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(cef): add dev-only GPU memory trace commands for #2218 diagnostics

--- a/.changesets/1784926378-feat-cef-add-dev-only-gpu-memory-trace-commands-for-2218-dia-w3mj.md
+++ b/.changesets/1784926378-feat-cef-add-dev-only-gpu-memory-trace-commands-for-2218-dia-w3mj.md
@@ -1,5 +1,5 @@
 ---
-type: patch
+type: minor
 ---
 
 feat(cef): add dev-only GPU memory trace commands for #2218 diagnostics

--- a/agentmux-cef/src/commands/window/gpu_trace.rs
+++ b/agentmux-cef/src/commands/window/gpu_trace.rs
@@ -13,13 +13,22 @@
 // Spec: docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md §2.2.
 // Not a user feature — no UI affordance. Diagnostics only, same tier as
 // `toggle_devtools`/`inspect_element_at` (meta.rs), which this is modeled on.
+//
+// `cef::begin_tracing`/`cef::end_tracing` must run on the CEF UI thread, same
+// as every other CEF-touching call in this codebase (see `post_show_dev_tools`
+// / `ShowDevToolsTask`, `ui_tasks/window.rs`) — this handler is invoked from
+// the IPC/Tokio task, not that thread, so both calls are marshaled via
+// `post_task(ThreadId::UI, ...)` rather than called inline. That makes both
+// RPC commands fire-and-forget: the real begin/end outcome is logged from
+// inside each `Task::execute()`, not returned synchronously to the caller
+// (matches `post_show_dev_tools`'s own fire-and-forget shape).
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use cef::{
-    rc::Rc, wrap_end_tracing_callback, CefString, EndTracingCallback, ImplEndTracingCallback,
-    WrapEndTracingCallback,
+    post_task, rc::Rc, wrap_end_tracing_callback, wrap_task, CefString, EndTracingCallback,
+    ImplEndTracingCallback, ImplTask, Task, ThreadId, WrapEndTracingCallback, WrapTask,
 };
 
 use crate::state::AppState;
@@ -29,7 +38,11 @@ use crate::state::AppState;
 /// one means and why the GPU process's own `gpu` category size is the number
 /// that matters for #2218. `-*` first disables every default category so we
 /// aren't also capturing full per-frame event timing, which would make an
-/// hours-long capture enormous for no benefit to this investigation.
+/// hours-long capture enormous for no benefit to this investigation. This is
+/// standard Chromium category-filter shorthand, not AgentMux-specific syntax
+/// — Chromium's own startup-tracing docs use the identical `-*,<category>`
+/// shape (`--trace-startup=-*,disabled-by-default-memory-infra`); multiple
+/// included categories after `-*` is the same mechanism, just more of them.
 const DEFAULT_TRACE_CATEGORIES: &str =
     "-*,disabled-by-default-memory-infra,gpu,cc,skia,disabled-by-default-gpu.memory";
 
@@ -57,12 +70,11 @@ fn require_dev_mode() -> Result<(), String> {
     }
 }
 
-/// Start a memory-infra GPU trace. Optional `categories` arg overrides
-/// `DEFAULT_TRACE_CATEGORIES`. Fire-and-forget: `cef::begin_tracing`'s own
-/// completion callback (fired once every process has started tracing) isn't
-/// wired up here — for a manually-triggered diagnostics capture the small
-/// delay before every process is actually recording doesn't matter, and it
-/// keeps this handler synchronous like its siblings in this module.
+/// Request a memory-infra GPU trace start. Optional `categories` arg
+/// overrides `DEFAULT_TRACE_CATEGORIES`. Fire-and-forget — see module doc for
+/// why: the actual `cef::begin_tracing` call happens on the UI thread via
+/// `BeginGpuTraceTask`, and its real outcome is logged from there, not
+/// returned here.
 pub fn begin_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     require_dev_mode()?;
     if TRACING_ACTIVE.swap(true, Ordering::SeqCst) {
@@ -71,27 +83,25 @@ pub fn begin_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Resu
     let categories = args
         .get("categories")
         .and_then(|v| v.as_str())
-        .unwrap_or(DEFAULT_TRACE_CATEGORIES);
-    let cef_categories = CefString::from(categories);
-    let started = cef::begin_tracing(Some(&cef_categories), None) != 0;
-    if !started {
-        TRACING_ACTIVE.store(false, Ordering::SeqCst);
-        return Err("cef::begin_tracing returned failure".to_string());
-    }
-    tracing::info!(categories, "gpu_trace: started");
-    Ok(serde_json::json!({ "started": true, "categories": categories }))
+        .unwrap_or(DEFAULT_TRACE_CATEGORIES)
+        .to_string();
+    tracing::info!(categories = %categories, "gpu_trace: requesting begin_tracing on UI thread");
+    let mut task = BeginGpuTraceTask::new(categories.clone());
+    post_task(ThreadId::UI, Some(&mut task));
+    Ok(serde_json::json!({ "requested": true, "categories": categories }))
 }
 
-/// Stop the trace started by `begin_gpu_trace` and flush every process's
-/// trace data to `<instance data dir>/gpu-traces/<filename>`. `filename`
-/// (required arg) is a bare file name, not a path — rejected outright if it
-/// contains a path separator or `..`, so the write target is always confined
-/// to `TRACE_SUBDIR` by construction rather than by validating an
-/// attacker-suppliable path after the fact. Completion is asynchronous — CEF
-/// calls back once every process has written its data, which this logs via
-/// `tracing::info!` rather than surfacing over IPC (this is a diagnostics
-/// tool; the operator reads the log / opens the resulting file directly,
-/// matching the spec's own scoping — see §5, no UI affordance planned).
+/// Request the trace started by `begin_gpu_trace` be stopped and flushed to
+/// `<instance data dir>/gpu-traces/<filename>`. `filename` (required arg) is
+/// a bare file name, not a path — rejected outright if it contains a path
+/// separator or `..`, so the write target is always confined to
+/// `TRACE_SUBDIR` by construction rather than by validating an
+/// attacker-suppliable path after the fact. Fire-and-forget for the same
+/// UI-thread reason as `begin_gpu_trace`; completion (once every process has
+/// flushed) is logged via `tracing::info!` from `GpuTraceEndCallback` rather
+/// than surfaced over IPC (this is a diagnostics tool — the operator reads
+/// the log / opens the resulting file directly, matching the spec's own
+/// scoping — see §5, no UI affordance planned).
 pub fn end_gpu_trace(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     require_dev_mode()?;
     let filename = args
@@ -103,15 +113,10 @@ pub fn end_gpu_trace(state: &Arc<AppState>, args: &serde_json::Value) -> Result<
         return Err("no GPU trace is running — call begin_gpu_trace first".to_string());
     }
     let path_str = path.to_string_lossy().into_owned();
-    let cef_path = CefString::from(path_str.as_str());
-    let mut callback = GpuTraceEndCallback::new(path_str.clone());
-    let stopping = cef::end_tracing(Some(&cef_path), Some(&mut callback)) != 0;
-    if !stopping {
-        tracing::warn!(path = path_str, "gpu_trace: cef::end_tracing returned failure");
-        return Err("cef::end_tracing returned failure".to_string());
-    }
-    tracing::info!(path = path_str, "gpu_trace: stopping, flush in progress");
-    Ok(serde_json::json!({ "stopping": true, "path": path_str }))
+    tracing::info!(path = %path_str, "gpu_trace: requesting end_tracing on UI thread");
+    let mut task = EndGpuTraceTask::new(path_str.clone());
+    post_task(ThreadId::UI, Some(&mut task));
+    Ok(serde_json::json!({ "requested": true, "path": path_str }))
 }
 
 /// Build `<instance data dir>/gpu-traces/<filename>`, creating the
@@ -136,6 +141,46 @@ fn resolve_trace_path(state: &Arc<AppState>, filename: &str) -> Result<std::path
     let dir = std::path::PathBuf::from(data_dir).join(TRACE_SUBDIR);
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     Ok(dir.join(filename))
+}
+
+wrap_task! {
+    pub struct BeginGpuTraceTask {
+        categories: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let cef_categories = CefString::from(self.categories.as_str());
+            let started = cef::begin_tracing(Some(&cef_categories), None) != 0;
+            if started {
+                tracing::info!(categories = %self.categories, "gpu_trace: started");
+            } else {
+                // Roll back the optimistic guard set in begin_gpu_trace so a
+                // failed start doesn't permanently block future attempts.
+                TRACING_ACTIVE.store(false, Ordering::SeqCst);
+                tracing::warn!(categories = %self.categories, "gpu_trace: cef::begin_tracing returned failure");
+            }
+        }
+    }
+}
+
+wrap_task! {
+    pub struct EndGpuTraceTask {
+        path: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let cef_path = CefString::from(self.path.as_str());
+            let mut callback = GpuTraceEndCallback::new(self.path.clone());
+            let stopping = cef::end_tracing(Some(&cef_path), Some(&mut callback)) != 0;
+            if !stopping {
+                tracing::warn!(path = %self.path, "gpu_trace: cef::end_tracing returned failure");
+            } else {
+                tracing::info!(path = %self.path, "gpu_trace: stopping, flush in progress");
+            }
+        }
+    }
 }
 
 wrap_end_tracing_callback! {

--- a/agentmux-cef/src/commands/window/gpu_trace.rs
+++ b/agentmux-cef/src/commands/window/gpu_trace.rs
@@ -1,0 +1,110 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// GPU memory tracing — dev-only diagnostics for #2218 (system commit charge
+// growing with no corresponding process-level growth, i.e. a bucket not
+// attributed to any process's own Private Bytes). Chromium's memory-infra
+// tracing breaks GPU allocations into named categories instead of one opaque
+// total; this pins that down to two RPC commands an operator/agent can
+// trigger for an arbitrary-length capture window (unlike `--trace-startup`,
+// which is bounded and requires restarting with the flag set before the
+// capture window starts).
+//
+// Spec: docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md §2.2.
+// Not a user feature — no UI affordance. Diagnostics only, same tier as
+// `toggle_devtools`/`inspect_element_at` (meta.rs), which this is modeled on.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use cef::{
+    rc::Rc, wrap_end_tracing_callback, CefString, EndTracingCallback, ImplEndTracingCallback,
+    WrapEndTracingCallback,
+};
+
+use crate::state::AppState;
+
+/// Categories covering GPU allocations (`gpu`), compositor resources (`cc`),
+/// Skia GPU resources, and GPU memory buffers — see the spec §1 for what each
+/// one means and why the GPU process's own `gpu` category size is the number
+/// that matters for #2218. `-*` first disables every default category so we
+/// aren't also capturing full per-frame event timing, which would make an
+/// hours-long capture enormous for no benefit to this investigation.
+const DEFAULT_TRACE_CATEGORIES: &str =
+    "-*,disabled-by-default-memory-infra,gpu,cc,skia,disabled-by-default-gpu.memory";
+
+/// Guards against overlapping begin/end calls. Module-local rather than an
+/// `AppState` field — this is a rarely-used diagnostic toggle, not
+/// app-lifecycle state, so it doesn't need to live alongside everything else
+/// `AppState` tracks.
+static TRACING_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Start a memory-infra GPU trace. Optional `categories` arg overrides
+/// `DEFAULT_TRACE_CATEGORIES`. Fire-and-forget: `cef::begin_tracing`'s own
+/// completion callback (fired once every process has started tracing) isn't
+/// wired up here — for a manually-triggered diagnostics capture the small
+/// delay before every process is actually recording doesn't matter, and it
+/// keeps this handler synchronous like its siblings in this module.
+pub fn begin_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    if TRACING_ACTIVE.swap(true, Ordering::SeqCst) {
+        return Err("GPU trace already running — call end_gpu_trace first".to_string());
+    }
+    let categories = args
+        .get("categories")
+        .and_then(|v| v.as_str())
+        .unwrap_or(DEFAULT_TRACE_CATEGORIES);
+    let cef_categories = CefString::from(categories);
+    let started = cef::begin_tracing(Some(&cef_categories), None) != 0;
+    if !started {
+        TRACING_ACTIVE.store(false, Ordering::SeqCst);
+        return Err("cef::begin_tracing returned failure".to_string());
+    }
+    tracing::info!(categories, "gpu_trace: started");
+    Ok(serde_json::json!({ "started": true, "categories": categories }))
+}
+
+/// Stop the trace started by `begin_gpu_trace` and flush every process's
+/// trace data to `path` (required arg). Completion is asynchronous — CEF
+/// calls back once every process has written its data, which this logs via
+/// `tracing::info!` rather than surfacing over IPC (this is a diagnostics
+/// tool; the operator reads the log / opens the resulting file directly,
+/// matching the spec's own scoping — see §5, no UI affordance planned).
+pub fn end_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let path = args
+        .get("path")
+        .and_then(|v| v.as_str())
+        .ok_or("end_gpu_trace requires a \"path\" arg")?
+        .to_string();
+    if !TRACING_ACTIVE.swap(false, Ordering::SeqCst) {
+        return Err("no GPU trace is running — call begin_gpu_trace first".to_string());
+    }
+    let cef_path = CefString::from(path.as_str());
+    let mut callback = GpuTraceEndCallback::new(path.clone());
+    let stopping = cef::end_tracing(Some(&cef_path), Some(&mut callback)) != 0;
+    if !stopping {
+        tracing::warn!(path, "gpu_trace: cef::end_tracing returned failure");
+        return Err("cef::end_tracing returned failure".to_string());
+    }
+    tracing::info!(path, "gpu_trace: stopping, flush in progress");
+    Ok(serde_json::json!({ "stopping": true, "path": path }))
+}
+
+wrap_end_tracing_callback! {
+    struct GpuTraceEndCallback {
+        requested_path: String,
+    }
+
+    impl EndTracingCallback {
+        fn on_end_tracing_complete(&self, tracing_file: Option<&CefString>) {
+            let written = tracing_file
+                .map(|f| f.to_string())
+                .unwrap_or_else(|| self.requested_path.clone());
+            let size_bytes = std::fs::metadata(&written).map(|m| m.len()).ok();
+            tracing::info!(
+                path = written,
+                size_bytes,
+                "gpu_trace: flush complete — open in chrome://tracing or ui.perfetto.dev"
+            );
+        }
+    }
+}

--- a/agentmux-cef/src/commands/window/gpu_trace.rs
+++ b/agentmux-cef/src/commands/window/gpu_trace.rs
@@ -125,12 +125,16 @@ pub fn end_gpu_trace(state: &Arc<AppState>, args: &serde_json::Value) -> Result<
 /// rules out escaping `TRACE_SUBDIR` regardless of what the caller passes
 /// (no canonicalize-and-check-prefix dance needed, since a bare component
 /// can't traverse anywhere).
+///
+/// `:` is rejected too, on top of the separators above: on Windows, `PathBuf`
+/// treats a `:`-prefixed component like `C:evil.txt` as "has a prefix but no
+/// root" (drive-relative), and `PathBuf::push`/`join` *replaces* the base path
+/// entirely for such a component instead of appending to it — so
+/// `dir.join("C:evil.txt")` would silently discard the `TRACE_SUBDIR` prefix
+/// and resolve outside it. Rejecting any `:` closes that gap without needing
+/// platform-specific logic.
 fn resolve_trace_path(state: &Arc<AppState>, filename: &str) -> Result<std::path::PathBuf, String> {
-    if filename.is_empty()
-        || filename.contains(['/', '\\', '\0'])
-        || filename == "."
-        || filename == ".."
-    {
+    if !is_valid_trace_filename(filename) {
         return Err(format!("invalid trace filename: {filename:?}"));
     }
     let data_dir = state
@@ -141,6 +145,43 @@ fn resolve_trace_path(state: &Arc<AppState>, filename: &str) -> Result<std::path
     let dir = std::path::PathBuf::from(data_dir).join(TRACE_SUBDIR);
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     Ok(dir.join(filename))
+}
+
+fn is_valid_trace_filename(filename: &str) -> bool {
+    !filename.is_empty()
+        && !filename.contains(['/', '\\', '\0', ':'])
+        && filename != "."
+        && filename != ".."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_trace_filename;
+
+    #[test]
+    fn rejects_separators_and_special_components() {
+        assert!(!is_valid_trace_filename(""));
+        assert!(!is_valid_trace_filename("."));
+        assert!(!is_valid_trace_filename(".."));
+        assert!(!is_valid_trace_filename("a/b.json"));
+        assert!(!is_valid_trace_filename("a\\b.json"));
+        assert!(!is_valid_trace_filename("a\0b.json"));
+    }
+
+    /// The Windows drive-relative escape: `PathBuf::join`/`push` replaces the
+    /// base path (rather than appending) for a component with a prefix but no
+    /// root, so `dir.join("C:evil.json")` would land outside `TRACE_SUBDIR`.
+    #[test]
+    fn rejects_windows_drive_relative_component() {
+        assert!(!is_valid_trace_filename("C:evil.json"));
+        assert!(!is_valid_trace_filename("C:\\evil.json"));
+    }
+
+    #[test]
+    fn accepts_plain_filenames() {
+        assert!(is_valid_trace_filename("trace.json"));
+        assert!(is_valid_trace_filename("gpu-2026-07-25.json"));
+    }
 }
 
 wrap_task! {

--- a/agentmux-cef/src/commands/window/gpu_trace.rs
+++ b/agentmux-cef/src/commands/window/gpu_trace.rs
@@ -39,6 +39,24 @@ const DEFAULT_TRACE_CATEGORIES: &str =
 /// `AppState` tracks.
 static TRACING_ACTIVE: AtomicBool = AtomicBool::new(false);
 
+/// Subdirectory of the instance data dir traces are written into — fixed,
+/// not caller-controlled, so `end_gpu_trace`'s filename arg can never write
+/// outside it (see `resolve_trace_path`).
+const TRACE_SUBDIR: &str = "gpu-traces";
+
+/// Reject unconditionally unless explicitly opted into dev mode. Diagnostics
+/// only, no legitimate production use case — matches the runtime
+/// `AGENTMUX_DEV=1` check already used for the dev-only GPU-tier switch in
+/// `app/mod.rs`'s `on_before_command_line_processing` (`AGENTMUX_DEV`, not
+/// `is_dev_self()`, since that checks build identity, not opt-in).
+fn require_dev_mode() -> Result<(), String> {
+    if std::env::var("AGENTMUX_DEV").is_ok() {
+        Ok(())
+    } else {
+        Err("GPU tracing is dev-only — set AGENTMUX_DEV=1 to enable".to_string())
+    }
+}
+
 /// Start a memory-infra GPU trace. Optional `categories` arg overrides
 /// `DEFAULT_TRACE_CATEGORIES`. Fire-and-forget: `cef::begin_tracing`'s own
 /// completion callback (fired once every process has started tracing) isn't
@@ -46,6 +64,7 @@ static TRACING_ACTIVE: AtomicBool = AtomicBool::new(false);
 /// delay before every process is actually recording doesn't matter, and it
 /// keeps this handler synchronous like its siblings in this module.
 pub fn begin_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    require_dev_mode()?;
     if TRACING_ACTIVE.swap(true, Ordering::SeqCst) {
         return Err("GPU trace already running — call end_gpu_trace first".to_string());
     }
@@ -64,29 +83,59 @@ pub fn begin_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Resu
 }
 
 /// Stop the trace started by `begin_gpu_trace` and flush every process's
-/// trace data to `path` (required arg). Completion is asynchronous — CEF
+/// trace data to `<instance data dir>/gpu-traces/<filename>`. `filename`
+/// (required arg) is a bare file name, not a path — rejected outright if it
+/// contains a path separator or `..`, so the write target is always confined
+/// to `TRACE_SUBDIR` by construction rather than by validating an
+/// attacker-suppliable path after the fact. Completion is asynchronous — CEF
 /// calls back once every process has written its data, which this logs via
 /// `tracing::info!` rather than surfacing over IPC (this is a diagnostics
 /// tool; the operator reads the log / opens the resulting file directly,
 /// matching the spec's own scoping — see §5, no UI affordance planned).
-pub fn end_gpu_trace(_state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
-    let path = args
-        .get("path")
+pub fn end_gpu_trace(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    require_dev_mode()?;
+    let filename = args
+        .get("filename")
         .and_then(|v| v.as_str())
-        .ok_or("end_gpu_trace requires a \"path\" arg")?
-        .to_string();
+        .ok_or("end_gpu_trace requires a \"filename\" arg (bare file name, not a path)")?;
+    let path = resolve_trace_path(state, filename)?;
     if !TRACING_ACTIVE.swap(false, Ordering::SeqCst) {
         return Err("no GPU trace is running — call begin_gpu_trace first".to_string());
     }
-    let cef_path = CefString::from(path.as_str());
-    let mut callback = GpuTraceEndCallback::new(path.clone());
+    let path_str = path.to_string_lossy().into_owned();
+    let cef_path = CefString::from(path_str.as_str());
+    let mut callback = GpuTraceEndCallback::new(path_str.clone());
     let stopping = cef::end_tracing(Some(&cef_path), Some(&mut callback)) != 0;
     if !stopping {
-        tracing::warn!(path, "gpu_trace: cef::end_tracing returned failure");
+        tracing::warn!(path = path_str, "gpu_trace: cef::end_tracing returned failure");
         return Err("cef::end_tracing returned failure".to_string());
     }
-    tracing::info!(path, "gpu_trace: stopping, flush in progress");
-    Ok(serde_json::json!({ "stopping": true, "path": path }))
+    tracing::info!(path = path_str, "gpu_trace: stopping, flush in progress");
+    Ok(serde_json::json!({ "stopping": true, "path": path_str }))
+}
+
+/// Build `<instance data dir>/gpu-traces/<filename>`, creating the
+/// subdirectory if needed. `filename` must be a single path component — any
+/// separator (`/`, `\`) or `..`/`.` special component is rejected, which
+/// rules out escaping `TRACE_SUBDIR` regardless of what the caller passes
+/// (no canonicalize-and-check-prefix dance needed, since a bare component
+/// can't traverse anywhere).
+fn resolve_trace_path(state: &Arc<AppState>, filename: &str) -> Result<std::path::PathBuf, String> {
+    if filename.is_empty()
+        || filename.contains(['/', '\\', '\0'])
+        || filename == "."
+        || filename == ".."
+    {
+        return Err(format!("invalid trace filename: {filename:?}"));
+    }
+    let data_dir = state
+        .version_data_dir
+        .lock()
+        .clone()
+        .ok_or("instance data dir not yet initialized")?;
+    let dir = std::path::PathBuf::from(data_dir).join(TRACE_SUBDIR);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    Ok(dir.join(filename))
 }
 
 wrap_end_tracing_callback! {

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -45,6 +45,10 @@ mod meta;
 // Zoom / label / instance-listing / focus / devtools command handlers.
 pub use meta::*;
 
+mod gpu_trace;
+// Dev-only memory-infra GPU tracing (#2218 diagnostics) — begin_gpu_trace/end_gpu_trace.
+pub use gpu_trace::*;
+
 mod creation;
 // open_new_window / open_subwindow + frontend-URL resolution. The setters
 // are `pub` (ipc.rs); `resolve_frontend_base_url` / `assets_missing_data_url`

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -324,6 +324,10 @@ async fn route_command(
         "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),
         "inspect_element_at" => commands::window::inspect_element_at(state, args),
+        // Dev-only memory-infra GPU tracing (#2218 diagnostics) — see
+        // docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md.
+        "begin_gpu_trace" => commands::window::begin_gpu_trace(state, args),
+        "end_gpu_trace" => commands::window::end_gpu_trace(state, args),
         "show_context_menu" => {
             tracing::debug!("show_context_menu: handled in JS overlay");
             Ok(serde_json::Value::Null)

--- a/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
+++ b/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
@@ -70,10 +70,15 @@ can't cover the full multi-hour window tier 2 is built for.
 
 Launch with:
 ```
-AGENTMUX_CEF_EXTRA_FLAGS="trace-startup=-*,disabled-by-default-memory-infra;trace-startup-file=C:\path\to\trace.json;trace-startup-duration=1800"
+AGENTMUX_CEF_EXTRA_FLAGS="trace-startup=-*,disabled-by-default-memory-infra trace-startup-file=C:\path\to\trace.json trace-startup-duration=1800"
 ```
-(matches the existing `k=v` parsing already in `on_before_command_line_processing` for this env
-var — semicolon-separated, `=` splits switch from value).
+**Space-separated, not semicolon-separated** — `on_before_command_line_processing`
+(`agentmux-cef/src/app/mod.rs`) parses this env var with `.split_whitespace()`, then `=` splits
+each token into switch/value (verified against the actual parsing code, not assumed — an earlier
+draft of this recipe used semicolons, which that parser doesn't recognize as a separator, so it
+silently produced no trace file). Corollary: the output path can't contain a space, since
+`split_whitespace()` doesn't respect quoting — pick a path like `C:\Users\<you>\trace.json`, not
+one under a directory with a space in its name.
 
 Output is a Chrome trace JSON, viewable in `chrome://tracing` (load file) or
 [Perfetto UI](https://ui.perfetto.dev) — group by process, look at the GPU process's `gpu`

--- a/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
+++ b/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
@@ -1,0 +1,164 @@
+# Spec: GPU Memory Tracing Scaffolding — a real trace, not another process-level guess
+
+**Date:** 2026-07-24
+**Motivating issue:** #2218 (reopened) — `docs/status/STATUS_PF_COMMIT_GROWTH_INVESTIGATION_2026_07_24.md`
+§9-§12 established, from ~9 hours of real telemetry on a single idle-ish pane, that system commit
+grows ~0.8 GB/hour **independent of renderer count** (ruled out by the July 16 restart experiment)
+**and independent of logged content/activity** (ruled out §12, same session). Neither of the two
+obvious explanations holds. The next step that can actually narrow this further is a real GPU
+memory trace during confirmed-idle hours — process-level counters (`Private Bytes`, `Committed
+Bytes`) cannot see inside the GPU process's own allocator, which is exactly where the
+"unattributed" bucket lives.
+**Status:** Tier 2 (§2.2) implemented same-day — `agentmux-cef/src/commands/window/gpu_trace.rs`,
+`begin_gpu_trace`/`end_gpu_trace` RPC commands, `cargo check -p agentmux-cef` clean. Tier 1 (§2.1)
+is still just a documented recipe — no code needed there, nothing to implement. Neither tier has
+been run live yet (`task dev` on this branch is separately blocked — unrelated Gap B PATH issue,
+see conversation history — so this is verified by typecheck only, not a live capture).
+
+---
+
+## 1. What we're trying to see
+
+Every measurement so far (this investigation, and the July 2 / July 16 retros before it) treats
+the GPU/driver-committed memory as a black box: a number that grows, attributed to "System" by
+subtraction, with no visibility into *what kind* of GPU allocation is growing. Chromium's own
+`memory-infra` tracing system is the tool built for exactly this — it breaks GPU memory into
+named categories instead of one opaque total:
+
+| Category | What it tracks | Source |
+|---|---|---|
+| `gpu` (in the GPU process) | **All GPU allocations, size column** — the authoritative total regardless of which process references it | [probe-gpu.md](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/memory-infra/probe-gpu.md) |
+| `cc` (per renderer/browser process) | Chrome Compositor resource allocations — become GPU allocations under GPU rasterization | same |
+| `skia/gpu_resources` | GPU resources used by Skia (AgentMux's UI is Skia-rendered) | same |
+| `GPUMemoryBuffer` (per process) | Active GPU memory buffers in that process | same |
+
+Shared allocations (SharedImages, GMBs referenced from multiple processes) report their real
+`size` only in the *owning* process/category; everywhere else `effective size` reads 0 to avoid
+double-counting — so the `gpu` category's `size` column in the GPU process is the number to trust
+for a true total, matching what "unattributed" is measuring today by subtraction.
+
+**Goal: capture the `gpu` category (plus `cc`/`skia/gpu_resources`/`GPUMemoryBuffer` for
+attribution) across several idle hours and see which one actually grows.** If none of them grow
+while system commit still does, the leak is somewhere memory-infra doesn't instrument at all
+(driver-internal WDDM paging structures, ANGLE's own D3D11 layer) — which would itself be a
+useful, narrower negative result.
+
+## 2. Two tiers — a same-day manual experiment, then real scaffolding
+
+### 2.1 Tier 1 — zero code changes, can be run today
+
+AgentMux already has an escape hatch for exactly this kind of A/B: `AGENTMUX_CEF_EXTRA_FLAGS`
+(`agentmux-cef/src/app/mod.rs`, `on_before_command_line_processing` — "lets us A/B GPU/compositor
+flags"). Chromium's own startup-tracing mechanism is pure command-line:
+
+```
+--trace-startup=-*,disabled-by-default-memory-infra
+--trace-startup-file=<path>.json
+--trace-startup-duration=<seconds>
+```
+
+(syntax: [memory_infra_startup_tracing.md](https://chromium.googlesource.com/chromium/src/+/112.0.5615.165/docs/memory-infra/memory_infra_startup_tracing.md))
+
+**Caveat found during research, not yet verified against this exact CEF/Chromium build:**
+`--trace-startup-duration` is documented with short examples (single-digit seconds) — unclear
+whether it accepts a value large enough for a multi-hour idle-session capture (e.g. `32400` for
+9h), or whether the startup-tracing path is only intended for short boot-time traces. **First
+concrete step: try it with a moderate value (e.g. 1800s / 30min) as a dry run before trusting it
+for a full multi-hour capture.** If it doesn't hold up, tier 1 is still useful as a *short*
+before/after snapshot (e.g. 5 minutes idle vs. 5 minutes right after opening the pane) even if it
+can't cover the full multi-hour window tier 2 is built for.
+
+Launch with:
+```
+AGENTMUX_CEF_EXTRA_FLAGS="trace-startup=-*,disabled-by-default-memory-infra;trace-startup-file=C:\path\to\trace.json;trace-startup-duration=1800"
+```
+(matches the existing `k=v` parsing already in `on_before_command_line_processing` for this env
+var — semicolon-separated, `=` splits switch from value).
+
+Output is a Chrome trace JSON, viewable in `chrome://tracing` (load file) or
+[Perfetto UI](https://ui.perfetto.dev) — group by process, look at the GPU process's `gpu`
+category memory-infra dump entries over time.
+
+### 2.2 Tier 2 — a real trigger command, for an arbitrary-length idle-hours capture
+
+Tier 1 is bounded by whatever `--trace-startup-duration` turns out to actually support, and
+requires restarting AgentMux with the flag set *before* the idle period starts. For a real
+multi-hour, operator-controlled capture (start it, then just leave the pane alone for however
+long, stop it when done), the better fit is CEF's runtime tracing API:
+
+- `CefBeginTracing(categories, callback)` — starts tracing with an explicit category filter.
+- `CefEndTracingAsync(tracing_file, callback)` — flushes every process's trace data to disk;
+  callback fires once complete.
+([cef_trace.h reference](https://cef-builds.spotifycdn.com/docs/114.2/cef__trace_8h.html))
+
+**Implementation-time unknown from the first pass of this spec — now resolved.** Direct
+verification against the exact resolved crate version (`cef = "148.3.0+148.0.9"`, checked in
+`Cargo.lock`, source read from the local Cargo registry cache rather than guessed) confirmed both
+functions exist and are re-exported at the crate root: `cef::begin_tracing(categories:
+Option<&CefString>, callback: Option<&mut CompletionCallback>)` and `cef::end_tracing(tracing_file:
+Option<&CefString>, callback: Option<&mut EndTracingCallback>)`, plus the `EndTracingCallback`
+type and a `wrap_end_tracing_callback!` macro for implementing a custom completion handler (no
+prior usage of that macro pattern existed anywhere in `agentmux-cef` — this is the first).
+
+**Implemented**, modeled directly on the existing `toggle_devtools` handler
+(`agentmux-cef/src/commands/window/meta.rs:333-337` — same signature shape, same
+`state`/`args`/`Result<Value, String>` contract, dispatched the same way through `ipc.rs`):
+`agentmux-cef/src/commands/window/gpu_trace.rs` — `begin_gpu_trace` (guards against overlapping
+calls with a module-local `AtomicBool`, defaults to the categories listed in §1, fire-and-forget
+per the reasoning in the file's own doc comment) and `end_gpu_trace` (requires a `path` arg, wraps
+completion in a `GpuTraceEndCallback` via `wrap_end_tracing_callback!` that logs the flushed file
+path + size via `tracing::info!` once CEF's callback fires). Wired into `ipc.rs`'s dispatch table
+next to `toggle_devtools`/`inspect_element_at`, and re-exported from
+`commands/window/mod.rs` the same way every sibling module in that directory is. `cargo check -p
+agentmux-cef` is clean — zero warnings or errors in the new file.
+
+## 3. Long-duration capture — avoiding an unbounded trace file over multiple hours
+
+A full-event trace (every paint, every allocation) over 9 hours would be enormous and largely
+useless noise for this investigation — we only care about periodic memory *snapshots*, not
+frame-by-frame event timing. Chromium's memory-infra supports exactly this distinction via
+**periodic dump level**:
+
+- **BACKGROUND level** — "designed to have almost no impact in execution, running very fast" —
+  intended to be safe to leave on continuously (this is literally what production Chrome uses for
+  its own telemetry). **This is the level to use for the multi-hour capture window.**
+- **DETAILED level** — full breakdown, expensive, meant for short manual investigation, not
+  multi-hour background capture.
+
+Category string alone (as used in tier 1/2 above) may default to a reasonable periodic interval;
+if finer control turns out to be necessary, Chromium's advanced trace-config JSON supports an
+explicit `periodic_interval_ms` per dump level (documented example: `50` for light/background,
+`1000` for detailed) — pass via `--trace-config-file` for tier 1, or check whether
+`CefBeginTracing` accepts a full config object (vs. just a category string) for tier 2. **Pick a
+periodic interval on the order of tens of seconds to a few minutes for a multi-hour background
+capture** — frequent enough to see the ~0.8 GB/hour trend clearly (this investigation's own
+telemetry sampled every 10-13s and that was more than sufficient resolution), infrequent enough
+that hours of dumps stay a reasonably sized file.
+
+## 4. What to actually look for once a trace exists
+
+1. Open the resulting JSON in `chrome://tracing` or [ui.perfetto.dev](https://ui.perfetto.dev).
+2. Find the GPU process's `gpu` category memory-infra dumps; plot `size` over the capture window.
+3. **If `gpu` category size tracks the ~0.8 GB/hour growth this investigation measured** — the
+   leak is a genuine, instrumented GPU allocation category. Check the top-level allocator
+   breakdown within that dump (command buffer, texture pool, shared images) to narrow further —
+   that becomes the next concrete lead, likely mappable to a specific Chromium bug class from
+   `STATUS_PF_COMMIT_GROWTH_INVESTIGATION_2026_07_24.md` §11's research (SharedImage/GMB handles).
+4. **If `gpu` category size stays flat while system commit still grows** — memory-infra doesn't
+   see this allocation at all, meaning it's driver-internal (WDDM paging buffers, ANGLE D3D11
+   layer state) below Chromium's own instrumentation. That's a materially different, harder
+   problem — likely needs a GPU-vendor-specific tool (PIX, Nsight, or Windows' own ETW GPU
+   provider) rather than anything Chromium-side. Worth knowing either way; changes what the next
+   spec after this one should even attempt.
+
+## 5. Explicitly out of scope for this spec
+
+- Not proposing `--disable-gpu` as a mitigation anywhere in this document — already rejected,
+  owner policy, July 16 retro §5 item 3. This spec is purely about *seeing* the leak, not fixing
+  it yet.
+- Not committing to which tier ships first — tier 1 is a today-sized experiment; tier 2 is real
+  feature work (new Rust command, IPC wiring, testing) that should get its own implementation
+  pass and PR once tier 1 (or direct verification of the CEF binding surface) says it's worth
+  building.
+- Not designing the eventual mitigation (§11's "proactive renderer recycle" idea from the status
+  doc) — that's downstream of knowing what the trace actually shows.

--- a/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
+++ b/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
@@ -9,11 +9,15 @@ obvious explanations holds. The next step that can actually narrow this further 
 memory trace during confirmed-idle hours — process-level counters (`Private Bytes`, `Committed
 Bytes`) cannot see inside the GPU process's own allocator, which is exactly where the
 "unattributed" bucket lives.
-**Status:** Tier 2 (§2.2) implemented same-day — `agentmux-cef/src/commands/window/gpu_trace.rs`,
-`begin_gpu_trace`/`end_gpu_trace` RPC commands, `cargo check -p agentmux-cef` clean. Tier 1 (§2.1)
-is still just a documented recipe — no code needed there, nothing to implement. Neither tier has
-been run live yet (`task dev` on this branch is separately blocked — unrelated Gap B PATH issue,
-see conversation history — so this is verified by typecheck only, not a live capture).
+**Status:** Tier 2 (§2.2) implemented, PR #2294 (2 rounds of real review fixes: UI-thread
+marshaling, dev-gating, path confinement — see PR thread). **Run live, same day, after fixing
+the separate `task dev` Gap B PATH blocker** (see §6 — that fix was a prerequisite, not part of
+this spec, but is what made a live run possible at all). Real capture executed: `begin_gpu_trace`
+→ 20 minutes on a live idle-ish dev instance → `end_gpu_trace`, produced an 863 MB real Chromium
+trace file. **Result: the scaffolding works end-to-end, but the capture as currently configured
+does not contain the data this investigation needs — see §6 for why and what's next.** Not a
+failure of the code; a real, evidenced limit of the exposed CEF API surface, documented so nobody
+re-discovers it by repeating the same 20-minute wait.
 
 ---
 
@@ -180,3 +184,66 @@ that hours of dumps stay a reasonably sized file.
   building.
 - Not designing the eventual mitigation (§11's "proactive renderer recycle" idea from the status
   doc) — that's downstream of knowing what the trace actually shows.
+
+## 6. Live run result (2026-07-24) — scaffolding works, capture is missing the payload data
+
+**Prerequisite fixed first:** `task dev` was separately blocked all session by a Gap B PATH bug
+(`bash: executable file not found` deep inside go-task's `build:host:windows` step) — root cause
+turned out to be a cmd.exe quoting bug (`set "PATH=...;%PATH%"`, quoted, silently failed to
+actually update the environment variable; `set PATH=...` unquoted works). Not part of this spec,
+but the reason a live run was possible at all this session.
+
+**The run:** `begin_gpu_trace` (default categories) → confirmed `gpu_trace: started` in the srv
+log → left running 20 minutes on an otherwise-idle dev instance → `end_gpu_trace` → confirmed
+flush, 863 MB trace file written to `<data dir>/gpu-traces/`.
+
+**The problem:** the file contains real `GlobalMemoryDump` events (70 of them — periodic dumps
+genuinely fired, roughly every ~30s, matching Chromium's default background interval) but
+**zero** allocator/size payload data (`grep -c '"size"'` → 0, `grep -c "allocator"` → 0). Each
+dump's own args explain why: `"dump_type":"summary_only","level_of_detail":"background"`.
+Chromium's **background-level** dumps (the ones a bare category-filter string triggers by
+default) are deliberately near-zero-cost telemetry — they record *that* a dump happened, not the
+per-category size breakdown. That breakdown only exists in **detailed**-level dumps, which
+require an explicit `memory_dump_config.triggers[].mode: "detailed"` — normally set via a full
+JSON `TraceConfig`, not the simple comma-separated category-filter string.
+
+**Tried and empirically ruled out:** passing a full JSON `TraceConfig` string (with
+`memory_dump_config`) as `begin_gpu_trace`'s `categories` argument, on the theory that Chromium's
+`TraceConfig` constructor auto-detects JSON vs. category-filter shorthand from the same string
+parameter. Tested live with a short (40s) capture: the resulting trace had **no**
+`GlobalMemoryDump` events at all and no `disabled-by-default-memory-infra` events either — the
+JSON string was very likely parsed as a (nonsensical, matching nothing) category filter, not
+recognized as a config object. Also confirmed by direct binding search: `cef::begin_tracing`'s
+signature (`categories: Option<&CefString>, callback: Option<&mut CompletionCallback>`) has no
+separate parameter for a dump-trigger config, and the vendored crate source has no
+`RequestGlobalMemoryDump`-equivalent or richer `TraceConfig`-accepting entry point at all —
+checked directly against the exact resolved crate version, not assumed.
+
+**This is a real, hard limit of the exposed CEF API surface**, not a bug in `gpu_trace.rs` — the
+scaffolding correctly does everything `cef::begin_tracing`/`cef::end_tracing` support; those two
+functions just don't support requesting detailed dumps.
+
+### What would actually work (not implemented — next scoped step for whoever continues this)
+
+1. **Check whether CEF exposes a lower-level tracing API** beyond `begin_tracing`/`end_tracing` —
+   e.g. a way to submit a raw Perfetto `TraceConfig` protobuf, or a Chromium IPC/mojo interface
+   for `RequestGlobalMemoryDump` with an explicit `DETAILED` level. This may require going below
+   CEF's public API into Chromium internals CEF doesn't wrap, which likely isn't feasible from
+   `agentmux-cef` at all without patching CEF itself — worth a quick check before ruling it out,
+   but treat "not possible without a CEF patch" as a live, real possibility.
+2. **Chromium's own `--trace-startup-file` command-line path (Tier 1) may behave differently** —
+   it goes through `TracingController::StartTracing` with a config built from
+   `base::trace_event::TraceConfig::TraceConfig(category_filter_string, trace_option)`, which is
+   a different code path than `cef_begin_tracing`'s. Worth testing Tier 1 specifically (not yet
+   done — this session only validated Tier 2) before concluding detailed dumps are unreachable
+   from CEF entirely.
+3. **Fall back to a non-tracing measurement**: if detailed GPU memory-infra dumps prove
+   unreachable via any CEF-exposed path, the investigation may need a different instrument
+   entirely — e.g. Windows' own ETW GPU provider (`Microsoft-Windows-DxgKrnl`), or a
+   vendor-specific tool (PIX, Nsight), run externally against the GPU process PID rather than
+   through CEF/Chromium's own tracing at all. This sidesteps the CEF API limitation completely at
+   the cost of losing Chromium's own category/allocator semantics.
+
+The 863 MB (and a smaller ~79 KB failed-JSON-config) capture files are left in
+`<dev data dir>/gpu-traces/` in case someone wants to double-check this reading of the data
+before pursuing (1)-(3).

--- a/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
+++ b/docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md
@@ -105,12 +105,25 @@ prior usage of that macro pattern existed anywhere in `agentmux-cef` — this is
 `state`/`args`/`Result<Value, String>` contract, dispatched the same way through `ipc.rs`):
 `agentmux-cef/src/commands/window/gpu_trace.rs` — `begin_gpu_trace` (guards against overlapping
 calls with a module-local `AtomicBool`, defaults to the categories listed in §1, fire-and-forget
-per the reasoning in the file's own doc comment) and `end_gpu_trace` (requires a `path` arg, wraps
-completion in a `GpuTraceEndCallback` via `wrap_end_tracing_callback!` that logs the flushed file
-path + size via `tracing::info!` once CEF's callback fires). Wired into `ipc.rs`'s dispatch table
-next to `toggle_devtools`/`inspect_element_at`, and re-exported from
-`commands/window/mod.rs` the same way every sibling module in that directory is. `cargo check -p
-agentmux-cef` is clean — zero warnings or errors in the new file.
+per the reasoning in the file's own doc comment) and `end_gpu_trace` (requires a `filename` arg —
+a bare file name, not a path; see below — wraps completion in a `GpuTraceEndCallback` via
+`wrap_end_tracing_callback!` that logs the flushed file path + size via `tracing::info!` once
+CEF's callback fires). Wired into `ipc.rs`'s dispatch table next to
+`toggle_devtools`/`inspect_element_at`, and re-exported from `commands/window/mod.rs` the same way
+every sibling module in that directory is. `cargo check -p agentmux-cef` is clean — zero warnings
+or errors in the new file.
+
+**Post-review hardening (reagentx `CHANGES_REQUESTED`, PR #2294):** the first pass shipped both
+commands reachable unconditionally in every build and let `end_gpu_trace` write to any
+caller-supplied absolute path. Both fixed before merge:
+- Both commands now call `require_dev_mode()` first — a runtime `AGENTMUX_DEV=1` check (the same
+  pattern `app/mod.rs`'s GPU-tier switch already uses), not a build-identity check. No legitimate
+  production caller for a diagnostics-only tracing toggle.
+- `end_gpu_trace`'s arg changed from an arbitrary `path` to a `filename` — rejected outright if it
+  contains a path separator or `..`/`.`. The real output path is always
+  `<instance data dir>/gpu-traces/<filename>` (`resolve_trace_path`, creates the subdirectory if
+  missing). This confines the write target *by construction* rather than validating an
+  attacker-suppliable absolute path after the fact.
 
 ## 3. Long-duration capture — avoiding an unbounded trace file over multiple hours
 


### PR DESCRIPTION
## Summary
Implements Tier 2 of `docs/specs/SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md` -- diagnostics scaffolding for #2218 (system commit charge grows ~0.8 GB/hour, independent of both renderer count and logged content activity per that issue's investigation). Process-level counters can't see inside the GPU process's own allocator, which is exactly where the "unattributed" growth lives -- this adds the ability to actually look.

- `begin_gpu_trace` / `end_gpu_trace` RPC commands (`agentmux-cef/src/commands/window/gpu_trace.rs`), wrapping CEF's `begin_tracing`/`end_tracing` to capture Chromium's memory-infra GPU categories (`gpu`, `cc`, `skia`, `GPUMemoryBuffer`, `disabled-by-default-memory-infra`) for an arbitrary-length, operator-controlled capture window -- unlike `--trace-startup`, which is bounded and requires restarting before the capture window starts.
- Modeled directly on the existing `toggle_devtools` handler (`commands/window/meta.rs`), same signature shape, wired into `ipc.rs` the same way.
- Dev-only diagnostics -- no UI affordance, not a user feature.
- Resolves the one open unknown from the spec's first pass: verified against the exact resolved crate version (`cef 148.3.0+148.0.9`, read from the local Cargo registry cache, not guessed) that `begin_tracing`/`end_tracing` are exposed at the crate root, along with the `wrap_end_tracing_callback!` macro (first use of that pattern in this codebase).

## Test plan
- [x] `cargo check -p agentmux-cef` clean, zero warnings/errors in the new file
- [ ] Live capture during a confirmed-idle multi-hour session (blocked on this machine right now by an unrelated `task dev` PATH issue -- code is verified by typecheck only, not yet run)

<!-- agentmux:agent_id=agenta -->