### PR TITLE
fix(identity): oauth_config_dir secret_ref serde rename mismatch

### DIFF
--- a/.changesets/1784946191-fix-identity-oauth-config-dir-secret-ref-variant-mismatched--g3hs.md
+++ b/.changesets/1784946191-fix-identity-oauth-config-dir-secret-ref-variant-mismatched--g3hs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(identity): oauth_config_dir secret_ref variant mismatched its own derived serde rename, breaking My Agents for every real account

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -68,7 +68,16 @@ pub enum SecretRef {
     /// conventionally spelled), so the derived name silently stopped
     /// matching stored data — this makes the wire format explicit instead
     /// of relying on the derive macro to guess right for an acronym.
-    #[serde(rename = "oauth_config_dir")]
+    ///
+    /// The `alias` keeps accepting the derive-produced `o_auth_config_dir`
+    /// tag too: any account persisted by a backend running between this
+    /// variant's introduction and this fix would have round-tripped
+    /// self-consistently under that buggy tag, and `identity_list()` aborts
+    /// entirely on the first unparseable row — so dropping read support for
+    /// it would just move the "My Agents empty" incident to a different set
+    /// of accounts. Serialization always writes the canonical
+    /// `oauth_config_dir`; only deserialization accepts both.
+    #[serde(rename = "oauth_config_dir", alias = "o_auth_config_dir")]
     OAuthConfigDir {
         /// Absolute path to the per-bundle, per-provider config
         /// directory — e.g. `~/.agentmux/shared/identities/<id>/claude/`,
@@ -475,6 +484,37 @@ mod tests {
             }
             other => panic!("expected OAuthConfigDir, got {other:?}"),
         }
+    }
+
+    /// Pins the OTHER wire format still sitting in some accounts: whatever
+    /// backend was running between this variant's introduction and the
+    /// `oauth_config_dir` rename above wrote (and read back) the
+    /// derive-produced `o_auth_config_dir` tag. Losing read support for it
+    /// reproduces the exact "My Agents empty" incident for those accounts —
+    /// `identity_list()` aborts entirely on the first unparseable row.
+    #[test]
+    fn secret_ref_deserializes_legacy_derive_produced_tag_json() {
+        let json = r#"{"backend":"o_auth_config_dir","dir":"C:\\Users\\area54\\.agentmux\\shared\\identities\\269c028b-3894-4231-b884-fa5d0ecfabdf\\claude"}"#;
+        let parsed: SecretRef = serde_json::from_str(json).expect("must deserialize legacy derive-produced wire format");
+        match parsed {
+            SecretRef::OAuthConfigDir { dir } => {
+                assert!(dir.ends_with("claude"), "dir should round-trip: {dir}");
+            }
+            other => panic!("expected OAuthConfigDir, got {other:?}"),
+        }
+    }
+
+    /// Serialization must always emit the canonical tag, never the legacy
+    /// alias — the alias is read-only backward compat, not a second valid
+    /// output format.
+    #[test]
+    fn secret_ref_serializes_oauth_config_dir_with_canonical_tag() {
+        let value = SecretRef::OAuthConfigDir {
+            dir: "/tmp/claude".to_string(),
+        };
+        let json = serde_json::to_string(&value).unwrap();
+        assert!(json.contains(r#""backend":"oauth_config_dir""#), "got: {json}");
+        assert!(!json.contains("o_auth_config_dir"), "got: {json}");
     }
 
     fn sample_account(id: &str, provider: &str) -> IdentityAccount {

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -59,6 +59,16 @@ pub enum SecretRef {
     /// providers; the resolver (PR B) dispatches to a config-dir
     /// env-var injection mode rather than the api-key env-var path.
     /// See `docs/specs/archive/SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md`.
+    ///
+    /// Explicit `rename` — the enum-wide `rename_all = "snake_case"` splits
+    /// at every capital letter, including inside "OAuth" itself, producing
+    /// `o_auth_config_dir` (verified: that's what a live deserialization
+    /// failure actually expected). Every real account on disk was written
+    /// with `oauth_config_dir` (no extra underscore — how "OAuth" is
+    /// conventionally spelled), so the derived name silently stopped
+    /// matching stored data — this makes the wire format explicit instead
+    /// of relying on the derive macro to guess right for an acronym.
+    #[serde(rename = "oauth_config_dir")]
     OAuthConfigDir {
         /// Absolute path to the per-bundle, per-provider config
         /// directory — e.g. `~/.agentmux/shared/identities/<id>/claude/`,
@@ -443,6 +453,29 @@ mod tests {
 
     use super::super::store::{AgentDefinition, Store};
     use super::*;
+
+    /// Pins the on-disk wire format directly, rather than round-tripping
+    /// through this crate's own serializer (which would happily agree with
+    /// itself even if `rename_all`'s derived tag drifted from what's
+    /// actually stored). `oauth_config_dir` here is copied verbatim from a
+    /// real account row in `~/.agentmux/shared/store.db` — this is the
+    /// literal regression that broke `identity_list()` (and therefore "My
+    /// Agents"/recent-sessions, which aborts entirely on the first
+    /// unparseable row) for every account written before the enum-wide
+    /// `rename_all = "snake_case"` derive silently started expecting
+    /// `o_auth_config_dir` instead (serde splits at every capital letter,
+    /// including inside "OAuth" itself).
+    #[test]
+    fn secret_ref_deserializes_real_stored_oauth_config_dir_json() {
+        let json = r#"{"backend":"oauth_config_dir","dir":"C:\\Users\\area54\\.agentmux\\shared\\identities\\bfa59d03-7a99-420e-b912-716bba1c462d\\claude"}"#;
+        let parsed: SecretRef = serde_json::from_str(json).expect("must deserialize real stored wire format");
+        match parsed {
+            SecretRef::OAuthConfigDir { dir } => {
+                assert!(dir.ends_with("claude"), "dir should round-trip: {dir}");
+            }
+            other => panic!("expected OAuthConfigDir, got {other:?}"),
+        }
+    }
 
     fn sample_account(id: &str, provider: &str) -> IdentityAccount {
         IdentityAccount {

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -53,6 +53,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { ProviderLogo } from "@/element/ProviderLogo";
+import { Logger } from "@/util/logger";
 import { RuntimeBadge } from "./RuntimeBadge";
 
 /** ms epoch → human-readable relative timestamp. Centralized here +
@@ -124,7 +125,17 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                     // CommandListRecentSessionsData docs.
                     identity_id: id,
                 });
-            } catch {
+            } catch (e) {
+                // Was a silent `catch { return []; }` — indistinguishable from
+                // "genuinely no sessions" in the UI and left zero trace
+                // anywhere (not even a console entry), which is exactly what
+                // made a real regression here look like expected empty state.
+                // `Error` objects serialize to `{}` via structured/JSON clone
+                // (message/stack aren't own-enumerable) — pull them out explicitly.
+                const errInfo = e instanceof Error
+                    ? { name: e.name, message: e.message, stack: e.stack }
+                    : { value: String(e) };
+                Logger.error("agent", "MyAgentsList: ListRecentSessionsCommand failed", { error: errInfo, identityId: id });
                 return [];
             }
         },


### PR DESCRIPTION
## Summary
Reported live: "what happened to My Agents? its an empty list" -- on a dev instance with real agent definitions (7 rows in `db_agents`) but an empty recent-sessions view.

Root cause, traced end to end:
- `SecretRef::OAuthConfigDir`'s enum-wide `#[serde(rename_all = "snake_case")]` derives `o_auth_config_dir` -- serde's snake_case conversion splits at *every* capital letter, including inside "OAuth" itself.
- Every real account in `~/.agentmux/shared/store.db` (the global, cross-channel account store) was written with `oauth_config_dir` (no extra underscore -- how a human actually spells "OAuth").
- `identity_list()` (`agentmux-srv/src/backend/storage/identities.rs`) aborts entirely on the first row that fails to deserialize -- so one legacy-spelled row breaks the whole query, for every channel/dev-branch that shares the global store (which per `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md` is deliberately *all* of them -- "My Agents" is designed to show agents from any build/channel/version, not just the current instance).
- `listrecentsessions` (which "My Agents" calls) depends on this query, so it failed too -- silently, because `MyAgentsList.tsx` had `catch { return []; }` with zero logging, indistinguishable from "genuinely no sessions."

## Fix
- Explicit `#[serde(rename = "oauth_config_dir")]` on the `OAuthConfigDir` variant, overriding the derive for just this one acronym-containing name -- matches what's actually on disk.
- New test (`secret_ref_deserializes_real_stored_oauth_config_dir_json`) that pins the literal JSON copied from a real account row, rather than round-tripping through this crate's own serializer (which is how the existing test suite missed this -- write and read both used the same self-consistent-but-wrong tag).
- `MyAgentsList.tsx`'s silent catch now logs the real error via `Logger.error` (including `Error.message`/`.stack`, which don't survive structured-clone/JSON serialization without being pulled out explicitly) -- this is what actually surfaced the root cause during live debugging.

## Test plan
- [x] New unit test passes; full `cargo test -p agentmux-srv` clean (1655 passed, 0 failed)
- [x] Verified live: found the exact error via the newly-added frontend logging, traced it to the exact stored JSON, confirmed the fix compiles
- [ ] Full end-to-end re-verification (needs a backend restart to pick up the fix in a running instance -- `restart_backend` is disabled under launcher-owned lifecycle per this build; next full app restart will pick it up)

<!-- agentmux:agent_id=agenta -->