### PR TITLE
feat(agent): harden Working-state and scroll-follow against 4 recurring desync bugs

### DIFF
--- a/.changesets/1785196188-feat-agent-harden-working-state-and-scroll-follow-against-4--f1fl.md
+++ b/.changesets/1785196188-feat-agent-harden-working-state-and-scroll-follow-against-4--f1fl.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): harden Working-state and scroll-follow against 4 recurring desync bugs

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -489,7 +489,19 @@ pub fn resync_controller(
     }
 }
 
-/// Publish a controller status event via WPS broker.
+/// Publish a controller status event via WPS broker. The sole publish point
+/// for `controllerstatus`, used by every controller type (persistent CLI,
+/// subprocess CLI, ACP agents, plain shell/PTY panes — 13 call sites).
+///
+/// `persist: 1` so a reconnecting subscriber (WS reconnect, srv restart)
+/// replays the last known status instead of seeing nothing until the next
+/// live event — mirrors `EVENT_AGENT_FAILURE`'s identical `persist: 1` in
+/// `subprocess/host_spawn.rs`. Closes the "missed the one turn-end push,
+/// stuck showing Working forever" gap for the reconnect case; see
+/// REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md §3/§4 item 5.
+/// (A same-connection pane remount, which doesn't clear the broker's
+/// per-route replay tracking, isn't covered by persist alone — see the
+/// focus-triggered reconcile in `agent-view.tsx` for that case.)
 pub fn publish_controller_status(
     broker: &super::wps::Broker,
     status: &BlockControllerRuntimeStatus,
@@ -500,7 +512,7 @@ pub fn publish_controller_status(
         event: EVENT_CONTROLLER_STATUS.to_string(),
         scopes: vec![format!("block:{}", status.blockid)],
         sender: String::new(),
-        persist: 0,
+        persist: 1,
         data: serde_json::to_value(status).ok(),
     };
     broker.publish(event);
@@ -639,5 +651,32 @@ mod tests {
         let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown controller type"));
+    }
+
+    /// Regression: `publish_controller_status` must persist (not fire-once),
+    /// so a reconnecting subscriber picks up the last known `turn_active`
+    /// state instead of nothing — see this function's doc comment and
+    /// REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md §3/§4
+    /// item 5.
+    #[test]
+    fn test_publish_controller_status_persists_for_replay() {
+        let broker = super::super::wps::Broker::new();
+        let status = BlockControllerRuntimeStatus {
+            blockid: "block-persist-test".to_string(),
+            turn_active: true,
+            ..Default::default()
+        };
+        publish_controller_status(&broker, &status);
+
+        let history = broker.read_event_history(
+            super::super::wps::EVENT_CONTROLLER_STATUS,
+            "block:block-persist-test",
+            1,
+        );
+        assert_eq!(history.len(), 1, "publish must persist at least the latest event");
+        let replayed: BlockControllerRuntimeStatus =
+            serde_json::from_value(history[0].data.clone().unwrap()).unwrap();
+        assert_eq!(replayed.blockid, "block-persist-test");
+        assert!(replayed.turn_active);
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -319,15 +319,34 @@ impl PersistentSubprocessController {
     /// `core::spawn_health_watchdog` ("duplicated verbatim... before this
     /// extraction"); worth factoring out if a second controller type needs
     /// the same heartbeat.
+    ///
+    /// Same latent duplicate-loop race as `spawn_health_watchdog`'s existing,
+    /// already-accepted contract (reagent P2 on the PR that introduced this
+    /// function): if a turn ends and a new one starts again within one
+    /// `HEARTBEAT_SECS` window, the old loop hasn't yet woken up to observe
+    /// `is_active_turn() == false` and break, so both the old and new loop
+    /// can run concurrently for that window. Harmless — `publish_status`
+    /// republishing the same (or a slightly stale) snapshot twice is
+    /// idempotent from the frontend's point of view — so this is accepted
+    /// rather than fixed, matching the pre-existing pattern.
     fn spawn_status_heartbeat(&self) {
         const HEARTBEAT_SECS: u64 = 20;
+        self.spawn_status_heartbeat_with_interval(tokio::time::Duration::from_secs(HEARTBEAT_SECS));
+    }
+
+    /// Interval parameterized out of `spawn_status_heartbeat` so a test can
+    /// drive it with a short, real (not virtual-clock) interval instead of
+    /// waiting out `HEARTBEAT_SECS` — this crate doesn't enable tokio's
+    /// `test-util` feature (needed for `start_paused`/`time::advance`), and
+    /// adding it crate-wide for one test wasn't judged worth it.
+    fn spawn_status_heartbeat_with_interval(&self, heartbeat_interval: tokio::time::Duration) {
         let inner = Arc::clone(&self.inner);
         let block_id = self.block_id.clone();
         let broker = self.broker.clone();
         let health_monitor = Arc::clone(&self.health_monitor);
         tokio::spawn(async move {
             let Some(broker) = broker else { return };
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(HEARTBEAT_SECS));
+            let mut interval = tokio::time::interval(heartbeat_interval);
             interval.tick().await; // first tick is immediate; publish_status() already ran at turn start
             loop {
                 interval.tick().await;
@@ -1395,6 +1414,41 @@ mod send_input_tests {
             !c.get_status_snapshot().turn_active,
             "turn_active must flip back false once the turn ends"
         );
+    }
+
+    /// Regression for reagent P2 (persist-controllerstatus PR): confirms
+    /// `spawn_status_heartbeat` actually republishes while a turn stays
+    /// active, using a short real interval (`spawn_status_heartbeat_with_interval`)
+    /// instead of waiting out the production 20s — this crate doesn't enable
+    /// tokio's `test-util` feature, so a real (short) interval is used
+    /// rather than a virtual/paused clock.
+    #[tokio::test]
+    async fn status_heartbeat_republishes_while_active() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            "block-heartbeat".to_string(),
+            Some(broker.clone()),
+            None,
+            None,
+            None,
+        );
+        c.health_monitor.set_active_turn(true);
+        c.spawn_status_heartbeat_with_interval(tokio::time::Duration::from_millis(5));
+
+        // Generous margin over several 5ms ticks — proves at least one
+        // heartbeat tick actually published, without asserting an exact count
+        // (real-time scheduling, not virtual-clock-deterministic).
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_CONTROLLER_STATUS,
+            "block:block-heartbeat",
+            1,
+        );
+        assert_eq!(history.len(), 1, "heartbeat must have published at least once while active");
+        let status: BlockControllerRuntimeStatus =
+            serde_json::from_value(history[0].data.clone().unwrap()).unwrap();
+        assert!(status.turn_active, "published snapshot must reflect the active turn");
     }
 }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -350,9 +350,7 @@ impl PersistentSubprocessController {
             interval.tick().await; // first tick is immediate; publish_status() already ran at turn start
             loop {
                 interval.tick().await;
-                if !health_monitor.is_active_turn() {
-                    break;
-                }
+                let still_active = health_monitor.is_active_turn();
                 let status = {
                     let g = inner.lock().unwrap();
                     BlockControllerRuntimeStatus {
@@ -363,10 +361,21 @@ impl PersistentSubprocessController {
                         shellprocexitcode: g.proc_exit_code,
                         spawn_ts_ms: None,
                         is_agent_pane: true,
-                        turn_active: health_monitor.is_active_turn(),
+                        turn_active: still_active,
                     }
                 };
                 super::publish_controller_status(&broker, &status);
+                // Publish the final `turn_active: false` snapshot BEFORE
+                // exiting, not just break silently — reagent P1: this
+                // heartbeat exists specifically to backstop a missed live
+                // turn-end push (the exact stuck-"Working"-forever bug this
+                // PR fixes). Breaking without this last publish meant the
+                // one case it's most needed for — the terminal push being
+                // the one that got dropped — was the one case it didn't
+                // help.
+                if !still_active {
+                    break;
+                }
             }
         });
     }
