### PR TITLE
fix(window): restore exact secondary-window geometry after a full app restart

### DIFF
--- a/.changesets/1785052913-fix-window-restore-exact-secondary-window-geometry-after-a-f-numt.md
+++ b/.changesets/1785052913-fix-window-restore-exact-secondary-window-geometry-after-a-f-numt.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): restore exact secondary-window geometry after a full app restart

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -248,6 +248,88 @@ pub(crate) fn backend_set_window_opacity(web_endpoint: &str, auth_key: &str, win
     }
 }
 
+/// Write-through a window's position/size to srv's `Window.pos`/`winsize`
+/// mirror (via `backend_get_window_pos_and_size` below) so a full
+/// process-tree restart — where the launcher's live in-memory
+/// `WindowMirror.last_rect` is also gone, not just the main window — can
+/// still recreate secondary windows at their exact last geometry instead of
+/// a default placement. Fire-and-forget, same shape as
+/// `backend_set_window_opacity`: raw TCP, always called from its own
+/// background thread (see `report_position_for_srv_writethrough` in
+/// `commands/window/position_persist.rs`) so a slow/failed srv round-trip
+/// never stalls the live window move the user is actively making.
+///
+/// `rect` is Win32 screen-coordinate `left/top/right/bottom`
+/// (`agentmux_common::ipc::Rect`); converted here to srv's `pos: {x, y}` /
+/// `size: {width, height}` shape (`agentmux-srv/src/backend/obj.rs`'s
+/// `Point`/`WinSize`) since the two crates don't share these types directly
+/// — the wire format is plain JSON either way.
+pub(crate) fn backend_set_window_pos_and_size(web_endpoint: &str, auth_key: &str, window_id: &str, rect: agentmux_common::ipc::Rect) {
+    use std::io::Write;
+
+    let Some(addr) = parse_web_endpoint(web_endpoint, "backend_set_window_pos_and_size") else {
+        return;
+    };
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "SetWindowPosAndSize",
+        "args": [
+            window_id,
+            { "x": rect.left, "y": rect.top },
+            { "width": rect.right - rect.left, "height": rect.bottom - rect.top },
+        ],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    match std::net::TcpStream::connect_timeout(&addr, timeout) {
+        Ok(mut stream) => {
+            stream.set_write_timeout(Some(timeout)).ok();
+            stream.set_read_timeout(Some(timeout)).ok();
+            if let Err(e) = stream.write_all(request.as_bytes()) {
+                tracing::warn!(
+                    window_id = %window_id,
+                    error = %e,
+                    "[backend_set_window_pos_and_size] write failed — position mirror not persisted"
+                );
+                return;
+            }
+            use std::io::Read;
+            let mut resp = String::new();
+            let _ = stream.read_to_string(&mut resp);
+            let first_line = resp.lines().next().unwrap_or("(empty)");
+            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
+                tracing::warn!(
+                    window_id = %window_id,
+                    response = %first_line,
+                    "[backend_set_window_pos_and_size] SetWindowPosAndSize did not succeed — position mirror not persisted"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                window_id = %window_id,
+                addr = %addr,
+                error = %e,
+                "[backend_set_window_pos_and_size] connect failed — position mirror not persisted"
+            );
+        }
+    }
+}
+
 /// SPEC_PILLAR1_STEP3 Phase 2 — write-through a window's `kind` +
 /// `parent_window_id` to srv, so a future reproject can tell which
 /// native-window creation path to drive for each window. Fire-and-forget,
@@ -388,6 +470,85 @@ pub(crate) fn backend_get_window_opacity(web_endpoint: &str, auth_key: &str, win
         return None;
     }
     parsed.get("data")?.get("opacity")?.as_f64().map(|o| o as f32)
