### PR TITLE
feat(armory): add TouchDesigner to the MCP preload catalog

### DIFF
--- a/.changesets/1784977373-feat-armory-add-touchdesigner-to-the-mcp-preload-catalog-zevc.md
+++ b/.changesets/1784977373-feat-armory-add-touchdesigner-to-the-mcp-preload-catalog-zevc.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): add TouchDesigner to the MCP preload catalog

--- a/frontend/app/view/mcp/McpCatalogPicker.tsx
+++ b/frontend/app/view/mcp/McpCatalogPicker.tsx
@@ -32,6 +32,7 @@ export function McpCatalogPicker(props: { model: McpCatalogModel }): JSX.Element
                             <button type="button" class="mcp-picker-entry" onClick={() => model.startFromCatalog(entry)}>
                                 <span class="mcp-picker-entry-name">{entry.name}</span>
                                 <span class="mcp-picker-entry-note">{entry.prereqNote}</span>
+                                {entry.riskNote && <span class="mcp-picker-entry-risk">⚠ {entry.riskNote}</span>}
                                 <span class="mcp-picker-entry-docs">{entry.docsUrl}</span>
                             </button>
                         )}

--- a/frontend/app/view/mcp/mcp-catalog-picker.scss
+++ b/frontend/app/view/mcp/mcp-catalog-picker.scss
@@ -86,6 +86,14 @@
     color: var(--secondary-text-color);
 }
 
+// Persistent risk disclosure (spec §4 policy #2) — visually distinct from
+// prereqNote above, never suppressed once a server is connected/usable
+// (see .mcp-status-risk in mcp-status-pill.scss for the other surface).
+.mcp-picker-entry-risk {
+    font-size: var(--text-xs);
+    color: var(--warning-color);
+}
+
 .mcp-picker-entry-docs {
     font-size: 10px;
     color: var(--accent-color);

--- a/frontend/app/view/mcp/mcp-manager.tsx
+++ b/frontend/app/view/mcp/mcp-manager.tsx
@@ -38,6 +38,11 @@ function McpStatusPill(props: { serverId: string; serverName: string }): JSX.Ele
         if (s === "unknown" || s === "checking" || s === "connected") return null;
         return findPreloadEntryByName(props.serverName)?.prereqNote ?? null;
     };
+    // Unlike remediation() above, this is NOT gated on status — a risk that's
+    // real once the server is connected and usable must stay visible exactly
+    // then, not disappear the moment the server starts working (spec §4
+    // policy #2; this is what Codex flagged on #2298).
+    const riskNote = () => findPreloadEntryByName(props.serverName)?.riskNote ?? null;
 
     return (
         <div class="mcp-status-block">
@@ -49,6 +54,9 @@ function McpStatusPill(props: { serverId: string; serverName: string }): JSX.Ele
             </span>
             <Show when={remediation()}>
                 <p class="mcp-status-remediation">{remediation()}</p>
+            </Show>
+            <Show when={riskNote()}>
+                <p class="mcp-status-risk">⚠ {riskNote()}</p>
             </Show>
         </div>
     );

--- a/frontend/app/view/mcp/mcp-preload-catalog.ts
+++ b/frontend/app/view/mcp/mcp-preload-catalog.ts
@@ -35,6 +35,13 @@ export interface McpPreloadEntry {
      *  acceptance bar: a user who hasn't opened the app yet should see this
      *  sentence in the Armory, not a bare "Error"). */
     prereqNote: string;
+    /** Set only for Tier B entries with real code-exec risk inside the
+     *  third-party app (SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS
+     *  _2026_07_10.md §4 policy #2). Rendered as a persistent callout
+     *  regardless of connection status — unlike prereqNote, this must NOT
+     *  disappear once the server is connected and actually usable, since
+     *  that's exactly when the risk is live. Not fine print. */
+    riskNote?: string;
     docsUrl: string;
 }
 
@@ -55,16 +62,24 @@ export const MCP_PRELOAD_CATALOG: McpPreloadEntry[] = [
         id: "touchdesigner",
         name: "TouchDesigner",
         transport: "stdio",
-        config: { command: "npx", args: ["-y", "touchdesigner-mcp-server@latest", "--stdio"] },
+        // Pinned per spec §4 policy #1 — validated against 1.5.0 this session
+        // (real TD + Ableton instance, router up with all 12 routes). Bump
+        // this deliberately and re-validate; never widen back to @latest.
+        // (Spec §4 policy #3 also calls for a mandatory `verifiedAgainst`
+        // field with a review cadence — not added here, out of scope for
+        // this fix; neither catalog entry has it yet.)
+        config: { command: "npx", args: ["-y", "touchdesigner-mcp-server@1.5.0", "--stdio"] },
         prereqNote:
             "Requires TouchDesigner already running with mcp_webserver_base.tox imported into the " +
-            "project (download touchdesigner-mcp-td.zip from the latest release at " +
-            "github.com/8beeeaaat/touchdesigner-mcp/releases, import mcp_webserver_base.tox — " +
+            "project (download touchdesigner-mcp-td.zip from the v1.5.0 release at " +
+            "github.com/8beeeaaat/touchdesigner-mcp/releases/tag/v1.5.0, import mcp_webserver_base.tox — " +
             "/project1/mcp_webserver_base is recommended — and keep its modules/ folder alongside " +
-            "it; the component references those files by relative path). Includes exec_python_script " +
-            "— arbitrary Python execution inside the running TouchDesigner instance — as a first-class " +
-            "tool, more exposed than a typically-scoped bridge. This bridge cannot launch TouchDesigner " +
-            "or import the component for you.",
+            "it; the component references those files by relative path. This bridge cannot launch " +
+            "TouchDesigner or import the component for you.",
+        riskNote:
+            "This connector's tool list includes exec_python_script — arbitrary Python execution " +
+            "inside the running TouchDesigner instance — as a first-class, non-opt-in tool. More " +
+            "exposed than a typically-scoped bridge (e.g. Ableton's, above).",
         docsUrl: "https://github.com/8beeeaaat/touchdesigner-mcp",
     },
 ];

