### PR TITLE
feat(muxbus): per-agent M2M credential fetch/cache

### DIFF
--- a/.changesets/1785260036-feat-muxbus-per-agent-m2m-credential-fetch-cache-wired-into--jgbu.md
+++ b/.changesets/1785260036-feat-muxbus-per-agent-m2m-credential-fetch-cache-wired-into--jgbu.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxbus): per-agent M2M credential fetch/cache, wired into cloud_subscriber's reactive requests

--- a/agentmux-srv/src/backend/storage/agent_credentials.rs
+++ b/agentmux-srv/src/backend/storage/agent_credentials.rs
@@ -1,0 +1,206 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-agent M2M Cognito credential for muxbus Tier-4 credential binding.
+//! See db_agent_credentials in migrations.rs (SHARED_STORE_SCHEMA_VERSION v4)
+//! and agentmux-cloud's PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md.
+//!
+//! One row per locally-registered agent_id — distinct from the single
+//! account-level db_muxbus_credentials singleton (muxbus.rs), which stores
+//! the human's PKCE login used only to provision these.
+
+use rusqlite::params;
+
+use super::error::StoreError;
+use super::store::Store;
+
+#[derive(Debug, Clone, Default)]
+pub struct AgentCredential {
+    pub agent_id: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub token_endpoint: String,
+    /// Cached client_credentials access token — separate from client_secret
+    /// so a fresh token fetch doesn't require re-provisioning.
+    pub access_token: String,
+    pub expires_at: i64,
+}
+
+impl AgentCredential {
+    fn now_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+    }
+
+    /// client_credentials tokens carry no refresh token (per the design in
+    /// agentmux-cloud#2) — "valid" just means "not expired yet," with the
+    /// same 300s early-refresh margin used by MuxBusCredentials.
+    pub fn is_valid(&self) -> bool {
+        !self.access_token.is_empty() && self.expires_at - Self::now_secs() > 300
+    }
+}
+
+impl Store {
+    pub fn agent_credential_load(&self, agent_id: &str) -> Result<Option<AgentCredential>, StoreError> {
+        let key = agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT agent_id, client_id, client_secret, token_endpoint, access_token, expires_at
+             FROM db_agent_credentials WHERE agent_id = ?1",
+        )?;
+        match stmt.query_row(params![key], |row| {
+            Ok(AgentCredential {
+                agent_id: row.get(0)?,
+                client_id: row.get(1)?,
+                client_secret: row.get(2)?,
+                token_endpoint: row.get(3)?,
+                access_token: row.get(4)?,
+                expires_at: row.get(5)?,
+            })
+        }) {
+            Ok(c) => Ok(Some(c)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Save a newly-provisioned client_id/client_secret (access_token/expires_at
+    /// left at their defaults — the caller fetches a token separately via
+    /// agent_credential_save_token).
+    pub fn agent_credential_save(
+        &self,
+        agent_id: &str,
+        client_id: &str,
+        client_secret: &str,
+        token_endpoint: &str,
+    ) -> Result<(), StoreError> {
+        let key = agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_agent_credentials
+                 (agent_id, client_id, client_secret, token_endpoint, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(agent_id) DO UPDATE SET
+                 client_id = excluded.client_id,
+                 client_secret = excluded.client_secret,
+                 token_endpoint = excluded.token_endpoint",
+            params![key, client_id, client_secret, token_endpoint, AgentCredential::now_secs()],
+        )?;
+        Ok(())
+    }
+
+    /// Cache a freshly-fetched client_credentials access token against an
+    /// already-provisioned agent. No-op if the agent has no row yet (the
+    /// caller should provision first).
+    pub fn agent_credential_save_token(
+        &self,
+        agent_id: &str,
+        access_token: &str,
+        expires_at: i64,
+    ) -> Result<(), StoreError> {
+        let key = agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE db_agent_credentials SET access_token = ?2, expires_at = ?3 WHERE agent_id = ?1",
+            params![key, access_token, expires_at],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A shared-schema store built on a temp file (open_shared needs a real
+    // path; :memory: would be re-created per connection) — db_agent_credentials
+    // lives in the shared schema (SHARED_STORE_SCHEMA_VERSION v3), not objects.db.
+    fn shared_store() -> Store {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        Store::open_shared(tmp.path()).unwrap()
+    }
+
+    #[test]
+    fn load_returns_none_when_unprovisioned() {
+        let store = shared_store();
+        assert!(store.agent_credential_load("agentx").unwrap().is_none());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let store = shared_store();
+        store
+            .agent_credential_save("AgentX", "client-1", "secret-1", "https://auth.example.com/oauth2/token")
+            .unwrap();
+
+        // Lookup is case-insensitive — normalized the same way agent_id is
+        // normalized everywhere else in this codebase.
+        let loaded = store.agent_credential_load("agentx").unwrap().unwrap();
+        assert_eq!(loaded.client_id, "client-1");
+        assert_eq!(loaded.client_secret, "secret-1");
+        assert_eq!(loaded.token_endpoint, "https://auth.example.com/oauth2/token");
+        assert_eq!(loaded.access_token, "");
+        assert!(!loaded.is_valid()); // no access_token yet
+    }
+
+    #[test]
+    fn save_is_idempotent_and_updates_in_place() {
+        let store = shared_store();
+        store.agent_credential_save("agentx", "client-1", "secret-1", "endpoint-1").unwrap();
+        store.agent_credential_save("agentx", "client-2", "secret-2", "endpoint-2").unwrap();
+
+        let loaded = store.agent_credential_load("agentx").unwrap().unwrap();
+        assert_eq!(loaded.client_id, "client-2");
+        assert_eq!(loaded.client_secret, "secret-2");
+    }
+
+    #[test]
+    fn save_token_caches_access_token_and_expiry() {
+        let store = shared_store();
+        store.agent_credential_save("agentx", "client-1", "secret-1", "endpoint-1").unwrap();
+
+        let future = AgentCredential::now_secs() + 3600;
+        store.agent_credential_save_token("agentx", "tok-abc", future).unwrap();
+
+        let loaded = store.agent_credential_load("agentx").unwrap().unwrap();
+        assert_eq!(loaded.access_token, "tok-abc");
+        assert_eq!(loaded.expires_at, future);
+        assert!(loaded.is_valid());
+    }
+
+    #[test]
+    fn save_token_is_a_noop_when_not_provisioned() {
+        let store = shared_store();
+        // No agent_credential_save call first -- row doesn't exist.
+        store.agent_credential_save_token("agentx", "tok-abc", AgentCredential::now_secs() + 3600).unwrap();
+        assert!(store.agent_credential_load("agentx").unwrap().is_none());
+    }
+
+    #[test]
+    fn is_valid_respects_the_300s_early_refresh_margin() {
+        let mut cred = AgentCredential {
+            agent_id: "agentx".to_string(),
+            client_id: "c".to_string(),
+            client_secret: "s".to_string(),
+            token_endpoint: "e".to_string(),
+            access_token: "tok".to_string(),
+            expires_at: AgentCredential::now_secs() + 301,
+        };
+        assert!(cred.is_valid());
+
+        cred.expires_at = AgentCredential::now_secs() + 299;
+        assert!(!cred.is_valid());
+    }
+
+    #[test]
+    fn is_valid_false_with_no_access_token() {
+        let cred = AgentCredential {
+            agent_id: "agentx".to_string(),
+            expires_at: AgentCredential::now_secs() + 3600,
+            ..Default::default()
+        };
+        assert!(!cred.is_valid());
+    }
+}

--- a/agentmux-srv/src/backend/storage/agent_credentials.rs
+++ b/agentmux-srv/src/backend/storage/agent_credentials.rs
@@ -108,6 +108,23 @@ impl Store {
         )?;
         Ok(())
     }
+
+    /// Clear a per-agent credential's cached access token (client_id/secret
+    /// are left intact — only the token is suspect). Used when the server
+    /// rejects a request with 401 despite our cached expires_at still
+    /// looking valid (revoked/rotated out-of-band): forces the next
+    /// ensure_agent_credential call to re-fetch via fetch_m2m_token instead
+    /// of retrying the exact same rejected token. No-op if the agent has no
+    /// row. reagentx P1 on PR #2342.
+    pub fn agent_credential_invalidate_token(&self, agent_id: &str) -> Result<(), StoreError> {
+        let key = agent_id.to_lowercase();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE db_agent_credentials SET access_token = '', expires_at = 0 WHERE agent_id = ?1",
+            params![key],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -175,6 +192,32 @@ mod tests {
         let store = shared_store();
         // No agent_credential_save call first -- row doesn't exist.
         store.agent_credential_save_token("agentx", "tok-abc", AgentCredential::now_secs() + 3600).unwrap();
+        assert!(store.agent_credential_load("agentx").unwrap().is_none());
+    }
+
+    #[test]
+    fn invalidate_token_clears_token_and_expiry_but_keeps_client() {
+        let store = shared_store();
+        store.agent_credential_save("agentx", "client-1", "secret-1", "endpoint-1").unwrap();
+        store
+            .agent_credential_save_token("agentx", "tok-abc", AgentCredential::now_secs() + 3600)
+            .unwrap();
+
+        store.agent_credential_invalidate_token("agentx").unwrap();
+
+        let loaded = store.agent_credential_load("agentx").unwrap().unwrap();
+        assert_eq!(loaded.access_token, "");
+        assert_eq!(loaded.expires_at, 0);
+        assert!(!loaded.is_valid());
+        // Provisioned client identity survives — only the token was suspect.
+        assert_eq!(loaded.client_id, "client-1");
+        assert_eq!(loaded.client_secret, "secret-1");
+    }
+
+    #[test]
+    fn invalidate_token_is_a_noop_when_not_provisioned() {
+        let store = shared_store();
+        store.agent_credential_invalidate_token("agentx").unwrap();
         assert!(store.agent_credential_load("agentx").unwrap().is_none());
     }
 

--- a/agentmux-srv/src/backend/storage/agent_credentials.rs
+++ b/agentmux-srv/src/backend/storage/agent_credentials.rs
@@ -125,6 +125,23 @@ impl Store {
         )?;
         Ok(())
     }
+
+    /// Wipe every cached per-agent M2M credential. `db_agent_credentials`
+    /// carries no account/user_sub column of its own — each row is only
+    /// ever meaningful under the muxbus account that provisioned it — so a
+    /// genuine account switch (muxbus_save with a different user_sub) or a
+    /// logout (muxbus_clear) must wipe this cache wholesale; otherwise a
+    /// stale row keeps authenticating this agent_id's requests as the
+    /// PREVIOUS account after the human has switched to a different one.
+    /// Re-provisioning is cheap and idempotent server-side (see
+    /// agent-provisioning.ts), so clearing on every account transition —
+    /// not just the ones that turn out to matter — is the safe default.
+    /// reagentx P0 on PR #2342.
+    pub fn agent_credentials_clear_all(&self) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM db_agent_credentials", [])?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -218,6 +235,25 @@ mod tests {
     fn invalidate_token_is_a_noop_when_not_provisioned() {
         let store = shared_store();
         store.agent_credential_invalidate_token("agentx").unwrap();
+        assert!(store.agent_credential_load("agentx").unwrap().is_none());
+    }
+
+    #[test]
+    fn clear_all_wipes_every_agent_credential() {
+        let store = shared_store();
+        store.agent_credential_save("agentx", "client-1", "secret-1", "endpoint-1").unwrap();
+        store.agent_credential_save("agenty", "client-2", "secret-2", "endpoint-2").unwrap();
+
+        store.agent_credentials_clear_all().unwrap();
+
+        assert!(store.agent_credential_load("agentx").unwrap().is_none());
+        assert!(store.agent_credential_load("agenty").unwrap().is_none());
+    }
+
+    #[test]
+    fn clear_all_is_a_noop_on_an_empty_table() {
+        let store = shared_store();
+        store.agent_credentials_clear_all().unwrap();
         assert!(store.agent_credential_load("agentx").unwrap().is_none());
     }
 

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -29,7 +29,13 @@ use super::error::StoreError;
 ///   v3 — Phase 4a of SPEC_PRESET_TO_BUNDLE_REFACTOR_2026_07_02.md: rename
 ///        db_identity_accounts -> db_accounts, db_memory_bundles -> db_bundles
 ///        (SPEC_ARMORY_PHASE4_STORAGE_RENAME_COMPLETION_2026_07_12.md).
-pub const SHARED_STORE_SCHEMA_VERSION: i64 = 3;
+///   v4 — db_agent_credentials: per-agent M2M Cognito client_id/secret +
+///        cached access token, one row per locally-registered agent_id.
+///        Lets cloud_subscriber use a credential bound to a specific agent
+///        (see agentmux-cloud's PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md)
+///        instead of the single shared per-account MUXBUS_TOKEN for every
+///        /reactive/* call.
+pub const SHARED_STORE_SCHEMA_VERSION: i64 = 4;
 
 /// `user_version` value stamped into `objects.db` after `run_object_schema`.
 /// The flat schema reset the counter to 1 (the pre-flatten chain never set
@@ -66,7 +72,12 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 3;
 ///        SPEC_ACCOUNT_DELETE_DEAUTH_LAYERS_2_4_2026_07_14.md §2.3). Defaults
 ///        to 0 (fail-by-default); the m0017 data migration grandfathers
 ///        pre-existing linkless agents to 1.
-pub const OBJECT_SCHEMA_VERSION: i64 = 12;
+///   v13 — db_agent_credentials: per-agent M2M muxbus credential, mirroring
+///        db_muxbus_credentials' presence in both schemas — id_store falls
+///        back to this (per-channel) schema on installs that haven't yet
+///        applied 0011_shared_store_backfill, so cloud_subscriber's calls
+///        must not assume the shared-schema copy (v4 there) is the one in use.
+pub const OBJECT_SCHEMA_VERSION: i64 = 13;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -471,6 +482,18 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             expires_at     INTEGER NOT NULL DEFAULT 0,
             user_email     TEXT NOT NULL DEFAULT '',
             user_sub       TEXT NOT NULL DEFAULT ''
+        );
+
+        -- v13: per-agent M2M muxbus credential — see db_agent_credentials in
+        -- run_shared_store_schema's doc comment for the full rationale.
+        CREATE TABLE IF NOT EXISTS db_agent_credentials (
+            agent_id       TEXT PRIMARY KEY,
+            client_id      TEXT NOT NULL DEFAULT '',
+            client_secret  TEXT NOT NULL DEFAULT '',
+            token_endpoint TEXT NOT NULL DEFAULT '',
+            access_token   TEXT NOT NULL DEFAULT '',
+            expires_at     INTEGER NOT NULL DEFAULT 0,
+            created_at     INTEGER NOT NULL DEFAULT 0
         );",
     )?;
 
@@ -736,7 +759,22 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
             created_at  INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_ss_cron_jobs_enabled
-            ON db_cron_jobs(enabled);",
+            ON db_cron_jobs(enabled);
+
+        -- v4: per-agent M2M credential for muxbus Tier-4 binding (see
+        -- SHARED_STORE_SCHEMA_VERSION's doc comment above). client_secret is
+        -- a Cognito app client secret, not a user password — same trust
+        -- tier as MUXBUS_TOKEN in db_muxbus_credentials above, stored
+        -- unencrypted in the same shared store.db for the same reason.
+        CREATE TABLE IF NOT EXISTS db_agent_credentials (
+            agent_id       TEXT PRIMARY KEY,
+            client_id      TEXT NOT NULL DEFAULT '',
+            client_secret  TEXT NOT NULL DEFAULT '',
+            token_endpoint TEXT NOT NULL DEFAULT '',
+            access_token   TEXT NOT NULL DEFAULT '',
+            expires_at     INTEGER NOT NULL DEFAULT 0,
+            created_at     INTEGER NOT NULL DEFAULT 0
+        );",
     )?;
 
     // Seed the blank Memory singleton — same fixed id as objects.db so

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -4,6 +4,7 @@
 //! Storage layer: SQLite-backed object store and file store.
 //! Port of Go's pkg/wstore and pkg/filestore.
 
+pub mod agent_credentials;
 pub mod agents;
 pub mod agents_consolidate;
 pub mod content;
@@ -23,6 +24,7 @@ pub mod skills;
 pub mod snapshot;
 pub mod store;
 
+pub use agent_credentials::AgentCredential;
 pub use agents::{AgentDefinition, AgentInstance, InstanceStatus, InstanceUpdate};
 pub use content::AgentContent;
 pub use cron::CronJob;

--- a/agentmux-srv/src/backend/storage/muxbus.rs
+++ b/agentmux-srv/src/backend/storage/muxbus.rs
@@ -237,6 +237,20 @@ impl Store {
         // already-committed credential.
         let _save_guard = self.muxbus_save_lock.lock().unwrap();
 
+        // Read the outgoing account's user_sub now, before it's overwritten
+        // below, so a genuine account switch (vs. a same-account token
+        // refresh) can be detected after the write succeeds and the stale
+        // per-agent credential cache cleared. reagentx P0 on PR #2342.
+        let previous_user_sub: Option<String> = {
+            let conn = self.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT user_sub FROM db_muxbus_credentials WHERE id = 'global'",
+                [],
+                |row| row.get(0),
+            )
+            .ok()
+        };
+
         let tokens = MuxBusTokens {
             access_token: creds.access_token.clone(),
             refresh_token: creds.refresh_token.clone(),
@@ -329,6 +343,23 @@ impl Store {
             }
             return Err(e.into());
         }
+
+        // Account switch (not a same-account token refresh): the previous
+        // account's per-agent M2M credentials must not silently keep
+        // authenticating this different account's requests. A first-ever
+        // login (previous_user_sub is None/empty) has nothing to clear.
+        // reagentx P0 on PR #2342.
+        if let Some(prev) = previous_user_sub {
+            if !prev.is_empty() && prev != creds.user_sub {
+                if let Err(e) = self.agent_credentials_clear_all() {
+                    tracing::warn!(
+                        error = %e,
+                        "muxbus_save: failed to clear stale per-agent credentials after account switch",
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -343,8 +374,15 @@ impl Store {
         // Best-effort — a missing/inaccessible keychain entry must not block
         // clearing the (still-useful) SQL row.
         let _ = secret_store::delete(MUXBUS_KEYCHAIN_ID);
-        let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM db_muxbus_credentials WHERE id = 'global'", [])?;
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute("DELETE FROM db_muxbus_credentials WHERE id = 'global'", [])?;
+        }
+        // Logging out invalidates any per-agent credentials provisioned
+        // under this account too. reagentx P0 on PR #2342.
+        if let Err(e) = self.agent_credentials_clear_all() {
+            tracing::warn!(error = %e, "muxbus_clear: failed to clear per-agent credentials");
+        }
         Ok(())
     }
 }

--- a/agentmux-srv/src/muxbus/agent_credentials.rs
+++ b/agentmux-srv/src/muxbus/agent_credentials.rs
@@ -22,10 +22,34 @@
 //! message delivery, only degrade the binding guarantee back to today's
 //! self-declared behavior for that agent.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use crate::backend::storage::store::Store;
 use crate::muxbus::cloud_subscriber::{load_valid_token, MUXBUS_REST_URL};
+
+/// How long to skip re-attempting provisioning for an agent after a
+/// failure, before trying again. InjectAvailable broadcasts for ANY
+/// injection to ANY agent, so without this an agent that can never
+/// provision (quota exceeded, malformed agent_id, provisioning endpoint
+/// down) gets a fresh provisioning attempt on every single broadcast —
+/// an unthrottled retry storm against the provisioning endpoint, unlike
+/// the broker's single-flight-guarded scheduler used for the shared
+/// token. reagentx P2 on PR #2342.
+const PROVISION_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+
+static PROVISION_COOLDOWN: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+
+fn provision_cooldown() -> &'static Mutex<HashMap<String, Instant>> {
+    PROVISION_COOLDOWN.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn provision_recently_failed(agent_id: &str) -> bool {
+    let map = provision_cooldown().lock().unwrap();
+    map.get(agent_id)
+        .is_some_and(|t| t.elapsed() < PROVISION_RETRY_COOLDOWN)
+}
 
 /// Get a live per-agent access token, provisioning the Cognito client on
 /// first use. Returns None (never an error) on any failure — provisioning
@@ -43,10 +67,22 @@ pub async fn ensure_agent_credential(
     let creds = match creds {
         Some(c) if !c.client_id.is_empty() => c,
         _ => {
-            // Not provisioned yet — do it now, once. A failure here (e.g. no
-            // human login yet, network error) just means this agent keeps
-            // using the shared token until a later call succeeds.
-            provision_agent_client(&key, wstore, http).await.ok()?;
+            // Not provisioned yet. Skip if a recent attempt already failed
+            // (see PROVISION_RETRY_COOLDOWN) — this agent keeps using the
+            // shared token until the cooldown lapses or provisioning
+            // succeeds.
+            if provision_recently_failed(&key) {
+                return None;
+            }
+            if let Err(e) = provision_agent_client(&key, wstore, http).await {
+                tracing::warn!(
+                    agent_id = %key, error = %e,
+                    "muxbus: agent credential provisioning failed, backing off {}s",
+                    PROVISION_RETRY_COOLDOWN.as_secs(),
+                );
+                provision_cooldown().lock().unwrap().insert(key, Instant::now());
+                return None;
+            }
             wstore.agent_credential_load(&key).ok().flatten()?
         }
     };
@@ -58,6 +94,22 @@ pub async fn ensure_agent_credential(
     fetch_m2m_token(&key, &creds.client_id, &creds.client_secret, &creds.token_endpoint, wstore, http)
         .await
         .ok()
+}
+
+/// Clear a per-agent credential's cached access token — called by
+/// cloud_subscriber when a request using it comes back 401 even though the
+/// credential looked locally valid (revoked/rotated server-side out-of-band).
+/// Without this, the next InjectAvailable round retries the exact same
+/// rejected token forever. Best-effort: a store error here just means the
+/// stale token survives until its local expiry, matching the pre-existing
+/// failure mode rather than introducing a new one. reagentx P1 on PR #2342.
+pub fn invalidate_cached_token(agent_id: &str, wstore: &Arc<Store>) {
+    if let Err(e) = wstore.agent_credential_invalidate_token(&agent_id.to_lowercase()) {
+        tracing::warn!(
+            agent_id = %agent_id, error = %e,
+            "muxbus: failed to invalidate stale per-agent credential",
+        );
+    }
 }
 
 /// Calls POST /agents/provision (authenticated with the human's own PKCE

--- a/agentmux-srv/src/muxbus/agent_credentials.rs
+++ b/agentmux-srv/src/muxbus/agent_credentials.rs
@@ -1,0 +1,166 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-agent M2M Cognito credential fetch/cache — the client-side half of
+//! agentmux-cloud's PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md.
+//!
+//! Historically every agent under one AgentMux login shared the same
+//! account-level MUXBUS_TOKEN for every /reactive/* call, self-declaring its
+//! identity via an unverified X-Agent-ID header — any credential could claim
+//! any agent_id. This module gets each agent its own bound Cognito
+//! client_credentials identity instead:
+//!   1. provision_agent_client(): calls POST /agents/provision using the
+//!      human's own PKCE token, receiving a Cognito client_id/client_secret
+//!      scoped to exactly this (account, agent_id) pair. One-time per agent
+//!      (idempotent server-side; cached locally in db_agent_credentials).
+//!   2. ensure_agent_credential(): returns a live access_token for that
+//!      agent, provisioning on first use and re-fetching via
+//!      client_credentials whenever the cached token has expired.
+//!
+//! Callers (cloud_subscriber.rs) fall back to the shared MUXBUS_TOKEN
+//! whenever this returns None — provisioning failure must never block
+//! message delivery, only degrade the binding guarantee back to today's
+//! self-declared behavior for that agent.
+
+use std::sync::Arc;
+
+use crate::backend::storage::store::Store;
+use crate::muxbus::cloud_subscriber::{load_valid_token, MUXBUS_REST_URL};
+
+/// Get a live per-agent access token, provisioning the Cognito client on
+/// first use. Returns None (never an error) on any failure — provisioning
+/// being down or an agent not yet migrated must degrade to the caller's
+/// shared-token fallback, not block delivery.
+pub async fn ensure_agent_credential(
+    agent_id: &str,
+    wstore: &Arc<Store>,
+    http: &reqwest::Client,
+) -> Option<String> {
+    let key = agent_id.to_lowercase();
+
+    let creds = wstore.agent_credential_load(&key).ok().flatten();
+
+    let creds = match creds {
+        Some(c) if !c.client_id.is_empty() => c,
+        _ => {
+            // Not provisioned yet — do it now, once. A failure here (e.g. no
+            // human login yet, network error) just means this agent keeps
+            // using the shared token until a later call succeeds.
+            provision_agent_client(&key, wstore, http).await.ok()?;
+            wstore.agent_credential_load(&key).ok().flatten()?
+        }
+    };
+
+    if creds.is_valid() {
+        return Some(creds.access_token);
+    }
+
+    fetch_m2m_token(&key, &creds.client_id, &creds.client_secret, &creds.token_endpoint, wstore, http)
+        .await
+        .ok()
+}
+
+/// Calls POST /agents/provision (authenticated with the human's own PKCE
+/// token — an M2M agent credential can never provision another one) and
+/// caches the returned client_id/client_secret.
+async fn provision_agent_client(agent_id: &str, wstore: &Arc<Store>, http: &reqwest::Client) -> Result<(), String> {
+    // The scheduler is a process-wide singleton, initialized by
+    // cloud_subscriber::run_loop before any WS session (and therefore any
+    // handle_server_msg call reaching this function) can start — see
+    // crate::broker's own doc comment. get_global() (not init_global) here:
+    // this code path has no sweep_interval opinion of its own, it just needs
+    // the already-running scheduler ensure_fresh uses for the shared token.
+    let scheduler = crate::broker::get_global()
+        .ok_or_else(|| "muxbus refresh scheduler not initialized yet".to_string())?;
+    let user_token = load_valid_token(wstore, &scheduler)
+        .await
+        .ok_or_else(|| "no valid user-level muxbus login to provision from".to_string())?;
+
+    #[derive(serde::Deserialize)]
+    struct ProvisionResp {
+        client_id: String,
+        client_secret: String,
+        token_endpoint: String,
+    }
+
+    let url = format!("{}/agents/provision", MUXBUS_REST_URL);
+    let resp = http
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", user_token))
+        .json(&serde_json::json!({ "agent_id": agent_id }))
+        .send()
+        .await
+        .map_err(|e| format!("provision request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("provision failed: {body}"));
+    }
+
+    let parsed: ProvisionResp = resp
+        .json()
+        .await
+        .map_err(|e| format!("provision response parse failed: {e}"))?;
+
+    wstore
+        .agent_credential_save(agent_id, &parsed.client_id, &parsed.client_secret, &parsed.token_endpoint)
+        .map_err(|e| format!("failed to save agent credential: {e}"))?;
+
+    tracing::info!(agent_id = %agent_id, "muxbus: provisioned per-agent credential");
+    Ok(())
+}
+
+/// Fetches a fresh client_credentials access token and caches it.
+/// client_credentials tokens carry no refresh token — expiry just means
+/// re-fetching from scratch with the (already-provisioned) client secret.
+async fn fetch_m2m_token(
+    agent_id: &str,
+    client_id: &str,
+    client_secret: &str,
+    token_endpoint: &str,
+    wstore: &Arc<Store>,
+    http: &reqwest::Client,
+) -> Result<String, String> {
+    if client_id.is_empty() || token_endpoint.is_empty() {
+        return Err("agent credential missing client_id/token_endpoint".to_string());
+    }
+
+    let params = [
+        ("grant_type", "client_credentials"),
+        ("client_id", client_id),
+        ("client_secret", client_secret),
+    ];
+    let resp = http
+        .post(token_endpoint)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| format!("m2m token request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("m2m token request failed: {body}"));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("m2m token response parse failed: {e}"))?;
+
+    let access_token = json["access_token"].as_str().unwrap_or("").to_string();
+    if access_token.is_empty() {
+        return Err("m2m token response missing access_token".to_string());
+    }
+    let expires_in = json["expires_in"].as_i64().unwrap_or(3600);
+    let expires_at = (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64)
+        + expires_in;
+
+    if let Err(e) = wstore.agent_credential_save_token(agent_id, &access_token, expires_at) {
+        tracing::warn!(agent_id = %agent_id, error = %e, "muxbus: failed to cache m2m token (will re-fetch next time)");
+    }
+
+    Ok(access_token)
+}

--- a/agentmux-srv/src/muxbus/agent_credentials.rs
+++ b/agentmux-srv/src/muxbus/agent_credentials.rs
@@ -29,26 +29,44 @@ use std::time::{Duration, Instant};
 use crate::backend::storage::store::Store;
 use crate::muxbus::cloud_subscriber::{load_valid_token, MUXBUS_REST_URL};
 
-/// How long to skip re-attempting provisioning for an agent after a
-/// failure, before trying again. InjectAvailable broadcasts for ANY
-/// injection to ANY agent, so without this an agent that can never
-/// provision (quota exceeded, malformed agent_id, provisioning endpoint
-/// down) gets a fresh provisioning attempt on every single broadcast —
-/// an unthrottled retry storm against the provisioning endpoint, unlike
-/// the broker's single-flight-guarded scheduler used for the shared
-/// token. reagentx P2 on PR #2342.
-const PROVISION_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+/// Per-request timeout for the two HTTP calls in this module. The shared
+/// `http` client (built via `reqwest::Client::new()` in
+/// `cloud_subscriber::run_loop`) carries no default timeout, and both
+/// calls here are awaited inline in the per-agent InjectAvailable loop —
+/// without an explicit override, a stalled provisioning or Cognito token
+/// endpoint would hang the whole loop indefinitely, blocking pings and
+/// delivery for every OTHER registered agent too. reagentx P1 on PR #2342.
+const CREDENTIAL_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
-static PROVISION_COOLDOWN: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+/// How long to skip re-attempting this agent's credential pipeline
+/// (provisioning OR token fetch) after either step fails, before trying
+/// again. InjectAvailable broadcasts for ANY injection to ANY agent, so
+/// without this an agent whose pipeline can't currently succeed (quota
+/// exceeded, malformed agent_id, provisioning/token endpoint down) gets a
+/// fresh network round-trip on every single broadcast — an unthrottled
+/// retry storm, unlike the broker's single-flight-guarded scheduler used
+/// for the shared token. reagentx P2 on PR #2342 (round 1: provisioning
+/// only; round 2: also covers fetch_m2m_token, the gap round 1 left open
+/// for an already-provisioned agent whose token endpoint is failing).
+const CREDENTIAL_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
 
-fn provision_cooldown() -> &'static Mutex<HashMap<String, Instant>> {
-    PROVISION_COOLDOWN.get_or_init(|| Mutex::new(HashMap::new()))
+static CREDENTIAL_COOLDOWN: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+
+fn credential_cooldown() -> &'static Mutex<HashMap<String, Instant>> {
+    CREDENTIAL_COOLDOWN.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn provision_recently_failed(agent_id: &str) -> bool {
-    let map = provision_cooldown().lock().unwrap();
+fn credential_recently_failed(agent_id: &str) -> bool {
+    let map = credential_cooldown().lock().unwrap();
     map.get(agent_id)
-        .is_some_and(|t| t.elapsed() < PROVISION_RETRY_COOLDOWN)
+        .is_some_and(|t| t.elapsed() < CREDENTIAL_RETRY_COOLDOWN)
+}
+
+fn record_credential_failure(agent_id: &str) {
+    credential_cooldown()
+        .lock()
+        .unwrap()
+        .insert(agent_id.to_string(), Instant::now());
 }
 
 /// Get a live per-agent access token, provisioning the Cognito client on
@@ -62,25 +80,26 @@ pub async fn ensure_agent_credential(
 ) -> Option<String> {
     let key = agent_id.to_lowercase();
 
+    // One guard covers both network steps below (provisioning and token
+    // fetch) — a recent failure in either means skip straight to the
+    // shared-token fallback until the cooldown lapses.
+    if credential_recently_failed(&key) {
+        return None;
+    }
+
     let creds = wstore.agent_credential_load(&key).ok().flatten();
 
     let creds = match creds {
         Some(c) if !c.client_id.is_empty() => c,
         _ => {
-            // Not provisioned yet. Skip if a recent attempt already failed
-            // (see PROVISION_RETRY_COOLDOWN) — this agent keeps using the
-            // shared token until the cooldown lapses or provisioning
-            // succeeds.
-            if provision_recently_failed(&key) {
-                return None;
-            }
+            // Not provisioned yet — do it now, once.
             if let Err(e) = provision_agent_client(&key, wstore, http).await {
                 tracing::warn!(
                     agent_id = %key, error = %e,
                     "muxbus: agent credential provisioning failed, backing off {}s",
-                    PROVISION_RETRY_COOLDOWN.as_secs(),
+                    CREDENTIAL_RETRY_COOLDOWN.as_secs(),
                 );
-                provision_cooldown().lock().unwrap().insert(key, Instant::now());
+                record_credential_failure(&key);
                 return None;
             }
             wstore.agent_credential_load(&key).ok().flatten()?
@@ -91,9 +110,18 @@ pub async fn ensure_agent_credential(
         return Some(creds.access_token);
     }
 
-    fetch_m2m_token(&key, &creds.client_id, &creds.client_secret, &creds.token_endpoint, wstore, http)
-        .await
-        .ok()
+    match fetch_m2m_token(&key, &creds.client_id, &creds.client_secret, &creds.token_endpoint, wstore, http).await {
+        Ok(access_token) => Some(access_token),
+        Err(e) => {
+            tracing::warn!(
+                agent_id = %key, error = %e,
+                "muxbus: agent m2m token fetch failed, backing off {}s",
+                CREDENTIAL_RETRY_COOLDOWN.as_secs(),
+            );
+            record_credential_failure(&key);
+            None
+        }
+    }
 }
 
 /// Clear a per-agent credential's cached access token — called by
@@ -136,10 +164,16 @@ async fn provision_agent_client(agent_id: &str, wstore: &Arc<Store>, http: &reqw
     }
 
     let url = format!("{}/agents/provision", MUXBUS_REST_URL);
+    // `http` (built via reqwest::Client::new() in cloud_subscriber::run_loop)
+    // carries no default timeout, and this call is awaited inline in the
+    // per-agent InjectAvailable loop — a stalled provisioning endpoint would
+    // otherwise block pings/delivery for every OTHER agent too, compounding
+    // across N agents per broadcast. reagentx P1 on PR #2342.
     let resp = http
         .post(&url)
         .header("Authorization", format!("Bearer {}", user_token))
         .json(&serde_json::json!({ "agent_id": agent_id }))
+        .timeout(CREDENTIAL_HTTP_TIMEOUT)
         .send()
         .await
         .map_err(|e| format!("provision request failed: {e}"))?;
@@ -185,6 +219,7 @@ async fn fetch_m2m_token(
     let resp = http
         .post(token_endpoint)
         .form(&params)
+        .timeout(CREDENTIAL_HTTP_TIMEOUT)
         .send()
         .await
         .map_err(|e| format!("m2m token request failed: {e}"))?;

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -554,9 +554,8 @@ async fn handle_server_msg(
                 // back to `token` (today's self-declared behavior) whenever
                 // this agent isn't provisioned yet or provisioning fails, so
                 // rollout never blocks delivery.
-                let agent_token = crate::muxbus::agent_credentials::ensure_agent_credential(agent_id, wstore, http)
-                    .await
-                    .unwrap_or_else(|| token.to_string());
+                let per_agent_token = crate::muxbus::agent_credentials::ensure_agent_credential(agent_id, wstore, http).await;
+                let agent_token = per_agent_token.clone().unwrap_or_else(|| token.to_string());
 
                 let url = format!("{}/reactive/pending/{}", MUXBUS_REST_URL, agent_id);
                 let resp = match http
@@ -574,7 +573,22 @@ async fn handle_server_msg(
                 };
 
                 if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-                    // Token expired during session — reconnect to refresh.
+                    if per_agent_token.is_some() {
+                        // The per-agent credential's cached token is stale/
+                        // revoked server-side even though it looked locally
+                        // valid — invalidate it so the next round re-fetches
+                        // instead of retrying the same rejected token and
+                        // tearing down the whole shared session (which would
+                        // starve delivery for every OTHER agent too) on every
+                        // InjectAvailable broadcast. reagentx P1 on PR #2342.
+                        crate::muxbus::agent_credentials::invalidate_cached_token(agent_id, wstore);
+                        tracing::warn!(
+                            agent_id = %agent_id,
+                            "cloud_subscriber: per-agent credential rejected (401) — invalidated, will retry next round",
+                        );
+                        continue;
+                    }
+                    // Shared account-level token expired during session — reconnect to refresh.
                     return Err("reconnect:token_expired".to_string());
                 }
                 if !resp.status().is_success() {

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -640,7 +640,22 @@ async fn handle_server_msg(
                     }
                 };
                 if claim_resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-                    // Token expired during session — reconnect to refresh.
+                    if per_agent_token.is_some() {
+                        // Same reasoning as the /reactive/pending 401 branch
+                        // above: a revoked/rotated per-agent credential must
+                        // only invalidate itself, not tear down the shared
+                        // session and starve every other agent. reagentx P1
+                        // + codex P2 on PR #2342 (round 3) — this second 401
+                        // site was missed when the pending-request branch
+                        // was fixed last round.
+                        crate::muxbus::agent_credentials::invalidate_cached_token(agent_id, wstore);
+                        tracing::warn!(
+                            agent_id = %agent_id,
+                            "cloud_subscriber: per-agent credential rejected (401) on claim — invalidated, will retry next round",
+                        );
+                        continue; // nothing claimed — retried on the next wake/poll
+                    }
+                    // Shared account-level token expired during session — reconnect to refresh.
                     return Err("reconnect:token_expired".to_string());
                 }
                 if !claim_resp.status().is_success() {

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -531,237 +531,30 @@ async fn handle_server_msg(
         ServerMsg::InjectAvailable => {
             // Collect currently-registered agents without holding the lock across awaits.
             let registered: Vec<String> = agents.lock().unwrap().iter().cloned().collect();
-
-            #[derive(Deserialize)]
-            struct PendingResp { injections: Vec<PendingInj> }
-            #[derive(Deserialize)]
-            struct PendingInj {
-                id: String,
-                source_agent: Option<String>,
-                message: String,
-                priority: Option<String>,
-            }
-            #[derive(Deserialize)]
-            struct AckResp {
-                acknowledged: Vec<String>,
-                delivered_at: String,
-            }
-
             let handler = get_global_handler();
-            for agent_id in &registered {
-                // Prefer a credential bound to exactly this agent_id over the
-                // shared account-level token — see agent_credentials.rs. Falls
-                // back to `token` (today's self-declared behavior) whenever
-                // this agent isn't provisioned yet or provisioning fails, so
-                // rollout never blocks delivery.
-                let per_agent_token = crate::muxbus::agent_credentials::ensure_agent_credential(agent_id, wstore, http).await;
-                let agent_token = per_agent_token.clone().unwrap_or_else(|| token.to_string());
 
-                let url = format!("{}/reactive/pending/{}", MUXBUS_REST_URL, agent_id);
-                let resp = match http
-                    .get(&url)
-                    .header("Authorization", format!("Bearer {}", agent_token))
-                    .header("X-Agent-ID", agent_id)
-                    .send()
-                    .await
-                {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::warn!(agent_id = %agent_id, error = %e, "cloud_subscriber: fetch pending failed");
-                        continue;
-                    }
-                };
+            // Concurrent, not sequential: each agent's sync can incur up to
+            // two CREDENTIAL_HTTP_TIMEOUT-bounded HTTP calls (credential
+            // fetch + pending fetch, worst case an unrevoked-then-retried
+            // claim too) — sequentially awaiting N agents compounds that
+            // into an N-times-longer block of this whole select! loop
+            // (pings, incoming messages, ctrl signals all wait on it).
+            // join_all bounds the wall-clock cost to the slowest single
+            // agent's chain regardless of N. reagentx P1 (round 4) on
+            // PR #2342.
+            let outcomes = futures_util::future::join_all(
+                registered
+                    .iter()
+                    .map(|agent_id| sync_agent_reactive(agent_id, token, http, wstore, handler)),
+            )
+            .await;
 
-                if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-                    if per_agent_token.is_some() {
-                        // The per-agent credential's cached token is stale/
-                        // revoked server-side even though it looked locally
-                        // valid — invalidate it so the next round re-fetches
-                        // instead of retrying the same rejected token and
-                        // tearing down the whole shared session (which would
-                        // starve delivery for every OTHER agent too) on every
-                        // InjectAvailable broadcast. reagentx P1 on PR #2342.
-                        crate::muxbus::agent_credentials::invalidate_cached_token(agent_id, wstore);
-                        tracing::warn!(
-                            agent_id = %agent_id,
-                            "cloud_subscriber: per-agent credential rejected (401) — invalidated, will retry next round",
-                        );
-                        continue;
-                    }
-                    // Shared account-level token expired during session — reconnect to refresh.
-                    return Err("reconnect:token_expired".to_string());
-                }
-                if !resp.status().is_success() {
-                    tracing::warn!(
-                        status = %resp.status(),
-                        agent_id = %agent_id,
-                        "cloud_subscriber: fetch pending non-2xx"
-                    );
-                    continue;
-                }
-
-                let body: PendingResp = match resp.json().await {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::warn!(error = %e, "cloud_subscriber: parse pending failed");
-                        continue;
-                    }
-                };
-
-                if body.injections.is_empty() {
-                    continue;
-                }
-
-                // Claim BEFORE delivering, not after: this is what prevents
-                // double-delivery when the same agent_id is concurrently
-                // registered by another AgentMux channel on this host (an
-                // intentionally-supported "two seats" workflow — see
-                // docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md).
-                // /reactive/ack now performs an atomic pending->delivered
-                // transition server-side; only injection ids that come back
-                // in `acknowledged` were actually won by this call and get
-                // delivered locally below. A previous version of this code
-                // delivered first and only acked successes afterward, which
-                // let two concurrent pollers both deliver the same injection.
-                let all_ids: Vec<String> = body.injections.iter().map(|inj| inj.id.clone()).collect();
-                let ack_url = format!("{}/reactive/ack", MUXBUS_REST_URL);
-                let claim_resp = match http
-                    .post(&ack_url)
-                    .header("Authorization", format!("Bearer {}", agent_token))
-                    .header("X-Agent-ID", agent_id)
-                    .json(&serde_json::json!({ "injection_ids": all_ids }))
-                    .send()
-                    .await
-                {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::warn!(agent_id = %agent_id, error = %e, "cloud_subscriber: claim request failed");
-                        continue; // nothing claimed — retried on the next wake/poll
-                    }
-                };
-                if claim_resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-                    if per_agent_token.is_some() {
-                        // Same reasoning as the /reactive/pending 401 branch
-                        // above: a revoked/rotated per-agent credential must
-                        // only invalidate itself, not tear down the shared
-                        // session and starve every other agent. reagentx P1
-                        // + codex P2 on PR #2342 (round 3) — this second 401
-                        // site was missed when the pending-request branch
-                        // was fixed last round.
-                        crate::muxbus::agent_credentials::invalidate_cached_token(agent_id, wstore);
-                        tracing::warn!(
-                            agent_id = %agent_id,
-                            "cloud_subscriber: per-agent credential rejected (401) on claim — invalidated, will retry next round",
-                        );
-                        continue; // nothing claimed — retried on the next wake/poll
-                    }
-                    // Shared account-level token expired during session — reconnect to refresh.
-                    return Err("reconnect:token_expired".to_string());
-                }
-                if !claim_resp.status().is_success() {
-                    tracing::warn!(
-                        status = %claim_resp.status(),
-                        agent_id = %agent_id,
-                        "cloud_subscriber: claim request non-2xx"
-                    );
-                    continue; // nothing claimed — retried on the next wake/poll
-                }
-                let claimed: AckResp = match claim_resp.json().await {
-                    Ok(b) => b,
-                    Err(e) => {
-                        // The server processed the claim (status was 2xx) before this
-                        // body failed to parse — some subset of `all_ids` may now be
-                        // flipped to "delivered" server-side with no local delivery
-                        // and no way for us to release them, since we don't know
-                        // which ids succeeded or their delivered_at stamp (required
-                        // by /reactive/release). We deliberately do NOT guess (e.g.
-                        // via /reactive/status) and release whatever looks delivered:
-                        // some of `all_ids` may have been legitimately claimed and
-                        // delivered by a *different* concurrent poller (another
-                        // channel/seat racing for the same agent_id), and blindly
-                        // releasing those would reintroduce the exact duplicate-
-                        // delivery bug this change exists to fix. Logging every
-                        // affected id loudly is the safe tradeoff: rare silent
-                        // message loss here, never a resurrected duplicate.
-                        tracing::error!(
-                            agent_id = %agent_id,
-                            injection_ids = ?all_ids,
-                            error = %e,
-                            "cloud_subscriber: parse claim response failed — these injections may be claimed server-side with no local delivery and cannot be safely auto-recovered"
-                        );
-                        continue;
-                    }
-                };
-                let delivered_at = claimed.delivered_at;
-                let claimed_ids: std::collections::HashSet<String> =
-                    claimed.acknowledged.into_iter().collect();
-
-                for inj in &body.injections {
-                    if !claimed_ids.contains(&inj.id) {
-                        // Another concurrent poller (this account's other
-                        // channel/seat) already won this claim — expected
-                        // under the "two seats" workflow, not an error.
-                        continue;
-                    }
-
-                    let req = InjectionRequest {
-                        target_agent: agent_id.clone(),
-                        message: inj.message.clone(),
-                        source_agent: inj.source_agent.clone(),
-                        request_id: Some(inj.id.clone()),
-                        priority: inj.priority.clone(),
-                        wait_for_idle: false,
-                        jekt_tier: None,       // auto-detected from keywords
-                        delivery_tier: Some("wan".to_string()),
-                    };
-                    let delivery = handler.inject_message(req);
-                    tracing::debug!(
-                        injection_id = %inj.id,
-                        agent_id = %agent_id,
-                        success = delivery.success,
-                        "cloud_subscriber: delivered injection"
-                    );
-
-                    if !delivery.success {
-                        // We hold the claim but local delivery failed (e.g.
-                        // agent not ready) — release it back to pending so
-                        // it's retried, instead of silently dropping it now
-                        // that claiming already marked it "delivered".
-                        let release_url = format!("{}/reactive/release", MUXBUS_REST_URL);
-                        match http
-                            .post(&release_url)
-                            .header("Authorization", format!("Bearer {}", agent_token))
-                            .header("X-Agent-ID", agent_id)
-                            .json(&serde_json::json!({
-                                "injection_id": inj.id,
-                                "delivered_at": delivered_at,
-                            }))
-                            .send()
-                            .await
-                        {
-                            Ok(r) if r.status().is_success() => {}
-                            Ok(r) => {
-                                // Claim is stranded as "delivered" with no local
-                                // delivery and no retry until this is visible —
-                                // log loudly rather than discarding silently.
-                                tracing::warn!(
-                                    injection_id = %inj.id,
-                                    agent_id = %agent_id,
-                                    status = %r.status(),
-                                    "cloud_subscriber: release request non-2xx — injection stranded as delivered, message lost"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    injection_id = %inj.id,
-                                    agent_id = %agent_id,
-                                    error = %e,
-                                    "cloud_subscriber: release request failed — injection stranded as delivered, message lost"
-                                );
-                            }
-                        }
-                    }
-                }
+            if outcomes
+                .iter()
+                .any(|o| matches!(o, AgentSyncOutcome::ReconnectSharedTokenExpired))
+            {
+                // Shared account-level token expired during session — reconnect to refresh.
+                return Err("reconnect:token_expired".to_string());
             }
         }
         ServerMsg::Error { message } => {
@@ -774,6 +567,275 @@ async fn handle_server_msg(
         ServerMsg::Pong | ServerMsg::Subscribed { .. } | ServerMsg::Unknown => {}
     }
     Ok(())
+}
+
+enum AgentSyncOutcome {
+    /// This agent's sync finished (successfully or with an already-logged,
+    /// non-fatal error) — nothing further to signal to the caller.
+    Ok,
+    /// The SHARED account-level token (not a per-agent credential) was
+    /// rejected — the whole WS session's auth is stale and needs a
+    /// reconnect. Only ever produced when no per-agent credential was in
+    /// play for the rejected call.
+    ReconnectSharedTokenExpired,
+}
+
+/// One registered agent's full pending-fetch → claim → deliver cycle for an
+/// `InjectAvailable` broadcast. Extracted from the loop body it used to be
+/// so `handle_server_msg` can run every agent's sync concurrently via
+/// `join_all` instead of sequentially — see the call site's own comment.
+///
+/// Retries once with the shared `token` if a per-agent credential is
+/// rejected (401) — without this, invalidating the credential alone left
+/// this agent's pending injection undelivered until an unrelated
+/// InjectAvailable broadcast happened to fire again (no periodic resync
+/// exists). reagentx P1 (round 4) on PR #2342.
+async fn sync_agent_reactive(
+    agent_id: &str,
+    token: &str,
+    http: &reqwest::Client,
+    wstore: &Arc<Store>,
+    handler: &'static crate::backend::reactive::handler::ReactiveHandler,
+) -> AgentSyncOutcome {
+    #[derive(Deserialize)]
+    struct PendingResp { injections: Vec<PendingInj> }
+    #[derive(Deserialize)]
+    struct PendingInj {
+        id: String,
+        source_agent: Option<String>,
+        message: String,
+        priority: Option<String>,
+    }
+    #[derive(Deserialize)]
+    struct AckResp {
+        acknowledged: Vec<String>,
+        delivered_at: String,
+    }
+
+    // Prefer a credential bound to exactly this agent_id over the shared
+    // account-level token — see agent_credentials.rs. Falls back to `token`
+    // (today's self-declared behavior) whenever this agent isn't
+    // provisioned yet or provisioning fails, so rollout never blocks
+    // delivery. `using_per_agent` tracks which one is currently in play so
+    // a 401 can be attributed correctly and, for a per-agent credential,
+    // retried once with the shared token instead of just giving up.
+    let per_agent_token = crate::muxbus::agent_credentials::ensure_agent_credential(agent_id, wstore, http).await;
+    let mut agent_token = per_agent_token.clone().unwrap_or_else(|| token.to_string());
+    let mut using_per_agent = per_agent_token.is_some();
+
+    let url = format!("{}/reactive/pending/{}", MUXBUS_REST_URL, agent_id);
+    let body: PendingResp = loop {
+        let resp = match http
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", agent_token))
+            .header("X-Agent-ID", agent_id)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(agent_id = %agent_id, error = %e, "cloud_subscriber: fetch pending failed");
+                return AgentSyncOutcome::Ok;
+            }
+        };
+
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            if using_per_agent {
+                // The per-agent credential's cached token is stale/revoked
+                // server-side even though it looked locally valid —
+                // invalidate it (so the next agent_credentials call
+                // re-fetches instead of retrying the same rejected token)
+                // and retry THIS fetch immediately with the shared token,
+                // rather than tearing down the whole shared session (which
+                // would starve delivery for every OTHER agent too).
+                crate::muxbus::agent_credentials::invalidate_cached_token(agent_id, wstore);
+                tracing::warn!(
+                    agent_id = %agent_id,
+                    "cloud_subscriber: per-agent credential rejected (401) — invalidated, retrying with shared token",
+                );
+                agent_token = token.to_string();
+                using_per_agent = false;
+                continue;
+            }
+            return AgentSyncOutcome::ReconnectSharedTokenExpired;
+        }
+        if !resp.status().is_success() {
+            tracing::warn!(
+                status = %resp.status(),
+                agent_id = %agent_id,
+                "cloud_subscriber: fetch pending non-2xx"
+            );
+            return AgentSyncOutcome::Ok;
+        }
+
+        break match resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(error = %e, "cloud_subscriber: parse pending failed");
+                return AgentSyncOutcome::Ok;
+            }
+        };
+    };
+
+    if body.injections.is_empty() {
+        return AgentSyncOutcome::Ok;
+    }
+
+    // Claim BEFORE delivering, not after: this is what prevents
+    // double-delivery when the same agent_id is concurrently registered by
+    // another AgentMux channel on this host (an intentionally-supported
+    // "two seats" workflow — see
+    // docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DUPLICATE_DELIVERY_2026_07_04.md).
+    // /reactive/ack now performs an atomic pending->delivered transition
+    // server-side; only injection ids that come back in `acknowledged` were
+    // actually won by this call and get delivered locally below. A
+    // previous version of this code delivered first and only acked
+    // successes afterward, which let two concurrent pollers both deliver
+    // the same injection.
+    let all_ids: Vec<String> = body.injections.iter().map(|inj| inj.id.clone()).collect();
+    let ack_url = format!("{}/reactive/ack", MUXBUS_REST_URL);
+    let claimed: AckResp = loop {
+        let claim_resp = match http
+            .post(&ack_url)
+            .header("Authorization", format!("Bearer {}", agent_token))
+            .header("X-Agent-ID", agent_id)
+            .json(&serde_json::json!({ "injection_ids": all_ids }))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(agent_id = %agent_id, error = %e, "cloud_subscriber: claim request failed");
+                return AgentSyncOutcome::Ok; // nothing claimed — retried on the next wake/poll
+            }
+        };
+
+        if claim_resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            if using_per_agent {
+                // Same reasoning as the /reactive/pending 401 branch above:
+                // invalidate and retry THIS claim immediately with the
+                // shared token, rather than reconnecting the whole session
+                // or leaving this agent's already-fetched pending
+                // injections unclaimed until an unrelated broadcast fires.
+                crate::muxbus::agent_credentials::invalidate_cached_token(agent_id, wstore);
+                tracing::warn!(
+                    agent_id = %agent_id,
+                    "cloud_subscriber: per-agent credential rejected (401) on claim — invalidated, retrying with shared token",
+                );
+                agent_token = token.to_string();
+                using_per_agent = false;
+                continue;
+            }
+            return AgentSyncOutcome::ReconnectSharedTokenExpired;
+        }
+        if !claim_resp.status().is_success() {
+            tracing::warn!(
+                status = %claim_resp.status(),
+                agent_id = %agent_id,
+                "cloud_subscriber: claim request non-2xx"
+            );
+            return AgentSyncOutcome::Ok; // nothing claimed — retried on the next wake/poll
+        }
+
+        break match claim_resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                // The server processed the claim (status was 2xx) before this
+                // body failed to parse — some subset of `all_ids` may now be
+                // flipped to "delivered" server-side with no local delivery
+                // and no way for us to release them, since we don't know
+                // which ids succeeded or their delivered_at stamp (required
+                // by /reactive/release). We deliberately do NOT guess (e.g.
+                // via /reactive/status) and release whatever looks delivered:
+                // some of `all_ids` may have been legitimately claimed and
+                // delivered by a *different* concurrent poller (another
+                // channel/seat racing for the same agent_id), and blindly
+                // releasing those would reintroduce the exact duplicate-
+                // delivery bug this change exists to fix. Logging every
+                // affected id loudly is the safe tradeoff: rare silent
+                // message loss here, never a resurrected duplicate.
+                tracing::error!(
+                    agent_id = %agent_id,
+                    injection_ids = ?all_ids,
+                    error = %e,
+                    "cloud_subscriber: parse claim response failed — these injections may be claimed server-side with no local delivery and cannot be safely auto-recovered"
+                );
+                return AgentSyncOutcome::Ok;
+            }
+        };
+    };
+
+    let delivered_at = claimed.delivered_at;
+    let claimed_ids: std::collections::HashSet<String> = claimed.acknowledged.into_iter().collect();
+
+    for inj in &body.injections {
+        if !claimed_ids.contains(&inj.id) {
+            // Another concurrent poller (this account's other channel/seat)
+            // already won this claim — expected under the "two seats"
+            // workflow, not an error.
+            continue;
+        }
+
+        let req = InjectionRequest {
+            target_agent: agent_id.to_string(),
+            message: inj.message.clone(),
+            source_agent: inj.source_agent.clone(),
+            request_id: Some(inj.id.clone()),
+            priority: inj.priority.clone(),
+            wait_for_idle: false,
+            jekt_tier: None,       // auto-detected from keywords
+            delivery_tier: Some("wan".to_string()),
+        };
+        let delivery = handler.inject_message(req);
+        tracing::debug!(
+            injection_id = %inj.id,
+            agent_id = %agent_id,
+            success = delivery.success,
+            "cloud_subscriber: delivered injection"
+        );
+
+        if !delivery.success {
+            // We hold the claim but local delivery failed (e.g. agent not
+            // ready) — release it back to pending so it's retried, instead
+            // of silently dropping it now that claiming already marked it
+            // "delivered".
+            let release_url = format!("{}/reactive/release", MUXBUS_REST_URL);
+            match http
+                .post(&release_url)
+                .header("Authorization", format!("Bearer {}", agent_token))
+                .header("X-Agent-ID", agent_id)
+                .json(&serde_json::json!({
+                    "injection_id": inj.id,
+                    "delivered_at": delivered_at,
+                }))
+                .send()
+                .await
+            {
+                Ok(r) if r.status().is_success() => {}
+                Ok(r) => {
+                    // Claim is stranded as "delivered" with no local
+                    // delivery and no retry until this is visible — log
+                    // loudly rather than discarding silently.
+                    tracing::warn!(
+                        injection_id = %inj.id,
+                        agent_id = %agent_id,
+                        status = %r.status(),
+                        "cloud_subscriber: release request non-2xx — injection stranded as delivered, message lost"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        injection_id = %inj.id,
+                        agent_id = %agent_id,
+                        error = %e,
+                        "cloud_subscriber: release request failed — injection stranded as delivered, message lost"
+                    );
+                }
+            }
+        }
+    }
+
+    AgentSyncOutcome::Ok
 }
 
 /// Load a valid (non-expired) access token via the broker, refreshing first

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -45,7 +45,7 @@ use crate::broker::RefreshErrorKind;
 // the API's default stage. Full design/history in the agentmux-cloud repo's
 // muxbus/ directory (search for the WebSocket relay redesign writeup).
 const MUXBUS_WS_URL: &str = "wss://muxbus-ws.agentmux.ai";
