### PR TITLE
feat(agent): guarantee pane close/reopen resumes the real conversation, or discloses it couldn't

### DIFF
--- a/.changesets/1785186317-feat-agent-guarantee-pane-close-reopen-resumes-the-real-conv-j2it.md
+++ b/.changesets/1785186317-feat-agent-guarantee-pane-close-reopen-resumes-the-real-conv-j2it.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): guarantee pane close/reopen resumes the real conversation, or discloses it couldn't

--- a/agentmux-srv/src/backend/blockcontroller/core.rs
+++ b/agentmux-srv/src/backend/blockcontroller/core.rs
@@ -121,6 +121,19 @@ pub(crate) fn spawn_health_watchdog(health_monitor: &Arc<HealthMonitor>) {
 /// missing this step (it only set `inner.session_id` in memory) — A5 fixes it
 /// by routing ACP through this same function.
 ///
+/// Also writes through to the matching `db_agent_instances` row's
+/// `session_id` column (SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
+/// §4.1). Without this, that column was set to `""` at instance creation and
+/// never updated again in production — `ListRecentSessionsCommand` prefers
+/// the local row over the shared registry whenever both exist, so the "My
+/// Agents" picker's reattach flow (`AgentPicker.tsx`'s `handleReattach`) was
+/// handed an empty session id even mid-session, and — per
+/// `agent-model.ts`'s own documented invariant that an empty
+/// `continueSessionId` clears `agent:sessionid` on the new block — silently
+/// started a genuinely fresh conversation instead of resuming. Best-effort:
+/// logs and continues on failure, since the block-meta write above (the
+/// live-turn source of truth) already succeeded.
+///
 /// No-ops silently when `wstore` is `None` (e.g. in unit tests that don't wire
 /// up a store).
 pub(crate) fn persist_session_id(
@@ -147,6 +160,8 @@ pub(crate) fn persist_session_id(
             );
         }
         Ok(_) => {
+            sync_instance_session_id(store, block_id, sid);
+
             let Some(ref event_bus) = event_bus else {
                 return;
             };
@@ -169,6 +184,37 @@ pub(crate) fn persist_session_id(
                 });
             }
         }
+    }
+}
+
+/// Write `sid` into the `db_agent_instances` row for `block_id`, if one
+/// exists. Best-effort — no-ops (with a debug log, not a warn — most turns
+/// on a block with no matching instance row are expected, e.g. terminal
+/// panes never have one) when there's nothing to update.
+fn sync_instance_session_id(store: &Arc<Store>, block_id: &str, sid: &str) {
+    let instance = match store.instance_get_by_block_id(block_id) {
+        Ok(Some(i)) => i,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::debug!(
+                block_id = %block_id,
+                error = %e,
+                "sync_instance_session_id: instance lookup failed"
+            );
+            return;
+        }
+    };
+    let upd = crate::backend::storage::InstanceUpdate {
+        session_id: Some(sid.to_string()),
+        ..Default::default()
+    };
+    if let Err(e) = store.instance_update_partial(&instance.id, &upd) {
+        tracing::warn!(
+            block_id = %block_id,
+            instance_id = %instance.id,
+            error = %e,
+            "sync_instance_session_id: failed to write session_id"
+        );
     }
 }
 
