### PR TITLE
chore: release v0.54.6

### DIFF
--- a/.changesets/1785003182-feat-macos-tab-redock-via-cgeventtap-cross-window-tab-drag-n-ny0j.md
+++ b/.changesets/1785003182-feat-macos-tab-redock-via-cgeventtap-cross-window-tab-drag-n-ny0j.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(macos): tab redock via CGEventTap — cross-window tab drag now merges directly with a live insertion indicator, matching Windows

--- a/.changesets/1785039727-feat-media-add-media-pane-widget-with-live-directory-watch-u-diib.md
+++ b/.changesets/1785039727-feat-media-add-media-pane-widget-with-live-directory-watch-u-diib.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(media): add Media pane widget with live directory-watch updates

--- a/.changesets/1785076559-fix-auth-notify-before-an-automatic-relogin-and-on-resume-vs-ln9z.md
+++ b/.changesets/1785076559-fix-auth-notify-before-an-automatic-relogin-and-on-resume-vs-ln9z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): notify before an automatic relogin, and on resume vs fresh start, per LaunchAuthState

--- a/.changesets/1785098338-fix-diag-restore-wer-crash-dump-registration-for-agentmux-sr-dm9o.md
+++ b/.changesets/1785098338-fix-diag-restore-wer-crash-dump-registration-for-agentmux-sr-dm9o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(diag): restore WER crash-dump registration for agentmux-srv, correcting a stale binary filename

--- a/.changesets/1785113272-feat-agent-promote-long-running-bash-tool-calls-sleep-dev-se-lm3y.md
+++ b/.changesets/1785113272-feat-agent-promote-long-running-bash-tool-calls-sleep-dev-se-lm3y.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): promote long-running Bash tool calls (sleep, dev servers, builds) to the activity dock after 30s, freeing the Working banner to go calm

--- a/.changesets/1785123261-rename-the-per-agent-agent-setup-modal-to-stash-backpack-ico-ikmr.md
+++ b/.changesets/1785123261-rename-the-per-agent-agent-setup-modal-to-stash-backpack-ico-ikmr.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-rename the per-agent 'Agent setup' modal to Stash (backpack icon), distinguishing it from the global Armory pane

--- a/.changesets/1785132254-fix-armory-render-skill-content-as-markdown-and-fix-the-brok-99xq.md
+++ b/.changesets/1785132254-fix-armory-render-skill-content-as-markdown-and-fix-the-brok-99xq.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(armory): render Skill content as Markdown and fix the broken catalog Bind-to-agent action

--- a/.changesets/1785132255-fix-agent-pane-modals-close-on-backdrop-click-when-they-carr-ec7i.md
+++ b/.changesets/1785132255-fix-agent-pane-modals-close-on-backdrop-click-when-they-carr-ec7i.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): pane modals close on backdrop click when they carry no in-flight form state

--- a/.changesets/1785133835-fix-warden-decouple-container-query-context-from-the-scrolli-h1lb.md
+++ b/.changesets/1785133835-fix-warden-decouple-container-query-context-from-the-scrolli-h1lb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(warden): decouple container-query context from the scrolling pane; send auth on LAN fetch

--- a/.changesets/1785137808-fix-armory-mcp-servers-bind-to-agent-had-the-same-check-s1-a-h7b9.md
+++ b/.changesets/1785137808-fix-armory-mcp-servers-bind-to-agent-had-the-same-check-s1-a-h7b9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): MCP Servers Bind-to-agent had the same check_s1 auth gap as Skills — fixed identically

--- a/.changesets/1785161098-feat-cef-windows-codec-enabled-cef-build-support-proprietary-d67b.md
+++ b/.changesets/1785161098-feat-cef-windows-codec-enabled-cef-build-support-proprietary-d67b.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(cef): Windows codec-enabled CEF build support (proprietary codecs)

--- a/.changesets/1785165307-fix-auth-remove-mount-time-auto-login-trigger-fix-login-pers-vozj.md
+++ b/.changesets/1785165307-fix-auth-remove-mount-time-auto-login-trigger-fix-login-pers-vozj.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-fix(auth): remove mount-time auto-login trigger, fix login persistence and turn-state races

--- a/.changesets/1785177296-feat-dev-opt-in-isolated-auth-store-for-destructive-armory-t-5v2s.md
+++ b/.changesets/1785177296-feat-dev-opt-in-isolated-auth-store-for-destructive-armory-t-5v2s.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(dev): opt-in isolated auth store for destructive Armory testing (AGENTMUX_ISOLATED_AUTH=1)

--- a/.changesets/1785179340-fix-auth-gate-relogin-opened-tier-success-on-persist-result--k6zw.md
+++ b/.changesets/1785179340-fix-auth-gate-relogin-opened-tier-success-on-persist-result--k6zw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): gate relogin() opened-tier success on persist result, restore Log-in button on failure

