### PR TITLE
chore: release v0.54.5

### DIFF
--- a/.changesets/1784870112-fix-tabs-hide-the-single-tab-pill-until-a-2nd-tab-exists-tra-t4p4.md
+++ b/.changesets/1784870112-fix-tabs-hide-the-single-tab-pill-until-a-2nd-tab-exists-tra-t4p4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): hide the single tab pill until a 2nd tab exists, transparent strip background

--- a/.changesets/1784889011-fix-term-give-view-term-an-opaque-background-so-the-tab-stri-82rn.md
+++ b/.changesets/1784889011-fix-term-give-view-term-an-opaque-background-so-the-tab-stri-82rn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): give .view-term an opaque background so the tab-strip row doesn't show the block frame's translucent tint

--- a/.changesets/1784893740-fix-term-drop-await-on-init-resync-to-stop-n-pane-spawn-seri-anu6.md
+++ b/.changesets/1784893740-fix-term-drop-await-on-init-resync-to-stop-n-pane-spawn-seri-anu6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): drop await on init resync to stop N-pane spawn serialization (#121)

--- a/.changesets/1784911825-feat-agent-fix-silent-auto-scroll-drops-extend-message-list--cfho.md
+++ b/.changesets/1784911825-feat-agent-fix-silent-auto-scroll-drops-extend-message-list--cfho.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): fix silent auto-scroll drops, extend message-list scrollbar past Working row, replace Host row with a compact tag

--- a/.changesets/1784922128-fix-agent-auto-clear-error-activity-dock-rows-after-15s-add--odmy.md
+++ b/.changesets/1784922128-fix-agent-auto-clear-error-activity-dock-rows-after-15s-add--odmy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): auto-clear error activity-dock rows after 15s, add landing/departure flash

--- a/.changesets/1784926378-feat-cef-add-dev-only-gpu-memory-trace-commands-for-2218-dia-w3mj.md
+++ b/.changesets/1784926378-feat-cef-add-dev-only-gpu-memory-trace-commands-for-2218-dia-w3mj.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(cef): add dev-only GPU memory trace commands for #2218 diagnostics

--- a/.changesets/1784943486-fix-agent-fix-invalid-sass-compound-selector-syntax-in-runti-i4hp.md
+++ b/.changesets/1784943486-fix-agent-fix-invalid-sass-compound-selector-syntax-in-runti-i4hp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): fix invalid Sass compound-selector syntax in RuntimeBadge, blocking dev server

--- a/.changesets/1784946191-fix-identity-oauth-config-dir-secret-ref-variant-mismatched--g3hs.md
+++ b/.changesets/1784946191-fix-identity-oauth-config-dir-secret-ref-variant-mismatched--g3hs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): oauth_config_dir secret_ref variant mismatched its own derived serde rename, breaking My Agents for every real account

--- a/.changesets/1784977373-feat-armory-add-touchdesigner-to-the-mcp-preload-catalog-zevc.md
+++ b/.changesets/1784977373-feat-armory-add-touchdesigner-to-the-mcp-preload-catalog-zevc.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): add TouchDesigner to the MCP preload catalog

--- a/.changesets/1785050454-fix-auth-skip-doomed-headless-url-capture-wait-for-claude-lo-fwcn.md
+++ b/.changesets/1785050454-fix-auth-skip-doomed-headless-url-capture-wait-for-claude-lo-fwcn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): skip doomed headless URL-capture wait for Claude login, surface phase status + cancel

--- a/.changesets/1785052913-fix-window-restore-exact-secondary-window-geometry-after-a-f-numt.md
+++ b/.changesets/1785052913-fix-window-restore-exact-secondary-window-geometry-after-a-f-numt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): restore exact secondary-window geometry after a full app restart

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "dirs",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.4"
+version = "0.54.5"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,20 @@
 # AgentMux Version History
 
+## 0.54.5 — 2026-07-26
+
+- fix(tabs): hide the single tab pill until a 2nd tab exists, transparent strip background
+- fix(term): give .view-term an opaque background so the tab-strip row doesn't show the block frame's translucent tint
+- fix(term): drop await on init resync to stop N-pane spawn serialization (#121)
+- feat(agent): fix silent auto-scroll drops, extend message-list scrollbar past Working row, replace Host row with a compact tag
+- fix(agent): auto-clear error activity-dock rows after 15s, add landing/departure flash
+- feat(cef): add dev-only GPU memory trace commands for #2218 diagnostics
+- fix(agent): fix invalid Sass compound-selector syntax in RuntimeBadge, blocking dev server
+- fix(identity): oauth_config_dir secret_ref variant mismatched its own derived serde rename, breaking My Agents for every real account
+- feat(armory): add TouchDesigner to the MCP preload catalog
+- fix(auth): skip doomed headless URL-capture wait for Claude login, surface phase status + cancel
+- fix(window): restore exact secondary-window geometry after a full app restart
+
+
 ## 0.54.4 — 2026-07-23
 
 - fix: batch of small triaged issue fixes (#1397, #780, #859, #2155)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.4",
+  "version": "0.54.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.4",
+      "version": "0.54.5",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.4",
+  "version": "0.54.5",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming 11 pending changesets. Forced to **patch** (`task release -- --as patch`) rather than the computed **minor** (3 of the 11 changesets are `minor`) — per explicit instruction.

**0.54.4 → 0.54.5**

- fix(tabs): hide the single tab pill until a 2nd tab exists, transparent strip background
- fix(term): give .view-term an opaque background so the tab-strip row doesn't show the block frame's translucent tint
- fix(term): drop await on init resync to stop N-pane spawn serialization (#121)
- feat(agent): fix silent auto-scroll drops, extend message-list scrollbar past Working row, replace Host row with a compact tag
- fix(agent): auto-clear error activity-dock rows after 15s, add landing/departure flash
- feat(cef): add dev-only GPU memory trace commands for #2218 diagnostics
- fix(agent): fix invalid Sass compound-selector syntax in RuntimeBadge, blocking dev server
- fix(identity): oauth_config_dir secret_ref variant mismatched its own derived serde rename, breaking My Agents for every real account
- feat(armory): add TouchDesigner to the MCP preload catalog
- fix(auth): skip doomed headless URL-capture wait for Claude login, surface phase status + cancel
- fix(window): restore exact secondary-window geometry after a full app restart

All 11 consumed `.changesets/*.md` files deleted; `VERSION_HISTORY.md` updated.

## Test plan

- [x] Release-consistency invariant: `VERSION_HISTORY.md` top entry, `package.json`, `Cargo.toml`, `Cargo.lock` (workspace members), and `package-lock.json` all agree at `0.54.5`
- [x] `task release` ran clean, no manual edits needed

<!-- agentmux:agent_id=agentx -->