### PR TITLE
feat(armory): add bundle.export RPC — ABF Phase 1 exporter

### DIFF
--- a/.changesets/1785196086-feat-armory-add-bundle-export-rpc-abf-phase-1-exporter-52zs.md
+++ b/.changesets/1785196086-feat-armory-add-bundle-export-rpc-abf-phase-1-exporter-52zs.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): add bundle.export RPC — ABF Phase 1 exporter

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -608,7 +608,7 @@ fn truncate_utf16_units(s: &str, max_units: usize) -> String {
 /// correctly-escaped YAML value — this avoids hand-rolling YAML escaping or
 /// adding a yaml crate dependency (this workspace has neither today) just
 /// for two scalar fields.
-fn render_skill_md(slug: &str, description: &str, body: &str) -> String {
+pub(crate) fn render_skill_md(slug: &str, description: &str, body: &str) -> String {
     let owned_description;
     let description = if description.trim().is_empty() {
         "No description provided."
@@ -673,8 +673,11 @@ fn skill_name_slug(name: &str) -> String {
 /// `-2`, `-3`, ... until the slug is unique within `used`, truncating the
 /// base first so the suffixed result never exceeds the spec's 64-character
 /// max (Codex P2, PR #2322 — a 64-char base plus `-2` was previously 66
-/// chars).
-fn unique_skill_slug(name: &str, used: &mut HashSet<String>) -> String {
+/// chars). `bundle_export.rs` also reuses this for MCP server export
+/// filenames, where the underscore-free/64-char constraints are stricter
+/// than strictly required but remain filesystem-safe, so sharing this
+/// implementation is still correct there.
+pub(crate) fn unique_skill_slug(name: &str, used: &mut HashSet<String>) -> String {
     const MAX_LEN: usize = 64;
     let base = skill_name_slug(name);
     if used.insert(base.clone()) {

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -85,6 +85,15 @@ pub struct BundleExport {
     /// slash-command skills have no ABF representation, see Phase 0 /
     /// `SKILL_TYPE_AGENT_SKILL`).
     pub skipped_skills: Vec<String>,
+    /// Non-fatal problems encountered while exporting: malformed source
+    /// JSON (`context_files`/`mcp_servers`) that had to be treated as
+    /// empty, or a context-file path that collided with an earlier one
+    /// after normalization and was skipped rather than silently
+    /// overwriting it. Never blocks the export — surfaced to the
+    /// caller/UI instead of being silently swallowed, since a backup tool
+    /// losing data without saying so defeats its own purpose (reagent P1,
+    /// PR #2333).
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
@@ -157,6 +166,7 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
     let root_slug = derive_slug(&bundle.name);
     let mut files = Vec::new();
     let mut skipped_skills = Vec::new();
+    let mut warnings = Vec::new();
 
     let mut manifest_instructions: Vec<String> = Vec::new();
     let mut manifest_skills: Vec<String> = Vec::new();
@@ -173,11 +183,28 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
         manifest_instructions.push("instructions/AGENTS.md".to_string());
     }
 
-    let context_files: Vec<ContextFileEntry> =
-        serde_json::from_str(&bundle.context_files).unwrap_or_default();
+    let context_files: Vec<ContextFileEntry> = parse_json_field_or_warn(
+        &bundle.context_files,
+        "context_files",
+        &mut warnings,
+    );
+    let mut used_context_paths: HashSet<String> = HashSet::new();
     for entry in context_files {
         if let Some(safe_path) = sanitize_context_relative_path(&entry.path) {
             let out_path = format!("instructions/context/{safe_path}");
+            // Two distinct source paths can normalize to the same output
+            // (e.g. "docs/a.md" and "docs/./a.md") -- without this check the
+            // second silently overwrites the first's `files` entry, and the
+            // zip archive ends up with the same duplicate risk (reagent P2,
+            // PR #2333).
+            if !used_context_paths.insert(out_path.clone()) {
+                warnings.push(format!(
+                    "context_files: \"{}\" normalizes to the same path as an \
+                     earlier entry ({out_path}); skipped to avoid overwriting it",
+                    entry.path
+                ));
+                continue;
+            }
             manifest_instructions.push(out_path.clone());
             files.push(BundleExportFile {
                 path: out_path,
@@ -215,7 +242,8 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
     // ------------------------------------------------------------------
     // mcp/<slug>.server.json + inferred accounts/requirements.json
     // ------------------------------------------------------------------
-    let mcp_entries: Vec<Value> = serde_json::from_str(&bundle.mcp_servers).unwrap_or_default();
+    let mcp_entries: Vec<Value> =
+        parse_json_field_or_warn(&bundle.mcp_servers, "mcp_servers", &mut warnings);
     let mut used_mcp_slugs: HashSet<String> = HashSet::new();
     let mut requirements: Vec<Value> = Vec::new();
     for (index, entry) in mcp_entries.iter().enumerate() {
@@ -305,6 +333,30 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
         root_slug,
         files,
         skipped_skills,
+        warnings,
+    }
+}
+
+/// Parse a `db_bundles` JSON-array column (`context_files`/`mcp_servers`),
+/// treating a blank/whitespace-only value as "genuinely no data" (not an
+/// error) but pushing a warning to `warnings` for anything non-blank that
+/// fails to parse, rather than silently discarding it via
+/// `unwrap_or_default()` — an export that quietly loses data defeats its
+/// own backup/portability purpose (reagent P1, PR #2333).
+fn parse_json_field_or_warn<T: serde::de::DeserializeOwned + Default>(
+    raw: &str,
+    field_name: &str,
+    warnings: &mut Vec<String>,
+) -> T {
+    if raw.trim().is_empty() {
+        return T::default();
+    }
+    match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(e) => {
+            warnings.push(format!("{field_name}: malformed JSON, treated as empty ({e})"));
+            T::default()
+        }
     }
 }
 
@@ -495,6 +547,66 @@ mod tests {
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
         let export = export_bundle(&bundle, &[]);
         assert!(!export.files.iter().any(|f| f.path == "accounts/requirements.json"));
+    }
+
+    #[test]
+    fn malformed_context_files_json_warns_instead_of_silently_dropping_data() {
+        // reagent P1, PR #2333: previously unwrap_or_default() silently
+        // treated malformed context_files as empty, with no signal to the
+        // caller that data was lost -- defeats the exporter's stated
+        // backup/portability guarantee.
+        let bundle = make_bundle("", "{not valid json", "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+        assert!(
+            export.warnings.iter().any(|w| w.contains("context_files") && w.contains("malformed")),
+            "expected a warning about malformed context_files, got: {:?}",
+            export.warnings
+        );
+    }
+
+    #[test]
+    fn malformed_mcp_servers_json_warns_instead_of_silently_dropping_data() {
+        let bundle = make_bundle("", "[]", "not an array at all", "[]");
+        let export = export_bundle(&bundle, &[]);
+        assert!(
+            export.warnings.iter().any(|w| w.contains("mcp_servers") && w.contains("malformed")),
+            "expected a warning about malformed mcp_servers, got: {:?}",
+            export.warnings
+        );
+    }
+
+    #[test]
+    fn blank_context_files_and_mcp_servers_produce_no_warning() {
+        // A genuinely empty/unset field is not an error -- must not warn.
+        let bundle = make_bundle("", "", "", "[]");
+        let export = export_bundle(&bundle, &[]);
+        assert!(export.warnings.is_empty(), "blank fields must not warn: {:?}", export.warnings);
+    }
+
+    #[test]
+    fn colliding_context_file_paths_are_deduped_with_a_warning() {
+        // reagent P2, PR #2333: two distinct source paths that normalize to
+        // the same output (e.g. a redundant "./" component) previously
+        // silently overwrote one `files` entry with the other.
+        let context_files = r#"[
+            {"path":"docs/a.md","content":"first"},
+            {"path":"docs/./a.md","content":"second, would silently clobber the first"}
+        ]"#;
+        let bundle = make_bundle("", context_files, "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+
+        let matches: Vec<_> = export
+            .files
+            .iter()
+            .filter(|f| f.path == "instructions/context/docs/a.md")
+            .collect();
+        assert_eq!(matches.len(), 1, "must not produce duplicate file entries for the same path");
+        assert_eq!(matches[0].content, "first", "the first entry must win, not be silently overwritten");
+        assert!(
+            export.warnings.iter().any(|w| w.contains("docs/./a.md")),
+            "expected a warning naming the skipped duplicate, got: {:?}",
+            export.warnings
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -38,6 +38,20 @@
 //! requirement declaration (name/provider guess, no values, ever) — this
 //! matches ABF's own "declare, don't bundle secrets" design and MCP's own
 //! `isSecret`/env-placeholder convention (see the research report §3b/§3d).
+//!
+//! **`mcp/<slug>.server.json` content note:** this writes AgentMux's own
+//! runtime MCP config shape (`{type, command, args, env}` — the same object
+//! `.mcp.json` uses), NOT the official MCP registry `server.json` schema
+//! (`packages[].registry_type`/`identifier`/`environment_variables`, etc.).
+//! Real conversion would require fabricating fields this data doesn't
+//! contain (registry type/package identifier aren't derivable from a bare
+//! stdio command) — worse than an honest runtime-shape export. Deferred to
+//! Phase 2 (schema validation), tracked alongside the importer rather than
+//! guessed at here (Codex P1, PR #2325 — flagged as a real gap, not
+//! disputed; this comment documents the deliberate scope decision).
+//! `env` values ARE redacted before being written (see [`redact_mcp_entry`])
+//! regardless of this open question — the credential-leak fix does not wait
+//! on the schema question.
 
 use std::collections::HashSet;
 
@@ -79,6 +93,30 @@ struct ContextFileEntry {
     path: String,
     #[serde(default)]
     content: String,
+}
+
+/// Redact secret-shaped values out of an MCP server config entry before it
+/// is written into a shareable bundle export. `env` and `headers` are the
+/// two fields AgentMux's own MCP config editors accept literal secret
+/// values into (e.g. `env.GITHUB_TOKEN`, `headers.Authorization` on an
+/// HTTP/SSE-transport server) — every value under either key is replaced
+/// with a `${VAR_NAME}`-style placeholder so the exported `.server.json`
+/// never contains a real credential, matching ABF's "declare, don't bundle
+/// secrets" principle that `accounts/requirements.json` already follows
+/// (security finding, Codex P1 x2, PR #2325). Any other field passes
+/// through unchanged.
+fn redact_mcp_entry(entry: &Value) -> Value {
+    let mut redacted = entry.clone();
+    if let Some(obj) = redacted.as_object_mut() {
+        for field in ["env", "headers"] {
+            if let Some(Value::Object(map)) = obj.get_mut(field) {
+                for (key, value) in map.iter_mut() {
+                    *value = json!(format!("${{{key}}}"));
+                }
+            }
+        }
+    }
+    redacted
 }
 
 /// Validate a context-file's relative path is safe to place under
@@ -162,12 +200,16 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
             continue;
         }
         let slug = unique_skill_slug(&skill.name, &mut used_skill_slugs);
-        let path = format!("skills/{slug}/SKILL.md");
         files.push(BundleExportFile {
-            path: path.clone(),
+            path: format!("skills/{slug}/SKILL.md"),
             content: render_skill_md(&slug, &skill.description, &skill.content),
         });
-        manifest_skills.push(path);
+        // Manifest references the skill's DIRECTORY, not the SKILL.md file
+        // inside it -- per the ABF spec's own on-disk layout example
+        // (`"skills": ["skills/deploy-checklist"]`), which lets an importer
+        // locate SKILL.md plus any optional scripts/references/assets
+        // alongside it (Codex P1, PR #2325).
+        manifest_skills.push(format!("skills/{slug}"));
     }
 
     // ------------------------------------------------------------------
@@ -184,7 +226,8 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
             .unwrap_or_else(|| format!("mcp-server-{}", index + 1));
         let slug = unique_skill_slug(&display_name, &mut used_mcp_slugs);
         let path = format!("mcp/{slug}.server.json");
-        let pretty = serde_json::to_string_pretty(entry).unwrap_or_else(|_| "{}".to_string());
+        let redacted_entry = redact_mcp_entry(entry);
+        let pretty = serde_json::to_string_pretty(&redacted_entry).unwrap_or_else(|_| "{}".to_string());
         files.push(BundleExportFile {
             path: path.clone(),
             content: pretty,
@@ -385,6 +428,49 @@ mod tests {
     }
 
     #[test]
+    fn redacts_real_secret_values_from_the_exported_server_json() {
+        // Security finding, Codex P1 x2, PR #2325: the exported .server.json
+        // must never contain the literal secret value stored in env/headers,
+        // even though requirements.json was already value-free.
+        let mcp_servers = r#"[{
+            "name": "github",
+            "type": "stdio",
+            "command": "gh-mcp",
+            "env": {"GITHUB_TOKEN": "ghp_realSecretValue123"},
+            "headers": {"Authorization": "Bearer realBearerToken456"}
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+
+        let server_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "mcp/github.server.json")
+            .expect("expected mcp/github.server.json");
+        assert!(
+            !server_file.content.contains("ghp_realSecretValue123"),
+            "exported .server.json must never contain the real env secret value: {}",
+            server_file.content
+        );
+        assert!(
+            !server_file.content.contains("realBearerToken456"),
+            "exported .server.json must never contain the real header secret value: {}",
+            server_file.content
+        );
+        // Redacted to a placeholder, not silently dropped -- the key/shape survives.
+        assert!(server_file.content.contains("${GITHUB_TOKEN}"));
+        assert!(server_file.content.contains("${Authorization}"));
+
+        // requirements.json inference is unaffected (it only ever read keys).
+        let req_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "accounts/requirements.json")
+            .unwrap();
+        assert!(req_file.content.contains("GITHUB_TOKEN"));
+    }
+
+    #[test]
     fn no_requirements_file_when_no_env_vars_present() {
         let mcp_servers = r#"[{"name":"local-tool","type":"stdio","command":"local-tool"}]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
@@ -418,6 +504,20 @@ mod tests {
         assert!(manifest["components"]["skills"].as_array().unwrap().len() == 1);
         assert!(manifest["components"]["mcpServers"].as_array().unwrap().len() == 1);
         assert_eq!(manifest["components"]["accounts"], "accounts/requirements.json");
+    }
+
+    #[test]
+    fn manifest_references_the_skill_directory_not_the_skill_md_file() {
+        // Codex P1, PR #2325: the ABF spec's manifest example references
+        // "skills/<slug>" (the directory), not "skills/<slug>/SKILL.md".
+        let bundle = make_bundle("", "[]", "[]", r#"["skill-a"]"#);
+        let export = export_bundle(&bundle, &[make_agent_skill("Deploy Checklist")]);
+        let manifest_file = export.files.iter().find(|f| f.path == "armory.json").unwrap();
+        let manifest: Value = serde_json::from_str(&manifest_file.content).unwrap();
+        let skills = manifest["components"]["skills"].as_array().unwrap();
+        assert_eq!(skills, &vec![json!("skills/deploy-checklist")]);
+        // The actual file on disk still lives at the nested SKILL.md path.
+        assert!(export.files.iter().any(|f| f.path == "skills/deploy-checklist/SKILL.md"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -234,15 +234,30 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
         });
         manifest_mcp.push(path);
 
-        if let Some(env_obj) = entry.get("env").and_then(|v| v.as_object()) {
-            for key in env_obj.keys() {
-                requirements.push(json!({
-                    "id": format!("{slug}-{key}"),
-                    "provider": slug,
-                    "kind": "api-key",
-                    "env": key,
-                    "optional": false,
-                }));
+        // Both `env` and `headers` are credential-bearing per `redact_mcp_entry`
+        // (a header-only-authenticated server, e.g. `headers.Authorization`, is
+        // just as real a credential requirement as an env-var one) -- infer a
+        // requirement entry from each key of EITHER field, not just `env`, so
+        // the redaction in the exported .server.json and the declared
+        // requirement never disagree on whether a credential is needed here
+        // (reagent P2, PR #2325).
+        for field in ["env", "headers"] {
+            if let Some(field_obj) = entry.get(field).and_then(|v| v.as_object()) {
+                for key in field_obj.keys() {
+                    requirements.push(json!({
+                        "id": format!("{slug}-{key}"),
+                        "provider": slug,
+                        "kind": "api-key",
+                        // "Where it lands" per the requirements.json schema
+                        // (research report §5.3) -- an env var name for `env`
+                        // entries, or the header name for `headers` entries;
+                        // the resolver substitutes into whichever the exported
+                        // .server.json's redacted `${key}` placeholder sits
+                        // under.
+                        "env": key,
+                        "optional": false,
+                    }));
+                }
             }
         }
     }
@@ -461,13 +476,17 @@ mod tests {
         assert!(server_file.content.contains("${GITHUB_TOKEN}"));
         assert!(server_file.content.contains("${Authorization}"));
 
-        // requirements.json inference is unaffected (it only ever read keys).
+        // reagent P2, PR #2325: requirements.json must be inferred from BOTH
+        // env and headers keys -- a header-only-authenticated server's
+        // redacted `${Authorization}` placeholder must have a matching
+        // requirement entry telling an importer a credential is needed there.
         let req_file = export
             .files
             .iter()
             .find(|f| f.path == "accounts/requirements.json")
             .unwrap();
         assert!(req_file.content.contains("GITHUB_TOKEN"));
+        assert!(req_file.content.contains("Authorization"));
     }
 
     #[test]
@@ -476,6 +495,34 @@ mod tests {
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
         let export = export_bundle(&bundle, &[]);
         assert!(!export.files.iter().any(|f| f.path == "accounts/requirements.json"));
+    }
+
+    #[test]
+    fn infers_a_requirement_for_a_header_only_authenticated_server() {
+        // reagent P2, PR #2325: a server authenticated ENTIRELY via headers
+        // (no env at all) previously produced no requirements.json -- its
+        // redacted `${Authorization}` placeholder in the exported
+        // .server.json had nothing telling an importer a credential is
+        // needed there.
+        let mcp_servers = r#"[{
+            "name": "notion",
+            "type": "http",
+            "url": "https://mcp.notion.com",
+            "headers": {"Authorization": "Bearer realToken789"}
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+
+        let req_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "accounts/requirements.json")
+            .expect("a header-only-authenticated server must still infer a requirement");
+        assert!(req_file.content.contains("Authorization"));
+        assert!(
+            !req_file.content.to_lowercase().contains("realtoken789"),
+            "must never contain a real secret value"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -107,35 +107,26 @@ struct ContextFileEntry {
 /// Flag names (case/dash/underscore-insensitive, `-`/`--` prefix optional)
 /// whose value is credential-shaped in common CLI/MCP server invocations —
 /// a curated allowlist rather than a broad substring match (e.g. `--keymap`
-/// must NOT trigger this), so `redact_mcp_entry` also scans `args` for
-/// these, not just the structured `env`/`headers` fields (Codex + reagent
-/// P1, PR #2333: `--api-key <secret>` or `--token=<secret>` in the runtime
-/// `args` array exported the secret verbatim).
-const SECRET_ARG_FLAG_NAMES: &[&str] = &[
-    "api-key", "apikey", "api_key",
+/// must NOT trigger this). Used for BOTH `args` flag names AND `url` query
+/// param names — a single shared list so the two can never drift apart
+/// again (reagent P1, PR #2333: the two lists started separate and the
+/// query-param one was missing several names the args one already had).
+const SECRET_NAMES: &[&str] = &[
+    "key", "api-key", "apikey", "api_key",
     "token", "access-token", "access_token", "auth-token", "auth_token",
     "bearer-token", "bearer_token",
     "secret", "secret-key", "secret_key", "client-secret", "client_secret",
     "password", "passwd",
 ];
 
-fn secret_arg_placeholder(flag: &str) -> String {
-    let normalized = flag.trim_start_matches('-').to_uppercase().replace('-', "_");
+fn secret_placeholder(name: &str) -> String {
+    let normalized = name.trim_start_matches('-').to_uppercase().replace('-', "_");
     format!("${{{normalized}}}")
 }
 
-fn is_secret_flag(flag: &str) -> bool {
-    let normalized = flag.trim_start_matches('-').to_lowercase();
-    SECRET_ARG_FLAG_NAMES.contains(&normalized.as_str())
-}
-
-/// Query-string parameter names commonly used to pass a credential in a
-/// URL (curated allowlist, same rationale as [`SECRET_ARG_FLAG_NAMES`]).
-fn is_secret_query_param(key: &str) -> bool {
-    matches!(
-        key.to_lowercase().as_str(),
-        "api_key" | "apikey" | "key" | "token" | "access_token" | "secret" | "password"
-    )
+fn is_secret_name(name: &str) -> bool {
+    let normalized = name.trim_start_matches('-').to_lowercase();
+    SECRET_NAMES.contains(&normalized.as_str())
 }
 
 /// Redact userinfo (`scheme://user:pass@host`) and known secret-bearing
@@ -144,9 +135,14 @@ fn is_secret_query_param(key: &str) -> bool {
 /// this module's existing style — see `sanitize_context_relative_path`) —
 /// deliberately conservative: only touches the exact shapes below, leaving
 /// anything it doesn't recognize unchanged rather than risking a malformed
-/// rewrite of a URL this scan doesn't fully understand.
-fn redact_url_credentials(url: &str) -> String {
+/// rewrite of a URL this scan doesn't fully understand. Returns the
+/// redacted URL plus the "landing" names for each thing redacted, so the
+/// caller can generate a matching `requirements.json` entry per name
+/// (reagent P2, PR #2333: redaction and the declared requirement must
+/// never disagree, the same invariant already enforced for headers).
+fn redact_url_credentials(url: &str) -> (String, Vec<String>) {
     let mut result = url.to_string();
+    let mut redacted_names = Vec::new();
 
     if let Some(scheme_end) = result.find("://") {
         let after_scheme = scheme_end + 3;
@@ -156,7 +152,8 @@ fn redact_url_credentials(url: &str) -> String {
             // before the `@` -- otherwise a bare `@` further into the URL
             // (rare, but possible in a path/fragment) would be misread.
             if !result[after_scheme..userinfo_end].contains('/') {
-                result.replace_range(after_scheme..userinfo_end, "${REDACTED}");
+                result.replace_range(after_scheme..userinfo_end, "${URL_CREDENTIALS}");
+                redacted_names.push("url_credentials".to_string());
             }
         }
     }
@@ -168,9 +165,10 @@ fn redact_url_credentials(url: &str) -> String {
         let new_pairs: Vec<String> = query
             .split('&')
             .map(|pair| match pair.split_once('=') {
-                Some((key, _)) if is_secret_query_param(key) => {
+                Some((key, _)) if is_secret_name(key) => {
                     changed = true;
-                    format!("{key}={}", secret_arg_placeholder(key))
+                    redacted_names.push(key.to_string());
+                    format!("{key}={}", secret_placeholder(key))
                 }
                 _ => pair.to_string(),
             })
@@ -180,7 +178,7 @@ fn redact_url_credentials(url: &str) -> String {
         }
     }
 
-    result
+    (result, redacted_names)
 }
 
 /// Redact secret-shaped values out of an MCP server config entry before it
@@ -197,34 +195,43 @@ fn redact_url_credentials(url: &str) -> String {
 /// `--api-key <secret>` or `https://user:pass@host` is just as real a leak
 /// as one in `env`/`headers` (Codex + reagent P1, PR #2333). Any other
 /// field passes through unchanged.
-fn redact_mcp_entry(entry: &Value) -> Value {
+///
+/// Returns the redacted entry PLUS every "landing" name that was actually
+/// redacted (env/header keys, arg flag names, url credential markers), so
+/// the caller derives `requirements.json` directly from what was redacted
+/// here instead of re-scanning separately — the two can never disagree by
+/// construction (reagent P2, PR #2333).
+fn redact_mcp_entry(entry: &Value) -> (Value, Vec<String>) {
     let mut redacted = entry.clone();
+    let mut redacted_names: Vec<String> = Vec::new();
     if let Some(obj) = redacted.as_object_mut() {
         for field in ["env", "headers"] {
             if let Some(Value::Object(map)) = obj.get_mut(field) {
                 for (key, value) in map.iter_mut() {
                     *value = json!(format!("${{{key}}}"));
+                    redacted_names.push(key.clone());
                 }
             }
         }
         if let Some(Value::Array(args)) = obj.get_mut("args") {
             let mut i = 0;
             while i < args.len() {
-                let Some(s) = args[i].as_str() else {
+                let Some(s) = args[i].as_str().map(|s| s.to_string()) else {
                     i += 1;
                     continue;
                 };
                 if let Some((flag, _value)) = s.split_once('=') {
                     // "--flag=value" form: redact just the value portion.
-                    if is_secret_flag(flag) {
-                        args[i] = json!(format!("{flag}={}", secret_arg_placeholder(flag)));
+                    if is_secret_name(flag) {
+                        args[i] = json!(format!("{flag}={}", secret_placeholder(flag)));
+                        redacted_names.push(flag.trim_start_matches('-').to_string());
                     }
                     i += 1;
-                } else if is_secret_flag(s) && i + 1 < args.len() {
+                } else if is_secret_name(&s) && i + 1 < args.len() {
                     // "--flag value" form: redact the NEXT element, leave
                     // the flag itself (it's not a secret) untouched.
-                    let placeholder = secret_arg_placeholder(s);
-                    args[i + 1] = json!(placeholder);
+                    args[i + 1] = json!(secret_placeholder(&s));
+                    redacted_names.push(s.trim_start_matches('-').to_string());
                     i += 2;
                 } else {
                     i += 1;
@@ -232,13 +239,14 @@ fn redact_mcp_entry(entry: &Value) -> Value {
             }
         }
         if let Some(url_str) = obj.get("url").and_then(|v| v.as_str()).map(|s| s.to_string()) {
-            let redacted_url = redact_url_credentials(&url_str);
+            let (redacted_url, url_names) = redact_url_credentials(&url_str);
             if redacted_url != url_str {
                 obj.insert("url".to_string(), json!(redacted_url));
+                redacted_names.extend(url_names);
             }
         }
     }
-    redacted
+    (redacted, redacted_names)
 }
 
 /// Validate a context-file's relative path is safe to place under
@@ -301,16 +309,22 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
         "context_files",
         &mut warnings,
     );
+    // Compared case-INSENSITIVELY (stores the lowercased form) because the
+    // most common export/extract targets (Windows, macOS default) have
+    // case-insensitive filesystems -- "Docs/A.md" and "docs/a.md" collide
+    // on extraction there even though they're distinct paths byte-for-byte
+    // (reagent P2, PR #2333). The path actually written to `files` keeps
+    // its original case; only the collision check is case-folded.
     let mut used_context_paths: HashSet<String> = HashSet::new();
     for entry in context_files {
         if let Some(safe_path) = sanitize_context_relative_path(&entry.path) {
             let out_path = format!("instructions/context/{safe_path}");
             // Two distinct source paths can normalize to the same output
-            // (e.g. "docs/a.md" and "docs/./a.md") -- without this check the
-            // second silently overwrites the first's `files` entry, and the
-            // zip archive ends up with the same duplicate risk (reagent P2,
-            // PR #2333).
-            if !used_context_paths.insert(out_path.clone()) {
+            // (e.g. "docs/a.md" and "docs/./a.md", or a case-only
+            // difference) -- without this check the second silently
+            // overwrites the first's `files` entry, and the zip archive
+            // ends up with the same duplicate risk (reagent P2, PR #2333).
+            if !used_context_paths.insert(out_path.to_lowercase()) {
                 warnings.push(format!(
                     "context_files: \"{}\" normalizes to the same path as an \
                      earlier entry ({out_path}); skipped to avoid overwriting it",
@@ -379,7 +393,7 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
             .unwrap_or_else(|| format!("mcp-server-{}", index + 1));
         let slug = unique_skill_slug(&display_name, &mut used_mcp_slugs);
         let path = format!("mcp/{slug}.server.json");
-        let redacted_entry = redact_mcp_entry(entry);
+        let (redacted_entry, redacted_names) = redact_mcp_entry(entry);
         let pretty = serde_json::to_string_pretty(&redacted_entry).unwrap_or_else(|_| "{}".to_string());
         files.push(BundleExportFile {
             path: path.clone(),
@@ -387,31 +401,32 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
         });
         manifest_mcp.push(path);
 
-        // Both `env` and `headers` are credential-bearing per `redact_mcp_entry`
-        // (a header-only-authenticated server, e.g. `headers.Authorization`, is
-        // just as real a credential requirement as an env-var one) -- infer a
-        // requirement entry from each key of EITHER field, not just `env`, so
-        // the redaction in the exported .server.json and the declared
-        // requirement never disagree on whether a credential is needed here
-        // (reagent P2, PR #2325).
-        for field in ["env", "headers"] {
-            if let Some(field_obj) = entry.get(field).and_then(|v| v.as_object()) {
-                for key in field_obj.keys() {
-                    requirements.push(json!({
-                        "id": format!("{slug}-{key}"),
-                        "provider": slug,
-                        "kind": "api-key",
-                        // "Where it lands" per the requirements.json schema
-                        // (research report §5.3) -- an env var name for `env`
-                        // entries, or the header name for `headers` entries;
-                        // the resolver substitutes into whichever the exported
-                        // .server.json's redacted `${key}` placeholder sits
-                        // under.
-                        "env": key,
-                        "optional": false,
-                    }));
-                }
+        // Requirements are derived DIRECTLY from what redact_mcp_entry
+        // actually redacted (env/header keys, arg flag names, url
+        // credential markers) -- not re-scanned separately here -- so the
+        // exported placeholder and the declared requirement can never
+        // disagree by construction. This invariant was broken twice
+        // already by re-scanning only a subset of fields (reagent P2, PR
+        // #2325 for headers, PR #2333 for args/url); deriving from the
+        // single redaction pass closes it for good.
+        let mut seen_names: HashSet<&str> = HashSet::new();
+        for name in &redacted_names {
+            if !seen_names.insert(name.as_str()) {
+                continue; // e.g. the same flag name appearing twice in args
             }
+            requirements.push(json!({
+                "id": format!("{slug}-{name}"),
+                "provider": slug,
+                "kind": "api-key",
+                // "Where it lands" per the requirements.json schema
+                // (research report §5.3) -- an env var name, header name,
+                // arg flag name, or url_credentials for a userinfo/query
+                // redaction; the resolver substitutes into whichever the
+                // exported .server.json's redacted `${NAME}` placeholder
+                // sits under.
+                "env": name,
+                "optional": false,
+            }));
         }
     }
 
@@ -766,6 +781,30 @@ mod tests {
     }
 
     #[test]
+    fn colliding_context_file_paths_case_insensitive() {
+        // reagent P2, PR #2333: "Docs/A.md" and "docs/a.md" are distinct
+        // byte-for-byte but collide on extraction on the most common
+        // export targets (Windows, macOS default case-insensitive
+        // filesystems) -- must be caught the same way an exact-match
+        // collision is.
+        let context_files = r#"[
+            {"path":"Docs/A.md","content":"first"},
+            {"path":"docs/a.md","content":"second, would collide on a case-insensitive filesystem"}
+        ]"#;
+        let bundle = make_bundle("", context_files, "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+
+        let matches: Vec<_> = export
+            .files
+            .iter()
+            .filter(|f| f.path.to_lowercase() == "instructions/context/docs/a.md")
+            .collect();
+        assert_eq!(matches.len(), 1, "must not produce case-only-different duplicate entries");
+        assert_eq!(matches[0].content, "first");
+        assert!(export.warnings.iter().any(|w| w.contains("docs/a.md")));
+    }
+
+    #[test]
     fn infers_a_requirement_for_a_header_only_authenticated_server() {
         // reagent P2, PR #2325: a server authenticated ENTIRELY via headers
         // (no env at all) previously produced no requirements.json -- its
@@ -810,6 +849,11 @@ mod tests {
         assert!(!server_file.content.contains("lin_realSecretAbc123"));
         assert!(server_file.content.contains("${API_KEY}"));
         assert!(server_file.content.contains("--verbose"), "unrelated flags must survive untouched");
+
+        // reagent P2, PR #2333: an args-derived redaction must infer a
+        // matching requirement too, not just env/headers ones.
+        let req_file = export.files.iter().find(|f| f.path == "accounts/requirements.json").unwrap();
+        assert!(req_file.content.contains("api-key"));
     }
 
     #[test]
@@ -827,6 +871,9 @@ mod tests {
         assert!(server_file.content.contains("${TOKEN}"));
         // "--port 8080" is not a secret flag -- must survive untouched.
         assert!(server_file.content.contains("8080"));
+
+        let req_file = export.files.iter().find(|f| f.path == "accounts/requirements.json").unwrap();
+        assert!(req_file.content.contains("token"));
     }
 
     #[test]
@@ -861,10 +908,40 @@ mod tests {
         let server_file = export.files.iter().find(|f| f.path == "mcp/remote.server.json").unwrap();
         assert!(!server_file.content.contains("realPass456"));
         assert!(!server_file.content.contains("realKeyAbc"));
-        assert!(server_file.content.contains("${REDACTED}@mcp.example.com"));
+        assert!(server_file.content.contains("${URL_CREDENTIALS}@mcp.example.com"));
         assert!(server_file.content.contains("api_key=${API_KEY}"));
         // Non-secret query params must survive untouched.
         assert!(server_file.content.contains("region=us"));
+
+        // reagent P2, PR #2333: requirements.json must be derived from
+        // the SAME redaction pass, not a separate env/headers-only scan.
+        let req_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "accounts/requirements.json")
+            .expect("url-embedded credentials must still infer requirements");
+        assert!(req_file.content.contains("url_credentials"));
+        assert!(req_file.content.contains("api_key"));
+    }
+
+    #[test]
+    fn query_param_redaction_uses_the_same_allowlist_as_args() {
+        // reagent P1, PR #2333: is_secret_query_param's list previously
+        // omitted names already recognized for args (client_secret,
+        // auth_token, bearer_token, secret_key) -- the two lists could
+        // silently drift apart. Now backed by one shared SECRET_NAMES list.
+        let mcp_servers = r#"[{
+            "name": "oauth-server",
+            "type": "http",
+            "url": "https://api.example.com/mcp?client_secret=realClientSecret123&auth_token=realAuthToken456"
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/oauth-server.server.json").unwrap();
+        assert!(!server_file.content.contains("realClientSecret123"));
+        assert!(!server_file.content.contains("realAuthToken456"));
+        assert!(server_file.content.contains("client_secret=${CLIENT_SECRET}"));
+        assert!(server_file.content.contains("auth_token=${AUTH_TOKEN}"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -148,10 +148,16 @@ fn redact_url_credentials(url: &str) -> (String, Vec<String>) {
         let after_scheme = scheme_end + 3;
         if let Some(at_offset) = result[after_scheme..].find('@') {
             let userinfo_end = after_scheme + at_offset;
-            // Only treat this as userinfo if there's no path separator
-            // before the `@` -- otherwise a bare `@` further into the URL
-            // (rare, but possible in a path/fragment) would be misread.
-            if !result[after_scheme..userinfo_end].contains('/') {
+            // Only treat this as userinfo if there's no path separator OR
+            // query-string start before the `@` -- otherwise a bare `@`
+            // further into the URL (rare, but possible in a path/query/
+            // fragment, e.g. "?a=b@c") would be misread, and — critically —
+            // consuming a `?` into this replacement would blind the
+            // query-param pass below to a real secret sitting right after
+            // it (reagent P0, PR #2333: "?a=b@c&api_key=SECRET" lost its
+            // `?` here, so api_key never got redacted at all).
+            let candidate = &result[after_scheme..userinfo_end];
+            if !candidate.contains('/') && !candidate.contains('?') {
                 result.replace_range(after_scheme..userinfo_end, "${URL_CREDENTIALS}");
                 redacted_names.push("url_credentials".to_string());
             }
@@ -942,6 +948,32 @@ mod tests {
         assert!(!server_file.content.contains("realAuthToken456"));
         assert!(server_file.content.contains("client_secret=${CLIENT_SECRET}"));
         assert!(server_file.content.contains("auth_token=${AUTH_TOKEN}"));
+    }
+
+    #[test]
+    fn userinfo_detection_does_not_swallow_the_query_string_delimiter() {
+        // reagent P0, PR #2333: a bare "@" appearing INSIDE the query
+        // string (not real userinfo) was previously misdetected as
+        // userinfo, and the replacement consumed the "?" along with it --
+        // blinding the query-param redaction pass to a real secret sitting
+        // right after it. No path, no real userinfo, just an "@" in a
+        // param value.
+        let mcp_servers = r#"[{
+            "name": "svc",
+            "type": "http",
+            "url": "https://svc.example.com?a=b@c&api_key=realSecretShouldBeRedacted"
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/svc.server.json").unwrap();
+        assert!(
+            !server_file.content.contains("realSecretShouldBeRedacted"),
+            "the real secret must still be redacted even with a bare '@' earlier in the query string: {}",
+            server_file.content
+        );
+        assert!(server_file.content.contains("api_key=${API_KEY}"));
+        // No genuine userinfo here -- must not fabricate a ${URL_CREDENTIALS}.
+        assert!(!server_file.content.contains("URL_CREDENTIALS"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -1,0 +1,452 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Armory Bundle Format (ABF) exporter — Phase 1 of
+//! `docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md` /
+//! <https://docs.agentmux.ai/abf/>. Serializes a `db_bundles` row (the
+//! `Memory` struct — table/UI say "Bundles", the type name predates the
+//! rename) plus its referenced skills and inline MCP server configs into
+//! the ABF v0.1 on-disk layout:
+//!
+//! ```text
+//! <bundle-slug>/
+//! ├── armory.json
+//! ├── instructions/
+//! │   ├── AGENTS.md
+//! │   └── context/…
+//! ├── skills/
+//! │   └── <skill-slug>/
+//! │       └── SKILL.md
+//! ├── mcp/
+//! │   └── <server-slug>.server.json
+//! └── accounts/
+//!     └── requirements.json   (only written when inferred requirements exist)
+//! ```
+//!
+//! Pure functions only — no I/O, no Store access. Callers (the `bundle.export`
+//! RPC handler) own fetching the `Memory` row and resolving its `skills`
+//! id-array into `Skill` rows before calling [`export_bundle`].
+//!
+//! **`accounts/requirements.json` design note:** the plan this implements
+//! says these entries come from "`db_agent_identity_links`-implied needs",
+//! but no such link exists at the bundle level — `db_agent_identity_links`
+//! is keyed on `(agent_id, provider)`, and bundles are reusable across many
+//! agents with no FK to any one of them. Rather than requiring an arbitrary
+//! agent context (and risking exporting a real `db_accounts` pointer),
+//! requirements are inferred abstractly from the bundle's own inline
+//! `mcp_servers` configs: each `env` key on a server config becomes one
+//! requirement declaration (name/provider guess, no values, ever) — this
+//! matches ABF's own "declare, don't bundle secrets" design and MCP's own
+//! `isSecret`/env-placeholder convention (see the research report §3b/§3d).
+
+use std::collections::HashSet;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use super::agent_config::{render_skill_md, unique_skill_slug, SKILL_TYPE_AGENT_SKILL};
+use super::storage::store::{derive_slug, Memory};
+use super::storage::Skill;
+
+/// One file within an exported bundle, path relative to the bundle root
+/// (e.g. `"armory.json"`, `"instructions/AGENTS.md"`).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BundleExportFile {
+    pub path: String,
+    pub content: String,
+}
+
+/// Result of exporting one bundle: every file to write, plus bookkeeping
+/// about anything that couldn't be represented in ABF and was left out
+/// (surfaced to the caller/UI rather than silently dropped).
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleExport {
+    /// Filesystem-safe slug derived from the bundle's name — the
+    /// recommended root directory / zip base name.
+    pub root_slug: String,
+    pub files: Vec<BundleExportFile>,
+    /// Names of skills that were NOT exported because their `skill_type`
+    /// isn't `"agent-skill"` (ABF's `skills` component is Agent Skills
+    /// (SKILL.md) format specifically — AgentMux's proprietary
+    /// slash-command skills have no ABF representation, see Phase 0 /
+    /// `SKILL_TYPE_AGENT_SKILL`).
+    pub skipped_skills: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize, Default)]
+struct ContextFileEntry {
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    content: String,
+}
+
+/// Validate a context-file's relative path is safe to place under
+/// `instructions/context/` in an exported bundle: non-empty, not absolute,
+/// no drive letter, no `..` traversal component. Pure string validation
+/// (no filesystem access) so [`export_bundle`] can stay a pure function.
+/// Returns `None` for anything that fails; callers skip that entry.
+fn sanitize_context_relative_path(path: &str) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    let normalized = path.replace('\\', "/");
+    if normalized.starts_with('/') || normalized.contains(':') {
+        return None;
+    }
+    let mut parts = Vec::new();
+    for component in normalized.split('/') {
+        match component {
+            "" | "." => continue,
+            ".." => return None,
+            other => parts.push(other),
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
+/// Export a bundle + its already-resolved skills into the ABF v0.1 layout.
+///
+/// `skills` must already be resolved from `bundle.skills` (a JSON array of
+/// skill ids) via `Store::skill_get` per id — this function does no
+/// lookups. Callers should skip ids that failed to resolve (deleted skills)
+/// before calling this; it does not distinguish "missing" from "not
+/// passed."
+pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
+    let root_slug = derive_slug(&bundle.name);
+    let mut files = Vec::new();
+    let mut skipped_skills = Vec::new();
+
+    let mut manifest_instructions: Vec<String> = Vec::new();
+    let mut manifest_skills: Vec<String> = Vec::new();
+    let mut manifest_mcp: Vec<String> = Vec::new();
+
+    // ------------------------------------------------------------------
+    // instructions/AGENTS.md + instructions/context/*
+    // ------------------------------------------------------------------
+    if !bundle.instructions.trim().is_empty() {
+        files.push(BundleExportFile {
+            path: "instructions/AGENTS.md".to_string(),
+            content: bundle.instructions.clone(),
+        });
+        manifest_instructions.push("instructions/AGENTS.md".to_string());
+    }
+
+    let context_files: Vec<ContextFileEntry> =
+        serde_json::from_str(&bundle.context_files).unwrap_or_default();
+    for entry in context_files {
+        if let Some(safe_path) = sanitize_context_relative_path(&entry.path) {
+            let out_path = format!("instructions/context/{safe_path}");
+            manifest_instructions.push(out_path.clone());
+            files.push(BundleExportFile {
+                path: out_path,
+                content: entry.content,
+            });
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // skills/<slug>/SKILL.md — Agent Skills format only (see doc comment)
+    // ------------------------------------------------------------------
+    let mut used_skill_slugs: HashSet<String> = HashSet::new();
+    for skill in skills {
+        if skill.skill_type != SKILL_TYPE_AGENT_SKILL {
+            skipped_skills.push(skill.name.clone());
+            continue;
+        }
+        if skill.content.is_empty() {
+            skipped_skills.push(skill.name.clone());
+            continue;
+        }
+        let slug = unique_skill_slug(&skill.name, &mut used_skill_slugs);
+        let path = format!("skills/{slug}/SKILL.md");
+        files.push(BundleExportFile {
+            path: path.clone(),
+            content: render_skill_md(&slug, &skill.description, &skill.content),
+        });
+        manifest_skills.push(path);
+    }
+
+    // ------------------------------------------------------------------
+    // mcp/<slug>.server.json + inferred accounts/requirements.json
+    // ------------------------------------------------------------------
+    let mcp_entries: Vec<Value> = serde_json::from_str(&bundle.mcp_servers).unwrap_or_default();
+    let mut used_mcp_slugs: HashSet<String> = HashSet::new();
+    let mut requirements: Vec<Value> = Vec::new();
+    for (index, entry) in mcp_entries.iter().enumerate() {
+        let display_name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("mcp-server-{}", index + 1));
+        let slug = unique_skill_slug(&display_name, &mut used_mcp_slugs);
+        let path = format!("mcp/{slug}.server.json");
+        let pretty = serde_json::to_string_pretty(entry).unwrap_or_else(|_| "{}".to_string());
+        files.push(BundleExportFile {
+            path: path.clone(),
+            content: pretty,
+        });
+        manifest_mcp.push(path);
+
+        if let Some(env_obj) = entry.get("env").and_then(|v| v.as_object()) {
+            for key in env_obj.keys() {
+                requirements.push(json!({
+                    "id": format!("{slug}-{key}"),
+                    "provider": slug,
+                    "kind": "api-key",
+                    "env": key,
+                    "optional": false,
+                }));
+            }
+        }
+    }
+
+    let mut components = serde_json::Map::new();
+    if !manifest_instructions.is_empty() {
+        components.insert("instructions".to_string(), json!(manifest_instructions));
+    }
+    if !manifest_skills.is_empty() {
+        components.insert("skills".to_string(), json!(manifest_skills));
+    }
+    if !manifest_mcp.is_empty() {
+        components.insert("mcpServers".to_string(), json!(manifest_mcp));
+    }
+    if !requirements.is_empty() {
+        components.insert(
+            "accounts".to_string(),
+            json!("accounts/requirements.json"),
+        );
+        let requirements_doc = json!({ "requirements": requirements });
+        files.push(BundleExportFile {
+            path: "accounts/requirements.json".to_string(),
+            content: serde_json::to_string_pretty(&requirements_doc)
+                .unwrap_or_else(|_| "{}".to_string()),
+        });
+    }
+
+    let manifest = json!({
+        "$schema": "https://docs.agentmux.ai/schemas/armory-bundle/v0.1/bundle.schema.json",
+        "name": root_slug,
+        // Bundles have no native version concept (no `version` column) --
+        // ABF requires one, so this is an export-time default the user is
+        // expected to bump before actually publishing the bundle anywhere.
+        "version": "0.1.0",
+        "description": bundle.description,
+        "components": Value::Object(components),
+        "metadata": {},
+    });
+    files.push(BundleExportFile {
+        path: "armory.json".to_string(),
+        content: serde_json::to_string_pretty(&manifest).unwrap_or_else(|_| "{}".to_string()),
+    });
+
+    BundleExport {
+        root_slug,
+        files,
+        skipped_skills,
+    }
+}
+
+/// Pack an export's files into a zip archive in memory. First `ZipWriter`
+/// usage in this workspace — `tool_store.rs` only ever reads zips. No
+/// filesystem access: writes into an in-memory buffer, so this stays as
+/// side-effect-free as the exporter itself (the RPC handler decides what
+/// to do with the resulting bytes).
+pub fn zip_bundle_export(export: &BundleExport) -> Result<Vec<u8>, String> {
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(&mut buf);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    for file in &export.files {
+        let zip_path = format!("{}/{}", export.root_slug, file.path);
+        writer
+            .start_file(zip_path, options)
+            .map_err(|e| format!("zip_bundle_export: {e}"))?;
+        writer
+            .write_all(file.content.as_bytes())
+            .map_err(|e| format!("zip_bundle_export: {e}"))?;
+    }
+
+    writer
+        .finish()
+        .map_err(|e| format!("zip_bundle_export: {e}"))?;
+    Ok(buf.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_bundle(instructions: &str, context_files: &str, mcp_servers: &str, skills: &str) -> Memory {
+        Memory {
+            id: "bundle-1".to_string(),
+            name: "Backend Dev Bundle".to_string(),
+            description: "Backend dev conventions".to_string(),
+            is_blank: false,
+            is_global: false,
+            provider: String::new(),
+            model: String::new(),
+            instructions: instructions.to_string(),
+            context_files: context_files.to_string(),
+            mcp_servers: mcp_servers.to_string(),
+            skills: skills.to_string(),
+            sort_order: 0,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
+
+    fn make_agent_skill(name: &str) -> Skill {
+        Skill {
+            id: format!("skill-{name}"),
+            name: name.to_string(),
+            trigger: String::new(),
+            skill_type: "agent-skill".to_string(),
+            description: format!("{name} description"),
+            content: format!("{name} content"),
+            is_global: true,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn exports_instructions_as_agents_md() {
+        let bundle = make_bundle("Follow repo conventions.", "[]", "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+        let f = export.files.iter().find(|f| f.path == "instructions/AGENTS.md").unwrap();
+        assert_eq!(f.content, "Follow repo conventions.");
+    }
+
+    #[test]
+    fn exports_context_files_under_instructions_context() {
+        let context_files = r#"[{"path":"docs/readme.md","content":"Readme heading"}]"#;
+        let bundle = make_bundle("", context_files, "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+        let f = export
+            .files
+            .iter()
+            .find(|f| f.path == "instructions/context/docs/readme.md")
+            .expect("expected instructions/context/docs/readme.md");
+        assert_eq!(f.content, "Readme heading");
+    }
+
+    #[test]
+    fn rejects_path_traversal_in_context_files() {
+        let context_files = r#"[{"path":"../../etc/passwd","content":"evil"}]"#;
+        let bundle = make_bundle("", context_files, "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+        assert!(export.files.iter().all(|f| !f.content.contains("evil")));
+        assert!(!export.files.iter().any(|f| f.path.contains("..")));
+    }
+
+    #[test]
+    fn exports_agent_skill_format_skills_and_skips_prompt_format() {
+        let bundle = make_bundle("", "[]", "[]", r#"["skill-a","skill-b"]"#);
+        let mut prompt_skill = make_agent_skill("Slash Skill");
+        prompt_skill.skill_type = "prompt".to_string();
+        let skills = vec![make_agent_skill("Deploy Checklist"), prompt_skill];
+
+        let export = export_bundle(&bundle, &skills);
+        assert!(export
+            .files
+            .iter()
+            .any(|f| f.path == "skills/deploy-checklist/SKILL.md"));
+        assert!(!export.files.iter().any(|f| f.path.contains("slash-skill")));
+        assert_eq!(export.skipped_skills, vec!["Slash Skill".to_string()]);
+    }
+
+    #[test]
+    fn exports_mcp_servers_and_infers_requirements_from_env_keys() {
+        let mcp_servers = r#"[{"name":"github","type":"stdio","command":"gh-mcp","env":{"GITHUB_TOKEN":""}}]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+
+        let server_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "mcp/github.server.json")
+            .expect("expected mcp/github.server.json");
+        assert!(server_file.content.contains("gh-mcp"));
+
+        let req_file = export
+            .files
+            .iter()
+            .find(|f| f.path == "accounts/requirements.json")
+            .expect("expected accounts/requirements.json to be inferred");
+        assert!(req_file.content.contains("GITHUB_TOKEN"));
+        assert!(!req_file.content.to_lowercase().contains("ghp_"), "must never contain a real secret value");
+    }
+
+    #[test]
+    fn no_requirements_file_when_no_env_vars_present() {
+        let mcp_servers = r#"[{"name":"local-tool","type":"stdio","command":"local-tool"}]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        assert!(!export.files.iter().any(|f| f.path == "accounts/requirements.json"));
+    }
+
+    #[test]
+    fn dedupes_colliding_mcp_server_names() {
+        let mcp_servers = r#"[{"name":"Server!!!One"},{"name":"Server One"}]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let paths: HashSet<&str> = export.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains("mcp/server-one.server.json"));
+        assert!(paths.contains("mcp/server-one-2.server.json"));
+    }
+
+    #[test]
+    fn manifest_lists_every_component_and_validates_as_json() {
+        let bundle = make_bundle(
+            "Instructions",
+            r#"[{"path":"a.md","content":"A"}]"#,
+            r#"[{"name":"github","env":{"GITHUB_TOKEN":""}}]"#,
+            r#"["skill-a"]"#,
+        );
+        let export = export_bundle(&bundle, &[make_agent_skill("Deploy")]);
+        let manifest_file = export.files.iter().find(|f| f.path == "armory.json").unwrap();
+        let manifest: Value = serde_json::from_str(&manifest_file.content).expect("armory.json must be valid JSON");
+        assert_eq!(manifest["name"], "backend-dev-bundle");
+        assert!(manifest["components"]["instructions"].as_array().unwrap().len() == 2);
+        assert!(manifest["components"]["skills"].as_array().unwrap().len() == 1);
+        assert!(manifest["components"]["mcpServers"].as_array().unwrap().len() == 1);
+        assert_eq!(manifest["components"]["accounts"], "accounts/requirements.json");
+    }
+
+    #[test]
+    fn empty_bundle_still_produces_a_valid_manifest() {
+        let bundle = make_bundle("", "[]", "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+        // armory.json is always written, even for a fully empty bundle.
+        assert_eq!(export.files.len(), 1);
+        let manifest: Value = serde_json::from_str(&export.files[0].content).unwrap();
+        assert_eq!(manifest["components"], json!({}));
+    }
+
+    #[test]
+    fn zip_bundle_export_produces_a_valid_archive_with_all_files() {
+        let bundle = make_bundle("Instructions here", "[]", "[]", "[]");
+        let export = export_bundle(&bundle, &[]);
+        let zip_bytes = zip_bundle_export(&export).expect("zip should succeed");
+
+        let cursor = std::io::Cursor::new(zip_bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("valid zip archive");
+        assert_eq!(archive.len(), export.files.len());
+
+        let mut found = false;
+        for i in 0..archive.len() {
+            let file = archive.by_index(i).unwrap();
+            if file.name() == "backend-dev-bundle/armory.json" {
+                found = true;
+            }
+        }
+        assert!(found, "expected backend-dev-bundle/armory.json in the archive");
+    }
+}

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -104,16 +104,99 @@ struct ContextFileEntry {
     content: String,
 }
 
+/// Flag names (case/dash/underscore-insensitive, `-`/`--` prefix optional)
+/// whose value is credential-shaped in common CLI/MCP server invocations —
+/// a curated allowlist rather than a broad substring match (e.g. `--keymap`
+/// must NOT trigger this), so `redact_mcp_entry` also scans `args` for
+/// these, not just the structured `env`/`headers` fields (Codex + reagent
+/// P1, PR #2333: `--api-key <secret>` or `--token=<secret>` in the runtime
+/// `args` array exported the secret verbatim).
+const SECRET_ARG_FLAG_NAMES: &[&str] = &[
+    "api-key", "apikey", "api_key",
+    "token", "access-token", "access_token", "auth-token", "auth_token",
+    "bearer-token", "bearer_token",
+    "secret", "secret-key", "secret_key", "client-secret", "client_secret",
+    "password", "passwd",
+];
+
+fn secret_arg_placeholder(flag: &str) -> String {
+    let normalized = flag.trim_start_matches('-').to_uppercase().replace('-', "_");
+    format!("${{{normalized}}}")
+}
+
+fn is_secret_flag(flag: &str) -> bool {
+    let normalized = flag.trim_start_matches('-').to_lowercase();
+    SECRET_ARG_FLAG_NAMES.contains(&normalized.as_str())
+}
+
+/// Query-string parameter names commonly used to pass a credential in a
+/// URL (curated allowlist, same rationale as [`SECRET_ARG_FLAG_NAMES`]).
+fn is_secret_query_param(key: &str) -> bool {
+    matches!(
+        key.to_lowercase().as_str(),
+        "api_key" | "apikey" | "key" | "token" | "access_token" | "secret" | "password"
+    )
+}
+
+/// Redact userinfo (`scheme://user:pass@host`) and known secret-bearing
+/// query params from a URL string. Hand-rolled string scanning rather than
+/// a `url`-crate parse (no such dependency in this workspace, matching
+/// this module's existing style — see `sanitize_context_relative_path`) —
+/// deliberately conservative: only touches the exact shapes below, leaving
+/// anything it doesn't recognize unchanged rather than risking a malformed
+/// rewrite of a URL this scan doesn't fully understand.
+fn redact_url_credentials(url: &str) -> String {
+    let mut result = url.to_string();
+
+    if let Some(scheme_end) = result.find("://") {
+        let after_scheme = scheme_end + 3;
+        if let Some(at_offset) = result[after_scheme..].find('@') {
+            let userinfo_end = after_scheme + at_offset;
+            // Only treat this as userinfo if there's no path separator
+            // before the `@` -- otherwise a bare `@` further into the URL
+            // (rare, but possible in a path/fragment) would be misread.
+            if !result[after_scheme..userinfo_end].contains('/') {
+                result.replace_range(after_scheme..userinfo_end, "${REDACTED}");
+            }
+        }
+    }
+
+    if let Some(query_start) = result.find('?') {
+        let (base, query_with_qmark) = result.split_at(query_start);
+        let query = &query_with_qmark[1..];
+        let mut changed = false;
+        let new_pairs: Vec<String> = query
+            .split('&')
+            .map(|pair| match pair.split_once('=') {
+                Some((key, _)) if is_secret_query_param(key) => {
+                    changed = true;
+                    format!("{key}={}", secret_arg_placeholder(key))
+                }
+                _ => pair.to_string(),
+            })
+            .collect();
+        if changed {
+            result = format!("{base}?{}", new_pairs.join("&"));
+        }
+    }
+
+    result
+}
+
 /// Redact secret-shaped values out of an MCP server config entry before it
 /// is written into a shareable bundle export. `env` and `headers` are the
-/// two fields AgentMux's own MCP config editors accept literal secret
-/// values into (e.g. `env.GITHUB_TOKEN`, `headers.Authorization` on an
-/// HTTP/SSE-transport server) — every value under either key is replaced
-/// with a `${VAR_NAME}`-style placeholder so the exported `.server.json`
-/// never contains a real credential, matching ABF's "declare, don't bundle
-/// secrets" principle that `accounts/requirements.json` already follows
-/// (security finding, Codex P1 x2, PR #2325). Any other field passes
-/// through unchanged.
+/// two structured fields AgentMux's own MCP config editors accept literal
+/// secret values into (e.g. `env.GITHUB_TOKEN`, `headers.Authorization` on
+/// an HTTP/SSE-transport server) — every value under either key is
+/// replaced with a `${VAR_NAME}`-style placeholder so the exported
+/// `.server.json` never contains a real credential, matching ABF's
+/// "declare, don't bundle secrets" principle that `accounts/requirements.json`
+/// already follows (security finding, Codex P1 x2, PR #2325). `args` (CLI
+/// flag/value pairs) and `url` (userinfo/query-param credentials) are
+/// ALSO scanned for the same reason — a credential passed as
+/// `--api-key <secret>` or `https://user:pass@host` is just as real a leak
+/// as one in `env`/`headers` (Codex + reagent P1, PR #2333). Any other
+/// field passes through unchanged.
 fn redact_mcp_entry(entry: &Value) -> Value {
     let mut redacted = entry.clone();
     if let Some(obj) = redacted.as_object_mut() {
@@ -122,6 +205,36 @@ fn redact_mcp_entry(entry: &Value) -> Value {
                 for (key, value) in map.iter_mut() {
                     *value = json!(format!("${{{key}}}"));
                 }
+            }
+        }
+        if let Some(Value::Array(args)) = obj.get_mut("args") {
+            let mut i = 0;
+            while i < args.len() {
+                let Some(s) = args[i].as_str() else {
+                    i += 1;
+                    continue;
+                };
+                if let Some((flag, _value)) = s.split_once('=') {
+                    // "--flag=value" form: redact just the value portion.
+                    if is_secret_flag(flag) {
+                        args[i] = json!(format!("{flag}={}", secret_arg_placeholder(flag)));
+                    }
+                    i += 1;
+                } else if is_secret_flag(s) && i + 1 < args.len() {
+                    // "--flag value" form: redact the NEXT element, leave
+                    // the flag itself (it's not a secret) untouched.
+                    let placeholder = secret_arg_placeholder(s);
+                    args[i + 1] = json!(placeholder);
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+        if let Some(url_str) = obj.get("url").and_then(|v| v.as_str()).map(|s| s.to_string()) {
+            let redacted_url = redact_url_credentials(&url_str);
+            if redacted_url != url_str {
+                obj.insert("url".to_string(), json!(redacted_url));
             }
         }
     }
@@ -337,13 +450,14 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
     }
 }
 
-/// Parse a `db_bundles` JSON-array column (`context_files`/`mcp_servers`),
-/// treating a blank/whitespace-only value as "genuinely no data" (not an
-/// error) but pushing a warning to `warnings` for anything non-blank that
-/// fails to parse, rather than silently discarding it via
+/// Parse a `db_bundles` JSON-array column (`context_files`/`mcp_servers`,
+/// and — via the `bundle.export` RPC handler in `app_api/bundle.rs` —
+/// `skills`), treating a blank/whitespace-only value as "genuinely no
+/// data" (not an error) but pushing a warning to `warnings` for anything
+/// non-blank that fails to parse, rather than silently discarding it via
 /// `unwrap_or_default()` — an export that quietly loses data defeats its
 /// own backup/portability purpose (reagent P1, PR #2333).
-fn parse_json_field_or_warn<T: serde::de::DeserializeOwned + Default>(
+pub(crate) fn parse_json_field_or_warn<T: serde::de::DeserializeOwned + Default>(
     raw: &str,
     field_name: &str,
     warnings: &mut Vec<String>,
@@ -584,6 +698,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_json_field_or_warn_direct_unit_test() {
+        // reagent P1, PR #2333: `bundle.export`'s RPC handler
+        // (app_api/bundle.rs) reuses this exact helper for `bundle.skills`,
+        // which previously had the same unwrap_or_default() silent-loss bug
+        // already fixed here for context_files/mcp_servers.
+        let mut warnings = Vec::new();
+        let blank: Vec<String> = parse_json_field_or_warn("", "skills", &mut warnings);
+        assert!(blank.is_empty());
+        assert!(warnings.is_empty(), "blank must not warn");
+
+        let malformed: Vec<String> = parse_json_field_or_warn("not json", "skills", &mut warnings);
+        assert!(malformed.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("skills") && warnings[0].contains("malformed"));
+
+        let mut warnings2 = Vec::new();
+        let valid: Vec<String> = parse_json_field_or_warn(r#"["a","b"]"#, "skills", &mut warnings2);
+        assert_eq!(valid, vec!["a".to_string(), "b".to_string()]);
+        assert!(warnings2.is_empty());
+    }
+
+    #[test]
     fn colliding_context_file_paths_are_deduped_with_a_warning() {
         // reagent P2, PR #2333: two distinct source paths that normalize to
         // the same output (e.g. a redundant "./" component) previously
@@ -635,6 +771,80 @@ mod tests {
             !req_file.content.to_lowercase().contains("realtoken789"),
             "must never contain a real secret value"
         );
+    }
+
+    #[test]
+    fn redacts_credentials_from_args_flag_equals_value_form() {
+        // Codex + reagent P1, PR #2333: a real credential passed as
+        // "--api-key=<secret>" in the runtime args array previously
+        // exported verbatim.
+        let mcp_servers = r#"[{
+            "name": "linear",
+            "type": "stdio",
+            "command": "linear-mcp",
+            "args": ["--api-key=lin_realSecretAbc123", "--verbose"]
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/linear.server.json").unwrap();
+        assert!(!server_file.content.contains("lin_realSecretAbc123"));
+        assert!(server_file.content.contains("${API_KEY}"));
+        assert!(server_file.content.contains("--verbose"), "unrelated flags must survive untouched");
+    }
+
+    #[test]
+    fn redacts_credentials_from_args_flag_space_value_form() {
+        let mcp_servers = r#"[{
+            "name": "custom",
+            "type": "stdio",
+            "command": "custom-mcp",
+            "args": ["--token", "realSecretXyz789", "--port", "8080"]
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/custom.server.json").unwrap();
+        assert!(!server_file.content.contains("realSecretXyz789"));
+        assert!(server_file.content.contains("${TOKEN}"));
+        // "--port 8080" is not a secret flag -- must survive untouched.
+        assert!(server_file.content.contains("8080"));
+    }
+
+    #[test]
+    fn unrelated_args_flags_are_never_redacted() {
+        // "--keymap" contains neither "key" as a whole segment nor any
+        // other curated secret-flag name -- must not false-positive.
+        let mcp_servers = r#"[{
+            "name": "editor",
+            "type": "stdio",
+            "command": "editor-mcp",
+            "args": ["--keymap=vim", "--theme", "dark"]
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/editor.server.json").unwrap();
+        assert!(server_file.content.contains("--keymap=vim"));
+        assert!(server_file.content.contains("dark"));
+    }
+
+    #[test]
+    fn redacts_userinfo_and_secret_query_params_from_url() {
+        // Codex + reagent P1, PR #2333: a credential embedded in the `url`
+        // field (userinfo or a secret-bearing query param) previously
+        // exported verbatim.
+        let mcp_servers = r#"[{
+            "name": "remote",
+            "type": "http",
+            "url": "https://admin:realPass456@mcp.example.com/api?api_key=realKeyAbc&region=us"
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/remote.server.json").unwrap();
+        assert!(!server_file.content.contains("realPass456"));
+        assert!(!server_file.content.contains("realKeyAbc"));
+        assert!(server_file.content.contains("${REDACTED}@mcp.example.com"));
+        assert!(server_file.content.contains("api_key=${API_KEY}"));
+        // Non-secret query params must survive untouched.
+        assert!(server_file.content.contains("region=us"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -129,6 +129,50 @@ fn is_secret_name(name: &str) -> bool {
     SECRET_NAMES.contains(&normalized.as_str())
 }
 
+/// HTTP header names whose value is credential-shaped when embedded in a
+/// `"HeaderName: value"` string passed as a CLI flag's argument (see
+/// [`redact_header_value`]) — a separate curated list from `SECRET_NAMES`
+/// because header names (`authorization`, `cookie`) and CLI flag names
+/// (`api-key`, `token`) are different vocabularies that happen to overlap
+/// only partially.
+const SECRET_HEADER_NAMES: &[&str] = &[
+    "authorization", "x-api-key", "x-auth-token", "proxy-authorization", "cookie",
+];
+
+fn is_secret_header_name(name: &str) -> bool {
+    SECRET_HEADER_NAMES.contains(&name.trim().to_lowercase().as_str())
+}
+
+fn is_header_flag(flag: &str) -> bool {
+    matches!(
+        flag.trim_start_matches('-').to_lowercase().as_str(),
+        "header" | "headers" | "h"
+    )
+}
+
+/// Redact a `"HeaderName: value"` string -- the shape a `--header`/`-H`
+/// flag's argument takes in common CLI/MCP server invocations -- when the
+/// header name is secret-shaped, e.g. turning
+/// `"Authorization: Bearer <token>"` into `"Authorization: ${AUTHORIZATION}"`.
+/// The flag name itself (`--header`) is never secret-shaped, so the
+/// `is_secret_name` flag check above can never catch this: the secret is
+/// smuggled inside the *value*, not signaled by the flag (Codex + reagent
+/// P0, PR #2333, flagged across multiple review rounds). Returns the
+/// rebuilt string plus the header name to record in `requirements.json`,
+/// or `None` if `value` isn't `name: value`-shaped or the name isn't a
+/// recognized secret-bearing header.
+fn redact_header_value(value: &str) -> Option<(String, String)> {
+    let (header_name, _header_value) = value.split_once(':')?;
+    let header_name = header_name.trim();
+    if header_name.is_empty() || !is_secret_header_name(header_name) {
+        return None;
+    }
+    Some((
+        format!("{header_name}: {}", secret_placeholder(header_name)),
+        header_name.to_string(),
+    ))
+}
+
 /// Redact userinfo (`scheme://user:pass@host`) and known secret-bearing
 /// query params from a URL string. Hand-rolled string scanning rather than
 /// a `url`-crate parse (no such dependency in this workspace, matching
@@ -146,21 +190,26 @@ fn redact_url_credentials(url: &str) -> (String, Vec<String>) {
 
     if let Some(scheme_end) = result.find("://") {
         let after_scheme = scheme_end + 3;
-        if let Some(at_offset) = result[after_scheme..].find('@') {
+        // The authority section (the only place userinfo can legally
+        // appear) ends at the first '/', '?', or '#' -- the complete set
+        // of authority-terminating delimiters per RFC 3986 §3.2. An `@`
+        // at or after that boundary is inside the path/query/fragment,
+        // not userinfo. Finding the boundary once up front (rather than
+        // excluding one delimiter at a time as edge cases surface) is the
+        // robust fix: this handles '/', '?', AND '#' — and any future
+        // reader can see the fix's completeness at a glance instead of
+        // wondering "what about the next delimiter" (reagent P0 + P2, PR
+        // #2333: a bare '@' after either '?' or '#' was each independently
+        // misread as userinfo, and the '?' case additionally blinded the
+        // query-param redaction pass by consuming the delimiter itself).
+        let authority_end = result[after_scheme..]
+            .find(['/', '?', '#'])
+            .map(|p| after_scheme + p)
+            .unwrap_or(result.len());
+        if let Some(at_offset) = result[after_scheme..authority_end].find('@') {
             let userinfo_end = after_scheme + at_offset;
-            // Only treat this as userinfo if there's no path separator OR
-            // query-string start before the `@` -- otherwise a bare `@`
-            // further into the URL (rare, but possible in a path/query/
-            // fragment, e.g. "?a=b@c") would be misread, and — critically —
-            // consuming a `?` into this replacement would blind the
-            // query-param pass below to a real secret sitting right after
-            // it (reagent P0, PR #2333: "?a=b@c&api_key=SECRET" lost its
-            // `?` here, so api_key never got redacted at all).
-            let candidate = &result[after_scheme..userinfo_end];
-            if !candidate.contains('/') && !candidate.contains('?') {
-                result.replace_range(after_scheme..userinfo_end, "${URL_CREDENTIALS}");
-                redacted_names.push("url_credentials".to_string());
-            }
+            result.replace_range(after_scheme..userinfo_end, "${URL_CREDENTIALS}");
+            redacted_names.push("url_credentials".to_string());
         }
     }
 
@@ -226,11 +275,16 @@ fn redact_mcp_entry(entry: &Value) -> (Value, Vec<String>) {
                     i += 1;
                     continue;
                 };
-                if let Some((flag, _value)) = s.split_once('=') {
+                if let Some((flag, value)) = s.split_once('=') {
                     // "--flag=value" form: redact just the value portion.
                     if is_secret_name(flag) {
                         args[i] = json!(format!("{flag}={}", secret_placeholder(flag)));
                         redacted_names.push(flag.trim_start_matches('-').to_string());
+                    } else if is_header_flag(flag) {
+                        if let Some((redacted_value, header_name)) = redact_header_value(value) {
+                            args[i] = json!(format!("{flag}={redacted_value}"));
+                            redacted_names.push(header_name);
+                        }
                     }
                     i += 1;
                 } else if is_secret_name(&s) && i + 1 < args.len() {
@@ -238,6 +292,20 @@ fn redact_mcp_entry(entry: &Value) -> (Value, Vec<String>) {
                     // the flag itself (it's not a secret) untouched.
                     args[i + 1] = json!(secret_placeholder(&s));
                     redacted_names.push(s.trim_start_matches('-').to_string());
+                    i += 2;
+                } else if is_header_flag(&s) && i + 1 < args.len() {
+                    // "--header value" form, where the secret is embedded
+                    // in the value as "HeaderName: <secret>", not signaled
+                    // by the flag name -- e.g.
+                    // args: ["--header", "Authorization: Bearer <tok>"].
+                    if let Some(value_str) = args[i + 1].as_str() {
+                        if let Some((redacted_value, header_name)) =
+                            redact_header_value(value_str)
+                        {
+                            args[i + 1] = json!(redacted_value);
+                            redacted_names.push(header_name);
+                        }
+                    }
                     i += 2;
                 } else {
                     i += 1;
@@ -974,6 +1042,82 @@ mod tests {
         assert!(server_file.content.contains("api_key=${API_KEY}"));
         // No genuine userinfo here -- must not fabricate a ${URL_CREDENTIALS}.
         assert!(!server_file.content.contains("URL_CREDENTIALS"));
+    }
+
+    #[test]
+    fn userinfo_detection_excludes_the_fragment_delimiter() {
+        // reagent P2, PR #2333: a bare "@" appearing after "#" (inside the
+        // URL fragment, no path/query present) was previously misdetected
+        // as userinfo -- the authority section ends at the FIRST of '/',
+        // '?', OR '#', and the old check only excluded the first two.
+        let mcp_servers = r#"[{
+            "name": "svc",
+            "type": "http",
+            "url": "https://mcp.example.com#note@example.com"
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/svc.server.json").unwrap();
+        assert!(
+            server_file.content.contains("mcp.example.com#note@example.com"),
+            "no genuine userinfo present (the '@' is inside the fragment) -- host must not be mangled: {}",
+            server_file.content
+        );
+        assert!(!server_file.content.contains("URL_CREDENTIALS"));
+    }
+
+    #[test]
+    fn redacts_secret_header_value_embedded_in_args_flag_space_value_form() {
+        // Codex + reagent P0, PR #2333: a credential smuggled inside a
+        // "--header"/"-H" flag's value as "HeaderName: <secret>" -- the
+        // flag name itself is not secret-shaped, so is_secret_name never
+        // catches it; the secret only becomes visible once the value is
+        // itself parsed as a header.
+        let mcp_servers = r#"[{
+            "name": "remote",
+            "type": "stdio",
+            "command": "remote-mcp",
+            "args": ["--header", "Authorization: Bearer realSecretToken789", "--verbose"]
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/remote.server.json").unwrap();
+        assert!(!server_file.content.contains("realSecretToken789"));
+        assert!(server_file.content.contains("Authorization: ${AUTHORIZATION}"));
+        assert!(server_file.content.contains("--verbose"), "unrelated flags must survive untouched");
+
+        let req_file = export.files.iter().find(|f| f.path == "accounts/requirements.json").unwrap();
+        assert!(req_file.content.contains("Authorization"));
+    }
+
+    #[test]
+    fn redacts_secret_header_value_embedded_in_args_flag_equals_value_form() {
+        let mcp_servers = r#"[{
+            "name": "remote2",
+            "type": "stdio",
+            "command": "remote-mcp",
+            "args": ["--header=Authorization: Bearer realSecretToken456"]
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/remote2.server.json").unwrap();
+        assert!(!server_file.content.contains("realSecretToken456"));
+        assert!(server_file.content.contains("--header=Authorization: ${AUTHORIZATION}"));
+    }
+
+    #[test]
+    fn non_secret_header_values_in_args_are_never_redacted() {
+        let mcp_servers = r#"[{
+            "name": "remote3",
+            "type": "stdio",
+            "command": "remote-mcp",
+            "args": ["--header", "X-Request-Id: abc123", "-H", "Content-Type: application/json"]
+        }]"#;
+        let bundle = make_bundle("", "[]", mcp_servers, "[]");
+        let export = export_bundle(&bundle, &[]);
+        let server_file = export.files.iter().find(|f| f.path == "mcp/remote3.server.json").unwrap();
+        assert!(server_file.content.contains("X-Request-Id: abc123"));
+        assert!(server_file.content.contains("Content-Type: application/json"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -323,6 +323,18 @@ pub fn export_bundle(bundle: &Memory, skills: &[Skill]) -> BundleExport {
                 path: out_path,
                 content: entry.content,
             });
+        } else {
+            // Rejected by sanitization (absolute path, ".." traversal, a
+            // drive-letter colon, or an empty path) -- must warn the same
+            // way the collision case right above does, or a backup export
+            // can silently lose a context file with no signal anywhere in
+            // the returned `warnings` (Codex + reagent P2, PR #2333 --
+            // flagged twice, unaddressed in the prior push).
+            warnings.push(format!(
+                "context_files: \"{}\" is not a safe relative path (absolute, \
+                 contains \"..\", a drive letter, or empty); skipped",
+                entry.path
+            ));
         }
     }
 
@@ -568,6 +580,14 @@ mod tests {
         let export = export_bundle(&bundle, &[]);
         assert!(export.files.iter().all(|f| !f.content.contains("evil")));
         assert!(!export.files.iter().any(|f| f.path.contains("..")));
+        // Codex + reagent P2, PR #2333: a rejected entry must not just
+        // vanish -- an export used as a backup can silently lose a context
+        // file with no signal anywhere in `warnings` otherwise.
+        assert!(
+            export.warnings.iter().any(|w| w.contains("../../etc/passwd")),
+            "expected a warning naming the rejected path, got: {:?}",
+            export.warnings
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -5,6 +5,7 @@
 pub mod agent_config;
 pub mod agent_session;
 pub mod blockcontroller;
+pub mod bundle_export;
 pub mod mcp_probe;
 pub mod mcp_seed;
 /// Phase E.4.B Phase 4 — pure layout-tree helpers (Rust port of layoutTree.ts).

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -308,6 +308,11 @@ pub const COMMAND_BUNDLE_GET: &str = "bundle.get";
 pub const COMMAND_BUNDLE_UPSERT: &str = "bundle.upsert";
 pub const COMMAND_BUNDLE_DELETE: &str = "bundle.delete";
 pub const COMMAND_BUNDLE_SELF_GET: &str = "bundle.self.get";
+// Armory Bundle Format (ABF) exporter — Phase 1 of
+// docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md /
+// https://docs.agentmux.ai/abf/. Serializes a bundle + its referenced
+// skills/MCP servers into the ABF on-disk layout.
+pub const COMMAND_BUNDLE_EXPORT: &str = "bundle.export";
 // Deprecated `preset.*` aliases — kept wired for one release (remove in Phase 4).
 pub const COMMAND_PRESET_LIST: &str = "preset.list";
 pub const COMMAND_PRESET_GET: &str = "preset.get";

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -6,6 +6,7 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_bundle_upsert(engine, state);
     register_bundle_delete(engine, state);
     register_bundle_self_get(engine, state);
+    register_bundle_export(engine, state);
 }
 
 /// Normalize a `bundle.upsert` request body into the shape the `Memory` struct
@@ -189,4 +190,64 @@ fn register_bundle_self_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
     };
     engine.register_handler(COMMAND_BUNDLE_SELF_GET, make(state.clone()));
     engine.register_handler(COMMAND_PRESET_SELF_GET, make(state.clone()));
+}
+
+/// `bundle.export` — Armory Bundle Format (ABF) exporter, Phase 1 of
+/// docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md /
+/// https://docs.agentmux.ai/abf/. Window-scoped (no `check_s1`) like the
+/// rest of `bundle.*` — bundles aren't agent-specific. Reads the bundle
+/// from `id_store` and resolves its referenced skill ids against `wstore`
+/// (skills live in a different Store instance than bundles — see
+/// `Store::skill_get` callers elsewhere in this codebase), then hands both
+/// to the pure `bundle_export::export_bundle`. `format: "zip"` returns a
+/// base64-encoded archive; anything else (including omitted) returns the
+/// raw file list for the caller to write out itself.
+fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let id_store = state.id_store.clone();
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_BUNDLE_EXPORT,
+        Box::new(move |data, _ctx| {
+            let id_store = id_store.clone();
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                #[derive(serde::Deserialize, Default)]
+                struct Req {
+                    id: String,
+                    #[serde(default)]
+                    format: String,
+                }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("bundle.export: {e}"))?;
+
+                let bundle = id_store
+                    .bundle_memory_get(&req.id)
+                    .map_err(|e| format!("bundle.export: {e}"))?
+                    .ok_or_else(|| format!("bundle.export: no bundle with id {}", req.id))?;
+
+                let skill_ids: Vec<String> =
+                    serde_json::from_str(&bundle.skills).unwrap_or_default();
+                let skills: Vec<crate::backend::storage::Skill> = skill_ids
+                    .iter()
+                    .filter_map(|id| wstore.skill_get(id).ok().flatten())
+                    .collect();
+
+                let export = crate::backend::bundle_export::export_bundle(&bundle, &skills);
+
+                if req.format == "zip" {
+                    let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
+                        .map_err(|e| format!("bundle.export: {e}"))?;
+                    use base64::Engine as _;
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&zip_bytes);
+                    return Ok(Some(json!({
+                        "root_slug": export.root_slug,
+                        "skipped_skills": export.skipped_skills,
+                        "zip_base64": encoded,
+                    })));
+                }
+
+                Ok(Some(serde_json::to_value(&export).map_err(|e| e.to_string())?))
+            })
+        }),
+    );
 }

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -225,8 +225,18 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("bundle.export: {e}"))?
                     .ok_or_else(|| format!("bundle.export: no bundle with id {}", req.id))?;
 
-                let skill_ids: Vec<String> =
-                    serde_json::from_str(&bundle.skills).unwrap_or_default();
+                // Same silent-data-loss pattern already fixed for
+                // context_files/mcp_servers in bundle_export.rs -- a
+                // malformed bundle.skills value must warn, not just
+                // vanish, but a genuinely blank one is not an error
+                // (reagent P1, PR #2333). Shares the same helper so all
+                // three fields behave identically.
+                let mut handler_warnings: Vec<String> = Vec::new();
+                let skill_ids: Vec<String> = crate::backend::bundle_export::parse_json_field_or_warn(
+                    &bundle.skills,
+                    "skills",
+                    &mut handler_warnings,
+                );
                 // Distinguish a genuine DB error from a legitimately deleted
                 // skill id: `.ok().flatten()` previously collapsed both to
                 // "absent", so a locked/damaged store silently reported a
@@ -249,6 +259,9 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 let export = crate::backend::bundle_export::export_bundle(&bundle, &skills);
 
+                let mut all_warnings = export.warnings.clone();
+                all_warnings.append(&mut handler_warnings);
+
                 if req.format == "zip" {
                     let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
                         .map_err(|e| format!("bundle.export: {e}"))?;
@@ -257,7 +270,7 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     return Ok(Some(json!({
                         "root_slug": export.root_slug,
                         "skipped_skills": export.skipped_skills,
-                        "warnings": export.warnings,
+                        "warnings": all_warnings,
                         "missing_skill_ids": missing_skill_ids,
                         "zip_base64": encoded,
                     })));
@@ -266,6 +279,7 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let mut result = serde_json::to_value(&export).map_err(|e| e.to_string())?;
                 if let Some(obj) = result.as_object_mut() {
                     obj.insert("missing_skill_ids".to_string(), json!(missing_skill_ids));
+                    obj.insert("warnings".to_string(), json!(all_warnings));
                 }
                 Ok(Some(result))
             })

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -227,10 +227,25 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 let skill_ids: Vec<String> =
                     serde_json::from_str(&bundle.skills).unwrap_or_default();
-                let skills: Vec<crate::backend::storage::Skill> = skill_ids
-                    .iter()
-                    .filter_map(|id| wstore.skill_get(id).ok().flatten())
-                    .collect();
+                // Distinguish a genuine DB error from a legitimately deleted
+                // skill id: `.ok().flatten()` previously collapsed both to
+                // "absent", so a locked/damaged store silently reported a
+                // successful export missing content instead of failing loudly
+                // -- unsafe for the advertised backup use case (Codex P2, PR
+                // #2325). A lookup error now fails the whole export; a
+                // missing row (Ok(None), i.e. actually deleted) is skipped
+                // and reported back in `missing_skill_ids`.
+                let mut skills: Vec<crate::backend::storage::Skill> = Vec::new();
+                let mut missing_skill_ids: Vec<String> = Vec::new();
+                for id in &skill_ids {
+                    match wstore.skill_get(id) {
+                        Ok(Some(skill)) => skills.push(skill),
+                        Ok(None) => missing_skill_ids.push(id.clone()),
+                        Err(e) => {
+                            return Err(format!("bundle.export: failed to look up skill {id}: {e}"));
+                        }
+                    }
+                }
 
                 let export = crate::backend::bundle_export::export_bundle(&bundle, &skills);
 
@@ -242,11 +257,16 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     return Ok(Some(json!({
                         "root_slug": export.root_slug,
                         "skipped_skills": export.skipped_skills,
+                        "missing_skill_ids": missing_skill_ids,
                         "zip_base64": encoded,
                     })));
                 }
 
-                Ok(Some(serde_json::to_value(&export).map_err(|e| e.to_string())?))
+                let mut result = serde_json::to_value(&export).map_err(|e| e.to_string())?;
+                if let Some(obj) = result.as_object_mut() {
+                    obj.insert("missing_skill_ids".to_string(), json!(missing_skill_ids));
+                }
+                Ok(Some(result))
             })
         }),
     );

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -257,6 +257,7 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     return Ok(Some(json!({
                         "root_slug": export.root_slug,
                         "skipped_skills": export.skipped_skills,
+                        "warnings": export.warnings,
                         "missing_skill_ids": missing_skill_ids,
                         "zip_base64": encoded,
                     })));

--- a/docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md
+++ b/docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md
@@ -529,7 +529,7 @@ my-bundle/
 
 ```jsonc
 {
-  "$schema": "https://agentmux.ai/schemas/armory-bundle/v0.1/bundle.schema.json",
+  "$schema": "https://docs.agentmux.ai/schemas/armory-bundle/v0.1/bundle.schema.json",
   "name": "acme-backend-dev",            // reverse-DNS optional for registry use
   "version": "1.2.0",                    // semver; immutable once published
   "description": "Backend dev bundle: repo conventions, GH tooling, deploy skills",

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -293,6 +293,7 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "agent.status",
     "agent.stop",
     "bundle.delete",
+    "bundle.export",
     "bundle.get",
     "bundle.list",
     "bundle.self.get",


### PR DESCRIPTION
## Summary
Re-opens #2325, which GitHub auto-closed when its base branch
(`agentx/abf-phase0-agent-skills-format`) was deleted after Phase 0 (#2322)
merged. Same branch (`agentx/abf-phase1-exporter`), rebased cleanly onto
`main` (no conflicts — Phase 0's content is already there via #2322's squash
merge). No code changes beyond the rebase itself.

Implements **Phase 1** of the rollout plan in
`docs/specs/REPORT_ARMORY_BUNDLE_STANDARD_RESEARCH_2026_07_16.md`: serialize
a bundle + its referenced skills/MCP servers into the ABF v0.1 on-disk
layout via a new `bundle.export` RPC.

## Review history carried over from #2325
Both reagent and Codex review rounds already ran on this branch and their
findings were fixed:
- **Security**: `env`/`headers` secret values are redacted (`${VAR_NAME}`
  placeholder) before writing `mcp/*.server.json`.
- Manifest references the skill's directory (`skills/<slug>`), not the
  `SKILL.md` file, per the ABF spec's own example.
- Skill-lookup DB errors now fail the export loudly instead of being
  swallowed; genuinely-deleted skills are reported via `missing_skill_ids`.
- `bundle.export` registered in the RPC contract test's known-undeclared
  list.
- `accounts/requirements.json` now infers from `headers` as well as `env`,
  so header-only-authenticated servers get a matching requirement entry.
- Deliberately NOT attempted: converting the exported MCP config to the
  official MCP registry `server.json` schema — needs fields (registry type,
  package identifier) this data doesn't have for an arbitrary stdio
  command; documented as an accepted Phase 2 follow-up in the code.

## Not yet addressed (reagent's most recent pass, reviewed against an
## intermediate commit before the headers fix above — re-checking after
## this push)
- Malformed `context_files`/`mcp_servers` JSON silently becomes an empty
  component via `unwrap_or_default()`, no error surfaced.
- Manifest `$schema` host mismatch (`docs.agentmux.ai` vs spec's
  `agentmux.ai`).
- Context-file entries whose sanitized paths normalize to the same value
  aren't collision-detected before being pushed into `files`.

## Test plan
- [x] `cargo test -p agentmux-srv`: 1711 passed on the rebased branch.
- [x] `cargo build -p agentmux-srv` clean.
- [ ] Manual: call `bundle.export` for a real bundle with skills + MCP
      servers bound, inspect the returned file list / decoded zip.

<!-- agentmux:agent_id=agentx -->