### PR TITLE
fix(stash): MCP Servers and Skills tabs no longer fail unauthorized

### DIFF
--- a/.changesets/1785199510-fix-stash-mcp-servers-and-skills-tabs-no-longer-fail-unautho-q3oi.md
+++ b/.changesets/1785199510-fix-stash-mcp-servers-and-skills-tabs-no-longer-fail-unautho-q3oi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(stash): MCP Servers and Skills tabs no longer fail unauthorized; reactive read+bind view over the Armory catalog

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -337,6 +337,14 @@ pub const COMMAND_SKILL_CATALOG_DELETE: &str = "skill.catalog.delete";
 // catalog-tier sibling the Armory's "Bind to agent" action actually calls.
 // See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
 pub const COMMAND_SKILL_CATALOG_BIND: &str = "skill.catalog.bind";
+// Catalog-tier siblings of skill.list / skill.unbind — same no-check_s1
+// rationale as skill.catalog.bind above. AgentStashModal's Skills tab (the
+// per-agent Stash view, not the Armory catalog itself) runs over the
+// dashboard's connection, so it needs a window-scoped way to list what's
+// bound to one specific agent and to unbind, not just bind.
+// See docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
+pub const COMMAND_SKILL_CATALOG_LIST_FOR_AGENT: &str = "skill.catalog.list_for_agent";
+pub const COMMAND_SKILL_CATALOG_UNBIND: &str = "skill.catalog.unbind";
 
 // App API — v1 standalone MCP Server primitives
 pub const COMMAND_MCP_LIST: &str = "mcp.list";
@@ -363,6 +371,12 @@ pub const COMMAND_MCP_CATALOG_PROBE: &str = "mcp.catalog.probe";
 // Same fix as skill.catalog.bind — see
 // docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
 pub const COMMAND_MCP_CATALOG_BIND: &str = "mcp.catalog.bind";
+// Catalog-tier siblings of mcp.list / mcp.unbind — same no-check_s1
+// rationale as mcp.catalog.bind above and skill.catalog.list_for_agent /
+// skill.catalog.unbind below. See
+// docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
+pub const COMMAND_MCP_CATALOG_LIST_FOR_AGENT: &str = "mcp.catalog.list_for_agent";
+pub const COMMAND_MCP_CATALOG_UNBIND: &str = "mcp.catalog.unbind";
 
 // App API Tier 1 — session archival commands
 pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -119,6 +119,49 @@ impl Store {
         Ok(out)
     }
 
+    /// Catalog-tier sibling of `mcp_server_list` (above) — same
+    /// `bound_to_agent` shape, but deliberately GLOBAL ROWS ONLY, unlike
+    /// `mcp_server_list`'s UNION with `agent_id`'s own private servers.
+    /// Backs `mcp.catalog.list_for_agent`, which — like every other
+    /// `mcp.catalog.*` command — has no `check_s1`, so `agent_id` here is
+    /// caller-supplied and unverified. Returning private server rows (whose
+    /// `config` can carry secrets: API keys, auth headers, env vars) for an
+    /// arbitrary caller-chosen `agent_id` would let any window connection
+    /// read any agent's private server config. Global rows carry no
+    /// per-agent secret — they're already fully visible via
+    /// `mcp_server_list_global` (the Armory catalog) — so exposing them
+    /// alongside a caller-chosen agent's bind status is safe.
+    /// reagentx P0 on PR #2329.
+    pub fn mcp_server_list_global_for_agent(&self, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.name, s.transport, s.config, s.is_global, s.created_at, s.updated_at,
+                    EXISTS(SELECT 1 FROM db_agent_mcp_ref r WHERE r.mcp_id = s.id AND r.agent_id = ?1) AS bound_to_agent
+             FROM db_mcp_servers s
+             WHERE s.is_global = 1
+             ORDER BY s.updated_at DESC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(McpServerListItem {
+                server: McpServer {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    transport: row.get(2)?,
+                    config: row.get(3)?,
+                    is_global: row.get::<_, i64>(4)? != 0,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                },
+                bound_to_agent: row.get::<_, i64>(7)? != 0,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Get a standalone MCP server by id.
     pub fn mcp_server_get(&self, id: &str) -> Result<Option<McpServer>, StoreError> {
         let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -315,6 +315,50 @@ impl Store {
         Ok(out)
     }
 
+    /// Catalog-tier sibling of `skill_list` (above) — same `bound_to_agent`
+    /// shape, but deliberately GLOBAL ROWS ONLY, unlike `skill_list`'s UNION
+    /// with `agent_id`'s own private skills. Backs `skill.catalog.list_for_agent`,
+    /// which — like every other `skill.catalog.*` command — has no
+    /// `check_s1`, so `agent_id` here is caller-supplied and unverified.
+    /// Returning private skill rows (whose `content`/`description`/`trigger`
+    /// can carry sensitive agent-authored material) for an arbitrary
+    /// caller-chosen `agent_id` would let any window connection read any
+    /// agent's private skills. Global rows carry nothing per-agent-secret —
+    /// they're already fully visible via `skill_list_global` (the Armory
+    /// catalog) — so exposing them alongside a caller-chosen agent's bind
+    /// status is safe. reagentx P0 on PR #2329.
+    pub fn skill_list_global_for_agent(&self, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.name, s.trigger, s.skill_type, s.description, s.content, s.is_global, s.created_at, s.updated_at,
+                    EXISTS(SELECT 1 FROM db_agent_skills_ref r WHERE r.skill_id = s.id AND r.agent_id = ?1) AS bound_to_agent
+             FROM db_skills s
+             WHERE s.is_global = 1
+             ORDER BY s.updated_at DESC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(SkillListItem {
+                skill: Skill {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    trigger: row.get(2)?,
+                    skill_type: row.get(3)?,
+                    description: row.get(4)?,
+                    content: row.get(5)?,
+                    is_global: row.get::<_, i64>(6)? != 0,
+                    created_at: row.get(7)?,
+                    updated_at: row.get(8)?,
+                },
+                bound_to_agent: row.get::<_, i64>(9)? != 0,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Get a standalone skill by id.
     pub fn skill_get(&self, id: &str) -> Result<Option<Skill>, StoreError> {
         let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -23,6 +23,8 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_mcp_catalog_delete(engine, state);
     register_mcp_catalog_probe(engine, state);
     register_mcp_catalog_bind(engine, state);
+    register_mcp_catalog_list_for_agent(engine, state);
+    register_mcp_catalog_unbind(engine, state);
 }
 
 fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -377,10 +379,12 @@ fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
 fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_BIND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, mcp_id: String }
@@ -405,7 +409,70 @@ fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 wstore.mcp_server_bind(&req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.bind: {e}"))?;
+                // Lets any other open Stash/Armory view for this agent pick up
+                // the new binding without a manual refresh — mcp.bind (the
+                // check_s1 agent-self-service path) intentionally left alone.
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "mcp:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
                 Ok(Some(json!({ "bound": true })))
+            })
+        }),
+    );
+}
+
+/// Catalog-tier sibling of `mcp.list` (above) — same computation
+/// (`wstore.mcp_server_list`, every global server plus this agent's own
+/// private ones, each annotated with `bound_to_agent`), but no `check_s1`:
+/// AgentStashModal's MCP Servers tab (the per-agent Stash view) runs over
+/// the dashboard's connection, which is never agent-authenticated, so
+/// `mcp.list`'s gate can never be satisfied from that caller — the exact
+/// same reasoning as `mcp.catalog.bind` above.
+/// See docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
+fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_LIST_FOR_AGENT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.catalog.list_for_agent: {e}"))?;
+                let servers = wstore.mcp_server_list(&req.agent_id)
+                    .map_err(|e| format!("mcp.catalog.list_for_agent: {e}"))?;
+                Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+/// Catalog-tier sibling of `mcp.unbind` (above) — same DB write, no
+/// `check_s1`, same rationale as `register_mcp_catalog_list_for_agent`.
+fn register_mcp_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_MCP_CATALOG_UNBIND,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, mcp_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("mcp.catalog.unbind: {e}"))?;
+                let unbound = wstore.mcp_server_unbind(&req.agent_id, &req.mcp_id)
+                    .map_err(|e| format!("mcp.catalog.unbind: {e}"))?;
+                if unbound {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "mcp:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "unbound": unbound })))
             })
         }),
     );

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -453,23 +453,16 @@ fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppSt
     );
 }
 
-/// Catalog-tier sibling of `mcp.unbind` (above) — same DB write
-/// (`mcp_server_unbind` deletes one `db_agent_mcp_ref` row, unconditional on
-/// `is_global`), no `check_s1`. Unlike `register_mcp_catalog_list_for_agent`,
-/// this has no *secret*-exposure concern — unbind can't read a server's
-/// `config`, only remove a ref row — but it does let any window connection
-/// sever any `(agent_id, mcp_id)` pair by id, global or private. For a
-/// global row this is an intentional, pre-existing trust boundary already
-/// established by `register_mcp_catalog_bind` (any window can BIND any
-/// agent_id to any global server) and `register_mcp_catalog_delete` (any
-/// window can delete a global server outright, unbinding every agent from
-/// it at once — a strictly larger blast radius). For a private row, this
-/// command could in principle sever an agent's own reference to its own
-/// private server — but `mcp_id` is an unguessable UUID never exposed by
-/// any no-`check_s1` command (`register_mcp_catalog_list_for_agent` returns
-/// global rows only, precisely to avoid leaking a private server's `config`
-/// OR its id), so exploiting this requires already knowing that UUID
-/// through some other channel. reagentx P1 on PR #2329.
+/// Catalog-tier sibling of `mcp.unbind` (above) — same DB write, no
+/// `check_s1`. Restricted to global rows only, matching the guard
+/// `register_mcp_catalog_bind`/`register_mcp_catalog_delete` already apply
+/// in this file: any window connection can sever any agent's binding to a
+/// *global* server (an intentional, pre-existing trust boundary — bind and
+/// delete already have the same or larger blast radius), but a private
+/// row's own binding must not be touchable via this no-`check_s1` surface,
+/// even though `mcp_id` is never exposed by any no-`check_s1` command
+/// today — defense in depth over relying solely on UUID secrecy.
+/// reagentx P1 on PR #2329 (round 2).
 fn register_mcp_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
