### PR TITLE
chore: release v0.54.7

### DIFF
--- a/.changesets/1785184446-feat-telemetry-wave-turn-diagnostic-logging-for-the-turn-pha-zlnv.md
+++ b/.changesets/1785184446-feat-telemetry-wave-turn-diagnostic-logging-for-the-turn-pha-zlnv.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(telemetry): [wave-turn] diagnostic logging for the turn-phase state machine + watchdog reasoning

--- a/.changesets/1785185774-feat-armory-add-agent-skills-skill-md-format-for-skills-abf--s97c.md
+++ b/.changesets/1785185774-feat-armory-add-agent-skills-skill-md-format-for-skills-abf--s97c.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): add Agent Skills (SKILL.md) format for skills, ABF Phase 0

--- a/.changesets/1785186317-feat-agent-guarantee-pane-close-reopen-resumes-the-real-conv-j2it.md
+++ b/.changesets/1785186317-feat-agent-guarantee-pane-close-reopen-resumes-the-real-conv-j2it.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): guarantee pane close/reopen resumes the real conversation, or discloses it couldn't

--- a/.changesets/1785195417-fix-armory-align-armorysection-ids-with-their-labels-memory--0itj.md
+++ b/.changesets/1785195417-fix-armory-align-armorysection-ids-with-their-labels-memory--0itj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): align ArmorySection ids with their labels (memory/bundles, not brain/memories)

--- a/.changesets/1785196086-feat-armory-add-bundle-export-rpc-abf-phase-1-exporter-52zs.md
+++ b/.changesets/1785196086-feat-armory-add-bundle-export-rpc-abf-phase-1-exporter-52zs.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): add bundle.export RPC — ABF Phase 1 exporter

--- a/.changesets/1785196188-feat-agent-harden-working-state-and-scroll-follow-against-4--f1fl.md
+++ b/.changesets/1785196188-feat-agent-harden-working-state-and-scroll-follow-against-4--f1fl.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): harden Working-state and scroll-follow against 4 recurring desync bugs

--- a/.changesets/1785196299-fix-agent-harden-my-agents-against-single-source-failures-di-56hd.md
+++ b/.changesets/1785196299-fix-agent-harden-my-agents-against-single-source-failures-di-56hd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): harden My Agents against single-source failures, distinguish error from empty

--- a/.changesets/1785199510-fix-stash-mcp-servers-and-skills-tabs-no-longer-fail-unautho-q3oi.md
+++ b/.changesets/1785199510-fix-stash-mcp-servers-and-skills-tabs-no-longer-fail-unautho-q3oi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(stash): MCP Servers and Skills tabs no longer fail unauthorized; reactive read+bind view over the Armory catalog

--- a/.changesets/1785199520-fix-agent-keep-my-agents-loading-state-visible-during-a-retr-iar3.md
+++ b/.changesets/1785199520-fix-agent-keep-my-agents-loading-state-visible-during-a-retr-iar3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): keep My Agents loading state visible during a retry, don't flash empty

--- a/.changesets/1785201516-feat-agent-collapse-mid-line-spinner-progress-redraws-in-too-sink.md
+++ b/.changesets/1785201516-feat-agent-collapse-mid-line-spinner-progress-redraws-in-too-sink.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): collapse mid-line spinner/progress redraws in tool preview + bashwrap

--- a/.changesets/1785201569-fix-agent-let-an-askuserquestion-answer-survive-a-pane-reope-2ga5.md
+++ b/.changesets/1785201569-fix-agent-let-an-askuserquestion-answer-survive-a-pane-reope-2ga5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): let an AskUserQuestion answer survive a pane reopen or process respawn

--- a/.changesets/1785201955-fix-floating-pane-restore-resize-hit-target-from-4px-to-8px-sfnn.md
+++ b/.changesets/1785201955-fix-floating-pane-restore-resize-hit-target-from-4px-to-8px-sfnn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): restore resize hit-target from 4px to 8px

--- a/.changesets/1785205234-feat-agent-surface-a-restart-action-when-an-agent-process-go-8i3g.md
+++ b/.changesets/1785205234-feat-agent-surface-a-restart-action-when-an-agent-process-go-8i3g.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): surface a Restart action when an agent process goes unresponsive

--- a/.changesets/1785237139-fix-auth-fast-fail-sends-from-a-pane-already-known-unauthent-qpio.md
+++ b/.changesets/1785237139-fix-auth-fast-fail-sends-from-a-pane-already-known-unauthent-qpio.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(auth): fast-fail sends from a pane already known-unauthenticated

--- a/.changesets/1785240611-fix-deps-pin-brace-expansion-to-patch-the-dos-advisory-sec-0-wd0f.md
+++ b/.changesets/1785240611-fix-deps-pin-brace-expansion-to-patch-the-dos-advisory-sec-0-wd0f.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(deps): pin brace-expansion to patch the DoS advisory (SEC-005)

--- a/.changesets/1785254683-fix-agent-remove-legacy-standalone-subagent-pane-never-show--cywg.md
+++ b/.changesets/1785254683-fix-agent-remove-legacy-standalone-subagent-pane-never-show--cywg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): remove legacy standalone subagent pane, never show raw slugs in the agent pane

