### PR TITLE
fix(armory): Skill content renders as Markdown; fix broken Bind-to-agent

### DIFF
--- a/.changesets/1785132254-fix-armory-render-skill-content-as-markdown-and-fix-the-brok-99xq.md
+++ b/.changesets/1785132254-fix-armory-render-skill-content-as-markdown-and-fix-the-brok-99xq.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(armory): render Skill content as Markdown and fix the broken catalog Bind-to-agent action

--- a/.changesets/1785132255-fix-agent-pane-modals-close-on-backdrop-click-when-they-carr-ec7i.md
+++ b/.changesets/1785132255-fix-agent-pane-modals-close-on-backdrop-click-when-they-carr-ec7i.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): pane modals close on backdrop click when they carry no in-flight form state

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -331,6 +331,12 @@ pub const COMMAND_SKILL_UNBIND: &str = "skill.unbind";
 pub const COMMAND_SKILL_CATALOG_LIST: &str = "skill.catalog.list";
 pub const COMMAND_SKILL_CATALOG_UPSERT: &str = "skill.catalog.upsert";
 pub const COMMAND_SKILL_CATALOG_DELETE: &str = "skill.catalog.delete";
+// skill.bind is check_s1-gated (agent binds a skill to itself over its own
+// authenticated connection) — the Armory dashboard's WebSocket never
+// authenticates as an agent, so it can never satisfy that gate. This is the
+// catalog-tier sibling the Armory's "Bind to agent" action actually calls.
+// See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
+pub const COMMAND_SKILL_CATALOG_BIND: &str = "skill.catalog.bind";
 
 // App API — v1 standalone MCP Server primitives
 pub const COMMAND_MCP_LIST: &str = "mcp.list";

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -352,9 +352,31 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// Bind a skill to an agent (insert ref row). Idempotent.
+    /// Bind a skill to an agent (insert ref row). Idempotent — binding an
+    /// already-bound pair is a silent no-op success.
+    ///
+    /// Errors if `agent_id` isn't a LOCAL agent definition:
+    /// `db_agent_skills_ref.agent_id` has an ON-enforced FK to
+    /// `db_agent_definitions(id)` (store.rs), but the Armory's agent
+    /// picker (`ListAgentDefinitionsCommand` → `agent_def_list()`) also
+    /// lists cross-channel agents that only exist in another channel's
+    /// local database. Binding one of those would otherwise have the FK
+    /// silently swallow the `INSERT OR IGNORE` — indistinguishable, by
+    /// affected-row-count alone, from the equally-silent "already bound"
+    /// case — reporting success while creating nothing. reagentx P1, PR
+    /// #2315.
     pub fn skill_bind(&self, agent_id: &str, skill_id: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        let agent_exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM db_agent_definitions WHERE id = ?1)",
+            params![agent_id],
+            |row| row.get(0),
+        )?;
+        if !agent_exists {
+            return Err(StoreError::Other(format!(
+                "agent {agent_id} not found in this channel's local registry — cross-channel skill binding is not supported"
+            )));
+        }
         conn.execute(
             "INSERT OR IGNORE INTO db_agent_skills_ref (agent_id, skill_id) VALUES (?1, ?2)",
             params![agent_id, skill_id],

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -20,6 +20,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_skill_catalog_list(engine, state);
     register_skill_catalog_upsert(engine, state);
     register_skill_catalog_delete(engine, state);
+    register_skill_catalog_bind(engine, state);
 }
 
 fn register_skill_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -311,6 +312,51 @@ fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     scopes: vec![], sender: String::new(), persist: 0, data: None,
                 });
                 Ok(Some(serde_json::to_value(&skill).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+// Catalog-tier sibling of register_skill_bind (above) — same DB write and
+// "only global skills may be bound" safety check, but no check_s1: the
+// Armory's WebSocket never authenticates as an agent (see this file's
+// module doc comment), so a check_s1-gated bind can never be satisfied from
+// that caller. skill.bind itself is left untouched — it may still be the
+// intended surface for an agent binding a skill to itself over its own
+// authenticated connection, and loosening its gate would silently widen
+// what any authenticated agent connection can do (bind arbitrary skills to
+// *other* agent ids), which nobody asked for.
+// See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md §2.4.
+fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_CATALOG_BIND,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, skill_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.catalog.bind: {e}"))?;
+                // Only global skills (or ones already bound) may be bound, so the
+                // catalog surface can't be used to bootstrap read access to
+                // another agent's private skill — same rule as skill.bind.
+                match wstore.skill_get(&req.skill_id)
+                    .map_err(|e| format!("skill.catalog.bind: {e}"))?
+                {
+                    None => return Err("skill.catalog.bind: skill not found".to_string()),
+                    Some(s) if !s.is_global => {
+                        if !wstore.skill_is_bound_to(&req.agent_id, &req.skill_id)
+                            .map_err(|e| format!("skill.catalog.bind: {e}"))?
+                        {
+                            return Err("FORBIDDEN: can only bind global skills".to_string());
+                        }
+                    }
+                    Some(_) => {}
+                }
+                wstore.skill_bind(&req.agent_id, &req.skill_id)
+                    .map_err(|e| format!("skill.catalog.bind: {e}"))?;
+                Ok(Some(json!({ "bound": true })))
             })
         }),
     );

