### PR TITLE
fix(agent): harden My Agents against single-source failures

### DIFF
--- a/.changesets/1785196299-fix-agent-harden-my-agents-against-single-source-failures-di-56hd.md
+++ b/.changesets/1785196299-fix-agent-harden-my-agents-against-single-source-failures-di-56hd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): harden My Agents against single-source failures, distinguish error from empty

--- a/agentmux-srv/src/backend/rpc_types/instance.rs
+++ b/agentmux-srv/src/backend/rpc_types/instance.rs
@@ -178,6 +178,26 @@ pub struct RecentSessionRow {
     pub agent_type: String,
 }
 
+/// Response envelope for `listrecentsessions`. Introduced alongside the
+/// per-source degradation hardening in `session.rs` (reagent P1 on
+/// PR #2327, re-reviewing
+/// docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md's
+/// fix): once every one of that handler's six data sources degrades to
+/// empty on its OWN failure instead of aborting the whole RPC, the
+/// response can no longer distinguish "genuinely zero agents" from "a
+/// data source failed and we got nothing" by transport success/failure
+/// alone — the exact ambiguity this whole fix exists to close, just
+/// pushed one layer deeper. `degraded` lists which source(s) fell back
+/// this call (empty = fully healthy); the frontend treats an empty
+/// `rows` alongside a non-empty `degraded` as an error state, not a
+/// trustworthy zero.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ListRecentSessionsResult {
+    pub rows: Vec<RecentSessionRow>,
+    #[serde(default)]
+    pub degraded: Vec<String>,
+}
+
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is
 /// optional — absent fields preserve their current value.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -131,7 +131,7 @@ fn collapse_preview(s: &str) -> String {
 #[cfg(test)]
 mod recent_sessions_tests {
     use super::*;
-    use crate::backend::rpc_types::{RecentSessionRow, COMMAND_LIST_RECENT_SESSIONS};
+    use crate::backend::rpc_types::{ListRecentSessionsResult, COMMAND_LIST_RECENT_SESSIONS};
     use crate::backend::storage::filestore::FileStore;
 
     fn fresh_filestore() -> std::sync::Arc<FileStore> {
@@ -513,13 +513,15 @@ mod recent_sessions_tests {
     #[tokio::test]
     async fn handler_returns_sessions_with_previews_sorted_by_snapshot_first() {
         let (_state, engine, mut rx) = build_state_with_seed();
-        let rows: Vec<RecentSessionRow> = call_rpc(
+        let result: ListRecentSessionsResult = call_rpc(
             &engine,
             &mut rx,
             COMMAND_LIST_RECENT_SESSIONS,
             serde_json::json!({}),
         )
         .await;
+        let rows = result.rows;
+        assert!(result.degraded.is_empty(), "healthy seed must report no degraded sources");
         assert_eq!(rows.len(), 3, "all three sessions surfaced");
 
         // Sort: snapshot-bearing rows first (recent then older), then
@@ -554,49 +556,49 @@ mod recent_sessions_tests {
     async fn handler_identity_filter_restricts_rows() {
         let (_state, engine, mut rx) = build_state_with_seed();
         // Filter to a non-existent identity → empty list.
-        let rows: Vec<RecentSessionRow> = call_rpc(
+        let result: ListRecentSessionsResult = call_rpc(
             &engine,
             &mut rx,
             COMMAND_LIST_RECENT_SESSIONS,
             serde_json::json!({ "identity_id": "no-such-bundle" }),
         )
         .await;
-        assert_eq!(rows.len(), 0);
+        assert_eq!(result.rows.len(), 0);
 
         // Filter to the seeded one → all three.
-        let rows: Vec<RecentSessionRow> = call_rpc(
+        let result: ListRecentSessionsResult = call_rpc(
             &engine,
             &mut rx,
             COMMAND_LIST_RECENT_SESSIONS,
             serde_json::json!({ "identity_id": "id-work" }),
         )
         .await;
-        assert_eq!(rows.len(), 3);
+        assert_eq!(result.rows.len(), 3);
 
         // Empty-string identity_id is treated as "no filter" so the
         // frontend can pass `""` without special-casing.
-        let rows: Vec<RecentSessionRow> = call_rpc(
+        let result: ListRecentSessionsResult = call_rpc(
             &engine,
             &mut rx,
             COMMAND_LIST_RECENT_SESSIONS,
             serde_json::json!({ "identity_id": "" }),
         )
         .await;
-        assert_eq!(rows.len(), 3);
+        assert_eq!(result.rows.len(), 3);
     }
 
     #[tokio::test]
     async fn handler_respects_limit() {
         let (_state, engine, mut rx) = build_state_with_seed();
-        let rows: Vec<RecentSessionRow> = call_rpc(
+        let result: ListRecentSessionsResult = call_rpc(
             &engine,
             &mut rx,
             COMMAND_LIST_RECENT_SESSIONS,
             serde_json::json!({ "limit": 1 }),
         )
         .await;
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].instance_id, "inst-recent");
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].instance_id, "inst-recent");
     }
 
     // ---- Two-tier picker Phase 1: create-from-template + listagents filter ----

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::{
     COMMAND_LIST_RECENT_SESSIONS, CommandListRecentSessionsData,
-    RecentSessionRow,
+    ListRecentSessionsResult, RecentSessionRow,
     // Option E (PR 1 of 2) — agent-anchored session zones.
     COMMAND_AGENT_SESSION_READ, COMMAND_AGENT_SESSION_WRITE_STATE,
     COMMAND_AGENT_SESSION_APPEND_OUTPUT, COMMAND_AGENT_SESSION_ARCHIVE,
@@ -432,7 +432,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "listrecentsessions: completed"
                 );
 
-                Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
+                // `degraded` must also reach the CALLER, not just the log
+                // (reagent P1 on PR #2327): once every source degrades to
+                // empty instead of erroring the whole RPC, a transport-level
+                // success/failure check can no longer tell "genuinely zero
+                // agents" apart from "a source failed and we got nothing" —
+                // the exact ambiguity this hardening exists to close, just
+                // pushed from the RPC layer down into the response body.
+                // See ListRecentSessionsResult's own doc comment.
+                let result = ListRecentSessionsResult {
+                    rows,
+                    degraded: degraded.iter().map(|s| s.to_string()).collect(),
+                };
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
             })
         }),
     );
@@ -668,12 +680,17 @@ mod tests {
         let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
 
         assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
-        let rows: Vec<RecentSessionRow> =
-            serde_json::from_value(resp.data.expect("expected row data")).unwrap();
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
         assert_eq!(
-            rows.len(),
+            result.rows.len(),
             3,
             "all 3 cross-channel registry agents must appear on a channel that never created any of them locally"
+        );
+        assert!(
+            result.degraded.is_empty(),
+            "a fully healthy call must report no degraded sources, got: {:?}",
+            result.degraded
         );
     }
 
@@ -719,14 +736,24 @@ mod tests {
         let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
 
         assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
-        let rows: Vec<RecentSessionRow> =
-            serde_json::from_value(resp.data.expect("expected row data")).unwrap();
+        let result: ListRecentSessionsResult =
+            serde_json::from_value(resp.data.expect("expected result data")).unwrap();
         assert_eq!(
-            rows.len(),
+            result.rows.len(),
             2,
             "a single malformed db_accounts row must not zero out the whole \
              My Agents list — it must only degrade identity-name display for \
              affected rows"
+        );
+        // reagent P1 on PR #2327: the degradation must reach the CALLER, not
+        // just a server-side log line — otherwise the frontend has no way to
+        // ever distinguish "a source failed" from "genuinely zero agents"
+        // when a failure DOES happen to zero out the row count (e.g. both
+        // instance sources failing at once, unlike this identity-only case).
+        assert!(
+            result.degraded.contains(&"accounts".to_string()),
+            "the accounts source's failure must be reported in the response, got: {:?}",
+            result.degraded
         );
     }
 }