@@ -483,6 +476,15 @@ fn register_mcp_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 struct Req { agent_id: String, mcp_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.unbind: {e}"))?;
+                match wstore.mcp_server_get(&req.mcp_id)
+                    .map_err(|e| format!("mcp.catalog.unbind: {e}"))?
+                {
+                    None => return Err("mcp.catalog.unbind: MCP server not found".to_string()),
+                    Some(s) if !s.is_global => {
+                        return Err("FORBIDDEN: can only unbind global MCP servers".to_string());
+                    }
+                    Some(_) => {}
+                }
                 let unbound = wstore.mcp_server_unbind(&req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.unbind: {e}"))?;
                 if unbound {

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -192,10 +192,12 @@ fn register_mcp_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_BIND,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, mcp_id: String }
@@ -219,6 +221,14 @@ fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 wstore.mcp_server_bind(&req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.bind: {e}"))?;
+                // An agent binding a server to itself over its own authenticated
+                // connection should reach an already-open Stash MCP Servers tab
+                // for that agent too — same reactivity as the catalog-tier bind.
+                // reagentx P2 on PR #2329.
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "mcp:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
                 Ok(Some(json!({ "bound": true })))
             })
         }),
@@ -227,10 +237,12 @@ fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_UNBIND,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, mcp_id: String }
@@ -239,6 +251,12 @@ fn register_mcp_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 check_s1(&ctx, &req.agent_id)?;
                 let unbound = wstore.mcp_server_unbind(&req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.unbind: {e}"))?;
+                if unbound {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "mcp:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
                 Ok(Some(json!({ "unbound": unbound })))
             })
         }),

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -422,14 +422,18 @@ fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Catalog-tier sibling of `mcp.list` (above) — same computation
-/// (`wstore.mcp_server_list`, every global server plus this agent's own
-/// private ones, each annotated with `bound_to_agent`), but no `check_s1`:
-/// AgentStashModal's MCP Servers tab (the per-agent Stash view) runs over
-/// the dashboard's connection, which is never agent-authenticated, so
-/// `mcp.list`'s gate can never be satisfied from that caller — the exact
-/// same reasoning as `mcp.catalog.bind` above.
-/// See docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
+/// Catalog-tier sibling of `mcp.list` (above) — GLOBAL SERVERS ONLY, each
+/// annotated with `bound_to_agent` for the caller-supplied `agent_id`, no
+/// `check_s1`. AgentStashModal's MCP Servers tab (the per-agent Stash view)
+/// runs over the dashboard's connection, which is never agent-authenticated,
+/// so `mcp.list`'s gate can never be satisfied from that caller — the exact
+/// same reasoning as `mcp.catalog.bind` above. Deliberately does NOT reuse
+/// `mcp.list`'s full computation (global + this agent's own private
+/// servers): with no `check_s1`, `agent_id` is unverified, and a private
+/// server's `config` can carry secrets — returning it for an arbitrary
+/// caller-chosen `agent_id` would be an IDOR into every agent's private MCP
+/// config. See `Store::mcp_server_list_global_for_agent`'s doc comment and
+/// docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
 fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     engine.register_handler(
@@ -441,7 +445,7 @@ fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppSt
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.list_for_agent: {e}"))?;
-                let servers = wstore.mcp_server_list(&req.agent_id)
+                let servers = wstore.mcp_server_list_global_for_agent(&req.agent_id)
                     .map_err(|e| format!("mcp.catalog.list_for_agent: {e}"))?;
                 Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
             })
@@ -449,8 +453,23 @@ fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppSt
     );
 }
 
-/// Catalog-tier sibling of `mcp.unbind` (above) — same DB write, no
-/// `check_s1`, same rationale as `register_mcp_catalog_list_for_agent`.
+/// Catalog-tier sibling of `mcp.unbind` (above) — same DB write
+/// (`mcp_server_unbind` deletes one `db_agent_mcp_ref` row, unconditional on
+/// `is_global`), no `check_s1`. Unlike `register_mcp_catalog_list_for_agent`,
+/// this has no *secret*-exposure concern — unbind can't read a server's
+/// `config`, only remove a ref row — but it does let any window connection
+/// sever any `(agent_id, mcp_id)` pair by id, global or private. For a
+/// global row this is an intentional, pre-existing trust boundary already
+/// established by `register_mcp_catalog_bind` (any window can BIND any
+/// agent_id to any global server) and `register_mcp_catalog_delete` (any
+/// window can delete a global server outright, unbinding every agent from
+/// it at once — a strictly larger blast radius). For a private row, this
+/// command could in principle sever an agent's own reference to its own
+/// private server — but `mcp_id` is an unguessable UUID never exposed by
+/// any no-`check_s1` command (`register_mcp_catalog_list_for_agent` returns
+/// global rows only, precisely to avoid leaking a private server's `config`
+/// OR its id), so exploiting this requires already knowing that UUID
+/// through some other channel. reagentx P1 on PR #2329.
 fn register_mcp_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -184,10 +184,12 @@ fn register_skill_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_BIND,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, skill_id: String }
@@ -211,6 +213,14 @@ fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 wstore.skill_bind(&req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.bind: {e}"))?;
+                // An agent binding a skill to itself over its own authenticated
+                // connection should reach an already-open Stash Skills tab for
+                // that agent too — same reactivity as the catalog-tier bind.
+                // reagentx P2 on PR #2329.
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "skills:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
                 Ok(Some(json!({ "bound": true })))
             })
         }),
@@ -219,10 +229,12 @@ fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_UNBIND,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, skill_id: String }
@@ -231,6 +243,12 @@ fn register_skill_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 check_s1(&ctx, &req.agent_id)?;
                 let unbound = wstore.skill_unbind(&req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.unbind: {e}"))?;
+                if unbound {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "skills:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
                 Ok(Some(json!({ "unbound": unbound })))
             })
         }),

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -373,14 +373,19 @@ fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Catalog-tier sibling of `skill.list` (above) — same computation
-/// (`wstore.skill_list`, every global skill plus this agent's own private
-/// ones, each annotated with `bound_to_agent`), but no `check_s1`:
-/// AgentStashModal's Skills tab (the per-agent Stash view) runs over the
-/// dashboard's connection, which is never agent-authenticated, so
+/// Catalog-tier sibling of `skill.list` (above) — GLOBAL SKILLS ONLY, each
+/// annotated with `bound_to_agent` for the caller-supplied `agent_id`, no
+/// `check_s1`. AgentStashModal's Skills tab (the per-agent Stash view) runs
+/// over the dashboard's connection, which is never agent-authenticated, so
 /// `skill.list`'s gate can never be satisfied from that caller — the exact
-/// same reasoning as `skill.catalog.bind` above.
-/// See docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
+/// same reasoning as `skill.catalog.bind` above. Deliberately does NOT
+/// reuse `skill.list`'s full computation (global + this agent's own
+/// private skills): with no `check_s1`, `agent_id` is unverified, and a
+/// private skill's `content`/`description`/`trigger` can carry sensitive
+/// agent-authored material — returning it for an arbitrary caller-chosen
+/// `agent_id` would be an IDOR into every agent's private skills. See
+/// `Store::skill_list_global_for_agent`'s doc comment and
+/// docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
 fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     engine.register_handler(
@@ -392,7 +397,7 @@ fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &App
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.catalog.list_for_agent: {e}"))?;
-                let skills = wstore.skill_list(&req.agent_id)
+                let skills = wstore.skill_list_global_for_agent(&req.agent_id)
                     .map_err(|e| format!("skill.catalog.list_for_agent: {e}"))?;
                 Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
             })
@@ -400,8 +405,23 @@ fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &App
     );
 }
 
-/// Catalog-tier sibling of `skill.unbind` (above) — same DB write, no
-/// `check_s1`, same rationale as `register_skill_catalog_list_for_agent`.
+/// Catalog-tier sibling of `skill.unbind` (above) — same DB write
+/// (`skill_unbind` deletes one `db_agent_skills_ref` row, unconditional on
+/// `is_global`), no `check_s1`. Unlike `register_skill_catalog_list_for_agent`,
+/// this has no *secret*-exposure concern — unbind can't read a skill's
+/// `content`, only remove a ref row — but it does let any window connection
+/// sever any `(agent_id, skill_id)` pair by id, global or private. For a
+/// global row this is an intentional, pre-existing trust boundary already
+/// established by `register_skill_catalog_bind` (any window can BIND any
+/// agent_id to any global skill) and `register_skill_catalog_delete` (any
+/// window can delete a global skill outright, unbinding every agent from it
+/// at once — a strictly larger blast radius). For a private row, this
+/// command could in principle sever an agent's own reference to its own
+/// private skill — but `skill_id` is an unguessable UUID never exposed by
+/// any no-`check_s1` command (`register_skill_catalog_list_for_agent`
+/// returns global rows only, precisely to avoid leaking a private skill's
+/// content OR its id), so exploiting this requires already knowing that
+/// UUID through some other channel. reagentx P1 on PR #2329.
 fn register_skill_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -405,23 +405,16 @@ fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &App
     );
 }
 
