### PR TITLE
fix(agent): keep My Agents loading state visible during a retry

### DIFF
--- a/.changesets/1785199520-fix-agent-keep-my-agents-loading-state-visible-during-a-retr-iar3.md
+++ b/.changesets/1785199520-fix-agent-keep-my-agents-loading-state-visible-during-a-retr-iar3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): keep My Agents loading state visible during a retry, don't flash empty

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -264,6 +264,41 @@ describe("MyAgentsList — fetch error (retro-my-agents-fresh-channel-regression
         consoleErrorSpy.mockRestore();
     });
 
+    // reagent P2 on PR #2328's re-review: switching `isLoading` to
+    // `rows.loading` (to fix the retry-flash bug above) is true for ANY
+    // in-flight fetch, including background refetches the old
+    // `rows() === undefined` check never touched (visibility regain,
+    // agents:changed events). The count badge's guard must not use the
+    // same `isLoading`, or it flickers away on every background refetch
+    // instead of just the very first load.
+    it("keeps the count badge visible during a background refetch, not just the initial load", async () => {
+        vi.mocked(RpcApi.ListRecentSessionsCommand)
+            .mockResolvedValueOnce(okResult([makeRow({ instance_id: "a", node_count: 3 })]))
+            // Never resolves — simulates a still-in-flight background
+            // refetch (e.g. an identity switch, or an agents:changed
+            // re-poll) so the count badge's behavior DURING that window
+            // is directly observable.
+            .mockImplementationOnce(() => new Promise(() => {}));
+
+        const [identityId, setIdentityId] = createSignal<string>("id-1");
+        render(() => (
+            <MyAgentsList identityId={identityId} onReattach={() => {}} />
+        ));
+
+        await screen.findAllByTestId("agent-my-agents-entry");
+        expect(screen.getByTestId("agent-my-agents-count")).toHaveTextContent("1");
+
+        // Trigger a refetch while the previous row is still showing.
+        setIdentityId("id-2");
+        await Promise.resolve();
+
+        // The stale row + its count badge must still be visible while the
+        // new (deliberately never-resolving, for this test) fetch is
+        // in flight — this is exactly what flickered away under the bug.
+        expect(screen.getByTestId("agent-my-agents-entry")).toBeInTheDocument();
+        expect(screen.getByTestId("agent-my-agents-count")).toHaveTextContent("1");
+    });
+
     // reagent P1 on PR #2327: session.rs's hardening (each of 6 data
     // sources degrades to empty on its own failure instead of aborting
     // the whole RPC) means the RPC itself basically never throws anymore

--- a/frontend/app/view/agent/components/MyAgentsList.test.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.test.tsx
@@ -227,6 +227,43 @@ describe("MyAgentsList — fetch error (retro-my-agents-fresh-channel-regression
         consoleErrorSpy.mockRestore();
     });
 
+    // codex P2 on PR #2327's post-merge re-review: Solid's createResource
+    // keeps the previous resolved value ([]) visible while a refetch is in
+    // flight (stale-while-revalidate) — `fetchError` is cleared synchronously
+    // when Retry starts, so checking `rows() === undefined` for "loading"
+    // only catches the very first fetch. A retry would fall straight
+    // through to the empty-state branch for its ENTIRE in-flight duration,
+    // flashing "No agents yet" and recreating the exact error/empty
+    // ambiguity this whole fix exists to remove.
+    it("does not flash the empty-agents message while a retry is in flight", async () => {
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        let resolveRetry!: (result: { rows: RecentSessionRow[]; degraded: string[] }) => void;
+        const retryPromise = new Promise<{ rows: RecentSessionRow[]; degraded: string[] }>((resolve) => {
+            resolveRetry = resolve;
+        });
+        vi.mocked(RpcApi.ListRecentSessionsCommand)
+            .mockRejectedValueOnce(new Error("backend unreachable"))
+            .mockImplementationOnce(() => retryPromise);
+
+        render(() => <MyAgentsList onReattach={() => {}} />);
+
+        const retryBtn = await screen.findByTestId("agent-my-agents-retry");
+        await userEvent.click(retryBtn);
+
+        // The retry is now in flight (retryPromise hasn't resolved yet) —
+        // neither the error banner nor the "genuinely empty" message must
+        // show during this window.
+        expect(screen.queryByTestId("agent-my-agents-empty")).toBeNull();
+        expect(screen.queryByTestId("agent-my-agents-error")).toBeNull();
+
+        resolveRetry(okResult([makeRow({ instance_id: "recovered" })]));
+        const entries = await screen.findAllByTestId("agent-my-agents-entry");
+        expect(entries).toHaveLength(1);
+
+        consoleErrorSpy.mockRestore();
+    });
+
     // reagent P1 on PR #2327: session.rs's hardening (each of 6 data
     // sources degrades to empty on its own failure instead of aborting
     // the whole RPC) means the RPC itself basically never throws anymore

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -288,12 +288,29 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
     };
 
     // Surfacing rules:
