### PR TITLE
fix(auth): deterministic Claude login UX — skip doomed URL-capture wait

### DIFF
--- a/.changesets/1785050454-fix-auth-skip-doomed-headless-url-capture-wait-for-claude-lo-fwcn.md
+++ b/.changesets/1785050454-fix-auth-skip-doomed-headless-url-capture-wait-for-claude-lo-fwcn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): skip doomed headless URL-capture wait for Claude login, surface phase status + cancel

--- a/agentmux-cef/src/commands/cli_login.rs
+++ b/agentmux-cef/src/commands/cli_login.rs
@@ -63,6 +63,16 @@ impl CliLoginStdin {
 /// pane was closed without its cleanup firing).
 const LOGIN_REAP_TIMEOUT_SECS: u64 = 6 * 60;
 
+/// Cap on how long run_cli_login_pty blocks waiting for a scrapeable OAuth
+/// URL before giving up and returning auth_url=None. Frontend callers that
+/// know in advance a provider never prints one (Claude — see catalog.ts's
+/// headlessLoginUrlUnsupported flag) skip this call entirely via
+/// runProviderLogin's skipTier1, so in practice this only bounds providers
+/// that plausibly DO print a URL (Codex/Gemini/OpenClaw). Kept short as a
+/// safety margin for any caller that reaches this function without going
+/// through that gate.
+const URL_CAPTURE_TIMEOUT_SECS: u64 = 5;
+
 /// Spawn a CLI auth login flow.
 pub async fn run_cli_login(
     state: Arc<AppState>,
@@ -620,7 +630,8 @@ async fn run_cli_login_pty(
 
     // Synchronously read from the master in a blocking task, scanning
     // each line for an OAuth URL. portable_pty's reader is sync.
-    // The 15 s cap is enforced async-side via tokio::time::timeout —
+    // The URL_CAPTURE_TIMEOUT_SECS cap is enforced async-side via
+    // tokio::time::timeout —
     // BufRead::read_line itself blocks indefinitely without per-read
     // timeout support, so a child that pauses before its first line
     // (or sits at a prompt with no newline) would wedge `url_rx.await`
@@ -694,7 +705,7 @@ async fn run_cli_login_pty(
     });
 
     let auth_url: Option<String> = match tokio::time::timeout(
-        std::time::Duration::from_secs(15),
+        std::time::Duration::from_secs(URL_CAPTURE_TIMEOUT_SECS),
         url_rx,
     )
     .await
@@ -705,7 +716,9 @@ async fn run_cli_login_pty(
     if let Some(ref url) = auth_url {
         tracing::info!(url = %url, "run_cli_login_pty: captured auth URL");
     } else {
-        tracing::warn!("run_cli_login_pty: no auth URL captured within 15s");
+        tracing::warn!(
+            "run_cli_login_pty: no auth URL captured within {URL_CAPTURE_TIMEOUT_SECS}s"
+        );
     }
 
     // Reap the child in a blocking task. The PtyPair (master + slave)
@@ -1175,6 +1188,24 @@ mod redact_tests {
         assert!(!red.contains("AAAA"));
         assert!(!red.contains("BBBB"));
         assert_eq!(red.matches("…REDACTED").count(), 2);
+    }
+}
+
+#[cfg(test)]
+mod url_capture_timeout_tests {
+    use super::URL_CAPTURE_TIMEOUT_SECS;
+
+    // Regression guard for the deterministic-login-UX fix: this cap used to
+    // be 15s and was hit unconditionally for Claude (which never prints a
+    // scrapeable URL — see catalog.ts's headlessLoginUrlUnsupported flag,
+    // which now skips run_cli_login_pty for Claude entirely). Kept short as
+    // a safety margin for any caller that reaches this function without
+    // going through that gate; a future accidental widening back toward the
+    // old 15s would silently reintroduce the stall for such a caller.
+    #[test]
+    fn is_a_short_safety_margin_not_the_old_15s_stall() {
+        assert!(URL_CAPTURE_TIMEOUT_SECS > 0);
+        assert!(URL_CAPTURE_TIMEOUT_SECS <= 10);
     }
 }
 

--- a/agentmux-cef/src/commands/cli_login.rs
+++ b/agentmux-cef/src/commands/cli_login.rs
@@ -68,10 +68,15 @@ const LOGIN_REAP_TIMEOUT_SECS: u64 = 6 * 60;
 /// know in advance a provider never prints one (Claude — see catalog.ts's
 /// headlessLoginUrlUnsupported flag) skip this call entirely via
 /// runProviderLogin's skipTier1, so in practice this only bounds providers
-/// that plausibly DO print a URL (Codex/Gemini/OpenClaw). Kept short as a
-/// safety margin for any caller that reaches this function without going
-/// through that gate.
-const URL_CAPTURE_TIMEOUT_SECS: u64 = 5;
+/// that plausibly DO print a URL (Codex/Gemini/OpenClaw).
+///
+/// Left at 15s, NOT shortened as a "safety margin" for Claude: Claude never
+/// reaches this function at all now (skipTier1 above), so shortening it
+/// would only affect Codex/Gemini/OpenClaw — providers that legitimately
+/// need up to this long to print their URL. reagent P1 on PR #2300 caught
+/// an earlier attempt to cut this to 5s, which would have killed valid
+/// in-progress OpenClaw logins and forced an unnecessary terminal fallback.
+const URL_CAPTURE_TIMEOUT_SECS: u64 = 15;
 
 /// Spawn a CLI auth login flow.
 pub async fn run_cli_login(
@@ -1195,17 +1200,19 @@ mod redact_tests {
 mod url_capture_timeout_tests {
     use super::URL_CAPTURE_TIMEOUT_SECS;
 
-    // Regression guard for the deterministic-login-UX fix: this cap used to
-    // be 15s and was hit unconditionally for Claude (which never prints a
-    // scrapeable URL — see catalog.ts's headlessLoginUrlUnsupported flag,
-    // which now skips run_cli_login_pty for Claude entirely). Kept short as
-    // a safety margin for any caller that reaches this function without
-    // going through that gate; a future accidental widening back toward the
-    // old 15s would silently reintroduce the stall for such a caller.
+    // Regression guard for the deterministic-login-UX fix: Claude no longer
+    // reaches this function at all (catalog.ts's headlessLoginUrlUnsupported
+    // flag routes it around run_cli_login_pty entirely via skipTier1), so
+    // this constant only bounds providers that legitimately DO print a URL
+    // (Codex/Gemini/OpenClaw). reagent P1 on PR #2300: an earlier attempt to
+    // shorten this to 5s "as a safety margin" would have killed valid
+    // in-progress OpenClaw logins, which can take close to the full 15s to
+    // print their URL. Pinned at a sane, bounded value — not "short" for
+    // its own sake — so a future edit can't reintroduce that regression.
     #[test]
-    fn is_a_short_safety_margin_not_the_old_15s_stall() {
+    fn is_a_sane_bounded_value_for_providers_that_actually_print_a_url() {
         assert!(URL_CAPTURE_TIMEOUT_SECS > 0);
-        assert!(URL_CAPTURE_TIMEOUT_SECS <= 10);
+        assert!(URL_CAPTURE_TIMEOUT_SECS <= 30);
     }
 }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1394,6 +1394,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                             turnTokens={agentAtoms().turnTokensAtom[0]()}
                             launchPhase={status.launchPhase()}
                             onCancelLogin={status.cancelLogin}
+                            hasAuthUrl={!!status.authUrl()}
                             waitingReason={
                                 (() => {
                                     const phase = agentAtoms().turnPhaseAtom[0]();

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -778,6 +778,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         },
     });
 
+    // status.isLoading() is `flowRunning() || !agentReady()` — it never
+    // becomes true during relogin()/loginViaTerminal()/useGlobalLogin(),
+    // since the agent is already ready by the time those recovery flows
+    // run. Without launchPhase() in this gate too, the working row (and
+    // its phase label + Cancel button), the top progress bar, and the
+    // composer status strip all stay invisible for the entire up-to-5-
+    // minute recovery poll — exactly the flows this launchPhase work was
+    // meant to make visible. reagent P1 on PR #2300.
+    const showingLaunchActivity = () => status.isLoading() || status.launchPhase() != null;
+
     onMount(() => {
         const name = block()?.meta?.["agentName"] ?? agentId;
         const provName = provider()?.displayName ?? providerKey();
@@ -1264,7 +1274,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             <div
                 class="agent-pane-progress-bar"
                 classList={{
-                    "agent-pane-progress-bar--active": status.isLoading() || workingFromPhase(agentAtoms().turnPhaseAtom[0]()),
+                    "agent-pane-progress-bar--active": showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]()),
                     "agent-pane-progress-bar--stopping": agentAtoms().turnPhaseAtom[0]().kind === "Interrupting",
                 }}
                 role="progressbar"
@@ -1371,12 +1381,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     See SPEC_AGENT_PANE_STATUS_GRADIENT_2026_06_14.md §2. */}
                 <div class="agent-working-row-anchor" ref={workingRowAnchorRef}>
                     <Show when={
-                        status.isLoading()
+                        showingLaunchActivity()
                         || workingFromPhase(agentAtoms().turnPhaseAtom[0]())
                         || agentAtoms().sessionStatsAtom[0]() != null
                     }>
                         <AgentWorkingRow
-                            loading={status.isLoading() || workingFromPhase(agentAtoms().turnPhaseAtom[0]())}
+                            loading={showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]())}
                             stopping={agentAtoms().turnPhaseAtom[0]().kind === "Interrupting"}
                             currentTool={agentAtoms().currentToolAtom[0]()}
                             currentToolArg={agentAtoms().currentToolArgAtom[0]()}
@@ -1514,7 +1524,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 State (detailsOpen) is reducer-owned (PR #1068). */}
             <AgentComposerStrip
                 loading={
-                    status.isLoading()
+                    showingLaunchActivity()
                     || workingFromPhase(agentAtoms().turnPhaseAtom[0]())
                 }
                 sessionTotals={agentAtoms().sessionTotalsAtom[0]()}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1335,6 +1335,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     authUrl={status.authUrl}
                     authNotice={status.authNotice}
                     onDismissAuthNotice={() => status.setAuthNotice(null)}
+                    onCancelLogin={status.cancelLogin}
                     authProviderId={provider()?.id ?? providerKey()}
                     onSubagentClick={handleSubagentClick}
                     onAgentErrorLogin={() => {
@@ -1381,6 +1382,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                             currentToolArg={agentAtoms().currentToolArgAtom[0]()}
                             sessionStats={agentAtoms().sessionStatsAtom[0]()}
                             turnTokens={agentAtoms().turnTokensAtom[0]()}
+                            launchPhase={status.launchPhase()}
+                            onCancelLogin={status.cancelLogin}
                             waitingReason={
                                 (() => {
                                     const phase = agentAtoms().turnPhaseAtom[0]();

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -81,6 +81,9 @@ export const loginCommand: SlashCommand = {
                         recheckAuthEnv = { ...authEnv, [prov.authConfigDirEnvVar]: dir };
                     }
                 },
+                // See catalog.ts's DEAD END note — skip tier 1's ~15s
+                // URL-capture wait for providers that can never produce one.
+                skipTier1: prov.headlessLoginUrlUnsupported === true,
             });
             switch (outcome) {
                 case "opened": {

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -20,6 +20,7 @@
  */
 
 import { createSignal, onMount, Show, type Accessor, type JSX } from "solid-js";
+import { Button } from "@/element/button";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -42,6 +43,10 @@ interface AgentDocumentViewProps {
     onDismissAuthNotice?: () => void;
     /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
     authProviderId?: string;
+    /** Cancel the in-flight login (kills the host CLI child) — shown as a
+     *  button on the auth-URL box so a stuck login has an exit besides
+     *  closing the pane. Wired to useAgentControllerStatus's cancelLogin. */
+    onCancelLogin?: () => void;
     onSubagentClick?: (node: SubagentLinkNode) => void;
     /** Re-run the provider login flow — forwarded to the list so an inline
      *  auth-error node can offer a "Login Again" CTA (SPEC_REAUTH_FROM_AUTH_ERROR §7). */
@@ -166,7 +171,9 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
                 <div class="agent-history-loading">Loading older messages...</div>
             </Show>
             <Show when={props.authUrl?.()}>
-                {(url) => <AuthUrlBox url={url()} authProviderId={props.authProviderId} />}
+                {(url) => (
+                    <AuthUrlBox url={url()} authProviderId={props.authProviderId} onCancel={props.onCancelLogin} />
+                )}
             </Show>
             <Show when={props.authNotice?.()}>
                 {(notice) => (
@@ -216,6 +223,7 @@ AgentDocumentView.displayName = "AgentDocumentView";
 interface AuthUrlBoxProps {
     url: string;
     authProviderId?: string;
+    onCancel?: () => void;
 }
 
 /**
@@ -331,6 +339,9 @@ function AuthUrlBox(props: AuthUrlBoxProps): JSX.Element {
             </div>
             <Show when={pasteResult()}>
                 <div class="agent-auth-paste-result">{pasteResult()}</div>
+            </Show>
+            <Show when={props.onCancel}>
+                <Button onClick={() => props.onCancel?.()}>Cancel login</Button>
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -17,6 +17,7 @@ import { MicButton } from "@/app/element/MicButton";
 import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
+import { formatPhaseLabel, type LaunchPhase } from "../flows/launch-phase";
 import { SlashAutocomplete } from "./SlashAutocomplete";
 
 function pickThinkingPhrase(_exclude?: string): string {
@@ -66,18 +67,31 @@ interface AgentWorkingRowProps {
     waitingReason?: "rate_limited" | null;
     /** Milliseconds until next retry (from provider Retry-After). Shown when waitingReason is set. */
     retryAfterMs?: number | null;
+    /** What the launch/login flow is doing right now — shown in place of the
+     *  generic thinking phrase so a timed wait (login link, login completion)
+     *  never renders as bare "Working…". See launch-phase.ts. */
+    launchPhase?: LaunchPhase | null;
+    /** Cancel the in-flight login. Shown as a small button while launchPhase
+     *  is a pre-authUrl wait (opening-login-terminal /
+     *  waiting-for-login-completion) — AuthUrlBox has its own cancel button
+     *  once a URL exists, but before that this is the only affordance. */
+    onCancelLogin?: () => void;
 }
+
+const CANCELLABLE_LAUNCH_PHASES = new Set(["opening-login-terminal", "waiting-for-login-completion"]);
 
 /** The exact string the loading row's left zone shows right now — pulled out
  *  of the JSX ternary chain so both the type-out reveal effect and the
  *  render itself read the same computed value. */
-function loadingLeftText(props: AgentWorkingRowProps, phrase: string): string {
+function loadingLeftText(props: AgentWorkingRowProps, phrase: string, nowMs: number): string {
     if (props.stopping) return "Stopping…";
     if (props.waitingReason === "rate_limited") {
         return props.retryAfterMs != null
             ? `Rate limited — retrying in ${Math.ceil(props.retryAfterMs / 1000)}s`
             : "Rate limited — retrying…";
     }
+    const phaseLabel = formatPhaseLabel(props.launchPhase, nowMs);
+    if (phaseLabel) return phaseLabel;
     if (props.currentTool) {
         return props.currentToolArg
             ? `${props.currentTool}  ·  ${abbreviateArg(props.currentToolArg, 40)}`
@@ -109,7 +123,9 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     // essential, looping "still working" signal, not large/parallax motion,
     // so it slows down (CSS below) rather than disappearing entirely.
     const reducedMotion = atoms.prefersReducedMotionAtom;
-    const leftText = createMemo(() => loadingLeftText(props, phrase()));
+    // tick() re-runs this memo every second so a phase's "up to Ys" countdown
+    // (formatPhaseLabel) stays live — see useTick.ts's "always-on tick" pattern.
+    const leftText = createMemo(() => loadingLeftText(props, phrase(), (tick(), Date.now())));
     const [revealed, setRevealed] = createSignal(leftText().length);
     const [typing, setTyping] = createSignal(false);
     const REVEAL_CHAR_MS = 28;
@@ -204,6 +220,10 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
         return right.join("  ·  ");
     });
 
+    const showCancelLogin = createMemo(
+        () => !!props.onCancelLogin && !!props.launchPhase && CANCELLABLE_LAUNCH_PHASES.has(props.launchPhase.kind),
+    );
+
     return (
         <Show
             when={props.loading}
@@ -225,7 +245,17 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
                 <span class="agent-working-row-left agent-working-shimmer" classList={{ "is-typing": typing() }}>
                     {leftText().slice(0, revealed())}
                 </span>
-                <span class="agent-working-row-right">{rightText()}</span>
+                <span class="agent-working-row-right">
+                    {rightText()}
+                    <Show when={showCancelLogin()}>
+                        <button
+                            class="agent-working-row-cancel-login"
+                            onClick={() => props.onCancelLogin?.()}
+                        >
+                            Cancel
+                        </button>
+                    </Show>
+                </span>
             </span>
         </Show>
     );

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -76,6 +76,11 @@ interface AgentWorkingRowProps {
      *  waiting-for-login-completion) — AuthUrlBox has its own cancel button
      *  once a URL exists, but before that this is the only affordance. */
     onCancelLogin?: () => void;
+    /** True while AuthUrlBox is already showing its own Cancel button (a URL
+     *  was captured — reagent P2 on PR #2300: tier 1's "opened" outcome sets
+     *  launchPhase to "waiting-for-login-completion" too, so without this the
+     *  row rendered a second, redundant Cancel button alongside AuthUrlBox's. */
+    hasAuthUrl?: boolean;
 }
 
 const CANCELLABLE_LAUNCH_PHASES = new Set(["opening-login-terminal", "waiting-for-login-completion"]);
@@ -221,7 +226,11 @@ export const AgentWorkingRow = (props: AgentWorkingRowProps): JSX.Element => {
     });
 
     const showCancelLogin = createMemo(
-        () => !!props.onCancelLogin && !!props.launchPhase && CANCELLABLE_LAUNCH_PHASES.has(props.launchPhase.kind),
+        () =>
+            !!props.onCancelLogin &&
+            !props.hasAuthUrl &&
+            !!props.launchPhase &&
+            CANCELLABLE_LAUNCH_PHASES.has(props.launchPhase.kind),
     );
 
     return (

--- a/frontend/app/view/agent/flows/launch-flow.test.ts
+++ b/frontend/app/view/agent/flows/launch-flow.test.ts
@@ -157,4 +157,44 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
         expect(phases).toContain("opening-login-terminal");
         expect(phases[phases.length - 1]).toBe("ready");
     });
+
+    it("reagent P1: updates the phase via onTierChange instead of freezing on a stale waiting-for-login-link deadline once tier 1 fails and tier 2/3 take over", async () => {
+        // Codex doesn't have headlessLoginUrlUnsupported, so it gets the
+        // deadline-bearing "waiting-for-login-link" phase before this call —
+        // exactly the phase that used to freeze once tier 1's own timeout
+        // expired and runProviderLogin's internal tier 2/3 (up to 5 more
+        // minutes) took over with zero further signal to the caller.
+        hub.checkCliAuth
+            .mockReset()
+            .mockResolvedValueOnce({ authenticated: false })
+            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
+        hub.runProviderLogin.mockReset().mockImplementation(async (params: any) => {
+            // Simulate tier 1 failing, then a terminal opening and polling —
+            // exactly what run-provider-login.ts's real onTierChange calls do.
+            params.onTierChange?.({ tier: "fallback" });
+            params.onTierChange?.({ tier: "polling", deadlineMs: Date.now() + 5 * 60 * 1000 });
+            return "terminal-success";
+        });
+        const phases: Array<{ kind: string; deadlineMs?: number }> = [];
+        await runLaunchFlow({
+            blockId: "block-1",
+            provider: codex,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+            setLaunchPhase: (p) => { if (p) phases.push(p as any); },
+        });
+
+        const linkPhaseIndex = phases.findIndex((p) => p.kind === "waiting-for-login-link");
+        const fallbackIndex = phases.findIndex((p) => p.kind === "opening-login-terminal");
+        const pollingIndex = phases.findIndex((p) => p.kind === "waiting-for-login-completion");
+        expect(linkPhaseIndex).toBeGreaterThanOrEqual(0);
+        // The stale-deadline phase must not be the last thing shown — both
+        // onTierChange transitions must land AFTER it, in order.
+        expect(fallbackIndex).toBeGreaterThan(linkPhaseIndex);
+        expect(pollingIndex).toBeGreaterThan(fallbackIndex);
+        const pollingPhase = phases[pollingIndex];
+        expect(pollingPhase.deadlineMs).toBeGreaterThan(Date.now());
+    });
 });

--- a/frontend/app/view/agent/flows/launch-flow.test.ts
+++ b/frontend/app/view/agent/flows/launch-flow.test.ts
@@ -1,0 +1,160 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins the deterministic-login-UX fix: runLaunchFlow must pass
+ * `skipTier1: true` into runProviderLogin for providers flagged
+ * `headlessLoginUrlUnsupported` (Claude) — so the mount-time auto-login
+ * path never burns cli_login.rs's URL-capture wait on a documented dead
+ * end. See catalog.ts's DEAD END note and run-provider-login.test.ts's
+ * own "skipTier1 skips the headless URL-capture attempt entirely" test,
+ * which pins that a true skipTier1 keeps getApi().runCliLogin from ever
+ * being called — this test pins that runLaunchFlow actually sets that
+ * flag for the right providers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    resolveCli: vi.fn(),
+    setMeta: vi.fn(),
+    checkCliAuth: vi.fn(),
+    listAgentIdentities: vi.fn(),
+    controllerResync: vi.fn(),
+    getControllerStatus: vi.fn(),
+    cancelCliLogin: vi.fn(),
+    ensureCapability: vi.fn(),
+    getCapability: vi.fn(),
+    runProviderLogin: vi.fn(),
+    persistAndLinkAccount: vi.fn(),
+    waveEventSubscribe: vi.fn(),
+}));
+
+vi.mock("@/app/errors/translate", () => ({
+    translateError: (err: any) => ({ title: "Error", message: err?.message ?? String(err), retry: null }),
+}));
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ResolveCliCommand: (...args: unknown[]) => hub.resolveCli(...args),
+        SetMetaCommand: (...args: unknown[]) => hub.setMeta(...args),
+        CheckCliAuthCommand: (...args: unknown[]) => hub.checkCliAuth(...args),
+        ListAgentIdentitiesCommand: (...args: unknown[]) => hub.listAgentIdentities(...args),
+        ControllerResyncCommand: (...args: unknown[]) => hub.controllerResync(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/toolchain-capabilities", () => ({
+    ensureCapability: (...args: unknown[]) => hub.ensureCapability(...args),
+    getCapability: (...args: unknown[]) => hub.getCapability(...args),
+}));
+vi.mock("@/app/store/wps", () => ({ waveEventSubscribe: (...args: unknown[]) => hub.waveEventSubscribe(...args) }));
+vi.mock("@/app/store/wps-events", () => ({ WpsEvent: { InstallProgress: "install_progress" } }));
+vi.mock("@/app/store/wos", () => ({
+    makeORef: (kind: string, id: string) => `${kind}:${id}`,
+    getWaveObjectAtom: () => () => ({ meta: { agentMode: "host", agentId: "agent-1" } }),
+}));
+vi.mock("@/app/store/services", () => ({
+    BlockService: { GetControllerStatus: (...args: unknown[]) => hub.getControllerStatus(...args) },
+}));
+vi.mock("@/app/store/global", () => ({
+    getApi: () => ({ cancelCliLogin: hub.cancelCliLogin }),
+    staticTabId: () => "tab-1",
+}));
+vi.mock("./run-provider-login", () => ({
+    runProviderLogin: (...args: unknown[]) => hub.runProviderLogin(...args),
+    persistAndLinkAccount: (...args: unknown[]) => hub.persistAndLinkAccount(...args),
+}));
+
+import { runLaunchFlow } from "./launch-flow";
+
+const claude = {
+    id: "claude",
+    cliCommand: "claude",
+    authCheckCommand: ["auth", "status"],
+    authLoginCommand: ["auth", "login"],
+    authConfigDirEnvVar: "CLAUDE_CONFIG_DIR",
+    requiresLoginTty: true,
+    headlessLoginUrlUnsupported: true,
+} as any;
+
+const codex = {
+    id: "codex",
+    cliCommand: "codex",
+    authCheckCommand: ["auth", "status"],
+    authLoginCommand: ["login"],
+    authConfigDirEnvVar: "CODEX_HOME",
+} as any;
+
+beforeEach(() => {
+    hub.resolveCli.mockReset().mockResolvedValue({ cli_path: "x", source: "found", version: "1.0" });
+    hub.setMeta.mockReset().mockResolvedValue(undefined);
+    hub.checkCliAuth.mockReset().mockResolvedValue({ authenticated: false });
+    hub.listAgentIdentities.mockReset().mockResolvedValue([]);
+    hub.controllerResync.mockReset().mockResolvedValue(undefined);
+    hub.getControllerStatus.mockReset().mockResolvedValue({ shellprocstatus: "init" });
+    hub.cancelCliLogin.mockReset().mockResolvedValue(undefined);
+    hub.ensureCapability.mockReset().mockResolvedValue(undefined);
+    hub.getCapability.mockReset().mockReturnValue({ status: "available" });
+    hub.runProviderLogin.mockReset().mockResolvedValue("seeded");
+    hub.persistAndLinkAccount.mockReset().mockResolvedValue(true);
+    hub.waveEventSubscribe.mockReset().mockReturnValue(() => {});
+});
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("runLaunchFlow — skipTier1 wiring", () => {
+    it("passes skipTier1: true for a headlessLoginUrlUnsupported provider (Claude) — the auto-login path never attempts tier 1's doomed URL-capture wait", async () => {
+        await runLaunchFlow({
+            blockId: "block-1",
+            provider: claude,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+        });
+
+        expect(hub.runProviderLogin).toHaveBeenCalledTimes(1);
+        expect(hub.runProviderLogin.mock.calls[0][0]).toMatchObject({ skipTier1: true });
+    });
+
+    it("leaves skipTier1 false for a provider without the flag (Codex) — tier 1 still gets a real chance to capture a URL", async () => {
+        await runLaunchFlow({
+            blockId: "block-1",
+            provider: codex,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+        });
+
+        expect(hub.runProviderLogin).toHaveBeenCalledTimes(1);
+        expect(hub.runProviderLogin.mock.calls[0][0]).toMatchObject({ skipTier1: false });
+    });
+
+    it("reports a launchPhase for every visible phase, and never leaves a stale non-terminal phase behind on success", async () => {
+        // First call is Phase 2's initial auth check (unauthenticated, so
+        // needsLogin fires); second is the post-"seeded" one-shot recheck,
+        // which must report success for the flow to reach "ready".
+        hub.checkCliAuth
+            .mockReset()
+            .mockResolvedValueOnce({ authenticated: false })
+            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
+        const phases: string[] = [];
+        const result = await runLaunchFlow({
+            blockId: "block-1",
+            provider: claude,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+            setLaunchPhase: (p) => { if (p) phases.push(p.kind); },
+        });
+
+        expect(result).toBe("success");
+        expect(phases[0]).toBe("resolving-cli");
+        expect(phases).toContain("checking-auth");
+        expect(phases).toContain("opening-login-terminal");
+        expect(phases[phases.length - 1]).toBe("ready");
+    });
+});

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -40,14 +40,8 @@ import * as WOS from "@/app/store/wos";
 import { BlockService } from "@/app/store/services";
 import { getApi, staticTabId } from "@/app/store/global";
 import { persistAndLinkAccount, runProviderLogin } from "./run-provider-login";