--- a/.changesets/1785179751-fix-window-first-window-titles-consistently-as-window-1-inst-a177.md
+++ b/.changesets/1785179751-fix-window-first-window-titles-consistently-as-window-1-inst-a177.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): first window titles consistently as 'Window 1' instead of sometimes leaking the unrenamed bootstrap workspace name

--- a/.changesets/1785180769-fix-auth-forcecontrollerrefresh-seeds-termsize-and-reports-c-p61z.md
+++ b/.changesets/1785180769-fix-auth-forcecontrollerrefresh-seeds-termsize-and-reports-c-p61z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): forceControllerRefresh seeds termsize and reports controller status like Phase 3

--- a/.changesets/1785183216-fix-auth-stop-isolated-boot-from-rewriting-the-global-regist-1m4n.md
+++ b/.changesets/1785183216-fix-auth-stop-isolated-boot-from-rewriting-the-global-regist-1m4n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): stop isolated boot from rewriting the global registry, fix flaky test lock, distinguish confirmed vs unconfirmed auth

--- a/.changesets/1785184148-fix-auth-gate-login-s-opened-tier-success-on-persistandlinka-ztz6.md
+++ b/.changesets/1785184148-fix-auth-gate-login-s-opened-tier-success-on-persistandlinka-ztz6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): gate /login's opened-tier success on persistAndLinkAccount's return, matching relogin()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.5"
+version = "0.54.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.5"
+version = "0.54.6"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.5"
+version = "0.54.6"
 dependencies = [
  "dirs",
  "serde",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.5"
+version = "0.54.6"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.5"
+version = "0.54.6"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.5"
+version = "0.54.6"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.5"
+version = "0.54.6"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,27 @@
 # AgentMux Version History
 
+## 0.54.6 — 2026-07-27
+
+- feat(macos): tab redock via CGEventTap — cross-window tab drag now merges directly with a live insertion indicator, matching Windows
+- feat(media): add Media pane widget with live directory-watch updates
+- fix(auth): notify before an automatic relogin, and on resume vs fresh start, per LaunchAuthState
+- fix(diag): restore WER crash-dump registration for agentmux-srv, correcting a stale binary filename
+- feat(agent): promote long-running Bash tool calls (sleep, dev servers, builds) to the activity dock after 30s, freeing the Working banner to go calm
+- rename the per-agent 'Agent setup' modal to Stash (backpack icon), distinguishing it from the global Armory pane
+- fix(armory): render Skill content as Markdown and fix the broken catalog Bind-to-agent action
+- fix(agent): pane modals close on backdrop click when they carry no in-flight form state
+- fix(warden): decouple container-query context from the scrolling pane; send auth on LAN fetch
+- fix(armory): MCP Servers Bind-to-agent had the same check_s1 auth gap as Skills — fixed identically
+- feat(cef): Windows codec-enabled CEF build support (proprietary codecs)
+- fix(auth): remove mount-time auto-login trigger, fix login persistence and turn-state races
+- feat(dev): opt-in isolated auth store for destructive Armory testing (AGENTMUX_ISOLATED_AUTH=1)
+- fix(auth): gate relogin() opened-tier success on persist result, restore Log-in button on failure
+- fix(window): first window titles consistently as 'Window 1' instead of sometimes leaking the unrenamed bootstrap workspace name
+- fix(auth): forceControllerRefresh seeds termsize and reports controller status like Phase 3
+- fix(auth): stop isolated boot from rewriting the global registry, fix flaky test lock, distinguish confirmed vs unconfirmed auth
+- fix(auth): gate /login's opened-tier success on persistAndLinkAccount's return, matching relogin()
+
+
 ## 0.54.5 — 2026-07-26
 
 - fix(tabs): hide the single tab pill until a 2nd tab exists, transparent strip background

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.5",
+  "version": "0.54.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.5",
+      "version": "0.54.6",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.5",
+  "version": "0.54.6",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Release PR consuming all 18 pending changesets. Bump type forced to **patch** via `--as patch` (overriding the computed `minor` — several queued changesets are `feat`-level; see `scripts/release.sh`'s loud warning in the build log).

- 0.54.5 → 0.54.6
- All 5 version locations verified in agreement (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md)
- Includes PR #2318 (auth: remove mount-time auto-login trigger + login persistence/turn-state fixes + opt-in isolated-auth dev testing) plus 12 other agents' queued changesets (macOS tab redock, Media pane widget, WER crash-dump fix, long-running Bash tool promotion, Stash modal rename, Armory skill/MCP bind fixes, Warden container-query fix, CEF Windows codec support, window-title fix).

## Test plan
- [x] `task release -- --as patch` completed with all 5 version locations in agreement
- [x] `git diff --staged` reviewed before commit — only version files + VERSION_HISTORY.md + changeset deletions
- [ ] CI green on this PR

<!-- agentmux:agent_id=agenta -->