### PR TITLE
fix(armory): MCP Servers Bind-to-agent — same check_s1 + cross-channel bugs as Skills

### DIFF
--- a/.changesets/1785137808-fix-armory-mcp-servers-bind-to-agent-had-the-same-check-s1-a-h7b9.md
+++ b/.changesets/1785137808-fix-armory-mcp-servers-bind-to-agent-had-the-same-check-s1-a-h7b9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): MCP Servers Bind-to-agent had the same check_s1 auth gap as Skills — fixed identically

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -356,6 +356,13 @@ pub const COMMAND_MCP_CATALOG_LIST: &str = "mcp.catalog.list";
 pub const COMMAND_MCP_CATALOG_UPSERT: &str = "mcp.catalog.upsert";
 pub const COMMAND_MCP_CATALOG_DELETE: &str = "mcp.catalog.delete";
 pub const COMMAND_MCP_CATALOG_PROBE: &str = "mcp.catalog.probe";
+// mcp.bind is check_s1-gated (agent binds a server to itself over its own
+// authenticated connection) — the Armory dashboard's WebSocket never
+// authenticates as an agent, so it can never satisfy that gate. This is the
+// catalog-tier sibling the Armory's "Bind to agent" action actually calls.
+// Same fix as skill.catalog.bind — see
+// docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
+pub const COMMAND_MCP_CATALOG_BIND: &str = "mcp.catalog.bind";
 
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -153,7 +153,6 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// Bind an MCP server to an agent (insert ref row). Idempotent.
     /// Bind an MCP server to an agent (insert ref row). Idempotent —
     /// binding an already-bound pair is a silent no-op success.
     ///

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -154,8 +154,32 @@ impl Store {
     }
 
     /// Bind an MCP server to an agent (insert ref row). Idempotent.
+    /// Bind an MCP server to an agent (insert ref row). Idempotent —
+    /// binding an already-bound pair is a silent no-op success.
+    ///
+    /// Errors if `agent_id` isn't a LOCAL agent definition:
+    /// `db_agent_mcp_ref.agent_id` has an ON-enforced FK to
+    /// `db_agent_definitions(id)` (store.rs), but the Armory's agent
+    /// picker (`ListAgentDefinitionsCommand` → `agent_def_list()`) also
+    /// lists cross-channel agents that only exist in another channel's
+    /// local database. Binding one of those would otherwise have the FK
+    /// silently swallow the `INSERT OR IGNORE` — indistinguishable, by
+    /// affected-row-count alone, from the equally-silent "already bound"
+    /// case — reporting success while creating nothing. Same fix as
+    /// skill_bind — see
+    /// docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
     pub fn mcp_server_bind(&self, agent_id: &str, mcp_id: &str) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        let agent_exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM db_agent_definitions WHERE id = ?1)",
+            params![agent_id],
+            |row| row.get(0),
+        )?;
+        if !agent_exists {
+            return Err(StoreError::Other(format!(
+                "agent {agent_id} not found in this channel's local registry — cross-channel MCP server binding is not supported"
+            )));
+        }
         conn.execute(
             "INSERT OR IGNORE INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES (?1, ?2)",
             params![agent_id, mcp_id],

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -22,6 +22,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_mcp_catalog_upsert(engine, state);
     register_mcp_catalog_delete(engine, state);
     register_mcp_catalog_probe(engine, state);
+    register_mcp_catalog_bind(engine, state);
 }
 
 fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -359,6 +360,52 @@ fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     scopes: vec![], sender: String::new(), persist: 0, data: None,
                 });
                 Ok(Some(serde_json::to_value(&server).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+// Catalog-tier sibling of register_mcp_bind (above) — same DB write and
+// "only global servers may be bound" safety check, but no check_s1: the
+// Armory's WebSocket never authenticates as an agent (see this file's
+// module doc comment), so a check_s1-gated bind can never be satisfied from
+// that caller. mcp.bind itself is left untouched — it may still be the
+// intended surface for an agent binding a server to itself over its own
+// authenticated connection, and loosening its gate would silently widen
+// what any authenticated agent connection can do (bind arbitrary servers to
+// *other* agent ids), which nobody asked for.
+// See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
+fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_BIND,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, mcp_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.catalog.bind: {e}"))?;
+                // Only global servers (or ones already bound) may be bound, so
+                // the catalog surface can't be used to bootstrap read access
+                // to another agent's private server config — same rule as
+                // mcp.bind.
+                match wstore.mcp_server_get(&req.mcp_id)
+                    .map_err(|e| format!("mcp.catalog.bind: {e}"))?
+                {
+                    None => return Err("mcp.catalog.bind: MCP server not found".to_string()),
+                    Some(s) if !s.is_global => {
+                        if !wstore.mcp_server_is_bound_to(&req.agent_id, &req.mcp_id)
+                            .map_err(|e| format!("mcp.catalog.bind: {e}"))?
+                        {
+                            return Err("FORBIDDEN: can only bind global MCP servers".to_string());
+                        }
+                    }
+                    Some(_) => {}
+                }
+                wstore.mcp_server_bind(&req.agent_id, &req.mcp_id)
+                    .map_err(|e| format!("mcp.catalog.bind: {e}"))?;
+                Ok(Some(json!({ "bound": true })))
             })
         }),
     );

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -103,4 +103,16 @@ export const McpApi = {
     ): Promise<McpProbeResult> {
         return client.rpcCall("mcp.catalog.probe", data, opts);
     },
