### PR TITLE
fix(warden): decouple container-query context from scrolling pane; send auth on LAN fetch

### DIFF
--- a/.changesets/1785133835-fix-warden-decouple-container-query-context-from-the-scrolli-h1lb.md
+++ b/.changesets/1785133835-fix-warden-decouple-container-query-context-from-the-scrolli-h1lb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(warden): decouple container-query context from the scrolling pane; send auth on LAN fetch

--- a/docs/retro/retro-warden-pane-black-render-2026-07-27.md
+++ b/docs/retro/retro-warden-pane-black-render-2026-07-27.md
@@ -1,0 +1,56 @@
+# Retro: Warden pane renders as a solid black area
+
+**Date:** 2026-07-27
+**Severity:** Medium (one widget unusable while the state persists — no data loss, no crash)
+**Area:** Renderer/compositor state, NOT Warden's own code (see §4 — Warden's DOM was proven healthy while the pane showed black)
+**Status:** Symptom resolved live (pane renders again, screenshot-verified). Root cause narrowed to a sticky renderer/rasterization condition, cleared by a full page reload; the precise trigger remains unproven. Two genuinely-broken things found and fixed/flagged along the way.
+
+---
+
+## 1. What the user saw
+
+> "figure out why the warden pane is rendering as just a black pane .. it used to work"
+
+Reproduced live in a `task dev` instance (branch `main` @ `38978e6b`, channel `dev-main-a68420d74efcd632`). The black state **persisted across closing and re-creating the Warden pane** (two different block ids, `a30c3719…` then `5be72106…`, both black) but **was cleared by a full renderer page reload** (triggered incidentally by Vite full-reloads during this investigation). After the reloads, the pane rendered correctly under BOTH the old and new CSS (see §5), and could no longer be re-broken on demand.
+
+---
+
+## 2. Investigation method
+
+This was diagnosed live against the running instance, in escalating steps, each eliminating a layer:
+
+1. **Host-log sweep** — no `block-error-boundary` catches anywhere in the session: Warden never crashed. (`BlockErrorBoundary` forwards every pane crash to the host log; zero entries.)
+2. **Settings/transparency audit** — the instance runs opaque (`window_transparent=0` in the renderer URL; `window:transparent` unset in its `settings.json`), ruling out the known first-paint-alpha/tile-bake issue documented in `theme.scss`.
+3. **In-app DOM instrumentation** — temporary `[warden-diag]` logging added to `WardenView` (geometry, computed styles up 12 ancestors, `elementsFromPoint` at pane center). Result, while the user was seeing black: **the DOM was perfectly healthy** — `.warden-container` laid out at 1060×1042, every ancestor `visible`/`opacity: 1`/no transform/no filter, and `elementsFromPoint` at the pane's center returned `.warden-pane` itself as the topmost DOM element. Nothing in the DOM was covering it, and the content genuinely existed.
+4. **Native HWND enumeration** (PowerShell `EnumWindows`/`EnumChildWindows` against the host PID) — the visible window contains only its own `Chrome_RenderWidgetHostHWND` + `Intermediate D3D Window`; all pooled windows (`floating-pool-*`, `window-pool-*`) are parked far off-screen at (-25600,…)/(-26214,…) and invisible. **No native surface covers the pane** — ruling out the browser-pane/pane-pool airspace theory.
+5. **Pixel capture** (`PrintWindow` with `PW_RENDERFULLCONTENT`) — after the investigation's incidental page reloads, the pane **renders correctly**: header, Host section, LAN section, Internet section all painted. Screenshot-verified twice (with and without the diagnostics code).
+
+## 3. Falsification test — the first hypothesis was WRONG
+
+The initially-promising lead: at the moment the first Warden block was created (03:59:07), the host log recorded a burst of **18 consecutive** `ResizeObserver loop completed with undelivered notifications` errors within ~300ms — the only uncaught error type in the whole session, appearing nowhere else. `.warden-pane` was also the only pane in the codebase combining `container-type: inline-size` with `overflow: auto` on the same element (every sibling — Armory, Settings, agent setup modal — uses a dedicated non-scrolling wrapper, a convention `armory-view.scss` explicitly documents; `.agent-view` uses `overflow: hidden`). Scrollbar↔container-query feedback is a textbook resize-loop trigger.
+
+A wrapper fix was applied and the pane rendered — but to prove causality rather than assume it, the fix was then **reverted to the original broken CSS and the window reloaded: the pane still rendered correctly.** The CSS combination is therefore NOT the root cause of the black pane. (It IS a real defect: with the wrapper in place, the ResizeObserver bursts drop from 18-per-creation to zero. The wrapper fix is kept as convention/hygiene hardening, with comments that are explicit about what it does and doesn't fix.)
+
+## 4. Where the evidence actually points
+
+Assembled facts:
+
+- The black state **survives pane destruction and re-creation** (fresh block id, fresh SolidJS component tree, fresh DOM subtree — still black), so it is not per-component state.
+- While black, the pane's DOM is **fully laid out, visible, and topmost** — so the failure is strictly in turning that DOM into pixels: rasterization/compositing.
+- A **full renderer page reload clears it** — consistent with discarding the renderer's compositor/tile state wholesale.
+- No native window covers the area; no GPU-process crash entries in the host log.
+- Context at the time it broke: the machine was under **severe commit pressure** — `mem_attribution` shows 68–75GB used of a 78.6GB commit limit through the session, and the in-app memory-pressure banner (`memory-pressure-banner--warn`) was actively mounted. This repo has an **open GPU-memory investigation** (#2218, `SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md` landed dev-only GPU trace commands for exactly this class of problem), and `SPEC_CEF_SANDBOX_2026_06_20.md` already documents "browser panes go black" as a known failure mode when GPU resources misbehave.
+
+The best-supported conclusion: **a Chromium compositor/raster failure — most plausibly GPU-memory-pressure-induced — left the tile(s) for that layout region un-rasterized (black), and the condition was sticky at the renderer level until a full reload rebuilt the compositor tree.** Warden was the victim, not the culprit: it happened to be the newly-created layer when resources were exhausted. This also cleanly explains "it used to work" — nothing in Warden changed since June 24; what changed was the machine/GPU-memory conditions (and possibly ambient GPU memory cost from the recent feature growth that #2218 is already tracking).
+
+Not proven: a deterministic reproduction. The state could not be re-triggered on demand once cleared, so this stops at "strongly indicated" rather than "reproduced under controlled conditions."
+
+## 5. Fixes and findings shipped from this investigation
+
+1. **`warden.tsx`/`warden.scss` — container-query context moved to a dedicated non-scrolling `.warden-container` wrapper** (matching the documented Armory/Settings convention). Not the black-pane cause (§3), but it eliminates a real, measured ResizeObserver loop burst (18→0 per pane creation) and removes the codebase's only remaining `container-type`+`overflow: auto` same-element combination.
+2. **Found in passing and fixed — Warden's LAN section has 401'd since the day it shipped.** Visible in the working pane's LAN section: `⚠ Error: warden: GET /api/lan-instances → 401`. `warden.tsx`'s comment claimed the route is public ("no auth required") and sent no auth header — but `/api/lan-instances` sits in `authed_routes` (`server/mod.rs`), and the 2026-05-11 security audit (which removed all unauthenticated localhost routes, enforced by `auth_middleware`'s header-only check) predates the LAN section's ship date (~May 25). Not a recent server regression: the comment was wrong from birth and the fetch never once succeeded. Fixed by sending `authedHeaders()` from `fetchLanPeers`, matching what the Host section always did.
+
+## 6. Follow-ups
+
+- **Feed this incident to the #2218 GPU-memory investigation** — a concrete, user-visible "pane rasterizes black under commit pressure, sticky until reload" data point, with the DOM-healthy/native-clear/reload-fixes evidence chain above. The new dev-only GPU trace commands (`gpu_trace.rs`) are the right tool if it recurs; capture a trace BEFORE reloading next time.
+- If a pane goes black again: don't reload immediately. Run the checklist from §2 (it's fast): error-boundary grep → `elementsFromPoint` via a diag build or DevTools → native HWND enum → `PrintWindow` capture → GPU trace. The reload destroys the evidence.

--- a/frontend/app/view/warden/warden.scss
+++ b/frontend/app/view/warden/warden.scss
@@ -3,6 +3,26 @@
 //
 // Warden widget shell. Spec: specs/SPEC_WARDEN_WIDGET_2026-05-25.md
 
+// Container wrapper — carries container-type so the @container warden
+// queries below evaluate against a NON-scrolling element (same technique
+// as armory-view.scss's .armory-container / settings.scss's
+// .settings-container). Putting container-type on the scrolling
+// .warden-pane itself produced a real resize feedback loop: content
+// growth toggles the auto scrollbar, which changes the pane's inline
+// size, which re-evaluates the container query, which reflows content —
+// observed live as a burst of 18 "ResizeObserver loop completed with
+// undelivered notifications" errors at pane creation (zero after this
+// split). NOTE: this was NOT the cause of the 2026-07-27 black-pane
+// incident (disproven by falsification test) — it's convention/hygiene
+// hardening found during that investigation. See
+// docs/retro/retro-warden-pane-black-render-2026-07-27.md.
+.warden-container {
+    width: 100%;
+    height: 100%;
+    container-type: inline-size;
+    container-name: warden;
+}
+
 .warden-pane {
     display: flex;
     flex-direction: column;
@@ -11,8 +31,6 @@
     background: var(--main-bg-color);
     font-size: 13px;
     overflow: auto;
-    container-type: inline-size;
-    container-name: warden;
 }
 
 .warden-header {

--- a/frontend/app/view/warden/warden.tsx
+++ b/frontend/app/view/warden/warden.tsx
@@ -287,8 +287,15 @@ interface LanPeer {
 }
 
 async function fetchLanPeers(): Promise<LanPeer[]> {
-    // /api/lan-instances is a public route (no auth required).
-    const resp = await fetch(getWebServerEndpoint() + "/api/lan-instances");
+    // /api/lan-instances sits in `authed_routes` (server/mod.rs) like every
+    // other HTTP route — the 2026-05-11 audit removed all unauthenticated
+    // localhost routes, which predates this section. The original "public
+    // route (no auth required)" comment here was wrong from the start, so
+    // this fetch 401'd from the day it shipped (visible as the LAN
+    // section's inline "GET /api/lan-instances → 401" error).
+    const resp = await fetch(getWebServerEndpoint() + "/api/lan-instances", {
+        headers: authedHeaders(),
+    });
     if (!resp.ok) {
         throw new Error(`warden: GET /api/lan-instances → ${resp.status}`);
     }
@@ -419,29 +426,37 @@ const SECTIONS: LayerSection[] = [
 ];
 
 function WardenView({ model: _model }: { model: WardenViewModel }): JSX.Element {
+    // .warden-container carries the container-query context; .warden-pane
+    // scrolls. Keeping those on separate elements avoids a scrollbar <->
+    // container-query resize feedback loop (observed live as ResizeObserver
+    // loop errors at pane creation) — see warden.scss's comment and
+    // docs/retro/retro-warden-pane-black-render-2026-07-27.md for why this
+    // was hygiene hardening, not the black-pane root cause.
     return (
-        <div class="warden-pane">
-            <header class="warden-header">
-                <span class="warden-title">Warden</span>
-                <span class="warden-subtitle">3-layer operator surface</span>
-            </header>
-            <div class="warden-sections">
-                <For each={SECTIONS}>
-                    {(section) => (
-                        <section
-                            class="warden-section"
-                            data-status={section.status}
-                            data-layer={section.key}
-                        >
-                            <header class="warden-section-header">
-                                <span class="warden-section-title">{section.title}</span>
-                                <span class="warden-section-summary">{section.summary}</span>
-                                <span class="warden-section-status">{section.status}</span>
-                            </header>
-                            <div class="warden-section-body">{section.render()}</div>
-                        </section>
-                    )}
-                </For>
+        <div class="warden-container">
+            <div class="warden-pane">
+                <header class="warden-header">
+                    <span class="warden-title">Warden</span>
+                    <span class="warden-subtitle">3-layer operator surface</span>
+                </header>
+                <div class="warden-sections">
+                    <For each={SECTIONS}>
+                        {(section) => (
+                            <section
+                                class="warden-section"
+                                data-status={section.status}
+                                data-layer={section.key}
+                            >
+                                <header class="warden-section-header">
+                                    <span class="warden-section-title">{section.title}</span>
+                                    <span class="warden-section-summary">{section.summary}</span>
+                                    <span class="warden-section-status">{section.status}</span>
+                                </header>
+                                <div class="warden-section-body">{section.render()}</div>
+                            </section>
+                        )}
+                    </For>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

Investigation + fixes for a user report of the Warden pane rendering as a solid black area in a `task dev` instance. Full evidence chain: `docs/retro/retro-warden-pane-black-render-2026-07-27.md`.

**The black pane itself was NOT a Warden bug.** Live diagnosis (in-app DOM instrumentation, native HWND enumeration, `PrintWindow` pixel captures) proved the pane's DOM was fully laid out, visible, and topmost while showing black, with no native surface covering it — and a falsification test (reverting the CSS fix below and reloading) rendered fine, disproving the initial CSS hypothesis. The condition was a sticky renderer/rasterization failure under severe commit pressure (68–75GB of a 78.6GB limit; the in-app memory-pressure banner was actively showing), cleared only by a full page reload, and it survived pane re-creation. The retro documents this as a data point for the #2218 GPU-memory investigation, including a capture-before-reload checklist so the evidence isn't destroyed next time.

## Changes

- **`warden.scss`/`warden.tsx` — container-query context moved to a dedicated non-scrolling `.warden-container` wrapper.** `.warden-pane` was the only element in the codebase combining `container-type: inline-size` with `overflow: auto` — every other consumer (armory, settings, agent-setup modal) uses the wrapper convention `armory-view.scss` documents. The same-element combination produced a real, measured resize feedback loop: a burst of 18 `ResizeObserver loop completed with undelivered notifications` per pane creation, zero after the split. Code comments are explicit that this is convention/hygiene hardening, not the black-pane root cause.
- **`warden.tsx` — LAN section now sends `authedHeaders()` on `GET /api/lan-instances`.** The route has required `X-AuthKey` since the 2026-05-11 security audit, which predates the LAN section's ship date — its "public route (no auth required)" comment was wrong from birth, so the fetch has silently 401'd since day one (visible as an inline `→ 401` error in the section).
- **`docs/retro/retro-warden-pane-black-render-2026-07-27.md`** — the incident retro, including the disproven-hypothesis trail and follow-ups.

## Test plan

- [x] Live-verified in the running `dev-main` instance via `PrintWindow` captures: Warden renders all three sections with the wrapper fix in place.
- [x] Falsification test: old CSS restored + reload → still renders (documented in retro §3).
- [x] LAN 401 fix live-verified: the inline `GET /api/lan-instances → 401` error is gone after the auth header change.
- [x] ResizeObserver loop burst: 18 errors per pane creation before the wrapper split, zero after.

<!-- agentmux:agent_id=agent1 -->
