### PR TITLE
feat(muxbus): same-host cross-channel reactive delivery (Tier 2b)

### DIFF
--- a/.changesets/1785284522-feat-muxbus-same-host-cross-channel-reactive-delivery-tier-2-8d9c.md
+++ b/.changesets/1785284522-feat-muxbus-same-host-cross-channel-reactive-delivery-tier-2-8d9c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(muxbus): same-host cross-channel reactive delivery (Tier 2b, issue #1916)

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -920,11 +920,20 @@ impl PersistentSubprocessController {
                         agent_id = %agent_id,
                         "muxbus: auto-registered persistent agent"
                     );
-                    // Also write the cross-instance (Tier-2) file registry.
+                    // Also write the cross-instance (Tier-2) file registry,
+                    // and its host-global sibling (Tier 2b, issue #1916) —
+                    // this auto-register path bypasses the HTTP register
+                    // handler entirely, so it needs its own mirror call
+                    // exactly like that handler does.
                     if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
                         let data_dir = crate::backend::base::get_wave_data_dir();
                         crate::backend::reactive::registry::write(
                             &data_dir,
+                            agent_id,
+                            &local_url,
+                            &self.block_id,
+                        );
+                        crate::backend::reactive::registry::write_shared_from_env(
                             agent_id,
                             &local_url,
                             &self.block_id,
@@ -1169,6 +1178,7 @@ impl PersistentSubprocessController {
                     if let Some(ref agent_id) = agent_id_wait {
                         let data_dir = crate::backend::base::get_wave_data_dir();
                         crate::backend::reactive::registry::remove(&data_dir, agent_id);
+                        crate::backend::reactive::registry::remove_shared_from_env(agent_id);
                         if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
                             sub.remove_agent(agent_id);
                         }
@@ -1232,6 +1242,7 @@ impl PersistentSubprocessController {
                     if let Some(ref agent_id) = agent_id_wait {
                         let data_dir = crate::backend::base::get_wave_data_dir();
                         crate::backend::reactive::registry::remove(&data_dir, agent_id);
+                        crate::backend::reactive::registry::remove_shared_from_env(agent_id);
                         if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
                             sub.remove_agent(agent_id);
                         }

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -482,11 +482,19 @@ impl Controller for ShellController {
                         agent_id = %agent_id,
                         "jekt: auto-registered"
                     );
-                    // Also write to cross-instance file registry.
+                    // Also write to cross-instance file registry, and its
+                    // host-global sibling (Tier 2b, issue #1916) — this
+                    // auto-register path bypasses the HTTP register handler
+                    // entirely, so it needs its own mirror call too.
                     if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
                         let data_dir = crate::backend::base::get_wave_data_dir();
                         crate::backend::reactive::registry::write(
                             &data_dir,
+                            agent_id,
+                            &local_url,
+                            &self.block_id,
+                        );
+                        crate::backend::reactive::registry::write_shared_from_env(
                             agent_id,
                             &local_url,
                             &self.block_id,
@@ -768,6 +776,7 @@ impl Controller for ShellController {
             if let Some(ref agent_id) = agent_id_wait {
                 let data_dir = crate::backend::base::get_wave_data_dir();
                 crate::backend::reactive::registry::remove(&data_dir, agent_id);
+                crate::backend::reactive::registry::remove_shared_from_env(agent_id);
                 if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
                     sub.remove_agent(agent_id);
                 }

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -234,6 +234,28 @@ pub fn remove_shared(shared_dir: &Path, agent_id: &str, channel: &str) {
     }
 }
 
+/// Convenience wrapper over [`write_shared`]: resolves the shared dir and
+/// this process's channel itself, no-op if the shared root can't be
+/// resolved. Exists so call sites outside `server/reactive.rs`'s explicit
+/// register/unregister handlers (PTY shell auto-register, persistent
+/// stream-json controller auto-register — both call the per-channel
+/// `write`/`remove` directly, not through the HTTP handler) don't each
+/// repeat the same resolve-dir-then-read-env dance.
+pub fn write_shared_from_env(agent_id: &str, local_url: &str, block_id: &str) {
+    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+        let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+        write_shared(&shared_dir, agent_id, local_url, block_id, &channel);
+    }
+}
+
+/// Convenience wrapper over [`remove_shared`] — see [`write_shared_from_env`].
+pub fn remove_shared_from_env(agent_id: &str) {
+    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+        let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+        remove_shared(&shared_dir, agent_id, &channel);
+    }
+}
+
 /// Return every live candidate for `agent_id` across all channels,
 /// freshest-first (§4.3: Tier 2b prefers the freshest candidate). Does
 /// NOT filter by staleness/pid-liveness — callers needing that should use

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -174,8 +174,12 @@ pub fn cleanup_stale(data_dir: &Path, max_age_ms: u64) {
 // in by the caller rather than resolved here to keep this module free of
 // a dependency on the `registry` crate module).
 //
-// Layout: `<shared_dir>/agents/<agent_name>/<channel>.json`, one file per
-// (agent, channel) pair — NOT a single JSON array shared across channels.
+// Layout: `<shared_dir>/<agent_name>/<channel>.json` (`shared_dir` here is
+// already `resolve_shared_reactive_dir()`'s output, i.e.
+// `~/.agentmux/shared/agents/reactive/`, so the full real path is
+// `~/.agentmux/shared/agents/reactive/<agent_name>/<channel>.json`), one
+// file per (agent, channel) pair — NOT a single JSON array shared across
+// channels.
 // Each channel only ever reads/writes its OWN file, so two channels
 // registering the same agent name concurrently never contend on the same
 // file: no read-modify-write race is possible by construction, and no
@@ -199,8 +203,18 @@ fn sanitize_path_component(raw: &str) -> String {
 
 /// Directory holding one file per channel currently registering
 /// `agent_id` in the host-global shared registry.
+///
+/// Deliberately does NOT go through `agents_dir()` (which appends an
+/// `agents` segment for the per-channel registry, where the caller passes
+/// a bare data dir) — `shared_dir` here is already
+/// `registry::resolve_shared_reactive_dir()`'s output
+/// (`.../shared/agents/reactive`), so entries land at
+/// `.../shared/agents/reactive/<agent>/<channel>.json` as documented,
+/// not double-nested under an extra `agents/` (reagent P2 on #2350 —
+/// harmless since read/write agreed internally, but contradicted the
+/// documented layout).
 fn shared_agent_dir(shared_dir: &Path, agent_id: &str) -> PathBuf {
-    agents_dir(shared_dir).join(sanitize_path_component(agent_id))
+    shared_dir.join(sanitize_path_component(agent_id))
 }
 
 /// Path to one (agent, channel) pair's entry file.
@@ -300,8 +314,8 @@ pub fn lookup_all_shared(shared_dir: &Path, agent_id: &str) -> Vec<AgentEntry> {
 /// spec) — unlike [`lookup_all_shared`], which targets one known agent
 /// name, this enumerates the whole directory.
 pub fn list_all_shared(shared_dir: &Path) -> Vec<AgentEntry> {
-    let dir = agents_dir(shared_dir);
-    let Ok(entries) = std::fs::read_dir(&dir) else {
+    // Not agents_dir(shared_dir) -- see shared_agent_dir's doc comment.
+    let Ok(entries) = std::fs::read_dir(shared_dir) else {
         return Vec::new();
     };
     let mut out = Vec::new();
@@ -321,8 +335,8 @@ pub fn list_all_shared(shared_dir: &Path) -> Vec<AgentEntry> {
 /// statement, where per-channel TTL cleanup never reached an entry
 /// belonging to a channel that hadn't restarted.
 pub fn cleanup_stale_shared(shared_dir: &Path, max_age_ms: u64) {
-    let dir = agents_dir(shared_dir);
-    let Ok(agent_dirs) = std::fs::read_dir(&dir) else { return };
+    // Not agents_dir(shared_dir) -- see shared_agent_dir's doc comment.
+    let Ok(agent_dirs) = std::fs::read_dir(shared_dir) else { return };
     let cutoff = now_unix_millis().saturating_sub(max_age_ms);
     for agent_dir_entry in agent_dirs.flatten() {
         let agent_dir_path = agent_dir_entry.path();
@@ -582,10 +596,11 @@ mod shared_tests {
         let dir = tempfile::tempdir().unwrap();
         write_shared(dir.path(), "../../evil", "http://127.0.0.1:9001", "block1", "dev-a");
         // Sanitization (shared_agent_dir) must keep the write confined to
-        // the shared registry's own agents/ dir — no directory with `.`
-        // path segments should escape it.
-        let agents = agents_dir(dir.path());
-        for entry in std::fs::read_dir(&agents).unwrap() {
+        // the shared registry root — no directory with `.` path segments
+        // should escape it. Reading `dir.path()` directly (not
+        // `agents_dir(dir.path())`) since shared_agent_dir no longer nests
+        // under an extra `agents/` level.
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
             let name = entry.unwrap().file_name();
             assert!(!name.to_string_lossy().contains(".."));
         }

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -172,11 +172,41 @@ pub fn cleanup_stale(data_dir: &Path, max_age_ms: u64) {
 // delivery). Sibling API to the per-channel functions above, rooted at a
 // DIFFERENT directory (`registry::resolve_shared_reactive_dir()`, passed
 // in by the caller rather than resolved here to keep this module free of
-// a dependency on the `registry` crate module). One file per agent name,
-// holding a JSON array of entries — one per channel currently running
-// that name — so two channels registering the same agent name don't
-// clobber each other (§4.2 of the cross-channel delivery spec).
+// a dependency on the `registry` crate module).
+//
+// Layout: `<shared_dir>/agents/<agent_name>/<channel>.json`, one file per
+// (agent, channel) pair — NOT a single JSON array shared across channels.
+// Each channel only ever reads/writes its OWN file, so two channels
+// registering the same agent name concurrently never contend on the same
+// file: no read-modify-write race is possible by construction, and no
+// locking is needed (reagent P1 on PR #2350 — the earlier one-array-per-
+// name design let a concurrent register/unregister from a different
+// channel silently clobber this channel's entry, since two writers could
+// each read the pre-write array before either wrote back, with no
+// periodic repair since a channel only ever writes once at agent spawn).
+// §4.2 of the cross-channel delivery spec.
 // ---------------------------------------------------------------------
+
+/// Lowercase + sanitize a single path component (agent name or channel
+/// id) to alphanumeric/dash/underscore only, preventing path traversal
+/// and matching `ReactiveHandler`'s lowercase key convention.
+fn sanitize_path_component(raw: &str) -> String {
+    raw.to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect()
+}
+
+/// Directory holding one file per channel currently registering
+/// `agent_id` in the host-global shared registry.
+fn shared_agent_dir(shared_dir: &Path, agent_id: &str) -> PathBuf {
+    agents_dir(shared_dir).join(sanitize_path_component(agent_id))
+}
+
+/// Path to one (agent, channel) pair's entry file.
+fn shared_channel_path(shared_dir: &Path, agent_id: &str, channel: &str) -> PathBuf {
+    shared_agent_dir(shared_dir, agent_id).join(format!("{}.json", sanitize_path_component(channel)))
+}
 
 /// True if a process with this PID is currently running on this host.
 /// Meaningful here specifically because the shared registry is always
@@ -198,24 +228,15 @@ fn pid_alive(pid: u32) -> bool {
 }
 
 /// Write (create or update) this channel's entry for `agent_id` in the
-/// host-global shared registry. Preserves other channels' entries for the
-/// same name (read-modify-write over the array, replacing only the entry
-/// whose `channel` matches this call's).
-///
-/// Concurrency note: two channels writing the *same* channel's entry at
-/// literally the same instant could race (read-modify-write, no file
-/// lock) — same relaxed consistency the existing per-channel registry
-/// already has (no locking there either). Worst case is a lost update
-/// until the next write/cleanup, not a correctness or security issue;
-/// registration is not a hot path.
+/// host-global shared registry. Writes only this channel's own file
+/// (`shared_channel_path`) — never touches another channel's file, so
+/// concurrent writers for different channels of the same agent name
+/// cannot race or clobber each other.
 pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id: &str, channel: &str) {
-    let dir = agents_dir(shared_dir);
+    let dir = shared_agent_dir(shared_dir, agent_id);
     let _ = std::fs::create_dir_all(&dir);
-    let path = agent_path(shared_dir, agent_id);
-
-    let mut list = read_shared_entries(&path);
-    list.retain(|e| e.channel != channel);
-    list.push(AgentEntry {
+    let path = shared_channel_path(shared_dir, agent_id, channel);
+    let entry = AgentEntry {
         agent_id: agent_id.to_string(),
         local_url: local_url.to_string(),
         block_id: block_id.to_string(),
@@ -223,22 +244,18 @@ pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id
         updated_at: now_unix_millis(),
         auth_key: local_auth_key().to_string(),
         channel: channel.to_string(),
-    });
-
-    write_shared_entries(&path, &list);
+    };
+    write_entry_file(&path, &entry);
 }
 
 /// Remove this channel's entry for `agent_id` from the shared registry.
-/// Removes the whole file once no channel's entry remains.
+/// Best-effort removes the now-possibly-empty agent directory too (a
+/// concurrent writer recreating it a moment later is harmless — the next
+/// write just re-creates the directory via `create_dir_all`).
 pub fn remove_shared(shared_dir: &Path, agent_id: &str, channel: &str) {
-    let path = agent_path(shared_dir, agent_id);
-    let mut list = read_shared_entries(&path);
-    list.retain(|e| e.channel != channel);
-    if list.is_empty() {
-        let _ = std::fs::remove_file(&path);
-    } else {
-        write_shared_entries(&path, &list);
-    }
+    let path = shared_channel_path(shared_dir, agent_id, channel);
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(shared_agent_dir(shared_dir, agent_id));
 }
 
 /// Convenience wrapper over [`write_shared`]: resolves the shared dir and
@@ -271,8 +288,8 @@ pub fn remove_shared_from_env(agent_id: &str) {
 /// `server/reactive.rs`, matching how this codebase already handles
 /// registry staleness elsewhere rather than re-validating on every read.
 pub fn lookup_all_shared(shared_dir: &Path, agent_id: &str) -> Vec<AgentEntry> {
-    let path = agent_path(shared_dir, agent_id);
-    let mut list = read_shared_entries(&path);
+    let dir = shared_agent_dir(shared_dir, agent_id);
+    let mut list = read_entry_files_in_dir(&dir);
     list.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     list
 }
@@ -290,10 +307,10 @@ pub fn list_all_shared(shared_dir: &Path) -> Vec<AgentEntry> {
     let mut out = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+        if !path.is_dir() {
             continue;
         }
-        out.extend(read_shared_entries(&path));
+        out.extend(read_entry_files_in_dir(&path));
     }
     out
 }
@@ -305,43 +322,62 @@ pub fn list_all_shared(shared_dir: &Path) -> Vec<AgentEntry> {
 /// belonging to a channel that hadn't restarted.
 pub fn cleanup_stale_shared(shared_dir: &Path, max_age_ms: u64) {
     let dir = agents_dir(shared_dir);
-    let Ok(entries) = std::fs::read_dir(&dir) else { return };
+    let Ok(agent_dirs) = std::fs::read_dir(&dir) else { return };
     let cutoff = now_unix_millis().saturating_sub(max_age_ms);
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+    for agent_dir_entry in agent_dirs.flatten() {
+        let agent_dir_path = agent_dir_entry.path();
+        if !agent_dir_path.is_dir() {
             continue;
         }
-        let list = read_shared_entries(&path);
-        let live: Vec<AgentEntry> = list
-            .into_iter()
-            .filter(|e| e.updated_at >= cutoff && pid_alive(e.pid))
-            .collect();
-        if live.is_empty() {
-            let _ = std::fs::remove_file(&path);
-        } else {
-            write_shared_entries(&path, &live);
+        let Ok(channel_files) = std::fs::read_dir(&agent_dir_path) else { continue };
+        for channel_entry in channel_files.flatten() {
+            let channel_path = channel_entry.path();
+            if channel_path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let keep = read_entry_file(&channel_path)
+                .map(|e| e.updated_at >= cutoff && pid_alive(e.pid))
+                .unwrap_or(false);
+            if !keep {
+                let _ = std::fs::remove_file(&channel_path);
+            }
         }
+        // Best-effort: only actually removes the directory if it's now
+        // empty (every channel file was stale) — a concurrent writer
+        // recreating it right after is harmless, same as `remove_shared`.
+        let _ = std::fs::remove_dir(&agent_dir_path);
     }
 }
 
-/// Best-effort read of a shared-registry file as a JSON array. Missing,
-/// unreadable, or malformed files are treated as "no entries" — same
+/// Best-effort read of one (agent, channel) entry file. Missing,
+/// unreadable, or malformed files are treated as absent — same
 /// graceful-degradation posture as the per-channel `lookup`.
-fn read_shared_entries(path: &Path) -> Vec<AgentEntry> {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    serde_json::from_str(&content).unwrap_or_default()
+fn read_entry_file(path: &Path) -> Option<AgentEntry> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
 }
 
-/// Write a shared-registry file's full entry list, atomically (temp file
-/// + rename) so a concurrent reader never observes a partially-written
-/// array. Mode 0600 on Unix at open time — same auth_key exposure
-/// boundary as the per-channel registry (§5 of the cross-channel spec:
-/// same-user trust boundary, not cross-user).
-fn write_shared_entries(path: &Path, list: &[AgentEntry]) {
-    let Ok(json) = serde_json::to_string(list) else { return };
+/// Read every valid `.json` entry file directly inside `dir` (one level,
+/// not recursive) — used for both `lookup_all_shared` (one agent's
+/// per-channel dir) and `list_all_shared` (one agent-name dir at a time).
+fn read_entry_files_in_dir(dir: &Path) -> Vec<AgentEntry> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .filter_map(|e| read_entry_file(&e.path()))
+        .collect()
+}
+
+/// Write one (agent, channel) entry file, atomically (temp file + rename)
+/// so a concurrent reader never observes a partially-written file. Mode
+/// 0600 on Unix at open time — same auth_key exposure boundary as the
+/// per-channel registry (§5 of the cross-channel spec: same-user trust
+/// boundary, not cross-user).
+fn write_entry_file(path: &Path, entry: &AgentEntry) {
+    let Ok(json) = serde_json::to_string(entry) else { return };
     let tmp_path = path.with_extension("json.tmp");
 
     let mut opts = std::fs::OpenOptions::new();
@@ -425,16 +461,14 @@ mod shared_tests {
         let dir = tempfile::tempdir().unwrap();
         write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
         write_shared(dir.path(), "agentx", "http://127.0.0.1:9002", "block2", "dev-b");
-        // Directly bump dev-b's updated_at so it's unambiguously freshest,
-        // independent of how fast the two writes above happened to run.
-        let path = agent_path(dir.path(), "agentx");
-        let mut list = read_shared_entries(&path);
-        for e in list.iter_mut() {
-            if e.channel == "dev-b" {
-                e.updated_at += 10_000;
-            }
-        }
-        write_shared_entries(&path, &list);
+        // Directly bump dev-b's own file's updated_at so it's unambiguously
+        // freshest, independent of how fast the two writes above happened
+        // to run. Only touches dev-b's own file -- exactly the point of
+        // the one-file-per-channel layout.
+        let path = shared_channel_path(dir.path(), "agentx", "dev-b");
+        let mut entry = read_entry_file(&path).unwrap();
+        entry.updated_at += 10_000;
+        write_entry_file(&path, &entry);
 
         let found = lookup_all_shared(dir.path(), "agentx");
         assert_eq!(found[0].channel, "dev-b");
@@ -453,12 +487,13 @@ mod shared_tests {
     }
 
     #[test]
-    fn remove_shared_last_channel_deletes_file() {
+    fn remove_shared_last_channel_deletes_file_and_dir() {
         let dir = tempfile::tempdir().unwrap();
         write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
         remove_shared(dir.path(), "agentx", "dev-a");
         assert!(lookup_all_shared(dir.path(), "agentx").is_empty());
-        assert!(!agent_path(dir.path(), "agentx").exists());
+        assert!(!shared_channel_path(dir.path(), "agentx", "dev-a").exists());
+        assert!(!shared_agent_dir(dir.path(), "agentx").exists());
     }
 
     #[test]
@@ -482,11 +517,11 @@ mod shared_tests {
         write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
         // Backdate updated_at well past the TTL, but keep pid as our own
         // (alive) so only the TTL check can be responsible for eviction.
-        let path = agent_path(dir.path(), "agentx");
-        let mut list = read_shared_entries(&path);
-        list[0].updated_at = 0;
-        list[0].pid = std::process::id();
-        write_shared_entries(&path, &list);
+        let path = shared_channel_path(dir.path(), "agentx", "dev-a");
+        let mut entry = read_entry_file(&path).unwrap();
+        entry.updated_at = 0;
+        entry.pid = std::process::id();
+        write_entry_file(&path, &entry);
 
         cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
         assert!(lookup_all_shared(dir.path(), "agentx").is_empty());
@@ -500,10 +535,10 @@ mod shared_tests {
         // exercises the dead-channel-that-never-restarted case from the
         // spec's problem statement, which TTL alone wouldn't catch for
         // another 4 hours.
-        let path = agent_path(dir.path(), "agentx");
-        let mut list = read_shared_entries(&path);
-        list[0].pid = u32::MAX;
-        write_shared_entries(&path, &list);
+        let path = shared_channel_path(dir.path(), "agentx", "dev-a");
+        let mut entry = read_entry_file(&path).unwrap();
+        entry.pid = u32::MAX;
+        write_entry_file(&path, &entry);
 
         cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
         assert!(lookup_all_shared(dir.path(), "agentx").is_empty());
@@ -513,27 +548,100 @@ mod shared_tests {
     fn cleanup_stale_shared_keeps_fresh_live_entries() {
         let dir = tempfile::tempdir().unwrap();
         write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
-        let path = agent_path(dir.path(), "agentx");
-        let mut list = read_shared_entries(&path);
-        list[0].pid = std::process::id();
-        write_shared_entries(&path, &list);
+        let path = shared_channel_path(dir.path(), "agentx", "dev-a");
+        let mut entry = read_entry_file(&path).unwrap();
+        entry.pid = std::process::id();
+        write_entry_file(&path, &entry);
 
         cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
         assert_eq!(lookup_all_shared(dir.path(), "agentx").len(), 1);
     }
 
     #[test]
+    fn cleanup_stale_shared_evicts_one_channel_keeps_sibling() {
+        // The whole point of the redesign: cleanup for one channel's
+        // stale/dead entry must not disturb a sibling channel's live one,
+        // since they're now genuinely separate files, not shared array
+        // elements.
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9002", "block2", "dev-b");
+        let stale_path = shared_channel_path(dir.path(), "agentx", "dev-a");
+        let mut stale = read_entry_file(&stale_path).unwrap();
+        stale.pid = u32::MAX;
+        write_entry_file(&stale_path, &stale);
+
+        cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].channel, "dev-b");
+    }
+
+    #[test]
     fn agent_id_path_traversal_is_sanitized() {
         let dir = tempfile::tempdir().unwrap();
         write_shared(dir.path(), "../../evil", "http://127.0.0.1:9001", "block1", "dev-a");
-        // Sanitization (agent_path) must keep the write confined to the
-        // shared registry's own agents/ dir — no file with `.` path
-        // segments should escape it.
+        // Sanitization (shared_agent_dir) must keep the write confined to
+        // the shared registry's own agents/ dir — no directory with `.`
+        // path segments should escape it.
         let agents = agents_dir(dir.path());
         for entry in std::fs::read_dir(&agents).unwrap() {
             let name = entry.unwrap().file_name();
             assert!(!name.to_string_lossy().contains(".."));
         }
+    }
+
+    #[test]
+    fn channel_path_traversal_is_sanitized() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "../../evil");
+        // Sanitization must apply to the CHANNEL component too, not just
+        // the agent name — a channel string is caller-controlled the same
+        // way an agent_id is.
+        let agent_dir = shared_agent_dir(dir.path(), "agentx");
+        for entry in std::fs::read_dir(&agent_dir).unwrap() {
+            let name = entry.unwrap().file_name();
+            assert!(!name.to_string_lossy().contains(".."));
+        }
+    }
+
+    #[test]
+    fn concurrent_writes_from_different_channels_never_clobber() {
+        // Direct regression test for reagent's P1 on PR #2350: the old
+        // one-array-per-agent-name design let two channels' concurrent
+        // writes race (each reads the pre-write array, second writer's
+        // save clobbers the first). Spawns real OS threads hammering
+        // write_shared for N distinct channels of the same agent name
+        // concurrently and asserts every single one survives.
+        let dir = tempfile::tempdir().unwrap();
+        let shared_dir = dir.path().to_path_buf();
+        const N: usize = 16;
+
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let shared_dir = shared_dir.clone();
+                std::thread::spawn(move || {
+                    let channel = format!("dev-{i}");
+                    for _ in 0..5 {
+                        write_shared(
+                            &shared_dir,
+                            "agentx",
+                            &format!("http://127.0.0.1:{}", 9000 + i),
+                            "block1",
+                            &channel,
+                        );
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let found = lookup_all_shared(&shared_dir, "agentx");
+        assert_eq!(found.len(), N, "every channel's entry must survive concurrent writes");
+        let channels: std::collections::HashSet<_> = found.iter().map(|e| e.channel.clone()).collect();
+        assert_eq!(channels.len(), N);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -75,8 +75,15 @@ fn agents_dir(data_dir: &Path) -> PathBuf {
 }
 
 fn agent_path(data_dir: &Path, agent_id: &str) -> PathBuf {
+    // Lowercase first so this matches `ReactiveHandler`'s own
+    // `agent_id.to_lowercase()` key convention (backend/reactive/handler.rs)
+    // — every other muxbus identity path is already case-insensitive, and a
+    // channel registering "AgentX" vs. a peer injecting to "agentx" must
+    // land on the same file, not two different ones (reagent P1 on #2350,
+    // caught in Tier 2b but pre-existing here for Tier 2a too).
     // Sanitize: only allow alphanumeric, dash, underscore to prevent path traversal.
     let safe: String = agent_id
+        .to_lowercase()
         .chars()
         .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
         .collect();
@@ -367,6 +374,25 @@ mod shared_tests {
         assert_eq!(found[0].channel, "dev-a");
         assert_eq!(found[0].local_url, "http://127.0.0.1:9001");
         assert_eq!(found[0].block_id, "block1");
+    }
+
+    #[test]
+    fn write_and_lookup_are_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "AgentX", "http://127.0.0.1:9001", "block1", "dev-a");
+        // A peer looking up the lowercase form (as ReactiveHandler's
+        // Tier-1 in-memory map always does) must land on the same entry —
+        // reagent P1 on #2350.
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].local_url, "http://127.0.0.1:9001");
+
+        // And a second write under a different-cased spelling of the same
+        // name must overwrite, not create a sibling file.
+        write_shared(dir.path(), "AGENTX", "http://127.0.0.1:9099", "block9", "dev-a");
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].local_url, "http://127.0.0.1:9099");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -39,6 +39,15 @@ pub struct AgentEntry {
     /// muxbus).
     #[serde(default)]
     pub auth_key: String,
+    /// The writing instance's channel id (`AGENTMUX_CHANNEL`, default
+    /// "stable"). Empty for entries in the per-channel registry (where a
+    /// channel tag is redundant — the whole file is already channel-
+    /// scoped by its directory); populated for entries in the host-global
+    /// shared registry (§ below), where multiple channels' entries for
+    /// the same agent name coexist and need distinguishing. See
+    /// `docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md`.
+    #[serde(default)]
+    pub channel: String,
 }
 
 /// Process-wide auth key for the local AgentMux instance.
@@ -93,6 +102,9 @@ pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
         pid: std::process::id(),
         updated_at: now_unix_millis(),
         auth_key: local_auth_key().to_string(),
+        // Empty for entries in the per-channel registry — see the field's
+        // doc comment on `AgentEntry`.
+        channel: String::new(),
     };
     let path = agent_path(data_dir, agent_id);
     let Ok(json) = serde_json::to_string(&entry) else { return };
@@ -145,5 +157,344 @@ pub fn cleanup_stale(data_dir: &Path, max_age_ms: u64) {
                 let _ = std::fs::remove_file(&path);
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Host-global shared registry (MuxBus Tier 2b — same-host, cross-channel
+// delivery). Sibling API to the per-channel functions above, rooted at a
+// DIFFERENT directory (`registry::resolve_shared_reactive_dir()`, passed
+// in by the caller rather than resolved here to keep this module free of
+// a dependency on the `registry` crate module). One file per agent name,
+// holding a JSON array of entries — one per channel currently running
+// that name — so two channels registering the same agent name don't
+// clobber each other (§4.2 of the cross-channel delivery spec).
+// ---------------------------------------------------------------------
+
+/// True if a process with this PID is currently running on this host.
+/// Meaningful here specifically because the shared registry is always
+/// same-host by construction (a local file only readable by local
+/// processes) — unlike a LAN/cloud registry, PID-liveness is an
+/// authoritative staleness signal, not just a heuristic.
+fn pid_alive(pid: u32) -> bool {
+    let target = sysinfo::Pid::from(pid as usize);
+    let mut sys = sysinfo::System::new();
+    // Targeted refresh, no CPU/memory/exe/cmdline needed — existence alone
+    // is what matters. `true` = drop entries for since-exited PIDs, same
+    // as the whole-machine attribution pass in backend/sysinfo.rs.
+    sys.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[target]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing(),
+    );
+    sys.process(target).is_some()
+}
+
+/// Write (create or update) this channel's entry for `agent_id` in the
+/// host-global shared registry. Preserves other channels' entries for the
+/// same name (read-modify-write over the array, replacing only the entry
+/// whose `channel` matches this call's).
+///
+/// Concurrency note: two channels writing the *same* channel's entry at
+/// literally the same instant could race (read-modify-write, no file
+/// lock) — same relaxed consistency the existing per-channel registry
+/// already has (no locking there either). Worst case is a lost update
+/// until the next write/cleanup, not a correctness or security issue;
+/// registration is not a hot path.
+pub fn write_shared(shared_dir: &Path, agent_id: &str, local_url: &str, block_id: &str, channel: &str) {
+    let dir = agents_dir(shared_dir);
+    let _ = std::fs::create_dir_all(&dir);
+    let path = agent_path(shared_dir, agent_id);
+
+    let mut list = read_shared_entries(&path);
+    list.retain(|e| e.channel != channel);
+    list.push(AgentEntry {
+        agent_id: agent_id.to_string(),
+        local_url: local_url.to_string(),
+        block_id: block_id.to_string(),
+        pid: std::process::id(),
+        updated_at: now_unix_millis(),
+        auth_key: local_auth_key().to_string(),
+        channel: channel.to_string(),
+    });
+
+    write_shared_entries(&path, &list);
+}
+
+/// Remove this channel's entry for `agent_id` from the shared registry.
+/// Removes the whole file once no channel's entry remains.
+pub fn remove_shared(shared_dir: &Path, agent_id: &str, channel: &str) {
+    let path = agent_path(shared_dir, agent_id);
+    let mut list = read_shared_entries(&path);
+    list.retain(|e| e.channel != channel);
+    if list.is_empty() {
+        let _ = std::fs::remove_file(&path);
+    } else {
+        write_shared_entries(&path, &list);
+    }
+}
+
+/// Return every live candidate for `agent_id` across all channels,
+/// freshest-first (§4.3: Tier 2b prefers the freshest candidate). Does
+/// NOT filter by staleness/pid-liveness — callers needing that should use
+/// [`cleanup_stale_shared`] (startup sweep) plus the existing
+/// evict-on-forward-failure pattern already used by Tier 2a/3 in
+/// `server/reactive.rs`, matching how this codebase already handles
+/// registry staleness elsewhere rather than re-validating on every read.
+pub fn lookup_all_shared(shared_dir: &Path, agent_id: &str) -> Vec<AgentEntry> {
+    let path = agent_path(shared_dir, agent_id);
+    let mut list = read_shared_entries(&path);
+    list.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    list
+}
+
+/// List every entry currently in the host-global shared registry, across
+/// every agent name and channel. Used by the `/agentmux/discovery` endpoint
+/// to populate `host.cross_channel[]` (§4.5 of the cross-channel delivery
+/// spec) — unlike [`lookup_all_shared`], which targets one known agent
+/// name, this enumerates the whole directory.
+pub fn list_all_shared(shared_dir: &Path) -> Vec<AgentEntry> {
+    let dir = agents_dir(shared_dir);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        out.extend(read_shared_entries(&path));
+    }
+    out
+}
+
+/// Startup sweep over the host-global registry: remove any entry whose
+/// `updated_at` is past `max_age_ms` OR whose `pid` is no longer alive on
+/// this host (§4.4) — the dead-`Agent3` case from the spec's problem
+/// statement, where per-channel TTL cleanup never reached an entry
+/// belonging to a channel that hadn't restarted.
+pub fn cleanup_stale_shared(shared_dir: &Path, max_age_ms: u64) {
+    let dir = agents_dir(shared_dir);
+    let Ok(entries) = std::fs::read_dir(&dir) else { return };
+    let cutoff = now_unix_millis().saturating_sub(max_age_ms);
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let list = read_shared_entries(&path);
+        let live: Vec<AgentEntry> = list
+            .into_iter()
+            .filter(|e| e.updated_at >= cutoff && pid_alive(e.pid))
+            .collect();
+        if live.is_empty() {
+            let _ = std::fs::remove_file(&path);
+        } else {
+            write_shared_entries(&path, &live);
+        }
+    }
+}
+
+/// Best-effort read of a shared-registry file as a JSON array. Missing,
+/// unreadable, or malformed files are treated as "no entries" — same
+/// graceful-degradation posture as the per-channel `lookup`.
+fn read_shared_entries(path: &Path) -> Vec<AgentEntry> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+/// Write a shared-registry file's full entry list, atomically (temp file
+/// + rename) so a concurrent reader never observes a partially-written
+/// array. Mode 0600 on Unix at open time — same auth_key exposure
+/// boundary as the per-channel registry (§5 of the cross-channel spec:
+/// same-user trust boundary, not cross-user).
+fn write_shared_entries(path: &Path, list: &[AgentEntry]) {
+    let Ok(json) = serde_json::to_string(list) else { return };
+    let tmp_path = path.with_extension("json.tmp");
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let Ok(mut f) = opts.open(&tmp_path) else { return };
+    use std::io::Write;
+    if f.write_all(json.as_bytes()).is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return;
+    }
+    drop(f);
+    let _ = std::fs::rename(&tmp_path, path);
+}
+
+#[cfg(test)]
+mod shared_tests {
+    use super::*;
+
+    #[test]
+    fn write_then_lookup_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].channel, "dev-a");
+        assert_eq!(found[0].local_url, "http://127.0.0.1:9001");
+        assert_eq!(found[0].block_id, "block1");
+    }
+
+    #[test]
+    fn multiple_channels_coexist_for_same_name() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9002", "block2", "dev-b");
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 2);
+        let channels: std::collections::HashSet<_> =
+            found.iter().map(|e| e.channel.clone()).collect();
+        assert_eq!(
+            channels,
+            ["dev-a", "dev-b"].into_iter().map(String::from).collect()
+        );
+    }
+
+    #[test]
+    fn write_same_channel_twice_replaces_not_duplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9099", "block9", "dev-a");
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].local_url, "http://127.0.0.1:9099");
+    }
+
+    #[test]
+    fn lookup_all_shared_sorts_freshest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9002", "block2", "dev-b");
+        // Directly bump dev-b's updated_at so it's unambiguously freshest,
+        // independent of how fast the two writes above happened to run.
+        let path = agent_path(dir.path(), "agentx");
+        let mut list = read_shared_entries(&path);
+        for e in list.iter_mut() {
+            if e.channel == "dev-b" {
+                e.updated_at += 10_000;
+            }
+        }
+        write_shared_entries(&path, &list);
+
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found[0].channel, "dev-b");
+        assert_eq!(found[1].channel, "dev-a");
+    }
+
+    #[test]
+    fn remove_shared_drops_only_that_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9002", "block2", "dev-b");
+        remove_shared(dir.path(), "agentx", "dev-a");
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].channel, "dev-b");
+    }
+
+    #[test]
+    fn remove_shared_last_channel_deletes_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        remove_shared(dir.path(), "agentx", "dev-a");
+        assert!(lookup_all_shared(dir.path(), "agentx").is_empty());
+        assert!(!agent_path(dir.path(), "agentx").exists());
+    }
+
+    #[test]
+    fn list_all_shared_covers_multiple_agent_names() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        write_shared(dir.path(), "agenty", "http://127.0.0.1:9002", "block2", "dev-b");
+        let all = list_all_shared(dir.path());
+        assert_eq!(all.len(), 2);
+        let names: std::collections::HashSet<_> =
+            all.iter().map(|e| e.agent_id.clone()).collect();
+        assert_eq!(
+            names,
+            ["agentx", "agenty"].into_iter().map(String::from).collect()
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_shared_evicts_by_ttl() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        // Backdate updated_at well past the TTL, but keep pid as our own
+        // (alive) so only the TTL check can be responsible for eviction.
+        let path = agent_path(dir.path(), "agentx");
+        let mut list = read_shared_entries(&path);
+        list[0].updated_at = 0;
+        list[0].pid = std::process::id();
+        write_shared_entries(&path, &list);
+
+        cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
+        assert!(lookup_all_shared(dir.path(), "agentx").is_empty());
+    }
+
+    #[test]
+    fn cleanup_stale_shared_evicts_dead_pid_even_if_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        // Fresh updated_at, but a PID essentially guaranteed not to exist —
+        // exercises the dead-channel-that-never-restarted case from the
+        // spec's problem statement, which TTL alone wouldn't catch for
+        // another 4 hours.
+        let path = agent_path(dir.path(), "agentx");
+        let mut list = read_shared_entries(&path);
+        list[0].pid = u32::MAX;
+        write_shared_entries(&path, &list);
+
+        cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
+        assert!(lookup_all_shared(dir.path(), "agentx").is_empty());
+    }
+
+    #[test]
+    fn cleanup_stale_shared_keeps_fresh_live_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        let path = agent_path(dir.path(), "agentx");
+        let mut list = read_shared_entries(&path);
+        list[0].pid = std::process::id();
+        write_shared_entries(&path, &list);
+
+        cleanup_stale_shared(dir.path(), 4 * 60 * 60 * 1000);
+        assert_eq!(lookup_all_shared(dir.path(), "agentx").len(), 1);
+    }
+
+    #[test]
+    fn agent_id_path_traversal_is_sanitized() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "../../evil", "http://127.0.0.1:9001", "block1", "dev-a");
+        // Sanitization (agent_path) must keep the write confined to the
+        // shared registry's own agents/ dir — no file with `.` path
+        // segments should escape it.
+        let agents = agents_dir(dir.path());
+        for entry in std::fs::read_dir(&agents).unwrap() {
+            let name = entry.unwrap().file_name();
+            assert!(!name.to_string_lossy().contains(".."));
+        }
+    }
+
+    #[test]
+    fn pid_alive_true_for_self() {
+        assert!(pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn pid_alive_false_for_max_pid() {
+        assert!(!pid_alive(u32::MAX));
     }
 }

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -259,6 +259,7 @@ fn test_handler_inject_no_sender() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     assert!(!resp.success);
@@ -278,6 +279,7 @@ fn test_handler_inject_agent_not_found() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     assert!(!resp.success);
@@ -313,6 +315,7 @@ async fn test_handler_inject_success() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     assert!(resp.success);
@@ -374,6 +377,7 @@ fn test_handler_inject_structured_delivery_skips_pty() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     assert!(resp.success);
@@ -419,6 +423,7 @@ async fn test_handler_inject_pty_fallback() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     assert!(resp.success);
@@ -465,6 +470,7 @@ fn test_handler_inject_structured_failure_no_pty_fallback() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     assert!(!resp.success);
@@ -490,6 +496,7 @@ fn test_handler_audit_log() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     });
 
     let log = handler.get_audit_log(10);