+}
+
+/// Read back the last-persisted position/size for `window_id` from srv —
+/// the slow-path reproject counterpart to `backend_get_window_opacity`
+/// above. Used only by `reproject_from_srv`
+/// (`commands/window/creation.rs`), the full-process-tree-restart path
+/// where the launcher's in-memory `WindowMirror.last_rect` is also gone,
+/// unlike the fast path (`reproject_from_snapshot`) which already has it.
+/// Same raw-TCP/blocking shape and same caller obligation (off the UI
+/// thread — `reproject_from_srv` already runs on its own `std::thread`).
+///
+/// Returns `None` on any failure (parse/connect/non-200/missing field) —
+/// the caller already treats "no rect available" as a valid fallback case
+/// (falls through to the existing default-placement heuristic in
+/// `open_window_with_kind`), same as it does today when this function
+/// doesn't exist at all.
+pub(crate) fn backend_get_window_pos_and_size(web_endpoint: &str, auth_key: &str, window_id: &str) -> Option<agentmux_common::ipc::Rect> {
+    use std::io::Write;
+
+    let addr = parse_web_endpoint(web_endpoint, "backend_get_window_pos_and_size")?;
+
+    let body = serde_json::json!({
+        "service": "window",
+        "method": "GetWindow",
+        "args": [window_id],
+        "uicontext": null,
+    })
+    .to_string();
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key, body.len(), body
+    );
+
+    let timeout = std::time::Duration::from_millis(2000);
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_pos_and_size] connect failed"))
+        .ok()?;
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_pos_and_size] write failed"))
+        .ok()?;
+
+    use std::io::Read;
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok()?;
+
+    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
+    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let data = parsed.get("data")?;
+    let x = data.get("pos")?.get("x")?.as_i64()?;
+    let y = data.get("pos")?.get("y")?.as_i64()?;
+    let width = data.get("winsize")?.get("width")?.as_i64()?;
+    let height = data.get("winsize")?.get("height")?.as_i64()?;
+    if width <= 0 || height <= 0 {
+        // Never-written Window.pos/winsize default to zero (Point/WinSize's
+        // #[derive(Default)]), which is indistinguishable from "this row
+        // predates the write-through" — treat a zero-or-negative size as
+        // "no real geometry persisted" rather than recreating a
+        // zero-sized window.
+        return None;
+    }
+    Some(agentmux_common::ipc::Rect {
+        left: x as i32,
+        top: y as i32,
+        right: (x + width) as i32,
+        bottom: (y + height) as i32,
+    })
 }
 
 /// SPEC_PILLAR1_STEP4 Phase 3 — slow-path reproject: read srv's durable

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -68,6 +68,11 @@ pub(crate) use helpers::backend_close_window;
 // SPEC_PILLAR1_STEP2 Slice A Phase 2 — durable opacity mirror write-through
 // / read-back, used by `commands/window/transparency.rs`.
 pub(crate) use helpers::{backend_get_window_opacity, backend_set_window_opacity};
+// Durable window position/size mirror write-through / read-back, used by
+// `commands/window/position_persist.rs` and
+// `commands/window/creation.rs::reproject_from_srv` — closes
+// SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md §4's documented gap.
+pub(crate) use helpers::{backend_get_window_pos_and_size, backend_set_window_pos_and_size};
 // SPEC_PILLAR1_STEP2 Slice B Phase 4 — floating-pane placement write-through,
 // used by `commands/window/chrome.rs`.
 pub(crate) use helpers::backend_update_block_meta;

--- a/agentmux-cef/src/commands/window/creation.rs
+++ b/agentmux-cef/src/commands/window/creation.rs
@@ -758,6 +758,16 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
                     pid
                 }
             });
+            // Position/size mirror, added alongside `position_persist`'s
+            // write-through — was unconditionally `None` before (see this
+            // file's git history / SPEC_PILLAR1_STEP4_CRASH_REPROJECT_
+            // 2026_07_07.md §4), the one case the fast path
+            // (`reproject_from_snapshot`, which already has `w.last_rect`
+            // from the launcher's live snapshot) didn't cover: a full
+            // process-tree restart where the launcher died too. `None` here
+            // still falls through to `open_window_with_kind`'s existing
+            // default-placement heuristic, same as before this existed.
+            let last_rect = crate::client::backend_get_window_pos_and_size(&web_endpoint, &auth_key, window_id);
             snapshots.push(agentmux_common::ipc::WindowSnapshot {
                 label: window_id.clone(),
                 kind,
@@ -765,7 +775,7 @@ pub(crate) fn reproject_from_srv(state: &Arc<AppState>, main_window_id: String) 
                 hwnd: None,
                 visible: true,
                 iconic: false,
-                last_rect: None,
+                last_rect,
                 foregrounded_since_open: true,
             });
         }

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -56,3 +56,10 @@ mod creation;
 // so they're re-exported explicitly (the `*` glob only covers `pub` items).
 pub use creation::*;
 pub(crate) use creation::{assets_missing_data_url, resolve_frontend_base_url};
