### PR TITLE
feat(srv): enforce cross-process session lease on host-mode agent turns

### DIFF
--- a/.changesets/1785335800-feat-srv-enforce-cross-process-session-lease-on-host-mode-ag-7h8c.md
+++ b/.changesets/1785335800-feat-srv-enforce-cross-process-session-lease-on-host-mode-ag-7h8c.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(srv): enforce cross-process session lease on host-mode agent turns

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -359,6 +359,8 @@ pub fn resync_controller(
     event_bus: Option<Arc<EventBus>>,
     wstore: Option<Arc<Store>>,
     filestore: Option<Arc<FileStore>>,
+    registry: Option<Arc<crate::registry::Registry>>,
+    boot_id: Arc<str>,
 ) -> Result<(), String> {
     let block_id = &block.oid;
     let block_meta = &block.meta;
@@ -449,6 +451,8 @@ pub fn resync_controller(
                 event_bus,
                 wstore,
                 filestore,
+                registry,
+                boot_id,
             );
             let ctrl = Arc::new(ctrl);
             ctrl.set_self_ref();
@@ -631,7 +635,7 @@ mod tests {
             ..Default::default()
         };
         // No "controller" key in meta = no-op
-        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
+        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None, None, std::sync::Arc::from("test-boot"));
         assert!(result.is_ok());
     }
 
@@ -648,7 +652,7 @@ mod tests {
             meta,
             ..Default::default()
         };
-        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
+        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None, None, std::sync::Arc::from("test-boot"));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown controller type"));
     }

--- a/agentmux-srv/src/backend/blockcontroller/shell/tests.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/tests.rs
@@ -545,7 +545,7 @@ use std::sync::Arc;
             ..Default::default()
         };
 
-        let result = super::super::resync_controller(&block, "tab-1", None, false, None, None, None, None);
+        let result = super::super::resync_controller(&block, "tab-1", None, false, None, None, None, None, None, std::sync::Arc::from("test-boot"));
         assert!(result.is_ok());
 
         let ctrl = super::super::get_controller("resync-test-block");

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -45,34 +45,19 @@ impl SubprocessController {
             return Ok(());
         }
 
-        // Direct-spawn path (queue was empty): emit the accepted event
-        // now so the frontend can promote its pending entry. The
-        // drain-from-queue path (in process_waiter) emits the same
-        // event just before calling spawn_turn recursively.
-        self.emit_message_accepted(&config);
-
-        // Hydrate inner.session_id from the config-supplied id if the
-        // controller hasn't captured one yet. See
-        // `hydrate_session_id_from_config` for the full rationale.
-        self.hydrate_session_id_from_config(config.session_id.as_deref());
-
-        // Build CLI args, appending resume flag + session_id if we have one and the provider supports it
-        let mut args = config.cli_args.clone();
-        let session_id_hint = {
-            let inner = self.inner.lock().unwrap();
-            if let Some(ref sid) = inner.session_id {
-                if !config.resume_flag.is_empty() {
-                    args.push(config.resume_flag.clone());
-                    args.push(sid.clone());
-                }
-            }
-            inner.session_id.clone()
-        };
+        // Read the previously-captured session id once, up front — used
+        // both by the lease claim below and by the resume-flag args
+        // built after it.
+        let session_id_hint = self.inner.lock().unwrap().session_id.clone();
 
         // Claim the cross-process session-ownership lease BEFORE
-        // flipping status to running — a refusal here should look like
-        // the turn never started, not leave status stuck mid-flight.
-        // Empty `instance_id` (container-mode branch in this PR) or no
+        // `emit_message_accepted` / flipping status to running — a
+        // refusal here must look like the turn never started at all,
+        // not "frontend was told this message was accepted, then it
+        // silently never ran" (reagent P1 on #2359: emitting accepted
+        // before the claim meant a HeldByOther refusal left the
+        // frontend believing the message was in flight). Empty
+        // `instance_id` (container-mode branch in this PR) or no
         // `lease_store` (registry unavailable) both mean leasing is a
         // no-op for this spawn. See `registry::LeaseStore` and
         // `docs/retros/RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md`.
@@ -109,6 +94,28 @@ impl SubprocessController {
                 },
             }
         };