@@ -616,6 +623,7 @@ fn test_injection_request_serde() {
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: None,
+        forward_hops: 0,
     };
 
     let json = serde_json::to_string(&req).unwrap();
@@ -694,4 +702,30 @@ fn test_reactive_handler_list() {
 
     let agents = handler.list_agents();
     assert_eq!(agents.len(), 2);
+}
+
+// -- InjectionRequest::forward_hops --
+
+#[test]
+fn injection_request_forward_hops_defaults_to_zero_when_absent() {
+    // Older callers (muxbus client, any payload predating this field) must
+    // still deserialize -- the hop-count guard added for PR #2350's forward-
+    // loop fix must not break existing cross-instance callers.
+    let json = serde_json::json!({
+        "target_agent": "agent1",
+        "message": "hello",
+    });
+    let req: InjectionRequest = serde_json::from_value(json).unwrap();
+    assert_eq!(req.forward_hops, 0);
+}
+
+#[test]
+fn injection_request_forward_hops_round_trips() {
+    let json = serde_json::json!({
+        "target_agent": "agent1",
+        "message": "hello",
+        "forward_hops": 2,
+    });
+    let req: InjectionRequest = serde_json::from_value(json).unwrap();
+    assert_eq!(req.forward_hops, 2);
 }

--- a/agentmux-srv/src/backend/reactive/types.rs
+++ b/agentmux-srv/src/backend/reactive/types.rs
@@ -52,6 +52,16 @@ pub struct InjectionRequest {
     /// Delivery tier of this jekt (host/lan/wan) — used in the marker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delivery_tier: Option<String>,
+    /// Number of cross-instance HTTP forwards this request has already gone
+    /// through (Tier 2a/2b/3 each increment before forwarding). Bounds a
+    /// pathological cycle where two channels each hold a stale-but-
+    /// PID-alive shared-registry entry pointing at the other for the same
+    /// agent name — without this, such a cycle would forward back and
+    /// forth indefinitely, hanging the original request (reagent P1 on
+    /// PR #2350). `#[serde(default)]` so older callers (muxbus client,
+    /// any request that predates this field) default to 0, unaffected.
+    #[serde(default)]
+    pub forward_hops: u8,
 }
 
 /// Response from a message injection attempt.

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1409,7 +1409,20 @@ pub fn build_app_state(
         lan_discovery: net.lan_discovery.clone(),
         lsp_supervisor: net.lsp_supervisor.clone(),
         local_web_url: net.local_web_url.clone(),
-        http_client: reqwest::Client::new(),
+        // Bounded request timeout: cross-instance reactive-inject forwards
+        // (Tier 2/2b/3) chain through this client, and an unbounded client
+        // combined with a forwarding cycle (two channels each holding a
+        // stale-but-PID-alive shared-registry entry pointing at the other)
+        // could otherwise hang a request indefinitely. The hop-count guard
+        // in server/reactive.rs bounds the CYCLE; this bounds each
+        // individual HOP (reagent P1 on PR #2350).
+        http_client: reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "failed to build http_client with timeout, using default");
+                reqwest::Client::new()
+            }),
         process_tracker: net.process_tracker.clone(),
         process_broker: net.process_broker.clone(),
         // Phase E.2c.2 — reducer state + event bus exposed to HTTP/WS

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1236,6 +1236,15 @@ pub async fn bind_listeners_and_network(
         4 * 60 * 60 * 1000,
     );
 