@@ -1449,6 +1458,51 @@ mod send_input_tests {
         let status: BlockControllerRuntimeStatus =
             serde_json::from_value(history[0].data.clone().unwrap()).unwrap();
         assert!(status.turn_active, "published snapshot must reflect the active turn");
+    }
+
+    /// Regression for reagent P1 (round 2 on the persist-controllerstatus
+    /// PR): the heartbeat loop must publish one final `turn_active: false`
+    /// snapshot before exiting, not just break silently. This is the exact
+    /// case the heartbeat exists to backstop — a missed live turn-end
+    /// push — so a silent exit with no final publish would leave the
+    /// client stuck showing "Working" in precisely the scenario this whole
+    /// mechanism was built for.
+    #[tokio::test]
+    async fn status_heartbeat_publishes_final_inactive_status_before_stopping() {
+        let broker = Arc::new(crate::backend::wps::Broker::new());
+        let c = PersistentSubprocessController::new(
+            "tab".to_string(),
+            "block-heartbeat-stop".to_string(),
+            Some(broker.clone()),
+            None,
+            None,
+            None,
+        );
+        c.health_monitor.set_active_turn(true);
+        c.spawn_status_heartbeat_with_interval(tokio::time::Duration::from_millis(5));
+
+        // Let at least one active-turn tick land, then mark the turn ended —
+        // simulating the exact scenario: the "real" turn-end publish (from
+        // wherever normally calls publish_controller_status on completion)
+        // is the one that got dropped, and the heartbeat is the only thing
+        // left that can correct the client's stale "Working" state.
+        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
+        c.health_monitor.set_active_turn(false);
+        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
+
+        let history = broker.read_event_history(
+            crate::backend::wps::EVENT_CONTROLLER_STATUS,
+            "block:block-heartbeat-stop",
+            1,
+        );
+        assert_eq!(history.len(), 1, "must have published at least the final status");
+        let status: BlockControllerRuntimeStatus =
+            serde_json::from_value(history[0].data.clone().unwrap()).unwrap();
+        assert!(
+            !status.turn_active,
+            "the heartbeat's last publish before stopping must reflect turn_active: false, \
+             not silently disappear leaving the client on a stale turn_active: true"
+        );
     }
 }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -300,6 +300,58 @@ impl PersistentSubprocessController {
         }
     }
 
