### PR TITLE
fix(auth): remove mount-time auto-login trigger, fix login persistence and turn-state races

### DIFF
--- a/.changesets/1785165307-fix-auth-remove-mount-time-auto-login-trigger-fix-login-pers-vozj.md
+++ b/.changesets/1785165307-fix-auth-remove-mount-time-auto-login-trigger-fix-login-pers-vozj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+fix(auth): remove mount-time auto-login trigger, fix login persistence and turn-state races

--- a/.changesets/1785177296-feat-dev-opt-in-isolated-auth-store-for-destructive-armory-t-5v2s.md
+++ b/.changesets/1785177296-feat-dev-opt-in-isolated-auth-store-for-destructive-armory-t-5v2s.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(dev): opt-in isolated auth store for destructive Armory testing (AGENTMUX_ISOLATED_AUTH=1)

--- a/.changesets/1785179340-fix-auth-gate-relogin-opened-tier-success-on-persist-result--k6zw.md
+++ b/.changesets/1785179340-fix-auth-gate-relogin-opened-tier-success-on-persist-result--k6zw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): gate relogin() opened-tier success on persist result, restore Log-in button on failure

--- a/.changesets/1785180769-fix-auth-forcecontrollerrefresh-seeds-termsize-and-reports-c-p61z.md
+++ b/.changesets/1785180769-fix-auth-forcecontrollerrefresh-seeds-termsize-and-reports-c-p61z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): forceControllerRefresh seeds termsize and reports controller status like Phase 3

--- a/.changesets/1785183216-fix-auth-stop-isolated-boot-from-rewriting-the-global-regist-1m4n.md
+++ b/.changesets/1785183216-fix-auth-stop-isolated-boot-from-rewriting-the-global-regist-1m4n.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): stop isolated boot from rewriting the global registry, fix flaky test lock, distinguish confirmed vs unconfirmed auth

--- a/.changesets/1785184148-fix-auth-gate-login-s-opened-tier-success-on-persistandlinka-ztz6.md
+++ b/.changesets/1785184148-fix-auth-gate-login-s-opened-tier-success-on-persistandlinka-ztz6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(auth): gate /login's opened-tier success on persistAndLinkAccount's return, matching relogin()

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -348,8 +348,19 @@ impl DataPaths {
     /// account-wide and version-independent: upgrading agentmux does
     /// not move a user's bundle credentials. Per
     /// `docs/specs/archive/SPEC_OAUTH_IDENTITY_BUNDLES_2026_05_22.md` §4.1.
+    ///
+    /// When [`isolated_auth_enabled`] is set, this resolves to
+    /// `instance_dir/identities/` instead — a channel-scoped credential
+    /// tree for destructive Armory testing (delete-account flows) that
+    /// can never touch the real global identity store other channels/
+    /// instances use. Opt-in only; default behavior above is unchanged.
+    /// See `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`.
     pub fn identities_dir(&self) -> PathBuf {
-        self.shared_dir.join("identities")
+        if isolated_auth_enabled() {
+            self.instance_dir.join("identities")
+        } else {
+            self.shared_dir.join("identities")
+        }
     }
 
     /// `~/.agentmux/shared/identities/<bundle_id>/` — a specific
@@ -386,6 +397,28 @@ impl DataPaths {
     pub fn provider_auth_dir(&self, auth_dir_name: &str) -> PathBuf {
         self.shared_dir.join("providers").join(auth_dir_name)
     }
+}
+
+/// Opt-in flag for isolated per-channel auth (identity accounts + OAuth
+/// credential dirs), for destructive Armory testing (delete-account
+/// flows) that must never touch the real global identity store other
+/// channels/instances depend on. Read directly at every call site
+/// rather than cached on `DataPaths` so `identities_dir()` behaves
+/// consistently regardless of whether the caller built its `DataPaths`
+/// via `resolve()` (launcher) or `from_env()` (downstream host/srv).
+///
+/// Default (unset/false): zero behavior change from today — every
+/// channel/branch/instance shares one global identity store, exactly
+/// as before this flag existed. This is deliberate: re-authenticating
+/// every provider on every branch switch is real daily friction (it's
+/// the whole reason the seed-from-global login tier exists), so
+/// isolation must never be the default.
+///
+/// See `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`.
+pub fn isolated_auth_enabled() -> bool {
+    std::env::var("AGENTMUX_ISOLATED_AUTH")
+        .map(|v| v == "1")
+        .unwrap_or(false)
 }
 
 /// `~/.agentmux/` root, or the test override via
@@ -942,6 +975,71 @@ mod tests {
             assert!(
                 !a.starts_with(&installed.config_dir),
                 "provider auth dir must NOT be under the per-channel config dir"
+            );
+        });
+    }
+
+    /// RAII guard clearing `AGENTMUX_ISOLATED_AUTH` on drop, even on panic —
+    /// mirrors `HomeOverrideGuard` above.
+    struct IsolatedAuthGuard;
+    impl Drop for IsolatedAuthGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+        }
+    }
+
+    #[test]
+    fn identities_dir_is_shared_by_default() {
+        // Flag unset (the default): identical to today — channel/mode-
+        // independent, lives under shared_dir. Contrast case for the
+        // isolated test below; mirrors provider_auth_dir_is_shared_and_
+        // channel_independent's shape.
+        with_home_override(|_root| {
+            clear_channel_env();
+            std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+            let installed = DataPaths::resolve("0.42.0", &RuntimeMode::Installed).unwrap();
+            let dev = DataPaths::resolve(
+                "0.42.0",
+                &RuntimeMode::Dev { branch: "some-branch".into(), clone_id: None },
+            )
+            .unwrap();
+
+            assert_eq!(
+                installed.identities_dir(),
+                dev.identities_dir(),
+                "identities_dir must not vary by channel/mode when isolation is off"
+            );
+            assert!(installed.identities_dir().ends_with("shared/identities"));
+        });
+    }
+
+    #[test]
+    fn identities_dir_is_per_channel_when_isolated_auth_set() {
+        with_home_override(|_root| {
+            clear_channel_env();
+            std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+            let _guard = IsolatedAuthGuard;
+
+            let dev_a = DataPaths::resolve(
+                "0.42.0",
+                &RuntimeMode::Dev { branch: "branch-a".into(), clone_id: None },
+            )
+            .unwrap();
+            let dev_b = DataPaths::resolve(
+                "0.42.0",
+                &RuntimeMode::Dev { branch: "branch-b".into(), clone_id: None },
+            )
+            .unwrap();
+
+            assert_ne!(
+                dev_a.identities_dir(),
+                dev_b.identities_dir(),
+                "isolated identities_dir must differ per channel"
+            );
+            assert_eq!(dev_a.identities_dir(), dev_a.instance_dir.join("identities"));
+            assert!(
+                !dev_a.identities_dir().starts_with(&dev_a.shared_dir),
+                "isolated identities_dir must NOT live under the global shared_dir"
             );
         });
     }

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -13,7 +13,7 @@ pub mod runtime_mode;
 pub mod toolchain_path;
 
 pub use cli::make_cli_cmd;
-pub use data_paths::DataPaths;
+pub use data_paths::{isolated_auth_enabled, DataPaths};
 pub use errors::{AgentMuxError, AmxCode};
 pub use layout_types::{
     FlexDirection, LayoutClientSlices, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition,

--- a/agentmux-srv/src/backend/storage/identities.rs
+++ b/agentmux-srv/src/backend/storage/identities.rs
@@ -118,7 +118,18 @@ pub struct IdentityAccount {
     pub context: serde_json::Value,
     #[serde(default = "default_identity_status")]
     pub status: String, // "unknown" | "ok" | "expired" | "invalid"
+    // `#[serde(default)]` — the `upsertidentityaccount` handler (agent_handlers/
+    // identity.rs) server-stamps both fields with `now` when they're `0`, but
+    // that logic runs AFTER `serde_json::from_value` succeeds. Every real
+    // frontend caller (persistSeededAccount, register-seeded-account.ts) omits
+    // both fields entirely, expecting the server to fill them in — without
+    // `default` here, deserialization rejects the payload before the handler's
+    // own timestamp logic ever runs, so every seed-from-global / terminal
+    // login's account-persist call failed 100% of the time with no visible
+    // error (report: REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md).
+    #[serde(default)]
     pub created_at: i64,
+    #[serde(default)]
     pub updated_at: i64,
 }
 
@@ -502,6 +513,34 @@ mod tests {
             }
             other => panic!("expected OAuthConfigDir, got {other:?}"),
         }