+    // Same sweep for the host-global shared registry (Tier 2b, issue #1916)
+    // — additionally drops entries whose owning PID no longer exists on this
+    // host, since a channel that crashed without a clean unregister can
+    // leave an entry behind indefinitely otherwise (no other channel's
+    // startup would ever revisit it).
+    if let Some(shared_dir) = registry::resolve_shared_reactive_dir() {
+        backend::reactive::registry::cleanup_stale_shared(&shared_dir, 4 * 60 * 60 * 1000);
+    }
+
     // Tracks agent-spawned OS processes per block. Registered trackers
     // live as long as their agent pane; the background poller emits
     // delta events (`agent:process-added`/`-exited`) to the frontend.

--- a/agentmux-srv/src/messaging/discord/gateway.rs
+++ b/agentmux-srv/src/messaging/discord/gateway.rs
@@ -422,6 +422,7 @@ fn handle_dispatch(
                 wait_for_idle: false,
                 jekt_tier: None,
                 delivery_tier: Some("wan".to_string()),
+                forward_hops: 0,
             };
             let result = handler.inject_message(req);
             if result.success {

--- a/agentmux-srv/src/messaging/slack/socket.rs
+++ b/agentmux-srv/src/messaging/slack/socket.rs
@@ -519,6 +519,7 @@ fn route_event(
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: Some("wan".to_string()),
+        forward_hops: 0,
     };
     let result = handler.inject_message(req);
     if result.success {

--- a/agentmux-srv/src/messaging/telegram/poller.rs
+++ b/agentmux-srv/src/messaging/telegram/poller.rs
@@ -201,6 +201,7 @@ fn handle_update(update: &Update, config: &TelegramConfig, health: &Arc<Mutex<Br
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: Some("wan".to_string()),
+        forward_hops: 0,
     };
     let result = handler.inject_message(req);
     if result.success {

--- a/agentmux-srv/src/messaging/whatsapp/webhook.rs
+++ b/agentmux-srv/src/messaging/whatsapp/webhook.rs
@@ -138,6 +138,7 @@ pub async fn handle_inbound(headers: HeaderMap, body: Bytes) -> impl IntoRespons
             wait_for_idle: false,
             jekt_tier: None,
             delivery_tier: Some("wan".to_string()),
+            forward_hops: 0,
         };
         let result = handler.inject_message(req);
         if !result.success {

--- a/agentmux-srv/src/muxbus/cloud_subscriber.rs
+++ b/agentmux-srv/src/muxbus/cloud_subscriber.rs
@@ -785,6 +785,7 @@ async fn sync_agent_reactive(
             wait_for_idle: false,
             jekt_tier: None,       // auto-detected from keywords
             delivery_tier: Some("wan".to_string()),
+            forward_hops: 0,
         };
         let delivery = handler.inject_message(req);
         tracing::debug!(

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -34,8 +34,8 @@ pub use migrate::{
     SourceBackfillStats,
 };
 pub use paths::{
-    resolve_shared_definitions_dir, resolve_shared_registry_dir, resolve_shared_store_path,
-    resolve_shared_transcripts_dir,
+    resolve_shared_definitions_dir, resolve_shared_reactive_dir, resolve_shared_registry_dir,
+    resolve_shared_store_path, resolve_shared_transcripts_dir,
 };
 // crate-internal only — see resolve_global_shared_root's doc comment for why
 // migrations/runner.rs must call this directly instead of deriving `home`

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -71,6 +71,26 @@ pub fn resolve_shared_store_path() -> Option<std::path::PathBuf> {
     resolve_global_shared_root().map(|h| h.join("store.db"))
 }
 
+/// Resolve the GLOBAL `<home>/shared/agents/reactive/` directory — the
+/// cross-channel presence registry for live reactive-injection targets
+/// (agent_id -> local_url/block_id/pid/auth_key, one entry per channel),
+/// used by MuxBus Tier 2b same-host cross-channel delivery
+/// (issue #1916 / `SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md`).
+///
+/// Sibling of [`resolve_shared_registry_dir`] in *location* (both live
+/// under `shared/agents/`), but a different *concern*: that registry
+/// mirrors durable agent definitions/session-resume state, while this one
+/// tracks live, ephemeral reachability for message forwarding — entries
+/// here are written at reactive-register time and removed at unregister,
+/// not persisted across restarts.
+///
+/// Returns `None` only if the global shared root can't be resolved —
+/// caller treats this as "cross-channel delivery disabled," falling back
+/// to same-channel-only Tier 2 (no behavior regression).
+pub fn resolve_shared_reactive_dir() -> Option<PathBuf> {
+    resolve_global_shared_root().map(|h| h.join("agents").join("reactive"))
+}
+
 /// Resolve the GLOBAL `<home>/shared/agents/transcripts/` directory.
 ///
 /// Sibling of [`resolve_shared_registry_dir`] / [`resolve_shared_definitions_dir`]:
@@ -175,6 +195,43 @@ mod tests {
         clear();
         // No env set — uses dirs::home_dir()/.agentmux/shared. Non-None.
         assert!(resolve_shared_registry_dir().is_some());
+    }
+
+    #[test]
+    fn reactive_dir_uses_shared_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_SHARED_DIR", "/home/user/.agentmux/shared");
+        let r = resolve_shared_reactive_dir().unwrap();
+        assert_eq!(
+            r,
+            PathBuf::from("/home/user/.agentmux/shared/agents/reactive")
+        );
+        clear();
+    }
+
+    #[test]
+    fn reactive_dir_override_wins() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+        let r = resolve_shared_reactive_dir().unwrap();
+        assert_eq!(
+            r,
+            PathBuf::from("/tmp/test-home/shared/agents/reactive")
+        );
+        clear();
+    }
+
+    #[test]
+    fn reactive_dir_is_sibling_of_registry_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_SHARED_DIR", "/home/user/.agentmux/shared");
+        let reactive = resolve_shared_reactive_dir().unwrap();
+        let registry = resolve_shared_registry_dir().unwrap();
+        assert_eq!(reactive.parent(), registry.parent());
+        clear();
     }
 
     #[test]

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -101,6 +101,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
     // Filestore — the spawn-gate error frame must be PERSISTED to the
     // block file, not just live-broadcast (reagent P1, PR #2164 round 2).
     let filestore_ai = state.filestore.clone();
+    let local_web_url_ai = state.local_web_url.clone();
     engine.register_handler(
         COMMAND_AGENT_INPUT,
         Box::new(move |data, _ctx| {
@@ -110,6 +111,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
             let broker = broker_ai.clone();
             let container_manager = container_manager_ai.clone();
             let filestore_gate = filestore_ai.clone();
+            let local_web_url = local_web_url_ai.clone();
             Box::pin(async move {
                 let cmd: CommandAgentInputData = serde_json::from_value(data)
                     .map_err(|e| format!("agentinput: {e}"))?;
@@ -446,6 +448,26 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                         if let Some(sub) = crate::muxbus::cloud_subscriber::get_global_subscriber() {
                             sub.add_agent(&agent_name);
                         }
+                        // Also mirror into the per-channel + host-global
+                        // shared file registries — this AgentInput/
+                        // SubprocessController path (unlike ShellController/
+                        // PersistentSubprocessController) previously only
+                        // ever registered in the in-memory Tier-1 map,
+                        // leaving it permanently unreachable via Tier 2/2b
+                        // cross-instance/cross-channel delivery (reagent P1,
+                        // third round on PR #2350).
+                        let data_dir = crate::backend::base::get_wave_data_dir();
+                        crate::backend::reactive::registry::write(
+                            &data_dir,
+                            &agent_name,
+                            &local_web_url,
+                            &cmd.blockid,
+                        );
+                        crate::backend::reactive::registry::write_shared_from_env(
+                            &agent_name,
+                            &local_web_url,
+                            &cmd.blockid,
+                        );
                     }
                 }
 
@@ -471,6 +493,13 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                         let handler = crate::backend::reactive::handler::get_global_handler();
                         let agent_name = handler.agent_id_for_block(&cmd.blockid);
                         handler.unregister_block(&cmd.blockid);
+                        if let Some(ref name) = agent_name {
+                            // Symmetric teardown for the registry writes added
+                            // alongside SubprocessSpawn's register_agent call.
+                            let data_dir = crate::backend::base::get_wave_data_dir();
+                            crate::backend::reactive::registry::remove(&data_dir, name);
+                            crate::backend::reactive::registry::remove_shared_from_env(name);
+                        }
                         if let (Some(sub), Some(name)) = (
                             crate::muxbus::cloud_subscriber::get_global_subscriber(),
                             agent_name,

--- a/agentmux-srv/src/server/messagebus.rs
+++ b/agentmux-srv/src/server/messagebus.rs
@@ -139,6 +139,7 @@ pub(super) async fn handle_inject(
         wait_for_idle: false,
         jekt_tier: None,
         delivery_tier: Some("host".to_string()),
+        forward_hops: 0,
     };
     let resp = state.reactive_handler.inject_message(reactive_req);
     if resp.success {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -534,12 +534,35 @@ async fn handle_discovery(State(state): State<AppState>) -> Json<serde_json::Val
     let version = state.version.clone();
     let local_url = state.local_web_url.clone();
 
+    // Tier 2b — other channels' agents on this same host (issue #1916), via
+    // the host-global shared registry. Excludes this instance's own channel
+    // (already covered by `agents`/`addressable` above) and this instance's
+    // own URL (a stale self-entry from a prior crash, if any).
+    let own_channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+    let cross_channel: Vec<serde_json::Value> = crate::registry::resolve_shared_reactive_dir()
+        .map(|shared_dir| {
+            crate::backend::reactive::registry::list_all_shared(&shared_dir)
+                .into_iter()
+                .filter(|e| e.channel != own_channel && e.local_url != local_url)
+                .map(|e| {
+                    json!({
+                        "name": e.agent_id,
+                        "channel": e.channel,
+                        "local_url": e.local_url,
+                        "block_id": e.block_id,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     Json(json!({
         "host": {
             "version": version,
             "local_url": local_url,
             "addressable": reachable,
             "agents": agents,
+            "cross_channel": cross_channel,
         },
         "lan": lan,
         "wan": { "subscribed_agents": wan_agents },

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -168,6 +168,88 @@ pub(super) async fn handle_reactive_inject(
             }
         }
 
+        // Tier 2b: same host, DIFFERENT channel (host-global shared registry).
+        // Runs when Tier 2a had no same-channel entry or its forward already
+        // failed above — closes the gap issue #1916 tracked (Tier 2 previously
+        // only ever reached agents in the caller's own channel). Candidates are
+        // tried freshest-first (§4.3 of the cross-channel delivery spec);
+        // a failed forward evicts just that channel's entry and falls through
+        // to the next candidate, same evict-on-fail shape Tier 3 already uses.
+        if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+            let candidates = agent_registry::lookup_all_shared(&shared_dir, &req.target_agent);
+            for entry in candidates {
+                // Self-forward guard, matching Tier 2a. Also loopback-only
+                // (§5 of the spec): a poisoned registry entry can't redirect
+                // a forward off-box, since resolve_shared_reactive_dir() is a
+                // same-user local file, but defense in depth costs nothing here.
+                let is_loopback = entry.local_url.starts_with("http://127.0.0.1")
+                    || entry.local_url.starts_with("http://localhost")
+                    || entry.local_url.starts_with("http://[::1]");
+                if !is_loopback || entry.local_url == state.local_web_url {
+                    continue;
+                }
+
+                let forward_url = format!("{}/agentmux/reactive/inject", entry.local_url);
+                tracing::debug!(
+                    target = %req.target_agent,
+                    channel = %entry.channel,
+                    url = %forward_url,
+                    "cross-channel inject forward"
+                );
+                let mut fwd = state.http_client.post(&forward_url).json(&req);
+                if !entry.auth_key.is_empty() {
+                    fwd = fwd.header("X-AuthKey", &entry.auth_key);
+                }
+                match fwd.send().await {
+                    Ok(r) if r.status().is_success() => {
+                        if let Ok(body) = r.json::<serde_json::Value>().await {
+                            if body.get("success").and_then(|v| v.as_bool()) == Some(true) {
+                                echo_jekt_to_sender(
+                                    &state,
+                                    req.source_agent.as_deref(),
+                                    &req.target_agent,
+                                    &req.message,
+                                    body.get("request_id").and_then(|v| v.as_str()).unwrap_or(""),
+                                    body.get("effective_tier").and_then(|v| v.as_str()),
+                                    "host",
+                                    req.priority.as_deref().unwrap_or("normal"),
+                                );
+                                return Json(body);
+                            }
+                            // success:false — this channel's entry is stale
+                            // (e.g. agent unregistered without a clean
+                            // shutdown); evict and try the next candidate.
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                channel = %entry.channel,
+                                "cross-channel forward: success=false — evicting and trying next candidate"
+                            );
+                            agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
+                        }
+                    }
+                    Ok(r) => {
+                        tracing::warn!(
+                            target = %req.target_agent,
+                            channel = %entry.channel,
+                            status = %r.status(),
+                            url = %forward_url,
+                            "cross-channel forward: non-success status"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target = %req.target_agent,
+                            channel = %entry.channel,
+                            error = %e,
+                            url = %forward_url,
+                            "cross-channel forward failed — evicting stale entry"
+                        );
+                        agent_registry::remove_shared(&shared_dir, &req.target_agent, &entry.channel);
+                    }
+                }
+            }
+        }
+
         // Tier 3: LAN peer (mDNS lookup → HTTP). Runs when tier 2 had no registry
         // entry or its forward failed. Queries each discovered LAN peer for the
         // agent; result is cached for 60s to avoid per-inject mDNS fan-out.
@@ -317,6 +399,21 @@ pub(super) async fn handle_reactive_register(
             let data_dir = base::get_wave_data_dir();
             agent_registry::write(&data_dir, &req.agent_id, &state.local_web_url, &req.block_id);
 
+            // And to the host-global shared registry (Tier 2b) so instances
+            // running in OTHER channels on this host can reach this agent
+            // too — closes issue #1916 (Tier 2 previously only ever reached
+            // the caller's own channel).
+            if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+                let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+                agent_registry::write_shared(
+                    &shared_dir,
+                    &req.agent_id,
+                    &state.local_web_url,
+                    &req.block_id,
+                    &channel,
+                );
+            }
+
             // Auto-watch this agent's Claude Code config dir for subagent JSONL files.
             // Pass block_id so subagent events are stamped with the owning pane,
             // letting the frontend route ⚡ panels to that pane only. See
@@ -401,6 +498,11 @@ pub(super) async fn handle_reactive_unregister(
     // Also remove from cross-instance file registry.
     let data_dir = base::get_wave_data_dir();
     agent_registry::remove(&data_dir, &req.agent_id);
+    // And from the host-global shared registry (Tier 2b).
+    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
+        let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
+        agent_registry::remove_shared(&shared_dir, &req.agent_id, &channel);
+    }
     // Drop the subagent filesystem watcher (handle + channel + task) — the
     // symmetric teardown for the watch_agent() call in the register handler.
     // Passes block_id (captured above) so a shared-agent-id watcher with

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -416,16 +416,7 @@ pub(super) async fn handle_reactive_register(
             // running in OTHER channels on this host can reach this agent
             // too — closes issue #1916 (Tier 2 previously only ever reached
             // the caller's own channel).
-            if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
-                let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
-                agent_registry::write_shared(
-                    &shared_dir,
-                    &req.agent_id,
-                    &state.local_web_url,
-                    &req.block_id,
-                    &channel,
-                );
-            }
+            agent_registry::write_shared_from_env(&req.agent_id, &state.local_web_url, &req.block_id);
 
             // Auto-watch this agent's Claude Code config dir for subagent JSONL files.
             // Pass block_id so subagent events are stamped with the owning pane,
@@ -512,10 +503,7 @@ pub(super) async fn handle_reactive_unregister(
     let data_dir = base::get_wave_data_dir();
     agent_registry::remove(&data_dir, &req.agent_id);
     // And from the host-global shared registry (Tier 2b).
-    if let Some(shared_dir) = crate::registry::resolve_shared_reactive_dir() {
-        let channel = std::env::var("AGENTMUX_CHANNEL").unwrap_or_else(|_| "stable".to_string());
-        agent_registry::remove_shared(&shared_dir, &req.agent_id, &channel);
-    }
+    agent_registry::remove_shared_from_env(&req.agent_id);
     // Drop the subagent filesystem watcher (handle + channel + task) — the
     // symmetric teardown for the watch_agent() call in the register handler.
     // Passes block_id (captured above) so a shared-agent-id watcher with

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -143,8 +143,21 @@ pub(super) async fn handle_reactive_inject(
                                     "host",
                                     req.priority.as_deref().unwrap_or("normal"),
                                 );
+                                return Json(body);
                             }
-                            return Json(body);
+                            // success:false — this entry is stale (e.g. agent
+                            // unregistered without a clean shutdown); evict
+                            // and fall through to Tier 2b/3 instead of
+                            // returning the failure (reagent P1 on #2350 —
+                            // this previously returned unconditionally
+                            // whenever the body parsed, regardless of
+                            // success, so a stale same-channel entry never
+                            // fell through to any later tier).
+                            tracing::warn!(
+                                target = %req.target_agent,
+                                "cross-instance forward: success=false — evicting and falling through"
+                            );
+                            agent_registry::remove(&data_dir, &req.target_agent);
                         }
                     }
                     Ok(r) => {

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -15,6 +15,15 @@ use crate::backend::base;
 
 use super::AppState;
 
+/// Max cross-instance HTTP forwards a single inject request may go through
+/// (Tier 2a/2b/3 each increment before forwarding). A legitimate delivery
+/// is always exactly one hop (caller's instance → the owning instance);
+/// this only exists to bound a pathological cycle — two channels each
+/// holding a stale-but-PID-alive shared-registry entry pointing at the
+/// other for the same agent name would otherwise forward back and forth
+/// indefinitely, hanging the original request (reagent P1 on PR #2350).
+const MAX_FORWARD_HOPS: u8 = 3;
+
 /// Echo a successfully-sent jekt into the SENDER's own pane
 /// (SPEC_JEKT_SECURITY_AND_VISIBILITY §3.2).
 ///
@@ -113,6 +122,21 @@ pub(super) async fn handle_reactive_inject(
         .map(|e| e.starts_with("agent not found"))
         .unwrap_or(false);
 
+    if is_not_found && req.forward_hops >= MAX_FORWARD_HOPS {
+        tracing::warn!(
+            target = %req.target_agent,
+            hops = req.forward_hops,
+            "reactive inject: forward-hop limit reached, not forwarding further"
+        );
+        return Json(serde_json::to_value(&resp).unwrap_or_default());
+    }
+
+    // Every forward below sends this hop-incremented request, not the
+    // original `req` — a peer that also fails to find the agent locally
+    // and forwards onward needs to see the accumulated hop count too.
+    let mut forwarded_req = req.clone();
+    forwarded_req.forward_hops = req.forward_hops.saturating_add(1);
+
     if is_not_found {
         // Tier 2: same-host, different sidecar (file registry → HTTP loopback)
         let data_dir = base::get_wave_data_dir();
@@ -125,7 +149,7 @@ pub(super) async fn handle_reactive_inject(
                     url = %forward_url,
                     "cross-instance inject forward"
                 );
-                let mut fwd = state.http_client.post(&forward_url).json(&req);
+                let mut fwd = state.http_client.post(&forward_url).json(&forwarded_req);
                 if !entry.auth_key.is_empty() {
                     fwd = fwd.header("X-AuthKey", &entry.auth_key);
                 }
@@ -209,7 +233,7 @@ pub(super) async fn handle_reactive_inject(
                     url = %forward_url,
                     "cross-channel inject forward"
                 );
-                let mut fwd = state.http_client.post(&forward_url).json(&req);
+                let mut fwd = state.http_client.post(&forward_url).json(&forwarded_req);
                 if !entry.auth_key.is_empty() {
                     fwd = fwd.header("X-AuthKey", &entry.auth_key);
                 }
@@ -277,7 +301,7 @@ pub(super) async fn handle_reactive_inject(
                 url = %forward_url,
                 "LAN peer inject forward"
             );
-            let mut fwd = state.http_client.post(&forward_url).json(&req);
+            let mut fwd = state.http_client.post(&forward_url).json(&forwarded_req);
             if !peer_auth_key.is_empty() {
                 fwd = fwd.header("X-AuthKey", &peer_auth_key);
             }

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -424,6 +424,7 @@ async fn handle_incoming_text(
                         wait_for_idle: false,
                         jekt_tier: None,   // auto-detected from keywords
                         delivery_tier: Some("host".to_string()),
+                        forward_hops: 0,
                     };
                     let resp = state.reactive_handler.inject_message(reactive_req);
                     if resp.success {


### PR DESCRIPTION
## Summary

Closes #1916. MuxBus Tier 2 same-host forwarding previously only ever reached an
agent registered in the *caller's own channel* — a file registry rooted at
`AGENTMUX_DATA_HOME`, which is per-channel. An agent in `dev-a` had no way to
reach an agent in `dev-b` running on the same machine; `SendMessage` failed with
"agent not found" even though both instances were local.

This adds a sibling **host-global shared registry** at
`~/.agentmux/shared/agents/reactive/` (one JSON file per agent name, holding an
array of one entry per channel currently registering that name) and wires it in
as **Tier 2b**, between the existing Tier 2a (same-channel) and Tier 3 (LAN):

- `handle_reactive_register`/`unregister` now mirror into the shared registry
  alongside the existing per-channel one.
- `handle_reactive_inject` tries Tier 2b candidates freshest-first when Tier 2a
  has no entry or its forward failed; a failed forward evicts just that
  channel's entry and falls through to the next candidate (same evict-on-fail
  shape Tier 3 already uses).
- `GET /agentmux/discovery` gains `host.cross_channel[]`, listing other
  channels' live agents on this host.
- Startup sweep (`cleanup_stale_shared`) additionally evicts entries whose
  owning PID is no longer alive on this host — catches a channel that crashed
  without a clean unregister, which the existing TTL-only sweep could miss for
  up to 4 hours.

Implements the design in `SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md`
(parked in the `wt-xchannel` worktree since 2026-07-02), corrected against
current code — notably using the real, already-established `AGENTMUX_SHARED_DIR`
resolver rather than the spec's proposed (and since-superseded) env var name.

Same-user trust boundary as the existing per-channel registry (0600 file
perms, loopback-only forward target, auth_key required for the forward).

## Test plan

- [x] `cargo check -p agentmux-srv` — clean
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` — 1762 passed, 0 failed (13 new shared-registry tests: round-trip, multi-channel coexistence, replace-not-duplicate, freshest-first ordering, evict-one-channel, evict-last-channel-deletes-file, list-all, TTL eviction, dead-PID eviction, keep-fresh-live, path-traversal sanitization, pid_alive true/false)
- [x] `registry::paths` tests (existing + new `resolve_shared_reactive_dir` cases) — 11 passed

<!-- agentmux:agent_id=agenty -->