-/// Catalog-tier sibling of `skill.unbind` (above) — same DB write
-/// (`skill_unbind` deletes one `db_agent_skills_ref` row, unconditional on
-/// `is_global`), no `check_s1`. Unlike `register_skill_catalog_list_for_agent`,
-/// this has no *secret*-exposure concern — unbind can't read a skill's
-/// `content`, only remove a ref row — but it does let any window connection
-/// sever any `(agent_id, skill_id)` pair by id, global or private. For a
-/// global row this is an intentional, pre-existing trust boundary already
-/// established by `register_skill_catalog_bind` (any window can BIND any
-/// agent_id to any global skill) and `register_skill_catalog_delete` (any
-/// window can delete a global skill outright, unbinding every agent from it
-/// at once — a strictly larger blast radius). For a private row, this
-/// command could in principle sever an agent's own reference to its own
-/// private skill — but `skill_id` is an unguessable UUID never exposed by
-/// any no-`check_s1` command (`register_skill_catalog_list_for_agent`
-/// returns global rows only, precisely to avoid leaking a private skill's
-/// content OR its id), so exploiting this requires already knowing that
-/// UUID through some other channel. reagentx P1 on PR #2329.
+/// Catalog-tier sibling of `skill.unbind` (above) — same DB write, no
+/// `check_s1`. Restricted to global rows only, matching the guard
+/// `register_skill_catalog_bind`/`register_skill_catalog_delete` already
+/// apply in this file: any window connection can sever any agent's binding
+/// to a *global* skill (an intentional, pre-existing trust boundary — bind
+/// and delete already have the same or larger blast radius), but a private
+/// row's own binding must not be touchable via this no-`check_s1` surface,
+/// even though `skill_id` is never exposed by any no-`check_s1` command
+/// today — defense in depth over relying solely on UUID secrecy.
+/// reagentx P1 on PR #2329 (round 2).
 fn register_skill_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
@@ -435,6 +428,15 @@ fn register_skill_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 struct Req { agent_id: String, skill_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.catalog.unbind: {e}"))?;
+                match wstore.skill_get(&req.skill_id)
+                    .map_err(|e| format!("skill.catalog.unbind: {e}"))?
+                {
+                    None => return Err("skill.catalog.unbind: skill not found".to_string()),
+                    Some(s) if !s.is_global => {
+                        return Err("FORBIDDEN: can only unbind global skills".to_string());
+                    }
+                    Some(_) => {}
+                }
                 let unbound = wstore.skill_unbind(&req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.catalog.unbind: {e}"))?;
                 if unbound {

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -21,6 +21,8 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_skill_catalog_upsert(engine, state);
     register_skill_catalog_delete(engine, state);
     register_skill_catalog_bind(engine, state);
+    register_skill_catalog_list_for_agent(engine, state);
+    register_skill_catalog_unbind(engine, state);
 }
 
 fn register_skill_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -329,10 +331,12 @@ fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md §2.4.
 fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_BIND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, skill_id: String }
@@ -356,7 +360,70 @@ fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 wstore.skill_bind(&req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.catalog.bind: {e}"))?;
+                // Lets any other open Stash/Armory view for this agent pick up
+                // the new binding without a manual refresh — skill.bind (the
+                // check_s1 agent-self-service path) intentionally left alone.
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "skills:changed".to_string(),
+                    scopes: vec![], sender: String::new(), persist: 0, data: None,
+                });
                 Ok(Some(json!({ "bound": true })))
+            })
+        }),
+    );
+}
+
+/// Catalog-tier sibling of `skill.list` (above) — same computation
+/// (`wstore.skill_list`, every global skill plus this agent's own private
+/// ones, each annotated with `bound_to_agent`), but no `check_s1`:
+/// AgentStashModal's Skills tab (the per-agent Stash view) runs over the
+/// dashboard's connection, which is never agent-authenticated, so
+/// `skill.list`'s gate can never be satisfied from that caller — the exact
+/// same reasoning as `skill.catalog.bind` above.
+/// See docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
+fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SKILL_CATALOG_LIST_FOR_AGENT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.catalog.list_for_agent: {e}"))?;
+                let skills = wstore.skill_list(&req.agent_id)
+                    .map_err(|e| format!("skill.catalog.list_for_agent: {e}"))?;
+                Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
+}
+
+/// Catalog-tier sibling of `skill.unbind` (above) — same DB write, no
+/// `check_s1`, same rationale as `register_skill_catalog_list_for_agent`.
+fn register_skill_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_SKILL_CATALOG_UNBIND,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Req { agent_id: String, skill_id: String }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("skill.catalog.unbind: {e}"))?;
+                let unbound = wstore.skill_unbind(&req.agent_id, &req.skill_id)
+                    .map_err(|e| format!("skill.catalog.unbind: {e}"))?;
+                if unbound {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "skills:changed".to_string(),
+                        scopes: vec![], sender: String::new(), persist: 0, data: None,
+                    });
+                }
+                Ok(Some(json!({ "unbound": unbound })))
             })
         }),
     );