+    }
+
+    /// Pins the exact `upsertidentityaccount` payload shape sent by
+    /// `persistSeededAccount` (frontend/app/view/agent/flows/
+    /// register-seeded-account.ts) — no `created_at`/`updated_at` at all,
+    /// since the handler is documented to server-stamp them. Before
+    /// `#[serde(default)]` was added to those two fields, this exact shape
+    /// failed `serde_json::from_value` with "missing field `created_at`" on
+    /// every call, so every seed-from-global / terminal-fallback login
+    /// silently never persisted an account row (the credential landed on
+    /// disk, but no `db_accounts` row or agent link ever existed — see
+    /// REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md).
+    #[test]
+    fn identity_account_deserializes_frontend_seed_payload_missing_timestamps() {
+        let json = r#"{
+            "id": "8d34a369-6ba6-4071-93bd-d4e051cdb457",
+            "name": "claude-oauth",
+            "provider": "claude",
+            "kind": "oauth",
+            "secret_ref": {"backend": "oauth_config_dir", "dir": "/tmp/claude"},
+            "status": "valid"
+        }"#;
+        let parsed: IdentityAccount =
+            serde_json::from_value(serde_json::from_str(json).unwrap())
+                .expect("must deserialize the frontend's timestamp-less seed payload");
+        assert_eq!(parsed.created_at, 0);
+        assert_eq!(parsed.updated_at, 0);
+        assert_eq!(parsed.status, "valid");
     }
 
     /// Serialization must always emit the canonical tag, never the legacy

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -663,7 +663,11 @@ pub fn open_stores_and_migrate(config: &config::Config, version: &str, build_tim
             } else {
                 match Store::open_shared(&path) {
                     Ok(s) => {
-                        tracing::info!(path = %path.display(), "shared store: attached");
+                        if agentmux_common::isolated_auth_enabled() {
+                            tracing::info!(path = %path.display(), "shared store: attached (ISOLATED — channel-scoped)");
+                        } else {
+                            tracing::info!(path = %path.display(), "shared store: attached");
+                        }
                         Some(Arc::new(s))
                     }
                     Err(e) => {

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -24,6 +24,8 @@ mod muxbus;
 mod util;
 #[cfg(windows)]
 mod crash_monitor;
+#[cfg(test)]
+mod test_support;
 
 use std::future::IntoFuture;
 use std::sync::Arc;

--- a/agentmux-srv/src/migrations/m0011_shared_store_backfill.rs
+++ b/agentmux-srv/src/migrations/m0011_shared_store_backfill.rs
@@ -103,10 +103,14 @@ impl Migration for M0011SharedStoreBackfill {
 mod tests {
     use super::*;
     use crate::backend::storage::store::{IdentityAccount, SecretRef};
-    use std::sync::Mutex;
 
-    // Process-global env access — serialize so parallel tests don't race.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // Process-global env access — shared with registry::paths and
+    // migrations::runner's tests, which mutate the SAME
+    // AGENTMUX_ISOLATED_AUTH/AGENTMUX_INSTANCE_DIR vars. A module-local lock
+    // only serializes tests within this file; Cargo runs a crate's tests in
+    // one multi-threaded process, so a local-only lock still let this
+    // module's tests race against those two (reagent/codex on PR #2318).
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
 
     fn clear() {
         std::env::remove_var("AGENTMUX_ISOLATED_AUTH");

--- a/agentmux-srv/src/migrations/m0011_shared_store_backfill.rs
+++ b/agentmux-srv/src/migrations/m0011_shared_store_backfill.rs
@@ -35,11 +35,20 @@ impl Migration for M0011SharedStoreBackfill {
                 Err(e) => tracing::debug!(path = %ctx.channel_store_path.display(), error = %e, "shared_store_backfill: skip current channel store"),
             }
         }
-        for path in registry::enumerate_objects_dbs(&ctx.home) {
-            if path == ctx.channel_store_path { continue; } // already added above
-            match Store::open_source_readonly(&path) {
-                Ok(s) => sibling_stores.push(s),
-                Err(e) => tracing::debug!(path = %path.display(), error = %e, "shared_store_backfill: skip sibling"),
+        // Isolation boundary, not a bug: an isolated shared store (see
+        // agentmux_common::isolated_auth_enabled) must start genuinely
+        // empty of every OTHER channel's real identity accounts/links —
+        // scanning every sibling objects.db on the machine (ctx.home is
+        // always the true global root, per resolve_home's doc comment)
+        // would defeat the entire point of a disposable test store. This
+        // channel's own local data (added above) is fine to carry in.
+        if !agentmux_common::isolated_auth_enabled() {
+            for path in registry::enumerate_objects_dbs(&ctx.home) {
+                if path == ctx.channel_store_path { continue; } // already added above
+                match Store::open_source_readonly(&path) {
+                    Ok(s) => sibling_stores.push(s),
+                    Err(e) => tracing::debug!(path = %path.display(), error = %e, "shared_store_backfill: skip sibling"),
+                }
             }
         }
 
@@ -87,5 +96,98 @@ impl Migration for M0011SharedStoreBackfill {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::store::{IdentityAccount, SecretRef};
+    use std::sync::Mutex;
+
+    // Process-global env access — serialize so parallel tests don't race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear() {
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+    }
+
+    fn make_account(id: &str) -> IdentityAccount {
+        IdentityAccount {
+            id: id.to_string(),
+            name: format!("acct-{id}"),
+            provider: "claude".to_string(),
+            kind: "oauth".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::OAuthConfigDir { dir: format!("/tmp/{id}") },
+            context: serde_json::json!({}),
+            status: "valid".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    /// Sets up: a fresh empty shared store, this channel's own (empty)
+    /// objects.db, and ONE sibling dev-branch's objects.db (under
+    /// `<home>/dev/other-branch/data/db/objects.db`, the layout
+    /// `enumerate_objects_dbs` scans) seeded with a real identity account —
+    /// simulating another, unrelated dev branch's real credentials.
+    fn setup() -> (tempfile::TempDir, MigrationContext) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path().to_path_buf();
+
+        let sibling_db = home.join("dev").join("other-branch").join("data").join("db").join("objects.db");
+        std::fs::create_dir_all(sibling_db.parent().unwrap()).unwrap();
+        let sibling_store = Store::open(&sibling_db).unwrap();
+        sibling_store.identity_upsert(&make_account("sibling-acct")).unwrap();
+
+        let channel_store_path = home.join("this-channel").join("data").join("db").join("objects.db");
+        std::fs::create_dir_all(channel_store_path.parent().unwrap()).unwrap();
+        Store::open(&channel_store_path).unwrap(); // create, empty — no local accounts
+
+        let shared_store_path = home.join("shared").join("store.db");
+        std::fs::create_dir_all(shared_store_path.parent().unwrap()).unwrap();
+
+        let ctx = MigrationContext {
+            home,
+            data_dir: tmp.path().join("this-channel").join("data"),
+            shared_store_path,
+            channel_store_path,
+        };
+        (tmp, ctx)
+    }
+
+    #[test]
+    fn backfills_sibling_accounts_when_not_isolated() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        let (_tmp, ctx) = setup();
+
+        M0011SharedStoreBackfill.up(&ctx).unwrap();
+
+        let shared = Store::open_shared(&ctx.shared_store_path).unwrap();
+        let ids: Vec<String> = shared.identity_list(None).unwrap().into_iter().map(|a| a.id).collect();
+        assert!(
+            ids.contains(&"sibling-acct".to_string()),
+            "default (non-isolated) backfill must pick up the sibling branch's real account, got: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn skips_sibling_accounts_when_isolated() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        let (_tmp, ctx) = setup();
+
+        M0011SharedStoreBackfill.up(&ctx).unwrap();
+
+        let shared = Store::open_shared(&ctx.shared_store_path).unwrap();
+        let ids: Vec<String> = shared.identity_list(None).unwrap().into_iter().map(|a| a.id).collect();
+        assert!(
+            ids.is_empty(),
+            "isolated backfill must NOT pick up any other channel's real account, got: {ids:?}"
+        );
+        clear();
     }
 }

--- a/agentmux-srv/src/migrations/m0018_ambient_login_registry.rs
+++ b/agentmux-srv/src/migrations/m0018_ambient_login_registry.rs
@@ -33,6 +33,23 @@ impl Migration for M0018AmbientLoginRegistry {
     }
 
     fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        // Isolation boundary, not a bug: this migration reads oauth-linked
+        // agent ids from ctx.shared_store_path (isolated to a fresh,
+        // per-instance store — see agentmux_common::isolated_auth_enabled)
+        // and, unlike m0017's channel-scoped sibling, writes its conclusion
+        // into the REAL global cross-channel definitions registry
+        // (ctx.home is always the true global root, per resolve_home's doc
+        // comment). An isolated store starts with zero links by design, so
+        // without this guard, merely booting an isolated dev-test instance
+        // for the first time would flip every real agent everywhere to
+        // use_ambient_login=1 — reproducing the exact "changes real
+        // production auth state" bug this whole feature exists to prevent
+        // (reagent/codex on PR #2318). There is no isolated-store
+        // equivalent of this write to redirect to instead: it is skipped
+        // outright.
+        if agentmux_common::isolated_auth_enabled() {
+            return Ok(());
+        }
         let def_dir = ctx.home.join("shared").join("agents").join("definitions");
         if !def_dir.exists() {
             return Ok(());
@@ -81,6 +98,14 @@ impl Migration for M0018AmbientLoginRegistry {
 mod tests {
     use super::*;
     use crate::registry::{DefinitionRecord, DefinitionRecordV1, DEF_MAX_SUPPORTED_SCHEMA};
+    // Process-global env access — shared with registry::paths,
+    // migrations::runner, and migrations::m0011_shared_store_backfill's
+    // tests, which mutate the SAME AGENTMUX_ISOLATED_AUTH var. A
+    // module-local lock only serializes tests within this file; Cargo runs
+    // a crate's tests in one multi-threaded process, so a local-only lock
+    // would still let this module's test race against those (reagent/codex
+    // on PR #2318).
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
 
     fn record(id: &str) -> DefinitionRecord {
         DefinitionRecord {
@@ -97,6 +122,8 @@ mod tests {
 
     #[test]
     fn linkless_record_flips_to_ambient_linked_record_stays() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
         let home = tempfile::tempdir().unwrap();
         let def_dir = home.path().join("shared").join("agents").join("definitions");
         let def_store = registry::DefinitionStore::open(def_dir.clone()).unwrap();
@@ -147,8 +174,57 @@ mod tests {
         );
     }
 
+    /// reagent/codex P1 on PR #2318: an isolated boot's shared store is a
+    /// fresh, empty, per-instance file — computing `linked` from IT and
+    /// then rewriting the REAL global cross-channel definitions registry
+    /// would flip every genuinely-linked agent everywhere to
+    /// use_ambient_login=1, merely because a disposable test store had no
+    /// links yet. `up()` must skip entirely when isolated, leaving the
+    /// real registry completely untouched regardless of what the isolated
+    /// store contains.
+    #[test]
+    fn skips_global_registry_rewrite_when_isolated() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+
+        let home = tempfile::tempdir().unwrap();
+        let def_dir = home.path().join("shared").join("agents").join("definitions");
+        let def_store = registry::DefinitionStore::open(def_dir.clone()).unwrap();
+        // Already correctly marked fail-by-default, mirroring a real agent
+        // with a real oauth link in the REAL global shared store (which
+        // this test deliberately never touches — only ctx.shared_store_path,
+        // pointed at a separate, empty "isolated" file, as
+        // resolve_shared_store_path() would under AGENTMUX_ISOLATED_AUTH=1).
+        let mut linked_rec = record("remote-linked");
+        linked_rec.data.use_ambient_login = 0;
+        def_store.upsert(&linked_rec).unwrap();
+
+        let isolated_shared = home.path().join("isolated-instance").join("identity-store.db");
+        std::fs::create_dir_all(isolated_shared.parent().unwrap()).unwrap();
+
+        let ctx = MigrationContext {
+            home: home.path().to_path_buf(),
+            data_dir: home.path().to_path_buf(),
+            shared_store_path: isolated_shared,
+            channel_store_path: home.path().join("unused-objects.db"),
+        };
+        M0018AmbientLoginRegistry.up(&ctx).unwrap();
+
+        let reopened = registry::DefinitionStore::open(def_dir).unwrap();
+        assert_eq!(
+            reopened.get("remote-linked").unwrap().unwrap().data.use_ambient_login,
+            0,
+            "isolated boot must not rewrite the real global registry at all, \
+             even though the isolated shared store has zero links"
+        );
+
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+    }
+
     #[test]
     fn missing_registry_dir_is_a_noop() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
         let home = tempfile::tempdir().unwrap();
         let ctx = MigrationContext {
             home: home.path().to_path_buf(),

--- a/agentmux-srv/src/migrations/runner.rs
+++ b/agentmux-srv/src/migrations/runner.rs
@@ -424,10 +424,14 @@ fn write_error_log(home: &Path, msg: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    // Process-global env access — serialize so parallel tests don't race.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // Process-global env access — shared with registry::paths and
+    // migrations::m0011_shared_store_backfill's tests, which mutate the SAME
+    // AGENTMUX_ISOLATED_AUTH/AGENTMUX_INSTANCE_DIR vars. A module-local lock
+    // only serializes tests within this file; Cargo runs a crate's tests in
+    // one multi-threaded process, so a local-only lock still let this
+    // module's tests race against those two (reagent/codex on PR #2318).
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
 
     fn clear() {
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");

--- a/agentmux-srv/src/migrations/runner.rs
+++ b/agentmux-srv/src/migrations/runner.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::backend::storage::store::Store;
-use crate::registry::resolve_shared_store_path;
+use crate::registry::{resolve_global_shared_root, resolve_shared_store_path};
 
 use super::{MigrationContext, MigrationScope, REGISTRY};
 
@@ -34,6 +34,22 @@ fn emit_summary(applied: usize, skipped: usize) {
     );
 }
 
+/// The true, unconditional `~/.agentmux` root — `MigrationContext.home`.
+///
+/// Deliberately NOT derived from `resolve_shared_store_path()` (which
+/// varies under isolated-auth mode, resolving to a channel-scoped path
+/// instead of the global one) — 17 of 19 registered migrations build
+/// paths directly off `ctx.home` (registry/definitions/transcripts dirs),
+/// and `backup_stores`/`write_error_log` below use it too. All of those
+/// must stay anchored to the real global root regardless of isolation;
+/// only `ctx.shared_store_path` itself is meant to vary. A single shared
+/// helper (not one inline derivation per call site) so the two can't
+/// drift apart. See `registry::resolve_global_shared_root`'s doc comment
+/// and `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`.
+fn resolve_home() -> Option<PathBuf> {
+    resolve_global_shared_root().and_then(|p| p.parent().map(Path::to_path_buf))
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 /// Called from `main.rs` when the `migrate` subcommand is active.
@@ -50,8 +66,8 @@ pub fn run_migrate_command(data_dir: &Path, dry_run: bool, list: bool) -> i32 {
         }
     };
 
-    let home = match shared_store_path.parent().and_then(|p| p.parent()) {
-        Some(p) => p.to_path_buf(),
+    let home = match resolve_home() {
+        Some(p) => p,
         None => {
             emit_summary(0, 0);
             return 0;
@@ -284,9 +300,9 @@ pub fn run_pending_migrations(data_dir: &Path) -> Result<usize, String> {
         }
     }
 
-    let home = match shared_store_path.parent().and_then(|p| p.parent()) {
-        Some(p) => p.to_path_buf(),
-        None => return Err("run_pending_migrations: cannot derive home from shared store path".to_string()),
+    let home = match resolve_home() {
+        Some(p) => p,
+        None => return Err("run_pending_migrations: cannot resolve global shared root".to_string()),
     };
 
     let shared_store = match Store::open_shared(&shared_store_path) {
@@ -403,4 +419,59 @@ fn write_error_log(home: &Path, msg: &str) {
     let path = log_dir.join("migration-error.log");
     let content = format!("{}\n", msg);
     let _ = std::fs::write(path, content);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Process-global env access — serialize so parallel tests don't race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear() {
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        std::env::remove_var("AGENTMUX_SHARED_DIR");
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+        std::env::remove_var("AGENTMUX_INSTANCE_DIR");
+    }
+
+    /// The regression test that would have caught the `ctx.home` /
+    /// `shared_store_path` coupling bug before it shipped: `resolve_home()`
+    /// must return the SAME value whether or not isolated-auth is active,
+    /// even though `resolve_shared_store_path()` itself deliberately
+    /// returns a DIFFERENT (channel-scoped) path under isolation. Every
+    /// other Global migration, plus backups and the error log, anchor to
+    /// `home` and must never silently move just because one channel opted
+    /// into isolated auth.
+    #[test]
+    fn home_is_invariant_to_isolated_auth() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+
+        let home_default = resolve_home().unwrap();
+        assert_eq!(home_default, PathBuf::from("/tmp/test-home"));
+
+        let shared_store_path_default = resolve_shared_store_path().unwrap();
+
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        std::env::set_var("AGENTMUX_INSTANCE_DIR", "/tmp/test-home/dev/some-branch");
+        let home_isolated = resolve_home().unwrap();
+        let shared_store_path_isolated = resolve_shared_store_path().unwrap();
+
+        assert_eq!(
+            home_default, home_isolated,
+            "resolve_home() must be invariant to AGENTMUX_ISOLATED_AUTH/AGENTMUX_INSTANCE_DIR"
+        );
+        // Meanwhile resolve_shared_store_path() DOES vary — confirms the two
+        // functions have genuinely diverged as designed, not that isolation
+        // silently does nothing.
+        assert_ne!(
+            shared_store_path_default, shared_store_path_isolated,
+            "resolve_shared_store_path() must actually change under isolation"
+        );
+
+        clear();
+    }
 }

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -37,6 +37,10 @@ pub use paths::{
     resolve_shared_definitions_dir, resolve_shared_registry_dir, resolve_shared_store_path,
     resolve_shared_transcripts_dir,
 };
+// crate-internal only — see resolve_global_shared_root's doc comment for why
+// migrations/runner.rs must call this directly instead of deriving `home`
+// from resolve_shared_store_path()'s (isolation-aware) return value.
+pub(crate) use paths::resolve_global_shared_root;
 pub use def_migrate::{migrate_definitions_global_once, DefMigrateStats};
 pub use def_schema::{
     DefContentBlob, DefSkillBlob, DefValidationError, DefinitionRecord, DefinitionRecordV1,

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -44,7 +44,30 @@ pub fn resolve_shared_definitions_dir() -> Option<PathBuf> {
 /// Uses the same root as the agent registry/definitions so
 /// `AGENTMUX_HOME_OVERRIDE` and `AGENTMUX_SHARED_DIR` work consistently.
 /// Returns `None` only when the shared root itself can't be resolved.
+///
+/// When `agentmux_common::isolated_auth_enabled()` is set, resolves to
+/// `<instance_dir>/identity-store.db` instead — a channel-scoped store for
+/// destructive Armory testing (delete-account flows) that can never touch
+/// the real global store other channels/instances depend on. Falls back
+/// to the global path if `AGENTMUX_INSTANCE_DIR` isn't set (e.g. a bare
+/// `cargo run` outside the launcher) rather than failing outright — this
+/// function's existing `None`-on-unresolvable contract is preserved, just
+/// with an extra source to try first. See
+/// `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md`.
+///
+/// IMPORTANT: `MigrationContext.home` (`migrations/runner.rs`) must NEVER
+/// be derived from this function's return value (e.g. via
+/// `.parent().parent()`) — it needs the unconditional global root
+/// regardless of isolation, and must call `resolve_global_shared_root()`
+/// directly instead. See that module's comments.
 pub fn resolve_shared_store_path() -> Option<std::path::PathBuf> {
+    if agentmux_common::isolated_auth_enabled() {
+        if let Ok(instance_dir) = std::env::var("AGENTMUX_INSTANCE_DIR") {
+            if !instance_dir.is_empty() {
+                return Some(std::path::PathBuf::from(instance_dir).join("identity-store.db"));
+            }
+        }
+    }
     resolve_global_shared_root().map(|h| h.join("store.db"))
 }
 
@@ -65,8 +88,12 @@ pub fn resolve_shared_transcripts_dir() -> Option<PathBuf> {
     resolve_global_shared_root().map(|h| h.join("agents").join("transcripts"))
 }
 
-/// The global, channel-independent `<home>/shared` root.
-fn resolve_global_shared_root() -> Option<PathBuf> {
+/// The global, channel-independent `<home>/shared` root. Deliberately
+/// UNAFFECTED by `isolated_auth_enabled()` — callers that need the true
+/// `~/.agentmux` home (e.g. `migrations/runner.rs`'s `MigrationContext.home`)
+/// must call this directly rather than deriving it from
+/// `resolve_shared_store_path()`, which DOES vary with isolation.
+pub(crate) fn resolve_global_shared_root() -> Option<PathBuf> {
     if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
         if !s.is_empty() {
             // Consistent with data_paths everywhere else: the override is the
@@ -95,6 +122,8 @@ mod tests {
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
         std::env::remove_var("AGENTMUX_DATA_DIR");
         std::env::remove_var("AGENTMUX_SHARED_DIR");
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+        std::env::remove_var("AGENTMUX_INSTANCE_DIR");
     }
 
     #[test]
@@ -168,6 +197,49 @@ mod tests {
             r,
             PathBuf::from("/tmp/test-home/shared/agents/definitions")
         );
+        clear();
+    }
+
+    #[test]
+    fn shared_store_path_default_is_global() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+        // Isolation flag unset (the default) — unchanged from today, even
+        // with an instance dir present, since isolation must be opt-in.
+        std::env::set_var("AGENTMUX_INSTANCE_DIR", "/tmp/test-home/dev/some-branch");
+        let r = resolve_shared_store_path().unwrap();
+        assert_eq!(r, PathBuf::from("/tmp/test-home/shared/store.db"));
+        clear();
+    }
+
+    #[test]
+    fn shared_store_path_isolated_uses_instance_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        std::env::set_var("AGENTMUX_INSTANCE_DIR", "/tmp/test-home/dev/some-branch");
+        let r = resolve_shared_store_path().unwrap();
+        assert_eq!(
+            r,
+            PathBuf::from("/tmp/test-home/dev/some-branch/identity-store.db"),
+            "isolated shared store must live under the channel's own instance dir"
+        );
+        clear();
+    }
+
+    #[test]
+    fn shared_store_path_isolated_without_instance_dir_falls_back() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+        std::env::set_var("AGENTMUX_ISOLATED_AUTH", "1");
+        // AGENTMUX_INSTANCE_DIR deliberately left unset — e.g. a bare
+        // `cargo run` outside the launcher. Must degrade to the global
+        // path rather than returning None unnecessarily.
+        let r = resolve_shared_store_path().unwrap();
+        assert_eq!(r, PathBuf::from("/tmp/test-home/shared/store.db"));
         clear();
     }
 }

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -113,10 +113,14 @@ pub(crate) fn resolve_global_shared_root() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    // Process-global env access — serialize so parallel tests don't race.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // Process-global env access — shared with migrations::runner and
+    // migrations::m0011_shared_store_backfill's tests, which mutate the SAME
+    // AGENTMUX_ISOLATED_AUTH/AGENTMUX_INSTANCE_DIR vars. A module-local lock
+    // only serializes tests within this file; Cargo runs a crate's tests in
+    // one multi-threaded process, so a local-only lock still let this
+    // module's tests race against those two (reagent/codex on PR #2318).
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
 
     fn clear() {
         std::env::remove_var("AGENTMUX_HOME_OVERRIDE");

--- a/agentmux-srv/src/server/service/object_helpers.rs
+++ b/agentmux-srv/src/server/service/object_helpers.rs
@@ -83,43 +83,169 @@ pub(super) fn update_object(
 }
 
 /// Update object meta by oref string. Merges meta into existing object.
+///
+/// The whole read-merge-write round trip runs inside ONE `Store::with_tx`
+/// critical section (a single acquisition of the store's connection Mutex,
+/// wrapping a real SQLite transaction) instead of two separate
+/// `must_get`/`update` calls. This closes a lost-update race: two
+/// call sites can legitimately fire on the SAME block within milliseconds
+/// of each other — e.g. `persist_session_id` (clearing a stale `--resume`
+/// id) and `clear_active_pid` both run from independent async tasks on a
+/// persistent controller's process exit. Each used to read a pre-write
+/// snapshot of the block's *entire* meta map, merge in its own single key,
+/// and write the *entire* merged map back — so whichever of the two won
+/// the race to write LAST silently reverted the other's change (every key
+/// it didn't itself touch reverts to whatever it read, which may already
+/// be stale). `with_tx` holds the one connection lock across the full
+/// read+merge+write, so no other `Store::*` call for ANY object can
+/// interleave inside it — the two writers now strictly serialize instead
+/// of racing, and each one's merge is always built from the other's
+/// already-committed result. See
+/// REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md.
 pub(crate) fn update_object_meta(
     store: &Store,
     oref_str: &str,
     meta_update: &MetaMapType,
 ) -> Result<(), String> {
     let oref = crate::backend::ORef::parse(oref_str).map_err(|e| e.to_string())?;
+
+    // Validate the otype up front — StoreTx's methods return StoreError, so
+    // the "unsupported otype" case (a plain String) has to be rejected
+    // before entering with_tx rather than from inside its closure.
     match oref.otype.as_str() {
-        OTYPE_CLIENT => {
-            let mut obj = store.must_get::<Client>(&oref.oid).map_err(|e| e.to_string())?;
-            obj.meta = merge_meta(&obj.meta, meta_update, true);
-            store.update(&mut obj).map_err(|e| e.to_string())?;
-        }
-        OTYPE_WINDOW => {
-            let mut obj = store.must_get::<Window>(&oref.oid).map_err(|e| e.to_string())?;
-            obj.meta = merge_meta(&obj.meta, meta_update, true);
-            store.update(&mut obj).map_err(|e| e.to_string())?;
-        }
-        OTYPE_WORKSPACE => {
-            let mut obj = store
-                .must_get::<Workspace>(&oref.oid)
-                .map_err(|e| e.to_string())?;
-            obj.meta = merge_meta(&obj.meta, meta_update, true);
-            store.update(&mut obj).map_err(|e| e.to_string())?;
-        }
-        OTYPE_TAB => {
-            let mut obj = store.must_get::<Tab>(&oref.oid).map_err(|e| e.to_string())?;
-            obj.meta = merge_meta(&obj.meta, meta_update, true);
-            store.update(&mut obj).map_err(|e| e.to_string())?;
-        }
-        OTYPE_BLOCK => {
-            let mut obj = store.must_get::<Block>(&oref.oid).map_err(|e| e.to_string())?;
-            obj.meta = merge_meta(&obj.meta, meta_update, true);
-            store.update(&mut obj).map_err(|e| e.to_string())?;
-        }
+        OTYPE_CLIENT | OTYPE_WINDOW | OTYPE_WORKSPACE | OTYPE_TAB | OTYPE_BLOCK => {}
         _ => return Err(format!("cannot update meta for otype: {}", oref.otype)),
     }
-    Ok(())
+
+    store
+        .with_tx(|tx| {
+            match oref.otype.as_str() {
+                OTYPE_CLIENT => {
+                    let mut obj = tx.must_get::<Client>(&oref.oid)?;
+                    obj.meta = merge_meta(&obj.meta, meta_update, true);
+                    tx.update(&mut obj)?;
+                }
+                OTYPE_WINDOW => {
+                    let mut obj = tx.must_get::<Window>(&oref.oid)?;
+                    obj.meta = merge_meta(&obj.meta, meta_update, true);
+                    tx.update(&mut obj)?;
+                }
+                OTYPE_WORKSPACE => {
+                    let mut obj = tx.must_get::<Workspace>(&oref.oid)?;
+                    obj.meta = merge_meta(&obj.meta, meta_update, true);
+                    tx.update(&mut obj)?;
+                }
+                OTYPE_TAB => {
+                    let mut obj = tx.must_get::<Tab>(&oref.oid)?;
+                    obj.meta = merge_meta(&obj.meta, meta_update, true);
+                    tx.update(&mut obj)?;
+                }
+                OTYPE_BLOCK => {
+                    let mut obj = tx.must_get::<Block>(&oref.oid)?;
+                    obj.meta = merge_meta(&obj.meta, meta_update, true);
+                    tx.update(&mut obj)?;
+                }
+                // Unreachable — validated above, before with_tx was entered.
+                _ => unreachable!("otype validated before with_tx"),
+            }
+            Ok(())
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::store::Store;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn insert_block(store: &Store, block_id: &str) {
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 0,
+            runtimeopts: None,
+            stickers: None,
+            meta: MetaMapType::new(),
+            subblockids: None,
+        };
+        store.insert(&mut block).unwrap();
+    }
+
+    /// Pins the fix for a real, reproduced lost-update race: two concurrent
+    /// `update_object_meta` calls on the SAME block, each merging in a
+    /// DIFFERENT single key, must both survive — neither may silently
+    /// revert the other's key by writing back a merged snapshot it read
+    /// before the other's write landed. This is exactly the shape of the
+    /// `persist_session_id` / `clear_active_pid` race
+    /// (REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md): both
+    /// fire from independent async tasks on a persistent controller's
+    /// process exit, each touching one key of the same block's meta.
+    ///
+    /// A `Barrier` forces both threads to call `update_object_meta` as
+    /// close to simultaneously as real concurrent tasks would, maximizing
+    /// the odds this test actually exercises the race window rather than
+    /// happening to run the two calls back-to-back. Before the `with_tx`
+    /// fix (two separate `must_get`+`update` lock acquisitions instead of
+    /// one spanning both), this test was flaky — failing whenever the two
+    /// threads' read-then-write windows overlapped.
+    #[test]
+    fn update_object_meta_concurrent_writers_both_keys_survive() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        // ORef::parse requires a UUID-shaped oid (see oref.rs) — a plain
+        // slug like "block-race" fails to parse, not the race itself.
+        let block_id = uuid::Uuid::new_v4().to_string();
+        insert_block(&store, &block_id);
+        let oref_str = format!("block:{block_id}");
+
+        let barrier = Arc::new(Barrier::new(2));
+
+        let store_a = Arc::clone(&store);
+        let oref_a = oref_str.clone();
+        let barrier_a = Arc::clone(&barrier);
+        let handle_a = thread::spawn(move || {
+            let mut meta = MetaMapType::new();
+            meta.insert("agent:sessionid".to_string(), serde_json::Value::String(String::new()));
+            barrier_a.wait();
+            update_object_meta(&store_a, &oref_a, &meta).unwrap();
+        });
+
+        let store_b = Arc::clone(&store);
+        let oref_b = oref_str.clone();
+        let barrier_b = Arc::clone(&barrier);
+        let handle_b = thread::spawn(move || {
+            let mut meta = MetaMapType::new();
+            meta.insert("session:active_pid".to_string(), serde_json::Value::from(4242));
+            barrier_b.wait();
+            update_object_meta(&store_b, &oref_b, &meta).unwrap();
+        });
+
+        handle_a.join().unwrap();
+        handle_b.join().unwrap();
+
+        let final_block = store.must_get::<Block>(&block_id).unwrap();
+        // Both threads' writes must have stuck — a lost-update race would
+        // have whichever writer finished LAST silently revert the other's
+        // key back to absent, since it wrote back a meta snapshot it read
+        // before the other's write landed.
+        assert_eq!(
+            final_block.meta.get("agent:sessionid").and_then(|v| v.as_str()),
+            Some(""),
+            "agent:sessionid should be the empty string thread A wrote, not missing/reverted",
+        );
+        assert_eq!(
+            final_block.meta.get("session:active_pid").and_then(|v| v.as_i64()),
+            Some(4242),
+            "session:active_pid should be the value thread B wrote, not missing/reverted",
+        );
+        // Version must reflect exactly two applied updates (1 insert + 2
+        // updates = version 3) — a lost update would also show as a
+        // version that skipped one of the two writers' increments in a
+        // way that leaves one key's write invisible (already covered by
+        // the assert above); this is a secondary, cheap corroboration.
+        assert_eq!(final_block.version, 3, "both concurrent updates must have applied, not one clobbering the other");
+    }
 }
 
 /// Mirror an agent block's `term:zoom` into the per-agent `ui:zoom` content

--- a/agentmux-srv/src/test_support.rs
+++ b/agentmux-srv/src/test_support.rs
@@ -1,0 +1,18 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Crate-wide test-only helpers shared across `#[cfg(test)]` modules.
+//!
+//! `ISOLATED_AUTH_ENV_LOCK` guards every test that mutates the process-global
+//! `AGENTMUX_ISOLATED_AUTH`/`AGENTMUX_INSTANCE_DIR` env vars. Before this
+//! existed, `registry::paths`, `migrations::runner`, and
+//! `migrations::m0011_shared_store_backfill` each declared their own
+//! module-local `Mutex<()>` — serializing tests *within* a module but not
+//! *across* them. Cargo's default test runner executes all of a crate's
+//! tests in one process with many threads, so those three modules' tests
+//! could still interleave: one test clears the flag while another (holding
+//! only its own module's lock) is mid-assertion on it, producing
+//! nondeterministic failures (reagent/codex on PR #2318). Every test that
+//! touches these env vars must acquire THIS lock instead of a local one.
+
+pub(crate) static ISOLATED_AUTH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md
+++ b/docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md
@@ -1,0 +1,448 @@
+# Report: "Error: not logged in" after a successful login, and two stuck-"Working…" states
+
+**Date:** 2026-07-27
+**Author:** AgentA
+**Status:** Fixes 1-5 applied and verified (see §5); §6 is a design-only addition, not yet built.
+**Test round analyzed:** agent "Nark" (block `507ecd63-8144-4ad1-878c-64af534a6a0c`),
+dev instance on branch `agenta/remove-auto-login-trigger`, srv log
+`agentmuxsrv-v0.54.5.log.2026-07-27`, window 08:41:09–08:41:48 UTC.
+
+Three reported symptoms:
+
+1. After clicking "Log in" and seeing "✓ Login successful" in the pane, the very
+   first message ("u there") comes back with **"Error: not logged in"**.
+2. After that error, the pane stays in **"Working…" indefinitely** — the turn
+   never ends.
+3. Tangential: **AgentA's own pane** (in the user's main instance) is
+   consistently shown as "Working…" even after its turns visibly complete.
+
+---
+
+## 1. Problem 1 — "Error: not logged in" after a successful login
+
+### Root cause (CONFIRMED, static + DB + log evidence)
+
+**Every account-persist call made by the login flow fails at serde
+deserialization, so no `db_accounts` row and no agent↔account link is ever
+created. The "Login successful" message is a false positive: the credential is
+seeded onto disk into an account dir whose account row never comes into
+existence — and which the identity sweeper then deletes as an orphan on the
+next login attempt.**
+
+The failure chain, each link verified:
+
+1. `relogin()` → `runProviderLogin` tier 2 mints account
+   `8d34a369-6ba6-4071-93bd-d4e051cdb457` and seeds a valid credential into it.
+   Log (08:41:15.877): `seed_provider_auth_from_global: seeded isolated dir from
+   valid global login … dest=…\identities\8d34a369-…\claude\.credentials.json`.
+2. Tier 2 then calls `persistSeededAccount`
+   (`frontend/app/view/agent/flows/register-seeded-account.ts:78-103`), which
+   sends this payload to the `upsertidentityaccount` RPC:
+
+   ```ts
+   await RpcApi.UpsertIdentityAccountCommand(TabRpcClient, {
+       id: accountId,
+       name: `${providerId}-oauth`,
+       provider: providerId,
+       kind: "oauth",
+       secret_ref: { backend: "oauth_config_dir", dir },
+       status: "valid",
+   });
+   ```
+
+   Note: **no `created_at`, no `updated_at`.**
+3. The srv handler
+   (`agentmux-srv/src/server/agent_handlers/identity.rs:154-188`) does
+   `serde_json::from_value::<IdentityAccount>(data)` **before** its own
+   "`created_at` and `updated_at` are server-set so callers don't have to know
+   the current time" logic can run. The struct
+   (`agentmux-srv/src/backend/storage/identities.rs:107-123`) declares:
+
+   ```rust
+   pub created_at: i64,   // ← NO #[serde(default)]
+   pub updated_at: i64,   // ← NO #[serde(default)]
+   ```
+
+   `display_name`, `context`, and `status` all have `#[serde(default…)]`;
+   the two timestamps do not. Deserialization therefore fails with
+   `missing field 'created_at'` on **every** call — instantly and
+   deterministically. The handler's timestamp-defaulting code (lines 165-175)
+   is unreachable for this caller.
+4. `persistSeededAccount` catches the RPC error, logs it **only to the pane's
+   hidden activity log** (visible only if the Shell drawer is open — it appears
+   in no muxlog channel), and returns `false`. Tier 2 retries once (same
+   deterministic failure, ~5 ms total — log shows the terminal opening at
+   08:41:15.882, 5 ms after the successful seed), then falls through to tier 3.
+5. Tier 3 opens a real terminal; its 5-second poll immediately finds the
+   already-seeded credential (second `seed_provider_auth_from_global` at
+   08:41:20.898), tries `persistSeededAccount` again → same serde failure →
+   the flow still reports **`terminal-success`** → the pane shows
+   "✓ Login successful".
+6. **DB state after the round (queried directly):** `db_accounts` has **no row**
+   `8d34a369…`; `db_agent_identity_links` has **no link** for it. The newest
+   claude account row in the global store (`~/.agentmux/shared/store.db`) is
+   from **2026-07-24** — i.e. no login flow has persisted an account in days.
+7. Poetic detail: at 08:41:15.869 the identity sweeper deleted the **previous
+   round's** orphaned account dir
+   (`963d1a95…`, age 10719 s ≈ 3 h): *"identity.sweep: orphaned account dir
+   removed (no matching account row, past age threshold)"*. Every login round
+   seeds a real credential into a dir that the next round garbage-collects.
+   This is why the symptom "resets" between test sessions.
+8. When the user then sends "u there" (08:41:47), the spawn env still has no
+   valid credential anywhere to find:
+   - The block's `cmd:env` points `CLAUDE_CONFIG_DIR` at the **provider-level
+     shared dir** `…\shared\providers\claude` (written by launch-flow Phase 1's
+     `SetMeta` from `buildAuthEnv`/`ensureAuthDir`) — which `CheckCliAuth`
+     itself logged as credential-less: `check dir=…\providers\claude
+     present=true token=none` / `no credentials in provider dir`.
+   - The identity resolver's injection had nothing to inject (no account row,
+     no link) — the srv log shows **no** `identity.spawn.blocked`, no
+     `LinkAgentIdentity`, no injection line in the whole window.
+   - The message went to an **already-running** persistent CLI process
+     (`send_message` emitted `agent-message-accepted` with **no**
+     "persistent process spawned" line → `is_running()` was true), i.e. a
+     process spawned in an earlier round with that same credential-less env.
+   The CLI (correctly) answers that it is not logged in.
+
+### Contributing design gaps (each would have masked or shrunk the bug)
+
+- **G1 — persist failure is invisible.** The "credential seeded but the Armory
+  account couldn't be registered" error goes only to the hidden activity log.
+  It never reaches `authNotice`, the pane conversation, or any muxlog channel.
+  A deterministic 100%-failure ran for days without a trace anywhere visible.
+- **G2 — `terminal-success` does not require persist to have succeeded.** The
+  flow's contract says "registers it once the login lands on disk", but the
+  outcome (and the "Login successful" UX) is reported even when registration
+  failed — success is decided by the credential file appearing, not by the
+  account being persisted + linked.
+- **G3 — `relogin()` never updates the block's `cmd:env`.** `useGlobalLogin()`
+  explicitly rewrites `cmd:env` to the new account dir after linking;
+  `relogin()`'s success paths do not (they rely on `persistAndLinkAccount`'s
+  linkTarget, which never ran here). Even with the serde bug fixed, a live
+  pane's next spawn would still read the stale provider-dir env until
+  something rewrites it — and:
+- **G4 — a stale, already-running persistent process is reused.** Env changes
+  (link, cmd:env rewrite) only take effect on respawn. A login recovery that
+  succeeds while the old unauthenticated CLI process is still alive changes
+  nothing for that process. Nothing restarts it after a successful login.
+- **G5 — after the mount flow bails with `auth_failed`, nothing re-runs
+  Phase 3.** By design (2026-07-27) the mount flow stops before
+  `ControllerResync` when unauthenticated. After a successful "Log in" click,
+  no code path performs the Phase-3 controller resync / ready notification for
+  the pane. (With `retryAfterLogin: false` — correct for not resending old
+  messages — there is now *no* post-login reconciliation at all.)
+
+### Recommended fixes (in order)
+
+1. **One-line Rust fix (the root cause):** add `#[serde(default)]` to
+   `created_at` / `updated_at` on `IdentityAccount` — the handler already
+   treats `0` as "server should stamp now". Alternatively `#[serde(default)]`
+   on the whole struct insert path via a dedicated upsert-payload type. Add a
+   regression test deserializing exactly the frontend's payload shape.
+2. **Make persist failure loud:** on `persistSeededAccount === false`, set
+   `authNotice` (and/or post a warning notification) instead of only the hidden
+   log; do NOT report `seeded`/`terminal-success` (or at minimum do not post
+   "Login successful") when registration failed — G2.
+3. **Post-login reconciliation:** on a successful `relogin()`, (a) update the
+   block's `cmd:env` to the account dir (mirror `useGlobalLogin`), and (b) if
+   the pane's persistent process is running with stale env, force a respawn
+   (`forcerestart` resync) — G3/G4/G5 together explain why even a "fixed" login
+   wouldn't have worked until the pane was fully reopened.
+
+---
+
+## 2. Problem 2 — pane stuck in "Working…" after the error
+
+### Root cause (code-confirmed mechanism)
+
+**The persistent controller ends a turn in exactly one place: on seeing a
+`{"type":"result"}` frame on the CLI's stdout**
+(`agentmux-srv/src/backend/blockcontroller/persistent.rs:922-944`):
+
+```rust
+if parsed.get("type").and_then(|v| v.as_str()) == Some("result") {
+    health_read.set_active_turn(false);
+    // …publish controllerstatus { turn_active: false } …
+}
+```
+
+There is **no other path back to `turn_active = false`** while the process
+stays alive: no timeout, no stderr-based classification, and the
+`agents/failure.rs` classifier only runs on **process exit**. An
+unauthenticated CLI that answers with a plain error line (not a stream-json
+`result` frame) — exactly the "Error: not logged in" case — leaves
+`turn_active` true forever. The frontend faithfully renders that as
+"Working…" forever. (The `agent health transition Healthy→Idle` seen 48 ms
+after the accept is the *health* monitor, a separate state from
+`turn_active`.)
+
+Because no `result` frame arrives and the process doesn't exit, no
+`agentfailure` event is emitted either — so the failure-recovery row (with its
+"Login Again" action) never appears. The user gets a raw error line, an
+eternal spinner, and no recovery affordance: the worst of all three surfaces.
+
+### Recommended fixes
+
+1. **Turn-end watchdog:** the per-turn health watchdog
+   (`core::spawn_health_watchdog`) already exists — extend it (or add a
+   parallel arm) so that N seconds of a turn with output that has stopped (or
+   an auth-pattern match on stderr, see `identity/auth_patterns.rs` which
+   already recognizes "not logged in") synthesizes a turn end: set
+   `turn_active=false`, publish status, and emit a classified `agentfailure`
+   (code `auth` for this case) so the recovery row appears.
+2. **Classify inband errors, not just exits:** `classify_output_line` already
+   runs per line (`persistent.rs:916`); a line matching the auth patterns
+   during an active turn should end the turn with an `auth` failure rather
+   than only counting toward health.
+
+---
+
+## 3. Problem 3 — AgentA's own pane stuck "Working…" (main instance)
+
+### What the logs show
+
+For AgentA's block (`01da2fb8-2486-4f0e-a85a-c536bcefe81e`) in the main
+instance's srv (`agentmuxsrv-v0.54.4.log.2026-07-27`), the server-side state is
+**healthy and correct**: every long turn shows `Idle → Healthy` at turn start
+and `Healthy → Idle` at turn end (e.g. 05:44:25 → 06:02:21 for an 18-minute
+turn, with intermediate `Healthy → Stalled → Healthy` flaps during quiet tool
+stretches). The server knows the turns end. The stuck "Working…" is therefore
+a **frontend-side desync**, not a backend turn_active leak (contrast with
+problem 2, where the backend flag itself is stuck).
+
+### Most likely mechanism (hypothesis — not yet instrumented)
+
+The turn-end `controllerstatus { turn_active: false }` publish is
+**fire-once with `persist: 0`** (`persistent.rs:930-945`). If the pane's
+frontend misses that single event — backgrounded/throttled window, WPS
+reconnect gap, pane not currently subscribed — nothing ever re-publishes it.
+The only repair paths are:
+
+- the mount-time one-shot `GetControllerStatus` (runs only on pane re-open),
+- the *next* turn's own start/end events.
+
+So one missed turn-end event pins the pane at "Working…" until the user
+reopens the pane or starts a new turn — matching the observed "stuck even
+though the agent returned" behavior, and consistent with the prior
+stuck-"Working" incidents
+(`docs/specs/REPORT_AGENT_PANE_STATE_RECONCILIATION_2026_07_07.md`, reagent
+P1s on PR #2241/#2303). The `Stalled` flaps also suggest long quiet stretches
+during which a throttled renderer is most likely to drop events.
+
+### Recommended fixes
+
+1. **Persist the last controllerstatus event** (`persist: 1`) or include
+   `turn_active` in a periodic low-frequency heartbeat, so a missed flip is
+   self-healing.
+2. **Reconcile on window focus/visibility:** the pane already has the one-shot
+   `GetControllerStatus` reconcile; re-running it on `visibilitychange`/focus
+   (cheap, once) would repair any missed event the moment the user looks.
+
+---
+
+## 4. Suggested fix order
+
+| # | Fix | Size | Fixes |
+|---|-----|------|-------|
+| 1 | `#[serde(default)]` on `IdentityAccount.created_at/updated_at` + payload-shape regression test | XS (Rust) | P1 root cause |
+| 2 | Surface persist failure (authNotice + no false "Login successful") | S (TS) | P1 G1/G2 |
+| 3 | Post-relogin reconciliation: update `cmd:env`, force respawn of stale process | M (TS) | P1 G3/G4/G5 |
+| 4 | Inband auth-error → synthesized turn end + `auth` failure classification | M (Rust) | P2 |
+| 5 | Persisted/heartbeat controllerstatus + focus-time reconcile | M (Rust+TS) | P3 |
+
+Items 1-2 are enough to make the next manual test round meaningful; item 3 is
+required for a login to fix a pane *without reopening it*; item 4 removes the
+infinite spinner; item 5 addresses the tangential busy-status desync.
+
+Note: fixes 1+2+3 must land together with a Rust rebuild (`task build:backend`)
+before the next dev round — the frontend changes alone cannot help while the
+upsert RPC rejects every payload.
+
+---
+
+## 5. Fixes 4 and 5 — found during manual verification of fixes 1-3
+
+Fixes 1-3 landed and were retested live. Two more concrete bugs surfaced,
+neither anticipated in §1-4 above, both now fixed and covered by new tests.
+
+### 5a. Lost-update race in `update_object_meta` (the "most robust route" fix)
+
+Retrying a message after a fixed login still failed identically: the backend's
+own stale-`--resume`-session-id self-heal (`persistent.rs`'s stderr reader,
+`core::persist_session_id(block_id, "", ...)`) fired and logged success, but
+`agent:sessionid` in the DB never actually cleared.
+
+Root cause: `agentmux-srv/src/server/service/object_helpers.rs`'s
+`update_object_meta` did a plain `must_get` → `merge_meta` → `update` — two
+SEPARATE `Store` connection-mutex acquisitions, not one atomic unit. On every
+persistent-controller process exit, TWO independent async tasks write to the
+SAME block's meta within ~400ms of each other: the stderr reader clearing
+`agent:sessionid`, and the exit-wait task's `clear_active_pid` clearing
+`session:active_pid`. Each read a pre-write snapshot of the block's *entire*
+meta map, merged in its own single key, and wrote the *entire* merged map back
+— so whichever writer finished LAST silently reverted every key it didn't
+itself touch back to whatever it read, including the other writer's
+already-applied change.
+
+**Fix:** rewrote `update_object_meta` to run the whole read-merge-write inside
+one `Store::with_tx` critical section — a single acquisition of the store's
+connection `Mutex` wrapping a real SQLite transaction, via `StoreTx`'s
+already-existing `get`/`update` (used internally, no additional locking).
+Any two `Store::*` callers for ANY object now strictly serialize instead of
+racing. Added a genuine multi-threaded regression test (`object_helpers.rs`'s
+`update_object_meta_concurrent_writers_both_keys_survive` — two OS threads,
+synchronized via a `Barrier`, each writing a different key to the same block;
+asserts both keys survive). Full backend suite (1659 tests) passes.
+
+### 5b. Optimistic `TurnStart` never reverted on a synchronous send failure
+
+Separately, sending a message into a pane whose backend controller was gone
+(e.g. right after a `task dev` restart, before the pane is reopened — an
+everyday consequence of the manual test loop in this session, not a
+credential issue at all) showed "Working…" forever with no error surfaced.
+This is the direct answer to *"why does it say Working… — doesn't it know
+it's not logged in?"*: **it isn't about auth-error detection at all** — the
+turn never even started server-side.
+
+`agent-view.tsx`'s `handleSendMessage` dispatches `TurnStart` OPTIMISTICALLY,
+before `RpcApi.AgentInputCommand` is even awaited (so the composer clears and
+the spinner appears instantly on send, without waiting a round trip). If that
+RPC call rejects — no controller registered, the identity spawn gate blocking
+on a bad credential, a plain network hiccup, anything — `deliverToBackend`'s
+catch block (`useAgentCommands.ts`) only ever dispatched
+`PendingMessageRejected`, which removes the ghost pending-message row and
+**does nothing to `turnPhase`**. There was no path back to `Idle` for this
+failure mode at all, independent of anything the CLI itself does — this is a
+strictly more general and more common bug than the "auth-error doesn't end
+the turn" gap in §2/§4 item 4 above (which is about a `result`-frame-only
+turn-end contract for a process that DID spawn).
+
+**Fix:** added an `initiatesTurn` parameter to `deliverToBackend` (true for
+the idle/turn-initiating send path, false for a message flushed from the
+"held while busy" queue mid-turn — a held-message's OWN delivery failure must
+NOT cut short a turn that's genuinely already streaming). On
+`initiatesTurn && RPC rejects`, dispatch the existing `TurnReset` action
+(already used identically for the bang-command / handled-slash-command "no
+real turn happened" cases in the same file) to put `turnPhase` back to
+`Idle`. Added `useAgentCommands.test.ts` (previously no test file existed for
+this hook) with two tests: the idle-send-rejects case resets to Idle, and the
+held-message-flush-rejects case leaves an already-active turn's phase
+untouched. Full frontend suite (1943 tests) passes.
+
+Item 4 from §4's table (inband-auth-error → synthesized turn end, for a
+process that DID spawn and IS alive but never emits a `result` frame) remains
+open — 5b fixes the "RPC never even reached a controller" case, not the
+"CLI is running but hung/erroring without a terminal frame" case. Both are
+real; they're different failure points in the same turn-lifecycle.
+
+---
+
+## 6. HTTP 429 (rate-limited) handling — a proper backoff-retry design
+
+Requested alongside the fixes above: rate-limit handling should follow retry
+best practices (exponential backoff + jitter), not the current fixed
+two-step schedule. Design only in this section — not yet implemented.
+
+### Current state (grounded in the actual code, 2026-07-27)
+
+- `agentmux-srv/src/agents/failure.rs`'s `classify()` recognizes a 429 via
+  plain substring/keyword matching on the CLI's stderr + terminal
+  stream-json `result` frame text (`"rate limited"`, `"temporarily limiting
+  requests"`, `"rate_limit"`, or a mentioned HTTP status `429` —
+  `mentions_http_status(&hay, "429")`) → `FailureClass::RateLimited`,
+  `retryable: true`.
+- `frontend/app/view/agent/failure/failure-accessory.ts`'s `isTransient()`
+  auto-retry-eligibility check covers exactly three classes: `rate_limited`,
+  `overloaded`, `network` — all three share the same schedule below.
+- `frontend/app/view/agent/hooks/useAgentFailure.ts`'s `armAutoRetry()` runs
+  a **fixed, non-exponential, 2-entry schedule**:
+  `const AUTO_RETRY_BACKOFF_S = [5, 10] as const; // then manual-only`
+  — a 1-second countdown ticks down from 5, then (if it fails again) from
+  10, then permanently falls back to the manual "Retry" button
+  (`SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md §6`'s "2-attempt episode
+  budget"). Identical for all three transient classes — no 429-specific
+  tuning.
+- **No `Retry-After` (or equivalent hint) is ever parsed.** The classifier
+  extracts only a title/detail/stderr-tail; nothing reads a suggested wait
+  time out of the matched text even on the rare occasion the CLI's own error
+  output happens to include one. The CLI subprocess only exposes plain
+  stdout/stderr text to us — no raw HTTP response headers are available
+  regardless, so any `Retry-After` support here is necessarily best-effort
+  text-parsing, not a guaranteed structured value.
+
+### Gaps vs. best practice
+
+1. **Not exponential.** 5s → 10s is a fixed doubling for exactly two steps,
+   not real exponential growth — a THIRD consecutive 429 has no automatic
+   retry left at all and drops straight to manual, even though 429 bursts
+   are frequently short and self-clearing over more than two attempts.
+2. **No jitter.** `armAutoRetry` fires at exactly T+5s / T+10s,
+   deterministically. Multiple agent panes sharing one account/quota (a real
+   scenario in this app — several agents, one Anthropic subscription) would
+   all retry in lockstep and collide on the SAME rate limit again
+   (thundering herd).
+3. **No `Retry-After` honoring**, as above — the schedule is blind to any
+   hint the API/CLI does surface.
+4. **Uniform across transient classes.** A network blip and a 529 overload
+   plausibly clear faster than an account-level 429 throttle; today's
+   schedule doesn't distinguish.
+
+### Proposed design
+
+- **Decorrelated jitter** (the AWS Architecture Blog's recommended formula —
+  avoids both the thundering-herd problem plain jitter has and the
+  self-synchronizing failure mode capped-exponential-without-jitter has):
+
+  ```
+  sleep = min(cap, random_between(base, previous_sleep * 3))
+  ```
+
+  Per-class `(base, cap, max_attempts)`, since 429s specifically tend to
+  need a longer runway than a network blip:
+  - `rate_limited`: base=2s, cap=60s, max_attempts=5
+  - `overloaded`:   base=2s, cap=30s, max_attempts=4
+  - `network`:      base=1s, cap=15s, max_attempts=3
+
+  Worst-case total auto-retry window stays bounded (a few minutes) — same
+  spirit as today's fallback-to-manual safety net, just wider for the class
+  most likely to actually clear on its own.
+- **`Retry-After` honoring, best-effort:** extend `classify()` to optionally
+  extract `retry_after_secs: Option<u64>` from the matched rate-limited /
+  overloaded text (regex over patterns like `retry-after`,
+  `retry after (\d+)`, `wait (\d+)s`) and thread it onto `AgentFailure`. When
+  present, the frontend's computed delay becomes
+  `max(retry_after_secs, jittered_delay)` instead of ignoring the hint.
+  Absent (the common case) falls through to pure jittered backoff — no
+  required behavior change for the classifier's existing callers.
+- **Manual fallback unchanged.** Once `max_attempts` is exhausted for the
+  failure's class, the existing manual "Retry" button UI
+  (`SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md §6`) takes over exactly as
+  it does today — only the SCHEDULE feeding the auto-retry countdown
+  changes, not the episode/budget/manual-fallback architecture around it.
+- **UI unchanged.** `autoRetryIn`'s live countdown render already exists;
+  it just needs to be fed the new computed delay instead of a flat array
+  lookup by attempt index.
+
+### Implementation sketch (not yet built)
+
+- `frontend/app/view/agent/hooks/useAgentFailure.ts`: replace the flat
+  `AUTO_RETRY_BACKOFF_S` array with a per-class policy table
+  (`{ base, cap, maxAttempts }`) and a `nextDelaySecs(code, attempt,
+  retryAfterSecs?)` helper implementing the decorrelated-jitter formula
+  above (needs a `previousSleep` carried alongside the existing `autoRetries`
+  counter). `armAutoRetry` calls the helper instead of indexing the array,
+  and stops once `attempt >= maxAttempts` for that failure's class instead
+  of the current shared `AUTO_RETRY_BACKOFF_S.length` check.
+- `agentmux-srv/src/agents/failure.rs`: add `retry_after_secs: Option<u64>`
+  to `AgentFailure` (`#[serde(skip_serializing_if = "Option::is_none")]`,
+  matching the existing `exit_code`/`signal` pattern), populated by a
+  best-effort regex inside the existing rate-limited/overloaded branches.
+- Tests: extend `failure.rs`'s existing unit tests with a
+  `retry_after_secs` extraction case (and a no-hint-present case asserting
+  `None`); add a new `useAgentFailure.test.ts` (none exists today) pinning
+  the jitter formula's bounds (`base <= delay <= cap` across many samples,
+  since jitter is randomized) and the per-class `max_attempts` cutoff.
+
+This is fully additive — nothing about the existing manual-retry fallback,
+failure-row UI, or 2-attempt "episode" concept (dismiss/new-turn resets the
+budget) needs to change, only the schedule feeding the auto-retry countdown.

--- a/docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md
+++ b/docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md
@@ -1,0 +1,179 @@
+# Spec: Opt-in isolated auth for `task dev` testing
+
+**Date:** 2026-07-27
+**Status:** Implemented
+**Related:** `docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md`,
+`docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md`
+
+## The incident that motivated this
+
+Armory identity accounts (`db_accounts`, `db_agent_identity_links` — Claude/
+Anthropic OAuth tokens, API keys, etc.) live in exactly ONE global,
+channel-independent store: `~/.agentmux/shared/store.db` plus
+`~/.agentmux/shared/identities/<account_id>/` for the on-disk OAuth
+credential directories. This store is shared by **every** `task dev`
+branch, every portable build, every instance on the machine — there was
+no isolation at all.
+
+While manually testing a destructive Armory flow ("delete an account") in
+a `task dev` test branch, the destructive delete removed the same account
+backing a live, unrelated Claude Code agent session on the same machine.
+Nothing about the test branch was isolated from the real, in-use
+credential store.
+
+## What this adds
+
+An opt-in env var, `AGENTMUX_ISOLATED_AUTH=1`. When set for a `task dev`
+process, that instance gets its own fully isolated identity store and
+credential directory tree, colocated under its own channel dir
+(`instance_dir`) — safe to delete accounts from, impossible to affect any
+other instance's real credentials.
+
+**When unset (the default): zero behavior change.** This is deliberate.
+Re-authenticating every provider on every branch switch is real daily
+friction — it's the whole reason the seed-from-global login tier exists
+in the first place. Isolation must never be the default.
+
+## Explicit non-goals
+
+- **Does not touch `provider_auth_dir()`** (the ambient/no-account-bound
+  default provider config dir, e.g. `~/.agentmux/shared/providers/claude/`).
+  That directory's global, channel-independent nature is the structural
+  fix for a real prior regression — see
+  `docs/retro/retro-provider-auth-isolation-regression-2026-06-05.md` ("the
+  validate-spin bug"). This feature is orthogonal to that fix: the
+  Armory-account-bound login path always resolves `CLAUDE_CONFIG_DIR` from
+  `identities_dir()`, never from `provider_auth_dir()` — confirmed by
+  reading `CheckCliAuthCommand`'s implementation, which reads
+  `auth_env["CLAUDE_CONFIG_DIR"]` identically regardless of isolation mode.
+  `provider_auth_dir()` is reached only on the true ambient/no-account-bound
+  path, which this feature never touches.
+- **Does not change default `task dev` behavior at all.** Every existing
+  test, every existing workflow, is byte-for-byte unaffected when the flag
+  is unset.
+- **Does not isolate agent definitions, the agent registry, or
+  transcripts.** Those are separate subsystems (`resolve_shared_registry_dir`,
+  `resolve_shared_definitions_dir`, `resolve_shared_transcripts_dir`) with
+  their own already-correct cross-channel-sharing semantics, untouched by
+  this flag.
+
+## What becomes isolated vs. what stays global
+
+| Isolated (when flag is set) | Stays global (always) |
+|---|---|
+| `db_accounts`, `db_agent_identity_links` | Agent registry (`~/.agentmux/shared/agents/registry/`) |
+| Memory bundles, drone definitions, MuxBus credentials (same `shared_store`/`id_store` file) | Agent definitions (`~/.agentmux/shared/agents/definitions/`) |
+| OAuth credential directories (`identities_dir()`) | Global transcripts (`~/.agentmux/shared/agents/transcripts/`) |
+| | Ambient/default provider auth dir (`provider_auth_dir()`) |
+
+Memory bundles, drone definitions, and MuxBus credentials are isolated as
+a side effect of `shared_store`/`id_store` being one physical file with
+one migration-tracking table — they aren't separable without a larger,
+riskier surgery, and isolating them too is arguably correct anyway: a
+disposable test channel shouldn't depend on or pollute real shared
+bundles/drones either.
+
+## How it works
+
+`id_store` (`bootstrap.rs`) isn't a separate database — it's an `Arc<Store>`
+alias that points at `shared_store` when available and migrated, else
+falls back to the per-channel `wstore`. Two functions decide where
+`shared_store` physically lives:
+
+1. **`agentmux_common::isolated_auth_enabled()`** — the single source of
+   truth for the flag (`AGENTMUX_ISOLATED_AUTH == "1"`). One helper, read
+   fresh at every call site, rather than three independent env-var reads
+   that could drift out of sync.
+2. **`DataPaths::identities_dir()`** — returns `instance_dir.join("identities")`
+   instead of `shared_dir.join("identities")` when isolated.
+3. **`registry::resolve_shared_store_path()`** — returns
+   `instance_dir.join("identity-store.db")` (reading `AGENTMUX_INSTANCE_DIR`,
+   already exported to every child process) instead of the global
+   `store.db` path when isolated. Falls back to the global path if
+   `AGENTMUX_INSTANCE_DIR` is unresolvable (e.g. a bare `cargo run` outside
+   the launcher).
+
+### The two load-bearing fixes this required
+
+**Migration `ctx.home` must stay anchored to the true global root,
+independent of isolation.** `migrations/runner.rs`'s `MigrationContext.home`
+used to be derived by walking up from `shared_store_path`
+(`.parent().parent()`), which assumed the shared store was always exactly
+`<home>/shared/store.db`. Once `resolve_shared_store_path()` can return an
+isolated path, that arithmetic would silently produce the wrong `home` for
+every other Global migration (registry/definitions/transcripts dirs,
+backups, the error log) — and would make migration `0011_shared_store_backfill`'s
+cross-channel sibling scan resolve the wrong root entirely. Fixed by adding
+`resolve_home()` (a single shared helper, not one inline derivation per
+call site) that calls `registry::resolve_global_shared_root()` directly —
+a function deliberately **unaffected** by the isolation flag.
+
+**Migration `0011_shared_store_backfill` must skip its cross-channel
+sibling scan when isolated.** With `ctx.home` correctly anchored, this
+migration would otherwise correctly find and backfill every other
+channel's REAL `db_accounts`/`db_agent_identity_links` rows into the new
+isolated store on its first boot — defeating the entire "starts genuinely
+empty" point of this feature. This channel's own local objects.db is still
+included (that's this channel's own data, fine to carry in); only the
+scan across every *other* channel/branch on the machine is skipped.
+
+## First-boot behavior
+
+The first time an isolated store boots for a given channel, every
+currently-registered Global-scope migration runs once against it (migration
+state is tracked per-file in `db_migrations`) — this is expected and
+desirable: the isolated store ends up looking like a normal fresh install
+(starter skills/MCP servers seeded, etc.), not a broken one. Only
+migration 0011's cross-channel backfill is intentionally skipped, per above.
+
+## How to opt in
+
+Set the env var directly in your shell before invoking `task dev` — do
+**not** add a Taskfile `env:` block for this.
+
+```bash
+# bash / Git Bash
+AGENTMUX_ISOLATED_AUTH=1 task dev
+```
+
+```powershell
+# PowerShell
+$env:AGENTMUX_ISOLATED_AUTH=1; task dev
+```
+
+**Why not a Taskfile `env:` block:** Task's own declarative `env:` key does
+NOT cascade across a nested `- task: X` invocation on Windows — this is a
+real, already-hit bug in this exact `Taskfile.yml`. `AGENTMUX_DEV=1` had to
+be inlined directly onto `dev:serve`'s shell command line instead of
+relying on the `dev` task's own `env:` key for exactly this reason (see the
+comment at `Taskfile.yml` around the `dev:serve` task). Direct
+shell-env-var usage is ambient-env inheritance, not Task's `env:`
+cascading, so it isn't subject to that bug and requires zero Taskfile
+changes. If a discoverable `task dev:isolated-auth` convenience target is
+ever added, it must inline the var onto `dev:serve`'s command line the same
+way `AGENTMUX_DEV` already does — not rely on a YAML `env:` block.
+
+## Verification
+
+1. `cargo test -p agentmux-srv && cargo test -p agentmux-common` — all
+   tests pass, including the isolation-specific ones:
+   - `agentmux-common`: `data_paths::tests::identities_dir_is_shared_by_default`,
+     `identities_dir_is_per_channel_when_isolated_auth_set`
+   - `agentmux-srv`: `registry::paths::tests::shared_store_path_default_is_global`,
+     `shared_store_path_isolated_uses_instance_dir`,
+     `shared_store_path_isolated_without_instance_dir_falls_back`,
+     `migrations::runner::tests::home_is_invariant_to_isolated_auth`,
+     `migrations::m0011_shared_store_backfill::tests::backfills_sibling_accounts_when_not_isolated`,
+     `skips_sibling_accounts_when_isolated`
+2. Boot `AGENTMUX_ISOLATED_AUTH=1 task dev` on a scratch branch. Confirm
+   via `muxlog srv grep "shared store"` that the log line reads
+   `"shared store: attached (ISOLATED — channel-scoped)"` with a path
+   under `dev/<branch>/.../identity-store.db`.
+3. Create an Armory account in that isolated boot. Confirm it does NOT
+   appear in a normal (`task dev`, no flag) boot of the same or a
+   different branch, and vice versa.
+4. Delete that isolated account — confirm the real global store/credentials
+   (`~/.agentmux/shared/store.db`, `~/.agentmux/shared/identities/`) are
+   completely untouched.
+5. Confirm a normal `task dev` (no flag) boot is unaffected: same global
+   store, same account list as before this feature shipped.

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -333,6 +333,29 @@ describe("agent-pane-state reducer", () => {
             expect(r.state.sessionStats).toBe(null);
             expect(r.state.sessionTotals).toBe(null);
         });
+
+        it("TurnStartFailed reverts turnPhase to Idle WITHOUT wiping accumulated sessionTotals — unlike TurnReset", () => {
+            // A transient send failure (no controller registered, spawn gate
+            // blocked, network rejection) on an agent that already has prior
+            // completed turns must not wipe the session's accumulated
+            // cost/token display — reagent/codex P2 on PR #2318.
+            const s0 = ready(100);
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, {
+                type: "TurnEnd",
+                stats: { input_tokens: 100, output_tokens: 50, cost_usd: 0.01 } as any,
+            }).state;
+            expect(s2.sessionTotals).not.toBeNull();
+
+            // A new, unrelated turn optimistically starts, then its own send fails.
+            const s3 = update(s2, { type: "TurnStart", at: 200 }).state;
+            const r = update(s3, { type: "TurnStartFailed" });
+
+            expect(r.state.turnPhase.kind).toBe("Idle");
+            expect(r.state.sessionTotals).toMatchObject({ input_tokens: 100, output_tokens: 50, cost_usd: 0.01 });
+            expect(r.state.lastEventMs).not.toBeNull();
+            expect(r.events).toEqual([{ type: "turn-start-failed" }]);
+        });
     });
 
     describe("Tool", () => {

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -585,6 +585,17 @@ export function update(
                 events: [{ type: "turn-reset" }],
             };
 
+        case "TurnStartFailed":
+            // Deliberately touches ONLY turnPhase — see this command's doc
+            // comment in types.ts for why TurnReset's wholesale clear is
+            // wrong here (a transient send failure must not wipe
+            // sessionStats/sessionTotals/lastContextTokens accumulated by
+            // prior real turns in this same pane).
+            return {
+                state: { ...state, turnPhase: { kind: "Idle" } },
+                events: [{ type: "turn-start-failed" }],
+            };
+
         case "ToolStart": {
             const nextState = bumpEvent(
                 { ...state, currentTool: command.name, currentToolArg: command.arg ?? null },

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -438,6 +438,19 @@ export type AgentPaneCommand =
      * pending or streaming.
      */
     | { type: "TurnReset" }
+    /**
+     * Revert an OPTIMISTIC `TurnStart` when the turn never actually began —
+     * the initiating send's own RPC call failed synchronously (no
+     * controller registered, the identity spawn gate blocked it, a plain
+     * network rejection). Phase-only: unlike `TurnReset`, this must NOT
+     * touch `sessionStats`/`sessionTotals`/`lastContextTokens` — those
+     * accumulate across a pane's whole lifetime, and a transient send
+     * failure on an agent with prior completed turns must not wipe that
+     * history (reagent/codex P2 on PR #2318 — `TurnReset` was reused here
+     * first and incorrectly cleared them). See
+     * `useAgentCommands.ts`'s `deliverToBackend`.
+     */
+    | { type: "TurnStartFailed" }
 
     // ── Tool ───────────────────────────────────────────────────────
     | { type: "ToolStart"; name: string; arg?: string }
@@ -615,6 +628,7 @@ export type AgentPaneEvent =
           stoppingCleared: boolean;
       }
     | { type: "turn-reset" }
+    | { type: "turn-start-failed" }
     | {
           /**
            * Invariant fire: TurnStart while streaming inactive OR

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -800,6 +800,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // meant to make visible. reagent P1 on PR #2300.
     const showingLaunchActivity = () => status.isLoading() || status.launchPhase() != null;
 
+    // Composer strip's logged-in/out tag. `status.authStatus()` is the
+    // durable signal (set at mount and on every successful login/relogin),
+    // but a mid-turn 401 (credential went stale while the agent was already
+    // marked authenticated) surfaces first as an "auth"-classified failure
+    // row, not a fresh authStatus transition — so a live auth failure
+    // overrides the tag to "unauthenticated" the instant it appears, instead
+    // of waiting for the user to click "Login Again" first.
+    const loginStatus = createMemo((): "authenticated" | "unauthenticated" | "unknown" => {
+        if (agentAtoms().failureAtom[0]()?.data.code === "auth") return "unauthenticated";
+        return status.authStatus();
+    });
+
     onMount(() => {
         const name = block()?.meta?.["agentName"] ?? agentId;
         const provName = provider()?.displayName ?? providerKey();
@@ -1454,8 +1466,22 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
             <Show when={status.canRetry()}>
                 <div class="agent-retry-bar">
-                    <button class="agent-retry-btn" onClick={status.startLaunchFlow}>
-                        Retry Login
+                    {/* Wired to relogin(), not startLaunchFlow: the mount-time
+                        launch flow now only ever notifies and stops on
+                        auth_failed (launch-flow.ts), so re-running it here
+                        would immediately hit the same not-authenticated check
+                        and bail again with no login ever attempted — an
+                        infinite dead-end. relogin() is the one path that
+                        actually starts a login.
+                        retryAfterLogin: false — no turn was ever attempted
+                        here (Phase 2 bailed before Phase 3), so there's no
+                        failed turn to retry. Without this, a successful
+                        login on an agent with prior history silently resent
+                        its last old message as a new turn, burying the
+                        "Login successful" notification under that turn's
+                        immediate stream of output. */}
+                    <button class="agent-retry-btn" onClick={() => void status.relogin({ retryAfterLogin: false })}>
+                        Log in
                     </button>
                 </div>
             </Show>
@@ -1580,6 +1606,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 }
                 contextTokens={agentAtoms().contextTokensAtom[0]()}
                 contextWindow={agentAtoms().contextWindowAtom[0]() ?? provider()?.contextWindow}
+                authStatus={loginStatus()}
                 blockId={model.blockId}
                 blockAtom={block}
                 providerId={provider()?.id ?? ""}

--- a/frontend/app/view/agent/commands/global/login.test.ts
+++ b/frontend/app/view/agent/commands/global/login.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * reagent P1 (re-review of PR #2318): the /login command's tier-1 "opened"
+ * branch discarded persistAndLinkAccount's boolean return and reported
+ * success unconditionally — the exact same gap found and fixed in
+ * useAgentControllerStatus.ts's relogin() "opened" branch, but this
+ * parallel path was never updated. A DB-write failure here must surface as
+ * an error, not "login complete", since the resolver's spawn gate will
+ * still block the very next turn with no real account behind it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    checkCliAuth: vi.fn(),
+    runProviderLogin: vi.fn(),
+    persistAndLinkAccount: vi.fn(),
+}));
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        CheckCliAuthCommand: (...args: unknown[]) => hub.checkCliAuth(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("../../flows/run-provider-login", () => ({
+    runProviderLogin: (...args: unknown[]) => hub.runProviderLogin(...args),
+    persistAndLinkAccount: (...args: unknown[]) => hub.persistAndLinkAccount(...args),
+}));
+
+import { loginCommand } from "./login";
+import type { SlashCommandContext } from "../types";
+
+const claude = {
+    id: "claude",
+    displayName: "Claude",
+    authCheckCommand: ["auth", "status"],
+    headlessLoginUrlUnsupported: false,
+} as any;
+
+function makeCtx(): SlashCommandContext {
+    return {
+        blockId: "block-1",
+        provider: () => claude,
+        block: () => ({ meta: { cmd: "claude-cli", agentId: "agent-1" } }),
+        documentAtom: [() => [], vi.fn()] as any,
+        log: vi.fn(),
+        setAuthUrl: vi.fn(),
+        openPicker: vi.fn(),
+        openHelp: vi.fn(),
+    };
+}
+
+beforeEach(() => {
+    hub.checkCliAuth.mockReset().mockResolvedValue({ authenticated: true });
+    // Simulates tier 1: onAccountRegistered fires with a minted (not yet
+    // persisted) account, then the outcome resolves "opened" — the handler's
+    // own poll loop below is what confirms completion and triggers persist.
+    hub.runProviderLogin.mockReset().mockImplementation(async (opts: any) => {
+        opts.onAccountRegistered?.("acct-1", "/tmp/acct-1-dir");
+        return "opened";
+    });
+    hub.persistAndLinkAccount.mockReset();
+});
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+});
+
+describe("/login — tier-1 'opened' branch persist-failure gating", () => {
+    it("returns ok and logs success when persistAndLinkAccount actually persists the account", async () => {
+        vi.useFakeTimers();
+        hub.persistAndLinkAccount.mockResolvedValue(true);
+        const ctx = makeCtx();
+
+        const promise = loginCommand.handler(ctx, "");
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await promise;
+
+        expect(result).toEqual({ kind: "ok" });
+        expect(ctx.log).toHaveBeenCalledWith("auth", "login complete — run /cost to verify");
+    });
+
+    it("reagent P1 (re-review of PR #2318): returns an error, not ok, when persistAndLinkAccount fails to save the account", async () => {
+        vi.useFakeTimers();
+        hub.persistAndLinkAccount.mockResolvedValue(false);
+        const ctx = makeCtx();
+
+        const promise = loginCommand.handler(ctx, "");
+        await vi.advanceTimersByTimeAsync(2_000);
+        const result = await promise;
+
+        expect(result).toEqual({
+            kind: "error",
+            message: "/login: the login succeeded, but AgentMux couldn't save the account record. Try again in a moment.",
+        });
+        expect(ctx.log).not.toHaveBeenCalledWith("auth", "login complete — run /cost to verify");
+    });
+});

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -104,11 +104,25 @@ export const loginCommand: SlashCommand = {
                         }
                     }
                     if (authenticated && openedAccountId && openedAccountDir) {
-                        await persistAndLinkAccount(
+                        // reagent P1 (re-review of PR #2318): must check the
+                        // return value — the exact same persist-failure gap
+                        // found and fixed in useAgentControllerStatus.ts's
+                        // relogin() "opened" branch. Without this, a DB-write
+                        // failure here still reported "login complete" while
+                        // leaving no real account behind for the resolver's
+                        // spawn gate to find on the very next turn.
+                        const persisted = await persistAndLinkAccount(
                             { provider: prov, cliPath, authEnv, setAuthUrl: ctx.setAuthUrl, log: ctx.log, linkTarget },
                             openedAccountId,
                             openedAccountDir,
                         );
+                        if (!persisted) {
+                            return {
+                                kind: "error",
+                                message:
+                                    "/login: the login succeeded, but AgentMux couldn't save the account record. Try again in a moment.",
+                            };
+                        }
                         ctx.log("auth", "login complete — run /cost to verify");
                         return { kind: "ok" };
                     }

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -120,10 +120,24 @@ export const loginCommand: SlashCommand = {
                     };
                 }
                 case "seeded":
-                    return { kind: "ok" };
                 case "terminal-success":
-                    ctx.log("auth", "login complete — run /cost to verify");
-                    return { kind: "ok" };
+                    // openedAccountId/openedAccountDir are only set once
+                    // onAccountRegistered fires — run-provider-login.ts only
+                    // calls it once the account row is actually persisted, so
+                    // this also catches the case where a credential seeded/
+                    // typed in successfully but the DB write itself failed.
+                    // See REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md.
+                    if (openedAccountId && openedAccountDir) {
+                        if (outcome === "terminal-success") {
+                            ctx.log("auth", "login complete — run /cost to verify");
+                        }
+                        return { kind: "ok" };
+                    }
+                    return {
+                        kind: "error",
+                        message:
+                            "/login: the login succeeded, but AgentMux couldn't save the account record. Try again in a moment.",
+                    };
                 case "terminal-timeout":
                     // Never report success for a login that didn't complete
                     // (retro-agent-auth-relogin-noop-2026-07-01 §5.1).

--- a/frontend/app/view/agent/components/AgentComposerStrip.tsx
+++ b/frontend/app/view/agent/components/AgentComposerStrip.tsx
@@ -90,6 +90,11 @@ interface AgentComposerStripProps {
     contextTokens?: number | null;
     /** Provider's max context window size. undefined = unknown. */
     contextWindow?: number;
+    /** Durable logged-in/out state (useAgentControllerStatus's authStatus) —
+     *  rendered as a small red/green tag right of the context text. Hidden
+     *  entirely for "unknown" (before the first auth check resolves), so the
+     *  strip doesn't flash a wrong color for an instant on every mount. */
+    authStatus?: "authenticated" | "unauthenticated" | "unknown";
 
     // ── Inline model / effort controls ────────────────────────────
     /** Block id — needed for applyRuntimeChange. */
@@ -225,6 +230,23 @@ export const AgentComposerStrip = (props: AgentComposerStripProps): JSX.Element 
                         }
                     >
                         {ctxText()}
+                    </span>
+                </Show>
+                <Show when={props.authStatus === "authenticated" || props.authStatus === "unauthenticated"}>
+                    <span
+                        class="agent-composer-strip-auth"
+                        classList={{
+                            "agent-composer-strip-auth--ok": props.authStatus === "authenticated",
+                            "agent-composer-strip-auth--bad": props.authStatus === "unauthenticated",
+                        }}
+                        title={
+                            props.authStatus === "authenticated"
+                                ? "Signed in to this agent's provider"
+                                : "Not signed in — click Log in to continue"
+                        }
+                    >
+                        <span class="agent-composer-strip-auth-dot" aria-hidden="true" />
+                        {props.authStatus === "authenticated" ? "Logged in" : "Not logged in"}
                     </span>
                 </Show>
                 <button

--- a/frontend/app/view/agent/flows/launch-flow.test.ts
+++ b/frontend/app/view/agent/flows/launch-flow.test.ts
@@ -245,4 +245,41 @@ describe("runLaunchFlow — Phase 3 (already authenticated)", () => {
         expect(last.text).not.toMatch(/^Ready/i);
         expect(last.text).not.toMatch(/^Resumed/i);
     });
+
+    it("reports onAuthCheckResult(true) when CheckCliAuthCommand actually confirms authentication", async () => {
+        const results: boolean[] = [];
+        const result = await runLaunchFlow({
+            blockId: "block-1",
+            provider: claude,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+            onAuthCheckResult: (confirmed) => results.push(confirmed),
+        });
+
+        expect(result).toBe("success");
+        expect(results).toEqual([true]);
+    });
+
+    it("reagent/codex P2 on PR #2318: reports onAuthCheckResult(false) — not true — when the auth check itself throws, even though the flow still proceeds to 'success'", async () => {
+        // Phase 2 deliberately doesn't fail launch on a transient auth-check
+        // RPC error ("authentication status unknown — will attempt anyway"),
+        // but the caller must be able to tell this apart from an actually
+        // confirmed login — otherwise it shows a false "Logged in" tag.
+        hub.checkCliAuth.mockReset().mockRejectedValue(new Error("timeout"));
+        const results: boolean[] = [];
+        const result = await runLaunchFlow({
+            blockId: "block-1",
+            provider: claude,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+            onAuthCheckResult: (confirmed) => results.push(confirmed),
+        });
+
+        expect(result).toBe("success");
+        expect(results).toEqual([false]);
+    });
 });

--- a/frontend/app/view/agent/flows/launch-flow.test.ts
+++ b/frontend/app/view/agent/flows/launch-flow.test.ts
@@ -1,16 +1,19 @@
-// Copyright 2026, AgentMux Corp.
+// Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Pins the deterministic-login-UX fix: runLaunchFlow must pass
- * `skipTier1: true` into runProviderLogin for providers flagged
- * `headlessLoginUrlUnsupported` (Claude) — so the mount-time auto-login
- * path never burns cli_login.rs's URL-capture wait on a documented dead
- * end. See catalog.ts's DEAD END note and run-provider-login.test.ts's
- * own "skipTier1 skips the headless URL-capture attempt entirely" test,
- * which pins that a true skipTier1 keeps getApi().runCliLogin from ever
- * being called — this test pins that runLaunchFlow actually sets that
- * flag for the right providers.
+ * Pins the no-auto-login fix: runLaunchFlow's Phase 2 must NEVER call
+ * runProviderLogin (or open a browser/terminal) on its own. Before this
+ * fix, an unauthenticated agent's mount-time flow silently launched a
+ * login attempt with no click and no way to decline — this is the exact
+ * behavior the user reported as broken across multiple test rounds
+ * ("it will launch the browser immediately without my clicking login").
+ * The flow must instead post a notification, set a terminal phase
+ * (first-login / auth-expired), and return "auth_failed" immediately —
+ * an actual login only ever starts from the user's own click on the
+ * "Log in" button (agent-view.tsx), wired to relogin() in
+ * useAgentControllerStatus.ts, not from this function. See
+ * docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md §8 Q6.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,8 +28,6 @@ const hub = vi.hoisted(() => ({
     cancelCliLogin: vi.fn(),
     ensureCapability: vi.fn(),
     getCapability: vi.fn(),
-    runProviderLogin: vi.fn(),
-    persistAndLinkAccount: vi.fn(),
     waveEventSubscribe: vi.fn(),
     getWaveObjectAtom: vi.fn(),
 }));
@@ -61,29 +62,18 @@ vi.mock("@/app/store/global", () => ({
     getApi: () => ({ cancelCliLogin: hub.cancelCliLogin }),
     staticTabId: () => "tab-1",
 }));
-vi.mock("./run-provider-login", () => ({
-    runProviderLogin: (...args: unknown[]) => hub.runProviderLogin(...args),
-    persistAndLinkAccount: (...args: unknown[]) => hub.persistAndLinkAccount(...args),
-}));
 
 import { runLaunchFlow } from "./launch-flow";
 
 const claude = {
     id: "claude",
+    displayName: "Claude",
     cliCommand: "claude",
     authCheckCommand: ["auth", "status"],
     authLoginCommand: ["auth", "login"],
     authConfigDirEnvVar: "CLAUDE_CONFIG_DIR",
     requiresLoginTty: true,
     headlessLoginUrlUnsupported: true,
-} as any;
-
-const codex = {
-    id: "codex",
-    cliCommand: "codex",
-    authCheckCommand: ["auth", "status"],
-    authLoginCommand: ["login"],
-    authConfigDirEnvVar: "CODEX_HOME",
 } as any;
 
 beforeEach(() => {
@@ -96,8 +86,6 @@ beforeEach(() => {
     hub.cancelCliLogin.mockReset().mockResolvedValue(undefined);
     hub.ensureCapability.mockReset().mockResolvedValue(undefined);
     hub.getCapability.mockReset().mockReturnValue({ status: "available" });
-    hub.runProviderLogin.mockReset().mockResolvedValue("seeded");
-    hub.persistAndLinkAccount.mockReset().mockResolvedValue(true);
     hub.waveEventSubscribe.mockReset().mockReturnValue(() => {});
     // Default: a brand-new agent that has never resolved its CLI before
     // (no "cmd" in meta) — see the first-login vs auth-expired tests below
@@ -108,9 +96,55 @@ afterEach(() => {
     vi.clearAllMocks();
 });
 
-describe("runLaunchFlow — skipTier1 wiring", () => {
-    it("passes skipTier1: true for a headlessLoginUrlUnsupported provider (Claude) — the auto-login path never attempts tier 1's doomed URL-capture wait", async () => {
-        await runLaunchFlow({
+describe("runLaunchFlow — no auto-login on Phase 2", () => {
+    it("returns auth_failed immediately on an unauthenticated first-ever login, without opening anything", async () => {
+        const phases: string[] = [];
+        const notices: Array<{ text: string; style: string }> = [];
+        const result = await runLaunchFlow({
+            blockId: "block-1",
+            provider: claude,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+            setLaunchPhase: (p) => { if (p) phases.push(p.kind); },
+            onNotify: (text, style) => notices.push({ text, style }),
+        });
+
+        expect(result).toBe("auth_failed");
+        expect(phases).toEqual(["resolving-cli", "checking-auth", "first-login"]);
+        // No login attempt of any kind — no terminal-opening / polling phases.
+        expect(phases).not.toContain("opening-login-terminal");
+        expect(phases).not.toContain("waiting-for-login-link");
+        expect(phases).not.toContain("waiting-for-login-completion");
+        expect(notices[0].style).toBe("info");
+        expect(notices[0].text).toMatch(/sign in/i);
+    });
+
+    it("returns auth_failed with auth-expired (not first-login) when a real account link already exists for this agent+provider", async () => {
+        hub.listAgentIdentities.mockResolvedValue([{ provider: "claude", account_id: "acct-1" }]);
+        const phases: string[] = [];
+        const notices: Array<{ text: string; style: string }> = [];
+        const result = await runLaunchFlow({
+            blockId: "block-1",
+            provider: claude,
+            log: vi.fn(),
+            setAuthUrl: vi.fn(),
+            isCancelled: () => false,
+            setLoginWaiting: vi.fn(),
+            setLaunchPhase: (p) => { if (p) phases.push(p.kind); },
+            onNotify: (text, style) => notices.push({ text, style }),
+        });
+
+        expect(result).toBe("auth_failed");
+        expect(phases).toContain("auth-expired");
+        expect(phases).not.toContain("first-login");
+        expect(notices[0].style).toBe("warning");
+        expect(notices[0].text).toMatch(/expired/i);
+    });
+
+    it("does not throw or hang when onNotify/setLaunchPhase are omitted (both optional)", async () => {
+        const result = await runLaunchFlow({
             blockId: "block-1",
             provider: claude,
             log: vi.fn(),
@@ -119,32 +153,16 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
             setLoginWaiting: vi.fn(),
         });
 
-        expect(hub.runProviderLogin).toHaveBeenCalledTimes(1);
-        expect(hub.runProviderLogin.mock.calls[0][0]).toMatchObject({ skipTier1: true });
+        expect(result).toBe("auth_failed");
     });
+});
 
-    it("leaves skipTier1 false for a provider without the flag (Codex) — tier 1 still gets a real chance to capture a URL", async () => {
-        await runLaunchFlow({
-            blockId: "block-1",
-            provider: codex,
-            log: vi.fn(),
-            setAuthUrl: vi.fn(),
-            isCancelled: () => false,
-            setLoginWaiting: vi.fn(),
-        });
-
-        expect(hub.runProviderLogin).toHaveBeenCalledTimes(1);
-        expect(hub.runProviderLogin.mock.calls[0][0]).toMatchObject({ skipTier1: false });
+describe("runLaunchFlow — Phase 3 (already authenticated)", () => {
+    beforeEach(() => {
+        hub.checkCliAuth.mockReset().mockResolvedValue({ authenticated: true, email: "user@example.com" });
     });
 
     it("reports a launchPhase for every visible phase, and never leaves a stale non-terminal phase behind on success", async () => {
-        // First call is Phase 2's initial auth check (unauthenticated, so
-        // needsLogin fires); second is the post-"seeded" one-shot recheck,
-        // which must report success for the flow to reach "ready".
-        hub.checkCliAuth
-            .mockReset()
-            .mockResolvedValueOnce({ authenticated: false })
-            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
         const phases: string[] = [];
         const result = await runLaunchFlow({
             blockId: "block-1",
@@ -157,68 +175,10 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
         });
 
         expect(result).toBe("success");
-        expect(phases[0]).toBe("resolving-cli");
-        expect(phases).toContain("checking-auth");
-        // No prior "cmd" in meta (see beforeEach) — this is a first-ever
-        // login, not a lapsed one.
-        expect(phases).toContain("first-login");
-        expect(phases).toContain("opening-login-terminal");
-        // getControllerStatus defaults to shellprocstatus: "init" (beforeEach).
-        expect(phases[phases.length - 1]).toBe("fresh-ready");
-    });
-
-    it("reports auth-expired (not first-login) when a real account link already exists for this agent+provider", async () => {
-        hub.getWaveObjectAtom.mockReturnValue(() => ({
-            meta: { agentMode: "host", agentId: "agent-1" },
-        }));
-        // A real, persisted prior login — the only trustworthy "has logged in
-        // before" signal (see agent-model.ts's launchAgent(): meta.cmd is set
-        // unconditionally at agent-creation time, before any login, so it
-        // can't be used for this — reagent P1 on PR #2304).
-        hub.listAgentIdentities.mockResolvedValue([{ provider: "claude", account_id: "acct-1" }]);
-        const phases: string[] = [];
-        await runLaunchFlow({
-            blockId: "block-1",
-            provider: claude,
-            log: vi.fn(),
-            setAuthUrl: vi.fn(),
-            isCancelled: () => false,
-            setLoginWaiting: vi.fn(),
-            setLaunchPhase: (p) => { if (p) phases.push(p.kind); },
-        });
-
-        expect(phases).toContain("auth-expired");
-        expect(phases).not.toContain("first-login");
-    });
-
-    it("notifies with a warning before an expired-token relogin, and a neutral message for a first-ever login", async () => {
-        const notices: Array<{ text: string; style: string }> = [];
-        hub.getWaveObjectAtom.mockReturnValue(() => ({
-            meta: { agentMode: "host", agentId: "agent-1" },
-        }));
-        hub.listAgentIdentities.mockResolvedValue([{ provider: "claude", account_id: "acct-1" }]);
-        await runLaunchFlow({
-            blockId: "block-1",
-            provider: claude,
-            log: vi.fn(),
-            setAuthUrl: vi.fn(),
-            isCancelled: () => false,
-            setLoginWaiting: vi.fn(),
-            onNotify: (text, style) => notices.push({ text, style }),
-        });
-
-        expect(notices[0].style).toBe("warning");
-        expect(notices[0].text).toMatch(/expired/i);
+        expect(phases).toEqual(["resolving-cli", "checking-auth", "verifying", "fresh-ready"]);
     });
 
     it("notifies 'Resumed...' (not 'Ready...') when GetControllerStatus reports a prior turn (shellprocstatus: done)", async () => {
-        // Needs the login to actually succeed (auth_failed returns before
-        // Phase 3 ever runs) — same recheck-succeeds pattern as the
-        // "reports a launchPhase for every visible phase" test above.
-        hub.checkCliAuth
-            .mockReset()
-            .mockResolvedValueOnce({ authenticated: false })
-            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
         hub.getControllerStatus.mockResolvedValue({ shellprocstatus: "done" });
         const phases: string[] = [];
         const notices: Array<{ text: string; style: string }> = [];
@@ -241,10 +201,6 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
     });
 
     it("reagent P1 on PR #2303: also notifies 'Resumed...' for shellprocstatus 'running' — a persistent controller can resume while still alive/mid-turn, not just 'done'", async () => {
-        hub.checkCliAuth
-            .mockReset()
-            .mockResolvedValueOnce({ authenticated: false })
-            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
         hub.getControllerStatus.mockResolvedValue({ shellprocstatus: "running" });
         const phases: string[] = [];
         const notices: Array<{ text: string; style: string }> = [];
@@ -271,12 +227,7 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
         // gate refusing the controller) was logged but still fell through to
         // the unconditional ready/resumed-ready notification — misrepresenting
         // a failed, possibly-unusable agent as ready.
-        hub.checkCliAuth
-            .mockReset()
-            .mockResolvedValueOnce({ authenticated: false })
-            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
         hub.controllerResync.mockRejectedValue(new Error("memory full"));
-        const phases: string[] = [];
         const notices: Array<{ text: string; style: string }> = [];
         const result = await runLaunchFlow({
             blockId: "block-1",
@@ -285,7 +236,6 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
             setAuthUrl: vi.fn(),
             isCancelled: () => false,
             setLoginWaiting: vi.fn(),
-            setLaunchPhase: (p) => { if (p) phases.push(p.kind); },
             onNotify: (text, style) => notices.push({ text, style }),
         });
 
@@ -294,45 +244,5 @@ describe("runLaunchFlow — skipTier1 wiring", () => {
         expect(last.style).toBe("warning");
         expect(last.text).not.toMatch(/^Ready/i);
         expect(last.text).not.toMatch(/^Resumed/i);
-    });
-
-    it("reagent P1: updates the phase via onTierChange instead of freezing on a stale waiting-for-login-link deadline once tier 1 fails and tier 2/3 take over", async () => {
-        // Codex doesn't have headlessLoginUrlUnsupported, so it gets the
-        // deadline-bearing "waiting-for-login-link" phase before this call —
-        // exactly the phase that used to freeze once tier 1's own timeout
-        // expired and runProviderLogin's internal tier 2/3 (up to 5 more
-        // minutes) took over with zero further signal to the caller.
-        hub.checkCliAuth
-            .mockReset()
-            .mockResolvedValueOnce({ authenticated: false })
-            .mockResolvedValue({ authenticated: true, email: "user@example.com" });
-        hub.runProviderLogin.mockReset().mockImplementation(async (params: any) => {
-            // Simulate tier 1 failing, then a terminal opening and polling —
-            // exactly what run-provider-login.ts's real onTierChange calls do.
-            params.onTierChange?.({ tier: "fallback" });
-            params.onTierChange?.({ tier: "polling", deadlineMs: Date.now() + 5 * 60 * 1000 });
-            return "terminal-success";
-        });
-        const phases: Array<{ kind: string; deadlineMs?: number }> = [];
-        await runLaunchFlow({
-            blockId: "block-1",
-            provider: codex,
-            log: vi.fn(),
-            setAuthUrl: vi.fn(),
-            isCancelled: () => false,
-            setLoginWaiting: vi.fn(),
-            setLaunchPhase: (p) => { if (p) phases.push(p as any); },
-        });
-
-        const linkPhaseIndex = phases.findIndex((p) => p.kind === "waiting-for-login-link");
-        const fallbackIndex = phases.findIndex((p) => p.kind === "opening-login-terminal");
-        const pollingIndex = phases.findIndex((p) => p.kind === "waiting-for-login-completion");
-        expect(linkPhaseIndex).toBeGreaterThanOrEqual(0);
-        // The stale-deadline phase must not be the last thing shown — both
-        // onTierChange transitions must land AFTER it, in order.
-        expect(fallbackIndex).toBeGreaterThan(linkPhaseIndex);
-        expect(pollingIndex).toBeGreaterThan(fallbackIndex);
-        const pollingPhase = phases[pollingIndex];
-        expect(pollingPhase.deadlineMs).toBeGreaterThan(Date.now());
     });
 });

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -90,6 +90,22 @@ export interface LaunchFlowOptions {
      * Finding 1.
      */
     onControllerStatus?: (rts: BlockControllerRuntimeStatus) => void;
+    /**
+     * Reports whether Phase 2's auth check actually PROVED the CLI is
+     * authenticated (`authResult.authenticated === true`) versus proceeding
+     * on an unconfirmed check (the RPC itself threw or timed out — logged
+     * as "authentication status unknown — will attempt anyway" and NOT
+     * treated as `auth_failed`, since a transient check failure shouldn't
+     * block launch). Without this, "success" alone is ambiguous: it means
+     * "controller registered, ready for input" (see LaunchFlowResult's own
+     * doc comment) and is returned identically whether or not login was
+     * ever actually confirmed — a caller that maps every "success" straight
+     * to `authStatus: "authenticated"` shows a false green "Logged in" tag
+     * for a credential that was never checked (reagent/codex P2 on
+     * PR #2318). Not called at all on the `auth_failed`/`fatal` paths —
+     * those already have their own explicit outcome.
+     */
+    onAuthCheckResult?: (confirmed: boolean) => void;
 }
 
 export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
@@ -212,12 +228,14 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             const emailPart = authResult.email ? ` as ${authResult.email}` : "";
             const methodPart = authResult.auth_method ? ` (${authResult.auth_method})` : "";
             log("auth", `authenticated${emailPart}${methodPart}`);
+            opts.onAuthCheckResult?.(true);
         } else {
             needsLogin = true;
         }
     } catch (err: any) {
         log("auth", `check failed: ${err?.message ?? String(err)}`, "warn");
         log("auth", "authentication status unknown — will attempt anyway", "warn");
+        opts.onAuthCheckResult?.(false);
     }
 
     if (needsLogin) {

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -14,21 +14,27 @@
  *      to `install_progress` events so the caller's log sink sees each npm
  *      line as it happens.
  *   2. Auth check — calls the provider's check-auth command. If unauthenticated,
- *      spawns the login command via the CEF host (so the browser opens
- *      correctly on Windows), then polls with 2s cadence until authenticated,
- *      cancelled, or 5 minutes elapse.
+ *      this does NOT open a browser/terminal on its own — it posts a visible
+ *      notification explaining that a login is needed and returns
+ *      "auth_failed" immediately. The user must click the resulting "Log in"
+ *      affordance (wired to `relogin()`) to actually trigger a login attempt.
+ *      A login opening with no prior user action was the exact bug this
+ *      changed to fix — see docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md.
  *   3. Controller registration — ControllerResync on the tab, read status, post
  *      a visible "Resumed…"/"Ready…" notification (or, if the resync itself
  *      failed, an honest warning instead of a false all-clear — see
  *      `resyncFailed` below) depending on whether there's a prior turn.
  *
- * The caller provides a log sink, a cancellation accessor, and callbacks for
- * two pieces of external state (`authUrl`, `loginWaiting`). All other state
- * is derived from the block_id + provider definition.
+ * The caller provides a log sink and a phase/notify callback. All other
+ * state is derived from the block_id + provider definition. `setAuthUrl`/
+ * `isCancelled`/`setLoginWaiting` remain on `LaunchFlowOptions` for callers
+ * that still pass them, but this function itself no longer drives a login
+ * attempt, so it never touches them.
  *
  * Return values:
  *   - "success"     — controller registered, ready for user input
- *   - "auth_failed" — login timed out, cancelled, or erred (retry makes sense)
+ *   - "auth_failed" — not authenticated; the caller must show a "Log in" affordance
+ *                     (wired to `relogin()`) — this function never attempts a login itself
  *   - "fatal"       — CLI missing, docker missing, provider unknown (retry won't help)
  */
 
@@ -40,9 +46,8 @@ import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import * as WOS from "@/app/store/wos";
 import { BlockService } from "@/app/store/services";
-import { getApi, staticTabId } from "@/app/store/global";
-import { persistAndLinkAccount, runProviderLogin } from "./run-provider-login";
-import { LOGIN_LINK_CAPTURE_LABEL_MS, type LaunchPhase } from "./launch-phase";
+import { staticTabId } from "@/app/store/global";
+import type { LaunchPhase } from "./launch-phase";
 import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
@@ -90,7 +95,7 @@ export interface LaunchFlowOptions {
 export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
 
 export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlowResult> {
-    const { blockId, provider, log, setAuthUrl, isCancelled, setLoginWaiting, authEnv } = opts;
+    const { blockId, provider, log, authEnv } = opts;
     const setPhase = opts.setLaunchPhase ?? (() => {});
     const notify = opts.onNotify ?? (() => {});
 
@@ -219,14 +224,9 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         const agentDefinitionId = blockData?.meta?.agentId as string | undefined;
 
         // Reuse the account already bound to this agent for this provider,
-        // if any — reagent P1: without this, every retry through this flow
-        // minted a brand-new account+dir instead of refreshing the one
-        // already in use, orphaning an unlinked IdentityAccount row/dir on
-        // every failed "Retry Login" click. Computed up front (not just
-        // where it's used below) because it doubles as the "has this agent
-        // ever actually logged in before" signal for the notification
-        // below — a REAL account link can only exist if a prior login
-        // completed and got persisted (persistAndLinkAccount/
+        // if any — used only to distinguish first-login from auth-expired
+        // wording below. A REAL account link can only exist if a prior
+        // login completed and got persisted (persistAndLinkAccount/
         // finalizeAccount), unlike blockData?.meta?.["cmd"] (an earlier,
         // broken attempt at this signal — reagent P1 on PR #2304: agent-
         // model.ts's launchAgent() writes `cmd` into meta unconditionally
@@ -240,210 +240,31 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 });
                 existingAccountId = links.find((l) => l.provider === provider.id)?.account_id;
             } catch {
-                // Best-effort — a fresh account still gets minted below if this lookup fails.
+                // Best-effort — treated as "no existing account" if this lookup fails.
             }
         }
 
-        // See docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md §8
-        // Q6: a brand-new agent needing its first login isn't "expired," and
-        // telling the user otherwise would be both wrong and alarming.
+        // DELIBERATELY DOES NOT open a browser/terminal here. This function
+        // used to call runProviderLogin() automatically the instant an
+        // unauthenticated agent was opened — a login window appearing with
+        // no click, no warning, and no way to decline. Per direct user
+        // instruction (2026-07-27, superseding SPEC_AGENT_PANE_AUTH_
+        // NOTIFICATIONS_2026_07_26.md §8 Q2's "notify-then-proceed"
+        // decision): the mount-time flow now only ever posts a notification
+        // and stops — actually starting a login is exclusively a user
+        // action, via the "Log in" button (`agent-view.tsx`) wired to
+        // `relogin()` in `useAgentControllerStatus.ts`. See
+        // docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md §8 Q6
+        // for why first-login and auth-expired still get different wording.
         if (existingAccountId) {
             setPhase({ kind: "auth-expired" });
-            notify(`Your ${provider.displayName} login has expired — signing back in…`, "warning");
+            notify(`Your ${provider.displayName} login has expired. Click "Log in" to continue.`, "warning");
         } else {
             setPhase({ kind: "first-login" });
-            notify(`Signing in to ${provider.displayName}…`, "info");
+            notify(`${provider.displayName} needs you to sign in before this agent can start. Click "Log in" to continue.`, "info");
         }
-        log("auth", "not authenticated — starting login flow...");
-        setLoginWaiting(true);
-        try {
-            // Shared with `/login` and the "Login Again" failure-banner action
-            // (retro-headless-login-browser-open-2026-07-20 / retro-login-
-            // three-code-paths-2026-07-20) — this used to be a hand-rolled
-            // `runCliLogin` call with no fallback when the CLI produced no
-            // scrapeable URL, which is every time for Claude Code v2.1.x. That
-            // left this specific call site — the one "Retry Login" actually
-            // triggers — stuck polling CheckCliAuth against a dir nothing was
-            // writing to, for the full 5-minute deadline, every single click.
-            // linkTarget lets a tier-2/3 success register a real Armory
-            // account bound to THIS agent instead of just seeding a file
-            // nothing tracks (PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md
-            // §7 — required now that the resolver's spawn gate has no
-            // ambient exception).
-
-            // Tier 2/3 mint (or reuse) an isolated account dir that's
-            // DIFFERENT from the pre-login `authEnv` closure above — this
-            // local copy is what the post-login recheck below actually
-            // queries, so it must be refreshed. reagent P0: without this,
-            // the "seeded"/"terminal-success" recheck queried the OLD
-            // directory (nothing had ever been written there) and reported
-            // authenticated: false even though the login just succeeded,
-            // defeating the entire "Retry Login" flow this file exists for.
-            let recheckAuthEnv = authEnv ?? {};
-            // Captured for the "opened" case specifically — tier 1 mints
-            // and reports the account but does NOT persist/link it (it
-            // returns before confirming completion); once THIS function's
-            // own poll below confirms authenticated: true, it must call
-            // persistAndLinkAccount itself using these. reagent P0 on
-            // #2263: without this, a tier-1 login that succeeds for any
-            // provider whose CLI actually prints a URL (not
-            // requiresLoginTty — e.g. gemini/copilot) never gets a real
-            // IdentityAccount, and the resolver's spawn gate blocks the
-            // agent on its very next spawn regardless of what this poll
-            // reports now.
-            let openedAccountId: string | undefined;
-            let openedAccountDir: string | undefined;
-            // See catalog.ts's DEAD END note — providers with
-            // headlessLoginUrlUnsupported skip straight past tier 1's
-            // URL-capture wait, so there's no login-link timer to label here.
-            setPhase(
-                provider.headlessLoginUrlUnsupported
-                    ? { kind: "opening-login-terminal" }
-                    : { kind: "waiting-for-login-link", deadlineMs: Date.now() + LOGIN_LINK_CAPTURE_LABEL_MS },
-            );
-            const outcome = await runProviderLogin({
-                provider,
-                cliPath: cliResult.cli_path,
-                authEnv: authEnv ?? {},
-                setAuthUrl,
-                log,
-                isCancelled,
-                linkTarget: agentDefinitionId ? { blockId, agentDefinitionId } : undefined,
-                existingAccountId,
-                onAccountRegistered: (accountId, dir) => {
-                    openedAccountId = accountId;
-                    openedAccountDir = dir;
-                    if (provider.authConfigDirEnvVar) {
-                        recheckAuthEnv = { ...(authEnv ?? {}), [provider.authConfigDirEnvVar]: dir };
-                    }
-                },
-                // See catalog.ts's DEAD END note — for these providers tier 1
-                // cannot ever succeed, so skip its ~15s capture wait instead
-                // of running (and always losing) it on every login.
-                skipTier1: provider.headlessLoginUrlUnsupported === true,
-                // Without this, the phase set just above (a URL-capture
-                // countdown, or a static "opening terminal" for skipTier1)
-                // never updates again for the rest of this single await —
-                // tier 2/3 inside runProviderLogin can run for up to 5 more
-                // minutes with the footer frozen on whatever was true when
-                // this call started. reagent P1 on PR #2300.
-                onTierChange: (event) => {
-                    if (event.tier === "fallback") {
-                        setPhase({ kind: "opening-login-terminal" });
-                    } else {
-                        setPhase({ kind: "waiting-for-login-completion", deadlineMs: event.deadlineMs });
-                    }
-                },
-            });
-
-            let authenticated = false;
-            let authedEmail: string | null = null;
-
-            if (outcome === "opened") {
-                // A real OAuth URL was captured and opened — poll until the
-                // user finishes there, cancels, or 5 minutes elapse.
-                log("auth", "waiting for login to complete...");
-                const deadline = Date.now() + 5 * 60 * 1000;
-                setPhase({ kind: "waiting-for-login-completion", deadlineMs: deadline });
-                while (!isCancelled() && Date.now() < deadline && !authenticated) {
-                    await new Promise<void>((r) => setTimeout(r, 2000));
-                    if (isCancelled()) break;
-                    try {
-                        const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
-                            cli_path: cliResult.cli_path,
-                            auth_check_args: provider.authCheckCommand,
-                            auth_env: recheckAuthEnv,
-                        }, { timeout: 10000 });
-                        if (recheck.authenticated) {
-                            authenticated = true;
-                            authedEmail = recheck.email ?? null;
-                        }
-                    } catch {
-                        // keep polling on transient RPC errors
-                    }
-                }
-                // Tier 1 minted the account but deliberately didn't persist
-                // it (see run-provider-login.ts's persistAndLinkAccount doc
-                // comment) — now that THIS poll has confirmed the login
-                // actually completed, persist and link it for real.
-                if (authenticated && openedAccountId && openedAccountDir) {
-                    await persistAndLinkAccount(
-                        {
-                            provider,
-                            cliPath: cliResult.cli_path,
-                            authEnv: authEnv ?? {},
-                            setAuthUrl,
-                            log,
-                            linkTarget: agentDefinitionId ? { blockId, agentDefinitionId } : undefined,
-                        },
-                        openedAccountId,
-                        openedAccountDir,
-                    );
-                }
-            } else if (outcome === "seeded" || outcome === "terminal-success") {
-                // A credential already landed on disk (copied from a valid
-                // global login, or completed in the terminal-fallback tier,
-                // which already polled internally) — one-shot confirm instead
-                // of polling again.
-                setPhase({ kind: "verifying" });
-                try {
-                    const recheck = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
-                        cli_path: cliResult.cli_path,
-                        auth_check_args: provider.authCheckCommand,
-                        auth_env: recheckAuthEnv,
-                    }, { timeout: 10000 });
-                    authenticated = recheck.authenticated;
-                    authedEmail = recheck.email ?? null;
-                } catch {
-                    // The credential is on disk even if this recheck RPC
-                    // itself failed transiently — don't block success on it.
-                    authenticated = true;
-                }
-            }
-            // "terminal-timeout" / "terminal-unavailable" leave authenticated
-            // false and fall through to the AMX-AUTH-002 error below.
-
-            setLoginWaiting(false);
-            // Reap the login CLI now the attempt has concluded (success,
-            // timeout, or cancel). On manual-paste success the child self-exits;
-            // if creds appeared without a paste it would otherwise linger at the
-            // prompt. cancelCliLogin is idempotent and host-side.
-            getApi().cancelCliLogin().catch(() => {});
-            setAuthUrl(null);
-
-            if (isCancelled()) {
-                setPhase({ kind: "failed", reason: "cancelled" });
-                return "auth_failed";
-            }
-
-            if (authenticated) {
-                const emailPart = authedEmail ? ` as ${authedEmail}` : "";
-                log("auth", `authenticated${emailPart}`);
-                opts.onLoginSuccess?.(authedEmail);
-            } else {
-                // Synthesize an AMX-AUTH-002 wire payload so the log
-                // entry renders with the catalog's friendly title +
-                // retry hint, matching the typed-error pattern used
-                // elsewhere. Same retry-first / error-last ordering
-                // as above.
-                const t = translateError({
-                    code: "AMX-AUTH-002",
-                    details: { provider: provider.id, seconds: 300 },
-                });
-                log("auth", `retry: ${t.retry ?? `run '${provider.cliCommand} ${provider.authLoginCommand.join(" ")}' manually`}`, "warn");
-                log("auth", `${t.title}: ${t.message}`, "error");
-                setPhase({ kind: "failed", reason: t.message });
-                return "auth_failed";
-            }
-        } catch (err: any) {
-            setLoginWaiting(false);
-            getApi().cancelCliLogin().catch(() => {});
-            setAuthUrl(null);
-            log("auth", `login failed: ${err?.message ?? String(err)}`, "error");
-            log("auth", `run: ${provider.cliCommand} ${provider.authLoginCommand.join(" ")}`, "warn");
-            setPhase({ kind: "failed", reason: err?.message ?? String(err) });
-            return "auth_failed";
-        }
+        log("auth", "not authenticated — waiting for the user to start a login");
+        return "auth_failed";
     }
 
     // Phase 3: Controller Registration

--- a/frontend/app/view/agent/flows/launch-phase.ts
+++ b/frontend/app/view/agent/flows/launch-phase.ts
@@ -33,13 +33,18 @@ export type LaunchPhase =
      *  sets it unconditionally at agent-creation time, before any login ever
      *  happens, so it was true on every genuine first-ever login too (reagent
      *  P1 on PR #2304). Kept distinct from `auth-expired` so the conversation
-     *  notification never wrongly implies something broke. See
-     *  docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md §8 Q6. */
+     *  notification never wrongly implies something broke.
+     *
+     *  Terminal, not transient: launch-flow.ts posts the notification and
+     *  stops here — it does NOT go on to open a browser/terminal itself.
+     *  Per direct user instruction (2026-07-27), a login attempt only
+     *  starts from the user's own click on the "Log in" button, wired to
+     *  `relogin()`. See docs/specs/SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md §8 Q6. */
     | { kind: "first-login" }
     /** Auth check failed but a real account link already exists for this
-     *  agent+provider — a previously-working credential has gone stale. This
-     *  is the case the notification needs to actually warn about before a
-     *  browser/terminal pops open with no explanation. */
+     *  agent+provider — a previously-working credential has gone stale. Also
+     *  terminal, same reasoning as `first-login` above: this only posts the
+     *  warning and stops, it never opens anything on its own. */
     | { kind: "auth-expired" }
     /** Tier 1's PTY/pipe URL-capture attempt — only reachable for providers
      *  where `headlessLoginUrlUnsupported` is NOT set (Codex/Gemini/OpenClaw).
@@ -77,9 +82,9 @@ export function formatPhaseLabel(phase: LaunchPhase | null | undefined, nowMs: n
         case "checking-auth":
             return "Checking authentication";
         case "first-login":
-            return "Signing in";
+            return "Sign-in required";
         case "auth-expired":
-            return "Login expired — signing back in";
+            return "Login expired — sign in required";
         case "waiting-for-login-link":
             return `Waiting for login link… up to ${fmtRemaining(phase.deadlineMs - nowMs)}`;
         case "opening-login-terminal":

--- a/frontend/app/view/agent/flows/run-provider-login.test.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.test.ts
@@ -557,7 +557,10 @@ describe("runProviderLogin", () => {
         expect(onAccountRegistered).toHaveBeenCalledWith(MINTED.accountId, MINTED.dir);
 
         onAccountRegistered.mockClear();
-        hub.upsertIdentityAccount.mockRejectedValueOnce(new Error("db error"));
+        // Rejects on BOTH attempts — tier 3 retries once (reagent P2,
+        // matching tier 2's identical safety net), so a single-rejection
+        // mock would now succeed on the retry and fire onAccountRegistered.
+        hub.upsertIdentityAccount.mockRejectedValue(new Error("db error"));
         hub.seedProviderAuthFromGlobal
             .mockReset()
             .mockResolvedValueOnce({ seeded: false, status: "missing" })
@@ -574,6 +577,33 @@ describe("runProviderLogin", () => {
         await vi.advanceTimersByTimeAsync(5_000);
         await promise2;
         expect(onAccountRegistered).not.toHaveBeenCalled();
+    });
+
+    it("retries persistSeededAccount once on tier 3 too, on a transient failure after terminal-success is detected (reagent P2, mirrors tier 2's identical retry)", async () => {
+        vi.useFakeTimers();
+        hub.runCliLogin.mockResolvedValue(null);
+        hub.seedProviderAuthFromGlobal
+            .mockResolvedValueOnce({ seeded: false, status: "missing" })
+            .mockResolvedValueOnce({ seeded: true });
+        hub.upsertIdentityAccount
+            .mockRejectedValueOnce(new Error("transient RPC error"))
+            .mockResolvedValueOnce({});
+        const onAccountRegistered = vi.fn();
+
+        const promise = runProviderLogin({
+            provider: claude,
+            cliPath: "x",
+            authEnv: { CLAUDE_CONFIG_DIR: "C:/auth" },
+            setAuthUrl: vi.fn(),
+            log: vi.fn(),
+            onAccountRegistered,
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+        const outcome = await promise;
+
+        expect(outcome).toBe("terminal-success");
+        expect(hub.upsertIdentityAccount).toHaveBeenCalledTimes(2);
+        expect(onAccountRegistered).toHaveBeenCalledWith(MINTED.accountId, MINTED.dir);
     });
 
     it("onAccountRegistered fires on non-claude tier 3 success too", async () => {

--- a/frontend/app/view/agent/flows/run-provider-login.ts
+++ b/frontend/app/view/agent/flows/run-provider-login.ts
@@ -384,9 +384,34 @@ export async function runProviderLogin(p: RunProviderLoginParams): Promise<Provi
     }
 
     if (minted) {
-        if (await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log)) {
+        // Same one-retry safety net as tier 2 above (reagent P2) — a
+        // transient persist hiccup shouldn't report a false "Login
+        // successful" for a credential that's genuinely sitting on disk and
+        // valid. Without EITHER the retry or the loud error below, a persist
+        // failure here used to be invisible: this function still returned
+        // "terminal-success" unconditionally, so every caller displayed
+        // "Login successful" while no IdentityAccount ever existed — the
+        // very next spawn hit the resolver's spawn gate and errored "not
+        // logged in" (REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md).
+        let persisted = await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log);
+        if (!persisted) {
+            p.log("auth", "account registration failed — retrying once…", "warn");
+            persisted = await persistSeededAccount(p.provider.id, minted.accountId, minted.dir, p.log);
+        }
+        if (persisted) {
             p.onAccountRegistered?.(minted.accountId, minted.dir);
             await finalizeAccount(p, minted.accountId, minted.dir);
+        } else {
+            // Deliberately does NOT change the return value — callers gate
+            // their own "Login successful" messaging on whether
+            // onAccountRegistered fired (it didn't), not on this string
+            // alone. See relogin()/loginViaTerminal()/login.ts's matching
+            // `openedAccountId && openedAccountDir` checks.
+            p.log(
+                "auth",
+                "your login succeeded, but AgentMux couldn't save the account record — it may still show as not logged in; try again in a moment",
+                "error",
+            );
         }
     }
     return "terminal-success";

--- a/frontend/app/view/agent/hooks/useAgentCommands.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.test.ts
@@ -1,0 +1,149 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins the fix for a real, user-reported bug: the pane showed "Working…"
+ * forever whenever `AgentInputCommand` itself failed synchronously (no
+ * controller registered for the block — e.g. right after a backend
+ * restart, before the pane is reopened; the identity spawn gate blocking
+ * on a bad credential; any network-level rejection) — completely
+ * independent of whatever happens deeper in the agent's own turn
+ * lifecycle. `handleSendMessage` (agent-view.tsx) dispatches `TurnStart`
+ * OPTIMISTICALLY before this RPC call ever runs; the catch block used to
+ * only remove the pending "ghost" row (`PendingMessageRejected`) and never
+ * reverted `turnPhase`, so it stayed stuck at Submitting/Streaming with no
+ * path back to Idle. See
+ * REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRoot } from "solid-js";
+
+const hub = vi.hoisted(() => ({
+    agentInput: vi.fn(),
+}));
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        AgentInputCommand: (...args: unknown[]) => hub.agentInput(...args),
+        SetMetaCommand: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { useAgentCommands } from "./useAgentCommands";
+import {
+    registerPane,
+    unregisterPane,
+    type PaneRegistration,
+} from "@/app/store/agent-pane-registration";
+import { snapshot as paneSnapshot, __resetAllSlots as resetPaneStateSlots } from "@/app/store/agent-pane-state-store";
+import { __resetAllSlots as resetDocSlots } from "@/app/store/agent-document-store";
+import type { AgentPaneProjections } from "@/app/store/agent-pane-state-store";
+
+function noopProjections(): AgentPaneProjections {
+    return {
+        streaming: () => {},
+        sessionStats: () => {},
+        sessionTotals: () => {},
+        currentTool: () => {},
+        turnTokens: () => {},
+        pending: () => {},
+        initPhase: () => {},
+        turnPhase: () => {},
+    };
+}
+
+function fullRegistration(): PaneRegistration {
+    return {
+        agentId: "agent-1",
+        documentSetter: () => {},
+        projections: noopProjections(),
+    };
+}
+
+const BLOCK_ID = "block-send-fail";
+
+beforeEach(() => {
+    hub.agentInput.mockReset();
+});
+afterEach(() => {
+    unregisterPane(BLOCK_ID);
+    resetDocSlots();
+    resetPaneStateSlots();
+});
+
+describe("useAgentCommands — turnPhase recovery on a failed send", () => {
+    it("resets turnPhase to Idle when the idle-send AgentInputCommand rejects", async () => {
+        hub.agentInput.mockRejectedValue(new Error("no controller for block"));
+        const model = registerPane(BLOCK_ID, fullRegistration());
+        // Move past InitPending — a fresh pane blocks sendMessage entirely
+        // until its history fetch resolves. TurnStart also requires a
+        // subscribed stream (state.lastEventMs != null) — mirrors what a
+        // real mount does before the user can ever send.
+        model.dispatchPane({ type: "InitReady", at: Date.now() }, "system");
+        model.dispatchPane({ type: "StreamSubscribe", at: Date.now() }, "system");
+
+        await createRoot(async (dispose) => {
+            const commands = useAgentCommands({
+                blockId: BLOCK_ID,
+                model,
+                block: () => undefined,
+                provider: () => undefined,
+                documentAtom: [() => [], () => {}] as any,
+                log: () => {},
+                setAuthUrl: () => {},
+                backToPicker: async () => {},
+            });
+
+            // Mirrors handleSendMessage's optimistic TurnStart before calling
+            // commands.sendMessage — see agent-view.tsx.
+            model.dispatchPane({ type: "TurnStart", at: Date.now() }, "user");
+            expect(paneSnapshot(BLOCK_ID)?.turnPhase.kind).not.toBe("Idle");
+
+            await commands.sendMessage("u there", false);
+
+            expect(paneSnapshot(BLOCK_ID)?.turnPhase.kind).toBe("Idle");
+            expect(paneSnapshot(BLOCK_ID)?.pending).toEqual([]);
+            dispose();
+        });
+    });
+
+    it("does NOT reset turnPhase when a held (queued-while-busy) message's flush rejects — a real turn is already in flight", async () => {
+        const model = registerPane(BLOCK_ID, fullRegistration());
+        model.dispatchPane({ type: "InitReady", at: Date.now() }, "system");
+        model.dispatchPane({ type: "StreamSubscribe", at: Date.now() }, "system");
+
+        await createRoot(async (dispose) => {
+            const commands = useAgentCommands({
+                blockId: BLOCK_ID,
+                model,
+                block: () => undefined,
+                provider: () => undefined,
+                documentAtom: [() => [], () => {}] as any,
+                log: () => {},
+                setAuthUrl: () => {},
+                backToPicker: async () => {},
+            });
+
+            // A real turn is genuinely active (e.g. the agent is streaming
+            // the first message) — queue a second message behind it.
+            hub.agentInput.mockResolvedValueOnce(undefined);
+            model.dispatchPane({ type: "TurnStart", at: Date.now() }, "user");
+            await commands.sendMessage("first message", false);
+            await commands.sendMessage("held message", true);
+            expect(commands.hasHeldMessages()).toBe(true);
+
+            const busyPhase = paneSnapshot(BLOCK_ID)?.turnPhase.kind;
+            expect(busyPhase).not.toBe("Idle");
+
+            // The flush's own delivery fails — the ALREADY-active turn above
+            // must not be cut short by this unrelated failure.
+            hub.agentInput.mockRejectedValueOnce(new Error("transient send failure"));
+            await commands.flushHeldMessages();
+
+            expect(paneSnapshot(BLOCK_ID)?.turnPhase.kind).toBe(busyPhase);
+            dispose();
+        });
+    });
+});

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -384,7 +384,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }
 
         // Idle send: deliver immediately and arm the lost-delivery safety timer.
-        await deliverToBackend(message, messageId, /* armExpiry */ true);
+        await deliverToBackend(message, messageId, /* armExpiry */ true, /* initiatesTurn */ true);
     };
 
     /**
@@ -398,6 +398,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         message: string,
         messageId: string,
         armExpiry: boolean,
+        /** True only for the idle-send path (this message is what put the
+         *  pane into Submitting/Streaming via handleSendMessage's optimistic
+         *  `TurnStart`, before this RPC call ever ran). False for a held
+         *  message flushed mid-turn — a real turn is already genuinely in
+         *  flight there, independent of whether THIS specific flushed
+         *  message's delivery succeeds, so its failure must not cut that
+         *  turn short. */
+        initiatesTurn: boolean,
     ): Promise<void> => {
         // Apply runtime args (permission mode, model, effort) before this turn.
         const prov = opts.provider();
@@ -435,6 +443,22 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 type: "PendingMessageRejected",
                 id: messageId,
             });
+            // handleSendMessage (agent-view.tsx) dispatches TurnStart
+            // OPTIMISTICALLY, before this RPC call even runs — a synchronous
+            // AgentInputCommand failure (no controller registered for this
+            // block, e.g. after a backend restart before the pane is
+            // reopened; the identity spawn gate blocking on a bad
+            // credential; any network-level rejection) otherwise left the
+            // pane showing "Working…" forever with no path back to Idle:
+            // PendingMessageRejected only ever removed the ghost pending
+            // row above, never touched turnPhase. Only revert when this
+            // send is what started the turn — see initiatesTurn's doc
+            // comment. Mirrors the identical TurnReset already used for the
+            // bang-command / handled-slash-command "no real turn happened"
+            // paths above in sendMessage().
+            if (initiatesTurn) {
+                opts.model.dispatchPane({ type: "TurnReset" }, "system");
+            }
             return;
         }
 
@@ -472,7 +496,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             // shift() (not a snapshot) so items queued mid-flush are included.
             while (heldQueue.length > 0) {
                 const item = heldQueue.shift()!;
-                await deliverToBackend(item.text, item.id, /* armExpiry */ false);
+                await deliverToBackend(item.text, item.id, /* armExpiry */ false, /* initiatesTurn */ false);
             }
         } finally {
             flushing = false;

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -453,11 +453,18 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             // PendingMessageRejected only ever removed the ghost pending
             // row above, never touched turnPhase. Only revert when this
             // send is what started the turn — see initiatesTurn's doc
-            // comment. Mirrors the identical TurnReset already used for the
-            // bang-command / handled-slash-command "no real turn happened"
-            // paths above in sendMessage().
+            // comment.
+            //
+            // TurnStartFailed, NOT TurnReset: this used to reuse TurnReset
+            // (the bang-command / handled-slash-command "no real turn
+            // happened" paths above in sendMessage() still do), but
+            // TurnReset is a deliberate wholesale session wipe — it also
+            // clears sessionStats/sessionTotals/lastContextTokens. A
+            // transient send failure on an agent with prior completed turns
+            // must not wipe that accumulated history; TurnStartFailed
+            // touches only turnPhase. reagent/codex P2 on PR #2318.
             if (initiatesTurn) {
-                opts.model.dispatchPane({ type: "TurnReset" }, "system");
+                opts.model.dispatchPane({ type: "TurnStartFailed" }, "system");
             }
             return;
         }

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -386,6 +386,15 @@ export function useAgentControllerStatus(
         reloginInFlight = true;
         setLoginWaiting(true);
         setLaunchPhase({ kind: "checking-auth" });
+        // Tracks whether this attempt actually reached a genuine success
+        // branch below — declared outside the try so the `finally` block
+        // (which needs to read it) can see it. Used to decide whether to
+        // restore the mount-time "Log in" button (reagent/codex P1 on
+        // PR #2318: every failure exit — timeout, terminal-unavailable,
+        // persistence failure, cancellation, or a thrown exception —
+        // previously left `canRetry` stuck at false with no way back into
+        // a login attempt short of reopening the pane).
+        let succeeded = false;
         try {
             if (!cliPath) {
                 // reagent P2 on PR #2300: this step is resolving the CLI path,
@@ -486,7 +495,16 @@ export function useAgentControllerStatus(
                         }
                     }
                     if (authenticated && openedAccountId && openedAccountDir) {
-                        await persistAndLinkAccount(
+                        // Tier 1's mint-only registration can still fail to
+                        // persist (the same DB-write failure mode this PR's
+                        // own report documents) — the `seeded`/
+                        // `terminal-success` branch below already gates its
+                        // success actions on this; this branch previously
+                        // discarded the return value and reported success
+                        // unconditionally, reproducing the exact "Error: not
+                        // logged in" bug this PR set out to fix (reagent/
+                        // codex P1 on the re-review of PR #2318).
+                        const persisted = await persistAndLinkAccount(
                             {
                                 provider: prov,
                                 cliPath,
@@ -500,35 +518,43 @@ export function useAgentControllerStatus(
                             openedAccountId,
                             openedAccountDir,
                         );
-                        opts.log("auth", retryAfterLogin ? "Login successful — retrying…" : "Login successful");
-                        setAuthNotice(null);
-                        setAuthStatus("authenticated");
-                        // Before onRecovered (which may immediately resend the
-                        // failed turn) — an already-running stale process must
-                        // be refreshed BEFORE anything is sent to it, or the
-                        // resend just hits the same stale credential again.
-                        await forceControllerRefresh();
-                        // Post a visible confirmation into the pane itself — this used to
-                        // ONLY happen on the very first auto-login (launch-flow.ts); "Login
-                        // Again" retried the failed turn silently, so a user with nothing
-                        // queued to retry (or who didn't notice the retry) never saw ANY
-                        // acknowledgement that the login actually succeeded.
-                        opts.onLoginSuccess?.(authedEmail);
-                        if (retryAfterLogin) {
-                            opts.onRecovered?.();
+                        if (persisted) {
+                            opts.log("auth", retryAfterLogin ? "Login successful — retrying…" : "Login successful");
+                            setAuthNotice(null);
+                            setAuthStatus("authenticated");
+                            // Before onRecovered (which may immediately resend the
+                            // failed turn) — an already-running stale process must
+                            // be refreshed BEFORE anything is sent to it, or the
+                            // resend just hits the same stale credential again.
+                            await forceControllerRefresh();
+                            // Post a visible confirmation into the pane itself — this used to
+                            // ONLY happen on the very first auto-login (launch-flow.ts); "Login
+                            // Again" retried the failed turn silently, so a user with nothing
+                            // queued to retry (or who didn't notice the retry) never saw ANY
+                            // acknowledgement that the login actually succeeded.
+                            opts.onLoginSuccess?.(authedEmail);
+                            succeeded = true;
+                            if (retryAfterLogin) {
+                                opts.onRecovered?.();
+                            } else {
+                                // Mount-time "Log in" success on an agent that never
+                                // reached Phase 3 (no turn ever started — see
+                                // launch-flow.ts's needsLogin bail). onReadyFn only
+                                // ever fires from startLaunchFlow's own success
+                                // branch, so without this a first-time login via
+                                // this button left the agent running with no
+                                // startup sequence ever sent (no instructions,
+                                // identity, or context) — reagent/codex P1 on
+                                // PR #2318. onReadyFn self-guards on
+                                // `agent:sessionid` already being set, so this is a
+                                // safe no-op for anything but a genuine first login.
+                                opts.onReady?.();
+                            }
                         } else {
-                            // Mount-time "Log in" success on an agent that never
-                            // reached Phase 3 (no turn ever started — see
-                            // launch-flow.ts's needsLogin bail). onReadyFn only
-                            // ever fires from startLaunchFlow's own success
-                            // branch, so without this a first-time login via
-                            // this button left the agent running with no
-                            // startup sequence ever sent (no instructions,
-                            // identity, or context) — reagent/codex P1 on
-                            // PR #2318. onReadyFn self-guards on
-                            // `agent:sessionid` already being set, so this is a
-                            // safe no-op for anything but a genuine first login.
-                            opts.onReady?.();
+                            setAuthStatus("unauthenticated");
+                            setAuthNotice(
+                                "Your login succeeded, but AgentMux couldn't save the account record. Try again in a moment.",
+                            );
                         }
                     } else if (!loginCancelled) {
                         setAuthNotice(
@@ -561,6 +587,7 @@ export function useAgentControllerStatus(
                         setAuthStatus("authenticated");
                         await forceControllerRefresh();
                         opts.onLoginSuccess?.(null);
+                        succeeded = true;
                         if (retryAfterLogin) {
                             opts.onRecovered?.();
                         } else {
@@ -599,6 +626,19 @@ export function useAgentControllerStatus(
             reloginInFlight = false;
             setLoginWaiting(false);
             setLaunchPhase(null);
+            // Restore the mount-time "Log in" button on any unsuccessful
+            // outcome — timeout, terminal-unavailable, persistence failure,
+            // cancellation, or a thrown exception all fall through to here
+            // via `return`/`break`/the catch above. Scoped to
+            // `!retryAfterLogin`: that's the only case where THIS call set
+            // `canRetry` false in the first place (the "Log in" bar's own
+            // click handler); the `retryAfterLogin: true` ("Login Again")
+            // call site guards against a stale true from a *different*
+            // origin and was never showing that bar to begin with, so it
+            // must not start showing it now (reagent/codex on PR #2318).
+            if (!succeeded && !retryAfterLogin) {
+                setCanRetry(true);
+            }
         }
     };
 

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -514,7 +514,22 @@ export function useAgentControllerStatus(
                         // queued to retry (or who didn't notice the retry) never saw ANY
                         // acknowledgement that the login actually succeeded.
                         opts.onLoginSuccess?.(authedEmail);
-                        if (retryAfterLogin) opts.onRecovered?.();
+                        if (retryAfterLogin) {
+                            opts.onRecovered?.();
+                        } else {
+                            // Mount-time "Log in" success on an agent that never
+                            // reached Phase 3 (no turn ever started — see
+                            // launch-flow.ts's needsLogin bail). onReadyFn only
+                            // ever fires from startLaunchFlow's own success
+                            // branch, so without this a first-time login via
+                            // this button left the agent running with no
+                            // startup sequence ever sent (no instructions,
+                            // identity, or context) — reagent/codex P1 on
+                            // PR #2318. onReadyFn self-guards on
+                            // `agent:sessionid` already being set, so this is a
+                            // safe no-op for anything but a genuine first login.
+                            opts.onReady?.();
+                        }
                     } else if (!loginCancelled) {
                         setAuthNotice(
                             "Opened a login page, but no login was detected within 5 minutes. " +
@@ -546,7 +561,14 @@ export function useAgentControllerStatus(
                         setAuthStatus("authenticated");
                         await forceControllerRefresh();
                         opts.onLoginSuccess?.(null);
-                        if (retryAfterLogin) opts.onRecovered?.();
+                        if (retryAfterLogin) {
+                            opts.onRecovered?.();
+                        } else {
+                            // See the identical "opened" case above — first-time
+                            // login via the mount-time "Log in" button never
+                            // otherwise triggers the startup sequence.
+                            opts.onReady?.();
+                        }
                     } else {
                         setAuthStatus("unauthenticated");
                         setAuthNotice(

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -36,6 +36,7 @@
 import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
 import { getApi, getBlockMetaKeyAtom, staticTabId } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
+import { BlockService } from "@/app/store/services";
 import * as WOS from "@/app/store/wos";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { runLaunchFlow } from "../flows/launch-flow";
@@ -306,14 +307,25 @@ export function useAgentControllerStatus(
      *  own SetMetaCommand) actually takes effect. Best-effort: a failure here
      *  just means the stale process persists until its own next natural
      *  respawn. See REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md
-     *  G4/G5. */
+     *  G4/G5.
+     *
+     *  Mirrors launch-flow.ts's Phase 3 registration (termsize seed +
+     *  onControllerStatus) rather than just the bare resync call — for the
+     *  first-ever-login path this IS that pane's only registration, so
+     *  omitting either left a freshly spawned CLI's PTY at the default width
+     *  until the next manual resize, and callers relying on
+     *  `onControllerStatus` never heard about it (reagent P2 on PR #2318). */
     const forceControllerRefresh = async (): Promise<void> => {
         try {
+            const initialTermSize = opts.getInitialTermSize?.();
             await RpcApi.ControllerResyncCommand(TabRpcClient, {
                 tabid: staticTabId(),
                 blockid: opts.blockId,
                 forcerestart: true,
+                ...(initialTermSize ? { rtopts: { termsize: initialTermSize } } : {}),
             });
+            const rts = await BlockService.GetControllerStatus(opts.blockId);
+            if (rts) opts.onControllerStatus?.(rts);
         } catch (e: any) {
             opts.log(
                 "auth",

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -34,7 +34,7 @@
  */
 
 import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
-import { getApi, getBlockMetaKeyAtom } from "@/app/store/global";
+import { getApi, getBlockMetaKeyAtom, staticTabId } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import * as WOS from "@/app/store/wos";
 import { TabRpcClient } from "@/app/store/rpc-util";
@@ -46,6 +46,15 @@ import type { ProviderDefinition } from "../providers";
 
 import type { LogFn } from "../types";
 export type { LogFn };
+
+/**
+ * Durable logged-in/logged-out signal for the composer strip's status tag —
+ * distinct from the transient `launchPhase`/`canRetry` signals, which only
+ * describe the in-progress launch/recovery flow and get cleared the instant
+ * it finishes. "unknown" only applies before the very first auth check
+ * resolves (or after a fatal, non-auth error where the check never ran).
+ */
+export type AuthStatus = "authenticated" | "unauthenticated" | "unknown";
 
 export interface UseAgentControllerStatusOptions {
     blockId: string;
@@ -94,16 +103,28 @@ export interface UseAgentControllerStatus {
     /** What the flow is doing right now, for a specific footer label instead
      *  of a generic "Working…" — see launch-phase.ts. */
     launchPhase: Accessor<LaunchPhase | null>;
+    /** Durable logged-in/logged-out state for the composer strip's status
+     *  tag — see the `AuthStatus` doc comment above. */
+    authStatus: Accessor<AuthStatus>;
     startLaunchFlow: () => Promise<void>;
     /**
-     * Force a provider re-login, bypassing the auth-status check. Wired to the
-     * failure-banner / inline-error "Login Again" actions: a 401 means the token
-     * is bad even though `CheckCliAuth` still reports it present, so re-running
-     * the gated launch flow would trust the lying check and skip the very login
-     * the user needs. This always opens the OAuth. See
+     * Force a provider re-login, bypassing the auth-status check. Wired to
+     * TWO different call sites with different retry semantics:
+     *   - The failure-banner "Login Again" action (a real turn failed on a
+     *     401): `retryAfterLogin` defaults to true so the failed turn
+     *     resends automatically once the credential is fixed.
+     *   - The mount-time "Log in" button (agent-view.tsx, shown on
+     *     `canRetry`/auth_failed — no turn was ever attempted): callers MUST
+     *     pass `{ retryAfterLogin: false }`, or a successful login on an
+     *     agent with prior history silently resends its LAST OLD MESSAGE as
+     *     a brand-new turn the instant login completes — surprising on its
+     *     own, and it also buries the "Login successful" notification under
+     *     the new turn's immediate stream of output (reported: "no
+     *     indication" after a successful mount-time login).
+     * Always opens the OAuth, bypassing CheckCliAuth. See
      * SPEC_REAUTH_FROM_AUTH_ERROR §11.
      */
-    relogin: () => Promise<void>;
+    relogin: (opts?: { retryAfterLogin?: boolean }) => Promise<void>;
     /**
      * "Use my existing login" — seed this agent's isolated auth dir from the
      * user's already-valid GLOBAL Claude login instead of a fresh OAuth, the
@@ -173,6 +194,7 @@ export function useAgentControllerStatus(
     // AgentFooter show a specific status (and, for timed phases, a "waiting
     // on X, up to Ys" label) instead of a generic "Working…" for every phase.
     const [launchPhase, setLaunchPhase] = createSignal<LaunchPhase | null>(null);
+    const [authStatus, setAuthStatus] = createSignal<AuthStatus>("unknown");
 
     // Derived spinner state — caller wires this into the AgentFooter loading prop
     const isLoading = createMemo(() => flowRunning() || !agentReady());
@@ -211,10 +233,12 @@ export function useAgentControllerStatus(
             });
             if (result === "success") {
                 setAgentReady(true);
+                setAuthStatus("authenticated");
                 opts.onReady?.();
             } else if (result === "auth_failed" && !loginCancelled) {
                 setCanRetry(true);
                 setAgentReady(true); // clear spinner so retry button is usable
+                setAuthStatus("unauthenticated");
             }
         } catch (err: any) {
             opts.log("error", err?.message ?? String(err), "error");
@@ -268,6 +292,37 @@ export function useAgentControllerStatus(
         }
     };
 
+    /** Force the persistent controller to restart (or register, if none
+     *  exists yet) after a login recovery actually persisted a new/refreshed
+     *  account. `send_message` only spawns a fresh process when one isn't
+     *  already running — an agent whose CLI was already alive (spawned
+     *  earlier with the old/missing credential) keeps running on that stale
+     *  env forever otherwise, so a successful login changes nothing for it
+     *  until the pane is manually closed and reopened. `forcerestart: true`
+     *  is a no-op when no controller exists yet (the first-ever-login case —
+     *  this just performs the Phase-3-equivalent registration launch-flow.ts
+     *  itself skipped when it bailed on auth_failed) and kills+recreates one
+     *  that does, so the new `cmd:env` (from `finalizeAccount`/`useGlobalLogin`'s
+     *  own SetMetaCommand) actually takes effect. Best-effort: a failure here
+     *  just means the stale process persists until its own next natural
+     *  respawn. See REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md
+     *  G4/G5. */
+    const forceControllerRefresh = async (): Promise<void> => {
+        try {
+            await RpcApi.ControllerResyncCommand(TabRpcClient, {
+                tabid: staticTabId(),
+                blockid: opts.blockId,
+                forcerestart: true,
+            });
+        } catch (e: any) {
+            opts.log(
+                "auth",
+                `signed in, but couldn't refresh the running agent with the new login — reopen this pane if it still shows as logged out: ${e?.message ?? String(e)}`,
+                "warn",
+            );
+        }
+    };
+
     /** Look up the account already bound to THIS agent for `providerId`, if
      *  any — pass as `runProviderLogin`'s `existingAccountId` so a recovery
      *  action reuses/refreshes the same account instead of minting and
@@ -302,13 +357,20 @@ export function useAgentControllerStatus(
         return (await buildAuthEnv(prov)) ?? {};
     };
 
-    const relogin = async () => {
+    const relogin = async (reloginOpts: { retryAfterLogin?: boolean } = {}) => {
         if (reloginInFlight) return;
+        const retryAfterLogin = reloginOpts.retryAfterLogin ?? true;
         const prov = opts.provider();
         if (!prov) {
             opts.log("auth", "re-login: no active provider", "warn");
             return;
         }
+        // Clears the "Log in" button immediately on click — this is also the
+        // action the mount-time launch flow's first-login/auth-expired
+        // states hand off to (they never trigger a login themselves; see
+        // launch-flow.ts), so a stale canRetry=true must not survive into
+        // this attempt's own outcome.
+        setCanRetry(false);
         setAuthNotice(null);
         // Clear any OAuth URL box left by a PRIOR attempt before starting a
         // fresh one — otherwise a subsequent no-progress outcome would stack
@@ -438,15 +500,21 @@ export function useAgentControllerStatus(
                             openedAccountId,
                             openedAccountDir,
                         );
-                        opts.log("auth", "Login successful — retrying…");
+                        opts.log("auth", retryAfterLogin ? "Login successful — retrying…" : "Login successful");
                         setAuthNotice(null);
+                        setAuthStatus("authenticated");
+                        // Before onRecovered (which may immediately resend the
+                        // failed turn) — an already-running stale process must
+                        // be refreshed BEFORE anything is sent to it, or the
+                        // resend just hits the same stale credential again.
+                        await forceControllerRefresh();
                         // Post a visible confirmation into the pane itself — this used to
                         // ONLY happen on the very first auto-login (launch-flow.ts); "Login
                         // Again" retried the failed turn silently, so a user with nothing
                         // queued to retry (or who didn't notice the retry) never saw ANY
                         // acknowledgement that the login actually succeeded.
                         opts.onLoginSuccess?.(authedEmail);
-                        opts.onRecovered?.();
+                        if (retryAfterLogin) opts.onRecovered?.();
                     } else if (!loginCancelled) {
                         setAuthNotice(
                             "Opened a login page, but no login was detected within 5 minutes. " +
@@ -456,16 +524,35 @@ export function useAgentControllerStatus(
                     break;
                 }
                 case "seeded":
-                    opts.log("auth", "Signed in from your global login — retrying…");
-                    setAuthNotice(null);
-                    opts.onLoginSuccess?.(null);
-                    opts.onRecovered?.();
-                    break;
                 case "terminal-success":
-                    opts.log("auth", "Login successful — retrying…");
-                    setAuthNotice(null);
-                    opts.onLoginSuccess?.(null);
-                    opts.onRecovered?.();
+                    // openedAccountId/openedAccountDir are only set by
+                    // onAccountRegistered, which run-provider-login.ts fires
+                    // ONLY once the account row is actually persisted — a
+                    // credential can be validly seeded/typed-in on disk while
+                    // that persist call itself fails (was previously silent;
+                    // see REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md).
+                    // Trusting the outcome string alone reported "Login
+                    // successful" for a login the resolver's spawn gate would
+                    // then block on the very next turn with no account ever
+                    // having existed.
+                    if (openedAccountId && openedAccountDir) {
+                        opts.log(
+                            "auth",
+                            outcome === "seeded"
+                                ? (retryAfterLogin ? "Signed in from your global login — retrying…" : "Signed in from your global login")
+                                : (retryAfterLogin ? "Login successful — retrying…" : "Login successful"),
+                        );
+                        setAuthNotice(null);
+                        setAuthStatus("authenticated");
+                        await forceControllerRefresh();
+                        opts.onLoginSuccess?.(null);
+                        if (retryAfterLogin) opts.onRecovered?.();
+                    } else {
+                        setAuthStatus("unauthenticated");
+                        setAuthNotice(
+                            "Your login succeeded, but AgentMux couldn't save the account record. Try again in a moment.",
+                        );
+                    }
                     break;
                 case "terminal-timeout":
                     // Never fail silently (retro §5.1): tell the user nothing
@@ -548,12 +635,15 @@ export function useAgentControllerStatus(
                         );
                     }
                 }
-                // Credential is now valid on disk — but the agent spawns fresh
-                // per turn and the failure row only clears on the next turn, so
-                // a successful seed looks like it "did nothing". Drive the
-                // recovery: retry the failed turn (fresh spawn picks up the new
-                // token and TurnStart clears the row).
+                // Credential is now valid on disk, but a persistent-mode
+                // agent whose CLI is already alive won't pick it up on its
+                // own — send_message only respawns a controller that isn't
+                // already running. Force one before retrying so the resend
+                // doesn't just hit the same stale process again (see
+                // forceControllerRefresh's doc comment).
                 opts.log("auth", "Signed in from your global login — retrying…");
+                setAuthStatus("authenticated");
+                await forceControllerRefresh();
                 opts.onLoginSuccess?.(null);
                 opts.onRecovered?.();
             } else {
@@ -615,6 +705,12 @@ export function useAgentControllerStatus(
             setLaunchPhase({ kind: "opening-login-terminal" });
             const authEnv = await recoveryAuthEnv(prov);
             const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+            // Captured so the switch below can gate its "Login successful"
+            // messaging on the account having actually been persisted, not
+            // just on the outcome string — see relogin()'s matching check
+            // and REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md.
+            let registeredAccountId: string | undefined;
+            let registeredAccountDir: string | undefined;
             const outcome = await runProviderLogin({
                 provider: prov,
                 cliPath,
@@ -627,6 +723,10 @@ export function useAgentControllerStatus(
                     ? { blockId: opts.blockId, agentDefinitionId }
                     : undefined,
                 existingAccountId: await existingAccountIdFor(prov.id),
+                onAccountRegistered: (accountId, dir) => {
+                    registeredAccountId = accountId;
+                    registeredAccountDir = dir;
+                },
                 // "fallback" still fires here even though skipTier1 is true —
                 // run-provider-login.ts fires it unconditionally right after
                 // the (skipped) tier-1 block, not conditioned on skipTier1 —
@@ -646,10 +746,19 @@ export function useAgentControllerStatus(
                     break;
                 case "seeded":
                 case "terminal-success":
-                    opts.log("auth", "Login successful — retrying…");
-                    setAuthNotice(null);
-                    opts.onLoginSuccess?.(null);
-                    opts.onRecovered?.();
+                    if (registeredAccountId && registeredAccountDir) {
+                        opts.log("auth", "Login successful — retrying…");
+                        setAuthNotice(null);
+                        setAuthStatus("authenticated");
+                        await forceControllerRefresh();
+                        opts.onLoginSuccess?.(null);
+                        opts.onRecovered?.();
+                    } else {
+                        setAuthStatus("unauthenticated");
+                        setAuthNotice(
+                            "Your login succeeded, but AgentMux couldn't save the account record. Try again in a moment.",
+                        );
+                    }
                     break;
                 case "terminal-timeout":
                     if (!loginCancelled) {
@@ -686,6 +795,11 @@ export function useAgentControllerStatus(
     const notifyControllerHealthy = () => {
         setCanRetry(false);
         setAuthNotice(null);
+        // A live controllerstatus event proves the CLI is running turns right
+        // now, independent of whichever recovery path (or none) got it there
+        // — the same independent-proof reasoning this function already
+        // applies to canRetry/authNotice above.
+        setAuthStatus("authenticated");
     };
 
     // If the pane is closed while login is in progress, cancel and kill
@@ -713,6 +827,7 @@ export function useAgentControllerStatus(
         isLoading,
         loginWaiting,
         launchPhase,
+        authStatus,
         startLaunchFlow,
         relogin,
         useGlobalLogin,

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -216,6 +216,15 @@ export function useAgentControllerStatus(
         setAuthNotice(null);
         setLaunchPhase(null);
         const prov = opts.provider();
+        // "success" from runLaunchFlow means "controller registered, ready
+        // for input" — NOT "login confirmed" (its own doc comment is
+        // explicit about this: Phase 2 proceeds on an unconfirmed auth
+        // check rather than blocking launch on a transient RPC failure).
+        // Without tracking this separately, every "success" got mapped
+        // straight to authStatus "authenticated", showing a false green
+        // "Logged in" tag for a credential that was never actually checked
+        // (reagent/codex P2 on PR #2318).
+        let authConfirmed = false;
         try {
             const authEnv = await buildAuthEnv(prov);
             const result = await runLaunchFlow({
@@ -231,10 +240,11 @@ export function useAgentControllerStatus(
                 onNotify: opts.onNotify,
                 getInitialTermSize: opts.getInitialTermSize,
                 onControllerStatus: opts.onControllerStatus,
+                onAuthCheckResult: (confirmed) => { authConfirmed = confirmed; },
             });
             if (result === "success") {
                 setAgentReady(true);
-                setAuthStatus("authenticated");
+                setAuthStatus(authConfirmed ? "authenticated" : "unknown");
                 opts.onReady?.();
             } else if (result === "auth_failed" && !loginCancelled) {
                 setCanRetry(true);

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -228,6 +228,29 @@
     50%       { opacity: 0.4; }
 }
 
+// Logged-in/out tag — sits between the context text and the Shell toggle.
+// Simple dot + label, same neutral-chrome-with-a-color-accent treatment as
+// the process badge above rather than a loud filled pill, so it doesn't
+// compete with Shell (the strip's one real call-to-action) for attention.
+.agent-composer-strip-auth {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    white-space: nowrap;
+
+    &--ok { color: var(--success-color); }
+    &--bad { color: var(--error-color); }
+}
+
+.agent-composer-strip-auth-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+}
+
 @include mixins.respect-reduced-motion {
     .agent-composer-strip-ctx--critical {
         animation-duration: 2.4s;


### PR DESCRIPTION
## Summary

- **Removed the mount-time auto-login trigger.** Opening an agent pane that needs authentication no longer opens a browser/terminal automatically — it posts a notification and waits for an explicit "Log in" click (wired to `relogin()`). This was the original, long-standing complaint: a login window appearing with no click and no way to decline.
- Added a durable red/green "Logged in" / "Not logged in" status pill to the composer strip.
- Gated `relogin()`'s auto-retry-last-message behavior (`retryAfterLogin`) so a fresh mount-time login doesn't silently resend an unrelated old message — only the failure-row "Login Again" path (a genuinely failed turn) retries.

## Three deeper bugs found and fixed during manual verification

Logins had never previously persisted far enough in this app's history to hit these — they're pre-existing, not introduced by the above:

1. **`IdentityAccount.created_at`/`updated_at` lacked `#[serde(default)]`** — every login's account-persist RPC call failed deserialization 100% of the time. Credentials seeded to disk correctly, but no Armory account or agent↔account link was ever created, so the resolver's spawn gate blocked the very next turn with "not logged in" even after a reported "Login successful."
2. **Lost-update race in `update_object_meta`** — read-merge-write ran across two separate connection-mutex acquisitions instead of one transaction. Two independent writers on the same block (the stale-`--resume`-session-id self-heal vs. the process-exit cleanup) raced on every persistent-controller exit; whichever wrote second silently reverted the other's change. Fixed by wrapping the whole operation in `Store::with_tx`.
3. **Optimistic `TurnStart` never reverted on a synchronous send failure** — `handleSendMessage` sets "Working…" before `AgentInputCommand` is even awaited; if that RPC failed (no controller, spawn gate, network hiccup — anything), nothing ever reverted `turnPhase`, leaving the pane stuck on "Working…" forever regardless of the actual cause.

Full writeup with logs, root-cause traces, and a not-yet-implemented HTTP 429 exponential-backoff design: `docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full frontend suite: 1943 passed, 3 skipped (pre-existing e2e skips)
- [x] Full backend suite: 1659 passed
- [x] New regression tests: `launch-flow.test.ts` rewritten for no-auto-login behavior, `run-provider-login.test.ts` extended for tier-3 persist retry, `useAgentCommands.test.ts` (new file) for the turnPhase-revert fix, `object_helpers.rs` (new multi-threaded test) for the lost-update race
- [x] Manual end-to-end: fresh login → persist → force-refresh of an already-running stale process → message delivery, verified live against a running dev instance with real Claude Code
- [ ] More manual testing in progress — flagging this PR is up for early review, not necessarily ready to merge yet

<!-- agentmux:agent_id=agenta -->