--- a/agentmux-srv/src/server/agent_handlers/session.rs
+++ b/agentmux-srv/src/server/agent_handlers/session.rs
@@ -49,6 +49,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let id_store = id_store_lrs.clone();
             let filestore = filestore.clone();
             Box::pin(async move {
+                let t0 = std::time::Instant::now();
                 let cmd: CommandListRecentSessionsData =
                     serde_json::from_value(data).unwrap_or_default();
                 let limit = if cmd.limit == 0 {
@@ -56,6 +57,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 } else {
                     cmd.limit.min(100)
                 };
+                // Tracks which of this handler's data sources degraded to
+                // empty this call. Every source below used to `.map_err(..)?`
+                // — one bad row anywhere aborted the ENTIRE "My Agents" list,
+                // and that exact failure mode has already broken it to an
+                // empty list at least twice in production (PR #2296's oauth
+                // serde-tag mismatch; see
+                // docs/retro/retro-my-agents-fresh-channel-regression-2026_07_27.md
+                // §4/§9 rec 1). A single malformed row must degrade THAT
+                // source only, not the whole response — logged here so the
+                // next incident's log can actually show what happened
+                // (§9 rec 3), unlike this retro's investigation, which had
+                // no way to tell whether this handler ran at all.
+                let mut degraded: Vec<&'static str> = Vec::new();
                 // Pull up to ~10x the requested cap so we can post-
                 // filter by snapshot presence + identity_id without
                 // running out of candidates. 10x is a safety margin
@@ -87,9 +101,18 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let instances: Vec<AgentInstance> = match wstore.shared_agent_registry() {
                     Some(reg) => {
                         let agents_root = wstore.registry_agents_base();
-                        let mut records = reg
-                            .list_active()
-                            .map_err(|e| format!("listrecentsessions: registry: {e}"))?;
+                        let mut records = match reg.list_active() {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "listrecentsessions: registry list_active failed — \
+                                     degrading to local-only instances for this call"
+                                );
+                                degraded.push("registry");
+                                Vec::new()
+                            }
+                        };
                         if let Some(idf) = identity_filter {
                             records.retain(|r| r.data.identity_id.as_deref() == Some(idf));
                         }
@@ -124,7 +147,15 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         // local-only append agree on identity (reagent P1).
                         let local = wstore
                             .instance_list_named(raw_limit, None, identity_filter, true)
-                            .unwrap_or_default();
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(
+                                    error = %e,
+                                    "listrecentsessions: local instance_list_named failed — \
+                                     degrading to registry-only instances for this call"
+                                );
+                                degraded.push("local_instances");
+                                Vec::new()
+                            });
                         let mut local_by_key: std::collections::HashMap<
                             (String, String),
                             AgentInstance,
@@ -220,24 +251,53 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                     None => wstore
                         .instance_list_named(raw_limit, None, identity_filter, true)
-                        .map_err(|e| format!("listrecentsessions: {e}"))?,
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(
+                                error = %e,
+                                "listrecentsessions: local instance_list_named failed \
+                                 (no shared registry attached) — degrading to empty list"
+                            );
+                            degraded.push("local_instances");
+                            Vec::new()
+                        }),
                 };
 
-                let defs = wstore
-                    .agent_def_list()
-                    .map_err(|e| format!("listrecentsessions: defs: {e}"))?;
+                let defs = wstore.agent_def_list().unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "listrecentsessions: agent_def_list failed — degrading to empty \
+                         (rows will show \"(missing definition)\")"
+                    );
+                    degraded.push("agent_defs");
+                    Vec::new()
+                });
                 // Identity display names resolve off the direct
                 // agent<->account links now (db_agent_identity_links /
                 // db_accounts), not the retired bundle tables — see
                 // SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md
                 // §4 item 1. Bulk-fetched once and grouped by definition_id
                 // rather than queried per-row.
-                let agent_identity_links = id_store
-                    .agent_identity_list_all()
-                    .map_err(|e| format!("listrecentsessions: agent_identity_links: {e}"))?;
-                let accounts = id_store
-                    .identity_list(None)
-                    .map_err(|e| format!("listrecentsessions: accounts: {e}"))?;
+                let agent_identity_links = id_store.agent_identity_list_all().unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "listrecentsessions: agent_identity_list_all failed — degrading to \
+                         empty (rows will show \"(ambient creds)\")"
+                    );
+                    degraded.push("identity_links");
+                    Vec::new()
+                });
+                let accounts = id_store.identity_list(None).unwrap_or_else(|e| {
+                    // The exact call PR #2296 broke (an oauth secret_ref serde-tag
+                    // mismatch aborted this and, before this hardening, the whole
+                    // handler with it) — now degrades in isolation instead.
+                    tracing::warn!(
+                        error = %e,
+                        "listrecentsessions: identity_list failed — degrading to empty \
+                         (rows will show \"(missing account)\")"
+                    );
+                    degraded.push("accounts");
+                    Vec::new()
+                });
                 let accounts_by_id: std::collections::HashMap<&str, &IdentityAccount> =
                     accounts.iter().map(|a| (a.id.as_str(), a)).collect();
                 let mut links_by_agent: std::collections::HashMap<&str, Vec<&AgentIdentityLink>> =
@@ -248,9 +308,15 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         .or_default()
                         .push(link);
                 }
-                let memories = id_store
-                    .bundle_memory_list()
-                    .map_err(|e| format!("listrecentsessions: memories: {e}"))?;
+                let memories = id_store.bundle_memory_list().unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "listrecentsessions: bundle_memory_list failed — degrading to empty \
+                         (rows will show \"(missing memory)\")"
+                    );
+                    degraded.push("memories");
+                    Vec::new()
+                });
 
                 // Build rows. Hits filestore once per instance; with
                 // raw_limit ≤ 500 and stat() being a single indexed
@@ -352,6 +418,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     (false, true) => std::cmp::Ordering::Greater,
                 });
                 rows.truncate(limit);
+
+                // Command-level completion trace (retro §9 rec 3) — the
+                // prior incident's own log had no way to show whether this
+                // RPC ran, succeeded, or returned degraded data; this line
+                // answers all three going forward. `degraded` is non-empty
+                // only when at least one source above fell back to empty —
+                // an all-clear call logs an empty list here.
+                tracing::info!(
+                    rows = rows.len(),
+                    degraded = ?degraded,
+                    elapsed_ms = t0.elapsed().as_millis() as u64,
+                    "listrecentsessions: completed"
+                );
 
                 Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
             })