--- a/.changesets/1785260036-feat-muxbus-per-agent-m2m-credential-fetch-cache-wired-into--jgbu.md
+++ b/.changesets/1785260036-feat-muxbus-per-agent-m2m-credential-fetch-cache-wired-into--jgbu.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxbus): per-agent M2M credential fetch/cache, wired into cloud_subscriber's reactive requests

--- a/.changesets/1785260414-fix-build-wire-up-windows-codec-enabled-cef-default-location-zsxl.md
+++ b/.changesets/1785260414-fix-build-wire-up-windows-codec-enabled-cef-default-location-zsxl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(build): wire up Windows codec-enabled CEF default-location auto-pickup + advisory warning

--- a/.changesets/1785260934-fix-muxbus-set-muxbus-agent-id-directly-at-spawn-time-arch-0-ndr7.md
+++ b/.changesets/1785260934-fix-muxbus-set-muxbus-agent-id-directly-at-spawn-time-arch-0-ndr7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(muxbus): set MUXBUS_AGENT_ID directly at spawn time (ARCH-002)

--- a/.changesets/1785283404-fix-agent-pane-keep-scrollbar-visible-above-working-row-dock-akoa.md
+++ b/.changesets/1785283404-fix-agent-pane-keep-scrollbar-visible-above-working-row-dock-akoa.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): keep scrollbar visible above working-row/dock overlays and harden scroll-follow against programmatic-scroll races

--- a/.changesets/1785332715-feat-srv-cross-process-session-ownership-lease-foundation-re-efno.md
+++ b/.changesets/1785332715-feat-srv-cross-process-session-ownership-lease-foundation-re-efno.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): cross-process session-ownership lease foundation (registry::LeaseStore)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "dirs",
  "serde",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.54.6"
+version = "0.54.7"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,30 @@
 # AgentMux Version History
 
+## 0.54.7 — 2026-07-29
+
+- feat(telemetry): [wave-turn] diagnostic logging for the turn-phase state machine + watchdog reasoning
+- feat(armory): add Agent Skills (SKILL.md) format for skills, ABF Phase 0
+- feat(agent): guarantee pane close/reopen resumes the real conversation, or discloses it couldn't
+- fix(armory): align ArmorySection ids with their labels (memory/bundles, not brain/memories)
+- feat(armory): add bundle.export RPC — ABF Phase 1 exporter
+- feat(agent): harden Working-state and scroll-follow against 4 recurring desync bugs
+- fix(agent): harden My Agents against single-source failures, distinguish error from empty
+- fix(stash): MCP Servers and Skills tabs no longer fail unauthorized; reactive read+bind view over the Armory catalog
+- fix(agent): keep My Agents loading state visible during a retry, don't flash empty
+- feat(agent): collapse mid-line spinner/progress redraws in tool preview + bashwrap
+- fix(agent): let an AskUserQuestion answer survive a pane reopen or process respawn
+- fix(floating-pane): restore resize hit-target from 4px to 8px
+- feat(agent): surface a Restart action when an agent process goes unresponsive
+- fix(auth): fast-fail sends from a pane already known-unauthenticated
+- fix(deps): pin brace-expansion to patch the DoS advisory (SEC-005)
+- fix(agent): remove legacy standalone subagent pane, never show raw slugs in the agent pane
+- feat(muxbus): per-agent M2M credential fetch/cache, wired into cloud_subscriber's reactive requests
+- fix(build): wire up Windows codec-enabled CEF default-location auto-pickup + advisory warning
+- fix(muxbus): set MUXBUS_AGENT_ID directly at spawn time (ARCH-002)
+- fix(agent-pane): keep scrollbar visible above working-row/dock overlays and harden scroll-follow against programmatic-scroll races
+- feat(srv): cross-process session-ownership lease foundation (registry::LeaseStore)
+
+
 ## 0.54.6 — 2026-07-27
 
 - feat(macos): tab redock via CGEventTap — cross-window tab drag now merges directly with a live insertion indicator, matching Windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.54.6",
+  "version": "0.54.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.54.6",
+      "version": "0.54.7",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.54.6",
+  "version": "0.54.7",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Forces a **patch** bump (0.54.6 → 0.54.7) via `task release:patch`, overriding the auto-detected `minor` bump (several pending changesets are `feat`-typed) per explicit request.
- Consumes all 21 pending `.changesets/*.md` files, appending their descriptions to `VERSION_HISTORY.md` and deleting the consumed files.
- Bumps `package.json`, `Cargo.toml`, `Cargo.lock`, and `package-lock.json` to `0.54.7` — all 5 version locations verified consistent by `scripts/release.sh`'s own post-bump check.

Note: this intentionally ships several `feat`-level changes (Agent Skills format, bundle.export RPC, per-agent M2M credential cache, session-ownership lease foundation, etc.) under a patch version rather than the minor bump they'd normally trigger — per `scripts/release.sh`'s documented override semantics, the higher-typed changesets are still fully consumed and changelogged, only the version number is forced lower.

## Test plan
- [x] `scripts/release.sh --dry-run --as patch` previewed the exact same 21 changesets/bump before running for real
- [x] Post-bump consistency check (built into `release.sh`) confirmed `package.json`, `Cargo.toml`, `package-lock.json`, `Cargo.lock`, and `VERSION_HISTORY.md` all agree at `0.54.7`
- [ ] CI green on this PR