+
+pub(crate) mod position_persist;
+// Debounced srv write-through for window position/size (the position-side
+// counterpart to `transparency`'s opacity write-through). Not glob-exported
+// — called via the full path (`crate::commands::window::position_persist::
+// report_position_for_srv_writethrough`) from its one caller in
+// `wrr::win_event`, same as this module's own doc comment describes.

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -57,9 +57,18 @@ mod creation;
 pub use creation::*;
 pub(crate) use creation::{assets_missing_data_url, resolve_frontend_base_url};
 
-pub(crate) mod position_persist;
 // Debounced srv write-through for window position/size (the position-side
-// counterpart to `transparency`'s opacity write-through). Not glob-exported
-// — called via the full path (`crate::commands::window::position_persist::
-// report_position_for_srv_writethrough`) from its one caller in
-// `wrr::win_event`, same as this module's own doc comment describes.
+// counterpart to `transparency`'s opacity write-through). Windows-only,
+// matching its one caller: `wrr::win_event`'s EVENT_OBJECT_LOCATIONCHANGE
+// hook (`wrr` itself is only compiled on Windows — see `wrr/mod.rs` — macOS/
+// Linux have no equivalent WinEvent-based live position stream today, so
+// there is nothing for this module to hook into there). Reagent P0 on
+// PR #2302: this module unconditionally uses `windows_sys::HWND` and
+// `AppState::label_for_hwnd` (itself `#[cfg(windows)]`), so it must not be
+// declared on other platforms — `windows-sys` is only a dependency under
+// `[target.'cfg(target_os = "windows")'.dependencies]` in Cargo.toml. Not
+// glob-exported — called via the full path
+// (`crate::commands::window::position_persist::
+// report_position_for_srv_writethrough`) from its one caller.
+#[cfg(target_os = "windows")]
+pub(crate) mod position_persist;