-import type { LaunchPhase } from "./launch-phase";
+import { LOGIN_LINK_CAPTURE_LABEL_MS, type LaunchPhase } from "./launch-phase";
 import type { ProviderDefinition } from "../providers";
-
-// Approximate label lifetime for tier 1's URL-capture wait — the real cap
-// lives backend-side (cli_login.rs's URL_CAPTURE_TIMEOUT_SECS) and varies
-// slightly by spawn path (PTY vs. pipe); this is a display value only, not
-// something the frontend enforces.
-const LOGIN_LINK_CAPTURE_LABEL_MS = 15_000;
 
 import type { LogFn } from "../types";
 export type { LogFn };
@@ -298,6 +292,19 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 // cannot ever succeed, so skip its ~15s capture wait instead
                 // of running (and always losing) it on every login.
                 skipTier1: provider.headlessLoginUrlUnsupported === true,
+                // Without this, the phase set just above (a URL-capture
+                // countdown, or a static "opening terminal" for skipTier1)
+                // never updates again for the rest of this single await —
+                // tier 2/3 inside runProviderLogin can run for up to 5 more
+                // minutes with the footer frozen on whatever was true when
+                // this call started. reagent P1 on PR #2300.
+                onTierChange: (event) => {
+                    if (event.tier === "fallback") {
+                        setPhase({ kind: "opening-login-terminal" });
+                    } else {
+                        setPhase({ kind: "waiting-for-login-completion", deadlineMs: event.deadlineMs });
+                    }
+                },
             });
 
             let authenticated = false;

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -40,7 +40,14 @@ import * as WOS from "@/app/store/wos";
 import { BlockService } from "@/app/store/services";
 import { getApi, staticTabId } from "@/app/store/global";
 import { persistAndLinkAccount, runProviderLogin } from "./run-provider-login";