--- a/docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md
+++ b/docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md
@@ -1,0 +1,128 @@
+# Analysis: Armory Skills — plain-text content rendering + broken "Bind to agent"
+
+**Date:** 2026-07-27
+**Author:** Agent3
+**Verified against:** `main` @ `38978e6ba`, live-verified against the running `task dev` build (branch `agent3/agent-armory-rename-stash`, no relevant divergence from `main` for this area).
+**Status:** Analysis — root causes confirmed (one live-verified via CDP), fix not yet implemented.
+**Scope:** `frontend/app/view/skill/skill-manager.tsx` (Armory's Skills tab) + its backend, `agentmux-srv/src/server/app_api/skill.rs`.
+
+## User's request (verbatim, for traceability)
+
+> lets shift to the armory pane .. first, get the Content of the Skills parts to be rendered in markdown (currently it is just plain text) .. also, binding to an agent is not working, fix that too .. first write analysis to file
+
+## 1. Skill content renders as plain text, not Markdown
+
+`frontend/app/view/skill/skill-manager.tsx:75-84` renders `description`, `trigger`, and `content` as raw `<pre>` text nodes — no Markdown processing:
+
+```tsx
+<Show when={skill().description}>
+    <span class="agent-primitive-modal-field-label">Description</span>
+    <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
+</Show>
+<Show when={skill().trigger}>
+    <span class="agent-primitive-modal-field-label">Trigger</span>
+    <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
+</Show>
+<span class="agent-primitive-modal-field-label">Content</span>
+<pre class="agent-primitive-modal-field-value">{skill().content || "(none)"}</pre>
+```
+
+Confirmed live (screenshot below) — the "Systematic Debugging" skill's `content` field is genuine Markdown (`# Systematic Debugging`, `**bold**`, numbered lists, a code-style trigger) rendered completely unstyled.
+
+**Fix: reuse the existing `Markdown` component** (`frontend/app/element/markdown.tsx`) — a `unified`/`remark-gfm`/`rehype-sanitize` pipeline already used throughout the app (agent chat messages via `MarkdownBlock.tsx`, the editor, tool-result overlays), not a new dependency. Standard invocation:
+
+```tsx
+<Markdown text={skill().content || "(none)"} scrollable={false} />
+```
+
+`scrollable={false}` matches `MarkdownBlock.tsx`'s own usage — the Skills detail pane already has its own scroll container (`.agent-primitive-modal-detail` / `PrimitiveListDetail`), so `Markdown`'s own internal scroll wrapper would double up otherwise.
+
+**Scope decision — `content` only, not `description`/`trigger`.** `description` and `trigger` are short, single-line-ish free text (a UI label + a trigger phrase, per the create/edit form's plain `<input type="text">` fields, `skill-manager.tsx:147-152` and `:138-145`) — there's no evidence they're meant to hold Markdown, and the create form doesn't offer a Markdown-authoring affordance for them (single-line inputs, not a textarea). Only `content` is authored via a multi-line `<textarea>` (`skill-manager.tsx:154-160`) and is the field the example skill's real body demonstrates is genuine prose Markdown. Recommend leaving `description`/`trigger` as `<pre>` (or even a plain `<span>`, since they're single-line) and converting only `content`.
+
+**Two render sites need this fix, not one.** `frontend/app/view/agent/components/AgentSkillsModal.tsx:107-116` (the per-agent Skills tab, opened via the Stash modal) has the byte-for-byte identical `<pre>`-for-`content` pattern — it's effectively a duplicated detail view, not a shared component. Both need the same `<Markdown>` swap; there's no single shared "skill detail" component to fix once. (Extracting one is a reasonable follow-up but out of scope for this fix — matching the existing duplication rather than doing an unrelated refactor alongside a bug fix.)
+
+The Brain/Memories manager (`global-brain-manager.tsx:199-200`) has the same `<pre>`-for-user-content pattern independently — noted for awareness, but out of scope (not part of this request).
+
+## 2. "Bind to agent" is completely non-functional — live-verified
+
+### 2.1 Reproduction
+
+Live in the running dev build: Armory → Skills → select a skill → pick an agent in "Bind to agent" → click **Bind**. Result, verbatim, rendered in the error banner:
+
+> **Bind failed: FORBIDDEN: unauthenticated agent connection**
+
+This happens for **every** agent, **every** skill — it is not data-dependent. Screenshot evidence and the exact CDP-driven repro steps are in this investigation's working notes; the failure string above was captured directly from the live DOM after a scripted click, not inferred.
+
+### 2.2 Root cause
+
+The call chain:
+
+```
+skill-manager.tsx:100        onClick → model.bindToAgent(skill().id, model.bindAgentIdAtom())
+skill-model.ts:112           RpcApi.SkillBindCommand(TabRpcClient, { agent_id, skill_id })
+rpc-api/skill.ts:47-53       client.rpcCall("skill.bind", data, opts)
+skill.rs:182-215             register_skill_bind → check_s1(&ctx, &req.agent_id)?   ← fails here
+```
+
+`check_s1` (`agentmux-srv/src/server/app_api/mod.rs`) requires the **calling WebSocket connection itself** to be authenticated as the same agent named in the request:
+
+```rust
+pub(super) fn check_s1(ctx: &RpcContext, req_agent_id: &str) -> Result<(), String> {
+    if ctx.agent_id.is_empty() {
+        return Err("FORBIDDEN: unauthenticated agent connection".to_string());
+    }
+    if ctx.agent_id != req_agent_id {
+        return Err("FORBIDDEN: agent_id mismatch".to_string());
+    }
+    Ok(())
+}
+```
+
+`ctx.agent_id` is stamped exactly once per connection, only when that connection sends a `bus:register` frame (`agentmux-srv/src/server/websocket.rs:373-380`) — something only an actual agent CLI process does on its own out-of-band connection. The Armory pane's WebSocket (`TabRpcClient` / the shared per-window `globalWS`, `frontend/app/store/rpc-util.ts`) is the ordinary human/CEF dashboard connection and **never** sends `bus:register` — grepped the entire `frontend/` tree, zero matches outside a manual test harness script. So `ctx.agent_id` is permanently empty for every RPC call the Armory ever makes, and `check_s1` rejects the bind request before `wstore.skill_bind(...)` (the actual DB write, `skill.rs:209`) is ever reached.
+
+**This is a design/wiring gap, not a data bug.** No DB schema mismatch, no wrong column, no swallowed error — the write path (`Store::skill_bind`, `skills.rs:355-363`, `INSERT OR IGNORE INTO db_agent_skills_ref`) and the read-back path (`skill_list_global`'s `bound_count`) both correctly agree on parameter names and would work fine *if the write ever ran*.
+
+### 2.3 Why this exists — `skill.bind` was built for a different caller
+
+`skill.rs`'s own header comment says the plain (non-catalog) commands are "Agent-scoped" — i.e. `skill.bind`/`skill.unbind` were designed for an **agent to bind a skill to itself**, over its own authenticated MCP/agent connection (the same trust model the catalog commands explicitly opt out of: *"skill.catalog.*: … no `check_s1` (mirrors bundle.* auth shape, since the Armory has no agent connection context to gate on")*). No REST route or `agentmux-mcp` tool wraps `skill.bind` either (grepped `agentmux-mcp/src/main.rs` and the REST router — no matches), so as designed, `skill.bind` was likely never reachable from anywhere except a hand-authenticated test harness.
+
+The Armory's catalog-side "Bind to agent" UI (button, `bindToAgent()`, the agent-picker dropdown) was added by a later PR extending the catalog surface (`skill-model.ts:62`'s own comment: `// Catalog-side bind action (#1960 gap #3)`) — but it was wired to call the pre-existing agent-scoped `skill.bind` command instead of a catalog-safe equivalent. The gate that makes sense for "an agent binds a skill to itself" was never relaxed (or forked) for "a human clicks Bind in the dashboard" — so the feature has been unreachable since the button was added.
+
+**The identical bug affects MCP Servers' bind, by the same construction** (`mcp.rs`'s `register_mcp_bind` calls the same `check_s1` at the same call depth, added and catalog-wired in the same two PRs as Skills) — flagged here for awareness since it's the same root cause, but **out of scope for this fix**; the user asked specifically about Skills. Worth a follow-up once this pattern is proven out.
+
+### 2.4 Recommended fix
+
+Add a **catalog-scoped bind command**, mirroring the existing `skill.catalog.list/upsert/delete` trust tier exactly (no `agent_id` context to check, no `check_s1`) rather than loosening the existing `skill.bind`'s `check_s1` gate:
+
+- `agentmux-srv/src/backend/rpc_types/commands.rs`: new `COMMAND_SKILL_CATALOG_BIND = "skill.catalog.bind"`.
+- `agentmux-srv/src/server/app_api/skill.rs`: new `register_skill_catalog_bind`, same handler body as `register_skill_bind` minus the `check_s1` call (keep the existing "only global skills, or already-bound ones, may be bound" safety check — that's an ownership/data-integrity rule, unrelated to the auth gate being removed).
+- `frontend/app/store/rpc-api/skill.ts`: new `SkillCatalogBindCommand`.
+- `frontend/app/view/skill/skill-model.ts:112`: `bindToAgent` calls the new command instead of `SkillBindCommand`.
+
+**Why a new command instead of just removing `check_s1` from `skill.bind`:** `skill.bind` may still be the intended future surface for an agent binding a skill to *itself* (self-service), and its `check_s1` gate (same-agent-only) is a real, meaningful restriction for that caller — removing it would silently widen what an authenticated agent connection can do (bind arbitrary skills to *other* agent ids), a security-relevant change nobody asked for. A catalog-tier sibling command is the same pattern already established for list/upsert/delete, costs one small mirrored handler, and leaves the existing command's contract untouched.
+
+**Unbind:** the Armory's Skills catalog view currently has no "Unbind" affordance at all (confirmed reading `skill-manager.tsx` — only a Bind button and dropdown, no per-agent bound-list to unbind from) — so there is nothing to fix on the unbind side to make the currently-exposed UI work. Not adding one here; flagged as a possible small follow-up, not part of "binding is not working."
+
+## 3. Suggested implementation order
+
+1. Backend: `commands.rs` constant + `skill.rs` handler (small, additive, no existing behavior changed).
+2. Frontend: `rpc-api/skill.ts` command wrapper + `skill-model.ts` call-site swap.
+3. Frontend: `skill-manager.tsx` + `AgentSkillsModal.tsx` — `<pre>` → `<Markdown text={...} scrollable={false} />` for `content` only, in both files.
+4. Verify live: re-run the exact CDP repro from §2.1 and confirm Bind now succeeds and `bound_count`/"Used by N agents" updates; visually confirm Markdown renders (headings, bold, numbered list) in both the Armory and per-agent Skills detail views.
+
+## File/line reference table
+
+| Concern | File | Line(s) |
+|---|---|---|
+| Armory Skills detail view — plain-text render | `frontend/app/view/skill/skill-manager.tsx` | 75-84 |
+| Per-agent Skills detail view — same bug | `frontend/app/view/agent/components/AgentSkillsModal.tsx` | 107-116 |
+| Markdown component to reuse | `frontend/app/element/markdown.tsx` | 67-75 (props), exported component |
+| Bind button / call site | `frontend/app/view/skill/skill-manager.tsx` | 97-103 |
+| `bindToAgent` view-model method | `frontend/app/view/skill/skill-model.ts` | 105-117 |
+| `SkillBindCommand` RPC wrapper | `frontend/app/store/rpc-api/skill.ts` | 47-53 |
+| `register_skill_bind` handler (the `check_s1` failure site) | `agentmux-srv/src/server/app_api/skill.rs` | 182-215 |
+| `check_s1` definition | `agentmux-srv/src/server/app_api/mod.rs` | ~856-864 |
+| `bus:register` — the only thing that ever sets `ctx.agent_id` | `agentmux-srv/src/server/websocket.rs` | 373-380 |
+| Catalog commands' existing no-`check_s1` precedent | `agentmux-srv/src/server/app_api/skill.rs` | 237-351 (list/upsert/delete) |
+| DB write (confirmed correct, never reached) | `agentmux-srv/src/backend/storage/skills.rs` | 355-363 |
+| MCP Servers has the identical bug (not in scope here) | `agentmux-srv/src/server/app_api/mcp.rs` | ~190-223 |

--- a/frontend/app/element/ModalLayer.tsx
+++ b/frontend/app/element/ModalLayer.tsx
@@ -54,6 +54,22 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
         if (!submitting()) setCurrent(null);
     };
 