--- a/agentmux-cef/src/commands/window/position_persist.rs
+++ b/agentmux-cef/src/commands/window/position_persist.rs
@@ -1,0 +1,142 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Debounced srv write-through for window position/size — the position-side
+// counterpart to `transparency.rs`'s opacity write-through. Closes the gap
+// documented in SPEC_PILLAR1_STEP4_CRASH_REPROJECT_2026_07_07.md §4:
+// `reproject_from_srv` (the slow-path reproject used when the launcher
+// process itself also died, not just the main window closing) had no rect
+// to restore secondary windows to, because position/size was only ever
+// tracked in the launcher's live in-memory `WindowMirror.last_rect` — gone
+// the moment the launcher process exits.
+//
+// `Window.pos`/`Window.winsize` (agentmux-srv/src/backend/obj.rs) already
+// existed as fields, and the `SetWindowPosAndSize` RPC
+// (agentmux-srv/src/server/service/window_mutate.rs) already existed to
+// write them — this file is the first caller of that RPC.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use windows_sys::Win32::Foundation::HWND;
+
+use crate::state::AppState;
+
+/// Trailing-edge debounce for the srv position write-through, keyed by
+/// window label — same generation-counter shape as
+/// `transparency.rs::OPACITY_WRITE_DEBOUNCE_MS`, with its own map (not
+/// shared with opacity's) since the two properties change independently.
+///
+/// Position changes arrive far more often than opacity changes (every
+/// `EVENT_OBJECT_LOCATIONCHANGE` during a drag, already smoothed to ~20Hz
+/// by `position_debounce::should_emit` upstream) and are lower-urgency —
+/// nothing reads the persisted value until the next full-restart reproject,
+/// unlike opacity which a live crash-recovery path can read moments later.
+/// A longer window than opacity's 400ms is deliberate: 1500ms collapses an
+/// entire drag-then-release gesture to one write instead of firing on every
+/// intermediate pause.
+const POSITION_WRITE_DEBOUNCE_MS: u64 = 1500;
+
+fn position_write_generations() -> &'static Mutex<HashMap<String, u64>> {
+    static MAP: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    MAP.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Bump and return the new generation for `label`.
+fn next_position_write_generation(label: &str) -> u64 {
+    let mut m = position_write_generations()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let gen = m.entry(label.to_string()).or_insert(0);
+    *gen += 1;
+    *gen
+}
+
+/// True if `generation` is still the latest recorded generation for
+/// `label` — i.e. no newer position report for this label has arrived
+/// since this write was scheduled.
+fn is_current_position_write_generation(label: &str, generation: u64) -> bool {
+    let m = position_write_generations()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    m.get(label).copied() == Some(generation)
+}
+
+/// Called from `wrr::win_event`'s `EVENT_OBJECT_LOCATIONCHANGE` handler on
+/// every already-20Hz-debounced real (non-pool-move) position report,
+/// alongside the existing `launcher_ipc::report_hwnd_position_changed`
+/// call. A second, independent consumer of the same position stream — does
+/// not touch or replace the launcher-IPC forwarding.
+///
+/// No-ops (same as opacity's write-through) when the hwnd's label can't be
+/// resolved, or when the label has no registered `backend_window_id` yet
+/// (e.g. early in window creation, or a floating pane — floating panes
+/// have no srv `Window` row, see SPEC_PILLAR1_STEP2_WINDOW_TOPOLOGY_
+/// PERSISTENCE_2026_07_06.md §1.B).
+pub(crate) fn report_position_for_srv_writethrough(state: &Arc<AppState>, hwnd: HWND, rect: agentmux_common::ipc::Rect) {
+    let Some(label) = state.label_for_hwnd(hwnd) else {
+        return;
+    };
+    let Some(window_id) = state.backend_window_id(&label) else {
+        return;
+    };
+
+    let generation = next_position_write_generation(&label);
+    let web_endpoint = state.backend_endpoints.lock().web_endpoint.clone();
+    let auth_key = state.auth_key.lock().clone();
+    let debounce_label = label.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(POSITION_WRITE_DEBOUNCE_MS));
+        if !is_current_position_write_generation(&debounce_label, generation) {
+            // A newer report for this label superseded us during the
+            // sleep — this rect is stale, don't persist it.
+            return;
+        }
+        crate::client::backend_set_window_pos_and_size(&web_endpoint, &auth_key, &window_id, rect);
+    });
+}
+
+#[cfg(test)]
+mod position_debounce_tests {
+    use super::{is_current_position_write_generation, next_position_write_generation};
+
+    /// Simulates a rapid burst (a drag): only the LAST report's generation
+    /// should still be "current" once all bumps have happened — the same
+    /// scenario opacity's debounce guards against, applied to position.
+    #[test]
+    fn burst_only_the_last_generation_is_current() {
+        let label = "test-position-burst-only-last-wins";
+        let gens: Vec<u64> = (0..5).map(|_| next_position_write_generation(label)).collect();
+        for &g in &gens[..gens.len() - 1] {
+            assert!(
+                !is_current_position_write_generation(label, g),
+                "earlier generation {g} must be superseded after a burst"
+            );
+        }
+        assert!(
+            is_current_position_write_generation(label, *gens.last().unwrap()),
+            "the last generation in the burst must still be current"
+        );
+    }
+
+    /// A single, deliberate (non-burst) report must still be current.
+    #[test]
+    fn single_report_is_current() {
+        let label = "test-position-single-report-is-current";
+        let g = next_position_write_generation(label);
+        assert!(is_current_position_write_generation(label, g));
+    }
+
+    /// Generations are tracked independently per label — a burst on one
+    /// window must not supersede a pending write for a different window.
+    #[test]
+    fn generations_are_independent_per_label() {
+        let a = "test-position-independent-label-a";
+        let b = "test-position-independent-label-b";
+        let ga = next_position_write_generation(a);
+        let gb = next_position_write_generation(b);
+        next_position_write_generation(a);
+        assert!(!is_current_position_write_generation(a, ga));
+        assert!(is_current_position_write_generation(b, gb));
+    }
+}

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -832,10 +832,25 @@ unsafe extern "system" fn win_event_callback(
                 // windows at their exact last geometry — see
                 // `commands::window::position_persist` for the full
                 // rationale. Does not touch the launcher-IPC forward above.
-                if let Some(state) = app_state().get() {
-                    crate::commands::window::position_persist::report_position_for_srv_writethrough(
-                        state, hwnd, rect,
-                    );
+                //
+                // IsIconic guard (reagent P1 on PR #2302): a minimize can
+                // reach this branch too — the pool-move check above only
+                // returns early when `IsIconic(hwnd) == 0`, so a minimized
+                // window's LOCATIONCHANGE (reporting GetWindowRect's
+                // (-32000,-32000) sentinel, same one the comment above this
+                // block already documents) falls through here. That sentinel
+                // has a positive width/height (it's a real rect, just
+                // off-screen), so `backend_get_window_pos_and_size`'s
+                // zero-size guard alone wouldn't catch it — without this
+                // check, a full restart would reproject the window
+                // off-screen. The launcher-IPC forward above is left as-is
+                // (pre-existing behavior, unrelated to this write-through).
+                if IsIconic(hwnd) == 0 {
+                    if let Some(state) = app_state().get() {
+                        crate::commands::window::position_persist::report_position_for_srv_writethrough(
+                            state, hwnd, rect,
+                        );
+                    }
                 }
             }
         }

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -826,6 +826,17 @@ unsafe extern "system" fn win_event_callback(
             // Normal on-screen position reporting, debounced to ~20 Hz.
             if position_debounce::should_emit(raw_hwnd) {
                 launcher_ipc::report_hwnd_position_changed(raw_hwnd, rect);
+                // Second, independent consumer of the same position stream:
+                // debounced srv write-through so a full process-tree
+                // restart (launcher included) can still reproject secondary
+                // windows at their exact last geometry — see
+                // `commands::window::position_persist` for the full
+                // rationale. Does not touch the launcher-IPC forward above.
+                if let Some(state) = app_state().get() {
+                    crate::commands::window::position_persist::report_position_for_srv_writethrough(
+                        state, hwnd, rect,
+                    );
+                }
             }
         }
         _ => {}