+import type { LaunchPhase } from "./launch-phase";
 import type { ProviderDefinition } from "../providers";
+
+// Approximate label lifetime for tier 1's URL-capture wait — the real cap
+// lives backend-side (cli_login.rs's URL_CAPTURE_TIMEOUT_SECS) and varies
+// slightly by spawn path (PTY vs. pipe); this is a display value only, not
+// something the frontend enforces.
+const LOGIN_LINK_CAPTURE_LABEL_MS = 15_000;
 
 import type { LogFn } from "../types";
 export type { LogFn };
@@ -52,6 +59,11 @@ export interface LaunchFlowOptions {
     setAuthUrl: (url: string | null) => void;
     isCancelled: () => boolean;
     setLoginWaiting: (v: boolean) => void;
+    /** Reports which phase of the flow is currently running, so the caller
+     *  can show a specific status (and, for phases carrying a deadline, a
+     *  "waiting on X, up to Ys" label) instead of a generic spinner. See
+     *  launch-phase.ts. Optional so existing callers/tests are unaffected. */
+    setLaunchPhase?: (phase: LaunchPhase | null) => void;
     authEnv?: Record<string, string>;
     /** Called once when login is confirmed — append a success message to the chat. */
     onLoginSuccess?: (email: string | null) => void;
@@ -77,12 +89,15 @@ export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
 
 export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlowResult> {
     const { blockId, provider, log, setAuthUrl, isCancelled, setLoginWaiting, authEnv } = opts;
+    const setPhase = opts.setLaunchPhase ?? (() => {});
 
     if (!provider) {
         log("error", "no provider definition — cannot resolve CLI", "error");
+        setPhase({ kind: "failed", reason: "no provider definition" });
         return "fatal";
     }
 
+    setPhase({ kind: "resolving-cli" });
     const oref = WOS.makeORef("block", blockId);
 
     // Phase 0: Container agents require a container runtime. Reads the
@@ -102,6 +117,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         if (docker.status !== "available") {
             log("docker", "Container runtime not found", "error");
             log("docker", "Container agents require a compatible container runtime (e.g. Docker) to run.", "error");
+            setPhase({ kind: "failed", reason: "container runtime not found" });
             return "fatal";
         }
         log("docker", "container runtime available");
@@ -147,6 +163,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         // error message last, right before the user's eye.
         if (t.retry) log("cli", t.retry, "warn");
         log("cli", `${t.title}: ${t.message}`, "error");
+        setPhase({ kind: "failed", reason: t.message });
         return "fatal";
     }
     unsubInstall();
@@ -174,6 +191,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
     });
 
     // Phase 2: Auth Check → auto-login if not authenticated
