### PR TITLE
fix(ci): sort agentmuxai/cef CEF release resolution by publishedAt

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -132,9 +132,17 @@ jobs:
             # agentmuxai/cef now holds BOTH platforms' releases — filter to the
             # Linux x86_64 prefix (a bare --limit 1 would grab whichever platform
             # released most recently, e.g. a macOS framework).
+            #
+            # gh release list's default order is NOT reliably publish-time-descending
+            # on this fork — a release cut without an explicit --target inherits a
+            # frozen default-branch-HEAD created_at instead of the actual cut time, so
+            # trusting [0] after the filter can silently pick a stale tag (this bit the
+            # macOS codec release — see
+            # docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md). Sort by
+            # publishedAt explicitly instead.
             TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                    --json tagName \
-                    --jq '[.[].tagName | select(startswith("cef-linux-x86_64-"))][0]')
+                    --json tagName,publishedAt \
+                    --jq '[.[] | select(.tagName | startswith("cef-linux-x86_64-"))] | sort_by(.publishedAt) | reverse | .[0].tagName')
           fi
           if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
             echo "ERROR: no cef-linux-x86_64-* release found in agentmuxai/cef"; exit 1

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -123,9 +123,17 @@ jobs:
           if [ -z "$TAG" ]; then
             # agentmuxai/cef holds BOTH platforms' releases — filter to macOS arm64
             # (a bare --limit 1 would grab whichever platform released most recently).
+            #
+            # gh release list's default order is NOT reliably publish-time-descending
+            # on this fork — a release cut without an explicit --target inherits a
+            # frozen default-branch-HEAD created_at instead of the actual cut time, so
+            # trusting [0] after the filter can silently pick a stale tag (this bit the
+            # 2026-07-28 macOS codec release itself — see
+            # docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md). Sort by
+            # publishedAt explicitly instead.
             TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                    --json tagName \
-                    --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
+                    --json tagName,publishedAt \
+                    --jq '[.[] | select(.tagName | startswith("cef-macos-arm64-"))] | sort_by(.publishedAt) | reverse | .[0].tagName')
           fi
           if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
             echo "❌ no cef-macos-arm64-* release found in agentmuxai/cef" >&2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -115,9 +115,16 @@ jobs:
         run: |
           TAG="${{ steps.in.outputs.cef_tag }}"
           if [ -z "$TAG" ]; then
+            # gh release list's default order is NOT reliably publish-time-descending
+            # on this fork — a release cut without an explicit --target inherits a
+            # frozen default-branch-HEAD created_at instead of the actual cut time, so
+            # trusting [0] after the filter can silently pick a stale tag (this bit the
+            # macOS codec release — see
+            # docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md). Sort by
+            # publishedAt explicitly instead.
             TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                    --json tagName \
-                    --jq '[.[].tagName | select(startswith("cef-windows-x86_64-"))][0]')
+                    --json tagName,publishedAt \
+                    --jq '[.[] | select(.tagName | startswith("cef-windows-x86_64-"))] | sort_by(.publishedAt) | reverse | .[0].tagName')
           fi
           if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
             echo "ERROR: no cef-windows-x86_64-* release found in agentmuxai/cef"; exit 1

--- a/.github/workflows/ci-nightly-artifacts.yml
+++ b/.github/workflows/ci-nightly-artifacts.yml
@@ -50,8 +50,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
         run: |
+          # gh release list's default order is NOT reliably publish-time-descending on
+          # this fork — sort by publishedAt explicitly rather than trusting [0]. See
+          # docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md.
           TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                  --json tagName --jq '[.[].tagName | select(startswith("cef-windows-x86_64-"))][0]')
+                  --json tagName,publishedAt \
+                  --jq '[.[] | select(.tagName | startswith("cef-windows-x86_64-"))] | sort_by(.publishedAt) | reverse | .[0].tagName')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Cache codec-enabled CEF runtime
@@ -186,8 +190,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CEF_RUNTIME_TOKEN }}
         run: |
+          # gh release list's default order is NOT reliably publish-time-descending on
+          # this fork — sort by publishedAt explicitly rather than trusting [0]. See
+          # docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md.
           TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                  --json tagName --jq '[.[].tagName | select(startswith("cef-macos-arm64-"))][0]')
+                  --json tagName,publishedAt \
+                  --jq '[.[] | select(.tagName | startswith("cef-macos-arm64-"))] | sort_by(.publishedAt) | reverse | .[0].tagName')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Cache patched macOS CEF framework
         id: cef-cache
@@ -297,8 +305,14 @@ jobs:
           # filter by the Linux prefix so a newer macOS tag can't shadow it
           # (this bit us: the unfiltered --limit 1 grabbed a macOS tarball with
           # no libcef.so inside, see docs/specs/SPEC_PATCHED_MACOS_CEF_FRAMEWORK_RELEASE_2026_06_29.md).
+          #
+          # gh release list's default order is ALSO not reliably publish-time-descending
+          # on this fork even after filtering to one platform — sort by publishedAt
+          # explicitly rather than trusting [0]. See
+          # docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md.
           TAG=$(gh release list --repo agentmuxai/cef --limit 30 \
-                  --json tagName --jq '[.[].tagName | select(startswith("cef-linux-x86_64-"))][0]')
+                  --json tagName,publishedAt \
+                  --jq '[.[] | select(.tagName | startswith("cef-linux-x86_64-"))] | sort_by(.publishedAt) | reverse | .[0].tagName')
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Cache patched libcef.so
         id: cef-cache


### PR DESCRIPTION
## Summary

- All three per-platform build workflows (`build-linux.yml`, `build-windows.yml`, `build-macos.yml`) plus `ci-nightly-artifacts.yml` resolve the "latest patched CEF release" for their platform with the same pattern: filter `gh release list` output by tag prefix, take `[0]`. That trusts `gh release list`'s default order to be publish-time-descending — it isn't, reliably, on `agentmuxai/cef`.
- Found while shipping the macOS proprietary-codecs work (#2311/#2347): a release cut without an explicit `--target` inherits `created_at` from whatever commit `agentmuxai/cef`'s default branch HEAD happens to be at cut time (frozen — that repo is purely a release-distribution channel, no regular commits), not the actual creation time. `gh release list`'s default order follows `created_at`. Concretely, `cef-macos-arm64-148.23.23-codecs` (cut 2026-07-28) sorted *behind* the older `cef-macos-arm64-148.23.21` (cut 2026-07-02, but with a "real" `created_at`) in this exact query — every consuming workflow would have kept silently shipping the pre-codec framework. Full incident write-up: `docs/specs/STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md`.
- Fix: request `publishedAt` in the `--json` field list (confirmed accurate — real timestamps — for every release checked) and `sort_by(.publishedAt) | reverse` before taking `[0]`, instead of trusting implicit list order. Same one-line-ish fix applied identically at all 6 call sites.

No functional/runtime code touched — CI workflow YAML only.

## Test plan

- [x] All 4 edited workflow files parse as valid YAML (`ruby -ryaml`)
- [x] Reproduced the corrected `gh release list ... | sort_by(.publishedAt) | reverse | .[0].tagName` query live against `agentmuxai/cef` for all three platform prefixes — confirmed it now resolves to the intended (newest-published) tag in each case, including the macOS codec tag that the old query got wrong
- [ ] Not run inside an actual GitHub Actions job (would need a workflow_dispatch or the next nightly run) — the query itself is verified correct against the live repo, but flagging that this wasn't exercised end-to-end inside CI before merge

<!-- agentmux:agent_id=agento -->