### PR TITLE
fix(dnd): tab + pane tear-off show correct cursor, not circle-slash (Windows)

### DIFF
--- a/.changesets/1785203678-fix-layout-pane-tear-off-shows-correct-cursor-on-windows-4wsr.md
+++ b/.changesets/1785203678-fix-layout-pane-tear-off-shows-correct-cursor-on-windows-4wsr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): pane tear-off shows correct cursor on Windows

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -249,34 +249,80 @@ pub fn get_mouse_button_state() -> Result<serde_json::Value, String> {
     Ok(serde_json::json!(false))
 }
 
-/// Replace the system no-drop cursor with a crosshair during drag.
+/// Whether the cursor-override thread should keep running.
+#[cfg(target_os = "windows")]
+static DRAG_CURSOR_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Start a cursor-override thread that calls `SetCursor(IDC_CROSS)` every 2ms,
+/// so the cursor reads as "creates something new" instead of the OS's default
+/// no-drop circle-slash while a tab/pane tear-off drag is outside the window.
+///
+/// # Why a thread instead of SetSystemCursor
+///
+/// A prior attempt (unmerged, `agenta/fix-tab-drag-cursor`, 2026-03) used
+/// `SetSystemCursor(cross, OCR_NO)` — replacing the shared `OCR_NO` system
+/// cursor resource once at drag start. That doesn't work: OLE's
+/// `IDropSource::GiveFeedback` caches its own `LoadCursor(NULL, IDC_NO)`
+/// handle on the *first* `GiveFeedback` call of a drag session, so a
+/// `SetSystemCursor` call afterwards never reaches that cached handle.
+/// Windows Explorer also draws `WM_SETCURSOR` from its own cursor resources,
+/// not the system cursor table. There is no static replacement that reaches
+/// every code path that might paint the cursor during an active OLE drag.
+///
+/// A 2ms polling thread instead repaints the cursor out from under whatever
+/// just set it. It wins every race when the mouse is stationary (the common
+/// "am I over a valid target" case) and, at 500Hz vs. a typical 125-250Hz
+/// mouse-report rate, dominates during movement too — occasional flicker is
+/// possible but not disruptive. This is also why the JS-only fix
+/// (`dropEffect = "copy"` in `TileLayout.win32.tsx`/`tab-reorder.ts`) isn't
+/// sufficient on its own: it only ever reaches the OS cursor while the
+/// pointer is still over *this app's* HTML content. The moment a tear-off
+/// drag crosses the window's own boundary onto the desktop or another
+/// window, no dragover event fires here at all, and only host-level cursor
+/// control (this function) can still influence what's drawn.
 pub fn set_drag_cursor() -> Result<serde_json::Value, String> {
     #[cfg(target_os = "windows")]
     {
-        use windows_sys::Win32::UI::WindowsAndMessaging::{
-            CopyIcon, LoadCursorW, SetSystemCursor, IDC_CROSS, OCR_NO,
-        };
-        unsafe {
-            let cross = LoadCursorW(std::ptr::null_mut(), IDC_CROSS);
-            if !cross.is_null() {
-                let copy = CopyIcon(cross);
-                if !copy.is_null() {
-                    SetSystemCursor(copy, OCR_NO);
-                }
-            }
+        use std::sync::atomic::Ordering;
+        use windows_sys::Win32::UI::WindowsAndMessaging::{LoadCursorW, SetCursor, IDC_CROSS};
+
+        // Idempotent — a second start_cross_drag while the thread is already
+        // running (e.g. a stale-session self-heal) must not spawn a duplicate.
+        if DRAG_CURSOR_ACTIVE.swap(true, Ordering::Relaxed) {
+            return Ok(serde_json::Value::Null);
         }
+
+        let hcursor = unsafe { LoadCursorW(std::ptr::null_mut(), IDC_CROSS) };
+        if hcursor.is_null() {
+            DRAG_CURSOR_ACTIVE.store(false, Ordering::Relaxed);
+            return Err("LoadCursorW(IDC_CROSS) failed".to_string());
+        }
+        // HCURSOR is not Send; move it across the thread boundary as a plain
+        // integer. The handle is a shared system resource (IDC_CROSS is a
+        // predefined cursor, never freed) valid for the process's lifetime.
+        let hcursor_usize = hcursor as usize;
+
+        std::thread::spawn(move || {
+            while DRAG_CURSOR_ACTIVE.load(Ordering::Relaxed) {
+                unsafe { SetCursor(hcursor_usize as _) };
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+        });
+
+        tracing::debug!(target: "dnd:cursor", "set_drag_cursor: override thread started");
     }
     Ok(serde_json::Value::Null)
 }
 
-/// Restore all system cursors to defaults.
+/// Stop the cursor-override thread started by [`set_drag_cursor`]. Must be
+/// called on every drag end (drop, tear-off, or cancel) — leaving the thread
+/// running would pin the crosshair cursor after the drag session ends.
 pub fn restore_drag_cursor() -> Result<serde_json::Value, String> {
     #[cfg(target_os = "windows")]
     {
-        use windows_sys::Win32::UI::WindowsAndMessaging::{SystemParametersInfoW, SPI_SETCURSORS};
-        unsafe {
-            SystemParametersInfoW(SPI_SETCURSORS, 0, std::ptr::null_mut(), 0);
-        }
+        use std::sync::atomic::Ordering;
+        DRAG_CURSOR_ACTIVE.store(false, Ordering::Relaxed);
+        tracing::debug!(target: "dnd:cursor", "restore_drag_cursor: override thread stopped");
     }
     Ok(serde_json::Value::Null)
 }

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -134,6 +134,17 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
                 // by PR #1175 (darwin/linux only). In-window tab reorder still
                 // works via pragmatic-dnd's own drop targets.
                 if (!isWindows()) preventUnhandled.start();
+                // Windows counterpart to preventUnhandled above: dropEffect
+                // (tab-reorder.ts's onTearOffDragOver) only reaches the OS
+                // cursor while the pointer is still over this app's own HTML
+                // content — the moment a tear-off drag crosses the window's
+                // own boundary, no dragover fires here at all and the OS's
+                // OLE drag-feedback falls back to the no-drop circle-slash.
+                // set_drag_cursor's host-level polling thread is the only
+                // thing that still works out there (see its doc comment in
+                // agentmux-cef/src/commands/drag.rs for why a thread, not a
+                // one-shot cursor swap, is required).
+                if (isWindows()) void getApi().setDragCursor?.();
                 setGlobalDragTabId(props.tabId);
                 setDragEscaped(false);
                 setInsertionPoint(null);
@@ -174,6 +185,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
             },
             onDrop: () => {
                 if (!isWindows()) preventUnhandled.stop();
+                if (isWindows()) void getApi().restoreDragCursor?.();
                 setGlobalDragTabId(null);
                 setIsDragging(false);
                 // Belt-and-suspenders hook teardown. Ordinarily the hook

--- a/frontend/app/tab/tab-reorder.ts
+++ b/frontend/app/tab/tab-reorder.ts
@@ -11,6 +11,7 @@
 import { onCleanup, onMount } from "solid-js";
 import { fireAndForget } from "@/util/util";
 import { isWindows } from "@/util/platformutil";
+import { getApi } from "@/store/global";
 import { monitorForElements, dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { clearCrossTabDrop, getLayoutModelForTabById, tileItemType } from "@/layout/index";
 import { setTileDragInFlight } from "@/layout/lib/dragInFlight";
@@ -131,6 +132,19 @@ export function useTabDragAndDrop(
             };
             window.addEventListener("dragover", onTearOffDragOver);
             onCleanup(() => window.removeEventListener("dragover", onTearOffDragOver));
+
+            // Safety net for droppable-tab.tsx's setDragCursor/restoreDragCursor
+            // pair: if that draggable's own onDrop is skipped (the same Win11
+            // swallowed-dragend class of failure this file already guards
+            // against elsewhere — see cleanupTileDragState's comment below),
+            // restoreDragCursor never runs and the host's cursor-override
+            // polling thread is left running. Mirrors TileLayout.win32.tsx's
+            // own resetDragState safety net.
+            const onTearOffDragEnd = () => {
+                if (globalDragTabId != null) void getApi().restoreDragCursor?.();
+            };
+            window.addEventListener("dragend", onTearOffDragEnd);
+            onCleanup(() => window.removeEventListener("dragend", onTearOffDragEnd));
         }
 
         // Escape-to-abort (cross-platform): pragmatic-drag-and-drop's HTML5

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -17,7 +17,7 @@ import { useNodeModel, useTileLayout } from "./layoutModelHooks";
 import "./tilelayout.scss";
 import { FlexDirection, LayoutNode, LayoutTreeActionType, ResizeHandleProps, TileLayoutContents } from "./types";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
-import { setTileDragInFlight } from "./dragInFlight";
+import { isTileDragInFlight, setTileDragInFlight } from "./dragInFlight";
 import { clearCrossTabDrop } from "./crossTabDrag";
 import { dragState } from "./tilelayout-drag-state";
 import {
@@ -162,8 +162,35 @@ function TileLayoutComponent(props: TileLayoutProps) {
         }
     });
 
+    // Tear-off cursor. During a pane drag, the tear-off zone (cursor dragged
+    // outside the tile layout) has no pragmatic drop target, and
+    // preventUnhandled is gated off on Windows (tear-off relies on the
+    // native window-move handshake, not the HTML5 snapback) -- so out in the
+    // tear-off zone Chromium falls back to the no-drop circle-slash cursor,
+    // which reads as "you can't drop this", the opposite of the truth:
+    // releasing there spawns a NEW floating window. Same root cause and fix
+    // shape as tab-reorder.ts's onTearOffDragOver (PR #2175) -- ported here
+    // since panes never got the equivalent fix (see
+    // docs/retro/retro-pane-tearoff-cursor-never-fixed-2026-07-27.md).
+    //
+    // Not folded into the debounced checkForCursorBounds above: that 100ms
+    // debounce is fine for its own purpose (clearing a pending drop-target
+    // action) but would read as laggy for cursor feedback, which should
+    // track the pointer every event.
+    const setTearOffCursor = (e: DragEvent) => {
+        if (!isTileDragInFlight()) return; // not a pane drag
+        if (!layoutModel.displayContainerRef?.current) return;
+        const rect = layoutModel.displayContainerRef.current.getBoundingClientRect();
+        const overLayout =
+            e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom;
+        if (overLayout) return; // the layout's own drop target owns the cursor here
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+
     // Global dragover handler to detect when cursor leaves tile layout
     const onWindowDragOver = (e: DragEvent) => {
+        setTearOffCursor(e);
         checkForCursorBounds(e.clientX, e.clientY);
     };
 

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -5,6 +5,7 @@
 // dragHandle: undefined — whole-tile drag (pragmatic-dnd dragHandle breaks WebView2).
 
 import { notifyPaneReflow } from "@/app/platform/pane-anim";
+import { getApi } from "@/store/global";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import clsx from "clsx";
 import { toPng } from "html-to-image";
@@ -128,6 +129,10 @@ function TileLayoutComponent(props: TileLayoutProps) {
                 setTileDragInFlight(false);
                 dragState.layoutModel.activeDrag._set(false);
                 dragState.layoutModel = null;
+                // onDrop never ran (swallowed dragend) — its restoreDragCursor
+                // call didn't either, which would otherwise pin the
+                // cursor-override thread from onDragStart running forever.
+                void getApi()?.restoreDragCursor?.();
             }
         };
         window.addEventListener("dragend", resetDragState);
@@ -408,6 +413,16 @@ const DisplayNode = (props: DisplayNodeProps) => {
                         node: props.node,
                         sourceTabId: props.layoutModel.tabAtom()?.oid,
                     });