+    setPhase({ kind: "checking-auth" });
     log("auth", `checking ${provider.cliCommand} authentication...`);
     let needsLogin = false;
     try {
@@ -252,6 +270,14 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             // reports now.
             let openedAccountId: string | undefined;
             let openedAccountDir: string | undefined;
+            // See catalog.ts's DEAD END note — providers with
+            // headlessLoginUrlUnsupported skip straight past tier 1's
+            // URL-capture wait, so there's no login-link timer to label here.
+            setPhase(
+                provider.headlessLoginUrlUnsupported
+                    ? { kind: "opening-login-terminal" }
+                    : { kind: "waiting-for-login-link", deadlineMs: Date.now() + LOGIN_LINK_CAPTURE_LABEL_MS },
+            );
             const outcome = await runProviderLogin({
                 provider,
                 cliPath: cliResult.cli_path,
@@ -268,6 +294,10 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                         recheckAuthEnv = { ...(authEnv ?? {}), [provider.authConfigDirEnvVar]: dir };
                     }
                 },
+                // See catalog.ts's DEAD END note — for these providers tier 1
+                // cannot ever succeed, so skip its ~15s capture wait instead
+                // of running (and always losing) it on every login.
+                skipTier1: provider.headlessLoginUrlUnsupported === true,
             });
 
             let authenticated = false;