--- a/frontend/app/view/mcp/mcp-preload-catalog.ts
+++ b/frontend/app/view/mcp/mcp-preload-catalog.ts
@@ -17,10 +17,12 @@
  * creating it from the catalog — acceptable known limitation for Phase B,
  * not silently hidden.
  *
- * Scope per spec §7/§8 Q1: ship Ableton MCP alone; expand only after this
- * pattern validates. TouchDesigner/ComfyUI research lives in
- * docs/specs/SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS_2026_07_10.md as
- * candidate follow-on entries, not shipped here.
+ * Scope per spec §7/§8 Q1: ship Ableton MCP first, expand only after that
+ * pattern validates. TouchDesigner (researched as a candidate in
+ * docs/specs/SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS_2026_07_10.md)
+ * is the first expansion, added after end-to-end manual validation against
+ * a real TouchDesigner + Ableton Live instance (router up with all 12
+ * routes, AbletonOSC bridge live). ComfyUI remains an unshipped candidate.
  */
 
 export interface McpPreloadEntry {
@@ -48,6 +50,22 @@ export const MCP_PRELOAD_CATALOG: McpPreloadEntry[] = [
             "and selected as the active Control Surface (Preferences → Link, Tempo & MIDI). " +
             "This bridge cannot launch Live or install the Remote Script for you.",
         docsUrl: "https://github.com/ahujasid/ableton-mcp",
+    },
+    {
+        id: "touchdesigner",
+        name: "TouchDesigner",
+        transport: "stdio",
+        config: { command: "npx", args: ["-y", "touchdesigner-mcp-server@latest", "--stdio"] },
+        prereqNote:
+            "Requires TouchDesigner already running with mcp_webserver_base.tox imported into the " +
+            "project (download touchdesigner-mcp-td.zip from the latest release at " +
+            "github.com/8beeeaaat/touchdesigner-mcp/releases, import mcp_webserver_base.tox — " +
+            "/project1/mcp_webserver_base is recommended — and keep its modules/ folder alongside " +
+            "it; the component references those files by relative path). Includes exec_python_script " +
+            "— arbitrary Python execution inside the running TouchDesigner instance — as a first-class " +
+            "tool, more exposed than a typically-scoped bridge. This bridge cannot launch TouchDesigner " +
+            "or import the component for you.",
+        docsUrl: "https://github.com/8beeeaaat/touchdesigner-mcp",
     },
 ];
 

--- a/frontend/app/view/mcp/mcp-status-pill.scss
+++ b/frontend/app/view/mcp/mcp-status-pill.scss
@@ -31,3 +31,15 @@
     background: var(--panel-bg-color);
     border-left: 2px solid var(--border-color);
 }
+
+// Persistent risk disclosure (spec §4 policy #2) — rendered regardless of
+// connection status, unlike .mcp-status-remediation above which is
+// deliberately suppressed once connected. See McpStatusPill's riskNote().
+.mcp-status-risk {
+    margin: var(--space-1) 0 0 0;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--warning-color);
+    background: color-mix(in srgb, var(--warning-color) 10%, transparent);
+    border-left: 2px solid var(--warning-color);
+}


### PR DESCRIPTION
## Summary
- Adds TouchDesigner as the second entry in the Armory's MCP Servers preload catalog (`frontend/app/view/mcp/mcp-preload-catalog.ts`), following the Ableton Live pattern from #2030 — picking it in "+ Browse catalog" pre-fills the add-server form with `npx -y touchdesigner-mcp-server@latest --stdio`.
- This is the first expansion past Ableton-alone, gated in spec §7/§8 Q1 on "expand only after this pattern validates." That candidate research already existed in `docs/specs/SPEC_ARMORY_PRELOADED_CREATIVE_MCP_CONNECTORS_2026_07_10.md` — this PR is validation, not just research: I set up a real TouchDesigner + Ableton Live instance end-to-end this session (AbletonOSC bridge, the touchdesigner-mcp connector's WebServer DAT component, and confirmed the MCP router comes up with all 12 routes and live tempo/beat data flowing from Ableton), then wired the catalog entry against what actually worked.
- `prereqNote` calls out that this connector's tool list includes `exec_python_script` (arbitrary Python execution inside the running TouchDesigner instance) as a first-class tool — more exposed than Ableton's scoped bridge — matching the existing pattern of surfacing real setup/risk info inline rather than a bare "Error" (spec §6).

## Test plan
- [x] `npx tsc --noEmit` — no new errors (one pre-existing, unrelated `qrcode` module error in `HostPopover.tsx`)
- [x] Manually verified the underlying connector end-to-end (not just this catalog entry): TouchDesigner MCP router initialized with 12/12 routes, OpenAPI schema loaded, HTTP server live on 127.0.0.1:9981
- [ ] Armory catalog picker UI not smoke-tested in a running `task dev` session — the picker component (`McpCatalogPicker.tsx`) iterates `MCP_PRELOAD_CATALOG` generically with no per-entry logic, so this should render without further changes, but flagging since I didn't launch the app to confirm visually

<!-- agentmux:agent_id=agenty -->