### PR TITLE
fix(agent-pane): scrollbar visible above overlays, hardened scroll-follow

### DIFF
--- a/.changesets/1785283404-fix-agent-pane-keep-scrollbar-visible-above-working-row-dock-akoa.md
+++ b/.changesets/1785283404-fix-agent-pane-keep-scrollbar-visible-above-working-row-dock-akoa.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): keep scrollbar visible above working-row/dock overlays and harden scroll-follow against programmatic-scroll races

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -91,10 +91,14 @@ a.plain-link {
 
 // Full-width exception: the agent pane's main conversation scroll. More specific
 // than the universal rule above, so it wins on size only (cursor/colour still
-// come from the shared rules).
+// come from the shared rules). Width driven by --agent-document-scrollbar-width
+// (declared on .agent-view, view/agent/styles/_document.scss — inherited here
+// since .agent-document is its descendant) so .agent-working-row-anchor can
+// inset itself by exactly this much and never paint over the scrollbar
+// gutter, instead of fighting it with z-index.
 .agent-document::-webkit-scrollbar {
-    width: 14px;
-    height: 14px;
+    width: var(--agent-document-scrollbar-width, 14px);
+    height: var(--agent-document-scrollbar-width, 14px);
 }
 
 *::-webkit-scrollbar-track {

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -165,14 +165,28 @@
     .agent-working-row-anchor {
         position: absolute;
         left: 0;
-        right: 0;
+        // Inset from the scrollbar gutter, not flush against it (right: 0)
+        // — .agent-working-row's opaque background (see --loading/--worked
+        // below) previously extended the full anchor width, painting over
+        // .agent-document's native scrollbar in that strip since this
+        // anchor's z-index: 2 sits above .agent-document's implicit
+        // z-index: auto. A right padding on the row used to compensate for
+        // the TEXT overlapping the scrollbar, but never stopped the row's
+        // own BACKGROUND from covering it — the scrollbar was still there,
+        // just invisible underneath. Insetting the anchor itself means
+        // nothing painted inside it can ever reach that strip, so the
+        // scrollbar stays visible and clickable without any z-index
+        // fight (which would also make .agent-document's own content
+        // paint over this row's text, defeating the overlay).
+        right: var(--agent-document-scrollbar-width, 14px);
         bottom: 0;
         z-index: 2;
-        // The anchor spans the full pane width (left:0/right:0) but the row
-        // itself only fills its own content width — without this, the empty
-        // margin beside the row would still intercept clicks meant for the
-        // message list underneath. Re-enabled on .agent-working-row itself
-        // below so its own text stays selectable/clickable.
+        // The anchor spans the full pane width (left:0/right:<scrollbar
+        // width>) but the row itself only fills its own content width —
+        // without this, the empty margin beside the row would still
+        // intercept clicks meant for the message list underneath.
+        // Re-enabled on .agent-working-row itself below so its own text
+        // stays selectable/clickable.
         pointer-events: none;
     }
 
@@ -182,13 +196,11 @@
         display: flex;
         align-items: center;
         gap: 5px;
-        // Right padding bumped past the left/top/bottom (space-3 → space-4 +
-        // 3px live-QA nudge): this row's right edge sits flush against
-        // .agent-document's native scrollbar (both it and the row fill the
-        // same .agent-document-scroll-region box), so the right-side
-        // elapsed-time/"Worked · Ns" text needs more breathing room there
-        // than the rest of the row needs elsewhere.
-        padding: var(--space-1) calc(var(--space-4) + 3px) var(--space-1-5) var(--space-3);
+        // Right padding now matches the other three sides — the anchor's
+        // own right inset (above) already clears the scrollbar gutter, so
+        // this no longer needs the extra buffer that used to compensate
+        // for the row extending flush against it.
+        padding: var(--space-1) var(--space-3) var(--space-1-5) var(--space-3);
         pointer-events: auto; // opt back in — the anchor wrapper disables it
 
         &--loading {

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -4,6 +4,13 @@
 // Document container + status log (terminal-style). Wrapped in .agent-view so the cascade chain matches
 // the pre-split file (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
 .agent-view {
+    // Matches .agent-document::-webkit-scrollbar's width (app.scss) — shared
+    // here so .agent-working-row-anchor (_control-bar.scss) can inset itself
+    // by exactly this much and never paint over the scrollbar gutter, instead
+    // of fighting it with z-index. See that selector's own comment for the
+    // z-index-obscures-scrollbar bug this closes.
+    --agent-document-scrollbar-width: 14px;
+
     // Wraps AgentDocumentView + the AgentWorkingRow anchor — takes over the
     // flex-1 slot .agent-document used to occupy directly. .agent-document
     // fills this box via position:absolute so AgentWorkingRow can float

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -142,6 +142,26 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // scroll position is current when the frame runs is the one applied.
     let scrollRafId: number | null = null;
 
+    // Set immediately before every programmatic scrollTo() call below
+    // (pin-to-bottom effect, ResizeObserver re-pin, jumpToBottom), consumed
+    // by the very next handleScrollNow() call. A `scrollTo()` call itself
+    // fires a native `scroll` event, coalesced by scrollRafId into the same
+    // handleScrollNow() batch as any other scroll activity in that frame —
+    // this flag lets that call distinguish "this scroll event resulted from
+    // OUR OWN auto-scroll" from a genuine user scroll landing in the same
+    // batch, so the disengage branch below doesn't misattribute it. Third
+    // documented attempt at the "scroll-follow silently stops" class of bug
+    // (docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md,
+    // docs/specs/SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md §3/§5)
+    // — this is the "input-gating race" both prior passes deferred pending
+    // live reports continuing, which they did.
+    let pendingProgrammaticScroll = false;
+    function scrollToTrueBottom(): void {
+        if (!scrollRef) return;
+        pendingProgrammaticScroll = true;
+        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+    }
+
     // Sticky frontier id — set once when the document first crosses
     // STREAMING_BUFFER_SIZE; advanced whenever the buffer exceeds the
     // cap (see below) to keep streamingNodes.length ≤ STREAMING_BUFFER_SIZE.
@@ -420,7 +440,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 // Re-check: user may have disengaged stickToBottom between
                 // when this microtask was queued and when it fires.
                 if (!props.viewState.stickToBottom()) return;
-                scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+                scrollToTrueBottom();
                 // New content may have pushed a held-open tool above the top
                 // without a user scroll event — collapse it now (pinned to
                 // bottom, so no visible jump).
@@ -453,7 +473,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         const ro = new ResizeObserver(() => {
             const h = scrollRef.clientHeight;
             if (h > 0 && props.viewState.stickToBottom()) {
-                scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+                scrollToTrueBottom();
             }
             // Phase 3: the scroll container resizing changes the viewport the
             // slice windows against — feed it (covers hidden→visible 0→N and
@@ -476,7 +496,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     const jumpToBottom = (): void => {
         if (!scrollRef) return;
         props.viewState.engageStickToBottom();
-        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+        scrollToTrueBottom();
     };
     if (props.scrollToBottomRef) props.scrollToBottomRef(jumpToBottom);
 
@@ -551,6 +571,14 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
 
+        // Consume the programmatic-scroll flag for THIS batch — see
+        // scrollToTrueBottom's own comment. Read once, up front: every
+        // branch below that might disengage needs to know whether this
+        // scroll event batch was (at least partly) caused by our own
+        // auto-scroll, not just the disengage branch specifically.
+        const wasProgrammatic = pendingProgrammaticScroll;
+        pendingProgrammaticScroll = false;
+
         // Phase 4: scrollTop / clientHeight are already unzoomed CSS px under the
         // ancestor CSS `zoom` (CDP-confirmed: ratio 1.0 at zoom 0.5/2 — only
         // getBoundingClientRect is zoomed), so push them raw. The lone ÷zoom is
@@ -581,7 +609,29 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             }
         } else {
             if (props.viewState.stickToBottom()) {
-                props.viewState.disengageStickToBottom();
+                const gapPx = scrollHeight - clientHeight - scrollTop;
+                if (wasProgrammatic) {
+                    // This scroll event batch included our own scrollTo()
+                    // call — isNearBottom() reading "not near bottom" here
+                    // means either new content landed in the same tick
+                    // (the pin effect's own reactive deps will re-fire and
+                    // re-scroll) or a user scroll got coalesced into the
+                    // same frame. Either way, disengaging on THIS event
+                    // would be misattributing our own auto-scroll (or a
+                    // same-frame race) as the user scrolling away.
+                    console.info(
+                        "[wave-scroll]",
+                        `pane=${props.blockId?.slice(0, 7) ?? "?"}`,
+                        `suppressed disengage — programmatic scroll in this batch, gap=${gapPx}px`,
+                    );
+                } else {
+                    console.info(
+                        "[wave-scroll]",
+                        `pane=${props.blockId?.slice(0, 7) ?? "?"}`,
+                        `disengage — scrollTop=${scrollTop} scrollHeight=${scrollHeight} clientHeight=${clientHeight} gap=${gapPx}px`,
+                    );
+                    props.viewState.disengageStickToBottom();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Two related fixes to the agent pane's conversation scroll, both reported live: the scrollbar being visually obscured, and stick-to-bottom silently disengaging with no user input.

- **Scrollbar obscured by the Working…/Worked. + token row**: `.agent-working-row-anchor` extended full pane width with `z-index: 2`, above `.agent-document`'s implicit stacking, so the row's intentionally-opaque background painted directly over the native scrollbar's screen-space strip in that region. Fixed by insetting the anchor by the scrollbar's own width (new shared `--agent-document-scrollbar-width` CSS var, 14px) instead of fighting it with z-index — nothing painted inside the anchor can now reach that strip. Verified live via CDP: the anchor and its rendered row both stop exactly 14px short of `.agent-document`'s right edge, both idle and while "Working…" renders.
- **Scrollbar obscured by the ActivityDock**: `ActivityDock` is a genuine normal-flow sibling *after* the scroll region — no absolute positioning, no overlap mechanism found. Its appearance shrinks `.agent-document`'s `clientHeight` via CSS reflow, which is exactly the class of change the scroll-follow hardening below now re-pins on, so the dock report should resolve as a byproduct rather than needing its own CSS fix.
- **Scroll-follow silently loses the bottom**: third pass at this recurring bug (see `SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md` and `SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md`, both of which deferred this exact race pending live reports continuing — they did). Root cause: `scrollTo()` fires a native `scroll` event indistinguishable from a genuine user scroll; a same-frame auto-scroll could get misattributed as "user scrolled away" and silently disengage `stickToBottom`. Added a `pendingProgrammaticScroll` flag, set before every internal `scrollTo()` and consumed by the next `handleScrollNow()` batch, so the disengage branch can tell the two apart. Added `[wave-scroll]` telemetry (`console.info`, matching the `[wave-turn]` precedent) so a future regression has real data instead of re-guessing a 4th time.

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run frontend/app/view/agent` — 825/825 passing, no regressions
- [x] Live CDP verification against a `task dev` build: confirmed the working-row anchor/rendered row both stop exactly at the scrollbar gutter boundary (1059.5 vs `.agent-document`'s 1073.5, a 14px inset), both idle and while streaming
- [ ] Manual: reproduce the scroll-follow disengage race in a long-running stream and confirm `[wave-scroll]` fires `suppressed disengage` instead of `disengage` — not completed live this round (see note below); flag for reviewer/follow-up monitoring

**Note on live verification scope**: mid-verification, a CDP script accidentally submitted a synthetic message into a live, already-running agent session (the dev build shares backend session storage with a live instance) instead of an isolated test target. No destructive action resulted (an echo/sleep loop), and the user was informed and confirmed no cleanup was needed, but out of caution I stopped further live UI fuzzing rather than risk repeating it, and leaned on the geometric CDP check already gathered, the full test suite, and code-level reasoning for the remaining two claims instead.

<!-- agentmux:agent_id=agent3 -->