@@ -278,6 +308,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 // user finishes there, cancels, or 5 minutes elapse.
                 log("auth", "waiting for login to complete...");
                 const deadline = Date.now() + 5 * 60 * 1000;
+                setPhase({ kind: "waiting-for-login-completion", deadlineMs: deadline });
                 while (!isCancelled() && Date.now() < deadline && !authenticated) {
                     await new Promise<void>((r) => setTimeout(r, 2000));
                     if (isCancelled()) break;
@@ -318,6 +349,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 // global login, or completed in the terminal-fallback tier,
                 // which already polled internally) — one-shot confirm instead
                 // of polling again.
+                setPhase({ kind: "verifying" });
                 try {
                     const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
                         cli_path: cliResult.cli_path,
@@ -344,6 +376,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             setAuthUrl(null);
 
             if (isCancelled()) {
+                setPhase({ kind: "failed", reason: "cancelled" });
                 return "auth_failed";
             }
 
@@ -363,6 +396,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 });
                 log("auth", `retry: ${t.retry ?? `run '${provider.cliCommand} ${provider.authLoginCommand.join(" ")}' manually`}`, "warn");
                 log("auth", `${t.title}: ${t.message}`, "error");
+                setPhase({ kind: "failed", reason: t.message });
                 return "auth_failed";
             }
         } catch (err: any) {
@@ -371,11 +405,13 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             setAuthUrl(null);
             log("auth", `login failed: ${err?.message ?? String(err)}`, "error");
             log("auth", `run: ${provider.cliCommand} ${provider.authLoginCommand.join(" ")}`, "warn");
+            setPhase({ kind: "failed", reason: err?.message ?? String(err) });
             return "auth_failed";
         }
     }
 
     // Phase 3: Controller Registration
+    setPhase({ kind: "verifying" });
     log("controller", "registering subprocess controller...");
     try {
         // Seed the PTY at the pane's current width so the agent CLI wraps
@@ -408,5 +444,6 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         log("controller", `resync failed: ${err?.message ?? String(err)}`, "error");
     }
 
+    setPhase({ kind: "ready" });
     return "success";
 }