@@ -251,5 +297,135 @@ pub(crate) fn persist_last_failure(
                 });
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::{Block, MetaMapType};
+    use crate::backend::storage::store::{AgentDefinition, AgentInstance, InstanceStatus};
+
+    /// Minimal definition satisfying `db_agent_instances`'s FK on
+    /// `definition_id` — field values otherwise irrelevant to these tests.
+    fn sample_agent(id: &str) -> AgentDefinition {
+        AgentDefinition {
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: id.to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+        }
+    }
+
+    /// SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.1: this
+    /// is the end-to-end assertion that `persist_session_id` (the live-turn
+    /// call site every controller uses) keeps `db_agent_instances.session_id`
+    /// current, not just the block's own `agent:sessionid` meta — closing the
+    /// gap where "My Agents"'s reattach flow saw a permanently-empty local
+    /// session id.
+    #[test]
+    fn persist_session_id_writes_through_to_the_instance_row() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let block_id = "55555555-5555-5555-5555-555555555555";
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m
+            },
+            subblockids: None,
+        };
+        store.insert(&mut block).unwrap();
+
+        let mut def = sample_agent("def-live");
+        store.agent_def_insert(&mut def).unwrap();
+
+        let inst = AgentInstance {
+            id: "inst-live".to_string(),
+            definition_id: "def-live".to_string(),
+            parent_instance_id: String::new(),
+            block_id: block_id.to_string(),
+            session_id: String::new(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: String::new(),
+            started_at: 1000,
+            ended_at: 0,
+            created_at: 1000,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
+        };
+        store.instance_create(&inst).unwrap();
+
+        persist_session_id(block_id, "sess-abc", &Some(store.clone()), &None);
+
+        // Block meta: the pre-existing behavior.
+        let updated_block: Block = store.get(block_id).unwrap().unwrap();
+        assert_eq!(
+            updated_block.meta.get(META_SESSION_ID).and_then(|v| v.as_str()),
+            Some("sess-abc"),
+        );
+
+        // Instance row: the new write-through.
+        let updated_instance = store.instance_get_by_block_id(block_id).unwrap().unwrap();
+        assert_eq!(updated_instance.session_id, "sess-abc");
+    }
+
+    /// A block with no matching instance row (e.g. a terminal pane) must not
+    /// cause persist_session_id to error or panic — sync_instance_session_id
+    /// is best-effort and silently no-ops.
+    #[test]
+    fn persist_session_id_is_a_noop_for_a_block_with_no_instance_row() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let block_id = "66666666-6666-6666-6666-666666666666";
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: MetaMapType::new(),
+            subblockids: None,
+        };
+        store.insert(&mut block).unwrap();
+
+        // Must not panic.
+        persist_session_id(block_id, "sess-xyz", &Some(store.clone()), &None);
+
+        let updated_block: Block = store.get(block_id).unwrap().unwrap();
+        assert_eq!(
+            updated_block.meta.get(META_SESSION_ID).and_then(|v| v.as_str()),
+            Some("sess-xyz"),
+            "block meta write still happens regardless of instance-row presence",
+        );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -772,6 +772,18 @@ impl PersistentSubprocessController {
                                  clearing so the next message starts a fresh conversation"
                             );
                             core::persist_session_id(&block_id_stderr, "", &wstore_stderr, &event_bus_stderr);
+                            // Surface this to the user — previously silent
+                            // (only the warn! above). See
+                            // SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
+                            // §4.2: a resumed conversation silently starting
+                            // fresh, with no indication anything happened, is
+                            // exactly the failure mode this flag exists to close.
+                            if let Some(ref store) = wstore_stderr {
+                                crate::backend::blockcontroller::session_recovery::mark_resume_failed(
+                                    store,
+                                    &block_id_stderr,
+                                );
+                            }
                         }
                     }
                 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -781,6 +781,7 @@ impl PersistentSubprocessController {
                             if let Some(ref store) = wstore_stderr {
                                 crate::backend::blockcontroller::session_recovery::mark_resume_failed(
                                     store,
+                                    &event_bus_stderr,
                                     &block_id_stderr,
                                 );
                             }

--- a/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
+++ b/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
@@ -34,6 +34,7 @@
 
 use std::sync::Arc;
 
+use crate::backend::eventbus::EventBus;
 use crate::backend::obj::{Block, MetaMapType};
 use crate::backend::storage::store::Store;
 
@@ -64,12 +65,39 @@ pub fn mark_active_pid(wstore: &Arc<Store>, block_id: &str, pid: u32) {
 /// `persistent.rs`'s stderr reader the moment it detects the CLI's "No
 /// conversation found with session ID" line, right alongside the existing
 /// `core::persist_session_id(block_id, "", ...)` clear.
-pub fn mark_resume_failed(wstore: &Arc<Store>, block_id: &str) {
+///
+/// Broadcasts `waveobj:update` on success (reagent P1 on the initial PR):
+/// this fires while the user may be actively watching the pane that just
+/// lost its resume, so — unlike `mark_active_pid`/`scan_orphans`, both of
+/// which run before any frontend subscriber could be watching (spawn time /
+/// server boot) — the write must reach an already-open `blockAtom` live, not
+/// only on the pane's next reload/reopen. Mirrors `persist_session_id`'s
+/// broadcast in `core.rs`. `event_bus: None` (tests / no live subscribers)
+/// silently skips the broadcast, matching every other call site's contract.
+pub fn mark_resume_failed(wstore: &Arc<Store>, event_bus: &Option<Arc<EventBus>>, block_id: &str) {
     let mut meta = MetaMapType::new();
     meta.insert(META_SESSION_RESUME_FAILED.to_string(), serde_json::json!(true));
     let oref_str = format!("block:{}", block_id);
     if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
         tracing::warn!(block_id = %block_id, error = %e, "session_recovery: failed to mark resume_failed");
+        return;
+    }
+    let Some(ref bus) = event_bus else {
+        return;
+    };
+    if let Ok(updated_block) = wstore.must_get::<Block>(block_id) {
+        let update_data = serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
+            updatetype: "update".into(),
+            otype: "block".into(),
+            oid: block_id.to_string(),
+            obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
+        })
+        .ok();
+        bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+            eventtype: "waveobj:update".to_string(),
+            oref: oref_str,
+            data: update_data,
+        });
     }
 }
 
