### PR TITLE
fix(build): wire up Windows codec-enabled CEF default-location auto-pickup + advisory warning

### DIFF
--- a/.changesets/1785260414-fix-build-wire-up-windows-codec-enabled-cef-default-location-zsxl.md
+++ b/.changesets/1785260414-fix-build-wire-up-windows-codec-enabled-cef-default-location-zsxl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): wire up Windows codec-enabled CEF default-location auto-pickup + advisory warning

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -554,39 +554,62 @@ tasks:
         platforms: [windows]
         cmds:
             - cmd: |
-                # Optional override: substitute a custom-built (e.g. codec-enabled)
-                # CEF runtime into target/release/ BEFORE the version-matched logic
-                # below runs, so everything downstream — including the
-                # verify-cef-version.sh gate — behaves identically whether the
-                # source was this override or the normal cargo-staged files. No-op
-                # when the env var is unset: default behavior is byte-for-byte
-                # unchanged from before this block existed. Mirrors bundle:darwin's
-                # resolver-driven override, adapted to bundle:windows's
-                # "source everything from target/release" design instead of a
-                # separate CEF_DIR variable, since target/release is what every
-                # downstream cp in this task already reads from.
+                # Resolve which directory to bundle CEF runtime files FROM.
+                # cefDir is set to that directory directly (never copied
+                # wholesale into target/release/) — the override and
+                # cef-build-default directories are raw Chromium ninja build
+                # output trees (potentially dozens of GB of intermediate/
+                # debug artifacts, not just runtime files), so a recursive
+                # `cp -rf .../. target/release/` of one of those is extremely
+                # slow and was observed to hang bundle:windows for 10+
+                # minutes copying files nothing downstream needs. Every
+                # downstream step in this task already does per-file `cp -f
+                # "$cefDir/<name>" dist/cef/` for exactly the runtime files
+                # it needs, so pointing cefDir at the source directly (no
+                # staging copy) is both correct and far cheaper.
                 # See docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md.
+                #
+                # cefSource tracks WHICH tier resolved the runtime, so the
+                # advisory warning below can fire only when we actually landed
+                # on the stock (no-codec) cargo cache — mirrors bundle:darwin's
+                # verify-cef-framework-darwin.sh warning, which Windows never
+                # had despite resolve-cef-runtime-windows.ps1 already
+                # containing the equivalent tier/warning logic — that script
+                # was written but never wired into this task, so `task dev`/
+                # `task package` silently used the stock CEF with no signal.
+                cefSource="cargo-cache"
+                cefDir="target/release"
+                cefBuildDefault="$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64"
                 if [ -n "${AGENTMUX_CEF_RUNTIME_DIR_WINDOWS:-}" ]; then
-                  echo "AGENTMUX_CEF_RUNTIME_DIR_WINDOWS set — staging override CEF runtime from $AGENTMUX_CEF_RUNTIME_DIR_WINDOWS"
+                  echo "AGENTMUX_CEF_RUNTIME_DIR_WINDOWS set — using override CEF runtime at $AGENTMUX_CEF_RUNTIME_DIR_WINDOWS"
                   if [ ! -f "$AGENTMUX_CEF_RUNTIME_DIR_WINDOWS/libcef.dll" ] || [ ! -f "$AGENTMUX_CEF_RUNTIME_DIR_WINDOWS/icudtl.dat" ]; then
                     echo "❌ AGENTMUX_CEF_RUNTIME_DIR_WINDOWS is set but missing libcef.dll + icudtl.dat" >&2
                     exit 1
                   fi
-                  mkdir -p target/release
-                  cp -rf "$AGENTMUX_CEF_RUNTIME_DIR_WINDOWS/." target/release/
+                  cefDir="$AGENTMUX_CEF_RUNTIME_DIR_WINDOWS"
+                  cefSource="override"
+                elif [ -f "$cefBuildDefault/libcef.dll" ] && [ -f "$cefBuildDefault/icudtl.dat" ]; then
+                  # Tier 2: the standard cef-build layout from
+                  # docs/cef-build/build-patched-cef-windows.md, which
+                  # documents this as picked up "automatically" — previously
+                  # untrue, since this task never checked for it.
+                  echo "Found codec-enabled CEF at default cef-build location — using $cefBuildDefault"
+                  cefDir="$cefBuildDefault"
+                  cefSource="cef-build-default"
                 fi
-                # cargo/cef-dll-sys copies the ACTIVE build's full CEF runtime
-                # (libcef.dll + paks + icudtl.dat + GL dlls + en-US locale) into
-                # target/release/ alongside the linked host — always matching the
-                # host's CEF version. Source from there directly: deterministic and
-                # version-correct. The old `find … | head -1` was non-deterministic
-                # and could grab a STALE cef-dll-sys build-dir copy from a previous
-                # CEF version — after the 146→148 bump (#1221) it picked a 146
-                # libcef.dll, so the 148-linked host died with "unsupported CEF API
-                # version 14800". (Avoids `ls -t`/`find -printf` too — task's shell
-                # uses a limited Go coreutils that rejects those flags.)
-                cefDir=target/release
-                if [ ! -f "$cefDir/libcef.dll" ] || [ ! -f "$cefDir/icudtl.dat" ]; then
+                # Tier 3 (cefSource still "cargo-cache"): cargo/cef-dll-sys
+                # copies the ACTIVE build's full CEF runtime (libcef.dll +
+                # paks + icudtl.dat + GL dlls + en-US locale) into
+                # target/release/ alongside the linked host — always matching
+                # the host's CEF version. Source from there directly:
+                # deterministic and version-correct. The old `find … | head
+                # -1` was non-deterministic and could grab a STALE
+                # cef-dll-sys build-dir copy from a previous CEF version —
+                # after the 146→148 bump (#1221) it picked a 146 libcef.dll,
+                # so the 148-linked host died with "unsupported CEF API
+                # version 14800". (Avoids `ls -t`/`find -printf` too — task's
+                # shell uses a limited Go coreutils that rejects those flags.)
+                if [ "$cefSource" = "cargo-cache" ] && { [ ! -f "$cefDir/libcef.dll" ] || [ ! -f "$cefDir/icudtl.dat" ]; }; then
                   # rust-cache hit: cef-dll-sys build script didn't re-run →
                   # DLLs not staged to target/release/. The CEF SDK is still in
                   # the build OUT_DIR (rust-cache preserves