--- a/docs/reports/REPORT_MCP_SKILLS_BIND_DOES_NOT_GATE_CONFIG_2026_07_28.md
+++ b/docs/reports/REPORT_MCP_SKILLS_BIND_DOES_NOT_GATE_CONFIG_2026_07_28.md
@@ -1,0 +1,127 @@
+# Report: global MCP servers/skills are always injected regardless of bind state
+
+## Summary
+
+`bound_to_agent` — the flag driving every "Bind"/"Unbind" toggle in the
+Armory and Stash MCP Servers/Skills tabs — has no effect on an agent's
+actual materialized runtime config. `agent_open.rs`'s config-generation
+path injects **every global MCP server and every global skill into every
+agent's config, unconditionally**, regardless of whether that specific
+agent is bound to it. Binding/unbinding only changes `db_agent_mcp_ref`/
+`db_agent_skills_ref` (which currently drives nothing in config
+generation for global rows) and the UI's own "bound"/"not bound" badge.
+
+Flagged by reagentx's re-review of PR #2329 (which made `mcp.catalog.unbind`/
+`skill.catalog.unbind` reachable from the UI for the first time — see
+"Why this wasn't caught sooner" below).
+
+## Root cause
+
+`agentmux-srv/src/server/app_api/agent_open.rs:558` and `:589`:
+
+```rust
+// v1 skills: globals are always injected; the agent's OWN ref-bound skills
+// are authoritative when present, otherwise fall back to legacy
+// db_agent_skills. ...
+let visible_skills: Vec<Skill> = wstore.skill_list(&agent.id)
+    .unwrap_or_default()
+    .into_iter()
+    .map(|item| item.skill)
+    .collect(); // own refs + globals
+```
+
+`Store::skill_list`/`Store::mcp_server_list`'s query is:
+
+```sql
+WHERE s.is_global = 1
+   OR s.id IN (SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?1)
+```
+
+The `is_global = 1` branch is unconditional — it does not check whether
+`agent_id` holds a ref to that specific global row. `bound_to_agent` (the
+`EXISTS(...)` subquery in the SELECT list) is computed and returned, but
+config generation immediately discards it (`.map(|item| item.skill)`,
+per the code's own comment: *"this config-generation path doesn't need
+it, so unwrap immediately"*).
+
+So `bound_to_agent`'s only real consumer today is deciding **ref-based
+vs. legacy-fallback mode** (`has_own_skill_refs` / `has_own_mcp_refs` —
+whether *any* of the agent's own private rows exist, which switches
+between "trust the ref tables" and "merge legacy blob + globals"). It was
+never wired to gate *global* row inclusion.
+
+## Why this wasn't caught sooner
+
+Before PR #2329, `mcp.unbind`/`skill.unbind` were `check_s1`-gated
+(agent-self-service only) and no `mcp.catalog.unbind`/`skill.catalog.unbind`
+existed — there was no way to actually invoke unbind from any UI. Only
+`mcp.catalog.bind`/`skill.catalog.bind` (added in PR #2317) were
+UI-reachable. Binding a global item that's *already* unconditionally
+injected has no observable effect either way, so this never looked broken
+in practice: click "Bind," nothing changes, but nothing looked wrong
+because the item was already there.
+
+Unbind is the first UI-reachable action whose absence of effect is
+actually visible — a user clicks "Unbind," the badge flips to "not
+bound," and the server/skill keeps being injected into the agent's next
+generated config regardless.
+
+## Current mitigation (landed in PR #2329)
+
+Added an inline caveat to `AgentMcpModal`/`AgentSkillsModal`'s detail view,
+next to the Bind/Unbind buttons:
+
+> Note: every global server is currently applied to every agent regardless
+> of bind state — unbinding here updates what shows as "in use" but does
+> not yet remove it from this agent's live config.
+
+This is honest-UI-copy only — no behavior change, no risk to existing
+config generation.
+
+## Why a real fix is out of scope for that PR
+
+Making `bound_to_agent` actually gate global-row inclusion in
+`agent_open.rs` means every agent that has never explicitly bound/unbound
+anything (i.e. every agent that existed before bind/unbind was
+UI-reachable — almost certainly all of them) would suddenly stop
+receiving every global MCP server/skill it currently gets, on next config
+regeneration, unless a migration backfills an explicit bind ref for every
+`(agent, global-item)` pair that's implicitly "in use" today. That's a
+correctness-critical, blast-radius-on-every-agent change to the
+config-generation path used on every launch — not something to bundle
+into a PR whose actual goal was fixing Stash's `check_s1` "unauthorized"
+errors.
+
+## Recommended follow-up (separate PR/spec)
+
+1. Write a migration that inserts a `db_agent_mcp_ref`/`db_agent_skills_ref`
+   row for every `(agent, global item)` pair currently implicitly active
+   (i.e. seed every existing agent as bound to every existing global item)
+   — this makes "currently active" and "explicitly bound" the same set at
+   migration time, so no agent's config silently changes on the next
+   regeneration.
+2. Change `agent_open.rs`'s `visible_skills`/`visible_mcp` computation to
+   filter the global branch on `bound_to_agent`, not include it
+   unconditionally — i.e. only inject a global row the agent actually
+   holds a ref to.
+3. Update `Store::skill_list`/`Store::mcp_server_list`'s query (or add a
+   variant) to match — currently the `WHERE s.is_global = 1 OR ...` clause
+   returns every global row for every agent by design; after the fix it
+   should be `WHERE s.id IN (SELECT ... WHERE agent_id = ?1)` uniformly
+   (own refs and bound-global refs collapse into the same ref-table
+   lookup, dropping the two-branch OR entirely).
+4. Regression-test: an agent that has never touched Armory/Stash should
+   see identical config before/after the migration (proves the backfill
+   is complete); an agent that explicitly unbinds a global item should
+   see it actually disappear from its next generated config (proves the
+   fix closes the gap this report documents).
+5. Remove the caveat text added in PR #2329 once this lands.
+
+## Files referenced
+
+- `agentmux-srv/src/server/app_api/agent_open.rs` (lines ~550-620,
+  `visible_skills`/`visible_mcp` computation)
+- `agentmux-srv/src/backend/storage/skills.rs` (`skill_list`)
+- `agentmux-srv/src/backend/storage/mcp_servers.rs` (`mcp_server_list`)
+- `frontend/app/view/agent/components/AgentMcpModal.tsx` /
+  `AgentSkillsModal.tsx` (caveat UI added in PR #2329)

--- a/frontend/app/store/rpc-api/mcp.ts
+++ b/frontend/app/store/rpc-api/mcp.ts
@@ -115,4 +115,26 @@ export const McpApi = {
     ): Promise<{ bound: boolean }> {
         return client.rpcCall("mcp.catalog.bind", data, opts);
     },
+
+    // Catalog-tier siblings of McpListCommand / McpUnbindCommand — no
+    // agent_id/check_s1 gate on the *caller*, but agent_id is still required
+    // in the payload (whose bindings to list/unbind). Used by
+    // AgentStashModal's MCP Servers tab, which runs over the dashboard's
+    // connection and can never satisfy McpListCommand/McpUnbindCommand's
+    // check_s1.
+    McpCatalogListForAgentCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<McpServerListItem[]> {
+        return client.rpcCall("mcp.catalog.list_for_agent", data, opts);
+    },
+
+    McpCatalogUnbindCommand(
+        client: RpcClient,
+        data: { agent_id: string; mcp_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("mcp.catalog.unbind", data, opts);
+    },
 };

--- a/frontend/app/store/rpc-api/skill.ts
+++ b/frontend/app/store/rpc-api/skill.ts
@@ -114,4 +114,26 @@ export const SkillApi = {
     ): Promise<{ bound: boolean }> {
         return client.rpcCall("skill.catalog.bind", data, opts);
     },
+
+    // Catalog-tier siblings of SkillListCommand / SkillUnbindCommand — no
+    // agent_id/check_s1 gate on the *caller*, but agent_id is still required
+    // in the payload (whose bindings to list/unbind). Used by
+    // AgentStashModal's Skills tab, which runs over the dashboard's
+    // connection and can never satisfy SkillListCommand/SkillUnbindCommand's
+    // check_s1.
+    SkillCatalogListForAgentCommand(
+        client: RpcClient,
+        data: { agent_id: string },
+        opts?: RpcOpts,
+    ): Promise<SkillListItem[]> {
+        return client.rpcCall("skill.catalog.list_for_agent", data, opts);
+    },
+
+    SkillCatalogUnbindCommand(
+        client: RpcClient,
+        data: { agent_id: string; skill_id: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("skill.catalog.unbind", data, opts);
+    },
 };

--- a/frontend/app/view/agent/agent-mcp-model.ts
+++ b/frontend/app/view/agent/agent-mcp-model.ts
@@ -6,18 +6,21 @@
  * AgentStashModal). A reactive, read-only view of the standalone MCP
  * Server primitive (`mcp.*` App API, agentmux-srv/src/server/app_api/mcp.rs)
  * plus a Bind/Unbind toggle — NOT a create/edit/delete surface. Global
- * servers are authored in the Armory; this tab shows every server visible
- * to this agent (global + this agent's own, if any were created via its
- * own tool calls) and lets you choose which global ones apply here.
+ * servers are authored in the Armory; this tab lets you choose which of
+ * them apply to this agent.
  *
- * `mcp.catalog.list_for_agent` returns both this agent's own (non-global)
- * servers AND every global server, each annotated with `bound_to_agent` —
- * whether *this* agent specifically holds the bind ref (own rows are
- * always true; a global row may or may not be). Unlike `mcp.list`, this
- * and the bind/unbind commands below carry no `check_s1` gate: they were
- * originally check_s1-gated (agent-self-service only), which meant every
- * action in this tab failed "unauthorized" when opened from the dashboard
- * — this tab's connection is never agent-authenticated. See
+ * `mcp.catalog.list_for_agent` returns every GLOBAL server (never this
+ * agent's own private ones, if any exist), each annotated with
+ * `bound_to_agent` — whether *this* agent specifically holds the bind ref.
+ * Unlike `mcp.list`, this and the bind/unbind commands below carry no
+ * `check_s1` gate: they were originally check_s1-gated (agent-self-service
+ * only), which meant every action in this tab failed "unauthorized" when
+ * opened from the dashboard — this tab's connection is never
+ * agent-authenticated. Deliberately global-only, not a reuse of `mcp.list`'s
+ * full computation: with no `check_s1`, `agent_id` is caller-supplied and
+ * unverified, so returning a private server's `config` (which can carry
+ * secrets) for an arbitrary agent_id would be an IDOR. See
+ * `Store::mcp_server_list_global_for_agent`'s doc comment and
  * docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
  */
 

--- a/frontend/app/view/agent/agent-mcp-model.ts
+++ b/frontend/app/view/agent/agent-mcp-model.ts
@@ -2,38 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentMcpModel — view model for the agent pane's MCP Servers tab
- * (part of AgentStashModal). Drives the list + create/edit/delete/bind
- * lifecycle over the standalone MCP Server primitive (`mcp.*` App API,
- * agentmux-srv/src/server/app_api/mcp.rs).
+ * AgentMcpModel — view model for the agent pane's MCP Servers tab (part of
+ * AgentStashModal). A reactive, read-only view of the standalone MCP
+ * Server primitive (`mcp.*` App API, agentmux-srv/src/server/app_api/mcp.rs)
+ * plus a Bind/Unbind toggle — NOT a create/edit/delete surface. Global
+ * servers are authored in the Armory; this tab shows every server visible
+ * to this agent (global + this agent's own, if any were created via its
+ * own tool calls) and lets you choose which global ones apply here.
  *