-    // - rows undefined            → still loading (skeleton hint)
+    // - rows.loading              → still loading (skeleton hint) — uses the
+    //                                RESOURCE's own loading flag, not
+    //                                `rows() === undefined`: Solid's
+    //                                createResource keeps the previous
+    //                                value visible while a refetch is in
+    //                                flight (stale-while-revalidate), so
+    //                                after Retry on a failed fetch, `rows()`
+    //                                is still `[]` from the failed attempt
+    //                                even though a fresh request is
+    //                                pending. Checking `rows() === undefined`
+    //                                only catches the very first load — a
+    //                                retry would fall straight through to
+    //                                the empty branch below for its entire
+    //                                in-flight duration, flashing "No agents
+    //                                yet" and recreating the exact
+    //                                error/empty ambiguity this fix exists
+    //                                to remove (codex P2 on PR #2327's
+    //                                post-merge re-review).
     // - fetchError()              → error state (retry affordance), never
     //                                confused with a genuinely empty list
     // - rows [] (fetch succeeded) → empty state (filter-aware copy)
     // - rows non-empty            → list
-    const isLoading = () => rows() === undefined;
+    const isLoading = () => rows.loading;
     const isEmpty = () => !isLoading() && !fetchError() && (rows() ?? []).length === 0;
 
     return (

--- a/frontend/app/view/agent/components/MyAgentsList.tsx
+++ b/frontend/app/view/agent/components/MyAgentsList.tsx
@@ -317,8 +317,20 @@ export const MyAgentsList = (props: MyAgentsListProps): JSX.Element => {
         <div class="agent-recent-sessions" data-testid="agent-my-agents-list">
             <div class="agent-recent-sessions-header">
                 <span class="agent-recent-sessions-title">My Agents</span>
-                <Show when={!isLoading() && (rows() ?? []).length > 0}>
-                    <span class="agent-recent-sessions-count">
+                {/* No `!isLoading()` guard here (reagent P2 on PR #2328):
+                    that check was already redundant even before isLoading
+                    switched to rows.loading — if rows() were undefined,
+                    `.length > 0` is already false — but now that isLoading
+                    also covers BACKGROUND refetches (visibility regain,
+                    agents:changed events), keeping the guard would hide
+                    the count on every one of those instead of just the
+                    very first load, which is a real, visible flicker
+                    regression this component never had before. Solid's
+                    stale-while-revalidate means `rows()` keeps showing the
+                    last real count during a background refetch anyway —
+                    exactly what should render. */}
+                <Show when={(rows() ?? []).length > 0}>
+                    <span class="agent-recent-sessions-count" data-testid="agent-my-agents-count">
                         {(rows() ?? []).length}
                     </span>
                 </Show>


### PR DESCRIPTION
## Summary
Follow-up to #2327 (merged) — chatgpt-codex-connector's post-merge re-review of commit e5de8e15 found a real gap in that PR's fix: `frontend/app/view/agent/components/MyAgentsList.tsx:149`.

Solid's `createResource` keeps the previous resolved value (`[]`) visible while a refetch is in flight (stale-while-revalidate). Since `fetchError` is cleared synchronously the instant Retry starts, and `isLoading` checked `rows() === undefined` (only true before the very first fetch ever resolves), clicking Retry after a failure fell straight through to the empty-state branch for the retry's entire in-flight duration — flashing "No agents yet, pick a template below" and recreating the exact error/empty ambiguity #2327 exists to remove.

`isLoading` now reads the resource's own `.loading` flag instead, which Solid sets for any in-flight fetch (initial or refetch) regardless of whether a stale value is still visible.

## Test plan
- [x] Added a regression test that clicks Retry, holds the retry promise pending, and asserts neither the empty nor error state renders during that window
- [x] Verified the test actually catches the bug: reverted the fix, confirmed the test fails, restored the fix
- [x] `npx vitest run` — 1966 passed (frontend), same pre-existing unrelated flake as #2327
- [x] `npx tsc --noEmit -p .` — clean
- [ ] CI green on this PR

<!-- agentmux:agent_id=agenta -->
Codex finding: https://github.com/agentmuxai/agentmux/pull/2327#discussion_r3661921580