+                    // dropEffect="copy" (setTearOffCursor above) only reaches the
+                    // OS cursor while the pointer is still over this app's own
+                    // HTML content. The moment a tear-off drag crosses the
+                    // window's own boundary, no dragover event fires here at
+                    // all and the OS's OLE drag-feedback shows its default
+                    // no-drop circle-slash — a host-level cursor override is
+                    // the only thing that still works out there. See
+                    // set_drag_cursor's doc comment (agentmux-cef/src/commands/drag.rs)
+                    // for why this needs a polling thread, not a one-shot call.
+                    void getApi()?.setDragCursor?.();
                 },
                 onDrop: () => {
                     dragState.nodeId = null;
@@ -416,6 +431,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     setTileDragInFlight(false);
                     props.layoutModel.activeDrag._set(false);
                     setIsDragging(false);
+                    void getApi()?.restoreDragCursor?.();
                     // Do NOT clear currentDragPayload here — fires for ALL drops including
                     // out-of-window. Cleared in dropTargetForElements.onDrop instead.
                 },


### PR DESCRIPTION
## Summary

Both tab tear-off and pane tear-off showed the OS "not-allowed" circle-slash cursor on Windows when dragged **outside the app window** — instead of an affordance indicating a new window will be created.

## Root cause (revised from this PR's first commit)