@@ -481,4 +560,173 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::rpc_types::RpcMessage;
+    use crate::registry::{
+        DefinitionRecord, DefinitionRecordV1, DefinitionStore, NamedAgentRecord,
+        NamedAgentRecordV1, Registry,
+    };
+    use crate::server::tests::test_state;
+
+    fn named_record(instance_id: &str, definition_id: &str) -> NamedAgentRecord {
+        NamedAgentRecord {
+            schema_version: 1,
+            data: NamedAgentRecordV1 {
+                instance_id: instance_id.to_string(),
+                instance_name: format!("session-{instance_id}"),
+                definition_id: definition_id.to_string(),
+                identity_id: None,
+                memory_id: None,
+                session_id: None,
+                working_dir: format!("{definition_id}-workdir"),
+                source_agents_base: None,
+                created_at_ms: 1,
+                last_launched_at_ms: 1,
+                created_by_version: "test".to_string(),
+                last_launched_by_version: "test".to_string(),
+            },
+        }
+    }
+
+    fn definition_record(id: &str) -> DefinitionRecord {
+        DefinitionRecord {
+            schema_version: 1,
+            data: DefinitionRecordV1 {
+                id: id.to_string(),
+                name: format!("Agent {id}"),
+                provider: "claude".to_string(),
+                is_seeded: 0,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Seeds `state.wstore` with N cross-channel registry + definition
+    /// records (as they'd exist on a REAL machine before a fresh channel
+    /// ever boots) and returns the dispatch machinery ready to call
+    /// `listrecentsessions`.
+    fn setup_with_n_cross_channel_agents(
+        n: usize,
+    ) -> (
+        AppState,
+        std::sync::Arc<WshRpcEngine>,
+        tokio::sync::mpsc::UnboundedReceiver<RpcMessage>,
+        tempfile::TempDir,
+        tempfile::TempDir,
+    ) {
+        let state = test_state();
+        let registry_dir = tempfile::tempdir().unwrap();
+        let def_dir = tempfile::tempdir().unwrap();
+        let registry = Registry::open(registry_dir.path().to_path_buf()).unwrap();
+        let def_store = DefinitionStore::open(def_dir.path().to_path_buf()).unwrap();
+        for i in 0..n {
+            let id = format!("inst-{i}");
+            let def_id = format!("def-{i}");
+            registry.upsert(&named_record(&id, &def_id)).unwrap();
+            def_store.upsert(&definition_record(&def_id)).unwrap();
+        }
+        state.wstore.set_registry(std::sync::Arc::new(registry));
+        state.wstore.set_def_registry(std::sync::Arc::new(def_store));
+
+        let (engine, output_rx) = WshRpcEngine::new();
+        register(&engine, &state);
+        (state, engine, output_rx, registry_dir, def_dir)
+    }
+
+    async fn dispatch_list_recent_sessions(
+        engine: &std::sync::Arc<WshRpcEngine>,
+        output_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RpcMessage>,
+    ) -> RpcMessage {
+        engine.handle_message(RpcMessage {
+            command: COMMAND_LIST_RECENT_SESSIONS.to_string(),
+            reqid: "req-1".to_string(),
+            data: Some(serde_json::json!({ "limit": 20 })),
+            ..Default::default()
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    /// Retro
+    /// `docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md`
+    /// §9 rec 5: this exact path (fresh channel + pre-populated global
+    /// registry) had broken three separate times with no regression test
+    /// covering it. Directly exercises the RPC end-to-end against a real
+    /// `Registry`/`DefinitionStore` on disk — the same code path a fresh
+    /// `task package` channel hits on its very first "My Agents" fetch.
+    #[tokio::test]
+    async fn cross_channel_registry_agents_populate_a_fresh_channels_my_agents_list() {
+        let (_state, engine, mut output_rx, _reg_dir, _def_dir) =
+            setup_with_n_cross_channel_agents(3);
+
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let rows: Vec<RecentSessionRow> =
+            serde_json::from_value(resp.data.expect("expected row data")).unwrap();
+        assert_eq!(
+            rows.len(),
+            3,
+            "all 3 cross-channel registry agents must appear on a channel that never created any of them locally"
+        );
+    }
+
+    /// Retro §4/§9 rec 1 — the core hardening this test locks in. Before
+    /// this fix, `identity_list()` failing on one unparseable `db_accounts`
+    /// row (PR #2296's exact incident: an oauth secret_ref serde-tag
+    /// mismatch) `?`-aborted the ENTIRE `listrecentsessions` response,
+    /// zeroing "My Agents" even though the registry/definitions themselves
+    /// were completely healthy. Reproduces that exact malformed-row shape
+    /// directly via raw SQL (bypassing `identity_upsert`, which would
+    /// never produce an invalid `secret_ref`) and asserts the response
+    /// still contains every agent — only the identity-name enrichment
+    /// degrades, not the whole list.
+    #[tokio::test]
+    async fn a_malformed_identity_account_row_degrades_that_source_without_zeroing_the_whole_list() {
+        let (state, engine, mut output_rx, _reg_dir, _def_dir) =
+            setup_with_n_cross_channel_agents(2);
+
+        // Same malformed shape as the real PR #2296 incident: a
+        // `secret_ref.backend` tag no `SecretRef` variant matches.
+        {
+            let conn = state.wstore.conn().lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_accounts
+                    (id, name, provider, kind, display_name, secret_ref, context, status, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                rusqlite::params![
+                    "acct-broken",
+                    "broken-account",
+                    "claude",
+                    "oauth",
+                    "",
+                    r#"{"backend":"totally_bogus_backend"}"#,
+                    "{}",
+                    "unknown",
+                    0i64,
+                    0i64,
+                ],
+            )
+            .unwrap();
+        }
+
+        let resp = dispatch_list_recent_sessions(&engine, &mut output_rx).await;
+
+        assert!(resp.error.is_empty(), "unexpected error: {}", resp.error);
+        let rows: Vec<RecentSessionRow> =
+            serde_json::from_value(resp.data.expect("expected row data")).unwrap();
+        assert_eq!(
+            rows.len(),
+            2,
+            "a single malformed db_accounts row must not zero out the whole \
+             My Agents list — it must only degrade identity-name display for \
+             affected rows"
+        );
+    }
 }

--- a/docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md
+++ b/docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md
@@ -1,0 +1,386 @@
+# Retro: "My Agents" empty on a fresh `task package` portable (0.54.6)
+
+**Date:** 2026-07-27
+**Severity:** P1 if it recurs (the entire custom-agent roster — ~24 agents including "AgentA" — appears wiped), but **not reproduced live** and **not currently explained by any bad data on this machine**
+**Status:** Partially root-caused. One architectural fragility is **confirmed** (by code reading) and **proven exploitable** (it already caused this exact symptom once, 2 days earlier, via PR #2296). A live server log from the user's *actual* reported session was found and analyzed, but it does not contain enough detail (no per-RPC-command tracing) to prove what the frontend rendered. Root cause for **this specific incident** is not pinned down — see §6 for the honest verdict.
+
+---
+
+## 1. What the user reported
+
+> Built a fresh portable release (`task package`, version 0.54.6), opened it. The
+> "My Agents" section of the agent picker — which normally lists ~24 custom
+> agents, most importantly "AgentA" — was empty or missing agents.
+> "This is a regression, loading DEV instances always came with the My Agents
+> populated."
+
+## 2. Ground truth going in (established by direct investigation before git archaeology; not re-derived here)
+
+- "My Agents" = `frontend/app/view/agent/components/MyAgentsList.tsx` (renamed
+  from `RecentSessionsList.tsx`, PR #977/#1008 cascade), calling
+  `RpcApi.ListRecentSessionsCommand` → backend `COMMAND_LIST_RECENT_SESSIONS`
+  in `agentmux-srv/src/server/agent_handlers/session.rs`.
+- That handler sources from the **global, cross-channel instance registry**
+  (`~/.agentmux/shared/agents/registry/`, `Registry::list_active()`,
+  `agentmux-srv/src/registry/store.rs:150-176`), not per-channel SQLite — so a
+  brand-new channel is *supposed* to still show every agent ever created,
+  anywhere.
+- **Direct validation, done live on this machine before this retro:** all 24
+  files in `~/.agentmux/shared/agents/registry/*.json` pass
+  `schema.rs`'s `validate()` (schema_version, instance_id/filename match,
+  non-empty fields, safe relative `working_dir`). All 23 files in the sibling
+  `~/.agentmux/shared/agents/definitions/*.json` (`DefinitionStore`, a
+  different store backing a different picker section) also pass its
+  `def_schema.rs` validate(). **Zero rows would be skipped by validation.**
+- `session.rs`'s row-construction does **not** drop a row when its
+  `definition_id` has no matching `AgentDefinition` — it falls back to
+  `"(missing definition)"` display text. So there is no silent per-row drop in
+  the merge logic either.
+- A live test-launch of the fresh build from inside an agent shell was
+  attempted twice, but the agent's own shell environment leaks an ambient
+  `AGENTMUX_CHANNEL` that the launcher's nested-instance detection (correctly,
+  per its own documented logic) treats as an explicit standalone override, not
+  a leak — so neither attempt exercised a genuinely fresh channel end-to-end.
+  **This investigation could not directly reproduce the symptom.**
+
+This retro picks up from there: git/PR archaeology, and a search for whether
+this exact complaint is already tracked.
+
+---
+
+## 3. Is this already a known pattern? Yes — repeatedly
+
+`docs/retro/` already has **three** prior incidents in the same feature area,
+all within the last six weeks:
+
+| Retro | Date | Symptom | Root cause |
+|---|---|---|---|
+| `retro-local-build-isolation-regression-2026-06-09.md` | 06-09 | New local build joins an old running instance instead of starting fresh | Pipe-hash key didn't include the build stamp |
+| `retro-per-build-launch-isolation-2026-06-13.md` | 06-13 | Same, plus nested-launch channel leak | cef-cache stayed per-branch; ambient `AGENTMUX_CHANNEL` leaked into nested launches |
+| `docs/analysis/ANALYSIS_CROSS_CHANNEL_AGENT_RETENTION_2026_06_13.md` | 06-13 | Fresh channel shows **zero** custom agents (only 7 seeded templates) | The one-shot definitions-backfill migration skipped 10/12 DBs on a schema-drift error, never scanned `dev/`, and its one-shot marker made the failure permanent |
+| `retro-legacy-agent-history-cross-channel-2026-06-16.md` + `retro-cross-channel-conversation-continuity-regression-2026-06-16.md` | 06-16 | Agent *appears in the list* but opens blank / loses history cross-channel | `sourceBlockId` in the global snapshot was channel-local, so the cross-channel read fallback couldn't anchor it |
+
+None of these four is a live match for *this* incident (the registry/definition
+data here is 100% valid, ruling out the 06-13 migration-skip bug; the symptom
+is "list is empty," not "list shows agents that then open blank," ruling out
+the 06-16 pair) — but they establish that "fresh channel, cross-channel
+agent-visibility feature, breaks in a new way" is a **recurring failure class**
+in this codebase, not a one-off.
+
+More importantly, there is a **direct fourth instance, 2 days before this
+report**, that reproduces this incident's exact wording:
+
+---
+
+## 4. The smoking gun: PR #2296 already hit this exact symptom, 2 days earlier
+
+`git log -S"Was a silent" -- frontend/app/view/agent/components/MyAgentsList.tsx`
+→ commit `cb8c9eeb` (`fix(identity): oauth_config_dir secret_ref serde rename
+mismatch (#2296)`, merged **2026-07-25**, i.e. two days before this report).
+Its commit message, verbatim:
+
+> `SecretRef::OAuthConfigDir`'s enum-wide `rename_all = "snake_case"` derives
+> `o_auth_config_dir` ... but every real account in `~/.agentmux/shared/store.db`
+> was written with `oauth_config_dir` ... `identity_list()` aborts entirely on
+> the first unparseable row, so this broke "My Agents"/recent-sessions for any
+> instance with a real oauth-class account — **reported live as "what happened
+> to My Agents? its an empty list."**
+
+This is not analogous — it is **the identical user-facing symptom**, already
+filed once. The fix (`agentmux-srv/src/backend/storage/identities.rs:80`,
+explicit `#[serde(rename = "oauth_config_dir", alias = "o_auth_config_dir")]`)
+also touched `MyAgentsList.tsx` to replace a silent `catch { return []; }`
+with one that at least logs (`MyAgentsList.tsx:128-140`) — its own comment
+says the silent version is "indistinguishable from 'genuinely no sessions'…
+exactly what made a real regression here look like expected empty state."
+
+**Is this specific bug present in the reported 0.54.6 build?** No —
+`git merge-base --is-ancestor cb8c9eeb 178f7cee` (178f7cee = the `chore:
+release v0.54.6` commit) confirms it **is** an ancestor; the fix shipped in
+0.54.6. Direct inspection of this machine's actual
+`~/.agentmux/shared/store.db` `db_accounts` table (2 rows) confirms both use
+the canonical, already-fixed `"backend":"oauth_config_dir"` tag — this
+specific bug cannot be firing here right now.
+
+### But the *structural* fragility it exposed is still fully present
+
+`session.rs`'s `COMMAND_LIST_RECENT_SESSIONS` handler makes **six** sequential
+data-source calls, and aborts the **entire** list on the **first** error from
+any of them:
+
+| Call | Line | Source |
+|---|---|---|
+| `reg.list_active()` | `session.rs:92` | global instance registry |
+| `wstore.instance_list_named(...)` (local fallback / append) | `session.rs:201` | per-channel SQLite |
+| `wstore.agent_def_list()` | `session.rs:206` | global + local agent definitions |
+| `id_store.agent_identity_list_all()` | `session.rs:215` | `db_agent_identity_links` |
+| `id_store.identity_list(None)` | `session.rs:218` | `db_accounts` — **the exact call #2296 fixed** |
+| `id_store.bundle_memory_list()` | `session.rs:231` | `db_bundles` |
+
+Every one of these uses `.map_err(|e| format!("listrecentsessions: ..."))?` —
+**any single malformed row in any of the four SQLite-backed sources, or any
+I/O error against either global file-store, still takes down the whole list**,
+identically to how #2296's bug did. The fix for #2296 patched the *one*
+concrete instance (an enum-tag mismatch); it did not change this handler's
+all-or-nothing structure. Nothing prevents the same class of failure from a
+*different* malformed row in `db_accounts`, `db_agent_identity_links`, or
+`db_bundles` tomorrow.
+
+I directly checked this machine's live data against that risk (same technique
+the original investigation used for the registry/definition JSON files, just
+extended to the identity/memory-bundle side it hadn't covered):
+
+- `db_accounts`: 2 rows, both parse cleanly against the current `SecretRef` enum.
+- `db_agent_identity_links`: 1 row, plain TEXT columns, no enum-tag risk.
+- `db_bundles`: 4 rows, plain TEXT/INTEGER/JSON-array columns, no enum-tag risk.
+- Grepped `identities.rs` and `agents.rs` for every other `#[serde(rename_all
+  = ...)]` — one more exists (`agents.rs:161`, `rename_all = "lowercase"`,
+  which doesn't split on capitals the way `snake_case` does, so it isn't
+  vulnerable to the same acronym trap) — not independently fuzzed further.
+
+**Conclusion: none of the six data sources is currently broken on this
+machine.** The fragility is real and previously proven, but not the live
+cause today.
+
+### And the frontend still can't tell "error" from "empty"
+
+`MyAgentsList.tsx:245-246`:
+
+```ts
+const isLoading = () => rows() === undefined;
+const isEmpty = () => !isLoading() && (rows() ?? []).length === 0;
+```
+
+Whether the resource settled to `[]` because the RPC *succeeded* with zero
+rows, or because it *threw* and the `catch` block (`MyAgentsList.tsx:120-141`)
+swallowed the error into `return []`, renders the **exact same** UI:
+`EMPTY_GLOBAL` — *"No agents yet — pick a template below to create your first
+one."* (`MyAgentsList.tsx:72-74`). #2296 added a `Logger.error` call inside
+that catch, which is real progress for someone who checks logs — but a user
+looking at the picker itself sees no difference at all between "you have zero
+agents" and "the backend call just failed." No retry affordance, no error
+banner.
+
+---
+
+## 5. What the user's *actual* reported session's log shows
+
+The orchestrating investigation identified the exact log file and a ~9-second
+session but hadn't read it. I did:
+`~/.agentmux/logs/agentmuxsrv-v0.54.6.log.2026-07-27`, lines 1-53.
+
+Confirmed directly from the log (all timestamps UTC, same file):
+
+- `21:03:16.825` — process starts. `data_dir` is
+  `channels\local-agenta-release-v0.54.6-347f00-e771f5b3\versions\0.54.6\data`
+  — this channel slug is derived from the branch `agenta/release-v0.54.6`
+  (the exact branch this retro is written on), confirming this log **is** the
+  user's own reported build/session, not a different agent's.
+- `21:03:16.981` — `"First launch: created initial data"` /
+  `"agent seed: no agents found, seeding from manifest v11..."` → **this
+  channel had genuinely never run before.** Confirmed fresh, first-ever boot.
+- `21:03:16.945` / `.951` / `.960` / `.962` — `"registry: shared agent
+  registry attached"`, `"def registry: global definition store attached"`,
+  `"global transcripts: store attached"`, `"shared store: attached"` — **all
+  four cross-channel stores attached successfully** in this exact process.
+  The backend-side prerequisite for cross-channel "My Agents" sourcing was
+  healthy in the reported session.
+- `21:03:18.811` — `"WebSocket client connected"` (~2s after process start).
+- **No RPC command names appear anywhere in this log** (not for this session,
+  nor the two other fresh-channel sessions later in the same file at 22:33
+  and 22:36) — RPC traffic isn't traced at INFO level in this build. I cannot
+  confirm from the log whether `listrecentsessions` was ever issued, or what
+  it returned.
+- `21:03:25.372` (~6.5s after WS connect) — **two WARNs**: `"object not found
+  in wstore; skipping broadcast"`, `otype:"workspace"`, contexts
+  `"TabDeleted parent"` and `"ActiveTab/Reorder"`
+  (`agentmux-srv/src/server/wave_obj_bridge.rs:336-361`). Tracing that code:
+  a `TabDeleted` event tries to re-fetch and broadcast its **parent
+  workspace**'s new state, and an `ActiveTabChanged`/`TabReordered` event does
+  the same — but the workspace object was already gone by the time either
+  fetch ran. This is consistent with the normal (if racy) bootstrap dance of
+  tearing down the seeded default "Starter workspace" and replacing it with
+  the real one on a genuinely first launch (the same seeded-workspace
+  mechanism `fix(window): first window's title no longer leaks the unrenamed
+  bootstrap workspace name (#2319)` — already in this exact 0.54.6 build —
+  was independently patching around, for a *different* symptom, the same day).
+- `21:03:25.479` — `"WebSocket client disconnected"`. Total process lifetime
+  from start to disconnect: **~8.65 seconds** — matches "~9 seconds."
+
+**What this proves:** the reported session was a genuinely fresh, first-ever
+channel boot, whose backend-side cross-channel stores all attached cleanly,
+and which underwent bootstrap workspace/tab churn (tab deleted, active tab
+reordered) within the same few seconds before the window closed.
+**What this does not prove:** whether `MyAgentsList` ever completed a fetch,
+what it fetched, or whether the tab/workspace churn interrupted or remounted
+the component mid-flight. The log format is the limiting factor, not the
+absence of a plausible mechanism.
+
+---
+
+## 6. Verdict — which of the four hypotheses?
+
+Reconciling against the four candidates posed at the start of this
+investigation:
+
+- **(a) A pinpointed code regression** — not found. Every registry/definition
+  file and every identity/link/bundle row on this machine is currently valid;
+  the one prior concrete bug of exactly this shape (#2296) is confirmed fixed
+  in 0.54.6; the backend startup ordering (`agentmux-srv/src/main.rs:63-143`
+  — `bootstrap::open_stores_and_migrate` runs to completion, synchronously,
+  before `AGENTMUXSRV-ESTART` is even emitted and before `axum::serve` starts
+  listening) **rules out** a startup race between registry-attach and the
+  frontend's first RPC — by construction, no client can connect before the
+  registry is either attached or not.
+- **(b) A data/timing issue specific to fresh channels** — partially true:
+  the log **confirms** this was a fresh channel with real first-launch
+  bootstrap churn happening in the same few seconds. But I can't extend that
+  into "and that's what caused an empty render," because RPC traffic isn't
+  logged.
+- **(c) Test-methodology artifact** — well-supported by direct evidence: an
+  8.65-second session, with active tab/workspace churn 6.5s in, is a strong
+  candidate for "closed before (or during) the picker's first successful
+  fetch," independent of any bug.
+- **(d) A real but narrower issue** — yes, but not the one initially
+  suspected (a startup race, ruled out above). The real, narrower, *proven*
+  issue is the **single-point-of-failure handler design** (§4): it has
+  already caused this precise symptom once, the fix only patched the one
+  instance found, and the frontend's error handling still can't distinguish
+  "backend threw" from "genuinely empty."
+
+**Honest bottom line:** I cannot pin a definitive, reproduced root cause for
+*this specific* report. The most defensible summary is a hybrid of (c) and
+(d): the direct evidence (an 8.65s session with mid-flight workspace churn)
+best supports a **transient, first-launch-timing artifact** rather than a
+standing bug — but the codebase carries a **confirmed, previously-exploited,
+still-unfixed structural fragility** (any one bad identity/definition/memory
+row anywhere silently zeroes the entire feature, indistinguishably from a
+real empty state) that makes this class of incident likely to recur under
+slightly different conditions, as it already has at least twice
+(2026-06-13's migration-skip bug, 2026-07-25's serde-rename bug).
+
+---
+
+## 7. Found in passing, likely unrelated to this symptom — CORRECTION: already shipped
+
+`git log --oneline --since="2026-07-25"` on the registry/bootstrap area
+surfaced `aeb4f024` (`fix(auth): stop isolated boot from rewriting the global
+registry, ...`), committed **2026-07-27 13:13** on branch
+`agenta/remove-auto-login-trigger`. An earlier draft of this retro used
+`git merge-base --is-ancestor aeb4f024 178f7cee` and concluded the fix was
+**not** merged — that check is invalid here: `4db519b7` (the PR #2318 merge
+commit) has a **single parent** (`git log 4db519b7 -1 --format=%P` →
+`128633ce...`), meaning PR #2318 was **squash-merged**. A squash merge
+produces a brand-new commit disconnected from the original branch's commit
+graph, so none of that branch's original hashes (`aeb4f024` included) will
+ever show up as an "ancestor" of main, regardless of whether their content
+shipped.
+
+**Corrected, directly verified**: `git show origin/main:agentmux-srv/src/test_support.rs`
+(a file `aeb4f024` introduced) and `git show
+origin/main:agentmux-srv/src/migrations/m0018_ambient_login_registry.rs`
+(grepped for `isolated_auth_enabled`, found at line 50) both confirm **the
+actual fix is present on `main`**, and therefore in the reported 0.54.6 build.
+Recommendation #4 below ("merge aeb4f024") is **stale — no action needed**;
+left in the numbered list struck through rather than silently deleted, since
+the reasoning-error itself (trusting `--is-ancestor` across a squash merge) is
+worth keeping visible for whoever reads this next.
+
+The bug `aeb4f024` fixes, for context (already shipped, not a live risk):
+`m0018_ambient_login_registry.rs` (before the fix) read `ctx.shared_store_path`
+to compute which agents are oauth-linked, but under `AGENTMUX_ISOLATED_AUTH=1`
+(this session's own opt-in dev-testing flag from PR #2318) that path points at
+a fresh, empty, per-instance store — and then unconditionally wrote its
+conclusion into the REAL global cross-channel definitions registry. Booting a
+single isolated dev-test instance could have flipped every real agent
+everywhere to `use_ambient_login=1`. This is very unlikely to explain the
+reported "My Agents" symptom regardless (it requires `AGENTMUX_ISOLATED_AUTH=1`
+to be set, which a normal `task package` build never sets; and even when
+triggered it only flips a boolean on already-valid definitions, it doesn't drop
+rows or invalidate JSON) — but it's now moot either way since the fix shipped.
+
+---
+
+## 8. What's confirmed vs. inferred (summary)
+
+**Confirmed (code + logs + direct data inspection):**
+- Registry/definition files: 100% schema-valid (24 + 23 files).
+- Identity accounts / links / bundles: 100% parseable against current code
+  (2 + 1 + 4 rows).
+- `#2296`'s specific bug is fixed and present in 0.54.6; not currently live.
+- The reported session was a genuine first-ever channel boot; all four
+  cross-channel stores attached successfully in it; it underwent bootstrap
+  workspace/tab churn ~6.5s after WS connect; it lasted ~8.65s total.
+- No startup race is possible between registry-attach and the frontend's
+  first RPC (backend ordering is fully synchronous and precedes the readiness
+  signal).
+- `session.rs`'s handler is structurally all-or-nothing across 6 data
+  sources; the frontend cannot distinguish "RPC failed" from "genuinely
+  empty" in its rendered UI (only in a console log, since #2296).
+- `aeb4f024` (registry-corruption-under-isolation fix) exists, is real, and
+  **is** in the 0.54.6 build the user tested (verified directly against
+  `origin/main`'s file content, not commit ancestry — PR #2318 was
+  squash-merged, so `--is-ancestor` checks against its original commits are
+  invalid; see §7's correction).
+
+**Inferred / not proven:**
+- That the workspace/tab churn in the user's session actually interrupted
+  the `MyAgentsList` fetch (plausible mechanism, no direct log evidence).
+- That the user's impression of "empty" reflects a fully-settled
+  `EMPTY_GLOBAL` render rather than a loading state glimpsed during a very
+  short session.
+- Whether repeating this exact build/launch today would reproduce anything —
+  not attempted (this investigation, like the one before it, had no clean way
+  to launch a genuinely fresh channel without an ambient-env leak; see §2).
+
+---
+
+## 9. Recommendations (not implemented — diagnostic retro only)
+
+1. **Harden `COMMAND_LIST_RECENT_SESSIONS` to degrade per-source, not
+   all-or-nothing.** `session.rs:206/215/218/231` — on error from
+   `agent_def_list()`, `agent_identity_list_all()`, `identity_list()`, or
+   `bundle_memory_list()`, log and substitute an empty map/vec (accepting
+   degraded display: "(missing definition)"/"(ambient creds)"/"(vanilla
+   CLI)" — all of which already exist as fallback strings for the
+   *not-found* case, lines 248-265) instead of aborting the whole list.
+   Given this exact failure mode has now caused this reported symptom at
+   least once for a confirmed reason, and the structure hasn't changed,
+   this is the highest-leverage fix.
+2. **`MyAgentsList.tsx`: give the UI a way to distinguish "confirmed zero
+   agents" from "fetch failed."** Currently both hit `EMPTY_GLOBAL`
+   (`MyAgentsList.tsx:72-74`, `258-267`). At minimum, catch and surface a
+   distinct error state/retry affordance rather than only logging to
+   console (`MyAgentsList.tsx:128-140`).
+3. **Add RPC-command-level tracing** (command name, success/failure, latency)
+   at INFO for this handler at least — this investigation's biggest single
+   evidentiary gap was that the user's own log couldn't show whether
+   `listrecentsessions` ran, succeeded, or failed.
+4. ~~Merge `aeb4f024`~~ — **stale, no action needed.** An earlier draft of
+   this retro (§7) mistakenly concluded this fix hadn't shipped, based on
+   `git merge-base --is-ancestor` across a squash-merged PR — invalid check,
+   corrected in §7. The fix is already on `main` and in 0.54.6.
+5. **Add an automated e2e regression test**: seed a global registry +
+   definitions store with N valid agents, boot a *fresh* channel against
+   them, assert "My Agents" renders N rows. This exact path (fresh channel +
+   pre-populated global registry) has now broken three separate times
+   (2026-06-13 migration-skip, 2026-06-16 snapshot-anchoring, 2026-07-25
+   serde-rename) without ever having its own regression test.
+
+---
+
+## 10. Related docs
+
+- `docs/retro/retro-local-build-isolation-regression-2026-06-09.md`
+- `docs/retro/retro-per-build-launch-isolation-2026-06-13.md`
+- `docs/analysis/ANALYSIS_CROSS_CHANNEL_AGENT_RETENTION_2026_06_13.md`
+- `docs/retro/retro-legacy-agent-history-cross-channel-2026-06-16.md`
+- `docs/retro/retro-cross-channel-conversation-continuity-regression-2026-06-16.md`
+- `docs/specs/SPEC_CROSS_CHANNEL_AGENT_PERSISTENCE_2026-06-13.md`
+- `docs/specs/SPEC_AGENT_PICKER_TWO_TIER_2026_05_24.md`
+- `docs/specs/SPEC_ISOLATED_AUTH_DEV_TESTING_2026_07_27.md` (§7's `aeb4f024`
+  context)
+- PR #2296 (`cb8c9eeb`) — the direct prior instance of this exact symptom.
+- PR #2319 (`128633ce`) — same-day, same-build fix for a different
+  fresh-channel-only timing bug (window title), cited in §5 as pattern
+  corroboration, not as the cause.

--- a/frontend/app/store/rpc-api/agent.ts
+++ b/frontend/app/store/rpc-api/agent.ts
@@ -308,11 +308,19 @@ export const AgentApi = {
     // orphaned conversation (e.g. after a renderer crash) becomes
     // recoverable from normal UI. See docs/recovery/MAKS_CONVERSATION_2026_05_23.md
     // and PR #977 for the underlying continueOfId reattach plumbing.
+    // Response envelope (not a bare array) since the backend hardening in
+    // session.rs — every one of its data sources now degrades to empty on
+    // its own failure instead of aborting the whole RPC (retro
+    // docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md).
+    // `degraded` lists which source(s), if any, fell back this call; the
+    // caller uses it to tell "genuinely zero agents" apart from "a source
+    // failed and we got nothing" — a distinction transport success/failure
+    // alone can no longer make once the RPC itself never throws for this.
     ListRecentSessionsCommand(
         client: RpcClient,
         data: { limit?: number; identity_id?: string },
         opts?: RpcOpts,
-    ): Promise<RecentSessionRow[]> {
+    ): Promise<{ rows: RecentSessionRow[]; degraded: string[] }> {
         return client.rpcCall("listrecentsessions", data, opts);
     },
 

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     EMPTY_FILTERED,
     EMPTY_GLOBAL,
+    FETCH_ERROR,
     formatRelative,
     MyAgentsList,
 } from "./MyAgentsList";
@@ -180,6 +181,44 @@ describe("MyAgentsList — populated", () => {
         render(() => <MyAgentsList onReattach={() => {}} />);
         await screen.findByTestId("agent-my-agents-entry");
         expect(screen.getByText("My Agents")).toBeInTheDocument();
+    });
+});
+
+describe("MyAgentsList — fetch error (retro-my-agents-fresh-channel-regression-2026-07-27.md)", () => {
+    it("renders a distinct error state, not the empty-agents copy, when the RPC rejects", async () => {
+        // Suppress the expected console.error from Logger.error inside the
+        // component's own catch block — this test is asserting that catch
+        // path fires correctly, not treating its logging as a test failure.
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockRejectedValue(new Error("backend unreachable"));
+        render(() => <MyAgentsList onReattach={() => {}} />);
+
+        const error = await screen.findByTestId("agent-my-agents-error");
+        expect(error).toHaveTextContent(FETCH_ERROR);
+        // Must NOT also render (or ever have rendered) the "genuinely empty"
+        // copy — that ambiguity is the exact bug this hardening fixes.
+        expect(screen.queryByTestId("agent-my-agents-empty")).toBeNull();
+        expect(screen.queryByText(EMPTY_GLOBAL)).toBeNull();
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("retries the RPC when the Retry button is clicked, and shows the list on success", async () => {
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        vi.mocked(RpcApi.ListRecentSessionsCommand)
+            .mockRejectedValueOnce(new Error("backend unreachable"))
+            .mockResolvedValueOnce([makeRow({ instance_id: "recovered" })]);
+        render(() => <MyAgentsList onReattach={() => {}} />);
+
+        const retryBtn = await screen.findByTestId("agent-my-agents-retry");
+        await userEvent.click(retryBtn);
+
+        const entries = await screen.findAllByTestId("agent-my-agents-entry");
+        expect(entries).toHaveLength(1);
+        expect(screen.queryByTestId("agent-my-agents-error")).toBeNull();
+        expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledTimes(2);
+
+        consoleErrorSpy.mockRestore();
     });
 });
 

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -265,6 +265,42 @@ describe("MyAgentsList — fetch error (retro-my-agents-fresh-channel-regression
         expect(entries).toHaveLength(1);
         expect(screen.queryByTestId("agent-my-agents-error")).toBeNull();
     });
+
+    // reagent P1 on PR #2327's re-review: `fetchError` was a single shared
+    // signal with no per-request guard — a stale (superseded) fetch's late
+    // rejection could overwrite the state a NEWER, already-succeeded fetch
+    // just set, painting the error panel over valid loaded data.
+    it("does not let a stale fetch's late rejection overwrite a newer fetch's successful data", async () => {
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        let rejectStale!: (err: unknown) => void;
+        const stalePromise = new Promise<never>((_, reject) => { rejectStale = reject; });
+        vi.mocked(RpcApi.ListRecentSessionsCommand)
+            .mockImplementationOnce(() => stalePromise)
+            .mockResolvedValueOnce(okResult([makeRow({ instance_id: "fresh" })]));
+
+        const [identityId, setIdentityId] = createSignal<string>("id-1");
+        render(() => (
+            <MyAgentsList identityId={identityId} onReattach={() => {}} />
+        ));
+
+        // Supersede the still-pending first fetch before it ever resolves.
+        setIdentityId("id-2");
+        const entries = await screen.findAllByTestId("agent-my-agents-entry");
+        expect(entries).toHaveLength(1);
+
+        // Now let the stale first fetch fail, late.
+        rejectStale(new Error("stale failure"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // The already-loaded, correct data must still be showing — not the
+        // error panel from a fetch that no longer matters.
+        expect(screen.queryByTestId("agent-my-agents-error")).toBeNull();
+        expect(screen.getAllByTestId("agent-my-agents-entry")).toHaveLength(1);
+
+        consoleErrorSpy.mockRestore();
+    });
 });
 
 describe("formatRelative", () => {

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -47,6 +47,12 @@ afterEach(() => {
     cleanup();
 });
 
+/** Wraps rows in the `listrecentsessions` response envelope
+ * (`{ rows, degraded }`) introduced alongside the per-source
+ * degradation hardening — see `ListRecentSessionsCommand`'s return
+ * type and `session.rs`'s `ListRecentSessionsResult`. */
+const okResult = (rows: RecentSessionRow[] = []) => ({ rows, degraded: [] as string[] });
+
 const makeRow = (overrides: Partial<RecentSessionRow> = {}): RecentSessionRow => ({
     instance_id: "inst-1",
     instance_name: "Maks",
@@ -70,7 +76,7 @@ const makeRow = (overrides: Partial<RecentSessionRow> = {}): RecentSessionRow =>
 
 describe("MyAgentsList — empty state", () => {
     it("renders the generic empty copy when no filter is applied", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult());
         render(() => <MyAgentsList onReattach={() => {}} />);
         const empty = await screen.findByTestId("agent-my-agents-empty");
         expect(empty).toHaveTextContent(EMPTY_GLOBAL);
@@ -79,7 +85,7 @@ describe("MyAgentsList — empty state", () => {
     });
 
     it("renders the identity-specific empty copy when filtered", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult());
         const [identityId] = createSignal<string>("id-work");
         render(() => (
             <MyAgentsList
@@ -94,7 +100,7 @@ describe("MyAgentsList — empty state", () => {
 
 describe("MyAgentsList — populated", () => {
     it("renders one row per agent with preview + node count", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
             makeRow({ instance_id: "a", instance_name: "Maks", preview: "fix the live-feed" }),
             makeRow({
                 instance_id: "b",
@@ -102,7 +108,7 @@ describe("MyAgentsList — populated", () => {
                 preview: "earlier conversation",
                 node_count: 1,
             }),
-        ]);
+        ]));
         render(() => <MyAgentsList onReattach={() => {}} />);
         // Wait for resource to settle.
         const entries = await screen.findAllByTestId("agent-my-agents-entry");
@@ -118,9 +124,9 @@ describe("MyAgentsList — populated", () => {
     });
 
     it("renders an italic empty-preview hint when has_snapshot but no user message", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
             makeRow({ preview: "", has_snapshot: true, node_count: 0 }),
-        ]);
+        ]));
         render(() => <MyAgentsList onReattach={() => {}} />);
         await screen.findByTestId("agent-my-agents-entry");
         expect(
@@ -129,9 +135,9 @@ describe("MyAgentsList — populated", () => {
     });
 
     it("renders a 'no snapshot' hint when the block has no snapshot file", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([
             makeRow({ preview: "", has_snapshot: false, node_count: 0 }),
-        ]);
+        ]));
         render(() => <MyAgentsList onReattach={() => {}} />);
         await screen.findByTestId("agent-my-agents-entry");
         expect(
@@ -142,7 +148,7 @@ describe("MyAgentsList — populated", () => {
     it("fires onReattach with the row when an entry is clicked", async () => {
         const onReattach = vi.fn();
         const row = makeRow({ instance_id: "click-me" });
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([row]);
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([row]));
         render(() => <MyAgentsList onReattach={onReattach} />);
         const entry = await screen.findByTestId("agent-my-agents-entry");
         await userEvent.click(entry);
@@ -151,7 +157,7 @@ describe("MyAgentsList — populated", () => {
     });
 
     it("passes identity_id to the RPC when filter is set", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult());
         const [identityId] = createSignal<string>("id-work");
         render(() => (
             <MyAgentsList
@@ -167,7 +173,7 @@ describe("MyAgentsList — populated", () => {
     });
 
     it("treats null / undefined identityId as no-filter (empty string sent)", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([]);
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult());
         render(() => <MyAgentsList onReattach={() => {}} />);
         await screen.findByTestId("agent-my-agents-empty");
         expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledWith(
@@ -177,7 +183,7 @@ describe("MyAgentsList — populated", () => {
     });
 
     it("renders the 'My Agents' section title", async () => {
-        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue([makeRow()]);
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue(okResult([makeRow()]));
         render(() => <MyAgentsList onReattach={() => {}} />);
         await screen.findByTestId("agent-my-agents-entry");
         expect(screen.getByText("My Agents")).toBeInTheDocument();
@@ -207,7 +213,7 @@ describe("MyAgentsList — fetch error (retro-my-agents-fresh-channel-regression
         const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         vi.mocked(RpcApi.ListRecentSessionsCommand)
             .mockRejectedValueOnce(new Error("backend unreachable"))
-            .mockResolvedValueOnce([makeRow({ instance_id: "recovered" })]);
+            .mockResolvedValueOnce(okResult([makeRow({ instance_id: "recovered" })]));
         render(() => <MyAgentsList onReattach={() => {}} />);
 
         const retryBtn = await screen.findByTestId("agent-my-agents-retry");
@@ -219,6 +225,45 @@ describe("MyAgentsList — fetch error (retro-my-agents-fresh-channel-regression
         expect(RpcApi.ListRecentSessionsCommand).toHaveBeenCalledTimes(2);
 
         consoleErrorSpy.mockRestore();
+    });
+
+    // reagent P1 on PR #2327: session.rs's hardening (each of 6 data
+    // sources degrades to empty on its own failure instead of aborting
+    // the whole RPC) means the RPC itself basically never throws anymore
+    // — so a resolved call with zero rows AND a non-empty `degraded` is
+    // now the ONLY signal that something failed rather than "you
+    // genuinely have no agents." Without checking `degraded`, this exact
+    // scenario would silently render EMPTY_GLOBAL — the very ambiguity
+    // this whole fix exists to close, just one layer deeper than the
+    // reject-based path the two tests above cover.
+    it("renders the error state (not empty) when the RPC resolves with zero rows but reports a degraded source", async () => {
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue({
+            rows: [],
+            degraded: ["registry", "local_instances"],
+        });
+        render(() => <MyAgentsList onReattach={() => {}} />);
+
+        const error = await screen.findByTestId("agent-my-agents-error");
+        expect(error).toHaveTextContent(FETCH_ERROR);
+        expect(screen.queryByTestId("agent-my-agents-empty")).toBeNull();
+        expect(screen.queryByText(EMPTY_GLOBAL)).toBeNull();
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("still renders real rows when a source degrades but rows are non-empty — partial degradation is not an error state", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand).mockResolvedValue({
+            rows: [makeRow({ instance_id: "still-here" })],
+            // e.g. identity_list failed — rows still come back with
+            // fallback display text, per session.rs's own design intent.
+            degraded: ["accounts"],
+        });
+        render(() => <MyAgentsList onReattach={() => {}} />);
+
+        const entries = await screen.findAllByTestId("agent-my-agents-entry");
+        expect(entries).toHaveLength(1);
+        expect(screen.queryByTestId("agent-my-agents-error")).toBeNull();
     });
 });
 

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -72,6 +72,14 @@ export function formatRelative(now: number, ms: number): string {
 export const EMPTY_GLOBAL =
     "No agents yet — pick a template below to create your first one.";
 export const EMPTY_FILTERED = "No agents for this identity yet.";
+/** Shown when ListRecentSessionsCommand itself failed — distinct from
+ * EMPTY_GLOBAL/EMPTY_FILTERED so a backend error never looks identical
+ * to "you genuinely have zero agents" (retro
+ * docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md §4/§9
+ * rec 2 — this exact ambiguity is what let a real regression, PR #2296,
+ * go unnoticed as "expected empty state" the first time it happened). */
+export const FETCH_ERROR =
+    "Couldn't load your agents — check the connection and try again.";
 
 export interface MyAgentsListProps {
     /** Optional reactive accessor for the identity filter. `null` /
@@ -114,10 +122,20 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
         return String(raw).trim();
     });
 
+    // Separate from the resource's own value: `rows()` still resolves to
+    // `[]` on a failed fetch (see the catch below) so nothing here needs
+    // to special-case Solid's throw-on-read error-state accessor — this
+    // signal is the ONLY thing that distinguishes "backend call failed"
+    // from "genuinely zero agents" for the render below. Cleared at the
+    // start of every fetch so a stale error doesn't survive into a fresh
+    // attempt's loading state.
+    const [fetchError, setFetchError] = createSignal(false);
+
     const [rows, { refetch }] = createResource<RecentSessionRow[], string>(
         // Key the resource on the filter so changes refetch.
         filterId,
         async (id) => {
+            setFetchError(false);
             try {
                 return await RpcApi.ListRecentSessionsCommand(TabRpcClient, {
                     limit: props.limit ?? 20,
@@ -136,6 +154,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                     ? { name: e.name, message: e.message, stack: e.stack }
                     : { value: String(e) };
                 Logger.error("agent", "MyAgentsList: ListRecentSessionsCommand failed", { error: errInfo, identityId: id });
+                setFetchError(true);
                 return [];
             }
         },
@@ -239,11 +258,13 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     };
 
     // Surfacing rules:
-    // - rows undefined → still loading (skeleton hint)
-    // - rows []        → empty state (filter-aware copy)
-    // - rows non-empty → list
+    // - rows undefined            → still loading (skeleton hint)
+    // - fetchError()              → error state (retry affordance), never
+    //                                confused with a genuinely empty list
+    // - rows [] (fetch succeeded) → empty state (filter-aware copy)
+    // - rows non-empty            → list
     const isLoading = () => rows() === undefined;
-    const isEmpty = () => !isLoading() && (rows() ?? []).length === 0;
+    const isEmpty = () => !isLoading() && !fetchError() && (rows() ?? []).length === 0;
 
     return (
         <div class="agent-recent-sessions" data-testid="agent-my-agents-list">
@@ -256,14 +277,34 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                 </Show>
             </div>
             <Show
-                when={!isEmpty()}
+                when={!isEmpty() && !fetchError()}
                 fallback={
-                    <div
-                        class="agent-recent-sessions-empty"
-                        data-testid="agent-my-agents-empty"
+                    <Show
+                        when={fetchError()}
+                        fallback={
+                            <div
+                                class="agent-recent-sessions-empty"
+                                data-testid="agent-my-agents-empty"
+                            >
+                                {filterId() ? EMPTY_FILTERED : EMPTY_GLOBAL}
+                            </div>
+                        }
                     >
-                        {filterId() ? EMPTY_FILTERED : EMPTY_GLOBAL}
-                    </div>
+                        <div
+                            class="agent-recent-sessions-error"
+                            data-testid="agent-my-agents-error"
+                        >
+                            <span class="agent-recent-sessions-error-msg">{FETCH_ERROR}</span>
+                            <button
+                                type="button"
+                                class="agent-recent-sessions-retry"
+                                onClick={() => void refetch()}
+                                data-testid="agent-my-agents-retry"
+                            >
+                                Retry
+                            </button>
+                        </div>
+                    </Show>
                 }
             >
                 <ul class="agent-recent-sessions-list">

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -130,11 +130,22 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     // start of every fetch so a stale error doesn't survive into a fresh
     // attempt's loading state.
     const [fetchError, setFetchError] = createSignal(false);
+    // Guards the two `setFetchError(true)` calls below against a stale
+    // (superseded) fetch's late resolution overwriting a NEWER fetch's
+    // already-settled state — e.g. rapid identity-filter switching, or
+    // clicking Retry again before the first attempt has finished, could
+    // otherwise let an old failure paint the error panel over valid,
+    // already-loaded data from the fetch that actually matters now
+    // (reagent P1 on PR #2327's re-review). Incremented synchronously at
+    // the start of each fetcher call, so invocation order is always
+    // correct even though resolution order isn't.
+    let fetchGeneration = 0;
 
     const [rows, { refetch }] = createResource<RecentSessionRow[], string>(
         // Key the resource on the filter so changes refetch.
         filterId,
         async (id) => {
+            const myGeneration = ++fetchGeneration;
             setFetchError(false);
             try {
                 const result = await RpcApi.ListRecentSessionsCommand(TabRpcClient, {
@@ -158,7 +169,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                         "MyAgentsList: listrecentsessions reported degraded sources with zero rows",
                         { degraded: result.degraded, identityId: id },
                     );
-                    setFetchError(true);
+                    if (myGeneration === fetchGeneration) setFetchError(true);
                     return [];
                 }
                 return result.rows;
@@ -173,7 +184,7 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
                     ? { name: e.name, message: e.message, stack: e.stack }
                     : { value: String(e) };
                 Logger.error("agent", "MyAgentsList: ListRecentSessionsCommand failed", { error: errInfo, identityId: id });
-                setFetchError(true);
+                if (myGeneration === fetchGeneration) setFetchError(true);
                 return [];
             }
         },

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -137,12 +137,31 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
         async (id) => {
             setFetchError(false);
             try {
-                return await RpcApi.ListRecentSessionsCommand(TabRpcClient, {
+                const result = await RpcApi.ListRecentSessionsCommand(TabRpcClient, {
                     limit: props.limit ?? 20,
                     // Backend treats "" as "no filter" — see
                     // CommandListRecentSessionsData docs.
                     identity_id: id,
                 });
+                // Zero rows AND a reported degradation means a backend data
+                // source failed and we got nothing back — NOT a trustworthy
+                // "you have no agents." A healthy call with genuinely zero
+                // agents never populates `degraded` (session.rs's six
+                // sources only degrade on their own error, never on "found
+                // nothing"). Partial degradation alongside real rows (e.g.
+                // identity lookups failing but the registry/defs succeeding)
+                // is left alone here — those rows still render, just with
+                // the existing "(missing account)"-style fallback text.
+                if (result.rows.length === 0 && result.degraded.length > 0) {
+                    Logger.error(
+                        "agent",
+                        "MyAgentsList: listrecentsessions reported degraded sources with zero rows",
+                        { degraded: result.degraded, identityId: id },
+                    );
+                    setFetchError(true);
+                    return [];
+                }
+                return result.rows;
             } catch (e) {
                 // Was a silent `catch { return []; }` — indistinguishable from
                 // "genuinely no sessions" in the UI and left zero trace

--- a/frontend/app/view/agent/styles/_recent-sessions.scss
+++ b/frontend/app/view/agent/styles/_recent-sessions.scss
@@ -52,6 +52,40 @@
         font-style: italic;
     }
 
+    // Distinct from .agent-recent-sessions-empty on purpose — a failed
+    // ListRecentSessionsCommand must never look identical to "you
+    // genuinely have zero agents" (retro
+    // retro-my-agents-fresh-channel-regression-2026-07-27.md §4/§9 rec 2).
+    .agent-recent-sessions-error {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-2);
+        font-size: 12px;
+        padding: var(--space-2) var(--space-3);
+        border: 1px solid var(--error-color);
+        background: color-mix(in srgb, var(--error-color) 10%, transparent);
+        text-align: center;
+    }
+
+    .agent-recent-sessions-error-msg {
+        color: var(--error-color);
+    }
+
+    .agent-recent-sessions-retry {
+        font-size: 12px;
+        padding: var(--space-1) var(--space-3);
+        border: 1px solid var(--error-color);
+        border-radius: 0;
+        background: transparent;
+        color: var(--error-color);
+        cursor: pointer;
+
+        &:hover {
+            background: color-mix(in srgb, var(--error-color) 15%, transparent);
+        }
+    }
+
     .agent-recent-sessions-list {
         list-style: none;
         padding: 0;


### PR DESCRIPTION
## Summary
Root-caused in `docs/retro/retro-my-agents-fresh-channel-regression-2026-07-27.md` (included in this PR), written after a user report that a fresh portable build's "My Agents" list appeared empty.

Investigation found no live data corruption on the reporting machine, but surfaced a proven, still-exploitable structural fragility: PR #2296 (merged 2026-07-25) already hit this exact user-facing symptom once — one unparseable `db_accounts` row aborted the entire `listrecentsessions` response. That fix patched the one instance; the all-or-nothing handler shape was untouched, so any other malformed row in any of six sequential data sources could reproduce it.

- **Backend** (`session.rs`): each of the six data sources now degrades to empty + logs a warning on its own failure, instead of `?`-aborting the whole response. Added a completion-level trace (row count, which sources degraded, latency) — the investigation's biggest evidentiary gap was that this RPC wasn't traced at all.
- **Frontend** (`MyAgentsList.tsx`): a failed fetch and a genuinely empty list used to render identical UI — exactly what let PR #2296's regression go unnoticed as "expected empty state" the first time. Added a distinct error state with a retry button.
- **Tests**: a Rust integration test seeding a real cross-channel `Registry` + `DefinitionStore` and asserting all agents populate on a fresh channel (this exact path has broken 3 times with no regression test covering it), a second test reproducing PR #2296's exact malformed-row shape via raw SQL and asserting the list still returns the other agents, plus frontend tests for the new error state and its retry action.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1676 passed, including the 2 new regression tests
- [x] `npx vitest run` — 1962 passed, including the 2 new MyAgentsList tests
- [x] `npx tsc --noEmit -p .` — clean
- [ ] CI green on this PR

<!-- agentmux:agent_id=agenta -->