### PR TITLE
fix(deps): pin brace-expansion to patch the DoS advisory (SEC-005)

### DIFF
--- a/.changesets/1785240611-fix-deps-pin-brace-expansion-to-patch-the-dos-advisory-sec-0-wd0f.md
+++ b/.changesets/1785240611-fix-deps-pin-brace-expansion-to-patch-the-dos-advisory-sec-0-wd0f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(deps): pin brace-expansion to patch the DoS advisory (SEC-005)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4064,16 +4064,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -11332,16 +11332,16 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -135,5 +135,8 @@
   },
   "workspaces": [
     "docs"
-  ]
+  ],
+  "overrides": {
+    "brace-expansion@5.x": "^5.0.8"
+  }
 }


### PR DESCRIPTION
## Summary

From the 2026-07-27 Weekly Security Researcher run (`a5af/shared-infrastructure`, finding SEC-005, LOW): `brace-expansion <=5.0.7` (GHSA-mh99-v99m-4gvg, unbounded-expansion OOM DoS, CVSS 7.5) was resolved at `5.0.7` in two places in the tree — under `@vitest/coverage-istanbul`'s `test-exclude -> glob -> minimatch` chain, and under `typescript-eslint`'s `typescript-estree -> minimatch` chain.

Added an npm `overrides` entry scoped to only the vulnerable 5.x line (`"brace-expansion@5.x": "^5.0.8"`), not a blanket override — the unrelated, much older 1.x line (eslint's own `minimatch@3.1.5` dependency) and 2.x line aren't force-bumped across a major version for no reason.

**Residual `npm audit` noise, not fixed (intentionally):** one instance against `brace-expansion@1.1.16` (the eslint/`minimatch@3.1.5` chain) still shows up. Confirmed this is a tooling false positive, not a real finding — the GHSA advisory's declared range (`<=5.0.7`, no floor) matches this unrelated, much older major-version line purely on numeric semver ordering, not because 1.1.16 is actually affected by the same rewrite-specific bug. `npm audit fix --force` would only "fix" this by force-upgrading eslint `8.57.1 -> 10.8.0`, a real breaking change for no genuine security benefit.

## Test plan

- [x] `npm install` — both vulnerable 5.x instances now resolve to `5.0.8`, confirmed via `npm ls brace-expansion` and direct `node_modules` inspection
- [x] `npx eslint --version` — unaffected (still on its own untouched `minimatch@3.1.5 -> brace-expansion@1.1.16` chain)
- [x] `npx tsc --noEmit` (frontend) — clean
- [x] `npx vitest run app/store/agent-pane-state/reducer.test.ts` — 153 passed, sanity-checking the touched `test-exclude`/`glob` coverage-tooling chain didn't break anything

<!-- agentmux:agent_id=agent1 -->