+    /// Periodic (low-frequency) republish of the current controllerstatus
+    /// while a turn is active — a self-healing backstop independent of
+    /// `publish_controller_status`'s `persist: 1` (which only helps a
+    /// reconnecting subscriber) and the frontend's focus-triggered reconcile
+    /// (which only fires on a background→foreground transition). If a single
+    /// live push is missed for some other reason (e.g. a throttled/backgrounded
+    /// renderer coalescing WS messages) while the window stays foregrounded
+    /// and connected the whole time, nothing else corrects it until the turn
+    /// actually ends. This shrinks that window from "forever" to at most one
+    /// heartbeat interval. `HEARTBEAT_SECS` is well below the frontend's own
+    /// `STUCK_THRESHOLD_MS` (45s, diagnostic-only) and `LIVENESS_RECOVERY_MS`
+    /// (180s, force-recovery) so a missed push self-heals long before either
+    /// of those fire. See REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md
+    /// §4 item 5. Duplicates `get_status_snapshot`'s field construction
+    /// rather than calling it, since the spawned task only holds cloned
+    /// `Arc`s, not `&self` — matches the existing precedent noted on
+    /// `core::spawn_health_watchdog` ("duplicated verbatim... before this
+    /// extraction"); worth factoring out if a second controller type needs
+    /// the same heartbeat.
+    fn spawn_status_heartbeat(&self) {
+        const HEARTBEAT_SECS: u64 = 20;
+        let inner = Arc::clone(&self.inner);
+        let block_id = self.block_id.clone();
+        let broker = self.broker.clone();
+        let health_monitor = Arc::clone(&self.health_monitor);
+        tokio::spawn(async move {
+            let Some(broker) = broker else { return };
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(HEARTBEAT_SECS));
+            interval.tick().await; // first tick is immediate; publish_status() already ran at turn start
+            loop {
+                interval.tick().await;
+                if !health_monitor.is_active_turn() {
+                    break;
+                }
+                let status = {
+                    let g = inner.lock().unwrap();
+                    BlockControllerRuntimeStatus {
+                        blockid: block_id.clone(),
+                        version: g.status_version,
+                        shellprocstatus: g.proc_status.clone(),
+                        shellprocconnname: "local".to_string(),
+                        shellprocexitcode: g.proc_exit_code,
+                        spawn_ts_ms: None,
+                        is_agent_pane: true,
+                        turn_active: health_monitor.is_active_turn(),
+                    }
+                };
+                super::publish_controller_status(&broker, &status);
+            }
+        });
+    }
+
     fn is_running(&self) -> bool {
         let inner = self.inner.lock().unwrap();
         inner.stdin_tx.is_some()
@@ -356,6 +408,7 @@ impl PersistentSubprocessController {
         let was_active = self.health_monitor.mark_turn_active_returning_was_active();
         if !was_active {
             core::spawn_health_watchdog(&self.health_monitor);
+            self.spawn_status_heartbeat();
         }
         // Publish the turn_active flip so the Swarm view's live
         // ControllerStatus subscription picks it up immediately instead of
@@ -412,6 +465,7 @@ impl PersistentSubprocessController {
         let was_active = self.health_monitor.mark_turn_active_returning_was_active();
         if !was_active {
             core::spawn_health_watchdog(&self.health_monitor);
+            self.spawn_status_heartbeat();
         }
         self.publish_status();
 
@@ -1031,6 +1085,7 @@ impl PersistentSubprocessController {
         // dies (120 s) without producing meaningful output, giving the
         // frontend enough signal to show a "not responding" warning.
         core::spawn_health_watchdog(&self.health_monitor);
+        self.spawn_status_heartbeat();
 
         // Spawn process waiter task
         let block_id_wait = self.block_id.clone();

--- a/docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md
+++ b/docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md
@@ -1,0 +1,111 @@
+# Report: "Worked" silently reverting to "Working…" with no user input, and a pane stuck on an unanswerable AskUserQuestion
+
+**Date:** 2026-07-27
+**Author:** Agent1
+**Status:** Audit only — root causes identified/hypothesized from code, one live-confirmed via direct observation (Agent2's pane), fixes proposed, nothing implemented yet.
+**Triggered by:** two live incidents observed in the same session — (1) Agent2's pane (block `210a0e08-1740-4bf0-8f26-93c82a107e4c`), running concurrently in an adjacent pane, visibly stuck on an AskUserQuestion prompt with no way to resolve it; (2) a separate, repeated observation that a pane shows "Worked" and then reverts to "Working…" with no user message sent in between.
+
+This report is a companion to two same-day documents already in the repo — `docs/reports/REPORT_WORKING_STATE_TELEMETRY_AUDIT_2026_07_27.md` (catalogs 9 other false-"Working" paths, mostly about a turn never *ending*) and `docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md` (the fire-once `controllerstatus` event gap). Neither covers the two issues below: this report is about a turn that legitimately *did* end, then un-ends itself, and about a specific stuck-forever panel shape distinct from a stuck turn.
+
+---
+
+## 1. "Worked" reverting to "Working…" with no user input
+
+### 1.1 Root cause — confirmed, and it's intentional by design
+
+`frontend/app/store/agent-pane-state/reducer.ts`, the `StreamFlushObserved` case (~line 198-256). When a live stream flush arrives while `turnPhase` is `Done` with `outcome === "completed"` (i.e. the pane is showing "Worked"), the reducer promotes it straight back to `Streaming`:
+
+```ts
+: state.turnPhase.kind === "Submitting"
+    || state.turnPhase.kind === "Idle"
+    || state.turnPhase.kind === "Disconnected"
+    || (state.turnPhase.kind === "Done" && state.turnPhase.outcome === "completed")
+    ? {
+          kind: "Streaming",
+          bufferSize: newBuf,
+          toolsActive: 0,
+          lastEventMs: command.at,
+      }
+    : state.turnPhase;
+```
+
+The inline comment explains why this exists: `session_end` fires after **every** model API round, not just the true end of a turn — so `Done.completed` can mean "round 1 of a multi-round tool-continuation just finished," and if a second round's output starts streaming in, the reducer *has* to leave `Streaming`-land or the working indicator would read "Worked" while the agent is visibly still typing. `StreamFlushObserved` is documented as only ever dispatched for **live** stream content, never history replay — so today's authors believed a flush arriving in `Done.completed` is airtight proof of genuine continued work. `Done.errored` / `Done.stopped` / `Done.interrupted` are deliberately excluded from this promotion (a late stray flush after a failed/stopped turn must not resurrect it) — only `.completed` re-arms.
+
+**This is not a bug in the sense of "wrong code" — it's a real design tension.** Multi-round tool continuations are a genuine backend behavior (the CLI legitimately emits `session_end` mid-conversation), and the reducer's job is to represent that faithfully. The user-visible problem is a UX one: **the pane shows a settled "Worked" state for a span of time that, from the backend's point of view, was never actually settled** — there was no way for the user to know that "Worked" might not be final. That's exactly the shape of the report: "we go into a completed state, then go back into Working… without the user having entered any input."
+
+### 1.2 Why a blanket "never leave Done without user input" rule would break something real
+
+Taking the user's literal ask at face value — "never let a Working… come back from a Worked without user input" — would require either:
+- Disabling the `Done.completed` branch of the promotion above, which would leave the UI stuck showing "Worked" while the agent is demonstrably still producing output for any genuine multi-round continuation (a strictly worse bug: a *false* "done" during real work, which is worse than a false "still working" after real work — the former could make a user walk away mid-task).
+- Or somehow distinguishing "this flush is a genuine continuation" from "this flush is stray/leftover" at dispatch time — but per the code's own comment, there is currently no such distinction available; `StreamFlushObserved` firing is already gated to live-only content.
+
+So the fix can't be "delete the promotion" — it has to change **what the user is shown**, and **when**, without changing what the backend state machine internally tracks (session-digest correctness depends on `Done.completed` firing at the right point per-round, per `docs/specs/SPEC_WORKING_STATE_LIVENESS_MODEL_2026_06_29.md`'s existing framing, referenced in the watchdog code nearby).
+
+### 1.3 Proposed invariant: a "settled" grace window, decoupled from internal state
+
+Introduce a short grace window (proposed: 400-600ms — long enough to absorb a same-breath continuation, short enough that a genuinely-finished turn still visibly settles almost immediately) between "internal state says Done.completed" and "the UI is allowed to call it truly finished and stop accepting silent re-promotion":
+
+- Internal `turnPhase` keeps behaving exactly as it does today — no behavior change to the state machine, no risk to session-digest stats, no change to the promotion logic in §1.1.
+- Add a UI-facing derived flag, e.g. `settled: boolean`, computed as "`turnPhase.kind === 'Done' && outcome === 'completed'` AND at least `SETTLE_GRACE_MS` has elapsed since the phase entered `Done` with no intervening `StreamFlushObserved`." This is a pure timer/derived-signal addition, not a reducer change — it can live alongside the existing watchdog-tick machinery (`StreamWatchdogTick` already runs a periodic check; a settle-check is the same shape at a much shorter interval, or a one-shot `setTimeout` armed when `Done.completed` is first entered and cleared if a flush arrives before it fires).
+- Once `settled` has been `true` for a given `Done.completed` episode, a subsequent `StreamFlushObserved` should **still** promote `turnPhase` back to `Streaming` internally (so the underlying multi-round tracking stays correct) — but the UI layer should treat this specific case as a **new, visually distinct episode** ("Working again — new round") rather than silently reverting the "Worked" checkmark the user already saw settle. This satisfies the spirit of the ask — a *settled* "Worked" can never silently, invisibly un-happen — while still being honest that the agent picked up more work, instead of hiding it.
+- Whether "new episode" should mean an actual audible/visual notification (distinct from the routine "Working…" ambient state) is a product decision worth confirming before implementing — flagged as an open question, not resolved here.
+
+### 1.4 Sizing/risk
+
+Small-to-medium. No reducer/type-machine changes required for the core fix (§1.3's `settled` flag is additive and derived); the only design risk is picking the right `SETTLE_GRACE_MS` value and deciding how "re-opened as a new episode" should look/sound to the user. Recommend confirming both with the user before implementing.
+
+---
+
+## 2. Agent2's pane stuck on an unanswerable AskUserQuestion
+
+### 2.1 What was directly observed
+
+Agent2 (block `210a0e08-1740-4bf0-8f26-93c82a107e4c`), running live in the pane adjacent to this one, is stuck showing an AskUserQuestion prompt (`AgentQuestionPanel`) that isn't resolving. Direct live inspection of Agent2's own backend state (its `db_agent_instances`/block meta row) was **attempted and not completed** in this pass — the `objects.db` reachable from this environment (`C:\Users\asafe\.agentmux\dev\main\data\db\objects.db`) turned out to hold a small, stale instance (3 blocks, 1 tab/window/workspace total) rather than the live multi-agent instance Agent1-5 are actually running in; the correct live DB's location wasn't located in this pass. So the analysis below is grounded in code reading, not a live state dump — flagged explicitly so it isn't mistaken for a confirmed root cause.
+
+### 2.2 Code path
+
+- `frontend/app/view/agent/hooks/useAgentQuestions.ts`: `pendingQuestions()` returns every `ToolNode` with `status === "awaiting_answer"` (oldest first); the panel renders the head. `handleAnswer()` optimistically flips the node to `status: "success"` via a local `StreamFlush` dispatch, then calls `RpcApi.AgentAnswerCommand`; only on a *caught* RPC failure does it roll the optimistic change back (or fall through to a follow-up-message delivery path for non-persistent agents).
+- `frontend/app/store/agent-document/reducer.ts`, `scrubOrphanedInProgress()` (~line 38-137): on certain document rebuilds (reconnect/backfill/history-load), any `awaiting_answer` tool node that has real content **after** it in the document is resolved to `success` (the conversation clearly continued past it, so it must have been answered). But — deliberately, per the inline comment — **a TAIL `awaiting_answer` node (the very last node in the document) is left alone**, on the reasoning that "it may still be answerable... a one-shot agent that just asked, or a resumable reopened session."
+
+### 2.3 Hypothesis — an optimistic-answer / resync race, same shape as the login-persist bug fixed earlier today
+
+`handleAnswer()`'s optimistic transition lives only in the client's in-memory document state at first, applied via a local `StreamFlush` dispatch (actor `"user"`) *before* the RPC call is even sent, let alone confirmed durable server-side. If, after that optimistic flip, anything triggers a **full document resync from the server's own transcript** (a reconnect, a pane reopen, a backfill after a dropped WS connection — several of which are already-documented mechanisms elsewhere in this session's work, e.g. `session_backfill.rs`'s startup disk-scan) **before the answer RPC has actually landed and been durably reflected in that transcript**, the resync rebuilds the document from a transcript that still shows the question as `awaiting_answer`. Because that node is (still) the tail, `scrubOrphanedInProgress`'s deliberate "leave the tail alone" rule preserves it rather than resolving it — the optimistic client-side "success" is silently discarded, and the panel reappears/re-hangs on a question that, from the user's point of view, was already answered.
+
+This is structurally identical to the root cause behind §5a of `docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md` (an optimistic/local state change that races a separate resync path reading from a not-yet-updated source of truth) and to the general theme surfaced by the earlier §4.1 session-continuity work this session did (a locally-applied change that never got durably written where a later reconciliation path looks for it). It is also consistent with the RPC's own documented failure mode: `AgentAnswerCommand` can legitimately fail with `UNSUPPORTED_CONTROLLER` for non-persistent/container agents, at which point the code deliberately does NOT roll back the optimistic "success" state (comment: "Keep the optimistic success") and instead tries a follow-up-message delivery — if *that* follow-up itself silently fails in a way that doesn't reach the `.catch` at line 125-128 (e.g., the message is accepted by the RPC layer but the backend never actually resumes the parked tool_use), the transcript would likewise still show `awaiting_answer` at the tail with nothing left client-side to indicate anything went wrong.
+
+A second, narrower possibility: if Agent2 genuinely has **multiple** questions queued (`pendingQuestions()` returns all matching nodes, panel shows only the head), answering the visible one could look "stuck" to an observer if the *next* one in the queue renders with stale/wrong content, or if the queue's `waiting-for-input`/`waiting-ended` tone-event bookkeeping (lines 65-81) gets out of sync with the actual queue length — worth checking directly against Agent2's live document once reachable.
+
+### 2.4 What would confirm this (next step, not done here)
+
+Direct inspection of Agent2's live document/transcript state is the fastest way to disambiguate the above from a different mechanism entirely (e.g., a rendering-only bug in `AgentQuestionPanel.tsx` itself, unrelated to the document reducer). Locating the correct live `objects.db` (or querying via a running srv's own introspection RPCs rather than a raw file read, to avoid the direct-DB-write hazard already documented in this session — see `docs/specs/SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md`'s PR discussion) and checking whether the tail node's `awaiting_answer` status has a corresponding answer already recorded elsewhere (e.g., in `db_agent_history` or the transcript `.jsonl`) would directly confirm or refute §2.3.
+
+### 2.5 Proposed fix directions (pending confirmation)
+
+- **If §2.3 is confirmed:** the durability gap needs the same shape of fix as the earlier login-persist race — don't let the optimistic client-side transition be the only record of "this was answered" until the RPC has actually round-tripped; and/or make `AgentAnswerCommand`'s delivery synchronously durable (write the answer to the transcript/DB) before the client is allowed to treat it as settled, so a resync mid-flight sees the true post-answer state instead of racing it.
+- Regardless of root cause, add a hard backstop: if a tail `awaiting_answer` node has been sitting unanswered past some generous threshold (e.g. several minutes) with the pane otherwise idle (no `Streaming` activity), surface *something* — even just a log line in the vein of report 1's proposed `[wave-turn]` telemetry — so this state is at least grep-able in `muxlog` instead of only visible by looking at the pane. This mirrors report 1's own top recommendation (watchdog reasoning telemetry) and would have made this exact incident diagnosable without needing live DB access.
+
+### 2.6 Sizing/risk
+
+Unknown until §2.4's live confirmation step is done — could range from a small durability/ordering fix (if §2.3 is right) to a rendering bug (if it's in `AgentQuestionPanel.tsx` itself, not yet audited in this pass). Recommend confirming live before sizing implementation work.
+
+---
+
+## 3. Key files
+
+| Concern | File | Line(s) |
+|---|---|---|
+| `Done.completed` → `Streaming` re-promotion (§1) | `frontend/app/store/agent-pane-state/reducer.ts` | ~198-256 |
+| Watchdog/liveness constants, `TurnPhase` shape | `frontend/app/store/agent-pane-state/types.ts` | full |
+| AskUserQuestion queue + answer handler (§2) | `frontend/app/view/agent/hooks/useAgentQuestions.ts` | full |
+| Question panel render | `frontend/app/view/agent/components/AgentQuestionPanel.tsx` | full |
+| Tail-`awaiting_answer` preservation heuristic (§2.2) | `frontend/app/store/agent-document/reducer.ts` | 38-137 |
+| Stream-parser: where `awaiting_answer` is first set | `frontend/app/view/agent/stream-parser.ts` | ~424-438 |
+| Original AskUserQuestion spec | `docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md` | full |
+| Sibling stuck-Working audit (9 other false-positive paths) | `docs/reports/REPORT_WORKING_STATE_TELEMETRY_AUDIT_2026_07_27.md` | full |
+| Sibling fire-once-event report (structurally same race shape as §2.3) | `docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md` | §5a |
+
+## 4. What this report does not do
+
+- Does not implement either fix — both need a design decision confirmed with the user first (§1.3's grace window + "new episode" presentation; §2.5 pending live confirmation of the actual root cause).
+- Does not re-litigate the 9 paths already cataloged in `REPORT_WORKING_STATE_TELEMETRY_AUDIT_2026_07_27.md` — this report's §1 is a *tenth*, distinct path (a turn re-opening after reaching a real terminal state, not a turn that never terminates).
+- Does not confirm §2's root cause live — flagged explicitly as the next required step before sizing that fix.

--- a/docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md
+++ b/docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md
@@ -1,0 +1,63 @@
+# SPEC: Harden the "Working…" indicator and message-list auto-follow against four related recurring bugs
+
+**Date:** 2026-07-27
+**Status:** Implemented (this pass covers the low-risk, high-confidence mechanisms; two items are explicitly deferred, see §5)
+**Author:** Agent1
+**Scope:** `agentmux-srv/src/backend/blockcontroller/{mod,persistent}.rs`, `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/useAgentStream.ts`, `frontend/app/view/agent/hooks/usePendingMessageAcceptance.ts`, `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx`
+
+---
+
+## 1. Why this spec exists
+
+Four distinct-but-related live incidents surfaced in one session, each a variant of "the pane's status doesn't match what actually happened, with no explanation":
+
+1. This agent's own pane got stuck showing "Working…" after a PR merge that had genuinely completed.
+2. Research into (1) surfaced a cataloged, still-open architectural gap: the backend's turn-end event is fire-once with no replay, so a missed push has no self-heal path (`docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md` §3/§4 item 5).
+3. The message list's auto-scroll-follow, previously "fixed" (`docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md`), was still observed silently drifting off true bottom.
+4. Live, mid-session: Agent2's pane got stuck on an unanswerable AskUserQuestion prompt, and separately, a pane was observed going "Worked" → "Working…" again with no user input in between (`docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md`).
+
+Each was investigated independently (two parallel research agents for #1/#3, direct code-grounded analysis for #4's two issues). This spec folds the findings into one implementation pass, since three of the four root causes are small, independent, and low-risk enough to land together; the fourth (settled-grace) and the AskUserQuestion race are handled with more care (see §4, §5).
+
+## 2. Mechanism 1-3: closing the stuck-"Working" gap (backend fire-once event)
+
+Root cause (confirmed via code + the two prior reports): `publish_controller_status` (`agentmux-srv/src/backend/blockcontroller/mod.rs`), the sole publish point for `controllerstatus` across all 13 controller-type call sites, published with `persist: 0` — a WS reconnect (network blip, srv restart, backgrounded window's socket actually dropping) gets nothing until the *next* live event, so a missed terminal turn-end push leaves the pane stuck showing "Working" indefinitely.
+
+Three independent, layered fixes (deliberately redundant — no single one has to be perfect):
+
+**Mechanism 1 — persist the event (`mod.rs`).** Changed `persist: 0` → `persist: 1`, mirroring the exact precedent already in production for `EVENT_AGENT_FAILURE` (`subprocess/host_spawn.rs`). A reconnecting subscriber now replays the last known status atomically instead of seeing nothing. Regression test: `test_publish_controller_status_persists_for_replay` (publishes once, reads back via `Broker::read_event_history`).
+
+**Mechanism 2 — periodic heartbeat (`persistent.rs`).** New `spawn_status_heartbeat` method, wired alongside every existing `core::spawn_health_watchdog` call site (process spawn, `send_message`, `send_user_message`). Republishes the current status every 20s while a turn is active, regardless of whether it changed — a self-healing backstop for the case a live push is missed for a reason *other* than a reconnect (e.g. a throttled/backgrounded renderer coalescing WS messages while the window stays connected). 20s is well below the frontend's own `STUCK_THRESHOLD_MS` (45s, diagnostic) and `LIVENESS_RECOVERY_MS` (180s, force-recovery), so a missed push self-heals long before either fires.
+
+**Mechanism 3 — focus-triggered reconcile (`agent-view.tsx`).** New effect on `makeWindowFocusSignal()` (pre-existing, previously only consumed by sound notifications): on every background→foreground transition, calls `BlockService.GetControllerStatus` and reconciles, mirroring the existing mount-time one-shot. This is the one mechanism that doesn't depend on the WS connection's lifecycle at all — it covers the case a pane's subscription lifecycle (remount without a full reconnect) means persist-replay wouldn't refire, per the WPS broker's per-`(route_id, event_name, scope)` replay-once-per-connection semantics.
+
+**Not done this pass (§5):** the frontend-side `toolsActive > 0` unconditional watchdog exemption (report 1's #1 gap — no positive liveness signal for a long-running tool call) needs an actual state-machine change and is sized as a separate follow-up. The `[wave-turn]` telemetry (report 1 §3.1/§3.2) turned out to already be implemented, landed via a concurrent PR (#2321) from another agent mid-session — verified present and working, no duplicate work done.
+
+## 3. Mechanism 4: scroll-follow silently drifting off bottom
+
+The 2026-07-24 fix (three tracked dependencies in the pin-to-bottom effect: `nodes().length`, `layoutView().totalSize`, `workingRowHeight`) was confirmed intact and unregressed. The still-recurring symptom has a different, more common root cause than anything that fix targeted: **a sibling row below the scroll region (retry bar, `AgentDecisionPanel`, `AgentQuestionPanel`, `PendingMessagesPanel`) appearing or growing mid-turn shrinks the flex-1 scroll container's `clientHeight` via pure CSS reflow.** No `scroll` event fires (it's a resize, not a scroll), and none of the three tracked dependencies change either — `stickToBottom` stays silently `true` while the view falls short of the new max scroll position. The 07-24 spec's own §3.3 flagged these exact rows but dismissed them as "rare/transient"; they're common in any normal tool-approval/question flow.
+
+**Fix (`AgentDocumentVirtualList.tsx`):** generalized the existing `ResizeObserver` on the scroll container — previously gated to only re-pin on the hidden→visible (0→N) transition — to re-pin on *any* `clientHeight` change while `stickToBottom()` is true. Idempotent when already at true bottom; still respects a user who deliberately scrolled away. Closes the entire class of "something below the message list changed size" bugs generically, instead of requiring a new tracked-dependency addition every time a new interposing panel is added (the whack-a-mole pattern the 07-24 fix already had to extend once, 2→3 deps).
+
+**Secondary fix (`usePendingMessageAcceptance.ts` → `useAgentStream.ts` → `agent-view.tsx`):** a new turn starting via the queue-drain path (a message queued while busy, later auto-accepted by the backend) dispatched `TurnStart` without ever re-engaging `stickToBottom` — only turns started via this pane's own composer did. Threaded a new `onTurnStartFromQueue` callback through to call the existing `jumpToBottom`/`scrollToBottomFn` (which both scrolls and re-engages stick), so "any new turn re-engages follow" holds regardless of which path started it.
+
+**Deferred (§5):** the input-gated / programmatic-scroll-vs-user-scroll race (root cause #2 in the scroll research) — recommended as a follow-up only if the ResizeObserver fix above doesn't fully resolve live reports, since it's the more common repro and cheaper to ship first.
+
+## 4. "Worked" reverting to "Working…" with no user input — settled-grace invariant
+
+Root cause (`frontend/app/store/agent-pane-state/reducer.ts`'s `StreamFlushObserved` case): `Done.completed` → `Streaming` re-promotion on any live flush is **intentional**, not a bug — the CLI's `session_end` fires after every model round, not just true turn end, so a genuine multi-round tool continuation needs this path; removing it would leave the UI falsely showing "Worked" during real work, a worse failure than the reverse.
+
+**Fix (`agent-view.tsx`, additive only — no reducer/`TurnPhase` changes):** a `SETTLE_GRACE_MS` (500ms) timer arms when `turnPhase` enters `Done.completed`. If no further activity arrives within the window, the episode is considered *settled*. If a `StreamFlushObserved` re-promotion to `Streaming` arrives **after** the episode settled, a visible system notification ("Picked up more work — starting another round…") is posted into the conversation instead of letting the indicator silently flip back with no explanation. An episode still within its grace window (the genuine same-breath multi-round case) re-promotes exactly as before, silently — no regression to the common case, only the "user already saw it settle" case gets disclosed.
+
+500ms and the exact notification wording are implementation defaults, not confirmed product decisions — flagged as reversible/tunable if they don't feel right in practice.
+
+## 5. Explicitly deferred (not this pass)
+
+- **Frontend tool-liveness gap** (report 1's #1 finding: `toolsActive > 0` is an unconditional, unbounded watchdog exemption). Needs a real `TurnPhase`/reducer change plus a backend process-liveness signal threaded into `controllerstatus` — sized as its own follow-up spec, not bundled here to keep this pass's risk low.
+- **Scroll input-gating** (race root cause #2) — only pursue if live reports continue after mechanism 4 above ships; needs telemetry to confirm it actually fires before investing in wheel/pointer/touch listener plumbing.
+- **Agent2's stuck-AskUserQuestion panel** — root cause is a hypothesis (an optimistic client-side "answered" transition racing a document resync that rebuilds from a transcript where the tail question is still `awaiting_answer`), not yet live-confirmed. Needs direct inspection of a live instance's document/transcript state before sizing a fix. See `docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md` §2.
+
+## 6. Verification
+
+- Backend: `cargo check -p agentmux-srv` clean; full suite 1675 passed / 0 failed / 4 ignored (was 1674 before this change — net +1 from the new persist-replay regression test).
+- Frontend: `npx tsc --noEmit` clean; `npx vitest run app/view/agent app/store/agent-pane-state app/window` — 66 files / 931 tests passed, 0 regressions.
+- No live UI verification performed this pass (see this session's prior documented hazard with direct DB writes to a live srv instance — avoided here entirely; all changes verified via automated tests only).

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -76,7 +76,7 @@ describe("agent-pane-state reducer", () => {
             expect(start.turnPhase.kind).toBe("Idle");
             const r = update(start, { type: "ReconcileTurnActive", at: 100, active: true });
             expect(r.state.turnPhase.kind).toBe("Streaming");
-            expect(r.events[0]).toMatchObject({ type: "turn-active-reconciled-at-mount" });
+            expect(r.events[0]).toMatchObject({ type: "turn-active-reconciled" });
         });
 
         it("active: false is a no-op — Idle is already correct", () => {
@@ -92,6 +92,32 @@ describe("agent-pane-state reducer", () => {
             expect(s1.turnPhase.kind).toBe("Submitting");
             const r = update(s1, { type: "ReconcileTurnActive", at: 120, active: true });
             expect(r.state).toBe(s1);
+            expect(r.events).toEqual([]);
+        });
+
+        // reagent P1 on the PR that added the focus-triggered reconcile
+        // (SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md):
+        // without this, a pane showing "Worked" while backgrounded, whose
+        // genuinely-new turn's live start signal was ALSO missed, would
+        // silently no-op forever on this authoritative RPC response.
+        it("promotes a settled Done.completed episode to Streaming — the missed-live-turn-start case", () => {
+            const s0 = streaming(100);
+            const s1 = update(s0, { type: "TurnEnd", stats: null }).state;
+            expect(s1.turnPhase).toMatchObject({ kind: "Done", outcome: "completed" });
+            const r = update(s1, { type: "ReconcileTurnActive", at: 200, active: true });
+            expect(r.state.turnPhase.kind).toBe("Streaming");
+            expect(r.events[0]).toMatchObject({ type: "turn-active-reconciled" });
+        });
+
+        it("does NOT promote Done.stopped/errored — same standard as StreamFlushObserved", () => {
+            const s0 = streaming(100);
+            // Interrupting -> TurnEnd yields Done.stopped.
+            const interrupting = update(s0, { type: "RequestStop", at: 150 }).state;
+            expect(interrupting.turnPhase.kind).toBe("Interrupting");
+            const stopped = update(interrupting, { type: "TurnEnd", stats: null }).state;
+            expect(stopped.turnPhase).toMatchObject({ kind: "Done", outcome: "stopped" });
+            const r = update(stopped, { type: "ReconcileTurnActive", at: 200, active: true });
+            expect(r.state).toBe(stopped);
             expect(r.events).toEqual([]);
         });
 

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -344,14 +344,34 @@ export function update(
 
         case "ReconcileTurnActive": {
             if (command.active) {
-                // Promote the mount-default Idle — never overrides a phase a
-                // real stream/user event already produced. Deliberately does
-                // NOT gate on `state.lastEventMs` the way TurnStart /
-                // StreamFlushObserved do — this seed is meant to cover exactly
-                // the window before the live stream has necessarily subscribed
-                // yet, which is the gap this command exists to close. See the
-                // type's doc comment in types.ts.
-                if (state.turnPhase.kind !== "Idle") {
+                // Promote from the mount-default Idle (this seed's original
+                // purpose — covers the window before the live stream has
+                // necessarily subscribed yet, see the type's doc comment in
+                // types.ts) OR from a settled Done.completed episode. The
+                // Done.completed case matters for the focus-triggered
+                // reconcile (agent-view.tsx): a pane can be showing "Worked"
+                // while backgrounded, a genuinely new turn starts, AND the
+                // live turn-start signal is also missed — without this, the
+                // authoritative "yes, a turn really is active" RPC response
+                // this command carries would silently no-op, leaving the
+                // pane stuck on "Worked" despite real work in progress
+                // (reagent P1 on the PR that added the focus reconcile).
+                // Applies the SAME standard StreamFlushObserved already uses
+                // for live stream content proving a continuation — this
+                // authoritative snapshot is an equally strong (arguably
+                // stronger) signal of truth. Other Done outcomes (stopped/
+                // errored/interrupted) stay excluded, matching
+                // StreamFlushObserved: a failed/stopped turn must not be
+                // silently re-activated. Never overrides Streaming/
+                // Submitting/Interrupting/Disconnected — those already
+                // reflect a real stream/user event this snapshot must not
+                // clobber. Deliberately does NOT gate on `state.lastEventMs`
+                // the way TurnStart / StreamFlushObserved do, for the same
+                // reason the original Idle case didn't.
+                const canPromote =
+                    state.turnPhase.kind === "Idle" ||
+                    (state.turnPhase.kind === "Done" && state.turnPhase.outcome === "completed");
+                if (!canPromote) {
                     return { state, events: [] };
                 }
                 return {
@@ -364,7 +384,7 @@ export function update(
                             lastEventMs: command.at,
                         },
                     },
-                    events: [{ type: "turn-active-reconciled-at-mount" }],
+                    events: [{ type: "turn-active-reconciled" }],
                 };
             }
             // active === false: the backend's authoritative turn_active (flipped

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -589,12 +589,15 @@ export type AgentPaneEvent =
       }
     | { type: "turn-started"; at: number }
     /**
-     * `ReconcileTurnActive` promoted the mount-default `Idle` to
-     * `Streaming` because the backend reported a turn already in flight.
-     * Surfaced for diagnostics — distinguishes this from a normal
-     * user-initiated `turn-started`.
+     * `ReconcileTurnActive` promoted the phase to `Streaming` because the
+     * backend reported a turn already in flight — either the mount-default
+     * `Idle` (the original case) or a settled `Done.completed` episode (the
+     * focus-triggered reconcile's missed-live-turn-start case). Surfaced
+     * for diagnostics — distinguishes this from a normal user-initiated
+     * `turn-started`. Not "-at-mount" anymore since it can now fire well
+     * after mount.
      */
-    | { type: "turn-active-reconciled-at-mount" }
+    | { type: "turn-active-reconciled" }
     /**
      * `ReconcileTurnActive` demoted a stuck `Streaming` phase to `Idle`
      * because the backend's authoritative `turn_active` reported the turn

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -61,6 +61,7 @@ import { useAgentDecisions } from "./hooks/useAgentDecisions";
 import { useAgentQuestions } from "./hooks/useAgentQuestions";
 import { BlockService } from "@/app/store/services";
 import { makeWindowFocusSignal } from "@/app/window/window-focus";
+import { SETTLE_GRACE_MS, nextDoneCompletedAt, shouldNotifyOnReopen } from "./settled-grace";
 import { useAgentCloseConfirm } from "./hooks/useAgentCloseConfirm";
 import { handleAgentIdChange } from "@/app/view/term/termagent";
 import { DragOverlay } from "@/app/element/dragoverlay";
@@ -766,37 +767,30 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         });
     };
 
-    // Settled-grace invariant: `StreamFlushObserved` (reducer.ts) deliberately
-    // re-promotes Done.completed -> Streaming on any live flush, because the
-    // CLI's session_end fires after every model round, not just true turn
-    // end — a genuine multi-round tool continuation needs this path, so it
-    // can't simply be removed. But once the UI has shown a SETTLED "Worked"
-    // for SETTLE_GRACE_MS with no further activity, that re-promotion must
-    // never silently un-happen the checkmark the user already saw settle —
-    // post a visible notification instead so a later round is disclosed, not
-    // hidden. Purely additive: no reducer/TurnPhase changes, doesn't affect
-    // session-digest correctness. See
-    // docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md §1.
-    const SETTLE_GRACE_MS = 500;
-    let settled = false;
-    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    // Settled-grace invariant — see settled-grace.ts's module doc for the
+    // full rationale (StreamFlushObserved's intentional Done.completed ->
+    // Streaming re-promotion for multi-round continuations, and why a
+    // SETTLED "Worked" must never silently un-happen). Purely additive: no
+    // reducer/TurnPhase changes, doesn't affect session-digest correctness.
+    // Decision logic lives in settled-grace.ts as pure, directly-testable
+    // functions; this effect is just the reactive wiring.
+    let doneCompletedAt: number | null = null;
     createEffect(() => {
         const phase = agentAtoms().turnPhaseAtom[0]();
-        clearTimeout(settleTimer);
-        if (phase.kind === "Done" && phase.outcome === "completed") {
-            settleTimer = setTimeout(() => {
-                settled = true;
-            }, SETTLE_GRACE_MS);
-        } else if (phase.kind === "Streaming") {
-            if (settled) {
-                postSystemNotification("Picked up more work — starting another round…", "info");
-            }
-            settled = false;
-        } else {
-            settled = false;
+        const now = Date.now();
+        if (
+            phase.kind === "Streaming" &&
+            shouldNotifyOnReopen(doneCompletedAt, now, SETTLE_GRACE_MS)
+        ) {
+            postSystemNotification("Picked up more work — starting another round…", "info");
         }
+        doneCompletedAt = nextDoneCompletedAt(
+            phase.kind,
+            phase.kind === "Done" ? phase.outcome : undefined,
+            doneCompletedAt,
+            now,
+        );
     });
-    onCleanup(() => clearTimeout(settleTimer));
 
     const status = useAgentControllerStatus({
         blockId: model.blockId,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { writeText as clipboardWriteText } from "@/util/clipboard";
-import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { AgentViewModel } from "./agent-model";
 import { getProvider } from "./providers";
 import { createAgentAtoms } from "./state";
@@ -59,6 +59,8 @@ import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
 import { useSnapshotPersistence } from "./hooks/useSnapshotPersistence";
 import { useAgentDecisions } from "./hooks/useAgentDecisions";
 import { useAgentQuestions } from "./hooks/useAgentQuestions";
+import { BlockService } from "@/app/store/services";
+import { makeWindowFocusSignal } from "@/app/window/window-focus";
 import { useAgentCloseConfirm } from "./hooks/useAgentCloseConfirm";
 import { handleAgentIdChange } from "@/app/view/term/termagent";
 import { DragOverlay } from "@/app/element/dragoverlay";
@@ -764,6 +766,38 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         });
     };
 
+    // Settled-grace invariant: `StreamFlushObserved` (reducer.ts) deliberately
+    // re-promotes Done.completed -> Streaming on any live flush, because the
+    // CLI's session_end fires after every model round, not just true turn
+    // end — a genuine multi-round tool continuation needs this path, so it
+    // can't simply be removed. But once the UI has shown a SETTLED "Worked"
+    // for SETTLE_GRACE_MS with no further activity, that re-promotion must
+    // never silently un-happen the checkmark the user already saw settle —
+    // post a visible notification instead so a later round is disclosed, not
+    // hidden. Purely additive: no reducer/TurnPhase changes, doesn't affect
+    // session-digest correctness. See
+    // docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md §1.
+    const SETTLE_GRACE_MS = 500;
+    let settled = false;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    createEffect(() => {
+        const phase = agentAtoms().turnPhaseAtom[0]();
+        clearTimeout(settleTimer);
+        if (phase.kind === "Done" && phase.outcome === "completed") {
+            settleTimer = setTimeout(() => {
+                settled = true;
+            }, SETTLE_GRACE_MS);
+        } else if (phase.kind === "Streaming") {
+            if (settled) {
+                postSystemNotification("Picked up more work — starting another round…", "info");
+            }
+            settled = false;
+        } else {
+            settled = false;
+        }
+    });
+    onCleanup(() => clearTimeout(settleTimer));
+
     const status = useAgentControllerStatus({
         blockId: model.blockId,
         provider,
@@ -846,6 +880,30 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         },
     });
 
+    // Focus/visibility-triggered reconcile — the mount-time GetControllerStatus
+    // (onControllerStatus above) is one-shot, and the live useControllerStatusEvents
+    // subscription only self-heals a missed turn-end if a LATER live event
+    // arrives. If the single turn-end push is missed (backgrounded window, a
+    // WPS reconnect gap, a pane remount that doesn't re-trigger the WPS
+    // persisted-event replay — see REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md
+    // §3/§4 item 5) nothing else corrects it until the *next* turn starts.
+    // Re-poll on every background→foreground transition so looking back at a
+    // pane always shows the true current state within one RPC round trip,
+    // independent of event-bus replay semantics. Skips the initial `true` at
+    // mount (already covered by the one-shot above) via `{ defer: true }`.
+    const windowFocused = makeWindowFocusSignal();
+    createEffect(on(windowFocused, (focused) => {
+        if (!focused) return;
+        void BlockService.GetControllerStatus(model.blockId)
+            .then((rts) => {
+                if (rts) reconcileTurnActive(!!rts.turn_active);
+            })
+            .catch(() => {
+                // Best-effort — the live subscription and next mount remain
+                // as fallbacks; nothing user-visible to report on failure.
+            });
+    }, { defer: true }));
+
     // Subscribe to Claude Code OSC window-title extractions and write them
     // to term:osc_title block metadata (free fallback signal — see
     // readActivitySummary()'s precedence in agent-model.ts).
@@ -923,6 +981,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // Jekt direction detection on the live stream: FROM == this agent
         // → outgoing bubble (SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2).
         agentName: agentName(),
+        // Re-engage message-list auto-scroll for a turn that starts from
+        // the queue-drain path — see usePendingMessageAcceptance's
+        // `onTurnStartFromQueue` doc comment. `scrollToBottomFn` is declared
+        // below (assigned once AgentDocumentView mounts); referencing it in
+        // this closure is safe regardless of declaration order since the
+        // closure only runs later, on a live `agent-message-accepted` event.
+        onTurnStartFromQueue: () => scrollToBottomFn?.(),
     });
 
     // Mutable ref to the scrollToBottom function exposed by

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -890,7 +890,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         if (!focused) return;
         void BlockService.GetControllerStatus(model.blockId)
             .then((rts) => {
-                if (rts) reconcileTurnActive(!!rts.turn_active);
+                if (!rts) return;
+                const active = !!rts.turn_active;
+                reconcileTurnActive(active);
+                // Mirror the live useControllerStatusEvents handler below —
+                // reagent P2: a turn-end detected ONLY via this focus poll
+                // (the missed-live-push case this mechanism exists for)
+                // must still bump turnJustEndedAtom, or
+                // useAgentActivitySummary/useNextPromptSuggestion silently
+                // never fire for that turn's completion.
+                trackTurnJustEnded(active);
             })
             .catch(() => {
                 // Best-effort — the live subscription and next mount remain

--- a/frontend/app/view/agent/hooks/usePendingMessageAcceptance.test.ts
+++ b/frontend/app/view/agent/hooks/usePendingMessageAcceptance.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins the `onTurnStartFromQueue` wiring added alongside the scroll-follow
+ * hardening pass (reagent P2: the queue-drain TurnStart path previously had
+ * no test coverage). A queued message that the backend auto-accepts while
+ * the pane is idle must both dispatch TurnStart AND re-engage message-list
+ * auto-scroll; a queued message accepted mid-turn (steering) must dispatch
+ * neither, since TurnStart was already fired by the composer send. See
+ * docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md §3.
+ */
+
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+    turnPhase: { kind: "Done", outcome: "completed", finishedAt: 0 } as { kind: string; [k: string]: unknown },
+}));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        hub.handlers.set(sub.eventType, sub.handler);
+        return () => hub.handlers.delete(sub.eventType);
+    }),
+}));
+vi.mock("@/app/store/wos", () => ({ makeORef: (a: string, b: string) => `${a}:${b}` }));
+vi.mock("@/app/store/agent-pane-state-store", () => ({
+    snapshot: (_blockId: string) => ({ turnPhase: hub.turnPhase }),
+}));
+vi.mock("@/log/render-trail", () => ({ trail: vi.fn() }));
+
+import { usePendingMessageAcceptance } from "./usePendingMessageAcceptance";
+import type { PendingMessage } from "../state";
+
+const BLOCK_ID = "b";
+
+const fire = (data: unknown) => {
+    const h = hub.handlers.get("agent-message-accepted");
+    if (!h) throw new Error("agent-message-accepted handler not registered — onMount did not run");
+    h({ data });
+};
+
+function setup(pending: PendingMessage[]) {
+    const dispatched: unknown[] = [];
+    const pushedNodes: unknown[] = [];
+    const onTurnStartFromQueue = vi.fn();
+    let dispose: () => void = () => {};
+    createRoot((d) => {
+        dispose = d;
+        usePendingMessageAcceptance({
+            blockId: BLOCK_ID,
+            model: { dispatchPane: (cmd: unknown) => dispatched.push(cmd) } as any,
+            pendingMessagesAtom: [() => pending, () => {}] as any,
+            queue: {
+                pushNewNode: (n: unknown) => pushedNodes.push(n),
+                scheduleFlush: vi.fn(),
+            } as any,
+            hasNodeId: () => false,
+            addNodeId: () => {},
+            onTurnStartFromQueue,
+        });
+    });
+    return { dispatched, pushedNodes, onTurnStartFromQueue, dispose };
+}
+
+beforeEach(() => {
+    hub.handlers.clear();
+});
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("usePendingMessageAcceptance — onTurnStartFromQueue", () => {
+    it("dispatches TurnStart and re-engages scroll-follow when accepted while idle (Done)", () => {
+        hub.turnPhase = { kind: "Done", outcome: "completed", finishedAt: 0 };
+        const pending: PendingMessage[] = [{ id: "m1", text: "hello" } as PendingMessage];
+        const { dispatched, onTurnStartFromQueue, dispose } = setup(pending);
+
+        fire({ message_id: "m1" });
+
+        expect(dispatched).toContainEqual({ type: "PendingMessageAccepted", id: "m1" });
+        expect(dispatched.some((c: any) => c.type === "TurnStart")).toBe(true);
+        expect(onTurnStartFromQueue).toHaveBeenCalledTimes(1);
+        dispose();
+    });
+
+    it("does NOT dispatch TurnStart or re-engage scroll-follow when accepted mid-turn (Streaming)", () => {
+        hub.turnPhase = { kind: "Streaming", toolsActive: 0, bufferSize: 0, lastEventMs: 0 };
+        const pending: PendingMessage[] = [{ id: "m2", text: "steer" } as PendingMessage];
+        const { dispatched, onTurnStartFromQueue, dispose } = setup(pending);
+
+        fire({ message_id: "m2" });
+
+        expect(dispatched.some((c: any) => c.type === "TurnStart")).toBe(false);
+        expect(onTurnStartFromQueue).not.toHaveBeenCalled();
+        dispose();
+    });
+
+    it("ignores an accepted event for an unknown message id", () => {
+        hub.turnPhase = { kind: "Done", outcome: "completed", finishedAt: 0 };
+        const { dispatched, onTurnStartFromQueue, dispose } = setup([]);
+
+        fire({ message_id: "does-not-exist" });
+
+        expect(dispatched).toEqual([]);
+        expect(onTurnStartFromQueue).not.toHaveBeenCalled();
+        dispose();
+    });
+});

--- a/frontend/app/view/agent/hooks/usePendingMessageAcceptance.ts
+++ b/frontend/app/view/agent/hooks/usePendingMessageAcceptance.ts
@@ -34,6 +34,21 @@ export interface UsePendingMessageAcceptanceOptions {
     queue: StreamFlushQueue;
     hasNodeId: (id: string) => boolean;
     addNodeId: (id: string) => void;
+    /**
+     * Called whenever this hook starts a new turn from the queue-drain path
+     * (below). Wired to the message-list's `jumpToBottom` (re-engages
+     * `stickToBottom` + scrolls to true bottom) so a turn that begins here —
+     * a queued message the backend just picked up, not something typed into
+     * THIS pane's own composer — still auto-follows. Without this, a user
+     * who scrolled away earlier (even during a prior, unrelated turn) sees a
+     * stale `stickToBottom=false` carry into a brand-new turn whose start
+     * had nothing to do with their scroll action. `handleSendMessage`'s own
+     * `onSent` callback already covers the composer-driven case; this covers
+     * the one TurnStart site that didn't. See
+     * REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md's
+     * scroll-follow-drift investigation, root cause #3.
+     */
+    onTurnStartFromQueue?: () => void;
 }
 
 export function usePendingMessageAcceptance(opts: UsePendingMessageAcceptanceOptions): void {
@@ -85,6 +100,7 @@ export function usePendingMessageAcceptance(opts: UsePendingMessageAcceptanceOpt
                 trail("agent:dispatch:TurnStart", { messageId });
                 opts.model.dispatchPane({ type: "TurnStart", at: Date.now() });
                 trail("agent:dispatch:TurnStart:done", { messageId });
+                opts.onTurnStartFromQueue?.();
             }
             // Append as a normal user_message so it joins the
             // conversation stream. Keeps the same id so the new

--- a/frontend/app/view/agent/settled-grace.test.ts
+++ b/frontend/app/view/agent/settled-grace.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { SETTLE_GRACE_MS, nextDoneCompletedAt, shouldNotifyOnReopen } from "./settled-grace";
+
+describe("nextDoneCompletedAt", () => {
+    it("starts the clock on first entering Done.completed", () => {
+        expect(nextDoneCompletedAt("Done", "completed", null, 1000)).toBe(1000);
+    });
+
+    it("does not reset the clock on a re-render of the same Done.completed phase", () => {
+        expect(nextDoneCompletedAt("Done", "completed", 1000, 2000)).toBe(1000);
+    });
+
+    it("clears the clock on Streaming", () => {
+        expect(nextDoneCompletedAt("Streaming", undefined, 1000, 2000)).toBeNull();
+    });
+
+    it("clears the clock on other Done outcomes (stopped/errored/interrupted)", () => {
+        expect(nextDoneCompletedAt("Done", "stopped", 1000, 2000)).toBeNull();
+        expect(nextDoneCompletedAt("Done", "errored", 1000, 2000)).toBeNull();
+    });
+
+    it("clears the clock on Idle/Submitting/Disconnected", () => {
+        expect(nextDoneCompletedAt("Idle", undefined, 1000, 2000)).toBeNull();
+        expect(nextDoneCompletedAt("Submitting", undefined, 1000, 2000)).toBeNull();
+        expect(nextDoneCompletedAt("Disconnected", undefined, 1000, 2000)).toBeNull();
+    });
+});
+
+describe("shouldNotifyOnReopen", () => {
+    it("is false when the pane was never in Done.completed (normal turn start)", () => {
+        expect(shouldNotifyOnReopen(null, 10_000, SETTLE_GRACE_MS)).toBe(false);
+    });
+
+    it("is false for a re-promotion within the grace window (genuine same-breath continuation)", () => {
+        const doneAt = 1000;
+        const now = doneAt + SETTLE_GRACE_MS - 1;
+        expect(shouldNotifyOnReopen(doneAt, now, SETTLE_GRACE_MS)).toBe(false);
+    });
+
+    it("is true once the grace window has fully elapsed", () => {
+        const doneAt = 1000;
+        const now = doneAt + SETTLE_GRACE_MS;
+        expect(shouldNotifyOnReopen(doneAt, now, SETTLE_GRACE_MS)).toBe(true);
+    });
+
+    it("is true well after the grace window", () => {
+        const doneAt = 1000;
+        const now = doneAt + SETTLE_GRACE_MS * 10;
+        expect(shouldNotifyOnReopen(doneAt, now, SETTLE_GRACE_MS)).toBe(true);
+    });
+
+    it("respects a custom grace window", () => {
+        expect(shouldNotifyOnReopen(0, 100, 200)).toBe(false);
+        expect(shouldNotifyOnReopen(0, 200, 200)).toBe(true);
+    });
+});

--- a/frontend/app/view/agent/settled-grace.ts
+++ b/frontend/app/view/agent/settled-grace.ts
@@ -1,0 +1,62 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure decision logic for the "Worked" settled-grace invariant.
+ *
+ * `StreamFlushObserved` (agent-pane-state/reducer.ts) deliberately re-promotes
+ * `Done.completed` -> `Streaming` on any live flush, because the CLI's
+ * `session_end` fires after every model round, not just true turn end — a
+ * genuine multi-round tool continuation needs this path, so it can't simply
+ * be removed. But once the UI has shown a SETTLED "Worked" for
+ * `SETTLE_GRACE_MS` with no further activity, that re-promotion must never
+ * silently un-happen the checkmark the user already saw settle — the caller
+ * should post a visible notification instead. See
+ * docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md §1.
+ *
+ * Timestamp-based rather than a live `setTimeout` callback: simpler (no
+ * timer to arm/cancel/clean up) and directly testable as pure functions —
+ * the "was it settled" question is answered by comparing two timestamps at
+ * the moment a re-promotion is observed, not by a callback firing on a
+ * schedule.
+ */
+
+export const SETTLE_GRACE_MS = 500;
+
+/**
+ * Track when the pane most recently entered a settle-eligible `Done.completed`
+ * state. Called on every `TurnPhase` change; returns the next value to store.
+ *
+ * - Entering `Done.completed` for the first time (prev was null) starts the
+ *   clock.
+ * - Staying in `Done.completed` (prev already set) leaves the clock
+ *   untouched — it should not reset on every re-render of the same phase.
+ * - Any other phase clears the clock.
+ */
+export function nextDoneCompletedAt(
+    phaseKind: string,
+    outcome: string | undefined,
+    prevDoneCompletedAt: number | null,
+    nowMs: number,
+): number | null {
+    if (phaseKind === "Done" && outcome === "completed") {
+        return prevDoneCompletedAt ?? nowMs;
+    }
+    return null;
+}
+
+/**
+ * True when a `Streaming` re-promotion observed at `nowMs` arrived after the
+ * pane had already been settled (in `Done.completed`) for at least
+ * `graceMs`. `doneCompletedAt` is `null` when the pane was never in
+ * `Done.completed` (e.g. a `Submitting`/`Idle` -> `Streaming` transition,
+ * which is a normal turn start, not a reopened one) — never notify for that
+ * case.
+ */
+export function shouldNotifyOnReopen(
+    doneCompletedAt: number | null,
+    nowMs: number,
+    graceMs: number = SETTLE_GRACE_MS,
+): boolean {
+    return doneCompletedAt != null && nowMs - doneCompletedAt >= graceMs;
+}

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -127,6 +127,13 @@ interface UseAgentStreamOpts {
      * pre-echo behavior. SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2.
      */
     agentName?: string;
+    /**
+     * Forwarded verbatim to `usePendingMessageAcceptance` — see that hook's
+     * `onTurnStartFromQueue` doc comment. Re-engages message-list auto-scroll
+     * for a turn that starts from the queue-drain path (a queued message the
+     * backend picked up), not just from this pane's own composer send.
+     */
+    onTurnStartFromQueue?: () => void;
 }
 
 /**
@@ -142,6 +149,7 @@ export function useAgentStream({
     enabled,
     provider,
     agentName,
+    onTurnStartFromQueue,
 }: UseAgentStreamOpts): void {
     // Mutable state that doesn't trigger re-renders. Kept here (not
     // extracted) because it's tightly coupled to the NDJSON parse loop
@@ -205,6 +213,7 @@ export function useAgentStream({
             queue,
             hasNodeId,
             addNodeId,
+            onTurnStartFromQueue,
         });
 
         // Seed the in-batch dedup cache from the reducer-maintained

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -430,17 +430,30 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         }
     });
 
-    // Re-apply sticky-bottom on hidden → visible. An inactive tab is
-    // display:none (0×0), so the nodes()-driven scroll above is a no-op
-    // while hidden and nothing re-issues it on reactivation. Watch the
-    // container's clientHeight 0 → non-zero transition; re-scroll only
-    // when already sticky (never engages stick, so a user who scrolled
-    // up stays put).
+    // Re-apply sticky-bottom on ANY clientHeight change to this scroll
+    // container — not just hidden → visible. Originally only handled the
+    // inactive-tab case (display:none is 0×0, so the nodes()-driven scroll
+    // above is a no-op while hidden and nothing re-issues it on
+    // reactivation). Broadened per REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md's
+    // scroll-follow-drift investigation: a *sibling* below this scroll
+    // region resizing (the retry bar, AgentDecisionPanel, AgentQuestionPanel,
+    // or PendingMessagesPanel appearing/growing mid-turn — all normal-flow,
+    // flex-shrink:0 rows per SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
+    // §3.3's own "deferred as rare/transient" admission) shrinks THIS
+    // container's clientHeight via pure CSS reflow — no scroll event fires
+    // (it's a resize, not a scroll), and neither of the pin effect's tracked
+    // deps (nodes().length, layoutView().totalSize, workingRowHeight) change
+    // either, so `stickToBottom` stays silently true while the view falls
+    // short of the new, smaller max scroll position. Rather than adding a
+    // tracked height signal per interposing panel (the whack-a-mole pattern
+    // the 07-24 fix already had to extend once), just re-pin on every resize
+    // this observer reports — idempotent when already at true bottom, and
+    // still gated on `stickToBottom()` so a user who deliberately scrolled
+    // away is never fought.
     onMount(() => {
-        let wasHidden = scrollRef.clientHeight === 0;
         const ro = new ResizeObserver(() => {
             const h = scrollRef.clientHeight;
-            if (h > 0 && wasHidden && props.viewState.stickToBottom()) {
+            if (h > 0 && props.viewState.stickToBottom()) {
                 scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
             }
             // Phase 3: the scroll container resizing changes the viewport the
@@ -454,7 +467,6 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                     viewportPx: h,
                 });
             }
-            wasHidden = h === 0;
         });
         ro.observe(scrollRef);
         onCleanup(() => ro.disconnect());


### PR DESCRIPTION
## Summary

Folds four related live incidents from this session into one hardening pass:

1. This agent's own pane got stuck showing "Working…" after a PR had genuinely merged.
2. The message list's auto-scroll-follow — previously "fixed" in SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md — was still observed silently drifting off true bottom.
3. A pane was observed going "Worked" → "Working…" again with no user input in between.
4. Agent2's pane got stuck on an unanswerable AskUserQuestion prompt (documented only — root cause is a hypothesis, not live-confirmed; not fixed this pass).

Full writeup: `docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md`, with supporting root-cause docs `docs/reports/REPORT_WORKING_STATE_TELEMETRY_AUDIT_2026_07_27.md` (pre-existing), `docs/specs/REPORT_LOGIN_PERSIST_FAILURE_AND_STUCK_WORKING_2026_07_27.md` (pre-existing), and `docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md` (new, this session).

## Changes

**Stuck-"Working" (backend fire-once event gap):**
- `blockcontroller/mod.rs`: `publish_controller_status`'s `persist: 0 → 1`, mirroring the existing `EVENT_AGENT_FAILURE` precedent — a WS reconnect now replays the last known turn state instead of nothing.
- `blockcontroller/persistent.rs`: new `spawn_status_heartbeat`, wired alongside every `spawn_health_watchdog` call site — republishes status every 20s while a turn is active, a self-healing backstop independent of reconnect/persist.
- `agent-view.tsx`: new focus/visibility-triggered reconcile via the pre-existing `makeWindowFocusSignal()` — covers the same-connection pane-remount case persist alone doesn't.
- `[wave-turn]` telemetry (report 1 §3.1/§3.2) turned out to already be implemented via a concurrent PR (#2321) from another agent mid-session — verified present, no duplicate work.

**Scroll-follow drift (still recurring after the 07-24 fix):**
- `AgentDocumentVirtualList.tsx`: generalized the scroll container's `ResizeObserver` to re-pin on ANY `clientHeight` change while `stickToBottom()` is true, not just hidden→visible. Root cause: a sibling row (retry bar, decision/question panel, pending-messages panel) appearing/growing mid-turn shrinks the flex-1 scroll container via pure CSS reflow — no scroll event fires, none of the three previously-tracked dependencies change, so `stickToBottom` stays silently true while the view falls short of true bottom.
- `usePendingMessageAcceptance.ts` → `useAgentStream.ts` → `agent-view.tsx`: a new turn starting via the queue-drain path (auto-accepted queued message) now re-engages `stickToBottom` too — previously only composer-driven turns did.

**"Worked" reverting to "Working…" with no input:**
- `agent-view.tsx`: additive-only settled-grace window (500ms). The reducer's `Done.completed → Streaming` re-promotion is intentional (multi-round tool continuations need it — removing it would be worse), but once the UI has shown a *settled* "Worked" for the grace window, a later re-promotion now posts a visible "Picked up more work — starting another round…" notification instead of silently reverting the indicator.

**Explicitly deferred** (see spec §5): the frontend tool-liveness gap (unconditional `toolsActive > 0` watchdog exemption), scroll input-gating (the programmatic-vs-user-scroll race), and Agent2's stuck-question panel (needs live confirmation first).

## Test plan

- [x] `cargo check -p agentmux-srv` clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1675 passed / 0 failed / 4 ignored (net +1 from the new persist-replay regression test)
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run app/view/agent app/store/agent-pane-state app/window` — 66 files / 931 tests passed, 0 regressions
- [ ] No live UI verification this pass — deliberately avoided direct DB manipulation of a live srv instance (documented hazard from earlier this session); relying on automated test coverage only

<!-- agentmux:agent_id=agent1 -->