### PR TITLE
rename per-agent "Agent setup" modal to "Stash" (backpack icon)

### DIFF
--- a/.changesets/1785123261-rename-the-per-agent-agent-setup-modal-to-stash-backpack-ico-ikmr.md
+++ b/.changesets/1785123261-rename-the-per-agent-agent-setup-modal-to-stash-backpack-ico-ikmr.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+rename the per-agent 'Agent setup' modal to Stash (backpack icon), distinguishing it from the global Armory pane

--- a/docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md
+++ b/docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md
@@ -1,0 +1,94 @@
+# Report: disambiguating the global Armory pane from the per-agent "agent armory" — naming + icon proposal
+
+**Date:** 2026-07-27
+**Author:** Agent3
+**Verified against:** `main` @ `38978e6ba` (pulled 2026-07-27).
+**Status:** Audit + naming proposal — not yet implemented, awaiting a name decision.
+**Related:** `docs/specs/archive/SPEC_TRUST_CENTER_RENAME_2026_07_02.md` (original "Armory" naming brainstorm), `docs/specs/archive/SPEC_RENAME_TRUST_CENTER_TO_ARMORY_2026_07_02.md` (execution), `docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md` (gave the per-agent button the same vault icon "for parity"), `docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md` (prior architecture/naming audit, 4 days before this one — did not address this specific two-surfaces-one-name problem).
+
+## User's request (verbatim, for traceability)
+
+> where are we in regard to the armory .. I am thinking we need a new name for the Agent's armory .. perhaps we can call it "Stash" ? so we can easily distinguish the armory pane and the per-agent accessible via the agent pane header .. what names, or icons do you propose? audit the current system
+
+## 1. What "Armory" is today — one code concept, two surfaces sharing its name
+
+**There is exactly one thing actually called "Armory" in the codebase and in user-facing copy: the global, fleet-wide pane** (`view: "armory"`, hamburger menu → Armory, `frontend/app/view/armory/`). It's a rail of five independently-owned managers over **shared, reusable** resources — Accounts, Memories, Skills, MCP Servers, Bundles — governed by an explicit architecture doc (`ARCHITECTURE_ARMORY_2026_07_20.md` §0): *"Armory holds shared, reusable resources... What deliberately does NOT live in Armory: per-agent-instance data."*
+
+**The per-agent surface you're describing is `AgentSetupModal`** — opened by the single header icon on an agent pane (title/tooltip: **"Agent setup"**). It is a *separate* component tree (own Accounts/Memories/MCP Servers/Skills/Startup tabs), not the global pane reopened pre-filtered. Its user-facing button text has never said "Armory" — but three independent places in code and specs informally call it **"the agent armory"**:
+
+- `AgentSetupModal.tsx:1-25`'s own doc comment.
+- `SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md:26-31`, verbatim: *""The armory" in the original ask refers to `AgentSetupModal`... informally called "the agent armory" (a per-agent-scoped analogue of the global Armory pane)."*
+- The header button's own code comment (`agent-model.ts:149-154`).
+
+**So the ambiguity you're running into is real, but it currently lives in code comments, spec prose, and shared iconography — not in two on-screen labels both literally saying "Armory."** That's actually good news: there's no user-facing string to migrate, only an icon collision and an informal name that's leaking into how the team (and now you) talks about the feature. A name decision now, before "agent armory" calcifies into shipped UI copy, is well-timed.
+
+## 2. The icon collision — the actual visible symptom today
+
+Every Armory-adjacent surface deliberately reuses the same `fa-solid fa-vault` glyph, "for visual parity":
+
+| Surface | Icon | File:line |
+|---|---|---|
+| Global Armory — hamburger menu | `vault` | `hamburger-menu.tsx:119` |
+| Global Armory — widget/pane icon | `vault` | `agentmux-srv/src/config/widgets.json:211`, `armory-model.ts:22` |
+| Global Armory — failure-banner "Open Armory → Accounts" action | `vault` | `failure-accessory.ts:104-107` |
+| Per-agent header button ("Agent setup") | `vault` — **identical** | `agent-model.ts:149-155` |
+
+This is the one place the two surfaces are genuinely indistinguishable at a glance: same glyph, same color, both reachable within a couple of clicks of each other (pane header vs. hamburger menu). A rename that doesn't also change this icon leaves the confusion fully intact — the label is secondary to the glyph for quick visual scanning. (For context: `vault` itself only exists because an earlier version of Armory used `shield-halved`, which collided with the **Warden** pane's icon — commit `9b88b7ca7` fixed that collision by switching to `vault`. Don't reintroduce a new collision picking the replacement.)
+
+## 3. Prior naming history — directly relevant precedent
+
+The 2026-07-02 brainstorm that produced "Armory" (`SPEC_TRUST_CENTER_RENAME_2026_07_02.md`) evaluated it as an **umbrella over multiple shared resource types**, and explicitly rejected two names worth knowing about before you pick a name for the *per-agent* surface:
+
+- **"Vault"** — rejected for the umbrella: *"Credentials-only; undersells Brain + Presets + Identities."* Correctly avoided already (the per-agent modal never adopted it either).
+- **"Loadout"** — runner-up, not rejected outright: *"The complete set an agent carries into a task... Slightly more 'the thing you assemble' than 'the place you manage it.'"* This objection was specifically about the *global* pane needing to read as a **place**, not a **thing one agent carries**. That objection doesn't apply to the per-agent surface — "this agent's loadout" is a *more* natural fit at the narrower, single-agent scope than it was at the umbrella scope. Worth surfacing as a real alternative, not just a footnote.
+
+Also worth knowing: `REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md` §4 already reserves **"Connectors"** for a distinct, not-yet-built concept (preloaded MCP server integrations) and recommends against reusing it here — so it's off the table for this rename too, for the same reason.
+
+## 4. Is "Stash" (or any short personal-kit name) actually a good semantic fit?
+
+Mostly yes, with one honest caveat. Architecturally, `AgentSetupModal`'s tabs are not uniform in how "personal" they really are:
+
+- **Accounts, Memories** — genuinely agent-scoped data (identity bindings, this agent's own memory files).
+- **MCP Servers, Skills** — the modal is a *filtered view/binding* into the **same shared `db_mcp_servers`/`db_skills` tables** Armory itself manages, using hand-duplicated model code (`AgentMcpModel`/`AgentSkillModel` vs. Armory's `McpCatalogModel`/`SkillCatalogModel`) rather than genuinely separate, agent-owned copies (flagged as existing debt in the 07-23 report, not something this rename needs to fix).
+
+"Stash" (and similarly, "Loadout") implies **this agent's own private collection**, which slightly oversells the MCP/Skills tabs' actual sharedness. In practice this is a minor, common naming simplification (a player's "inventory" in most games is also drawing from a shared item pool, not literally private) — not a reason to avoid the name, just worth a one-line clarifier in the modal's own copy ("bindings to shared Armory resources, scoped to this agent") if it's ever written, rather than implying true per-agent private storage.
+
+## 5. Recommendation
+
+**Keep "Armory" for the global pane** — it's shipped, well-established (three-week-old rename, zero regressions since), fits the Swarm/Warden/Drone register, and nothing in this request asks to touch it.
+
+**For the per-agent surface (`AgentSetupModal`), ranked:**
+
+1. **Stash** (your instinct) — top pick. Short, on-voice, reads as "this agent's personal kit" pulled *from* the Armory — a natural depot/personal-kit pairing (quartermaster's armory vs. a soldier's stash), distinct enough from "Armory" that the two can't be confused verbally, unlike a name that's a synonym or sub-word of "Armory" itself.
+2. **Loadout** — strong runner-up, and arguably a *better* semantic fit than it would have been for the global pane (see §3) — "this agent's loadout" is exactly what the modal shows. Slightly more "assembled thing" than "place," which is fine at this scope (you open a modal, not a pane).
+3. **Kit** — shortest option, clean, but generic enough that it undersells the identity/memory tabs (reads as "tools," similar undersell risk "Vault" had for the global pane).
+4. **Locker** — "this agent's locker," familiar personal-storage metaphor, distinct from both Armory and Vault — reasonable fourth option if Stash/Loadout feel too game-y for your taste.
+
+**Icon: `fa-solid fa-backpack`** for whichever name is chosen. Checked for collisions — `backpack`, `suitcase`, `toolbox`, `sack`, `locker` are all currently **unused** anywhere in the frontend or widget catalog (`vault`, `shield-halved`, `key`, `brain`, `plug`, `wand-magic-sparkles`, `layer-group`, `box` (Container runtime badge), `cog` (Settings), `id-card` (the button's *old*, pre-vault icon) are all already claimed elsewhere and worth continuing to avoid). A backpack reads as "personal gear you carry," is visually distinct from a vault's boxy/secure silhouette at a glance (the actual failure mode in §2), and keeps the same "equip an agent" metaphor register as Armory without duplicating its glyph family.
+
+## 6. Suggested minimal-risk implementation scope (not yet done — awaiting your name pick)
+
+Mirroring the original Trust Center → Armory rename's own "minimal-risk scope" precedent (`SPEC_TRUST_CENTER_RENAME_2026_07_02.md` §"Recommended minimal-risk scope"):
+
+- User-facing: header button `title: "Agent setup"` → `title: "<Name>"` (`agent-model.ts:156`); `icon: "vault"` → `icon: "backpack"` (`agent-model.ts:155`).
+- Non-user-facing, same PR for coherence: rename `AgentSetupModal` → `Agent<Name>Modal` (or keep the filename and just fix the doc comment — file rename is optional churn), update the "the agent armory" comments in `agent-model.ts`/`failure-accessory.ts`/the header-icon spec's own historical note (leave the spec's *history* section as-is; specs are a record, not live docs) to the new name.
+- **Leave untouched:** `AgentMcpModel`/`AgentSkillModel`/RPC names/DB tables — same reasoning the original rename spec gave (internal key ≠ display name is already an accepted pattern in this codebase).
+- Small bonus, same area, already flagged as debt independent of this rename: the `ArmorySection` id/label mismatch (`id:"brain"` renders "Memories," `id:"memories"` renders "Bundles," `armory-view.tsx:17-23`) — a natural one-line fix to bundle into the same PR if you want it, not required.
+
+## File/line reference table
+
+| Concern | File | Line(s) |
+|---|---|---|
+| Global Armory pane model (icon) | `frontend/app/view/armory/armory-model.ts` | 22 |
+| Global Armory rail (labels+icons, id/label mismatch) | `frontend/app/view/armory/armory-view.tsx` | 17-23 |
+| Armory hamburger entry | `frontend/app/window/hamburger-menu.tsx` | 117-120 |
+| Armory widget def | `agentmux-srv/src/config/widgets.json` | 208-219 |
+| Architecture/intent doc | `docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md` | §0 |
+| Per-agent header button (label + vault icon) | `frontend/app/view/agent/agent-model.ts` | 143-158 |
+| Per-agent modal ("the agent armory") | `frontend/app/view/agent/components/AgentSetupModal.tsx` | 1-25 |
+| Header icon rationale spec | `docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md` | 23-31 |
+| Failure banner "Open Armory → Accounts" (vault reuse) | `frontend/app/view/agent/failure/failure-accessory.ts` | 100-108 |
+| Naming brainstorm (Vault rejected, Loadout runner-up) | `docs/specs/archive/SPEC_TRUST_CENTER_RENAME_2026_07_02.md` | 36-53 |
+| Icon collision precedent (vault replaced shield-halved to avoid Warden clash) | git commit `9b88b7ca7` | — |
+| "Connectors" already reserved for a different concept | `docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md` | §4 |
+| MCP/Skills hand-duplication (the §4 semantic caveat) | same report | §1, §2 |

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -18,11 +18,11 @@ import { AgentCreateFromTemplateModalPanel } from "@/app/view/agent/components/A
 import { BrowserAuthModalPanel } from "@/app/view/browser/components/BrowserAuthModal";
 import { AgentIdentityModalPanel } from "@/app/view/agent/components/AgentIdentityModal";
 import { AgentNativeMemoryModal } from "@/app/view/agent/components/AgentNativeMemoryModal";
-import { AgentSetupModal } from "@/app/view/agent/components/AgentSetupModal";
+import { AgentStashModal } from "@/app/view/agent/components/AgentStashModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
 import "@/app/view/agent/components/AgentIdentityModal.scss";
-import "@/app/view/agent/components/AgentSetupModal.scss";
+import "@/app/view/agent/components/AgentStashModal.scss";
 import "@/app/view/browser/components/BrowserAuthModal.scss";
 
 import type { ModalLayerApi, ModalLayerRequest } from "./modal-layer";
@@ -47,8 +47,8 @@ export function requestLabel(req: ModalLayerRequest): string {
             return `Identity — ${req.agent.name}`;
         case "agent-memory":
             return `Memory — ${req.agentName}`;
-        case "agent-setup":
-            return "Agent setup";
+        case "agent-stash":
+            return "Stash";
     }
 }
 
@@ -279,11 +279,11 @@ export function renderRequest(
                     />
                 ),
             };
-        case "agent-setup":
+        case "agent-stash":
             return {
                 label: requestLabel(req),
                 panel: (
-                    <AgentSetupModal
+                    <AgentStashModal
                         agentId={req.agentId}
                         agentName={req.agentName}
                         workingDirectory={req.workingDirectory}

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -25,7 +25,7 @@ export type ModalLayerRequest =
     | BrowserAuthRequest
     | AgentIdentityRequest
     | AgentMemoryRequest
-    | AgentSetupRequest;
+    | AgentStashRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -294,15 +294,17 @@ export interface AgentMemoryRequest {
 }
 
 /**
- * Agent setup modal — opened by the single id-card icon in the agent
+ * Agent Stash modal — opened by the single backpack icon in the agent
  * pane header. Unified tabbed container hosting the former Identity
  * ("Accounts") + native Memory surfaces as tabs; supersedes the separate
  * agent-identity / agent-memory icons. Structured so future primitives
  * (MCP Servers · Skills · Briefs · Bundle) slot in as additional tabs.
+ * Named "Stash" (not "Armory") to distinguish it from the global Armory
+ * pane — see docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md.
  * Spec: SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md §3.2b.
  */
-export interface AgentSetupRequest {
-    kind: "agent-setup";
+export interface AgentStashRequest {
+    kind: "agent-stash";
     /** Provider/definition id — used by the Accounts tab (read-only linked-
      *  accounts view, keyed on agentId alone) and the Memory tab. */
     agentId: string;

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -265,7 +265,7 @@ export interface BrowserAuthRequest {
 
 /**
  * Agent pane identity modal — formerly opened by the id-card icon in the
- * agent pane header. Superseded by agent-setup (the unified tabbed modal
+ * agent pane header. Superseded by agent-stash (the unified tabbed modal
  * now hosts this panel as the "Accounts" tab); kept for the dispatch case
  * and any future direct callers. Spec:
  * SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md.
@@ -281,7 +281,7 @@ export interface AgentIdentityRequest {
 /**
  * Agent pane memory modal — formerly opened by the brain icon in the
  * agent pane header. Shows the native memory folder for the agent.
- * Superseded by agent-setup (the unified tabbed modal now hosts this
+ * Superseded by agent-stash (the unified tabbed modal now hosts this
  * panel as the "Memory" tab); kept for the dispatch case and any future
  * direct callers. Spec: SPEC_AGENT_PANE_MEMORY_IDENTITY_MODALS_2026_06_19.md.
  */

--- a/frontend/app/view/agent/agent-mcp-model.ts
+++ b/frontend/app/view/agent/agent-mcp-model.ts
@@ -3,7 +3,7 @@
 
 /**
  * AgentMcpModel — view model for the agent pane's MCP Servers tab
- * (part of AgentSetupModal). Drives the list + create/edit/delete/bind
+ * (part of AgentStashModal). Drives the list + create/edit/delete/bind
  * lifecycle over the standalone MCP Server primitive (`mcp.*` App API,
  * agentmux-srv/src/server/app_api/mcp.rs).
  *

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -34,11 +34,13 @@ export class AgentViewModel implements ViewModel {
     nodejsError: string | null = null;
 
     // Callback wired by AgentPresentationView on mount so the title-bar
-    // button can open the pane-scoped Agent-setup modal without holding a
+    // button can open the pane-scoped Stash modal without holding a
     // SolidJS context in the model. Replaced the former separate
     // _openIdentityModal / _openMemoryModal pair (Phase 3 slice 1 — one
-    // "Agent setup" icon opens a unified tabbed modal).
-    _openAgentSetupModal: (() => void) | null = null;
+    // "Stash" icon opens a unified tabbed modal). Named "Stash" (not
+    // "Armory") to distinguish it from the global Armory pane — see
+    // docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md.
+    _openAgentStashModal: (() => void) | null = null;
 
     // Voice-input target ref. AgentFooter populates this on mount with a
     // textarea-backed handle (and clears it on unmount). The exposed
@@ -132,7 +134,7 @@ export class AgentViewModel implements ViewModel {
             await RpcApi.SetMetaCommand(TabRpcClient, { oref, meta: { agentName: name.trim() } });
         };
 
-        // Pane-frame header button: a single "Agent setup" (vault) icon
+        // Pane-frame header button: a single "Stash" (backpack) icon
         // when an agent is loaded — opens the unified tabbed modal
         // (Accounts + Memory). Hidden when no agent is loaded (picker
         // screen). Always shown when agentId exists: quick-launch panes
@@ -146,15 +148,16 @@ export class AgentViewModel implements ViewModel {
             return [
                 {
                     elemtype: "iconbutton",
-                    // Same "vault" FontAwesome icon as the global Armory pane
-                    // (hamburger menu, failure-accessory banner) — visual
-                    // parity, since this opens the per-agent analogue of it
-                    // (AgentSetupModal: Accounts/Memories/MCP Servers/Skills
-                    // scoped to this one agent). Was "id-card"; same click
-                    // handler, icon only.
-                    icon: "vault",
-                    title: "Agent setup",
-                    click: () => { this._openAgentSetupModal?.(); },
+                    // Deliberately NOT the "vault" icon the global Armory
+                    // pane uses — this opens AgentStashModal, the per-agent
+                    // analogue of Armory, and a distinct name/icon is the
+                    // whole point of the rename (previously shared "vault"
+                    // "for parity," which was exactly the confusion between
+                    // the two surfaces this fixes). See
+                    // docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md.
+                    icon: "backpack",
+                    title: "Stash",
+                    click: () => { this._openAgentStashModal?.(); },
                 },
             ];
         };

--- a/frontend/app/view/agent/agent-skill-model.ts
+++ b/frontend/app/view/agent/agent-skill-model.ts
@@ -3,7 +3,7 @@
 
 /**
  * AgentSkillModel — view model for the agent pane's Skills tab (part of
- * AgentSetupModal). Drives the list + create/edit/delete/bind lifecycle
+ * AgentStashModal). Drives the list + create/edit/delete/bind lifecycle
  * over the standalone Skill primitive (`skill.*` App API,
  * agentmux-srv/src/server/app_api/skill.rs). Same shape as AgentMcpModel —
  * see its doc comment for the is_global / bound_to_agent details, which

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -353,13 +353,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     };
 
     // Wire the pane-scoped modal callback into the model so the single
-    // title-bar "Agent setup" (vault) icon can open the unified tabbed
+    // title-bar "Stash" (backpack) icon can open the unified tabbed
     // modal (Accounts + Memory) without holding a SolidJS context in the
     // model. Mirrors the former _setOverlayTab pattern; supersedes the
     // separate _openIdentityModal / _openMemoryModal callbacks.
     const modalLayer = useModalLayer();
     onMount(() => {
-        model._openAgentSetupModal = () => {
+        model._openAgentStashModal = () => {
             // Prefer cmd:cwd (actual launch cwd, set by launchAgentDefinition)
             // over AgentDefinition.working_directory, which is often empty or a
             // stale default for template-launched and continuation agents.
@@ -370,7 +370,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 "";
             const agent = currentAgent() ?? null;
             modalLayer.open({
-                kind: "agent-setup",
+                kind: "agent-stash",
                 agentId,
                 agentName: agentName(),
                 workingDirectory,
@@ -383,7 +383,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         };
     });
     onCleanup(() => {
-        model._openAgentSetupModal = null;
+        model._openAgentStashModal = null;
     });
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentMcpModal — the "MCP Servers" tab body inside AgentSetupModal.
+ * AgentMcpModal — the "MCP Servers" tab body inside AgentStashModal.
  * List/create/edit/delete for this agent's own MCP servers, plus a
  * bound-state-aware Bind/Unbind toggle for global ones (driven by
  * `bound_to_agent` — see AgentMcpModel's doc comment).

--- a/frontend/app/view/agent/components/AgentNativeMemoryModal.scss
+++ b/frontend/app/view/agent/components/AgentNativeMemoryModal.scss
@@ -7,7 +7,7 @@
 // The hosting <Modal> is size="fit", so the root sets explicit
 // dimensions to give the single-pane browser a bounded box (when used via
 // the standalone agent-memory dispatch; neutralized to 100%/100% when
-// embedded in AgentSetupModal — see that file's override).
+// embedded in AgentStashModal — see that file's override).
 //
 // Single-pane list/detail via PrimitiveListDetail (element/primitive-list-
 // detail.scss) — was a fixed two-column split with a non-shrinking 220px

--- a/frontend/app/view/agent/components/AgentPrimitiveModal.scss
+++ b/frontend/app/view/agent/components/AgentPrimitiveModal.scss
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Shared styles for the agent-scoped primitive list/detail tabs (MCP
-// Servers, Skills) hosted inside AgentSetupModal, and reused by Armory's
+// Servers, Skills) hosted inside AgentStashModal, and reused by Armory's
 // own Skills/MCP Servers tabs (skill-manager.tsx / mcp-manager.tsx). Content
 // styling only — the outer list/detail layout and the list-vs-detail toggle
 // live in PrimitiveListDetail (frontend/app/element/primitive-list-detail.tsx).

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentSkillsModal — the "Skills" tab body inside AgentSetupModal.
+ * AgentSkillsModal — the "Skills" tab body inside AgentStashModal.
  * List/create/edit/delete for this agent's own skills, plus a
  * bound-state-aware Bind/Unbind toggle for global ones (driven by
  * `bound_to_agent` — see AgentSkillModel's doc comment). Distinct from the

--- a/frontend/app/view/agent/components/AgentStartupModal.tsx
+++ b/frontend/app/view/agent/components/AgentStartupModal.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentStartupModal — the "Startup" tab body inside AgentSetupModal.
+ * AgentStartupModal — the "Startup" tab body inside AgentStashModal.
  *
  * Lets an agent select an existing Armory Bundle to serve as its Session
  * Context "Startup Instructions" (see buildStartupPayload.ts). This is a

--- a/frontend/app/view/agent/components/AgentStashModal.scss
+++ b/frontend/app/view/agent/components/AgentStashModal.scss
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// AgentSetupModal — unified tabbed container hosting the Accounts (identity)
+// AgentStashModal — unified tabbed container hosting the Accounts (identity)
 // and Memory (native memory) panels. The inner panels keep their own styling
 // (_identity-panel.scss / AgentNativeMemoryModal.scss); this file only styles
 // the top tab bar + panel wrapper.
@@ -32,33 +32,36 @@
 // own parent `.modal-root`, which is `position: fixed|absolute; inset: 0`
 // — genuinely definite, unlike `.modal-panel` itself). This element then
 // just fills whatever `.modal-panel` resolves to.
-// See docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.1.
-.modal-panel:has(.agent-setup-modal) {
+// See docs/specs/SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.1
+// (written when this modal was still named AgentSetupModal — class names
+// below were renamed by docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md,
+// the underlying layout logic is unchanged).
+.modal-panel:has(.agent-stash-modal) {
     width: min(780px, 100%);
     height: 560px;
     max-height: 85vh;
 }
 
-.agent-setup-modal {
+.agent-stash-modal {
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100%;
     min-width: 0;
-    // Container-query context for .agent-setup-modal-tab below (a
+    // Container-query context for .agent-stash-modal-tab below (a
     // descendant) — same technique as armory-view.scss's .armory-container.
     container-type: inline-size;
-    container-name: agent-setup;
+    container-name: agent-stash;
 }
 
-.agent-setup-modal-tabs {
+.agent-stash-modal-tabs {
     display: flex;
     gap: var(--space-1);
     padding: var(--space-2) var(--space-4) 0;
     border-bottom: 1px solid var(--border-color);
 }
 
-.agent-setup-modal-tab {
+.agent-stash-modal-tab {
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -96,8 +99,8 @@
 
 // Narrow modal — icon-only tabs, same "hide the label, keep the icon"
 // compression armory-view.scss's rail does at its 767px breakpoint.
-@container agent-setup (max-width: 560px) {
-    .agent-setup-modal-tab span {
+@container agent-stash (max-width: 560px) {
+    .agent-stash-modal-tab span {
         display: none;
     }
 }
@@ -108,17 +111,17 @@
 // also carries generic .modal-panel-body padding/font-size we don't want
 // here. .modal-layer-mount (ModalLayer.tsx) is the ancestor that establishes
 // the `modal-mount` container, so this fires correctly regardless of the
-// `agent-setup` container above (flex children default to min-width:auto,
+// `agent-stash` container above (flex children default to min-width:auto,
 // which this overrides once the real mount node — the pane, ultimately —
 // is this narrow).
 @container modal-mount (max-width: 400px) {
-    .agent-setup-modal-tabs,
-    .agent-setup-modal-panel {
+    .agent-stash-modal-tabs,
+    .agent-stash-modal-panel {
         min-width: 0;
     }
 }
 
-.agent-setup-modal-panel {
+.agent-stash-modal-panel {
     display: flex;
     flex-direction: column;
     flex: 1;

--- a/frontend/app/view/agent/components/AgentStashModal.tsx
+++ b/frontend/app/view/agent/components/AgentStashModal.tsx
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentSetupModal — unified tabbed container for per-agent setup surfaces,
- * opened by the single "Agent setup" (vault) icon in the agent pane
- * header. Consolidates the former two icons (identity + native memory)
- * into one modal with tabs:
+ * AgentStashModal — unified tabbed container for per-agent setup surfaces,
+ * opened by the single "Stash" (backpack) icon in the agent pane header.
+ * This is the per-agent-scoped analogue of the global Armory pane
+ * (frontend/app/view/armory/) — "Stash" vs. "Armory" is a deliberate naming
+ * split so the two are never confused for the same surface (see
+ * docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md). Consolidates
+ * the former two icons (identity + native memory) into one modal with tabs:
  *   - Accounts    — read-only linked-accounts view (AgentIdentityLinksPanel).
  *                   New bindings are created from the agent-launch flow;
  *                   see that component's own doc comment for why this tab
@@ -30,20 +33,20 @@ import { AgentMcpModal } from "./AgentMcpModal";
 import { AgentNativeMemoryModal } from "./AgentNativeMemoryModal";
 import { AgentSkillsModal } from "./AgentSkillsModal";
 import { AgentStartupModal } from "./AgentStartupModal";
-import "./AgentSetupModal.scss";
+import "./AgentStashModal.scss";
 
-type SetupTabId = "accounts" | "memory" | "mcp" | "skills" | "startup";
+type StashTabId = "accounts" | "memory" | "mcp" | "skills" | "startup";
 
-interface AgentSetupModalProps {
+interface AgentStashModalProps {
     agentId: string;
     agentName: string;
     workingDirectory: string;
-    initialTab?: SetupTabId;
+    initialTab?: StashTabId;
     onClose: () => void;
 }
 
-interface SetupTabDef {
-    id: SetupTabId;
+interface StashTabDef {
+    id: StashTabId;
     label: string;
     /** FontAwesome icon name — same choice as the matching section in the
      *  global Armory pane (armory-view.tsx's RAIL), for visual parity since
@@ -51,10 +54,10 @@ interface SetupTabDef {
     icon: string;
 }
 
-export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
+export const AgentStashModal = (props: AgentStashModalProps): JSX.Element => {
     // Data-driven tab list — Briefs slots in here later (no backend
     // primitive yet).
-    const tabs: SetupTabDef[] = [
+    const tabs: StashTabDef[] = [
         { id: "accounts", label: "Accounts", icon: "key" },
         { id: "memory", label: "Memories", icon: "brain" },
         { id: "mcp", label: "MCP Servers", icon: "plug" },
@@ -65,18 +68,18 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
         { id: "startup", label: "Startup", icon: "layer-group" },
     ];
 
-    const [activeTab, setActiveTab] = createSignal<SetupTabId>(props.initialTab ?? "accounts");
+    const [activeTab, setActiveTab] = createSignal<StashTabId>(props.initialTab ?? "accounts");
 
     return (
-        // agent-setup-modal carries container-type so the tabs below (a
-        // descendant) can be targeted by @container agent-setup queries —
+        // agent-stash-modal carries container-type so the tabs below (a
+        // descendant) can be targeted by @container agent-stash queries —
         // same technique as armory-view.tsx's .armory-container wrapper.
-        <div class="agent-setup-modal">
-            <div class="agent-setup-modal-tabs" role="tablist">
+        <div class="agent-stash-modal">
+            <div class="agent-stash-modal-tabs" role="tablist">
                 <For each={tabs}>
                     {(tab) => (
                         <button
-                            class="agent-setup-modal-tab"
+                            class="agent-stash-modal-tab"
                             classList={{ "is-active": activeTab() === tab.id }}
                             role="tab"
                             aria-selected={activeTab() === tab.id}
@@ -90,7 +93,7 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
                 </For>
             </div>
 
-            <div class="agent-setup-modal-panel">
+            <div class="agent-stash-modal-panel">
                 <Show when={activeTab() === "accounts"}>
                     <AgentIdentityLinksPanel agentId={props.agentId} />
                 </Show>
@@ -122,4 +125,4 @@ export const AgentSetupModal = (props: AgentSetupModalProps): JSX.Element => {
     );
 };
 
-AgentSetupModal.displayName = "AgentSetupModal";
+AgentStashModal.displayName = "AgentStashModal";

--- a/frontend/app/view/agent/styles/_identity-panel.scss
+++ b/frontend/app/view/agent/styles/_identity-panel.scss
@@ -55,8 +55,9 @@
 // not a flex item's. Reflow to a 2-row stack instead of trying to compress
 // content that has no room left to give — the assignment info and the
 // actions cell each get a full-width row of their own.
-// See SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.3.
-@container agent-setup (max-width: 460px) {
+// See SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md §7.3 (container name
+// renamed agent-setup → agent-stash by REPORT_ARMORY_STASH_NAMING_2026_07_27.md).
+@container agent-stash (max-width: 460px) {
     .agent-identity-provider-row {
         grid-template-columns: 16px 1fr;
         grid-template-areas:


### PR DESCRIPTION
## Summary
- Renamed the per-agent header-button modal (informally "the agent armory" in code/specs, user-facing label "Agent setup", `vault` icon) to **Stash**, with a distinct `backpack` icon — disambiguating it from the global, fleet-wide **Armory** pane, which is unchanged and keeps `vault`.
- `AgentSetupModal.tsx`/`.scss` → `AgentStashModal.tsx`/`.scss` (via `git mv`), `agent-setup-modal` CSS classes/container-query name → `agent-stash`, modal-layer request `kind: "agent-setup"` → `"agent-stash"`, `_openAgentSetupModal` → `_openAgentStashModal`.
- Internal-only identifiers left untouched (RPC names, DB tables, `AgentMcpModel`/`AgentSkillModel`), matching the original Trust Center → Armory rename's own minimal-risk scope.

See `docs/reports/REPORT_ARMORY_STASH_NAMING_2026_07_27.md` for the full audit (icon-collision analysis, naming alternatives considered, why "Stash" fits) that this PR implements.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx stylelint` on the touched/renamed scss files — clean (repo-wide `lint:scss` has 526 pre-existing, unrelated hex-color findings in other files)
- [x] `npx vitest run app/view/agent app/element` — 769 passed
- [ ] Manual: open an agent pane, confirm the header button now shows a backpack icon with tooltip "Stash" and opens the same 5-tab modal at the same width/responsiveness as before

<!-- agentmux:agent_id=agent3 -->