The first commit here (and tabs' own earlier fix, #2175) used `dropEffect = "copy"` on `dragover`. That only reaches the OS cursor while the pointer is still over this app's own HTML content. The moment a tear-off drag crosses the window's own boundary onto the desktop or another window, no `dragover` event fires here at all — Windows' OLE drag-feedback takes over and shows its default no-drop cursor regardless of what `dropEffect` was last set to. Confirmed live: both tabs and panes still showed the circle-slash once dragged past the window edge, despite the dropEffect fix being in place for both.

`set_drag_cursor`/`restore_drag_cursor` already existed in `agentmux-cef/src/commands/drag.rs`, fully wired end-to-end (IPC dispatch, frontend wrapper) — but dead code, called from nowhere, using a known-broken implementation (`SetSystemCursor(OCR_NO)`). An unmerged March 2026 branch (`agenta/fix-tab-drag-cursor`) had already diagnosed why: OLE's `IDropSource::GiveFeedback` caches its own no-drop cursor handle on the *first* `GiveFeedback` call of a drag session, so replacing the system cursor resource afterwards never reaches that cached handle. That branch's final commit fixed it with a 2ms polling thread that repaints `SetCursor(IDC_CROSS)` out from under whatever last set it — but the branch was never merged.

## Fix

- Ported the working polling-thread implementation into `set_drag_cursor`/`restore_drag_cursor`.
- Wired both draggable sources — `droppable-tab.tsx` (tab tear-off) and `TileLayout.win32.tsx` (pane tear-off) — to call `setDragCursor()` on drag start and `restoreDragCursor()` on drop, each with a `dragend`-based safety net for the swallowed-dragend failure mode this codebase already guards against elsewhere (Win11 snap-layouts/Alt+Tab interrupting a drag).
- Kept the `dropEffect` fixes from the first commit — still correct for the in-window-but-outside-the-drop-target case, just not sufficient on their own for tear-off past the window edge.

## Test plan

- [x] `cargo check -p agentmux-cef` clean
- [x] `npx tsc --noEmit` clean
- [x] Changeset added
- [ ] Manual test — will run `task dev` for the user to verify both tab and pane tear-off cursors directly before merge

<!-- agentmux:agent_id=agent2 -->
