### PR TITLE
fix(muxbus): set MUXBUS_AGENT_ID directly at spawn time (ARCH-002)

### DIFF
--- a/.changesets/1785260934-fix-muxbus-set-muxbus-agent-id-directly-at-spawn-time-arch-0-ndr7.md
+++ b/.changesets/1785260934-fix-muxbus-set-muxbus-agent-id-directly-at-spawn-time-arch-0-ndr7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(muxbus): set MUXBUS_AGENT_ID directly at spawn time (ARCH-002)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,7 @@ The cloud messaging layer has gone through several names (`agentbus`, `agentmux`
 
 | Layer | Canonical prefix | Examples |
 |-------|-----------------|---------|
-| Cloud auth env vars | `MUXBUS_` | `MUXBUS_TOKEN`, `MUXBUS_COGNITO_DOMAIN` |
+| Cloud auth env vars | `MUXBUS_` | `MUXBUS_TOKEN`, `MUXBUS_COGNITO_DOMAIN`, `MUXBUS_AGENT_ID` (mirrors the canonical app-wide `AGENTMUX_AGENT_ID`, set alongside it at spawn time — see `agentmux-srv/src/server/agent_handlers/input.rs`) |
 | Frontend build vars | `VITE_MUXBUS_` | `VITE_MUXBUS_CLIENT_ID` |
 | Rust types/modules | `MuxBus` / `muxbus` | `MuxBusCredentials`, `crate::muxbus::` |
 | RPC commands | `muxbus.` | `muxbus.login`, `muxbus.status` |

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -223,7 +223,17 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                 // doesn't receive them.
                 env_vars.insert("AGENTMUX_BLOCKID".to_string(), cmd.blockid.clone());
                 // Agent display name for MuxBus self-identification.
-                // muxbus-client reads AGENTMUX_AGENT_ID (preferred) or AGENT_NAME.
+                // AGENTMUX_AGENT_ID is the canonical, app-wide agent-identity
+                // variable (used far beyond muxbus -- MCP tool routing, native
+                // memory, shell OSC titling, jekt auto-registration, etc; see
+                // this repo's CLAUDE.md Naming Conventions table). MUXBUS_AGENT_ID
+                // is set below too, mirroring the same value, purely so
+                // muxbus-client picks it up under the MUXBUS_* prefix it already
+                // checks first (alongside MUXBUS_TOKEN/MUXBUS_COGNITO_DOMAIN
+                // injected above) -- this does NOT make MUXBUS_AGENT_ID a second
+                // source of truth for agent identity app-wide, it's scoped to
+                // this one muxbus hand-off point (ARCH-002, 2026-07-28
+                // architecture analyst report).
                 // Only set if not already present in cmd:env — user-provided values take precedence.
                 if !env_vars.contains_key("AGENTMUX_AGENT_ID") {
                     let agent_display_name = crate::backend::obj::meta_get_string(
@@ -231,6 +241,11 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                     );
                     if !agent_display_name.is_empty() {
                         env_vars.insert("AGENTMUX_AGENT_ID".to_string(), agent_display_name);
+                    }
+                }
+                if !env_vars.contains_key("MUXBUS_AGENT_ID") {
+                    if let Some(agent_id) = env_vars.get("AGENTMUX_AGENT_ID").cloned() {
+                        env_vars.insert("MUXBUS_AGENT_ID".to_string(), agent_id);
                     }
                 }
                 // PATH includes BOTH bundled tools dir (portable

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -222,6 +222,14 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // fall back to the computed slug derived from the display name.
                 let routing_id = if !agent.slug.is_empty() { &agent.slug } else { &agent_slug };
                 env_vars.insert("AGENTMUX_AGENT_ID".to_string(), json!(routing_id));
+                // Mirror under MUXBUS_AGENT_ID too, matching the same
+                // additive fix in agent_handlers/input.rs (ARCH-002) --
+                // this App API path (agent.open -> agent.send, via
+                // agent_io.rs reading this back from persisted cmd:env)
+                // builds its own env_vars independently of input.rs's spawn
+                // path, so it needs the same mirror applied here rather than
+                // inheriting it (codex P2 on PR #2345).
+                env_vars.insert("MUXBUS_AGENT_ID".to_string(), json!(routing_id));
                 // Exit delay only for subprocess
                 if !is_persistent {
                     env_vars.insert("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY".to_string(), json!("30000"));


### PR DESCRIPTION
## Summary

Companion to `agentmuxai/agentmux-cloud`'s `muxbus-client` fix for the same finding (2026-07-28 architecture analyst report, coherence 6/10). See that PR for the client-side half.

## What I found (correcting the original finding's framing)

The finding assumed `MUXBUS_*` should become canonical everywhere in place of `AGENTMUX_*`. That's wrong once you read the real codebase: `AGENTMUX_AGENT_ID` is **not** a muxbus-specific fossil — it's the canonical, pervasively-used app-wide agent-identity variable (MCP tool routing, native memory, shell OSC titling, jekt auto-registration — dozens of call sites across `agentmux-srv`, `agentmux-mcp`, `agentmux-bashwrap`, and the frontend). Renaming it was never the right move, and would have been a much larger, riskier change than this finding actually warrants.

What was actually missing: nothing in this repo ever set `MUXBUS_AGENT_ID` (confirmed via a repo-wide grep), so `muxbus-client`'s own `MUXBUS_AGENT_ID`-first fallback chain was dead code in practice, always falling through to `AGENTMUX_AGENT_ID`.

## Change

Right where `AGENTMUX_AGENT_ID` already gets set for a spawned pane (`agentmux-srv/src/server/agent_handlers/input.rs`), now also set `MUXBUS_AGENT_ID` to the same value, additively. This is scoped to the one muxbus hand-off point — it is **not** a second app-wide identity variable, and doesn't touch `AGENTMUX_AGENT_ID`'s dozens of other consumers.

Also updated `CLAUDE.md`'s Naming Conventions table's example list for `MUXBUS_*` to include `MUXBUS_AGENT_ID` and note where it's actually set.

## Test plan

- [x] `cargo check -p agentmux-srv` — compiles clean

<!-- agentmux:agent_id=agent1 -->