### PR TITLE
feat(armory): add Agent Skills (SKILL.md) format for skills — ABF Phase 0

### DIFF
--- a/.changesets/1785185774-feat-armory-add-agent-skills-skill-md-format-for-skills-abf--s97c.md
+++ b/.changesets/1785185774-feat-armory-add-agent-skills-skill-md-format-for-skills-abf--s97c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): add Agent Skills (SKILL.md) format for skills, ABF Phase 0

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -562,6 +562,21 @@ pub fn expand_template(content: &str, vars: &HashMap<String, String>) -> String 
 /// Agent Skills spec caps `description` at 1024 characters.
 const SKILL_DESCRIPTION_MAX_LEN: usize = 1024;
 
+/// Truncate `s` to at most `max_units` UTF-16 code units, on a UTF-8 char
+/// boundary. Mirrors JS `.slice(0, n)` semantics (JS strings are indexed in
+/// UTF-16 code units, so a Rust byte-length cap diverges from the TS mirror
+/// for any non-ASCII text — reagent P2, PR #2322).
+fn truncate_utf16_units(s: &str, max_units: usize) -> String {
+    let mut units = 0usize;
+    for (byte_idx, ch) in s.char_indices() {
+        units += ch.len_utf16();
+        if units > max_units {
+            return s[..byte_idx].to_string();
+        }
+    }
+    s.to_string()
+}
+
 /// Render an Agent Skills-format `SKILL.md`: YAML frontmatter with the two
 /// required fields (`name`, `description` — per the spec's six-field
 /// frontmatter; AgentMux doesn't populate the four optional ones today:
@@ -572,9 +587,12 @@ const SKILL_DESCRIPTION_MAX_LEN: usize = 1024;
 /// requires `name` be lowercase/hyphenated and match its parent directory;
 /// callers must pass the same value used to build the `.claude/skills/<slug>/`
 /// path (reagent P1, PR #2322). `description` is validated: the spec requires
-/// a non-empty value (falls back to a placeholder) capped at 1024 characters
-/// (truncated on a char boundary, since the UI permits arbitrary-length free
-/// text with no spec-awareness).
+/// a non-empty value (falls back to a placeholder) capped at 1024 **UTF-16
+/// code units** — matching the TS mirror's `.slice(0, 1024)` (JS string
+/// indexing is UTF-16-code-unit based), since the UI permits arbitrary-length
+/// free text with no spec-awareness and non-ASCII descriptions previously
+/// truncated to different byte vs. UTF-16 lengths between the two paths
+/// (reagent P2, PR #2322).
 ///
 /// YAML double-quoted scalars use JSON-compatible escaping (YAML 1.2
 /// §7.3.1), so `serde_json::to_string` on a plain string produces a valid,