@@ -264,12 +292,60 @@ mod tests {
         };
         wstore.insert(&mut block).unwrap();
 
-        mark_resume_failed(&wstore, block_id);
+        mark_resume_failed(&wstore, &None, block_id);
 
         let after: Block = wstore.get(block_id).unwrap().unwrap();
         assert_eq!(
             after.meta.get(META_SESSION_RESUME_FAILED).and_then(|v| v.as_bool()),
             Some(true),
+        );
+    }
+
+    /// reagent P1 on the original PR: mark_resume_failed wrote the meta but
+    /// never broadcast waveobj:update, so an already-open pane's blockAtom
+    /// never saw the flag live — the disclosure banner wouldn't render until
+    /// the pane was reloaded, defeating the point of a live-disclosure
+    /// signal. This asserts the broadcast actually reaches a connected
+    /// WebSocket client, not just that the DB write succeeded.
+    #[tokio::test]
+    async fn test_mark_resume_failed_broadcasts_waveobj_update() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+        let event_bus = Arc::new(EventBus::new());
+
+        let block_id = "77777777-7777-7777-7777-777777777777";
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m
+            },
+            subblockids: None,
+        };
+        wstore.insert(&mut block).unwrap();
+
+        let mut receivers = event_bus.register_ws("test-conn", "test-tab");
+
+        mark_resume_failed(&wstore, &Some(event_bus.clone()), block_id);
+
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(2), receivers.priority.recv())
+            .await
+            .expect("timed out waiting for waveobj:update broadcast")
+            .expect("priority channel closed");
+        assert_eq!(msg.get("eventtype").and_then(|v| v.as_str()), Some("waveobj:update"));
+        assert_eq!(msg.get("oref").and_then(|v| v.as_str()), Some(format!("block:{}", block_id).as_str()));
+        let obj = msg.get("data").and_then(|d| d.get("obj")).expect("data.obj present");
+        assert_eq!(
+            obj.get("meta")
+                .and_then(|m| m.get(META_SESSION_RESUME_FAILED))
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "broadcast payload must carry the flag, not just trigger a generic refetch",
         );
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
+++ b/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
@@ -22,6 +22,15 @@
 //! `session:was_interrupted` is a frontend-only signal — the backend doesn't
 //! consume it. The frontend `AgentControlBar` renders a banner when it's set,
 //! and `service:update_object_meta` clears it when the user dismisses.
+//!
+//! A second, unrelated flag lives here for the same reason: `session:resume_failed`
+//! (SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.2) marks a
+//! block whose `--resume <sid>` was rejected by the CLI (stale/unreachable
+//! session id — see `persistent.rs`'s `poison_resume`) and silently fell
+//! through to a fresh conversation. Same shape, same frontend-only contract,
+//! different trigger (a resume rejection mid-session, not a stale PID found
+//! at boot) — kept in this file rather than a new module since it's the
+//! established home for "frontend-only session-state signal flags."
 
 use std::sync::Arc;
 
@@ -32,6 +41,9 @@ use crate::backend::storage::store::Store;
 pub const META_SESSION_ACTIVE_PID: &str = "session:active_pid";
 /// Set to `true` by startup scan when a pre-existing `active_pid` is found.
 pub const META_SESSION_WAS_INTERRUPTED: &str = "session:was_interrupted";
+/// Set to `true` when a `--resume <sid>` was rejected by the CLI and the
+/// controller silently started a fresh conversation instead.
+pub const META_SESSION_RESUME_FAILED: &str = "session:resume_failed";
 
 /// Record that a subprocess with `pid` has been spawned for `block_id`.
 /// Best-effort — logs on failure but never panics.