+
+    // Catalog-tier sibling of McpBindCommand — no agent_id/check_s1 gate,
+    // since the Armory's connection is never agent-authenticated and can
+    // never satisfy McpBindCommand's check_s1. See
+    // docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
+    McpCatalogBindCommand(
+        client: RpcClient,
+        data: { agent_id: string; mcp_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ bound: boolean }> {
+        return client.rpcCall("mcp.catalog.bind", data, opts);
+    },
 };

--- a/frontend/app/view/mcp/mcp-model.ts
+++ b/frontend/app/view/mcp/mcp-model.ts
@@ -3,11 +3,13 @@
 
 /**
  * McpCatalogModel — view model for the Armory's MCP Servers tab. Drives
- * list + create/edit/delete over the window-scoped `mcp.catalog.*` App API
- * (agentmux-srv/src/server/app_api/mcp.rs). Every row here is global by
- * construction — the catalog only ever lists/creates/edits is_global rows.
- * Per-agent private servers and bind/unbind live in the Agent-setup modal
- * (AgentMcpModel), not here.
+ * list + create/edit/delete, plus binding a global server to an agent,
+ * over the window-scoped `mcp.catalog.*` App API
+ * (agentmux-srv/src/server/app_api/mcp.rs) — no `agent_id`/`check_s1`
+ * context, since the Armory's connection is never agent-authenticated.
+ * Every row here is global by construction — the catalog only ever
+ * lists/creates/edits is_global rows. Per-agent private servers, and
+ * unbinding, live in the Agent-setup modal (AgentMcpModel), not here.
  */
 
 import { createMemo, createSignal, type Accessor } from "solid-js";
@@ -106,7 +108,7 @@ export class McpCatalogModel {
         }
         this.setError(null);
         try {
-            await RpcApi.McpBindCommand(TabRpcClient, { agent_id: agentId, mcp_id: serverId });
+            await RpcApi.McpCatalogBindCommand(TabRpcClient, { agent_id: agentId, mcp_id: serverId });
             await this.refresh();
         } catch (e) {
             this.setError(`Bind failed: ${(e as Error).message ?? e}`);


### PR DESCRIPTION
## Summary
Follow-up to #2315. MCP Servers' catalog "Bind to agent" had the exact same two bugs Skills had, since both primitives were built and catalog-wired together in the same original PR:

- `mcp.bind` is `check_s1`-gated (agent binds a server to itself over its own authenticated connection), but the Armory dashboard's connection never authenticates as an agent — every catalog bind attempt failed with `FORBIDDEN: unauthenticated agent connection`. Added `mcp.catalog.bind`, a `check_s1`-free sibling mirroring the existing `mcp.catalog.list/upsert/delete/probe` trust tier. `mcp.bind` itself is untouched.
- `mcp_server_bind` now checks `db_agent_definitions` for the agent id first (same as `skill_bind`), so binding a cross-channel-only agent id fails loudly instead of the FK on `db_agent_mcp_ref.agent_id` silently swallowing the insert and reporting success while creating nothing.

Audited for any other bind-shaped commands beyond Skill/MCP (grepped `commands.rs` for BIND/LINK/ASSIGN/ATTACH) — `linkagentidentity` is a different, older handler with no `check_s1` gate at all, never affected. Skill and MCP are the only two.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv` — 1657/1657 passed
- [x] `npx vitest run app/view/mcp app/view/skill app/view/agent app/element` — 769 passed
- [x] Live-verified via CDP against a running dev build: clicked Bind on a real MCP server (`git`) → "Used by 1 agent", no error (previously failed 100% of the time)

<!-- agentmux:agent_id=agent3 -->