-const MUXBUS_REST_URL: &str = "https://muxbus.agentmux.ai";
+pub(crate) const MUXBUS_REST_URL: &str = "https://muxbus.agentmux.ai";
 const RECONNECT_DELAY_SECS: u64 = 5;
 const MAX_RECONNECT_DELAY_SECS: u64 = 60;
 // AWS API Gateway WebSocket APIs enforce a 10-minute idle timeout with no
@@ -353,7 +353,7 @@ async fn run_loop(
         tracing::info!("cloud_subscriber: connecting to {}", MUXBUS_WS_URL);
         let session_start = std::time::Instant::now();
 
-        match connect_and_run(&token, agents.clone(), &mut ctrl_rx, &http).await {
+        match connect_and_run(&token, agents.clone(), &mut ctrl_rx, &wstore, &http).await {
             Ok(()) => {
                 // Apply the same >30s healthy-session guard as the error branch: a server
                 // that immediately closes after handshake must not suppress back-off.
@@ -398,6 +398,7 @@ async fn connect_and_run(
     token: &str,
     agents: Arc<Mutex<HashSet<String>>>,
     ctrl_rx: &mut mpsc::UnboundedReceiver<CtrlMsg>,
+    wstore: &Arc<Store>,
     http: &reqwest::Client,
 ) -> Result<(), String> {
     use tokio_tungstenite::tungstenite::ClientRequestBuilder;
@@ -470,7 +471,7 @@ async fn connect_and_run(
                     Some(Err(e)) => return Err(format!("ws recv: {e}")),
                     Some(Ok(Message::Text(text))) => {
                         if let Ok(server_msg) = serde_json::from_str::<ServerMsg>(&text) {
-                            match handle_server_msg(server_msg, token, http, &agents).await {
+                            match handle_server_msg(server_msg, token, http, &agents, wstore).await {
                                 Ok(()) => {}
                                 // Eviction or expired token — close stream to trigger reconnect.
                                 Err(ref e) if e.starts_with("reconnect:") => {
@@ -524,6 +525,7 @@ async fn handle_server_msg(
     token: &str,
     http: &reqwest::Client,
     agents: &Arc<Mutex<HashSet<String>>>,
+    wstore: &Arc<Store>,
 ) -> Result<(), String> {
     match msg {
         ServerMsg::InjectAvailable => {
@@ -547,10 +549,19 @@ async fn handle_server_msg(
 
             let handler = get_global_handler();
             for agent_id in &registered {
+                // Prefer a credential bound to exactly this agent_id over the
+                // shared account-level token — see agent_credentials.rs. Falls
+                // back to `token` (today's self-declared behavior) whenever
+                // this agent isn't provisioned yet or provisioning fails, so
+                // rollout never blocks delivery.
+                let agent_token = crate::muxbus::agent_credentials::ensure_agent_credential(agent_id, wstore, http)
+                    .await
+                    .unwrap_or_else(|| token.to_string());
+
                 let url = format!("{}/reactive/pending/{}", MUXBUS_REST_URL, agent_id);
                 let resp = match http
                     .get(&url)
-                    .header("Authorization", format!("Bearer {}", token))
+                    .header("Authorization", format!("Bearer {}", agent_token))
                     .header("X-Agent-ID", agent_id)
                     .send()
                     .await
@@ -602,7 +613,7 @@ async fn handle_server_msg(
                 let ack_url = format!("{}/reactive/ack", MUXBUS_REST_URL);
                 let claim_resp = match http
                     .post(&ack_url)
-                    .header("Authorization", format!("Bearer {}", token))
+                    .header("Authorization", format!("Bearer {}", agent_token))
                     .header("X-Agent-ID", agent_id)
                     .json(&serde_json::json!({ "injection_ids": all_ids }))
                     .send()
@@ -690,7 +701,7 @@ async fn handle_server_msg(
                         let release_url = format!("{}/reactive/release", MUXBUS_REST_URL);
                         match http
                             .post(&release_url)
-                            .header("Authorization", format!("Bearer {}", token))
+                            .header("Authorization", format!("Bearer {}", agent_token))
                             .header("X-Agent-ID", agent_id)
                             .json(&serde_json::json!({
                                 "injection_id": inj.id,
@@ -742,7 +753,11 @@ async fn handle_server_msg(
 /// is absent — `ensure_fresh`'s own single-flight guard means this can run
 /// concurrently with the broker's background sweep for the same credential
 /// without either one duplicating the other's refresh attempt.
-async fn load_valid_token(
+///
+/// pub(crate): also used by agent_credentials.rs to authenticate the
+/// POST /agents/provision call, which requires the human's own user-level
+/// (PKCE) token, not an agent-bound M2M one.
+pub(crate) async fn load_valid_token(
     wstore: &Arc<Store>,
     scheduler: &crate::broker::RefreshScheduler,
 ) -> Option<String> {

--- a/agentmux-srv/src/muxbus/mod.rs
+++ b/agentmux-srv/src/muxbus/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod agent_credentials;
 pub mod cloud_subscriber;
 pub mod pkce;
 


### PR DESCRIPTION
## Summary

Client-side half of agentmux-cloud's `PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md` — server side already shipped in [agentmuxai/agentmux-cloud#25](https://github.com/agentmuxai/agentmux-cloud/pull/25) ("per-agent credential binding, inert by default" — `ENFORCE_AGENT_BINDING` unset means log-only enforcement until per-agent clients are actually issued end-to-end, so this is low-risk to land).

Historically every agent under one AgentMux login shared the single account-level `MUXBUS_TOKEN` for every `/reactive/*` call, self-declaring its identity via an unverified `X-Agent-ID` header — any credential could claim any agent_id.

## Changes

- **`db_agent_credentials`** (new table, `SHARED_STORE_SCHEMA_VERSION` v4 / `OBJECT_SCHEMA_VERSION` v13): one row per locally-registered agent_id — Cognito `client_id`/`client_secret` + cached `client_credentials` access token, distinct from the account-level `db_muxbus_credentials` singleton (which stores only the human's own PKCE login, used to *provision* these).
- **`muxbus::agent_credentials`**: `ensure_agent_credential()` provisions a per-agent Cognito client on first use (`POST /agents/provision`, authenticated with the human's own PKCE token — an M2M credential can never provision another one) and fetches/caches a `client_credentials` token thereafter. Falls back to the shared `MUXBUS_TOKEN` on any failure — provisioning being down must degrade the binding guarantee, never block message delivery.
- **`cloud_subscriber.rs`**: `InjectAvailable`'s pending-fetch now prefers the per-agent credential over the shared token when available.

## Note on provenance

This was originally written earlier in this session, stashed with a note that its base had gone stale, and only resurrected now. Rebasing surfaced real architecture drift: `main` had since introduced `crate::broker::RefreshScheduler` for proactive token refresh, replacing this branch's own direct-refresh `load_valid_token`. Resolved by keeping main's broker-based implementation (making it `pub(crate)` so `agent_credentials.rs` can reuse it via the process-wide `broker::get_global()` singleton) rather than reintroducing the older direct-refresh path alongside it — verified the request/response shape against the already-merged cloud endpoint's actual implementation (`agent-provisioning.ts`) to confirm end-to-end compatibility.

## Verification

- `cargo check -p agentmux-srv` — clean (no new warnings beyond pre-existing baseline)
- `cargo test -p agentmux-srv` (full suite) — 1742 passed, 0 failed, 4 ignored
- `cargo test -p agentmux-srv agent_credential` — 7/7 passed (storage-layer round-trip, idempotency, expiry-margin tests)
- `cargo test -p agentmux-srv migrations::` — 32/32 passed (schema idempotency unaffected by the new table)
- Verified the cloud endpoint's actual response shape (`{client_id, client_secret, token_endpoint}`) matches this branch's `ProvisionResp` struct exactly, and that `POST /agents/provision` requires a Cognito user-level token (matching this branch's use of the PKCE `load_valid_token`, not an M2M one)

Not live-verified end-to-end against the real cloud endpoint in this pass (would require a live muxbus login) — the server-side `ENFORCE_AGENT_BINDING` log-only default means an issue here degrades to today's shared-token behavior, not a delivery break.

<!-- agentmux:agent_id=agent3 -->