@@ -635,6 +658,23 @@ tasks:
                 # window). Fail loudly here instead of shipping a broken build.
                 # See docs/specs/SPEC_WINDOWS_CEF_BUNDLE_VERSION_INTEGRITY_2026_06_03.md.
                 bash scripts/verify-cef-version.sh "$cefDir" || exit 1
+                # Advisory-only, same posture as bundle:darwin's unpatched-
+                # framework warning: don't fail `task dev`/`task package` on
+                # the stock cef-dll-sys fallback (that's still a legitimate,
+                # working build for everything except proprietary codecs), but
+                # make it loud and actionable rather than silent — this is
+                # exactly the gap that let MP4/MOV playback silently fail with
+                # no signal pointing at the cause. See
+                # docs/reports/REPORT_CEF_PROPRIETARY_CODEC_GAP_2026_07_26.md.
+                if [ "$cefSource" = "cargo-cache" ]; then
+                  echo "" >&2
+                  echo "⚠️ ⚠️ ⚠️  BUNDLING THE STOCK (NO-CODEC) CEF RUNTIME  ⚠️ ⚠️ ⚠️" >&2
+                  echo "    MP4/MOV/HEVC/AC3 playback will fail app-wide (DEMUXER_ERROR_NO_SUPPORTED_STREAMS)." >&2
+                  echo "    To use the codec-enabled build: docs/cef-build/build-patched-cef-windows.md," >&2
+                  echo "    then either place it at $cefBuildDefault or set AGENTMUX_CEF_RUNTIME_DIR_WINDOWS." >&2
+                  echo "    (Dev build continues anyway — this is advisory.)" >&2
+                  echo "" >&2
+                fi
                 mkdir -p dist/cef/locales
                 # Core DLLs (required)
                 cp -f "$cefDir/libcef.dll" dist/cef/


### PR DESCRIPTION
## What

`task dev` / `task package` on Windows never checked the documented
default cef-build location (`~/cef-build/.../Release_GN_x64`), despite
`docs/cef-build/build-patched-cef-windows.md` promising automatic pickup
from there ("Option A"). Only the explicit `AGENTMUX_CEF_RUNTIME_DIR_WINDOWS`
override and the stock cargo `cef-dll-sys` cache were ever checked.

On this machine, that meant an already-built codec-enabled CEF sat unused
at the documented location while `task dev` silently bundled the stock,
no-codec build instead — with no warning anywhere pointing at why MP4/MOV
playback would fail (`DEMUXER_ERROR_NO_SUPPORTED_STREAMS`).

## Changes

1. **Adds the missing default-location check** (tier 2 of 3: override →
   `~/cef-build/.../Release_GN_x64` → stock cargo cache).
2. **Adds a non-fatal advisory warning** when the build genuinely falls
   through to the stock cache — mirrors `bundle:darwin`'s existing
   unpatched-framework warning pattern, which Windows never had.
3. **Fixes a real perf bug surfaced while testing this**: the override
   tier (pre-existing) and my first pass at the new default-location tier
   both did a recursive `cp -rf .../. target/release/` of the *entire*
   raw Chromium ninja build output directory — dozens of GB of
   intermediate/debug artifacts, not just runtime files. Observed this
   hang `bundle:windows` for 10+ minutes on a real run. Fixed by pointing
   `cefDir` directly at the resolved source directory instead of staging
   a wholesale copy — every downstream step already does per-file
   `cp -f "$cefDir/<name>" dist/cef/` for exactly the files it needs.

## Verification

Ran the extracted script directly against this machine's real state
(which has a codec-enabled CEF built at the default location):

- **Positive path**: default-location pickup found and used, completed in
  ~3s (previously would have hung 10+ min via the old copy-everything
  approach), version-check passed (`148.0.7778.180` matches linked crate
  major 148), `dist/cef/libcef.dll` confirmed byte-identical to the
  source build's DLL.
- **Negative path**: verified separately by hiding the default location
  (`HOME` override) — falls through to the stock cache correctly, prints
  the new advisory warning, build still completes successfully (advisory,
  non-fatal, as intended).

Related: #2311, `docs/reports/REPORT_CEF_PROPRIETARY_CODEC_GAP_2026_07_26.md`

## Test plan

- [x] `task --list` still parses (YAML valid)
- [x] Extracted script passes `bash -n` syntax check
- [x] Ran extracted script directly: default-location tier resolves correctly, ~3s
- [x] Ran extracted script with default location hidden: falls back to stock cache, prints advisory warning, still succeeds
- [ ] Real `task dev` smoke test on Windows (not run — the direct-script test above exercises the identical logic `bundle:windows` runs; a reviewer with a clean Windows box may want to additionally confirm end-to-end)

<!-- agentmux:agent_id=agenty -->