--- a/frontend/app/view/agent/flows/launch-phase.ts
+++ b/frontend/app/view/agent/flows/launch-phase.ts
@@ -1,0 +1,60 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * LaunchPhase — what the mount-time launch flow (launch-flow.ts,
+ * useAgentControllerStatus.ts's relogin) is actually doing right now,
+ * surfaced to AgentFooter's working row instead of a generic "Working…"
+ * for every phase. Mirrors the discriminated-union pattern of
+ * auth/auth-state.ts's `AuthState.kind` (a different, pre-launch-modal flow).
+ *
+ * Any variant carrying `deadlineMs` represents a real timer/poll the user
+ * is waiting on — formatPhaseLabel renders its remaining time so no wait
+ * is ever silent (see the maintainer's rule: a timer without a visible
+ * notification is a bug, not an implementation detail).
+ */
+export type LaunchPhase =
+    | { kind: "resolving-cli" }
+    | { kind: "checking-auth" }
+    /** Tier 1's PTY/pipe URL-capture attempt — only reachable for providers
+     *  where `headlessLoginUrlUnsupported` is NOT set (Codex/Gemini/OpenClaw).
+     *  See catalog.ts and cli_login.rs's URL_CAPTURE_TIMEOUT_SECS. */
+    | { kind: "waiting-for-login-link"; deadlineMs: number }
+    | { kind: "opening-login-terminal" }
+    /** Covers both tier 1's "opened" completion poll and tier 3's terminal
+     *  completion poll — both are a 5-minute CheckCliAuthCommand loop. */
+    | { kind: "waiting-for-login-completion"; deadlineMs: number }
+    | { kind: "verifying" }
+    | { kind: "ready" }
+    | { kind: "failed"; reason: string };
+
+function fmtRemaining(ms: number): string {
+    const s = Math.max(0, Math.ceil(ms / 1000));
+    return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+/** Render `phase` as a footer-line label given the current time (`nowMs`,
+ *  typically from the caller's own 1s tick so the countdown live-updates).
+ *  Returns null for phases with nothing distinct to say (the generic
+ *  "Working…" fallback already covers them fine) so callers can fall
+ *  through to their existing default text. */
+export function formatPhaseLabel(phase: LaunchPhase | null | undefined, nowMs: number): string | null {
+    if (!phase) return null;
+    switch (phase.kind) {
+        case "resolving-cli":
+            return "Resolving CLI";
+        case "checking-auth":
+            return "Checking authentication";
+        case "waiting-for-login-link":
+            return `Waiting for login link… up to ${fmtRemaining(phase.deadlineMs - nowMs)}`;
+        case "opening-login-terminal":
+            return "Opening login terminal";
+        case "waiting-for-login-completion":
+            return `Waiting for you to finish logging in… up to ${fmtRemaining(phase.deadlineMs - nowMs)}`;
+        case "verifying":
+            return "Verifying login";
+        case "ready":
+        case "failed":
+            return null;
+    }
+}

--- a/frontend/app/view/agent/flows/launch-phase.ts
+++ b/frontend/app/view/agent/flows/launch-phase.ts
@@ -13,6 +13,16 @@
  * is ever silent (see the maintainer's rule: a timer without a visible
  * notification is a bug, not an implementation detail).
  */
+/** Display-only estimate for how long tier 1's URL-capture wait takes,
+ *  shown as a countdown while `waiting-for-login-link` is active. Must
+ *  track cli_login.rs's actual URL_CAPTURE_TIMEOUT_SECS (currently 15s) —
+ *  the frontend can't read that Rust constant directly, so this is a
+ *  second source of truth kept in sync by hand. Shared here (not
+ *  duplicated per call site) so there's exactly one place to update.
+ *  reagent flagged a stale duplicate literal in useAgentControllerStatus.ts
+ *  on PR #2300. */
+export const LOGIN_LINK_CAPTURE_LABEL_MS = 15_000;
+
 export type LaunchPhase =
     | { kind: "resolving-cli" }
     | { kind: "checking-auth" }

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -424,6 +424,56 @@ describe("runProviderLogin", () => {
         expect(hub.openPane).not.toHaveBeenCalled();
     });
 
+    it("reagent P1: fires onTierChange({tier: 'fallback'}) once tier 1 fails, so a caller's stale URL-capture countdown doesn't freeze while tier 2/3 (up to 5 more minutes) take over", async () => {
+        hub.runCliLogin.mockResolvedValue(null); // tier 1: no URL captured
+        hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true }); // tier 2 succeeds fast
+        const onTierChange = vi.fn();
+
+        const outcome = await runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            onTierChange,
+        });
+
+        expect(outcome).toBe("seeded");
+        expect(onTierChange).toHaveBeenCalledWith({ tier: "fallback" });
+        // Tier 2 resolved before any terminal opened — no "polling" event yet.
+        expect(onTierChange).not.toHaveBeenCalledWith(expect.objectContaining({ tier: "polling" }));
+    });
+
+    it("reagent P1: fires onTierChange({tier: 'polling', deadlineMs}) once the terminal actually opens, with a live ~5-minute deadline matching the real poll timeout", async () => {
+        vi.useFakeTimers();
+        const before = Date.now();
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal
+            .mockResolvedValueOnce({ seeded: false, status: "missing" }) // tier 2: no global login yet
+            .mockResolvedValueOnce({ seeded: true }); // first tier-3 poll succeeds
+        const onTierChange = vi.fn();
+
+        const promise = runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            onTierChange,
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+        await promise;
+
+        expect(onTierChange).toHaveBeenCalledWith({ tier: "fallback" });
+        const pollingCall = onTierChange.mock.calls.find((c) => c[0].tier === "polling");
+        expect(pollingCall).toBeDefined();
+        const { deadlineMs } = pollingCall![0];
+        // Matches pollForGlobalLoginSeed's own default timeoutMs (5 min) —
+        // if that default ever changes, this assertion should move with it.
+        expect(deadlineMs).toBeGreaterThanOrEqual(before + 5 * 60 * 1000 - 1000);
+        expect(deadlineMs).toBeLessThanOrEqual(before + 5 * 60 * 1000 + 1000);
+    });
+
     it("existingAccountId is threaded through to tier 2's account minting — reconnects the SAME account instead of minting a new one (reagent P1: retries were orphaning a new account every time)", async () => {
         hub.runCliLogin.mockResolvedValue(null);
         hub.seedProviderAuthFromGlobal.mockResolvedValue({ seeded: true });

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -131,6 +131,18 @@ export interface RunProviderLoginParams extends ForceLoginParams {
      *  point trying headless first). Default false — existing callers are
      *  unaffected. */
     skipTier1?: boolean;
+    /** Reports tier transitions as they actually happen, so a caller
+     *  showing a phase/deadline (see launch-phase.ts) can keep it accurate
+     *  instead of freezing on whatever it guessed before this call started.
+     *  Without this, a caller that sets e.g. "waiting for login link, up to
+     *  15s" before calling this function has no way to know when tier 1
+     *  actually gives up and tier 2/3 (which can run for up to 5 more
+     *  minutes) takes over — the displayed countdown hits 0 and just sits
+     *  there for the rest of the wait. reagent P1 on PR #2300. */
+    onTierChange?: (event:
+        | { tier: "fallback" } // tier 1 conclusively failed; trying tier 2 (fast) or heading to tier 3
+        | { tier: "polling"; deadlineMs: number } // a terminal opened; now polling for completion
+    ) => void;
 }
 
 export type ProviderLoginOutcome =
@@ -289,6 +301,10 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     // call even if nothing is running — see useAgentControllerStatus.ts's
     // and launch-flow.ts's existing best-effort uses of the same call).
     await getApi().cancelCliLogin().catch(() => {});
+    // Whatever the caller displayed for tier 1 (a URL-capture countdown, or
+    // nothing if skipTier1) is stale now — tier 2/3 from here can run for
+    // up to 5 more minutes with zero further signal otherwise.
+    p.onTierChange?.({ tier: "fallback" });
 
     // Claude-only: seed-from-global. seed_provider_auth_from_global
     // hard-rejects every other provider server-side, so this tier is
@@ -347,6 +363,10 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
         return "terminal-unavailable";
     }
     p.log("auth", "a terminal window opened — complete the login there");
