### PR TITLE
fix(floating-pane): restore resize hit-target from 4px to 8px

### DIFF
--- a/.changesets/1785201955-fix-floating-pane-restore-resize-hit-target-from-4px-to-8px-sfnn.md
+++ b/.changesets/1785201955-fix-floating-pane-restore-resize-hit-target-from-4px-to-8px-sfnn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): restore resize hit-target from 4px to 8px

--- a/docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md
+++ b/docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md
@@ -82,7 +82,7 @@ doc exists to prevent).
 - During drag, throttled `update_floating_redock_hover` (~50ms) drives the drop-target highlight.
 
 ### 2.3 Edge-resize (floater only)
-`floating-pane-workspace.tsx:130-260` — a 12px (`FLOATER_EDGE_RESIZE_BORDER`) invisible **pointer** grab-band → `get_window_rect`/`set_window_rect`. Browser floaters inset their web-content child by the band depth (`browser-view.tsx:114`) so the frontend owns the band. **Note:** the band overlaps the top of the 33px header → grabbing the top edge resizes instead of moving (a known UX sharp-edge; reagent flagged it on #1177).
+`floating-pane-workspace.tsx:130-260` — an 8px (`FLOATER_EDGE_RESIZE_BORDER`) invisible **pointer** grab-band → `get_window_rect`/`set_window_rect`. Browser floaters inset their web-content child by the band depth (`use-pane-rect-sync.ts:70`) so the frontend owns the band. **Note:** the band overlaps the top of the 33px header → grabbing the top edge resizes instead of moving (a known UX sharp-edge; reagent flagged it on #1177). Shipped at 12px, regressed to 4px as a side effect of PR #1829's browser-pane matte fix, restored to 8px — see `docs/retro/retro-floating-pane-resize-hit-target-2026-07-27.md`.
 
 ### 2.4 Redock (floater → drop on a window)
 `onMouseUp` → `clear_floating_redock_hover` → `tryRedockAtCursor()` (`floating-pane-workspace.tsx:409`):

--- a/docs/retro/retro-floating-pane-resize-hit-target-2026-07-27.md
+++ b/docs/retro/retro-floating-pane-resize-hit-target-2026-07-27.md
@@ -1,0 +1,67 @@
+# Retro: floating-pane resize hit-target shrank from 12px to 4px as a side effect
+
+**Date:** 2026-07-27
+**Severity:** Low-medium — no crash/data-loss, but a persistent UX regression
+(resize handle "really hard to select") that shipped silently for a month.
+**Observed by:** user, comparing current behavior to an earlier "working well,
+best practice" version they remembered.
+
+---
+
+## TL;DR
+
+`FLOATER_EDGE_RESIZE_BORDER` (`frontend/app/workspace/floater-resize.ts`)
+drives two different things with one constant: (1) how wide the invisible
+mouse hit-test band is for resizing a floating pane by its edge, and (2) how
+much a floating *browser* pane's separate OS child window is inset so that
+band stays clickable underneath it. It shipped at a comfortable **12px** in
+PR #1177 (2026-05-29). A month later, PR #1829 (2026-06-29) fixed a real
+visual complaint — browser panes showing a background-colored matte around
+their web content, from the child-window inset — by shrinking the *shared*
+constant, first to 6px then to 4px in the same PR. That fixed the matte for
+browser panes, but also shrank the mouse target for every other floating pane
+type (agent, terminal, editor, sysinfo, drone, ...) — none of which have a
+matte problem at all, since they have no separate child window sitting over
+the frontend DOM. Two docs (`ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md`,
+`SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md`) still cited the original 12px
+and were never updated, so there was no documentation trail pointing at the
+regression either.
+
+## Why this shape of bug is easy to miss
+
+The constant's own doc-comment said "nothing is painted at this width... so it
+can be widened freely" — true in isolation, but the same file's next paragraph
+explains the browser-pane inset shares the constant specifically *to keep the
+detector and the inset from ever drifting*. That coupling is exactly what
+turned a browser-pane-only cosmetic fix into an every-pane-type functional
+regression: there was no way to shrink the value for one consumer without
+shrinking it for the other, so PR #1829 shrank it for both, and nobody
+re-evaluated whether the resulting width was still fair to grab with a mouse
+on the panes that didn't have the visual problem in the first place.
+
+## Fix
+
+Restored `FLOATER_EDGE_RESIZE_BORDER` to **8px** — a deliberate middle point:
+roughly double the unusable 4px, and comfortably under the 12px that read as
+a border on browser panes. Did not split the constant into two (a
+browser-only vs. general-purpose value): the browser-pane inset must
+mechanically equal the hit-test width for the exposed band to actually
+receive pointer events (a wider hit-test zone than the inset would just have
+the CEF child window swallow clicks in the extra region), and per-pane-type
+branching in the hot pointer-move path was judged more risk than the marginal
+gain over a single well-chosen shared value. Updated both stale docs to match.
+
+## Prevention
+
+Nothing structural changed here — this is a narrow, single-constant fix. The
+actionable takeaway for future changes to `FLOATER_EDGE_RESIZE_BORDER` (or any
+shared constant with more than one consumer): when a change is motivated by
+one consumer's complaint, check what the *other* consumers lose, not just
+whether the motivating consumer's problem is solved. Grep for the constant's
+usages before changing its value, not just before deleting it.
+
+## Files
+
+- `frontend/app/workspace/floater-resize.ts` — the constant + updated doc-comment
+- `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` — stale 12px reference
+- `docs/specs/SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md` — stale 12px reference

--- a/docs/specs/SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md
+++ b/docs/specs/SPEC_FLOATING_PANE_EDGE_RESIZE_2026_05_29.md
@@ -15,11 +15,13 @@ The `HTTRANSPARENT` forwarder (Phase 1) was implemented and **abandoned**: on ce
 
 **Shipped instead — JS-driven resize**, mirroring the already-working JS header MOVE:
 
-1. The floater's frontend DOM (`floating-pane-workspace.tsx`) detects a pointerdown within `FLOATER_EDGE_RESIZE_BORDER` (12 CSS px, `frontend/app/workspace/floater-resize.ts`) of an edge/corner.
+1. The floater's frontend DOM (`floating-pane-workspace.tsx`) detects a pointerdown within `FLOATER_EDGE_RESIZE_BORDER` (8 CSS px, `frontend/app/workspace/floater-resize.ts`) of an edge/corner.
 2. It takes **pointer capture** (so it keeps getting moves after the cursor leaves the window), reads the start rect via `get_window_rect`, and on each move computes the new rect (cursor delta + which of the 8 edges) and calls `set_window_rect` → `SetWindowPos`. Moves coalesce one-IPC-in-flight (last wins). No native loop, no NCHITTEST/capture conflict.
 3. New host IPC: `get_window_rect` / `set_window_rect` in `commands/window/motion.rs`.
 
-**Browser floaters** have a second OS child (the web-content window) layered over the frontend DOM in the content region, which would cover the grab band. `browser-view.tsx` therefore insets that child by the band depth on the three window-edge sides (left/right/bottom — the top edge is over the 33px header, already frontend), exposing the band. The full-size placeholder div paints the strip, so there's **no native white border** (the failure mode the `WS_THICKFRAME` design hit).
+**Browser floaters** have a second OS child (the web-content window) layered over the frontend DOM in the content region, which would cover the grab band. `use-pane-rect-sync.ts` therefore insets that child by the band depth on the three window-edge sides (left/right/bottom — the top edge is over the 33px header, already frontend), exposing the band. The full-size placeholder div paints the strip, so there's **no native white border** (the failure mode the `WS_THICKFRAME` design hit).
+
+**Note (2026-07-27):** `FLOATER_EDGE_RESIZE_BORDER` shipped at 12px here, was shrunk to 4px in PR #1829 as a side effect of fixing a browser-pane-only visual complaint (the inset above reading as a border around web content), and was restored to 8px after the resulting every-pane-type grab-target regression was diagnosed — see `docs/retro/retro-floating-pane-resize-hit-target-2026-07-27.md`.
 
 The Phase 1 forwarder design below is kept for the record.
 

--- a/frontend/app/workspace/floater-resize.ts
+++ b/frontend/app/workspace/floater-resize.ts
@@ -7,18 +7,39 @@
  * A floater is a frameless WS_POPUP; native edge-resize via the parent wndproc
  * never fires (the embedded CEF child consumes WM_NCHITTEST), so the resize is
  * driven from the DOM: `floating-pane-workspace.tsx` detects a pointerdown
- * within this many CSS px of an edge and drives `set_window_rect`.
+ * within this many CSS px of an edge and drives `set_window_rect`. This applies
+ * on all three platforms — Windows, macOS, and Linux all run the same
+ * DOM-driven detection (see `posScale()` in `floating-pane-workspace.tsx` for
+ * the per-platform coordinate-space handling).
  *
- * Nothing is painted at this width — it's purely a hit-test zone — so it can be
- * widened freely for an easier grab target.
+ * Nothing is painted at this width — it's purely a hit-test zone — so widening
+ * it costs nothing visually *except* for floating browser panes (see below).
  *
  * A floating *browser* pane's web-content is a separate OS child window layered
  * over the floater's frontend DOM, so it would cover this band and swallow the
- * pointerdown. `browser-view.tsx` therefore insets that child by this same
+ * pointerdown. `use-pane-rect-sync.ts` therefore insets that child by this same
  * value on the three window-edge sides (left/right/bottom — the top edge is
  * over the header, already frontend), exposing the band underneath. Sharing one
- * constant keeps the detector and the inset from ever drifting.
+ * constant keeps the detector and the inset from ever drifting — but it also
+ * means this value is a genuine tradeoff between two competing pane types:
+ * wider is strictly better for grabbability everywhere, but for browser panes
+ * specifically, the inset exposes the floater's own background as a matte
+ * around the web content, and a wide matte reads as an unwanted border.
+ *
+ * History: shipped at 12px (PR #1177, 2026-05-29) — a comfortable grab target
+ * with no reported issues for non-browser floaters. PR #1829 (2026-06-29)
+ * treated the *browser-pane matte* complaint as a reason to shrink the *shared*
+ * constant, first to 6px then to 4px in the same PR — which fixed the matte at
+ * the cost of making every floating pane (agent, terminal, editor, etc., none
+ * of which have this matte problem at all) hard to grab. Restored to 8px: a
+ * deliberate middle point, roughly double the unusable 4px and comfortably
+ * under the 12px that read as a border for browser panes. Matches the
+ * tiled-layout splitter's hit-target (`layoutModel.ts`'s `resizeHandleSizePx`,
+ * effectively 6px at default settings) in the same spirit, sized slightly
+ * larger here specifically because floating panes have no visible hover line
+ * to help a user find the zone the way the tiled splitter's 2px accent line
+ * does — see `docs/retro/retro-floating-pane-resize-hit-target-2026-07-27.md`.
  *
  * SPEC_FLOATING_PANE_EDGE_RESIZE.
  */
-export const FLOATER_EDGE_RESIZE_BORDER = 4;
+export const FLOATER_EDGE_RESIZE_BORDER = 8;


### PR DESCRIPTION
## Summary

Floating-pane resize handles regressed from a comfortable 12px grab target down to an unusable 4px, as an unintended side effect of an unrelated cosmetic fix.

## Root cause

`FLOATER_EDGE_RESIZE_BORDER` (`frontend/app/workspace/floater-resize.ts`) drives two things with one constant: the invisible mouse hit-test band width for resizing a floating pane by its edge, *and* how much a floating browser pane's separate OS child window is inset so that band stays clickable underneath it.

- Shipped at **12px** in #1177 (2026-05-29) — comfortable, no complaints for non-browser floaters.
- #1829 (2026-06-29) fixed a real visual bug — browser panes' web-content inset reading as a background-colored border around the content — by shrinking the *shared* constant, first to 6px then to **4px** in the same PR.

That fixed the browser-pane matte, but also shrank the grab target for every other floating pane type (agent, terminal, editor, sysinfo, drone, ...) — none of which have a matte problem at all, since they have no separate child window sitting over the frontend DOM. Two docs still cited the original 12px and were never updated, so there was no trail pointing at the regression.

## Fix

Restored to **8px** — roughly double the unusable 4px, comfortably under the 12px that read as a border on browser panes. Kept a single shared constant rather than splitting hit-test width from the browser-pane inset: the two must mechanically match for the exposed band to actually receive pointer events (a wider hit-test zone than the inset would just have the CEF child window swallow clicks in the extra region), and per-pane-type branching in the hot pointer-move path was judged more risk than the marginal gain over a single well-chosen shared value.

Also fixed two stale doc references (both still cited 12px; one also pointed at `browser-view.tsx` for inset logic that's since moved to `use-pane-rect-sync.ts`) and wrote a retro documenting the regression pattern for future reference: `docs/retro/retro-floating-pane-resize-hit-target-2026-07-27.md`.

Cross-platform: this code path runs identically on Windows, macOS, and Linux (verified — no platform gating around the resize detection or the browser-pane inset; `posScale()` handles the Windows-physical-px vs. macOS/Linux-DIP coordinate difference, unrelated to this fix).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Changeset added
- [ ] Manual test — will run `task dev` for the user to verify the grab feel directly before merge

<!-- agentmux:agent_id=agent2 -->