+
+        // Direct-spawn path (queue was empty): emit the accepted event
+        // now so the frontend can promote its pending entry. The
+        // drain-from-queue path (in process_waiter) emits the same
+        // event just before calling spawn_turn recursively. Only
+        // reached once the lease claim above has succeeded (or was a
+        // no-op) — see that block's comment.
+        self.emit_message_accepted(&config);
+
+        // Hydrate inner.session_id from the config-supplied id if the
+        // controller hasn't captured one yet. See
+        // `hydrate_session_id_from_config` for the full rationale.
+        self.hydrate_session_id_from_config(config.session_id.as_deref());
+
+        // Build CLI args, appending resume flag + session_id if we have one and the provider supports it
+        let mut args = config.cli_args.clone();
+        if let Some(ref sid) = session_id_hint {
+            if !config.resume_flag.is_empty() {
+                args.push(config.resume_flag.clone());
+                args.push(sid.clone());
+            }
+        }
 
         // Update status to running
         {
@@ -705,6 +712,32 @@ impl SubprocessController {
                             error = %e,
                             "failed to spawn queued turn"
                         );
+                        // The message was already popped from the queue —
+                        // a bare warn-log here means it vanishes with no
+                        // trace the user can see (reagent P1 on #2359,
+                        // most likely to fire on a lease refusal: another
+                        // process claimed this session in the gap between
+                        // this turn's release and the drain). Surface it
+                        // the same way other pre-spawn failures in this
+                        // module do (e.g. input.rs's container
+                        // ensure_running failure): a visible error frame
+                        // in the block, not just a log line.
+                        let error_frame = serde_json::json!({
+                            "type": "result",
+                            "is_error": true,
+                            "subtype": "error_during_execution",
+                            "error": {"message": format!("[AgentMux] queued message could not be sent: {e}")}
+                        }).to_string();
+                        if let Some(ref broker) = broker_wait {
+                            crate::backend::blockcontroller::shell::handle_append_block_file(
+                                broker,
+                                &block_id_wait,
+                                SUBPROCESS_OUTPUT_SUBJECT,
+                                format!("{error_frame}\n").as_bytes(),
+                                None,
+                                None,
+                            );
+                        }
                     }
                 }
             }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -58,7 +58,7 @@ impl SubprocessController {
 
         // Build CLI args, appending resume flag + session_id if we have one and the provider supports it
         let mut args = config.cli_args.clone();
-        {
+        let session_id_hint = {
             let inner = self.inner.lock().unwrap();
             if let Some(ref sid) = inner.session_id {
                 if !config.resume_flag.is_empty() {
@@ -66,7 +66,49 @@ impl SubprocessController {
                     args.push(sid.clone());
                 }
             }
-        }
+            inner.session_id.clone()
+        };
+
+        // Claim the cross-process session-ownership lease BEFORE
+        // flipping status to running — a refusal here should look like
+        // the turn never started, not leave status stuck mid-flight.
+        // Empty `instance_id` (container-mode branch in this PR) or no
+        // `lease_store` (registry unavailable) both mean leasing is a
+        // no-op for this spawn. See `registry::LeaseStore` and
+        // `docs/retros/RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md`.
+        let claimed_lease: Option<crate::registry::Lease> = if config.instance_id.is_empty() {
+            None
+        } else {
+            match &self.lease_store {
+                None => None,
+                Some(store) => match store.claim(
+                    &config.instance_id,
+                    &self.boot_id,
+                    &self.block_id,
+                    session_id_hint.as_deref(),
+                ) {
+                    Ok(lease) => Some(lease),
+                    Err(crate::registry::LeaseError::HeldByOther { owner_boot_id, age_ms, .. }) => {
+                        self.unlock_run();
+                        return Err(format!(
+                            "session '{}' is already owned by another AgentMux process \
+                             (boot {owner_boot_id}, renewed {age_ms}ms ago) — refusing to \
+                             start a turn against the same session from two processes at once",
+                            config.instance_id
+                        ));
+                    }
+                    Err(crate::registry::LeaseError::Io(e)) => {
+                        tracing::warn!(
+                            block_id = %self.block_id,
+                            instance_id = %config.instance_id,
+                            error = %e,
+                            "lease claim failed (io) — proceeding without a lease for this turn"
+                        );
+                        None
+                    }
+                },
+            }
+        };
 
         // Update status to running
         {
@@ -99,6 +141,15 @@ impl SubprocessController {
             let mut inner = self.inner.lock().unwrap();
             Self::set_status(&mut inner, STATUS_DONE);
             inner.proc_exit_code = -1;
+            if let (Some(store), Some(lease)) = (&self.lease_store, &claimed_lease) {
+                if let Err(release_err) = store.release(lease) {
+                    tracing::warn!(
+                        block_id = %self.block_id,
+                        error = %release_err,
+                        "lease release failed after spawn failure (self-heals via TTL expiry)"
+                    );
+                }
+            }
             self.unlock_run();
             format!("failed to spawn subprocess: {e}")
         })?;
@@ -372,6 +423,45 @@ impl SubprocessController {
 
         core::spawn_health_watchdog(&self.health_monitor);
 
+        // Renew the lease (if any) on the same cadence as the health
+        // watchdog above, for as long as this turn is active. A
+        // dedicated task rather than widening `spawn_health_watchdog`'s
+        // signature — that helper has 7 call sites across every
+        // controller type (ACP, persistent, container, host); only
+        // host-mode claims a lease in this PR (see module + struct doc
+        // comments), so touching the other 6 for an always-`None`
+        // param isn't warranted.
+        if let (Some(store), Some(lease)) = (self.lease_store.clone(), claimed_lease.clone()) {
+            let health_renew = Arc::clone(&self.health_monitor);
+            let block_id_renew = self.block_id.clone();
+            tokio::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(std::time::Duration::from_millis(
+                        crate::registry::RENEW_INTERVAL_MS,
+                    ));
+                loop {
+                    interval.tick().await;
+                    if !health_renew.is_active_turn() {
+                        break;
+                    }
+                    if let Err(e) = store.renew(&lease) {
+                        // Lost the lease to a TTL reclaim mid-turn — log and
+                        // let the turn finish naturally rather than killing
+                        // it. Force-killing on lost renewal is deliberately
+                        // deferred (see the analysis doc's follow-ups); this
+                        // is a real residual gap, not an oversight.
+                        tracing::warn!(
+                            block_id = %block_id_renew,
+                            instance_id = %lease.instance_id(),
+                            error = %e,
+                            "lease renew failed — lease may have been reclaimed by another process"
+                        );
+                        break;
+                    }
+                }
+            });
+        }
+
         // Spawn process_waiter task
         let inner_wait = Arc::clone(&self.inner);
         let block_id_wait = self.block_id.clone();
@@ -384,6 +474,8 @@ impl SubprocessController {
         let last_inband_error_wait = Arc::clone(&last_inband_error);
         let wstore_wait = self.wstore.clone();
         let event_bus_wait = self.event_bus.clone();
+        let lease_store_wait = self.lease_store.clone();
+        let claimed_lease_wait = claimed_lease;
         tokio::spawn(async move {
             // Classified failure cause, surfaced to the pane after the readers drain.
             let mut run_failure: Option<crate::agents::failure::AgentFailure> = None;
@@ -559,7 +651,18 @@ impl SubprocessController {
                 });
             }
 
-            // Release run lock
+            // Release the lease (if any), then the run lock — mirrors
+            // the ordering in the spawn-failure closure above.
+            if let (Some(store), Some(lease)) = (&lease_store_wait, &claimed_lease_wait) {
+                if let Err(e) = store.release(lease) {
+                    tracing::warn!(
+                        block_id = %block_id_wait,
+                        instance_id = %lease.instance_id(),
+                        error = %e,
+                        "lease release failed (self-heals via TTL expiry)"
+                    );
+                }
+            }
             run_lock.store(false, Ordering::SeqCst);
 
             // Drain message queue: if messages were queued while this turn

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -12,7 +12,7 @@
 //! `spawn_turn` is one continuous, non-trivially-ordered state machine and
 //! is moved here WHOLE rather than decomposed further.
 
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -424,15 +424,28 @@ impl SubprocessController {
         core::spawn_health_watchdog(&self.health_monitor);
 
         // Renew the lease (if any) on the same cadence as the health
-        // watchdog above, for as long as this turn is active. A
+        // watchdog above, for as long as THIS turn is active. A
         // dedicated task rather than widening `spawn_health_watchdog`'s
         // signature — that helper has 7 call sites across every
         // controller type (ACP, persistent, container, host); only
         // host-mode claims a lease in this PR (see module + struct doc
         // comments), so touching the other 6 for an always-`None`
         // param isn't warranted.
+        //
+        // Exit condition is a fresh per-turn flag (`turn_done`), NOT
+        // `health_monitor.is_active_turn()` — that flag is shared by
+        // the whole controller, not scoped to this specific spawn.
+        // Queued messages drain synchronously in process_waiter: the
+        // next turn's `set_active_turn(true)` can land in the same
+        // tick this turn's process_waiter releases its lease, with no
+        // async gap. A stale renewal task watching the shared flag
+        // would see it flip back to `true` before its next 5s tick and
+        // loop forever, leaking one never-terminating renewal task
+        // (blocking flock + file write every tick) per turn in a busy,
+        // back-to-back conversation — reagent P1 on #2359.
+        let turn_done = Arc::new(AtomicBool::new(false));
         if let (Some(store), Some(lease)) = (self.lease_store.clone(), claimed_lease.clone()) {
-            let health_renew = Arc::clone(&self.health_monitor);
+            let turn_done_renew = Arc::clone(&turn_done);
             let block_id_renew = self.block_id.clone();
             tokio::spawn(async move {
                 let mut interval =
@@ -441,7 +454,7 @@ impl SubprocessController {
                     ));
                 loop {
                     interval.tick().await;
-                    if !health_renew.is_active_turn() {
+                    if turn_done_renew.load(Ordering::SeqCst) {
                         break;
                     }
                     if let Err(e) = store.renew(&lease) {
@@ -468,6 +481,7 @@ impl SubprocessController {
         let broker_wait = self.broker.clone();
         let run_lock = Arc::clone(&self.run_lock);
         let health_wait = Arc::clone(&self.health_monitor);
+        let turn_done_wait = Arc::clone(&turn_done);
         let self_ref_wait = self.self_ref.lock().unwrap().clone().unwrap_or_default();
         let stderr_tail_wait = Arc::clone(&stderr_tail);
         let last_result_frame_wait = Arc::clone(&last_result_frame);
@@ -650,6 +664,13 @@ impl SubprocessController {
                     data: serde_json::to_value(failure).ok(),
                 });
             }
+
+            // Signal the renewal task to stop BEFORE releasing the
+            // lease/run_lock — a queued next turn (dequeued a few
+            // lines below) may spawn immediately and claim its own
+            // lease; this turn's renewal task must not still be
+            // ticking when that happens (reagent P1 on #2359).
+            turn_done_wait.store(true, Ordering::SeqCst);
 
             // Release the lease (if any), then the run lock — mirrors
             // the ordering in the spawn-failure closure above.

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/host_spawn.rs
@@ -45,7 +45,19 @@ impl SubprocessController {
             return Ok(());
         }
 
-        // Read the previously-captured session id once, up front — used
+        // Hydrate inner.session_id from the config-supplied id if the
+        // controller hasn't captured one yet — MUST run before the
+        // session_id_hint read just below. See
+        // `hydrate_session_id_from_config` for the full rationale
+        // (picker reattach: a fresh controller's inner.session_id is
+        // None, but config.session_id carries the persisted id).
+        // Reordering this after the read (reagent P0 on #2359, an
+        // earlier revision of this same PR) silently dropped --resume
+        // on every reattach's first turn — hydration ran too late for
+        // the read below to see it.
+        self.hydrate_session_id_from_config(config.session_id.as_deref());
+
+        // Read the (now-hydrated) session id once, up front — used
         // both by the lease claim below and by the resume-flag args
         // built after it.
         let session_id_hint = self.inner.lock().unwrap().session_id.clone();
@@ -102,11 +114,6 @@ impl SubprocessController {
         // reached once the lease claim above has succeeded (or was a
         // no-op) — see that block's comment.
         self.emit_message_accepted(&config);
-
-        // Hydrate inner.session_id from the config-supplied id if the
-        // controller hasn't captured one yet. See
-        // `hydrate_session_id_from_config` for the full rationale.
-        self.hydrate_session_id_from_config(config.session_id.as_deref());
 
         // Build CLI args, appending resume flag + session_id if we have one and the provider supports it
         let mut args = config.cli_args.clone();

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/mod.rs
@@ -104,6 +104,13 @@ pub struct SubprocessSpawnConfig {
     /// session and emits its own id, which then becomes the in-
     /// memory authority for every subsequent turn.
     pub session_id: Option<String>,
+    /// The registry's `instance_id` (`block.meta["agentId"]`) for this
+    /// agent — the cross-process session-lease key (see
+    /// `registry::LeaseStore`; NOT `session_id` above, which can be
+    /// `None` on a greenfield first turn). Empty string disables
+    /// leasing for this spawn (e.g. the container-mode branch in this
+    /// PR — see `host_spawn::spawn_turn`'s own doc comment).
+    pub instance_id: String,
 }
 
 /// Inner state protected by mutex.
@@ -151,10 +158,25 @@ pub struct SubprocessController {
     /// Weak self-reference for queue drain. Set by `set_self_ref` after
     /// the controller is wrapped in Arc.
     self_ref: Mutex<Option<std::sync::Weak<Self>>>,
+    /// Cross-process session-ownership lease store. `None` when the
+    /// shared registry can't be resolved (CI / unusual envs) — leasing
+    /// degrades to a no-op in that case, same convention as
+    /// `shared_agent_registry()` elsewhere. See
+    /// `docs/retros/RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md`.
+    lease_store: Option<Arc<crate::registry::LeaseStore>>,
+    /// This process's boot id — the lease owner id. See `AppState::boot_id`.
+    boot_id: Arc<str>,
 }
 
 impl SubprocessController {
     /// Create a new SubprocessController.
+    ///
+    /// `registry`/`boot_id` back the cross-process session-ownership
+    /// lease (see `lease_store` field doc). Passing `registry: None`
+    /// (or a registry whose root can't be opened as a `LeaseStore`,
+    /// which is logged and degrades the same way) disables leasing
+    /// for every turn this controller spawns — used by test call
+    /// sites that don't need a real registry.
     pub fn new(
         tab_id: String,
         block_id: String,
@@ -162,6 +184,8 @@ impl SubprocessController {
         event_bus: Option<Arc<EventBus>>,
         wstore: Option<Arc<Store>>,
         filestore: Option<Arc<FileStore>>,
+        registry: Option<Arc<crate::registry::Registry>>,
+        boot_id: Arc<str>,
     ) -> Self {
         let health_monitor = Arc::new(HealthMonitor::new(
             block_id.clone(),
@@ -169,6 +193,18 @@ impl SubprocessController {
             wstore.clone(),
             event_bus.clone(),
         ));
+        let lease_store = registry.and_then(|r| {
+            crate::registry::LeaseStore::open(r.root())
+                .map(Arc::new)
+                .map_err(|e| {
+                    tracing::warn!(
+                        block_id = %block_id,
+                        error = %e,
+                        "subprocess controller: failed to open lease store — leasing disabled for this controller"
+                    );
+                })
+                .ok()
+        });
         Self {
             tab_id,
             block_id,
@@ -188,6 +224,8 @@ impl SubprocessController {
             filestore,
             health_monitor,
             self_ref: Mutex::new(None),
+            lease_store,
+            boot_id,
         }
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/subprocess/tests.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess/tests.rs
@@ -16,6 +16,8 @@ fn test_subprocess_controller_new() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     assert_eq!(ctrl.controller_type(), BLOCK_CONTROLLER_SUBPROCESS);
     assert_eq!(ctrl.block_id(), "block-1");
@@ -34,6 +36,8 @@ fn test_subprocess_controller_rejects_raw_input() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()), None);
     assert!(result.is_err());
@@ -49,6 +53,8 @@ fn test_subprocess_controller_start_is_noop() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     let result = ctrl.start(HashMap::new(), None, false);
     assert!(result.is_ok());
@@ -67,6 +73,8 @@ fn test_subprocess_controller_stop_when_idle() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     let result = ctrl.stop(true, STATUS_DONE);
     assert!(result.is_ok());
@@ -84,6 +92,8 @@ fn test_subprocess_controller_session_id_initially_none() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     assert!(ctrl.session_id().is_none());
 }
@@ -97,6 +107,8 @@ fn test_subprocess_controller_concurrent_spawn_blocked() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
 
     // Manually acquire run lock
@@ -112,6 +124,7 @@ fn test_subprocess_controller_concurrent_spawn_blocked() {
         session_id_field: "session_id".to_string(),
         message_id: None,
         session_id: None,
+        instance_id: String::new(),
     };
 
     let result = ctrl.spawn_turn(config);
@@ -148,6 +161,8 @@ fn hydrate_session_id_populates_inner_when_none() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     assert!(ctrl.inner.lock().unwrap().session_id.is_none());
 
@@ -174,6 +189,8 @@ fn hydrate_session_id_is_noop_when_value_already_present() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     ctrl.inner.lock().unwrap().session_id = Some("captured-sid".to_string());
 
@@ -202,6 +219,8 @@ fn record_captured_overwrites_hydrated_value() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     ctrl.hydrate_session_id_from_config(Some("stale-hydrated-sid"));
     assert_eq!(
@@ -231,6 +250,8 @@ fn record_captured_dedups_same_value() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     assert!(ctrl.record_captured_session_id("sid-1"));
     assert!(!ctrl.record_captured_session_id("sid-1"),
@@ -249,6 +270,8 @@ fn record_captured_ignores_empty() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     ctrl.record_captured_session_id("real-sid");
     assert!(!ctrl.record_captured_session_id(""),
@@ -269,6 +292,8 @@ fn hydrate_session_id_ignores_empty_and_none() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     ctrl.hydrate_session_id_from_config(None);
     assert!(ctrl.inner.lock().unwrap().session_id.is_none());
@@ -291,6 +316,8 @@ fn spawn_turn_preserves_session_id_in_queued_config() {
         None,
         None,
         None,
+        None,
+        std::sync::Arc::from("test-boot"),
     );
     ctrl.run_lock.store(true, Ordering::SeqCst);
 
@@ -304,6 +331,7 @@ fn spawn_turn_preserves_session_id_in_queued_config() {
         session_id_field: "session_id".to_string(),
         message_id: None,
         session_id: Some("prior-sid".to_string()),
+        instance_id: String::new(),
     };
     let _ = ctrl.spawn_turn(config);
 
@@ -316,4 +344,64 @@ fn spawn_turn_preserves_session_id_in_queued_config() {
     // Hydration didn't run yet — direct-spawn path was bypassed
     // by the busy lock; the drain will hydrate when it dequeues.
     assert!(inner.session_id.is_none());
+}
+
+/// End-to-end proof of the fix for
+/// `RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md`: a
+/// session already leased by a different boot_id refuses `spawn_turn`
+/// before any child process is spawned, rather than silently racing a
+/// second driver against the same session.
+#[test]
+fn spawn_turn_refuses_when_lease_held_by_another_process() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(
+        crate::registry::Registry::open(tmp.path().to_path_buf()).unwrap(),
+    );
+
+    // Simulate another live process already owning this instance_id.
+    let lease_store = crate::registry::LeaseStore::open(registry.root()).unwrap();
+    lease_store
+        .claim(
+            "instance-under-test",
+            &std::sync::Arc::from("other-process-boot-id"),
+            "other-block-id",
+            None,
+        )
+        .unwrap();
+
+    let ctrl = SubprocessController::new(
+        "tab-1".to_string(),
+        "block-1".to_string(),
+        None,
+        None,
+        None,
+        None,
+        Some(registry),
+        std::sync::Arc::from("this-process-boot-id"),
+    );
+
+    let config = SubprocessSpawnConfig {
+        cli_command: "claude".to_string(),
+        cli_args: vec!["-p".to_string()],
+        working_dir: String::new(),
+        env_vars: HashMap::new(),
+        message: "hi".to_string(),
+        resume_flag: String::new(),
+        session_id_field: "session_id".to_string(),
+        message_id: None,
+        session_id: None,
+        instance_id: "instance-under-test".to_string(),
+    };
+
+    let result = ctrl.spawn_turn(config);
+    let err = result.expect_err("spawn_turn must refuse when another process holds the lease");
+    assert!(
+        err.contains("already owned by another AgentMux process"),
+        "unexpected error message: {err}"
+    );
+
+    // The run lock must be released on refusal too — otherwise a
+    // legitimate retry against the SAME process would be permanently
+    // blocked by this controller's own busy-lock, not just the lease.
+    assert!(!ctrl.run_lock.load(Ordering::SeqCst));
 }

--- a/agentmux-srv/src/server/agent_handlers/input.rs
+++ b/agentmux-srv/src/server/agent_handlers/input.rs
@@ -21,6 +21,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
     let broker_spawn = state.broker.clone();
     let event_bus_spawn = state.event_bus.clone();
     let filestore_spawn = state.filestore.clone();
+    let boot_id_spawn = state.boot_id.clone();
     engine.register_handler(
         COMMAND_SUBPROCESS_SPAWN,
         Box::new(move |data, _ctx| {
@@ -28,6 +29,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
             let broker = broker_spawn.clone();
             let event_bus = event_bus_spawn.clone();
             let filestore = filestore_spawn.clone();
+            let boot_id = boot_id_spawn.clone();
             Box::pin(async move {
                 let cmd: CommandSubprocessSpawnData = serde_json::from_value(data)
                     .map_err(|e| format!("subprocessspawn: {e}"))?;
@@ -42,6 +44,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                     Some(c) if c.controller_type() == blockcontroller::BLOCK_CONTROLLER_SUBPROCESS => c,
                     _ => {
                         // Create and register a new SubprocessController
+                        let registry = wstore.shared_agent_registry();
                         let ctrl = blockcontroller::subprocess::SubprocessController::new(
                             cmd.tabid.clone(),
                             cmd.blockid.clone(),
@@ -49,6 +52,8 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                             Some(event_bus),
                             Some(wstore),
                             Some(filestore),
+                            registry,
+                            boot_id,
                         );
                         let ctrl = std::sync::Arc::new(ctrl);
                         ctrl.set_self_ref();
@@ -77,6 +82,10 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                     // is None; spawn_turn captures it from CLI stdout
                     // on the first turn as before.
                     session_id: None,
+                    // COMMAND_SUBPROCESS_SPAWN has no block to read
+                    // agentId from (dead code — unused by the
+                    // frontend, per grep); empty disables leasing.
+                    instance_id: String::new(),
                 };
                 subprocess_ctrl.spawn_turn(config)?;
                 Ok(None)
@@ -338,6 +347,14 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                     let agent_mode = crate::backend::obj::meta_get_string(
                         &block.meta, "agentMode", "host",
                     );
+                    // Cross-process session-lease key (registry::LeaseStore) —
+                    // read once here for both branches below. Only the host
+                    // branch's spawn_turn actually enforces it in this PR;
+                    // the container branch's config field is unused for now
+                    // (struct-completeness — see host_spawn.rs's doc comment).
+                    let instance_id = crate::backend::obj::meta_get_string(
+                        &block.meta, "agentId", "",
+                    );
                     if agent_mode == "container" {
                         let cm = container_manager.get().await
                             .ok_or_else(|| "Docker not available on this host; cannot start container agent".to_string())?;
@@ -417,6 +434,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                             } else {
                                 Some(persisted_session_id)
                             },
+                            instance_id: instance_id.clone(),
                         };
                         subprocess_ctrl.spawn_container_turn(cm.clone(), container_name, base_cmd, config)?;
                     } else {
@@ -435,6 +453,7 @@ pub fn register_agent_input_handlers(engine: &Arc<WshRpcEngine>, state: &AppStat
                             } else {
                                 Some(persisted_session_id)
                             },
+                            instance_id,
                         };
                         subprocess_ctrl.spawn_turn(config)?;
                     }

--- a/agentmux-srv/src/server/app_api/agent_io.rs
+++ b/agentmux-srv/src/server/app_api/agent_io.rs
@@ -263,6 +263,11 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // Container agent branch: use Docker socket API exec (P1a: no
                     // secrets in argv). Host agent branch: regular CLI subprocess.
                     let agent_mode = obj::meta_get_string(&block.meta, "agentMode", "host");
+                    // Cross-process session-lease key (registry::LeaseStore) —
+                    // read once for both branches below. Only the host
+                    // branch's spawn_turn enforces it in this PR; the
+                    // container branch's field is unused for now.
+                    let instance_id = obj::meta_get_string(&block.meta, "agentId", "");
                     if agent_mode == "container" {
                         let cm = container_manager.get().await
                             .ok_or_else(|| "Docker not available on this host; cannot start container agent".to_string())?;
@@ -321,6 +326,7 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             } else {
                                 Some(persisted_session_id)
                             },
+                            instance_id: instance_id.clone(),
                         };
                         subprocess_ctrl.spawn_container_turn(cm.clone(), container_name, base_cmd, config)?;
                     } else {
@@ -339,6 +345,7 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             } else {
                                 Some(persisted_session_id)
                             },
+                            instance_id,
                         };
                         subprocess_ctrl.spawn_turn(config)?;
                     }

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -103,7 +103,8 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         let _ = blockcontroller::resync_controller(
                             &block_for_resync, &tab_id, None, true,
                             Some(broker.clone()), Some(event_bus.clone()), Some(wstore.clone()),
-                            Some(filestore.clone()),
+                            Some(filestore.clone()), wstore.shared_agent_registry(),
+                            app_state.boot_id.clone(),
                         );
                     }
                     let status = blockcontroller::get_block_controller_status(&existing.oid)
@@ -435,6 +436,8 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     Some(event_bus.clone()),
                     Some(wstore.clone()),
                     Some(filestore.clone()),
+                    wstore.shared_agent_registry(),
+                    app_state.boot_id.clone(),
                 )?;
 
                 // 10. Broadcast block + tab + layout updates to frontend

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -771,6 +771,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     let broker_resync = state.broker.clone();
     let event_bus_resync = state.event_bus.clone();
     let filestore_resync = state.filestore.clone();
+    let boot_id_resync = state.boot_id.clone();
     engine.register_handler(
         COMMAND_CONTROLLER_RESYNC,
         Box::new(move |data, _ctx| {
@@ -778,6 +779,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
             let broker = broker_resync.clone();
             let event_bus = event_bus_resync.clone();
             let filestore = filestore_resync.clone();
+            let boot_id = boot_id_resync.clone();
             Box::pin(async move {
                 let cmd: CommandControllerResyncData = serde_json::from_value(data)
                     .map_err(|e| format!("controllerresync: {e}"))?;
@@ -791,6 +793,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     .get(&cmd.blockid)
                     .map_err(|e| format!("controllerresync: load block: {e}"))?
                     .ok_or_else(|| format!("controllerresync: block {} not found", cmd.blockid))?;
+                let registry = wstore.shared_agent_registry();
                 blockcontroller::resync_controller(
                     &block,
                     &cmd.tabid,
@@ -800,6 +803,8 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     Some(event_bus),
                     Some(wstore),
                     Some(filestore),
+                    registry,
+                    boot_id,
                 )?;
                 Ok(None)
             })


### PR DESCRIPTION
## Summary

PR 2 of 2 for the session-ownership lease work (PR 1: #2355, merged). Wires `registry::LeaseStore` into the real turn-spawn path.

- `SubprocessController::spawn_turn` (host-mode) now claims the lease for `config.instance_id` before flipping status to running. A refusal (`HeldByOther`) unwinds cleanly — releases the run lock, returns a clear error naming the other process and how long ago it last renewed — before any child process is spawned.
- Renewed every 5s for as long as the turn is active, via a small dedicated task (not by widening `spawn_health_watchdog`'s signature — that helper has 7 call sites across ACP/persistent/container/host controllers; only host-mode claims a lease in this PR).
- Released on every exit path: spawn failure, normal completion, and kill (all converge through the same process_waiter release point).
- `instance_id` (`block.meta["agentId"]`) threaded through `SubprocessSpawnConfig` and the controller constructor from every real construction site: `input.rs`'s live `agentinput` handler, `agent_io.rs`'s `agent.send` handler, and `resync_controller`'s three callers.

**Explicitly deferred** (per the approved plan, not an oversight): container-mode (`spawn_container_turn`) and persistent/background agents (`PersistentSubprocessController`) share the identical exposure but aren't wired in this PR — fast-follow once this lands.

Context: `docs/retros/RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md` (the incident this closes) and `docs/analysis/ANALYSIS_MULTI_AGENT_SESSION_AND_WORKDIR_ISOLATION_2026-07-29.md` (the design).

## Test plan

- [x] `cargo check -p agentmux-srv` / `--tests` — clean
- [x] New integration test `spawn_turn_refuses_when_lease_held_by_another_process`: pre-claims a lease under a different `boot_id` in a real temp registry, then asserts `spawn_turn` refuses with "already owned by another AgentMux process" *before* any child process spawns, and that the run lock is released on refusal (so a legitimate retry against the same process isn't permanently blocked by its own busy-lock).
- [x] `cargo test -p agentmux-srv --bin agentmux-srv` (full suite) — 1765/1765 passing, run twice for stability

<!-- agentmux:agent_id=agent3 -->