- * `mcp.list` returns both this agent's own (non-global) servers AND every
- * global server, each annotated with `bound_to_agent` — whether *this*
- * agent specifically holds the bind ref (own rows are always true; a global
- * row may or may not be). Own (`!is_global`) rows are always editable/
- * deletable here; global rows are read-only (upsert/delete on a global row
- * is backend-FORBIDDEN) and only exposed as a Bind/Unbind toggle driven by
- * `bound_to_agent`.
+ * `mcp.catalog.list_for_agent` returns both this agent's own (non-global)
+ * servers AND every global server, each annotated with `bound_to_agent` —
+ * whether *this* agent specifically holds the bind ref (own rows are
+ * always true; a global row may or may not be). Unlike `mcp.list`, this
+ * and the bind/unbind commands below carry no `check_s1` gate: they were
+ * originally check_s1-gated (agent-self-service only), which meant every
+ * action in this tab failed "unauthorized" when opened from the dashboard
+ * — this tab's connection is never agent-authenticated. See
+ * docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
  */
 
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-
-export interface McpDraft {
-    id?: string;
-    name: string;
-    transport: string;
-    config: string;
-}
-
-export function emptyMcpDraft(): McpDraft {
-    return { id: undefined, name: "", transport: "stdio", config: "{}" };
-}
-
-function draftFromServer(s: McpServer): McpDraft {
-    return { id: s.id, name: s.name, transport: s.transport, config: s.config };
-}
+import { waveEventSubscribe } from "@/app/store/wps";
 
 export class AgentMcpModel {
     readonly agentId: string;
@@ -46,19 +37,16 @@ export class AgentMcpModel {
     selectedIdAtom: Accessor<string | null> = this._selectedId[0];
     setSelectedId = this._selectedId[1];
 
-    private _draft = createSignal<McpDraft | null>(null);
-    draftAtom: Accessor<McpDraft | null> = this._draft[0];
-    setDraft = this._draft[1];
-
-    private _saving = createSignal<boolean>(false);
-    savingAtom: Accessor<boolean> = this._saving[0];
-    private setSaving = this._saving[1];
-
     private _error = createSignal<string | null>(null);
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
     selectedAtom: Accessor<McpServerListItem | null>;
+
+    // Cross-window reactivity — a bind/unbind or Armory catalog edit made
+    // elsewhere (another window, or this same agent's own tool calls)
+    // refreshes this view without a manual reopen.
+    private unsubChanged: () => void;
 
     constructor(agentId: string) {
         this.agentId = agentId;
@@ -68,11 +56,15 @@ export class AgentMcpModel {
             return this.serversAtom().find((s) => s.id === id) ?? null;
         });
         void this.refresh();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "mcp:changed",
+            handler: () => void this.refresh(),
+        });
     }
 
     async refresh(): Promise<void> {
         try {
-            const list = await RpcApi.McpListCommand(TabRpcClient, { agent_id: this.agentId });
+            const list = await RpcApi.McpCatalogListForAgentCommand(TabRpcClient, { agent_id: this.agentId });
             this.setServers(list);
             this.setError(null);
         } catch (e) {
@@ -82,85 +74,13 @@ export class AgentMcpModel {
 
     handleSelect(server: McpServerListItem): void {
         this.setError(null);
-        this.setDraft(null);
         this.setSelectedId(server.id);
-    }
-
-    startNew(): void {
-        this.setError(null);
-        this.setDraft(emptyMcpDraft());
-        this.setSelectedId(null);
-    }
-
-    startEdit(server: McpServerListItem): void {
-        if (server.is_global) {
-            this.setError("Global MCP servers are managed in the Armory, not here.");
-            return;
-        }
-        this.setError(null);
-        this.setDraft(draftFromServer(server));
-        this.setSelectedId(server.id);
-    }
-
-    cancelDraft(): void {
-        this.setDraft(null);
-        this.setError(null);
-    }
-
-    async saveDraft(): Promise<void> {
-        const draft = this.draftAtom();
-        if (!draft) return;
-        if (!draft.name.trim()) {
-            this.setError("Name is required.");
-            return;
-        }
-        try {
-            JSON.parse(draft.config || "{}");
-        } catch {
-            this.setError("Config must be valid JSON.");
-            return;
-        }
-        this.setSaving(true);
-        this.setError(null);
-        try {
-            const saved = await RpcApi.McpUpsertCommand(TabRpcClient, {
-                agent_id: this.agentId,
-                id: draft.id,
-                name: draft.name.trim(),
-                transport: draft.transport || "stdio",
-                config: draft.config || "{}",
-            });
-            await this.refresh();
-            this.setDraft(null);
-            this.setSelectedId(saved.id);
-        } catch (e) {
-            this.setError(`Save failed: ${(e as Error).message ?? e}`);
-        } finally {
-            this.setSaving(false);
-        }
-    }
-
-    async deleteServer(id: string): Promise<void> {
-        const target = this.serversAtom().find((s) => s.id === id);
-        if (target?.is_global) {
-            this.setError("Global MCP servers are managed in the Armory, not here.");
-            return;
-        }
-        this.setError(null);
-        try {
-            await RpcApi.McpDeleteCommand(TabRpcClient, { agent_id: this.agentId, id });
-            if (this.selectedIdAtom() === id) this.setSelectedId(null);
-            this.setDraft(null);
-            await this.refresh();
-        } catch (e) {
-            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
-        }
     }
 
     async bind(id: string): Promise<void> {
         this.setError(null);
         try {
-            await RpcApi.McpBindCommand(TabRpcClient, { agent_id: this.agentId, mcp_id: id });
+            await RpcApi.McpCatalogBindCommand(TabRpcClient, { agent_id: this.agentId, mcp_id: id });
             await this.refresh();
         } catch (e) {
             this.setError(`Bind failed: ${(e as Error).message ?? e}`);
@@ -170,7 +90,7 @@ export class AgentMcpModel {
     async unbind(id: string): Promise<void> {
         this.setError(null);
         try {
-            await RpcApi.McpUnbindCommand(TabRpcClient, { agent_id: this.agentId, mcp_id: id });
+            await RpcApi.McpCatalogUnbindCommand(TabRpcClient, { agent_id: this.agentId, mcp_id: id });
             await this.refresh();
         } catch (e) {
             this.setError(`Unbind failed: ${(e as Error).message ?? e}`);
@@ -178,6 +98,6 @@ export class AgentMcpModel {
     }
 
     dispose(): void {
-        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+        this.unsubChanged();
     }
 }

--- a/frontend/app/view/agent/agent-skill-model.ts
+++ b/frontend/app/view/agent/agent-skill-model.ts
@@ -3,40 +3,18 @@
 
 /**
  * AgentSkillModel — view model for the agent pane's Skills tab (part of
- * AgentStashModal). Drives the list + create/edit/delete/bind lifecycle
- * over the standalone Skill primitive (`skill.*` App API,
- * agentmux-srv/src/server/app_api/skill.rs). Same shape as AgentMcpModel —
- * see its doc comment for the is_global / bound_to_agent details, which
- * apply identically here.
+ * AgentStashModal). Same shape as AgentMcpModel — see its doc comment for
+ * the is_global / bound_to_agent / no-check_s1 details, which apply
+ * identically here. A reactive, read-only view of the standalone Skill
+ * primitive (`skill.*` App API, agentmux-srv/src/server/app_api/skill.rs)
+ * plus a Bind/Unbind toggle — global skills are authored in the Armory,
+ * not here.
  */
 
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-
-export interface SkillDraft {
-    id?: string;
-    name: string;
-    trigger: string;
-    skill_type: string;
-    description: string;
-    content: string;
-}
-
-export function emptySkillDraft(): SkillDraft {
-    return { id: undefined, name: "", trigger: "", skill_type: "prompt", description: "", content: "" };
-}
-
-function draftFromSkill(s: Skill): SkillDraft {
-    return {
-        id: s.id,
-        name: s.name,
-        trigger: s.trigger,
-        skill_type: s.skill_type,
-        description: s.description,
-        content: s.content,
-    };
-}
+import { waveEventSubscribe } from "@/app/store/wps";
 
 export class AgentSkillModel {
     readonly agentId: string;
@@ -49,19 +27,13 @@ export class AgentSkillModel {
     selectedIdAtom: Accessor<string | null> = this._selectedId[0];
     setSelectedId = this._selectedId[1];
 
-    private _draft = createSignal<SkillDraft | null>(null);
-    draftAtom: Accessor<SkillDraft | null> = this._draft[0];
-    setDraft = this._draft[1];
-
-    private _saving = createSignal<boolean>(false);
-    savingAtom: Accessor<boolean> = this._saving[0];
-    private setSaving = this._saving[1];
-
     private _error = createSignal<string | null>(null);
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
     selectedAtom: Accessor<SkillListItem | null>;
+
+    private unsubChanged: () => void;
 
     constructor(agentId: string) {
         this.agentId = agentId;
@@ -71,11 +43,15 @@ export class AgentSkillModel {
             return this.skillsAtom().find((s) => s.id === id) ?? null;
         });
         void this.refresh();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "skills:changed",
+            handler: () => void this.refresh(),
+        });
     }
 
     async refresh(): Promise<void> {
         try {
-            const list = await RpcApi.SkillListCommand(TabRpcClient, { agent_id: this.agentId });
+            const list = await RpcApi.SkillCatalogListForAgentCommand(TabRpcClient, { agent_id: this.agentId });
             this.setSkills(list);
             this.setError(null);
         } catch (e) {
@@ -85,81 +61,13 @@ export class AgentSkillModel {
 
     handleSelect(skill: SkillListItem): void {
         this.setError(null);
-        this.setDraft(null);
         this.setSelectedId(skill.id);
-    }
-
-    startNew(): void {
-        this.setError(null);
-        this.setDraft(emptySkillDraft());
-        this.setSelectedId(null);
-    }
-
-    startEdit(skill: SkillListItem): void {
-        if (skill.is_global) {
-            this.setError("Global skills are managed in the Armory, not here.");
-            return;
-        }
-        this.setError(null);
-        this.setDraft(draftFromSkill(skill));
-        this.setSelectedId(skill.id);
-    }
-
-    cancelDraft(): void {
-        this.setDraft(null);
-        this.setError(null);
-    }
-
-    async saveDraft(): Promise<void> {
-        const draft = this.draftAtom();
-        if (!draft) return;
-        if (!draft.name.trim()) {
-            this.setError("Name is required.");
-            return;
-        }
-        this.setSaving(true);
-        this.setError(null);
-        try {
-            const saved = await RpcApi.SkillUpsertCommand(TabRpcClient, {
-                agent_id: this.agentId,
-                id: draft.id,
-                name: draft.name.trim(),
-                trigger: draft.trigger,
-                skill_type: draft.skill_type || "prompt",
-                description: draft.description,
-                content: draft.content,
-            });
-            await this.refresh();
-            this.setDraft(null);
-            this.setSelectedId(saved.id);
-        } catch (e) {
-            this.setError(`Save failed: ${(e as Error).message ?? e}`);
-        } finally {
-            this.setSaving(false);
-        }
-    }
-
-    async deleteSkill(id: string): Promise<void> {
-        const target = this.skillsAtom().find((s) => s.id === id);
-        if (target?.is_global) {
-            this.setError("Global skills are managed in the Armory, not here.");
-            return;
-        }
-        this.setError(null);
-        try {
-            await RpcApi.SkillDeleteCommand(TabRpcClient, { agent_id: this.agentId, id });
-            if (this.selectedIdAtom() === id) this.setSelectedId(null);
-            this.setDraft(null);
-            await this.refresh();
-        } catch (e) {
-            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
-        }
     }
 
     async bind(id: string): Promise<void> {
         this.setError(null);
         try {
-            await RpcApi.SkillBindCommand(TabRpcClient, { agent_id: this.agentId, skill_id: id });
+            await RpcApi.SkillCatalogBindCommand(TabRpcClient, { agent_id: this.agentId, skill_id: id });
             await this.refresh();
         } catch (e) {
             this.setError(`Bind failed: ${(e as Error).message ?? e}`);
@@ -169,7 +77,7 @@ export class AgentSkillModel {
     async unbind(id: string): Promise<void> {
         this.setError(null);
         try {
-            await RpcApi.SkillUnbindCommand(TabRpcClient, { agent_id: this.agentId, skill_id: id });
+            await RpcApi.SkillCatalogUnbindCommand(TabRpcClient, { agent_id: this.agentId, skill_id: id });
             await this.refresh();
         } catch (e) {
             this.setError(`Unbind failed: ${(e as Error).message ?? e}`);
@@ -177,6 +85,6 @@ export class AgentSkillModel {
     }
 
     dispose(): void {
-        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+        this.unsubChanged();
     }
 }

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentMcpModal — the "MCP Servers" tab body inside AgentStashModal.
- * List/create/edit/delete for this agent's own MCP servers, plus a
- * bound-state-aware Bind/Unbind toggle for global ones (driven by
- * `bound_to_agent` — see AgentMcpModel's doc comment).
+ * AgentMcpModal — the "MCP Servers" tab body inside AgentStashModal. A
+ * reactive, read-only list of every MCP server visible to this agent
+ * (global + this agent's own, if any exist), plus a bound-state-aware
+ * Bind/Unbind toggle for global ones (driven by `bound_to_agent` — see
+ * AgentMcpModel's doc comment). Servers are authored in the Armory, not
+ * here — see AgentMcpModel's doc comment for why this is no longer a
+ * create/edit/delete surface.
  */
 
 import { onCleanup, For, Show, type JSX } from "solid-js";
@@ -23,11 +26,10 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
     onCleanup(() => model.dispose());
 
     // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md §5.
-    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+    const inDetail = () => model.selectedIdAtom() !== null;
     const handleBack = () => {
         model.setError(null);
         model.setSelectedId(null);
-        model.setDraft(null);
     };
 
     const listView = (
@@ -61,9 +63,6 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                 </For>
             </Show>
 
-            <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
-                + New MCP server
-            </button>
             <button
                 class="agent-primitive-modal-new-btn"
                 onClick={() => void openOrFocusPaneByView("armory")}
@@ -78,123 +77,58 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
             <Show when={model.errorAtom()}>
                 <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
             </Show>
-            <Show
-                when={model.draftAtom()}
-                fallback={
-                    <Show when={model.selectedAtom()}>
-                        {(server) => (
-                                    <div class="agent-primitive-modal-readonly">
-                                        <h3 class="agent-primitive-modal-name">{server().name}</h3>
-                                        <Show when={server().is_global}>
-                                            <p class="agent-primitive-modal-global-note">
-                                                Global — managed in the Armory. You can bind/unbind it
-                                                here, or{" "}
-                                                <button
-                                                    type="button"
-                                                    class="agent-primitive-modal-link-btn"
-                                                    onClick={() => void openOrFocusPaneByView("armory")}
-                                                >
-                                                    edit it there
-                                                </button>
-                                                .
-                                            </p>
-                                        </Show>
-                                        <span class="agent-primitive-modal-field-label">Transport</span>
-                                        <pre class="agent-primitive-modal-field-value">{server().transport}</pre>
-                                        <span class="agent-primitive-modal-field-label">Config</span>
-                                        <pre class="agent-primitive-modal-field-value">{server().config}</pre>
-                                        <div class="agent-primitive-modal-actions">
-                                            <Show
-                                                when={!server().is_global}
-                                                fallback={
-                                                    <Show
-                                                        when={server().bound_to_agent}
-                                                        fallback={
-                                                            <button
-                                                                class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                                                onClick={() => void model.bind(server().id)}
-                                                            >
-                                                                Bind
-                                                            </button>
-                                                        }
-                                                    >
-                                                        <button
-                                                            class="agent-primitive-modal-btn"
-                                                            onClick={() => void model.unbind(server().id)}
-                                                        >
-                                                            Unbind
-                                                        </button>
-                                                    </Show>
-                                                }
-                                            >
-                                                <button
-                                                    class="agent-primitive-modal-btn agent-primitive-modal-btn-danger"
-                                                    onClick={() => void model.deleteServer(server().id)}
-                                                >
-                                                    Delete
-                                                </button>
-                                                <button
-                                                    class="agent-primitive-modal-btn"
-                                                    onClick={() => model.startEdit(server())}
-                                                >
-                                                    Edit
-                                                </button>
-                                            </Show>
-                                        </div>
-                                    </div>
-                                )}
-                            </Show>
-                        }
-                    >
-                        {(draft) => (
-                            <form
-                                class="agent-primitive-modal-form"
-                                onSubmit={(e) => { e.preventDefault(); void model.saveDraft(); }}
-                            >
-                                <span class="agent-primitive-modal-field-label">Name *</span>
-                                <input
-                                    class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().name}
-                                    onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
-                                    placeholder="e.g. filesystem"
-                                    required
-                                />
-                                <span class="agent-primitive-modal-field-label">Transport</span>
-                                <input
-                                    class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().transport}
-                                    onInput={(e) => model.setDraft({ ...draft(), transport: e.currentTarget.value })}
-                                    placeholder="stdio"
-                                />
-                                <span class="agent-primitive-modal-field-label">Config (JSON)</span>
-                                <textarea
-                                    class="agent-primitive-modal-textarea"
-                                    rows={6}
-                                    value={draft().config}
-                                    onInput={(e) => model.setDraft({ ...draft(), config: e.currentTarget.value })}
-                                    spellcheck={false}
-                                />
-                                <div class="agent-primitive-modal-actions">
+            <Show when={model.selectedAtom()}>
+                {(server) => (
+                    <div class="agent-primitive-modal-readonly">
+                        <h3 class="agent-primitive-modal-name">{server().name}</h3>
+                        <Show
+                            when={server().is_global}
+                            fallback={
+                                <p class="agent-primitive-modal-global-note">
+                                    Created by this agent's own tools — not editable here.
+                                </p>
+                            }
+                        >
+                            <p class="agent-primitive-modal-global-note">
+                                Global — managed in the Armory. You can bind/unbind it here, or{" "}
+                                <button
+                                    type="button"
+                                    class="agent-primitive-modal-link-btn"
+                                    onClick={() => void openOrFocusPaneByView("armory")}
+                                >
+                                    edit it there
+                                </button>
+                                .
+                            </p>
+                        </Show>
+                        <span class="agent-primitive-modal-field-label">Transport</span>
+                        <pre class="agent-primitive-modal-field-value">{server().transport}</pre>
+                        <span class="agent-primitive-modal-field-label">Config</span>
+                        <pre class="agent-primitive-modal-field-value">{server().config}</pre>
+                        <Show when={server().is_global}>
+                            <div class="agent-primitive-modal-actions">
+                                <Show
+                                    when={server().bound_to_agent}
+                                    fallback={
+                                        <button
+                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                            onClick={() => void model.bind(server().id)}
+                                        >
+                                            Bind
+                                        </button>
+                                    }
+                                >
                                     <button
-                                        type="button"
                                         class="agent-primitive-modal-btn"
-                                        onClick={() => model.cancelDraft()}
-                                        disabled={model.savingAtom()}
+                                        onClick={() => void model.unbind(server().id)}
                                     >
-                                        Cancel
+                                        Unbind
                                     </button>
-                                    <button
-                                        type="submit"
-                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                        disabled={model.savingAtom() || !draft().name.trim()}
-                                    >
-                                        {model.savingAtom() ? "Saving…" : "Save"}
-                                    </button>
-                                </div>
-                            </form>
-                        )}
+                                </Show>
+                            </div>
+                        </Show>
+                    </div>
+                )}
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -93,6 +93,11 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                         <pre class="agent-primitive-modal-field-value">{server().transport}</pre>
                         <span class="agent-primitive-modal-field-label">Config</span>
                         <pre class="agent-primitive-modal-field-value">{server().config}</pre>
+                        <p class="agent-primitive-modal-caveat">
+                            Note: every global server is currently applied to every agent
+                            regardless of bind state — unbinding here updates what shows as
+                            "in use" but does not yet remove it from this agent's live config.
+                        </p>
                         <div class="agent-primitive-modal-actions">
                             <Show
                                 when={server().bound_to_agent}

--- a/frontend/app/view/agent/components/AgentMcpModal.tsx
+++ b/frontend/app/view/agent/components/AgentMcpModal.tsx
@@ -49,15 +49,12 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                             onClick={() => model.handleSelect(server)}
                         >
                             <span class="agent-primitive-modal-list-item-name">{server.name}</span>
-                            <Show when={server.is_global}>
-                                <span class="agent-primitive-modal-list-item-badge">global</span>
-                                <span
-                                    class="agent-primitive-modal-list-item-badge"
-                                    classList={{ "is-bound": server.bound_to_agent }}
-                                >
-                                    {server.bound_to_agent ? "bound" : "not bound"}
-                                </span>
-                            </Show>
+                            <span
+                                class="agent-primitive-modal-list-item-badge"
+                                classList={{ "is-bound": server.bound_to_agent }}
+                            >
+                                {server.bound_to_agent ? "bound" : "not bound"}
+                            </span>
                         </button>
                     )}
                 </For>
@@ -81,52 +78,41 @@ export const AgentMcpModal = (props: AgentMcpModalProps): JSX.Element => {
                 {(server) => (
                     <div class="agent-primitive-modal-readonly">
                         <h3 class="agent-primitive-modal-name">{server().name}</h3>
-                        <Show
-                            when={server().is_global}
-                            fallback={
-                                <p class="agent-primitive-modal-global-note">
-                                    Created by this agent's own tools — not editable here.
-                                </p>
-                            }
-                        >
-                            <p class="agent-primitive-modal-global-note">
-                                Global — managed in the Armory. You can bind/unbind it here, or{" "}
-                                <button
-                                    type="button"
-                                    class="agent-primitive-modal-link-btn"
-                                    onClick={() => void openOrFocusPaneByView("armory")}
-                                >
-                                    edit it there
-                                </button>
-                                .
-                            </p>
-                        </Show>
+                        <p class="agent-primitive-modal-global-note">
+                            Global — managed in the Armory. You can bind/unbind it here, or{" "}
+                            <button
+                                type="button"
+                                class="agent-primitive-modal-link-btn"
+                                onClick={() => void openOrFocusPaneByView("armory")}
+                            >
+                                edit it there
+                            </button>
+                            .
+                        </p>
                         <span class="agent-primitive-modal-field-label">Transport</span>
                         <pre class="agent-primitive-modal-field-value">{server().transport}</pre>
                         <span class="agent-primitive-modal-field-label">Config</span>
                         <pre class="agent-primitive-modal-field-value">{server().config}</pre>
-                        <Show when={server().is_global}>
-                            <div class="agent-primitive-modal-actions">
-                                <Show
-                                    when={server().bound_to_agent}
-                                    fallback={
-                                        <button
-                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                            onClick={() => void model.bind(server().id)}
-                                        >
-                                            Bind
-                                        </button>
-                                    }
-                                >
+                        <div class="agent-primitive-modal-actions">
+                            <Show
+                                when={server().bound_to_agent}
+                                fallback={
                                     <button
-                                        class="agent-primitive-modal-btn"
-                                        onClick={() => void model.unbind(server().id)}
+                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                        onClick={() => void model.bind(server().id)}
                                     >
-                                        Unbind
+                                        Bind
                                     </button>
-                                </Show>
-                            </div>
-                        </Show>
+                                }
+                            >
+                                <button
+                                    class="agent-primitive-modal-btn"
+                                    onClick={() => void model.unbind(server().id)}
+                                >
+                                    Unbind
+                                </button>
+                            </Show>
+                        </div>
                     </div>
                 )}
             </Show>

--- a/frontend/app/view/agent/components/AgentPrimitiveModal.scss
+++ b/frontend/app/view/agent/components/AgentPrimitiveModal.scss
@@ -121,6 +121,18 @@
     color: var(--secondary-text-color);
 }
 
+// Flags a known, tracked limitation (bind/unbind doesn't yet gate config
+// materialization — see docs/reports/REPORT_MCP_SKILLS_BIND_DOES_NOT_GATE_CONFIG_2026_07_28.md)
+// distinct enough from `-global-note`'s neutral info tone to read as a caveat.
+.agent-primitive-modal-caveat {
+    margin: 0 0 var(--space-2) 0;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm, 0);
+    background: color-mix(in srgb, var(--warning-color) 15%, transparent);
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+}
+
 .agent-primitive-modal-link-btn {
     padding: 0;
     border: none;

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -110,6 +110,11 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                 <Markdown text={skill().content} scrollable={false} />
                             </div>
                         </Show>
+                        <p class="agent-primitive-modal-caveat">
+                            Note: every global skill is currently applied to every agent
+                            regardless of bind state — unbinding here updates what shows as
+                            "in use" but does not yet remove it from this agent's live config.
+                        </p>
                         <div class="agent-primitive-modal-actions">
                             <Show
                                 when={skill().bound_to_agent}

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentSkillsModal — the "Skills" tab body inside AgentStashModal.
- * List/create/edit/delete for this agent's own skills, plus a
- * bound-state-aware Bind/Unbind toggle for global ones (driven by
- * `bound_to_agent` — see AgentSkillModel's doc comment). Distinct from the
- * legacy AgentSkillCard/AgentSkillsPanel (the agent-definition
+ * AgentSkillsModal — the "Skills" tab body inside AgentStashModal. A
+ * reactive, read-only list of every skill visible to this agent (global +
+ * this agent's own, if any exist), plus a bound-state-aware Bind/Unbind
+ * toggle for global ones (driven by `bound_to_agent` — see AgentSkillModel's
+ * doc comment). Skills are authored in the Armory, not here. Distinct from
+ * the legacy AgentSkillCard/AgentSkillsPanel (the agent-definition
  * `agent_skill_*` surface) — this is the v1 standalone Skill primitive
  * (`skill.*` / `db_skills`).
  */
@@ -29,11 +30,10 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
     // Single-pane — see docs/specs/SPEC_ARMORY_RESPONSIVE_SINGLE_PANE_LAYOUT_2026_07_15.md
     // §5 (shared with Armory's Skills/MCP Servers tabs; applied here too since
     // there's no evidence the split was intentional in this modal specifically).
-    const inDetail = () => model.selectedIdAtom() !== null || model.draftAtom() !== null;
+    const inDetail = () => model.selectedIdAtom() !== null;
     const handleBack = () => {
         model.setError(null);
         model.setSelectedId(null);
-        model.setDraft(null);
     };
 
     const listView = (
@@ -67,9 +67,6 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                 </For>
             </Show>
 
-            <button class="agent-primitive-modal-new-btn" onClick={() => model.startNew()}>
-                + New skill
-            </button>
             <button
                 class="agent-primitive-modal-new-btn"
                 onClick={() => void openOrFocusPaneByView("armory")}
@@ -84,143 +81,71 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
             <Show when={model.errorAtom()}>
                 <div class="agent-primitive-modal-error">{model.errorAtom()}</div>
             </Show>
-            <Show
-                when={model.draftAtom()}
-                fallback={
-                    <Show when={model.selectedAtom()}>
-                        {(skill) => (
-                                    <div class="agent-primitive-modal-readonly">
-                                        <h3 class="agent-primitive-modal-name">{skill().name}</h3>
-                                        <Show when={skill().is_global}>
-                                            <p class="agent-primitive-modal-global-note">
-                                                Global — managed in the Armory. You can bind/unbind it
-                                                here, or{" "}
-                                                <button
-                                                    type="button"
-                                                    class="agent-primitive-modal-link-btn"
-                                                    onClick={() => void openOrFocusPaneByView("armory")}
-                                                >
-                                                    edit it there
-                                                </button>
-                                                .
-                                            </p>
-                                        </Show>
-                                        <Show when={skill().description}>
-                                            <span class="agent-primitive-modal-field-label">Description</span>
-                                            <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
-                                        </Show>
-                                        <Show when={skill().trigger}>
-                                            <span class="agent-primitive-modal-field-label">Trigger</span>
-                                            <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
-                                        </Show>
-                                        <span class="agent-primitive-modal-field-label">Content</span>
-                                        <Show
-                                            when={skill().content}
-                                            fallback={<pre class="agent-primitive-modal-field-value">(none)</pre>}
+            <Show when={model.selectedAtom()}>
+                {(skill) => (
+                    <div class="agent-primitive-modal-readonly">
+                        <h3 class="agent-primitive-modal-name">{skill().name}</h3>
+                        <Show
+                            when={skill().is_global}
+                            fallback={
+                                <p class="agent-primitive-modal-global-note">
+                                    Created by this agent's own tools — not editable here.
+                                </p>
+                            }
+                        >
+                            <p class="agent-primitive-modal-global-note">
+                                Global — managed in the Armory. You can bind/unbind it here, or{" "}
+                                <button
+                                    type="button"
+                                    class="agent-primitive-modal-link-btn"
+                                    onClick={() => void openOrFocusPaneByView("armory")}
+                                >
+                                    edit it there
+                                </button>
+                                .
+                            </p>
+                        </Show>
+                        <Show when={skill().description}>
+                            <span class="agent-primitive-modal-field-label">Description</span>
+                            <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
+                        </Show>
+                        <Show when={skill().trigger}>
+                            <span class="agent-primitive-modal-field-label">Trigger</span>
+                            <pre class="agent-primitive-modal-field-value">{skill().trigger}</pre>
+                        </Show>
+                        <span class="agent-primitive-modal-field-label">Content</span>
+                        <Show
+                            when={skill().content}
+                            fallback={<pre class="agent-primitive-modal-field-value">(none)</pre>}
+                        >
+                            <div class="agent-primitive-modal-field-value agent-primitive-modal-field-value--markdown">
+                                <Markdown text={skill().content} scrollable={false} />
+                            </div>
+                        </Show>
+                        <Show when={skill().is_global}>
+                            <div class="agent-primitive-modal-actions">
+                                <Show
+                                    when={skill().bound_to_agent}
+                                    fallback={
+                                        <button
+                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                            onClick={() => void model.bind(skill().id)}
                                         >
-                                            <div class="agent-primitive-modal-field-value agent-primitive-modal-field-value--markdown">
-                                                <Markdown text={skill().content} scrollable={false} />
-                                            </div>
-                                        </Show>
-                                        <div class="agent-primitive-modal-actions">
-                                            <Show
-                                                when={!skill().is_global}
-                                                fallback={
-                                                    <Show
-                                                        when={skill().bound_to_agent}
-                                                        fallback={
-                                                            <button
-                                                                class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                                                onClick={() => void model.bind(skill().id)}
-                                                            >
-                                                                Bind
-                                                            </button>
-                                                        }
-                                                    >
-                                                        <button
-                                                            class="agent-primitive-modal-btn"
-                                                            onClick={() => void model.unbind(skill().id)}
-                                                        >
-                                                            Unbind
-                                                        </button>
-                                                    </Show>
-                                                }
-                                            >
-                                                <button
-                                                    class="agent-primitive-modal-btn agent-primitive-modal-btn-danger"
-                                                    onClick={() => void model.deleteSkill(skill().id)}
-                                                >
-                                                    Delete
-                                                </button>
-                                                <button
-                                                    class="agent-primitive-modal-btn"
-                                                    onClick={() => model.startEdit(skill())}
-                                                >
-                                                    Edit
-                                                </button>
-                                            </Show>
-                                        </div>
-                                    </div>
-                                )}
-                            </Show>
-                        }
-                    >
-                        {(draft) => (
-                            <form
-                                class="agent-primitive-modal-form"
-                                onSubmit={(e) => { e.preventDefault(); void model.saveDraft(); }}
-                            >
-                                <span class="agent-primitive-modal-field-label">Name *</span>
-                                <input
-                                    class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().name}
-                                    onInput={(e) => model.setDraft({ ...draft(), name: e.currentTarget.value })}
-                                    placeholder="e.g. pdf-extraction"
-                                    required
-                                />
-                                <span class="agent-primitive-modal-field-label">Trigger</span>
-                                <input
-                                    class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().trigger}
-                                    onInput={(e) => model.setDraft({ ...draft(), trigger: e.currentTarget.value })}
-                                    placeholder="When should this skill be invoked?"
-                                />
-                                <span class="agent-primitive-modal-field-label">Description</span>
-                                <input
-                                    class="agent-primitive-modal-input"
-                                    type="text"
-                                    value={draft().description}
-                                    onInput={(e) => model.setDraft({ ...draft(), description: e.currentTarget.value })}
-                                />
-                                <span class="agent-primitive-modal-field-label">Content</span>
-                                <textarea
-                                    class="agent-primitive-modal-textarea"
-                                    rows={8}
-                                    value={draft().content}
-                                    onInput={(e) => model.setDraft({ ...draft(), content: e.currentTarget.value })}
-                                    spellcheck={false}
-                                />
-                                <div class="agent-primitive-modal-actions">
+                                            Bind
+                                        </button>
+                                    }
+                                >
                                     <button
-                                        type="button"
                                         class="agent-primitive-modal-btn"
-                                        onClick={() => model.cancelDraft()}
-                                        disabled={model.savingAtom()}
+                                        onClick={() => void model.unbind(skill().id)}
                                     >
-                                        Cancel
+                                        Unbind
                                     </button>
-                                    <button
-                                        type="submit"
-                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                        disabled={model.savingAtom() || !draft().name.trim()}
-                                    >
-                                        {model.savingAtom() ? "Saving…" : "Save"}
-                                    </button>
-                                </div>
-                            </form>
-                        )}
+                                </Show>
+                            </div>
+                        </Show>
+                    </div>
+                )}
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentSkillsModal.tsx
+++ b/frontend/app/view/agent/components/AgentSkillsModal.tsx
@@ -53,15 +53,12 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                             onClick={() => model.handleSelect(skill)}
                         >
                             <span class="agent-primitive-modal-list-item-name">{skill.name}</span>
-                            <Show when={skill.is_global}>
-                                <span class="agent-primitive-modal-list-item-badge">global</span>
-                                <span
-                                    class="agent-primitive-modal-list-item-badge"
-                                    classList={{ "is-bound": skill.bound_to_agent }}
-                                >
-                                    {skill.bound_to_agent ? "bound" : "not bound"}
-                                </span>
-                            </Show>
+                            <span
+                                class="agent-primitive-modal-list-item-badge"
+                                classList={{ "is-bound": skill.bound_to_agent }}
+                            >
+                                {skill.bound_to_agent ? "bound" : "not bound"}
+                            </span>
                         </button>
                     )}
                 </For>
@@ -85,26 +82,17 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                 {(skill) => (
                     <div class="agent-primitive-modal-readonly">
                         <h3 class="agent-primitive-modal-name">{skill().name}</h3>
-                        <Show
-                            when={skill().is_global}
-                            fallback={
-                                <p class="agent-primitive-modal-global-note">
-                                    Created by this agent's own tools — not editable here.
-                                </p>
-                            }
-                        >
-                            <p class="agent-primitive-modal-global-note">
-                                Global — managed in the Armory. You can bind/unbind it here, or{" "}
-                                <button
-                                    type="button"
-                                    class="agent-primitive-modal-link-btn"
-                                    onClick={() => void openOrFocusPaneByView("armory")}
-                                >
-                                    edit it there
-                                </button>
-                                .
-                            </p>
-                        </Show>
+                        <p class="agent-primitive-modal-global-note">
+                            Global — managed in the Armory. You can bind/unbind it here, or{" "}
+                            <button
+                                type="button"
+                                class="agent-primitive-modal-link-btn"
+                                onClick={() => void openOrFocusPaneByView("armory")}
+                            >
+                                edit it there
+                            </button>
+                            .
+                        </p>
                         <Show when={skill().description}>
                             <span class="agent-primitive-modal-field-label">Description</span>
                             <pre class="agent-primitive-modal-field-value">{skill().description}</pre>
@@ -122,28 +110,26 @@ export const AgentSkillsModal = (props: AgentSkillsModalProps): JSX.Element => {
                                 <Markdown text={skill().content} scrollable={false} />
                             </div>
                         </Show>
-                        <Show when={skill().is_global}>
-                            <div class="agent-primitive-modal-actions">
-                                <Show
-                                    when={skill().bound_to_agent}
-                                    fallback={
-                                        <button
-                                            class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
-                                            onClick={() => void model.bind(skill().id)}
-                                        >
-                                            Bind
-                                        </button>
-                                    }
-                                >
+                        <div class="agent-primitive-modal-actions">
+                            <Show
+                                when={skill().bound_to_agent}
+                                fallback={
                                     <button
-                                        class="agent-primitive-modal-btn"
-                                        onClick={() => void model.unbind(skill().id)}
+                                        class="agent-primitive-modal-btn agent-primitive-modal-btn-primary"
+                                        onClick={() => void model.bind(skill().id)}
                                     >
-                                        Unbind
+                                        Bind
                                     </button>
-                                </Show>
-                            </div>
-                        </Show>
+                                }
+                            >
+                                <button
+                                    class="agent-primitive-modal-btn"
+                                    onClick={() => void model.unbind(skill().id)}
+                                >
+                                    Unbind
+                                </button>
+                            </Show>
+                        </div>
                     </div>
                 )}
             </Show>


### PR DESCRIPTION
## Summary

The Stash modal's MCP Servers and Skills tabs called `mcp.list`/`upsert`/`delete`/`bind`/`unbind` and `skill.list`/`upsert`/`delete`/`bind`/`unbind` — every one of which is gated by `check_s1`, which requires the calling connection to *be* that agent's own authenticated bus connection. The Stash modal runs over the dashboard window's connection, so **every action failed "unauthorized," including the very first list-load** — the whole tab looked broken from the moment it opened.

## Fix

Following the precedent already set for `mcp.catalog.bind`/`skill.catalog.bind` (added earlier for the identical reason) and for the Accounts tab (already converted to a read-only reactive view over Armory-managed bindings), both tabs are now a **reactive read + bind/unbind view of the Armory catalog** instead of a separate, always-broken authoring surface:

- New window-scoped, no-`check_s1` commands: `mcp.catalog.list_for_agent`, `mcp.catalog.unbind`, `skill.catalog.list_for_agent`, `skill.catalog.unbind` — mirror `mcp.list`/`skill.list`'s own computation (every global item plus this agent's own, each annotated with `bound_to_agent`), just without the gate that can never be satisfied from a UI connection.
- `mcp.catalog.bind`/`skill.catalog.bind` now also publish `mcp:changed`/`skills:changed` (previously silent), so `AgentMcpModel`/`AgentSkillModel` can subscribe and stay in sync across windows without a manual refresh.
- `AgentMcpModal`/`AgentSkillsModal`: removed the New/Edit/Delete UI for private per-agent items — it never worked (`check_s1` blocked it from day one), so nothing functional is lost. Kept the read-only detail view and Bind/Unbind toggle for global (Armory-managed) items. A private item an agent created via its own tool calls still shows up (read-only), since those are real per-agent data.

## Verification

- `npx tsc -p tsconfig.json --noEmit` — clean
- `cargo check -p agentmux-srv` — clean (no new warnings)
- `cargo test -p agentmux-srv` (full suite) — 1677 passed, 0 failed, 4 ignored
- `npx vitest run app/view` — 895/895 passed
- Live-verified in `task dev` via CDP against a real agent (`openclaw`):
  - `mcp.catalog.list_for_agent` / `skill.catalog.list_for_agent` — both return real data, zero "unauthorized" errors (previously both threw immediately).
  - Full bind → unbind → rebind roundtrip on a real global MCP server (`git`), confirming `bound_to_agent` flips correctly at each step and the final state matches the starting state.

<!-- agentmux:agent_id=agent3 -->