### PR TITLE
docs(specs): archive 2 superseded specs (DOC-008, DOC-009)

### DIFF
--- a/.changesets/1785333760-docs-specs-archive-2-superseded-specs-doc-008-doc-009-p39l.md
+++ b/.changesets/1785333760-docs-specs-archive-2-superseded-specs-doc-008-doc-009-p39l.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(specs): archive 2 superseded specs (DOC-008, DOC-009)

--- a/docs/specs/archive/double-click-magnify.md
+++ b/docs/specs/archive/double-click-magnify.md
@@ -2,7 +2,7 @@
 
 **Goal:** Double-clicking a pane's header bar toggles magnify (maximize/restore).
 
-**Status:** Ready for implementation.
+**Status:** Implemented (confirmed 2026-07-29, DOC-008 documentation analyst — `blockframe.tsx`'s `onDblClick={() => props.nodeModel.toggleMagnify()}` on the pane header, plus deliberate dblclick-swallowing guards on the view icon and `ViewNameEditor` that only make sense with this handler in place). Moved to `specs/archive` per this repo's spec-lifecycle convention.
 
 ---
 

--- a/docs/specs/archive/tab-context-menu-cleanup.md
+++ b/docs/specs/archive/tab-context-menu-cleanup.md
@@ -1,7 +1,7 @@
 # Spec: Tab Context Menu Cleanup
 
 **Date:** 2026-03-18
-**Status:** Ready to implement
+**Status:** Superseded — moot (confirmed 2026-07-29, DOC-009 documentation analyst). `tab.tsx`'s `handleContextMenu` no longer opens a native menu at all; right-click opens a custom `TabContextPanel` (a 14-color `ColorSwatchPalette` plus Rename/Close buttons). None of this spec's described current-state baseline (native menu with Pin Tab/Rename/Copy TabId/Color/Backgrounds/Close) or its proposal (emoji labels) match what shipped. Kept for historical reference only — moved to `specs/archive`.
 
 ---
 


### PR DESCRIPTION
## Summary

Both flagged by the 2026-07-29 documentation analyst as stuck at a pre-implementation status label though the described work is done (or, for `tab-context-menu-cleanup`, superseded by a different design entirely):

- **`double-click-magnify.md`**: "Ready for implementation" → confirmed live in `blockframe.tsx` (`toggleMagnify` on dblclick, plus dblclick-swallowing guards that only make sense with it in place). Status → Implemented.
- **`tab-context-menu-cleanup.md`**: "Ready to implement" → `tab.tsx`'s actual right-click handler opens a custom `TabContextPanel`, not the native menu this spec's baseline and proposal both describe. Neither the spec's current-state description nor its proposal match what shipped. Status → Superseded/moot.

Both moved to `specs/archive` per this repo's own spec-lifecycle convention.

<!-- agentmux:agent_id=agent1 -->