### PR TITLE
fix(window): first window's title no longer leaks the unrenamed bootstrap workspace name

### DIFF
--- a/.changesets/1785179751-fix-window-first-window-titles-consistently-as-window-1-inst-a177.md
+++ b/.changesets/1785179751-fix-window-first-window-titles-consistently-as-window-1-inst-a177.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): first window titles consistently as 'Window 1' instead of sometimes leaking the unrenamed bootstrap workspace name

--- a/frontend/app/element/ModalLayer.tsx
+++ b/frontend/app/element/ModalLayer.tsx
@@ -60,13 +60,12 @@ export const ModalLayer: Component<ModalLayerProps> = (props) => {
     // add-account/new-memory) — so clicking outside should just close
     // them, like any other dismissible overlay.
     //
-    // "agent-setup" is the per-agent Accounts/Memories/MCP Servers/Skills
-    // modal — renamed to "agent-stash" by the not-yet-merged
-    // agent3/agent-armory-rename-stash branch (PR #2314); update this key
-    // when that lands.
-    const BACKDROP_DISMISSIBLE_KINDS = new Set<ModalLayerRequest["kind"]>(["agent-setup"]);
+    // "agent-stash" is the per-agent Accounts/Memories/MCP Servers/Skills
+    // modal (PR #2314 renamed it from "agent-setup" to distinguish it from
+    // the global Armory pane).
+    const BACKDROP_DISMISSIBLE_KINDS = new Set<ModalLayerRequest["kind"]>(["agent-stash"]);
 
-    // "agent-setup" is only SOMETIMES pure browse/view, though — its own
+    // "agent-stash" is only SOMETIMES pure browse/view, though — its own
     // Skills/MCP Servers tabs (AgentSkillsModal/AgentMcpModal) can be
     // showing a "+ New"/edit draft form, and its Memory tab
     // (AgentNativeMemoryModal) an in-place edit textarea — all local

--- a/frontend/util/window-title.test.ts
+++ b/frontend/util/window-title.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { formatWindowTitle, resolveWindowName } from "./window-title";
+import { formatWindowTitle, resolveFloatingPaneName, resolveWindowName } from "./window-title";
 
 describe("resolveWindowName", () => {
     it("uses display name when set", () => {
@@ -83,6 +83,82 @@ describe("resolveWindowName", () => {
                 indexInOpenWindows: 4,
             }),
         ).toBe("Window 5");
+    });
+
+    it("falls through the unrenamed bootstrap workspace name to positional — window 1 must not depend on load timing", () => {
+        expect(
+            resolveWindowName({
+                displayName: undefined,
+                workspaceName: "Starter workspace",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Window 1");
+    });
+
+    it("still honors a real workspace name a user happened to rename to the bootstrap default's exact text", () => {
+        // Documented trade-off: a workspace deliberately renamed to the
+        // literal "Starter workspace" is indistinguishable from the
+        // never-renamed bootstrap default and also falls through — no
+        // schema flag exists to tell them apart. Low-risk edge case.
+        expect(
+            resolveWindowName({
+                displayName: undefined,
+                workspaceName: "Starter workspace",
+                indexInOpenWindows: 2,
+            }),
+        ).toBe("Window 3");
+    });
+
+    it("uses the workspace name when it's meaningfully different from the bootstrap default", () => {
+        expect(
+            resolveWindowName({
+                displayName: undefined,
+                workspaceName: "Starter workspace 2",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Starter workspace 2");
+    });
+});
+
+describe("resolveFloatingPaneName", () => {
+    it("uses block view label when set", () => {
+        expect(
+            resolveFloatingPaneName({
+                blockViewLabel: "Agent",
+                workspaceName: "Pulse",
+                indexInOpenPanes: 0,
+            }),
+        ).toBe("Agent");
+    });
+
+    it("falls through to workspace name when view label is missing", () => {
+        expect(
+            resolveFloatingPaneName({
+                blockViewLabel: undefined,
+                workspaceName: "Pulse",
+                indexInOpenPanes: 0,
+            }),
+        ).toBe("Pulse");
+    });
+
+    it("falls through the unrenamed bootstrap workspace name to positional", () => {
+        expect(
+            resolveFloatingPaneName({
+                blockViewLabel: undefined,
+                workspaceName: "Starter workspace",
+                indexInOpenPanes: 1,
+            }),
+        ).toBe("Pane 2");
+    });
+
+    it("falls through to positional when both are missing", () => {
+        expect(
+            resolveFloatingPaneName({
+                blockViewLabel: "",
+                workspaceName: "",
+                indexInOpenPanes: 0,
+            }),
+        ).toBe("Pane 1");
     });
 });
 

--- a/frontend/util/window-title.ts
+++ b/frontend/util/window-title.ts
@@ -15,6 +15,20 @@ const APP_NAME = "AgentMux";
 export const DISPLAY_NAME_META_KEY = "window:displayname";
 export const DISPLAY_NAME_MAX_LEN = 64;
 
+/**
+ * The bootstrap workspace name a fresh AgentMux data directory seeds on
+ * first-ever launch (`agentmux-srv/src/backend/wcore/mod.rs`,
+ * `create_workspace(store, "Starter workspace")`). Never renamed by the
+ * user, so it carries no more identifying information than "no name at
+ * all" — the spec's own example table
+ * (SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md §1.1) shows a fresh, unnamed
+ * window as `Window 1 - Shell - AgentMux`, not `Starter workspace - …`.
+ * Excluded from tier 2 below so window 1 titles the same deterministic
+ * way every other unnamed window does, instead of depending on whether
+ * this literal happened to load in time for the first title paint.
+ */
+const BOOTSTRAP_WORKSPACE_NAME = "Starter workspace";
+
 export interface ResolveWindowNameOpts {
     /** Value of `WaveWindow.meta["window:displayname"]` if set. */
     displayName?: string | null;
@@ -24,16 +38,23 @@ export interface ResolveWindowNameOpts {
     indexInOpenWindows: number;
 }
 
+/** A workspace name counts toward tier 2 only if it's non-empty and isn't
+ *  the never-renamed bootstrap default (see `BOOTSTRAP_WORKSPACE_NAME`). */
+function meaningfulWorkspaceName(name: string | null | undefined): string {
+    const trimmed = (name ?? "").trim();
+    return trimmed === BOOTSTRAP_WORKSPACE_NAME ? "" : trimmed;
+}
+
 /**
  * Three-tier resolution matching the InstancePanel rules:
  *   1. user-set display name (trimmed; empty falls through)
- *   2. workspace name (trimmed; empty falls through)
+ *   2. workspace name (trimmed; empty, or the unrenamed bootstrap default, falls through)
  *   3. positional fallback "Window N"
  */
 export function resolveWindowName(opts: ResolveWindowNameOpts): string {
     const display = (opts.displayName ?? "").trim();
     if (display) return display;
-    const ws = (opts.workspaceName ?? "").trim();
+    const ws = meaningfulWorkspaceName(opts.workspaceName);
     if (ws) return ws;
     return `Window ${opts.indexInOpenWindows + 1}`;
 }
@@ -50,13 +71,13 @@ export interface ResolveFloatingPaneNameOpts {
 /**
  * Two-tier resolution for floating pane display names:
  *   1. block view label (e.g. "Agent", "Terminal", "Browser")
- *   2. workspace name
+ *   2. workspace name (empty, or the unrenamed bootstrap default, falls through)
  *   3. positional fallback "Pane N"
  */
 export function resolveFloatingPaneName(opts: ResolveFloatingPaneNameOpts): string {
     const view = (opts.blockViewLabel ?? "").trim();
     if (view) return view;
-    const ws = (opts.workspaceName ?? "").trim();
+    const ws = meaningfulWorkspaceName(opts.workspaceName);
     if (ws) return ws;
     return `Pane ${opts.indexInOpenPanes + 1}`;
 }

--- a/test/e2e/crash-reproject.e2e.test.ts
+++ b/test/e2e/crash-reproject.e2e.test.ts
@@ -115,16 +115,27 @@ describe.skipIf(!RUN)("crash-reproject E2E: host OOM ⇒ session reprojects", ()
         // (sub-second in this session's live verifications) but runs
         // asynchronously relative to the new host's own startup. Poll on
         // "main's real title has settled" specifically, not merely
-        // "more than one target exists" — main's CDP target briefly shows a
-        // generic title before its content finishes loading and sets
-        // `document.title` to "Starter workspace...", so a bare count check
-        // can pass before main is actually the window we expect.
+        // "more than one target exists" — main's CDP target briefly shows
+        // `index.html`'s generic pre-init placeholder title ("AgentMux",
+        // bare, no " - " separator) before its content finishes loading
+        // and `document.title` resolves to the real
+        // `{Window Name} - {Tab} - AgentMux` format, so a bare count check
+        // can pass before main is actually the window we expect. Matched
+        // by `window_transparent=0` (a stable URL param the main window
+        // always carries), not by title text — the window name half of
+        // that format is no longer a fixed "Starter workspace..." string
+        // after frontend/util/window-title.ts's bootstrap-default-name
+        // exclusion fix (it's deterministically "Window 1 - ..." now, but
+        // matching on the URL is the correct identifier regardless of
+        // which of the 3 name tiers ends up resolving).
         const deadline = Date.now() + 15000;
         let targets: CdpTarget[] = [];
         let mainTarget: CdpTarget | undefined;
         while (Date.now() < deadline) {
             targets = await listCdpTargets(port2);
-            mainTarget = targets.find((t) => t.title.includes("Starter workspace"));
+            mainTarget = targets.find(
+                (t) => t.url.includes("window_transparent=0") && t.title !== "AgentMux",
+            );
             if (mainTarget && targets.length > 1) break;
             await sleep(500);
         }

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -65,10 +65,20 @@ export function wsSend(ws: WebSocket, method: string, params?: unknown): Promise
     });
 }
 
-/** Evaluate `expression` in the main window's page (found by title substring). */
+/**
+ * Evaluate `expression` in the main window's page. Matched by
+ * `window_transparent=0`, a stable URL param the main window always
+ * carries — NOT by title text: `resolveWindowName`'s tier-2 workspace-name
+ * fallback ("Starter workspace") only ever showed for a fresh data
+ * directory whose default workspace hadn't been renamed, and after
+ * frontend/util/window-title.ts's bootstrap-default exclusion fix, the
+ * title is deterministically "Window 1 - ..." instead — either way, a
+ * title-text match is the wrong kind of identifier for "which target is
+ * the main window" (it can also collide with a user-renamed window/tab).
+ */
 export async function evalInMainWindow(port: number, expression: string): Promise<any> {
     const targets = await listCdpTargets(port);
-    const main = targets.find((t) => t.title.includes("Starter workspace"));
+    const main = targets.find((t) => t.url.includes("window_transparent=0"));
     if (!main) throw new Error("main window's CDP target not found");
     const ws = await wsConnect(main.webSocketDebuggerUrl);
     await wsSend(ws, "Runtime.enable");


### PR DESCRIPTION
## Summary
Root-caused "sometimes the first window titles as 'Window 1', sometimes as 'Starter workspace'." The window-title 3-tier resolution (`window:displayname` → workspace name → `"Window N"`) let the literal seeded default workspace name (`"Starter workspace"`, `agentmux-srv/wcore/mod.rs`) count as a real tier-2 name. That name is never actually chosen by the user — every fresh data directory gets it — so whether it showed up depended on whether workspace data happened to resolve before the first title paint, producing the inconsistency.

- Excluded the bootstrap default literal from tier 2 in both `resolveWindowName` and `resolveFloatingPaneName` (same bug shape affects floating panes too).
- Window 1 now titles the same deterministic way every other unnamed window does — matching `SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md`'s own "Default unnamed window" example (`Window 1 - Shell - AgentMux`), and giving the user a reliably-distinguishable taskbar entry as requested.
- A workspace the user has actually renamed to something meaningful still shows via tier 2, unchanged — only the never-renamed bootstrap default is excluded.
- Also includes a small unrelated housekeeping fix: `ModalLayer.tsx` still referenced the pre-rename `"agent-setup"` modal-layer kind key; #2314 (merged) renamed it to `"agent-stash"`, flagged as a follow-up at the time.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run util/window-title.test.ts app/statusbar app/view/agent app/element` — 842 passed, including new coverage for the bootstrap-default exclusion (both `resolveWindowName` and `resolveFloatingPaneName`)
- [x] Live-verified against a fresh `task dev` launch via CDP: OS/taskbar title reads `Window 1 - tab1 - AgentMux`

<!-- agentmux:agent_id=agent3 -->