+    // Pure browse/view modals have no in-flight submit or form input a
+    // backdrop click could destroy, unlike the form-like kinds this guard
+    // exists for (launch/install/create-from-template/agent-prereqs/
+    // add-account/new-memory) — so clicking outside should just close
+    // them, like any other dismissible overlay.
+    //
+    // "agent-setup" is the per-agent Accounts/Memories/MCP Servers/Skills
+    // modal — renamed to "agent-stash" by the not-yet-merged
+    // agent3/agent-armory-rename-stash branch (PR #2314); update this key
+    // when that lands.
+    const BACKDROP_DISMISSIBLE_KINDS = new Set<ModalLayerRequest["kind"]>(["agent-setup"]);
+    const closeOnBackdropClick = createMemo(() => {
+        const kind = current()?.kind;
+        return kind != null && BACKDROP_DISMISSIBLE_KINDS.has(kind);
+    });
+
     const api: ModalLayerApi = {
         open: (req) => { setSubmitting(false); setCurrent(req); },
         replace: (next) => {
@@ -110,7 +126,7 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
                         open={current() != null}
                         scope={props.scope}
                         onClose={safeClose}
-                        closeOnBackdropClick={false}
+                        closeOnBackdropClick={closeOnBackdropClick()}
                         size="fit"
                         ariaLabel={modalLabel()}
                     >

--- a/frontend/app/element/ModalLayer.tsx
+++ b/frontend/app/element/ModalLayer.tsx
@@ -68,14 +68,22 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
 
     // "agent-setup" is only SOMETIMES pure browse/view, though — its own
     // Skills/MCP Servers tabs (AgentSkillsModal/AgentMcpModal) can be
-    // showing a "+ New"/edit draft form with local, un-tracked-by-
-    // `submitting` state (reagentx P1, PR #2315: an accidental backdrop
-    // click while composing a new entry silently discarded it). Rather
-    // than threading a bespoke "has unsaved draft" signal down through
-    // every current and future primitive tab, key off the one thing they
-    // already all share: every create/edit form in this family renders
-    // with the `agent-primitive-modal-form` class (skill-manager.tsx,
-    // mcp-manager.tsx, AgentSkillsModal.tsx, AgentMcpModal.tsx).
+    // showing a "+ New"/edit draft form, and its Memory tab
+    // (AgentNativeMemoryModal) an in-place edit textarea — all local
+    // draft state never tracked by the `submitting` guard (reagentx P1
+    // x2, PR #2315: an accidental backdrop click while composing a new
+    // entry, or editing a memory file, silently discarded it — the
+    // second finding specifically because the first fix's detector only
+    // matched the `agent-primitive-modal-form` class the Skills/MCP forms
+    // share, which the older Memory tab's edit view predates and doesn't
+    // use). Rather than keep chasing one component's specific markup at a
+    // time, key off what every one of these editable surfaces actually
+    // *is* regardless of which primitive owns it: a `<textarea>` — the
+    // only editable-surface kind in this whole modal that can hold
+    // enough free text for losing it to matter (Accounts/Startup are
+    // read-only/selection-only; Skills/MCP/Memory's name/trigger fields
+    // are plain `<input>`s not worth guarding, but their multi-line
+    // content fields, and Memory's whole edit view, are all textareas).
     //
     // Scoped to `.modal-root`'s own subtree via `<Modal>`'s `rootRef`
     // callback below — NOT `mountEl`, which also wraps `props.children`
@@ -94,7 +102,7 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
             setHasOpenForm(false);
             return;
         }
-        const recompute = () => setHasOpenForm(root.querySelector(".agent-primitive-modal-form") != null);
+        const recompute = () => setHasOpenForm(root.querySelector("textarea:not([readonly]):not([disabled])") != null);
         recompute();
         const observer = new MutationObserver(recompute);
         observer.observe(root, { childList: true, subtree: true });

--- a/frontend/app/element/ModalLayer.tsx
+++ b/frontend/app/element/ModalLayer.tsx
@@ -10,7 +10,7 @@
  * ESC is blocked while a submit RPC is in-flight (`safeClose` guard).
  */
 
-import { createMemo, createSignal, Show, type Component, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, onCleanup, Show, type Component, type JSX } from "solid-js";
 
 import { Modal, PaneModalScope, TabModalScope } from "@/element/modal";
 import { ModalLayerContext, type ModalLayerApi, type ModalLayerRequest } from "./modal-layer";
@@ -65,9 +65,45 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
     // agent3/agent-armory-rename-stash branch (PR #2314); update this key
     // when that lands.
     const BACKDROP_DISMISSIBLE_KINDS = new Set<ModalLayerRequest["kind"]>(["agent-setup"]);
+
+    // "agent-setup" is only SOMETIMES pure browse/view, though — its own
+    // Skills/MCP Servers tabs (AgentSkillsModal/AgentMcpModal) can be
+    // showing a "+ New"/edit draft form with local, un-tracked-by-
+    // `submitting` state (reagentx P1, PR #2315: an accidental backdrop
+    // click while composing a new entry silently discarded it). Rather
+    // than threading a bespoke "has unsaved draft" signal down through
+    // every current and future primitive tab, key off the one thing they
+    // already all share: every create/edit form in this family renders
+    // with the `agent-primitive-modal-form` class (skill-manager.tsx,
+    // mcp-manager.tsx, AgentSkillsModal.tsx, AgentMcpModal.tsx).
+    //
+    // Scoped to `.modal-root`'s own subtree via `<Modal>`'s `rootRef`
+    // callback below — NOT `mountEl`, which also wraps `props.children`
+    // (the underlying pane's own live content, e.g. a streaming agent
+    // chat mutating constantly); a subtree-wide observer on `mountEl`
+    // would re-scan on every token of unrelated pane activity. `rootRef`
+    // gives the exact node `<Portal>` renders `.modal-root` into (not
+    // necessarily `mountEl`'s direct child — confirmed live it isn't),
+    // so this bounds the scan to just the modal panel's own size and
+    // needs no DOM-structure guessing.
+    const [modalRootEl, setModalRootEl] = createSignal<HTMLDivElement | null>(null);
+    const [hasOpenForm, setHasOpenForm] = createSignal(false);
+    createEffect(() => {
+        const root = modalRootEl();
+        if (!root) {
+            setHasOpenForm(false);
+            return;
+        }
+        const recompute = () => setHasOpenForm(root.querySelector(".agent-primitive-modal-form") != null);
+        recompute();
+        const observer = new MutationObserver(recompute);
+        observer.observe(root, { childList: true, subtree: true });
+        onCleanup(() => observer.disconnect());
+    });
+
     const closeOnBackdropClick = createMemo(() => {
         const kind = current()?.kind;
-        return kind != null && BACKDROP_DISMISSIBLE_KINDS.has(kind);
+        return kind != null && BACKDROP_DISMISSIBLE_KINDS.has(kind) && !hasOpenForm();
     });
 
     const api: ModalLayerApi = {
@@ -127,6 +163,7 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
                         scope={props.scope}
                         onClose={safeClose}
                         closeOnBackdropClick={closeOnBackdropClick()}
+                        rootRef={setModalRootEl}
                         size="fit"
                         ariaLabel={modalLabel()}
                     >

--- a/frontend/app/element/modal.tsx
+++ b/frontend/app/element/modal.tsx
@@ -180,6 +180,13 @@ export interface ModalProps {
     ariaDescribedBy?: string;
     /** Element (or accessor) to focus on open. Defaults to the first focusable. */
     initialFocus?: HTMLElement | (() => HTMLElement | null);
+    /** Called with the mounted `.modal-root` element (and `null` on unmount).
+     *  For a caller that needs to observe/query the modal's own rendered
+     *  content directly — e.g. ModalLayer's backdrop-dismissibility check —
+     *  without assuming exactly where in the DOM tree `<Portal>` places it
+     *  relative to whatever ref the caller already holds (it's not always a
+     *  direct child — Portal/Show wrapping can interpose nodes). */
+    rootRef?: (el: HTMLDivElement | null) => void;
     children: JSX.Element;
 }
 
@@ -376,7 +383,11 @@ export const Modal: Component<ModalProps> = (props) => {
                 <Portal mount={mount()}>
                     <ModalTitleIdContext.Provider value={defaultTitleId}>
                         <div
-                            ref={rootRef}
+                            ref={(el) => {
+                                rootRef = el;
+                                props.rootRef?.(el);
+                                onCleanup(() => props.rootRef?.(null));
+                            }}
                             class="modal-root"
                             data-scope={resolvedScope()}
                             data-placement={props.placement ?? "center"}

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -102,4 +102,16 @@ export const SkillApi = {
     ): Promise<{ deleted: boolean }> {
         return client.rpcCall("skill.catalog.delete", data, opts);
     },
+
+    // Catalog-tier sibling of SkillBindCommand — no agent_id/check_s1 gate,
+    // since the Armory's connection is never agent-authenticated and can
+    // never satisfy SkillBindCommand's check_s1. See
+    // docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
+    SkillCatalogBindCommand(
+        client: RpcClient,
+        data: { agent_id: string; skill_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ bound: boolean }> {
+        return client.rpcCall("skill.catalog.bind", data, opts);
+    },
 };

--- a/frontend/app/view/agent/components/AgentPrimitiveModal.scss
+++ b/frontend/app/view/agent/components/AgentPrimitiveModal.scss
@@ -153,6 +153,18 @@
     white-space: pre-wrap;
     overflow-wrap: break-word;
     background: var(--panel-bg-color);
+
+    // Skill "Content" is rendered via <Markdown>, not raw text — the base
+    // class's monospace/pre-wrap treatment is for plain-text fields
+    // (description/trigger) and would double-space Markdown's own
+    // paragraph/list/code-block layout instead of rendering it. The
+    // <Markdown> component supplies its own typography; this variant keeps
+    // only the shared field box (padding/background) around it. See
+    // docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
+    &--markdown {
+        font-family: inherit;
+        white-space: normal;
+    }
 }
 
 .agent-primitive-modal-bind-row {

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -12,6 +12,7 @@
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
+import { Markdown } from "@/app/element/markdown";
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { openOrFocusPaneByView } from "@/app/store/global";
 import { AgentSkillModel } from "../agent-skill-model";
@@ -113,7 +114,14 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                             <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
                                         </Show>
                                         <span class="agent-primitive-modal-field-label">Content</span>
-                                        <pre class="agent-primitive-modal-field-value">{skill().content || "(none)"}</pre>
+                                        <Show
+                                            when={skill().content}
+                                            fallback={<pre class="agent-primitive-modal-field-value">(none)</pre>}
+                                        >
+                                            <div class="agent-primitive-modal-field-value agent-primitive-modal-field-value--markdown">
+                                                <Markdown text={skill().content} scrollable={false} />
+                                            </div>
+                                        </Show>
                                         <div class="agent-primitive-modal-actions">
                                             <Show
                                                 when={!skill().is_global}

--- a/frontend/app/view/skill/skill-manager.tsx
+++ b/frontend/app/view/skill/skill-manager.tsx
@@ -10,6 +10,7 @@
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
+import { Markdown } from "@/app/element/markdown";
 import { PrimitiveListDetail } from "@/app/element/primitive-list-detail";
 import { SkillCatalogModel } from "./skill-model";
 import "../agent/components/AgentPrimitiveModal.scss";
@@ -81,7 +82,14 @@ export const SkillManager = (): JSX.Element => {
                                             <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
                                         </Show>
                                         <span class="agent-primitive-modal-field-label">Content</span>
-                                        <pre class="agent-primitive-modal-field-value">{skill().content || "(none)"}</pre>
+                                        <Show
+                                            when={skill().content}
+                                            fallback={<pre class="agent-primitive-modal-field-value">(none)</pre>}
+                                        >
+                                            <div class="agent-primitive-modal-field-value agent-primitive-modal-field-value--markdown">
+                                                <Markdown text={skill().content} scrollable={false} />
+                                            </div>
+                                        </Show>
                                         <span class="agent-primitive-modal-field-label">Bind to agent</span>
                                         <div class="agent-primitive-modal-bind-row">
                                             <select

--- a/frontend/app/view/skill/skill-model.ts
+++ b/frontend/app/view/skill/skill-model.ts
@@ -3,11 +3,13 @@
 
 /**
  * SkillCatalogModel — view model for the Armory's Skills tab. Drives list +
- * create/edit/delete over the window-scoped `skill.catalog.*` App API
- * (agentmux-srv/src/server/app_api/skill.rs). Every row here is global by
- * construction — the catalog only ever lists/creates/edits is_global rows.
- * Per-agent private skills and bind/unbind live in the Agent-setup modal
- * (AgentSkillModel), not here.
+ * create/edit/delete, plus binding a global skill to an agent, over the
+ * window-scoped `skill.catalog.*` App API
+ * (agentmux-srv/src/server/app_api/skill.rs) — no `agent_id`/`check_s1`
+ * context, since the Armory's connection is never agent-authenticated.
+ * Every row here is global by construction — the catalog only ever
+ * lists/creates/edits is_global rows. Per-agent private skills, and
+ * unbinding, live in the Agent-setup modal (AgentSkillModel), not here.
  */
 
 import { createMemo, createSignal, type Accessor } from "solid-js";
@@ -109,7 +111,7 @@ export class SkillCatalogModel {
         }
         this.setError(null);
         try {
-            await RpcApi.SkillBindCommand(TabRpcClient, { agent_id: agentId, skill_id: skillId });
+            await RpcApi.SkillCatalogBindCommand(TabRpcClient, { agent_id: agentId, skill_id: skillId });
             await this.refresh();
         } catch (e) {
             this.setError(`Bind failed: ${(e as Error).message ?? e}`);


### PR DESCRIPTION
## Summary
- **Skill content → Markdown**: the Armory's Skills tab and the per-agent Skills tab (`AgentSkillsModal`) both rendered `content` via a raw `<pre>`. Swapped to the existing `<Markdown>` component (`frontend/app/element/markdown.tsx` — already used for agent chat/editor/tool output, no new dependency), scoped to `content` only (`description`/`trigger` are single-line inputs, left as plain text).
- **"Bind to agent" fixed** — live-verified via CDP against a running dev build, this previously failed 100% of the time with `Bind failed: FORBIDDEN: unauthenticated agent connection`. Root cause: `skill.bind` is `check_s1`-gated (requires the calling WebSocket to be an authenticated agent connection via `bus:register`), but the Armory dashboard's connection never authenticates as an agent. Added `skill.catalog.bind`, a `check_s1`-free sibling mirroring the existing `skill.catalog.list/upsert/delete` trust tier, and repointed the Armory's Bind action to it. `skill.bind` itself is untouched.
- **Bonus, batched in per request**: pane modals dispatched via `ModalLayer` now close on backdrop click when they carry no in-flight form/submit state to lose (currently just the per-agent Stash/setup modal) — previously every `ModalLayer`-hosted modal hardcoded `closeOnBackdropClick={false}` regardless of whether it was an actual form or a pure browse/view surface.

Full investigation + root-cause writeup: `docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md`.

**Known follow-up, not fixed here**: MCP Servers' catalog bind has the identical `check_s1` root cause (same originating PR introduced both) — flagged in the report, out of scope for this PR since only Skills was asked for.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx stylelint` on the touched scss — clean
- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv` — 1657/1657 (2 pre-existing, unrelated `agent_session` tests flake under parallel execution; pass cleanly in isolation, unrelated to this diff)
- [x] `npx vitest run app/view/skill app/view/agent app/element` — 769 passed
- [x] Live-verified via CDP against a running `task dev` build: clicked Bind on a real skill → "Used by 1 agent" (was 0, no error), and visually confirmed heading/bold/link/ordered-list Markdown rendering in the Content field
- [ ] Manual: same live check for the per-agent Skills tab (AgentSkillsModal) Markdown rendering

<!-- agentmux:agent_id=agent3 -->