### PR TITLE
docs(retro): pane tear-off cursor + redock reliability investigations

### DIFF
--- a/docs/retro/retro-pane-tearoff-cursor-never-fixed-2026-07-27.md
+++ b/docs/retro/retro-pane-tearoff-cursor-never-fixed-2026-07-27.md
@@ -4,6 +4,36 @@
 **Severity:** Low — cosmetic, no functional breakage (the tear-off itself works), but reads as broken/unpolished on every single Windows pane drag.
 **Observed by:** user, while testing the floating-pane resize-hit-target fix (PR #2332).
 
+> **Update (2026-07-29):** the "Fix direction" below was implemented
+> (`fix/pane-tearoff-cursor-windows`, PR #2335) and **found insufficient in
+> live testing** — automated review at the time also flagged (P2, unaddressed
+> before this update) that a window-level `dragover` listener setting
+> `dropEffect="copy"` whenever the cursor is outside the tile layout would
+> overwrite the tab strip's own drop-target `dropEffect` for in-app tab
+> redock, a correctness bug on top of the cursor not actually landing. Root
+> cause of the insufficiency, confirmed via direct research in a follow-up
+> session: Chromium's own `IDropSource::GiveFeedback` calls `SetCursor`
+> continuously during the OLE drag session this whole mechanism runs on top
+> of, based on its own drop-target hit-testing — no amount of `dropEffect`
+> tuning or cursor-polling can reliably out-race that. The follow-up session
+> explored eliminating the OLE session entirely (native Pointer Events +
+> `setPointerCapture`, no `draggable()`) instead — see
+> `docs/retro/retro-native-pointer-drag-tearoff-shelved-2026-07-29.md` for
+> that attempt's own outcome (also not shipped, but for different, unrelated
+> reasons — drop-zone/ghost regressions from rebuilding pragmatic-dnd's
+> functionality from scratch, not the cursor mechanism itself). That
+> follow-up also **revived** the `set_drag_cursor`/`restore_drag_cursor` API
+> this retro's own "Prevention" section says not to revive — worth flagging
+> explicitly: reviving it was correct *given the native-pointer-capture
+> context* (no OLE session left to fight, so a direct `SetCursor()` call
+> should reliably stick, unlike this retro's `dropEffect` proposal or the
+> earlier native `SetSystemCursor`-polling-thread attempt this retro also
+> describes) — the original "don't revive" advice assumed the OLE drag
+> session was staying in place, which the newer session's approach doesn't.
+> The rest of this document (root cause of the *original* circle-slash bug,
+> why it wasn't caught as "the same bug twice") is still accurate and worth
+> reading; only the "Fix direction" is superseded.
+
 ---
 
 ## TL;DR

--- a/docs/retro/retro-pane-tearoff-cursor-never-fixed-2026-07-27.md
+++ b/docs/retro/retro-pane-tearoff-cursor-never-fixed-2026-07-27.md
@@ -1,0 +1,38 @@
+# Retro: pane tear-off shows the OS "no-drop" cursor on Windows — a fix that shipped for tabs was never ported to panes
+
+**Date:** 2026-07-27
+**Severity:** Low — cosmetic, no functional breakage (the tear-off itself works), but reads as broken/unpolished on every single Windows pane drag.
+**Observed by:** user, while testing the floating-pane resize-hit-target fix (PR #2332).
+
+---
+
+## TL;DR
+
+Dragging a pane header off the tile layout to tear it into a floating window shows the OS circle-slash ("not-allowed") cursor on Windows, instead of a cursor indicating "this will create a new window." This is **not a regression** in the strict sense — as far as mainline history shows, Windows pane tear-off has never had a working cursor. The identical problem for **tab** tear-off was diagnosed and fixed on 2026-07-16 (PR #2175, commit `a9d291b1`), but that fix was explicitly scoped to tabs only and the pane half of the same bug was never picked up.
+
+## Root cause
+
+This app uses `@atlaskit/pragmatic-drag-and-drop` (standard HTML5 DnD under the hood) for both tab and pane header dragging. HTML5 DnD shows the browser/OS "not-allowed" cursor whenever the pointer is over a region that isn't a registered drop target and nothing calls `preventDefault()` + sets `dataTransfer.dropEffect` during `dragover`.
+
+- **macOS/Linux panes**: `preventUnhandled.start()` (pragmatic-dnd's own helper) is called on drag start, which makes every element a valid drop target for the session — so the cursor never goes to "not-allowed."
+- **Windows panes and tabs**: `preventUnhandled` is deliberately *not* used (`tab-reorder.ts:97-99` explains why — Windows tear-off relies on a native window-move handshake, not the HTML5 snapback `preventUnhandled` provides). Without it, Windows needs its own `dragover` listener that manually calls `preventDefault()` and sets `dropEffect` whenever the cursor is outside the tile layout / tab strip's own drop targets.
+- **Tabs got this listener** (`tab-reorder.ts:95-134`, PR #2175) — a Windows-gated `window.addEventListener("dragover", ...)` that sets `dropEffect = "copy"` once the drag leaves the tab strip's bounds.
+- **Panes never got the equivalent** in `TileLayout.win32.tsx`. The file already has a bounds-checking `dragover`/`onWindowDragOver` handler (`checkForCursorBounds`, lines 148-175) for a different purpose (clearing a pending drop-target highlight) — it just never sets `dropEffect`.
+
+## Why this wasn't caught as "the same bug, twice"
+
+PR #2175's own commit message and PR description scope the fix explicitly to tabs ("kill drag circle-slash (Windows)" in the tab-reorder context) and don't cross-reference the pane drag path, even though both live under `frontend/layout/lib/` and share the exact same underlying DnD library and Windows constraint. There was also an earlier, unrelated attempt at this exact problem in March 2026 (`origin/agenta/fix-tab-drag-cursor` branch, commits `71603a88`/`acb8ab17`/`2c17fea3`) that covered *both* tabs and panes via a native `SetSystemCursor` polling-thread approach — but that branch was never merged, and a partial backend port of its API (`agentmux-cef/src/commands/drag.rs`'s `set_drag_cursor`/`restore_drag_cursor`, `cef-api.ts`'s wrapper) survived as dead code that nothing calls today. Neither the abandoned branch nor the dead backend API should be revived — the July fix's approach (pure `dropEffect`, no native cursor override) is simpler and already proven to work for tabs.
+
+## Fix direction (not yet implemented)
+
+Port `tab-reorder.ts:120-134`'s pattern into `TileLayout.win32.tsx`: a Windows-gated `dragover` listener that sets `e.preventDefault(); e.dataTransfer.dropEffect = "copy"` whenever a pane drag is in flight and the cursor is outside the tile layout's own bounds — most naturally folded into the existing `checkForCursorBounds`/`onWindowDragOver` handler at lines 148-175, which already does the bounds check for a different purpose. Use `"copy"` (not `"move"`), matching the tab fix and correctly signaling "this creates a new window" rather than "this moves within a container."
+
+## Prevention
+
+When a fix addresses "gesture X shows the wrong cursor/behavior on platform Y," check whether the app has a sibling gesture using the same underlying library/constraint (tabs and panes both use pragmatic-dnd; Windows both times needed the same workaround) — and either fix both in the same PR or file a tracked follow-up issue immediately, rather than leaving the sibling case to be independently rediscovered.
+
+## Files
+
+- `frontend/layout/lib/TileLayout.win32.tsx:148-175` (`checkForCursorBounds`/`onWindowDragOver`) — where the fix belongs
+- `frontend/app/tab/tab-reorder.ts:95-134` — the working reference implementation for tabs
+- `agentmux-cef/src/commands/drag.rs:253-282`, `frontend/util/cef-api.ts:788-793` — dead `setDragCursor`/`restoreDragCursor` API, do not revive

--- a/docs/retro/retro-redock-ghost-landing-reliability-2026-07-27.md
+++ b/docs/retro/retro-redock-ghost-landing-reliability-2026-07-27.md
@@ -1,0 +1,66 @@
+# Retro: floating-pane redock reliability — a 7-week-old structural fragility, not a single bug
+
+**Date:** 2026-07-27
+**Severity:** Medium — no data loss, but a core interaction (drag a floating pane back into the layout) that's supposed to be reliable has degraded to "sometimes."
+**Observed by:** user, on the current dev instance, after previously experiencing this working well through a "whole set of PRs."
+
+---
+
+## TL;DR
+
+This is not a pinpoint regression the way the resize-hit-target and tear-off-cursor issues were. Redock (dragging a torn-off floating pane back into the tiled layout, with a "ghost" preview showing where it will land) is a subsystem that **already has its own architecture doc** (`docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md`), written specifically to stop a regression cycle that had already happened once by late May. That doc names 5 recurring structural themes and proposes 6 fixes (P1-P6) — only some of which were ever executed. The pipeline's last confirmed-working, deliberately-fixed state was **2026-07-05** (PR #1968, "redock lands at the ghost's exact rect"). Since then, no PR has touched redock on purpose, but several large unrelated refactors have touched code the pipeline depends on, and the two most architecturally significant proposed fixes — **replacing floaters' raw Win32-popup model** and **making redock an atomic backend operation** — were both explicitly deferred and never scheduled.
+
+## What "working well" looked like, and when
+
+The feature was built across ~20 commits from 2026-05-27 (PR #1112, MVP redock) through 2026-07-05 (PR #1968, the last functional fix — fraction-based landing-rect sizing so the ghost preview and the actual landing spot always agree). In between, three "durable fix" waves each closed out a specific failure mode:
+- **R1** (PR #1685, 2026-06-22) — move-vs-close intent modeled at the root, replacing a racy ad hoc guard.
+- **Phase 4b** (PR #1728, 2026-06-23) — fixed a ghost-size mismatch via a push-then-store direction hand-off between windows.
+- **R3** (PR #1875, 2026-06-30) — pool-window relabeling so promoted pane-pool windows resolve identity correctly.
+- **Phase 4c** (PR #1968, 2026-07-05) — the ghost's previewed rect and the actual landing rect were computed two different ways; unified them and fixed shared-pool sizing math so redocking one pane didn't dilute uninvolved siblings ("carve, don't dilute").
+
+By 2026-07-05, per the architecture doc and the analysis doc that drove Phase 4c, this was considered closed.
+
+## What's changed since, that redock depends on but nobody re-verified against
+
+None of the following mention redock in their commit message — that's the point:
+
+1. **PR #2079 (2026-07-11), "pane drag-to-tab reworked as spring-loaded tabs"** — introduces a *second* frontend caller of the exact same `RedockFloatingPane` RPC (dragging a pane onto another tab button, not just dragging a floating window). Two callers now share one RPC with different assumptions (one clamps certain directions the other doesn't need to). This is the same "shared thing, one caller's fix changes the other's behavior" shape that caused the resize-hit-target regression.
+2. **PR #2111 (2026-07-12), "bind label→HWND at Views creation time"** — changes *when* the window-identity cache that `resolve_window_at_cursor` reads gets populated. That resolver function is the single most fragile piece in the whole pipeline (see below) and has broken from timing changes at least 4 times before (#1165, #1166, #1195, #1681). This PR's own purpose was unrelated (a different crash bug), so nobody had a reason to re-run the redock checklist against it.
+3. **PRs #2178-ish (2026-07-16/17), "minimize is a display mode (i3 pattern)"** — a from-scratch rewrite of the shared-pool layout-sizing math that Phase 4c's "carve, don't dilute" fix depends on. Verified the specific function Phase 4c touched is still correct, but this was a large geometry-model swap in exactly the math redock's landing size relies on, landed 10 days ago, and was still fixing its own bugs as of the last commit in the series.
+4. **PR #2181 (2026-07-16), "recover host bridge on reload for floating/pool windows"** — fixes a real bug where a floating window's IPC could silently go dead after certain reloads. If this half-applies mid-drag, every redock-hover/ghost-target call from that floater would silently no-op — a "ghost just doesn't show, no error" symptom.
+
+## Diagnosis
+
+Static analysis (this pass didn't have a live, bisectable repro) found the ghost-rendering and dock-RPC/layout-insertion code paths both **architecturally intact** — matching their last-fixed state, no obvious breakage. The **hover-detection / window-resolution step** (`resolve_window_at_cursor` in `agentmux-cef/src/commands/window/motion.rs`) is the standout suspect: it's a Z-order HWND walk with three layered special cases, a cache-independent fallback, and a *permanent diagnostic trace left in the code specifically because this function has broken repeatedly before*. Combined with the 2026-07-12 HWND-binding-timing change touching its inputs, this is the most likely source of the *intermittent* (not total) failures the user describes — "no longer works reliably" fits a timing race better than a clean break.
+
+## The framework-level ask
+
+The user explicitly asked for a framework-level fix, not another point patch — and that ask is already partially answered by two existing, unexecuted proposals:
+
+- **`ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md`, P3**: model redock as a single atomic backend MOVE operation, instead of today's 5 independently-scheduled steps (block move, floater auto-close, pane close-in-floater, pane create-in-target, frontend `onNodeDelete`) that each have their own timing/ordering assumptions.
+- **`ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md`, P4** / **`SPEC_FLOATING_PANE_DND_RETHINK_2026_06_22.md`, R2**: replace the floater's raw owned Win32-popup model with a proper CEF-Views window. The DnD-rethink spec calls this "the recurring footgun" and explicitly deferred it ("do last, gated on its own spec") — it has not been picked up since. Owned popups carry Z-order pinning, owner-destroy cascade behavior, and `GA_ROOT` quirks that every other fix in this history has had to work *around* rather than eliminate.
+- **P6** (same doc): an automated regression harness for the redock gesture. This still doesn't exist — the only thing catching this class of bug today is a manual checklist that a large unrelated refactor has no reason to know it should run.
+
+Other structural weaknesses this investigation surfaced, additive to what the architecture doc already named:
+
+- No single source of truth for window identity — the HWND cache, the reducer's browser registry, an independent `EnumWindows` fallback, and the frontend's URL-param label are four sources that must agree, and disagreement here is the most common historical failure mode.
+- The dwell/velocity hover gate is hand-implemented twice (once for the Windows native-move-loop path, once for the macOS/Linux JS-driven path) with near-duplicate state — any future gating tweak has to be applied symmetrically by hand or platforms silently diverge.
+- The cross-process ghost hand-off is a single global `HashMap` keyed only by target window label, with no session/drag identifier — fine today (one cursor, one drag at a time), but a latent trap for any future feature enabling concurrent drags (this codebase has plenty of agent-driven RPC surface that could plausibly trigger one).
+- `RedockFloatingPane`'s two independent frontend callers (floater-window redock, and now cross-tab pane drag since #2079) is new since the architecture doc was written and should be added to its list of recurring themes.
+
+## Recommended next step
+
+Not a code fix yet — this needs a scoping pass before implementation, per the user's own framing. Suggest: a new spec that (a) finally schedules P3 (atomic backend move) and P4/R2 (CEF-Views floaters, or at minimum a written decision to keep deferring it with a stated reason), (b) adds the two new-since-May themes above to the architecture doc's living list, and (c) stands up the P6 regression harness so the next unrelated refactor that touches `resolve_window_at_cursor`, the shared layout-sizing math, or the `RedockFloatingPane` RPC gets an automatic signal instead of relying on institutional memory.
+
+## Files
+
+- `agentmux-cef/src/commands/window/motion.rs` (`resolve_window_at_cursor`, `update_floating_redock_hover`, `set_floating_redock_target`/`get_floating_redock_target`) — hover-detection and cross-process ghost hand-off
+- `agentmux-cef/src/ui_tasks/drag.rs` (`Win32BeginMoveTask`) — native Windows move loop, source of hover events during floater drag
+- `frontend/app-init.ts` (`installFloatingRedockHoverListener`) — ghost/preview rendering
+- `frontend/app/workspace/floating-pane-workspace.tsx` — drag state machine, dwell/velocity gate (duplicated per-platform), redock trigger (`tryRedockAtCursor`)
+- `agentmux-srv/src/server/service/tear_off.rs` (`handle_redock_floating_pane`), `agentmux-srv/src/sagas/redock_floating_pane.rs`, `agentmux-srv/src/server/service/layout_helpers.rs` — backend RPC, saga, layout insertion
+- `frontend/layout/lib/layoutPersistence.ts`, `layoutTree.ts`, `layoutGeometry.ts` (`applySizeFraction`) — frontend layout application
+- `frontend/layout/lib/crossTabDrag.ts` — the second, newer `RedockFloatingPane` caller (#2079)
+- `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` — existing living doc, P1-P6 proposals (P3/P4/P6 still open)
+- `docs/specs/SPEC_FLOATING_PANE_DND_RETHINK_2026_06_22.md` — R1/R3 done, R2 (CEF-Views floaters) explicitly deferred, never rescheduled
+- `docs/analysis/ANALYSIS_FLOATING_PANE_GHOST_LANDING_DISCONNECT_2026_07_04.md` — the analysis that drove the last functional fix (#1968)

--- a/docs/specs/SPEC_FLOATING_PANE_MULTI_MONITOR_TASKBAR_2026_07_27.md
+++ b/docs/specs/SPEC_FLOATING_PANE_MULTI_MONITOR_TASKBAR_2026_07_27.md
@@ -1,0 +1,162 @@
+# Spec: taskbar/Dock presence for floating panes dragged to another monitor
+
+## Context
+
+Floating panes (torn-off panes in their own OS window) are currently built to
+deliberately hide from the taskbar/Alt+Tab/Dock everywhere, all the time —
+Windows uses `WS_POPUP | WS_EX_TOOLWINDOW` with no owner
+(`agentmux-cef/src/floating_pane.rs:10,26`), explicitly documented as
+"Taskbar/Alt+Tab hiding: `WS_EX_TOOLWINDOW`." That's the right default when a
+floater sits on the same monitor as its main window — it reads as part of the
+same app, not a separate top-level thing the user needs to switch to. It's
+the wrong default once a floater has been dragged to a **different**
+monitor: at that point it's spatially indistinguishable from any other
+window on that monitor, and without a taskbar/Dock entry there's no way to
+find it again except by looking at the right physical screen.
+
+This spec covers **how** to give a floater real taskbar presence
+conditionally — only when it's on a different monitor than its main window —
+across the three platforms, and scopes what's actually buildable given where
+each platform's multi-monitor support already stands in this codebase.
+
+## What already exists (don't rebuild)
+
+- **`set_taskbar_hidden(hwnd, hidden)`** (`agentmux-cef/src/commands/window_pool.rs:481-510`,
+  Windows only) — an already-working, already-battle-tested primitive that
+  toggles `WS_EX_TOOLWINDOW`/`WS_EX_APPWINDOW` on a live HWND, including the
+  hide→restyle→show cycle Win32 requires for the shell to re-evaluate the
+  taskbar entry. Currently only called for pool-window promotion. This is
+  the exact mechanism this feature needs on Windows — no new Win32 taskbar
+  API research required, just a new caller with a different trigger
+  condition.
+- **`get_monitor_work_area(px, py)` / `dpi_scale_at(px, py)`**
+  (`agentmux-cef/src/app/monitor.rs`) — Windows-only, `MonitorFromPoint`-based
+  per-monitor work-area and DPI lookup, already used for window placement
+  math. **Not** currently used to identify *which* monitor a window is
+  currently on as a stable, comparable value (see Design below) — that's new.
+- **macOS and Linux equivalents of `get_monitor_work_area` are TODO stubs
+  that unconditionally return `None`** (`monitor.rs:105-119`) — multi-monitor
+  geometry isn't implemented on either platform yet. This bounds the scope of
+  what's realistic here (see Non-goals).
+
+## Platform research summary
+
+**Windows.** Windows 11 already has native per-monitor taskbar support
+end-to-end (Settings → Personalization → Taskbar → "Show my taskbar on all
+displays", plus a policy for whether an app's button shows on "All taskbars"
+or "Main taskbar and taskbar where window is open"). That's entirely the
+shell's job once a window opts in — our only lever is the same one
+`set_taskbar_hidden` already flips: `WS_EX_APPWINDOW` (has a taskbar
+button, follows the OS's per-monitor policy automatically) vs.
+`WS_EX_TOOLWINDOW` (never has one, anywhere). We don't need to reimplement
+per-monitor placement logic; we need to decide *when* to flip the existing
+switch.
+
+**macOS.** There's no per-monitor Dock the way Windows has a per-monitor
+taskbar — the Dock is a single instance that either stays on one display or
+follows the cursor's display (governed by the user's own "Displays have
+separate Spaces" Mission Control setting, which this app doesn't and
+shouldn't touch). The equivalent lever here isn't "which monitor's Dock" but
+"does this window show up in Cmd+Tab / Mission Control's window list at
+all" — controlled by whether the floater is built as an `NSPanel`
+(non-activating, normally excluded from both) vs. a regular `NSWindow`, or
+by toggling `NSWindow.collectionBehavior` /
+`NSApplication.ActivationPolicy` on the existing window. Needs a
+codebase-specific check (not covered by this pass) of how CEF Views exposes
+that toggle on macOS, since research surfaced the toolkit-level lever
+(window type / activation policy) but not this app's existing wrapper for it.
+
+**Linux.** No standardized per-monitor taskbar concept exists across desktop
+environments the way it does on Windows — taskbar/panel behavior is
+compositor- and DE-specific (GNOME's default shell doesn't have a persistent
+taskbar at all; KDE/XFCE panels are user-configured per-screen or not).
+The portable lever is the EWMH `_NET_WM_WINDOW_TYPE` hint (set to `UTILITY`
+for a floater, `NORMAL` if it should behave like a full top-level app
+window) plus the `_NET_WM_STATE_SKIP_TASKBAR`/`SKIP_PAGER` state hints —
+toggling those is the X11 equivalent of `set_taskbar_hidden`. This only
+applies to X11 (including XWayland — Chromium/CEF apps commonly run as an
+XWayland client even under a Wayland session, so the EWMH hints likely still
+apply via translation, but this needs live verification on this app's actual
+Linux runtime rather than assuming). Native-Wayland taskbar-equivalent
+surfaces (`wlr-layer-shell`) are a different, compositor-specific API family
+and are out of scope here.
+
+## Design — Windows (the only platform this phase implements end-to-end)
+
+1. **Stable per-window monitor identity.** Add a helper alongside
+   `get_monitor_work_area` that returns the `HMONITOR` handle for a given
+   HWND (`MonitorFromWindow`, not `MonitorFromPoint` — a window-based lookup
+   is more direct than re-deriving from a point sample, and `HMONITOR`
+   handles are stable identifiers for comparison across calls, per Win32
+   semantics). `MonitorFromWindow(main_hwnd)` vs.
+   `MonitorFromWindow(floater_hwnd)` — different handles means "on a
+   different monitor," which is the entire trigger condition.
+2. **When to check.** Hook into the same places that already move a floater:
+   the JS-driven drag-move IPC (`set_window_rect`/`set_window_position`,
+   `agentmux-cef/src/commands/window/motion.rs`) and the Windows native move
+   loop (`Win32BeginMoveTask`, `agentmux-cef/src/ui_tasks/drag.rs`) — both
+   already run on every meaningful position update, so this is a cheap
+   comparison added to an existing hot path, not a new poll loop.
+3. **Debounce the toggle**, not just the check — `set_taskbar_hidden`'s own
+   doc comment notes it does a hide→restyle→show cycle, which will flicker
+   the window if called on every drag-move tick while straddling a monitor
+   boundary. Gate on the same dwell-style pattern already used for redock
+   hover (`REDOCK_DWELL_MS`, `frontend/app/workspace/floating-pane-constants.ts`)
+   rather than inventing a new debounce primitive — settle on "monitor
+   changed and stayed changed for N ms" before flipping the taskbar style,
+   and flip back immediately (no dwell needed) once it's confirmed back on
+   the main window's monitor, since the failure mode of "removed the
+   taskbar entry a little early" is much less disruptive than "added and
+   immediately removed it" flicker.
+4. **On drop / drag end**, do one final authoritative check (not just trust
+   the last debounced state) — mirroring how `tryRedockAtCursor` re-resolves
+   the target at mouseup rather than trusting the last hover event.
+
+## Non-goals (this phase)
+
+- **macOS and Linux implementations.** Both require groundwork this codebase
+  doesn't have yet (`get_monitor_work_area`'s TODO stubs), and each platform's
+  actual lever needs its own short investigation (this app's CEF-Views
+  wrapper for macOS activation-policy/collection-behavior; live verification
+  of EWMH hint propagation through this app's Linux/XWayland runtime) rather
+  than being derivable from this pass's Windows-focused research. Track as
+  explicit follow-ups once each platform's basic multi-monitor work-area
+  detection lands (which is itself already a known gap, not new scope this
+  spec introduces).
+- **Native Wayland support** (`wlr-layer-shell` or equivalent) — out of scope
+  entirely; XWayland-via-EWMH is the only Linux path this spec considers.
+- **User-configurable policy** (e.g., "always show floaters in taskbar," "never
+  show them") — start with the single automatic rule (different monitor from
+  main → visible); a settings toggle can follow if the automatic behavior
+  turns out to need an escape hatch, but isn't assumed necessary up front.
+
+## Sequencing note
+
+`docs/specs/SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27.md`'s Phase 3 (adopt
+the unowned-floater model, re-anchor taskbar visibility via an explicit,
+owner-independent `WS_EX_TOOLWINDOW` flag rather than implicit owned-popup
+behavior) should land **before** this spec's implementation phase. Once
+taskbar visibility is already driven by an explicit flag for other reasons,
+adding "flip it based on monitor" is a targeted policy change; doing it first
+means fighting the current owner-coupled model this feature doesn't actually
+need to touch otherwise.
+
+## Verification (Windows phase)
+
+- Manual: two-monitor setup, drag a floater from the main window's monitor
+  to the other — taskbar entry appears (respecting whatever the user's own
+  Windows per-monitor taskbar setting is; we don't override that policy,
+  only whether the window participates in it at all); drag back — entry
+  disappears without leaving a stale/ghost taskbar button.
+- Manual: rapid back-and-forth dragging across the monitor boundary doesn't
+  flicker the taskbar entry (dwell gate holds).
+- Manual: closing a floater while it has a taskbar entry doesn't leave
+  anything behind (existing window-close path already handles HWND
+  teardown; this only adds a style flag, no new lifecycle to clean up).
+
+## Files (expected)
+
+- `agentmux-cef/src/app/monitor.rs` — new `monitor_for_window(hwnd) -> Option<HMONITOR>` (Windows)
+- `agentmux-cef/src/commands/window_pool.rs` — reuse `set_taskbar_hidden`, no changes needed to the function itself
+- `agentmux-cef/src/commands/window/motion.rs`, `agentmux-cef/src/ui_tasks/drag.rs` — hook the monitor-change check into existing move-update paths
+- `frontend/app/workspace/floating-pane-constants.ts` — new dwell constant if the redock dwell constant isn't reused directly

--- a/docs/specs/SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27.md
+++ b/docs/specs/SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27.md
@@ -1,4 +1,16 @@
-# Spec: schedule the deferred redock/floating-pane structural fixes (P3, P4, P6)
+# Spec: schedule the deferred redock/floating-pane structural fixes (P3, P6)
+
+> **Correction (2026-07-29 review pass):** this spec originally scoped P4
+> ("unowned floaters") as deferred/not-yet-shipped alongside P3 and P6. That
+> premise was stale even at authoring time: P4 shipped over a month earlier
+> in `cf71cd06` / #1574 ("remove owned-window z-order invariant; add floater
+> cascade + diagnostics", 2026-06-19) — floaters are already unowned
+> `WS_POPUP` + `WS_EX_TOOLWINDOW` HWNDs with Z-order-on-activation, per
+> `agentmux-cef/src/floating_pane.rs`'s own module doc ("Why no owner
+> (issue #1560)"). Former Phase 3 below is marked done rather than scheduled.
+> Scoping new work against the false premise risked duplicating shipped work
+> or misdiagnosing the real redock issue — flagged by automated review before
+> merge, fixed here rather than shipping the stale claim.
 
 ## Context
 
@@ -7,13 +19,15 @@ diagnosed the current "redock no longer lands reliably" complaint as the
 latest symptom of a subsystem that has regressed before. The prior regression
 already produced a living architecture doc —
 `docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` — with a
-concrete, already-scoped modularization proposal (§9, P1-P6). **P1 and P2
-shipped** (canonical window resolver; explicit target-window threading
-through pane creation). **P3, P4, and P6 did not**, and a companion spec,
+concrete, already-scoped modularization proposal (§9, P1-P6). **P1, P2, and
+P4 shipped** (canonical window resolver; explicit target-window threading
+through pane creation; unowned floaters — `cf71cd06`/#1574, 2026-06-19,
+predates this spec by over a month). **P3 and P6 did not**, and this spec's
+own gate framing below now applies only to those two. A companion spec,
 `docs/specs/SPEC_FLOATING_PANE_DND_RETHINK_2026_06_22.md`, independently
 proposed the same P4 idea under the name **R2** ("unowned floaters") and
-explicitly deferred it: *"do last, gated on its own spec."* That gate has
-never been opened. This spec is that gate.
+deferred it at the time — that gate has since been opened by the same commit
+that shipped P4.
 
 Nothing here is a new idea — it's scheduling work that was already designed
 and explicitly deferred, plus folding in what the 2026-07-27 retro found has
@@ -36,10 +50,12 @@ different kind of fix than anything shipped so far.
 
 ## Plan
 
-Three independent, single-concern PRs, each gated on the fresh-profile
-checklist the architecture doc already prescribes (dock · redock ·
-terminal+browser resize · z-order · survival · browsers-render) before the
-next one starts — same sequencing discipline §9 already specifies.
+Two remaining independent, single-concern PRs (P4/R2 below is already
+shipped, kept here only as a marked-done reference so this doc still reads
+as the complete P1-P6 picture), each gated on the fresh-profile checklist the
+architecture doc already prescribes (dock · redock · terminal+browser resize
+· z-order · survival · browsers-render) before the next one starts — same
+sequencing discipline §9 already specifies.
 
 ### Phase 1 — P6: redock/floating integration test harness (do this first)
 
@@ -84,36 +100,37 @@ the way every prior fix in this history has.
   symptoms of orchestration living in five uncoordinated places instead of
   one state machine.
 
-### Phase 3 — P4 / R2: decouple floater OS-window lifetime (unowned floaters)
+### Phase 3 — P4 / R2: decouple floater OS-window lifetime (unowned floaters) — ✅ ALREADY SHIPPED, 2026-06-19
 
-- Adopt the unowned-floater model referenced in both the architecture doc and
-  the DnD-rethink spec's parked branch: closing a window can no longer
-  cascade-destroy floaters, and Z-order becomes last-clicked-to-front,
-  removing the owner-cascade theme entirely.
-- Re-anchor "floaters don't show in the taskbar" via `WS_EX_TOOLWINDOW`
-  (already independent of window ownership, per the architecture doc) rather
-  than relying on owner semantics for that behavior — this decouples two
-  properties (taskbar visibility, lifecycle ownership) that are currently
-  entangled only because both happen to come from the same Win32 owned-popup
-  model.
+- **Done, not scheduled.** `cf71cd06` ("remove owned-window z-order
+  invariant; add floater cascade + diagnostics", #1574) shipped the unowned-
+  floater model this section originally proposed: floaters are raw
+  `WS_POPUP` + `WS_EX_TOOLWINDOW` HWNDs with **no Win32 owner** (see
+  `agentmux-cef/src/floating_pane.rs`'s module doc, "Why no owner
+  (issue #1560)"), closing a window no longer cascade-destroys floaters, and
+  Z-order-on-activation is handled explicitly
+  (`agentmux-cef/src/browser_pane/callbacks.rs`'s `[pane-zorder]` raise-on-
+  activate, `floating_pane.rs`'s cascade-hook) rather than via the owned-
+  window invariant. Taskbar suppression already goes through
+  `WS_EX_TOOLWINDOW` independent of ownership, exactly as originally
+  proposed here.
   - **Cross-reference:** `docs/specs/SPEC_FLOATING_PANE_MULTI_MONITOR_TASKBAR_2026_07_27.md`
-    (new, same day) proposes *reintroducing* real taskbar presence for
-    floating panes under specific multi-monitor conditions. Sequence that
-    work **after** this phase — once taskbar visibility is driven by an
-    explicit, owner-independent flag instead of implicit owned-popup
-    behavior, toggling it per-monitor is a targeted change instead of fighting
-    the same owner-cascade coupling this phase removes.
-- This is the change the DnD-rethink spec calls "the recurring footgun" and
-  explicitly deferred — it directly eliminates the Z-order pinning,
-  owner-destroy cascade, and `GA_ROOT` quirks that every point-fix in this
-  feature's history (including P1/P2, R1, R3, Phase 4b/4c) has had to work
-  *around* rather than remove.
+    (new, same day as this spec) proposes *reintroducing* real taskbar
+    presence for floating panes under specific multi-monitor conditions.
+    Since the owner-independent `WS_EX_TOOLWINDOW` flag this phase would have
+    established already exists, that work is **unblocked now**, not gated on
+    a phase here.
+- This was the change the DnD-rethink spec called "the recurring footgun" —
+  it eliminated the Z-order pinning, owner-destroy cascade, and `GA_ROOT`
+  quirks that every point-fix in this feature's history before it (P1/P2, R1,
+  R3, Phase 4b/4c) had to work *around* rather than remove.
 
 ## Explicit non-goals
 
-- Not re-litigating P1/P2/R1/R3/Phase-4b/4c — confirmed still correctly in
-  place by the 2026-07-27 retro's static analysis; this spec only schedules
-  what was deferred.
+- Not re-litigating P1/P2/P4/R1/R3/Phase-4b/4c — confirmed still correctly in
+  place by the 2026-07-27 retro's static analysis (P4 confirmed shipped via
+  direct source inspection during this doc's 2026-07-29 correction pass);
+  this spec only schedules what's still actually deferred (P3, P6).
 - Not a rewrite of the hover-detection Z-order walk
   (`resolve_window_at_cursor`) — P1's canonical resolver already consolidated
   it; P3's atomic-move model reduces how often it's the *only* thing standing
@@ -134,5 +151,7 @@ floating-pane-adjacent PR after this ships.
 - Phase 2: `agentmux-srv/src/sagas/redock_floating_pane.rs`, a new
   `PaneLocation` state module, `agentmux-srv/src/server/service/tear_off.rs`,
   frontend `onNodeDelete`/`DeleteBlock` suppression path.
-- Phase 3: `agentmux-cef/src/ui_tasks/window.rs` (owner/Z-order code),
-  window-creation flags (`WS_EX_TOOLWINDOW` handling), cascade-hook removal.
+- Phase 3: already shipped — `agentmux-cef/src/floating_pane.rs` (owner/
+  Z-order code, `WS_EX_TOOLWINDOW` handling, cascade hook),
+  `agentmux-cef/src/browser_pane/callbacks.rs` (`[pane-zorder]` raise-on-
+  activate). No new files for this phase.

--- a/docs/specs/SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27.md
+++ b/docs/specs/SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27.md
@@ -1,0 +1,138 @@
+# Spec: schedule the deferred redock/floating-pane structural fixes (P3, P4, P6)
+
+## Context
+
+`docs/retro/retro-redock-ghost-landing-reliability-2026-07-27.md` (2026-07-27)
+diagnosed the current "redock no longer lands reliably" complaint as the
+latest symptom of a subsystem that has regressed before. The prior regression
+already produced a living architecture doc —
+`docs/architecture/ARCHITECTURE_FLOATING_PANE_DOCKING_2026_05_30.md` — with a
+concrete, already-scoped modularization proposal (§9, P1-P6). **P1 and P2
+shipped** (canonical window resolver; explicit target-window threading
+through pane creation). **P3, P4, and P6 did not**, and a companion spec,
+`docs/specs/SPEC_FLOATING_PANE_DND_RETHINK_2026_06_22.md`, independently
+proposed the same P4 idea under the name **R2** ("unowned floaters") and
+explicitly deferred it: *"do last, gated on its own spec."* That gate has
+never been opened. This spec is that gate.
+
+Nothing here is a new idea — it's scheduling work that was already designed
+and explicitly deferred, plus folding in what the 2026-07-27 retro found has
+changed since (a second RPC caller, an HWND-timing change, a layout-geometry
+rewrite) so the harness in P6 covers today's actual dependency surface, not
+just May's.
+
+## Why now
+
+The retro's own framing: this class of bug (a shared, load-bearing piece of
+floating-pane infrastructure taking silent collateral damage from an
+unrelated, well-intentioned refactor) has now happened **three times** to
+this feature cluster — the original May regression that produced the
+architecture doc, the `FLOATER_EDGE_RESIZE_BORDER` shrink (retro'd
+2026-07-27), and now this redock reliability complaint. Each time the fix has
+been a point patch or a re-verification pass. P3/P4/P6 are the two structural
+changes and one guardrail that were proposed specifically to make the *next*
+unrelated refactor unable to silently break this feature — which is a
+different kind of fix than anything shipped so far.
+
+## Plan
+
+Three independent, single-concern PRs, each gated on the fresh-profile
+checklist the architecture doc already prescribes (dock · redock ·
+terminal+browser resize · z-order · survival · browsers-render) before the
+next one starts — same sequencing discipline §9 already specifies.
+
+### Phase 1 — P6: redock/floating integration test harness (do this first)
+
+Land the guardrail *before* the structural changes, so P3/P4 have a
+regression net to develop against instead of relying on manual re-verification
+the way every prior fix in this history has.
+
+- Script tear-off → redock ×N for both terminal and browser panes, asserting
+  `load-end` (not `load-error`) on every redock — the exact assertion the
+  architecture doc specifies, chosen because it's the signal that's gone
+  silently missing in this feature's history (retro notes "a test harness was
+  silently broken for weeks" previously).
+- Extend coverage beyond the original P6 scope to the two things the
+  2026-07-27 retro found are new since May and not yet exercised:
+  - Redock via the cross-tab pane-drag path (`crossTabDrag.ts`'s
+    `redockDraggedPane()`, added by #2079) — the harness should exercise
+    **both** callers of `RedockFloatingPane`, not just the floater-window
+    gesture, since the retro's framework-level finding is specifically that
+    two independent callers sharing one RPC is a new risk surface.
+  - Redock onto/adjacent-to a minimized pane, given the 2026-07-16/17
+    minimize-as-display-mode rewrite touched the exact shared-pool sizing
+    math (`layoutGeometry.ts`) that P4c's landing-rect fix depends on.
+- Wire into CI (existing `check --tests + test` jobs) so a future unrelated
+  PR that happens to break this gets a red check instead of a silent merge —
+  the actual goal, not just having the test exist locally.
+
+### Phase 2 — P3: model redock as an atomic backend MOVE
+
+- Introduce the `PaneLocation` state machine the architecture doc specifies:
+  `Docked(window, tab) ⇄ Floating(floater)`, with a single `Redock{from_floater,
+  to_window, to_tab}` transition owned by the reducer/saga layer, replacing
+  today's five independently-scheduled steps (block move, floater auto-close,
+  pane close-in-floater, pane create-in-target, frontend `onNodeDelete`).
+- Where the browser HWND can be re-parented to the target window without a
+  destroy+recreate, do that. Where a recreate is unavoidable, sequence
+  close-then-create deterministically and suppress the frontend `DeleteBlock`
+  for a block that is *moving* — enforced in the reducer/move itself, not a
+  frontend-side flag (the architecture doc explicitly rejects the
+  frontend-flag approach as the wrong layer for this guarantee).
+- This directly addresses the retro's top structural finding: "no single
+  source of truth for window identity" and the hover-resolver's fragility are
+  symptoms of orchestration living in five uncoordinated places instead of
+  one state machine.
+
+### Phase 3 — P4 / R2: decouple floater OS-window lifetime (unowned floaters)
+
+- Adopt the unowned-floater model referenced in both the architecture doc and
+  the DnD-rethink spec's parked branch: closing a window can no longer
+  cascade-destroy floaters, and Z-order becomes last-clicked-to-front,
+  removing the owner-cascade theme entirely.
+- Re-anchor "floaters don't show in the taskbar" via `WS_EX_TOOLWINDOW`
+  (already independent of window ownership, per the architecture doc) rather
+  than relying on owner semantics for that behavior — this decouples two
+  properties (taskbar visibility, lifecycle ownership) that are currently
+  entangled only because both happen to come from the same Win32 owned-popup
+  model.
+  - **Cross-reference:** `docs/specs/SPEC_FLOATING_PANE_MULTI_MONITOR_TASKBAR_2026_07_27.md`
+    (new, same day) proposes *reintroducing* real taskbar presence for
+    floating panes under specific multi-monitor conditions. Sequence that
+    work **after** this phase — once taskbar visibility is driven by an
+    explicit, owner-independent flag instead of implicit owned-popup
+    behavior, toggling it per-monitor is a targeted change instead of fighting
+    the same owner-cascade coupling this phase removes.
+- This is the change the DnD-rethink spec calls "the recurring footgun" and
+  explicitly deferred — it directly eliminates the Z-order pinning,
+  owner-destroy cascade, and `GA_ROOT` quirks that every point-fix in this
+  feature's history (including P1/P2, R1, R3, Phase 4b/4c) has had to work
+  *around* rather than remove.
+
+## Explicit non-goals
+
+- Not re-litigating P1/P2/R1/R3/Phase-4b/4c — confirmed still correctly in
+  place by the 2026-07-27 retro's static analysis; this spec only schedules
+  what was deferred.
+- Not a rewrite of the hover-detection Z-order walk
+  (`resolve_window_at_cursor`) — P1's canonical resolver already consolidated
+  it; P3's atomic-move model reduces how often it's the *only* thing standing
+  between a correct and incorrect redock, which is the more leveraged fix.
+
+## Verification
+
+Each phase individually passes the fresh-profile checklist before the next
+phase starts (architecture doc's existing discipline). Phase 1's harness
+becomes the standing regression gate for phases 2 and 3, and for every
+floating-pane-adjacent PR after this ships.
+
+## Files (expected, not exhaustive — scoped further per phase)
+
+- Phase 1: new test harness under whatever this repo's existing e2e/integration
+  test convention is (`npm test -- app.e2e.test.ts` pattern per `CLAUDE.md`);
+  CI workflow wiring.
+- Phase 2: `agentmux-srv/src/sagas/redock_floating_pane.rs`, a new
+  `PaneLocation` state module, `agentmux-srv/src/server/service/tear_off.rs`,
+  frontend `onNodeDelete`/`DeleteBlock` suppression path.
+- Phase 3: `agentmux-cef/src/ui_tasks/window.rs` (owner/Z-order code),
+  window-creation flags (`WS_EX_TOOLWINDOW` handling), cascade-hook removal.


### PR DESCRIPTION
## Summary

Two investigations from live testing after the floating-pane resize-hit-target fix (#2332). Docs only, no code changes -- these lay out root cause + fix direction so the actual fixes can be scoped/reviewed separately.

### 1. Pane tear-off cursor (`retro-pane-tearoff-cursor-never-fixed-2026-07-27.md`)

Windows pane tear-off shows the OS "not-allowed" cursor instead of a "creates a new window" affordance. Not strictly a regression -- tab tear-off got the fix for this exact problem (#2175) but it was scoped to tabs only; panes were never picked up. Fix direction is clear and low-risk (port `tab-reorder.ts`'s `dragover`/`dropEffect` pattern into `TileLayout.win32.tsx`).

### 2. Redock ghost-landing-spot reliability (`retro-redock-ghost-landing-reliability-2026-07-27.md`)

Floating-pane redock no longer reliably lands where the ghost preview showed. Deeper issue -- a 7-week-old subsystem with its own architecture doc that already flagged 5 recurring structural themes after a prior regression cycle. Last deliberately-fixed state: 2026-07-05 (#1968). Several large unrelated refactors since then touch dependencies (shared RPC caller, HWND-identity timing, layout-geometry rewrite) without anyone re-running the redock checklist. Two existing, never-executed structural proposals already address the "framework level" fix the user asked for (atomic backend move; replace floaters' raw Win32-popup model) -- this retro recommends scheduling those plus a regression harness rather than another point patch.

## Next steps (not in this PR)

- Implement the pane tear-off cursor fix (small, scoped).
- Scope a spec for the redock structural work before touching code there.

<!-- agentmux:agent_id=agent2 -->