### PR TITLE
fix(armory): align ArmorySection ids with their labels

### DIFF
--- a/.changesets/1785195417-fix-armory-align-armorysection-ids-with-their-labels-memory--0itj.md
+++ b/.changesets/1785195417-fix-armory-align-armorysection-ids-with-their-labels-memory--0itj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): align ArmorySection ids with their labels (memory/bundles, not brain/memories)

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -6,7 +6,7 @@ import { useBlockAtom } from "@/app/store/global";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, type Accessor } from "solid-js";
 
-export type ArmorySection = "accounts" | "brain" | "skills" | "mcp" | "memories";
+export type ArmorySection = "accounts" | "memory" | "skills" | "mcp" | "bundles";
 
 export class ArmoryViewModel implements ViewModel {
     viewType = "armory";

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -16,10 +16,10 @@ import "./armory-view.scss";
 
 const RAIL: { id: ArmorySection; label: string; icon: string }[] = [
     { id: "accounts", label: "Accounts",    icon: "key" },
-    { id: "brain",    label: "Memories",    icon: "brain" },
+    { id: "memory",   label: "Memories",    icon: "brain" },
     { id: "skills",   label: "Skills",      icon: "wand-magic-sparkles" },
     { id: "mcp",      label: "MCP Servers", icon: "plug" },
-    { id: "memories", label: "Bundles",     icon: "layer-group" },
+    { id: "bundles",  label: "Bundles",     icon: "layer-group" },
 ];
 
 export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Element {
@@ -84,7 +84,7 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "accounts" }}>
                         <AccountsManager />
                     </div>
-                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "brain" }}>
+                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "memory" }}>
                         <GlobalBrainManager />
                     </div>
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "skills" }}>
@@ -93,7 +93,7 @@ export function ArmoryView(props: ViewComponentProps<ArmoryViewModel>): JSX.Elem
                     <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "mcp" }}>
                         <McpManager />
                     </div>
-                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "memories" }}>
+                    <div class="bundle-manager-pane" classList={{ "is-hidden": section() !== "bundles" }}>
                         <MemoryManager />
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

The Armory rail's Phase 5 rename (Memory -> Memories, Bundles) changed the display labels but left the underlying `ArmorySection` ids pointing at the wrong-sounding pane:

- `id: "brain"` sat behind the **"Memories"** label and the `GlobalBrainManager` pane.
- `id: "memories"` sat behind the **"Bundles"** label and the `MemoryManager` pane.

So `section() === "memories"` actually finds the Bundles pane, not the one labeled "Memories" — misleading for anyone reading or extending `armory-view.tsx`.

## Fix

Renamed the two ids to match their labels/purpose: `"brain"` -> `"memory"`, `"memories"` -> `"bundles"`. This also aligns with the sibling per-agent `AgentStashModal`'s `StashTabId`, which already uses `"memory"` for its own Memories tab.

No behavior change — same five sections, same order, same panes, same labels. Confirmed (via grep) no other code references the old id strings; the existing rail test only asserts on labels/DOM, not ids.

## Verification

- `npx tsc -p tsconfig.json --noEmit` — clean
- `npx vitest run app/view/armory` — 9/9 passed
- `npx vitest run app/view` (full view suite, regression check) — 882/882 passed

<!-- agentmux:agent_id=agent3 -->