### PR DESCRIPTION
## Summary

Investigated during a user question about close/reopen persistence: tabs/panes/layout and agent conversation history already survive a full app restart well, but secondary windows land at an approximate default position instead of their exact last size/location on the slow-path reproject (a full process-tree restart, launcher included — not just the main window closing). The fast path (launcher still alive) already had this from its live in-memory `WindowMirror.last_rect`; the slow path (`reproject_from_srv`) never had a rect source at all.

`Window.pos`/`winsize` already existed as srv fields (`agentmux-srv/src/backend/obj.rs`) and the `SetWindowPosAndSize` RPC already existed to write them (`agentmux-srv/src/server/service/window_mutate.rs`) — both unused until now.

- New `commands/window/position_persist.rs`: debounced (1.5s trailing-edge, generation-counter keyed by label) srv write-through, mirroring `transparency.rs`'s proven opacity-write-through pattern exactly. Hooked into `wrr::win_event`'s existing ~20Hz position stream (`EVENT_OBJECT_LOCATIONCHANGE`), alongside (not replacing) the existing launcher-IPC forward.
- `client/helpers.rs`: `backend_set_window_pos_and_size` (write) and `backend_get_window_pos_and_size` (read), same raw-TCP/blocking shape as the existing opacity helpers.
- `commands/window/creation.rs::reproject_from_srv`: was hardcoding `last_rect: None` for every recreated window; now fetches the persisted rect per window and passes it through to `open_window_with_kind`'s existing `explicit_rect` parameter — the exact path the fast path already uses via `WindowMirror.last_rect`.

**Scope note:** floating-pane placement restore (a pane that was torn off into its own window when the app last closed) turned out to be a separate, larger gap on investigation — floating panes aren't recreated on app restart at all today (they have no srv `Window` row and aren't part of the `Client.windowids` reproject sweep), so there's no existing call site to wire a geometry fix into. Out of scope here; flagging separately rather than silently dropping it or forcing an unrelated call site to serve double duty.

## Test plan

- [x] `cargo check -p agentmux-cef -p agentmux-srv` — clean, no new warnings
- [x] `cargo build -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-cef position_debounce_tests` — 3/3 new tests pass (burst-collapses-to-last-write, single-report-is-current, per-label-independence — mirroring `transparency.rs`'s existing opacity-debounce test suite)
- [ ] Manual: open a secondary window, drag it to a distinctive position, fully quit the app (kill the whole process tree via Task Manager, not just the main window), relaunch, confirm the secondary window reappears at its last position/size instead of a default one

<!-- agentmux:agent_id=agentx -->