@@ -43,6 +55,21 @@ pub fn mark_active_pid(wstore: &Arc<Store>, block_id: &str, pid: u32) {
     let oref_str = format!("block:{}", block_id);
     if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
         tracing::warn!(block_id = %block_id, error = %e, "session_recovery: failed to mark active pid");
+    }
+}
+
+/// Mark that `block_id`'s `--resume <sid>` was rejected and the controller
+/// fell through to a fresh conversation. Best-effort — logs on failure but
+/// never panics, matching `mark_active_pid`'s contract. Called from
+/// `persistent.rs`'s stderr reader the moment it detects the CLI's "No
+/// conversation found with session ID" line, right alongside the existing
+/// `core::persist_session_id(block_id, "", ...)` clear.
+pub fn mark_resume_failed(wstore: &Arc<Store>, block_id: &str) {
+    let mut meta = MetaMapType::new();
+    meta.insert(META_SESSION_RESUME_FAILED.to_string(), serde_json::json!(true));
+    let oref_str = format!("block:{}", block_id);
+    if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
+        tracing::warn!(block_id = %block_id, error = %e, "session_recovery: failed to mark resume_failed");
     }
 }
 
@@ -213,6 +240,36 @@ mod tests {
         assert_eq!(
             term_after.meta.get(META_SESSION_ACTIVE_PID).and_then(|v| v.as_u64()),
             Some(67890),
+        );
+    }
+
+    #[test]
+    fn test_mark_resume_failed_sets_the_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(Store::open(&tmp.path().join("objects.db")).unwrap());
+
+        let block_id = "44444444-4444-4444-4444-444444444444";
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m
+            },
+            subblockids: None,
+        };
+        wstore.insert(&mut block).unwrap();
+
+        mark_resume_failed(&wstore, block_id);
+
+        let after: Block = wstore.get(block_id).unwrap().unwrap();
+        assert_eq!(
+            after.meta.get(META_SESSION_RESUME_FAILED).and_then(|v| v.as_bool()),
+            Some(true),
         );
     }
 }

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -1801,6 +1801,35 @@ impl Store {
         }
     }
 
+    /// Find the `db_agent_instances` row for `block_id`, regardless of
+    /// status — unlike `instance_get_active_for_block`, this reads
+    /// `db_agent_instances` directly (not the `db_agents` consolidated
+    /// projection) and returns the row's REAL `session_id`, so callers
+    /// that need to write back to that exact row (e.g. keeping
+    /// `session_id` live as the CLI emits it — see
+    /// `persist_session_id`/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
+    /// §4.1) have a real `id` to pass to `instance_update_partial`.
+    /// Most-recently-created row wins if a block_id was somehow reused
+    /// across rows (shouldn't happen in practice, but avoids ambiguity).
+    pub fn instance_get_by_block_id(&self, block_id: &str) -> Result<Option<AgentInstance>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
+             FROM db_agent_instances
+             WHERE block_id = ?1
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )?;
+        match stmt.query_row(params![block_id], map_instance_row) {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     // Dual-write helpers live in `super::dual_write`.
 }
 

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -675,6 +675,50 @@
     }
 
     #[test]