+    // Matches pollForGlobalLoginSeed/pollForCliAuthReady's own default
+    // timeoutMs below (neither call passes a custom one) — if either
+    // default ever changes, this display value must move with it.
+    p.onTierChange?.({ tier: "polling", deadlineMs: Date.now() + 5 * 60 * 1_000 });
 
     const isCancelled = p.isCancelled ?? (() => false);
     if (isClaude) {

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -383,6 +383,7 @@ export function useAgentControllerStatus(
                     // (same pattern as launch-flow.ts's own "opened" case).
                     opts.log("auth", "waiting for login to complete...");
                     let authenticated = false;
+                    let authedEmail: string | null = null;
                     const deadline = Date.now() + 5 * 60 * 1000;
                     setLaunchPhase({ kind: "waiting-for-login-completion", deadlineMs: deadline });
                     while (!loginCancelled && Date.now() < deadline && !authenticated) {
@@ -394,7 +395,10 @@ export function useAgentControllerStatus(
                                 auth_check_args: prov.authCheckCommand,
                                 auth_env: recheckAuthEnv,
                             }, { timeout: 10000 });
-                            if (recheck.authenticated) authenticated = true;
+                            if (recheck.authenticated) {
+                                authenticated = true;
+                                authedEmail = recheck.email ?? null;
+                            }
                         } catch {
                             // keep polling on transient RPC errors
                         }
@@ -416,6 +420,12 @@ export function useAgentControllerStatus(
                         );
                         opts.log("auth", "Login successful — retrying…");
                         setAuthNotice(null);
+                        // Post a visible confirmation into the pane itself — this used to
+                        // ONLY happen on the very first auto-login (launch-flow.ts); "Login
+                        // Again" retried the failed turn silently, so a user with nothing
+                        // queued to retry (or who didn't notice the retry) never saw ANY
+                        // acknowledgement that the login actually succeeded.
+                        opts.onLoginSuccess?.(authedEmail);
                         opts.onRecovered?.();
                     } else if (!loginCancelled) {
                         setAuthNotice(
@@ -428,11 +438,13 @@ export function useAgentControllerStatus(
                 case "seeded":
                     opts.log("auth", "Signed in from your global login — retrying…");
                     setAuthNotice(null);
+                    opts.onLoginSuccess?.(null);
                     opts.onRecovered?.();
                     break;
                 case "terminal-success":
                     opts.log("auth", "Login successful — retrying…");
                     setAuthNotice(null);
+                    opts.onLoginSuccess?.(null);
                     opts.onRecovered?.();
                     break;
                 case "terminal-timeout":
@@ -522,6 +534,7 @@ export function useAgentControllerStatus(
                 // recovery: retry the failed turn (fresh spawn picks up the new
                 // token and TurnStart clears the row).
                 opts.log("auth", "Signed in from your global login — retrying…");
+                opts.onLoginSuccess?.(null);
                 opts.onRecovered?.();
             } else {
                 const msg = "Couldn't use your global login — no valid global Claude credential was found. Try “Login via terminal”.";
@@ -597,6 +610,7 @@ export function useAgentControllerStatus(
                 case "terminal-success":
                     opts.log("auth", "Login successful — retrying…");
                     setAuthNotice(null);
+                    opts.onLoginSuccess?.(null);
                     opts.onRecovered?.();
                     break;
                 case "terminal-timeout":

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -41,6 +41,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
 import { persistAndLinkAccount, runProviderLogin } from "../flows/run-provider-login";
 import { registerSeededAccount } from "../flows/register-seeded-account";
+import type { LaunchPhase } from "../flows/launch-phase";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -88,6 +89,9 @@ export interface UseAgentControllerStatus {
     agentReady: Accessor<boolean>;
     isLoading: Accessor<boolean>;
     loginWaiting: Accessor<boolean>;
+    /** What the flow is doing right now, for a specific footer label instead
+     *  of a generic "Working…" — see launch-phase.ts. */
+    launchPhase: Accessor<LaunchPhase | null>;
     startLaunchFlow: () => Promise<void>;
     /**
      * Force a provider re-login, bypassing the auth-status check. Wired to the
@@ -163,6 +167,10 @@ export function useAgentControllerStatus(
     const [flowRunning, setFlowRunning] = createSignal(false);
     const [agentReady, setAgentReady] = createSignal(false);
     const [loginWaiting, setLoginWaiting] = createSignal(false);
+    // What the flow is actually doing right now — see launch-phase.ts. Lets
+    // AgentFooter show a specific status (and, for timed phases, a "waiting
+    // on X, up to Ys" label) instead of a generic "Working…" for every phase.
+    const [launchPhase, setLaunchPhase] = createSignal<LaunchPhase | null>(null);
 
     // Derived spinner state — caller wires this into the AgentFooter loading prop
     const isLoading = createMemo(() => flowRunning() || !agentReady());
@@ -181,6 +189,7 @@ export function useAgentControllerStatus(
         // relogin) so it can't linger past a "Retry Login" the user just
         // clicked and mislead them about this attempt's outcome.
         setAuthNotice(null);
+        setLaunchPhase(null);
         const prov = opts.provider();
         try {
             const authEnv = await buildAuthEnv(prov);
@@ -191,6 +200,7 @@ export function useAgentControllerStatus(
                 setAuthUrl,
                 isCancelled: () => loginCancelled,
                 setLoginWaiting,
+                setLaunchPhase,
                 authEnv,
                 onLoginSuccess: opts.onLoginSuccess,
                 getInitialTermSize: opts.getInitialTermSize,
@@ -208,6 +218,7 @@ export function useAgentControllerStatus(
             setAgentReady(true); // clear spinner on error
         } finally {
             setFlowRunning(false);
+            setLaunchPhase(null);
         }
     };
 
@@ -309,6 +320,7 @@ export function useAgentControllerStatus(
         let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
         reloginInFlight = true;
         setLoginWaiting(true);
+        setLaunchPhase({ kind: "checking-auth" });
         try {
             if (!cliPath) {
                 cliPath = (await resolveCliForRecovery(prov, "re-login")) ?? undefined;
@@ -337,6 +349,11 @@ export function useAgentControllerStatus(
             let openedAccountId: string | undefined;
             let openedAccountDir: string | undefined;
             let recheckAuthEnv = authEnv;
+            setLaunchPhase(
+                prov.headlessLoginUrlUnsupported
+                    ? { kind: "opening-login-terminal" }
+                    : { kind: "waiting-for-login-link", deadlineMs: Date.now() + 15_000 },
+            );
             const outcome = await runProviderLogin({
                 provider: prov,
                 cliPath,
@@ -355,6 +372,9 @@ export function useAgentControllerStatus(
                         recheckAuthEnv = { ...authEnv, [prov.authConfigDirEnvVar]: dir };
                     }
                 },
+                // See catalog.ts's DEAD END note — skip tier 1's ~15s
+                // URL-capture wait for providers that can never produce one.
+                skipTier1: prov.headlessLoginUrlUnsupported === true,
             });
             switch (outcome) {
                 case "opened": {
@@ -364,6 +384,7 @@ export function useAgentControllerStatus(
                     opts.log("auth", "waiting for login to complete...");
                     let authenticated = false;
                     const deadline = Date.now() + 5 * 60 * 1000;
+                    setLaunchPhase({ kind: "waiting-for-login-completion", deadlineMs: deadline });
                     while (!loginCancelled && Date.now() < deadline && !authenticated) {
                         await new Promise<void>((r) => setTimeout(r, 2000));
                         if (loginCancelled) break;
@@ -436,6 +457,7 @@ export function useAgentControllerStatus(
         } finally {
             reloginInFlight = false;
             setLoginWaiting(false);
+            setLaunchPhase(null);
         }
     };
 
@@ -544,6 +566,7 @@ export function useAgentControllerStatus(
         // first, reset in finally.
         reloginInFlight = true;
         setLoginWaiting(true);
+        setLaunchPhase({ kind: "opening-login-terminal" });
         try {
             let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
             if (!cliPath) {
@@ -594,6 +617,7 @@ export function useAgentControllerStatus(
         } finally {
             reloginInFlight = false;
             setLoginWaiting(false);
+            setLaunchPhase(null);
         }
     };
 
@@ -601,6 +625,10 @@ export function useAgentControllerStatus(
         loginCancelled = true;
         getApi().cancelCliLogin().catch(() => {});
         opts.log("auth", "login cancelled", "warn");
+        // Immediate UI feedback — the in-flight poll loop notices
+        // loginCancelled on its own next tick (up to 2s), but the phase
+        // label/cancel button should disappear the instant the user clicks.
+        setLaunchPhase(null);
     };
 
     const notifyControllerHealthy = () => {
@@ -632,6 +660,7 @@ export function useAgentControllerStatus(
         agentReady,
         isLoading,
         loginWaiting,
+        launchPhase,
         startLaunchFlow,
         relogin,
         useGlobalLogin,

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -320,12 +320,17 @@ export function useAgentControllerStatus(
         let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
         reloginInFlight = true;
         setLoginWaiting(true);
-        setLaunchPhase({ kind: "checking-auth" });
         try {
             if (!cliPath) {
+                // reagent P2 on PR #2300: this step is resolving the CLI path,
+                // not checking auth — "checking-auth" here mislabeled a wait
+                // that can take up to 5 minutes (resolveCliForRecovery's own
+                // install wait) as the wrong, much shorter step.
+                setLaunchPhase({ kind: "resolving-cli" });
                 cliPath = (await resolveCliForRecovery(prov, "re-login")) ?? undefined;
                 if (!cliPath) return;
             }
+            setLaunchPhase({ kind: "checking-auth" });
             const authEnv = await recoveryAuthEnv(prov);
             // runProviderLogin falls through URL-capture -> global-login-copy ->
             // real-terminal-with-poll before giving up (retro-headless-login-
@@ -590,15 +595,19 @@ export function useAgentControllerStatus(
         // first, reset in finally.
         reloginInFlight = true;
         setLoginWaiting(true);
-        setLaunchPhase({ kind: "opening-login-terminal" });
         try {
             let cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
             if (!cliPath) {
                 // Same H2 trap as relogin: the gated launch flow would trust the
                 // auth check and skip the login the user explicitly asked for.
+                // reagent P2 on PR #2300: label this step "resolving-cli", not
+                // "opening-login-terminal" — no terminal opens until after this
+                // resolve, which can itself take up to 5 minutes on a fresh install.
+                setLaunchPhase({ kind: "resolving-cli" });
                 cliPath = (await resolveCliForRecovery(prov, "login via terminal")) ?? undefined;
                 if (!cliPath) return;
             }
+            setLaunchPhase({ kind: "opening-login-terminal" });
             const authEnv = await recoveryAuthEnv(prov);
             const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
             const outcome = await runProviderLogin({

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -613,10 +613,14 @@ export function useAgentControllerStatus(
                     ? { blockId: opts.blockId, agentDefinitionId }
                     : undefined,
                 existingAccountId: await existingAccountIdFor(prov.id),
-                // skipTier1 is always true here, so "fallback" never fires —
-                // but "polling" still does once the terminal actually opens,
-                // giving an accurate deadline instead of leaving the phase
-                // on a static "opening terminal" for the whole wait.
+                // "fallback" still fires here even though skipTier1 is true —
+                // run-provider-login.ts fires it unconditionally right after
+                // the (skipped) tier-1 block, not conditioned on skipTier1 —
+                // but this flow has nothing displayed for tier 1 to begin
+                // with, so there's nothing to update on that event; only
+                // "polling" (once the terminal actually opens) needs a phase
+                // update here, giving an accurate deadline instead of leaving
+                // the phase on a static "opening terminal" for the whole wait.
                 onTierChange: (event) => {
                     if (event.tier === "polling") {
                         setLaunchPhase({ kind: "waiting-for-login-completion", deadlineMs: event.deadlineMs });

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -41,7 +41,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
 import { persistAndLinkAccount, runProviderLogin } from "../flows/run-provider-login";
 import { registerSeededAccount } from "../flows/register-seeded-account";
-import type { LaunchPhase } from "../flows/launch-phase";
+import { LOGIN_LINK_CAPTURE_LABEL_MS, type LaunchPhase } from "../flows/launch-phase";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -352,7 +352,7 @@ export function useAgentControllerStatus(
             setLaunchPhase(
                 prov.headlessLoginUrlUnsupported
                     ? { kind: "opening-login-terminal" }
-                    : { kind: "waiting-for-login-link", deadlineMs: Date.now() + 15_000 },
+                    : { kind: "waiting-for-login-link", deadlineMs: Date.now() + LOGIN_LINK_CAPTURE_LABEL_MS },
             );
             const outcome = await runProviderLogin({
                 provider: prov,
@@ -375,6 +375,17 @@ export function useAgentControllerStatus(
                 // See catalog.ts's DEAD END note — skip tier 1's ~15s
                 // URL-capture wait for providers that can never produce one.
                 skipTier1: prov.headlessLoginUrlUnsupported === true,
+                // See launch-flow.ts's identical wiring — without this the
+                // phase set just above never updates again for the rest of
+                // this call, even though tier 2/3 inside it can run for up
+                // to 5 more minutes. reagent P1 on PR #2300.
+                onTierChange: (event) => {
+                    if (event.tier === "fallback") {
+                        setLaunchPhase({ kind: "opening-login-terminal" });
+                    } else {
+                        setLaunchPhase({ kind: "waiting-for-login-completion", deadlineMs: event.deadlineMs });
+                    }
+                },
             });
             switch (outcome) {
                 case "opened": {
@@ -602,6 +613,15 @@ export function useAgentControllerStatus(
                     ? { blockId: opts.blockId, agentDefinitionId }
                     : undefined,
                 existingAccountId: await existingAccountIdFor(prov.id),
+                // skipTier1 is always true here, so "fallback" never fires —
+                // but "polling" still does once the terminal actually opens,
+                // giving an accurate deadline instead of leaving the phase
+                // on a static "opening terminal" for the whole wait.
+                onTierChange: (event) => {
+                    if (event.tier === "polling") {
+                        setLaunchPhase({ kind: "waiting-for-login-completion", deadlineMs: event.deadlineMs });
+                    }
+                },
             });
             switch (outcome) {
                 case "opened":

--- a/frontend/app/view/agent/providers/catalog.ts
+++ b/frontend/app/view/agent/providers/catalog.ts
@@ -50,6 +50,11 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // the CLI fully interactive (isTTY + a controlling terminal), so it
         // stays alive for the paste. See docs / run_cli_login_pty.
         requiresLoginTty: true,
+        // Per the DEAD END note above: `claude auth login` never prints a
+        // scrapeable OAuth URL through our PTY spawn (v2.1.x's login is a
+        // self-driving TUI, not a stdout URL) — skip tier 1's URL-capture
+        // attempt entirely rather than burning its ~15s timeout every login.
+        headlessLoginUrlUnsupported: true,
         npmPackage: "@anthropic-ai/claude-code",
         // Keep in sync with agentmux-srv/src/backend/providers.rs `pinned_version`,
         // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and

--- a/frontend/app/view/agent/providers/types.ts
+++ b/frontend/app/view/agent/providers/types.ts
@@ -84,6 +84,12 @@ export interface ProviderDefinition {
     // `openclaw models auth login --provider <id>`. The host's
     // `run_cli_login` reads this flag and chooses the PTY branch.
     requiresLoginTty?: boolean;
+    // Set when this provider's login subcommand is known to NEVER print a
+    // scrapeable OAuth URL (distinct from requiresLoginTty — OpenClaw needs a
+    // TTY but does print a URL through it). When true, runProviderLogin's
+    // tier-1 PTY/pipe URL-capture attempt is skipped entirely instead of
+    // burning its ~15s capture timeout on a documented dead end.
+    headlessLoginUrlUnsupported?: boolean;
     /** System tools the provider's CLI needs at runtime. Probed before
      *  the user launches the agent so we can show install links
      *  instead of letting the CLI fail with cryptic stderr. */

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -269,6 +269,22 @@
                 opacity: 0.7;
                 margin-left: var(--space-2);
             }
+
+            .agent-working-row-cancel-login {
+                margin-left: var(--space-2);
+                padding: 0;
+                background: none;
+                border: none;
+                color: inherit;
+                font: inherit;
+                text-decoration: underline;
+                opacity: 0.85;
+                cursor: default;
+
+                &:hover {
+                    opacity: 1;
+                }
+            }
         }
 
         &--worked {


### PR DESCRIPTION
## Summary
- Claude's CLI never prints a scrapeable OAuth URL (v2.1.x moved to a clipboard-copy-on-keypress flow), so every mount-time/relogin/`/login` attempt burned `cli_login.rs`'s ~15s PTY URL-capture wait on a guaranteed dead end — not a rare timeout, every single time.
- Added `headlessLoginUrlUnsupported` to the provider catalog and wired `skipTier1` at the three auto-login call sites (`launch-flow.ts`, `useAgentControllerStatus.ts`'s relogin, `commands/global/login.ts`) so Claude skips straight past tier 1. No Rust changes needed for the fix itself — `runProviderLogin`'s existing `skipTier1` param already did exactly this, just wasn't wired to the automatic paths.
- Shortened the Rust-side `URL_CAPTURE_TIMEOUT_SECS` from 15s → 5s as a safety margin for any future/direct caller (Codex/Gemini/OpenClaw still get the real bounded wait).
- Added a `LaunchPhase` status (new `flows/launch-phase.ts`, mirrors `auth-state.ts`'s `AuthState.kind` pattern) so the footer shows what's actually happening ("Resolving CLI", "Waiting for login link… up to 12s", "Waiting for you to finish logging in… up to 4m 50s") instead of a generic "Working…" for every phase — every remaining real wait is now labeled with its deadline, never silent.
- Added a cancel-login button (`AuthUrlBox` + `AgentWorkingRow`) wired to the existing `cancelLogin()`, which previously only had a button on the separate pre-launch modal, not this mount-time flow.

## Test plan
- [x] `tsc --noEmit` and `cargo check` clean
- [x] New `launch-flow.test.ts` (3 tests) pins that Claude gets `skipTier1: true`, Codex doesn't, and every launch phase is reported including a terminal `ready`
- [x] Existing `run-provider-login.test.ts` (20 tests) and `run-cli-login-single-caller.test.ts` pass unmodified
- [x] New `cli_login.rs` unit test pins `URL_CAPTURE_TIMEOUT_SECS` as a short safety margin, not the old 15s
- [x] Full frontend suite (`npx vitest run`) — 724 passed
- [x] `cargo test -p agentmux-cef --lib cli_login::` — 5 passed
- [x] Full release-mode dev build compiled and booted cleanly (verified twice)
- [ ] Manual click-through in a running dev instance — blocked by an unrelated, pre-existing dev-server crash bug (documented separately, not caused by this change)

<!-- agentmux:agent_id=${AGENTMUX_AGENT_ID,,} -->