@@ -582,16 +600,12 @@ const SKILL_DESCRIPTION_MAX_LEN: usize = 1024;
 /// adding a yaml crate dependency (this workspace has neither today) just
 /// for two scalar fields.
 fn render_skill_md(slug: &str, description: &str, body: &str) -> String {
+    let owned_description;
     let description = if description.trim().is_empty() {
         "No description provided."
-    } else if description.len() > SKILL_DESCRIPTION_MAX_LEN {
-        let mut end = SKILL_DESCRIPTION_MAX_LEN;
-        while !description.is_char_boundary(end) {
-            end -= 1;
-        }
-        &description[..end]
     } else {
-        description
+        owned_description = truncate_utf16_units(description, SKILL_DESCRIPTION_MAX_LEN);
+        owned_description.as_str()
     };
     let name_yaml =
         serde_json::to_string(slug).expect("string serialization is infallible");
@@ -600,21 +614,55 @@ fn render_skill_md(slug: &str, description: &str, body: &str) -> String {
     format!("---\nname: {name_yaml}\ndescription: {description_yaml}\n---\n\n{body}")
 }
 
-/// Derive a filesystem-safe, COLLISION-FREE slug for a skill within one
-/// `build_config_files` call. `derive_slug` alone can produce identical
-/// output for distinct names that differ only in punctuation/whitespace
-/// (e.g. "Deploy Checklist" and "Deploy!!!Checklist" both ->
-/// "deploy-checklist"), which would otherwise silently overwrite one
-/// skill's `SKILL.md` with another's on disk (reagent P1, PR #2322).
-/// Appends `-2`, `-3`, ... until the slug is unique within `used`.
+/// Derive a slug for an Agent Skill name that is valid per the Agent Skills
+/// `name` grammar: lowercase letters, digits, and hyphens ONLY (no
+/// underscores). `derive_slug` is shared with agent role-slugs, which
+/// deliberately DO permit underscores, so it isn't spec-valid here as-is —
+/// hyphenate underscores (and re-collapse any resulting run of hyphens)
+/// rather than reusing it directly (Codex P1, PR #2322).
+fn skill_name_slug(name: &str) -> String {
+    let base = derive_slug(name).replace('_', "-");
+    let collapsed: String = base
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if collapsed.is_empty() {
+        "skill".to_string()
+    } else {
+        collapsed
+    }
+}
+
+/// Derive a filesystem-safe, COLLISION-FREE, spec-valid slug for an Agent
+/// Skill name within one caller-scoped `used` set. `skill_name_slug` alone
+/// can produce identical output for distinct names that differ only in
+/// punctuation/whitespace (e.g. "Deploy Checklist" and "Deploy!!!Checklist"
+/// both -> "deploy-checklist"), which would otherwise silently overwrite one
+/// skill's `SKILL.md` with another's on disk (reagent P1, PR #2322). Appends
+/// `-2`, `-3`, ... until the slug is unique within `used`, truncating the
+/// base first so the suffixed result never exceeds the spec's 64-character
+/// max (Codex P2, PR #2322 — a 64-char base plus `-2` was previously 66
+/// chars).
 fn unique_skill_slug(name: &str, used: &mut HashSet<String>) -> String {
-    let base = derive_slug(name);
+    const MAX_LEN: usize = 64;
+    let base = skill_name_slug(name);
     if used.insert(base.clone()) {
         return base;
     }
     let mut n: u32 = 2;
     loop {
-        let candidate = format!("{base}-{n}");
+        let suffix = format!("-{n}");
+        let max_base_len = MAX_LEN.saturating_sub(suffix.len());
+        let mut truncated_base = base.clone();
+        if truncated_base.len() > max_base_len {
+            let mut end = max_base_len;
+            while end > 0 && !truncated_base.is_char_boundary(end) {
+                end -= 1;
+            }
+            truncated_base.truncate(end);
+        }
+        let candidate = format!("{truncated_base}{suffix}");
         if used.insert(candidate.clone()) {
             return candidate;
         }
@@ -878,6 +926,43 @@ mod tests {
         assert!(second.content.contains("body two"));
         let third = skill_files.iter().find(|f| f.filename.ends_with("deploy-checklist-3/SKILL.md")).unwrap();
         assert!(third.content.contains("body three"));
+    }
+
+    #[test]
+    fn test_unique_skill_slug_replaces_underscores_with_hyphens() {
+        // Codex P1, PR #2322: derive_slug (shared with agent role-slugs) keeps
+        // underscores, which is spec-invalid for an Agent Skills `name`.
+        let mut used = HashSet::new();
+        assert_eq!(unique_skill_slug("code_review", &mut used), "code-review");
+    }
+
+    #[test]
+    fn test_unique_skill_slug_suffixed_slug_stays_within_64_chars() {
+        // Codex P2, PR #2322: a 64-char base plus "-2" was previously 66 chars.
+        let mut used = HashSet::new();
+        let long = "a".repeat(100);
+        let first = unique_skill_slug(&long, &mut used);
+        assert_eq!(first.len(), 64);
+        let second = unique_skill_slug(&long, &mut used);
+        assert!(second.len() <= 64, "suffixed slug exceeds 64 chars: {second} ({})", second.len());
+        assert!(second.ends_with("-2"));
+    }
+
+    #[test]
+    fn test_render_skill_md_truncates_by_utf16_units_matching_ts_slice() {
+        // reagent P2, PR #2322: Rust previously capped by byte length while
+        // the TS mirror caps by UTF-16 code units (`.slice(0, 1024)`), so
+        // non-ASCII descriptions truncated to different lengths between the
+        // two paths. A 3-byte-per-char UTF-8 string (each char = 1 UTF-16
+        // unit) makes the byte-vs-unit divergence obvious: byte-based
+        // truncation would cut this off around char 341, not 1024.
+        let description: String = "\u{4e2d}".repeat(2000); // "中" x2000 (3 bytes each, 1 UTF-16 unit each)
+        let md = render_skill_md("slug", &description, "body");
+        let desc_line = md.lines().find(|l| l.starts_with("description: ")).unwrap();
+        let quoted = desc_line.trim_start_matches("description: ");
+        let inner = &quoted[1..quoted.len() - 1]; // strip surrounding quotes
+        let utf16_len: usize = inner.chars().map(|c| c.len_utf16()).sum();
+        assert_eq!(utf16_len, 1024, "expected exactly 1024 UTF-16 units, got {utf16_len}");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -12,7 +12,17 @@ use std::collections::HashMap;
 use chrono::Utc;
 use serde_json::{json, Value};
 
-use crate::backend::storage::store::AgentSkill;
+use crate::backend::storage::store::{derive_slug, AgentSkill};
+
+/// `skill_type` value that materializes a skill as an Agent Skills-format
+/// `.claude/skills/<slug>/SKILL.md` instead of a `.claude/commands/<trigger>.md`
+/// slash command. Any other value (in practice, always `"prompt"` today) keeps
+/// the pre-existing slash-command behavior. See
+/// `docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md` Phase 0 —
+/// `skill_type` already existed end-to-end but was never branched on before
+/// this, making it the lowest-friction place to hang the format discriminator
+/// rather than adding a new column.
+pub const SKILL_TYPE_AGENT_SKILL: &str = "agent-skill";
 
 /// A single file to be written to the agent working directory.
 #[derive(Debug, Clone)]
@@ -98,10 +108,23 @@ pub fn build_config_files(
     }
 
     // ----------------------------------------------------------------
-    // Write each skill as a slash command: .claude/commands/{trigger}.md
+    // Write each skill as either a slash command
+    // (.claude/commands/{trigger}.md, default) or an Agent Skills-format
+    // SKILL.md (.claude/skills/{slug}/SKILL.md, skill_type ==
+    // SKILL_TYPE_AGENT_SKILL) for native Claude Code consumption.
     // ----------------------------------------------------------------
     for skill in skills {
-        if !skill.trigger.is_empty() && !skill.content.is_empty() {
+        if skill.content.is_empty() {
+            continue;
+        }
+        if skill.skill_type == SKILL_TYPE_AGENT_SKILL {
+            let slug = derive_slug(&skill.name);
+            let content = expand_template(&skill.content, &template_vars);
+            files.push(AgentConfigFile {
+                filename: format!(".claude/skills/{slug}/SKILL.md"),
+                content: render_skill_md(&skill.name, &skill.description, &content),
+            });
+        } else if !skill.trigger.is_empty() {
             let content = expand_template(&skill.content, &template_vars);
             files.push(AgentConfigFile {
                 filename: format!(".claude/commands/{}.md", skill.trigger),
@@ -535,6 +558,25 @@ pub fn expand_template(content: &str, vars: &HashMap<String, String>) -> String 
     result
 }
 
+/// Render an Agent Skills-format `SKILL.md`: YAML frontmatter with the two
+/// required fields (`name`, `description` — per the spec's six-field
+/// frontmatter; AgentMux doesn't populate the four optional ones today:
+/// `license`, `compatibility`, `metadata`, `allowed-tools`), followed by the
+/// skill's content as the Markdown body. See https://agentskills.io/specification.
+///
+/// YAML double-quoted scalars use JSON-compatible escaping (YAML 1.2
+/// §7.3.1), so `serde_json::to_string` on a plain string produces a valid,
+/// correctly-escaped YAML value — this avoids hand-rolling YAML escaping or
+/// adding a yaml crate dependency (this workspace has neither today) just
+/// for two scalar fields.
+fn render_skill_md(name: &str, description: &str, body: &str) -> String {
+    let name_yaml =
+        serde_json::to_string(name).expect("string serialization is infallible");
+    let description_yaml =
+        serde_json::to_string(description).expect("string serialization is infallible");
+    format!("---\nname: {name_yaml}\ndescription: {description_yaml}\n---\n\n{body}")
+}
+
 // ============================================================
 // Tests
 // ============================================================
@@ -550,6 +592,19 @@ mod tests {
             name: name.to_string(),
             trigger: trigger.to_string(),
             skill_type: "prompt".to_string(),
+            description: description.to_string(),
+            content: content.to_string(),
+            created_at: 0,
+        }
+    }
+
+    fn make_agent_skill(name: &str, description: &str, content: &str) -> AgentSkill {
+        AgentSkill {
+            id: format!("skill-{}", derive_slug(name)),
+            agent_id: "agent-1".to_string(),
+            name: name.to_string(),
+            trigger: String::new(),
+            skill_type: SKILL_TYPE_AGENT_SKILL.to_string(),
             description: description.to_string(),
             content: content.to_string(),
             created_at: 0,
@@ -640,6 +695,65 @@ mod tests {
         // Individual skill command files
         assert!(files.iter().any(|f| f.filename == ".claude/commands/deploy.md"));
         assert!(files.iter().any(|f| f.filename == ".claude/commands/test.md"));
+    }
+
+    #[test]
+    fn test_build_config_files_agent_skill_format_writes_skill_md() {
+        let content_map = HashMap::new();
+        let skills = vec![make_agent_skill(
+            "Deploy Checklist",
+            "Runs the pre-deploy checklist",
+            "1. Run tests\n2. Check migrations\n3. Deploy",
+        )];
+
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+
+        // Materializes to .claude/skills/<slug>/SKILL.md, not .claude/commands/
+        let skill_file = files
+            .iter()
+            .find(|f| f.filename == ".claude/skills/deploy-checklist/SKILL.md")
+            .expect("expected .claude/skills/deploy-checklist/SKILL.md");
+        assert!(!files.iter().any(|f| f.filename.starts_with(".claude/commands/")));
+
+        // YAML frontmatter with the two required Agent Skills fields
+        assert!(skill_file.content.starts_with("---\n"));
+        assert!(skill_file.content.contains("name: \"Deploy Checklist\""));
+        assert!(skill_file
+            .content
+            .contains("description: \"Runs the pre-deploy checklist\""));
+        assert!(skill_file.content.contains("---\n\n1. Run tests"));
+
+        // Skills index in CLAUDE.md still lists it (trigger-agnostic)
+        let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
+        assert!(claude_md.content.contains("Deploy Checklist"));
+    }
+
+    #[test]
+    fn test_build_config_files_agent_skill_format_escapes_yaml_special_chars() {
+        // Names/descriptions with colons, quotes, or newlines must not
+        // corrupt the YAML frontmatter -- serde_json's escaping (valid YAML
+        // double-quoted-scalar syntax per YAML 1.2 §7.3.1) is what protects
+        // this; regression-test it explicitly rather than trusting the
+        // dependency silently.
+        let content_map = HashMap::new();
+        let skills = vec![make_agent_skill(
+            "Weird: \"Name\"",
+            "Has a colon: and \"quotes\"",
+            "body",
+        )];
+
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+        let skill_file = files
+            .iter()
+            .find(|f| f.filename.starts_with(".claude/skills/") && f.filename.ends_with("SKILL.md"))
+            .expect("expected a SKILL.md file");
+
+        // Frontmatter must parse as exactly 3 lines before the closing ---
+        // (name, description, and nothing else leaking onto a new line).
+        let end = skill_file.content.find("\n---\n\n").expect("closing frontmatter delimiter");
+        let frontmatter = &skill_file.content[4..end]; // skip leading "---\n"
+        let lines: Vec<&str> = frontmatter.lines().collect();
+        assert_eq!(lines.len(), 2, "frontmatter should be exactly name + description lines, got: {lines:?}");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -7,7 +7,7 @@
 //! functions from `frontend/app/view/agent/agent-model.ts`.
 //! All functions are pure — no I/O, no async.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::Utc;
 use serde_json::{json, Value};
@@ -113,12 +113,13 @@ pub fn build_config_files(
     // SKILL.md (.claude/skills/{slug}/SKILL.md, skill_type ==
     // SKILL_TYPE_AGENT_SKILL) for native Claude Code consumption.
     // ----------------------------------------------------------------
+    let mut used_skill_slugs: HashSet<String> = HashSet::new();
     for skill in skills {
         if skill.content.is_empty() {
             continue;
         }
         if skill.skill_type == SKILL_TYPE_AGENT_SKILL {
-            let slug = derive_slug(&skill.name);
+            let slug = unique_skill_slug(&skill.name, &mut used_skill_slugs);
             let content = expand_template(&skill.content, &template_vars);
             files.push(AgentConfigFile {
                 filename: format!(".claude/skills/{slug}/SKILL.md"),
@@ -577,6 +578,28 @@ fn render_skill_md(name: &str, description: &str, body: &str) -> String {
     format!("---\nname: {name_yaml}\ndescription: {description_yaml}\n---\n\n{body}")
 }
 
+/// Derive a filesystem-safe, COLLISION-FREE slug for a skill within one
+/// `build_config_files` call. `derive_slug` alone can produce identical
+/// output for distinct names that differ only in punctuation/whitespace
+/// (e.g. "Deploy Checklist" and "Deploy!!!Checklist" both ->
+/// "deploy-checklist"), which would otherwise silently overwrite one
+/// skill's `SKILL.md` with another's on disk (reagent P1, PR #2322).
+/// Appends `-2`, `-3`, ... until the slug is unique within `used`.
+fn unique_skill_slug(name: &str, used: &mut HashSet<String>) -> String {
+    let base = derive_slug(name);
+    if used.insert(base.clone()) {
+        return base;
+    }
+    let mut n: u32 = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 // ============================================================
 // Tests
 // ============================================================
@@ -754,6 +777,42 @@ mod tests {
         let frontmatter = &skill_file.content[4..end]; // skip leading "---\n"
         let lines: Vec<&str> = frontmatter.lines().collect();
         assert_eq!(lines.len(), 2, "frontmatter should be exactly name + description lines, got: {lines:?}");
+    }
+
+    #[test]
+    fn test_build_config_files_agent_skill_format_dedupes_colliding_slugs() {
+        // reagent P1 (PR #2322): two distinct skill names that derive_slug
+        // collapses to the same slug must NOT silently overwrite each
+        // other's SKILL.md file.
+        let content_map = HashMap::new();
+        let skills = vec![
+            make_agent_skill("Deploy Checklist", "First skill", "body one"),
+            make_agent_skill("Deploy!!!Checklist", "Second skill", "body two"),
+            make_agent_skill("Deploy   Checklist", "Third skill", "body three"),
+        ];
+
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+
+        let skill_files: Vec<&AgentConfigFile> = files
+            .iter()
+            .filter(|f| f.filename.starts_with(".claude/skills/") && f.filename.ends_with("SKILL.md"))
+            .collect();
+        assert_eq!(skill_files.len(), 3, "all three skills must materialize to distinct files");
+
+        let filenames: HashSet<&str> = skill_files.iter().map(|f| f.filename.as_str()).collect();
+        assert_eq!(filenames.len(), 3, "filenames must be unique: {filenames:?}");
+        assert!(filenames.contains(".claude/skills/deploy-checklist/SKILL.md"));
+        assert!(filenames.contains(".claude/skills/deploy-checklist-2/SKILL.md"));
+        assert!(filenames.contains(".claude/skills/deploy-checklist-3/SKILL.md"));
+
+        // Each file's content must correspond to the correct skill (not just
+        // present -- verify no cross-contamination from the dedup logic).
+        let first = skill_files.iter().find(|f| f.filename.ends_with("deploy-checklist/SKILL.md")).unwrap();
+        assert!(first.content.contains("body one"));
+        let second = skill_files.iter().find(|f| f.filename.ends_with("deploy-checklist-2/SKILL.md")).unwrap();
+        assert!(second.content.contains("body two"));
+        let third = skill_files.iter().find(|f| f.filename.ends_with("deploy-checklist-3/SKILL.md")).unwrap();
+        assert!(third.content.contains("body three"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -125,10 +125,10 @@ pub fn build_config_files(
                 filename: format!(".claude/skills/{slug}/SKILL.md"),
                 content: render_skill_md(&slug, &skill.description, &content),
             });
-        } else if !skill.trigger.is_empty() {
+        } else if let Some(safe_trigger) = sanitize_trigger(&skill.trigger) {
             let content = expand_template(&skill.content, &template_vars);
             files.push(AgentConfigFile {
-                filename: format!(".claude/commands/{}.md", skill.trigger),
+                filename: format!(".claude/commands/{safe_trigger}.md"),
                 content,
             });
         }
@@ -614,6 +614,27 @@ fn render_skill_md(slug: &str, description: &str, body: &str) -> String {
     format!("---\nname: {name_yaml}\ndescription: {description_yaml}\n---\n\n{body}")
 }
 
+/// Validate a skill's `trigger` is safe to use as a single path segment in
+/// `.claude/commands/<trigger>.md`. `trigger` is free-form user input with
+/// no format validation anywhere upstream (the skill create/update RPCs and
+/// the frontend form all accept it as-is), so a trigger containing a path
+/// separator or a `..` segment previously let the resulting filename
+/// resolve OUTSIDE the agent's working directory -- both for this write and,
+/// once stale-file cleanup existed, for the corresponding delete (reagent
+/// P1, PR #2322). Rejects (returns `None`) anything containing `/` or `\`,
+/// or that is exactly `.`/`..`; callers skip writing that skill's command
+/// file entirely rather than silently rewriting the trigger into something
+/// the user didn't ask for.
+fn sanitize_trigger(trigger: &str) -> Option<&str> {
+    if trigger.is_empty() || trigger == "." || trigger == ".." {
+        return None;
+    }
+    if trigger.contains('/') || trigger.contains('\\') {
+        return None;
+    }
+    Some(trigger)
+}
+
 /// Derive a slug for an Agent Skill name that is valid per the Agent Skills
 /// `name` grammar: lowercase letters, digits, and hyphens ONLY (no
 /// underscores). `derive_slug` is shared with agent role-slugs, which
@@ -702,6 +723,42 @@ mod tests {
             content: content.to_string(),
             created_at: 0,
         }
+    }
+
+    #[test]
+    fn test_sanitize_trigger_rejects_path_traversal() {
+        // reagent P1, PR #2322: a trigger with a path separator or ".."
+        // must never be allowed to steer .claude/commands/<trigger>.md
+        // outside the working directory.
+        assert_eq!(sanitize_trigger("../../../../.ssh/authorized_keys"), None);
+        assert_eq!(sanitize_trigger("../evil"), None);
+        assert_eq!(sanitize_trigger("sub/evil"), None);
+        assert_eq!(sanitize_trigger("sub\\evil"), None);
+        assert_eq!(sanitize_trigger(".."), None);
+        assert_eq!(sanitize_trigger("."), None);
+        assert_eq!(sanitize_trigger(""), None);
+        assert_eq!(sanitize_trigger("deploy"), Some("deploy"));
+    }
+
+    #[test]
+    fn test_build_config_files_skips_prompt_skill_with_traversal_trigger() {
+        // reagent P1, PR #2322: build_config_files must not materialize a
+        // command file for a malicious trigger, not even under a sanitized
+        // name -- skip it outright.
+        let content_map = HashMap::new();
+        let skills = vec![make_skill(
+            "Evil",
+            "../../../../.ssh/authorized_keys",
+            "desc",
+            "malicious content",
+        )];
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+        assert!(
+            files.iter().all(|f| !f.filename.contains("..")),
+            "no config file path may contain '..': {:?}",
+            files.iter().map(|f| &f.filename).collect::<Vec<_>>()
+        );
+        assert!(!files.iter().any(|f| f.filename.starts_with(".claude/commands/")));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -123,7 +123,7 @@ pub fn build_config_files(
             let content = expand_template(&skill.content, &template_vars);
             files.push(AgentConfigFile {
                 filename: format!(".claude/skills/{slug}/SKILL.md"),
-                content: render_skill_md(&skill.name, &skill.description, &content),
+                content: render_skill_md(&slug, &skill.description, &content),
             });
         } else if !skill.trigger.is_empty() {
             let content = expand_template(&skill.content, &template_vars);
@@ -559,20 +559,42 @@ pub fn expand_template(content: &str, vars: &HashMap<String, String>) -> String 
     result
 }
 
+/// Agent Skills spec caps `description` at 1024 characters.
+const SKILL_DESCRIPTION_MAX_LEN: usize = 1024;
+
 /// Render an Agent Skills-format `SKILL.md`: YAML frontmatter with the two
 /// required fields (`name`, `description` — per the spec's six-field
 /// frontmatter; AgentMux doesn't populate the four optional ones today:
 /// `license`, `compatibility`, `metadata`, `allowed-tools`), followed by the
 /// skill's content as the Markdown body. See https://agentskills.io/specification.
 ///
+/// `slug` (not the skill's raw display name) is REQUIRED here — the spec
+/// requires `name` be lowercase/hyphenated and match its parent directory;
+/// callers must pass the same value used to build the `.claude/skills/<slug>/`
+/// path (reagent P1, PR #2322). `description` is validated: the spec requires
+/// a non-empty value (falls back to a placeholder) capped at 1024 characters
+/// (truncated on a char boundary, since the UI permits arbitrary-length free
+/// text with no spec-awareness).
+///
 /// YAML double-quoted scalars use JSON-compatible escaping (YAML 1.2
 /// §7.3.1), so `serde_json::to_string` on a plain string produces a valid,
 /// correctly-escaped YAML value — this avoids hand-rolling YAML escaping or
 /// adding a yaml crate dependency (this workspace has neither today) just
 /// for two scalar fields.
-fn render_skill_md(name: &str, description: &str, body: &str) -> String {
+fn render_skill_md(slug: &str, description: &str, body: &str) -> String {
+    let description = if description.trim().is_empty() {
+        "No description provided."
+    } else if description.len() > SKILL_DESCRIPTION_MAX_LEN {
+        let mut end = SKILL_DESCRIPTION_MAX_LEN;
+        while !description.is_char_boundary(end) {
+            end -= 1;
+        }
+        &description[..end]
+    } else {
+        description
+    };
     let name_yaml =
-        serde_json::to_string(name).expect("string serialization is infallible");
+        serde_json::to_string(slug).expect("string serialization is infallible");
     let description_yaml =
         serde_json::to_string(description).expect("string serialization is infallible");
     format!("---\nname: {name_yaml}\ndescription: {description_yaml}\n---\n\n{body}")
@@ -738,9 +760,11 @@ mod tests {
             .expect("expected .claude/skills/deploy-checklist/SKILL.md");
         assert!(!files.iter().any(|f| f.filename.starts_with(".claude/commands/")));
 
-        // YAML frontmatter with the two required Agent Skills fields
+        // YAML frontmatter with the two required Agent Skills fields.
+        // `name` is the slug (matching its parent directory per the Agent
+        // Skills spec), NOT the raw display name -- reagent P1 on #2322.
         assert!(skill_file.content.starts_with("---\n"));
-        assert!(skill_file.content.contains("name: \"Deploy Checklist\""));
+        assert!(skill_file.content.contains("name: \"deploy-checklist\""));
         assert!(skill_file
             .content
             .contains("description: \"Runs the pre-deploy checklist\""));
@@ -777,6 +801,47 @@ mod tests {
         let frontmatter = &skill_file.content[4..end]; // skip leading "---\n"
         let lines: Vec<&str> = frontmatter.lines().collect();
         assert_eq!(lines.len(), 2, "frontmatter should be exactly name + description lines, got: {lines:?}");
+    }
+
+    #[test]
+    fn test_build_config_files_agent_skill_format_name_is_the_slug_not_display_name() {
+        // reagent P1 (PR #2322): the Agent Skills spec requires `name` be
+        // lowercase/hyphenated and match its parent directory -- the raw
+        // display name (e.g. "Deploy Checklist") is spec-invalid.
+        let content_map = HashMap::new();
+        let skills = vec![make_agent_skill("Deploy Checklist", "desc", "body")];
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+        let skill_file = files.iter().find(|f| f.filename.ends_with("SKILL.md")).unwrap();
+        assert!(skill_file.content.contains("name: \"deploy-checklist\""));
+        assert!(!skill_file.content.contains("name: \"Deploy Checklist\""));
+    }
+
+    #[test]
+    fn test_build_config_files_agent_skill_format_empty_description_gets_fallback() {
+        // reagent P1 (PR #2322): the Agent Skills spec requires a non-empty
+        // description; the UI permits creating a skill with none.
+        let content_map = HashMap::new();
+        let skills = vec![make_agent_skill("Deploy Checklist", "", "body")];
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+        let skill_file = files.iter().find(|f| f.filename.ends_with("SKILL.md")).unwrap();
+        assert!(!skill_file.content.contains("description: \"\""), "empty description must not reach the spec-invalid empty string: {}", skill_file.content);
+        assert!(skill_file.content.contains("description: \"No description provided.\""));
+    }
+
+    #[test]
+    fn test_build_config_files_agent_skill_format_truncates_long_description() {
+        // reagent P1 (PR #2322): the Agent Skills spec caps description at
+        // 1024 characters.
+        let content_map = HashMap::new();
+        let long_description = "x".repeat(2000);
+        let skills = vec![make_agent_skill("Deploy Checklist", &long_description, "body")];
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1", "aria", "/tmp/aria");
+        let skill_file = files.iter().find(|f| f.filename.ends_with("SKILL.md")).unwrap();
+        // Extract the description value between the quotes on its line.
+        let desc_line = skill_file.content.lines().find(|l| l.starts_with("description: ")).unwrap();
+        let quoted = desc_line.trim_start_matches("description: ");
+        let inner_len = quoted.len() - 2; // strip surrounding quotes
+        assert!(inner_len <= 1024, "description exceeds spec max of 1024 chars: {inner_len}");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -5,7 +5,16 @@
 //!
 //! Ports the `buildConfigFiles`, `buildMcpConfig`, and `expandTemplate`
 //! functions from `frontend/app/view/agent/agent-model.ts`.
-//! All functions are pure — no I/O, no async.
+//! Most functions here are pure — no I/O, no async. The exception is the
+//! `managed skill files manifest` section near the end: real filesystem
+//! I/O shared by the two independent RPC handlers that materialize config
+//! files to disk (`agent.open`'s `write_agent_config_files` in
+//! `server/app_api/agent_open.rs`, and `writeagentconfig` in
+//! `server/editor_handlers.rs` — the latter is the actual "click Launch"
+//! path used on every normal agent launch). Lives here rather than in
+//! either handler file so the two callers can't drift out of sync on the
+//! manifest format or the path-traversal defense (reagent P1, PR #2322 —
+//! `writeagentconfig` initially had no cleanup at all).
 
 use std::collections::{HashMap, HashSet};
 
@@ -688,6 +697,110 @@ fn unique_skill_slug(name: &str, used: &mut HashSet<String>) -> String {
             return candidate;
         }
         n += 1;
+    }
+}
+
+// ============================================================
+// Managed skill files manifest (I/O — see module doc comment)
+// ============================================================
+
+/// Hidden manifest (relative to the agent working directory) tracking which
+/// skill-derived paths (`.claude/commands/*.md`, `.claude/skills/*/SKILL.md`)
+/// AgentMux itself wrote on the last materialization, so a subsequent one
+/// can delete ones that are no longer current without touching any
+/// user-authored `.claude/commands`/`.claude/skills` content.
+pub const MANAGED_SKILL_FILES_MANIFEST: &str = ".claude/.agentmux-managed-skill-files.json";
+
+/// Compute the subset of `filenames` that are skill-derived managed paths
+/// (the ones tracked in [`MANAGED_SKILL_FILES_MANIFEST`]) — everything else
+/// (`CLAUDE.md`, `.mcp.json`, `.claude/settings.json`, ...) is always fully
+/// regenerated at a fixed path every launch, so it has no staleness problem
+/// to track.
+pub fn managed_skill_file_paths<'a>(
+    filenames: impl Iterator<Item = &'a str>,
+) -> std::collections::BTreeSet<String> {
+    filenames
+        .filter(|f| f.starts_with(".claude/commands/") || f.starts_with(".claude/skills/"))
+        .map(|f| f.to_string())
+        .collect()
+}
+
+/// Delete skill-derived files a PREVIOUS materialization wrote (per the
+/// on-disk manifest) but that are no longer part of `new_managed_paths` --
+/// e.g. a skill's format switched between `"prompt"`/`"agent-skill"`, or it
+/// was renamed/removed. Without this, the stale file stays on disk and
+/// Claude keeps treating it as active alongside the newly selected format
+/// (reagent P1 + Codex P1/P2, PR #2322).
+///
+/// MUST be called before writing the new files (so a deletion never races a
+/// write to the same path); callers must call
+/// [`write_managed_skill_file_manifest`] after writing to record the new
+/// set for the next materialization. Best-effort: any individual read/parse
+/// failure is treated as "no prior manifest" (nothing to clean up yet)
+/// rather than propagated, since a missing/corrupt manifest must never
+/// block the write that follows.
+///
+/// Every path is resolved through [`crate::backend::base::safe_join_within_base`]
+/// before deletion — defense in depth against a manifest path that somehow
+/// escapes the working directory (e.g. a future bypass of trigger
+/// sanitization upstream, or manual tampering with the manifest file
+/// itself); such a path is skipped with a warning, never followed.
+pub fn cleanup_stale_managed_skill_files(
+    base_path: &std::path::Path,
+    new_managed_paths: &std::collections::BTreeSet<String>,
+) {
+    let manifest_path = base_path.join(MANAGED_SKILL_FILES_MANIFEST);
+    let Ok(raw) = std::fs::read_to_string(&manifest_path) else {
+        return;
+    };
+    let Ok(old_paths) = serde_json::from_str::<Vec<String>>(&raw) else {
+        return;
+    };
+    for old in &old_paths {
+        if new_managed_paths.contains(old) {
+            continue;
+        }
+        let old_path = match crate::backend::base::safe_join_within_base(base_path, old) {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::warn!(
+                    work_dir = %base_path.display(),
+                    path = %old,
+                    "cleanup_stale_managed_skill_files: refusing to delete a manifest path \
+                     that escapes the working directory"
+                );
+                continue;
+            }
+        };
+        let _ = std::fs::remove_file(&old_path);
+        // Agent Skills format nests under .claude/skills/<slug>/ -- clean up
+        // the now-empty slug directory too (no-op/fails silently if
+        // anything else still lives there, e.g. a future scripts/ dir).
+        if let Some(parent) = old_path.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+}
+
+/// Record `new_managed_paths` as the manifest for the NEXT call to
+/// [`cleanup_stale_managed_skill_files`]. Best-effort: a write failure is
+/// logged, not propagated — losing this write only means the next
+/// materialization's stale-file cleanup is skipped once, not a correctness
+/// issue for the current one.
+pub fn write_managed_skill_file_manifest(
+    base_path: &std::path::Path,
+    new_managed_paths: &std::collections::BTreeSet<String>,
+) {
+    let manifest_path = base_path.join(MANAGED_SKILL_FILES_MANIFEST);
+    if let Ok(manifest_json) = serde_json::to_string(new_managed_paths) {
+        if let Err(e) = std::fs::write(&manifest_path, manifest_json) {
+            tracing::warn!(
+                work_dir = %base_path.display(),
+                error = %e,
+                "write_managed_skill_file_manifest: failed to write manifest; \
+                 stale file cleanup may be skipped on the next materialization"
+            );
+        }
     }
 }
 

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -275,6 +275,45 @@ impl Store {
         Ok(out)
     }
 
+    /// Effective skills for an agent at launch/config-materialization time:
+    /// this agent's own ref-bound skills (via `skill_list`) take over
+    /// *entirely* when present (globals still included), otherwise fall back
+    /// to the legacy `db_agent_skills` table with globals layered on top. The
+    /// fallback decision is gated on *own* refs only — not the
+    /// global-inclusive list — so adding a global skill never discards a
+    /// legacy-only agent's skills.
+    ///
+    /// Single source of truth for two call sites that must stay consistent:
+    /// `write_agent_config_files` (the authoritative Rust materialization
+    /// path) and the `listagentskills` RPC handler, which the frontend's
+    /// pre-launch `ListAgentSkillsCommand` call depends on for its own
+    /// `buildConfigFiles` mirror. Before this was extracted, `listagentskills`
+    /// returned only legacy skills — silently hiding every standalone/Armory-
+    /// catalog skill (including any Agent-Skills-format one, see
+    /// SKILL_TYPE_AGENT_SKILL) from the actual "click Launch" flow, since
+    /// that RPC is window-scoped (no `check_s1`) and can't call the
+    /// agent-scoped `skill.list` RPC the way an already-running, authenticated
+    /// agent connection could (reagent P0 on PR #2322 — the launch UI is not
+    /// an authenticated agent connection, so it was never able to reach the
+    /// standalone Skill primitive via the RPC layer at all).
+    pub fn effective_skills(&self, agent_id: &str) -> Vec<AgentSkill> {
+        let legacy_skills = self.agent_skill_list(agent_id).unwrap_or_default();
+        let visible_skills: Vec<Skill> = self
+            .skill_list(agent_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|item| item.skill)
+            .collect();
+        let has_own_skill_refs = visible_skills.iter().any(|s| !s.is_global);
+        if has_own_skill_refs {
+            crate::backend::agent_config::skills_to_agent_skills(&visible_skills, agent_id)
+        } else {
+            let mut merged = legacy_skills;
+            merged.extend(crate::backend::agent_config::skills_to_agent_skills(&visible_skills, agent_id));
+            merged
+        }
+    }
+
     /// List every GLOBAL skill — the Armory catalog view. Unlike
     /// `skill_list`, this takes no `agent_id` and never includes an agent's
     /// private skills; it backs the window-scoped `skill.catalog.*` App API
@@ -510,5 +549,155 @@ impl Store {
             |row| row.get(0),
         )?;
         Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod effective_skills_tests {
+    use super::*;
+    use crate::backend::storage::store::AgentDefinition;
+
+    fn make_store() -> Store {
+        Store::open_in_memory().unwrap()
+    }
+
+    fn insert_agent(store: &Store, id: &str) {
+        let mut def = AgentDefinition {
+            id: id.to_string(),
+            slug: String::new(),
+            name: "Test Agent".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_000_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_000_000,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        };
+        store.agent_def_insert(&mut def).unwrap();
+    }
+
+    fn global_skill(id: &str, name: &str) -> Skill {
+        Skill {
+            id: id.to_string(),
+            name: name.to_string(),
+            trigger: String::new(),
+            skill_type: "prompt".to_string(),
+            description: format!("{name} description"),
+            content: format!("{name} content"),
+            is_global: true,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn falls_back_to_legacy_plus_globals_when_agent_has_no_own_refs() {
+        let store = make_store();
+        insert_agent(&store, "agent-1");
+
+        store.agent_skill_insert(&AgentSkill {
+            id: "legacy-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            name: "Legacy Skill".to_string(),
+            trigger: "legacy".to_string(),
+            skill_type: "prompt".to_string(),
+            description: "legacy description".to_string(),
+            content: "legacy content".to_string(),
+            created_at: 1_700_000_000_000,
+        }).unwrap();
+
+        store.skill_upsert_unique_global(&global_skill("global-1", "Global Skill")).unwrap();
+        // Not bound to agent-1 -- has_own_skill_refs must stay false.
+
+        let effective = store.effective_skills("agent-1");
+        let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names.len(), 2, "expected legacy + global, got: {names:?}");
+        assert!(names.contains(&"Legacy Skill"));
+        assert!(names.contains(&"Global Skill"));
+    }
+
+    #[test]
+    fn own_refs_take_over_entirely_and_discard_legacy_skills() {
+        let store = make_store();
+        insert_agent(&store, "agent-1");
+
+        store.agent_skill_insert(&AgentSkill {
+            id: "legacy-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            name: "Legacy Skill".to_string(),
+            trigger: "legacy".to_string(),
+            skill_type: "prompt".to_string(),
+            description: "legacy description".to_string(),
+            content: "legacy content".to_string(),
+            created_at: 1_700_000_000_000,
+        }).unwrap();
+
+        store.skill_upsert_unique_global(&global_skill("global-1", "Global Skill")).unwrap();
+
+        // Bind a NEW (non-global) skill to agent-1 -- this must flip
+        // has_own_skill_refs to true and discard the legacy skill entirely.
+        let own_skill = Skill {
+            id: "own-1".to_string(),
+            name: "Own Skill".to_string(),
+            trigger: String::new(),
+            skill_type: "agent-skill".to_string(),
+            description: "own description".to_string(),
+            content: "own content".to_string(),
+            is_global: false,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        };
+        store.skill_upsert_unique("agent-1", &own_skill, true).unwrap();
+
+        let effective = store.effective_skills("agent-1");
+        let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names.len(), 2, "expected own + global, legacy discarded, got: {names:?}");
+        assert!(names.contains(&"Own Skill"));
+        assert!(names.contains(&"Global Skill"));
+        assert!(!names.contains(&"Legacy Skill"), "legacy skill must be discarded once own refs exist");
+    }
+
+    #[test]
+    fn agent_skill_format_survives_the_merge_with_correct_skill_type() {
+        // Regression for PR #2322: an agent-skill-format skill materialized
+        // via effective_skills must retain skill_type == "agent-skill" so
+        // build_config_files still branches it to SKILL.md, not a slash
+        // command.
+        let store = make_store();
+        insert_agent(&store, "agent-1");
+
+        let own_skill = Skill {
+            id: "own-1".to_string(),
+            name: "Deploy Checklist".to_string(),
+            trigger: String::new(),
+            skill_type: "agent-skill".to_string(),
+            description: "checklist".to_string(),
+            content: "1. test\n2. deploy".to_string(),
+            is_global: false,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        };
+        store.skill_upsert_unique("agent-1", &own_skill, true).unwrap();
+
+        let effective = store.effective_skills("agent-1");
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].skill_type, "agent-skill");
     }
 }

--- a/agentmux-srv/src/server/agent_handlers/skills.rs
+++ b/agentmux-srv/src/server/agent_handlers/skills.rs
@@ -18,7 +18,18 @@ use crate::backend::storage::AgentSkill;
 use super::super::AppState;
 
 pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    // listagentskills → return all skills for an agent
+    // listagentskills → return this agent's EFFECTIVE skills (legacy
+    // db_agent_skills, or its own ref-bound db_skills + globals when any own
+    // refs exist — see Store::effective_skills). Window-scoped (no
+    // `check_s1`, hence `_ctx` unused) because this is called from
+    // `agent-model.ts`'s pre-launch `launchAgentDefinition`, before any
+    // agent connection exists to authenticate as — that's also exactly why
+    // this must reuse the same merge algorithm as the Rust
+    // `write_agent_config_files` path rather than the frontend calling the
+    // agent-scoped `skill.list` RPC directly (it would fail check_s1 pre-
+    // launch). Previously returned only agent_skill_list (legacy-only),
+    // silently hiding every standalone/Armory-catalog skill from the actual
+    // launch flow (reagent P0 on PR #2322).
     let wstore_lfs = state.wstore.clone();
     engine.register_handler(
         COMMAND_LIST_AGENT_SKILLS,
@@ -27,8 +38,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let cmd: CommandListAgentSkillsData = serde_json::from_value(data)
                     .map_err(|e| format!("listagentskills: {e}"))?;
-                let skills = wstore.agent_skill_list(&cmd.agent_id)
-                    .map_err(|e| format!("listagentskills: {e}"))?;
+                let skills = wstore.effective_skills(&cmd.agent_id);
                 Ok(Some(serde_json::to_value(&skills).unwrap_or_default()))
             })
         }),

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -484,12 +484,6 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Hidden manifest (relative to the agent working directory) tracking which
-/// skill-derived paths AgentMux itself wrote on the last `write_agent_config_files`
-/// call, so a subsequent call can delete ones that are no longer current without
-/// touching any user-authored `.claude/commands`/`.claude/skills` content.
-const MANAGED_SKILL_FILES_MANIFEST: &str = ".claude/.agentmux-managed-skill-files.json";
-
 /// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.
 pub(super) fn write_agent_config_files(
     wstore: &Store,
@@ -621,53 +615,13 @@ pub(super) fn write_agent_config_files(
     // Remove skill-derived files (.claude/commands/*.md, .claude/skills/*/SKILL.md)
     // that WE wrote on a previous launch but aren't part of this run's output --
     // e.g. a skill's format switched between "prompt" and "agent-skill", or a
-    // skill was renamed/removed. Without this, the old file stays on disk and
-    // Claude keeps treating it as active alongside the newly selected format
-    // (reagent P1 + Codex P1/P2, PR #2322). Tracked via a small manifest of
-    // paths AgentMux itself wrote, rather than scanning .claude/commands or
-    // .claude/skills wholesale, so a user's own hand-authored commands/skills
-    // in the same working directory are never touched.
-    let new_managed_skill_paths: std::collections::BTreeSet<String> = config_files
-        .iter()
-        .filter(|f| {
-            f.filename.starts_with(".claude/commands/") || f.filename.starts_with(".claude/skills/")
-        })
-        .map(|f| f.filename.clone())
-        .collect();
-    let manifest_path = base_path.join(MANAGED_SKILL_FILES_MANIFEST);
-    if let Ok(raw) = std::fs::read_to_string(&manifest_path) {
-        if let Ok(old_paths) = serde_json::from_str::<Vec<String>>(&raw) {
-            for old in &old_paths {
-                if new_managed_skill_paths.contains(old) {
-                    continue;
-                }
-                // Defense in depth: `old` is manifest-recorded, itself built
-                // from `config_files` filenames derived from user-controlled
-                // skill triggers/names (now sanitized at the source in
-                // agent_config.rs, but this second gate means a bad path can
-                // never reach `remove_file`/`remove_dir` even if that
-                // sanitization is ever bypassed or the manifest file is
-                // tampered with) -- reagent P1, PR #2322.
-                let Ok(old_path) = crate::backend::base::safe_join_within_base(base_path, old)
-                else {
-                    tracing::warn!(
-                        work_dir = %expanded_dir,
-                        path = %old,
-                        "write_agent_config_files: refusing to delete a manifest path that \
-                         escapes the working directory"
-                    );
-                    continue;
-                };
-                let _ = std::fs::remove_file(&old_path);
-                // Agent Skills format nests under .claude/skills/<slug>/ -- clean
-                // up the now-empty slug directory too (no-op/fails silently if
-                // anything else still lives there, e.g. a future scripts/ dir).
-                if let Some(parent) = old_path.parent() {
-                    let _ = std::fs::remove_dir(parent);
-                }
-            }
-        }
-    }
+    // skill was renamed/removed. Shared with `writeagentconfig` (editor_handlers.rs)
+    // so the two RPC paths that materialize config files never drift out of sync
+    // on this (reagent P1 + Codex P1/P2, PR #2322).
+    let new_managed_skill_paths = crate::backend::agent_config::managed_skill_file_paths(
+        config_files.iter().map(|f| f.filename.as_str()),
+    );
+    crate::backend::agent_config::cleanup_stale_managed_skill_files(base_path, &new_managed_skill_paths);
 
     for file in &config_files {
         // Same defense-in-depth join as the cleanup pass above.
@@ -690,16 +644,7 @@ pub(super) fn write_agent_config_files(
             .map_err(|e| format!("failed to write {}: {e}", file.filename))?;
     }
 
-    if let Ok(manifest_json) = serde_json::to_string(&new_managed_skill_paths) {
-        if let Err(e) = std::fs::write(&manifest_path, manifest_json) {
-            tracing::warn!(
-                work_dir = %expanded_dir,
-                error = %e,
-                "write_agent_config_files: failed to write managed-skill-files manifest; \
-                 stale file cleanup may be skipped on the next launch"
-            );
-        }
-    }
+    crate::backend::agent_config::write_managed_skill_file_manifest(base_path, &new_managed_skill_paths);
 
     tracing::info!(
         agent_id = %agent.id,
@@ -855,7 +800,7 @@ mod write_agent_config_files_tests {
         );
         let malicious_manifest = serde_json::to_string(&vec![traversal_rel]).unwrap();
         std::fs::write(
-            work_dir.path().join(MANAGED_SKILL_FILES_MANIFEST),
+            work_dir.path().join(crate::backend::agent_config::MANAGED_SKILL_FILES_MANIFEST),
             malicious_manifest,
         )
         .unwrap();

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -492,10 +492,8 @@ pub(super) fn write_agent_config_files(
     agent_slug: &str,
     work_dir: &str,
 ) -> Result<(), String> {
-    // Load agent content and skills
+    // Load agent content
     let contents = wstore.agent_content_get_all(&agent.id)
-        .unwrap_or_default();
-    let skills = wstore.agent_skill_list(&agent.id)
         .unwrap_or_default();
 
     let mut content_map = std::collections::HashMap::new();
@@ -549,28 +547,10 @@ pub(super) fn write_agent_config_files(
 
     // v1 skills: globals are always injected; the agent's OWN ref-bound skills
     // are authoritative when present, otherwise fall back to legacy
-    // db_agent_skills. The fallback decision is gated on *own* refs only — NOT
-    // the global-inclusive list — so adding a global skill never discards a
-    // legacy-only agent's skills.
-    // skill_list now returns each skill wrapped with a per-agent bound_to_agent
-    // flag (for the App API's "bound to me" indicator, tracked in #1960) —
-    // this config-generation path doesn't need it, so unwrap immediately.
-    let visible_skills: Vec<crate::backend::storage::Skill> = wstore.skill_list(&agent.id)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|item| item.skill)
-        .collect(); // own refs + globals
-    let has_own_skill_refs = visible_skills.iter().any(|s| !s.is_global);
-    let effective_skills: Vec<crate::backend::storage::AgentSkill> = if has_own_skill_refs {
-        // Ref-based path: own bound + globals (the full visible list).
-        crate::backend::agent_config::skills_to_agent_skills(&visible_skills, &agent.id)
-    } else {
-        // Legacy path: keep legacy skills, then inject globals on top.
-        // `visible_skills` here contains only globals (no own refs).
-        let mut merged = skills;
-        merged.extend(crate::backend::agent_config::skills_to_agent_skills(&visible_skills, &agent.id));
-        merged
-    };
+    // db_agent_skills. See Store::effective_skills for the merge algorithm —
+    // shared with the `listagentskills` RPC handler so the frontend's
+    // pre-launch skill fetch and this materialization path never diverge.
+    let effective_skills = wstore.effective_skills(&agent.id);
 
     let mut config_files = crate::backend::agent_config::build_config_files(
         &content_map,

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -484,6 +484,12 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
+/// Hidden manifest (relative to the agent working directory) tracking which
+/// skill-derived paths AgentMux itself wrote on the last `write_agent_config_files`
+/// call, so a subsequent call can delete ones that are no longer current without
+/// touching any user-authored `.claude/commands`/`.claude/skills` content.
+const MANAGED_SKILL_FILES_MANIFEST: &str = ".claude/.agentmux-managed-skill-files.json";
+
 /// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.
 pub(super) fn write_agent_config_files(
     wstore: &Store,
@@ -612,6 +618,41 @@ pub(super) fn write_agent_config_files(
             .map_err(|e| format!("failed to create working dir: {e}"))?;
     }
 
+    // Remove skill-derived files (.claude/commands/*.md, .claude/skills/*/SKILL.md)
+    // that WE wrote on a previous launch but aren't part of this run's output --
+    // e.g. a skill's format switched between "prompt" and "agent-skill", or a
+    // skill was renamed/removed. Without this, the old file stays on disk and
+    // Claude keeps treating it as active alongside the newly selected format
+    // (reagent P1 + Codex P1/P2, PR #2322). Tracked via a small manifest of
+    // paths AgentMux itself wrote, rather than scanning .claude/commands or
+    // .claude/skills wholesale, so a user's own hand-authored commands/skills
+    // in the same working directory are never touched.
+    let new_managed_skill_paths: std::collections::BTreeSet<String> = config_files
+        .iter()
+        .filter(|f| {
+            f.filename.starts_with(".claude/commands/") || f.filename.starts_with(".claude/skills/")
+        })
+        .map(|f| f.filename.clone())
+        .collect();
+    let manifest_path = base_path.join(MANAGED_SKILL_FILES_MANIFEST);
+    if let Ok(raw) = std::fs::read_to_string(&manifest_path) {
+        if let Ok(old_paths) = serde_json::from_str::<Vec<String>>(&raw) {
+            for old in &old_paths {
+                if new_managed_skill_paths.contains(old) {
+                    continue;
+                }
+                let old_path = base_path.join(old);
+                let _ = std::fs::remove_file(&old_path);
+                // Agent Skills format nests under .claude/skills/<slug>/ -- clean
+                // up the now-empty slug directory too (no-op/fails silently if
+                // anything else still lives there, e.g. a future scripts/ dir).
+                if let Some(parent) = old_path.parent() {
+                    let _ = std::fs::remove_dir(parent);
+                }
+            }
+        }
+    }
+
     for file in &config_files {
         let file_path = base_path.join(&file.filename);
         if let Some(parent) = file_path.parent() {
@@ -623,6 +664,17 @@ pub(super) fn write_agent_config_files(
             .map_err(|e| format!("failed to write {}: {e}", file.filename))?;
     }
 
+    if let Ok(manifest_json) = serde_json::to_string(&new_managed_skill_paths) {
+        if let Err(e) = std::fs::write(&manifest_path, manifest_json) {
+            tracing::warn!(
+                work_dir = %expanded_dir,
+                error = %e,
+                "write_agent_config_files: failed to write managed-skill-files manifest; \
+                 stale file cleanup may be skipped on the next launch"
+            );
+        }
+    }
+
     tracing::info!(
         agent_id = %agent.id,
         work_dir = %expanded_dir,
@@ -631,4 +683,120 @@ pub(super) fn write_agent_config_files(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod write_agent_config_files_tests {
+    use super::*;
+    use crate::backend::storage::Skill;
+
+    fn make_store() -> Store {
+        Store::open_in_memory().unwrap()
+    }
+
+    fn make_agent(id: &str, working_directory: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: String::new(),
+            name: "Test Agent".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: working_directory.to_string(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1_700_000_000_000,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1_700_000_000_000,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        }
+    }
+
+    fn make_skill(skill_type: &str) -> Skill {
+        Skill {
+            id: "skill-1".to_string(),
+            name: "Deploy".to_string(),
+            trigger: "deploy".to_string(),
+            skill_type: skill_type.to_string(),
+            description: "Deploy the app".to_string(),
+            content: "1. Test\n2. Deploy".to_string(),
+            is_global: false,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
+
+    /// reagent P1 + Codex P1/P2, PR #2322: switching a skill's `skill_type`
+    /// between "prompt" and "agent-skill" must remove the artifact from the
+    /// PREVIOUS format, not just write the new one -- otherwise the stale
+    /// file stays active alongside the newly selected format.
+    #[test]
+    fn switching_skill_format_removes_the_stale_artifact() {
+        let wstore = make_store();
+        let id_store = make_store();
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_str().unwrap();
+
+        let mut agent = make_agent("agent-1", work_dir_str);
+        wstore.agent_def_insert(&mut agent).unwrap();
+        wstore.skill_upsert_unique("agent-1", &make_skill("agent-skill"), true).unwrap();
+
+        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        let skill_md = work_dir.path().join(".claude/skills/deploy/SKILL.md");
+        assert!(skill_md.exists(), "expected .claude/skills/deploy/SKILL.md to be written");
+
+        // Flip the same skill to "prompt" format and relaunch.
+        let mut prompt_skill = make_skill("prompt");
+        prompt_skill.updated_at = 1_700_000_000_001;
+        wstore.skill_upsert_unique("agent-1", &prompt_skill, true).unwrap();
+        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+
+        let command_md = work_dir.path().join(".claude/commands/deploy.md");
+        assert!(command_md.exists(), "expected .claude/commands/deploy.md to be written");
+        assert!(
+            !skill_md.exists(),
+            "stale .claude/skills/deploy/SKILL.md must be removed when the skill switches to prompt format"
+        );
+        assert!(
+            !skill_md.parent().unwrap().exists(),
+            "the now-empty .claude/skills/deploy/ directory should be cleaned up too"
+        );
+    }
+
+    /// A file the user hand-authored under .claude/commands or .claude/skills
+    /// (never part of any AgentMux-written manifest) must never be deleted by
+    /// the stale-cleanup pass.
+    #[test]
+    fn user_authored_files_outside_the_manifest_are_never_touched() {
+        let wstore = make_store();
+        let id_store = make_store();
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_str().unwrap();
+
+        let mut agent = make_agent("agent-1", work_dir_str);
+        wstore.agent_def_insert(&mut agent).unwrap();
+
+        let user_file = work_dir.path().join(".claude/commands/my-own-command.md");
+        std::fs::create_dir_all(user_file.parent().unwrap()).unwrap();
+        std::fs::write(&user_file, "# hand-authored, not from AgentMux").unwrap();
+
+        wstore.skill_upsert_unique("agent-1", &make_skill("agent-skill"), true).unwrap();
+        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+
+        assert!(user_file.exists(), "hand-authored file outside AgentMux's manifest must survive");
+    }
 }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -641,7 +641,23 @@ pub(super) fn write_agent_config_files(
                 if new_managed_skill_paths.contains(old) {
                     continue;
                 }
-                let old_path = base_path.join(old);
+                // Defense in depth: `old` is manifest-recorded, itself built
+                // from `config_files` filenames derived from user-controlled
+                // skill triggers/names (now sanitized at the source in
+                // agent_config.rs, but this second gate means a bad path can
+                // never reach `remove_file`/`remove_dir` even if that
+                // sanitization is ever bypassed or the manifest file is
+                // tampered with) -- reagent P1, PR #2322.
+                let Ok(old_path) = crate::backend::base::safe_join_within_base(base_path, old)
+                else {
+                    tracing::warn!(
+                        work_dir = %expanded_dir,
+                        path = %old,
+                        "write_agent_config_files: refusing to delete a manifest path that \
+                         escapes the working directory"
+                    );
+                    continue;
+                };
                 let _ = std::fs::remove_file(&old_path);
                 // Agent Skills format nests under .claude/skills/<slug>/ -- clean
                 // up the now-empty slug directory too (no-op/fails silently if
@@ -654,7 +670,17 @@ pub(super) fn write_agent_config_files(
     }
 
     for file in &config_files {
-        let file_path = base_path.join(&file.filename);
+        // Same defense-in-depth join as the cleanup pass above.
+        let Ok(file_path) = crate::backend::base::safe_join_within_base(base_path, &file.filename)
+        else {
+            tracing::warn!(
+                work_dir = %expanded_dir,
+                path = %file.filename,
+                "write_agent_config_files: refusing to write a config path that \
+                 escapes the working directory"
+            );
+            continue;
+        };
         if let Some(parent) = file_path.parent() {
             if !parent.exists() {
                 let _ = std::fs::create_dir_all(parent);
@@ -798,5 +824,46 @@ mod write_agent_config_files_tests {
         write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
 
         assert!(user_file.exists(), "hand-authored file outside AgentMux's manifest must survive");
+    }
+
+    /// Defense-in-depth: even if a manifest somehow contains a path-traversal
+    /// entry (e.g. from a bypass of the trigger sanitization added upstream
+    /// in agent_config.rs, or manual tampering with the manifest file
+    /// itself), the cleanup pass must never delete anything outside the
+    /// agent's working directory (reagent P1, PR #2322).
+    #[test]
+    fn cleanup_refuses_to_delete_a_manifest_path_that_escapes_the_working_dir() {
+        let wstore = make_store();
+        let id_store = make_store();
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_str().unwrap();
+
+        let mut agent = make_agent("agent-1", work_dir_str);
+        wstore.agent_def_insert(&mut agent).unwrap();
+
+        // A sentinel file OUTSIDE the working directory that a traversal
+        // attempt would target.
+        let sentinel_dir = tempfile::tempdir().unwrap();
+        let sentinel = sentinel_dir.path().join("outside-file.txt");
+        std::fs::write(&sentinel, "must survive").unwrap();
+
+        // Simulate a manifest that (however it got there) records an escape.
+        std::fs::create_dir_all(work_dir.path().join(".claude")).unwrap();
+        let traversal_rel = format!(
+            "../{}/outside-file.txt",
+            sentinel_dir.path().file_name().unwrap().to_str().unwrap()
+        );
+        let malicious_manifest = serde_json::to_string(&vec![traversal_rel]).unwrap();
+        std::fs::write(
+            work_dir.path().join(MANAGED_SKILL_FILES_MANIFEST),
+            malicious_manifest,
+        )
+        .unwrap();
+
+        // No skills at all this run, so the manifest's one entry is "stale"
+        // and would normally be deleted.
+        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+
+        assert!(sentinel.exists(), "file outside the working directory must never be deleted");
     }
 }

--- a/agentmux-srv/src/server/editor_handlers.rs
+++ b/agentmux-srv/src/server/editor_handlers.rs
@@ -249,6 +249,26 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     format!("failed to canonicalize working dir {}: {e}", base_path.display())
                 })?;
 
+                // Remove skill-derived files (.claude/commands/*.md,
+                // .claude/skills/*/SKILL.md) that WE wrote on a previous
+                // materialization but aren't part of this run's output --
+                // e.g. a skill's format switched between "prompt" and
+                // "agent-skill", or a skill was renamed/removed. This is the
+                // actual "click Launch" path used on every normal agent
+                // launch (`launchAgentDefinition`/`WriteAgentConfigCommand`)
+                // -- shared with `agent.open`'s `write_agent_config_files`
+                // (agent_open.rs) via `agent_config.rs` so the two paths
+                // that materialize config files can't drift out of sync on
+                // this (reagent P1, PR #2322 — this handler initially had
+                // no cleanup at all).
+                let new_managed_skill_paths = crate::backend::agent_config::managed_skill_file_paths(
+                    cmd.files.iter().map(|f| f.path.as_str()),
+                );
+                crate::backend::agent_config::cleanup_stale_managed_skill_files(
+                    base_path,
+                    &new_managed_skill_paths,
+                );
+
                 for file in &cmd.files {
                     // Lexical join + traversal check — works on Windows where
                     // canonicalize() adds the `\\?\` UNC prefix and breaks
@@ -284,6 +304,11 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         .map_err(|e| format!("failed to write {}: {e}", file.path))?;
                     tracing::debug!(path = %file_path.display(), "wrote config file");
                 }
+
+                crate::backend::agent_config::write_managed_skill_file_manifest(
+                    base_path,
+                    &new_managed_skill_paths,
+                );
 
                 // Return the final path so the caller can patch
                 // `cmd:cwd` if collision resolution changed it.
@@ -923,4 +948,93 @@ pub fn register_editor_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::rpc_types::AgentConfigFile;
+
+    /// reagent P1, PR #2322: `writeagentconfig` (this file) is the actual
+    /// "click Launch" path, distinct from `agent.open`'s
+    /// `write_agent_config_files` (agent_open.rs) which already had
+    /// stale-skill-file cleanup. This exercises the exact integration point
+    /// the handler uses -- `crate::backend::rpc_types::block::AgentConfigFile`
+    /// has a `path` field (not `filename`, unlike `agent_config::AgentConfigFile`)
+    /// -- to catch a field-name mismatch silently no-op'ing the cleanup, which
+    /// a test only calling `managed_skill_file_paths` with hand-built strings
+    /// would not catch.
+    #[test]
+    fn writeagentconfig_files_produce_the_expected_managed_skill_paths() {
+        let files = vec![
+            AgentConfigFile { path: "CLAUDE.md".to_string(), content: "soul".to_string() },
+            AgentConfigFile {
+                path: ".claude/commands/deploy.md".to_string(),
+                content: "deploy".to_string(),
+            },
+            AgentConfigFile {
+                path: ".claude/skills/review/SKILL.md".to_string(),
+                content: "review".to_string(),
+            },
+            AgentConfigFile { path: ".mcp.json".to_string(), content: "{}".to_string() },
+        ];
+        let managed = crate::backend::agent_config::managed_skill_file_paths(
+            files.iter().map(|f| f.path.as_str()),
+        );
+        assert_eq!(managed.len(), 2, "expected exactly the two skill-derived paths: {managed:?}");
+        assert!(managed.contains(".claude/commands/deploy.md"));
+        assert!(managed.contains(".claude/skills/review/SKILL.md"));
+        assert!(!managed.contains("CLAUDE.md"));
+        assert!(!managed.contains(".mcp.json"));
+    }
+
+    /// End-to-end proof (real filesystem, no RPC engine needed) that the
+    /// three shared calls this handler makes -- compute managed paths,
+    /// clean up stale ones from a prior manifest, write the new manifest --
+    /// actually remove a stale skill artifact between two materializations,
+    /// using this handler's own `AgentConfigFile{path, content}` shape.
+    #[test]
+    fn stale_skill_file_is_removed_across_two_materializations() {
+        let work_dir = tempfile::tempdir().unwrap();
+        let base_path = work_dir.path();
+
+        // "Launch 1": agent-skill format.
+        let launch1 = vec![AgentConfigFile {
+            path: ".claude/skills/deploy/SKILL.md".to_string(),
+            content: "body".to_string(),
+        }];
+        let managed1 = crate::backend::agent_config::managed_skill_file_paths(
+            launch1.iter().map(|f| f.path.as_str()),
+        );
+        crate::backend::agent_config::cleanup_stale_managed_skill_files(base_path, &managed1);
+        for f in &launch1 {
+            let p = base_path.join(&f.path);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, &f.content).unwrap();
+        }
+        crate::backend::agent_config::write_managed_skill_file_manifest(base_path, &managed1);
+        let skill_md = base_path.join(".claude/skills/deploy/SKILL.md");
+        assert!(skill_md.exists());
+
+        // "Launch 2": switched to prompt format -- same skill, different path.
+        let launch2 = vec![AgentConfigFile {
+            path: ".claude/commands/deploy.md".to_string(),
+            content: "body".to_string(),
+        }];
+        let managed2 = crate::backend::agent_config::managed_skill_file_paths(
+            launch2.iter().map(|f| f.path.as_str()),
+        );
+        crate::backend::agent_config::cleanup_stale_managed_skill_files(base_path, &managed2);
+        for f in &launch2 {
+            let p = base_path.join(&f.path);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, &f.content).unwrap();
+        }
+        crate::backend::agent_config::write_managed_skill_file_manifest(base_path, &managed2);
+
+        assert!(
+            !skill_md.exists(),
+            "stale .claude/skills/deploy/SKILL.md must be removed by the writeagentconfig path too"
+        );
+        assert!(base_path.join(".claude/commands/deploy.md").exists());
+    }
 }

--- a/frontend/app/view/agent/agent-config-builder.test.ts
+++ b/frontend/app/view/agent/agent-config-builder.test.ts
@@ -88,6 +88,24 @@ describe("uniqueSkillSlug", () => {
         const used = new Set<string>(["deploy-checklist", "deploy-checklist-2"]);
         expect(uniqueSkillSlug("Deploy!!Checklist", used)).toBe("deploy-checklist-3");
     });
+
+    it("replaces underscores with hyphens (Agent Skills name grammar has no underscores)", () => {
+        // Codex P1, PR #2322: deriveSlug (shared with agent role-slugs) keeps
+        // underscores, which is spec-invalid for an Agent Skills `name`.
+        const used = new Set<string>();
+        expect(uniqueSkillSlug("code_review", used)).toBe("code-review");
+    });
+
+    it("keeps the suffixed slug within the 64-character spec max", () => {
+        // Codex P2, PR #2322: a 64-char base plus "-2" was previously 66 chars.
+        const used = new Set<string>();
+        const long = "a".repeat(100);
+        const first = uniqueSkillSlug(long, used);
+        expect(first).toHaveLength(64);
+        const second = uniqueSkillSlug(long, used);
+        expect(second.length).toBeLessThanOrEqual(64);
+        expect(second.endsWith("-2")).toBe(true);
+    });
 });
 
 describe("buildConfigFiles — skill materialization", () => {

--- a/frontend/app/view/agent/agent-config-builder.test.ts
+++ b/frontend/app/view/agent/agent-config-builder.test.ts
@@ -41,19 +41,38 @@ describe("deriveSlug", () => {
 });
 
 describe("renderSkillMd", () => {
-    it("wraps content in YAML frontmatter with name + description", () => {
-        const md = renderSkillMd("Deploy Checklist", "Runs the checklist", "1. Test\n2. Deploy");
+    it("wraps content in YAML frontmatter with slug (as name) + description", () => {
+        // First arg is the SLUG (matching the parent directory per the Agent
+        // Skills spec), not the raw display name -- reagent P1 on #2322.
+        const md = renderSkillMd("deploy-checklist", "Runs the checklist", "1. Test\n2. Deploy");
         expect(md).toBe(
-            '---\nname: "Deploy Checklist"\ndescription: "Runs the checklist"\n---\n\n1. Test\n2. Deploy',
+            '---\nname: "deploy-checklist"\ndescription: "Runs the checklist"\n---\n\n1. Test\n2. Deploy',
         );
     });
 
     it("escapes YAML/JSON special characters via JSON.stringify", () => {
-        const md = renderSkillMd('Weird: "Name"', "Has a colon: and \"quotes\"", "body");
+        const md = renderSkillMd("weird-name", "Has a colon: and \"quotes\"", "body");
         const frontmatter = md.split("\n---\n\n")[0];
         // Must round-trip as exactly two lines (name + description) -- no
         // characters leaked out of the quoted scalar onto a new line.
         expect(frontmatter.split("\n")).toHaveLength(3); // "---", name line, description line
+    });
+
+    it("falls back to a placeholder for an empty description", () => {
+        const md = renderSkillMd("deploy-checklist", "", "body");
+        expect(md).toContain('description: "No description provided."');
+    });
+
+    it("falls back to a placeholder for a whitespace-only description", () => {
+        const md = renderSkillMd("deploy-checklist", "   ", "body");
+        expect(md).toContain('description: "No description provided."');
+    });
+
+    it("truncates a description longer than 1024 characters", () => {
+        const md = renderSkillMd("deploy-checklist", "x".repeat(2000), "body");
+        const descLine = md.split("\n").find((l) => l.startsWith("description: "))!;
+        const inner = descLine.slice("description: ".length + 1, -1); // strip quotes
+        expect(inner.length).toBeLessThanOrEqual(1024);
     });
 });
 
@@ -84,7 +103,9 @@ describe("buildConfigFiles — skill materialization", () => {
         ]);
         const skillFile = files.find((f) => f.path === ".claude/skills/deploy-checklist/SKILL.md");
         expect(skillFile).toBeDefined();
-        expect(skillFile!.content).toContain('name: "Deploy Checklist"');
+        // name is the slug, not the raw display name (reagent P1 on #2322).
+        expect(skillFile!.content).toContain('name: "deploy-checklist"');
+        expect(skillFile!.content).not.toContain('name: "Deploy Checklist"');
         expect(files.some((f) => f.path.startsWith(".claude/commands/"))).toBe(false);
     });
 

--- a/frontend/app/view/agent/agent-config-builder.test.ts
+++ b/frontend/app/view/agent/agent-config-builder.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { buildConfigFiles, deriveSlug, renderSkillMd, uniqueSkillSlug } from "./agent-config-builder";
+import { buildConfigFiles, deriveSlug, renderSkillMd, sanitizeTrigger, uniqueSkillSlug } from "./agent-config-builder";
 
 function makeSkill(over: Partial<AgentSkill> = {}): AgentSkill {
     return {
@@ -37,6 +37,36 @@ describe("deriveSlug", () => {
     it("trims to 64 characters", () => {
         const long = "a".repeat(100);
         expect(deriveSlug(long)).toHaveLength(64);
+    });
+});
+
+describe("sanitizeTrigger", () => {
+    it("rejects path traversal and separators", () => {
+        // reagent P1, PR #2322
+        expect(sanitizeTrigger("../../../../.ssh/authorized_keys")).toBeNull();
+        expect(sanitizeTrigger("../evil")).toBeNull();
+        expect(sanitizeTrigger("sub/evil")).toBeNull();
+        expect(sanitizeTrigger("sub\\evil")).toBeNull();
+        expect(sanitizeTrigger("..")).toBeNull();
+        expect(sanitizeTrigger(".")).toBeNull();
+        expect(sanitizeTrigger("")).toBeNull();
+    });
+
+    it("allows an ordinary trigger", () => {
+        expect(sanitizeTrigger("deploy")).toBe("deploy");
+    });
+});
+
+describe("buildConfigFiles — trigger sanitization", () => {
+    it("skips a prompt-format skill with a path-traversal trigger", () => {
+        // reagent P1, PR #2322: must not materialize a command file outside
+        // .claude/commands/, not even under a mangled name -- skip outright.
+        const files = buildConfigFiles(
+            {},
+            [makeSkill({ trigger: "../../../../.ssh/authorized_keys", content: "evil" })],
+        );
+        expect(files.every((f) => !f.path.includes(".."))).toBe(true);
+        expect(files.some((f) => f.path.startsWith(".claude/commands/"))).toBe(false);
     });
 });
 

--- a/frontend/app/view/agent/agent-config-builder.test.ts
+++ b/frontend/app/view/agent/agent-config-builder.test.ts
@@ -1,0 +1,81 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { buildConfigFiles, deriveSlug, renderSkillMd } from "./agent-config-builder";
+
+function makeSkill(over: Partial<AgentSkill> = {}): AgentSkill {
+    return {
+        id: "skill-1",
+        agent_id: "agent-1",
+        name: "Deploy",
+        trigger: "deploy",
+        skill_type: "prompt",
+        description: "Deploy the app",
+        content: "Run: deploy all",
+        created_at: 0,
+        ...over,
+    };
+}
+
+describe("deriveSlug", () => {
+    it("lowercases and dash-joins", () => {
+        expect(deriveSlug("Deploy Checklist")).toBe("deploy-checklist");
+    });
+
+    it("collapses runs of non-alphanumeric characters into a single dash", () => {
+        // Regression: naive strip-only slugifiers (e.g. slugifyInstanceName)
+        // would produce "deploychecklist" here (no dash), diverging from
+        // the Rust derive_slug this must mirror exactly.
+        expect(deriveSlug("Deploy!!!Checklist")).toBe("deploy-checklist");
+    });
+
+    it("falls back to 'agent' for names with no valid characters", () => {
+        expect(deriveSlug("!!!")).toBe("agent");
+    });
+
+    it("trims to 64 characters", () => {
+        const long = "a".repeat(100);
+        expect(deriveSlug(long)).toHaveLength(64);
+    });
+});
+
+describe("renderSkillMd", () => {
+    it("wraps content in YAML frontmatter with name + description", () => {
+        const md = renderSkillMd("Deploy Checklist", "Runs the checklist", "1. Test\n2. Deploy");
+        expect(md).toBe(
+            '---\nname: "Deploy Checklist"\ndescription: "Runs the checklist"\n---\n\n1. Test\n2. Deploy',
+        );
+    });
+
+    it("escapes YAML/JSON special characters via JSON.stringify", () => {
+        const md = renderSkillMd('Weird: "Name"', "Has a colon: and \"quotes\"", "body");
+        const frontmatter = md.split("\n---\n\n")[0];
+        // Must round-trip as exactly two lines (name + description) -- no
+        // characters leaked out of the quoted scalar onto a new line.
+        expect(frontmatter.split("\n")).toHaveLength(3); // "---", name line, description line
+    });
+});
+
+describe("buildConfigFiles — skill materialization", () => {
+    it("writes prompt-format skills as .claude/commands/<trigger>.md (default)", () => {
+        const files = buildConfigFiles({}, [makeSkill()]);
+        expect(files.find((f) => f.path === ".claude/commands/deploy.md")).toBeDefined();
+        expect(files.some((f) => f.path.startsWith(".claude/skills/"))).toBe(false);
+    });
+
+    it("writes agent-skill-format skills as .claude/skills/<slug>/SKILL.md", () => {
+        const files = buildConfigFiles({}, [
+            makeSkill({ skill_type: "agent-skill", trigger: "", name: "Deploy Checklist" }),
+        ]);
+        const skillFile = files.find((f) => f.path === ".claude/skills/deploy-checklist/SKILL.md");
+        expect(skillFile).toBeDefined();
+        expect(skillFile!.content).toContain('name: "Deploy Checklist"');
+        expect(files.some((f) => f.path.startsWith(".claude/commands/"))).toBe(false);
+    });
+
+    it("skips skills with empty content regardless of format", () => {
+        const files = buildConfigFiles({}, [makeSkill({ content: "" })]);
+        expect(files.some((f) => f.path.includes("deploy"))).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/agent-config-builder.test.ts
+++ b/frontend/app/view/agent/agent-config-builder.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { buildConfigFiles, deriveSlug, renderSkillMd } from "./agent-config-builder";
+import { buildConfigFiles, deriveSlug, renderSkillMd, uniqueSkillSlug } from "./agent-config-builder";
 
 function makeSkill(over: Partial<AgentSkill> = {}): AgentSkill {
     return {
@@ -57,6 +57,20 @@ describe("renderSkillMd", () => {
     });
 });
 
+describe("uniqueSkillSlug", () => {
+    it("appends -2, -3 for colliding slugs in call order", () => {
+        const used = new Set<string>();
+        expect(uniqueSkillSlug("Deploy Checklist", used)).toBe("deploy-checklist");
+        expect(uniqueSkillSlug("Deploy!!!Checklist", used)).toBe("deploy-checklist-2");
+        expect(uniqueSkillSlug("Deploy   Checklist", used)).toBe("deploy-checklist-3");
+    });
+
+    it("does not collide with a pre-existing -2 suffix", () => {
+        const used = new Set<string>(["deploy-checklist", "deploy-checklist-2"]);
+        expect(uniqueSkillSlug("Deploy!!Checklist", used)).toBe("deploy-checklist-3");
+    });
+});
+
 describe("buildConfigFiles — skill materialization", () => {
     it("writes prompt-format skills as .claude/commands/<trigger>.md (default)", () => {
         const files = buildConfigFiles({}, [makeSkill()]);
@@ -72,6 +86,19 @@ describe("buildConfigFiles — skill materialization", () => {
         expect(skillFile).toBeDefined();
         expect(skillFile!.content).toContain('name: "Deploy Checklist"');
         expect(files.some((f) => f.path.startsWith(".claude/commands/"))).toBe(false);
+    });
+
+    it("dedupes SKILL.md paths for names that collide after slugification", () => {
+        // reagent P1 (PR #2322): distinct skills must not silently overwrite
+        // each other's SKILL.md when their names slugify to the same value.
+        const files = buildConfigFiles({}, [
+            makeSkill({ skill_type: "agent-skill", trigger: "", name: "Deploy Checklist", content: "one" }),
+            makeSkill({ skill_type: "agent-skill", trigger: "", name: "Deploy!!!Checklist", content: "two" }),
+        ]);
+        const skillPaths = files.filter((f) => f.path.startsWith(".claude/skills/")).map((f) => f.path);
+        expect(new Set(skillPaths).size).toBe(2);
+        expect(skillPaths).toContain(".claude/skills/deploy-checklist/SKILL.md");
+        expect(skillPaths).toContain(".claude/skills/deploy-checklist-2/SKILL.md");
     });
 
     it("skips skills with empty content regardless of format", () => {

--- a/frontend/app/view/agent/agent-config-builder.ts
+++ b/frontend/app/view/agent/agent-config-builder.ts
@@ -84,10 +84,11 @@ export function buildConfigFiles(
     // Write each skill as either a slash command (.claude/commands/{trigger}.md,
     // default) or an Agent Skills-format SKILL.md (.claude/skills/{slug}/SKILL.md,
     // skill_type === SKILL_TYPE_AGENT_SKILL).
+    const usedSkillSlugs = new Set<string>();
     for (const skill of skills) {
         if (!skill.content) continue;
         if (skill.skill_type === SKILL_TYPE_AGENT_SKILL) {
-            const slug = deriveSlug(skill.name);
+            const slug = uniqueSkillSlug(skill.name, usedSkillSlugs);
             const content = expandTemplate(skill.content, templateVars);
             files.push({
                 path: `.claude/skills/${slug}/SKILL.md`,
@@ -168,6 +169,33 @@ export function deriveSlug(name: string): string {
  */
 export function renderSkillMd(name: string, description: string, body: string): string {
     return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n\n${body}`;
+}
+
+/**
+ * Derive a filesystem-safe, COLLISION-FREE slug for a skill within one
+ * `buildConfigFiles` call. `deriveSlug` alone can produce identical output
+ * for distinct names that differ only in punctuation/whitespace (e.g.
+ * "Deploy Checklist" and "Deploy!!!Checklist" both -> "deploy-checklist"),
+ * which would otherwise silently overwrite one skill's SKILL.md with
+ * another's (reagent P1, PR #2322). Appends "-2", "-3", ... until unique
+ * within `used`. Mirrors `unique_skill_slug` in
+ * `agentmux-srv/src/backend/agent_config.rs`.
+ */
+export function uniqueSkillSlug(name: string, used: Set<string>): string {
+    const base = deriveSlug(name);
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+    let n = 2;
+    for (;;) {
+        const candidate = `${base}-${n}`;
+        if (!used.has(candidate)) {
+            used.add(candidate);
+            return candidate;
+        }
+        n++;
+    }
 }
 
 /**

--- a/frontend/app/view/agent/agent-config-builder.ts
+++ b/frontend/app/view/agent/agent-config-builder.ts
@@ -94,9 +94,12 @@ export function buildConfigFiles(
                 path: `.claude/skills/${slug}/SKILL.md`,
                 content: renderSkillMd(slug, skill.description, content),
             });
-        } else if (skill.trigger) {
-            const content = expandTemplate(skill.content, templateVars);
-            files.push({ path: `.claude/commands/${skill.trigger}.md`, content });
+        } else {
+            const safeTrigger = sanitizeTrigger(skill.trigger);
+            if (safeTrigger) {
+                const content = expandTemplate(skill.content, templateVars);
+                files.push({ path: `.claude/commands/${safeTrigger}.md`, content });
+            }
         }
     }
 
@@ -181,6 +184,26 @@ export function renderSkillMd(slug: string, description: string, body: string): 
         ? description.slice(0, SKILL_DESCRIPTION_MAX_LEN)
         : "No description provided.";
     return `---\nname: ${JSON.stringify(slug)}\ndescription: ${JSON.stringify(desc)}\n---\n\n${body}`;
+}
+
+/**
+ * Validate a skill's `trigger` is safe to use as a single path segment in
+ * `.claude/commands/<trigger>.md`. `trigger` is free-form user input with no
+ * format validation anywhere upstream, so a trigger containing a path
+ * separator or a `..` segment previously let the resulting filename resolve
+ * OUTSIDE the agent's working directory (reagent P1, PR #2322). Returns
+ * `null` for anything containing "/" or "\\", or that is exactly "."/"..";
+ * callers skip writing that skill's command file entirely. Mirrors
+ * `sanitize_trigger` in `agentmux-srv/src/backend/agent_config.rs`.
+ */
+export function sanitizeTrigger(trigger: string): string | null {
+    if (!trigger || trigger === "." || trigger === "..") {
+        return null;
+    }
+    if (trigger.includes("/") || trigger.includes("\\")) {
+        return null;
+    }
+    return trigger;
 }
 
 /**

--- a/frontend/app/view/agent/agent-config-builder.ts
+++ b/frontend/app/view/agent/agent-config-builder.ts
@@ -92,7 +92,7 @@ export function buildConfigFiles(
             const content = expandTemplate(skill.content, templateVars);
             files.push({
                 path: `.claude/skills/${slug}/SKILL.md`,
-                content: renderSkillMd(skill.name, skill.description, content),
+                content: renderSkillMd(slug, skill.description, content),
             });
         } else if (skill.trigger) {
             const content = expandTemplate(skill.content, templateVars);
@@ -157,18 +157,30 @@ export function deriveSlug(name: string): string {
     return trimmed || "agent";
 }
 
+/** Agent Skills spec caps `description` at 1024 characters. */
+const SKILL_DESCRIPTION_MAX_LEN = 1024;
+
 /**
  * Render an Agent Skills-format `SKILL.md`: YAML frontmatter with the two
  * required fields (`name`, `description`), followed by the skill's content
  * as the Markdown body. See https://agentskills.io/specification.
+ *
+ * `slug` (not the skill's raw display name) is REQUIRED here — the spec
+ * requires `name` be lowercase/hyphenated and match its parent directory;
+ * callers must pass the same value used to build the `.claude/skills/<slug>/`
+ * path (reagent P1, PR #2322). `description` is validated: the spec requires
+ * a non-empty value (falls back to a placeholder) capped at 1024 characters.
  *
  * YAML double-quoted scalars use JSON-compatible escaping (YAML 1.2
  * §7.3.1), so `JSON.stringify` on a plain string produces a valid,
  * correctly-escaped YAML value — same reasoning as `render_skill_md` in
  * `agentmux-srv/src/backend/agent_config.rs`, which this mirrors.
  */
-export function renderSkillMd(name: string, description: string, body: string): string {
-    return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n\n${body}`;
+export function renderSkillMd(slug: string, description: string, body: string): string {
+    const desc = description.trim()
+        ? description.slice(0, SKILL_DESCRIPTION_MAX_LEN)
+        : "No description provided.";
+    return `---\nname: ${JSON.stringify(slug)}\ndescription: ${JSON.stringify(desc)}\n---\n\n${body}`;
 }
 
 /**

--- a/frontend/app/view/agent/agent-config-builder.ts
+++ b/frontend/app/view/agent/agent-config-builder.ts
@@ -14,11 +14,20 @@
 import { Logger } from "@/util/logger";
 
 /**
+ * `skill_type` value that materializes a skill as an Agent Skills-format
+ * `.claude/skills/<slug>/SKILL.md` instead of a `.claude/commands/<trigger>.md`
+ * slash command. Mirrors `SKILL_TYPE_AGENT_SKILL` in
+ * `agentmux-srv/src/backend/agent_config.rs` — keep the two in sync.
+ */
+const SKILL_TYPE_AGENT_SKILL = "agent-skill";
+
+/**
  * Build the list of config files to write to the agent working directory.
  * Assembles CLAUDE.md from soul + agentmd + memory + skills index,
- * writes each skill as a slash command in .claude/commands/,
- * writes hooks.json if present, auto-injects AgentMux MCP server,
- * and applies template variable substitution.
+ * writes each skill as a slash command in .claude/commands/ (or an Agent
+ * Skills-format SKILL.md under .claude/skills/, for skill_type ===
+ * SKILL_TYPE_AGENT_SKILL), writes hooks.json if present, auto-injects
+ * AgentMux MCP server, and applies template variable substitution.
  */
 export function buildConfigFiles(
     contentMap: Record<string, string>,
@@ -72,9 +81,19 @@ export function buildConfigFiles(
         files.push({ path: "CLAUDE.md", content: claudeMdParts.join("") });
     }
 
-    // Write each skill as a slash command: .claude/commands/{trigger}.md
+    // Write each skill as either a slash command (.claude/commands/{trigger}.md,
+    // default) or an Agent Skills-format SKILL.md (.claude/skills/{slug}/SKILL.md,
+    // skill_type === SKILL_TYPE_AGENT_SKILL).
     for (const skill of skills) {
-        if (skill.trigger && skill.content) {
+        if (!skill.content) continue;
+        if (skill.skill_type === SKILL_TYPE_AGENT_SKILL) {
+            const slug = deriveSlug(skill.name);
+            const content = expandTemplate(skill.content, templateVars);
+            files.push({
+                path: `.claude/skills/${slug}/SKILL.md`,
+                content: renderSkillMd(skill.name, skill.description, content),
+            });
+        } else if (skill.trigger) {
             const content = expandTemplate(skill.content, templateVars);
             files.push({ path: `.claude/commands/${skill.trigger}.md`, content });
         }
@@ -114,6 +133,41 @@ export function expandTemplate(content: string, vars: Record<string, string>): s
     return content.replace(/\{\{(\w+)\}\}/g, (match, key) => {
         return vars[key] ?? match;
     });
+}
+
+/**
+ * Derive a filesystem-safe slug from a display name. Lowercase, ASCII
+ * alphanumeric + dash/underscore, consecutive dashes collapsed, trimmed to
+ * 64 chars. Falls back to "agent" if the input has no valid characters.
+ *
+ * Mirrors `derive_slug` in `agentmux-srv/src/backend/storage/agents.rs` —
+ * keep the two in sync, or a SKILL.md preview built here won't match the
+ * path the authoritative Rust launch path actually writes to.
+ */
+export function deriveSlug(name: string): string {
+    const filtered = name
+        .toLowerCase()
+        .replace(/[^a-z0-9-_]/g, "-");
+    const collapsed = filtered
+        .split("-")
+        .filter((s) => s.length > 0)
+        .join("-");
+    const trimmed = collapsed.slice(0, 64);
+    return trimmed || "agent";
+}
+
+/**
+ * Render an Agent Skills-format `SKILL.md`: YAML frontmatter with the two
+ * required fields (`name`, `description`), followed by the skill's content
+ * as the Markdown body. See https://agentskills.io/specification.
+ *
+ * YAML double-quoted scalars use JSON-compatible escaping (YAML 1.2
+ * §7.3.1), so `JSON.stringify` on a plain string produces a valid,
+ * correctly-escaped YAML value — same reasoning as `render_skill_md` in
+ * `agentmux-srv/src/backend/agent_config.rs`, which this mirrors.
+ */
+export function renderSkillMd(name: string, description: string, body: string): string {
+    return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n\n${body}`;
 }
 
 /**

--- a/frontend/app/view/agent/agent-config-builder.ts
+++ b/frontend/app/view/agent/agent-config-builder.ts
@@ -184,24 +184,47 @@ export function renderSkillMd(slug: string, description: string, body: string): 
 }
 
 /**
- * Derive a filesystem-safe, COLLISION-FREE slug for a skill within one
- * `buildConfigFiles` call. `deriveSlug` alone can produce identical output
- * for distinct names that differ only in punctuation/whitespace (e.g.
- * "Deploy Checklist" and "Deploy!!!Checklist" both -> "deploy-checklist"),
- * which would otherwise silently overwrite one skill's SKILL.md with
- * another's (reagent P1, PR #2322). Appends "-2", "-3", ... until unique
- * within `used`. Mirrors `unique_skill_slug` in
+ * Derive a slug for an Agent Skill name that is valid per the Agent Skills
+ * `name` grammar: lowercase letters, digits, and hyphens ONLY (no
+ * underscores). `deriveSlug` is shared with agent role-slugs, which
+ * deliberately DO permit underscores, so it isn't spec-valid here as-is —
+ * hyphenate underscores (and re-collapse any resulting run of hyphens)
+ * rather than reusing it directly (Codex P1, PR #2322). Mirrors
+ * `skill_name_slug` in `agentmux-srv/src/backend/agent_config.rs`.
+ */
+function skillNameSlug(name: string): string {
+    const collapsed = deriveSlug(name)
+        .replace(/_/g, "-")
+        .split("-")
+        .filter((s) => s.length > 0)
+        .join("-");
+    return collapsed || "skill";
+}
+
+/**
+ * Derive a filesystem-safe, COLLISION-FREE, spec-valid slug for a skill
+ * within one `buildConfigFiles` call. `skillNameSlug` alone can produce
+ * identical output for distinct names that differ only in
+ * punctuation/whitespace (e.g. "Deploy Checklist" and "Deploy!!!Checklist"
+ * both -> "deploy-checklist"), which would otherwise silently overwrite one
+ * skill's SKILL.md with another's (reagent P1, PR #2322). Appends "-2",
+ * "-3", ... until unique within `used`, truncating the base first so the
+ * suffixed result never exceeds the spec's 64-character max (Codex P2, PR
+ * #2322). Mirrors `unique_skill_slug` in
  * `agentmux-srv/src/backend/agent_config.rs`.
  */
 export function uniqueSkillSlug(name: string, used: Set<string>): string {
-    const base = deriveSlug(name);
+    const MAX_LEN = 64;
+    const base = skillNameSlug(name);
     if (!used.has(base)) {
         used.add(base);
         return base;
     }
     let n = 2;
     for (;;) {
-        const candidate = `${base}-${n}`;
+        const suffix = `-${n}`;
+        const truncatedBase = base.slice(0, Math.max(0, MAX_LEN - suffix.length));
+        const candidate = `${truncatedBase}${suffix}`;
         if (!used.has(candidate)) {
             used.add(candidate);
             return candidate;

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -109,7 +109,13 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                             <span class="agent-primitive-modal-field-label">Description</span>
                                             <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
                                         </Show>
-                                        <Show when={skill().trigger}>
+                                        <span class="agent-primitive-modal-field-label">Format</span>
+                                        <pre class="agent-primitive-modal-field-value">
+                                            {skill().skill_type === "agent-skill"
+                                                ? "Agent Skill (SKILL.md)"
+                                                : "Slash command"}
+                                        </pre>
+                                        <Show when={skill().skill_type !== "agent-skill" && skill().trigger}>
                                             <span class="agent-primitive-modal-field-label">Trigger</span>
                                             <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
                                         </Show>
@@ -179,14 +185,25 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                     placeholder="e.g. pdf-extraction"
                                     required
                                 />
-                                <span class="agent-primitive-modal-field-label">Trigger</span>
-                                <input
+                                <span class="agent-primitive-modal-field-label">Format</span>
+                                <select
                                     class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().trigger}
-                                    onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
-                                    placeholder="When should this skill be invoked?"
-                                />
+                                    value={draft().skill_type || "prompt"}
+                                    onChange={(e) => model.setDraft({ ...draft(), skill_type: e.currentTarget.value })}
+                                >
+                                    <option value="prompt">Slash command (/trigger)</option>
+                                    <option value="agent-skill">Agent Skill (SKILL.md) — beta ABF format</option>
+                                </select>
+                                <Show when={(draft().skill_type || "prompt") !== "agent-skill"}>
+                                    <span class="agent-primitive-modal-field-label">Trigger</span>
+                                    <input
+                                        class="agent-primitive-modal-input"
+                                        type="text"
+                                        value={draft().trigger}
+                                        onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
+                                        placeholder="When should this skill be invoked?"
+                                    />
+                                </Show>
                                 <span class="agent-primitive-modal-field-label">Description</span>
                                 <input
                                     class="agent-primitive-modal-input"

--- a/frontend/app/view/skill/skill-manager.tsx
+++ b/frontend/app/view/skill/skill-manager.tsx
@@ -77,7 +77,13 @@ export const SkillManager = (): JSX.Element => {
                                             <span class="agent-primitive-modal-field-label">Description</span>
                                             <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
                                         </Show>
-                                        <Show when={skill().trigger}>
+                                        <span class="agent-primitive-modal-field-label">Format</span>
+                                        <pre class="agent-primitive-modal-field-value">
+                                            {skill().skill_type === "agent-skill"
+                                                ? "Agent Skill (SKILL.md)"
+                                                : "Slash command"}
+                                        </pre>
+                                        <Show when={skill().skill_type !== "agent-skill" && skill().trigger}>
                                             <span class="agent-primitive-modal-field-label">Trigger</span>
                                             <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
                                         </Show>
@@ -143,14 +149,25 @@ export const SkillManager = (): JSX.Element => {
                                     placeholder="e.g. pdf-extraction"
                                     required
                                 />
-                                <span class="agent-primitive-modal-field-label">Trigger</span>
-                                <input
+                                <span class="agent-primitive-modal-field-label">Format</span>
+                                <select
                                     class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().trigger}
-                                    onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
-                                    placeholder="When should this skill be invoked?"
-                                />
+                                    value={draft().skill_type || "prompt"}
+                                    onChange={(e) => model.setDraft({ ...draft(), skill_type: e.currentTarget.value })}
+                                >
+                                    <option value="prompt">Slash command (/trigger)</option>
+                                    <option value="agent-skill">Agent Skill (SKILL.md) — beta ABF format</option>
+                                </select>
+                                <Show when={(draft().skill_type || "prompt") !== "agent-skill"}>
+                                    <span class="agent-primitive-modal-field-label">Trigger</span>
+                                    <input
+                                        class="agent-primitive-modal-input"
+                                        type="text"
+                                        value={draft().trigger}
+                                        onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
+                                        placeholder="When should this skill be invoked?"
+                                    />
+                                </Show>
                                 <span class="agent-primitive-modal-field-label">Description</span>
                                 <input
                                     class="agent-primitive-modal-input"


### PR DESCRIPTION
## Summary
Implements **Phase 0** of the rollout plan in [`docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md) / [docs.agentmux.ai/abf](https://docs.agentmux.ai/abf/) — the report's own "highest-leverage single step": aligning Armory skills with the [Agent Skills](https://agentskills.io/specification) standard so any community `SKILL.md` becomes importable as-is.

**Zero schema migration.** Repurposes the existing `skill_type` column — confirmed via a full-repo search to always be `"prompt"` and never branched on anywhere in the codebase today — as the format discriminator, rather than adding a new column. `skill_type == "agent-skill"` now materializes a skill as `.claude/skills/<slug>/SKILL.md` (native Claude Code / Agent Skills consumption) instead of `.claude/commands/<trigger>.md`.

## Changes
- **`agentmux-srv/src/backend/agent_config.rs`** (authoritative launch path): branches `build_config_files`'s skill-materialization loop on `skill_type`. New `render_skill_md()` writes the two required Agent Skills frontmatter fields (`name`, `description`) via `serde_json` string escaping — which is valid YAML double-quoted-scalar syntax per YAML 1.2 §7.3.1 — avoiding hand-rolled YAML escaping or a new `yaml` crate dependency (this workspace has neither today) for two scalar fields. Slug derived via the existing `derive_slug()` (already used for agent workdir names).
- **`frontend/app/view/agent/agent-config-builder.ts`** (TS mirror — must stay in sync with the Rust path per the research report's own note, or the two diverge): identical branch, plus a `deriveSlug()` that exactly mirrors Rust's algorithm. Verified this needed to be a new function, not a reuse of the existing `slugifyInstanceName` — that helper strips invalid characters rather than collapsing runs of them into a single dash, which diverges from Rust on inputs like `"Deploy!!!Checklist"` (see the regression test).
- **UI**: `skill_type` was previously stored end-to-end but never surfaced in any form — the Armory catalog's `skill-manager.tsx` and the per-agent `AgentSkillsModal.tsx` both hardcoded `"prompt"`. Both now expose a **Format** select (Slash command / Agent Skill — beta ABF format); the Trigger field hides itself when Agent Skill format is selected since it's unused for that materialization path.

## Test plan
- [x] 2 new Rust unit tests (`agent_config.rs`): SKILL.md materialization path, and YAML-special-character escaping regression test.
- [x] 9 new Vitest tests (`agent-config-builder.test.ts`): `deriveSlug` parity with Rust (including the divergence-from-`slugifyInstanceName` regression case), `renderSkillMd`, and the `buildConfigFiles` branch (both formats + empty-content skip).
- [x] Full `agent_config::` Rust test module: 13/13 pass.
- [x] Full frontend `tsc --noEmit`: clean, no errors.
- [x] Full Vitest run across `frontend/app/view/agent/` + `frontend/app/view/skill/`: 251/251 pass.
- [ ] Manual: create an Agent Skill-format skill in the Armory, launch an agent bound to it, confirm `.claude/skills/<slug>/SKILL.md` is written with correct frontmatter and Claude Code picks it up natively.

## Scope note
This is Phase 0 only (of 6 phases in the rollout plan). Phases 1-4 (exporter, importer, Armory export/import UI, OCI distribution) are separate, larger follow-ups — not attempted here.

<!-- agentmux:agent_id=agentx -->