+    fn test_instance_get_by_block_id() {
+        // SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.1:
+        // this lookup is what lets persist_session_id write a live
+        // session_id back into db_agent_instances by block_id.
+        let store = v6_test_store();
+        let mut agent = sample_agent("defq", "agent-q");
+        store.agent_def_insert(&mut agent).unwrap();
+        let inst = AgentInstance {
+            id: "instq".to_string(),
+            definition_id: "defq".to_string(),
+            parent_instance_id: String::new(),
+            block_id: "block-q".to_string(),
+            session_id: String::new(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: String::new(),
+            started_at: 1000,
+            ended_at: 0,
+            created_at: 1000,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
+        };
+        store.instance_create(&inst).unwrap();
+
+        let found = store.instance_get_by_block_id("block-q").unwrap().expect("row");
+        assert_eq!(found.id, "instq");
+        assert_eq!(found.session_id, "", "starts empty, matching real launch-time behavior");
+
+        // Writing a live session id through instance_update_partial (as
+        // persist_session_id now does) is visible on the next lookup.
+        use crate::backend::storage::InstanceUpdate;
+        store
+            .instance_update_partial("instq", &InstanceUpdate { session_id: Some("sess-live".into()), ..Default::default() })
+            .unwrap();
+        let found = store.instance_get_by_block_id("block-q").unwrap().expect("row");
+        assert_eq!(found.session_id, "sess-live");
+
+        // No row for this block: None, not an error.
+        assert!(store.instance_get_by_block_id("no-such-block").unwrap().is_none());
+    }
+
+    #[test]
     fn test_agent_def_list_orders_by_last_used() {
         let store = v6_test_store();
         // Three definitions; none launched yet.

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -144,6 +144,28 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 let d = rec.data;
                                 let key = (d.definition_id.clone(), d.instance_name.clone());
                                 if let Some(li) = local_by_key.get(&key) {
+                                    // Defense-in-depth (SPEC_PANE_CLOSE_REOPEN_
+                                    // CONTINUITY_GUARANTEE_2026_07_27.md §4.1):
+                                    // the local row is normally the fresher
+                                    // source (persist_session_id keeps it live
+                                    // as of that spec), but fall back to the
+                                    // registry's session_id when the local one
+                                    // is empty rather than surfacing an empty
+                                    // session id the picker's reattach flow
+                                    // would silently treat as "start fresh."
+                                    // Correct regardless of whether the
+                                    // primary live-write fix is in place for
+                                    // this particular row (e.g. it predates
+                                    // that change, or the write raced/failed).
+                                    if li.session_id.is_empty() {
+                                        if let Some(ref registry_sid) = d.session_id {
+                                            if !registry_sid.is_empty() {
+                                                let mut merged = li.clone();
+                                                merged.session_id = registry_sid.clone();
+                                                return merged;
+                                            }
+                                        }
+                                    }
                                     return li.clone();
                                 }
                                 // Reconstruct the absolute workdir from the record's

--- a/docs/specs/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
+++ b/docs/specs/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md
@@ -1,0 +1,90 @@
+# Spec: pane close/reopen must guarantee conversation continuity, or say so
+
+**Status:** Draft — not implemented.
+**Author:** Agent1
+**Date:** 2026-07-27
+**Triggered by:** a user question about whether an agent's Armory-sourced workspace rules (Bundles/Skills/MCP) are "always available," which surfaced that reopening a pane goes through a resume (`--resume <sid>`) whose success is unverified end-to-end. Investigating that led to two real, evidenced gaps below.
+**Related:** `docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md`, `docs/plans/PLAN_PANE_REOPEN_SESSION_RESUME_AND_STATS_BAR_2026_07_10.md` (commit `3e720422`, #2059 — closed the *cross-channel* half of the June retro), `docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md` (the banner mechanism this spec extends), commit `c39911c2` (#2224 — the silent resume-poison recovery this spec makes visible).
+
+---
+
+## 1. The guarantee this spec establishes
+
+**Closing an agent's pane and reopening it later must resume the same conversation. If that's not possible for any reason, the user must be told — not silently handed a fresh session that looks like a continuation.**
+
+This is currently untrue in at least two concrete, evidenced ways (§3). Both fail *silently*: the user gets a working agent that responds normally, with no indication that its memory of the prior conversation is gone. That's strictly worse than an error, because nothing prompts the user to notice or recover.
+
+## 2. What already works (don't re-solve this)
+
+The June 2026-06-16 retro's headline scenario — reopening a pane in a **different channel/build** than the one the agent originally ran in, where the new block has no `agent:sessionid` meta at all — is fixed, verified by tests:
+
+- `session_backfill.rs::backfill_session_ids` runs at every app startup (`bootstrap.rs`), scans `~/.agentmux/shared/providers/claude/projects/<encoded-cwd>/` (or the identity-bundle equivalent) for the registry's empty `session_id` fields, and picks the **largest** `.jsonl` file's stem — deliberately largest-, not newest-, to avoid a short orphaning session winning over the real conversation.
+- `agent_open.rs` seeds a fresh block's `agent:sessionid` from that registry record, guarded by a same-agent concurrency check (`agent_live_elsewhere`) added alongside the same fix so two blocks can't `--resume` the same provider session at once.
+
+Do not touch this mechanism. The gaps below are elsewhere.
+
+## 3. What's actually broken, with evidence
+
+### 3.1 Same-instance "close pane, reopen via My Agents" can hand the picker a stale/empty session id
+
+`AgentPicker.tsx`'s `handleReattach()` — the live, wired reattach path — passes `continueSessionId: row.session_id ?? ""`, where `row` comes from `ListRecentSessionsCommand` (`agent_handlers/session.rs`). That handler **prefers the local `db_agent_instances` row over the registry record** whenever both exist for the same `(definition_id, instance_name)` key.
+
+The local row's `session_id` is initialized to `""` at `instance_create` and — this is the actual bug — **never updated afterward in production**. The RPC that would keep it live (`updateagentinstance` / `UpdateAgentInstanceCommand`) is fully implemented and registered server-side but has **zero frontend callers** (confirmed by grep). Live per-turn session-id capture (`persist_session_id`, `blockcontroller/core.rs`) only writes the block's own `agent:sessionid` meta — which is destroyed the moment the block/pane is deleted — never the instance row or registry.
+
+**Net effect:** any agent that has been launched at least once in the current running app has a local instance row with `session_id: ""`. Closing its pane and reopening via the "My Agents" list hands `handleReattach` that empty string, even though the disk-backfilled registry record might hold the correct session id. Left unverified in this pass whether the resulting spawn falls through to a fresh session or to `agent_open.rs`'s registry-seed path — **first implementation task is a live repro to confirm severity**, but the code path itself is unambiguous: the picker is reading a field nothing keeps current.
+
+### 3.2 A failed `--resume` silently starts a fresh session with no user-visible signal
+
+`persistent.rs`'s `poison_resume` / `try_capture_session_id` (added in `c39911c2`, #2224) handle the CLI reporting `"No conversation found with session ID: ..."` on stderr (e.g. after a config-dir/cwd mismatch breaks the `~/.claude/projects/<encoded-cwd>/` lookup `--resume` depends on). On that error, the code blanks the poisoned session id and lets the next respawn start genuinely fresh.
+
+This is a reasonable *recovery* — better than looping on the same error — but the fix commit's own message frames the outcome as "starts a fresh conversation and gets a real reply instead of erroring again," and the only trace is a `tracing::warn!` in the host log. **No `AgentFailure` is raised, no wave event fires, nothing reaches the frontend.** The user asks a question, gets a normal-looking reply, and has no way to know the agent just lost all memory of the prior conversation.
+
+The subprocess controller path (`blockcontroller/subprocess/session.rs`'s `hydrate_session_id_from_config`) has the same property — best-effort hydration, silently overwritten by whatever the CLI's own init event reports, no signal either way.
+
+### 3.3 Compounding factor: the registry backfill never re-heals an already-set (now-wrong) record
+
+`backfill_session_ids` explicitly skips any registry record that already has a non-empty `session_id` (idempotent by design, so it doesn't fight a legitimately-advancing conversation). But this means once 3.2 poisons and replaces a session, or once 3.1 launches a fresh session under a stale-but-non-empty id, the registry's record is wrong **forever** — nothing re-derives it from disk again. Any future cross-channel resume of that same agent inherits the wrong anchor.
+
+## 4. Design
+
+Two independent fixes, both scoped tightly to avoid re-touching the working cross-channel mechanism in §2.
+
+### 4.1 Fix the picker's session id staleness (closes 3.1)
+
+Preferred approach — make the local row authoritative instead of stale, since that's what `ListRecentSessionsCommand`'s existing "prefer local" logic already assumes is possible:
+
+- Wire `persist_session_id` (`blockcontroller/core.rs`) to also call `UpdateAgentInstanceCommand`'s underlying `Store::instance_update_partial` when it writes the block's `agent:sessionid` meta, so the local instance row tracks the live session id the same turn it's captured — not just at block-meta level.
+- This is the smallest change that restores the *intended* design (the June plan's Phase-1-item-1, "populate registry `session_id` on every turn," which #2059 shipped a disk-scan alternative to instead of the live-write — this closes that gap rather than reopening a design debate).
+- Fallback/defense-in-depth: `ListRecentSessionsCommand` should fall back to the registry record when the local row's `session_id` is empty, instead of trusting an empty local value as "no session exists." Cheap, and correct regardless of whether 4.1's primary fix lands cleanly.
+
+### 4.2 Surface resume failure/degradation to the user (closes 3.2, mitigates 3.3)
+
+Extend the existing `AgentFailure` taxonomy (`docs/specs/SPEC_AGENT_FAILURE_RECOVERY_UI_2026_06_16.md`, `failure-accessory.ts`) rather than inventing a new banner system:
+
+- New failure class, e.g. `session_resume_failed` (naming TBD at implementation time — `resume_poisoned` or `session_continuity_lost` are alternatives). Fired from `persistent.rs`'s `poison_resume` path (and the subprocess-controller equivalent) via `persist_last_failure` (`core.rs`) the same way every other classified failure already reaches the frontend, instead of only `tracing::warn!`.
+- Banner copy should be unambiguous that this is not a normal error: something like *"Couldn't resume the previous conversation — started a new one. Your prior conversation is still saved."* (Confirm the prior transcript really is still reachable — e.g. via the CLI's own session picker / `--resume` history — before finalizing this claim in copy; don't assert recoverability without checking.)
+- Action affordance: at minimum a dismiss. A "View prior conversation" action (if the old transcript is independently viewable) would be a strong follow-up but is not required for this spec's guarantee — the guarantee is *disclosure*, not automatic recovery.
+- Once 4.2 lands, also emit the same signal (or reuse the same event) at the moment 3.1's stale-empty-session-id causes a picker-driven reattach to spawn fresh instead of resuming — both are instances of the same user-facing promise being broken, and should look the same to the user regardless of which internal path caused it.
+
+### 4.3 Registry self-healing (mitigates 3.3, lower priority)
+
+Not required to satisfy the core guarantee (4.1 + 4.2 together already ensure either correct resume or visible disclosure), but worth tracking as a follow-up: once a poisoned/replaced session is flagged via 4.2, consider clearing the registry record's `session_id` back to empty so the next `backfill_session_ids` pass can re-derive the best available anchor from disk, rather than leaving a known-wrong value in place indefinitely.
+
+## 5. Acceptance criteria
+
+1. **Close/reopen in the same running instance, via the "My Agents" picker, resumes the real prior session** — verified by an e2e test: launch an agent, send a message, close the pane, reopen via `handleReattach`, assert the spawned CLI's `--resume` argument matches the session id from the first turn (not empty, not a newly-invented one).
+2. **A resume failure (simulated: point `--resume` at a session id that doesn't exist) produces a visible `AgentFailure`/banner**, not just a log line — verified by a test asserting the wave event / `agent:last_failure` meta is set and a `PaneRow` action-map entry exists for the new class.
+3. **No regression to the §2 cross-channel mechanism** — its existing tests (`largest_session_beats_a_fresh_short_one`, `backfill_fills_empties_picks_largest_and_is_idempotent`, the `agent_live_elsewhere` concurrency guard tests) continue passing unchanged.
+4. **`ListRecentSessionsCommand`'s local-row session id is live**, verified by a test: launch, send a message, query `ListRecentSessionsCommand` without closing the pane, assert the returned `session_id` is non-empty and matches the block's own `agent:sessionid` meta.
+
+## 6. Non-goals
+
+- Does not change `--resume`'s underlying CLI behavior or attempt to make Claude Code re-read `CLAUDE.md`/project-memory on resume — that's a separate, currently-unverified question (see the research trail that triggered this spec) about the CLI's own internals, out of scope here.
+- Does not build automatic prior-conversation recovery/merge UI — disclosure is the bar, not recovery, per §4.2.
+- Does not address the subprocess-controller path's lack of an equivalent `poison_resume` detector (`hydrate_session_id_from_config` currently has no failure-mode detection at all, only best-effort hydration) — flagged as a real gap but the persistent/Claude controller is the primary path and should land first; the subprocess controller should get the same treatment as a fast follow-up once the failure-classification wiring exists.
+
+## 7. Open questions for implementation time
+
+- Confirm via live repro whether 3.1's stale-empty-`session_id` actually reaches a silent-fresh-spawn today, or whether some other guard incidentally catches it (the research pass flagged the code path as unambiguous but did not drive a live repro to confirm the end-to-end outcome).
+- Confirm whether the prior transcript is genuinely still reachable/viewable after 3.2's silent replacement, before promising that in the banner copy.
+- Decide the exact failure-class name and whether it needs its own icon or can reuse an existing one from `failure-accessory.ts`'s map.

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -123,6 +123,29 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
         }
     };
 
+    // SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.2: server
+    // sets `session:resume_failed` when a `--resume <sid>` was rejected by
+    // the CLI (stale/unreachable session, e.g. after a relogin moved this
+    // agent to a different config dir) and it silently fell through to a
+    // fresh conversation. Unlike `was_interrupted`, there's nothing to
+    // "resume on next message" here — the fresh session already started;
+    // this banner only discloses that it happened, since the alternative
+    // (silence) means the user has no way to know their prior conversation
+    // is gone.
+    const resumeFailed = (): boolean =>
+        (blockAtom()?.meta?.["session:resume_failed"] as boolean | undefined) === true;
+
+    const dismissResumeFailed = async () => {
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", blockId),
+                meta: { "session:resume_failed": null } as MetaType,
+            });
+        } catch (e) {
+            console.error("failed to clear resume_failed:", e);
+        }
+    };
+
     return (
         <div class="agent-control-bar">
             {/* ── Interrupted-session recovery banner (4.2 multi-day continuity) ── */}
@@ -135,6 +158,22 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
                         class="agent-session-btn agent-session-btn-dismiss"
                         onClick={dismissInterrupted}
                         title="Dismiss this notice — your next message resumes the session either way"
+                    >
+                        Dismiss
+                    </button>
+                </div>
+            </Show>
+
+            {/* ── Resume-failed disclosure (continuity guarantee §4.2) ── */}
+            <Show when={resumeFailed()}>
+                <div class="agent-resume-failed-banner">
+                    <span class="agent-resume-failed-label">
+                        Couldn't resume the previous conversation — started a new one.
+                    </span>
+                    <button
+                        class="agent-session-btn agent-session-btn-dismiss"
+                        onClick={dismissResumeFailed}
+                        title="Dismiss this notice"
                     >
                         Dismiss
                     </button>

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -428,6 +428,27 @@
         }
     }
 
+    // SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.2 — same
+    // shape as .agent-interrupted-banner (a resume-related session-state
+    // notice), warning-toned instead of accent-toned since this reports a
+    // conversation was actually lost, not just a pending recovery step.
+    .agent-resume-failed-banner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+        padding: var(--space-1) var(--space-2);
+        background: color-mix(in srgb, var(--warning-color, #d97706) 14%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--warning-color, #d97706) 30%, transparent);
+        font-size: 11px;
+        color: var(--main-text-color);
+
+        .agent-resume-failed-label {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+    }
+
     .agent-large-session-banner {
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Summary

Implements `docs/specs/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md`: **closing an agent's pane and reopening it must resume the same conversation, or the user must be told it couldn't.** Written after a user question about whether Armory workspace rules are "always available" to a running agent surfaced that pane-reopen's `--resume` success was unverified end-to-end — investigating that turned up two real, evidenced gaps, both closed here.

### Gap 1 — the picker could be handed a permanently-stale session id

`ListRecentSessionsCommand` prefers the local `db_agent_instances` row over the shared registry, but that row's `session_id` was set to `""` at instance creation and **never updated again in production** — the RPC that would keep it live (`updateagentinstance`) had zero frontend callers. Any agent launched at least once in the running app had a stale local session id, so closing its pane and reopening via "My Agents" could silently start a genuinely fresh conversation instead of resuming (per `agent-model.ts`'s own documented invariant: an empty `continueSessionId` clears `agent:sessionid` on the new block, by design, to avoid a *different* prior bug).

**Fix:** `persist_session_id` (the live-turn call site every controller already uses) now also writes through to the matching `db_agent_instances` row, via a new `Store::instance_get_by_block_id` + `instance_update_partial`. Added a registry fallback in `ListRecentSessionsCommand` too, for defense-in-depth regardless of whether a given row predates this fix.

### Gap 2 — a failed resume recovered silently

`persistent.rs` already recovers gracefully when a `--resume <sid>` is rejected (stale/unreachable session, e.g. after a relogin moves an agent to a different config dir): it clears the poisoned id and lets the next respawn start fresh. But this was completely silent — only a `tracing::warn!`, no signal to the frontend at all. The user would just get an agent that's forgotten everything, with no indication anything happened.

**Fix:** a new `session:resume_failed` meta flag (`session_recovery.rs`, same frontend-only-signal contract as the existing `session:was_interrupted` flag/banner), set at the exact point `persistent.rs`'s `poison_resume` path fires, plus a matching `AgentControlBar` banner + dismiss action mirroring the existing `was_interrupted` banner's shape and copy style.

## Test plan

- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1661 passed, 0 failed. 5 new/updated tests: `instance_get_by_block_id`, `persist_session_id_writes_through_to_the_instance_row`, `persist_session_id_is_a_noop_for_a_block_with_no_instance_row`, `mark_resume_failed_sets_the_flag`.
- [x] `npx vitest run` frontend suite — 751 passed, 0 failed, no regressions.
- [x] `cargo check -p agentmux-srv` — clean.
- [~] Live UI verification of the banner itself was attempted in a `task dev` instance but inconclusive — a manual out-of-band SQLite edit used to set the flag (to avoid needing to trigger a real `--resume` failure) desynced the running srv's in-memory object-version tracking and left that one pane stuck loading. Not a regression from this PR's code (confirmed via host log — no errors, purely a side effect of writing to the live DB file outside the srv's own update path); the banner mechanism itself is code-identical to the already-shipped, working `session:was_interrupted` banner (same signal-read/dismiss/JSX pattern). Flagging this transparently rather than claiming a clean live verification that didn't actually happen.

<!-- agentmux:agent_id=agent1 -->
