### PR TITLE
fix(agent): fix invalid Sass compound-selector syntax in RuntimeBadge

### DIFF
--- a/.changesets/1784943486-fix-agent-fix-invalid-sass-compound-selector-syntax-in-runti-i4hp.md
+++ b/.changesets/1784943486-fix-agent-fix-invalid-sass-compound-selector-syntax-in-runti-i4hp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): fix invalid Sass compound-selector syntax in RuntimeBadge, blocking dev server

--- a/frontend/app/view/agent/components/RuntimeBadge.scss
+++ b/frontend/app/view/agent/components/RuntimeBadge.scss
@@ -42,13 +42,16 @@
         border: 1px solid color-mix(in srgb, var(--warning-color, #f59e0b) 30%, transparent);
     }
 
-    &--tag&--host {
+    // `&` can only appear once, at the start of a compound selector — `&--tag&--host`
+    // is invalid Sass. `#{&}` (interpolation) sidesteps that restriction while
+    // compiling to the exact same compound selector: `.runtime-badge--tag.runtime-badge--host`.
+    &--tag#{&}--host {
         color: var(--error-color);
         background: color-mix(in srgb, var(--error-color) 10%, transparent);
         border: none;
     }
 
-    &--tag&--container {
+    &--tag#{&}--container {
         color: var(--main-text-color);
         background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
         border: none;


### PR DESCRIPTION
## Summary
\`&--tag&--host\` / \`&--tag&--container\` in \`RuntimeBadge.scss\` used a second bare \`&\` mid-compound-selector, which Dart Sass rejects: \`"&" may only be used at the beginning of a compound selector\`. This broke \`task dev\`'s Vite server with a full-screen compile-error overlay -- found live while using a dev instance for unrelated work.

Both rules were meant to compile to a compound selector combining two BEM modifier classes at once (per the comment directly above them, overriding the single-modifier \`&--host\`/\`&--container\` rules via specificity). \`#{&}\` interpolation produces the identical compiled CSS (\`.runtime-badge--tag.runtime-badge--host\`) without hitting the syntax restriction -- no behavior change, pure syntax fix.

## Test plan
- [x] Applied live against a running \`task dev\` instance -- the compile error cleared, no new Sass errors in the log
- [ ] Visual check: RuntimeBadge still renders the intended override styling when both \`--tag\` and \`--host\`/\`--container\` modifiers are applied together

<!-- agentmux:agent_id=agenta -->